### PR TITLE
fix(jules): correct sourceContext schema to match Jules API

### DIFF
--- a/docs/designs/2026-01-05-jules-api-schema-fix.md
+++ b/docs/designs/2026-01-05-jules-api-schema-fix.md
@@ -1,0 +1,143 @@
+# Jules API Schema Fix + Source Validation
+
+## Problem Statement
+
+The `jules_create_task` MCP tool fails with:
+```
+Error: Invalid JSON payload received. Unknown name "branch" at 'session.source_context': Cannot find field
+```
+
+This occurs because our implementation uses an incorrect schema for the `sourceContext` field when creating Jules sessions.
+
+## Root Cause Analysis
+
+### Current Implementation (Incorrect)
+
+**types.ts:47-50:**
+```typescript
+export interface SourceContext {
+  source: string; // "sources/github-{owner}-{repo}"
+  branch?: string; // default: "main"
+}
+```
+
+**tools.ts:181-184:**
+```typescript
+sourceContext: {
+  source: `sources/github-${validated.repo.replace('/', '-')}`,
+  branch: validated.branch
+}
+```
+
+### Correct API Schema (from Jules docs)
+
+```json
+{
+  "sourceContext": {
+    "source": "sources/github/owner/repo",
+    "githubRepoContext": {
+      "startingBranch": "main"
+    }
+  }
+}
+```
+
+### Discrepancies
+
+| Aspect | Current | Correct |
+|--------|---------|---------|
+| Branch location | `sourceContext.branch` | `sourceContext.githubRepoContext.startingBranch` |
+| Branch field name | `branch` | `startingBranch` |
+| Source format | `sources/github-{owner}-{repo}` | `sources/github/{owner}/{repo}` |
+
+## Design: Approach B - Schema Fix + Source Validation
+
+### Changes Required
+
+#### 1. Update Type Definitions (`types.ts`)
+
+```typescript
+// Add new nested type
+export interface GitHubRepoContext {
+  startingBranch?: string;
+}
+
+// Update SourceContext
+export interface SourceContext {
+  source: string; // "sources/github/{owner}/{repo}"
+  githubRepoContext?: GitHubRepoContext;
+}
+```
+
+#### 2. Update Tool Implementation (`tools.ts`)
+
+**2a. Fix source format and schema in `jules_create_task`:**
+
+```typescript
+sourceContext: {
+  source: `sources/github/${validated.repo}`,  // Use slashes, not dashes
+  githubRepoContext: validated.branch ? {
+    startingBranch: validated.branch
+  } : undefined
+}
+```
+
+**2b. Add source validation before creating session:**
+
+```typescript
+async jules_create_task(input): Promise<ToolResult> {
+  const validated = createTaskSchema.parse(input);
+
+  // Validate repo is connected to Jules
+  const sources = await client.listSources();
+  const expectedSource = `sources/github/${validated.repo}`;
+  const sourceExists = sources.some(s => s.name === expectedSource);
+
+  if (!sourceExists) {
+    const connectedRepos = sources.map(s =>
+      `${s.githubRepo.owner}/${s.githubRepo.repo}`
+    ).join(', ');
+    return errorResult(
+      `Repository "${validated.repo}" is not connected to Jules. ` +
+      `Connected repos: ${connectedRepos || 'none'}. ` +
+      `Connect at https://jules.google`
+    );
+  }
+
+  // Proceed with session creation...
+}
+```
+
+#### 3. Update Tests (`tools.test.ts`, `jules-client.test.ts`)
+
+- Update mocks to use correct schema structure
+- Add test for source validation error case
+- Verify correct source format in API calls
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `plugins/jules/servers/jules-mcp/src/types.ts` | Add `GitHubRepoContext`, update `SourceContext` |
+| `plugins/jules/servers/jules-mcp/src/tools.ts` | Fix schema, add source validation |
+| `plugins/jules/servers/jules-mcp/src/tools.test.ts` | Update mocks, add validation test |
+| `plugins/jules/servers/jules-mcp/src/jules-client.test.ts` | Update schema in mocks |
+
+### Test Plan
+
+1. **Unit Tests:**
+   - Verify `sourceContext` schema matches API spec
+   - Verify source validation returns helpful error for unconnected repos
+   - Verify successful task creation with valid repo
+
+2. **Integration Test (manual):**
+   - Call `jules_create_task` with a connected repo
+   - Verify session creates successfully
+   - Verify branch parameter works correctly
+
+### Success Criteria
+
+- [ ] `jules_create_task` no longer throws "Unknown name 'branch'" error
+- [ ] Attempting to use an unconnected repo returns helpful error message
+- [ ] All existing tests pass with updated schema
+- [ ] New validation test covers the error case

--- a/docs/plans/2026-01-05-jules-api-schema-fix.md
+++ b/docs/plans/2026-01-05-jules-api-schema-fix.md
@@ -1,0 +1,369 @@
+# Implementation Plan: Jules API Schema Fix
+
+## Overview
+
+Fix the `sourceContext` schema to match the actual Jules API and add source validation.
+
+**Design:** `docs/designs/2026-01-05-jules-api-schema-fix.md`
+
+## Task Summary
+
+| ID | Task | Phase | Parallelizable |
+|----|------|-------|----------------|
+| 001 | Add GitHubRepoContext type and update SourceContext | RED→GREEN | No (foundation) |
+| 002 | Fix source format in fixtures | GREEN | Yes (after 001) |
+| 003 | Update tools.ts to use correct schema | RED→GREEN | Yes (after 001) |
+| 004 | Add source validation to jules_create_task | RED→GREEN | Yes (after 003) |
+| 005 | Update existing tests for new schema | GREEN | Yes (after 003) |
+
+---
+
+## Task 001: Add GitHubRepoContext type and update SourceContext
+
+**Phase:** RED → GREEN
+**Dependencies:** None
+**Parallelizable:** No (foundation for other tasks)
+
+### [RED] Write failing test
+
+**File:** `plugins/jules/servers/jules-mcp/src/types.test.ts` (new file)
+
+```typescript
+describe('SourceContext type', () => {
+  it('should have githubRepoContext with startingBranch', () => {
+    const context: SourceContext = {
+      source: 'sources/github/owner/repo',
+      githubRepoContext: {
+        startingBranch: 'main'
+      }
+    };
+    expect(context.githubRepoContext?.startingBranch).toBe('main');
+  });
+
+  it('should not have branch property at top level', () => {
+    const context: SourceContext = {
+      source: 'sources/github/owner/repo'
+    };
+    // TypeScript should error if 'branch' exists on SourceContext
+    expect((context as any).branch).toBeUndefined();
+  });
+});
+```
+
+**Expected failure:** TypeScript error - `githubRepoContext` doesn't exist on `SourceContext`
+
+### [GREEN] Implement minimum code
+
+**File:** `plugins/jules/servers/jules-mcp/src/types.ts`
+
+1. Add `GitHubRepoContext` interface after line 50:
+```typescript
+export interface GitHubRepoContext {
+  startingBranch?: string;
+}
+```
+
+2. Update `SourceContext` interface (lines 47-50):
+```typescript
+export interface SourceContext {
+  source: string; // "sources/github/{owner}/{repo}"
+  githubRepoContext?: GitHubRepoContext;
+}
+```
+
+---
+
+## Task 002: Fix source format in fixtures
+
+**Phase:** GREEN
+**Dependencies:** Task 001
+**Parallelizable:** Yes
+
+### [GREEN] Update fixtures
+
+**File:** `plugins/jules/servers/jules-mcp/src/test/fixtures.ts`
+
+Update source names from dash format to slash format:
+
+```typescript
+// Line 8: Change from
+name: 'sources/github-lvlup-sw-test-repo',
+// To
+name: 'sources/github/lvlup-sw/test-repo',
+
+// Line 9: Change from
+id: 'github-lvlup-sw-test-repo',
+// To
+id: 'github/lvlup-sw/test-repo',
+
+// Line 23: Change from
+name: 'sources/github-lvlup-sw-private-repo',
+// To
+name: 'sources/github/lvlup-sw/private-repo',
+
+// Line 24: Change from
+id: 'github-lvlup-sw-private-repo',
+// To
+id: 'github/lvlup-sw/private-repo',
+```
+
+---
+
+## Task 003: Update tools.ts to use correct schema
+
+**Phase:** RED → GREEN
+**Dependencies:** Task 001
+**Parallelizable:** Yes
+
+### [RED] Write failing test
+
+**File:** `plugins/jules/servers/jules-mcp/src/tools.test.ts`
+
+Add test in `jules_create_task` describe block:
+
+```typescript
+it('should use githubRepoContext.startingBranch for branch parameter', async () => {
+  // Arrange
+  vi.mocked(mockClient.listSources).mockResolvedValue([mockSource]);
+  vi.mocked(mockClient.createSession).mockResolvedValue(mockSession);
+
+  // Act
+  await tools.jules_create_task({
+    repo: 'lvlup-sw/test-repo',
+    prompt: 'Test task',
+    branch: 'develop'
+  });
+
+  // Assert
+  expect(mockClient.createSession).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sourceContext: {
+        source: 'sources/github/lvlup-sw/test-repo',
+        githubRepoContext: {
+          startingBranch: 'develop'
+        }
+      }
+    })
+  );
+});
+
+it('should use correct source format with slashes', async () => {
+  // Arrange
+  vi.mocked(mockClient.listSources).mockResolvedValue([mockSource]);
+  vi.mocked(mockClient.createSession).mockResolvedValue(mockSession);
+
+  // Act
+  await tools.jules_create_task({
+    repo: 'lvlup-sw/test-repo',
+    prompt: 'Test task'
+  });
+
+  // Assert
+  expect(mockClient.createSession).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sourceContext: expect.objectContaining({
+        source: 'sources/github/lvlup-sw/test-repo'
+      })
+    })
+  );
+});
+```
+
+**Expected failure:** sourceContext uses old schema with `branch` instead of `githubRepoContext.startingBranch`
+
+### [GREEN] Implement minimum code
+
+**File:** `plugins/jules/servers/jules-mcp/src/tools.ts`
+
+Update `jules_create_task` function (around lines 179-188):
+
+```typescript
+const session = await client.createSession({
+  prompt: enhancedPrompt,
+  sourceContext: {
+    source: `sources/github/${validated.repo}`,
+    githubRepoContext: validated.branch ? {
+      startingBranch: validated.branch
+    } : undefined
+  },
+  title: validated.title,
+  requirePlanApproval: true,
+  automationMode: 'AUTO_CREATE_PR'
+});
+```
+
+---
+
+## Task 004: Add source validation to jules_create_task
+
+**Phase:** RED → GREEN
+**Dependencies:** Task 003
+**Parallelizable:** Yes
+
+### [RED] Write failing test
+
+**File:** `plugins/jules/servers/jules-mcp/src/tools.test.ts`
+
+Add tests in `jules_create_task` describe block:
+
+```typescript
+it('should return error when repo is not connected to Jules', async () => {
+  // Arrange
+  vi.mocked(mockClient.listSources).mockResolvedValue([mockSource]);
+
+  // Act
+  const result = await tools.jules_create_task({
+    repo: 'other-org/other-repo',
+    prompt: 'Test task'
+  });
+
+  // Assert
+  expect(result.isError).toBe(true);
+  expect(result.content[0].text).toContain('not connected to Jules');
+  expect(result.content[0].text).toContain('lvlup-sw/test-repo');
+  expect(mockClient.createSession).not.toHaveBeenCalled();
+});
+
+it('should return error with empty connected repos message when none connected', async () => {
+  // Arrange
+  vi.mocked(mockClient.listSources).mockResolvedValue([]);
+
+  // Act
+  const result = await tools.jules_create_task({
+    repo: 'any/repo',
+    prompt: 'Test task'
+  });
+
+  // Assert
+  expect(result.isError).toBe(true);
+  expect(result.content[0].text).toContain('not connected to Jules');
+  expect(result.content[0].text).toContain('none');
+});
+```
+
+**Expected failure:** No source validation exists, `createSession` is called without checking sources
+
+### [GREEN] Implement minimum code
+
+**File:** `plugins/jules/servers/jules-mcp/src/tools.ts`
+
+Add source validation in `jules_create_task` before `createSession` call:
+
+```typescript
+async jules_create_task(
+  input: z.infer<typeof createTaskSchema>
+): Promise<ToolResult> {
+  try {
+    const validated = createTaskSchema.parse(input);
+
+    // Validate repo is connected to Jules
+    const sources = await client.listSources();
+    const expectedSource = `sources/github/${validated.repo}`;
+    const sourceExists = sources.some(s => s.name === expectedSource);
+
+    if (!sourceExists) {
+      const connectedRepos = sources.map(s =>
+        `${s.githubRepo.owner}/${s.githubRepo.repo}`
+      ).join(', ');
+      return errorResult(
+        `Repository "${validated.repo}" is not connected to Jules. ` +
+        `Connected repos: ${connectedRepos || 'none'}. ` +
+        `Connect at https://jules.google`
+      );
+    }
+
+    // ... rest of existing code
+  }
+}
+```
+
+---
+
+## Task 005: Update existing tests for new schema
+
+**Phase:** GREEN
+**Dependencies:** Task 003
+**Parallelizable:** Yes
+
+### [GREEN] Update tests
+
+**File:** `plugins/jules/servers/jules-mcp/src/tools.test.ts`
+
+1. Add `listSources` mock to `jules_create_task` tests that need it:
+
+```typescript
+// In each test that calls jules_create_task successfully:
+vi.mocked(mockClient.listSources).mockResolvedValue([mockSource]);
+```
+
+2. Update branch parameter test expectations (lines 116-122, 136-142):
+
+```typescript
+// Change from:
+sourceContext: expect.objectContaining({
+  branch: 'develop'
+})
+// To:
+sourceContext: {
+  source: 'sources/github/lvlup-sw/test-repo',
+  githubRepoContext: {
+    startingBranch: 'develop'
+  }
+}
+```
+
+3. Update default branch test (lines 125-143):
+
+```typescript
+// Test should verify githubRepoContext is undefined when branch not specified
+// or has startingBranch: 'main'
+```
+
+**File:** `plugins/jules/servers/jules-mcp/src/jules-client.test.ts`
+
+Update source context expectations in `createSession` tests (lines 100-150):
+
+```typescript
+// Update test at line 131-132:
+sourceContext: {
+  source: 'sources/github/lvlup-sw/test-repo',
+  githubRepoContext: { startingBranch: 'develop' }
+}
+```
+
+---
+
+## Execution Order
+
+```
+Task 001 (types.ts)
+       │
+       ├──────────┬──────────┐
+       ▼          ▼          ▼
+Task 002     Task 003    Task 005
+(fixtures)   (tools.ts)  (update tests)
+                  │
+                  ▼
+             Task 004
+         (source validation)
+```
+
+**Parallel groups:**
+- Group A: Task 002, Task 003, Task 005 (can run after Task 001)
+- Group B: Task 004 (runs after Task 003)
+
+---
+
+## Verification
+
+After all tasks complete:
+
+```bash
+cd plugins/jules/servers/jules-mcp
+npm test
+```
+
+All tests should pass with:
+- Correct `sourceContext` schema using `githubRepoContext.startingBranch`
+- Source format using slashes: `sources/github/{owner}/{repo}`
+- Source validation returning helpful error for unconnected repos

--- a/plugins/jules/servers/jules-mcp/src/jules-client.test.ts
+++ b/plugins/jules/servers/jules-mcp/src/jules-client.test.ts
@@ -14,7 +14,7 @@ import {
   mockErrorSourceNotFound
 } from './test/fixtures.js';
 
-const BASE_URL = 'https://jules.google/v1alpha';
+const BASE_URL = 'https://jules.googleapis.com/v1alpha';
 
 describe('JulesClient', () => {
   const apiKey = 'test-api-key';
@@ -33,7 +33,7 @@ describe('JulesClient', () => {
 
       // Assert
       expect(sources).toHaveLength(1);
-      expect(sources[0].name).toBe('sources/github-lvlup-sw-test-repo');
+      expect(sources[0].name).toBe('sources/github/lvlup-sw/test-repo');
       expect(sources[0].githubRepo.owner).toBe('lvlup-sw');
       expect(fetchMock).toHaveBeenCalledWith(
         `${BASE_URL}/sources`,
@@ -103,7 +103,7 @@ describe('JulesClient', () => {
       const client = new JulesClient(apiKey);
       const params = {
         prompt: 'Add user profile feature with TDD',
-        sourceContext: { source: 'sources/github-lvlup-sw-test-repo' }
+        sourceContext: { source: 'sources/github/lvlup-sw/test-repo' }
       };
 
       // Act
@@ -128,8 +128,8 @@ describe('JulesClient', () => {
       const params = {
         prompt: 'Add user profile feature',
         sourceContext: {
-          source: 'sources/github-lvlup-sw-test-repo',
-          branch: 'develop'
+          source: 'sources/github/lvlup-sw/test-repo',
+          githubRepoContext: { startingBranch: 'develop' }
         },
         title: 'User Profile Feature',
         requirePlanApproval: true,
@@ -143,7 +143,9 @@ describe('JulesClient', () => {
       const requestBody = JSON.parse(
         fetchMock.mock.calls[0][1]?.body as string
       );
-      expect(requestBody.sourceContext.branch).toBe('develop');
+      expect(requestBody.sourceContext.githubRepoContext.startingBranch).toBe(
+        'develop'
+      );
       expect(requestBody.title).toBe('User Profile Feature');
       expect(requestBody.requirePlanApproval).toBe(true);
       expect(requestBody.automationMode).toBe('AUTO_CREATE_PR');
@@ -157,7 +159,7 @@ describe('JulesClient', () => {
       await expect(
         client.createSession({
           prompt: '',
-          sourceContext: { source: 'sources/github-lvlup-sw-test-repo' }
+          sourceContext: { source: 'sources/github/lvlup-sw/test-repo' }
         })
       ).rejects.toThrow('Prompt cannot be empty');
     });
@@ -170,7 +172,7 @@ describe('JulesClient', () => {
       await expect(
         client.createSession({
           prompt: '   ',
-          sourceContext: { source: 'sources/github-lvlup-sw-test-repo' }
+          sourceContext: { source: 'sources/github/lvlup-sw/test-repo' }
         })
       ).rejects.toThrow('Prompt cannot be empty');
     });

--- a/plugins/jules/servers/jules-mcp/src/test/fixtures.ts
+++ b/plugins/jules/servers/jules-mcp/src/test/fixtures.ts
@@ -5,8 +5,8 @@ import type { Source, Session, Activity, PullRequestOutput } from '../types.js';
 // ============================================================================
 
 export const mockSource: Source = {
-  name: 'sources/github-lvlup-sw-test-repo',
-  id: 'github-lvlup-sw-test-repo',
+  name: 'sources/github/lvlup-sw/test-repo',
+  id: 'github/lvlup-sw/test-repo',
   githubRepo: {
     owner: 'lvlup-sw',
     repo: 'test-repo',
@@ -20,8 +20,8 @@ export const mockSource: Source = {
 };
 
 export const mockPrivateSource: Source = {
-  name: 'sources/github-lvlup-sw-private-repo',
-  id: 'github-lvlup-sw-private-repo',
+  name: 'sources/github/lvlup-sw/private-repo',
+  id: 'github/lvlup-sw/private-repo',
   githubRepo: {
     owner: 'lvlup-sw',
     repo: 'private-repo',

--- a/plugins/jules/servers/jules-mcp/src/tools.test.ts
+++ b/plugins/jules/servers/jules-mcp/src/tools.test.ts
@@ -85,6 +85,7 @@ describe('Jules MCP Tools', () => {
   describe('jules_create_task', () => {
     it('should create task and return session info', async () => {
       // Arrange
+      vi.mocked(mockClient.listSources).mockResolvedValue([mockSource]);
       vi.mocked(mockClient.createSession).mockResolvedValue(mockSession);
 
       // Act
@@ -101,8 +102,9 @@ describe('Jules MCP Tools', () => {
       expect(parsed.url).toContain('jules.google');
     });
 
-    it('should pass branch parameter correctly', async () => {
+    it('should pass branch parameter correctly using githubRepoContext', async () => {
       // Arrange
+      vi.mocked(mockClient.listSources).mockResolvedValue([mockSource]);
       vi.mocked(mockClient.createSession).mockResolvedValue(mockSession);
 
       // Act
@@ -115,15 +117,43 @@ describe('Jules MCP Tools', () => {
       // Assert
       expect(mockClient.createSession).toHaveBeenCalledWith(
         expect.objectContaining({
-          sourceContext: expect.objectContaining({
-            branch: 'develop'
-          })
+          sourceContext: {
+            source: 'sources/github/lvlup-sw/test-repo',
+            githubRepoContext: {
+              startingBranch: 'develop'
+            }
+          }
         })
       );
     });
 
-    it('should use default branch when not specified', async () => {
+    it('should use default branch main when not specified', async () => {
       // Arrange
+      vi.mocked(mockClient.listSources).mockResolvedValue([mockSource]);
+      vi.mocked(mockClient.createSession).mockResolvedValue(mockSession);
+
+      // Act
+      await tools.jules_create_task({
+        repo: 'lvlup-sw/test-repo',
+        prompt: 'Test task'
+      });
+
+      // Assert
+      expect(mockClient.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceContext: {
+            source: 'sources/github/lvlup-sw/test-repo',
+            githubRepoContext: {
+              startingBranch: 'main'
+            }
+          }
+        })
+      );
+    });
+
+    it('should use correct source format with slashes', async () => {
+      // Arrange
+      vi.mocked(mockClient.listSources).mockResolvedValue([mockSource]);
       vi.mocked(mockClient.createSession).mockResolvedValue(mockSession);
 
       // Act
@@ -136,14 +166,48 @@ describe('Jules MCP Tools', () => {
       expect(mockClient.createSession).toHaveBeenCalledWith(
         expect.objectContaining({
           sourceContext: expect.objectContaining({
-            branch: 'main'
+            source: 'sources/github/lvlup-sw/test-repo'
           })
         })
       );
     });
 
+    it('should return error when repo is not connected to Jules', async () => {
+      // Arrange
+      vi.mocked(mockClient.listSources).mockResolvedValue([mockSource]);
+
+      // Act
+      const result = await tools.jules_create_task({
+        repo: 'other-org/other-repo',
+        prompt: 'Test task'
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('not connected to Jules');
+      expect(result.content[0].text).toContain('lvlup-sw/test-repo');
+      expect(mockClient.createSession).not.toHaveBeenCalled();
+    });
+
+    it('should return error with empty connected repos message when none connected', async () => {
+      // Arrange
+      vi.mocked(mockClient.listSources).mockResolvedValue([]);
+
+      // Act
+      const result = await tools.jules_create_task({
+        repo: 'any/repo',
+        prompt: 'Test task'
+      });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('not connected to Jules');
+      expect(result.content[0].text).toContain('none');
+    });
+
     it('should automatically inject TDD instructions into prompt', async () => {
       // Arrange
+      vi.mocked(mockClient.listSources).mockResolvedValue([mockSource]);
       vi.mocked(mockClient.createSession).mockResolvedValue(mockSession);
 
       // Act
@@ -196,19 +260,20 @@ describe('Jules MCP Tools', () => {
 
     it('should handle API errors gracefully', async () => {
       // Arrange
+      vi.mocked(mockClient.listSources).mockResolvedValue([mockSource]);
       vi.mocked(mockClient.createSession).mockRejectedValue(
-        new Error('Source not found')
+        new Error('API error')
       );
 
       // Act
       const result = await tools.jules_create_task({
-        repo: 'invalid/repo',
+        repo: 'lvlup-sw/test-repo',
         prompt: 'Test task'
       });
 
       // Assert
       expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Source not found');
+      expect(result.content[0].text).toContain('API error');
     });
   });
 

--- a/plugins/jules/servers/jules-mcp/src/tools.ts
+++ b/plugins/jules/servers/jules-mcp/src/tools.ts
@@ -176,11 +176,29 @@ export function createJulesTools(client: IJulesClient) {
         // Automatically inject TDD instructions into the prompt
         const enhancedPrompt = buildPromptWithTDD(validated.prompt);
 
+        // Validate repo is connected to Jules
+        const sources = await client.listSources();
+        const expectedSource = `sources/github/${validated.repo}`;
+        const sourceExists = sources.some((s) => s.name === expectedSource);
+
+        if (!sourceExists) {
+          const connectedRepos = sources
+            .map((s) => `${s.githubRepo.owner}/${s.githubRepo.repo}`)
+            .join(', ');
+          return errorResult(
+            `Repository "${validated.repo}" is not connected to Jules. ` +
+              `Connected repos: ${connectedRepos || 'none'}. ` +
+              `Connect at https://jules.google`
+          );
+        }
+
         const session = await client.createSession({
           prompt: enhancedPrompt,
           sourceContext: {
-            source: `sources/github-${validated.repo.replace('/', '-')}`,
-            branch: validated.branch
+            source: expectedSource,
+            githubRepoContext: validated.branch
+              ? { startingBranch: validated.branch }
+              : undefined
           },
           title: validated.title,
           requirePlanApproval: true,

--- a/plugins/jules/servers/jules-mcp/src/types.ts
+++ b/plugins/jules/servers/jules-mcp/src/types.ts
@@ -17,8 +17,8 @@ export interface GitHubRepo {
 }
 
 export interface Source {
-  name: string; // "sources/github-{owner}-{repo}"
-  id: string; // "github-{owner}-{repo}"
+  name: string; // "sources/github/{owner}/{repo}"
+  id: string; // "github/{owner}/{repo}"
   githubRepo: GitHubRepo;
 }
 
@@ -44,9 +44,13 @@ export type SessionState =
 
 export type AutomationMode = 'AUTO_CREATE_PR' | 'MANUAL';
 
+export interface GitHubRepoContext {
+  startingBranch?: string;
+}
+
 export interface SourceContext {
-  source: string; // "sources/github-{owner}-{repo}"
-  branch?: string; // default: "main"
+  source: string; // "sources/github/{owner}/{repo}"
+  githubRepoContext?: GitHubRepoContext;
 }
 
 export interface PullRequestOutput {


### PR DESCRIPTION
## Summary

- Fix `sourceContext` schema to use `githubRepoContext.startingBranch` instead of `branch`
- Fix source format from dashes to slashes: `sources/github/{owner}/{repo}`
- Add source validation to verify repo is connected before creating session

## Problem

The `jules_create_task` MCP tool was failing with:
```
Error: Invalid JSON payload received. Unknown name "branch" at 'session.source_context': Cannot find field
```

## Root Cause

Our implementation used an incorrect schema for `sourceContext`:
- **Wrong:** `{ source, branch }`
- **Correct:** `{ source, githubRepoContext: { startingBranch } }`

## Changes

| File | Change |
|------|--------|
| `types.ts` | Added `GitHubRepoContext` type, updated `SourceContext` |
| `tools.ts` | Fixed schema, added source validation |
| `fixtures.ts` | Updated source names to use slash format |
| `tools.test.ts` | Updated tests, added source validation tests |
| `jules-client.test.ts` | Fixed BASE_URL, updated test expectations |

## Test Plan

- [x] All 60 tests passing
- [x] 99.65% code coverage
- [x] Spec review: PASS
- [x] Quality review: APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes the Jules MCP (Model Context Protocol) server implementation to correctly align with the Jules API schema specification. The fix resolves API validation errors that occurred when attempting to create tasks through the Jules integration.

## Problem

The MCP tool failed with: "Invalid JSON payload received. Unknown name 'branch' at 'session.source_context'". This error indicated a mismatch between the implemented session context structure and what the Jules API expected.

## Solution

**Schema Updates (types.ts)**
- Introduced new `GitHubRepoContext` interface with an optional `startingBranch` field
- Updated `SourceContext` interface to replace the flat `branch?: string` field with a nested `githubRepoContext?: GitHubRepoContext` object
- This change aligns the type definitions with the actual Jules API requirements

**Source Path Format Normalization**
- Changed source naming format from dash-separated (`sources/github-{owner}-{repo}`) to slash-separated (`sources/github/{owner}/{repo}`)
- Updated all fixtures and test expectations to reflect the new format

**Repository Connection Validation (tools.ts)**
- Added pre-creation validation in `jules_create_task` to verify the target repository is connected to Jules before attempting session creation
- The tool now lists available sources and matches against the expected source format
- If the repository is not connected, returns a descriptive error message that lists all connected repositories with a link for connection setup
- If connected, constructs the session with the correct `sourceContext.source` and conditionally includes `githubRepoContext.startingBranch` when a branch parameter is provided

**Test Coverage Expansion (tools.test.ts, jules-client.test.ts, fixtures.ts)**
- Extended test suite with comprehensive validation scenarios:
  - Default branch handling (defaults to `main` when not specified)
  - Source path format validation with slash notation
  - Error handling for unconnected repositories
  - Error handling when no repositories are connected
  - Graceful API error handling with updated error messages
- Updated existing tests to reflect the new schema structure
- Fixed Jules API base URL in tests from `https://jules.google/v1alpha` to `https://julius.googleapis.com/v1alpha`
- Updated mock fixtures to use the new source path format

**Test Results**
- All 60 tests passing
- 99.65% code coverage
- Spec review: PASS
- Quality review: APPROVED

## Impact

This fix enables proper integration with the Jules API while providing improved error messaging and validation. Users will now receive clear feedback when repositories aren't connected to Jules, with actionable next steps for connecting them. The implementation now correctly constructs session payloads that the Jules API accepts, resolving the JSON validation errors that prevented task creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->