### PR TITLE
feat(jules-mcp): add conversation and question detection tools

### DIFF
--- a/coderabbit-config/config.yaml
+++ b/coderabbit-config/config.yaml
@@ -2,6 +2,10 @@
 tone_instructions: Exacting, prioritizing technical optimality
 early_access: true
 reviews:
+  auto_review:
+    enabled: true
+    ignore_usernames:
+      - renovate[bot]  # Skip dependency update PRs, but review Jules and other bots
   request_changes_workflow: true
   high_level_summary_instructions: Review git commit messages and related documents in addition to code changes.
   auto_apply_labels: true

--- a/docs/designs/2026-01-05-jules-conversation-tools.md
+++ b/docs/designs/2026-01-05-jules-conversation-tools.md
@@ -1,0 +1,260 @@
+# Jules Conversation & Question Detection Tools
+
+## Problem Statement
+
+### Issue 1: No Visibility into Jules Conversations
+
+The current Jules MCP integration lacks visibility into session conversations and pending questions:
+
+1. **`jules_check_status`** only returns basic metadata (id, state, title, url, timestamp)
+2. **Session state is unreliable** — sessions with pending questions show `state: "COMPLETED"` despite having no PR and awaiting user input
+3. **No way to view conversation history** — cannot see what Jules is doing or has asked
+4. **Activities API exists but isn't exposed** — `JulesClient.getActivities()` exists but no MCP tool uses it
+
+This blocks the `/delegate` workflow from detecting when Jules needs clarification.
+
+### Issue 2: CodeRabbit Skips Jules PRs
+
+CodeRabbit is not reviewing PRs created by Jules (bot user). This means automated PRs bypass the code review workflow.
+
+**Current state:** `coderabbit-config/config.yaml` has no explicit `auto_review` settings
+**Required:** Configure CodeRabbit to review PRs from Jules bot user
+
+## Solution
+
+### Part A: Jules MCP Tools
+
+Add two specialized MCP tools:
+
+### Tool 1: `jules_get_conversation`
+
+Returns the chronological conversation history for a session.
+
+**Input:**
+```typescript
+{
+  sessionId: string;   // Required: Jules session ID
+  limit?: number;      // Optional: max activities to return (default: 50)
+}
+```
+
+**Output:**
+```typescript
+{
+  sessionId: string;
+  activities: Array<{
+    id: string;
+    type: 'plan' | 'user_message' | 'agent_message' | 'progress' | 'completed' | 'failed';
+    timestamp: string;
+    content: string;           // The message/plan/progress text
+    originator?: 'user' | 'agent' | 'system';
+    artifacts?: Array<{
+      type: 'changeset' | 'bash_output' | 'media';
+      summary: string;         // Brief description
+    }>;
+  }>;
+}
+```
+
+**Use case:** Monitoring progress, debugging, viewing full conversation.
+
+### Tool 2: `jules_get_pending_question`
+
+Detects if Jules is waiting for user input and extracts the question.
+
+**Input:**
+```typescript
+{
+  sessionId: string;   // Required: Jules session ID
+}
+```
+
+**Output:**
+```typescript
+{
+  sessionId: string;
+  hasPendingQuestion: boolean;
+  question?: string;           // The question text (if any)
+  context?: string;            // Surrounding context from agent
+  detectedAt?: string;         // Timestamp of the question
+}
+```
+
+**Detection logic:**
+1. Fetch recent activities (last 10)
+2. Find the most recent `agentMessaged` activity
+3. Check if it contains question indicators:
+   - Ends with `?`
+   - Contains phrases like "please clarify", "which option", "should I", "do you want"
+   - Session state is `AWAITING_USER_FEEDBACK` (when API is accurate)
+4. If the last activity is agent-originated and appears to be a question, return it
+
+**Use case:** Workflow automation to detect when Jules needs input.
+
+## Implementation
+
+### 1. Update Activity Types (`types.ts`)
+
+Expand the `Activity` interface to match the actual API response:
+
+```typescript
+export type ActivityEventType =
+  | 'planGenerated'
+  | 'planApproved'
+  | 'userMessaged'
+  | 'agentMessaged'
+  | 'progressUpdated'
+  | 'sessionCompleted'
+  | 'sessionFailed';
+
+export interface Artifact {
+  type: 'changeset' | 'bashOutput' | 'media';
+  // ChangeSet fields
+  baseCommitId?: string;
+  unidiffPatch?: string;
+  suggestedCommitMessage?: string;
+  // Bash output fields
+  command?: string;
+  output?: string;
+  exitCode?: number;
+  // Media fields
+  mimeType?: string;
+  data?: string;  // base64
+}
+
+export interface Activity {
+  name: string;
+  id: string;
+  originator: 'system' | 'agent' | 'user';
+  description: string;
+  createTime: string;
+
+  // Event-specific content (exactly one will be present)
+  planGenerated?: { steps: string[] };
+  planApproved?: { approvedBy: string };
+  userMessaged?: { content: string };
+  agentMessaged?: { content: string };
+  progressUpdated?: { status: string };
+  sessionCompleted?: { summary: string };
+  sessionFailed?: { reason: string };
+
+  artifacts?: Artifact[];
+}
+```
+
+### 2. Add Tool Schemas (`tools.ts`)
+
+```typescript
+const getConversationSchema = z.object({
+  sessionId: z.string().min(1, 'sessionId is required'),
+  limit: z.number().optional().default(50)
+});
+
+const getPendingQuestionSchema = z.object({
+  sessionId: z.string().min(1, 'sessionId is required')
+});
+```
+
+### 3. Implement Tool Functions (`tools.ts`)
+
+```typescript
+async jules_get_conversation(input): Promise<ToolResult> {
+  const activities = await client.getActivities(input.sessionId);
+  // Transform to simplified format
+  // Return chronological list
+}
+
+async jules_get_pending_question(input): Promise<ToolResult> {
+  const activities = await client.getActivities(input.sessionId);
+  const lastAgentMessage = activities
+    .filter(a => a.agentMessaged)
+    .pop();
+
+  if (!lastAgentMessage) {
+    return { hasPendingQuestion: false };
+  }
+
+  const content = lastAgentMessage.agentMessaged.content;
+  const isQuestion = detectQuestion(content);
+
+  return {
+    hasPendingQuestion: isQuestion,
+    question: isQuestion ? content : undefined,
+    detectedAt: lastAgentMessage.createTime
+  };
+}
+
+function detectQuestion(content: string): boolean {
+  // Heuristics for question detection
+  const questionPatterns = [
+    /\?$/,                           // Ends with ?
+    /please (clarify|confirm|let me know)/i,
+    /which (option|approach|method)/i,
+    /should I/i,
+    /do you (want|prefer|need)/i,
+    /can you (provide|specify|confirm)/i,
+    /what (should|would you)/i
+  ];
+  return questionPatterns.some(p => p.test(content));
+}
+```
+
+### 4. Register Tools (`index.ts`)
+
+Add tool registrations following the existing pattern.
+
+### Part B: CodeRabbit Configuration
+
+Update `coderabbit-config/config.yaml` to enable reviews for bot users:
+
+```yaml
+reviews:
+  auto_review:
+    enabled: true
+    ignore_usernames: []  # Explicitly empty - don't skip any users including bots
+```
+
+This ensures CodeRabbit reviews all PRs regardless of author, including those from Jules.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `plugins/jules/servers/jules-mcp/src/types.ts` | Expand `Activity` interface, add `Artifact` type |
+| `plugins/jules/servers/jules-mcp/src/tools.ts` | Add schemas, descriptions, and implementations for both tools |
+| `plugins/jules/servers/jules-mcp/src/index.ts` | Register `jules_get_conversation` and `jules_get_pending_question` |
+| `coderabbit-config/config.yaml` | Add `auto_review` settings to include bot users |
+
+## Testing Strategy
+
+1. **Unit tests** for `detectQuestion()` heuristics
+2. **Integration tests** mocking API responses with various activity types
+3. **Manual verification** with real Jules sessions that have pending questions
+
+## Workflow Integration
+
+After implementation, the `/delegate` skill can:
+
+```typescript
+// Poll for completion or questions
+const status = await jules_check_status({ sessionId });
+const question = await jules_get_pending_question({ sessionId });
+
+if (question.hasPendingQuestion) {
+  // Surface to user or auto-respond
+  await jules_send_feedback({ sessionId, message: response });
+}
+```
+
+## Open Questions
+
+1. **Pagination** — Should `jules_get_conversation` handle pagination automatically or expose `pageToken`?
+   - **Recommendation:** Auto-paginate up to `limit`, hide complexity
+
+2. **Question detection accuracy** — Heuristics may have false positives/negatives
+   - **Mitigation:** Start with conservative patterns, iterate based on real usage
+
+## References
+
+- [Jules Activities API](https://jules.google/docs/api/reference/activities)
+- [Jules Sessions API](https://jules.google/docs/api/reference/sessions)

--- a/docs/plans/2026-01-05-jules-conversation-tools.md
+++ b/docs/plans/2026-01-05-jules-conversation-tools.md
@@ -1,0 +1,215 @@
+# Implementation Plan: Jules Conversation & Question Detection Tools
+
+**Design:** `docs/designs/2026-01-05-jules-conversation-tools.md`
+**Created:** 2026-01-05
+
+## Summary
+
+Implement two new MCP tools for Jules session visibility:
+1. `jules_get_conversation` - View chronological activity history
+2. `jules_get_pending_question` - Detect if Jules is waiting for user input
+
+Plus: Update CodeRabbit config to review Jules bot PRs.
+
+## Task Overview
+
+| ID | Task | Dependencies | Parallelizable |
+|----|------|--------------|----------------|
+| 001 | Expand Activity types | None | Yes |
+| 002 | Add Activity fixtures | 001 | Yes |
+| 003 | Implement detectQuestion helper | None | Yes |
+| 004 | Implement jules_get_conversation tool | 001, 002 | No |
+| 005 | Implement jules_get_pending_question tool | 001, 002, 003 | No |
+| 006 | Register new tools in index.ts | 004, 005 | No |
+| 007 | Update CodeRabbit config | None | Yes |
+
+## Parallel Groups
+
+- **Group A (can run in parallel):** Tasks 001, 003, 007
+- **Group B (sequential after A):** Tasks 002, 004, 005, 006
+
+---
+
+## Task Details
+
+### Task 001: Expand Activity Types
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write type tests to validate Activity structure
+   - File: `plugins/jules/servers/jules-mcp/src/types.test.ts` (create)
+   - Test: `Activity_WithAgentMessage_HasExpectedStructure`
+   - Test: `Activity_WithPlanGenerated_HasStepsArray`
+   - Test: `Artifact_ChangeSet_HasPatchFields`
+   - Expected failure: Types don't exist yet
+
+2. [GREEN] Update types.ts with expanded Activity interface
+   - File: `plugins/jules/servers/jules-mcp/src/types.ts`
+   - Add: `ActivityEventType` union type
+   - Add: `Artifact` interface with changeset/bash/media fields
+   - Update: `Activity` interface with event-specific fields
+
+3. [REFACTOR] Ensure backward compatibility with existing code
+
+**Dependencies:** None
+**Parallelizable:** Yes
+
+---
+
+### Task 002: Add Activity Fixtures for Testing
+**Phase:** RED → GREEN
+
+1. [RED] Import new activity fixtures in tools.test.ts
+   - File: `plugins/jules/servers/jules-mcp/src/tools.test.ts`
+   - Expected failure: Fixtures don't exist
+
+2. [GREEN] Create expanded activity fixtures
+   - File: `plugins/jules/servers/jules-mcp/src/test/fixtures.ts`
+   - Add: `mockActivityAgentMessage` with question content
+   - Add: `mockActivityAgentMessageNoQuestion` with statement
+   - Add: `mockActivityUserMessage`
+   - Add: `mockActivityPlanGenerated`
+   - Add: `mockActivityWithArtifacts`
+
+**Dependencies:** Task 001
+**Parallelizable:** Yes (after 001)
+
+---
+
+### Task 003: Implement detectQuestion Helper
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write tests for question detection heuristics
+   - File: `plugins/jules/servers/jules-mcp/src/tools.test.ts`
+   - Test: `detectQuestion_EndsWithQuestionMark_ReturnsTrue`
+   - Test: `detectQuestion_ContainsShouldI_ReturnsTrue`
+   - Test: `detectQuestion_ContainsDoYouWant_ReturnsTrue`
+   - Test: `detectQuestion_ContainsPleaseConfirm_ReturnsTrue`
+   - Test: `detectQuestion_PlainStatement_ReturnsFalse`
+   - Test: `detectQuestion_EmptyString_ReturnsFalse`
+   - Expected failure: Function doesn't exist
+
+2. [GREEN] Implement detectQuestion function
+   - File: `plugins/jules/servers/jules-mcp/src/tools.ts`
+   - Export: `detectQuestion(content: string): boolean`
+   - Implement regex patterns for question detection
+
+3. [REFACTOR] Optimize regex patterns, add jsdoc
+
+**Dependencies:** None
+**Parallelizable:** Yes
+
+---
+
+### Task 004: Implement jules_get_conversation Tool
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write tests for jules_get_conversation
+   - File: `plugins/jules/servers/jules-mcp/src/tools.test.ts`
+   - Test: `jules_get_conversation_ValidSession_ReturnsActivities`
+   - Test: `jules_get_conversation_WithLimit_RespectsLimit`
+   - Test: `jules_get_conversation_EmptyActivities_ReturnsEmptyArray`
+   - Test: `jules_get_conversation_EmptySessionId_ReturnsError`
+   - Test: `jules_get_conversation_ApiError_ReturnsError`
+   - Expected failure: Tool doesn't exist
+
+2. [GREEN] Implement tool function
+   - File: `plugins/jules/servers/jules-mcp/src/tools.ts`
+   - Add: `getConversationSchema` with sessionId and optional limit
+   - Add: `jules_get_conversation` to tool factory
+   - Transform activities to simplified output format
+
+3. [REFACTOR] Extract activity transformation logic
+
+**Dependencies:** Tasks 001, 002
+**Parallelizable:** No
+
+---
+
+### Task 005: Implement jules_get_pending_question Tool
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write tests for jules_get_pending_question
+   - File: `plugins/jules/servers/jules-mcp/src/tools.test.ts`
+   - Test: `jules_get_pending_question_HasQuestion_ReturnsQuestion`
+   - Test: `jules_get_pending_question_NoQuestion_ReturnsFalse`
+   - Test: `jules_get_pending_question_NoAgentMessages_ReturnsFalse`
+   - Test: `jules_get_pending_question_EmptySessionId_ReturnsError`
+   - Test: `jules_get_pending_question_ApiError_ReturnsError`
+   - Expected failure: Tool doesn't exist
+
+2. [GREEN] Implement tool function
+   - File: `plugins/jules/servers/jules-mcp/src/tools.ts`
+   - Add: `getPendingQuestionSchema` with sessionId
+   - Add: `jules_get_pending_question` to tool factory
+   - Use `detectQuestion` helper for detection
+
+3. [REFACTOR] Improve question extraction (context handling)
+
+**Dependencies:** Tasks 001, 002, 003
+**Parallelizable:** No
+
+---
+
+### Task 006: Register New Tools in MCP Server
+**Phase:** RED → GREEN
+
+1. [RED] Verify tools are not yet registered
+   - File: `plugins/jules/servers/jules-mcp/src/index.ts`
+   - Manual verification: tools not in server registration
+
+2. [GREEN] Register both new tools
+   - File: `plugins/jules/servers/jules-mcp/src/index.ts`
+   - Add: `server.tool('jules_get_conversation', ...)`
+   - Add: `server.tool('jules_get_pending_question', ...)`
+   - Follow existing registration pattern
+
+3. [VERIFY] Run full test suite to ensure integration
+
+**Dependencies:** Tasks 004, 005
+**Parallelizable:** No
+
+---
+
+### Task 007: Update CodeRabbit Configuration
+**Phase:** GREEN (config change, no test needed)
+
+1. [GREEN] Add auto_review settings to config
+   - File: `coderabbit-config/config.yaml`
+   - Add: `auto_review.enabled: true`
+   - Add: `auto_review.ignore_usernames: []`
+
+2. [VERIFY] Validate YAML syntax
+
+**Dependencies:** None
+**Parallelizable:** Yes
+
+---
+
+## Execution Order
+
+```
+Parallel Group 1:
+├── Task 001: Expand Activity types
+├── Task 003: Implement detectQuestion helper
+└── Task 007: Update CodeRabbit config
+
+Sequential Chain:
+Task 001 → Task 002 → Task 004 → Task 005 → Task 006
+                 ↑
+            Task 003
+```
+
+## Test File Summary
+
+| File | New Tests |
+|------|-----------|
+| `src/types.test.ts` | 3 type validation tests |
+| `src/tools.test.ts` | ~16 new tests (6 detectQuestion + 5 get_conversation + 5 get_pending_question) |
+
+## Definition of Done
+
+- [ ] All new tests pass
+- [ ] Existing tests still pass
+- [ ] No TypeScript errors
+- [ ] Tools registered and callable via MCP
+- [ ] CodeRabbit config updated

--- a/plugins/jules/servers/jules-mcp/src/index.ts
+++ b/plugins/jules/servers/jules-mcp/src/index.ts
@@ -141,6 +141,47 @@ server.tool(
   }
 );
 
+// Register jules_get_conversation tool
+server.tool(
+  'jules_get_conversation',
+  toolDescriptions.jules_get_conversation,
+  {
+    sessionId: z.string().describe('The Jules session ID'),
+    limit: z
+      .number()
+      .optional()
+      .describe('Maximum number of activities to return (default: 50)')
+  },
+  async (args) => {
+    const result = await tools.jules_get_conversation({
+      sessionId: args.sessionId,
+      limit: args.limit ?? 50
+    });
+    return {
+      content: result.content,
+      isError: result.isError
+    };
+  }
+);
+
+// Register jules_get_pending_question tool
+server.tool(
+  'jules_get_pending_question',
+  toolDescriptions.jules_get_pending_question,
+  {
+    sessionId: z.string().describe('The Jules session ID')
+  },
+  async (args) => {
+    const result = await tools.jules_get_pending_question({
+      sessionId: args.sessionId
+    });
+    return {
+      content: result.content,
+      isError: result.isError
+    };
+  }
+);
+
 // Connect to stdio transport
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/plugins/jules/servers/jules-mcp/src/jules-client.test.ts
+++ b/plugins/jules/servers/jules-mcp/src/jules-client.test.ts
@@ -426,8 +426,10 @@ describe('JulesClient', () => {
 
       // Assert
       expect(activities).toHaveLength(2);
-      expect(activities[0].type).toBe('PLANNING');
-      expect(activities[1].type).toBe('CODING');
+      expect(activities[0].originator).toBe('agent');
+      expect(activities[0].description).toBe('Analyzing codebase structure');
+      expect(activities[1].originator).toBe('agent');
+      expect(activities[1].description).toBe('Implementing UserProfile entity');
     });
 
     it('should return empty array when no activities', async () => {

--- a/plugins/jules/servers/jules-mcp/src/test/fixtures.ts
+++ b/plugins/jules/servers/jules-mcp/src/test/fixtures.ts
@@ -89,23 +89,103 @@ export const mockSessionFailed: Session = {
 
 export const mockActivityPlanning: Activity = {
   name: 'sessions/abc123/activities/1',
-  type: 'PLANNING',
-  message: 'Analyzing codebase structure',
-  createTime: '2025-01-04T00:01:00Z'
+  id: '1',
+  originator: 'agent',
+  description: 'Analyzing codebase structure',
+  createTime: '2025-01-04T00:01:00Z',
+  planGenerated: { steps: ['Analyze codebase', 'Create UserProfile entity', 'Add tests'] }
 };
 
 export const mockActivityCoding: Activity = {
   name: 'sessions/abc123/activities/2',
-  type: 'CODING',
-  message: 'Implementing UserProfile entity',
-  createTime: '2025-01-04T00:05:00Z'
+  id: '2',
+  originator: 'agent',
+  description: 'Implementing UserProfile entity',
+  createTime: '2025-01-04T00:05:00Z',
+  progressUpdated: { status: 'Implementing UserProfile entity' }
 };
 
 export const mockActivityTesting: Activity = {
   name: 'sessions/abc123/activities/3',
-  type: 'TESTING',
-  message: 'Running test suite',
-  createTime: '2025-01-04T00:10:00Z'
+  id: '3',
+  originator: 'agent',
+  description: 'Running test suite',
+  createTime: '2025-01-04T00:10:00Z',
+  progressUpdated: { status: 'Running test suite' }
+};
+
+// Agent message with a question (for pending question detection)
+export const mockActivityAgentQuestion: Activity = {
+  name: 'sessions/abc123/activities/q1',
+  id: 'q1',
+  originator: 'agent',
+  description: 'Agent asked for clarification',
+  createTime: '2025-01-04T00:15:00Z',
+  agentMessaged: {
+    content: 'Which database should I use for this project? PostgreSQL or MongoDB?'
+  }
+};
+
+// Agent message without a question (plain statement)
+export const mockActivityAgentStatement: Activity = {
+  name: 'sessions/abc123/activities/s1',
+  id: 's1',
+  originator: 'agent',
+  description: 'Agent provided update',
+  createTime: '2025-01-04T00:20:00Z',
+  agentMessaged: {
+    content: 'I have completed the user authentication module. All tests are passing.'
+  }
+};
+
+// User message
+export const mockActivityUserMessage: Activity = {
+  name: 'sessions/abc123/activities/u1',
+  id: 'u1',
+  originator: 'user',
+  description: 'User sent message',
+  createTime: '2025-01-04T00:16:00Z',
+  userMessaged: {
+    content: 'Please use PostgreSQL for better relational data support.'
+  }
+};
+
+// Plan generated with steps
+export const mockActivityPlanGenerated: Activity = {
+  name: 'sessions/abc123/activities/p1',
+  id: 'p1',
+  originator: 'agent',
+  description: 'Plan generated',
+  createTime: '2025-01-04T00:05:00Z',
+  planGenerated: {
+    steps: [
+      'Set up project structure',
+      'Create database schema',
+      'Implement user authentication',
+      'Add API endpoints',
+      'Write tests'
+    ]
+  }
+};
+
+// Activity with artifacts (changeset)
+export const mockActivityWithArtifacts: Activity = {
+  name: 'sessions/abc123/activities/a1',
+  id: 'a1',
+  originator: 'agent',
+  description: 'Code changes committed',
+  createTime: '2025-01-04T00:30:00Z',
+  progressUpdated: {
+    status: 'Committed changes to feature branch'
+  },
+  artifacts: [
+    {
+      type: 'changeset',
+      baseCommitId: 'abc123def456',
+      unidiffPatch: '--- a/src/auth.ts\n+++ b/src/auth.ts\n@@ -1,3 +1,10 @@\n+import { hash } from "bcrypt";\n+\n export function authenticate(user: string, pass: string) {\n-  return true;\n+  const hashedPass = await hash(pass, 10);\n+  return validateCredentials(user, hashedPass);\n }',
+      suggestedCommitMessage: 'feat: add password hashing to authentication'
+    }
+  ]
 };
 
 // ============================================================================

--- a/plugins/jules/servers/jules-mcp/src/tools.test.ts
+++ b/plugins/jules/servers/jules-mcp/src/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createJulesTools } from './tools.js';
+import { createJulesTools, detectQuestion } from './tools.js';
 import type { IJulesClient } from './types.js';
 import {
   mockSource,
@@ -7,7 +7,13 @@ import {
   mockSession,
   mockSessionAwaitingApproval,
   mockSessionCompleted,
-  mockActivityPlanning
+  mockActivityPlanning,
+  // NEW FIXTURES TO ADD:
+  mockActivityAgentQuestion,
+  mockActivityAgentStatement,
+  mockActivityUserMessage,
+  mockActivityPlanGenerated,
+  mockActivityWithArtifacts
 } from './test/fixtures.js';
 
 describe('Jules MCP Tools', () => {
@@ -516,6 +522,248 @@ describe('Jules MCP Tools', () => {
       expect(toolDescriptions.jules_approve_plan.toLowerCase()).toContain('approve');
       expect(toolDescriptions.jules_send_feedback.toLowerCase()).toContain('feedback');
       expect(toolDescriptions.jules_cancel.toLowerCase()).toContain('cancel');
+    });
+  });
+
+  // ==========================================================================
+  // jules_get_conversation Tests
+  // ==========================================================================
+  describe('jules_get_conversation', () => {
+    it('jules_get_conversation_ValidSession_ReturnsActivities', async () => {
+      // Arrange
+      vi.mocked(mockClient.getActivities).mockResolvedValue([
+        mockActivityPlanGenerated,
+        mockActivityAgentQuestion,
+        mockActivityUserMessage,
+        mockActivityAgentStatement
+      ]);
+
+      // Act
+      const result = await tools.jules_get_conversation({ sessionId: 'abc123' });
+
+      // Assert
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.sessionId).toBe('abc123');
+      expect(parsed.activities).toHaveLength(4);
+      expect(parsed.activities[0].type).toBe('plan');
+      expect(parsed.activities[1].type).toBe('agent_message');
+      expect(parsed.activities[2].type).toBe('user_message');
+    });
+
+    it('jules_get_conversation_WithLimit_RespectsLimit', async () => {
+      // Arrange
+      vi.mocked(mockClient.getActivities).mockResolvedValue([
+        mockActivityPlanGenerated,
+        mockActivityAgentQuestion,
+        mockActivityUserMessage,
+        mockActivityAgentStatement
+      ]);
+
+      // Act
+      const result = await tools.jules_get_conversation({
+        sessionId: 'abc123',
+        limit: 2
+      });
+
+      // Assert
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.activities).toHaveLength(2);
+    });
+
+    it('jules_get_conversation_EmptyActivities_ReturnsEmptyArray', async () => {
+      // Arrange
+      vi.mocked(mockClient.getActivities).mockResolvedValue([]);
+
+      // Act
+      const result = await tools.jules_get_conversation({ sessionId: 'abc123' });
+
+      // Assert
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.activities).toEqual([]);
+    });
+
+    it('jules_get_conversation_EmptySessionId_ReturnsError', async () => {
+      // Act
+      const result = await tools.jules_get_conversation({ sessionId: '' });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('sessionId');
+    });
+
+    it('jules_get_conversation_ApiError_ReturnsError', async () => {
+      // Arrange
+      vi.mocked(mockClient.getActivities).mockRejectedValue(
+        new Error('Session not found')
+      );
+
+      // Act
+      const result = await tools.jules_get_conversation({ sessionId: 'invalid' });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Session not found');
+    });
+
+    it('jules_get_conversation_WithArtifacts_IncludesArtifactSummary', async () => {
+      // Arrange
+      vi.mocked(mockClient.getActivities).mockResolvedValue([
+        mockActivityWithArtifacts
+      ]);
+
+      // Act
+      const result = await tools.jules_get_conversation({ sessionId: 'abc123' });
+
+      // Assert
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.activities[0].artifacts).toBeDefined();
+      expect(parsed.activities[0].artifacts[0].type).toBe('changeset');
+    });
+  });
+
+  // ==========================================================================
+  // detectQuestion Tests
+  // ==========================================================================
+  describe('detectQuestion', () => {
+    it('detectQuestion_EndsWithQuestionMark_ReturnsTrue', () => {
+      expect(detectQuestion('What framework should I use?')).toBe(true);
+    });
+
+    it('detectQuestion_ContainsShouldI_ReturnsTrue', () => {
+      expect(detectQuestion('Should I use React or Vue for this project')).toBe(true);
+    });
+
+    it('detectQuestion_ContainsDoYouWant_ReturnsTrue', () => {
+      expect(detectQuestion('Do you want me to proceed with the implementation')).toBe(true);
+    });
+
+    it('detectQuestion_ContainsPleaseConfirm_ReturnsTrue', () => {
+      expect(detectQuestion('Please confirm the database schema before I continue')).toBe(true);
+    });
+
+    it('detectQuestion_ContainsWhichOption_ReturnsTrue', () => {
+      expect(detectQuestion('Which option would you prefer for the API design')).toBe(true);
+    });
+
+    it('detectQuestion_ContainsCanYouProvide_ReturnsTrue', () => {
+      expect(detectQuestion('Can you provide more details about the expected behavior')).toBe(true);
+    });
+
+    it('detectQuestion_PlainStatement_ReturnsFalse', () => {
+      expect(detectQuestion('I have completed the implementation.')).toBe(false);
+    });
+
+    it('detectQuestion_ProgressUpdate_ReturnsFalse', () => {
+      expect(detectQuestion('Working on the user profile feature now.')).toBe(false);
+    });
+
+    it('detectQuestion_EmptyString_ReturnsFalse', () => {
+      expect(detectQuestion('')).toBe(false);
+    });
+
+    it('detectQuestion_QuestionMarkInMiddle_ReturnsFalse', () => {
+      // Question mark in middle shouldn't trigger - must be end or question phrase
+      expect(detectQuestion('The file config?.json was updated successfully.')).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // jules_get_pending_question Tests
+  // ==========================================================================
+  describe('jules_get_pending_question', () => {
+    it('jules_get_pending_question_HasQuestion_ReturnsQuestion', async () => {
+      // Arrange - last activity is an agent question
+      vi.mocked(mockClient.getActivities).mockResolvedValue([
+        mockActivityPlanGenerated,
+        mockActivityUserMessage,
+        mockActivityAgentQuestion  // Last activity is a question
+      ]);
+
+      // Act
+      const result = await tools.jules_get_pending_question({ sessionId: 'abc123' });
+
+      // Assert
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.sessionId).toBe('abc123');
+      expect(parsed.hasPendingQuestion).toBe(true);
+      expect(parsed.question).toContain('Which database should I use');
+      expect(parsed.detectedAt).toBeDefined();
+    });
+
+    it('jules_get_pending_question_NoQuestion_ReturnsFalse', async () => {
+      // Arrange - last activity is a statement, not a question
+      vi.mocked(mockClient.getActivities).mockResolvedValue([
+        mockActivityPlanGenerated,
+        mockActivityAgentQuestion,
+        mockActivityUserMessage,
+        mockActivityAgentStatement  // Last activity is NOT a question
+      ]);
+
+      // Act
+      const result = await tools.jules_get_pending_question({ sessionId: 'abc123' });
+
+      // Assert
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.hasPendingQuestion).toBe(false);
+      expect(parsed.question).toBeUndefined();
+    });
+
+    it('jules_get_pending_question_NoAgentMessages_ReturnsFalse', async () => {
+      // Arrange - only user messages and plans, no agent messages
+      vi.mocked(mockClient.getActivities).mockResolvedValue([
+        mockActivityPlanGenerated,
+        mockActivityUserMessage
+      ]);
+
+      // Act
+      const result = await tools.jules_get_pending_question({ sessionId: 'abc123' });
+
+      // Assert
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.hasPendingQuestion).toBe(false);
+    });
+
+    it('jules_get_pending_question_EmptyActivities_ReturnsFalse', async () => {
+      // Arrange
+      vi.mocked(mockClient.getActivities).mockResolvedValue([]);
+
+      // Act
+      const result = await tools.jules_get_pending_question({ sessionId: 'abc123' });
+
+      // Assert
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.hasPendingQuestion).toBe(false);
+    });
+
+    it('jules_get_pending_question_EmptySessionId_ReturnsError', async () => {
+      // Act
+      const result = await tools.jules_get_pending_question({ sessionId: '' });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('sessionId');
+    });
+
+    it('jules_get_pending_question_ApiError_ReturnsError', async () => {
+      // Arrange
+      vi.mocked(mockClient.getActivities).mockRejectedValue(
+        new Error('Session not found')
+      );
+
+      // Act
+      const result = await tools.jules_get_pending_question({ sessionId: 'invalid' });
+
+      // Assert
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Session not found');
     });
   });
 });

--- a/plugins/jules/servers/jules-mcp/src/tools.ts
+++ b/plugins/jules/servers/jules-mcp/src/tools.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { IJulesClient, ToolResult } from './types.js';
+import type { IJulesClient, ToolResult, Activity } from './types.js';
 
 // ============================================================================
 // Input Schemas
@@ -31,6 +31,15 @@ const cancelSchema = z.object({
   sessionId: z.string().min(1, 'sessionId is required')
 });
 
+const getConversationSchema = z.object({
+  sessionId: z.string().min(1, 'sessionId is required'),
+  limit: z.number().optional().default(50)
+});
+
+const getPendingQuestionSchema = z.object({
+  sessionId: z.string().min(1, 'sessionId is required')
+});
+
 // ============================================================================
 // Exported Schemas and Descriptions
 // ============================================================================
@@ -41,7 +50,9 @@ export const toolSchemas = {
   jules_check_status: checkStatusSchema,
   jules_approve_plan: approvePlanSchema,
   jules_send_feedback: sendFeedbackSchema,
-  jules_cancel: cancelSchema
+  jules_cancel: cancelSchema,
+  jules_get_conversation: getConversationSchema,
+  jules_get_pending_question: getPendingQuestionSchema
 };
 
 export const toolDescriptions = {
@@ -50,7 +61,9 @@ export const toolDescriptions = {
   jules_check_status: 'Check the status of a Jules session',
   jules_approve_plan: 'Approve a pending Jules execution plan',
   jules_send_feedback: 'Send feedback or instructions to a Jules session',
-  jules_cancel: 'Cancel/delete a Jules session'
+  jules_cancel: 'Cancel/delete a Jules session',
+  jules_get_conversation: 'Get conversation history for a Jules session',
+  jules_get_pending_question: 'Check if Jules has a pending question requiring user input'
 };
 
 // ============================================================================
@@ -70,6 +83,32 @@ function jsonResult(data: object, isError = false): ToolResult {
 
 function errorResult(message: string): ToolResult {
   return textResult(`Error: ${message}`, true);
+}
+
+// ============================================================================
+// Activity Helpers
+// ============================================================================
+
+function getActivityType(activity: Activity): string {
+  if (activity.planGenerated) return 'plan';
+  if (activity.planApproved) return 'plan_approved';
+  if (activity.userMessaged) return 'user_message';
+  if (activity.agentMessaged) return 'agent_message';
+  if (activity.progressUpdated) return 'progress';
+  if (activity.sessionCompleted) return 'completed';
+  if (activity.sessionFailed) return 'failed';
+  return 'unknown';
+}
+
+function getActivityContent(activity: Activity): string {
+  if (activity.planGenerated) return activity.planGenerated.steps.join('\n');
+  if (activity.planApproved) return `Approved by: ${activity.planApproved.approvedBy}`;
+  if (activity.userMessaged) return activity.userMessaged.content;
+  if (activity.agentMessaged) return activity.agentMessaged.content;
+  if (activity.progressUpdated) return activity.progressUpdated.status;
+  if (activity.sessionCompleted) return activity.sessionCompleted.summary;
+  if (activity.sessionFailed) return activity.sessionFailed.reason;
+  return activity.description;
 }
 
 // ============================================================================
@@ -134,6 +173,42 @@ public async Task Method_Scenario_Outcome()
 
 function buildPromptWithTDD(userPrompt: string): string {
   return `${userPrompt}${TDD_INSTRUCTIONS}`;
+}
+
+// ============================================================================
+// Question Detection
+// ============================================================================
+
+/**
+ * Detects if content appears to be a question requiring user input.
+ * Uses heuristics to identify common question patterns.
+ */
+export function detectQuestion(content: string): boolean {
+  if (!content || content.trim().length === 0) {
+    return false;
+  }
+
+  const trimmed = content.trim();
+
+  // Pattern: ends with question mark (but not optional chaining like config?.json)
+  // Must have a space before the question mark or be a short string
+  if (/\?\s*$/.test(trimmed) && !/\w\?\.\w/.test(trimmed)) {
+    return true;
+  }
+
+  // Question phrase patterns (case insensitive)
+  const questionPatterns = [
+    /\bshould I\b/i,
+    /\bdo you (want|prefer|need)\b/i,
+    /\bcan you (provide|specify|confirm|clarify)\b/i,
+    /\bplease (clarify|confirm|let me know|specify)\b/i,
+    /\bwhich (option|approach|method|way)\b/i,
+    /\bwhat (should|would you)\b/i,
+    /\bwould you (like|prefer)\b/i,
+    /\bcould you (provide|clarify|confirm)\b/i
+  ];
+
+  return questionPatterns.some((pattern) => pattern.test(trimmed));
 }
 
 // ============================================================================
@@ -307,6 +382,86 @@ export function createJulesTools(client: IJulesClient) {
         }
         return errorResult((error as Error).message);
       }
+    },
+
+    async jules_get_conversation(
+      input: z.infer<typeof getConversationSchema>
+    ): Promise<ToolResult> {
+      try {
+        const validated = getConversationSchema.parse(input);
+        const activities = await client.getActivities(validated.sessionId);
+
+        const limitedActivities = activities.slice(0, validated.limit);
+
+        const formattedActivities = limitedActivities.map((activity) => ({
+          id: activity.id,
+          type: getActivityType(activity),
+          timestamp: activity.createTime,
+          content: getActivityContent(activity),
+          originator: activity.originator,
+          artifacts: activity.artifacts?.map((a) => ({
+            type: a.type,
+            summary:
+              a.type === 'changeset'
+                ? a.suggestedCommitMessage || 'Code changes'
+                : a.type === 'bashOutput'
+                  ? `Command: ${a.command}`
+                  : 'Media attachment'
+          }))
+        }));
+
+        return jsonResult({
+          sessionId: validated.sessionId,
+          activities: formattedActivities
+        });
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          return errorResult(error.errors[0].message);
+        }
+        return errorResult((error as Error).message);
+      }
+    },
+
+    async jules_get_pending_question(
+      input: z.infer<typeof getPendingQuestionSchema>
+    ): Promise<ToolResult> {
+      try {
+        const validated = getPendingQuestionSchema.parse(input);
+        const activities = await client.getActivities(validated.sessionId);
+
+        // Find the last agent message
+        const agentMessages = activities.filter((a) => a.agentMessaged);
+        const lastAgentMessage = agentMessages[agentMessages.length - 1];
+
+        if (!lastAgentMessage || !lastAgentMessage.agentMessaged) {
+          return jsonResult({
+            sessionId: validated.sessionId,
+            hasPendingQuestion: false
+          });
+        }
+
+        const content = lastAgentMessage.agentMessaged.content;
+        const isQuestion = detectQuestion(content);
+
+        if (isQuestion) {
+          return jsonResult({
+            sessionId: validated.sessionId,
+            hasPendingQuestion: true,
+            question: content,
+            detectedAt: lastAgentMessage.createTime
+          });
+        }
+
+        return jsonResult({
+          sessionId: validated.sessionId,
+          hasPendingQuestion: false
+        });
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          return errorResult(error.errors[0].message);
+        }
+        return errorResult((error as Error).message);
+      }
     }
   };
 }
@@ -318,3 +473,5 @@ export type CheckStatusInput = z.infer<typeof checkStatusSchema>;
 export type ApprovePlanInput = z.infer<typeof approvePlanSchema>;
 export type SendFeedbackInput = z.infer<typeof sendFeedbackSchema>;
 export type CancelInput = z.infer<typeof cancelSchema>;
+export type GetConversationInput = z.infer<typeof getConversationSchema>;
+export type GetPendingQuestionInput = z.infer<typeof getPendingQuestionSchema>;

--- a/plugins/jules/servers/jules-mcp/src/types.test.ts
+++ b/plugins/jules/servers/jules-mcp/src/types.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import type { Activity, Artifact } from './types.js';
+
+describe('Activity Types', () => {
+  it('Activity_WithAgentMessage_HasExpectedStructure', () => {
+    const activity: Activity = {
+      name: 'sessions/abc/activities/1',
+      id: '1',
+      originator: 'agent',
+      description: 'Agent asked a question',
+      createTime: '2025-01-04T00:00:00Z',
+      agentMessaged: { content: 'What framework should I use?' }
+    };
+
+    expect(activity.agentMessaged?.content).toBe('What framework should I use?');
+    expect(activity.originator).toBe('agent');
+  });
+
+  it('Activity_WithPlanGenerated_HasStepsArray', () => {
+    const activity: Activity = {
+      name: 'sessions/abc/activities/2',
+      id: '2',
+      originator: 'agent',
+      description: 'Plan generated',
+      createTime: '2025-01-04T00:00:00Z',
+      planGenerated: { steps: ['Step 1', 'Step 2', 'Step 3'] }
+    };
+
+    expect(activity.planGenerated?.steps).toHaveLength(3);
+  });
+
+  it('Artifact_ChangeSet_HasPatchFields', () => {
+    const artifact: Artifact = {
+      type: 'changeset',
+      baseCommitId: 'abc123',
+      unidiffPatch: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      suggestedCommitMessage: 'Update file.ts'
+    };
+
+    expect(artifact.type).toBe('changeset');
+    expect(artifact.unidiffPatch).toContain('--- a/file.ts');
+  });
+});

--- a/plugins/jules/servers/jules-mcp/src/types.ts
+++ b/plugins/jules/servers/jules-mcp/src/types.ts
@@ -96,18 +96,47 @@ export interface SendMessageParams {
 // Activity Types
 // ============================================================================
 
-export type ActivityType =
-  | 'PLANNING'
-  | 'CODING'
-  | 'TESTING'
-  | 'MESSAGE'
-  | 'ERROR';
+export type ActivityEventType =
+  | 'planGenerated'
+  | 'planApproved'
+  | 'userMessaged'
+  | 'agentMessaged'
+  | 'progressUpdated'
+  | 'sessionCompleted'
+  | 'sessionFailed';
+
+export interface Artifact {
+  type: 'changeset' | 'bashOutput' | 'media';
+  // ChangeSet fields
+  baseCommitId?: string;
+  unidiffPatch?: string;
+  suggestedCommitMessage?: string;
+  // Bash output fields
+  command?: string;
+  output?: string;
+  exitCode?: number;
+  // Media fields
+  mimeType?: string;
+  data?: string; // base64
+}
 
 export interface Activity {
   name: string;
-  type: ActivityType;
-  message: string;
+  id: string;
+  originator: 'system' | 'agent' | 'user';
+  description: string;
   createTime: string;
+
+  // Event-specific content (exactly one will be present)
+  planGenerated?: { steps: string[] };
+  planApproved?: { approvedBy: string };
+  userMessaged?: { content: string };
+  agentMessaged?: { content: string };
+  progressUpdated?: { status: string };
+  sessionCompleted?: { summary: string };
+  sessionFailed?: { reason: string };
+
+  artifacts?: Artifact[];
 }
 
 export interface ListActivitiesResponse {


### PR DESCRIPTION
## Summary

Add two new MCP tools for Jules session visibility:

- **`jules_get_conversation`**: View chronological activity history for a session
  - Returns activities with type, content, originator, timestamp, and artifact summaries
  - Supports pagination via `limit` parameter (default: 50)

- **`jules_get_pending_question`**: Detect if Jules is waiting for user input
  - Uses `detectQuestion` heuristics to identify questions in agent messages
  - Returns `hasPendingQuestion: boolean`, question text, and detection timestamp

### Additional Changes

- **Expanded Activity types** (`types.ts`): Updated to match Jules API response with event-specific fields (`planGenerated`, `agentMessaged`, `userMessaged`, etc.) and artifact support
- **CodeRabbit config**: Enable reviews for Jules bot PRs (only ignore `renovate[bot]`)

## Test Plan

- [x] 85 tests pass (22 new tests for conversation tools + detectQuestion)
- [x] TypeScript compiles without errors
- [x] All edge cases covered: empty sessions, API errors, validation errors, no agent messages

## Files Changed

| File | Change |
|------|--------|
| `plugins/jules/.../types.ts` | Expanded Activity/Artifact interfaces |
| `plugins/jules/.../tools.ts` | New tools + detectQuestion helper |
| `plugins/jules/.../index.ts` | Tool registrations |
| `plugins/jules/.../tools.test.ts` | 22 new tests |
| `plugins/jules/.../types.test.ts` | 3 type validation tests |
| `plugins/jules/.../test/fixtures.ts` | 5 new activity fixtures |
| `coderabbit-config/config.yaml` | auto_review settings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds two new MCP tools to the Jules integration for improved session visibility and implements a CodeRabbit configuration update to enable automated code reviews for Jules bot PRs.

### Key Changes

**New MCP Tools:**

1. **`jules_get_conversation`** - Returns chronological activity history for a Jules session
   - Input: `sessionId` (required), `limit` (optional, default 50)
   - Output: Structured activities with type, timestamp, content, originator, and optional artifacts
   - Provides visibility into session progress and conversation history

2. **`jules_get_pending_question`** - Detects if Jules is awaiting user input
   - Input: `sessionId` (required)
   - Output: `hasPendingQuestion` (boolean), optional question text and detection timestamp
   - Uses regex-based `detectQuestion` heuristic to identify questions via patterns (ends with `?`, contains phrases like "should I", "please clarify", etc.)

**Type System Expansion:**

- Replaced simple `ActivityType` union with richer `ActivityEventType` supporting: `planGenerated`, `planApproved`, `userMessaged`, `agentMessaged`, `progressUpdated`, `sessionCompleted`, `sessionFailed`
- Updated `Activity` interface with `id`, `originator` ('system'|'agent'|'user'), `description`, and event-specific payload fields (exactly one expected)
- Introduced `Artifact` type supporting changeset, bash output, and media kinds with appropriate fields

**CodeRabbit Configuration:**

- Added `auto_review` block to enable automated reviews for all users, removing `renovate[bot]` from ignore list to ensure Jules bot PRs are reviewed

### Implementation Details

- Added `getActivityType()` and `getActivityContent()` helpers in tools.ts to transform raw API activities
- Implemented `detectQuestion(content: string)` with regex patterns for heuristic-based question detection
- New tool schemas with Zod validation for input validation
- Tool registrations follow existing MCP server pattern
- Expanded test fixtures with diverse mock activities (agent questions, statements, user messages, plan generations, artifacts with diffs)

### Testing

- 22 new tests for conversation tools (6 for detectQuestion heuristics, 5 for `jules_get_conversation`, 5 for `jules_get_pending_question`, additional integration tests)
- 3 type validation tests ensuring Activity/Artifact structure
- 5 new activity test fixtures covering varied event types and artifact scenarios
- Edge cases covered: empty sessions, API errors, missing agent messages, invalid input validation

### Files Modified

- `plugins/jules/servers/jules-mcp/src/types.ts` - Activity/Artifact type expansion
- `plugins/jules/servers/jules-mcp/src/tools.ts` - New tool implementations and helpers
- `plugins/jules/servers/jules-mcp/src/index.ts` - Tool registration
- `plugins/jules/servers/jules-mcp/src/tools.test.ts` - New test suite (expanded)
- `plugins/jules/servers/jules-mcp/src/types.test.ts` - Type validation tests (new)
- `plugins/jules/servers/jules-mcp/src/test/fixtures.ts` - Expanded mock activity fixtures
- `plugins/jules/servers/jules-mcp/src/jules-client.test.ts` - Updated activity field expectations
- `coderabbit-config/config.yaml` - CodeRabbit auto-review configuration
- `docs/designs/2026-01-05-jules-conversation-tools.md` - Design documentation (new)
- `docs/plans/2026-01-05-jules-conversation-tools.md` - Implementation plan (new)

### Rationale

These tools enable the `/delegate` workflow to detect when Jules needs clarification without polling status, providing better visibility into autonomous agent sessions and ensuring PRs from Jules bot receive proper code review coverage. The expanded Activity types align the MCP interface with actual Jules API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->