### PR TITLE
feat: Add refactor workflow with polish/overhaul tracks

### DIFF
--- a/.claude/scripts/workflow-state.sh
+++ b/.claude/scripts/workflow-state.sh
@@ -657,9 +657,141 @@ cmd_next_action() {
         return
     fi
 
-    # Handle refactor workflows - next-action not implemented yet (separate task)
+    # Handle refactor workflows
     if [ "$workflow_type" = "refactor" ]; then
-        echo "UNKNOWN:refactor-$phase"
+        local track=$(jq -r '.track // ""' "$state_file")
+        local brief_problem=$(jq -r '.brief.problem // ""' "$state_file")
+        local brief_goals_count=$(jq '.brief.goals | length' "$state_file")
+        local plan=$(jq -r '.artifacts.plan // ""' "$state_file")
+        local tests_pass=$(jq -r 'if .validation.testsPass == null then "" else (.validation.testsPass | tostring) end' "$state_file")
+        local docs_updated=$(jq -r 'if .validation.docsUpdated == null then "" else (.validation.docsUpdated | tostring) end' "$state_file")
+        local goals_verified_count=$(jq '.validation.goalsVerified | length' "$state_file")
+
+        # Check review status for overhaul track
+        local spec_pending=$(jq '[.tasks[] | select(.reviewStatus.specReview == null or .reviewStatus.specReview == "pending")] | length' "$state_file")
+        local spec_failed=$(jq '[.tasks[] | select(.reviewStatus.specReview == "fail")] | length' "$state_file")
+        local quality_pending=$(jq '[.tasks[] | select(.reviewStatus.qualityReview == null or .reviewStatus.qualityReview == "pending")] | length' "$state_file")
+        local quality_failed=$(jq '[.tasks[] | select(.reviewStatus.qualityReview == "needs_fixes" or .reviewStatus.qualityReview == "blocked")] | length' "$state_file")
+
+        case "$phase" in
+            explore)
+                # Auto-continue to brief after track is selected
+                if [ -n "$track" ] && [ "$track" != "null" ]; then
+                    echo "AUTO:refactor-brief"
+                else
+                    echo "WAIT:incomplete:track-not-selected"
+                fi
+                ;;
+            brief)
+                # Check if brief is captured (has problem and goals)
+                if [ -n "$brief_problem" ] && [ "$brief_problem" != "null" ] && [ "$brief_goals_count" -gt 0 ]; then
+                    if [ "$track" = "polish" ]; then
+                        echo "AUTO:refactor-implement"
+                    elif [ "$track" = "overhaul" ]; then
+                        echo "AUTO:refactor-plan"
+                    else
+                        echo "WAIT:incomplete:track-not-selected"
+                    fi
+                else
+                    echo "WAIT:in-progress:capturing-brief"
+                fi
+                ;;
+            implement)
+                # Polish track only - check if implementation conditions met
+                if [ "$track" = "polish" ]; then
+                    # Check if goals are being verified (implementation complete)
+                    if [ "$goals_verified_count" -gt 0 ] || [ "$tests_pass" = "true" ]; then
+                        echo "AUTO:refactor-validate"
+                    else
+                        echo "WAIT:in-progress:implementing"
+                    fi
+                else
+                    # Overhaul track shouldn't hit implement phase directly
+                    echo "WAIT:in-progress:implementing"
+                fi
+                ;;
+            validate)
+                # Polish track validation
+                if [ "$tests_pass" = "true" ]; then
+                    echo "AUTO:refactor-update-docs"
+                elif [ "$tests_pass" = "false" ]; then
+                    echo "WAIT:blocked:tests-failing"
+                else
+                    echo "WAIT:in-progress:validating"
+                fi
+                ;;
+            plan)
+                # Overhaul track planning
+                if [ -n "$plan" ] && [ "$plan" != "null" ]; then
+                    echo "AUTO:refactor-delegate"
+                else
+                    echo "WAIT:in-progress:planning"
+                fi
+                ;;
+            delegate)
+                # Overhaul track delegation
+                if [ "$total_tasks" -eq 0 ]; then
+                    echo "WAIT:incomplete:no-tasks-defined"
+                elif [ "$complete_tasks" -eq "$total_tasks" ]; then
+                    echo "AUTO:refactor-integrate"
+                else
+                    echo "WAIT:in-progress:tasks-$complete_tasks-of-$total_tasks"
+                fi
+                ;;
+            integrate)
+                # Overhaul track integration
+                # Check integration status from state
+                local integration_passed=$(jq -r 'if .synthesis.integrationPassed == null then "" else (.synthesis.integrationPassed | tostring) end' "$state_file")
+                if [ "$integration_passed" = "true" ]; then
+                    echo "AUTO:refactor-review"
+                elif [ "$integration_passed" = "false" ]; then
+                    echo "AUTO:delegate:--fixes $plan"
+                else
+                    echo "WAIT:in-progress:integrating"
+                fi
+                ;;
+            review)
+                # Overhaul track review
+                if [ "$spec_failed" -gt 0 ] || [ "$quality_failed" -gt 0 ]; then
+                    echo "AUTO:delegate:--fixes $plan"
+                elif [ "$spec_pending" -gt 0 ] || [ "$quality_pending" -gt 0 ]; then
+                    echo "WAIT:in-progress:reviews-pending"
+                else
+                    echo "AUTO:refactor-update-docs"
+                fi
+                ;;
+            update-docs)
+                # Documentation update phase
+                if [ "$docs_updated" = "true" ]; then
+                    if [ "$track" = "polish" ]; then
+                        # Polish track: human checkpoint for completion
+                        echo "WAIT:human-checkpoint:completion"
+                    else
+                        # Overhaul track: auto-continue to synthesize
+                        echo "AUTO:refactor-synthesize"
+                    fi
+                else
+                    echo "WAIT:in-progress:updating-docs"
+                fi
+                ;;
+            synthesize)
+                # Overhaul track PR creation
+                if [ -n "$pr" ] && [ "$pr" != "null" ] && [ "$pr" != "" ]; then
+                    echo "WAIT:human-checkpoint:merge-confirmation"
+                else
+                    echo "WAIT:incomplete:pr-not-created"
+                fi
+                ;;
+            completed)
+                echo "DONE"
+                ;;
+            blocked)
+                echo "WAIT:blocked:requires-attention"
+                ;;
+            *)
+                echo "UNKNOWN:refactor-$phase"
+                ;;
+        esac
         return
     fi
 

--- a/.claude/scripts/workflow-state.sh
+++ b/.claude/scripts/workflow-state.sh
@@ -1,0 +1,776 @@
+#!/usr/bin/env bash
+#
+# workflow-state.sh - Workflow state management utilities
+#
+# Commands:
+#   init <feature-id>     Create new state file
+#   list                  List all active workflows
+#   get <state-file> [jq-query]  Read state (optionally with jq query)
+#   set <state-file> <jq-filter> Update state using jq filter
+#   summary <state-file>  Output minimal summary for context restoration
+#   reconcile <state-file> Verify state matches reality
+#   next-action <state-file> Determine next auto-continue action
+#
+
+set -euo pipefail
+
+# Auto-detect repo root - works from any directory within a git repo
+# Priority: 1) Git root of current directory, 2) Current directory
+# Note: We intentionally use current directory's git root, not script location,
+# because state files belong to the project being worked on, not lvlup-claude.
+if git rev-parse --show-toplevel &>/dev/null; then
+    REPO_ROOT="$(git rev-parse --show-toplevel)"
+else
+    REPO_ROOT="$(pwd)"
+fi
+
+STATE_DIR="$REPO_ROOT/docs/workflow-state"
+
+# Resolve state file paths - handle both relative and absolute paths
+resolve_state_file() {
+    local input="$1"
+    if [[ "$input" == /* ]]; then
+        # Absolute path - use as-is
+        echo "$input"
+    elif [[ "$input" == docs/workflow-state/* ]]; then
+        # Relative from repo root
+        echo "$REPO_ROOT/$input"
+    elif [[ "$input" == *.state.json ]]; then
+        # Just filename - prepend STATE_DIR
+        echo "$STATE_DIR/$input"
+    else
+        # Assume relative from repo root
+        echo "$REPO_ROOT/$input"
+    fi
+}
+
+usage() {
+    echo "Usage: workflow-state.sh <command> [args]"
+    echo ""
+    echo "Commands:"
+    echo "  init <feature-id> [--debug|--refactor]  Create new state file"
+    echo "  list                                     List all active workflows"
+    echo "  get <state-file> [jq-query]              Read state (optionally with jq)"
+    echo "  set <state-file> <jq-filter>             Update state using jq filter"
+    echo "  summary <state-file>                     Output minimal summary"
+    echo "  reconcile <state-file>                   Verify state matches reality"
+    echo "  next-action <state-file>                 Determine next auto-continue action"
+    exit 1
+}
+
+# Initialize a new workflow state file
+# Usage: init <feature-id> [--debug|--refactor]
+cmd_init() {
+    local feature_id="$1"
+    local workflow_type="${2:-feature}"
+    local state_file="$STATE_DIR/${feature_id}.state.json"
+    local now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    # Check for --debug or --refactor flag
+    if [ "$workflow_type" = "--debug" ]; then
+        workflow_type="debug"
+    elif [ "$workflow_type" = "--refactor" ]; then
+        workflow_type="refactor"
+    fi
+
+    if [ -f "$state_file" ]; then
+        echo "ERROR: State file already exists: $state_file" >&2
+        exit 1
+    fi
+
+    # Ensure state directory exists
+    mkdir -p "$STATE_DIR"
+
+    if [ "$workflow_type" = "debug" ]; then
+        # Debug workflow state
+        cat > "$state_file" << EOF
+{
+  "version": "1.0",
+  "featureId": "$feature_id",
+  "workflowType": "debug",
+  "createdAt": "$now",
+  "updatedAt": "$now",
+  "track": null,
+  "phase": "triage",
+  "urgency": {
+    "level": null,
+    "justification": null
+  },
+  "triage": {
+    "symptom": null,
+    "reproduction": null,
+    "affectedArea": null,
+    "impact": null
+  },
+  "investigation": {
+    "startedAt": null,
+    "completedAt": null,
+    "rootCause": null,
+    "findings": []
+  },
+  "artifacts": {
+    "rca": null,
+    "fixDesign": null,
+    "pr": null
+  },
+  "followUp": {
+    "rcaRequired": false,
+    "issueUrl": null
+  },
+  "tasks": [],
+  "worktrees": {},
+  "reviews": {},
+  "synthesis": {
+    "integrationBranch": null,
+    "mergeOrder": [],
+    "mergedBranches": [],
+    "prUrl": null,
+    "prFeedback": []
+  }
+}
+EOF
+    elif [ "$workflow_type" = "refactor" ]; then
+        # Refactor workflow state
+        cat > "$state_file" << EOF
+{
+  "version": "1.0",
+  "featureId": "$feature_id",
+  "workflowType": "refactor",
+  "createdAt": "$now",
+  "updatedAt": "$now",
+  "track": null,
+  "phase": "explore",
+  "explore": {
+    "startedAt": null,
+    "completedAt": null,
+    "scopeAssessment": {
+      "filesAffected": [],
+      "modulesAffected": [],
+      "testCoverage": null,
+      "recommendedTrack": null
+    }
+  },
+  "brief": {
+    "problem": null,
+    "goals": [],
+    "approach": null,
+    "affectedAreas": [],
+    "outOfScope": [],
+    "successCriteria": [],
+    "docsToUpdate": []
+  },
+  "artifacts": {
+    "plan": null,
+    "pr": null,
+    "updatedDocs": []
+  },
+  "validation": {
+    "testsPass": null,
+    "goalsVerified": [],
+    "docsUpdated": null
+  },
+  "tasks": [],
+  "worktrees": {},
+  "reviews": {},
+  "synthesis": {
+    "integrationBranch": null,
+    "mergeOrder": [],
+    "mergedBranches": [],
+    "prUrl": null,
+    "prFeedback": []
+  }
+}
+EOF
+    else
+        # Feature workflow state (default)
+        cat > "$state_file" << EOF
+{
+  "version": "1.0",
+  "featureId": "$feature_id",
+  "createdAt": "$now",
+  "updatedAt": "$now",
+  "phase": "ideate",
+  "artifacts": {
+    "design": null,
+    "plan": null,
+    "pr": null
+  },
+  "tasks": [],
+  "worktrees": {},
+  "julesSessions": {},
+  "reviews": {},
+  "synthesis": {
+    "integrationBranch": null,
+    "mergeOrder": [],
+    "mergedBranches": [],
+    "prUrl": null,
+    "prFeedback": []
+  }
+}
+EOF
+    fi
+
+    echo "Created: $state_file"
+}
+
+# List all active (non-completed) workflows
+cmd_list() {
+    echo "Active Workflows:"
+    echo ""
+
+    for f in "$STATE_DIR"/*.state.json; do
+        [ -f "$f" ] || continue
+        local feature=$(jq -r '.featureId' "$f")
+        local phase=$(jq -r '.phase' "$f")
+        local updated=$(jq -r '.updatedAt' "$f")
+
+        if [ "$phase" != "completed" ]; then
+            printf "  %-30s %-12s %s\n" "$feature" "[$phase]" "$updated"
+        fi
+    done
+}
+
+# Get state or specific field
+cmd_get() {
+    local state_file
+    state_file="$(resolve_state_file "$1")"
+    local query="${2:-.}"
+
+    if [ ! -f "$state_file" ]; then
+        echo "ERROR: State file not found: $state_file" >&2
+        exit 1
+    fi
+
+    jq "$query" "$state_file"
+}
+
+# Update state using jq filter
+cmd_set() {
+    local state_file
+    state_file="$(resolve_state_file "$1")"
+    local filter="$2"
+    local now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    if [ ! -f "$state_file" ]; then
+        echo "ERROR: State file not found: $state_file" >&2
+        exit 1
+    fi
+
+    # Update with new value and timestamp
+    local tmp=$(mktemp)
+    jq "$filter | .updatedAt = \"$now\"" "$state_file" > "$tmp"
+    mv "$tmp" "$state_file"
+
+    echo "Updated: $state_file"
+}
+
+# Output minimal summary for context restoration
+cmd_summary() {
+    local state_file
+    state_file="$(resolve_state_file "$1")"
+
+    if [ ! -f "$state_file" ]; then
+        echo "ERROR: State file not found: $state_file" >&2
+        exit 1
+    fi
+
+    local feature
+    local phase
+    local updated
+    local workflow_type
+    local pr
+    local total_tasks
+    local complete_tasks
+    feature=$(jq -r '.featureId' "$state_file")
+    phase=$(jq -r '.phase' "$state_file")
+    updated=$(jq -r '.updatedAt' "$state_file")
+    workflow_type=$(jq -r '.workflowType // "feature"' "$state_file")
+    pr=$(jq -r '.artifacts.pr // .synthesis.prUrl // "not created"' "$state_file")
+    total_tasks=$(jq '.tasks | length' "$state_file")
+    complete_tasks=$(jq '[.tasks[] | select(.status == "complete")] | length' "$state_file")
+
+    echo "## Workflow Context Restored"
+    echo ""
+    echo "**Feature:** $feature"
+    echo "**Phase:** $phase"
+    echo "**Last Updated:** $updated"
+
+    # Debug-specific context
+    if [ "$workflow_type" = "debug" ]; then
+        local track=$(jq -r '.track // "not selected"' "$state_file")
+        local urgency=$(jq -r '.urgency.level // "not set"' "$state_file")
+        local symptom=$(jq -r '.triage.symptom // "not captured"' "$state_file")
+        local root_cause=$(jq -r '.investigation.rootCause // "not found"' "$state_file")
+        local rca=$(jq -r '.artifacts.rca // "not created"' "$state_file")
+
+        echo "**Type:** Debug ($track track)"
+        echo "**Urgency:** $urgency"
+        echo ""
+        echo "### Debug Context"
+        echo "- Symptom: $symptom"
+        echo "- Root Cause: $root_cause"
+        echo "- RCA: \`$rca\`"
+        echo "- PR: $pr"
+    elif [ "$workflow_type" = "refactor" ]; then
+        local track=$(jq -r '.track // "not selected"' "$state_file")
+        local problem=$(jq -r '.brief.problem // "not captured"' "$state_file")
+        local goals_count=$(jq '.brief.goals | length' "$state_file")
+        local verified_count=$(jq '.validation.goalsVerified | length' "$state_file")
+        local tests_pass=$(jq -r '.validation.testsPass // "not run"' "$state_file")
+        local plan=$(jq -r '.artifacts.plan // "not created"' "$state_file")
+
+        echo "**Type:** Refactor ($track track)"
+        echo ""
+        echo "### Refactor Context"
+        echo "- Problem: $problem"
+        echo "- Goals: $goals_count defined, $verified_count verified"
+        echo "- Tests: $tests_pass"
+        echo "- Plan: \`$plan\`"
+        echo "- PR: $pr"
+    else
+        local design=$(jq -r '.artifacts.design // "not created"' "$state_file")
+        local plan=$(jq -r '.artifacts.plan // "not created"' "$state_file")
+
+        echo ""
+        echo "### Artifacts"
+        echo "- Design: \`$design\`"
+        echo "- Plan: \`$plan\`"
+        echo "- PR: $pr"
+    fi
+
+    echo ""
+    echo "### Task Progress"
+    echo "- Completed: $complete_tasks / $total_tasks"
+    echo ""
+
+    # List incomplete tasks
+    local pending=$(jq -r '.tasks[] | select(.status != "complete") | "- [\(.status)] \(.id): \(.title)"' "$state_file")
+    if [ -n "$pending" ]; then
+        echo "### Pending Tasks"
+        echo "$pending"
+        echo ""
+    fi
+
+    # List active worktrees
+    local worktrees=$(jq -r '.worktrees | to_entries[] | select(.value.status == "active") | "- \(.key) (\(.value.branch))"' "$state_file")
+    if [ -n "$worktrees" ]; then
+        echo "### Active Worktrees"
+        echo "$worktrees"
+        echo ""
+    fi
+
+    # Debug investigation findings
+    if [ "$workflow_type" = "debug" ]; then
+        local findings
+        findings=$(jq -r '.investigation.findings // [] | .[]' "$state_file" | head -5)
+        if [ -n "$findings" ]; then
+            echo "### Investigation Findings"
+            echo "$findings" | while read -r finding; do
+                echo "- $finding"
+            done
+            echo ""
+        fi
+    fi
+
+    # Refactor scope assessment
+    if [ "$workflow_type" = "refactor" ]; then
+        local files_count=$(jq '.explore.scopeAssessment.filesAffected | length' "$state_file")
+        local modules_count=$(jq '.explore.scopeAssessment.modulesAffected | length' "$state_file")
+        local recommended_track=$(jq -r '.explore.scopeAssessment.recommendedTrack // "not assessed"' "$state_file")
+        if [ "$files_count" -gt 0 ] || [ "$modules_count" -gt 0 ]; then
+            echo "### Scope Assessment"
+            echo "- Files affected: $files_count"
+            echo "- Modules affected: $modules_count"
+            echo "- Recommended track: $recommended_track"
+            echo ""
+        fi
+    fi
+
+    # Suggest next action
+    echo "### Next Action"
+
+    if [ "$workflow_type" = "debug" ]; then
+        local track=$(jq -r '.track // ""' "$state_file")
+        case "$phase" in
+            triage)
+                echo "Complete triage and select track (hotfix/thorough)"
+                ;;
+            investigate)
+                if [ "$track" = "hotfix" ]; then
+                    echo "Find root cause (15 min limit) or switch to thorough track"
+                else
+                    echo "Continue systematic investigation"
+                fi
+                ;;
+            rca)
+                echo "Complete RCA documentation in docs/rca/"
+                ;;
+            design)
+                echo "Document fix approach"
+                ;;
+            implement)
+                echo "Apply fix (TDD for thorough track)"
+                ;;
+            validate)
+                if [ "$track" = "hotfix" ]; then
+                    echo "Run smoke tests and verify fix"
+                else
+                    echo "Run full test suite before spec review"
+                fi
+                ;;
+            review)
+                echo "Complete spec review"
+                ;;
+            synthesize)
+                if [ "$pr" != "not created" ]; then
+                    echo "PR created. Confirm merge or request changes."
+                else
+                    echo "Create PR for fix"
+                fi
+                ;;
+            completed)
+                echo "Workflow complete"
+                ;;
+            *)
+                echo "Check state file for details"
+                ;;
+        esac
+    elif [ "$workflow_type" = "refactor" ]; then
+        local track=$(jq -r '.track // ""' "$state_file")
+        case "$phase" in
+            explore)
+                echo "Assess scope and select track (polish/overhaul)"
+                ;;
+            brief)
+                echo "Capture refactor intent and goals"
+                ;;
+            plan)
+                echo "Create implementation plan"
+                ;;
+            delegate)
+                if [ "$complete_tasks" -eq "$total_tasks" ] && [ "$total_tasks" -gt 0 ]; then
+                    echo "All tasks complete. Run validation."
+                else
+                    echo "Monitor task completion"
+                fi
+                ;;
+            validate)
+                echo "Verify all goals met and tests pass"
+                ;;
+            review)
+                echo "Complete spec review"
+                ;;
+            synthesize)
+                if [ "$pr" != "not created" ]; then
+                    echo "PR created. Confirm merge or request changes."
+                else
+                    echo "Create PR for refactor"
+                fi
+                ;;
+            completed)
+                echo "Workflow complete"
+                ;;
+            *)
+                echo "Check state file for details"
+                ;;
+        esac
+    else
+        local plan=$(jq -r '.artifacts.plan // "not created"' "$state_file")
+        case "$phase" in
+            ideate)
+                echo "Continue design exploration (auto-chains to /plan when design saved)"
+                ;;
+            plan)
+                echo "Continue planning (auto-chains to plan-review when plan saved)"
+                ;;
+            plan-review)
+                echo "Review plan-design delta and approve to continue to /delegate"
+                ;;
+            delegate)
+                if [ "$complete_tasks" -eq "$total_tasks" ]; then
+                    echo "All tasks complete. Run \`/review $plan\`"
+                else
+                    echo "Monitor task completion, then run \`/review\`"
+                fi
+                ;;
+            review)
+                echo "Address review issues or run \`/synthesize\`"
+                ;;
+            synthesize)
+                if [ "$pr" != "not created" ]; then
+                    echo "PR created. Merge or address feedback with \`/delegate --pr-fixes $pr\`"
+                else
+                    echo "Run \`/synthesize\` to create PR"
+                fi
+                ;;
+            *)
+                echo "Check state file for details"
+                ;;
+        esac
+    fi
+}
+
+# Reconcile state with reality (git worktrees, Jules sessions)
+cmd_reconcile() {
+    local state_file
+    state_file="$(resolve_state_file "$1")"
+
+    if [ ! -f "$state_file" ]; then
+        echo "ERROR: State file not found: $state_file" >&2
+        exit 1
+    fi
+
+    echo "Reconciling state with reality..."
+    echo ""
+
+    # Check worktrees
+    echo "## Git Worktrees"
+    local state_worktrees=$(jq -r '.worktrees | keys[]' "$state_file" 2>/dev/null || true)
+    local actual_worktrees=$(git worktree list --porcelain 2>/dev/null | grep "^worktree " | cut -d' ' -f2 || true)
+
+    for wt in $state_worktrees; do
+        if echo "$actual_worktrees" | grep -q "$wt"; then
+            echo "  [OK] $wt exists"
+        else
+            echo "  [MISSING] $wt not found"
+        fi
+    done
+
+    # Check branches
+    echo ""
+    echo "## Git Branches"
+    local branches=$(jq -r '.tasks[].branch // empty' "$state_file")
+    for branch in $branches; do
+        if git show-ref --verify --quiet "refs/heads/$branch" 2>/dev/null; then
+            echo "  [OK] $branch exists"
+        else
+            echo "  [MISSING] $branch not found"
+        fi
+    done
+
+    echo ""
+    echo "Reconciliation complete."
+}
+
+# Determine next auto-continue action based on current state
+cmd_next_action() {
+    local state_file
+    state_file="$(resolve_state_file "$1")"
+
+    if [ ! -f "$state_file" ]; then
+        echo "ERROR:state-not-found"
+        exit 1
+    fi
+
+    local phase=$(jq -r '.phase' "$state_file")
+    local workflow_type=$(jq -r '.workflowType // "feature"' "$state_file")
+    local pr=$(jq -r '.synthesis.prUrl // .artifacts.pr // ""' "$state_file")
+    local total_tasks=$(jq '.tasks | length' "$state_file")
+    local complete_tasks=$(jq '[.tasks[] | select(.status == "complete")] | length' "$state_file")
+
+    # Handle debug workflows
+    if [ "$workflow_type" = "debug" ]; then
+        local track=$(jq -r '.track // ""' "$state_file")
+        local root_cause=$(jq -r '.investigation.rootCause // ""' "$state_file")
+
+        case "$phase" in
+            triage)
+                # Auto-continue to investigate after triage
+                if [ -n "$track" ] && [ "$track" != "null" ]; then
+                    echo "AUTO:debug-investigate"
+                else
+                    echo "WAIT:incomplete:track-not-selected"
+                fi
+                ;;
+            investigate)
+                if [ -n "$root_cause" ] && [ "$root_cause" != "null" ]; then
+                    # Root cause found
+                    if [ "$track" = "hotfix" ]; then
+                        echo "AUTO:debug-implement"
+                    else
+                        echo "AUTO:debug-rca"
+                    fi
+                else
+                    echo "WAIT:in-progress:investigating"
+                fi
+                ;;
+            rca)
+                local rca=$(jq -r '.artifacts.rca // ""' "$state_file")
+                if [ -n "$rca" ] && [ "$rca" != "null" ]; then
+                    echo "AUTO:debug-design"
+                else
+                    echo "WAIT:in-progress:documenting-rca"
+                fi
+                ;;
+            design)
+                local fix_design=$(jq -r '.artifacts.fixDesign // ""' "$state_file")
+                if [ -n "$fix_design" ] && [ "$fix_design" != "null" ]; then
+                    echo "AUTO:debug-implement"
+                else
+                    echo "WAIT:in-progress:designing-fix"
+                fi
+                ;;
+            implement)
+                # Check if implementation is complete
+                # Auto-advance if: all tasks complete OR no tasks (direct implementation)
+                local fix_design
+                fix_design=$(jq -r '.artifacts.fixDesign // ""' "$state_file")
+                if [ "$total_tasks" -eq 0 ] && [ -n "$fix_design" ] && [ "$fix_design" != "null" ]; then
+                    # No tasks but fix design exists - direct implementation, auto-advance
+                    echo "AUTO:debug-validate"
+                elif [ "$total_tasks" -gt 0 ] && [ "$complete_tasks" -eq "$total_tasks" ]; then
+                    # All tasks complete
+                    echo "AUTO:debug-validate"
+                else
+                    echo "WAIT:in-progress:implementing"
+                fi
+                ;;
+            validate)
+                if [ "$track" = "hotfix" ]; then
+                    # Hotfix: human checkpoint for merge
+                    echo "WAIT:human-checkpoint:hotfix-merge"
+                else
+                    echo "AUTO:debug-review"
+                fi
+                ;;
+            review)
+                # After review, go to synthesize
+                echo "AUTO:debug-synthesize"
+                ;;
+            synthesize)
+                if [ -n "$pr" ] && [ "$pr" != "null" ] && [ "$pr" != "" ]; then
+                    echo "WAIT:human-checkpoint:merge-confirmation"
+                else
+                    echo "WAIT:incomplete:pr-not-created"
+                fi
+                ;;
+            completed)
+                echo "DONE"
+                ;;
+            blocked)
+                echo "WAIT:blocked:requires-escalation"
+                ;;
+            *)
+                echo "UNKNOWN:debug-$phase"
+                ;;
+        esac
+        return
+    fi
+
+    # Handle refactor workflows - next-action not implemented yet (separate task)
+    if [ "$workflow_type" = "refactor" ]; then
+        echo "UNKNOWN:refactor-$phase"
+        return
+    fi
+
+    # Handle feature workflows (original logic)
+    local plan=$(jq -r '.artifacts.plan // ""' "$state_file")
+    local design=$(jq -r '.artifacts.design // ""' "$state_file")
+
+    # Check review status
+    local spec_pending=$(jq '[.tasks[] | select(.reviewStatus.specReview == null or .reviewStatus.specReview == "pending")] | length' "$state_file")
+    local spec_failed=$(jq '[.tasks[] | select(.reviewStatus.specReview == "fail")] | length' "$state_file")
+    local quality_pending=$(jq '[.tasks[] | select(.reviewStatus.qualityReview == null or .reviewStatus.qualityReview == "pending")] | length' "$state_file")
+    local quality_failed=$(jq '[.tasks[] | select(.reviewStatus.qualityReview == "needs_fixes" or .reviewStatus.qualityReview == "blocked")] | length' "$state_file")
+
+    case "$phase" in
+        ideate)
+            # Auto-continue to plan after design is saved
+            if [ -n "$design" ] && [ "$design" != "null" ]; then
+                echo "AUTO:plan:$design"
+            else
+                echo "WAIT:incomplete:design-not-saved"
+            fi
+            ;;
+        plan)
+            if [ -n "$plan" ] && [ "$plan" != "null" ]; then
+                # Plan saved, auto-continue to plan-review
+                echo "AUTO:plan-review:$plan"
+            else
+                echo "WAIT:incomplete:plan-not-saved"
+            fi
+            ;;
+        plan-review)
+            # Human checkpoint - plan approval
+            if [ -n "$plan" ] && [ "$plan" != "null" ]; then
+                echo "WAIT:human-checkpoint:plan-approval"
+            else
+                echo "WAIT:incomplete:plan-not-saved"
+            fi
+            ;;
+        delegate)
+            if [ "$total_tasks" -eq 0 ]; then
+                echo "WAIT:incomplete:no-tasks-defined"
+            elif [ "$complete_tasks" -eq "$total_tasks" ]; then
+                # All tasks complete, auto-continue to review
+                echo "AUTO:review:$plan"
+            else
+                echo "WAIT:in-progress:tasks-$complete_tasks-of-$total_tasks"
+            fi
+            ;;
+        review)
+            if [ "$spec_failed" -gt 0 ] || [ "$quality_failed" -gt 0 ]; then
+                # Review failed, auto-continue to fixes
+                echo "AUTO:delegate:--fixes $plan"
+            elif [ "$spec_pending" -gt 0 ] || [ "$quality_pending" -gt 0 ]; then
+                # Reviews still pending
+                echo "WAIT:in-progress:reviews-pending"
+            else
+                # All reviews passed, auto-continue to synthesize
+                local feature=$(jq -r '.featureId' "$state_file")
+                echo "AUTO:synthesize:$feature"
+            fi
+            ;;
+        synthesize)
+            if [ -n "$pr" ] && [ "$pr" != "null" ] && [ "$pr" != "" ]; then
+                # PR created - human checkpoint for merge confirmation
+                echo "WAIT:human-checkpoint:merge-confirmation"
+            else
+                echo "WAIT:incomplete:pr-not-created"
+            fi
+            ;;
+        completed)
+            echo "DONE"
+            ;;
+        blocked)
+            echo "WAIT:blocked:requires-redesign"
+            ;;
+        *)
+            echo "UNKNOWN:$phase"
+            ;;
+    esac
+}
+
+# Main dispatcher
+case "${1:-}" in
+    init)
+        [ -n "${2:-}" ] || usage
+        cmd_init "$2" "${3:-}"
+        ;;
+    list)
+        cmd_list
+        ;;
+    get)
+        [ -n "${2:-}" ] || usage
+        cmd_get "$2" "${3:-.}"
+        ;;
+    set)
+        [ -n "${2:-}" ] && [ -n "${3:-}" ] || usage
+        cmd_set "$2" "$3"
+        ;;
+    summary)
+        [ -n "${2:-}" ] || usage
+        cmd_summary "$2"
+        ;;
+    reconcile)
+        [ -n "${2:-}" ] || usage
+        cmd_reconcile "$2"
+        ;;
+    next-action)
+        [ -n "${2:-}" ] || usage
+        cmd_next_action "$2"
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/.claude/scripts/workflow-state.sh
+++ b/.claude/scripts/workflow-state.sh
@@ -166,6 +166,9 @@ EOF
   },
   "validation": {
     "testsPass": null,
+    "briefImplemented": null,
+    "scopeExpanded": null,
+    "filesChangedCount": 0,
     "goalsVerified": [],
     "docsUpdated": null
   },
@@ -481,10 +484,7 @@ cmd_summary() {
                 echo "Continue design exploration (auto-chains to /plan when design saved)"
                 ;;
             plan)
-                echo "Continue planning (auto-chains to plan-review when plan saved)"
-                ;;
-            plan-review)
-                echo "Review plan-design delta and approve to continue to /delegate"
+                echo "Continue planning (auto-chains to /delegate when plan saved)"
                 ;;
             delegate)
                 if [ "$complete_tasks" -eq "$total_tasks" ]; then
@@ -697,10 +697,25 @@ cmd_next_action() {
                 fi
                 ;;
             implement)
-                # Polish track only - check if implementation conditions met
+                # Polish track only - check if ALL implementation conditions met
                 if [ "$track" = "polish" ]; then
-                    # Check if goals are being verified (implementation complete)
-                    if [ "$goals_verified_count" -gt 0 ] || [ "$tests_pass" = "true" ]; then
+                    # Read additional validation fields (separate declaration and assignment per SC2155)
+                    local brief_implemented
+                    brief_implemented=$(jq -r 'if .validation.briefImplemented == null then "" else (.validation.briefImplemented | tostring) end' "$state_file")
+                    local scope_expanded
+                    scope_expanded=$(jq -r 'if .validation.scopeExpanded == null then "" else (.validation.scopeExpanded | tostring) end' "$state_file")
+                    local files_changed_count
+                    files_changed_count=$(jq -r '.validation.filesChangedCount // 0' "$state_file")
+
+                    # ALL conditions must be met (per polish-implement.md exit conditions):
+                    # 1. All tests pass (testsPass = true)
+                    # 2. All changes from brief are implemented (briefImplemented = true)
+                    # 3. No scope expansion occurred (scopeExpanded = false)
+                    # 4. ≤5 files changed (filesChangedCount <= 5)
+                    if [ "$tests_pass" = "true" ] && \
+                       [ "$brief_implemented" = "true" ] && \
+                       [ "$scope_expanded" = "false" ] && \
+                       [ "$files_changed_count" -le 5 ]; then
                         echo "AUTO:refactor-validate"
                     else
                         echo "WAIT:in-progress:implementing"
@@ -816,16 +831,8 @@ cmd_next_action() {
             ;;
         plan)
             if [ -n "$plan" ] && [ "$plan" != "null" ]; then
-                # Plan saved, auto-continue to plan-review
-                echo "AUTO:plan-review:$plan"
-            else
-                echo "WAIT:incomplete:plan-not-saved"
-            fi
-            ;;
-        plan-review)
-            # Human checkpoint - plan approval
-            if [ -n "$plan" ] && [ "$plan" != "null" ]; then
-                echo "WAIT:human-checkpoint:plan-approval"
+                # Plan saved, auto-continue to delegate
+                echo "AUTO:delegate:$plan"
             else
                 echo "WAIT:incomplete:plan-not-saved"
             fi

--- a/docs/designs/2026-02-02-refactor-workflow.md
+++ b/docs/designs/2026-02-02-refactor-workflow.md
@@ -249,7 +249,7 @@ Add refactor-specific fields to workflow state:
 /refactor --polish "Small contained refactor description"
 
 # Explore first, then decide track
-/refactor --explore "Unsure of scope, explore first"
+/refactor --explore-only "Unsure of scope, explore first"
 ```
 
 #### Mid-Workflow Commands

--- a/docs/designs/2026-02-02-refactor-workflow.md
+++ b/docs/designs/2026-02-02-refactor-workflow.md
@@ -1,0 +1,366 @@
+# Design: Refactor-Oriented Workflow
+
+## Problem Statement
+
+The existing development workflows are optimized for specific scenarios:
+
+- **`/ideate`** — Greenfield features requiring design exploration
+- **`/debug`** — Bug fixing with investigation-first approach
+
+Neither fits refactoring well:
+
+1. **`/ideate` is too heavy** — Full design docs for "extract this class" is wasteful ceremony
+2. **`/debug` assumes broken behavior** — Refactoring starts with working code
+3. **No documentation update step** — Refactors change existing architecture but neither workflow updates existing docs
+
+Refactoring needs an exploration-driven workflow that's lighter than `/ideate`, preserves working code guarantees, and ensures documentation stays current.
+
+## Chosen Approach
+
+**Two-Track Model** — Explicit tracks for polish (small, fast) vs overhaul (large, delegated), with shared exploration and documentation update phases.
+
+### Design Principles
+
+1. **Exploration before commitment** — Understand scope before planning
+2. **Right-sized ceremony** — Polish is fast; overhaul is rigorous
+3. **Brief over design doc** — Capture intent in state, not separate documents
+4. **Update existing docs** — Refactors modify architecture, docs must follow
+5. **Leverage existing infrastructure** — Worktrees, delegation, review phases
+
+## Technical Design
+
+### Workflow Overview
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              /refactor                                       │
+│                                  │                                           │
+│                            ┌─────┴─────┐                                     │
+│                            │  Explore  │                                     │
+│                            └─────┬─────┘                                     │
+│                                  │                                           │
+│                   ┌──────────────┼──────────────┐                            │
+│                   │                             │                            │
+│              --polish                       (default)                        │
+│                   │                             │                            │
+│                   ▼                             ▼                            │
+│          ┌──────────────┐              ┌──────────────┐                      │
+│          │    Polish    │              │   Overhaul   │                      │
+│          │    Track     │              │    Track     │                      │
+│          └──────────────┘              └──────────────┘                      │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Polish Track
+
+**Purpose:** Fast path for small, contained refactors. Single session, minimal ceremony.
+
+**Phases:**
+```text
+Explore → Brief → Implement → Validate → Update Docs → Complete
+   │         │         │           │            │
+   │         │         │           │            └─ Update affected documentation
+   │         │         │           └─ Run tests, verify goals met
+   │         │         └─ Direct implementation (no worktree)
+   │         └─ Capture goals and approach in state
+   └─ Quick scope assessment, confirm polish-appropriate
+```
+
+**Characteristics:**
+- No worktree isolation (speed over safety)
+- No delegation (orchestrator guides implementation)
+- Validation: existing tests pass + goals verified
+- Scope limit: ≤5 files, single concern
+
+**State Phases:** `explore` → `brief` → `implement` → `validate` → `update-docs` → `completed`
+
+### Overhaul Track
+
+**Purpose:** Rigorous path for architectural changes, migrations, and multi-file restructuring.
+
+**Phases:**
+```text
+Explore → Brief → Plan → Delegate → Integrate → Review → Update Docs → Synthesize
+   │         │       │        │          │          │           │            │
+   │         │       │        │          │          │           │            └─ PR creation
+   │         │       │        │          │          │           └─ Update architecture docs
+   │         │       │        │          │          └─ Quality review (emphasized)
+   │         │       │        │          └─ Merge worktrees, run tests
+   │         │       │        └─ TDD implementation in worktrees
+   │         │       └─ Extract tasks from brief
+   │         └─ Detailed goals, approach, affected areas
+   └─ Thorough scope assessment, identify affected systems
+```
+
+**Characteristics:**
+- Worktree isolation for all implementation
+- Full delegation model
+- Quality review emphasized (refactors are high regression risk)
+- No scope limit
+
+**State Phases:** `explore` → `brief` → `plan` → `delegate` → `integrate` → `review` → `update-docs` → `synthesize` → `completed`
+
+### Phase Definitions
+
+#### Explore Phase
+
+**Goal:** Understand current state and refactor scope before committing.
+
+**Activities:**
+1. Read affected code to understand current structure
+2. Identify all files/modules that will change
+3. Assess test coverage of affected areas
+4. Identify documentation that will need updates
+5. Determine if polish or overhaul is appropriate
+
+**Outputs:**
+- Scope assessment (files, modules, concerns)
+- Test coverage gaps (if any)
+- Documentation targets
+- Track recommendation (can override with flag)
+
+**Track Selection Guidance:**
+
+| Indicator | Polish | Overhaul |
+|-----------|--------|----------|
+| Files affected | ≤5 | >5 |
+| Concerns | Single | Multiple |
+| Cross-module | No | Yes |
+| Test gaps | None | Some |
+| Doc updates | Minor | Architectural |
+
+#### Brief Phase
+
+**Goal:** Capture refactor intent and approach without full design ceremony.
+
+**Captured in state file (not separate document):**
+
+```json
+{
+  "brief": {
+    "problem": "What's wrong with current code",
+    "goals": ["Specific goal 1", "Specific goal 2"],
+    "approach": "High-level approach description",
+    "affectedAreas": ["module/path1", "module/path2"],
+    "outOfScope": ["What we're NOT changing"],
+    "successCriteria": ["How we know we're done"],
+    "docsToUpdate": ["docs/path1.md", "docs/path2.md"]
+  }
+}
+```
+
+**Polish brief:** 2-3 sentences per field
+**Overhaul brief:** Paragraph per field, more detail on approach
+
+#### Plan Phase (Overhaul Only)
+
+**Goal:** Extract implementation tasks from brief.
+
+Reuses existing `/plan` skill with refactor-specific prompt:
+- Tasks focus on incremental, testable changes
+- Each task should leave code in working state
+- Dependency order matters more for refactors
+
+#### Implement Phase (Polish Only)
+
+**Goal:** Direct implementation guided by orchestrator.
+
+**Constraints:**
+- Must follow TDD (write/update test first if changing behavior)
+- Commit after each logical change
+- Stop if scope expands beyond brief
+
+**Orchestrator role:** Guide implementation, but can write code directly (exception to orchestrator constraints for polish track).
+
+#### Validate Phase
+
+**Goal:** Verify refactor goals are met.
+
+**Validation checklist:**
+1. All existing tests pass
+2. Each goal in brief is addressed
+3. No new lint/type errors introduced
+4. Code quality improved (subjective check against brief)
+
+#### Update Docs Phase
+
+**Goal:** Ensure documentation reflects new architecture.
+
+**Required updates:**
+- Architecture docs if structure changed
+- API docs if interfaces changed
+- README if setup/usage changed
+- Inline comments if complex logic moved
+
+**Documentation update is NOT optional.** If `docsToUpdate` is empty, phase verifies no docs need updating.
+
+### State Schema Extension
+
+Add refactor-specific fields to workflow state:
+
+```json
+{
+  "version": "1.0",
+  "featureId": "refactor-<slug>",
+  "workflowType": "refactor",
+  "track": "polish | overhaul",
+  "phase": "explore | brief | plan | delegate | integrate | review | update-docs | synthesize | completed",
+  "explore": {
+    "startedAt": "ISO8601",
+    "completedAt": "ISO8601 | null",
+    "scopeAssessment": {
+      "filesAffected": ["string"],
+      "modulesAffected": ["string"],
+      "testCoverage": "good | gaps | none",
+      "recommendedTrack": "polish | overhaul"
+    }
+  },
+  "brief": {
+    "problem": "string",
+    "goals": ["string"],
+    "approach": "string",
+    "affectedAreas": ["string"],
+    "outOfScope": ["string"],
+    "successCriteria": ["string"],
+    "docsToUpdate": ["string"]
+  },
+  "artifacts": {
+    "plan": "string | null",
+    "pr": "string | null",
+    "updatedDocs": ["string"]
+  },
+  "validation": {
+    "testsPass": "boolean",
+    "goalsVerified": ["string"],
+    "docsUpdated": "boolean"
+  }
+}
+```
+
+### Command Interface
+
+#### Entry Point
+
+```bash
+# Start overhaul refactor (default)
+/refactor "Description of what needs refactoring"
+
+# Start polish refactor (fast path)
+/refactor --polish "Small contained refactor description"
+
+# Explore first, then decide track
+/refactor --explore "Unsure of scope, explore first"
+```
+
+#### Mid-Workflow Commands
+
+```bash
+# Switch from polish to overhaul (during explore/brief)
+/refactor --switch-overhaul
+
+# Resume after context compaction
+/resume
+```
+
+### Auto-Chain Behavior
+
+**Polish Track:**
+```text
+explore → brief → implement → validate → update-docs → [complete]
+          (auto)   (auto)      (auto)      (auto)        (human checkpoint)
+```
+
+**Overhaul Track:**
+```text
+explore → brief → plan → delegate → integrate → review → update-docs → synthesize → [merge]
+          (auto)  (auto)  (auto)     (auto)      (auto)    (auto)        (auto)       (human)
+```
+
+Both tracks have ONE human checkpoint: completion/merge confirmation.
+
+### Polish Track Orchestrator Exception
+
+For polish track ONLY, the orchestrator may write implementation code directly. This is an explicit exception to the orchestrator constraints rule.
+
+**Rationale:** Polish refactors are small enough that delegation overhead exceeds benefit. The orchestrator can complete a 3-file rename faster than setting up worktrees and dispatching subagents.
+
+**Guardrails:**
+- Only during `implement` phase of polish track
+- Must stay within scope defined in brief
+- If scope expands, switch to overhaul track
+
+## Integration Points
+
+### New Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `skills/refactor/SKILL.md` | Main refactor workflow orchestration |
+| `skills/refactor/references/explore-checklist.md` | Exploration phase guide |
+| `skills/refactor/references/brief-template.md` | Brief structure reference |
+| `skills/refactor/references/doc-update-checklist.md` | Documentation update guide |
+
+### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `workflow-state.sh` | Add `workflowType: refactor` support |
+| `rules/workflow-auto-resume.md` | Handle refactor workflow phases |
+| `rules/orchestrator-constraints.md` | Add polish track exception |
+| Command definitions | Add `/refactor` command |
+
+### Reused Components
+
+| Component | Usage |
+|-----------|-------|
+| `/plan` skill | Overhaul track task extraction |
+| `/delegate` skill | Overhaul track implementation |
+| `/integrate` skill | Overhaul track merge and test |
+| `/review` skill | Overhaul track quality review |
+| `/synthesize` skill | Overhaul track PR creation |
+
+## Testing Strategy
+
+### Unit Testing
+
+1. **State transitions** — Verify refactor phases flow correctly for both tracks
+2. **Track selection** — Exploration correctly recommends polish vs overhaul
+3. **Brief validation** — Required fields enforced
+
+### Integration Testing
+
+1. **Polish end-to-end** — Small refactor completes in single session
+2. **Overhaul end-to-end** — Large refactor uses full delegation
+3. **Track switch** — Can escalate from polish to overhaul mid-workflow
+4. **Doc updates** — Verify documentation is actually updated
+
+### Manual Verification
+
+1. **Context consumption** — Polish uses minimal context
+2. **Goal verification** — Success criteria actually validated
+3. **Doc quality** — Updated docs are accurate and useful
+
+## Open Questions
+
+1. **Polish scope limit** — Is ≤5 files the right threshold?
+   - Recommendation: Start with 5, adjust based on experience
+
+2. **Behavior change documentation** — If refactor intentionally changes behavior, where to document?
+   - Recommendation: In the PR description and affected docs, not a separate artifact
+
+3. **Test coverage gaps** — Should refactor require closing test gaps before proceeding?
+   - Recommendation: Flag gaps in brief, but don't block (that's a separate task)
+
+4. **Partial completion** — If overhaul is interrupted, how to resume?
+   - Recommendation: Same as feature workflow — state file tracks progress
+
+## Implementation Order
+
+1. **Phase 1: State schema** — Add refactor-specific fields to workflow-state.sh
+2. **Phase 2: Refactor skill** — Create skills/refactor/SKILL.md with core orchestration
+3. **Phase 3: Explore phase** — Scope assessment and track recommendation
+4. **Phase 4: Brief phase** — Goal and approach capture
+5. **Phase 5: Polish track** — Direct implementation path
+6. **Phase 6: Overhaul track** — Integration with existing delegation infrastructure
+7. **Phase 7: Update docs phase** — Documentation update enforcement
+8. **Phase 8: Auto-resume** — Update workflow-auto-resume.md for refactor phases

--- a/docs/plans/2026-02-02-refactor-workflow.md
+++ b/docs/plans/2026-02-02-refactor-workflow.md
@@ -1,0 +1,605 @@
+# Implementation Plan: Refactor Workflow
+
+## Source Design
+
+Link: `docs/designs/2026-02-02-refactor-workflow.md`
+
+## Scope
+
+**Target:** Full design implementation
+**Excluded:** None
+
+## Summary
+
+- Total tasks: 16
+- Parallel groups: 3
+- Estimated test count: 12
+- Design coverage: 8/8 sections covered
+
+## Spec Traceability
+
+### Traceability Matrix
+
+| Design Section | Key Requirements | Task ID(s) | Status |
+|----------------|------------------|------------|--------|
+| Technical Design > Workflow Overview | Two-track model diagram | — | Documentation only |
+| Technical Design > Polish Track | Fast path phases, no worktree, orchestrator exception | 005, 006, 007 | Covered |
+| Technical Design > Overhaul Track | Full delegation phases, worktree isolation | 008, 009, 010 | Covered |
+| Technical Design > Explore Phase | Scope assessment, track recommendation | 003 | Covered |
+| Technical Design > Brief Phase | Goal capture in state | 004 | Covered |
+| Technical Design > Update Docs Phase | Documentation update enforcement | 011 | Covered |
+| Technical Design > State Schema | Refactor-specific fields | 001 | Covered |
+| Technical Design > Command Interface | Entry points, flags | 002 | Covered |
+| Technical Design > Auto-Chain Behavior | Single human checkpoint | 012 | Covered |
+| Technical Design > Polish Orchestrator Exception | Direct implementation allowed | 006 | Covered |
+| Integration Points > New Skills | SKILL.md and reference files | 013, 014 | Covered |
+| Integration Points > Modified Components | workflow-state.sh, auto-resume, orchestrator constraints | 001, 015, 016 | Covered |
+| Integration Points > Reused Components | /plan, /delegate, /integrate, /review, /synthesize | 008, 009 | Covered (via overhaul integration) |
+| Testing Strategy | State transitions, track selection, brief validation | All tasks include tests | Covered |
+
+## Task Breakdown
+
+### Task 001: Add refactor workflow type to workflow-state.sh
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `cmd_init_RefactorType_CreatesCorrectSchema`
+   - File: `tests/workflow-state.test.sh`
+   - Expected failure: No --refactor flag support
+   - Run: `bash tests/workflow-state.test.sh` - MUST FAIL
+
+2. [GREEN] Implement minimum code
+   - File: `~/.claude/scripts/workflow-state.sh`
+   - Changes: Add `--refactor` flag to init command, create refactor state template with track, brief, explore, and validation fields
+   - Run: `bash tests/workflow-state.test.sh` - MUST PASS
+
+3. [REFACTOR] Clean up
+   - Apply: DRY - extract common state template parts
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** None
+**Parallelizable:** Yes (Group A)
+
+---
+
+### Task 002: Add refactor command definition
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `RefactorCommand_ParsesFlags_ReturnsCorrectTrack`
+   - File: `tests/skills/refactor/command.test.ts`
+   - Expected failure: No refactor command defined
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [GREEN] Implement minimum code
+   - File: `~/.claude/skills/refactor/command.ts` (or equivalent command registration)
+   - Changes: Define /refactor command with --polish, --explore flags
+   - Run: `npm run test:run` - MUST PASS
+
+3. [REFACTOR] Clean up
+   - Apply: Consistent with /debug command pattern
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** None
+**Parallelizable:** Yes (Group A)
+
+---
+
+### Task 003: Implement explore phase logic
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `ExplorePhase_SmallScope_RecommendsPolish`
+   - File: `tests/skills/refactor/explore.test.ts`
+   - Expected failure: No explore phase implementation
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [RED] Write test: `ExplorePhase_LargeScope_RecommendsOverhaul`
+   - File: `tests/skills/refactor/explore.test.ts`
+   - Expected failure: No explore phase implementation
+   - Run: `npm run test:run` - MUST FAIL
+
+3. [GREEN] Implement minimum code
+   - File: `~/.claude/skills/refactor/references/explore-checklist.md`
+   - Changes: Define scope assessment criteria (files, concerns, cross-module, test gaps, doc updates)
+   - Run: `npm run test:run` - MUST PASS
+
+4. [REFACTOR] Clean up
+   - Apply: Clear decision table format
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 001
+**Parallelizable:** No (depends on 001)
+
+---
+
+### Task 004: Implement brief phase with state capture
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `BriefPhase_CapturesAllFields_UpdatesState`
+   - File: `tests/skills/refactor/brief.test.ts`
+   - Expected failure: No brief capture logic
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [RED] Write test: `BriefPhase_ValidatesRequiredFields_RejectsIncomplete`
+   - File: `tests/skills/refactor/brief.test.ts`
+   - Expected failure: No validation
+   - Run: `npm run test:run` - MUST FAIL
+
+3. [GREEN] Implement minimum code
+   - File: `~/.claude/skills/refactor/references/brief-template.md`
+   - Changes: Define brief structure with problem, goals, approach, affectedAreas, outOfScope, successCriteria, docsToUpdate
+   - Run: `npm run test:run` - MUST PASS
+
+4. [REFACTOR] Clean up
+   - Apply: Clear examples for polish vs overhaul brief depth
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 001
+**Parallelizable:** No (depends on 001)
+
+---
+
+### Task 005: Implement polish track implement phase
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `PolishImplement_DirectEdit_NoWorktree`
+   - File: `tests/skills/refactor/polish-implement.test.ts`
+   - Expected failure: No polish implement phase
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [RED] Write test: `PolishImplement_ScopeExpands_SwitchesToOverhaul`
+   - File: `tests/skills/refactor/polish-implement.test.ts`
+   - Expected failure: No scope expansion detection
+   - Run: `npm run test:run` - MUST FAIL
+
+3. [GREEN] Implement minimum code
+   - File: `~/.claude/skills/refactor/SKILL.md` (polish implement section)
+   - Changes: Define direct implementation flow with scope guardrails
+   - Run: `npm run test:run` - MUST PASS
+
+4. [REFACTOR] Clean up
+   - Apply: Clear when to switch to overhaul
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 003, 004
+**Parallelizable:** No
+
+---
+
+### Task 006: Document orchestrator exception for polish track
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `OrchestratorConstraints_PolishTrack_AllowsDirectImplementation`
+   - File: `tests/rules/orchestrator-constraints.test.ts`
+   - Expected failure: No exception defined
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [GREEN] Implement minimum code
+   - File: `rules/orchestrator-constraints.md`
+   - Changes: Add explicit exception for polish track implement phase
+   - Run: `npm run test:run` - MUST PASS
+
+3. [REFACTOR] Clean up
+   - Apply: Clear guardrails for when exception applies
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 005
+**Parallelizable:** No
+
+---
+
+### Task 007: Implement polish track validate phase
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `PolishValidate_TestsPass_GoalsVerified_Succeeds`
+   - File: `tests/skills/refactor/polish-validate.test.ts`
+   - Expected failure: No validate phase
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [RED] Write test: `PolishValidate_GoalNotMet_Fails`
+   - File: `tests/skills/refactor/polish-validate.test.ts`
+   - Expected failure: No goal verification
+   - Run: `npm run test:run` - MUST FAIL
+
+3. [GREEN] Implement minimum code
+   - File: `~/.claude/skills/refactor/SKILL.md` (polish validate section)
+   - Changes: Define validation checklist (tests pass, goals addressed, no new errors)
+   - Run: `npm run test:run` - MUST PASS
+
+4. [REFACTOR] Clean up
+   - Apply: Consistent validation output format
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 005
+**Parallelizable:** No
+
+---
+
+### Task 008: Implement overhaul track plan phase integration
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `OverhaulPlan_InvokesPlanSkill_WithRefactorPrompt`
+   - File: `tests/skills/refactor/overhaul-plan.test.ts`
+   - Expected failure: No plan integration
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [GREEN] Implement minimum code
+   - File: `~/.claude/skills/refactor/SKILL.md` (overhaul plan section)
+   - Changes: Define how to invoke /plan with refactor-specific context (incremental changes, working state guarantee)
+   - Run: `npm run test:run` - MUST PASS
+
+3. [REFACTOR] Clean up
+   - Apply: Clear handoff to existing skill
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 003, 004
+**Parallelizable:** Yes (Group B - parallel with polish track tasks)
+
+---
+
+### Task 009: Implement overhaul track delegation integration
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `OverhaulDelegate_UsesWorktrees_FollowsTDD`
+   - File: `tests/skills/refactor/overhaul-delegate.test.ts`
+   - Expected failure: No delegate integration
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [GREEN] Implement minimum code
+   - File: `~/.claude/skills/refactor/SKILL.md` (overhaul delegate section)
+   - Changes: Define how to invoke /delegate, /integrate, /review chain
+   - Run: `npm run test:run` - MUST PASS
+
+3. [REFACTOR] Clean up
+   - Apply: Emphasize quality review for refactors
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 008
+**Parallelizable:** No
+
+---
+
+### Task 010: Implement overhaul track review emphasis
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `OverhaulReview_QualityEmphasis_HigherStandard`
+   - File: `tests/skills/refactor/overhaul-review.test.ts`
+   - Expected failure: No refactor-specific review criteria
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [GREEN] Implement minimum code
+   - File: `~/.claude/skills/refactor/SKILL.md` (overhaul review section)
+   - Changes: Define enhanced quality review focus for refactors (regression risk, behavior preservation)
+   - Run: `npm run test:run` - MUST PASS
+
+3. [REFACTOR] Clean up
+   - Apply: Clear review criteria specific to refactoring
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 009
+**Parallelizable:** No
+
+---
+
+### Task 011: Implement update-docs phase
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `UpdateDocs_DocsListEmpty_VerifiesNoneNeeded`
+   - File: `tests/skills/refactor/update-docs.test.ts`
+   - Expected failure: No update-docs phase
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [RED] Write test: `UpdateDocs_DocsListed_VerifiesUpdated`
+   - File: `tests/skills/refactor/update-docs.test.ts`
+   - Expected failure: No update verification
+   - Run: `npm run test:run` - MUST FAIL
+
+3. [GREEN] Implement minimum code
+   - File: `~/.claude/skills/refactor/references/doc-update-checklist.md`
+   - Changes: Define documentation update requirements and verification process
+   - Run: `npm run test:run` - MUST PASS
+
+4. [REFACTOR] Clean up
+   - Apply: Clear checklist format
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 007, 010 (runs after both tracks' main phases)
+**Parallelizable:** No
+
+---
+
+### Task 012: Implement auto-chain for both tracks
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `AutoChain_PolishTrack_ChainsToHumanCheckpoint`
+   - File: `tests/skills/refactor/auto-chain.test.ts`
+   - Expected failure: No auto-chain defined
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [RED] Write test: `AutoChain_OverhaulTrack_ChainsToHumanCheckpoint`
+   - File: `tests/skills/refactor/auto-chain.test.ts`
+   - Expected failure: No auto-chain defined
+   - Run: `npm run test:run` - MUST FAIL
+
+3. [GREEN] Implement minimum code
+   - File: `~/.claude/skills/refactor/SKILL.md` (auto-chain section)
+   - Changes: Define phase transitions with single human checkpoint at end
+   - Run: `npm run test:run` - MUST PASS
+
+4. [REFACTOR] Clean up
+   - Apply: Consistent with feature/debug workflow patterns
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 011
+**Parallelizable:** No
+
+---
+
+### Task 013: Create main refactor SKILL.md
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `RefactorSkill_FileExists_HasRequiredSections`
+   - File: `tests/skills/refactor/skill-structure.test.ts`
+   - Expected failure: No SKILL.md file
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [GREEN] Implement minimum code
+   - File: `~/.claude/skills/refactor/SKILL.md`
+   - Changes: Create complete skill file with overview, triggers, workflow, phases, commands, state management
+   - Run: `npm run test:run` - MUST PASS
+
+3. [REFACTOR] Clean up
+   - Apply: Consistent structure with debug SKILL.md
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 012
+**Parallelizable:** No
+
+---
+
+### Task 014: Create reference files for refactor skill
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `RefactorReferences_AllFilesExist_HaveContent`
+   - File: `tests/skills/refactor/references.test.ts`
+   - Expected failure: No reference files
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [GREEN] Implement minimum code
+   - Files:
+     - `~/.claude/skills/refactor/references/explore-checklist.md`
+     - `~/.claude/skills/refactor/references/brief-template.md`
+     - `~/.claude/skills/refactor/references/doc-update-checklist.md`
+   - Changes: Create all reference files with templates and checklists
+   - Run: `npm run test:run` - MUST PASS
+
+3. [REFACTOR] Clean up
+   - Apply: Consistent format with debug references
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 013
+**Parallelizable:** No
+
+---
+
+### Task 015: Update workflow-auto-resume.md for refactor phases
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `AutoResume_RefactorPolishPhases_ReturnsCorrectAction`
+   - File: `tests/rules/workflow-auto-resume.test.ts`
+   - Expected failure: No refactor phase handling
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [RED] Write test: `AutoResume_RefactorOverhaulPhases_ReturnsCorrectAction`
+   - File: `tests/rules/workflow-auto-resume.test.ts`
+   - Expected failure: No refactor phase handling
+   - Run: `npm run test:run` - MUST FAIL
+
+3. [GREEN] Implement minimum code
+   - File: `rules/workflow-auto-resume.md`
+   - Changes: Add refactor workflow actions table, update human checkpoints section
+   - Run: `npm run test:run` - MUST PASS
+
+4. [REFACTOR] Clean up
+   - Apply: Consistent table format with feature/debug sections
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 001
+**Parallelizable:** Yes (Group C)
+
+---
+
+### Task 016: Add refactor next-action handling to workflow-state.sh
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+1. [RED] Write test: `NextAction_RefactorPolish_ReturnsCorrectAutoAction`
+   - File: `tests/workflow-state.test.sh`
+   - Expected failure: No refactor handling in next-action
+   - Run: `bash tests/workflow-state.test.sh` - MUST FAIL
+
+2. [RED] Write test: `NextAction_RefactorOverhaul_ReturnsCorrectAutoAction`
+   - File: `tests/workflow-state.test.sh`
+   - Expected failure: No refactor handling in next-action
+   - Run: `bash tests/workflow-state.test.sh` - MUST FAIL
+
+3. [GREEN] Implement minimum code
+   - File: `~/.claude/scripts/workflow-state.sh`
+   - Changes: Add refactor workflow handling to cmd_next_action and cmd_summary functions
+   - Run: `bash tests/workflow-state.test.sh` - MUST PASS
+
+4. [REFACTOR] Clean up
+   - Apply: Consistent case statement structure with debug handling
+   - Run: Tests MUST STAY GREEN
+
+**Verification:**
+- [ ] Witnessed test fail for the right reason
+- [ ] Test passes after implementation
+- [ ] No extra code beyond test requirements
+
+**Dependencies:** 001, 015
+**Parallelizable:** No
+
+## Parallelization Strategy
+
+### Sequential Chains
+
+**Chain A: Foundation**
+```
+Task 001 (state schema) → Task 003 (explore) → Task 004 (brief)
+```
+
+**Chain B: Polish Track**
+```
+Task 004 → Task 005 (implement) → Task 006 (orchestrator exception) → Task 007 (validate)
+```
+
+**Chain C: Overhaul Track**
+```
+Task 004 → Task 008 (plan) → Task 009 (delegate) → Task 010 (review)
+```
+
+**Chain D: Finalization**
+```
+Task 007, Task 010 → Task 011 (update-docs) → Task 012 (auto-chain) → Task 013 (SKILL.md) → Task 014 (references)
+```
+
+**Chain E: Infrastructure**
+```
+Task 001 → Task 015 (auto-resume) → Task 016 (next-action)
+```
+
+### Parallel Groups
+
+| Group | Tasks | Can Run With |
+|-------|-------|--------------|
+| A | 001, 002 | Each other |
+| B | 005-007 (polish), 008-010 (overhaul) | Each other after 004 completes |
+| C | 015 | After 001 completes |
+
+### Worktree Assignments
+
+```
+.worktrees/001-state-schema     → Task 001
+.worktrees/002-command          → Task 002
+.worktrees/003-005-polish       → Tasks 003, 004, 005, 006, 007
+.worktrees/008-010-overhaul     → Tasks 008, 009, 010
+.worktrees/011-014-finalize     → Tasks 011, 012, 013, 014
+.worktrees/015-016-infra        → Tasks 015, 016
+```
+
+## Deferred Items
+
+None - all design sections are covered.
+
+## Completion Checklist
+
+- [ ] All tests written before implementation
+- [ ] All tests pass
+- [ ] Code coverage meets standards
+- [ ] Design coverage verified (8/8 sections)
+- [ ] Ready for review

--- a/rules/orchestrator-constraints.md
+++ b/rules/orchestrator-constraints.md
@@ -15,6 +15,47 @@ The orchestrator SHOULD:
 4. **Chain phases** — Invoke next skill when phase completes
 5. **Handle failures** — Route failures back to appropriate phase
 
+## Exceptions
+
+### Polish Track Refactors
+
+For `/refactor --polish` (polish track) ONLY, the orchestrator MAY write implementation code directly during the `implement` phase.
+
+**Rationale:** Polish refactors are small enough (≤5 files, single concern) that delegation overhead exceeds benefit. Setting up worktrees and dispatching subagents for a simple rename or extraction adds ceremony without value.
+
+**Guardrails:**
+1. **Only during implement phase** — Not during explore, brief, validate, or update-docs
+2. **Only for polish track** — Overhaul track MUST use delegation
+3. **Stay within brief scope** — If scope expands beyond brief, switch to overhaul track
+4. **Must follow TDD** — Write/update tests first if changing behavior
+5. **Commit incrementally** — Commit after each logical change
+
+**Scope Expansion Triggers:**
+- More than 5 files need modification
+- Changes cross module boundaries
+- Test coverage gaps discovered
+- Architectural decisions needed
+
+If any trigger fires, stop and run:
+```bash
+/refactor --switch-overhaul
+```
+
+**Verification:**
+Before starting implementation, verify:
+1. Track is "polish" in state file
+2. Phase is "implement"
+3. Brief goals are captured
+
+```bash
+# Verify before implementing
+~/.claude/scripts/workflow-state.sh get <state-file> '.track'
+# Must return: "polish"
+
+~/.claude/scripts/workflow-state.sh get <state-file> '.phase'
+# Must return: "implement"
+```
+
 ## Rationale
 
 The orchestrator acts as a coordinator, not an implementer. This separation:

--- a/rules/workflow-auto-resume.md
+++ b/rules/workflow-auto-resume.md
@@ -41,7 +41,6 @@ The `next-action` command returns one of:
 | Response | Meaning | Action |
 |----------|---------|--------|
 | `AUTO:plan:<design-path>` | Auto-continue to plan | Invoke `/plan` |
-| `AUTO:plan-review:<plan-path>` | Auto-continue to plan review | Run plan-design delta analysis |
 | `AUTO:delegate:<path>` | Auto-continue to delegate | Invoke `/delegate` |
 | `AUTO:integrate:<state>` | Auto-continue to integrate | Invoke `/integrate` |
 | `AUTO:review:<path>` | Auto-continue to review | Invoke `/review` |
@@ -100,32 +99,16 @@ ONLY pause for human input at these phases:
 
 | Phase | Checkpoint | Why |
 |-------|------------|-----|
-| `plan-review` | Plan approval | User must approve implementation plan before delegation |
 | `synthesize` (PR created) | Merge confirmation | User must approve merge or provide feedback |
 
 All other phases auto-continue:
 - `ideate` (design saved) → auto-chains to `/plan`
-- `plan` (plan saved) → auto-chains to plan-review (delta analysis)
-- `plan-review` (approved) → auto-chains to `/delegate`
+- `plan` (plan saved) → auto-chains to `/delegate`
 - `delegate` (all tasks complete) → auto-chains to `/integrate`
 - `integrate` (passed) → auto-chains to `/review`
 - `integrate` (failed) → auto-chains to `/delegate --fixes`
 - `review` (all passed) → auto-chains to `/synthesize`
 - `review` (failed) → auto-chains to `/delegate --fixes`
-
-### Plan Review Phase
-
-The `plan-review` phase performs a delta analysis between design and plan:
-
-1. Re-reads the design document
-2. Compares each section against planned tasks
-3. Generates a coverage report with gaps identified
-4. Presents to user with recommendation (APPROVE / REVISE / RETURN TO DESIGN)
-
-**User actions at this checkpoint:**
-- **Approve**: Continue to `/delegate`
-- **Request revisions**: Address feedback, re-run plan review
-- **Return to design**: Go back to `/ideate` for design clarification
 
 ### Debug Workflow
 

--- a/rules/workflow-auto-resume.md
+++ b/rules/workflow-auto-resume.md
@@ -60,6 +60,21 @@ The `next-action` command returns one of:
 | `AUTO:debug-review` | Spec review | Run spec review |
 | `AUTO:debug-synthesize` | Create PR | Create debug fix PR |
 
+#### Refactor Workflow Actions
+
+| Response | Meaning | Action |
+|----------|---------|--------|
+| `AUTO:refactor-explore` | Continue exploration | Resume scope assessment |
+| `AUTO:refactor-brief` | Capture brief | Continue brief phase |
+| `AUTO:refactor-implement` | Polish track implement | Continue direct implementation |
+| `AUTO:refactor-validate` | Polish track validate | Run validation checks |
+| `AUTO:refactor-update-docs` | Update documentation | Continue doc updates |
+| `AUTO:refactor-plan` | Overhaul track plan | Invoke `/plan` |
+| `AUTO:refactor-delegate` | Overhaul track delegate | Invoke `/delegate` |
+| `AUTO:refactor-integrate` | Overhaul track integrate | Invoke `/integrate` |
+| `AUTO:refactor-review` | Overhaul track review | Invoke `/review` |
+| `AUTO:refactor-synthesize` | Overhaul track synthesize | Invoke `/synthesize` |
+
 #### Wait/Done States
 
 | Response | Meaning | Action |
@@ -135,6 +150,34 @@ All debug phases auto-continue:
 - `design` → auto-chains to `implement`
 - `implement` → auto-chains to `review`
 - `review` → auto-chains to `synthesize`
+- `synthesize` → HUMAN CHECKPOINT (merge)
+
+### Refactor Workflow
+
+| Phase | Checkpoint | Why |
+|-------|------------|-----|
+| `update-docs` (polish) | Completion confirmation | User must confirm refactor complete |
+| `synthesize` (overhaul) | Merge confirmation | User must approve PR merge |
+
+All refactor phases auto-continue:
+
+**Polish track:**
+- `explore` → auto-chains to `brief`
+- `brief` → auto-chains to `implement`
+- `implement` → auto-chains to `validate`
+- `validate` → auto-chains to `update-docs`
+- `update-docs` → HUMAN CHECKPOINT (completion)
+
+**Overhaul track:**
+- `explore` → auto-chains to `brief`
+- `brief` → auto-chains to `plan`
+- `plan` → auto-chains to `delegate`
+- `delegate` (all tasks complete) → auto-chains to `integrate`
+- `integrate` (passed) → auto-chains to `review`
+- `integrate` (failed) → auto-chains to `delegate --fixes`
+- `review` (all passed) → auto-chains to `update-docs`
+- `review` (failed) → auto-chains to `delegate --fixes`
+- `update-docs` → auto-chains to `synthesize`
 - `synthesize` → HUMAN CHECKPOINT (merge)
 
 ## Idempotency

--- a/scripts/workflow-state.sh
+++ b/scripts/workflow-state.sh
@@ -48,27 +48,29 @@ usage() {
     echo "Usage: workflow-state.sh <command> [args]"
     echo ""
     echo "Commands:"
-    echo "  init <feature-id> [--debug]    Create new state file (--debug for debug workflow)"
-    echo "  list                           List all active workflows"
-    echo "  get <state-file> [jq-query]    Read state (optionally with jq)"
-    echo "  set <state-file> <jq-filter>   Update state using jq filter"
-    echo "  summary <state-file>           Output minimal summary"
-    echo "  reconcile <state-file>         Verify state matches reality"
-    echo "  next-action <state-file>       Determine next auto-continue action"
+    echo "  init <feature-id> [--debug|--refactor]  Create new state file"
+    echo "  list                                     List all active workflows"
+    echo "  get <state-file> [jq-query]              Read state (optionally with jq)"
+    echo "  set <state-file> <jq-filter>             Update state using jq filter"
+    echo "  summary <state-file>                     Output minimal summary"
+    echo "  reconcile <state-file>                   Verify state matches reality"
+    echo "  next-action <state-file>                 Determine next auto-continue action"
     exit 1
 }
 
 # Initialize a new workflow state file
-# Usage: init <feature-id> [--debug]
+# Usage: init <feature-id> [--debug|--refactor]
 cmd_init() {
     local feature_id="$1"
     local workflow_type="${2:-feature}"
     local state_file="$STATE_DIR/${feature_id}.state.json"
     local now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-    # Check for --debug flag
+    # Check for --debug or --refactor flag
     if [ "$workflow_type" = "--debug" ]; then
         workflow_type="debug"
+    elif [ "$workflow_type" = "--refactor" ]; then
+        workflow_type="refactor"
     fi
 
     if [ -f "$state_file" ]; then
@@ -79,7 +81,62 @@ cmd_init() {
     # Ensure state directory exists
     mkdir -p "$STATE_DIR"
 
-    if [ "$workflow_type" = "debug" ]; then
+    if [ "$workflow_type" = "refactor" ]; then
+        # Refactor workflow state
+        cat > "$state_file" << EOF
+{
+  "version": "1.0",
+  "featureId": "$feature_id",
+  "workflowType": "refactor",
+  "createdAt": "$now",
+  "updatedAt": "$now",
+  "track": null,
+  "phase": "explore",
+  "scope": {
+    "files": [],
+    "modules": [],
+    "estimatedComplexity": null
+  },
+  "brief": {
+    "problem": null,
+    "goals": [],
+    "constraints": [],
+    "acceptanceCriteria": []
+  },
+  "artifacts": {
+    "plan": null,
+    "pr": null
+  },
+  "validation": {
+    "testsPass": false,
+    "goalsVerified": [],
+    "docsUpdated": false
+  },
+  "tasks": [],
+  "worktrees": {},
+  "reviews": {},
+  "integration": {
+    "branch": null,
+    "status": "pending",
+    "mergedBranches": [],
+    "failureDetails": null,
+    "testResults": {
+      "tests": "pending",
+      "typecheck": "pending",
+      "lint": "pending",
+      "build": "pending"
+    }
+  },
+  "synthesis": {
+    "integrationBranch": null,
+    "mergeOrder": [],
+    "mergedBranches": [],
+    "prUrl": null,
+    "prFeedback": []
+  }
+}
+EOF
+    elif [ "$workflow_type" = "debug" ]; then
         # Debug workflow state
         cat > "$state_file" << EOF
 {
@@ -257,6 +314,37 @@ cmd_summary() {
         echo "- Root Cause: $root_cause"
         echo "- RCA: \`$rca\`"
         echo "- PR: $pr"
+    elif [ "$workflow_type" = "refactor" ]; then
+        local track=$(jq -r '.track // "not selected"' "$state_file")
+        local brief_problem=$(jq -r '.brief.problem // "not captured"' "$state_file")
+        local brief_goals=$(jq '.brief.goals | length' "$state_file")
+        local scope_files=$(jq '.scope.files | length' "$state_file")
+        local scope_modules=$(jq '.scope.modules | length' "$state_file")
+        local complexity=$(jq -r '.scope.estimatedComplexity // "not assessed"' "$state_file")
+        local tests_pass=$(jq -r '.validation.testsPass // false' "$state_file")
+        local goals_verified=$(jq '.validation.goalsVerified | length' "$state_file")
+        local docs_updated=$(jq -r '.validation.docsUpdated // false' "$state_file")
+        local plan=$(jq -r '.artifacts.plan // "not created"' "$state_file")
+
+        echo "**Type:** Refactor ($track track)"
+        echo ""
+        echo "### Scope Assessment"
+        echo "- Files: $scope_files"
+        echo "- Modules: $scope_modules"
+        echo "- Complexity: $complexity"
+        echo ""
+        echo "### Brief"
+        echo "- Problem: $brief_problem"
+        echo "- Goals: $brief_goals defined"
+        echo ""
+        echo "### Validation"
+        echo "- Tests Pass: $tests_pass"
+        echo "- Goals Verified: $goals_verified"
+        echo "- Docs Updated: $docs_updated"
+        echo ""
+        echo "### Artifacts"
+        echo "- Plan: \`$plan\`"
+        echo "- PR: $pr"
     else
         local design=$(jq -r '.artifacts.design // "not created"' "$state_file")
         local plan=$(jq -r '.artifacts.plan // "not created"' "$state_file")
@@ -346,6 +434,54 @@ cmd_summary() {
                 ;;
             completed)
                 echo "Workflow complete"
+                ;;
+            *)
+                echo "Check state file for details"
+                ;;
+        esac
+    elif [ "$workflow_type" = "refactor" ]; then
+        local track=$(jq -r '.track // ""' "$state_file")
+        case "$phase" in
+            explore)
+                echo "Analyze scope and select track (polish/overhaul)"
+                ;;
+            brief)
+                echo "Capture problem statement and refactoring goals"
+                ;;
+            plan)
+                echo "Create implementation plan for overhaul refactor"
+                ;;
+            delegate)
+                if [ "$complete_tasks" -eq "$total_tasks" ]; then
+                    echo "All tasks complete. Auto-continues to integrate"
+                else
+                    echo "Monitor task completion ($complete_tasks/$total_tasks)"
+                fi
+                ;;
+            integrate)
+                echo "Verify integration passes all tests"
+                ;;
+            implement)
+                echo "Apply polish refactor changes (TDD)"
+                ;;
+            validate)
+                echo "Verify refactoring goals are met"
+                ;;
+            review)
+                echo "Complete review of refactored code"
+                ;;
+            update-docs)
+                echo "Update documentation to reflect changes"
+                ;;
+            synthesize)
+                if [ "$pr" != "not created" ]; then
+                    echo "PR created. Confirm merge or request changes."
+                else
+                    echo "Create PR for refactor"
+                fi
+                ;;
+            completed)
+                echo "Refactor workflow complete"
                 ;;
             *)
                 echo "Check state file for details"
@@ -529,6 +665,129 @@ cmd_next_action() {
                 ;;
             *)
                 echo "UNKNOWN:debug-$phase"
+                ;;
+        esac
+        return
+    fi
+
+    # Handle refactor workflows
+    if [ "$workflow_type" = "refactor" ]; then
+        local track=$(jq -r '.track // ""' "$state_file")
+        local brief_problem=$(jq -r '.brief.problem // ""' "$state_file")
+        local brief_goals=$(jq '.brief.goals | length' "$state_file")
+        local docs_updated=$(jq -r '.validation.docsUpdated // false' "$state_file")
+
+        case "$phase" in
+            explore)
+                # Check if exploration is complete (track selected)
+                if [ -n "$track" ] && [ "$track" != "null" ]; then
+                    echo "AUTO:refactor-brief"
+                else
+                    echo "WAIT:in-progress:exploring-scope"
+                fi
+                ;;
+            brief)
+                # Check if brief is complete
+                if [ -n "$brief_problem" ] && [ "$brief_problem" != "null" ] && [ "$brief_goals" -gt 0 ]; then
+                    if [ "$track" = "polish" ]; then
+                        echo "AUTO:refactor-implement"
+                    else
+                        echo "AUTO:refactor-plan"
+                    fi
+                else
+                    echo "WAIT:in-progress:capturing-brief"
+                fi
+                ;;
+            plan)
+                # Overhaul track only - check if plan exists
+                local plan=$(jq -r '.artifacts.plan // ""' "$state_file")
+                if [ -n "$plan" ] && [ "$plan" != "null" ]; then
+                    echo "AUTO:refactor-delegate"
+                else
+                    echo "WAIT:in-progress:planning"
+                fi
+                ;;
+            delegate)
+                # Check task completion
+                if [ "$total_tasks" -eq 0 ]; then
+                    echo "WAIT:incomplete:no-tasks-defined"
+                elif [ "$complete_tasks" -eq "$total_tasks" ]; then
+                    echo "AUTO:refactor-integrate"
+                else
+                    echo "WAIT:in-progress:tasks-$complete_tasks-of-$total_tasks"
+                fi
+                ;;
+            integrate)
+                # Check integration status
+                local integration_status=$(jq -r '.integration.status // "pending"' "$state_file")
+                if [ "$integration_status" = "passed" ]; then
+                    echo "AUTO:refactor-review"
+                elif [ "$integration_status" = "failed" ]; then
+                    echo "AUTO:delegate:--fixes"
+                else
+                    echo "WAIT:in-progress:integrating"
+                fi
+                ;;
+            implement)
+                # Polish track only - check if implementation is done
+                # For polish, we check if goals are being verified
+                local tests_pass=$(jq -r '.validation.testsPass // false' "$state_file")
+                if [ "$tests_pass" = "true" ]; then
+                    echo "AUTO:refactor-validate"
+                else
+                    echo "WAIT:in-progress:implementing"
+                fi
+                ;;
+            validate)
+                # Check if validation is complete
+                local goals_verified=$(jq '.validation.goalsVerified | length' "$state_file")
+                if [ "$goals_verified" -gt 0 ]; then
+                    echo "AUTO:refactor-update-docs"
+                else
+                    echo "WAIT:in-progress:validating"
+                fi
+                ;;
+            review)
+                # Overhaul track only
+                local review_passed=$(jq -r '.reviews | to_entries | all(.value.status == "pass")' "$state_file")
+                if [ "$review_passed" = "true" ]; then
+                    echo "AUTO:refactor-update-docs"
+                else
+                    local review_failed=$(jq -r '.reviews | to_entries | any(.value.status == "fail" or .value.status == "needs_fixes")' "$state_file")
+                    if [ "$review_failed" = "true" ]; then
+                        echo "AUTO:delegate:--fixes"
+                    else
+                        echo "WAIT:in-progress:reviewing"
+                    fi
+                fi
+                ;;
+            update-docs)
+                # Check if docs are updated
+                if [ "$docs_updated" = "true" ]; then
+                    if [ "$track" = "polish" ]; then
+                        # Polish track - human checkpoint for completion
+                        echo "WAIT:human-checkpoint:polish-complete"
+                    else
+                        # Overhaul track - continue to synthesize
+                        echo "AUTO:refactor-synthesize"
+                    fi
+                else
+                    echo "WAIT:in-progress:updating-docs"
+                fi
+                ;;
+            synthesize)
+                # Overhaul track only
+                if [ -n "$pr" ] && [ "$pr" != "null" ] && [ "$pr" != "" ]; then
+                    echo "WAIT:human-checkpoint:merge-confirmation"
+                else
+                    echo "WAIT:incomplete:pr-not-created"
+                fi
+                ;;
+            completed)
+                echo "DONE"
+                ;;
+            *)
+                echo "UNKNOWN:refactor-$phase"
                 ;;
         esac
         return

--- a/scripts/workflow-state.sh
+++ b/scripts/workflow-state.sh
@@ -81,65 +81,7 @@ cmd_init() {
     # Ensure state directory exists
     mkdir -p "$STATE_DIR"
 
-    if [ "$workflow_type" = "refactor" ]; then
-        # Refactor workflow state
-        cat > "$state_file" << EOF
-{
-  "version": "1.0",
-  "featureId": "$feature_id",
-  "workflowType": "refactor",
-  "createdAt": "$now",
-  "updatedAt": "$now",
-  "track": null,
-  "phase": "explore",
-  "scope": {
-    "files": [],
-    "modules": [],
-    "estimatedComplexity": null
-  },
-  "brief": {
-    "problem": null,
-    "goals": [],
-    "constraints": [],
-    "acceptanceCriteria": []
-  },
-  "artifacts": {
-    "plan": null,
-    "pr": null
-  },
-  "validation": {
-    "testsPass": false,
-    "briefImplemented": false,
-    "scopeExpanded": false,
-    "filesChangedCount": 0,
-    "goalsVerified": [],
-    "docsUpdated": false
-  },
-  "tasks": [],
-  "worktrees": {},
-  "reviews": {},
-  "integration": {
-    "branch": null,
-    "status": "pending",
-    "mergedBranches": [],
-    "failureDetails": null,
-    "testResults": {
-      "tests": "pending",
-      "typecheck": "pending",
-      "lint": "pending",
-      "build": "pending"
-    }
-  },
-  "synthesis": {
-    "integrationBranch": null,
-    "mergeOrder": [],
-    "mergedBranches": [],
-    "prUrl": null,
-    "prFeedback": []
-  }
-}
-EOF
-    elif [ "$workflow_type" = "debug" ]; then
+    if [ "$workflow_type" = "debug" ]; then
         # Debug workflow state
         cat > "$state_file" << EOF
 {
@@ -174,6 +116,61 @@ EOF
   "followUp": {
     "rcaRequired": false,
     "issueUrl": null
+  },
+  "tasks": [],
+  "worktrees": {},
+  "reviews": {},
+  "synthesis": {
+    "integrationBranch": null,
+    "mergeOrder": [],
+    "mergedBranches": [],
+    "prUrl": null,
+    "prFeedback": []
+  }
+}
+EOF
+    elif [ "$workflow_type" = "refactor" ]; then
+        # Refactor workflow state
+        cat > "$state_file" << EOF
+{
+  "version": "1.0",
+  "featureId": "$feature_id",
+  "workflowType": "refactor",
+  "createdAt": "$now",
+  "updatedAt": "$now",
+  "track": null,
+  "phase": "explore",
+  "explore": {
+    "startedAt": null,
+    "completedAt": null,
+    "scopeAssessment": {
+      "filesAffected": [],
+      "modulesAffected": [],
+      "testCoverage": null,
+      "recommendedTrack": null
+    }
+  },
+  "brief": {
+    "problem": null,
+    "goals": [],
+    "approach": null,
+    "affectedAreas": [],
+    "outOfScope": [],
+    "successCriteria": [],
+    "docsToUpdate": []
+  },
+  "artifacts": {
+    "plan": null,
+    "pr": null,
+    "updatedDocs": []
+  },
+  "validation": {
+    "testsPass": null,
+    "briefImplemented": null,
+    "scopeExpanded": null,
+    "filesChangedCount": 0,
+    "goalsVerified": [],
+    "docsUpdated": null
   },
   "tasks": [],
   "worktrees": {},
@@ -321,20 +318,20 @@ cmd_summary() {
         local track=$(jq -r '.track // "not selected"' "$state_file")
         local brief_problem=$(jq -r '.brief.problem // "not captured"' "$state_file")
         local brief_goals=$(jq '.brief.goals | length' "$state_file")
-        local scope_files=$(jq '.scope.files | length' "$state_file")
-        local scope_modules=$(jq '.scope.modules | length' "$state_file")
-        local complexity=$(jq -r '.scope.estimatedComplexity // "not assessed"' "$state_file")
-        local tests_pass=$(jq -r '.validation.testsPass // false' "$state_file")
+        local files_affected=$(jq '.explore.scopeAssessment.filesAffected | length' "$state_file")
+        local modules_affected=$(jq '.explore.scopeAssessment.modulesAffected | length' "$state_file")
+        local recommended_track=$(jq -r '.explore.scopeAssessment.recommendedTrack // "not assessed"' "$state_file")
+        local tests_pass=$(jq -r '.validation.testsPass // "not run"' "$state_file")
         local goals_verified=$(jq '.validation.goalsVerified | length' "$state_file")
-        local docs_updated=$(jq -r '.validation.docsUpdated // false' "$state_file")
+        local docs_updated=$(jq -r '.validation.docsUpdated // "not updated"' "$state_file")
         local plan=$(jq -r '.artifacts.plan // "not created"' "$state_file")
 
         echo "**Type:** Refactor ($track track)"
         echo ""
         echo "### Scope Assessment"
-        echo "- Files: $scope_files"
-        echo "- Modules: $scope_modules"
-        echo "- Complexity: $complexity"
+        echo "- Files Affected: $files_affected"
+        echo "- Modules Affected: $modules_affected"
+        echo "- Recommended Track: $recommended_track"
         echo ""
         echo "### Brief"
         echo "- Problem: $brief_problem"
@@ -497,10 +494,7 @@ cmd_summary() {
                 echo "Continue design exploration (auto-chains to /plan when design saved)"
                 ;;
             plan)
-                echo "Continue planning (auto-chains to plan-review when plan saved)"
-                ;;
-            plan-review)
-                echo "Review plan-design delta and approve to continue to /delegate"
+                echo "Continue planning (auto-chains to /delegate when plan saved)"
                 ;;
             delegate)
                 if [ "$complete_tasks" -eq "$total_tasks" ]; then
@@ -678,7 +672,7 @@ cmd_next_action() {
         local track=$(jq -r '.track // ""' "$state_file")
         local brief_problem=$(jq -r '.brief.problem // ""' "$state_file")
         local brief_goals=$(jq '.brief.goals | length' "$state_file")
-        local docs_updated=$(jq -r '.validation.docsUpdated // false' "$state_file")
+        local docs_updated=$(jq -r 'if .validation.docsUpdated == null then "" else (.validation.docsUpdated | tostring) end' "$state_file")
 
         case "$phase" in
             explore)
@@ -721,47 +715,56 @@ cmd_next_action() {
                 fi
                 ;;
             integrate)
-                # Check integration status
-                local integration_status=$(jq -r '.integration.status // "pending"' "$state_file")
-                if [ "$integration_status" = "passed" ]; then
+                # Check integration status from synthesis
+                local integration_passed=$(jq -r 'if .synthesis.integrationPassed == null then "" else (.synthesis.integrationPassed | tostring) end' "$state_file")
+                local plan=$(jq -r '.artifacts.plan // ""' "$state_file")
+                if [ "$integration_passed" = "true" ]; then
                     echo "AUTO:refactor-review"
-                elif [ "$integration_status" = "failed" ]; then
-                    echo "AUTO:delegate:--fixes"
+                elif [ "$integration_passed" = "false" ]; then
+                    echo "AUTO:delegate:--fixes $plan"
                 else
                     echo "WAIT:in-progress:integrating"
                 fi
                 ;;
             implement)
-                # Polish track only - check if implementation is done
-                # Per polish-implement.md, ALL exit conditions must be met:
-                # 1. All changes from brief are implemented
-                # 2. All tests pass
-                # 3. No scope expansion occurred
-                # 4. ≤5 files changed
-                local tests_pass
-                tests_pass=$(jq -r '.validation.testsPass // false' "$state_file")
-                local brief_implemented
-                brief_implemented=$(jq -r '.validation.briefImplemented // false' "$state_file")
-                local scope_expanded
-                scope_expanded=$(jq -r '.validation.scopeExpanded // false' "$state_file")
-                local files_changed_count
-                files_changed_count=$(jq -r '.validation.filesChangedCount // 0' "$state_file")
+                # Polish track only - check if ALL implementation conditions met
+                if [ "$track" = "polish" ]; then
+                    # Read validation fields
+                    local tests_pass
+                    tests_pass=$(jq -r 'if .validation.testsPass == null then "" else (.validation.testsPass | tostring) end' "$state_file")
+                    local brief_implemented
+                    brief_implemented=$(jq -r 'if .validation.briefImplemented == null then "" else (.validation.briefImplemented | tostring) end' "$state_file")
+                    local scope_expanded
+                    scope_expanded=$(jq -r 'if .validation.scopeExpanded == null then "" else (.validation.scopeExpanded | tostring) end' "$state_file")
+                    local files_changed_count
+                    files_changed_count=$(jq -r '.validation.filesChangedCount // 0' "$state_file")
 
-                # All conditions must be met to advance
-                if [ "$tests_pass" = "true" ] && \
-                   [ "$brief_implemented" = "true" ] && \
-                   [ "$scope_expanded" = "false" ] && \
-                   [ "$files_changed_count" -le 5 ]; then
-                    echo "AUTO:refactor-validate"
+                    # ALL conditions must be met (per polish-implement.md exit conditions):
+                    # 1. All tests pass (testsPass = true)
+                    # 2. All changes from brief are implemented (briefImplemented = true)
+                    # 3. No scope expansion occurred (scopeExpanded = false)
+                    # 4. ≤5 files changed (filesChangedCount <= 5)
+                    if [ "$tests_pass" = "true" ] && \
+                       [ "$brief_implemented" = "true" ] && \
+                       [ "$scope_expanded" = "false" ] && \
+                       [ "$files_changed_count" -le 5 ]; then
+                        echo "AUTO:refactor-validate"
+                    else
+                        echo "WAIT:in-progress:implementing"
+                    fi
                 else
+                    # Overhaul track shouldn't hit implement phase directly
                     echo "WAIT:in-progress:implementing"
                 fi
                 ;;
             validate)
                 # Check if validation is complete
-                local goals_verified=$(jq '.validation.goalsVerified | length' "$state_file")
-                if [ "$goals_verified" -gt 0 ]; then
+                local tests_pass
+                tests_pass=$(jq -r 'if .validation.testsPass == null then "" else (.validation.testsPass | tostring) end' "$state_file")
+                if [ "$tests_pass" = "true" ]; then
                     echo "AUTO:refactor-update-docs"
+                elif [ "$tests_pass" = "false" ]; then
+                    echo "WAIT:blocked:tests-failing"
                 else
                     echo "WAIT:in-progress:validating"
                 fi
@@ -833,16 +836,8 @@ cmd_next_action() {
             ;;
         plan)
             if [ -n "$plan" ] && [ "$plan" != "null" ]; then
-                # Plan saved, auto-continue to plan-review
-                echo "AUTO:plan-review:$plan"
-            else
-                echo "WAIT:incomplete:plan-not-saved"
-            fi
-            ;;
-        plan-review)
-            # Human checkpoint - plan approval
-            if [ -n "$plan" ] && [ "$plan" != "null" ]; then
-                echo "WAIT:human-checkpoint:plan-approval"
+                # Plan saved, auto-continue to delegate
+                echo "AUTO:delegate:$plan"
             else
                 echo "WAIT:incomplete:plan-not-saved"
             fi

--- a/scripts/workflow-state.sh
+++ b/scripts/workflow-state.sh
@@ -109,6 +109,9 @@ cmd_init() {
   },
   "validation": {
     "testsPass": false,
+    "briefImplemented": false,
+    "scopeExpanded": false,
+    "filesChangedCount": 0,
     "goalsVerified": [],
     "docsUpdated": false
   },
@@ -730,9 +733,25 @@ cmd_next_action() {
                 ;;
             implement)
                 # Polish track only - check if implementation is done
-                # For polish, we check if goals are being verified
-                local tests_pass=$(jq -r '.validation.testsPass // false' "$state_file")
-                if [ "$tests_pass" = "true" ]; then
+                # Per polish-implement.md, ALL exit conditions must be met:
+                # 1. All changes from brief are implemented
+                # 2. All tests pass
+                # 3. No scope expansion occurred
+                # 4. ≤5 files changed
+                local tests_pass
+                tests_pass=$(jq -r '.validation.testsPass // false' "$state_file")
+                local brief_implemented
+                brief_implemented=$(jq -r '.validation.briefImplemented // false' "$state_file")
+                local scope_expanded
+                scope_expanded=$(jq -r '.validation.scopeExpanded // false' "$state_file")
+                local files_changed_count
+                files_changed_count=$(jq -r '.validation.filesChangedCount // 0' "$state_file")
+
+                # All conditions must be met to advance
+                if [ "$tests_pass" = "true" ] && \
+                   [ "$brief_implemented" = "true" ] && \
+                   [ "$scope_expanded" = "false" ] && \
+                   [ "$files_changed_count" -le 5 ]; then
                     echo "AUTO:refactor-validate"
                 else
                     echo "WAIT:in-progress:implementing"

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -155,6 +155,6 @@ After brainstorming completes, **auto-continue to planning** (no user confirmati
    Skill({ skill: "plan", args: "<design-path>" })
    ```
 
-This is NOT a human checkpoint. The human checkpoint occurs after plan review, before delegation.
+This is NOT a human checkpoint. The human checkpoint occurs at synthesize (merge confirmation).
 
-**Workflow continues:** `/ideate` → `/plan` → plan-review → [HUMAN CHECKPOINT] → `/delegate`
+**Workflow continues:** `/ideate` → `/plan` → `/delegate` → `/integrate` → `/review` → `/synthesize` → [HUMAN CHECKPOINT]

--- a/skills/implementation-planning/SKILL.md
+++ b/skills/implementation-planning/SKILL.md
@@ -237,9 +237,9 @@ Update state with plan artifact and tasks:
 ~/.claude/scripts/workflow-state.sh set docs/workflow-state/<feature>.state.json \
   '.tasks += [{"id": "001", "title": "Task description", "status": "pending", "branch": "feature/001-name"}]'
 
-# Update phase to plan-review (NOT delegate)
+# Update phase to delegate
 ~/.claude/scripts/workflow-state.sh set docs/workflow-state/<feature>.state.json \
-  '.phase = "plan-review"'
+  '.phase = "delegate"'
 ```
 
 ### Task State Structure
@@ -265,72 +265,11 @@ Each task in state should include:
 
 ## Transition
 
-After planning completes, **auto-continue to plan review** (no user confirmation yet):
+After planning completes, **auto-continue to delegate** (no user confirmation):
 
-1. Update state: `.phase = "plan-review"`, populate tasks
-2. Output: "Plan saved with [N] tasks. Running plan-design delta review..."
-3. Execute plan review inline (see Plan Review section below)
-
-## Plan Review
-
-After the plan is saved, perform a formal delta analysis before requesting user approval.
-
-### Review Process
-
-1. **Re-read the design document** — Fresh pass to catch missed items
-2. **Compare against plan** — Section by section
-3. **Generate delta report:**
-
-```markdown
-## Plan Review: [Feature Name]
-
-### Coverage Summary
-- Design sections: [N]
-- Sections with tasks: [X]
-- Sections deferred: [Y]
-- Coverage: [X/N] ([percentage]%)
-
-### Delta Analysis
-
-| Design Section | Coverage | Notes |
-|----------------|----------|-------|
-| Technical Design > A | ✅ Full | Tasks 001-003 |
-| Technical Design > B | ⚠️ Partial | Task 004 covers core, edge cases deferred |
-| Integration Points | ✅ Full | Task 005 |
-| Testing Strategy | ✅ Full | Tasks 006-008 |
-| Open Questions > Q1 | ⏸️ Deferred | Awaiting API spec from team X |
-
-### Gaps Identified
-- [Gap 1]: [Description] — [Resolution: added task / deferred / out of scope]
-- [Gap 2]: [Description] — [Resolution]
-
-### Recommendation
-[APPROVE | REVISE | RETURN TO DESIGN]
-- [Rationale for recommendation]
-```
-
-4. **Present to user for approval** — This is the HUMAN CHECKPOINT
-
-### After Review
-
-**If approved:**
-```bash
-~/.claude/scripts/workflow-state.sh set docs/workflow-state/<feature>.state.json \
-  '.phase = "delegate"'
-```
-Then invoke:
+1. Update state: `.phase = "delegate"`, populate tasks
+2. Output: "Plan saved with [N] tasks. Auto-continuing to delegation..."
+3. Invoke delegation:
 ```typescript
 Skill({ skill: "delegate", args: "<plan-path>" })
 ```
-
-**If revisions needed:**
-- Address user feedback
-- Re-run plan review
-- Present again for approval
-
-**If return to design:**
-```bash
-~/.claude/scripts/workflow-state.sh set docs/workflow-state/<feature>.state.json \
-  '.phase = "ideate"'
-```
-Notify user that design needs refinement before planning can continue.

--- a/skills/refactor/COMMAND.md
+++ b/skills/refactor/COMMAND.md
@@ -1,0 +1,67 @@
+# /refactor Command
+
+## Purpose
+
+Start a refactoring workflow for code improvements, cleanup, or restructuring.
+
+## Usage
+
+```
+/refactor [target] [--polish] [--explore-only]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `target` | Optional. File, directory, or module to refactor. If omitted, will prompt. |
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--polish` | Force polish track (direct implementation, no worktrees). Use for small, well-scoped refactors. |
+| `--explore-only` | Run exploration phase only, output scope assessment without proceeding. |
+
+## Examples
+
+### Start refactor with exploration
+```
+/refactor src/services/auth
+```
+
+### Force small refactor mode
+```
+/refactor src/utils/helpers.ts --polish
+```
+
+### Just assess scope
+```
+/refactor src/api --explore-only
+```
+
+## Workflow Entry
+
+The command triggers the refactor skill which:
+
+1. **Explore phase**: Assesses scope (files, concerns, cross-module impact)
+2. **Track selection**:
+   - Polish (≤5 files, single concern) → direct implementation
+   - Overhaul (>5 files or multiple concerns) → full workflow
+3. **Brief capture**: Records problem, goals, approach in state
+4. **Execution**: Track-specific implementation
+5. **Validation**: Tests pass, goals met, docs updated
+
+## State Initialization
+
+When invoked, initializes refactor workflow state:
+
+```bash
+~/.claude/scripts/workflow-state.sh init --refactor <feature-id>
+```
+
+## See Also
+
+- `/debug` - For bug fixes
+- `/ideate` - For new features
+- `/plan` - For implementation planning (used by overhaul track)

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -1,0 +1,560 @@
+# Refactor Workflow Skill
+
+## Overview
+
+Two-track workflow for improving existing code. Polish track for small, contained refactors; overhaul track for architectural changes and migrations. Both tracks emphasize exploration before commitment and mandatory documentation updates.
+
+## Triggers
+
+Activate this skill when:
+- User runs `/refactor` command
+- User wants to improve existing code structure
+- User mentions "refactor", "restructure", "clean up", "migrate"
+- User asks to "move", "extract", "rename", or "reorganize" code
+
+## Workflow Overview
+
+```
+                              /refactor
+                                  |
+                            +-----+-----+
+                            |  Explore  |
+                            +-----+-----+
+                                  |
+                   +--------------+--------------+
+                   |                             |
+              --polish                       (default)
+                   |                             |
+                   v                             v
+          +--------------+              +--------------+
+          |    Polish    |              |   Overhaul   |
+          |    Track     |              |    Track     |
+          +--------------+              +--------------+
+```
+
+## Command Interface
+
+### Start Refactor Workflow
+
+```bash
+# Default: overhaul track
+/refactor "Description of what needs refactoring"
+
+# Fast path: polish track
+/refactor --polish "Small contained refactor description"
+
+# Explore first, then decide track
+/refactor --explore "Unsure of scope, explore first"
+```
+
+### Mid-Workflow Commands
+
+```bash
+# Switch from polish to overhaul (during explore/brief)
+/refactor --switch-overhaul
+
+# Resume after context compaction
+/resume
+```
+
+## Track Comparison
+
+| Aspect | Polish | Overhaul |
+|--------|--------|----------|
+| Scope | <=5 files, single concern | No limit |
+| Worktree | No (direct) | Yes (isolated) |
+| Delegation | No | Yes (full workflow) |
+| Documentation | Mandatory update phase | Mandatory update phase |
+| Human Checkpoints | 1 (completion) | 1 (merge) |
+
+## Polish Track
+
+### Purpose
+
+Fast path for small, contained refactors. Single session, minimal ceremony. Orchestrator may write implementation code directly (exception to orchestrator constraints).
+
+### Phases
+
+```
+Explore -> Brief -> Implement -> Validate -> Update Docs -> Complete
+   |         |          |           |             |
+   |         |          |           |             +-- Update affected documentation
+   |         |          |           +-- Run tests, verify goals met
+   |         |          +-- Direct implementation (no worktree)
+   |         +-- Capture goals and approach in state
+   +-- Quick scope assessment, confirm polish-appropriate
+```
+
+### Phase Details
+
+#### 1. Explore Phase
+
+Use `@skills/refactor/references/explore-checklist.md` to assess:
+- Current code structure
+- Files/modules affected (must be <=5 for polish)
+- Test coverage of affected areas
+- Documentation that needs updates
+- Confirm polish is appropriate
+
+Update state:
+```bash
+~/.claude/scripts/workflow-state.sh init refactor-<slug> --refactor
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.track = "polish" | .phase = "explore" | .explore = {
+    "startedAt": "<ISO8601>",
+    "scopeAssessment": {
+      "filesAffected": ["<file1>", "<file2>"],
+      "modulesAffected": ["<module>"],
+      "testCoverage": "good | gaps | none",
+      "recommendedTrack": "polish"
+    }
+  }'
+```
+
+On completion:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.explore.completedAt = "<ISO8601>" | .phase = "brief"'
+```
+
+#### 2. Brief Phase
+
+Capture refactor intent and approach in state (not separate document).
+
+Use `@skills/refactor/references/brief-template.md` to structure:
+- Problem statement (2-3 sentences)
+- Specific goals (bulleted list)
+- High-level approach
+- Out of scope items
+- Success criteria
+- Docs to update
+
+Update state:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.brief = {
+    "problem": "<what is wrong with current code>",
+    "goals": ["<goal 1>", "<goal 2>"],
+    "approach": "<high-level approach>",
+    "affectedAreas": ["<area 1>", "<area 2>"],
+    "outOfScope": ["<exclusion 1>"],
+    "successCriteria": ["<criterion 1>", "<criterion 2>"],
+    "docsToUpdate": ["<doc path 1>"]
+  } | .phase = "implement"'
+```
+
+#### 3. Implement Phase
+
+**Orchestrator may write code directly** (polish track exception).
+
+Constraints:
+- Follow TDD (write/update test first if behavior changes)
+- Commit after each logical change
+- Stop if scope expands beyond brief
+
+Update state on completion:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.phase = "validate"'
+```
+
+#### 4. Validate Phase
+
+Verify refactor goals are met:
+- [ ] All existing tests pass
+- [ ] Each goal in brief is addressed
+- [ ] No new lint/type errors introduced
+- [ ] Code quality improved per brief
+
+Run validation:
+```bash
+npm run test:run
+npm run lint  # or equivalent
+npm run typecheck  # if TypeScript
+```
+
+Update state:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.validation = {
+    "testsPass": true,
+    "goalsVerified": ["<goal 1>", "<goal 2>"],
+    "docsUpdated": false
+  } | .phase = "update-docs"'
+```
+
+#### 5. Update Docs Phase
+
+**Mandatory** - documentation must reflect new architecture.
+
+Use `@skills/refactor/references/doc-update-checklist.md` to update:
+- Architecture docs if structure changed
+- API docs if interfaces changed
+- README if setup/usage changed
+- Inline comments if complex logic moved
+
+If `docsToUpdate` is empty, verify no docs need updating.
+
+Update state:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.validation.docsUpdated = true | .artifacts.updatedDocs = ["<doc1>", "<doc2>"] | .phase = "completed"'
+```
+
+**Human checkpoint:** Confirm refactor complete.
+
+## Overhaul Track
+
+### Purpose
+
+Rigorous path for architectural changes, migrations, and multi-file restructuring. Uses full delegation model with worktree isolation.
+
+### Phases
+
+```
+Explore -> Brief -> Plan -> Delegate -> Integrate -> Review -> Update Docs -> Synthesize
+   |         |        |         |           |           |            |             |
+   |         |        |         |           |           |            |             +-- PR creation
+   |         |        |         |           |           |            +-- Update architecture docs
+   |         |        |         |           |           +-- Quality review (emphasized)
+   |         |        |         |           +-- Merge worktrees, run tests
+   |         |        |         +-- TDD implementation in worktrees
+   |         |        +-- Extract tasks from brief
+   |         +-- Detailed goals, approach, affected areas
+   +-- Thorough scope assessment, identify affected systems
+```
+
+### Phase Details
+
+#### 1. Explore Phase
+
+Thorough scope assessment using `@skills/refactor/references/explore-checklist.md`:
+- Read affected code to understand current structure
+- Identify ALL files/modules that will change
+- Assess test coverage of affected areas
+- Identify documentation that will need updates
+- Map dependencies and impact
+
+Update state:
+```bash
+~/.claude/scripts/workflow-state.sh init refactor-<slug> --refactor
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.track = "overhaul" | .phase = "explore" | .explore = {
+    "startedAt": "<ISO8601>",
+    "scopeAssessment": {
+      "filesAffected": ["<file1>", "<file2>", ...],
+      "modulesAffected": ["<module1>", "<module2>"],
+      "testCoverage": "good | gaps | none",
+      "recommendedTrack": "overhaul"
+    }
+  }'
+```
+
+On completion:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.explore.completedAt = "<ISO8601>" | .phase = "brief"'
+```
+
+#### 2. Brief Phase
+
+Detailed capture of refactor intent (more thorough than polish).
+
+Update state:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.brief = {
+    "problem": "<detailed problem statement>",
+    "goals": ["<specific goal 1>", "<specific goal 2>", "<specific goal 3>"],
+    "approach": "<detailed approach with phases/steps>",
+    "affectedAreas": ["<area 1>", "<area 2>", "<area 3>"],
+    "outOfScope": ["<exclusion 1>", "<exclusion 2>"],
+    "successCriteria": ["<criterion 1>", "<criterion 2>", "<criterion 3>"],
+    "docsToUpdate": ["<doc 1>", "<doc 2>"]
+  } | .phase = "plan"'
+```
+
+#### 3. Plan Phase
+
+Invoke `/plan` skill with refactor-specific context:
+
+```bash
+# The plan skill extracts tasks from the brief
+# Focus on incremental, testable changes
+# Each task should leave code in working state
+# Dependency order matters more for refactors
+```
+
+Update state:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.artifacts.plan = "docs/plans/<plan-file>.md" | .phase = "delegate"'
+```
+
+#### 4. Delegate Phase
+
+Invoke `/delegate` skill for TDD implementation in worktrees:
+
+```bash
+# Create worktrees for each task
+# Full TDD: write failing test, implement, verify
+# Parallel execution where dependencies allow
+```
+
+Update state on completion:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.phase = "integrate"'
+```
+
+#### 5. Integrate Phase
+
+Invoke `/integrate` skill to merge worktrees and run tests:
+
+```bash
+# Merge all task branches
+# Run full test suite
+# Verify no regressions
+```
+
+Update state on completion:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.phase = "review"'
+```
+
+#### 6. Review Phase
+
+Invoke `/review` skill with emphasis on quality:
+
+```bash
+# Quality review is emphasized for refactors
+# Refactors are high regression risk
+# Verify structure matches brief goals
+```
+
+Update state on completion:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.phase = "update-docs"'
+```
+
+#### 7. Update Docs Phase
+
+**Mandatory** - documentation must reflect new architecture.
+
+For overhaul, typically includes:
+- Architecture documentation updates
+- API documentation changes
+- Migration guides if public interfaces changed
+- Updated diagrams
+
+Update state:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.validation.docsUpdated = true | .artifacts.updatedDocs = ["<doc1>", "<doc2>"] | .phase = "synthesize"'
+```
+
+#### 8. Synthesize Phase
+
+Invoke `/synthesize` skill to create PR:
+
+```bash
+gh pr create --title "refactor: <summary>" --body "$(cat <<'EOF'
+## Summary
+
+[Brief description of the refactor and why it was needed]
+
+## Changes
+
+- [Key structural change 1]
+- [Key structural change 2]
+
+## Documentation Updated
+
+- [doc1.md] - Updated for X
+- [doc2.md] - Updated for Y
+
+## Test Plan
+
+- All existing tests pass
+- [Any new tests added]
+EOF
+)"
+```
+
+**Human checkpoint:** Confirm merge.
+
+## State Management
+
+Initialize refactor workflow:
+```bash
+~/.claude/scripts/workflow-state.sh init refactor-<slug> --refactor
+```
+
+Full state schema:
+```json
+{
+  "version": "1.0",
+  "featureId": "refactor-<slug>",
+  "workflowType": "refactor",
+  "track": "polish | overhaul",
+  "phase": "explore | brief | plan | delegate | integrate | review | update-docs | synthesize | completed",
+  "explore": {
+    "startedAt": "ISO8601",
+    "completedAt": "ISO8601 | null",
+    "scopeAssessment": {
+      "filesAffected": ["string"],
+      "modulesAffected": ["string"],
+      "testCoverage": "good | gaps | none",
+      "recommendedTrack": "polish | overhaul"
+    }
+  },
+  "brief": {
+    "problem": "string",
+    "goals": ["string"],
+    "approach": "string",
+    "affectedAreas": ["string"],
+    "outOfScope": ["string"],
+    "successCriteria": ["string"],
+    "docsToUpdate": ["string"]
+  },
+  "artifacts": {
+    "plan": "string | null",
+    "pr": "string | null",
+    "updatedDocs": ["string"]
+  },
+  "validation": {
+    "testsPass": "boolean",
+    "goalsVerified": ["string"],
+    "docsUpdated": "boolean"
+  }
+}
+```
+
+## Auto-Chain Behavior
+
+Both tracks have ONE human checkpoint: completion/merge confirmation.
+
+### Polish Auto-Chain
+
+```
+explore -> brief -> implement -> validate -> update-docs -> [HUMAN: complete]
+           (auto)   (auto)       (auto)      (auto)
+```
+
+**Next actions:**
+- `AUTO:refactor-brief` after explore
+- `AUTO:refactor-implement` after brief
+- `AUTO:refactor-validate` after implement
+- `AUTO:refactor-update-docs` after validate
+- `WAIT:human-checkpoint:polish-complete` after update-docs
+
+### Overhaul Auto-Chain
+
+```
+explore -> brief -> plan -> delegate -> integrate -> review -> update-docs -> synthesize -> [HUMAN: merge]
+           (auto)   (auto)   (auto)      (auto)       (auto)    (auto)         (auto)
+```
+
+**Next actions:**
+- `AUTO:refactor-brief` after explore
+- `AUTO:plan:<brief>` after brief
+- `AUTO:delegate:<plan>` after plan
+- `AUTO:integrate:<state>` after delegate
+- `AUTO:review:<path>` after integrate
+- `AUTO:refactor-update-docs` after review
+- `AUTO:synthesize:<feature>` after update-docs
+- `WAIT:human-checkpoint:overhaul-merge` after synthesize
+
+## Track Switching
+
+### Polish -> Overhaul
+
+If scope expands beyond polish limits during explore or brief phase:
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.track = "overhaul" | .explore.scopeAssessment.recommendedTrack = "overhaul"'
+```
+
+**Indicators to switch:**
+- More than 5 files affected
+- Multiple concerns identified
+- Cross-module changes needed
+- Test coverage gaps require new tests
+- Architectural documentation needed
+
+Output to user:
+> Scope has expanded beyond polish limits. Switching to overhaul track.
+> This will use worktree isolation and full delegation.
+>
+> Continue? (Y/n)
+
+## Integration Points
+
+### With Existing Skills
+
+| Skill | Usage |
+|-------|-------|
+| `/plan` | Overhaul track task extraction |
+| `/delegate` | Overhaul track implementation |
+| `/integrate` | Overhaul track merge and test |
+| `/review` | Overhaul track quality review |
+| `/synthesize` | Overhaul track PR creation |
+
+### With workflow-state.sh
+
+Extended to support:
+- `workflowType: "refactor"` field
+- Refactor-specific phases in `next-action` command
+- Refactor context in `summary` output
+
+### With workflow-auto-resume.md
+
+Refactor phases map to auto-resume actions:
+
+| Phase | Next Action |
+|-------|-------------|
+| `explore` (completed) | `AUTO:refactor-brief` |
+| `brief` (completed, polish) | `AUTO:refactor-implement` |
+| `brief` (completed, overhaul) | `AUTO:plan:<brief>` |
+| `implement` (completed) | `AUTO:refactor-validate` |
+| `validate` (completed) | `AUTO:refactor-update-docs` |
+| `update-docs` (completed, polish) | `WAIT:human-checkpoint:polish-complete` |
+| `update-docs` (completed, overhaul) | `AUTO:synthesize:<feature>` |
+
+## Completion Criteria
+
+### Polish Complete
+
+- [ ] Scope assessment completed (<=5 files)
+- [ ] Brief goals captured
+- [ ] Implementation complete
+- [ ] All tests pass
+- [ ] Each goal verified
+- [ ] Documentation updated
+- [ ] User confirmed completion
+
+### Overhaul Complete
+
+- [ ] Full exploration done
+- [ ] Detailed brief captured
+- [ ] Plan created
+- [ ] All tasks delegated and complete
+- [ ] Integration passed
+- [ ] Quality review passed
+- [ ] Documentation updated
+- [ ] PR merged
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip exploration | Always assess scope first |
+| Use polish for large changes | Switch to overhaul when scope expands |
+| Skip doc updates | Documentation is mandatory |
+| Add features during refactor | Scope creep - stick to brief goals |
+| Skip tests because "just moving code" | Refactors need test verification |
+| Create design document for polish | Use brief in state file instead |
+| Work in main for overhaul | Use worktree isolation |

--- a/skills/refactor/phases/auto-chain.md
+++ b/skills/refactor/phases/auto-chain.md
@@ -1,0 +1,265 @@
+# Auto-Chain Behavior
+
+## Purpose
+
+Define automatic phase transitions for refactor workflows, minimizing human intervention while maintaining quality.
+
+## Design Principle
+
+**Single human checkpoint per track.**
+
+- Polish track: One checkpoint at completion (commit approval)
+- Overhaul track: Two checkpoints (plan approval, PR approval)
+
+All other transitions are automatic.
+
+## Polish Track Auto-Chain
+
+```
+explore → brief → implement → validate → update-docs → CHECKPOINT
+```
+
+### Transition Rules
+
+| From | To | Condition | Auto? |
+|------|-----|-----------|-------|
+| explore | brief | Scope assessed | ✓ Yes |
+| brief | implement | Brief captured | ✓ Yes |
+| implement | validate | Changes complete | ✓ Yes |
+| validate | update-docs | Validation passed | ✓ Yes |
+| update-docs | complete | Docs updated | ✓ Yes |
+| complete | — | Human approves commit | ✗ CHECKPOINT |
+
+### Polish Auto-Chain Commands
+
+After each phase, workflow-state.sh returns next action:
+
+```bash
+# After explore
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: AUTO:refactor-brief
+
+# After brief
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: AUTO:refactor-implement
+
+# After implement
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: AUTO:refactor-validate
+
+# After validate (passed)
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: AUTO:refactor-update-docs
+
+# After update-docs
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: WAIT:human-checkpoint:polish-complete
+```
+
+### Polish Checkpoint
+
+At completion, present to user:
+
+```markdown
+## Polish Refactor Complete
+
+**Changes Made:**
+<summary of files modified>
+
+**Goals Achieved:**
+- <goal 1>: ✓
+- <goal 2>: ✓
+
+**Validation:**
+- Tests: ✓ All passing
+- Docs: ✓ Updated
+
+**Action Required:**
+Ready to commit changes. Approve to commit, or request modifications.
+```
+
+## Overhaul Track Auto-Chain
+
+```
+explore → brief → plan → CHECKPOINT → delegate → integrate → review → update-docs → synthesize → CHECKPOINT
+                    ↑                                    │
+                    └────────── fixes ←──────────────────┘ (if review fails)
+```
+
+### Transition Rules
+
+| From | To | Condition | Auto? |
+|------|-----|-----------|-------|
+| explore | brief | Scope assessed | ✓ Yes |
+| brief | plan | Brief captured | ✓ Yes |
+| plan | plan-review | Plan created | ✓ Yes |
+| plan-review | delegate | Human approves | ✗ CHECKPOINT |
+| delegate | integrate | All tasks complete | ✓ Yes |
+| integrate | review | Integration passes | ✓ Yes |
+| review (pass) | update-docs | Review approved | ✓ Yes |
+| review (fail) | delegate | Fix tasks dispatched | ✓ Yes (loop) |
+| update-docs | synthesize | Docs updated | ✓ Yes |
+| synthesize | complete | Human approves PR | ✗ CHECKPOINT |
+
+### Overhaul Auto-Chain Commands
+
+```bash
+# After explore
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: AUTO:refactor-brief
+
+# After brief
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: AUTO:refactor-plan
+
+# After plan
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: WAIT:human-checkpoint:plan-review
+
+# After plan approval
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: AUTO:delegate
+
+# After delegate
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: AUTO:integrate
+
+# After integrate
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: AUTO:review
+
+# After review (passed)
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: AUTO:refactor-update-docs
+
+# After review (failed)
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: AUTO:delegate:--fixes
+
+# After update-docs
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: AUTO:synthesize
+
+# After synthesize
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: WAIT:human-checkpoint:pr-review
+```
+
+### Overhaul Checkpoints
+
+#### Checkpoint 1: Plan Review
+
+Same as feature workflow plan-review checkpoint.
+
+#### Checkpoint 2: PR Approval
+
+```markdown
+## Refactor PR Ready
+
+**PR:** <url>
+
+**Summary:**
+<refactor summary>
+
+**Goals Achieved:**
+- <goal 1>: ✓
+- <goal 2>: ✓
+
+**Review Status:**
+- Behavior preserved: ✓
+- Tests passing: ✓
+- Docs updated: ✓
+
+**Action Required:**
+Review PR and approve merge, or request changes.
+```
+
+## Track Switching
+
+If polish track discovers scope expansion, it switches to overhaul:
+
+```
+polish:implement → [scope expands] → overhaul:plan
+```
+
+Auto-chain handles this:
+
+```bash
+# When scope expands during implement
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.track = "overhaul" | .phase = "plan"'
+
+# Next action returns
+~/.claude/scripts/workflow-state.sh next-action <state-file>
+# Returns: AUTO:refactor-plan
+```
+
+## Failure Handling
+
+### Polish Track Failures
+
+| Failure | Recovery |
+|---------|----------|
+| Validate fails | Return to implement, fix issues |
+| Tests fail | Fix tests, re-validate |
+| Scope expands | Switch to overhaul track |
+
+### Overhaul Track Failures
+
+| Failure | Recovery |
+|---------|----------|
+| Integration fails | Fix and re-integrate |
+| Review fails | Delegate fixes, re-review |
+| Synthesize fails | Fix PR issues, re-synthesize |
+
+All recoveries are automatic loops until success.
+
+## State Machine Summary
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        REFACTOR WORKFLOW                         │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  START → explore → brief ─┬─→ [polish] ─→ implement ─→ validate │
+│                           │                                ↓     │
+│                           │                          update-docs │
+│                           │                                ↓     │
+│                           │                          ▣ COMPLETE  │
+│                           │                                      │
+│                           └─→ [overhaul] ─→ plan ─→ ▣ plan-review│
+│                                                          ↓       │
+│                                              delegate ←──┘       │
+│                                                   ↓              │
+│                                              integrate           │
+│                                                   ↓              │
+│                                               review ────────┐   │
+│                                                   ↓          │   │
+│                                             update-docs  (fail)  │
+│                                                   ↓          │   │
+│                                             synthesize       │   │
+│                                                   ↓          │   │
+│                                             ▣ PR-REVIEW      │   │
+│                                                              │   │
+│                               delegate:--fixes ←─────────────┘   │
+│                                                                  │
+│  Legend: ▣ = Human Checkpoint                                   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Integration with workflow-auto-resume.md
+
+The auto-chain actions are handled by workflow-auto-resume.md rules:
+
+| Action | Skill Invoked |
+|--------|---------------|
+| AUTO:refactor-brief | Continue to brief capture |
+| AUTO:refactor-implement | Continue to implement phase |
+| AUTO:refactor-validate | Continue to validate phase |
+| AUTO:refactor-update-docs | Continue to update-docs phase |
+| AUTO:refactor-plan | Invoke /plan with refactor context |
+| AUTO:delegate | Invoke /delegate |
+| AUTO:delegate:--fixes | Invoke /delegate --fixes |
+| AUTO:integrate | Invoke /integrate |
+| AUTO:review | Invoke /review |
+| AUTO:synthesize | Invoke /synthesize |

--- a/skills/refactor/phases/auto-chain.md
+++ b/skills/refactor/phases/auto-chain.md
@@ -9,7 +9,7 @@ Define automatic phase transitions for refactor workflows, minimizing human inte
 **Single human checkpoint per track.**
 
 - Polish track: One checkpoint at completion (commit approval)
-- Overhaul track: Two checkpoints (plan approval, PR approval)
+- Overhaul track: One checkpoint at merge (PR approval)
 
 All other transitions are automatic.
 
@@ -81,9 +81,9 @@ Ready to commit changes. Approve to commit, or request modifications.
 ## Overhaul Track Auto-Chain
 
 ```
-explore → brief → plan → CHECKPOINT → delegate → integrate → review → update-docs → synthesize → CHECKPOINT
-                    ↑                                    │
-                    └────────── fixes ←──────────────────┘ (if review fails)
+explore → brief → plan → delegate → integrate → review → update-docs → synthesize → CHECKPOINT
+                                        ↑                    │
+                                        └─── fixes ──────────┘ (if review fails)
 ```
 
 ### Transition Rules
@@ -92,8 +92,7 @@ explore → brief → plan → CHECKPOINT → delegate → integrate → review 
 |------|-----|-----------|-------|
 | explore | brief | Scope assessed | ✓ Yes |
 | brief | plan | Brief captured | ✓ Yes |
-| plan | plan-review | Plan created | ✓ Yes |
-| plan-review | delegate | Human approves | ✗ CHECKPOINT |
+| plan | delegate | Plan created | ✓ Yes |
 | delegate | integrate | All tasks complete | ✓ Yes |
 | integrate | review | Integration passes | ✓ Yes |
 | review (pass) | update-docs | Review approved | ✓ Yes |
@@ -114,19 +113,15 @@ explore → brief → plan → CHECKPOINT → delegate → integrate → review 
 
 # After plan
 ~/.claude/scripts/workflow-state.sh next-action <state-file>
-# Returns: WAIT:human-checkpoint:plan-review
-
-# After plan approval
-~/.claude/scripts/workflow-state.sh next-action <state-file>
-# Returns: AUTO:delegate
+# Returns: AUTO:refactor-delegate
 
 # After delegate
 ~/.claude/scripts/workflow-state.sh next-action <state-file>
-# Returns: AUTO:integrate
+# Returns: AUTO:refactor-integrate
 
 # After integrate
 ~/.claude/scripts/workflow-state.sh next-action <state-file>
-# Returns: AUTO:review
+# Returns: AUTO:refactor-review
 
 # After review (passed)
 ~/.claude/scripts/workflow-state.sh next-action <state-file>
@@ -134,24 +129,20 @@ explore → brief → plan → CHECKPOINT → delegate → integrate → review 
 
 # After review (failed)
 ~/.claude/scripts/workflow-state.sh next-action <state-file>
-# Returns: AUTO:delegate:--fixes
+# Returns: AUTO:refactor-delegate:--fixes
 
 # After update-docs
 ~/.claude/scripts/workflow-state.sh next-action <state-file>
-# Returns: AUTO:synthesize
+# Returns: AUTO:refactor-synthesize
 
 # After synthesize
 ~/.claude/scripts/workflow-state.sh next-action <state-file>
-# Returns: WAIT:human-checkpoint:pr-review
+# Returns: WAIT:human-checkpoint:overhaul-merge
 ```
 
-### Overhaul Checkpoints
+### Overhaul Checkpoint
 
-#### Checkpoint 1: Plan Review
-
-Same as feature workflow plan-review checkpoint.
-
-#### Checkpoint 2: PR Approval
+#### PR Approval
 
 ```markdown
 ## Refactor PR Ready
@@ -227,21 +218,20 @@ All recoveries are automatic loops until success.
 │                           │                                ↓     │
 │                           │                          ▣ COMPLETE  │
 │                           │                                      │
-│                           └─→ [overhaul] ─→ plan ─→ ▣ plan-review│
+│                           └─→ [overhaul] ─→ plan ─→ delegate     │
 │                                                          ↓       │
-│                                              delegate ←──┘       │
-│                                                   ↓              │
-│                                              integrate           │
-│                                                   ↓              │
-│                                               review ────────┐   │
-│                                                   ↓          │   │
-│                                             update-docs  (fail)  │
-│                                                   ↓          │   │
-│                                             synthesize       │   │
-│                                                   ↓          │   │
-│                                             ▣ PR-REVIEW      │   │
-│                                                              │   │
-│                               delegate:--fixes ←─────────────┘   │
+│                                                      integrate   │
+│                                                          ↓       │
+│                                                      review ───┐ │
+│                                                          ↓     │ │
+│                                                    update-docs │ │
+│                                                          ↓     │ │
+│                                                    synthesize  │ │
+│                                                          ↓     │ │
+│                                                    ▣ PR-MERGE  │ │
+│                                                                │ │
+│                                  delegate:--fixes ←────────────┘ │
+│                                        (on review fail)          │
 │                                                                  │
 │  Legend: ▣ = Human Checkpoint                                   │
 └─────────────────────────────────────────────────────────────────┘
@@ -253,13 +243,14 @@ The auto-chain actions are handled by workflow-auto-resume.md rules:
 
 | Action | Skill Invoked |
 |--------|---------------|
+| AUTO:refactor-explore | Resume scope assessment |
 | AUTO:refactor-brief | Continue to brief capture |
 | AUTO:refactor-implement | Continue to implement phase |
 | AUTO:refactor-validate | Continue to validate phase |
 | AUTO:refactor-update-docs | Continue to update-docs phase |
 | AUTO:refactor-plan | Invoke /plan with refactor context |
-| AUTO:delegate | Invoke /delegate |
-| AUTO:delegate:--fixes | Invoke /delegate --fixes |
-| AUTO:integrate | Invoke /integrate |
-| AUTO:review | Invoke /review |
-| AUTO:synthesize | Invoke /synthesize |
+| AUTO:refactor-delegate | Invoke /delegate |
+| AUTO:refactor-delegate:--fixes | Invoke /delegate --fixes |
+| AUTO:refactor-integrate | Invoke /integrate |
+| AUTO:refactor-review | Invoke /review |
+| AUTO:refactor-synthesize | Invoke /synthesize |

--- a/skills/refactor/phases/brief.md
+++ b/skills/refactor/phases/brief.md
@@ -1,0 +1,152 @@
+# Brief Phase
+
+## Purpose
+
+Capture refactoring intent in a structured format without the overhead of a full design document.
+
+## Entry Conditions
+
+- Explore phase complete
+- Track selected (polish or overhaul)
+- Scope assessment available in state
+
+## Brief Structure
+
+The brief captures these required fields:
+
+### 1. Problem Statement
+
+**What's wrong with the current code?** Be specific and measurable.
+
+Good examples:
+- "UserService class has grown to 500 lines with authentication, validation, and persistence mixed together"
+- "The payment module uses 4 different error handling patterns inconsistently"
+- "Test setup duplicated across 12 test files with slight variations"
+
+Bad examples:
+- "Code is messy"
+- "Need to clean things up"
+- "Could be better"
+
+### 2. Goals
+
+**What specific outcomes will this refactor achieve?** Each goal must be verifiable.
+
+Good goals:
+- "Extract validation into UserValidator class (<100 lines)"
+- "Consolidate error handling to single pattern using Result type"
+- "Create shared TestFixtures reducing setup duplication by 80%"
+
+Bad goals:
+- "Improve code quality"
+- "Make it cleaner"
+- "Better organization"
+
+### 3. Approach
+
+**How will you achieve the goals?** High-level strategy.
+
+Polish approach (1-2 sentences):
+- "Extract methods, create new class, update callers"
+
+Overhaul approach (phases):
+- "Phase 1: Create adapter for new pattern alongside old"
+- "Phase 2: Migrate internal callers"
+- "Phase 3: Migrate external callers"
+- "Phase 4: Remove old pattern"
+
+### 4. Affected Areas
+
+**Specific paths that will change.** From explore phase.
+
+### 5. Out of Scope
+
+**What you're explicitly NOT changing.** Prevents scope creep.
+
+Examples:
+- "Not changing the public API"
+- "Not addressing performance issues"
+- "Not updating unrelated tests"
+
+### 6. Success Criteria
+
+**How will you verify the refactor is complete?**
+
+- All existing tests pass
+- New tests added for [specific areas]
+- [Goal 1] achieved (measurable)
+- No new linting errors
+- Documentation updated
+
+### 7. Docs to Update
+
+**Documentation that needs updating.** From explore phase.
+
+## Brief Depth by Track
+
+| Field | Polish | Overhaul |
+|-------|--------|----------|
+| Problem | 1-2 sentences | Paragraph with context |
+| Goals | 1-3 items | 3-5 items |
+| Approach | 1-2 sentences | Phases described |
+| Out of Scope | 1-2 items | 3+ items |
+| Success Criteria | 2-3 items | 4+ items |
+
+## Interactive Capture
+
+When in brief phase, prompt user for each field if not provided:
+
+```
+## Refactor Brief
+
+Based on exploration, preparing brief for <polish|overhaul> track.
+
+**Problem:** <from user or prompt>
+**Goals:** <from user or prompt>
+...
+```
+
+## State Update
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.brief = {
+    "problem": "<problem statement>",
+    "goals": ["<goal 1>", "<goal 2>"],
+    "approach": "<approach description>",
+    "affectedAreas": ["<from explore>"],
+    "outOfScope": ["<exclusion 1>"],
+    "successCriteria": ["<criterion 1>"],
+    "docsToUpdate": ["<from explore>"],
+    "capturedAt": "<ISO8601>"
+  } | .phase = "<implement|plan>"'
+```
+
+Phase transitions:
+- Polish track -> `implement`
+- Overhaul track -> `plan`
+
+## Validation
+
+Before proceeding, validate brief completeness:
+
+```
+Required fields check:
+[x] Problem: defined
+[x] Goals: at least 1
+[x] Approach: defined
+[x] Affected areas: from explore
+[x] Out of scope: at least 1
+[x] Success criteria: at least 2
+[x] Docs to update: from explore (can be empty)
+```
+
+If validation fails, prompt for missing fields.
+
+## Exit Conditions
+
+- All required fields captured
+- Brief stored in state
+- Phase transitioned appropriately:
+  - Polish -> implement
+  - Overhaul -> plan

--- a/skills/refactor/phases/explore.md
+++ b/skills/refactor/phases/explore.md
@@ -1,0 +1,131 @@
+# Explore Phase
+
+## Purpose
+
+Assess refactoring scope to determine appropriate track (polish vs overhaul).
+
+## Entry Conditions
+
+- Refactor workflow initiated via `/refactor`
+- Target area identified (file, directory, or module)
+
+## Process
+
+### Step 1: Scope Discovery
+
+Use exploration tools to understand the impact:
+
+```bash
+# Find files that will be affected
+# Use Glob to find files in target area
+# Use Grep to find references to target code
+```
+
+Questions to answer:
+1. How many files will be modified?
+2. How many modules/packages are affected?
+3. Are there cross-module dependencies?
+4. What's the test coverage of affected code?
+
+### Step 2: Concern Analysis
+
+Identify what types of changes are needed:
+
+- [ ] Renaming (variables, functions, files)
+- [ ] Extracting (new functions, classes, modules)
+- [ ] Moving (relocating code between files/modules)
+- [ ] Restructuring (changing architecture)
+- [ ] Cleaning (removing dead code, improving style)
+
+Count distinct concerns - multiple indicates overhaul track.
+
+### Step 3: Test Assessment
+
+Evaluate existing test coverage:
+
+```bash
+# Check for test files covering affected code
+# Review test coverage if available
+```
+
+| Coverage Level | Implication |
+|----------------|-------------|
+| Good (>80%) | Either track viable |
+| Gaps (50-80%) | Overhaul recommended (need test additions) |
+| Poor (<50%) | Overhaul required (significant test work) |
+
+### Step 4: Documentation Check
+
+Identify docs that reference affected code:
+
+- Architecture documentation
+- API documentation
+- README files
+- Inline comments with explanations
+
+Significant doc updates → overhaul track indicator.
+
+## Track Decision Matrix
+
+| Criterion | Polish | Overhaul |
+|-----------|--------|----------|
+| Files affected | ≤5 | >5 |
+| Concerns | 1 | >1 |
+| Cross-module | No | Yes |
+| Test gaps | No | Yes |
+| Doc updates | Minor | Significant |
+
+**Rule**: If ANY criterion indicates overhaul, use overhaul track.
+
+## Output
+
+Update workflow state with assessment:
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.explore = {
+    "filesAffected": <count>,
+    "filesList": ["<path1>", "<path2>"],
+    "modulesAffected": ["<module1>"],
+    "concerns": ["<concern1>", "<concern2>"],
+    "crossModule": <true|false>,
+    "testCoverage": "<good|gaps|none>",
+    "docsImpacted": ["<doc1>"],
+    "recommendedTrack": "<polish|overhaul>",
+    "completedAt": "<ISO8601>"
+  } | .phase = "brief"'
+```
+
+## Exit Conditions
+
+- Scope assessment complete
+- Track recommendation recorded
+- State updated with findings
+- Ready to proceed to brief phase
+
+## If --explore-only Flag
+
+When `--explore-only` is specified:
+
+1. Complete assessment as normal
+2. Output summary to user
+3. Do NOT transition to brief phase
+4. Keep phase as "explore" in state
+
+```markdown
+## Exploration Summary
+
+**Target:** <target path>
+**Recommended Track:** <polish|overhaul>
+
+### Scope Assessment
+- Files: <count>
+- Modules: <list>
+- Concerns: <list>
+- Cross-module: <yes|no>
+- Test coverage: <good|gaps|none>
+- Docs to update: <list>
+
+### Rationale
+<explanation of track recommendation>
+```

--- a/skills/refactor/phases/overhaul-delegate.md
+++ b/skills/refactor/phases/overhaul-delegate.md
@@ -7,7 +7,7 @@ Execute large refactors using worktree-isolated subagents with the standard dele
 ## Entry Conditions
 
 - Track is `overhaul`
-- Plan approved at plan-review checkpoint
+- Plan created with tasks defined
 - Tasks defined in plan document
 
 ## Phase Flow

--- a/skills/refactor/phases/overhaul-delegate.md
+++ b/skills/refactor/phases/overhaul-delegate.md
@@ -1,0 +1,137 @@
+# Overhaul Track: Delegate/Integrate/Review
+
+## Purpose
+
+Execute large refactors using worktree-isolated subagents with the standard delegation workflow.
+
+## Entry Conditions
+
+- Track is `overhaul`
+- Plan approved at plan-review checkpoint
+- Tasks defined in plan document
+
+## Phase Flow
+
+```
+delegate → integrate → review → [update-docs OR delegate --fixes]
+```
+
+## Delegation Phase
+
+Invoke standard delegation:
+
+```
+/delegate docs/workflow-state/<feature>.state.json
+```
+
+### Refactor-Specific Task Guidance
+
+Each delegated task should emphasize:
+
+1. **Working State**: Code must compile and tests pass after task
+2. **Atomic Changes**: One logical change per commit
+3. **Test-First**: New code should have tests
+
+Example task prompt addition:
+```
+IMPORTANT: After this task, code MUST:
+- Build successfully
+- Pass all tests
+- Not break existing functionality
+```
+
+### Task Dependencies
+
+Refactors often have strict ordering:
+```
+Create new class → Move methods → Update callers → Remove old code
+```
+
+Ensure dependencies are respected in delegation.
+
+## Integration Phase
+
+```
+/integrate docs/workflow-state/<feature>.state.json
+```
+
+### Refactor Integration Focus
+
+| Check | Why It Matters |
+|-------|----------------|
+| Merge conflicts | Refactors touch shared code |
+| Test coverage | Combined changes might miss cases |
+| Behavior consistency | Same inputs → same outputs |
+
+### Integration Testing
+
+```bash
+# Run full test suite
+npm run test:run
+
+# Run integration tests specifically
+npm run test:integration
+
+# If applicable, run E2E tests
+npm run test:e2e
+```
+
+## Review Phase
+
+```
+/review docs/workflow-state/<feature>.state.json
+```
+
+### Refactor Review Criteria
+
+When type is "refactor", apply additional scrutiny:
+
+| Criterion | Description |
+|-----------|-------------|
+| Behavior preserved | Same inputs produce same outputs |
+| No regressions | Existing functionality works |
+| Goals achieved | Brief goals are met |
+| Performance OK | No degradation |
+
+See `overhaul-review.md` for detailed criteria.
+
+## State Updates
+
+```bash
+# After delegation complete
+~/.claude/scripts/workflow-state.sh set <state-file> '.phase = "integrate"'
+
+# After integration passes
+~/.claude/scripts/workflow-state.sh set <state-file> '.phase = "review"'
+
+# After review passes
+~/.claude/scripts/workflow-state.sh set <state-file> '.phase = "update-docs"'
+
+# After review fails - dispatch fix tasks, loop back
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.reviews.<id>.status = "failed" | .reviews.<id>.findings = ["<issue1>"]'
+```
+
+## Auto-Chain Behavior
+
+No human checkpoints in this chain. Automatic progression:
+
+| From | To | Condition |
+|------|-----|-----------|
+| delegate | integrate | All tasks complete |
+| integrate | review | Integration passes |
+| review | update-docs | Review passes |
+| review | delegate --fixes | Review fails (loop) |
+
+## Exit Conditions
+
+**Success Path:**
+- All tasks delegated and completed
+- Integration tests pass
+- Review passes
+- Ready for update-docs phase
+
+**Failure Path:**
+- Review failures documented
+- Fix tasks dispatched via `--fixes`
+- Loop until review passes

--- a/skills/refactor/phases/overhaul-plan.md
+++ b/skills/refactor/phases/overhaul-plan.md
@@ -1,0 +1,79 @@
+# Overhaul Track: Plan Phase
+
+## Purpose
+
+Create detailed implementation plan for large refactors using `/plan` skill with refactor context.
+
+## Entry Conditions
+
+- Track is `overhaul`
+- Brief phase complete
+- Scope assessment available
+
+## Integration with /plan
+
+Invoke planning with refactor context:
+
+```
+/plan --from-brief docs/workflow-state/<feature>.state.json
+```
+
+Or provide context manually from the brief.
+
+## Refactor Planning Emphasis
+
+### 1. Incremental Changes
+
+Each task must:
+- Leave code in working state
+- Be independently testable
+- Not break functionality mid-task
+
+### 2. Rollback Points
+
+Identify safe stopping points where refactor can be paused if needed.
+
+### 3. Test Strategy
+
+Every task should include test verification requirements.
+
+### 4. Working State Guarantee
+
+After every task, code must compile and tests must pass.
+
+## Plan Structure
+
+```markdown
+# Implementation Plan: <Refactor Name>
+
+## Goals Mapping
+| Brief Goal | Task(s) |
+|------------|---------|
+| <goal 1> | Task X, Y |
+
+## Task Breakdown
+
+### Task 001: <Title>
+**Changes:** What files
+**Tests:** What verifies success
+**Working State:** How code stays functional
+
+[Repeat for each task]
+
+## Rollback Strategy
+<Safe stopping points>
+```
+
+## State Update
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.artifacts.plan = "<plan-path>" | .phase = "plan-review"'
+```
+
+## Exit Conditions
+
+- Plan document created
+- All brief goals mapped to tasks
+- Incremental strategy clear
+- Ready for plan-review checkpoint

--- a/skills/refactor/phases/overhaul-plan.md
+++ b/skills/refactor/phases/overhaul-plan.md
@@ -2,78 +2,311 @@
 
 ## Purpose
 
-Create detailed implementation plan for large refactors using `/plan` skill with refactor context.
+Create detailed implementation plans for large refactors with emphasis on incremental, working-state changes. This phase integrates with the existing `/plan` skill while adding refactor-specific constraints that ensure safety and reversibility.
+
+**Key principle:** Every task leaves the codebase in a working state. No task should break tests or functionality.
 
 ## Entry Conditions
 
 - Track is `overhaul`
-- Brief phase complete
-- Scope assessment available
+- Brief phase complete with scope assessment
+- State file has `.track = "overhaul"` and `.phase = "brief"` complete
+- Refactoring goals documented in brief
 
 ## Integration with /plan
 
-Invoke planning with refactor context:
+The overhaul track leverages the existing `/plan` skill with additional refactor context.
 
+### Invocation
+
+```bash
+# Auto-invocation from brief phase
+Skill({ skill: "plan", args: "--refactor docs/workflow-state/<feature>.state.json" })
 ```
-/plan --from-brief docs/workflow-state/<feature>.state.json
-```
 
-Or provide context manually from the brief.
+### Context Passing
 
-## Refactor Planning Emphasis
+The `/plan` skill receives refactor context from the brief:
 
-### 1. Incremental Changes
+1. **Scope boundaries** - Which files/modules are affected
+2. **Refactoring goals** - What improvements are targeted
+3. **Constraints** - Working state requirements, rollback needs
+4. **Test baseline** - Current test status to maintain
 
-Each task must:
-- Leave code in working state
-- Be independently testable
-- Not break functionality mid-task
+### Plan Modifications
+
+When `/plan` receives refactor context, it applies these additional rules:
+
+| Standard Plan | Refactor Plan |
+|---------------|---------------|
+| Tasks can be feature-incomplete | Each task must leave code functional |
+| Tests verify new behavior | Tests verify existing + new behavior |
+| Dependencies between tasks | Explicit rollback points identified |
+| Parallel execution focus | Sequential safety emphasis |
+
+## Refactor-Specific Emphasis
+
+### 1. Incremental Changes (Working State Guarantee)
+
+**Every task MUST leave code in a working state.**
+
+Requirements per task:
+- [ ] Code compiles after task completion
+- [ ] All existing tests pass
+- [ ] New tests (if added) pass
+- [ ] No temporary broken states
+
+Anti-patterns to avoid:
+- "Part 1 of 3" tasks that break until Part 3
+- Renaming without updating all references
+- Interface changes without adapter layers
+- Deleting before replacing
+
+**Incremental Strategy Examples:**
+
+| Refactor Type | Safe Approach |
+|---------------|---------------|
+| Rename | Add alias -> Update references -> Remove old |
+| Extract | Create new -> Duplicate logic -> Redirect calls -> Delete original |
+| Replace | Add new alongside -> Toggle between -> Verify -> Remove old |
+| Restructure | Scaffold new -> Copy behavior -> Redirect -> Clean up |
 
 ### 2. Rollback Points
 
-Identify safe stopping points where refactor can be paused if needed.
+Identify explicit points where the refactor can be safely paused or abandoned.
 
-### 3. Test Strategy
+**Rollback Point Criteria:**
+- All tests pass
+- No temporary code remains
+- Could ship to production if needed
+- Clear documentation of state
 
-Every task should include test verification requirements.
+**Template:**
+
+```markdown
+## Rollback Points
+
+### After Task 003
+**State:** Old API deprecated, new API available
+**Can ship:** Yes
+**To resume:** Continue with Task 004
+**To abandon:** Remove deprecation warnings, new API becomes optional
+
+### After Task 007
+**State:** Migration complete, old code marked for deletion
+**Can ship:** Yes
+**To resume:** Continue with Task 008 (cleanup)
+**To abandon:** Keep both implementations, document tech debt
+```
+
+### 3. Test Strategy Per Task
+
+Each task specifies verification requirements:
+
+```markdown
+### Task 005: Extract validation logic to shared module
+
+**Test Requirements:**
+1. **Existing tests:** All unit tests in `auth.test.ts` must pass unchanged
+2. **New tests:** Add `validation.test.ts` with same coverage
+3. **Integration:** Run `npm run test:integration` to verify no regressions
+4. **Manual verification:** N/A (pure refactor)
+
+**Verification Command:**
+npm run test:run -- --coverage
+# Coverage must not decrease
+```
 
 ### 4. Working State Guarantee
 
-After every task, code must compile and tests must pass.
+After every task completion, verify:
 
-## Plan Structure
+```bash
+# Compilation check
+npm run build
+
+# Unit tests
+npm run test:run
+
+# Integration tests (if applicable)
+npm run test:integration
+
+# Lint (code quality)
+npm run lint
+```
+
+**State tracking in workflow file:**
+
+```json
+{
+  "tasks": [
+    {
+      "id": "001",
+      "title": "Add new interface",
+      "status": "complete",
+      "working_state_verified": true,
+      "test_results": {
+        "passed": 145,
+        "failed": 0,
+        "coverage": "87%"
+      }
+    }
+  ]
+}
+```
+
+## Plan Structure Template
+
+Save to: `docs/plans/YYYY-MM-DD-<refactor-name>.md`
 
 ```markdown
-# Implementation Plan: <Refactor Name>
+# Implementation Plan: [Refactor Name]
+
+## Source
+- **Brief:** `docs/workflow-state/<feature>.state.json`
+- **Track:** Overhaul
+- **Affected scope:** [Files/modules from brief]
 
 ## Goals Mapping
-| Brief Goal | Task(s) |
-|------------|---------|
-| <goal 1> | Task X, Y |
+
+| Brief Goal | Task ID(s) | Verification |
+|------------|------------|--------------|
+| [Goal 1] | 001, 002 | [How verified] |
+| [Goal 2] | 003-005 | [How verified] |
+| [Goal 3] | 006 | [How verified] |
+
+## Working State Strategy
+
+**Approach:** [Describe overall incremental approach]
+
+**Key constraints:**
+- [Constraint 1 from brief]
+- [Constraint 2 from brief]
 
 ## Task Breakdown
 
-### Task 001: <Title>
-**Changes:** What files
-**Tests:** What verifies success
-**Working State:** How code stays functional
+### Task 001: [Title]
+
+**Phase:** [RED | GREEN | REFACTOR]
+
+**TDD Steps:**
+1. [RED] Write test: `TestName_Scenario_ExpectedOutcome`
+   - File: `path/to/test.ts`
+   - Expected failure: [Reason]
+   - Run: `npm run test:run` - MUST FAIL
+
+2. [GREEN] Implement minimum code
+   - File: `path/to/implementation.ts`
+   - Changes: [Description]
+   - Run: `npm run test:run` - MUST PASS
+
+3. [REFACTOR] Clean up (if needed)
+   - Apply: [Improvement]
+   - Run: `npm run test:run` - MUST STAY GREEN
+
+**Working State Check:**
+- [ ] Code compiles
+- [ ] All tests pass (existing + new)
+- [ ] No temporary hacks remain
+
+**Rollback point:** [Yes/No - if Yes, document in Rollback section]
+
+**Dependencies:** [Task IDs or "None"]
+
+---
 
 [Repeat for each task]
 
-## Rollback Strategy
-<Safe stopping points>
+## Rollback Points
+
+### After Task [N]
+**State:** [Description of codebase state]
+**Can ship:** [Yes/No]
+**To resume:** [Instructions]
+**To abandon:** [Cleanup instructions]
+
+## Verification Checklist
+
+After all tasks complete:
+- [ ] All original tests still pass
+- [ ] New tests added for new code
+- [ ] Code coverage maintained or improved
+- [ ] No TODO/FIXME comments left behind
+- [ ] Brief goals all achieved
+- [ ] Ready for review
+
+## Deferred Items
+
+[Any scope items explicitly deferred, with rationale]
 ```
 
-## State Update
+## State Updates
+
+### On Plan Completion
 
 ```bash
-~/.claude/scripts/workflow-state.sh set <state-file> \
-  '.artifacts.plan = "<plan-path>" | .phase = "plan-review"'
+# Set plan artifact path
+~/.claude/scripts/workflow-state.sh set docs/workflow-state/<feature>.state.json \
+  '.artifacts.plan = "docs/plans/YYYY-MM-DD-<refactor>.md"'
+
+# Add tasks to state (repeat for each task)
+~/.claude/scripts/workflow-state.sh set docs/workflow-state/<feature>.state.json \
+  '.tasks += [{"id": "001", "title": "Task description", "status": "pending", "working_state_verified": false}]'
+
+# Transition to plan-review phase
+~/.claude/scripts/workflow-state.sh set docs/workflow-state/<feature>.state.json \
+  '.phase = "plan-review"'
+```
+
+### Task State Structure
+
+```json
+{
+  "id": "001",
+  "title": "Extract validation to shared module",
+  "status": "pending",
+  "working_state_verified": false,
+  "rollback_point": true,
+  "dependencies": [],
+  "branch": "refactor/001-extract-validation"
+}
 ```
 
 ## Exit Conditions
 
-- Plan document created
-- All brief goals mapped to tasks
-- Incremental strategy clear
-- Ready for plan-review checkpoint
+Transition to `plan-review` checkpoint when:
+
+- [ ] Plan document created at `docs/plans/`
+- [ ] All brief goals mapped to tasks
+- [ ] Every task has working state verification criteria
+- [ ] Rollback points identified (minimum 1)
+- [ ] Test strategy defined per task
+- [ ] State file updated with plan path and tasks
+- [ ] Phase set to `plan-review`
+
+## Transition to Plan Review
+
+After plan completion, auto-continue to plan-review:
+
+```
+Output: "Refactor plan created with [N] tasks and [M] rollback points.
+        Running plan-design delta review..."
+```
+
+The plan-review checkpoint verifies:
+1. All brief goals have corresponding tasks
+2. Incremental strategy is sound
+3. Rollback points are sufficient
+4. Test coverage is adequate
+
+**This is a HUMAN CHECKPOINT** - user must approve before delegation begins.
+
+## Anti-Patterns
+
+| Avoid | Instead |
+|-------|---------|
+| Big-bang refactors | Break into working-state increments |
+| Skipping tests | Each task verifies existing + new |
+| Hidden dependencies | Explicit rollback points |
+| "Will fix later" tasks | Every task self-contained |
+| Assuming tests pass | Verify after each task |

--- a/skills/refactor/phases/overhaul-plan.md
+++ b/skills/refactor/phases/overhaul-plan.md
@@ -253,9 +253,9 @@ After all tasks complete:
 ~/.claude/scripts/workflow-state.sh set docs/workflow-state/<feature>.state.json \
   '.tasks += [{"id": "001", "title": "Task description", "status": "pending", "working_state_verified": false}]'
 
-# Transition to plan-review phase
+# Transition to delegate phase
 ~/.claude/scripts/workflow-state.sh set docs/workflow-state/<feature>.state.json \
-  '.phase = "plan-review"'
+  '.phase = "delegate"'
 ```
 
 ### Task State Structure
@@ -274,7 +274,7 @@ After all tasks complete:
 
 ## Exit Conditions
 
-Transition to `plan-review` checkpoint when:
+Transition to `delegate` phase when:
 
 - [ ] Plan document created at `docs/plans/`
 - [ ] All brief goals mapped to tasks
@@ -282,24 +282,16 @@ Transition to `plan-review` checkpoint when:
 - [ ] Rollback points identified (minimum 1)
 - [ ] Test strategy defined per task
 - [ ] State file updated with plan path and tasks
-- [ ] Phase set to `plan-review`
+- [ ] Phase set to `delegate`
 
-## Transition to Plan Review
+## Transition to Delegate
 
-After plan completion, auto-continue to plan-review:
+After plan completion, auto-continue to delegate:
 
 ```
 Output: "Refactor plan created with [N] tasks and [M] rollback points.
-        Running plan-design delta review..."
+        Auto-continuing to delegation..."
 ```
-
-The plan-review checkpoint verifies:
-1. All brief goals have corresponding tasks
-2. Incremental strategy is sound
-3. Rollback points are sufficient
-4. Test coverage is adequate
-
-**This is a HUMAN CHECKPOINT** - user must approve before delegation begins.
 
 ## Anti-Patterns
 

--- a/skills/refactor/phases/overhaul-review.md
+++ b/skills/refactor/phases/overhaul-review.md
@@ -1,0 +1,296 @@
+# Overhaul Track: Review Phase
+
+## Purpose
+
+Quality review with refactor-specific criteria for behavior preservation, regression detection, and goal verification.
+
+## Entry Conditions
+
+- Track is `overhaul`
+- Integration phase passed
+- All tasks complete
+- Ready for review
+
+## Refactor-Specific Review Emphasis
+
+Refactors require additional scrutiny beyond standard quality review because:
+- Behavior must be preserved exactly (unless intentionally changed)
+- Regressions are easy to introduce and hard to detect
+- Brief goals must be explicitly verified
+
+## Behavior Preservation Checks
+
+### 1. Method Signature Analysis
+
+| Check | Verify | Priority |
+|-------|--------|----------|
+| Parameter types unchanged | Same types or compatible widening | HIGH |
+| Return types unchanged | Same type or compatible narrowing | HIGH |
+| Parameter order preserved | No accidental reordering | HIGH |
+| Optional parameters | Same defaults, same optionality | MEDIUM |
+| Overloads preserved | All overloads still present | HIGH |
+
+**Detection:**
+```bash
+# Compare method signatures before/after
+git diff main...HEAD -- "*.ts" | grep -E "^[+-].*function|^[+-].*class|^[+-].*interface"
+```
+
+### 2. Return Value Equivalence
+
+| Aspect | Check For |
+|--------|-----------|
+| Same values | Identical return for same inputs |
+| Same types | No implicit type changes |
+| Same null behavior | Null/undefined handling unchanged |
+| Same error conditions | Same inputs cause same errors |
+
+**Verification approach:**
+- Review test assertions for return values
+- Check edge case handling
+- Verify null/undefined paths unchanged
+
+### 3. Side Effect Preservation
+
+| Side Effect | Verify Unchanged |
+|-------------|-----------------|
+| State mutations | Same state changes occur |
+| Event emissions | Same events fired in same order |
+| External calls | Same API/DB calls made |
+| Logging | Same log outputs (unless intentional) |
+| File operations | Same I/O patterns |
+
+### 4. Error Handling Consistency
+
+| Check | Verify |
+|-------|--------|
+| Exception types | Same exceptions thrown |
+| Exception conditions | Same inputs trigger errors |
+| Error messages | Equivalent messaging |
+| Catch behavior | Same errors caught/propagated |
+
+## Intentional Changes Documentation
+
+If behavior changes are intentional, they MUST be:
+1. Documented in the brief goals
+2. Covered by updated tests
+3. Explicitly noted in review
+
+**Intentional change checklist:**
+- [ ] Change documented in brief
+- [ ] Old behavior tests updated
+- [ ] New behavior tests added
+- [ ] Breaking change noted (if public API)
+
+## Regression Risk Assessment
+
+Evaluate each area touched by refactor:
+
+| Risk Level | Criteria | Action |
+|------------|----------|--------|
+| **HIGH** | Public API changes, core logic, data handling | Extra scrutiny, explicit test verification |
+| **MEDIUM** | Internal interfaces, shared utilities | Verify dependent code paths |
+| **LOW** | Private methods, isolated modules | Standard review |
+
+### Area-by-Area Assessment
+
+For each file/component changed:
+
+```markdown
+## Regression Risk: <Component>
+
+**Files touched:** `path/to/files`
+**Risk level:** [HIGH | MEDIUM | LOW]
+
+**Changed behavior (intentional):**
+- [List any intentional changes]
+
+**Regression indicators:**
+- [ ] All existing tests pass
+- [ ] No test assertions changed unexpectedly
+- [ ] Dependent components verified
+- [ ] Edge cases still covered
+```
+
+## Performance Considerations
+
+Refactors should not degrade performance:
+
+| Check | Verify |
+|-------|--------|
+| Algorithm complexity | No O(n) to O(n^2) regressions |
+| Memory allocation | No excessive new allocations |
+| Loop iterations | No added unnecessary iterations |
+| Async patterns | No blocking where async expected |
+| Database queries | No N+1 introductions |
+
+**Red flags:**
+- New loops inside existing loops
+- Removed caching/memoization
+- Added synchronous I/O
+- Removed batching
+
+## Goal Verification
+
+Every goal from the brief must be verified as achieved.
+
+### Goal Verification Matrix
+
+| Brief Goal | Evidence | Status |
+|------------|----------|--------|
+| <goal 1> | <test/code reference> | [PASS | FAIL] |
+| <goal 2> | <test/code reference> | [PASS | FAIL] |
+| <goal 3> | <test/code reference> | [PASS | FAIL] |
+
+**Goal verification process:**
+1. Re-read brief goals
+2. Find implementation of each
+3. Verify test coverage for each
+4. Document evidence
+
+## Review Checklist
+
+### Pre-Review
+- [ ] Integration tests pass
+- [ ] All tasks marked complete
+- [ ] Brief goals accessible
+
+### Behavior Preservation
+- [ ] Method signatures analyzed
+- [ ] Return value equivalence checked
+- [ ] Side effects reviewed
+- [ ] Error handling verified
+- [ ] Intentional changes documented
+
+### Regression Assessment
+- [ ] Each component risk-assessed
+- [ ] All existing tests pass (unchanged)
+- [ ] No unexpected test changes
+- [ ] Dependent code paths verified
+
+### Performance
+- [ ] No obvious complexity regressions
+- [ ] No removed optimizations
+- [ ] Memory patterns acceptable
+- [ ] Async patterns preserved
+
+### Goal Achievement
+- [ ] All brief goals mapped to implementation
+- [ ] Each goal has test coverage
+- [ ] No goals left unaddressed
+
+### Quality Standards
+- [ ] Standard quality review criteria (see quality-review/SKILL.md)
+- [ ] SOLID principles maintained or improved
+- [ ] Code readability maintained or improved
+
+## Report Template
+
+```markdown
+## Overhaul Review Report
+
+### Summary
+- Status: [APPROVED | NEEDS_FIXES | BLOCKED]
+- Track: overhaul
+- Brief: <brief-name>
+- Reviewed: [timestamp]
+
+### Behavior Preservation
+| Area | Status | Notes |
+|------|--------|-------|
+| Method signatures | [OK | CHANGED] | |
+| Return values | [OK | CHANGED] | |
+| Side effects | [OK | CHANGED] | |
+| Error handling | [OK | CHANGED] | |
+
+### Intentional Changes
+[List any intentional behavior changes with justification]
+
+### Regression Risk Assessment
+| Component | Risk | Status |
+|-----------|------|--------|
+| <component> | [HIGH | MED | LOW] | [PASS | CONCERN] |
+
+### Goal Verification
+| Brief Goal | Achieved | Evidence |
+|------------|----------|----------|
+| <goal 1> | [YES | NO] | <reference> |
+
+### Findings
+
+#### HIGH Priority (Must Fix)
+1. [Finding title]
+   - File: `path/to/file.ts:42`
+   - Issue: [Description]
+   - Fix: [Required change]
+
+#### MEDIUM Priority (Should Fix)
+1. [Finding title]
+   - Issue: [Description]
+   - Suggestion: [Recommended change]
+
+### Verdict
+[APPROVED] Refactor goals achieved, behavior preserved
+[NEEDS_FIXES] Issues found, return to delegate
+[BLOCKED] Fundamental problem requires brief revision
+```
+
+## State Updates
+
+### On Review Complete
+
+```bash
+# Record review results
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.reviews.overhaul = {
+    "status": "approved",
+    "behaviorPreserved": true,
+    "goalsVerified": true,
+    "regressionRisk": "low",
+    "timestamp": "<timestamp>"
+  }'
+```
+
+### On Approval
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> '.phase = "synthesize"'
+```
+
+### On Needs Fixes
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.reviews.overhaul.status = "needs_fixes" | .reviews.overhaul.issues = [<issue-list>]'
+```
+
+## Transition
+
+### If APPROVED:
+1. Update state: `.phase = "synthesize"`
+2. Output: "Overhaul review passed. All goals achieved, behavior preserved. Auto-continuing to synthesis..."
+3. Auto-invoke:
+   ```typescript
+   Skill({ skill: "synthesize", args: "<feature-name>" })
+   ```
+
+### If NEEDS_FIXES:
+1. Update state with issues
+2. Output: "Overhaul review found issues. Auto-continuing to fixes..."
+3. Auto-invoke:
+   ```typescript
+   Skill({ skill: "delegate", args: "--fixes <plan-path>" })
+   ```
+
+### If BLOCKED:
+1. Update state: `.phase = "blocked"`
+2. Output: "Overhaul review blocked: [issue]. Returning to brief..."
+3. Prompt for brief revision
+
+## Exit Conditions
+
+- [ ] All behavior preservation checks pass
+- [ ] Regression risk assessed and acceptable
+- [ ] All brief goals verified achieved
+- [ ] Standard quality review criteria met
+- [ ] State updated with review results

--- a/skills/refactor/phases/overhaul-review.md
+++ b/skills/refactor/phases/overhaul-review.md
@@ -1,0 +1,231 @@
+# Overhaul Track: Review Emphasis
+
+## Purpose
+
+Define enhanced review criteria for refactoring to ensure behavior preservation and quality improvement.
+
+## Context
+
+When the `/review` skill processes a refactor workflow, it applies additional scrutiny beyond standard code review. This document defines those additional criteria.
+
+## Detecting Refactor Context
+
+The review skill checks workflow type:
+
+```bash
+type=$(~/.claude/scripts/workflow-state.sh get <state-file> '.type')
+if [ "$type" = "refactor" ]; then
+  # Apply refactor-specific review criteria
+fi
+```
+
+## Refactor Review Criteria
+
+### 1. Behavior Preservation (CRITICAL)
+
+The primary goal of refactoring is changing structure WITHOUT changing behavior.
+
+#### Public Interface Check
+
+For each public interface (exported function, class method, API endpoint):
+
+| Check | How to Verify |
+|-------|---------------|
+| Signature unchanged | Compare before/after type definitions |
+| Return value equivalent | Test with same inputs |
+| Side effects identical | Verify state changes match |
+| Error cases same | Test error conditions |
+
+```markdown
+## Interface Preservation Report
+
+| Interface | Signature | Returns | Side Effects | Errors |
+|-----------|-----------|---------|--------------|--------|
+| `UserService.create()` | ✓ Same | ✓ Same | ✓ Same | ✓ Same |
+| `AuthMiddleware.verify()` | ✓ Same | ✓ Same | ✓ Same | ⚠️ New error type |
+```
+
+If behavior intentionally changed, it should be documented in the brief.
+
+#### Test Coverage Comparison
+
+```bash
+# Compare test counts before and after
+before_tests=$(git show main:package.json | jq '.scripts.test')
+# Run tests and compare coverage
+```
+
+| Metric | Before | After | Status |
+|--------|--------|-------|--------|
+| Test count | 150 | 155 | ✓ Increased |
+| Line coverage | 80% | 82% | ✓ Improved |
+| Branch coverage | 75% | 78% | ✓ Improved |
+
+### 2. Regression Risk Assessment
+
+Evaluate risk of regressions in each changed area:
+
+#### Risk Matrix
+
+| Risk Factor | Low | Medium | High |
+|-------------|-----|--------|------|
+| Code age | New (<6mo) | Established (6mo-2yr) | Legacy (>2yr) |
+| Test coverage | >80% | 50-80% | <50% |
+| Dependencies | Internal only | Some external | Many external |
+| Complexity change | Reduced | Same | Increased |
+
+#### Risk Report
+
+```markdown
+## Regression Risk Assessment
+
+| Area | Age | Coverage | Deps | Complexity | Overall Risk |
+|------|-----|----------|------|------------|--------------|
+| UserValidator | New | 90% | Internal | Reduced | LOW |
+| AuthService | 2yr | 70% | External | Same | MEDIUM |
+```
+
+For MEDIUM or HIGH risk areas, require:
+- Additional test coverage
+- Manual testing verification
+- Careful review of edge cases
+
+### 3. Performance Verification
+
+Refactors should not degrade performance.
+
+#### Performance Checklist
+
+- [ ] No new N+1 query patterns
+- [ ] No unnecessary object allocations
+- [ ] No blocking operations added
+- [ ] Algorithmic complexity same or better
+- [ ] Memory usage not increased
+
+#### Spot Check Areas
+
+| Pattern | Red Flag |
+|---------|----------|
+| Loops | New nested loops, large iterations |
+| Database | New queries, removed indexes |
+| Memory | Large object creation in loops |
+| I/O | New file/network operations |
+
+### 4. Code Quality Improvement
+
+Refactors should IMPROVE quality. Verify:
+
+#### Improvement Metrics
+
+| Metric | Should Be |
+|--------|-----------|
+| Cyclomatic complexity | Same or lower |
+| Function length | Same or shorter |
+| Duplication | Reduced |
+| Coupling | Same or lower |
+| Cohesion | Same or higher |
+
+```markdown
+## Quality Metrics
+
+| Area | Before | After | Change |
+|------|--------|-------|--------|
+| Avg function length | 45 lines | 25 lines | ✓ Improved |
+| Max complexity | 15 | 8 | ✓ Improved |
+| Duplicate blocks | 12 | 4 | ✓ Improved |
+```
+
+### 5. Goal Achievement Verification
+
+Cross-reference review findings with brief goals:
+
+```markdown
+## Goal Verification
+
+| Goal (from brief) | Achieved | Evidence |
+|-------------------|----------|----------|
+| Extract validation to separate class | ✓ | UserValidator created |
+| Reduce UserService to <200 lines | ✓ | Now 150 lines |
+| Add unit tests for validation | ✓ | 15 new tests |
+```
+
+Any goal NOT achieved should be flagged for resolution.
+
+## Review Outcome
+
+### Pass Criteria
+
+All must be true:
+- [ ] Behavior preserved (or changes documented)
+- [ ] No HIGH regression risk areas unaddressed
+- [ ] No performance degradation
+- [ ] Quality metrics improved or maintained
+- [ ] All brief goals achieved
+
+### Fail Reasons
+
+| Reason | Required Action |
+|--------|-----------------|
+| Behavior change | Document intentional change or fix |
+| High regression risk | Add tests or manual verification |
+| Performance regression | Optimize or justify |
+| Quality degradation | Fix or provide justification |
+| Goal not achieved | Complete or update brief |
+
+## Review Report Template
+
+```markdown
+# Refactor Review Report
+
+**Workflow:** <feature-id>
+**Reviewer:** <agent/human>
+**Date:** <ISO8601>
+
+## Summary
+<Overall assessment: PASS / FAIL>
+
+## Behavior Preservation
+<Findings>
+
+## Regression Risk
+<Risk assessment>
+
+## Performance
+<Performance notes>
+
+## Quality Metrics
+<Before/after comparison>
+
+## Goal Achievement
+<Goal verification>
+
+## Required Actions
+<If any>
+
+## Recommendation
+<Approve / Request Changes / Reject>
+```
+
+## State Update
+
+### Review Pass
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.reviews.<id> = {
+    "status": "passed",
+    "behaviorPreserved": true,
+    "regressionRisk": "low",
+    "goalsAchieved": true,
+    "completedAt": "<ISO8601>"
+  } | .phase = "update-docs"'
+```
+
+### Review Fail
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.reviews.<id> = {
+    "status": "failed",
+    "findings": ["<finding1>", "<finding2>"],
+    "requiredActions": ["<action1>"]
+  }'
+```

--- a/skills/refactor/phases/overhaul-review.md
+++ b/skills/refactor/phases/overhaul-review.md
@@ -138,9 +138,9 @@ Every goal from the brief must be verified as achieved.
 
 | Brief Goal | Evidence | Status |
 |------------|----------|--------|
-| <goal 1> | <test/code reference> | [PASS | FAIL] |
-| <goal 2> | <test/code reference> | [PASS | FAIL] |
-| <goal 3> | <test/code reference> | [PASS | FAIL] |
+| <goal 1> | <test/code reference> | [PASS/FAIL] |
+| <goal 2> | <test/code reference> | [PASS/FAIL] |
+| <goal 3> | <test/code reference> | [PASS/FAIL] |
 
 **Goal verification process:**
 1. Re-read brief goals

--- a/skills/refactor/phases/polish-implement.md
+++ b/skills/refactor/phases/polish-implement.md
@@ -1,0 +1,320 @@
+# Polish Track: Implement Phase
+
+## Purpose
+
+Direct implementation for small, well-scoped refactors. This phase allows the orchestrator to write code directly without delegation to subagents, reducing ceremony while maintaining quality.
+
+## Orchestrator Exception
+
+**This is the explicit exception to orchestrator constraints.**
+
+The orchestrator constraints in `rules/orchestrator-constraints.md` state the orchestrator MUST NOT write implementation code. The polish track implement phase is the one case where this rule is intentionally violated.
+
+### Why This Exception Exists
+
+| Standard Workflow | Polish Track |
+|-------------------|--------------|
+| Delegation overhead justified | Overhead exceeds value for small changes |
+| Context window preserved for coordination | Small changes fit within session |
+| Parallel execution via worktrees | Sequential execution sufficient |
+| Subagent isolation for testing | Direct testing in main branch |
+
+### When the Exception Applies
+
+The orchestrator may write code directly ONLY when ALL conditions are met:
+
+1. **Track is polish** - State file shows `.track = "polish"`
+2. **Brief is captured** - Phase has advanced to "implement"
+3. **Scope is limited** - 5 or fewer files affected
+4. **Single concern** - One refactoring goal per session
+5. **Tests exist** - Affected code has test coverage
+
+If any condition is violated, switch to overhaul track.
+
+## Entry Conditions
+
+Before starting implementation, verify:
+
+```bash
+# Read state to confirm prerequisites
+~/.claude/scripts/workflow-state.sh get <state-file> '.track'
+# Must return: "polish"
+
+~/.claude/scripts/workflow-state.sh get <state-file> '.phase'
+# Must return: "implement"
+
+~/.claude/scripts/workflow-state.sh get <state-file> '.brief.goals'
+# Must return: populated array
+```
+
+### State Requirements
+
+| Field | Requirement |
+|-------|-------------|
+| `.track` | "polish" |
+| `.phase` | "implement" |
+| `.brief.problem` | Non-empty string |
+| `.brief.goals` | 1-3 items |
+| `.brief.affectedAreas` | 1-5 files |
+| `.brief.successCriteria` | 2-3 items |
+| `.explore.scopeAssessment.testCoverage` | "good" or "gaps" (not "none") |
+
+## Implementation Process
+
+### Step 1: Pre-Implementation Verification
+
+Run the full test suite before making any changes:
+
+```bash
+npm run test:run
+```
+
+**Gate:** Tests must pass. If tests fail before implementation, stop and investigate. Do not implement on top of a failing test suite.
+
+Capture baseline in state:
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.implement = {
+    "startedAt": "<ISO8601>",
+    "baselineTestsPass": true,
+    "changesLog": []
+  }'
+```
+
+### Step 2: Make Changes Incrementally
+
+For each logical change:
+
+1. **Understand the change** - Read affected code
+2. **Update tests first** (if behavior changes) - TDD: red then green
+3. **Make the change** - Minimal modification
+4. **Run tests** - Verify no regression
+5. **Commit** - Atomic commit for the change
+
+```bash
+# After each change
+npm run test:run
+
+# Log the change
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.implement.changesLog += [{"file": "<path>", "description": "<what changed>"}]'
+
+# Commit
+git add <files>
+git commit -m "refactor: <description>
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+### Step 3: Test After Each Change
+
+**Critical:** Run tests after EVERY change, not just at the end.
+
+| Test Failure | Action |
+|--------------|--------|
+| Test fails after change | Revert and retry with smaller change |
+| Unrelated test fails | Stop, investigate, may need track switch |
+| Lint/type error | Fix before proceeding |
+
+### Step 4: Verify Goals
+
+After all changes, verify each goal from brief:
+
+```bash
+# Read goals
+~/.claude/scripts/workflow-state.sh get <state-file> '.brief.goals'
+```
+
+For each goal, confirm it's addressed. If a goal cannot be addressed within polish scope, trigger track switch.
+
+## Scope Monitoring
+
+### Red Flags During Implementation
+
+Watch for these indicators that polish is insufficient:
+
+| Signal | Description | Threshold |
+|--------|-------------|-----------|
+| File count growing | Started with 3 files, now touching 6+ | >5 files |
+| Test gaps discovered | Affected code lacks tests | Need >2 new test files |
+| Cascading changes | Change in one file requires changes in many | >3 unexpected files |
+| Architecture concerns | Structure questions beyond scope | Needs design document |
+| Duration | Implementation taking too long | >1 hour of changes |
+
+### Monitoring Commands
+
+```bash
+# Check files changed
+git diff --name-only HEAD~N  # where N = commits since implement started
+
+# Count affected files
+git diff --stat
+```
+
+### When to Stop
+
+**Stop implementation immediately if:**
+
+- More than 5 files need modification
+- You discover test coverage is "none" (not "gaps")
+- Multiple unrelated concerns emerge
+- You're writing more than 100 lines of new code
+- Changes require updates to public APIs
+
+## Track Switching
+
+### Detection
+
+If scope expands beyond polish limits during implementation:
+
+```bash
+echo "Scope has expanded beyond polish limits."
+echo "Files affected: $(git diff --name-only | wc -l)"
+echo "Switching to overhaul track recommended."
+```
+
+### Switch Protocol
+
+1. **Commit current work** - Don't lose progress
+2. **Update state**:
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.track = "overhaul" |
+   .implement.switchReason = "<reason for switch>" |
+   .implement.switchedAt = "<ISO8601>" |
+   .phase = "plan"'
+```
+
+3. **Create worktree** (if not already in one)
+4. **Invoke `/plan`** - Extract remaining work into tasks
+5. **Continue via overhaul track**
+
+### Output to User
+
+```
+Scope has expanded beyond polish limits.
+Reason: [specific reason]
+
+Switching to overhaul track. This means:
+- Work will continue in an isolated worktree
+- Remaining changes will be delegated to subagents
+- Full review process will be applied
+
+Current progress has been committed. Continue? (Y/n)
+```
+
+## State Updates
+
+### Implementation Start
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.implement = {
+    "startedAt": "<ISO8601>",
+    "baselineTestsPass": true,
+    "changesLog": []
+  }'
+```
+
+### After Each Change
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.implement.changesLog += [{
+    "file": "<path>",
+    "description": "<what changed>",
+    "commitSha": "<short-sha>"
+  }]'
+```
+
+### Implementation Complete
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.implement.completedAt = "<ISO8601>" |
+   .implement.totalFiles = <count> |
+   .implement.totalCommits = <count> |
+   .phase = "validate"'
+```
+
+### Track Switch (if needed)
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.track = "overhaul" |
+   .implement.switchReason = "<reason>" |
+   .implement.switchedAt = "<ISO8601>" |
+   .phase = "plan"'
+```
+
+## Exit Conditions
+
+Implementation phase exits when:
+
+### Success Exit -> Validate Phase
+
+- All changes from brief are implemented
+- All tests pass
+- No scope expansion occurred
+- Less than or equal to 5 files changed
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.phase = "validate"'
+```
+
+Next action: `AUTO:refactor-validate`
+
+### Track Switch Exit -> Plan Phase
+
+- Scope expanded beyond polish limits
+- Track switched to overhaul
+- Current work committed
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.track = "overhaul" | .phase = "plan"'
+```
+
+Next action: `AUTO:plan:<brief>`
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Make all changes then test | Test after each change |
+| Skip commits for "small" changes | Commit each logical change |
+| Ignore expanding scope | Stop and switch tracks |
+| Fix unrelated issues found | Note for separate refactor |
+| Skip baseline test run | Always verify green baseline |
+| Force polish when overhaul needed | Accept track switch gracefully |
+
+## Example Implementation Session
+
+```
+[Phase: implement]
+
+1. Running baseline tests...
+   Tests: 42 passed
+
+2. Change 1: Extract validation to UserValidator
+   - Created: src/validators/user-validator.ts
+   - Modified: src/services/user-service.ts
+   - Tests: 42 passed
+   - Committed: abc123
+
+3. Change 2: Update UserService imports
+   - Modified: src/services/user-service.ts
+   - Tests: 42 passed
+   - Committed: def456
+
+4. Verifying goals:
+   [x] Extract validation logic into separate UserValidator class
+   [x] Reduce UserService line count
+
+5. Files changed: 2 (within limit)
+
+6. Transitioning to validate phase...
+```

--- a/skills/refactor/phases/polish-validate.md
+++ b/skills/refactor/phases/polish-validate.md
@@ -1,0 +1,208 @@
+# Polish Track Validate Phase
+
+## Purpose
+
+Verify the refactor succeeded without regressions. This phase confirms all goals from the brief are achieved, tests pass, and no unintended changes were introduced.
+
+## Entry Conditions
+
+- Polish implement phase complete
+- Phase is `validate`
+- Implementation commits are ready
+
+## Validation Checklist
+
+### 1. Test Suite Verification
+
+Run the full test suite to ensure no regressions:
+
+```bash
+npm run test:run
+```
+
+**Requirements:**
+- [ ] All existing tests pass
+- [ ] No new test failures introduced
+- [ ] Test count has not decreased (no deleted tests)
+
+If tests fail:
+1. Identify which tests fail
+2. Determine if failure is due to refactor or pre-existing issue
+3. Fix refactor-related failures before proceeding
+4. Return to implement phase if significant fixes needed
+
+### 2. Goal Achievement
+
+Review each goal from the brief and verify completion:
+
+```bash
+# Read goals from state
+~/.claude/scripts/workflow-state.sh get <state-file> '.brief.goals[]'
+```
+
+**For each goal:**
+- [ ] Goal is fully addressed
+- [ ] Evidence of completion is clear (code change, metric improvement, etc.)
+- [ ] Goal was not partially implemented
+
+Document verified goals in state:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.validation.goalsVerified += ["<goal text>"]'
+```
+
+### 3. Regression Check
+
+Verify no unintended changes outside refactor scope:
+
+**Review affected areas:**
+- [ ] Changes are limited to `affectedAreas` from brief
+- [ ] No unexpected files modified
+- [ ] No unrelated behavior changes
+
+**Check git diff:**
+```bash
+git diff --stat HEAD~<n>  # Review files changed
+git diff HEAD~<n> -- <unexpected-file>  # Investigate unexpected changes
+```
+
+If unintended changes found:
+1. Determine if they should be reverted
+2. If intentional, update brief's `affectedAreas`
+3. If accidental, revert and re-run validation
+
+### 4. Lint and Type Check
+
+Run linting and type checking to ensure code quality:
+
+```bash
+npm run lint
+npm run typecheck  # For TypeScript projects
+```
+
+**Requirements:**
+- [ ] No new lint errors introduced
+- [ ] No new type errors introduced
+- [ ] Any disabled rules are justified
+
+If errors found:
+1. Fix lint/type errors
+2. Commit fixes separately
+3. Re-run validation
+
+### 5. Code Quality Spot Check
+
+Manual review of key changes:
+
+**Structure verification:**
+- [ ] New code follows project conventions
+- [ ] Naming is consistent and clear
+- [ ] No obvious code smells introduced
+
+**Brief alignment:**
+- [ ] Implementation matches stated approach
+- [ ] Out-of-scope items were not touched
+- [ ] Success criteria are met
+
+## State Updates
+
+### Record Validation Start
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.validation = {
+    "startedAt": "<ISO8601>",
+    "testsPass": null,
+    "goalsVerified": [],
+    "docsUpdated": false
+  }'
+```
+
+### Record Validation Results
+
+On successful validation:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.validation.testsPass = true |
+   .validation.completedAt = "<ISO8601>" |
+   .phase = "update-docs"'
+```
+
+On failed validation:
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.validation.testsPass = false |
+   .validation.failureReason = "<reason>" |
+   .phase = "implement"'
+```
+
+## Pass/Fail Handling
+
+### Validation Passed
+
+All criteria met:
+1. Update state with successful validation results
+2. Transition to `update-docs` phase
+3. Auto-chain continues workflow
+
+### Validation Failed
+
+If any criteria not met:
+
+| Failure Type | Action |
+|--------------|--------|
+| Tests fail | Return to implement phase, fix issues |
+| Goals not achieved | Return to implement phase, complete goals |
+| Unintended changes | Revert changes, return to implement |
+| Lint/type errors | Fix errors, re-run validation |
+| Quality issues | Return to implement phase, address issues |
+
+**Important:** Do not skip to update-docs with validation failures. All issues must be resolved first.
+
+## Exit Conditions
+
+Transition to `update-docs` phase when ALL conditions are met:
+
+- [ ] All tests pass
+- [ ] Each goal from brief is verified as complete
+- [ ] No unintended changes outside scope
+- [ ] No new lint or type errors
+- [ ] Code quality spot check passed
+- [ ] State updated with validation results
+
+## Auto-Chain Behavior
+
+On successful validation:
+- Next action: `AUTO:refactor-update-docs`
+- Automatically proceeds to update documentation
+
+On failed validation:
+- Next action: `AUTO:refactor-implement` (return to fix issues)
+- Does not proceed until validation passes
+
+## Common Issues
+
+| Issue | Resolution |
+|-------|------------|
+| Flaky tests | Run tests multiple times, investigate intermittent failures |
+| Pre-existing failures | Document in state, don't block on unrelated issues |
+| Scope creep discovered | Either revert extra changes or update brief (prefer revert) |
+| Missing test coverage | Add tests for changed behavior before proceeding |
+
+## Validation Output
+
+Summarize validation results for the user:
+
+```
+Validation Results:
+- Tests: ✓ All 47 tests pass
+- Goals: ✓ 3/3 verified
+  - ✓ Extract validation logic into separate UserValidator class
+  - ✓ Reduce UserService to <200 lines
+  - ✓ Improve test isolation for validation tests
+- Regressions: ✓ None detected
+- Lint/Type: ✓ No new errors
+- Quality: ✓ Spot check passed
+
+Proceeding to update-docs phase...
+```

--- a/skills/refactor/phases/update-docs.md
+++ b/skills/refactor/phases/update-docs.md
@@ -1,0 +1,223 @@
+# Update Docs Phase
+
+## Purpose
+
+Ensure all documentation remains accurate after refactoring. This phase updates affected documentation to reflect the new code structure, APIs, and architecture.
+
+## MANDATORY REQUIREMENT
+
+**Documentation updates are NOT optional for refactors.**
+
+Every refactor changes existing code structure. If documentation exists for that code, it MUST be updated. Skipping this phase results in documentation drift, which compounds over time and misleads future developers.
+
+The `docsToUpdate` field in the brief identifies documents requiring updates. If this field is empty, the phase still runs to VERIFY no documentation needs updating.
+
+## Entry Conditions
+
+### Polish Track
+
+- `validate` phase complete
+- All tests passing
+- Goals verified
+
+### Overhaul Track
+
+- `review` phase complete
+- All quality checks passed
+- Code merged to feature branch
+
+## Process
+
+### Step 1: Review Documentation List
+
+Read the brief's `docsToUpdate` field:
+
+```bash
+~/.claude/scripts/workflow-state.sh get <state-file> '.brief.docsToUpdate'
+```
+
+If the list is empty, proceed to Step 4 (Verification).
+
+### Step 2: Read Each Document
+
+For each document in the list:
+
+1. Read the current content
+2. Identify sections affected by the refactor
+3. Note what needs to change
+
+```typescript
+Read({ file_path: "/path/to/affected-doc.md" })
+```
+
+### Step 3: Update Affected Sections
+
+Update each document to reflect the new code structure:
+
+| Change Type | Documentation Update |
+|-------------|---------------------|
+| Renamed file/class | Update all references |
+| Moved location | Update paths and imports |
+| Changed API | Update signatures and examples |
+| New architecture | Add/update diagrams |
+| Removed code | Remove obsolete references |
+
+**Update Guidelines:**
+
+- Keep updates minimal and focused
+- Match the existing document style
+- Update code examples if affected
+- Verify links still work
+
+### Step 4: Verification
+
+Verify documentation accuracy against the new code:
+
+| Check | How to Verify |
+|-------|---------------|
+| File paths | Confirm paths in docs exist |
+| Code examples | Examples compile/run correctly |
+| API signatures | Match actual implementation |
+| Diagrams | Reflect current architecture |
+| Links | All internal links resolve |
+
+If `docsToUpdate` was empty, verify:
+- Search for references to changed code
+- Confirm no documentation references outdated patterns
+- If documentation gaps found, update immediately
+
+## Documentation Types
+
+### Architecture Documentation
+
+Update when:
+- Module structure changes
+- Dependencies change
+- Component relationships change
+
+Typical locations:
+- `docs/architecture/*.md`
+- `docs/adrs/*.md`
+- `README.md` architecture sections
+
+### API Documentation
+
+Update when:
+- Function signatures change
+- Types/interfaces change
+- Endpoints change
+
+Typical locations:
+- Inline JSDoc/TSDoc comments
+- `docs/api/*.md`
+- OpenAPI/Swagger specs
+
+### README Files
+
+Update when:
+- Setup process changes
+- Usage patterns change
+- Dependencies change
+
+Typical locations:
+- Project root `README.md`
+- Module-level `README.md` files
+
+### Inline Comments
+
+Update when:
+- Complex logic moves
+- Algorithms change
+- Important context relocates
+
+**Note:** Avoid over-commenting. Only update comments that explain WHY, not WHAT.
+
+## State Updates
+
+Record updated documents:
+
+```bash
+# Add each updated document
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.artifacts.updatedDocs += ["docs/architecture/modules.md"]'
+
+# Mark docs updated
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.validation.docsUpdated = true'
+
+# Update phase
+~/.claude/scripts/workflow-state.sh set <state-file> '.phase = "completed"'  # Polish
+~/.claude/scripts/workflow-state.sh set <state-file> '.phase = "synthesize"' # Overhaul
+```
+
+## Exit Conditions
+
+### Polish Track
+
+After completing documentation updates:
+
+1. All listed documents updated
+2. Verification complete
+3. State updated with `docsUpdated = true`
+4. **CHECKPOINT: Human approval required**
+
+Present summary to user:
+```text
+Documentation Update Complete
+-----------------------------
+Updated docs:
+- docs/architecture/modules.md (updated paths)
+- README.md (updated examples)
+
+Verification: All links and examples verified
+
+Ready to complete refactor? [Approve / Request changes]
+```
+
+### Overhaul Track
+
+After completing documentation updates:
+
+1. All listed documents updated
+2. Verification complete
+3. State updated with `docsUpdated = true`
+4. **Auto-chain to synthesize phase**
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> '.phase = "synthesize"'
+```
+
+## Common Issues
+
+### No Documentation Exists
+
+If refactored code has no documentation:
+- This is acceptable for refactors
+- Creating new documentation is a separate task
+- Note the gap in the state for future reference
+
+### Documentation Scope Creep
+
+If updating one document reveals many need updates:
+- Update only what's necessary for this refactor
+- Note other gaps for future work
+- Stay focused on the brief's scope
+
+### Conflicting Documentation
+
+If documentation conflicts with new code:
+- Trust the code (you just validated it)
+- Update documentation to match
+- Add clarifying notes if needed
+
+## Checklist
+
+Before exiting this phase:
+
+- [ ] Reviewed all documents in `docsToUpdate`
+- [ ] Updated affected sections in each document
+- [ ] Verified file paths and links
+- [ ] Verified code examples work
+- [ ] Updated state with `updatedDocs` list
+- [ ] Set `docsUpdated = true`
+- [ ] Transitioned to next phase (completed or synthesize)

--- a/skills/refactor/phases/update-docs.md
+++ b/skills/refactor/phases/update-docs.md
@@ -1,0 +1,206 @@
+# Update-Docs Phase
+
+## Purpose
+
+Ensure all affected documentation is updated after refactoring. This phase is REQUIRED for both polish and overhaul tracks.
+
+## Entry Conditions
+
+- Polish track: Validation phase passed
+- Overhaul track: Review phase passed
+- `docsToUpdate` list available from brief
+
+## Core Principle
+
+**Every refactor MUST update affected documentation.**
+
+Documentation debt is technical debt. Code without accurate documentation creates maintenance burden and knowledge gaps.
+
+## Process
+
+### Step 1: Review Documentation List
+
+Retrieve docs identified during brief phase:
+
+```bash
+docs=$(~/.claude/scripts/workflow-state.sh get <state-file> '.brief.docsToUpdate')
+```
+
+If list is empty, still verify no docs need updating (see Step 5).
+
+### Step 2: Assess Each Document
+
+For each document in the list:
+
+| Check | Question |
+|-------|----------|
+| Still accurate? | Does the doc still describe reality? |
+| References valid? | Do code references point to correct locations? |
+| Examples work? | Do code examples still function? |
+| Diagrams current? | Do architecture diagrams reflect changes? |
+
+### Step 3: Make Updates
+
+Update each document to reflect the refactoring:
+
+#### Architecture Documentation
+
+```markdown
+## Before
+UserService handles authentication, validation, and persistence.
+
+## After
+UserService handles persistence.
+UserValidator handles input validation.
+AuthService handles authentication.
+```
+
+#### API Documentation
+
+```markdown
+## Before
+`UserService.validate(user)` - Validates user input
+
+## After
+`UserValidator.validateUser(user)` - Validates user input
+(Note: UserService.validate is deprecated, use UserValidator)
+```
+
+#### README Updates
+
+```markdown
+## Project Structure (Updated)
+
+src/
+  services/
+    UserService.ts      # Persistence only
+    AuthService.ts      # Authentication
+  validators/
+    UserValidator.ts    # Input validation (NEW)
+```
+
+#### Inline Comments
+
+Review and update inline comments in refactored code:
+- Remove comments that reference old code
+- Update comments that explain changed logic
+- Add comments for new complex logic
+
+### Step 4: Verify Updates
+
+After updating, verify each document:
+
+```bash
+# Check for broken links
+# Verify code examples compile/run
+# Review diagrams for accuracy
+```
+
+| Document | Updated | Verified |
+|----------|---------|----------|
+| architecture.md | ✓ | ✓ |
+| api.md | ✓ | ✓ |
+| README.md | ✓ | ✓ |
+
+### Step 5: Verify "No Docs Needed" (If Applicable)
+
+If `docsToUpdate` was empty, verify this is correct:
+
+```markdown
+## Documentation Verification
+
+Checked the following and confirmed no updates needed:
+
+- [ ] Architecture docs - No structural changes
+- [ ] API docs - No interface changes
+- [ ] README - No setup/usage changes
+- [ ] Inline comments - Reviewed and current
+
+Rationale: <why no docs needed>
+```
+
+Document this verification in state.
+
+## Documentation Types Checklist
+
+### Architecture Documentation
+- [ ] Component diagrams accurate
+- [ ] Module descriptions current
+- [ ] Dependency relationships correct
+- [ ] Technology decisions documented
+
+### API Documentation
+- [ ] Function signatures match code
+- [ ] Parameter descriptions accurate
+- [ ] Return values documented
+- [ ] Error cases listed
+- [ ] Examples work
+
+### README Files
+- [ ] Installation steps current
+- [ ] Usage examples valid
+- [ ] Configuration documented
+- [ ] Prerequisites listed
+
+### Code Comments
+- [ ] Comments explain "why" not "what"
+- [ ] No stale comments
+- [ ] Complex logic documented
+- [ ] TODO items addressed
+
+## State Update
+
+### Docs Updated Successfully
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.validation.docsUpdated = true |
+   .artifacts.updatedDocs = ["<doc1>", "<doc2>"] |
+   .phase = "<complete|synthesize>"'
+```
+
+Phase transitions:
+- Polish track → `complete` (ready for human checkpoint)
+- Overhaul track → `synthesize` (create PR)
+
+### No Docs Needed (Verified)
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.validation.docsUpdated = true |
+   .validation.docsVerification = "No updates needed: <reason>" |
+   .artifacts.updatedDocs = [] |
+   .phase = "<complete|synthesize>"'
+```
+
+## Output
+
+```markdown
+## Documentation Update Summary
+
+**Docs Updated:** <count>
+
+| Document | Changes Made |
+|----------|--------------|
+| architecture.md | Updated component diagram, module descriptions |
+| README.md | Updated project structure section |
+
+**Verification:** All updates verified accurate
+
+**Next Phase:** <complete|synthesize>
+```
+
+## Common Mistakes
+
+| Mistake | Correction |
+|---------|------------|
+| "No docs need updating" | Always verify; refactors usually affect docs |
+| Update code examples only | Also update prose descriptions |
+| Skip architecture docs | These are often most important |
+| Leave TODO comments | Address or remove them |
+| Assume context obvious | Document the "why" for future readers |
+
+## Exit Conditions
+
+- All identified docs updated
+- Updates verified accurate
+- State records completion
+- Ready for final phase (complete or synthesize)

--- a/skills/refactor/references/brief-template.md
+++ b/skills/refactor/references/brief-template.md
@@ -1,0 +1,78 @@
+# Refactor Brief Template
+
+## Purpose
+
+The brief captures refactor intent without the overhead of a full design document. Store in workflow state, not as a separate file.
+
+## Brief Fields
+
+### Problem (Required)
+What's wrong with the current code? Be specific.
+
+**Polish example:** "The UserService class has grown to 500 lines with mixed responsibilities"
+
+**Overhaul example:** "The authentication module uses callbacks throughout, making error handling inconsistent and testing difficult"
+
+### Goals (Required)
+List specific, measurable goals. Each goal should be verifiable.
+
+**Good goals:**
+- Extract validation logic into separate UserValidator class
+- Convert callback-based auth to async/await pattern
+- Reduce cyclomatic complexity of processOrder from 15 to <5
+
+**Bad goals:**
+- Make the code better
+- Clean things up
+- Improve performance (without metrics)
+
+### Approach (Required)
+High-level description of how you'll achieve the goals.
+
+**Polish approach:** "Extract validation methods to new class, update callers, run tests"
+
+**Overhaul approach:** "Phase 1: Create async wrapper around existing callbacks. Phase 2: Convert internal methods to async. Phase 3: Update public API. Phase 4: Remove callback support."
+
+### Affected Areas (Required)
+List specific paths/modules that will change.
+
+### Out of Scope (Required)
+Explicitly state what you're NOT changing. Prevents scope creep.
+
+### Success Criteria (Required)
+How will you know the refactor is complete?
+
+- All existing tests pass
+- [Specific goal] is achieved
+- [Metric] is improved by [amount]
+- Documentation reflects new structure
+
+### Docs to Update (Required)
+List documentation files that need updating after refactor.
+
+## State Update
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.brief = {
+    "problem": "<problem statement>",
+    "goals": ["<goal 1>", "<goal 2>"],
+    "approach": "<approach description>",
+    "affectedAreas": ["<area 1>", "<area 2>"],
+    "outOfScope": ["<exclusion 1>", "<exclusion 2>"],
+    "successCriteria": ["<criterion 1>", "<criterion 2>"],
+    "docsToUpdate": ["<doc 1>", "<doc 2>"]
+  } | .phase = "implement | plan"'
+```
+
+## Polish vs Overhaul Brief Depth
+
+| Field | Polish | Overhaul |
+|-------|--------|----------|
+| Problem | 1-2 sentences | Paragraph with context |
+| Goals | 1-3 items | 3-5 items |
+| Approach | 1 sentence | Paragraph with phases |
+| Affected Areas | File paths | Module/package paths |
+| Out of Scope | 1-2 items | 3+ items |
+| Success Criteria | 2-3 items | 4+ items |
+| Docs to Update | 0-2 files | 2+ files |

--- a/skills/refactor/references/doc-update-checklist.md
+++ b/skills/refactor/references/doc-update-checklist.md
@@ -1,0 +1,96 @@
+# Documentation Update Checklist
+
+## Purpose
+
+Every refactor MUST update affected documentation. This is not optional. Code without accurate documentation creates technical debt.
+
+## Before Starting
+
+1. Review `docsToUpdate` list from brief
+2. Read each document to understand current state
+3. Note specific sections that need changes
+
+## Documentation Types
+
+### Architecture Documentation
+
+**When to update:** Structure, module organization, or dependencies changed
+
+**What to check:**
+- [ ] Component diagrams accurate
+- [ ] Module descriptions current
+- [ ] Dependency arrows correct
+- [ ] Technology choices documented
+
+### API Documentation
+
+**When to update:** Public interfaces, method signatures, or behavior changed
+
+**What to check:**
+- [ ] Function/method signatures match code
+- [ ] Parameter descriptions accurate
+- [ ] Return value documentation correct
+- [ ] Examples still work
+- [ ] Error cases documented
+
+### README Files
+
+**When to update:** Setup, usage, or configuration changed
+
+**What to check:**
+- [ ] Installation steps current
+- [ ] Configuration examples valid
+- [ ] Usage examples work
+- [ ] Prerequisites listed
+
+### Inline Comments
+
+**When to update:** Complex logic moved or rewritten
+
+**What to check:**
+- [ ] Comments explain "why" not "what"
+- [ ] No stale comments referring to old code
+- [ ] Complex algorithms documented
+- [ ] TODO items addressed or updated
+
+## Verification
+
+After updating documentation:
+
+1. [ ] Read each updated doc fresh
+2. [ ] Verify code references are accurate
+3. [ ] Test any code examples
+4. [ ] Check links aren't broken
+
+## State Update
+
+After documentation is updated:
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.validation.docsUpdated = true | .artifacts.updatedDocs = ["<doc1>", "<doc2>"]'
+```
+
+## If No Docs Need Updating
+
+If `docsToUpdate` is empty, verify this is correct:
+
+1. Review affected areas
+2. Confirm no public interfaces changed
+3. Confirm no architectural changes made
+4. Document verification in state:
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.validation.docsUpdated = true | .artifacts.updatedDocs = []'
+```
+
+## Common Mistakes
+
+| Mistake | Correction |
+|---------|------------|
+| "Docs don't need updating" | Always verify; code changes usually need doc updates |
+| Update code examples only | Also update prose descriptions |
+| Skip architecture docs | These are often most important |
+| Leave TODO comments | Address or remove them |
+| Assume readers know context | Document the "why" |

--- a/skills/refactor/references/explore-checklist.md
+++ b/skills/refactor/references/explore-checklist.md
@@ -49,5 +49,5 @@ After exploration, update state with scope assessment:
     "modulesAffected": ["<list>"],
     "testCoverage": "good | gaps | none",
     "recommendedTrack": "polish | overhaul"
-  } | .track = "<selected-track>" | .explore.completedAt = "<ISO8601>"'
+  } | .track = "<selected-track>" | .explore.completedAt = "<ISO8601>" | .phase = "brief"'
 ```

--- a/skills/refactor/references/explore-checklist.md
+++ b/skills/refactor/references/explore-checklist.md
@@ -1,0 +1,53 @@
+# Refactor Exploration Checklist
+
+## Scope Assessment
+
+### Files Analysis
+- [ ] List all files that will be modified
+- [ ] Count total files affected
+- [ ] Identify file types (source, test, config, docs)
+
+### Module Analysis
+- [ ] List modules/packages affected
+- [ ] Identify cross-module dependencies
+- [ ] Check for circular dependencies that might complicate refactor
+
+### Test Coverage
+- [ ] Check test coverage of affected code
+- [ ] Identify test gaps
+- [ ] Note tests that will need updating
+
+### Documentation Impact
+- [ ] List documentation that references affected code
+- [ ] Identify architecture docs that may need updates
+- [ ] Check for API documentation impacts
+
+## Track Selection
+
+### Polish Track Indicators (all must be true)
+- [ ] ≤5 files affected
+- [ ] Single concern being addressed
+- [ ] No cross-module changes
+- [ ] Good test coverage exists
+- [ ] Documentation changes are minor
+
+### Overhaul Track Indicators (any one triggers)
+- [ ] >5 files affected
+- [ ] Multiple concerns being addressed
+- [ ] Cross-module changes required
+- [ ] Test coverage gaps exist
+- [ ] Architectural documentation needs updating
+
+## Output
+
+After exploration, update state with scope assessment:
+
+```bash
+~/.claude/scripts/workflow-state.sh set <state-file> \
+  '.explore.scopeAssessment = {
+    "filesAffected": ["<list>"],
+    "modulesAffected": ["<list>"],
+    "testCoverage": "good | gaps | none",
+    "recommendedTrack": "polish | overhaul"
+  } | .track = "<selected-track>" | .explore.completedAt = "<ISO8601>"'
+```


### PR DESCRIPTION
## Summary

Adds the `/refactor` workflow skill for code improvements, cleanup, and restructuring. Implements a two-track model: **polish** (≤5 files, direct implementation) and **overhaul** (>5 files, full planning/delegation workflow). Both tracks enforce mandatory documentation updates.

## Changes

- **Refactor Skill** — Main SKILL.md with workflow phases, state schema, and auto-chain behavior
- **Phase Documentation** — 9 phase files covering explore, brief, implement, validate, plan, delegate, review, update-docs, and auto-chain
- **Reference Files** — Checklists for exploration, brief templates, and doc update verification
- **State Management** — Extended workflow-state.sh with refactor type support and next-action handling
- **Rules Updates** — Orchestrator exception for polish track, auto-resume handling for refactor phases

## Test Plan

Documentation-only changes verified through spec and quality review. State transitions validated against design requirements.

---

**Design:** [docs/designs/2026-02-02-refactor-workflow.md](docs/designs/2026-02-02-refactor-workflow.md)