### PR TITLE
feat: add transactional writes with snapshot rollback to workflow-state MCP

### DIFF
--- a/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/index.test.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/index.test.ts
@@ -181,7 +181,7 @@ describe('MCP Server Entry Point', () => {
       await handler({ featureId: 'my-feat' });
 
       expect(handleReconcile).toHaveBeenCalledWith(
-        { featureId: 'my-feat' },
+        { featureId: 'my-feat', repair: false },
         '/tmp/test-state-dir',
       );
     });

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/integration.test.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/integration.test.ts
@@ -10,6 +10,7 @@ import {
   handleCheckpoint,
   handleSummary,
   handleNextAction,
+  handleReconcile,
 } from '../tools.js';
 import { executeTransition, getHSMDefinition } from '../state-machine.js';
 import { appendEvent } from '../events.js';
@@ -739,6 +740,63 @@ describe('Integration', () => {
       expect('mergedBranches' in synthesis).toBe(true);
       expect('prUrl' in synthesis).toBe(true);
       expect('prFeedback' in synthesis).toBe(true);
+    });
+  });
+
+  // ─── 9. Integration_ReconcileRepairsCorruptState_GetSucceeds ────────────
+
+  describe('Integration_ReconcileRepairsCorruptState_GetSucceeds', () => {
+    it('should repair a corrupt state file so handleGet succeeds afterwards', async () => {
+      // Step 1: Initialize a valid workflow
+      const initResult = await handleInit(
+        { featureId: 'reconcile-e2e', workflowType: 'feature' },
+        stateDir,
+      );
+      expect(initResult.success).toBe(true);
+
+      // Step 2: Read raw state and corrupt it
+      const raw = await readRawState('reconcile-e2e');
+
+      // Remove _events (set to non-array), set invalid task status
+      raw._events = 'corrupted';
+      raw._eventSequence = -5;
+      raw.tasks = [
+        { id: 'task-1', title: 'Corrupted task', status: 'nonexistent-status' },
+      ];
+      await writeRawState('reconcile-e2e', raw);
+
+      // Step 3: Reconcile with repair: true
+      const reconcileResult = await handleReconcile(
+        { featureId: 'reconcile-e2e', repair: true },
+        stateDir,
+      );
+      expect(reconcileResult.success).toBe(true);
+      const reconcileData = reconcileResult.data as Record<string, unknown>;
+      expect(reconcileData.valid).toBe(false); // Was invalid before repair
+      expect(reconcileData.repaired).toBe(true);
+
+      // Verify issues were found and marked repaired
+      const issues = reconcileData.issues as Array<Record<string, unknown>>;
+      expect(issues.length).toBeGreaterThan(0);
+      const repairedIssues = issues.filter((i) => i.repaired === true);
+      expect(repairedIssues.length).toBeGreaterThan(0);
+
+      // Step 4: handleGet should now succeed on the repaired state
+      const getResult = await handleGet(
+        { featureId: 'reconcile-e2e' },
+        stateDir,
+      );
+      expect(getResult.success).toBe(true);
+      const state = getResult.data as Record<string, unknown>;
+      expect(state.featureId).toBe('reconcile-e2e');
+      expect(state.workflowType).toBe('feature');
+      expect(state._events).toEqual([]);
+      expect(state._eventSequence).toBe(0);
+
+      // Task status should have been repaired to 'pending'
+      const tasks = state.tasks as Array<Record<string, unknown>>;
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].status).toBe('pending');
     });
   });
 });

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/integration.test.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/integration.test.ts
@@ -741,4 +741,51 @@ describe('Integration', () => {
       expect('prFeedback' in synthesis).toBe(true);
     });
   });
+
+  // ─── 9. HandleSet_InvalidMutation_RollbackPreservesState (e2e) ────────────
+
+  describe('Integration_HandleSetInvalidMutation_RollbackPreservesState', () => {
+    it('should roll back corrupting handleSet and preserve state from prior valid handleSet', async () => {
+      // Step 1: Init workflow
+      const initResult = await handleInit(
+        { featureId: 'rollback-e2e', workflowType: 'feature' },
+        stateDir,
+      );
+      expect(initResult.success).toBe(true);
+
+      // Step 2: Valid update — set artifacts.design
+      const validResult = await handleSet(
+        { featureId: 'rollback-e2e', updates: { 'artifacts.design': 'docs/design.md' } },
+        stateDir,
+      );
+      expect(validResult.success).toBe(true);
+
+      // Step 3: Corrupting update — set tasks to a string (violates schema)
+      const corruptResult = await handleSet(
+        { featureId: 'rollback-e2e', updates: { tasks: 'not-an-array' } },
+        stateDir,
+      );
+
+      // Step 4: Verify corruption was caught and rolled back
+      expect(corruptResult.success).toBe(false);
+      expect(corruptResult.error).toBeDefined();
+      expect(corruptResult.error?.code).toBe('STATE_CORRUPT');
+
+      // Step 5: Read state back via handleGet and verify it matches post-first-set state
+      const getResult = await handleGet({ featureId: 'rollback-e2e' }, stateDir);
+      expect(getResult.success).toBe(true);
+      const state = getResult.data as Record<string, unknown>;
+
+      // artifacts.design should still be set from the valid update
+      const artifacts = state.artifacts as Record<string, unknown>;
+      expect(artifacts.design).toBe('docs/design.md');
+
+      // tasks should still be an empty array (not a string)
+      expect(Array.isArray(state.tasks)).toBe(true);
+      expect((state.tasks as unknown[]).length).toBe(0);
+
+      // Phase should still be 'ideate' (unchanged)
+      expect(state.phase).toBe('ideate');
+    });
+  });
 });

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/schemas.test.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/schemas.test.ts
@@ -266,6 +266,27 @@ describe('Workflow State Schemas', () => {
       expect(result.success).toBe(true);
     });
 
+    it('reconcile — accepts featureId with repair: true', () => {
+      const result = ReconcileInputSchema.safeParse({
+        featureId: 'test-feature',
+        repair: true,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.repair).toBe(true);
+      }
+    });
+
+    it('reconcile — defaults repair to false when omitted', () => {
+      const result = ReconcileInputSchema.safeParse({
+        featureId: 'test-feature',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.repair).toBe(false);
+      }
+    });
+
     it('next-action — accepts featureId', () => {
       const result = NextActionInputSchema.safeParse({
         featureId: 'test-feature',

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/state-store.test.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/state-store.test.ts
@@ -6,11 +6,13 @@ import {
   initStateFile,
   readStateFile,
   writeStateFile,
+  writeStateFileUnsafe,
   applyDotPath,
   listStateFiles,
   resolveStateDir,
 } from '../state-store.js';
 import { ErrorCode } from '../schemas.js';
+import type { WorkflowState } from '../types.js';
 
 let tmpDir: string;
 
@@ -416,6 +418,77 @@ describe('State Store', () => {
       expect(scope.testCoverage).toBe('excellent'); // overwritten by source
       expect(scope.riskLevel).toBe('low');          // new key from source
       expect(explore.startedAt).toBe('2025-01-15T10:00:00Z'); // sibling preserved
+    });
+  });
+
+  describe('WriteStateFile_Validation', () => {
+    // Task 1 tests
+
+    it('should throw STATE_CORRUPT for invalid phase enum', async () => {
+      const { stateFile, state } = await initStateFile(tmpDir, 'validate-phase', 'feature');
+      const invalidState = { ...state, phase: 'nonexistent' } as unknown as WorkflowState;
+
+      await expect(writeStateFile(stateFile, invalidState)).rejects.toThrow(ErrorCode.STATE_CORRUPT);
+    });
+
+    it('should include field path in error message for invalid state', async () => {
+      const { stateFile, state } = await initStateFile(tmpDir, 'validate-path', 'feature');
+      const invalidState = { ...state, phase: 'nonexistent' } as unknown as WorkflowState;
+
+      await expect(writeStateFile(stateFile, invalidState)).rejects.toThrow(/phase/);
+    });
+
+    it('should write valid state to disk successfully', async () => {
+      const { stateFile, state } = await initStateFile(tmpDir, 'validate-ok', 'feature');
+      const updatedState = { ...state, updatedAt: new Date().toISOString() };
+
+      await writeStateFile(stateFile, updatedState);
+
+      const raw = await fs.readFile(stateFile, 'utf-8');
+      const parsed = JSON.parse(raw);
+      expect(parsed.updatedAt).toBe(updatedState.updatedAt);
+    });
+
+    // Task 2 tests
+
+    it('should throw STATE_CORRUPT when required field artifacts is missing', async () => {
+      const { stateFile, state } = await initStateFile(tmpDir, 'validate-missing', 'feature');
+      const { artifacts, ...stateWithoutArtifacts } = state;
+      const invalidState = stateWithoutArtifacts as unknown as WorkflowState;
+
+      await expect(writeStateFile(stateFile, invalidState)).rejects.toThrow(ErrorCode.STATE_CORRUPT);
+    });
+
+    it('should throw STATE_CORRUPT when _eventSequence is wrong type', async () => {
+      const { stateFile, state } = await initStateFile(tmpDir, 'validate-type', 'feature');
+      const invalidState = { ...state, _eventSequence: 'not-a-number' } as unknown as WorkflowState;
+
+      await expect(writeStateFile(stateFile, invalidState)).rejects.toThrow(ErrorCode.STATE_CORRUPT);
+    });
+
+    it('should not write file to disk when state is invalid', async () => {
+      const newFile = path.join(tmpDir, 'never-written.state.json');
+      const { state } = await initStateFile(tmpDir, 'validate-nowrite', 'feature');
+      const invalidState = { ...state, phase: 'nonexistent' } as unknown as WorkflowState;
+
+      await expect(writeStateFile(newFile, invalidState)).rejects.toThrow(ErrorCode.STATE_CORRUPT);
+
+      // Verify file was NOT created
+      await expect(fs.access(newFile)).rejects.toThrow();
+    });
+  });
+
+  describe('WriteStateFileUnsafe', () => {
+    it('should be exported and write without validation', async () => {
+      const { stateFile, state } = await initStateFile(tmpDir, 'unsafe-test', 'feature');
+
+      // writeStateFileUnsafe should write even invalid state (used for rollback)
+      const updatedState = { ...state, updatedAt: new Date().toISOString() };
+      await writeStateFileUnsafe(stateFile, updatedState);
+
+      const raw = await fs.readFile(stateFile, 'utf-8');
+      const parsed = JSON.parse(raw);
+      expect(parsed.updatedAt).toBe(updatedState.updatedAt);
     });
   });
 });

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/tools.test.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/tools.test.ts
@@ -1195,6 +1195,40 @@ describe('Query Tools', () => {
   });
 });
 
+// ─── Repair Deferred Marking Tests ──────────────────────────────────────────
+
+describe('handleReconcile_PartialRepairButStillInvalid_DoesNotMarkRepaired', () => {
+  it('should NOT mark issues as repaired when re-validation fails after repair attempt', async () => {
+    await handleInit({ featureId: 'repair-partial', workflowType: 'feature' }, tmpDir);
+
+    // Corrupt both a repairable field (_events) AND an unrepairable field (phase).
+    // The repair logic will fix _events (non-array → []) but phase = "BOGUS_PHASE"
+    // is not handled by any repair branch. After repair, re-validation should fail
+    // because phase is still invalid.
+    const stateFile = path.join(tmpDir, 'repair-partial.state.json');
+    const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+    raw._events = 'corrupt';           // Repairable: repair sets to []
+    raw.phase = 'BOGUS_PHASE';         // NOT repairable: no repair branch handles phase
+    await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+    const result = await handleReconcile({ featureId: 'repair-partial', repair: true }, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+
+    // Re-validation should fail because phase is still invalid
+    expect(data.valid).toBe(false);
+
+    // repaired should be false because the state couldn't be fully repaired
+    expect(data.repaired).toBe(false);
+
+    // No issues should be marked as repaired since re-validation failed
+    const issues = data.issues as Array<Record<string, unknown>>;
+    const repairedIssues = issues.filter((i) => i.repaired === true);
+    expect(repairedIssues).toHaveLength(0);
+  });
+});
+
 // ─── Integration Tests for Bug Fixes ────────────────────────────────────────
 
 describe('ToolSet_DynamicFields_SurviveRoundTrip', () => {

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/tools.test.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/tools.test.ts
@@ -1245,3 +1245,92 @@ describe('handleCheckpoint_ValidationFailure_RollsBackToPreviousState', () => {
     writeSpy.mockRestore();
   });
 });
+
+describe('ToolSet_SnapshotRollback', () => {
+  describe('handleSet_InvalidMutationProducesCorruptState_RollsBackToPreviousState', () => {
+    it('should roll back to previous state when mutation produces invalid state', async () => {
+      // Init a feature workflow
+      await handleInit({ featureId: 'set-rollback', workflowType: 'feature' }, tmpDir);
+
+      // Do a valid update first
+      const validResult = await handleSet(
+        { featureId: 'set-rollback', updates: { 'artifacts.design': 'docs/design.md' } },
+        tmpDir,
+      );
+      expect(validResult.success).toBe(true);
+
+      // Read the state before corruption attempt to know expected state
+      const stateBefore = await readStateFile(path.join(tmpDir, 'set-rollback.state.json'));
+      expect(stateBefore.artifacts.design).toBe('docs/design.md');
+      expect(Array.isArray(stateBefore.tasks)).toBe(true);
+
+      // Attempt an update that corrupts state: set `tasks` to a string value
+      // This will pass applyDotPath but fail schema validation at writeStateFile
+      const corruptResult = await handleSet(
+        { featureId: 'set-rollback', updates: { tasks: 'not-an-array' } },
+        tmpDir,
+      );
+
+      // Should return failure with STATE_CORRUPT code
+      expect(corruptResult.success).toBe(false);
+      expect(corruptResult.error).toBeDefined();
+      expect(corruptResult.error?.code).toBe('STATE_CORRUPT');
+
+      // Read state from disk and verify it matches the pre-corruption state
+      const stateAfter = await readStateFile(path.join(tmpDir, 'set-rollback.state.json'));
+      expect(stateAfter.artifacts.design).toBe('docs/design.md');
+      expect(Array.isArray(stateAfter.tasks)).toBe(true);
+      expect(stateAfter.tasks).toEqual(stateBefore.tasks);
+    });
+  });
+
+  describe('handleSet_InvalidMutation_ErrorIncludesValidationDetails', () => {
+    it('should include "rolled back" in the error message', async () => {
+      await handleInit({ featureId: 'set-rb-msg', workflowType: 'feature' }, tmpDir);
+
+      // Do a valid update first
+      await handleSet(
+        { featureId: 'set-rb-msg', updates: { 'artifacts.design': 'docs/design.md' } },
+        tmpDir,
+      );
+
+      // Attempt a corrupting update
+      const corruptResult = await handleSet(
+        { featureId: 'set-rb-msg', updates: { tasks: 'not-an-array' } },
+        tmpDir,
+      );
+
+      expect(corruptResult.success).toBe(false);
+      expect(corruptResult.error?.code).toBe('STATE_CORRUPT');
+      expect(corruptResult.error?.message).toContain('rolled back');
+    });
+  });
+
+  describe('handleSet_FileIOError_RethrowsWithoutSwallowing', () => {
+    it('should re-throw non-STATE_CORRUPT errors without catching them', async () => {
+      await handleInit({ featureId: 'set-rethrow', workflowType: 'feature' }, tmpDir);
+
+      // Do a valid update first to ensure state is in a good place
+      await handleSet(
+        { featureId: 'set-rethrow', updates: { 'artifacts.design': 'docs/design.md' } },
+        tmpDir,
+      );
+
+      // Make the directory read-only to cause a write failure (not STATE_CORRUPT)
+      await fs.chmod(tmpDir, 0o444);
+
+      try {
+        // This should throw a FILE_IO_ERROR, not return { success: false }
+        await expect(
+          handleSet(
+            { featureId: 'set-rethrow', updates: { 'artifacts.plan': 'docs/plan.md' } },
+            tmpDir,
+          ),
+        ).rejects.toThrow();
+      } finally {
+        // Restore permissions for cleanup
+        await fs.chmod(tmpDir, 0o755);
+      }
+    });
+  });
+});

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/tools.test.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -15,6 +15,7 @@ import {
   handleCheckpoint,
 } from '../tools.js';
 import { initStateFile, readStateFile, writeStateFile } from '../state-store.js';
+import * as stateStore from '../state-store.js';
 import type { WorkflowState } from '../types.js';
 
 let tmpDir: string;
@@ -1210,5 +1211,37 @@ describe('ToolCheckpoint_SlimResponse_ReturnsMinimalPayload', () => {
     expect(data._events).toBeUndefined();
     expect(data.synthesis).toBeUndefined();
     expect(data.artifacts).toBeUndefined();
+  });
+});
+
+// ─── Snapshot Rollback Tests ───────────────────────────────────────────────────
+
+describe('handleCheckpoint_ValidationFailure_RollsBackToPreviousState', () => {
+  it('should rollback on validation failure during checkpoint', async () => {
+    // Arrange
+    await handleInit({ featureId: 'cp-rb', workflowType: 'feature' }, tmpDir);
+
+    // Read state before checkpoint
+    const stateBefore = await readStateFile(path.join(tmpDir, 'cp-rb.state.json'));
+
+    // Mock writeStateFile to throw STATE_CORRUPT on next call
+    const writeSpy = vi.spyOn(stateStore, 'writeStateFile').mockRejectedValueOnce(
+      new Error('STATE_CORRUPT: Write-time validation failed: _checkpoint: Invalid'),
+    );
+
+    // Act
+    const result = await handleCheckpoint({ featureId: 'cp-rb', summary: 'test checkpoint' }, tmpDir);
+
+    // Assert
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('STATE_CORRUPT');
+    expect(result.error?.message).toContain('rolled back');
+
+    // Verify state on disk is restored (phase unchanged)
+    const stateAfter = await readStateFile(path.join(tmpDir, 'cp-rb.state.json'));
+    expect(stateAfter.phase).toBe(stateBefore.phase);
+    expect(stateAfter._eventSequence).toBe(stateBefore._eventSequence);
+
+    writeSpy.mockRestore();
   });
 });

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/tools.test.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -15,6 +15,7 @@ import {
   handleCheckpoint,
 } from '../tools.js';
 import { initStateFile, readStateFile, writeStateFile } from '../state-store.js';
+import * as stateStore from '../state-store.js';
 import type { WorkflowState } from '../types.js';
 
 let tmpDir: string;
@@ -1210,5 +1211,58 @@ describe('ToolCheckpoint_SlimResponse_ReturnsMinimalPayload', () => {
     expect(data._events).toBeUndefined();
     expect(data.synthesis).toBeUndefined();
     expect(data.artifacts).toBeUndefined();
+  });
+});
+
+// ─── Cancel Rollback Tests ──────────────────────────────────────────────────
+
+describe('ToolCancel_ValidationFailure_RollsBackToPreviousState', () => {
+  it('should rollback to pre-cancel state when writeStateFile throws STATE_CORRUPT', async () => {
+    // Arrange: create workflow and advance to plan phase
+    await handleInit({ featureId: 'cancel-rb', workflowType: 'feature' }, tmpDir);
+    await handleSet(
+      { featureId: 'cancel-rb', updates: { 'artifacts.design': 'docs/d.md' }, phase: 'plan' },
+      tmpDir,
+    );
+
+    // Read state before cancel attempt
+    const stateBefore = await readStateFile(path.join(tmpDir, 'cancel-rb.state.json'));
+    expect(stateBefore.phase).toBe('plan');
+
+    // Mock writeStateFile to throw STATE_CORRUPT on the next call
+    const writeSpy = vi.spyOn(stateStore, 'writeStateFile').mockRejectedValueOnce(
+      new Error('STATE_CORRUPT: Write-time validation failed: phase: Invalid'),
+    );
+
+    // Act
+    const result = await handleCancel({ featureId: 'cancel-rb' }, tmpDir);
+
+    // Assert: operation reports failure with rollback info
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('STATE_CORRUPT');
+    expect(result.error?.message).toContain('rolled back');
+
+    // Verify state on disk is restored to pre-cancel state
+    const stateAfter = await readStateFile(path.join(tmpDir, 'cancel-rb.state.json'));
+    expect(stateAfter.phase).toBe('plan'); // Not cancelled
+
+    writeSpy.mockRestore();
+  });
+
+  it('should re-throw non-STATE_CORRUPT errors without rollback', async () => {
+    // Arrange: create workflow
+    await handleInit({ featureId: 'cancel-rethrow', workflowType: 'feature' }, tmpDir);
+
+    // Mock writeStateFile to throw a generic error
+    const writeSpy = vi.spyOn(stateStore, 'writeStateFile').mockRejectedValueOnce(
+      new Error('FILE_IO_ERROR: Disk full'),
+    );
+
+    // Act & Assert: non-STATE_CORRUPT errors should be re-thrown
+    await expect(
+      handleCancel({ featureId: 'cancel-rethrow' }, tmpDir),
+    ).rejects.toThrow('FILE_IO_ERROR: Disk full');
+
+    writeSpy.mockRestore();
   });
 });

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/tools.test.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/__tests__/tools.test.ts
@@ -693,6 +693,233 @@ describe('Query Tools', () => {
     });
   });
 
+  // ─── ToolReconcile — Validation Checks ────────────────────────────────────
+
+  describe('handleReconcile_ValidState_ReturnsNoIssues', () => {
+    it('should return valid: true, issues: [], repaired: false for a valid state', async () => {
+      await handleInit({ featureId: 'reconcile-valid', workflowType: 'feature' }, tmpDir);
+
+      const result = await handleReconcile({ featureId: 'reconcile-valid', repair: false }, tmpDir);
+
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      expect(data.valid).toBe(true);
+      expect(data.issues).toEqual([]);
+      expect(data.repaired).toBe(false);
+      expect(data.worktrees).toBeDefined();
+      expect(Array.isArray(data.worktrees)).toBe(true);
+    });
+  });
+
+  describe('handleReconcile_InvalidPhaseEnum_ReportsIssue', () => {
+    it('should report an issue when phase has invalid value', async () => {
+      await handleInit({ featureId: 'reconcile-phase', workflowType: 'feature' }, tmpDir);
+
+      // Manually corrupt the phase
+      const stateFile = path.join(tmpDir, 'reconcile-phase.state.json');
+      const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+      raw.phase = 'nonexistent';
+      await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+      const result = await handleReconcile({ featureId: 'reconcile-phase', repair: false }, tmpDir);
+
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      expect(data.valid).toBe(false);
+      const issues = data.issues as Array<Record<string, unknown>>;
+      expect(issues.length).toBeGreaterThan(0);
+      // At least one issue should reference "phase"
+      const phaseIssue = issues.find((i) => (i.path as string).includes('phase'));
+      expect(phaseIssue).toBeDefined();
+      expect(phaseIssue?.severity).toBe('error');
+      expect(phaseIssue?.repaired).toBe(false);
+    });
+  });
+
+  describe('handleReconcile_MissingRequiredTaskFields_ReportsIssue', () => {
+    it('should report issue when task is missing status field', async () => {
+      await handleInit({ featureId: 'reconcile-task', workflowType: 'feature' }, tmpDir);
+
+      // Manually corrupt a task
+      const stateFile = path.join(tmpDir, 'reconcile-task.state.json');
+      const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+      raw.tasks = [{ id: 'task-1', title: 'Missing status' }]; // no status field
+      await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+      const result = await handleReconcile({ featureId: 'reconcile-task', repair: false }, tmpDir);
+
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      expect(data.valid).toBe(false);
+      const issues = data.issues as Array<Record<string, unknown>>;
+      expect(issues.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('handleReconcile_InvalidEventSequence_ReportsIssue', () => {
+    it('should report issue when _eventSequence is negative', async () => {
+      await handleInit({ featureId: 'reconcile-seq', workflowType: 'feature' }, tmpDir);
+
+      // Manually corrupt _eventSequence
+      const stateFile = path.join(tmpDir, 'reconcile-seq.state.json');
+      const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+      raw._eventSequence = -1;
+      await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+      const result = await handleReconcile({ featureId: 'reconcile-seq', repair: false }, tmpDir);
+
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      expect(data.valid).toBe(false);
+      const issues = data.issues as Array<Record<string, unknown>>;
+      expect(issues.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── ToolReconcile — Repair Mode ──────────────────────────────────────────
+
+  describe('handleReconcile_MissingFields_RepairInjectsDefaults', () => {
+    it('should repair corrupt _events (non-array) when repair: true', async () => {
+      await handleInit({ featureId: 'repair-events', workflowType: 'feature' }, tmpDir);
+
+      // Set _events to a non-array value to cause Zod failure
+      const stateFile = path.join(tmpDir, 'repair-events.state.json');
+      const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+      raw._events = 'corrupt';
+      await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+      const result = await handleReconcile({ featureId: 'repair-events', repair: true }, tmpDir);
+
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      expect(data.valid).toBe(false); // Was invalid before repair
+      expect(data.repaired).toBe(true);
+
+      const issues = data.issues as Array<Record<string, unknown>>;
+      const eventsIssue = issues.find((i) => (i.path as string).includes('_events'));
+      expect(eventsIssue).toBeDefined();
+      expect(eventsIssue?.repaired).toBe(true);
+    });
+  });
+
+  describe('handleReconcile_InvalidTaskStatus_RepairResetsToPending', () => {
+    it('should reset invalid task status to pending when repair: true', async () => {
+      await handleInit({ featureId: 'repair-task', workflowType: 'feature' }, tmpDir);
+
+      // Write task with invalid status
+      const stateFile = path.join(tmpDir, 'repair-task.state.json');
+      const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+      raw.tasks = [{ id: 'task-1', title: 'Bad status', status: 'bogus' }];
+      await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+      const result = await handleReconcile({ featureId: 'repair-task', repair: true }, tmpDir);
+
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      expect(data.repaired).toBe(true);
+
+      // Verify on disk that task status was repaired
+      const repairedRaw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+      expect(repairedRaw.tasks[0].status).toBe('pending');
+    });
+  });
+
+  describe('handleReconcile_MultipleIssues_RepairsAll', () => {
+    it('should repair multiple issues in a single pass', async () => {
+      await handleInit({ featureId: 'repair-multi', workflowType: 'feature' }, tmpDir);
+
+      // Corrupt multiple fields with values that cause Zod failures
+      const stateFile = path.join(tmpDir, 'repair-multi.state.json');
+      const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+      raw._events = 'corrupt';  // Non-array causes Zod failure
+      raw._eventSequence = -1;  // Negative causes Zod failure (min: 0)
+      raw._checkpoint = null;   // null causes Zod failure
+      raw.tasks = [{ id: 'task-1', title: 'Bad', status: 'bogus' }];
+      await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+      const result = await handleReconcile({ featureId: 'repair-multi', repair: true }, tmpDir);
+
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      expect(data.repaired).toBe(true);
+
+      const issues = data.issues as Array<Record<string, unknown>>;
+      const repairedIssues = issues.filter((i) => i.repaired === true);
+      expect(repairedIssues.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('handleReconcile_UnparseableJSON_ReportsCorruptFile', () => {
+    it('should return valid: false with JSON parse issue for non-JSON content', async () => {
+      // Write non-JSON content to the state file path
+      const stateFile = path.join(tmpDir, 'corrupt-json.state.json');
+      await fs.writeFile(stateFile, 'this is not valid JSON!!!', 'utf-8');
+
+      const result = await handleReconcile({ featureId: 'corrupt-json', repair: false }, tmpDir);
+
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      expect(data.valid).toBe(false);
+      expect(data.repaired).toBe(false);
+
+      const issues = data.issues as Array<Record<string, unknown>>;
+      expect(issues.length).toBe(1);
+      expect(issues[0].message).toContain('invalid JSON');
+      expect(issues[0].severity).toBe('error');
+    });
+  });
+
+  describe('handleReconcile_ReportOnly_DoesNotModifyFile', () => {
+    it('should NOT modify the file on disk when repair: false', async () => {
+      await handleInit({ featureId: 'no-modify', workflowType: 'feature' }, tmpDir);
+
+      // Corrupt state
+      const stateFile = path.join(tmpDir, 'no-modify.state.json');
+      const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+      raw.tasks = [{ id: 'task-1', title: 'Bad', status: 'bogus' }];
+      raw._eventSequence = -1;
+      await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+      // Read raw bytes before reconcile
+      const bytesBefore = await fs.readFile(stateFile, 'utf-8');
+
+      // Reconcile with repair: false (report-only)
+      const result = await handleReconcile({ featureId: 'no-modify', repair: false }, tmpDir);
+
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      expect(data.valid).toBe(false);
+      expect(data.repaired).toBe(false);
+
+      // Read raw bytes after reconcile — must be identical
+      const bytesAfter = await fs.readFile(stateFile, 'utf-8');
+      expect(bytesAfter).toBe(bytesBefore);
+    });
+  });
+
+  describe('handleReconcile_RepairProducesSchemaValidState', () => {
+    it('should produce a schema-valid state after repair that readStateFile can read', async () => {
+      await handleInit({ featureId: 'repair-valid', workflowType: 'feature' }, tmpDir);
+
+      // Corrupt state with values that cause Zod failures
+      const stateFile = path.join(tmpDir, 'repair-valid.state.json');
+      const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+      raw._events = 'not-an-array';
+      raw._eventSequence = -1;
+      raw.tasks = [{ id: 'task-1', title: 'Bad', status: 'bogus' }];
+      await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+      // Repair
+      await handleReconcile({ featureId: 'repair-valid', repair: true }, tmpDir);
+
+      // readStateFile should now succeed without throwing
+      const state = await readStateFile(stateFile);
+      expect(state.featureId).toBe('repair-valid');
+      expect(state._events).toEqual([]);
+      expect(state._eventSequence).toBe(0);
+    });
+  });
+
   // ─── ToolNextAction ───────────────────────────────────────────────────────
 
   describe('ToolNextAction_NonExistentWorkflow_ReturnsNotFound', () => {

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/index.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/index.ts
@@ -112,12 +112,13 @@ export function createServer(stateDir: string): McpServer {
   // ─── workflow_reconcile ────────────────────────────────────────────
   server.tool(
     'workflow_reconcile',
-    'Verify worktree paths and branches match state file',
+    'Validate state file schema, verify worktree paths, and optionally repair common corruption patterns. Returns structured issues array.',
     {
       featureId: featureIdParam,
+      repair: z.boolean().optional(),
     },
     async (args) => {
-      const result = await handleReconcile(args, stateDir);
+      const result = await handleReconcile({ ...args, repair: args.repair ?? false }, stateDir);
       return formatResult(result);
     },
   );

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/schemas.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/schemas.ts
@@ -246,6 +246,7 @@ export const SummaryInputSchema = z.object({
 
 export const ReconcileInputSchema = z.object({
   featureId: FeatureIdSchema,
+  repair: z.boolean().optional().default(false),
 });
 
 export const NextActionInputSchema = z.object({

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/state-store.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/state-store.ts
@@ -159,9 +159,10 @@ export async function readStateFile(stateFile: string): Promise<WorkflowState> {
   return result.data;
 }
 
-// ─── Write State File Atomically ───────────────────────────────────────────
+// ─── Write State File Atomically (Unsafe — No Validation) ────────────────
+// Used ONLY for rollback of previously-validated state.
 
-export async function writeStateFile(
+export async function writeStateFileUnsafe(
   stateFile: string,
   state: WorkflowState,
 ): Promise<void> {
@@ -181,6 +182,25 @@ export async function writeStateFile(
       `Failed to write state file: ${stateFile} — ${(err as Error).message}`,
     );
   }
+}
+
+// ─── Write State File with Schema Validation ─────────────────────────────
+
+export async function writeStateFile(
+  stateFile: string,
+  state: WorkflowState,
+): Promise<void> {
+  const result = WorkflowStateSchema.safeParse(state);
+  if (!result.success) {
+    const fieldPaths = result.error.issues
+      .map((i) => `${i.path.join('.')}: ${i.message}`)
+      .join('; ');
+    throw new StateStoreError(
+      ErrorCode.STATE_CORRUPT,
+      `Write-time validation failed: ${fieldPaths}`,
+    );
+  }
+  await writeStateFileUnsafe(stateFile, state);
 }
 
 // ─── Apply Dot-Path Update ─────────────────────────────────────────────────

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/tools.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/tools.ts
@@ -794,17 +794,20 @@ export async function handleReconcile(
   // Step 5: Repair mode
   let repaired = false;
   if (input.repair && issues.length > 0) {
+    const attemptedRepairs = new Set<string>();
+    let repairAttempted = false;
+
     // Apply repairs for common corruption patterns
     if (!Array.isArray(rawState._events)) {
       rawState._events = [];
-      markIssueRepaired(issues, '_events');
-      repaired = true;
+      attemptedRepairs.add('_events');
+      repairAttempted = true;
     }
 
     if (rawState._eventSequence === undefined || rawState._eventSequence === null) {
       rawState._eventSequence = 0;
-      markIssueRepaired(issues, '_eventSequence');
-      repaired = true;
+      attemptedRepairs.add('_eventSequence');
+      repairAttempted = true;
     } else if (typeof rawState._eventSequence === 'string') {
       const parsed = Number(rawState._eventSequence);
       if (!isNaN(parsed) && parsed >= 0) {
@@ -812,12 +815,12 @@ export async function handleReconcile(
       } else {
         rawState._eventSequence = 0;
       }
-      markIssueRepaired(issues, '_eventSequence');
-      repaired = true;
+      attemptedRepairs.add('_eventSequence');
+      repairAttempted = true;
     } else if (typeof rawState._eventSequence === 'number' && rawState._eventSequence < 0) {
       rawState._eventSequence = 0;
-      markIssueRepaired(issues, '_eventSequence');
-      repaired = true;
+      attemptedRepairs.add('_eventSequence');
+      repairAttempted = true;
     }
 
     if (rawState._checkpoint === undefined || rawState._checkpoint === null || typeof rawState._checkpoint !== 'object') {
@@ -831,14 +834,14 @@ export async function handleReconcile(
         lastActivityTimestamp: now,
         staleAfterMinutes: 120,
       };
-      markIssueRepaired(issues, '_checkpoint');
-      repaired = true;
+      attemptedRepairs.add('_checkpoint');
+      repairAttempted = true;
     }
 
     if (rawState._history === undefined || rawState._history === null || typeof rawState._history !== 'object' || Array.isArray(rawState._history)) {
       rawState._history = {};
-      markIssueRepaired(issues, '_history');
-      repaired = true;
+      attemptedRepairs.add('_history');
+      repairAttempted = true;
     }
 
     // Repair invalid task statuses
@@ -850,22 +853,25 @@ export async function handleReconcile(
         if (task && typeof task === 'object') {
           if (task.status !== undefined && !validStatuses.has(task.status as string)) {
             task.status = 'pending';
-            markIssueRepaired(issues, `tasks.${i}.status`);
-            repaired = true;
+            attemptedRepairs.add(`tasks.${i}.status`);
+            repairAttempted = true;
           }
         }
       }
     }
 
-    // After repair: re-validate and write if valid
-    if (repaired) {
+    // After repair: re-validate and write if valid, then mark issues as repaired
+    if (repairAttempted) {
       const revalidation = WorkflowStateSchema.safeParse(rawState);
       if (revalidation.success) {
-        // Write repaired state to disk atomically
-        const tmpPath = `${stateFile}.tmp.${process.pid}`;
-        await fs.writeFile(tmpPath, JSON.stringify(revalidation.data, null, 2), 'utf-8');
-        await fs.rename(tmpPath, stateFile);
+        await writeStateFileUnsafe(stateFile, revalidation.data);
+        // Only mark issues as repaired after successful re-validation and write
+        for (const pathPrefix of attemptedRepairs) {
+          markIssueRepaired(issues, pathPrefix);
+        }
+        repaired = true;
       }
+      // If re-validation fails, repaired stays false and no issues are marked
     }
   }
 

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/tools.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/tools.ts
@@ -163,6 +163,9 @@ export async function handleSet(
     throw err;
   }
 
+  // Save snapshot for rollback before any mutations
+  const snapshot = structuredClone(state);
+
   // Work with a deep copy to avoid shared reference mutation
   const mutableState = structuredClone(state) as Record<string, unknown>;
 
@@ -259,17 +262,31 @@ export async function handleSet(
   const checkpoint = mutableState._checkpoint as Record<string, unknown>;
   checkpoint.lastActivityTimestamp = new Date().toISOString();
 
-  // Write back to disk
-  await writeStateFile(stateFile, mutableState as WorkflowState);
+  try {
+    // Write back to disk
+    await writeStateFile(stateFile, mutableState as WorkflowState);
 
-  return {
-    success: true,
-    data: {
-      phase: mutableState.phase as string,
-      updatedAt: mutableState.updatedAt as string,
-    },
-    _meta: buildCheckpointMeta(mutableState._checkpoint as WorkflowState['_checkpoint']),
-  };
+    return {
+      success: true,
+      data: {
+        phase: mutableState.phase as string,
+        updatedAt: mutableState.updatedAt as string,
+      },
+      _meta: buildCheckpointMeta(mutableState._checkpoint as WorkflowState['_checkpoint']),
+    };
+  } catch (error) {
+    if (error instanceof Error && error.message.includes(ErrorCode.STATE_CORRUPT)) {
+      await writeStateFileUnsafe(stateFile, snapshot);
+      return {
+        success: false,
+        error: {
+          code: ErrorCode.STATE_CORRUPT,
+          message: `Set produced invalid state, rolled back to previous state. ${error.message}`,
+        },
+      };
+    }
+    throw error;
+  }
 }
 
 // ─── handleCancel ──────────────────────────────────────────────────────────

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/tools.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/tools.ts
@@ -17,6 +17,7 @@ import {
   initStateFile,
   readStateFile,
   writeStateFile,
+  writeStateFileUnsafe,
   applyDotPath,
   listStateFiles,
 } from './state-store.js';
@@ -306,6 +307,9 @@ export async function handleCancel(
     };
   }
 
+  // Snapshot for rollback in case write-time validation fails
+  const snapshot = structuredClone(state);
+
   const mutableState = structuredClone(state) as Record<string, unknown>;
   const currentPhase = state.phase;
   const events = (mutableState._events as WorkflowState['_events']) ?? [];
@@ -349,79 +353,94 @@ export async function handleCancel(
     };
   }
 
-  // Apply phase change
-  mutableState.phase = 'cancelled';
+  try {
+    // Apply phase change
+    mutableState.phase = 'cancelled';
 
-  // Build up events: start with existing events + compensation events
-  let updatedEvents = [...events, ...compensationResult.events];
-  let updatedSequence = eventSequence + compensationResult.events.length;
+    // Build up events: start with existing events + compensation events
+    let updatedEvents = [...events, ...compensationResult.events];
+    let updatedSequence = eventSequence + compensationResult.events.length;
 
-  // Append transition events from HSM
-  for (const transitionEvent of transitionResult.events) {
-    const appended = appendEvent(
+    // Append transition events from HSM
+    for (const transitionEvent of transitionResult.events) {
+      const appended = appendEvent(
+        updatedEvents,
+        updatedSequence,
+        transitionEvent.type as WorkflowState['_events'][number]['type'],
+        transitionEvent.trigger,
+        {
+          from: transitionEvent.from,
+          to: transitionEvent.to,
+          metadata: transitionEvent.metadata,
+        },
+      );
+      updatedEvents = appended.events;
+      updatedSequence = appended.eventSequence;
+    }
+
+    // Append cancel event with reason metadata
+    const cancelMetadata: Record<string, unknown> = {};
+    if (input.reason) {
+      cancelMetadata.reason = input.reason;
+    }
+    cancelMetadata.compensationActions = compensationResult.actions.length;
+    cancelMetadata.compensationSuccess = compensationResult.success;
+
+    const cancelAppended = appendEvent(
       updatedEvents,
       updatedSequence,
-      transitionEvent.type as WorkflowState['_events'][number]['type'],
-      transitionEvent.trigger,
+      'cancel',
+      'user-cancel',
       {
-        from: transitionEvent.from,
-        to: transitionEvent.to,
-        metadata: transitionEvent.metadata,
+        from: currentPhase,
+        to: 'cancelled',
+        metadata: cancelMetadata,
       },
     );
-    updatedEvents = appended.events;
-    updatedSequence = appended.eventSequence;
-  }
+    updatedEvents = cancelAppended.events;
+    updatedSequence = cancelAppended.eventSequence;
 
-  // Append cancel event with reason metadata
-  const cancelMetadata: Record<string, unknown> = {};
-  if (input.reason) {
-    cancelMetadata.reason = input.reason;
-  }
-  cancelMetadata.compensationActions = compensationResult.actions.length;
-  cancelMetadata.compensationSuccess = compensationResult.success;
+    mutableState._events = updatedEvents;
+    mutableState._eventSequence = updatedSequence;
 
-  const cancelAppended = appendEvent(
-    updatedEvents,
-    updatedSequence,
-    'cancel',
-    'user-cancel',
-    {
-      from: currentPhase,
-      to: 'cancelled',
-      metadata: cancelMetadata,
-    },
-  );
-  updatedEvents = cancelAppended.events;
-  updatedSequence = cancelAppended.eventSequence;
-
-  mutableState._events = updatedEvents;
-  mutableState._eventSequence = updatedSequence;
-
-  // Apply history updates from transition
-  if (transitionResult.historyUpdates) {
-    const history = { ...(mutableState._history as Record<string, string>) };
-    for (const [key, value] of Object.entries(transitionResult.historyUpdates)) {
-      history[key] = value;
+    // Apply history updates from transition
+    if (transitionResult.historyUpdates) {
+      const history = { ...(mutableState._history as Record<string, string>) };
+      for (const [key, value] of Object.entries(transitionResult.historyUpdates)) {
+        history[key] = value;
+      }
+      mutableState._history = history;
     }
-    mutableState._history = history;
+
+    // Reset checkpoint counter
+    mutableState._checkpoint = resetCounter(
+      mutableState._checkpoint as WorkflowState['_checkpoint'],
+      'cancelled',
+      'Workflow cancelled',
+    );
+
+    // Update timestamp
+    mutableState.updatedAt = new Date().toISOString();
+
+    const checkpoint = mutableState._checkpoint as Record<string, unknown>;
+    checkpoint.lastActivityTimestamp = new Date().toISOString();
+
+    // Write updated state
+    await writeStateFile(stateFile, mutableState as WorkflowState);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes(ErrorCode.STATE_CORRUPT)) {
+      // Rollback to pre-mutation snapshot
+      await writeStateFileUnsafe(stateFile, snapshot);
+      return {
+        success: false,
+        error: {
+          code: ErrorCode.STATE_CORRUPT,
+          message: `Cancel produced invalid state, rolled back to previous state. ${error.message}`,
+        },
+      };
+    }
+    throw error;
   }
-
-  // Reset checkpoint counter
-  mutableState._checkpoint = resetCounter(
-    mutableState._checkpoint as WorkflowState['_checkpoint'],
-    'cancelled',
-    'Workflow cancelled',
-  );
-
-  // Update timestamp
-  mutableState.updatedAt = new Date().toISOString();
-
-  const checkpoint = mutableState._checkpoint as Record<string, unknown>;
-  checkpoint.lastActivityTimestamp = new Date().toISOString();
-
-  // Write updated state
-  await writeStateFile(stateFile, mutableState as WorkflowState);
 
   return {
     success: true,

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/tools.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/tools.ts
@@ -12,7 +12,7 @@ import type {
   CheckpointMeta,
   WorkflowState,
 } from './types.js';
-import { ErrorCode, isReservedField } from './schemas.js';
+import { ErrorCode, WorkflowStateSchema, isReservedField } from './schemas.js';
 import {
   initStateFile,
   readStateFile,
@@ -664,6 +664,15 @@ export async function handleSummary(
   };
 }
 
+// ─── Reconcile Issue Interface ──────────────────────────────────────────────
+
+interface ReconcileIssue {
+  readonly path: string;
+  readonly message: string;
+  readonly severity: 'error' | 'warning';
+  repaired: boolean;
+}
+
 // ─── handleReconcile ────────────────────────────────────────────────────────
 
 export async function handleReconcile(
@@ -672,12 +681,12 @@ export async function handleReconcile(
 ): Promise<ToolResult> {
   const stateFile = path.join(stateDir, `${input.featureId}.state.json`);
 
-  // Read validated state for metadata and checkpoint
-  let state: WorkflowState;
+  // Step 1: Read raw file content (bypass readStateFile which throws on corrupt state)
+  let rawContent: string;
   try {
-    state = await readStateFile(stateFile);
+    rawContent = await fs.readFile(stateFile, 'utf-8');
   } catch (err) {
-    if (err instanceof Error && err.message.includes(ErrorCode.STATE_NOT_FOUND)) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
       return {
         success: false,
         error: {
@@ -689,8 +698,126 @@ export async function handleReconcile(
     throw err;
   }
 
-  // With .passthrough() on WorktreeSchema, path field is preserved through Zod parsing
-  const worktrees = state.worktrees as Record<
+  // Step 2: Parse JSON (handle unparseable JSON gracefully)
+  let rawState: Record<string, unknown>;
+  try {
+    rawState = JSON.parse(rawContent) as Record<string, unknown>;
+  } catch {
+    return {
+      success: true,
+      data: {
+        featureId: input.featureId,
+        valid: false,
+        issues: [{
+          path: '',
+          message: 'File contains invalid JSON',
+          severity: 'error' as const,
+          repaired: false,
+        }],
+        repaired: false,
+        worktrees: [],
+      },
+    };
+  }
+
+  // Step 3: Validate with WorkflowStateSchema.safeParse()
+  const parseResult = WorkflowStateSchema.safeParse(rawState);
+
+  // Step 4: Map Zod issues to structured array
+  const issues: ReconcileIssue[] = [];
+  if (!parseResult.success) {
+    for (const zodIssue of parseResult.error.issues) {
+      issues.push({
+        path: zodIssue.path.join('.'),
+        message: zodIssue.message,
+        severity: 'error',
+        repaired: false,
+      });
+    }
+  }
+
+  const valid = parseResult.success;
+
+  // Step 5: Repair mode
+  let repaired = false;
+  if (input.repair && issues.length > 0) {
+    // Apply repairs for common corruption patterns
+    if (!Array.isArray(rawState._events)) {
+      rawState._events = [];
+      markIssueRepaired(issues, '_events');
+      repaired = true;
+    }
+
+    if (rawState._eventSequence === undefined || rawState._eventSequence === null) {
+      rawState._eventSequence = 0;
+      markIssueRepaired(issues, '_eventSequence');
+      repaired = true;
+    } else if (typeof rawState._eventSequence === 'string') {
+      const parsed = Number(rawState._eventSequence);
+      if (!isNaN(parsed) && parsed >= 0) {
+        rawState._eventSequence = parsed;
+      } else {
+        rawState._eventSequence = 0;
+      }
+      markIssueRepaired(issues, '_eventSequence');
+      repaired = true;
+    } else if (typeof rawState._eventSequence === 'number' && rawState._eventSequence < 0) {
+      rawState._eventSequence = 0;
+      markIssueRepaired(issues, '_eventSequence');
+      repaired = true;
+    }
+
+    if (rawState._checkpoint === undefined || rawState._checkpoint === null || typeof rawState._checkpoint !== 'object') {
+      const now = new Date().toISOString();
+      rawState._checkpoint = {
+        timestamp: now,
+        phase: (rawState.phase as string) ?? 'init',
+        summary: 'Repaired by reconcile',
+        operationsSince: 0,
+        fixCycleCount: 0,
+        lastActivityTimestamp: now,
+        staleAfterMinutes: 120,
+      };
+      markIssueRepaired(issues, '_checkpoint');
+      repaired = true;
+    }
+
+    if (rawState._history === undefined || rawState._history === null || typeof rawState._history !== 'object' || Array.isArray(rawState._history)) {
+      rawState._history = {};
+      markIssueRepaired(issues, '_history');
+      repaired = true;
+    }
+
+    // Repair invalid task statuses
+    const tasks = rawState.tasks;
+    if (Array.isArray(tasks)) {
+      const validStatuses = new Set(['pending', 'in_progress', 'complete', 'failed']);
+      for (let i = 0; i < tasks.length; i++) {
+        const task = tasks[i] as Record<string, unknown> | undefined;
+        if (task && typeof task === 'object') {
+          if (task.status !== undefined && !validStatuses.has(task.status as string)) {
+            task.status = 'pending';
+            markIssueRepaired(issues, `tasks.${i}.status`);
+            repaired = true;
+          }
+        }
+      }
+    }
+
+    // After repair: re-validate and write if valid
+    if (repaired) {
+      const revalidation = WorkflowStateSchema.safeParse(rawState);
+      if (revalidation.success) {
+        // Write repaired state to disk atomically
+        const tmpPath = `${stateFile}.tmp.${process.pid}`;
+        await fs.writeFile(tmpPath, JSON.stringify(revalidation.data, null, 2), 'utf-8');
+        await fs.rename(tmpPath, stateFile);
+      }
+    }
+  }
+
+  // Step 6: Worktree reconciliation (use raw parsed state or validated state)
+  const worktrees = (rawState.worktrees ?? {}) as Record<
     string,
     { branch: string; taskId: string; status: string; path?: string }
   >;
@@ -698,6 +825,8 @@ export async function handleReconcile(
   const worktreeResults: Array<Record<string, unknown>> = [];
 
   for (const [id, wt] of Object.entries(worktrees)) {
+    if (typeof wt !== 'object' || wt === null) continue;
+
     let pathStatus: 'OK' | 'MISSING' | 'NO_PATH' = 'NO_PATH';
 
     if (wt.path) {
@@ -722,11 +851,24 @@ export async function handleReconcile(
   return {
     success: true,
     data: {
-      featureId: state.featureId,
+      featureId: input.featureId,
+      valid,
+      issues,
+      repaired,
       worktrees: worktreeResults,
     },
-    _meta: buildCheckpointMeta(state._checkpoint),
   };
+}
+
+/**
+ * Mark issues matching a given path prefix as repaired.
+ */
+function markIssueRepaired(issues: ReconcileIssue[], pathPrefix: string): void {
+  for (const issue of issues) {
+    if (issue.path === pathPrefix || issue.path.startsWith(`${pathPrefix}.`)) {
+      issue.repaired = true;
+    }
+  }
 }
 
 // ─── handleNextAction ───────────────────────────────────────────────────────

--- a/plugins/workflow-state/servers/workflow-state-mcp/src/tools.ts
+++ b/plugins/workflow-state/servers/workflow-state-mcp/src/tools.ts
@@ -17,6 +17,7 @@ import {
   initStateFile,
   readStateFile,
   writeStateFile,
+  writeStateFileUnsafe,
   applyDotPath,
   listStateFiles,
 } from './state-store.js';
@@ -458,44 +459,61 @@ export async function handleCheckpoint(
     throw err;
   }
 
+  // Save snapshot for rollback before any mutations
+  const snapshot = structuredClone(state);
+
   // Work with a deep copy to avoid shared reference mutation
   const mutableState = structuredClone(state) as Record<string, unknown>;
 
-  // Reset checkpoint counter with current phase and optional summary
-  mutableState._checkpoint = resetCounter(
-    mutableState._checkpoint as WorkflowState['_checkpoint'],
-    state.phase,
-    input.summary,
-  );
+  try {
+    // Reset checkpoint counter with current phase and optional summary
+    mutableState._checkpoint = resetCounter(
+      mutableState._checkpoint as WorkflowState['_checkpoint'],
+      state.phase,
+      input.summary,
+    );
 
-  // Append checkpoint event to event log
-  const trigger = input.summary ?? 'explicit checkpoint';
-  const appended = appendEvent(
-    mutableState._events as WorkflowState['_events'],
-    mutableState._eventSequence as number,
-    'checkpoint',
-    trigger,
-  );
-  mutableState._events = appended.events;
-  mutableState._eventSequence = appended.eventSequence;
+    // Append checkpoint event to event log
+    const trigger = input.summary ?? 'explicit checkpoint';
+    const appended = appendEvent(
+      mutableState._events as WorkflowState['_events'],
+      mutableState._eventSequence as number,
+      'checkpoint',
+      trigger,
+    );
+    mutableState._events = appended.events;
+    mutableState._eventSequence = appended.eventSequence;
 
-  // Update lastActivityTimestamp
-  const checkpoint = mutableState._checkpoint as Record<string, unknown>;
-  checkpoint.lastActivityTimestamp = new Date().toISOString();
+    // Update lastActivityTimestamp
+    const checkpoint = mutableState._checkpoint as Record<string, unknown>;
+    checkpoint.lastActivityTimestamp = new Date().toISOString();
 
-  // Update top-level timestamp
-  mutableState.updatedAt = new Date().toISOString();
+    // Update top-level timestamp
+    mutableState.updatedAt = new Date().toISOString();
 
-  // Write back to disk
-  await writeStateFile(stateFile, mutableState as WorkflowState);
+    // Write back to disk
+    await writeStateFile(stateFile, mutableState as WorkflowState);
 
-  return {
-    success: true,
-    data: {
-      phase: (mutableState._checkpoint as Record<string, unknown>).phase as string,
-    },
-    _meta: buildCheckpointMeta(mutableState._checkpoint as WorkflowState['_checkpoint']),
-  };
+    return {
+      success: true,
+      data: {
+        phase: (mutableState._checkpoint as Record<string, unknown>).phase as string,
+      },
+      _meta: buildCheckpointMeta(mutableState._checkpoint as WorkflowState['_checkpoint']),
+    };
+  } catch (error) {
+    if (error instanceof Error && error.message.includes(ErrorCode.STATE_CORRUPT)) {
+      await writeStateFileUnsafe(stateFile, snapshot);
+      return {
+        success: false,
+        error: {
+          code: ErrorCode.STATE_CORRUPT,
+          message: `Checkpoint produced invalid state, rolled back to previous state. ${error.message}`,
+        },
+      };
+    }
+    throw error;
+  }
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/rules/mcp-tool-guidance.md
+++ b/rules/mcp-tool-guidance.md
@@ -15,7 +15,7 @@ Persistent state machine for workflow orchestration. **Always use for workflow t
 | `workflow_set` | Updating phase, recording artifacts, marking tasks complete |
 | `workflow_summary` | Quick context restoration after session restart |
 | `workflow_next_action` | Determining what to auto-continue after phase completion |
-| `workflow_reconcile` | Verifying state matches git reality on resume |
+| `workflow_reconcile` | Verifying state matches git reality on resume; with `repair: true`, auto-fixes common corruption (missing `_events`, invalid `_eventSequence`, null `_checkpoint`, bad task statuses) |
 | `workflow_checkpoint` | Saving progress before likely context exhaustion |
 | `workflow_cancel` | Cleaning up abandoned workflows |
 | `workflow_transitions` | Checking valid phase transitions |

--- a/rules/mcp-tool-guidance.md
+++ b/rules/mcp-tool-guidance.md
@@ -1,0 +1,103 @@
+# MCP Tool Guidance
+
+Proactively use the installed MCP servers. Don't fall back to generic approaches when a specialized tool exists.
+
+## Available MCP Servers
+
+### Workflow State (`mcp__workflow-state__*`)
+
+Persistent state machine for workflow orchestration. **Always use for workflow tracking.**
+
+| Tool | When to Use |
+|------|-------------|
+| `workflow_init` | Starting any `/ideate`, `/debug`, or `/refactor` workflow |
+| `workflow_get` | Restoring context, checking phase, reading task details |
+| `workflow_set` | Updating phase, recording artifacts, marking tasks complete |
+| `workflow_summary` | Quick context restoration after session restart |
+| `workflow_next_action` | Determining what to auto-continue after phase completion |
+| `workflow_reconcile` | Verifying state matches git reality on resume |
+| `workflow_checkpoint` | Saving progress before likely context exhaustion |
+| `workflow_cancel` | Cleaning up abandoned workflows |
+| `workflow_transitions` | Checking valid phase transitions |
+| `workflow_list` | Finding active workflows at session start |
+
+### GitHub (`mcp__plugin_github_github__*`)
+
+GitHub platform integration. **Prefer over `gh` CLI when structured data is needed.**
+
+| Tool | When to Use |
+|------|-------------|
+| `get_file_contents` | Reading files from remote repos or other branches |
+| `search_code` | Finding code patterns across repositories |
+| `search_issues` | Checking for existing issues before creating new ones |
+| `list_pull_requests` / `search_pull_requests` | Finding related PRs |
+| `pull_request_read` | Reading PR details, diffs, review status |
+| `create_pull_request` | Creating PRs with structured metadata |
+| `issue_read` / `issue_write` | Reading/managing issues |
+| `list_commits` / `get_commit` | Examining commit history |
+| `list_branches` / `create_branch` | Branch management |
+| `add_issue_comment` | Commenting on issues |
+| `pull_request_review_write` | Submitting PR reviews |
+
+**Proactive use:** When the user mentions a PR number, issue, or GitHub URL, use these tools to fetch context rather than asking the user to paste content.
+
+### Serena (`mcp__plugin_serena_serena__*`)
+
+Semantic code analysis with symbol-level understanding. **Prefer over grep/glob for code structure questions.**
+
+| Tool | When to Use |
+|------|-------------|
+| `find_symbol` | Locating classes, functions, methods by name — faster and more precise than grep |
+| `get_symbols_overview` | Understanding file/module structure without reading entire files |
+| `find_referencing_symbols` | Finding all callers/users of a symbol — critical for safe refactoring |
+| `search_for_pattern` | Regex search when symbol name is unknown |
+| `replace_symbol_body` | Replacing entire function/class bodies with structural awareness |
+| `insert_before_symbol` / `insert_after_symbol` | Adding code at precise structural locations |
+| `rename_symbol` | Safe renames that update all references |
+| `replace_content` | Regex-based replacement within files |
+
+**Proactive use:** When exploring unfamiliar code, start with `get_symbols_overview` and `find_symbol` before reading full files. Use `find_referencing_symbols` before modifying any public API.
+
+### Context7 (`mcp__plugin_context7_context7__*`)
+
+Up-to-date library documentation. **Use instead of web search for library/framework questions.**
+
+| Tool | When to Use |
+|------|-------------|
+| `resolve-library-id` | Finding the Context7 ID for a library |
+| `query-docs` | Getting current API docs, examples, and usage patterns |
+
+**Proactive use:** When writing code that uses external libraries, query Context7 for current API docs rather than relying on training data which may be outdated.
+
+### Microsoft Docs (`mcp__plugin_microsoft-docs_microsoft-learn__*`)
+
+Official Microsoft/Azure documentation. **Use for any Microsoft technology questions.**
+
+| Tool | When to Use |
+|------|-------------|
+| `microsoft_docs_search` | Quick overview of Azure/.NET/M365 topics |
+| `microsoft_code_sample_search` | Finding working code examples for Microsoft SDKs |
+| `microsoft_docs_fetch` | Deep-reading full docs when search excerpts aren't enough |
+
+**Proactive use:** When working with .NET, Azure, or any Microsoft SDK, search docs to verify API usage rather than guessing from training data.
+
+## Tool Selection Priority
+
+When deciding which tool to use:
+
+1. **Workflow tracking** — Always use workflow-state MCP for state, never manual JSON files
+2. **Code structure** — Prefer Serena's `find_symbol` / `get_symbols_overview` over grep for understanding code architecture
+3. **GitHub operations** — Use GitHub MCP for structured data; fall back to `gh` CLI only for operations not covered by MCP tools
+4. **Library docs** — Use Context7 before web search for library documentation
+5. **Microsoft tech** — Use Microsoft Docs MCP for any Azure/.NET/Microsoft question
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Grep for class definitions | Use Serena `find_symbol` |
+| Ask user to paste PR content | Use GitHub `pull_request_read` |
+| Guess library APIs from memory | Use Context7 `query-docs` |
+| Manually edit workflow state JSON | Use `workflow_set` MCP tool |
+| Web search for .NET API reference | Use `microsoft_docs_search` |
+| Read entire files to find a function | Use Serena `get_symbols_overview` then `find_symbol` with `include_body` |


### PR DESCRIPTION
## Summary

Hardens the workflow-state MCP server against state corruption by adding write-time schema validation, snapshot rollback on mutation failure, and a reconcile tool that can detect and repair common corruption patterns. State corruption was the top friction source across 534 Claude Code sessions — this eliminates the root cause.

## Changes

- **writeStateFile** — Now validates via `WorkflowStateSchema.safeParse()` before every write; rejects invalid state with field-path details. Split into validated (`writeStateFile`) and unvalidated (`writeStateFileUnsafe`) variants.
- **handleSet / handleCancel / handleCheckpoint** — Snapshot state before mutation via `structuredClone`; on `STATE_CORRUPT` from validation, rollback to snapshot and return structured error. Non-validation errors re-thrown.
- **workflow_reconcile** — Extended with `repair` parameter. Reads raw JSON (handles unparseable files), validates with Zod, maps issues to structured array. Repair mode fixes missing `_events`, negative `_eventSequence`, null `_checkpoint`, invalid task statuses.
- **Tool registration** — Updated `workflow_reconcile` description and schema in `index.ts`.

## Test Plan

Added 27 new tests covering write validation, rollback for all three mutation handlers, reconcile validation/repair/report-only modes, and two end-to-end integration tests. All 317 tests pass with clean typecheck and build.

---

**Results:** Tests 317 ✓ · Build 0 errors
**Design:** [workflow-state-hardening.md](docs/designs/2026-02-08-workflow-state-hardening.md)