### PR TITLE
refactor: increase Exarchos MCP server test coverage to 96%

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/stack/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/stack/tools.test.ts
@@ -191,4 +191,77 @@ describe('handleStackPlace', () => {
     expect(positions[1].position).toBe(2);
     expect(positions[2].position).toBe(3);
   });
+
+  it('negative position returns INVALID_INPUT', async () => {
+    const result = await handleStackPlace(
+      { streamId: 'wf-001', position: -1, taskId: 't1' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('position must be a non-negative integer');
+  });
+
+  it('float position returns INVALID_INPUT', async () => {
+    const result = await handleStackPlace(
+      { streamId: 'wf-001', position: 1.5, taskId: 't1' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('position must be a non-negative integer');
+  });
+
+  it('NaN position returns INVALID_INPUT', async () => {
+    const result = await handleStackPlace(
+      { streamId: 'wf-001', position: NaN, taskId: 't1' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('position must be a non-negative integer');
+  });
+
+  it('without optional branch and prUrl includes only required fields', async () => {
+    const result = await handleStackPlace(
+      { streamId: 'wf-001', position: 0, taskId: 't1' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+
+    const events = await store.query('wf-001', { type: 'stack.position-filled' });
+    expect(events).toHaveLength(1);
+    expect(events[0].data).toEqual({ position: 0, taskId: 't1' });
+    expect(events[0].data).not.toHaveProperty('branch');
+    expect(events[0].data).not.toHaveProperty('prUrl');
+  });
+
+  it('when store.append() throws returns PLACE_FAILED', async () => {
+    const result = await handleStackPlace(
+      { streamId: 'wf-001', position: 1, taskId: 't1' },
+      '/nonexistent/path/that/does/not/exist',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('PLACE_FAILED');
+    expect(result.error?.message).toBeDefined();
+  });
+});
+
+describe('handleStackStatus error path', () => {
+  it('when store.query() throws returns STATUS_FAILED', async () => {
+    // Use an invalid stream ID (uppercase chars) to trigger validateStreamId error
+    const result = await handleStackStatus(
+      { streamId: 'INVALID_STREAM_ID!!' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('STATUS_FAILED');
+    expect(result.error?.message).toBeDefined();
+  });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
@@ -124,6 +124,17 @@ describe('handleTaskComplete', () => {
     );
   });
 
+  it('empty taskId returns INVALID_INPUT', async () => {
+    const result = await handleTaskComplete(
+      { taskId: '', streamId: 'wf-001' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('taskId is required');
+  });
+
   it('missing streamId returns error', async () => {
     const result = await handleTaskComplete(
       { taskId: 't1', streamId: '' },
@@ -210,6 +221,17 @@ describe('handleTaskFail', () => {
         error: 'Unknown error',
       }),
     );
+  });
+
+  it('empty taskId returns INVALID_INPUT', async () => {
+    const result = await handleTaskFail(
+      { taskId: '', error: 'some error', streamId: 'wf-001' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('taskId is required');
   });
 
   it('missing error returns error', async () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
@@ -62,6 +62,27 @@ describe('handleTaskClaim', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('INVALID_INPUT');
   });
+
+  it('missing agentId returns error', async () => {
+    const result = await handleTaskClaim(
+      { taskId: 't1', agentId: '', streamId: 'wf-001' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('agentId is required');
+  });
+
+  it('store.append() failure returns CLAIM_FAILED error', async () => {
+    const result = await handleTaskClaim(
+      { taskId: 't1', agentId: 'agent-1', streamId: 'wf-001' },
+      '/nonexistent/path/claim-test',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('CLAIM_FAILED');
+  });
 });
 
 describe('handleTaskComplete', () => {
@@ -101,6 +122,50 @@ describe('handleTaskComplete', () => {
     expect(events[0].data).toEqual(
       expect.objectContaining({ taskId: 't1' }),
     );
+  });
+
+  it('missing streamId returns error', async () => {
+    const result = await handleTaskComplete(
+      { taskId: 't1', streamId: '' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('streamId is required');
+  });
+
+  it('with artifacts but no duration only includes artifacts in event data', async () => {
+    const result = await handleTaskComplete(
+      {
+        taskId: 't1',
+        result: { artifacts: ['auth.ts', 'auth.test.ts'] },
+        streamId: 'wf-002',
+      },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+
+    const events = await store.query('wf-002', { type: 'task.completed' });
+    expect(events).toHaveLength(1);
+    expect(events[0].data).toEqual(
+      expect.objectContaining({
+        taskId: 't1',
+        artifacts: ['auth.ts', 'auth.test.ts'],
+      }),
+    );
+    expect((events[0].data as Record<string, unknown>).duration).toBeUndefined();
+  });
+
+  it('store.append() failure returns COMPLETE_FAILED error', async () => {
+    const result = await handleTaskComplete(
+      { taskId: 't1', streamId: 'wf-001' },
+      '/nonexistent/path/complete-test',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('COMPLETE_FAILED');
   });
 });
 
@@ -155,5 +220,26 @@ describe('handleTaskFail', () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('missing streamId returns error', async () => {
+    const result = await handleTaskFail(
+      { taskId: 't1', error: 'some error', streamId: '' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('streamId is required');
+  });
+
+  it('store.append() failure returns FAIL_FAILED error', async () => {
+    const result = await handleTaskFail(
+      { taskId: 't1', error: 'some error', streamId: 'wf-001' },
+      '/nonexistent/path/fail-test',
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('FAIL_FAILED');
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/team/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/team/tools.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as path from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { EventStore } from '../../event-store/store.js';
+import { TeamCoordinator } from '../../team/coordinator.js';
 import {
   handleTeamSpawn,
   handleTeamMessage,
@@ -83,6 +84,16 @@ describe('handleTeamSpawn', () => {
     expect(result.error?.message).toContain('streamId');
   });
 
+  it('whitespace-only taskTitle returns INVALID_INPUT', async () => {
+    const result = await handleTeamSpawn(
+      { name: 'agent-1', role: 'implementer', taskId: 't1', taskTitle: '   ', streamId: 'wf-001' },
+      tempDir,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toContain('taskTitle');
+  });
+
   it('invalid role returns error', async () => {
     const result = await handleTeamSpawn(
       {
@@ -146,6 +157,36 @@ describe('handleTeamMessage', () => {
     );
   });
 
+  it('whitespace-only from returns INVALID_INPUT', async () => {
+    const result = await handleTeamMessage(
+      { from: '   ', to: 'agent-2', content: 'Hello', streamId: 'wf-001' },
+      tempDir,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toContain('from');
+  });
+
+  it('whitespace-only to returns INVALID_INPUT', async () => {
+    const result = await handleTeamMessage(
+      { from: 'agent-1', to: '   ', content: 'Hello', streamId: 'wf-001' },
+      tempDir,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toContain('to');
+  });
+
+  it('whitespace-only content returns INVALID_INPUT', async () => {
+    const result = await handleTeamMessage(
+      { from: 'agent-1', to: 'agent-2', content: '   ', streamId: 'wf-001' },
+      tempDir,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toContain('content');
+  });
+
   it('message to unknown target returns error', async () => {
     const result = await handleTeamMessage(
       { from: 'agent-1', to: 'unknown', content: 'Hello', streamId: 'wf-001' },
@@ -167,6 +208,26 @@ describe('handleTeamBroadcast', () => {
       { name: 'agent-2', role: 'reviewer', taskId: 't2', taskTitle: 'Task 2', streamId: 'wf-001' },
       tempDir,
     );
+  });
+
+  it('whitespace-only from returns INVALID_INPUT', async () => {
+    const result = await handleTeamBroadcast(
+      { from: '   ', content: 'All tasks paused', streamId: 'wf-001' },
+      tempDir,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toContain('from');
+  });
+
+  it('whitespace-only content returns INVALID_INPUT', async () => {
+    const result = await handleTeamBroadcast(
+      { from: 'orchestrator', content: '   ', streamId: 'wf-001' },
+      tempDir,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toContain('content');
   });
 
   it('broadcasts to all teammates', async () => {
@@ -208,6 +269,16 @@ describe('handleTeamShutdown', () => {
     expect(data.activeCount).toBe(0);
   });
 
+  it('whitespace-only name returns INVALID_INPUT', async () => {
+    const result = await handleTeamShutdown(
+      { name: '   ', streamId: 'wf-001' },
+      tempDir,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toContain('name');
+  });
+
   it('unknown name returns error', async () => {
     const result = await handleTeamShutdown(
       { name: 'unknown', streamId: 'wf-001' },
@@ -220,6 +291,20 @@ describe('handleTeamShutdown', () => {
 });
 
 describe('handleTeamStatus', () => {
+  it('returns STATUS_FAILED when getStatus throws', async () => {
+    const spy = vi.spyOn(TeamCoordinator.prototype, 'getStatus').mockImplementation(() => {
+      throw new Error('Coordinator corrupted');
+    });
+
+    const result = await handleTeamStatus({}, tempDir);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('STATUS_FAILED');
+    expect(result.error?.message).toContain('Coordinator corrupted');
+
+    spy.mockRestore();
+  });
+
   it('returns all teammates', async () => {
     await handleTeamSpawn(
       { name: 'agent-1', role: 'implementer', taskId: 't1', taskTitle: 'Task 1', streamId: 'wf-001' },

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/team/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/team/tools.test.ts
@@ -187,6 +187,26 @@ describe('handleTeamMessage', () => {
     expect(result.error?.message).toContain('content');
   });
 
+  it('empty streamId returns INVALID_INPUT', async () => {
+    const result = await handleTeamMessage(
+      { from: 'agent-1', to: 'agent-2', content: 'Hello', streamId: '' },
+      tempDir,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('streamId is required');
+  });
+
+  it('whitespace-only streamId returns INVALID_INPUT', async () => {
+    const result = await handleTeamMessage(
+      { from: 'agent-1', to: 'agent-2', content: 'Hello', streamId: '   ' },
+      tempDir,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('streamId is required');
+  });
+
   it('message to unknown target returns error', async () => {
     const result = await handleTeamMessage(
       { from: 'agent-1', to: 'unknown', content: 'Hello', streamId: 'wf-001' },
@@ -228,6 +248,26 @@ describe('handleTeamBroadcast', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('INVALID_INPUT');
     expect(result.error?.message).toContain('content');
+  });
+
+  it('empty streamId returns INVALID_INPUT', async () => {
+    const result = await handleTeamBroadcast(
+      { from: 'orchestrator', content: 'All tasks paused', streamId: '' },
+      tempDir,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('streamId is required');
+  });
+
+  it('whitespace-only streamId returns INVALID_INPUT', async () => {
+    const result = await handleTeamBroadcast(
+      { from: 'orchestrator', content: 'All tasks paused', streamId: '   ' },
+      tempDir,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('streamId is required');
   });
 
   it('broadcasts to all teammates', async () => {
@@ -277,6 +317,26 @@ describe('handleTeamShutdown', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('INVALID_INPUT');
     expect(result.error?.message).toContain('name');
+  });
+
+  it('empty streamId returns INVALID_INPUT', async () => {
+    const result = await handleTeamShutdown(
+      { name: 'agent-1', streamId: '' },
+      tempDir,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('streamId is required');
+  });
+
+  it('whitespace-only streamId returns INVALID_INPUT', async () => {
+    const result = await handleTeamShutdown(
+      { name: 'agent-1', streamId: '   ' },
+      tempDir,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toBe('streamId is required');
   });
 
   it('unknown name returns error', async () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/materializer.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/materializer.test.ts
@@ -157,6 +157,91 @@ describe('ViewMaterializer', () => {
       expect(viewB2.count).toBe(1);
     });
   });
+
+  describe('hasProjection', () => {
+    it('should return true for a registered projection', () => {
+      materializer.register('counter', counterProjection);
+
+      expect(materializer.hasProjection('counter')).toBe(true);
+    });
+
+    it('should return false for an unregistered projection', () => {
+      expect(materializer.hasProjection('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('getProjection', () => {
+    it('should return the projection for a registered view', () => {
+      materializer.register('counter', counterProjection);
+
+      const projection = materializer.getProjection<CounterView>('counter');
+
+      expect(projection).toBeDefined();
+      expect(projection!.init).toBeTypeOf('function');
+      expect(projection!.apply).toBeTypeOf('function');
+      expect(projection!.init()).toEqual({ count: 0, lastType: '' });
+    });
+
+    it('should return undefined for an unregistered view', () => {
+      const projection = materializer.getProjection('nonexistent');
+
+      expect(projection).toBeUndefined();
+    });
+  });
+
+  describe('getState', () => {
+    it('should return cached state after materialization', () => {
+      materializer.register('counter', counterProjection);
+
+      const events = [
+        makeEvent(1, 'workflow.started'),
+        makeEvent(2, 'task.assigned'),
+        makeEvent(3, 'task.completed'),
+      ];
+
+      materializer.materialize<CounterView>('test-stream', 'counter', events);
+
+      const state = materializer.getState<CounterView>('test-stream', 'counter');
+
+      expect(state).toBeDefined();
+      expect(state!.view.count).toBe(3);
+      expect(state!.view.lastType).toBe('task.completed');
+      expect(state!.highWaterMark).toBe(3);
+    });
+
+    it('should return undefined before any materialization', () => {
+      materializer.register('counter', counterProjection);
+
+      const state = materializer.getState<CounterView>('test-stream', 'counter');
+
+      expect(state).toBeUndefined();
+    });
+  });
+
+  describe('loadState', () => {
+    it('should manually load state that affects subsequent materialization', () => {
+      materializer.register('counter', counterProjection);
+
+      // Pre-load state as if 100 events had been processed
+      materializer.loadState<CounterView>(
+        'test-stream',
+        'counter',
+        { count: 100, lastType: 'preloaded' },
+        50,
+      );
+
+      // Materialize with events 51-55 (only these should be processed)
+      const events = Array.from({ length: 55 }, (_, i) =>
+        makeEvent(i + 1, `event.${i + 1}`),
+      );
+
+      const view = materializer.materialize<CounterView>('test-stream', 'counter', events);
+
+      // Should have 100 (preloaded) + 5 (events 51-55) = 105
+      expect(view.count).toBe(105);
+      expect(view.lastType).toBe('event.55');
+    });
+  });
 });
 
 // ─── A10: View Snapshot Mechanism ──────────────────────────────────────────
@@ -293,6 +378,43 @@ describe('ViewMaterializer with Snapshots', () => {
 
       // Should rebuild from scratch: 10 events processed
       expect(view.count).toBe(10);
+    });
+  });
+
+  describe('NoSnapshotStore_SkipsSnapshotting', () => {
+    it('should process 100+ events without error when no snapshotStore is configured', () => {
+      const materializer = new ViewMaterializer();
+      materializer.register('counter', counterProjection);
+
+      const events = Array.from({ length: 110 }, (_, i) =>
+        makeEvent(i + 1, `event.${i + 1}`),
+      );
+
+      const view = materializer.materialize<CounterView>('test-stream', 'counter', events);
+
+      expect(view.count).toBe(110);
+      expect(view.lastType).toBe('event.110');
+    });
+  });
+
+  describe('SnapshotIntervalNotCrossed_NoSnapshotCreated', () => {
+    it('should not create a snapshot when event count is below the interval', async () => {
+      const snapshotStore = new SnapshotStore(tempDir);
+      const materializer = new ViewMaterializer({ snapshotStore, snapshotInterval: 50 });
+      materializer.register('counter', counterProjection);
+
+      // Process only 10 events (below the 50-event snapshot interval)
+      const events = Array.from({ length: 10 }, (_, i) =>
+        makeEvent(i + 1, `event.${i + 1}`),
+      );
+
+      materializer.materialize<CounterView>('test-stream', 'counter', events);
+
+      // Allow async operations to settle
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const snapshot = await snapshotStore.load<CounterView>('test-stream', 'counter');
+      expect(snapshot).toBeUndefined();
     });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/materializer.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/materializer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as path from 'node:path';
 import { mkdtemp, rm, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -155,6 +155,152 @@ describe('ViewMaterializer', () => {
 
       expect(viewA2.count).toBe(3);
       expect(viewB2.count).toBe(1);
+    });
+  });
+
+  describe('hasProjection', () => {
+    it('should return true for a registered projection', () => {
+      materializer.register('counter', counterProjection);
+      expect(materializer.hasProjection('counter')).toBe(true);
+    });
+
+    it('should return false for an unregistered projection', () => {
+      expect(materializer.hasProjection('nonexistent')).toBe(false);
+    });
+
+    it('should return false after checking a name that was never registered', () => {
+      materializer.register('counter', counterProjection);
+      expect(materializer.hasProjection('other')).toBe(false);
+    });
+  });
+
+  describe('getProjection', () => {
+    it('should return the projection for a registered view name', () => {
+      materializer.register('counter', counterProjection);
+      const projection = materializer.getProjection<CounterView>('counter');
+      expect(projection).toBeDefined();
+      expect(projection).toBe(counterProjection);
+    });
+
+    it('should return undefined for an unregistered view name', () => {
+      const projection = materializer.getProjection<CounterView>('nonexistent');
+      expect(projection).toBeUndefined();
+    });
+
+    it('should return the correct projection when multiple are registered', () => {
+      interface OtherView { value: string }
+      const otherProjection: ViewProjection<OtherView> = {
+        init: () => ({ value: '' }),
+        apply: (view, event) => ({ value: event.type }),
+      };
+
+      materializer.register('counter', counterProjection);
+      materializer.register('other', otherProjection);
+
+      expect(materializer.getProjection('counter')).toBe(counterProjection);
+      expect(materializer.getProjection('other')).toBe(otherProjection);
+    });
+  });
+
+  describe('getState', () => {
+    it('should return undefined when no state has been materialized', () => {
+      const state = materializer.getState<CounterView>('test-stream', 'counter');
+      expect(state).toBeUndefined();
+    });
+
+    it('should return the cached view state after materialization', () => {
+      materializer.register('counter', counterProjection);
+      const events = [makeEvent(1, 'event.one'), makeEvent(2, 'event.two')];
+      materializer.materialize<CounterView>('test-stream', 'counter', events);
+
+      const state = materializer.getState<CounterView>('test-stream', 'counter');
+      expect(state).toBeDefined();
+      expect(state!.view.count).toBe(2);
+      expect(state!.view.lastType).toBe('event.two');
+      expect(state!.highWaterMark).toBe(2);
+    });
+
+    it('should return undefined for a different stream that has not been materialized', () => {
+      materializer.register('counter', counterProjection);
+      materializer.materialize<CounterView>('stream-a', 'counter', [makeEvent(1, 'a')]);
+
+      const state = materializer.getState<CounterView>('stream-b', 'counter');
+      expect(state).toBeUndefined();
+    });
+  });
+
+  describe('loadState', () => {
+    it('should load pre-existing state that can be retrieved with getState', () => {
+      const preloaded: CounterView = { count: 100, lastType: 'preloaded' };
+      materializer.loadState('test-stream', 'counter', preloaded, 100);
+
+      const state = materializer.getState<CounterView>('test-stream', 'counter');
+      expect(state).toBeDefined();
+      expect(state!.view.count).toBe(100);
+      expect(state!.view.lastType).toBe('preloaded');
+      expect(state!.highWaterMark).toBe(100);
+    });
+
+    it('should allow materialize to continue from loaded state', () => {
+      materializer.register('counter', counterProjection);
+      const preloaded: CounterView = { count: 50, lastType: 'event.50' };
+      materializer.loadState('test-stream', 'counter', preloaded, 50);
+
+      // Feed events 1-55; only 51-55 should be processed incrementally
+      const events = Array.from({ length: 55 }, (_, i) =>
+        makeEvent(i + 1, `event.${i + 1}`),
+      );
+      const view = materializer.materialize<CounterView>('test-stream', 'counter', events);
+
+      expect(view.count).toBe(55); // 50 preloaded + 5 new
+      expect(view.lastType).toBe('event.55');
+    });
+
+    it('should overwrite previously loaded state', () => {
+      materializer.loadState('test-stream', 'counter', { count: 10, lastType: 'a' }, 10);
+      materializer.loadState('test-stream', 'counter', { count: 20, lastType: 'b' }, 20);
+
+      const state = materializer.getState<CounterView>('test-stream', 'counter');
+      expect(state!.view.count).toBe(20);
+      expect(state!.highWaterMark).toBe(20);
+    });
+  });
+
+  describe('materialize_WithoutSnapshotStore', () => {
+    it('should work correctly without a snapshot store configured', () => {
+      // Default materializer has no snapshot store
+      materializer.register('counter', counterProjection);
+
+      const events = Array.from({ length: 100 }, (_, i) =>
+        makeEvent(i + 1, `event.${i + 1}`),
+      );
+
+      // Should not throw even though we exceed the default snapshot interval
+      const view = materializer.materialize<CounterView>('test-stream', 'counter', events);
+      expect(view.count).toBe(100);
+      expect(view.lastType).toBe('event.100');
+    });
+  });
+
+  describe('materialize_SnapshotIntervalNotCrossed', () => {
+    it('should not create a snapshot when interval has not been crossed', async () => {
+      const snapshotStore = new SnapshotStore(tmpdir());
+      const saveSpy = vi.spyOn(snapshotStore, 'save');
+
+      const mat = new ViewMaterializer({ snapshotStore, snapshotInterval: 50 });
+      mat.register('counter', counterProjection);
+
+      // Process only 10 events — well below the 50-event interval
+      const events = Array.from({ length: 10 }, (_, i) =>
+        makeEvent(i + 1, `event.${i + 1}`),
+      );
+
+      mat.materialize<CounterView>('test-stream', 'counter', events);
+
+      // save should NOT have been called since we're below the interval
+      expect(saveSpy).not.toHaveBeenCalled();
+
+      saveSpy.mockRestore();
     });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as path from 'node:path';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { EventStore } from '../../event-store/store.js';
 import {
@@ -89,6 +89,16 @@ describe('handleViewWorkflowStatus', () => {
     expect(data.featureId).toBe('');
     expect(data.tasksTotal).toBe(0);
   });
+
+  it('should return VIEW_ERROR when an internal error occurs', async () => {
+    // Use an invalid streamId (uppercase) to trigger validateStreamId error in EventStore.query
+    const result = await handleViewWorkflowStatus({ workflowId: '../INVALID' }, tempDir);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('VIEW_ERROR');
+    expect(result.error!.message).toContain('Invalid streamId');
+  });
 });
 
 describe('handleViewTeamStatus', () => {
@@ -103,6 +113,16 @@ describe('handleViewTeamStatus', () => {
     expect(teammates).toHaveLength(2);
     expect(teammates[0].name).toBe('agent-1');
     expect(teammates[0].role).toBe('coder');
+  });
+
+  it('should return VIEW_ERROR when an internal error occurs', async () => {
+    // Use an invalid streamId (uppercase) to trigger validateStreamId error in EventStore.query
+    const result = await handleViewTeamStatus({ workflowId: '../INVALID' }, tempDir);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('VIEW_ERROR');
+    expect(result.error!.message).toContain('Invalid streamId');
   });
 });
 
@@ -135,6 +155,43 @@ describe('handleViewTasks', () => {
     expect(data).toHaveLength(1);
     expect(data[0].taskId).toBe('t1');
   });
+
+  it('should return VIEW_ERROR when an internal error occurs', async () => {
+    // Use an invalid streamId (uppercase) to trigger validateStreamId error in EventStore.query
+    const result = await handleViewTasks({ workflowId: '../INVALID' }, tempDir);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('VIEW_ERROR');
+    expect(result.error!.message).toContain('Invalid streamId');
+  });
+
+  it('should return all tasks when filter is an empty object', async () => {
+    await populateWorkflow('wf-001');
+
+    const result = await handleViewTasks(
+      { workflowId: 'wf-001', filter: {} },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as Array<Record<string, unknown>>;
+    // Empty filter object matches all tasks (every key passes vacuously)
+    expect(data).toHaveLength(2);
+  });
+
+  it('should return empty array when filter matches no tasks', async () => {
+    await populateWorkflow('wf-001');
+
+    const result = await handleViewTasks(
+      { workflowId: 'wf-001', filter: { status: 'nonexistent' } },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as Array<Record<string, unknown>>;
+    expect(data).toHaveLength(0);
+  });
 });
 
 describe('handleViewPipeline', () => {
@@ -164,5 +221,29 @@ describe('handleViewPipeline', () => {
     expect(wf2).toBeDefined();
     expect(wf1!.taskCount).toBe(2);
     expect(wf2!.taskCount).toBe(1);
+  });
+
+  it('should return empty workflows array when no event streams exist', async () => {
+    // tempDir is empty — no .events.jsonl files
+    const result = await handleViewPipeline({}, tempDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const workflows = data.workflows as Array<Record<string, unknown>>;
+    expect(workflows).toHaveLength(0);
+  });
+
+  it('should return VIEW_ERROR when a discovered stream has an invalid ID', async () => {
+    // Create a .events.jsonl file with an uppercase name so discoverStreams
+    // returns the ID, but EventStore.query rejects it via validateStreamId
+    const invalidFile = path.join(tempDir, 'UPPERCASE.events.jsonl');
+    await writeFile(invalidFile, '');
+
+    const result = await handleViewPipeline({}, tempDir);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('VIEW_ERROR');
+    expect(result.error!.message).toContain('Invalid streamId');
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -89,6 +90,31 @@ describe('handleViewWorkflowStatus', () => {
     expect(data.featureId).toBe('');
     expect(data.tasksTotal).toBe(0);
   });
+
+  it('should use default streamId when workflowId is omitted', async () => {
+    await store.append('default', {
+      type: 'workflow.started',
+      data: { featureId: 'default-feature', workflowType: 'feature' },
+    });
+
+    const result = await handleViewWorkflowStatus({}, tempDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.featureId).toBe('default-feature');
+  });
+
+  it('should return VIEW_ERROR when workflowId contains invalid characters', async () => {
+    const result = await handleViewWorkflowStatus(
+      { workflowId: 'INVALID/ID' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('VIEW_ERROR');
+    expect(result.error!.message).toBeTruthy();
+  });
 });
 
 describe('handleViewTeamStatus', () => {
@@ -103,6 +129,37 @@ describe('handleViewTeamStatus', () => {
     expect(teammates).toHaveLength(2);
     expect(teammates[0].name).toBe('agent-1');
     expect(teammates[0].role).toBe('coder');
+  });
+
+  it('should use default streamId when workflowId is omitted', async () => {
+    await store.append('default', {
+      type: 'team.formed',
+      data: {
+        teammates: [
+          { name: 'default-agent', role: 'coder' },
+        ],
+      },
+    });
+
+    const result = await handleViewTeamStatus({}, tempDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const teammates = data.teammates as Array<{ name: string; role: string }>;
+    expect(teammates).toHaveLength(1);
+    expect(teammates[0].name).toBe('default-agent');
+  });
+
+  it('should return VIEW_ERROR when workflowId contains invalid characters', async () => {
+    const result = await handleViewTeamStatus(
+      { workflowId: 'INVALID/ID' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('VIEW_ERROR');
+    expect(result.error!.message).toBeTruthy();
   });
 });
 
@@ -135,6 +192,58 @@ describe('handleViewTasks', () => {
     expect(data).toHaveLength(1);
     expect(data[0].taskId).toBe('t1');
   });
+
+  it('should return all tasks when filter is empty object', async () => {
+    await populateWorkflow('wf-001');
+
+    const result = await handleViewTasks(
+      { workflowId: 'wf-001', filter: {} },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as Array<Record<string, unknown>>;
+    expect(data).toHaveLength(2);
+  });
+
+  it('should return empty array when filter matches nothing', async () => {
+    await populateWorkflow('wf-001');
+
+    const result = await handleViewTasks(
+      { workflowId: 'wf-001', filter: { status: 'nonexistent-status' } },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as Array<Record<string, unknown>>;
+    expect(data).toHaveLength(0);
+  });
+
+  it('should use default streamId when workflowId is omitted', async () => {
+    await store.append('default', {
+      type: 'task.assigned',
+      data: { taskId: 'dt1', title: 'Default task', branch: 'feat/default' },
+    });
+
+    const result = await handleViewTasks({}, tempDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Array<Record<string, unknown>>;
+    expect(data).toHaveLength(1);
+    expect(data[0].taskId).toBe('dt1');
+  });
+
+  it('should return VIEW_ERROR when workflowId contains invalid characters', async () => {
+    const result = await handleViewTasks(
+      { workflowId: 'INVALID/ID' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('VIEW_ERROR');
+    expect(result.error!.message).toBeTruthy();
+  });
 });
 
 describe('handleViewPipeline', () => {
@@ -164,5 +273,30 @@ describe('handleViewPipeline', () => {
     expect(wf2).toBeDefined();
     expect(wf1!.taskCount).toBe(2);
     expect(wf2!.taskCount).toBe(1);
+  });
+
+  it('should return empty workflows array when no event streams exist', async () => {
+    const result = await handleViewPipeline({}, tempDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const workflows = data.workflows as Array<Record<string, unknown>>;
+    expect(workflows).toHaveLength(0);
+  });
+
+  it('should return VIEW_ERROR when discovered stream has invalid ID', async () => {
+    // Create an events file with uppercase characters in the name,
+    // which will cause assertSafeId to throw in SnapshotStore
+    await fs.writeFile(
+      path.join(tempDir, 'INVALID_STREAM.events.jsonl'),
+      JSON.stringify({ type: 'workflow.started', sequence: 1, streamId: 'INVALID_STREAM', timestamp: new Date().toISOString(), data: {} }) + '\n',
+    );
+
+    const result = await handleViewPipeline({}, tempDir);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('VIEW_ERROR');
+    expect(result.error!.message).toBeTruthy();
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/compensation.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/compensation.test.ts
@@ -296,6 +296,700 @@ describe('Compensation', () => {
     });
   });
 
+  describe('ExecuteCompensation_UnknownPhase_RunsAllActions', () => {
+    it('should run all compensation actions when phase is not in PHASE_ORDER', async () => {
+      const state = makeState({ phase: 'unknown-phase' });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'unknown-phase', events, 1, { dryRun: true });
+
+      // Should have actions from all phase groups since all phases are included
+      expect(result.actions.length).toBeGreaterThan(0);
+
+      // All actions should be dry-run
+      for (const action of result.actions) {
+        expect(action.status).toBe('dry-run');
+      }
+
+      // Should include actions from synthesize, integrate, AND delegate phases
+      // since an unknown phase causes getPhasesInReverseOrder to return ALL phases
+      const actionIds = result.actions.map((a) => a.actionId);
+      const hasSynthesize = actionIds.some((id) => id.startsWith('synthesize:'));
+      const hasIntegrate = actionIds.some((id) => id.startsWith('integrate:'));
+      const hasDelegate = actionIds.some((id) => id.startsWith('delegate:'));
+
+      expect(hasSynthesize).toBe(true);
+      expect(hasIntegrate).toBe(true);
+      expect(hasDelegate).toBe(true);
+
+      // Reverse order: synthesize before integrate before delegate
+      const synthesizeIdx = actionIds.findIndex((id) => id.startsWith('synthesize:'));
+      const integrateIdx = actionIds.findIndex((id) => id.startsWith('integrate:'));
+      const delegateIdx = actionIds.findIndex((id) => id.startsWith('delegate:'));
+
+      expect(synthesizeIdx).toBeLessThan(integrateIdx);
+      expect(integrateIdx).toBeLessThan(delegateIdx);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should run all compensation actions with execution when phase is unknown', async () => {
+      const state = makeState({ phase: 'unknown-phase' });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'unknown-phase', events, 1, { dryRun: false });
+
+      // Should have actions from all phase groups
+      expect(result.actions.length).toBeGreaterThan(0);
+
+      // Should include actions from all three registered phases
+      const actionIds = result.actions.map((a) => a.actionId);
+      expect(actionIds.some((id) => id.startsWith('synthesize:'))).toBe(true);
+      expect(actionIds.some((id) => id.startsWith('integrate:'))).toBe(true);
+      expect(actionIds.some((id) => id.startsWith('delegate:'))).toBe(true);
+    });
+  });
+
+  describe('ExecuteCompensation_IdeatePhase_OnlyEarlyActions', () => {
+    it('should only include actions up to ideate phase (no actions since ideate has none)', async () => {
+      // State at ideate phase with no resources created yet
+      const state = makeState({
+        phase: 'ideate',
+        synthesis: {
+          integrationBranch: null,
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {},
+        tasks: [],
+      });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'ideate', events, 1, { dryRun: false });
+
+      // ideate has no registered compensation actions, so result should be empty
+      expect(result.actions.length).toBe(0);
+      expect(result.events.length).toBe(0);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('ClosePrAction_NullPrUrl_ReturnsSkipped', () => {
+    it('should return skipped when prUrl is null but synthesis object exists', async () => {
+      const state = makeState({
+        phase: 'synthesize',
+        synthesis: {
+          integrationBranch: 'integrate/test-feature',
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {},
+        tasks: [],
+      });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'synthesize', events, 1, { dryRun: false });
+
+      // Find the close-pr action
+      const closePrAction = result.actions.find((a) => a.actionId === 'synthesize:close-pr');
+      expect(closePrAction).toBeDefined();
+      expect(closePrAction!.status).toBe('skipped');
+      expect(closePrAction!.message).toBe('No PR to close');
+    });
+
+    it('should return skipped when synthesis is undefined', async () => {
+      const state = makeState({
+        phase: 'synthesize',
+        synthesis: undefined,
+        worktrees: {},
+        tasks: [],
+      });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'synthesize', events, 1, { dryRun: false });
+
+      const closePrAction = result.actions.find((a) => a.actionId === 'synthesize:close-pr');
+      expect(closePrAction).toBeDefined();
+      expect(closePrAction!.status).toBe('skipped');
+      expect(closePrAction!.message).toBe('No PR to close');
+    });
+  });
+
+  describe('DeleteFeatureBranches_TasksWithMissingBranches_FiltersCorrectly', () => {
+    it('should skip tasks with no branch property and only process those with branches', async () => {
+      const state = makeState({
+        phase: 'delegate',
+        synthesis: {
+          integrationBranch: null,
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {},
+        tasks: [
+          { id: 'task-1', title: 'Task 1', status: 'pending' },
+          { id: 'task-2', title: 'Task 2', status: 'complete', branch: undefined },
+          { id: 'task-3', title: 'Task 3', status: 'complete', branch: 'feature/task-3' },
+        ],
+      });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: false });
+
+      const deleteAction = result.actions.find((a) => a.actionId === 'delegate:delete-feature-branches');
+      expect(deleteAction).toBeDefined();
+      // Should execute (not skip) since at least one task has a branch
+      expect(deleteAction!.status).toBe('executed');
+      expect(deleteAction!.message).toContain('1 feature branch');
+    });
+
+    it('should skip when all tasks lack branch property', async () => {
+      const state = makeState({
+        phase: 'delegate',
+        synthesis: {
+          integrationBranch: null,
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {},
+        tasks: [
+          { id: 'task-1', title: 'Task 1', status: 'pending' },
+          { id: 'task-2', title: 'Task 2', status: 'complete', branch: undefined },
+        ],
+      });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: false });
+
+      const deleteAction = result.actions.find((a) => a.actionId === 'delegate:delete-feature-branches');
+      expect(deleteAction).toBeDefined();
+      expect(deleteAction!.status).toBe('skipped');
+      expect(deleteAction!.message).toBe('No feature branches to delete');
+    });
+  });
+
+  describe('CleanupWorktrees_MissingPath_SkipsWorktree', () => {
+    it('should skip worktrees that have no path and continue processing others', async () => {
+      const state = makeState({
+        phase: 'delegate',
+        synthesis: {
+          integrationBranch: null,
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {
+          'task-1': { branch: 'feature/task-1', taskId: 'task-1', status: 'active' },
+          'task-2': { branch: 'feature/task-2', taskId: 'task-2', status: 'active', path: '/tmp/worktree-2' },
+        },
+        tasks: [],
+      });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: false });
+
+      const cleanupAction = result.actions.find((a) => a.actionId === 'delegate:cleanup-worktrees');
+      expect(cleanupAction).toBeDefined();
+      expect(cleanupAction!.status).toBe('executed');
+
+      // Only the worktree with a path should have triggered a git command
+      const worktreeRemoveCalls = mockedExecFile.mock.calls.filter((call) => {
+        const args = call[1] as string[] | undefined;
+        return args?.includes('worktree') && args?.includes('remove');
+      });
+
+      // Should only have 1 remove call (for task-2 which has a path)
+      expect(worktreeRemoveCalls.length).toBe(1);
+      const removeArgs = worktreeRemoveCalls[0][1] as string[];
+      expect(removeArgs).toContain('/tmp/worktree-2');
+    });
+  });
+
+  describe('ExecuteCompensation_PlanPhase_OnlyDelegateAndEarlier', () => {
+    it('should not include synthesize or integrate actions when phase is plan', async () => {
+      const state = makeState({ phase: 'plan' });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'plan', events, 1, { dryRun: true });
+
+      const actionIds = result.actions.map((a) => a.actionId);
+
+      // plan is before delegate in PHASE_ORDER, so only ideate and plan phases included
+      // Neither has registered actions, so there should be no actions
+      expect(actionIds.every((id) => !id.startsWith('synthesize:'))).toBe(true);
+      expect(actionIds.every((id) => !id.startsWith('integrate:'))).toBe(true);
+      expect(actionIds.every((id) => !id.startsWith('delegate:'))).toBe(true);
+      expect(result.actions.length).toBe(0);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('ExecuteCompensation_DelegatePhase_IncludesDelegateActionsOnly', () => {
+    it('should include delegate-phase actions but not integrate or synthesize', async () => {
+      const state = makeState({ phase: 'delegate' });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: true });
+
+      const actionIds = result.actions.map((a) => a.actionId);
+
+      // delegate phase should have delegate actions
+      expect(actionIds.some((id) => id.startsWith('delegate:'))).toBe(true);
+
+      // Should NOT have synthesize or integrate actions
+      expect(actionIds.every((id) => !id.startsWith('synthesize:'))).toBe(true);
+      expect(actionIds.every((id) => !id.startsWith('integrate:'))).toBe(true);
+    });
+  });
+
+  describe('DeleteFeatureBranches_DryRun_ListsBranchNames', () => {
+    it('should list branch names in dry-run message', async () => {
+      const state = makeState({
+        phase: 'delegate',
+        synthesis: {
+          integrationBranch: null,
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {},
+        tasks: [
+          { id: 'task-1', title: 'Task 1', status: 'complete', branch: 'feature/task-1' },
+          { id: 'task-2', title: 'Task 2', status: 'complete', branch: 'feature/task-2' },
+        ],
+      });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: true });
+
+      const deleteAction = result.actions.find((a) => a.actionId === 'delegate:delete-feature-branches');
+      expect(deleteAction).toBeDefined();
+      expect(deleteAction!.status).toBe('dry-run');
+      expect(deleteAction!.message).toContain('feature/task-1');
+      expect(deleteAction!.message).toContain('feature/task-2');
+    });
+  });
+
+  describe('CleanupWorktrees_DryRun_ListsBranchNames', () => {
+    it('should list worktree branch names in dry-run message', async () => {
+      const state = makeState({
+        phase: 'delegate',
+        synthesis: {
+          integrationBranch: null,
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {
+          'task-1': { branch: 'feature/task-1', taskId: 'task-1', status: 'active', path: '/tmp/wt-1' },
+          'task-2': { branch: 'feature/task-2', taskId: 'task-2', status: 'active', path: '/tmp/wt-2' },
+        },
+        tasks: [],
+      });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: true });
+
+      const cleanupAction = result.actions.find((a) => a.actionId === 'delegate:cleanup-worktrees');
+      expect(cleanupAction).toBeDefined();
+      expect(cleanupAction!.status).toBe('dry-run');
+      expect(cleanupAction!.message).toContain('feature/task-1');
+      expect(cleanupAction!.message).toContain('feature/task-2');
+    });
+  });
+
+  describe('CleanupWorktrees_OuterCatch_ReturnsFailed', () => {
+    it('should trigger outer catch when worktree property access throws', async () => {
+      // The outer catch (lines 189-196) wraps the entire for-loop body.
+      // Lines 176-177 (worktree.path access and the continue check) are OUTSIDE
+      // the inner try/catch. A throwing getter on .path triggers the outer catch.
+      const poisonedWorktree = {
+        branch: 'feature/poison',
+        taskId: 'task-poison',
+        status: 'active',
+        get path(): string {
+          throw new Error('Poisoned path getter');
+        },
+      };
+
+      const state = makeState({
+        phase: 'delegate',
+        synthesis: {
+          integrationBranch: null,
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {
+          'task-poison': poisonedWorktree,
+        },
+        tasks: [],
+      });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: false });
+
+      const cleanupAction = result.actions.find((a) => a.actionId === 'delegate:cleanup-worktrees');
+      expect(cleanupAction).toBeDefined();
+      expect(cleanupAction!.status).toBe('failed');
+      expect(cleanupAction!.message).toContain('Failed to clean up worktrees');
+      expect(cleanupAction!.message).toContain('Poisoned path getter');
+    });
+
+    it('should handle non-Error thrown values in outer catch via String()', async () => {
+      const poisonedWorktree = {
+        branch: 'feature/poison',
+        taskId: 'task-poison',
+        status: 'active',
+        get path(): string {
+          throw 'non-error-string-thrown'; // eslint-disable-line no-throw-literal
+        },
+      };
+
+      const state = makeState({
+        phase: 'delegate',
+        synthesis: {
+          integrationBranch: null,
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {
+          'task-poison': poisonedWorktree,
+        },
+        tasks: [],
+      });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: false });
+
+      const cleanupAction = result.actions.find((a) => a.actionId === 'delegate:cleanup-worktrees');
+      expect(cleanupAction).toBeDefined();
+      expect(cleanupAction!.status).toBe('failed');
+      expect(cleanupAction!.message).toContain('non-error-string-thrown');
+    });
+  });
+
+  describe('DeleteFeatureBranches_OuterCatch_ViaCorruptedIteration', () => {
+    it('should trigger outer catch when branches array iteration throws unexpectedly', async () => {
+      // The outer catch (lines 248-255) wraps the for-loop for branches.
+      // The for-loop body is: inner try (local delete) + inner try (remote delete).
+      // Everything in the for-loop body is wrapped by inner catches.
+      // However, we can trigger the outer catch by corrupting the branches array
+      // after it's created but before iteration completes.
+      // We achieve this by using a Proxy on the tasks array that produces
+      // a branches array with a corrupted Symbol.iterator.
+
+      // Override Array.prototype.filter to return an array with a throwing iterator
+      // only for the specific call in deleteFeatureBranches
+      const originalFilter = Array.prototype.filter;
+      let filterCallCount = 0;
+
+      // We need to intercept the specific filter call that creates the branches array.
+      // The code does: tasks.map(t => t.branch).filter(b => !!b)
+      // The filter is called on the mapped array.
+      vi.spyOn(Array.prototype, 'filter').mockImplementation(function (this: unknown[], ...args: unknown[]) {
+        filterCallCount++;
+        const result = originalFilter.apply(this, args as Parameters<typeof originalFilter>);
+
+        // The deleteFeatureBranches filter happens on the mapped branches array
+        // Check if this looks like the branches filter (array of strings/undefined)
+        if (result.length > 0 && typeof result[0] === 'string' && result[0].startsWith('feature/outer-catch')) {
+          // Return a proxy that throws during for-of iteration
+          const throwingArray = [...result];
+          const originalIterator = throwingArray[Symbol.iterator].bind(throwingArray);
+          let iterCount = 0;
+          throwingArray[Symbol.iterator] = function* () {
+            const iter = originalIterator();
+            for (const val of { [Symbol.iterator]: () => iter }) {
+              iterCount++;
+              if (iterCount > 0) {
+                throw new Error('Iterator corrupted');
+              }
+              yield val;
+            }
+          };
+          return throwingArray;
+        }
+
+        return result;
+      });
+
+      const state = makeState({
+        phase: 'delegate',
+        synthesis: {
+          integrationBranch: null,
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {},
+        tasks: [
+          { id: 'task-1', title: 'Task 1', status: 'complete', branch: 'feature/outer-catch-1' },
+        ],
+      });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: false });
+
+      // Restore the original filter
+      vi.restoreAllMocks();
+      // Re-establish the execFile mock since restoreAllMocks clears it
+      mockedExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, cb?: unknown) => {
+        if (typeof _opts === 'function') {
+          (_opts as (err: null, stdout: string, stderr: string) => void)(null, '', '');
+        } else if (typeof cb === 'function') {
+          (cb as (err: null, stdout: string, stderr: string) => void)(null, '', '');
+        }
+        return undefined as never;
+      });
+
+      const deleteAction = result.actions.find((a) => a.actionId === 'delegate:delete-feature-branches');
+      expect(deleteAction).toBeDefined();
+      expect(deleteAction!.status).toBe('failed');
+      expect(deleteAction!.message).toContain('Failed to delete feature branches');
+      expect(deleteAction!.message).toContain('Iterator corrupted');
+    });
+  });
+
+  describe('DeleteIntegrationBranch_RemoteDeleteFailure_StillSucceeds', () => {
+    it('should succeed when remote branch delete fails (inner catch swallows)', async () => {
+      const state = makeState({
+        phase: 'integrate',
+        synthesis: {
+          integrationBranch: 'integrate/test-feature',
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {},
+        tasks: [],
+      });
+      const events = makeEvents(1);
+
+      // Make remote delete (push --delete) fail
+      mockedExecFile.mockImplementation((cmd: unknown, args: unknown, opts: unknown, cb?: unknown) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        const argList = args as string[];
+        if (argList?.includes('push') && argList?.includes('--delete')) {
+          (callback as (err: Error) => void)(new Error('remote ref does not exist'));
+        } else {
+          (callback as (err: null, stdout: string, stderr: string) => void)(null, '', '');
+        }
+        return undefined as never;
+      });
+
+      const result = await executeCompensation(state, 'integrate', events, 1, { dryRun: false });
+
+      const deleteAction = result.actions.find((a) => a.actionId === 'integrate:delete-integration-branch');
+      expect(deleteAction).toBeDefined();
+      // Still succeeds because inner catch swallows remote delete failure
+      expect(deleteAction!.status).toBe('executed');
+      expect(deleteAction!.message).toContain('Deleted integration branch');
+    });
+  });
+
+  describe('CleanupWorktrees_WorktreeRemoveFailure_StillSucceeds', () => {
+    it('should succeed when worktree remove command fails (inner catch swallows)', async () => {
+      const state = makeState({
+        phase: 'delegate',
+        synthesis: {
+          integrationBranch: null,
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {
+          'task-1': { branch: 'feature/task-1', taskId: 'task-1', status: 'active', path: '/tmp/wt-1' },
+        },
+        tasks: [],
+      });
+      const events = makeEvents(1);
+
+      // Make worktree remove fail
+      mockedExecFile.mockImplementation((cmd: unknown, args: unknown, opts: unknown, cb?: unknown) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        const argList = args as string[];
+        if (argList?.includes('worktree') && argList?.includes('remove')) {
+          (callback as (err: Error) => void)(new Error('worktree not found'));
+        } else {
+          (callback as (err: null, stdout: string, stderr: string) => void)(null, '', '');
+        }
+        return undefined as never;
+      });
+
+      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: false });
+
+      const cleanupAction = result.actions.find((a) => a.actionId === 'delegate:cleanup-worktrees');
+      expect(cleanupAction).toBeDefined();
+      // Still succeeds because inner catch swallows the worktree remove failure
+      expect(cleanupAction!.status).toBe('executed');
+      expect(cleanupAction!.message).toContain('Cleaned up 1 worktree');
+    });
+  });
+
+  describe('DeleteIntegrationBranch_Executed_ReturnsSuccess', () => {
+    it('should successfully delete integration branch when it exists and commands succeed', async () => {
+      const state = makeState({
+        phase: 'integrate',
+        synthesis: {
+          integrationBranch: 'integrate/test-feature',
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {},
+        tasks: [],
+      });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'integrate', events, 1, { dryRun: false });
+
+      const deleteAction = result.actions.find((a) => a.actionId === 'integrate:delete-integration-branch');
+      expect(deleteAction).toBeDefined();
+      expect(deleteAction!.status).toBe('executed');
+      expect(deleteAction!.message).toContain('Deleted integration branch: integrate/test-feature');
+
+      // Should have called git branch -D and git push origin --delete
+      const branchDeleteCalls = mockedExecFile.mock.calls.filter((call) => {
+        const args = call[1] as string[] | undefined;
+        return args?.includes('branch') && args?.includes('-D');
+      });
+      const remotePushCalls = mockedExecFile.mock.calls.filter((call) => {
+        const args = call[1] as string[] | undefined;
+        return args?.includes('push') && args?.includes('--delete');
+      });
+
+      expect(branchDeleteCalls.length).toBeGreaterThanOrEqual(1);
+      expect(remotePushCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should still succeed when local branch delete fails but remote succeeds', async () => {
+      const state = makeState({
+        phase: 'integrate',
+        synthesis: {
+          integrationBranch: 'integrate/test-feature',
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {},
+        tasks: [],
+      });
+      const events = makeEvents(1);
+
+      // Make local branch delete fail, but remote succeeds
+      mockedExecFile.mockImplementation((cmd: unknown, args: unknown, opts: unknown, cb?: unknown) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        const argList = args as string[];
+        if (argList?.includes('branch') && argList?.includes('-D')) {
+          (callback as (err: Error) => void)(new Error('branch not found'));
+        } else {
+          (callback as (err: null, stdout: string, stderr: string) => void)(null, '', '');
+        }
+        return undefined as never;
+      });
+
+      const result = await executeCompensation(state, 'integrate', events, 1, { dryRun: false });
+
+      const deleteAction = result.actions.find((a) => a.actionId === 'integrate:delete-integration-branch');
+      expect(deleteAction).toBeDefined();
+      // Still succeeds because inner catch blocks swallow failures
+      expect(deleteAction!.status).toBe('executed');
+    });
+  });
+
+  describe('DeleteFeatureBranches_RemoteDeleteFailure_StillSucceeds', () => {
+    it('should succeed when remote branch push --delete fails (inner catch swallows)', async () => {
+      const state = makeState({
+        phase: 'delegate',
+        synthesis: {
+          integrationBranch: null,
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {},
+        tasks: [
+          { id: 'task-1', title: 'Task 1', status: 'complete', branch: 'feature/task-1' },
+        ],
+      });
+      const events = makeEvents(1);
+
+      // Make remote delete fail for all branches
+      mockedExecFile.mockImplementation((cmd: unknown, args: unknown, opts: unknown, cb?: unknown) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        const argList = args as string[];
+        if (argList?.includes('push') && argList?.includes('--delete')) {
+          (callback as (err: Error) => void)(new Error('remote ref not found'));
+        } else {
+          (callback as (err: null, stdout: string, stderr: string) => void)(null, '', '');
+        }
+        return undefined as never;
+      });
+
+      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: false });
+
+      const deleteAction = result.actions.find((a) => a.actionId === 'delegate:delete-feature-branches');
+      expect(deleteAction).toBeDefined();
+      // Still succeeds because inner catch swallows the remote delete failure
+      expect(deleteAction!.status).toBe('executed');
+      expect(deleteAction!.message).toContain('Deleted 1 feature branch');
+    });
+
+    it('should succeed when both local and remote deletes fail for feature branches', async () => {
+      const state = makeState({
+        phase: 'delegate',
+        synthesis: {
+          integrationBranch: null,
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        worktrees: {},
+        tasks: [
+          { id: 'task-1', title: 'Task 1', status: 'complete', branch: 'feature/task-1' },
+          { id: 'task-2', title: 'Task 2', status: 'complete', branch: 'feature/task-2' },
+        ],
+      });
+      const events = makeEvents(1);
+
+      // Make all git commands fail
+      mockedExecFile.mockImplementation((cmd: unknown, args: unknown, opts: unknown, cb?: unknown) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        (callback as (err: Error) => void)(new Error('command failed'));
+        return undefined as never;
+      });
+
+      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: false });
+
+      const deleteAction = result.actions.find((a) => a.actionId === 'delegate:delete-feature-branches');
+      expect(deleteAction).toBeDefined();
+      // Still 'executed' because inner catches swallow individual failures
+      expect(deleteAction!.status).toBe('executed');
+      expect(deleteAction!.message).toContain('Deleted 2 feature branch');
+    });
+  });
+
   describe('ExecuteCompensation_LogsEvents_ForEachAction', () => {
     it('should produce a compensation event for each executed action', async () => {
       const state = makeState({ phase: 'delegate' });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/compensation.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/compensation.test.ts
@@ -695,13 +695,11 @@ describe('Compensation', () => {
       // Override Array.prototype.filter to return an array with a throwing iterator
       // only for the specific call in deleteFeatureBranches
       const originalFilter = Array.prototype.filter;
-      let filterCallCount = 0;
 
       // We need to intercept the specific filter call that creates the branches array.
       // The code does: tasks.map(t => t.branch).filter(b => !!b)
       // The filter is called on the mapped array.
       vi.spyOn(Array.prototype, 'filter').mockImplementation(function (this: unknown[], ...args: unknown[]) {
-        filterCallCount++;
         const result = originalFilter.apply(this, args as Parameters<typeof originalFilter>);
 
         // The deleteFeatureBranches filter happens on the mapped branches array
@@ -743,19 +741,22 @@ describe('Compensation', () => {
       });
       const events = makeEvents(1);
 
-      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: false });
-
-      // Restore the original filter
-      vi.restoreAllMocks();
-      // Re-establish the execFile mock since restoreAllMocks clears it
-      mockedExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, cb?: unknown) => {
-        if (typeof _opts === 'function') {
-          (_opts as (err: null, stdout: string, stderr: string) => void)(null, '', '');
-        } else if (typeof cb === 'function') {
-          (cb as (err: null, stdout: string, stderr: string) => void)(null, '', '');
-        }
-        return undefined as never;
-      });
+      let result: Awaited<ReturnType<typeof executeCompensation>>;
+      try {
+        result = await executeCompensation(state, 'delegate', events, 1, { dryRun: false });
+      } finally {
+        // Guarantee restore even if the test throws, preventing mock leakage
+        vi.restoreAllMocks();
+        // Re-establish the execFile mock since restoreAllMocks clears it
+        mockedExecFile.mockImplementation((_cmd: unknown, _args: unknown, _opts: unknown, cb?: unknown) => {
+          if (typeof _opts === 'function') {
+            (_opts as (err: null, stdout: string, stderr: string) => void)(null, '', '');
+          } else if (typeof cb === 'function') {
+            (cb as (err: null, stdout: string, stderr: string) => void)(null, '', '');
+          }
+          return undefined as never;
+        });
+      }
 
       const deleteAction = result.actions.find((a) => a.actionId === 'delegate:delete-feature-branches');
       expect(deleteAction).toBeDefined();

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
@@ -4,7 +4,7 @@ import {
   executeTransition,
   getValidTransitions,
 } from '../../workflow/state-machine.js';
-import type { HSMDefinition } from '../../workflow/state-machine.js';
+import type { HSMDefinition, State, Transition } from '../../workflow/state-machine.js';
 
 // ─── Task 003: HSM State/Transition Definitions ─────────────────────────────
 
@@ -1925,5 +1925,112 @@ describe('Missing _events and _history defaults', () => {
 
     expect(result.success).toBe(true);
     expect(result.newPhase).toBe('plan');
+  });
+});
+
+// ─── Task: Leaf-state onEntry/onExit effect coverage ──────────────────────────
+
+describe('Leaf-state onEntry/onExit effects', () => {
+  // Build a minimal custom HSM where leaf (atomic) states have onEntry/onExit effects.
+  // This exercises the code paths at lines 843-844 (currentState.onExit) and
+  // 876-877 (targetState.onEntry) in state-machine.ts, which are not reached
+  // by the built-in HSM definitions (only compound states have effects there).
+
+  function createTestHSM(): HSMDefinition {
+    const states: Record<string, State> = {
+      alpha: {
+        id: 'alpha',
+        type: 'atomic',
+        onExit: ['log'],
+      },
+      beta: {
+        id: 'beta',
+        type: 'atomic',
+        onEntry: ['checkpoint'],
+      },
+      done: {
+        id: 'done',
+        type: 'final',
+      },
+      cancelled: {
+        id: 'cancelled',
+        type: 'final',
+      },
+    };
+
+    const transitions: Transition[] = [
+      { from: 'alpha', to: 'beta' },
+      { from: 'beta', to: 'done' },
+    ];
+
+    return { id: 'test-leaf-effects', states, transitions };
+  }
+
+  it('collects onExit effect from the current leaf state during transition', () => {
+    const hsm = createTestHSM();
+    const state: Record<string, unknown> = {
+      phase: 'alpha',
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'beta');
+
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('beta');
+    // Should include the onExit effect from the alpha leaf state
+    expect(result.effects).toContain('log');
+  });
+
+  it('collects onEntry effect from the target leaf state during transition', () => {
+    const hsm = createTestHSM();
+    const state: Record<string, unknown> = {
+      phase: 'alpha',
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'beta');
+
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('beta');
+    // Should include the onEntry effect from the beta leaf state
+    expect(result.effects).toContain('checkpoint');
+  });
+
+  it('collects both onExit and onEntry leaf effects in a single transition', () => {
+    const hsm = createTestHSM();
+    const state: Record<string, unknown> = {
+      phase: 'alpha',
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'beta');
+
+    expect(result.success).toBe(true);
+    // Both leaf-state exit (log) and entry (checkpoint) effects should be present
+    expect(result.effects).toContain('log');
+    expect(result.effects).toContain('checkpoint');
+    // Exit effects come before entry effects
+    const logIdx = result.effects.indexOf('log');
+    const checkpointIdx = result.effects.indexOf('checkpoint');
+    expect(logIdx).toBeLessThan(checkpointIdx);
+  });
+
+  it('collects onExit effect from leaf state on cancel transition', () => {
+    const hsm = createTestHSM();
+    const state: Record<string, unknown> = {
+      phase: 'alpha',
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'cancelled');
+
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('cancelled');
+    // Should include the onExit effect from the alpha leaf state via cancel path
+    expect(result.effects).toContain('log');
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
@@ -718,5 +718,1212 @@ describe('HSM Transition Algorithm', () => {
 
       expect(targets).toEqual([]);
     });
+
+    it('returns valid transitions for compound state children', () => {
+      const hsm = getHSMDefinition('feature');
+
+      // delegate is inside implementation compound
+      const delegateTargets = getValidTransitions(hsm, 'delegate');
+      expect(delegateTargets).toContain('integrate');
+      expect(delegateTargets).toContain('cancelled');
+
+      // integrate has two transitions: review (passed) and delegate (fix cycle)
+      const integrateTargets = getValidTransitions(hsm, 'integrate');
+      expect(integrateTargets).toContain('review');
+      expect(integrateTargets).toContain('delegate');
+      expect(integrateTargets).toContain('cancelled');
+
+      // review has two transitions: synthesize (passed) and delegate (fix cycle)
+      const reviewTargets = getValidTransitions(hsm, 'review');
+      expect(reviewTargets).toContain('synthesize');
+      expect(reviewTargets).toContain('delegate');
+      expect(reviewTargets).toContain('cancelled');
+    });
+
+    it('returns valid transitions for debug HSM phases', () => {
+      const hsm = getHSMDefinition('debug');
+
+      const triageTargets = getValidTransitions(hsm, 'triage');
+      expect(triageTargets).toContain('investigate');
+      expect(triageTargets).toContain('cancelled');
+
+      const investigateTargets = getValidTransitions(hsm, 'investigate');
+      expect(investigateTargets).toContain('rca');
+      expect(investigateTargets).toContain('hotfix-implement');
+      expect(investigateTargets).toContain('cancelled');
+
+      const rcaTargets = getValidTransitions(hsm, 'rca');
+      expect(rcaTargets).toContain('design');
+      expect(rcaTargets).toContain('cancelled');
+    });
+
+    it('returns valid transitions for refactor HSM phases', () => {
+      const hsm = getHSMDefinition('refactor');
+
+      const exploreTargets = getValidTransitions(hsm, 'explore');
+      expect(exploreTargets).toContain('brief');
+      expect(exploreTargets).toContain('cancelled');
+
+      const briefTargets = getValidTransitions(hsm, 'brief');
+      expect(briefTargets).toContain('polish-implement');
+      expect(briefTargets).toContain('overhaul-plan');
+      expect(briefTargets).toContain('cancelled');
+    });
+
+    it('returns empty array for cancelled (final) state', () => {
+      const hsm = getHSMDefinition('feature');
+      const targets = getValidTransitions(hsm, 'cancelled');
+      expect(targets).toEqual([]);
+    });
+  });
+});
+
+// ─── Task: Debug HSM executeTransition Tests ──────────────────────────────────
+
+describe('Debug HSM executeTransition', () => {
+  describe('investigate to thorough track', () => {
+    it('transitions from investigate to rca when thorough track selected', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'investigate',
+        track: 'thorough',
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'rca');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('rca');
+      expect(result.idempotent).toBe(false);
+      // Should have compound-entry event for thorough-track
+      const compoundEntry = result.events.find(
+        (e) => e.type === 'compound-entry'
+      );
+      expect(compoundEntry).toBeDefined();
+      expect(compoundEntry!.metadata!.compoundStateId).toBe('thorough-track');
+      // Should have onEntry effect from thorough-track compound
+      expect(result.effects).toContain('log');
+    });
+
+    it('fails to transition from investigate to rca when hotfix track selected', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'investigate',
+        track: 'hotfix',
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'rca');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+  });
+
+  describe('investigate to hotfix track', () => {
+    it('transitions from investigate to hotfix-implement when hotfix track selected', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'investigate',
+        track: 'hotfix',
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'hotfix-implement');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('hotfix-implement');
+      // Should have compound-entry event for hotfix-track
+      const compoundEntry = result.events.find(
+        (e) => e.type === 'compound-entry'
+      );
+      expect(compoundEntry).toBeDefined();
+      expect(compoundEntry!.metadata!.compoundStateId).toBe('hotfix-track');
+      // Should have onEntry effect from hotfix-track compound
+      expect(result.effects).toContain('log');
+    });
+
+    it('fails to transition from investigate to hotfix-implement when thorough track selected', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'investigate',
+        track: 'thorough',
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'hotfix-implement');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+  });
+
+  describe('full thorough track flow', () => {
+    it('completes rca to design transition', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'rca',
+        track: 'thorough',
+        artifacts: { rca: 'docs/rca.md' },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'design');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('design');
+      // Both rca and design are within thorough-track, so no compound events
+      const compoundEntry = result.events.find(
+        (e) => e.type === 'compound-entry'
+      );
+      expect(compoundEntry).toBeUndefined();
+    });
+
+    it('fails rca to design when rca artifact missing', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'rca',
+        track: 'thorough',
+        artifacts: {},
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'design');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+
+    it('completes design to debug-implement transition', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'design',
+        track: 'thorough',
+        artifacts: { fixDesign: 'docs/fix.md' },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'debug-implement');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('debug-implement');
+    });
+
+    it('fails design to debug-implement when fixDesign artifact missing', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'design',
+        track: 'thorough',
+        artifacts: {},
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'debug-implement');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+
+    it('completes debug-implement to debug-validate transition', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'debug-implement',
+        track: 'thorough',
+        _events: [],
+        _history: {},
+      };
+
+      // implementationComplete always returns true
+      const result = executeTransition(hsm, state, 'debug-validate');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('debug-validate');
+    });
+
+    it('completes debug-validate to debug-review transition', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'debug-validate',
+        track: 'thorough',
+        validation: { testsPass: true },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'debug-review');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('debug-review');
+    });
+
+    it('fails debug-validate to debug-review when validation fails', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'debug-validate',
+        track: 'thorough',
+        validation: { testsPass: false },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'debug-review');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+
+    it('completes debug-review to synthesize transition (exits thorough-track compound)', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'debug-review',
+        track: 'thorough',
+        reviews: { spec: { passed: true } },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'synthesize');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('synthesize');
+      // Should have compound-exit event for thorough-track
+      const compoundExit = result.events.find(
+        (e) => e.type === 'compound-exit'
+      );
+      expect(compoundExit).toBeDefined();
+      expect(compoundExit!.from).toBe('thorough-track');
+      // Should have onExit effect from thorough-track compound
+      expect(result.effects).toContain('log');
+      // History should record last sub-state
+      expect(result.historyUpdates).toBeDefined();
+      expect(result.historyUpdates!['thorough-track']).toBe('debug-review');
+    });
+
+    it('fails debug-review to synthesize when review fails', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'debug-review',
+        track: 'thorough',
+        reviews: { spec: { passed: false } },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'synthesize');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+
+    it('completes synthesize to completed in debug workflow', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'synthesize',
+        synthesis: { prUrl: 'https://github.com/org/repo/pull/1' },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'completed');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('completed');
+    });
+  });
+
+  describe('full hotfix track flow', () => {
+    it('completes hotfix-implement to hotfix-validate transition', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'hotfix-implement',
+        track: 'hotfix',
+        _events: [],
+        _history: {},
+      };
+
+      // implementationComplete always returns true
+      const result = executeTransition(hsm, state, 'hotfix-validate');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('hotfix-validate');
+    });
+
+    it('completes hotfix-validate to completed (exits hotfix-track compound)', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'hotfix-validate',
+        track: 'hotfix',
+        validation: { testsPass: true },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'completed');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('completed');
+      // Should have compound-exit event for hotfix-track
+      const compoundExit = result.events.find(
+        (e) => e.type === 'compound-exit'
+      );
+      expect(compoundExit).toBeDefined();
+      expect(compoundExit!.from).toBe('hotfix-track');
+      // Should have onExit effect from hotfix-track compound
+      expect(result.effects).toContain('log');
+      // History should record last sub-state
+      expect(result.historyUpdates).toBeDefined();
+      expect(result.historyUpdates!['hotfix-track']).toBe('hotfix-validate');
+    });
+
+    it('fails hotfix-validate to completed when validation fails', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'hotfix-validate',
+        track: 'hotfix',
+        validation: { testsPass: false },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'completed');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+  });
+
+  describe('triage to investigate', () => {
+    it('transitions from triage to investigate when triage complete', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'triage',
+        triage: { symptom: 'error on startup' },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'investigate');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('investigate');
+    });
+
+    it('fails triage to investigate when triage incomplete', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'triage',
+        triage: {},
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'investigate');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+  });
+
+  describe('cancel from debug phases', () => {
+    it('cancels from within thorough-track compound with history', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'rca',
+        track: 'thorough',
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'cancelled');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('cancelled');
+      // Should record history for the thorough-track compound
+      expect(result.historyUpdates).toBeDefined();
+      expect(result.historyUpdates!['thorough-track']).toBe('rca');
+    });
+
+    it('cancels from within hotfix-track compound with history', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'hotfix-implement',
+        track: 'hotfix',
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'cancelled');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('cancelled');
+      expect(result.historyUpdates).toBeDefined();
+      expect(result.historyUpdates!['hotfix-track']).toBe('hotfix-implement');
+    });
+  });
+});
+
+// ─── Task: Refactor HSM executeTransition Tests ───────────────────────────────
+
+describe('Refactor HSM executeTransition', () => {
+  describe('brief to polish track', () => {
+    it('transitions from brief to polish-implement when polish track selected', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'brief',
+        track: 'polish',
+        brief: { goals: ['g1'] },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'polish-implement');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('polish-implement');
+      // Should have compound-entry event for polish-track
+      const compoundEntry = result.events.find(
+        (e) => e.type === 'compound-entry'
+      );
+      expect(compoundEntry).toBeDefined();
+      expect(compoundEntry!.metadata!.compoundStateId).toBe('polish-track');
+      // Should have onEntry effect from polish-track compound
+      expect(result.effects).toContain('log');
+    });
+
+    it('fails brief to polish-implement when overhaul track selected', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'brief',
+        track: 'overhaul',
+        brief: { goals: ['g1'] },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'polish-implement');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+  });
+
+  describe('brief to overhaul track', () => {
+    it('transitions from brief to overhaul-plan when overhaul track selected', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'brief',
+        track: 'overhaul',
+        brief: { goals: ['g1'] },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'overhaul-plan');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('overhaul-plan');
+      // Should have compound-entry event for overhaul-track
+      const compoundEntry = result.events.find(
+        (e) => e.type === 'compound-entry'
+      );
+      expect(compoundEntry).toBeDefined();
+      expect(compoundEntry!.metadata!.compoundStateId).toBe('overhaul-track');
+      expect(result.effects).toContain('log');
+    });
+
+    it('fails brief to overhaul-plan when polish track selected', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'brief',
+        track: 'polish',
+        brief: { goals: ['g1'] },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'overhaul-plan');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+  });
+
+  describe('explore to brief', () => {
+    it('transitions from explore to brief when scope assessment complete', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'explore',
+        explore: { scopeAssessment: 'small' },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'brief');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('brief');
+    });
+
+    it('fails explore to brief when scope assessment missing', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'explore',
+        explore: {},
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'brief');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+  });
+
+  describe('full polish track flow', () => {
+    it('completes polish-implement to polish-validate transition', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'polish-implement',
+        track: 'polish',
+        _events: [],
+        _history: {},
+      };
+
+      // implementationComplete always returns true
+      const result = executeTransition(hsm, state, 'polish-validate');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('polish-validate');
+    });
+
+    it('completes polish-validate to polish-update-docs transition', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'polish-validate',
+        track: 'polish',
+        validation: { testsPass: true },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'polish-update-docs');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('polish-update-docs');
+    });
+
+    it('fails polish-validate to polish-update-docs when goals not verified', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'polish-validate',
+        track: 'polish',
+        validation: { testsPass: false },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'polish-update-docs');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+
+    it('completes polish-update-docs to completed (exits polish-track compound)', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'polish-update-docs',
+        track: 'polish',
+        validation: { docsUpdated: true },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'completed');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('completed');
+      // Should have compound-exit event for polish-track
+      const compoundExit = result.events.find(
+        (e) => e.type === 'compound-exit'
+      );
+      expect(compoundExit).toBeDefined();
+      expect(compoundExit!.from).toBe('polish-track');
+      // Should have onExit effect from polish-track compound
+      expect(result.effects).toContain('log');
+      // History should record last sub-state
+      expect(result.historyUpdates).toBeDefined();
+      expect(result.historyUpdates!['polish-track']).toBe('polish-update-docs');
+    });
+
+    it('fails polish-update-docs to completed when docs not updated', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'polish-update-docs',
+        track: 'polish',
+        validation: {},
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'completed');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+  });
+
+  describe('overhaul track flow', () => {
+    it('completes overhaul-plan to overhaul-delegate transition', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'overhaul-plan',
+        track: 'overhaul',
+        artifacts: { plan: 'docs/plan.md' },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'overhaul-delegate');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('overhaul-delegate');
+    });
+
+    it('completes overhaul-delegate to overhaul-integrate transition', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'overhaul-delegate',
+        track: 'overhaul',
+        tasks: [{ status: 'complete' }, { status: 'complete' }],
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'overhaul-integrate');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('overhaul-integrate');
+    });
+
+    it('fails overhaul-delegate to overhaul-integrate when tasks incomplete', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'overhaul-delegate',
+        track: 'overhaul',
+        tasks: [{ status: 'complete' }, { status: 'pending' }],
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'overhaul-integrate');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+
+    it('completes overhaul-integrate to overhaul-review on integration pass', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'overhaul-integrate',
+        track: 'overhaul',
+        integration: { passed: true },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'overhaul-review');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('overhaul-review');
+    });
+
+    it('cycles overhaul-integrate to overhaul-delegate on integration fail (fix cycle)', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'overhaul-integrate',
+        track: 'overhaul',
+        integration: { passed: false },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'overhaul-delegate');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('overhaul-delegate');
+      expect(result.effects).toContain('increment-fix-cycle');
+      // Should have fix-cycle event with compoundStateId
+      const fixCycleEvent = result.events.find((e) => e.type === 'fix-cycle');
+      expect(fixCycleEvent).toBeDefined();
+      expect(fixCycleEvent!.metadata!.compoundStateId).toBe('overhaul-track');
+    });
+
+    it('completes overhaul-review to overhaul-update-docs on review pass', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'overhaul-review',
+        track: 'overhaul',
+        reviews: { spec: { passed: true }, quality: { passed: true } },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'overhaul-update-docs');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('overhaul-update-docs');
+    });
+
+    it('cycles overhaul-review to overhaul-delegate on review fail (fix cycle)', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'overhaul-review',
+        track: 'overhaul',
+        reviews: { spec: { passed: true }, quality: { passed: false } },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'overhaul-delegate');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('overhaul-delegate');
+      expect(result.effects).toContain('increment-fix-cycle');
+      const fixCycleEvent = result.events.find((e) => e.type === 'fix-cycle');
+      expect(fixCycleEvent).toBeDefined();
+      expect(fixCycleEvent!.metadata!.compoundStateId).toBe('overhaul-track');
+    });
+
+    it('completes overhaul-update-docs to synthesize transition', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'overhaul-update-docs',
+        track: 'overhaul',
+        validation: { docsUpdated: true },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'synthesize');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('synthesize');
+      // Should exit overhaul-track compound
+      const compoundExit = result.events.find(
+        (e) => e.type === 'compound-exit'
+      );
+      expect(compoundExit).toBeDefined();
+      expect(compoundExit!.from).toBe('overhaul-track');
+      expect(result.effects).toContain('log');
+      expect(result.historyUpdates).toBeDefined();
+      expect(result.historyUpdates!['overhaul-track']).toBe(
+        'overhaul-update-docs'
+      );
+    });
+
+    it('completes synthesize to completed in refactor workflow', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'synthesize',
+        artifacts: { pr: 'https://github.com/org/repo/pull/1' },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'completed');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('completed');
+    });
+
+    it('circuit breaker triggers in overhaul-track after max fix cycles', () => {
+      const hsm = getHSMDefinition('refactor');
+
+      // Simulate 3 fix-cycle events within the overhaul-track compound
+      const fixCycleEvents = Array.from({ length: 3 }, (_, i) => ({
+        sequence: i + 1,
+        version: '1.0' as const,
+        timestamp: new Date().toISOString(),
+        type: 'fix-cycle' as const,
+        from: 'overhaul-integrate',
+        to: 'overhaul-delegate',
+        trigger: 'test',
+        metadata: { compoundStateId: 'overhaul-track' },
+      }));
+
+      const state: Record<string, unknown> = {
+        phase: 'overhaul-integrate',
+        track: 'overhaul',
+        integration: { passed: false },
+        _events: fixCycleEvents,
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'overhaul-delegate');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('CIRCUIT_OPEN');
+      expect(result.errorMessage).toContain('overhaul-track');
+    });
+  });
+
+  describe('cancel from refactor phases', () => {
+    it('cancels from within polish-track compound with history', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'polish-validate',
+        track: 'polish',
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'cancelled');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('cancelled');
+      expect(result.historyUpdates).toBeDefined();
+      expect(result.historyUpdates!['polish-track']).toBe('polish-validate');
+    });
+
+    it('cancels from within overhaul-track compound with history', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'overhaul-delegate',
+        track: 'overhaul',
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'cancelled');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('cancelled');
+      expect(result.historyUpdates).toBeDefined();
+      expect(result.historyUpdates!['overhaul-track']).toBe(
+        'overhaul-delegate'
+      );
+    });
+  });
+});
+
+// ─── Task: Feature HSM plan-review gap loop ───────────────────────────────────
+
+describe('Feature HSM plan-review transitions', () => {
+  it('transitions plan-review back to plan when gaps found', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'plan-review',
+      planReview: { gapsFound: true },
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'plan');
+
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('plan');
+    // Should include the log effect from the transition
+    expect(result.effects).toContain('log');
+  });
+
+  it('fails plan-review to plan when no gaps found', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'plan-review',
+      planReview: { gapsFound: false },
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'plan');
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('GUARD_FAILED');
+  });
+});
+
+// ─── Task: Final state and edge case transitions ──────────────────────────────
+
+describe('Final state transitions', () => {
+  it('returns INVALID_TRANSITION when transitioning from completed state', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'completed',
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'ideate');
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('INVALID_TRANSITION');
+    expect(result.errorMessage).toContain('final state');
+    expect(result.validTargets).toEqual([]);
+  });
+
+  it('returns INVALID_TRANSITION when transitioning from cancelled state', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'cancelled',
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'ideate');
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('INVALID_TRANSITION');
+    expect(result.errorMessage).toContain('final state');
+  });
+
+  it('returns INVALID_TRANSITION from debug completed state', () => {
+    const hsm = getHSMDefinition('debug');
+    const state: Record<string, unknown> = {
+      phase: 'completed',
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'triage');
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('INVALID_TRANSITION');
+  });
+
+  it('returns INVALID_TRANSITION from refactor completed state', () => {
+    const hsm = getHSMDefinition('refactor');
+    const state: Record<string, unknown> = {
+      phase: 'completed',
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'explore');
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('INVALID_TRANSITION');
+  });
+});
+
+// ─── Task: Additional guard coverage ──────────────────────────────────────────
+
+describe('Guard edge cases', () => {
+  it('prUrlExists guard checks synthesis.prUrl', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'synthesize',
+      synthesis: { prUrl: 'https://github.com/org/repo/pull/1' },
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'completed');
+    expect(result.success).toBe(true);
+  });
+
+  it('prUrlExists guard checks artifacts.pr as fallback', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'synthesize',
+      artifacts: { pr: 'https://github.com/org/repo/pull/1' },
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'completed');
+    expect(result.success).toBe(true);
+  });
+
+  it('allReviewsPassed returns false when no reviews', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'review',
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'synthesize');
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('GUARD_FAILED');
+  });
+
+  it('allReviewsPassed returns false when reviews is empty object', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'review',
+      reviews: {},
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'synthesize');
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('GUARD_FAILED');
+  });
+
+  it('allTasksComplete returns true when tasks array is empty', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'delegate',
+      tasks: [],
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'integrate');
+    expect(result.success).toBe(true);
+  });
+
+  it('allTasksComplete returns true when tasks is undefined', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'delegate',
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'integrate');
+    expect(result.success).toBe(true);
+  });
+
+  it('anyReviewFailed returns false when no reviews', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'review',
+      _events: [],
+      _history: {},
+    };
+
+    // Neither allReviewsPassed nor anyReviewFailed should pass
+    const toSynthesize = executeTransition(hsm, state, 'synthesize');
+    expect(toSynthesize.success).toBe(false);
+
+    const toDelegate = executeTransition(hsm, state, 'delegate');
+    expect(toDelegate.success).toBe(false);
+  });
+
+  it('humanUnblocked guard passes when unblocked is true', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'blocked',
+      unblocked: true,
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'delegate');
+    expect(result.success).toBe(true);
+  });
+
+  it('humanUnblocked guard fails when unblocked is false', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'blocked',
+      unblocked: false,
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'delegate');
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('GUARD_FAILED');
+  });
+
+  it('countFixCycles counts only matching compound events', () => {
+    const hsm = getHSMDefinition('feature');
+
+    // 2 fix cycles for 'implementation', 1 for unrelated compound
+    const mixedEvents = [
+      {
+        type: 'fix-cycle',
+        metadata: { compoundStateId: 'implementation' },
+      },
+      {
+        type: 'fix-cycle',
+        metadata: { compoundStateId: 'other-compound' },
+      },
+      {
+        type: 'fix-cycle',
+        metadata: { compoundStateId: 'implementation' },
+      },
+      {
+        type: 'transition',
+        metadata: {},
+      },
+    ];
+
+    const state: Record<string, unknown> = {
+      phase: 'integrate',
+      integration: { passed: false },
+      _events: mixedEvents,
+      _history: {},
+    };
+
+    // Should succeed because only 2 of 3 fix-cycle events match 'implementation'
+    // and maxFixCycles for implementation is 3
+    const result = executeTransition(hsm, state, 'delegate');
+    expect(result.success).toBe(true);
+  });
+
+  it('countFixCycles triggers circuit breaker at exact limit', () => {
+    const hsm = getHSMDefinition('feature');
+
+    // Exactly 3 fix-cycle events for 'implementation' (maxFixCycles is 3)
+    const events = Array.from({ length: 3 }, () => ({
+      type: 'fix-cycle',
+      metadata: { compoundStateId: 'implementation' },
+    }));
+
+    const state: Record<string, unknown> = {
+      phase: 'integrate',
+      integration: { passed: false },
+      _events: events,
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'delegate');
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('CIRCUIT_OPEN');
+  });
+});
+
+// ─── Task: Missing state/edge case coverage ──────────────────────────────────
+
+describe('Missing _events and _history defaults', () => {
+  it('handles missing _events gracefully (defaults to empty array)', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'integrate',
+      integration: { passed: false },
+      // No _events or _history
+    };
+
+    const result = executeTransition(hsm, state, 'delegate');
+
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('delegate');
+  });
+
+  it('handles missing _history gracefully (defaults to empty object)', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'ideate',
+      artifacts: { design: 'docs/design.md' },
+      // No _history
+    };
+
+    const result = executeTransition(hsm, state, 'plan');
+
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('plan');
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-store-resolve.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-store-resolve.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as path from 'node:path';
+
+// Mock child_process at module level to intercept execSync used by resolveStateDir
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(() => {
+    throw new Error('fatal: not a git repository');
+  }),
+}));
+
+// Import AFTER mock is registered so the module picks up the mock
+import { resolveStateDir } from '../../workflow/state-store.js';
+
+describe('resolveStateDir fallback', () => {
+  const originalEnv = process.env.WORKFLOW_STATE_DIR;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.WORKFLOW_STATE_DIR = originalEnv;
+    } else {
+      delete process.env.WORKFLOW_STATE_DIR;
+    }
+  });
+
+  it('should fall back to cwd-based path when git command fails', () => {
+    delete process.env.WORKFLOW_STATE_DIR;
+
+    const dir = resolveStateDir();
+    expect(dir).toBe(path.join(process.cwd(), 'docs', 'workflow-state'));
+  });
+
+  it('should still prefer WORKFLOW_STATE_DIR env var even when git fails', () => {
+    process.env.WORKFLOW_STATE_DIR = '/custom/state-dir';
+
+    const dir = resolveStateDir();
+    expect(dir).toBe('/custom/state-dir');
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-store.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-store.test.ts
@@ -9,6 +9,7 @@ import {
   applyDotPath,
   listStateFiles,
   resolveStateDir,
+  StateStoreError,
 } from '../../workflow/state-store.js';
 import { ErrorCode } from '../../workflow/schemas.js';
 
@@ -334,6 +335,285 @@ describe('State Store', () => {
       expect(scope.testCoverage).toBe('excellent'); // overwritten by source
       expect(scope.riskLevel).toBe('low');          // new key from source
       expect(explore.startedAt).toBe('2025-01-15T10:00:00Z'); // sibling preserved
+    });
+  });
+
+  // ─── Edge Cases and Error Paths ──────────────────────────────────────────
+
+  describe('listStateFiles_CorruptFile_SkipsAndReturnValid', () => {
+    it('should skip corrupt state files and return only valid ones', async () => {
+      // Create a valid state file
+      await initStateFile(tmpDir, 'valid-feature', 'feature');
+      // Create a corrupt state file (invalid JSON)
+      await fs.writeFile(
+        path.join(tmpDir, 'corrupt.state.json'),
+        'invalid json{{{',
+        'utf-8',
+      );
+
+      const results = await listStateFiles(tmpDir);
+      expect(results).toHaveLength(1);
+      expect(results[0].featureId).toBe('valid-feature');
+    });
+
+    it('should return empty array when all state files are corrupt', async () => {
+      await fs.writeFile(
+        path.join(tmpDir, 'bad1.state.json'),
+        '{not valid}}}',
+        'utf-8',
+      );
+      await fs.writeFile(
+        path.join(tmpDir, 'bad2.state.json'),
+        '',
+        'utf-8',
+      );
+
+      const results = await listStateFiles(tmpDir);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('listStateFiles_ENOENT_ReturnsEmptyArray', () => {
+    it('should return empty array when directory does not exist', async () => {
+      const nonExistentDir = path.join(tmpDir, 'does-not-exist');
+
+      const results = await listStateFiles(nonExistentDir);
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('listStateFiles_NonENOENTError_ThrowsStateStoreError', () => {
+    it('should throw StateStoreError with FILE_IO_ERROR for non-ENOENT readdir errors', async () => {
+      // Use a regular file as the "directory" path — readdir on a file gives ENOTDIR, not ENOENT
+      const filePath = path.join(tmpDir, 'not-a-directory');
+      await fs.writeFile(filePath, 'just a file', 'utf-8');
+
+      await expect(listStateFiles(filePath)).rejects.toThrow(ErrorCode.FILE_IO_ERROR);
+      // Verify it's a StateStoreError instance
+      try {
+        await listStateFiles(filePath);
+      } catch (err) {
+        expect(err).toBeInstanceOf(StateStoreError);
+        expect((err as StateStoreError).code).toBe(ErrorCode.FILE_IO_ERROR);
+      }
+    });
+  });
+
+  describe('resolveStateDir_GitFails_FallsToCwd', () => {
+    it('should fall back to cwd-based path when git command fails', () => {
+      const originalEnv = process.env.WORKFLOW_STATE_DIR;
+      delete process.env.WORKFLOW_STATE_DIR;
+
+      // resolveStateDir uses execSync('git rev-parse --show-toplevel')
+      // When in a git repo, it returns the git root.
+      // We can verify the fallback behavior by testing with env var set to empty string
+      // then testing without env var — it should always end with docs/workflow-state
+      try {
+        const dir = resolveStateDir();
+        // Should resolve to some path ending with docs/workflow-state
+        expect(dir).toMatch(/docs[/\\]workflow-state$/);
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.WORKFLOW_STATE_DIR = originalEnv;
+        }
+      }
+    });
+  });
+
+  describe('writeStateFile_FailurePath_ThrowsStateStoreError', () => {
+    it('should throw StateStoreError with FILE_IO_ERROR when writing to an invalid path', async () => {
+      const { state } = await initStateFile(tmpDir, 'write-fail-test', 'feature');
+
+      // Try to write to a path under a file (not a directory) — causes ENOTDIR or ENOENT
+      const blocker = path.join(tmpDir, 'blocker');
+      await fs.writeFile(blocker, 'I am a file', 'utf-8');
+      const invalidStateFile = path.join(blocker, 'nested', 'state.json');
+
+      await expect(writeStateFile(invalidStateFile, state)).rejects.toThrow(
+        ErrorCode.FILE_IO_ERROR,
+      );
+      // Verify it's a StateStoreError instance
+      try {
+        await writeStateFile(invalidStateFile, state);
+      } catch (err) {
+        expect(err).toBeInstanceOf(StateStoreError);
+      }
+    });
+
+    it('should not leave temp files behind after write failure', async () => {
+      const { state } = await initStateFile(tmpDir, 'cleanup-test', 'feature');
+
+      // Write to a read-only directory to cause rename failure
+      const readOnlyDir = path.join(tmpDir, 'readonly');
+      await fs.mkdir(readOnlyDir);
+      const stateFile = path.join(readOnlyDir, 'test.state.json');
+      // Make directory read-only so temp file write fails
+      await fs.chmod(readOnlyDir, 0o444);
+
+      try {
+        await expect(writeStateFile(stateFile, state)).rejects.toThrow(
+          ErrorCode.FILE_IO_ERROR,
+        );
+      } finally {
+        // Restore permissions for cleanup
+        await fs.chmod(readOnlyDir, 0o755);
+      }
+
+      // Verify no temp files left behind
+      const files = await fs.readdir(readOnlyDir);
+      const tmpFiles = files.filter((f) => f.includes('.tmp.'));
+      expect(tmpFiles).toHaveLength(0);
+    });
+  });
+
+  describe('initStateFile_WriteFailsNonEEXIST_ThrowsFileIOError', () => {
+    it('should throw StateStoreError with FILE_IO_ERROR when writeFile fails with non-EEXIST error', async () => {
+      // Create a read-only directory so writeFile fails with EACCES, not EEXIST
+      const readOnlyDir = path.join(tmpDir, 'readonly-dir');
+      await fs.mkdir(readOnlyDir);
+      await fs.chmod(readOnlyDir, 0o444);
+
+      try {
+        await expect(
+          initStateFile(readOnlyDir, 'write-blocked', 'feature'),
+        ).rejects.toThrow(ErrorCode.FILE_IO_ERROR);
+        // Verify it's a StateStoreError
+        try {
+          await initStateFile(readOnlyDir, 'write-blocked2', 'feature');
+        } catch (err) {
+          expect(err).toBeInstanceOf(StateStoreError);
+          expect((err as StateStoreError).code).toBe(ErrorCode.FILE_IO_ERROR);
+        }
+      } finally {
+        await fs.chmod(readOnlyDir, 0o755);
+      }
+    });
+  });
+
+  describe('applyDotPath_ArrayErrorPaths', () => {
+    it('should throw INVALID_INPUT when intermediate path expects array but finds object', () => {
+      const obj: Record<string, unknown> = {
+        data: { notArray: true },
+      };
+
+      expect(() => applyDotPath(obj, 'data[0].value', 'test')).toThrow(
+        ErrorCode.INVALID_INPUT,
+      );
+    });
+
+    it('should throw INVALID_INPUT when final path expects array but finds object', () => {
+      const obj: Record<string, unknown> = {
+        data: { notArray: true },
+      };
+
+      expect(() => applyDotPath(obj, 'data[0]', 'test')).toThrow(
+        ErrorCode.INVALID_INPUT,
+      );
+    });
+
+    it('should create intermediate array when navigating numeric segments', () => {
+      const obj: Record<string, unknown> = {};
+
+      // tasks -> create as array (next segment is numeric), [0] -> create as object (next segment is string)
+      applyDotPath(obj, 'tasks[0].name', 'task-1');
+
+      expect(Array.isArray(obj.tasks)).toBe(true);
+      expect((obj.tasks as Array<Record<string, unknown>>)[0].name).toBe('task-1');
+    });
+
+    it('should create intermediate array for undefined array segment via dot notation', () => {
+      const obj: Record<string, unknown> = {
+        matrix: [[1, 2], [3, 4]],
+      };
+
+      // Access matrix[2].[0] where matrix[2] doesn't exist — parsePath needs dot between brackets
+      applyDotPath(obj, 'matrix[2].[0]', 99);
+
+      expect((obj.matrix as number[][])[2][0]).toBe(99);
+    });
+  });
+
+  describe('readStateFile_NonENOENTReadError_ThrowsFileIOError', () => {
+    it('should throw StateStoreError with FILE_IO_ERROR for non-ENOENT read errors', async () => {
+      // Use a directory path as the file — reading a directory gives EISDIR, not ENOENT
+      const dirPath = path.join(tmpDir, 'a-directory');
+      await fs.mkdir(dirPath);
+
+      await expect(readStateFile(dirPath)).rejects.toThrow(ErrorCode.FILE_IO_ERROR);
+      // Verify it's a StateStoreError
+      try {
+        await readStateFile(dirPath);
+      } catch (err) {
+        expect(err).toBeInstanceOf(StateStoreError);
+        expect((err as StateStoreError).code).toBe(ErrorCode.FILE_IO_ERROR);
+      }
+    });
+  });
+
+  describe('readStateFile_MigrationFails_ThrowsStateCorrupt', () => {
+    it('should throw STATE_CORRUPT when migration fails due to unknown version', async () => {
+      const stateFile = path.join(tmpDir, 'bad-version.state.json');
+      // Write a file with a version that has no migration path
+      await fs.writeFile(
+        stateFile,
+        JSON.stringify({
+          version: '0.1',
+          featureId: 'test',
+          workflowType: 'feature',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          phase: 'ideate',
+          artifacts: { design: null, plan: null, pr: null },
+          tasks: [],
+          worktrees: {},
+          julesSessions: {},
+          reviews: {},
+          synthesis: {
+            integrationBranch: null,
+            mergeOrder: [],
+            mergedBranches: [],
+            prUrl: null,
+            prFeedback: [],
+          },
+          _history: {},
+          _events: [],
+          _eventSequence: 0,
+          _checkpoint: {
+            timestamp: new Date().toISOString(),
+            phase: 'ideate',
+            summary: '',
+            operationsSince: 0,
+            fixCycleCount: 0,
+            lastActivityTimestamp: new Date().toISOString(),
+            staleAfterMinutes: 120,
+          },
+        }),
+        'utf-8',
+      );
+
+      await expect(readStateFile(stateFile)).rejects.toThrow(ErrorCode.STATE_CORRUPT);
+      // Verify it's a StateStoreError
+      try {
+        await readStateFile(stateFile);
+      } catch (err) {
+        expect(err).toBeInstanceOf(StateStoreError);
+        expect((err as StateStoreError).code).toBe(ErrorCode.STATE_CORRUPT);
+      }
+    });
+
+    it('should throw STATE_CORRUPT when migration fails due to missing version', async () => {
+      const stateFile = path.join(tmpDir, 'no-version.state.json');
+      // Write valid JSON but without version field
+      await fs.writeFile(
+        stateFile,
+        JSON.stringify({
+          featureId: 'test',
+          workflowType: 'feature',
+        }),
+        'utf-8',
+      );
+
+      await expect(readStateFile(stateFile)).rejects.toThrow(ErrorCode.STATE_CORRUPT);
     });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/team/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/team/tools.ts
@@ -142,6 +142,16 @@ export async function handleTeamMessage(
     };
   }
 
+  if (!args.streamId || typeof args.streamId !== 'string' || args.streamId.trim() === '') {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'streamId is required',
+      },
+    };
+  }
+
   const coordinator = getCoordinator(stateDir);
 
   try {
@@ -189,6 +199,16 @@ export async function handleTeamBroadcast(
     };
   }
 
+  if (!args.streamId || typeof args.streamId !== 'string' || args.streamId.trim() === '') {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'streamId is required',
+      },
+    };
+  }
+
   const coordinator = getCoordinator(stateDir);
 
   try {
@@ -221,6 +241,16 @@ export async function handleTeamShutdown(
       error: {
         code: 'INVALID_INPUT',
         message: 'Field "name" is required and must be a non-empty string',
+      },
+    };
+  }
+
+  if (!args.streamId || typeof args.streamId !== 'string' || args.streamId.trim() === '') {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'streamId is required',
       },
     };
   }


### PR DESCRIPTION
## Summary

Raises Exarchos MCP server statement coverage from 88% to 96% by adding ~150 new test cases across 9 modules. Also fixes 3 missing `streamId` validation guards in team handler functions and a global prototype mock leakage risk in the compensation test suite.

## Changes

- **tasks/tools** — Validation and error path tests for `handleTaskClaim`, `handleTaskComplete`, `handleTaskFail`
- **team/tools** — Source fix: added `streamId` validation to `handleTeamMessage`, `handleTeamBroadcast`, `handleTeamShutdown`; error path and whitespace validation tests
- **stack/tools** — Position validation edge cases (negative, float, NaN) and store failure tests
- **views/tools** — Error handling catch blocks, empty filter, no-streams pipeline tests
- **views/materializer** — Function coverage for `hasProjection`, `getProjection`, `getState`, `loadState`; snapshot interval edge cases
- **workflow/state-store** — File I/O edge cases, corrupt file handling, git fallback
- **workflow/state-machine** — Debug/refactor HSM transitions, leaf-state onEntry/onExit effects
- **workflow/compensation** — Unknown phase handling, partial failure modes, mock cleanup with try/finally

## Test Plan

All tests run in isolated temp directories. Coverage verified per-module via `npm run test:coverage`.

---

**Results:** Tests 632 ✓ · Coverage 96.01% stmts · Build 0 errors
**Plan:** [docs/plans/2026-02-08-test-coverage.md](docs/plans/2026-02-08-test-coverage.md)