### PR TITLE
feat: add sync types, config, and state management

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/sync/config.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/sync/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/sync/config.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/sync/config.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { loadSyncConfig, getDefaultConfig } from '../../sync/config.js';
+
+describe('SyncConfig', () => {
+  let tempDir: string;
+  let stateDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'config-test-'));
+    stateDir = path.join(tempDir, 'state');
+    await mkdir(stateDir, { recursive: true });
+    // Clear env vars
+    delete process.env.EXARCHOS_API_TOKEN;
+    delete process.env.BASILEUS_API_URL;
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+    delete process.env.EXARCHOS_API_TOKEN;
+    delete process.env.BASILEUS_API_URL;
+  });
+
+  // ─── getDefaultConfig ─────────────────────────────────────────────────
+
+  describe('getDefaultConfig', () => {
+    it('should return defaults', () => {
+      const config = getDefaultConfig();
+      expect(config.mode).toBe('local');
+      expect(config.syncIntervalMs).toBe(30000);
+      expect(config.batchSize).toBe(50);
+      expect(config.maxRetries).toBe(10);
+      expect(config.remote).toBeUndefined();
+    });
+  });
+
+  // ─── loadSyncConfig ───────────────────────────────────────────────────
+
+  describe('loadSyncConfig', () => {
+    it('should apply default values when no config file or env vars', () => {
+      const config = loadSyncConfig(stateDir);
+      expect(config.mode).toBe('local');
+      expect(config.syncIntervalMs).toBe(30000);
+      expect(config.batchSize).toBe(50);
+      expect(config.maxRetries).toBe(10);
+    });
+
+    it('should load config from bridge-config.json in parent directory', async () => {
+      const configPath = path.join(tempDir, 'bridge-config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mode: 'dual',
+          syncIntervalMs: 15000,
+          batchSize: 25,
+          maxRetries: 5,
+          remote: {
+            apiBaseUrl: 'https://api.example.com',
+            apiToken: 'token-from-file',
+            exarchosId: 'exarchos-file',
+            timeoutMs: 10000,
+          },
+        }),
+        'utf-8',
+      );
+
+      const config = loadSyncConfig(stateDir);
+      expect(config.mode).toBe('dual');
+      expect(config.syncIntervalMs).toBe(15000);
+      expect(config.batchSize).toBe(25);
+      expect(config.remote?.apiBaseUrl).toBe('https://api.example.com');
+      expect(config.remote?.apiToken).toBe('token-from-file');
+    });
+
+    it('should force mode to local when no API token is available', () => {
+      // No env vars, no config file
+      const config = loadSyncConfig(stateDir);
+      expect(config.mode).toBe('local');
+    });
+
+    it('should use environment variables as fallback', () => {
+      process.env.EXARCHOS_API_TOKEN = 'env-token';
+      process.env.BASILEUS_API_URL = 'https://env.example.com';
+
+      const config = loadSyncConfig(stateDir);
+      expect(config.remote?.apiToken).toBe('env-token');
+      expect(config.remote?.apiBaseUrl).toBe('https://env.example.com');
+      expect(config.mode).toBe('local');
+    });
+
+    it('should force mode to local when config file has remote mode but no token', async () => {
+      const configPath = path.join(tempDir, 'bridge-config.json');
+      await writeFile(
+        configPath,
+        JSON.stringify({
+          mode: 'remote',
+        }),
+        'utf-8',
+      );
+
+      const config = loadSyncConfig(stateDir);
+      expect(config.mode).toBe('local');
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/sync/sync-state.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/sync/sync-state.test.ts
@@ -17,6 +17,23 @@ describe('SyncStateManager', () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
+  // ─── streamId validation ─────────────────────────────────────────────────
+
+  describe('streamId validation', () => {
+    it('should reject streamId with path traversal characters', async () => {
+      await expect(manager.load('../escape')).rejects.toThrow('Invalid streamId');
+    });
+
+    it('should reject streamId with slashes', async () => {
+      await expect(manager.load('foo/bar')).rejects.toThrow('Invalid streamId');
+    });
+
+    it('should accept valid streamId with dots, dashes, underscores', async () => {
+      const state = await manager.load('valid-stream_id.v2');
+      expect(state.streamId).toBe('valid-stream_id.v2');
+    });
+  });
+
   // ─── load ───────────────────────────────────────────────────────────────
 
   describe('load', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/sync/sync-state.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/sync/sync-state.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { SyncStateManager } from '../../sync/sync-state.js';
+
+describe('SyncStateManager', () => {
+  let tempDir: string;
+  let manager: SyncStateManager;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'sync-state-test-'));
+    manager = new SyncStateManager(tempDir);
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ─── load ───────────────────────────────────────────────────────────────
+
+  describe('load', () => {
+    it('should return default state when file does not exist', async () => {
+      const state = await manager.load('nonexistent');
+
+      expect(state).toEqual({
+        streamId: 'nonexistent',
+        localHighWaterMark: 0,
+        remoteHighWaterMark: 0,
+      });
+    });
+
+    it('should load saved state', async () => {
+      await manager.save('test-stream', {
+        streamId: 'test-stream',
+        localHighWaterMark: 5,
+        remoteHighWaterMark: 3,
+        lastSyncAt: '2026-02-08T00:00:00Z',
+        lastSyncResult: 'success',
+      });
+
+      const state = await manager.load('test-stream');
+      expect(state.localHighWaterMark).toBe(5);
+      expect(state.remoteHighWaterMark).toBe(3);
+      expect(state.lastSyncAt).toBe('2026-02-08T00:00:00Z');
+      expect(state.lastSyncResult).toBe('success');
+    });
+  });
+
+  // ─── save ───────────────────────────────────────────────────────────────
+
+  describe('save', () => {
+    it('should persist state to file', async () => {
+      await manager.save('test-stream', {
+        streamId: 'test-stream',
+        localHighWaterMark: 10,
+        remoteHighWaterMark: 7,
+      });
+
+      const filePath = path.join(tempDir, 'test-stream.sync.json');
+      const content = await readFile(filePath, 'utf-8');
+      const data = JSON.parse(content);
+      expect(data.localHighWaterMark).toBe(10);
+      expect(data.remoteHighWaterMark).toBe(7);
+    });
+
+    it('should roundtrip correctly', async () => {
+      const original = {
+        streamId: 'test-stream',
+        localHighWaterMark: 42,
+        remoteHighWaterMark: 38,
+        lastSyncAt: '2026-02-08T12:00:00Z',
+        lastSyncResult: 'partial' as const,
+      };
+
+      await manager.save('test-stream', original);
+      const loaded = await manager.load('test-stream');
+      expect(loaded).toEqual(original);
+    });
+  });
+
+  // ─── updateLocalHWM ──────────────────────────────────────────────────
+
+  describe('updateLocalHWM', () => {
+    it('should update only local high water mark', async () => {
+      await manager.save('test-stream', {
+        streamId: 'test-stream',
+        localHighWaterMark: 5,
+        remoteHighWaterMark: 3,
+      });
+
+      await manager.updateLocalHWM('test-stream', 10);
+
+      const state = await manager.load('test-stream');
+      expect(state.localHighWaterMark).toBe(10);
+      expect(state.remoteHighWaterMark).toBe(3);
+    });
+
+    it('should create state with default if none exists', async () => {
+      await manager.updateLocalHWM('new-stream', 5);
+
+      const state = await manager.load('new-stream');
+      expect(state.localHighWaterMark).toBe(5);
+      expect(state.remoteHighWaterMark).toBe(0);
+    });
+  });
+
+  // ─── updateRemoteHWM ─────────────────────────────────────────────────
+
+  describe('updateRemoteHWM', () => {
+    it('should update only remote high water mark', async () => {
+      await manager.save('test-stream', {
+        streamId: 'test-stream',
+        localHighWaterMark: 5,
+        remoteHighWaterMark: 3,
+      });
+
+      await manager.updateRemoteHWM('test-stream', 8);
+
+      const state = await manager.load('test-stream');
+      expect(state.localHighWaterMark).toBe(5);
+      expect(state.remoteHighWaterMark).toBe(8);
+    });
+
+    it('should create state with default if none exists', async () => {
+      await manager.updateRemoteHWM('new-stream', 7);
+
+      const state = await manager.load('new-stream');
+      expect(state.localHighWaterMark).toBe(0);
+      expect(state.remoteHighWaterMark).toBe(7);
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/sync/config.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/sync/config.ts
@@ -25,8 +25,10 @@ export function loadSyncConfig(stateDir: string): SyncConfig {
   try {
     const content = fs.readFileSync(configPath, 'utf-8');
     fileConfig = JSON.parse(content) as Partial<SyncConfig>;
-  } catch {
-    // No config file — use defaults
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.warn(`Failed to load config from ${configPath}:`, err);
+    }
   }
 
   // Merge file config over defaults

--- a/plugins/exarchos/servers/exarchos-mcp/src/sync/config.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/sync/config.ts
@@ -44,7 +44,7 @@ export function loadSyncConfig(stateDir: string): SyncConfig {
     syncIntervalMs: fileConfig.syncIntervalMs ?? defaults.syncIntervalMs,
     batchSize: fileConfig.batchSize ?? defaults.batchSize,
     maxRetries: fileConfig.maxRetries ?? defaults.maxRetries,
-    remote: fileConfig.remote
+    remote: fileConfig.remote?.apiToken
       ? {
           apiToken: fileConfig.remote.apiToken,
           apiBaseUrl: fileConfig.remote.apiBaseUrl ?? remoteDefaults.apiBaseUrl,

--- a/plugins/exarchos/servers/exarchos-mcp/src/sync/config.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/sync/config.ts
@@ -1,0 +1,63 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { SyncConfig } from './types.js';
+
+// ─── Default Config ──────────────────────────────────────────────────────────
+
+export function getDefaultConfig(): SyncConfig {
+  return {
+    mode: 'local',
+    syncIntervalMs: 30000,
+    batchSize: 50,
+    maxRetries: 10,
+  };
+}
+
+// ─── Load Sync Config ────────────────────────────────────────────────────────
+
+export function loadSyncConfig(stateDir: string): SyncConfig {
+  const defaults = getDefaultConfig();
+
+  // Try loading from bridge-config.json in parent directory
+  const configPath = path.join(stateDir, '..', 'bridge-config.json');
+  let fileConfig: Partial<SyncConfig> = {};
+
+  try {
+    const content = fs.readFileSync(configPath, 'utf-8');
+    fileConfig = JSON.parse(content) as Partial<SyncConfig>;
+  } catch {
+    // No config file — use defaults
+  }
+
+  // Merge file config over defaults
+  const config: SyncConfig = {
+    mode: fileConfig.mode ?? defaults.mode,
+    syncIntervalMs: fileConfig.syncIntervalMs ?? defaults.syncIntervalMs,
+    batchSize: fileConfig.batchSize ?? defaults.batchSize,
+    maxRetries: fileConfig.maxRetries ?? defaults.maxRetries,
+    remote: fileConfig.remote,
+  };
+
+  // Fall back to environment variables for remote config if not in file
+  if (!config.remote) {
+    const apiToken = process.env.EXARCHOS_API_TOKEN;
+    const apiBaseUrl = process.env.BASILEUS_API_URL;
+
+    if (apiToken) {
+      config.remote = {
+        apiToken,
+        apiBaseUrl: apiBaseUrl ?? 'http://localhost:5000',
+        exarchosId: 'default',
+        timeoutMs: 5000,
+      };
+    }
+  }
+
+  // Force local mode if no API token is available
+  const hasToken = !!config.remote?.apiToken;
+  if (!hasToken && config.mode !== 'local') {
+    config.mode = 'local';
+  }
+
+  return config;
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/sync/config.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/sync/config.ts
@@ -31,13 +31,27 @@ export function loadSyncConfig(stateDir: string): SyncConfig {
     }
   }
 
-  // Merge file config over defaults
+  // Default remote config values
+  const remoteDefaults = {
+    apiBaseUrl: 'http://localhost:5000',
+    exarchosId: 'default',
+    timeoutMs: 5000,
+  };
+
+  // Merge file config over defaults, normalizing remote with defaults
   const config: SyncConfig = {
     mode: fileConfig.mode ?? defaults.mode,
     syncIntervalMs: fileConfig.syncIntervalMs ?? defaults.syncIntervalMs,
     batchSize: fileConfig.batchSize ?? defaults.batchSize,
     maxRetries: fileConfig.maxRetries ?? defaults.maxRetries,
-    remote: fileConfig.remote,
+    remote: fileConfig.remote
+      ? {
+          apiToken: fileConfig.remote.apiToken,
+          apiBaseUrl: fileConfig.remote.apiBaseUrl ?? remoteDefaults.apiBaseUrl,
+          exarchosId: fileConfig.remote.exarchosId ?? remoteDefaults.exarchosId,
+          timeoutMs: fileConfig.remote.timeoutMs ?? remoteDefaults.timeoutMs,
+        }
+      : undefined,
   };
 
   // Fall back to environment variables for remote config if not in file

--- a/plugins/exarchos/servers/exarchos-mcp/src/sync/sync-state.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/sync/sync-state.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { mkdtemp, rm, readFile, writeFile, chmod } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { SyncStateManager } from '../../sync/sync-state.js';
+import { SyncStateManager } from './sync-state.js';
 
 describe('SyncStateManager', () => {
   let tempDir: string;
@@ -61,6 +61,26 @@ describe('SyncStateManager', () => {
       expect(state.remoteHighWaterMark).toBe(3);
       expect(state.lastSyncAt).toBe('2026-02-08T00:00:00Z');
       expect(state.lastSyncResult).toBe('success');
+    });
+
+    it('should rethrow on non-ENOENT errors (e.g. invalid JSON)', async () => {
+      const filePath = path.join(tempDir, 'corrupt.sync.json');
+      await writeFile(filePath, '<<<not-json>>>', 'utf-8');
+
+      await expect(manager.load('corrupt')).rejects.toThrow();
+    });
+
+    it('should rethrow on permission errors', async () => {
+      const filePath = path.join(tempDir, 'noperm.sync.json');
+      await writeFile(filePath, '{}', 'utf-8');
+      await chmod(filePath, 0o000);
+
+      try {
+        await expect(manager.load('noperm')).rejects.toThrow();
+      } finally {
+        // Restore permissions so afterEach cleanup can remove the file
+        await chmod(filePath, 0o644);
+      }
     });
   });
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/sync/sync-state.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/sync/sync-state.ts
@@ -20,15 +20,12 @@ export class SyncStateManager {
     let release!: () => void;
     const next = new Promise<void>((r) => { release = r; });
     this.locks.set(streamId, next);
-    await prev;
     try {
+      await prev;
       return await fn();
     } finally {
       release();
-      // Clean up if no other operation is queued
-      if (this.locks.get(streamId) === next) {
-        this.locks.delete(streamId);
-      }
+      this.locks.delete(streamId);
     }
   }
 
@@ -59,10 +56,10 @@ export class SyncStateManager {
       const content = await fs.readFile(filePath, 'utf-8');
       return JSON.parse(content) as SyncState;
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        console.warn(`Failed to load sync state for ${streamId}:`, err);
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return this.defaultState(streamId);
       }
-      return this.defaultState(streamId);
+      throw err;
     }
   }
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/sync/sync-state.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/sync/sync-state.ts
@@ -25,7 +25,9 @@ export class SyncStateManager {
       return await fn();
     } finally {
       release();
-      this.locks.delete(streamId);
+      if (this.locks.get(streamId) === next) {
+        this.locks.delete(streamId);
+      }
     }
   }
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/sync/sync-state.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/sync/sync-state.ts
@@ -1,0 +1,64 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { SyncState } from './types.js';
+
+// ─── Sync State Manager ─────────────────────────────────────────────────────
+
+export class SyncStateManager {
+  constructor(private readonly stateDir: string) {}
+
+  // ─── File Path ──────────────────────────────────────────────────────────
+
+  private getFilePath(streamId: string): string {
+    return path.join(this.stateDir, `${streamId}.sync.json`);
+  }
+
+  // ─── Default State ─────────────────────────────────────────────────────
+
+  private defaultState(streamId: string): SyncState {
+    return {
+      streamId,
+      localHighWaterMark: 0,
+      remoteHighWaterMark: 0,
+    };
+  }
+
+  // ─── Load ───────────────────────────────────────────────────────────────
+
+  async load(streamId: string): Promise<SyncState> {
+    const filePath = this.getFilePath(streamId);
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      return JSON.parse(content) as SyncState;
+    } catch {
+      return this.defaultState(streamId);
+    }
+  }
+
+  // ─── Save ───────────────────────────────────────────────────────────────
+
+  async save(streamId: string, state: SyncState): Promise<void> {
+    const filePath = this.getFilePath(streamId);
+    const tmpPath = `${filePath}.tmp.${Date.now()}`;
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf-8');
+    await fs.rename(tmpPath, filePath);
+  }
+
+  // ─── Update Local HWM ──────────────────────────────────────────────────
+
+  async updateLocalHWM(streamId: string, mark: number): Promise<void> {
+    const state = await this.load(streamId);
+    state.localHighWaterMark = mark;
+    await this.save(streamId, state);
+  }
+
+  // ─── Update Remote HWM ─────────────────────────────────────────────────
+
+  async updateRemoteHWM(streamId: string, mark: number): Promise<void> {
+    const state = await this.load(streamId);
+    state.remoteHighWaterMark = mark;
+    await this.save(streamId, state);
+  }
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/sync/sync-state.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/sync/sync-state.ts
@@ -2,14 +2,38 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import type { SyncState } from './types.js';
 
+// ─── Stream ID Validation ────────────────────────────────────────────────────
+
+const SAFE_STREAM_ID = /^[A-Za-z0-9._-]+$/;
+
 // ─── Sync State Manager ─────────────────────────────────────────────────────
 
 export class SyncStateManager {
+  private readonly locks = new Map<string, Promise<void>>();
+
   constructor(private readonly stateDir: string) {}
+
+  // ─── Per-Stream Locking ─────────────────────────────────────────────────
+
+  private async withLock<T>(streamId: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.locks.get(streamId) ?? Promise.resolve();
+    let release!: () => void;
+    const next = new Promise<void>((r) => { release = r; });
+    this.locks.set(streamId, next);
+    await prev;
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
 
   // ─── File Path ──────────────────────────────────────────────────────────
 
   private getFilePath(streamId: string): string {
+    if (!SAFE_STREAM_ID.test(streamId)) {
+      throw new Error(`Invalid streamId: ${streamId}`);
+    }
     return path.join(this.stateDir, `${streamId}.sync.json`);
   }
 
@@ -49,16 +73,20 @@ export class SyncStateManager {
   // ─── Update Local HWM ──────────────────────────────────────────────────
 
   async updateLocalHWM(streamId: string, mark: number): Promise<void> {
-    const state = await this.load(streamId);
-    state.localHighWaterMark = mark;
-    await this.save(streamId, state);
+    await this.withLock(streamId, async () => {
+      const state = await this.load(streamId);
+      state.localHighWaterMark = mark;
+      await this.save(streamId, state);
+    });
   }
 
   // ─── Update Remote HWM ─────────────────────────────────────────────────
 
   async updateRemoteHWM(streamId: string, mark: number): Promise<void> {
-    const state = await this.load(streamId);
-    state.remoteHighWaterMark = mark;
-    await this.save(streamId, state);
+    await this.withLock(streamId, async () => {
+      const state = await this.load(streamId);
+      state.remoteHighWaterMark = mark;
+      await this.save(streamId, state);
+    });
   }
 }

--- a/plugins/exarchos/servers/exarchos-mcp/src/sync/sync-state.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/sync/sync-state.ts
@@ -25,6 +25,10 @@ export class SyncStateManager {
       return await fn();
     } finally {
       release();
+      // Clean up if no other operation is queued
+      if (this.locks.get(streamId) === next) {
+        this.locks.delete(streamId);
+      }
     }
   }
 
@@ -54,7 +58,10 @@ export class SyncStateManager {
     try {
       const content = await fs.readFile(filePath, 'utf-8');
       return JSON.parse(content) as SyncState;
-    } catch {
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.warn(`Failed to load sync state for ${streamId}:`, err);
+      }
       return this.defaultState(streamId);
     }
   }

--- a/plugins/exarchos/servers/exarchos-mcp/src/sync/types.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/sync/types.ts
@@ -1,0 +1,113 @@
+import type { WorkflowEvent } from '../event-store/schemas.js';
+
+// ─── Remote Configuration ────────────────────────────────────────────────────
+
+export interface RemoteConfig {
+  apiBaseUrl: string;
+  apiToken: string;
+  exarchosId: string;
+  timeoutMs: number;
+}
+
+// ─── Sync Configuration ─────────────────────────────────────────────────────
+
+export interface SyncConfig {
+  mode: 'local' | 'remote' | 'dual';
+  syncIntervalMs: number;
+  batchSize: number;
+  maxRetries: number;
+  remote?: RemoteConfig;
+}
+
+// ─── Sync State ──────────────────────────────────────────────────────────────
+
+export interface SyncState {
+  streamId: string;
+  localHighWaterMark: number;
+  remoteHighWaterMark: number;
+  lastSyncAt?: string;
+  lastSyncResult?: 'success' | 'partial' | 'failed';
+}
+
+// ─── Sync Result ─────────────────────────────────────────────────────────────
+
+export interface SyncResult {
+  pushed: number;
+  pulled: number;
+  conflicts: ConflictInfo[];
+}
+
+// ─── Conflict Info ───────────────────────────────────────────────────────────
+
+export interface ConflictInfo {
+  streamId: string;
+  type: string;
+  localEvent?: unknown;
+  remoteEvent?: unknown;
+  resolution: string;
+}
+
+// ─── Outbox Entry ────────────────────────────────────────────────────────────
+
+export interface OutboxEntry {
+  id: string;
+  streamId: string;
+  event: WorkflowEvent;
+  status: 'pending' | 'sent' | 'confirmed' | 'dead-letter';
+  attempts: number;
+  lastAttemptAt?: string;
+  nextRetryAt?: string;
+  createdAt: string;
+  error?: string;
+}
+
+// ─── Wire Format (matches C# ExarchosEventDto) ──────────────────────────────
+
+export interface ExarchosEventDto {
+  streamId: string;
+  sequence: number;
+  timestamp: string;
+  type: string;
+  correlationId?: string;
+  causationId?: string;
+  agentId?: string;
+  agentRole?: string;
+  source?: string;
+  schemaVersion?: string;
+  data?: Record<string, unknown>;
+}
+
+// ─── Workflow Registration ───────────────────────────────────────────────────
+
+export interface WorkflowRegistration {
+  featureId: string;
+  workflowType: string;
+  registeredAt: string;
+  streamVersion: number;
+}
+
+// ─── Event Sender (used by Outbox to decouple from BasileusClient) ──────────
+
+export interface EventSender {
+  appendEvents(
+    streamId: string,
+    events: ExarchosEventDto[],
+  ): Promise<AppendEventsResponse>;
+}
+
+// ─── Append Events Response ──────────────────────────────────────────────────
+
+export interface AppendEventsResponse {
+  accepted: number;
+  streamVersion: number;
+}
+
+// ─── Pending Command ─────────────────────────────────────────────────────────
+
+export interface PendingCommand {
+  id: string;
+  type: string;
+  workflowId: string;
+  taskId?: string;
+  payload?: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary

Foundation layer for the Exarchos bidirectional sync engine:

- **`types.ts`** — Wire format types (`ExarchosEventDto`, `SyncConfig`, `RemoteConfig`, `EventSender` interface), outbox/conflict/sync-state contracts
- **`config.ts`** — `loadSyncConfig()` from environment variables with sensible defaults
- **`sync-state.ts`** — Per-stream high-water mark tracking (local/remote sequence positions)

## Test plan

- [x] `config.test.ts` — 5 tests covering env loading, defaults, and validation
- [x] `sync-state.test.ts` — 6 tests covering load/save/update state persistence

Part 1 of 3 in the sync engine stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)