### PR TITLE
fix: accept tasks array in worktree schema + write-time validation

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/schemas.test.ts
@@ -585,7 +585,7 @@ describe('Workflow State Schemas', () => {
   });
 
   describe('WorktreeSchema', () => {
-    it('should parse a valid worktree', () => {
+    it('should parse a valid worktree with taskId', () => {
       const wt = {
         branch: 'feature/task-001',
         taskId: 'task-001',
@@ -593,6 +593,46 @@ describe('Workflow State Schemas', () => {
       };
       const result = WorktreeSchema.safeParse(wt);
       expect(result.success).toBe(true);
+    });
+
+    it('should parse a valid worktree with tasks array', () => {
+      const wt = {
+        branch: 'feat/track-a',
+        tasks: ['A01', 'A02', 'A03'],
+        status: 'active',
+      };
+      const result = WorktreeSchema.safeParse(wt);
+      expect(result.success).toBe(true);
+    });
+
+    it('should parse a worktree with both taskId and tasks', () => {
+      const wt = {
+        branch: 'feat/track-a',
+        taskId: 'A01',
+        tasks: ['A01', 'A02'],
+        status: 'active',
+      };
+      const result = WorktreeSchema.safeParse(wt);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject worktree with neither taskId nor tasks', () => {
+      const wt = {
+        branch: 'feat/orphan',
+        status: 'active',
+      };
+      const result = WorktreeSchema.safeParse(wt);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject worktree with empty tasks array', () => {
+      const wt = {
+        branch: 'feat/empty',
+        tasks: [],
+        status: 'active',
+      };
+      const result = WorktreeSchema.safeParse(wt);
+      expect(result.success).toBe(false);
     });
 
     it('should reject invalid worktree status', () => {
@@ -603,6 +643,20 @@ describe('Workflow State Schemas', () => {
       };
       const result = WorktreeSchema.safeParse(wt);
       expect(result.success).toBe(false);
+    });
+
+    it('should preserve extra fields via passthrough', () => {
+      const wt = {
+        branch: 'feature/task-001',
+        taskId: 'task-001',
+        status: 'active',
+        path: '/tmp/worktree',
+      };
+      const result = WorktreeSchema.safeParse(wt);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect((result.data as Record<string, unknown>).path).toBe('/tmp/worktree');
+      }
     });
   });
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-store.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-store.test.ts
@@ -420,6 +420,22 @@ describe('State Store', () => {
     });
   });
 
+  describe('writeStateFile_WritetimeValidation_RejectsInvalidState', () => {
+    it('should reject state with invalid worktree (neither taskId nor tasks)', async () => {
+      const { stateFile, state } = await initStateFile(tmpDir, 'validate-test', 'feature');
+      const mutated = structuredClone(state) as Record<string, unknown>;
+      (mutated.worktrees as Record<string, unknown>)['bad-wt'] = {
+        branch: 'feat/bad',
+        status: 'active',
+        // Missing both taskId and tasks
+      };
+
+      await expect(
+        writeStateFile(stateFile, mutated as typeof state),
+      ).rejects.toThrow(ErrorCode.INVALID_INPUT);
+    });
+  });
+
   describe('writeStateFile_FailurePath_ThrowsStateStoreError', () => {
     it('should throw StateStoreError with FILE_IO_ERROR when writing to an invalid path', async () => {
       const { state } = await initStateFile(tmpDir, 'write-fail-test', 'feature');

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/schemas.ts
@@ -132,9 +132,13 @@ export const WorktreeStatusSchema = z.enum(['active', 'merged', 'removed']);
 
 export const WorktreeSchema = z.object({
   branch: z.string(),
-  taskId: z.string(),
+  taskId: z.string().optional(),
+  tasks: z.array(z.string()).optional(),
   status: WorktreeStatusSchema,
-}).passthrough();
+}).passthrough().refine(
+  (wt) => wt.taskId !== undefined || (wt.tasks !== undefined && wt.tasks.length > 0),
+  { message: 'Either taskId or tasks (non-empty) must be provided' },
+);
 
 // ─── Synthesis Schema ───────────────────────────────────────────────────────
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/state-store.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/state-store.ts
@@ -165,6 +165,15 @@ export async function writeStateFile(
   stateFile: string,
   state: WorkflowState,
 ): Promise<void> {
+  // Validate before writing to catch schema violations at write time (not deferred to read)
+  const validation = WorkflowStateSchema.safeParse(state);
+  if (!validation.success) {
+    throw new StateStoreError(
+      ErrorCode.INVALID_INPUT,
+      `Write-time validation failed: ${validation.error.message}`,
+    );
+  }
+
   const tmpPath = `${stateFile}.tmp.${process.pid}`;
   try {
     await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf-8');

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
@@ -694,7 +694,7 @@ export async function handleReconcile(
   // With .passthrough() on WorktreeSchema, path field is preserved through Zod parsing
   const worktrees = state.worktrees as Record<
     string,
-    { branch: string; taskId: string; status: string; path?: string }
+    { branch: string; taskId?: string; tasks?: string[]; status: string; path?: string }
   >;
 
   const worktreeResults: Array<Record<string, unknown>> = [];
@@ -711,14 +711,17 @@ export async function handleReconcile(
       }
     }
 
-    worktreeResults.push({
+    const result: Record<string, unknown> = {
       id,
       branch: wt.branch,
-      taskId: wt.taskId,
       status: wt.status,
       path: wt.path ?? null,
       pathStatus,
-    });
+    };
+    if (wt.taskId !== undefined) result.taskId = wt.taskId;
+    if (wt.tasks !== undefined) result.tasks = wt.tasks;
+
+    worktreeResults.push(result);
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixes #59 — worktree schema rejects array-valued `tasks` field, corrupting state.

- **Schema**: `WorktreeSchema` now accepts both `taskId?: string` and `tasks?: string[]` (at least one required via Zod refinement; `tasks` must be non-empty)
- **Write-time validation**: `writeStateFile` now validates against `WorkflowStateSchema` before persisting, catching invalid shapes at write time instead of silently corrupting state
- **Reconcile handler**: Updated to output both `taskId` and `tasks` fields when present

## Test plan

- [x] `schemas.test.ts` — 5 new tests: tasks array, both fields, neither field, empty array, passthrough
- [x] `state-store.test.ts` — 1 new test: write-time validation rejects invalid worktree
- [x] All 638 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)