### PR TITLE
refactor: encode Graphite stacking into delegation implementer prompt

### DIFF
--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -239,7 +239,7 @@ Before dispatching ANY implementer:
 ### Worktree State Tracking
 
 Track worktrees in the workflow state file using `mcp__exarchos__exarchos_workflow_set`:
-- Set `worktrees.<worktree-path>` to an object containing branch, taskId, and status
+- Set `worktrees.<worktree-id>` to an object containing `branch`, `status`, and either `taskId` (single task) or `tasks` (array of task IDs for multi-task worktrees)
 
 ### Implementer Prompt Requirements
 
@@ -398,14 +398,11 @@ When Exarchos MCP tools are available, emit events during delegation:
 3. **For each task dispatch:** Use `mcp__exarchos__exarchos_team_spawn` to register the agent with the team coordinator, then use the Task tool to launch the subagent. `team_spawn` handles role assignment, event emission, and health tracking; the Task tool handles actual subprocess execution. Both are always used together — `team_spawn` does not replace the Task tool
 4. **For each task assignment:** Call `mcp__exarchos__exarchos_event_append` with event type `task.assigned` including taskId, title, branch, worktree
 5. **Monitor progress:** Use `mcp__exarchos__exarchos_view_workflow_status` to check task completion status
-6. **On task completion — progressive stacking:**
-   - Call `mcp__exarchos__exarchos_stack_place` with position, taskId, and branch to record the stack position
-   - Use `mcp__graphite__run_gt_cmd` to create the stacked branch:
-     ```
-     mcp__graphite__run_gt_cmd({ args: ["create", "-m", "<task-title>"], cwd: "<worktree-path>" })
-     ```
-   - Submit the stack to create/update PRs:
-     ```
-     mcp__graphite__run_gt_cmd({ args: ["submit", "--no-interactive"], cwd: "<worktree-path>" })
-     ```
+6. **On task completion — Graphite stacking:**
+   Subagents handle stacking directly using `gt create` (per implementer prompt template).
+   When a multi-task agent completes, it will have created a Graphite stack with one branch per logical review unit.
+   The orchestrator should:
+   - Call `mcp__exarchos__exarchos_stack_place` with position, taskId, and branch to record each stack position
+   - Verify the stack was submitted by checking for PRs: `mcp__graphite__run_gt_cmd({ args: ["ls"], cwd: "<worktree-path>" })`
+   - If the subagent used standard git (no Graphite), the orchestrator can restructure into a stack post-hoc
 7. **On all tasks complete:** Call `mcp__exarchos__exarchos_event_append` with event type `phase.transitioned` from delegate to next phase

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -404,5 +404,12 @@ When Exarchos MCP tools are available, emit events during delegation:
    The orchestrator should:
    - Call `mcp__exarchos__exarchos_stack_place` with position, taskId, and branch to record each stack position
    - Verify the stack was submitted by checking for PRs: `mcp__graphite__run_gt_cmd({ args: ["--no-interactive", "ls"], cwd: "<worktree-path>" })`
-   - If the subagent used standard git (no Graphite), the orchestrator can restructure into a stack post-hoc
+   - If the subagent used standard git (no Graphite), restructure into a stack post-hoc:
+     ```bash
+     # From the worktree, for each logical commit to convert:
+     gt create -m "feat: <description>"  # Creates a Graphite branch from current HEAD
+     gt submit --no-interactive           # Pushes and creates PR
+     ```
+     Then record each branch: `mcp__exarchos__exarchos_stack_place({ position, taskId, branch })`
+     See also: [Graphite post-hoc stacking docs](https://graphite.dev/docs/stacking-existing-branches)
 7. **On all tasks complete:** Call `mcp__exarchos__exarchos_event_append` with event type `phase.transitioned` from delegate to next phase

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -283,7 +283,7 @@ Update task status when dispatched using `mcp__exarchos__exarchos_workflow_set`:
 - Update the task's status to "in_progress"
 - Set the task's startedAt timestamp
 
-If creating worktree, also set the worktree entry with branch, taskId, and status.
+If creating worktree, also set the worktree entry with branch, status, and either taskId (single task) or tasks (multi-task).
 
 ### On Task Complete
 
@@ -403,6 +403,6 @@ When Exarchos MCP tools are available, emit events during delegation:
    When a multi-task agent completes, it will have created a Graphite stack with one branch per logical review unit.
    The orchestrator should:
    - Call `mcp__exarchos__exarchos_stack_place` with position, taskId, and branch to record each stack position
-   - Verify the stack was submitted by checking for PRs: `mcp__graphite__run_gt_cmd({ args: ["ls"], cwd: "<worktree-path>" })`
+   - Verify the stack was submitted by checking for PRs: `mcp__graphite__run_gt_cmd({ args: ["--no-interactive", "ls"], cwd: "<worktree-path>" })`
    - If the subagent used standard git (no Graphite), the orchestrator can restructure into a stack post-hoc
 7. **On all tasks complete:** Call `mcp__exarchos__exarchos_event_append` with event type `phase.transitioned` from delegate to next phase

--- a/skills/delegation/references/implementer-prompt.md
+++ b/skills/delegation/references/implementer-prompt.md
@@ -129,10 +129,10 @@ Use standard git commits:
 
 ### Detection
 
-Check if `gt` is available before your first commit:
+Check if Graphite is available and initialized before your first commit:
 
 ```bash
-gt --version 2>/dev/null && echo "GRAPHITE" || echo "GIT"
+gt --version 2>/dev/null && test -f .git/.graphite_repo_config && echo "GRAPHITE" || echo "GIT"
 ```
 
 ### Grouping Guidance

--- a/skills/delegation/references/implementer-prompt.md
+++ b/skills/delegation/references/implementer-prompt.md
@@ -104,13 +104,49 @@ npm run typecheck
 
 This regenerates TypeScript types from the OpenAPI spec. Include generated files in your commit.
 
+## Commit Strategy
+
+### If Graphite CLI (`gt`) is available:
+
+After completing each logical task within your assignment:
+
+1. Stage the relevant files: `git add <files>`
+2. Create a stacked branch: `gt create <task-branch-name> -m "feat: <task summary>"`
+3. Continue to the next task (you are now on a new branch stacked on the previous)
+
+After all tasks are complete:
+4. Submit the full stack: `gt submit --no-interactive --stack`
+
+**IMPORTANT:** When using Graphite, never use `git commit` or `git push`. Always use `gt create` and `gt submit`.
+
+### If Graphite is NOT available:
+
+Use standard git commits:
+
+1. Stage the relevant files: `git add <files>`
+2. Commit: `git commit -m "feat: <task summary>"`
+3. After all tasks: `git push -u origin <branch-name>`
+
+### Detection
+
+Check if `gt` is available before your first commit:
+
+```bash
+gt --version 2>/dev/null && echo "GRAPHITE" || echo "GIT"
+```
+
+### Grouping Guidance
+
+Stack branches should match logical review units, not individual TDD test cycles. Group related changes that form a coherent feature into one stack layer. For example, if you implement types + config + tests for a module, that's one `gt create`, not three.
+
 ## Completion
 
 When done, report:
 1. Test file path and test name
 2. Implementation file path
 3. Test results (pass/fail)
-4. Any issues encountered
+4. Commit strategy used (Graphite stack / standard git)
+5. Any issues encountered
 ```
 
 ## Usage Example
@@ -216,4 +252,5 @@ describe('validateEmail', () => {
 2. **No File References** - Don't say "see plan.md" - paste content
 3. **Explicit Paths** - Absolute paths to working directory and files
 4. **TDD Mandatory** - Always include TDD requirements
-5. **Clear Success Criteria** - Checkboxes for completion
+5. **Graphite-Aware** - Include commit strategy section; subagents auto-detect `gt`
+6. **Clear Success Criteria** - Checkboxes for completion

--- a/skills/delegation/references/implementer-prompt.md.test.sh
+++ b/skills/delegation/references/implementer-prompt.md.test.sh
@@ -33,7 +33,31 @@ if ! grep -q "STOP\|abort\|DO NOT proceed" "$PROMPT_FILE"; then
     exit 1
 fi
 
-# Test 6: Verification appears BEFORE TDD Requirements
+# Test 6: Contains Commit Strategy section with Graphite
+if ! grep -q "Commit Strategy" "$PROMPT_FILE"; then
+    echo "FAIL: Missing 'Commit Strategy' section"
+    exit 1
+fi
+
+# Test 7: Contains gt create instruction
+if ! grep -q "gt create" "$PROMPT_FILE"; then
+    echo "FAIL: Missing 'gt create' instruction in Commit Strategy"
+    exit 1
+fi
+
+# Test 8: Contains gt submit instruction
+if ! grep -q "gt submit" "$PROMPT_FILE"; then
+    echo "FAIL: Missing 'gt submit' instruction in Commit Strategy"
+    exit 1
+fi
+
+# Test 9: Contains fallback to standard git
+if ! grep -q "git commit" "$PROMPT_FILE"; then
+    echo "FAIL: Missing standard git fallback in Commit Strategy"
+    exit 1
+fi
+
+# Test 10: Verification appears BEFORE TDD Requirements
 TDD_LINE=$(grep -n "TDD Requirements" "$PROMPT_FILE" | head -1 | cut -d: -f1)
 VERIFY_LINE=$(grep -n "Worktree Verification" "$PROMPT_FILE" | head -1 | cut -d: -f1)
 


### PR DESCRIPTION
## Summary

Closes #60 — subagents now handle Graphite stacking directly instead of relying on orchestrator post-hoc restructuring.

### Changes

**`implementer-prompt.md`** — New "Commit Strategy" section:
- Teaches subagents to use `gt create` after each logical task instead of `git commit`
- Auto-detects `gt` availability via `gt --version` check
- Falls back to standard `git commit` when Graphite isn't available
- Includes grouping guidance: stack branches = logical review units, not individual TDD cycles

**`SKILL.md`** — Updated step 6 (Exarchos Integration):
- Subagents handle stacking directly (vs. orchestrator running `gt create` between completions)
- Orchestrator verifies stack via `gt ls` and records positions via `stack_place`
- Updated worktree tracking docs to reference `tasks: string[]` (from #59)

**`implementer-prompt.md.test.sh`** — 4 new assertions:
- Commit Strategy section exists
- `gt create` instruction present
- `gt submit` instruction present
- Standard git fallback present

## Test plan

- [x] `implementer-prompt.md.test.sh` — All 10 tests pass
- [x] Works for both C# (.NET) and TypeScript contexts (language-agnostic instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)