### PR TITLE
docs: add Exarchos Integration to refactor and debug skills

### DIFF
--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -432,3 +432,14 @@ Extended to support:
 | Exceed 15 min on hotfix investigation | Switch to thorough track |
 | Add features during bug fix | Scope creep - only fix the bug |
 | Skip tests because "it's just a fix" | Fixes need tests to prevent regression |
+
+## Exarchos Integration
+
+When Exarchos MCP tools are available, emit events throughout the debug workflow:
+
+1. **At workflow start (triage):** `exarchos_event_append` → `workflow.started` with workflowType "debug", urgency
+2. **On track selection:** `exarchos_event_append` → `phase.transitioned` with selected track (hotfix/thorough)
+3. **On each phase transition:** `exarchos_event_append` → `phase.transitioned` from→to
+4. **Thorough track stacking:** Handled by `/synthesize` (Graphite stack submission)
+5. **Hotfix track commit:** Single `gt create -m "fix: <description>"` — no multi-branch stacking needed
+6. **On complete:** `exarchos_event_append` → `phase.transitioned` to "completed"

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -324,7 +324,7 @@ Skill({ skill: "synthesize", args: "<feature-name>" })
 The `/synthesize` skill creates the PR via Graphite MCP:
 
 ```typescript
-# Submit the stack to create PRs
+// Submit the stack to create PRs
 mcp__graphite__run_gt_cmd({ args: ["submit", "--no-interactive"], cwd: "<repo-root>" })
 ```
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -126,7 +126,7 @@ Constraints:
 - Stop if scope expands beyond brief
 
 When done, commit via Graphite:
-```
+```typescript
 mcp__graphite__run_gt_cmd({ args: ["create", "-m", "refactor: <description>"], cwd: "<repo-root>" })
 ```
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -323,13 +323,13 @@ Skill({ skill: "synthesize", args: "<feature-name>" })
 
 The `/synthesize` skill creates the PR via Graphite MCP:
 
-```
+```typescript
 # Submit the stack to create PRs
 mcp__graphite__run_gt_cmd({ args: ["submit", "--no-interactive"], cwd: "<repo-root>" })
 ```
 
 Then update the PR description using GitHub MCP:
-```
+```typescript
 mcp__plugin_github_github__update_pull_request({
   owner, repo, pullNumber,
   body: "## Summary\n[Brief description of the refactor]\n\n## Changes\n- [Key structural change 1]\n\n## Documentation Updated\n- [doc1.md] - Updated for X\n\n## Test Plan\n- All existing tests pass"

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -125,6 +125,11 @@ Constraints:
 - Commit after each logical change
 - Stop if scope expands beyond brief
 
+When done, commit via Graphite:
+```
+mcp__graphite__run_gt_cmd({ args: ["create", "-m", "refactor: <description>"], cwd: "<repo-root>" })
+```
+
 Update state on completion using `mcp__exarchos__exarchos_workflow_set` to set `phase` to "polish-validate".
 
 #### 4. Validate Phase
@@ -515,3 +520,14 @@ Refactor phases map to auto-resume actions:
 | Skip tests because "just moving code" | Refactors need test verification |
 | Create design document for polish | Use brief in state file instead |
 | Work in main for overhaul | Use worktree isolation |
+
+## Exarchos Integration
+
+When Exarchos MCP tools are available, emit events throughout the refactor workflow:
+
+1. **At workflow start (explore):** `exarchos_event_append` → `workflow.started` with workflowType "refactor"
+2. **On track selection:** `exarchos_event_append` → `phase.transitioned` with selected track (polish/overhaul)
+3. **On each phase transition:** `exarchos_event_append` → `phase.transitioned` from→to
+4. **Overhaul track stacking:** Handled by `/delegate` (subagents use `gt create` per implementer prompt)
+5. **Polish track commit:** Single `gt create -m "refactor: <description>"` — no multi-branch stacking needed
+6. **On complete:** `exarchos_event_append` → `phase.transitioned` to "completed"


### PR DESCRIPTION
## Summary

- Add Exarchos Integration section to `skills/refactor/SKILL.md` with event emissions (workflow.started, phase.transitioned) and Graphite stacking guidance for polish/overhaul tracks
- Add Exarchos Integration section to `skills/debug/SKILL.md` with event emissions and Graphite stacking guidance for hotfix/thorough tracks
- Add `gt create` commit instruction to polish-track implement phase

## Test plan

- [x] Markdown renders correctly
- [x] Consistent section structure with existing Exarchos Integration in delegation skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)