### PR TITLE
fix: align MCP instructions with server behavior

### DIFF
--- a/docs/bugs/ex.md
+++ b/docs/bugs/ex.md
@@ -1,0 +1,31 @@
+```bash
+● exarchos - exarchos_workflow_set (MCP)(featureId: "refactor-arch-rigor", updates:
+{"worktrees":{"chain-a-guards-hsm":{"branch":"refactor/arch-rigor/chain-a-guar
+ds-hsm","status":"in_progress","tasks":["1","2"]},"chain-b-tools-decomp":{"bra
+nch":"refactor/arch-rigor/chain-b-tools-decomp","status":"in_progress","tasks"
+:["3","4","5","6"]},"task-7-snapshot-tests":{"branch":"refactor/arch-rigor/tas
+k-7-snapshot-tests","status":"in_progress","taskId":"7"}}})
+⎿  Error: INVALID_INPUT: Write-time validation failed: [
+{
+"received": "in_progress",
+"code": "invalid_enum_value",
+"options": [
+"active",
+"merged",
+"removed"
+],
+"path": [
+… +37 lines (ctrl+o to see all)
+
+● exarchos - exarchos_workflow_set (MCP)(featureId: "refactor-arch-rigor", updates:
+{"worktrees":{"chain-a-guards-hsm":{"branch":"refactor/arch-rigor/chain-a-guar
+ds-hsm","status":"active","tasks":["1","2"]},"chain-b-tools-decomp":{"branch":
+"refactor/arch-rigor/chain-b-tools-decomp","status":"active","tasks":["3","4",
+"5","6"]},"task-7-snapshot-tests":{"branch":"refactor/arch-rigor/task-7-snapsh
+ot-tests","status":"active","taskId":"7"}}})
+⎿  {
+"success": true,
+"data": {
+… +7 lines (ctrl+o to expand)
+```
+

--- a/docs/designs/2026-02-04-workflow-state-mcp.md
+++ b/docs/designs/2026-02-04-workflow-state-mcp.md
@@ -239,7 +239,7 @@ z.object({
 
 // Response
 {
-  action: string,              // "AUTO:plan:<path>", "WAIT:human-checkpoint:...", "DONE"
+  action: string,              // "AUTO:plan", "WAIT:human-checkpoint:...", "DONE"
   validTransitions: Array<{
     to: string,
     guardSatisfied: boolean,
@@ -459,7 +459,7 @@ RefactorWorkflow (root)
 │   │   └─→ update-docs [guard: tests pass]
 │   │
 │   └── update-docs (atomic)
-│       └─→ EXIT → HUMAN_CHECKPOINT(polish-complete)
+│       └─→ EXIT → HUMAN_CHECKPOINT(polish-update-docs)
 │
 ├── OverhaulTrack (compound state, maxFixCycles: 3)
 │   │   entry: checkpoint

--- a/docs/plans/2026-02-11-mcp-consistency.md
+++ b/docs/plans/2026-02-11-mcp-consistency.md
@@ -1,0 +1,198 @@
+# Implementation Plan: MCP Instruction-Implementation Consistency
+
+## Source
+Brief: `docs/workflow-state/refactor-mcp-consistency.state.json`
+Bug report: `docs/bugs/ex.md`
+
+## Scope
+**Target:** Fix 2 server code bugs + 8 documentation mismatches between Exarchos MCP tool behavior and instruction files
+**Base branch:** `fix/arch-rigor-remaining` (PR #76) — edits `next-action.ts` (decomposed from `tools.ts`)
+**Excluded:** New server functionality, HSM transition/guard changes, review status casing
+
+## Summary
+- Total tasks: 3
+- Parallel groups: 1 server task + 1 doc task in parallel, then 1 verification task
+- Estimated test count: ~8 new tests (refactor next_action coverage)
+- All 10 discrepancies (D1–D10) covered
+
+## Spec Traceability
+
+| Discrepancy | Type | Task ID |
+|-------------|------|---------|
+| D1: Worktree status enum incomplete | Doc | 2 |
+| D2: Feature next_action phantom path suffixes | Doc | 2 |
+| D3: AUTO:plan:--revise phantom value | Doc | 2 |
+| D4: Refactor action map off-by-one naming | Server | 1 |
+| D5: Phantom refactor action values | Doc | 2 |
+| D6: Human checkpoint suffix mismatch | Doc | 2 |
+| D7: Debug phase names missing prefixes | Doc | 2 |
+| D8: State version outdated (1.0 → 1.1) | Doc | 2 |
+| D9: workflowType documented as optional | Doc | 2 |
+| D10: BLOCKED:circuit-open undocumented | Doc | 2 |
+
+## Task Breakdown
+
+---
+
+### Task 1: Fix refactor PHASE_ACTION_MAP and add tests
+
+**Phase:** RED → GREEN → REFACTOR
+
+**TDD Steps:**
+
+1. [RED] Write tests for refactor next_action behavior
+   - File: `plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts`
+   - Add `describe('ToolNextAction_Refactor_ReturnsCorrectActions')` block with tests:
+     - `explore_GuardPasses_ReturnsAutoRefactorBrief` — init refactor, set `explore.scopeAssessment` + `explore.completedAt`, expect `AUTO:refactor-brief`
+     - `brief_PolishGuardPasses_ReturnsAutoPolishImplement` — set `track: 'polish'`, `brief.problem` populated, expect `AUTO:polish-implement`
+     - `brief_OverhaulGuardPasses_ReturnsAutoOverhaulPlan` — set `track: 'overhaul'`, `brief.problem` populated, expect `AUTO:overhaul-plan`
+     - `polishImplement_GuardPasses_ReturnsAutoRefactorValidate` — expect `AUTO:refactor-validate`
+     - `polishValidate_GuardPasses_ReturnsAutoRefactorUpdateDocs` — expect `AUTO:refactor-update-docs`
+     - `polishUpdateDocs_HumanCheckpoint_ReturnsWait` — expect `WAIT:human-checkpoint:polish-update-docs`
+     - `overhaulDelegate_GuardPasses_ReturnsAutoRefactorReview` — expect `AUTO:refactor-review`
+     - `synthesize_HumanCheckpoint_ReturnsWait` — expect `WAIT:human-checkpoint:synthesize`
+   - Run: `cd plugins/exarchos/servers/exarchos-mcp && npm run test:run` — tests for `explore` and `brief` MUST FAIL (wrong action values)
+
+2. [GREEN] Fix `PHASE_ACTION_MAP` in `src/workflow/next-action.ts`
+   - Change `explore: 'AUTO:refactor-explore'` → `explore: 'AUTO:refactor-brief'`
+   - Remove `brief: 'AUTO:refactor-brief'` entry entirely (let fallback `AUTO:${transition.to}` produce track-aware values)
+   - Run: `npm run test:run` — ALL tests MUST PASS
+
+3. [REFACTOR] Verify no regressions
+   - Run full test suite: `npm run test:run`
+   - Run typecheck: `npm run typecheck`
+
+**Verification:**
+- [ ] `explore` returns `AUTO:refactor-brief` (not `AUTO:refactor-explore`)
+- [ ] `brief` (polish) returns `AUTO:polish-implement` (not `AUTO:refactor-brief`)
+- [ ] `brief` (overhaul) returns `AUTO:overhaul-plan` (not `AUTO:refactor-brief`)
+- [ ] All existing tests still pass
+- [ ] Human checkpoints return correct phase-name suffixes
+
+**Dependencies:** None
+**Parallelizable:** Yes (with Task 2)
+
+---
+
+### Task 2: Update all documentation to match server behavior
+
+**Phase:** Documentation (no TDD)
+
+**Changes by file:**
+
+#### 2a. `rules/workflow-auto-resume.md`
+- **D2:** Remove path suffixes from feature actions:
+  - `AUTO:plan:<design-path>` → `AUTO:plan`
+  - `AUTO:plan:--revise <design-path>` → remove entirely (D3)
+  - `AUTO:plan-review:<plan-path>` → `AUTO:plan-review`
+  - `AUTO:delegate:<path>` → `AUTO:delegate`
+  - `AUTO:review:<path>` → `AUTO:review`
+  - `AUTO:synthesize:<feature>` → `AUTO:synthesize`
+  - `AUTO:delegate:--fixes <path>` → `AUTO:delegate:--fixes`
+- **D5:** Update refactor action table:
+  - `AUTO:refactor-explore` → `AUTO:refactor-brief` (after explore, transition to brief)
+  - `AUTO:refactor-brief` → remove (brief no longer has a map entry)
+  - `AUTO:refactor-implement` → `AUTO:polish-implement` (fallback-generated for polish track)
+  - `AUTO:refactor-plan` → `AUTO:overhaul-plan` (fallback-generated for overhaul track)
+  - Add: `AUTO:polish-implement` — Polish track: continue to implementation
+  - Add: `AUTO:overhaul-plan` — Overhaul track: invoke /plan
+- **D10:** Add `BLOCKED:circuit-open:<compoundId>` to Wait/Done States table with description
+
+#### 2b. `skills/refactor/SKILL.md`
+- **D5/D6:** Update Polish Auto-Chain next actions:
+  - `AUTO:refactor-brief` after explore → `AUTO:refactor-brief` (correct — matches new map)
+  - `AUTO:refactor-implement` after brief → `AUTO:polish-implement`
+  - `WAIT:human-checkpoint:polish-complete` → `WAIT:human-checkpoint:polish-update-docs`
+- **D5/D6:** Update Overhaul Auto-Chain next actions:
+  - `AUTO:refactor-brief` after explore → `AUTO:refactor-brief` (correct)
+  - `AUTO:plan:<brief>` after brief → `AUTO:overhaul-plan`
+  - `AUTO:delegate:<plan>` after overhaul-plan → `AUTO:refactor-delegate`
+  - `AUTO:review:<path>` after overhaul-delegate → `AUTO:refactor-review`
+  - `AUTO:synthesize:<feature>` after overhaul-update-docs → `AUTO:refactor-synthesize`
+  - `WAIT:human-checkpoint:overhaul-merge` → `WAIT:human-checkpoint:synthesize`
+- **D5/D6:** Update Integration Points (HSM Phase → Next Action) table
+- **D8:** Update `"version": "1.0"` → `"1.1"` in state schema example
+
+#### 2c. `skills/refactor/phases/auto-chain.md`
+- Update all `Returns:` lines to match actual server values
+- Update action-to-behavior mapping table
+
+#### 2d. `skills/refactor/phases/polish-validate.md`
+- Fix `Next action: AUTO:refactor-implement` → correct action value
+
+#### 2e. `skills/refactor/phases/polish-implement.md`
+- Fix `Next action: AUTO:plan:<brief>` → correct action value
+
+#### 2f. `skills/debug/references/state-schema.md`
+- **D7:** Add track prefixes to all phase names:
+  - `implement` → `hotfix-implement` / `debug-implement`
+  - `validate` → `hotfix-validate` / `debug-validate`
+  - `review` → `debug-review`
+- **D8:** Update `"version": "1.0"` → `"1.1"` (4 occurrences)
+
+#### 2g. `skills/workflow-state/SKILL.md`
+- **D1:** Document all worktree status values: `'active' | 'merged' | 'removed'`
+- **D8:** Update version reference from "1.0" to "1.1"
+- **D9:** Mark `workflowType` as required (remove "defaults to feature" language)
+
+#### 2h. `docs/designs/2026-02-04-workflow-state-mcp.md`
+- **D2:** Remove `:<path>` from next_action example: `"AUTO:plan:<path>"` → `"AUTO:plan"`
+- **D6:** Fix `HUMAN_CHECKPOINT(polish-complete)` → `HUMAN_CHECKPOINT(polish-update-docs)`
+
+**Dependencies:** None (doc changes don't depend on server fix)
+**Parallelizable:** Yes (with Task 1)
+
+---
+
+### Task 3: Verify consistency end-to-end
+
+**Phase:** Verification
+
+1. Run full MCP server test suite: `cd plugins/exarchos/servers/exarchos-mcp && npm run test:run`
+2. Run typecheck: `npm run typecheck`
+3. Grep for any remaining phantom values across all instruction files:
+   - `AUTO:plan:` (with colon-suffix, excluding `AUTO:plan-review`)
+   - `AUTO:refactor-explore`
+   - `AUTO:refactor-implement`
+   - `AUTO:refactor-plan`
+   - `in_progress` near worktree context
+   - `polish-complete`
+   - `overhaul-merge`
+   - `"version": "1.0"` in skill/rule files
+4. Verify zero matches for all phantom values
+
+**Dependencies:** Tasks 1, 2
+**Parallelizable:** No
+
+---
+
+## Parallelization Strategy
+
+```
+Task 1 (server fix + tests)  ──────┐
+                                    ├─→ Task 3 (verification)
+Task 2 (documentation fixes) ──────┘
+```
+
+- Tasks 1 and 2 can run in parallel (different file sets, no overlap)
+- Task 3 runs after both complete
+
+### Worktree Plan
+
+| Worktree | Branch | Tasks |
+|----------|--------|-------|
+| server-fix | refactor/mcp-consistency/server | 1 |
+| doc-fix | refactor/mcp-consistency/docs | 2 |
+| (main) | refactor/mcp-consistency | 3 (verification) |
+
+## Completion Checklist
+- [ ] Refactor PHASE_ACTION_MAP entries for explore/brief fixed
+- [ ] 8 new tests covering all refactor next_action phases
+- [ ] All next_action values in docs match server behavior
+- [ ] All worktree status values documented (active/merged/removed)
+- [ ] All debug phase names use track prefixes
+- [ ] Version references updated to 1.1
+- [ ] workflowType documented as required
+- [ ] BLOCKED:circuit-open documented
+- [ ] No phantom action values remain
+- [ ] Full test suite green

--- a/plugins/exarchos/servers/exarchos-mcp/package-lock.json
+++ b/plugins/exarchos/servers/exarchos-mcp/package-lock.json
@@ -1049,6 +1049,7 @@
       "integrity": "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1722,6 +1723,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2021,6 +2023,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2503,6 +2506,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3124,6 +3128,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3197,6 +3202,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3295,6 +3301,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -3503,6 +3510,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -1415,6 +1415,61 @@ describe('ToolNextAction_Refactor_ReturnsCorrectActions', () => {
     expect(data.action).toBe('AUTO:refactor-synthesize');
   });
 
+  it('polishValidate_GuardPasses_ReturnsAutoRefactorUpdateDocs', async () => {
+    await handleInit({ featureId: 'refactor-na-polish-val', workflowType: 'refactor' }, tmpDir);
+
+    // Advance to polish-validate via direct state manipulation
+    const stateFile = path.join(tmpDir, 'refactor-na-polish-val.state.json');
+    const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+    raw.phase = 'polish-validate';
+    raw.track = 'polish';
+    raw.validation = { testsPass: true };
+    raw._checkpoint.phase = 'polish-validate';
+    await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+    const result = await handleNextAction({ featureId: 'refactor-na-polish-val' }, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.action).toBe('AUTO:refactor-update-docs');
+  });
+
+  it('overhaulDelegate_GuardPasses_ReturnsAutoRefactorReview', async () => {
+    await handleInit({ featureId: 'refactor-na-oh-del', workflowType: 'refactor' }, tmpDir);
+
+    const stateFile = path.join(tmpDir, 'refactor-na-oh-del.state.json');
+    const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+    raw.phase = 'overhaul-delegate';
+    raw.track = 'overhaul';
+    raw.tasks = [{ id: '1', title: 'Task 1', status: 'complete' }];
+    raw._checkpoint.phase = 'overhaul-delegate';
+    await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+    const result = await handleNextAction({ featureId: 'refactor-na-oh-del' }, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.action).toBe('AUTO:refactor-review');
+  });
+
+  it('overhaulReview_GuardPasses_ReturnsAutoRefactorUpdateDocs', async () => {
+    await handleInit({ featureId: 'refactor-na-oh-rev', workflowType: 'refactor' }, tmpDir);
+
+    const stateFile = path.join(tmpDir, 'refactor-na-oh-rev.state.json');
+    const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+    raw.phase = 'overhaul-review';
+    raw.track = 'overhaul';
+    raw.reviews = { spec: { status: 'approved' } };
+    raw._checkpoint.phase = 'overhaul-review';
+    await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+    const result = await handleNextAction({ featureId: 'refactor-na-oh-rev' }, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.action).toBe('AUTO:refactor-update-docs');
+  });
+
   it('synthesize_HumanCheckpoint_ReturnsWait', async () => {
     await handleInit({ featureId: 'refactor-na-synth', workflowType: 'refactor' }, tmpDir);
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -1207,3 +1207,228 @@ describe('ToolCheckpoint_SlimResponse_ReturnsMinimalPayload', () => {
     expect(data.artifacts).toBeUndefined();
   });
 });
+
+// ─── Refactor Next-Action Tests ──────────────────────────────────────────────
+
+describe('ToolNextAction_Refactor_ReturnsCorrectActions', () => {
+  it('explore_GuardPasses_ReturnsAutoRefactorBrief', async () => {
+    await handleInit({ featureId: 'refactor-na-explore', workflowType: 'refactor' }, tmpDir);
+
+    // Set explore.scopeAssessment so the explore->brief guard passes
+    await handleSet(
+      {
+        featureId: 'refactor-na-explore',
+        updates: {
+          'explore.scopeAssessment': {
+            filesAffected: ['a.ts'],
+            modulesAffected: ['mod'],
+            testCoverage: 'good',
+            recommendedTrack: 'polish',
+          },
+          'explore.completedAt': new Date().toISOString(),
+        },
+      },
+      tmpDir,
+    );
+
+    const result = await handleNextAction({ featureId: 'refactor-na-explore' }, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.action).toBe('AUTO:refactor-brief');
+  });
+
+  it('brief_PolishGuardPasses_ReturnsAutoPolishImplement', async () => {
+    await handleInit({ featureId: 'refactor-na-brief-polish', workflowType: 'refactor' }, tmpDir);
+
+    // Transition explore -> brief
+    await handleSet(
+      {
+        featureId: 'refactor-na-brief-polish',
+        updates: {
+          'explore.scopeAssessment': {
+            filesAffected: ['a.ts'],
+            modulesAffected: ['mod'],
+            testCoverage: 'good',
+            recommendedTrack: 'polish',
+          },
+        },
+      },
+      tmpDir,
+    );
+    await handleSet(
+      { featureId: 'refactor-na-brief-polish', phase: 'brief' },
+      tmpDir,
+    );
+
+    // Set track and brief data so polishTrackSelected guard passes
+    await handleSet(
+      {
+        featureId: 'refactor-na-brief-polish',
+        updates: {
+          track: 'polish',
+          brief: {
+            problem: 'test',
+            goals: ['g1'],
+            approach: 'a',
+            affectedAreas: ['a.ts'],
+            outOfScope: [],
+            successCriteria: ['s1'],
+            docsToUpdate: [],
+          },
+        },
+      },
+      tmpDir,
+    );
+
+    const result = await handleNextAction({ featureId: 'refactor-na-brief-polish' }, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    // Fallback produces AUTO:polish-implement (transition.to)
+    expect(data.action).toBe('AUTO:polish-implement');
+  });
+
+  it('brief_OverhaulGuardPasses_ReturnsAutoOverhaulPlan', async () => {
+    await handleInit({ featureId: 'refactor-na-brief-overhaul', workflowType: 'refactor' }, tmpDir);
+
+    // Transition explore -> brief
+    await handleSet(
+      {
+        featureId: 'refactor-na-brief-overhaul',
+        updates: {
+          'explore.scopeAssessment': {
+            filesAffected: ['a.ts'],
+            modulesAffected: ['mod'],
+            testCoverage: 'good',
+            recommendedTrack: 'overhaul',
+          },
+        },
+      },
+      tmpDir,
+    );
+    await handleSet(
+      { featureId: 'refactor-na-brief-overhaul', phase: 'brief' },
+      tmpDir,
+    );
+
+    // Set track to overhaul so overhaulTrackSelected guard passes
+    await handleSet(
+      {
+        featureId: 'refactor-na-brief-overhaul',
+        updates: {
+          track: 'overhaul',
+          brief: {
+            problem: 'test',
+            goals: ['g1'],
+            approach: 'a',
+            affectedAreas: ['a.ts'],
+            outOfScope: [],
+            successCriteria: ['s1'],
+            docsToUpdate: [],
+          },
+        },
+      },
+      tmpDir,
+    );
+
+    const result = await handleNextAction({ featureId: 'refactor-na-brief-overhaul' }, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    // Fallback produces AUTO:overhaul-plan (transition.to)
+    expect(data.action).toBe('AUTO:overhaul-plan');
+  });
+
+  it('polishImplement_GuardPasses_ReturnsAutoRefactorValidate', async () => {
+    await handleInit({ featureId: 'refactor-na-polish-impl', workflowType: 'refactor' }, tmpDir);
+
+    // Advance to polish-implement via direct state manipulation
+    const stateFile = path.join(tmpDir, 'refactor-na-polish-impl.state.json');
+    const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+    raw.phase = 'polish-implement';
+    raw.track = 'polish';
+    raw._checkpoint.phase = 'polish-implement';
+    await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+    // implementationComplete guard always returns true, so next_action should proceed
+    const result = await handleNextAction({ featureId: 'refactor-na-polish-impl' }, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.action).toBe('AUTO:refactor-validate');
+  });
+
+  it('polishUpdateDocs_HumanCheckpoint_ReturnsWait', async () => {
+    await handleInit({ featureId: 'refactor-na-polish-docs', workflowType: 'refactor' }, tmpDir);
+
+    // Advance to polish-update-docs via direct state manipulation
+    const stateFile = path.join(tmpDir, 'refactor-na-polish-docs.state.json');
+    const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+    raw.phase = 'polish-update-docs';
+    raw.track = 'polish';
+    raw._checkpoint.phase = 'polish-update-docs';
+    await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+    const result = await handleNextAction({ featureId: 'refactor-na-polish-docs' }, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.action).toBe('WAIT:human-checkpoint:polish-update-docs');
+  });
+
+  it('overhaulPlan_GuardPasses_ReturnsAutoRefactorDelegate', async () => {
+    await handleInit({ featureId: 'refactor-na-overhaul-plan', workflowType: 'refactor' }, tmpDir);
+
+    // Advance to overhaul-plan via direct state manipulation
+    const stateFile = path.join(tmpDir, 'refactor-na-overhaul-plan.state.json');
+    const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+    raw.phase = 'overhaul-plan';
+    raw.track = 'overhaul';
+    raw.artifacts = { design: null, plan: 'plan.md', pr: null };
+    raw._checkpoint.phase = 'overhaul-plan';
+    await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+    const result = await handleNextAction({ featureId: 'refactor-na-overhaul-plan' }, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.action).toBe('AUTO:refactor-delegate');
+  });
+
+  it('overhaulUpdateDocs_GuardPasses_ReturnsAutoRefactorSynthesize', async () => {
+    await handleInit({ featureId: 'refactor-na-overhaul-docs', workflowType: 'refactor' }, tmpDir);
+
+    // Advance to overhaul-update-docs via direct state manipulation
+    const stateFile = path.join(tmpDir, 'refactor-na-overhaul-docs.state.json');
+    const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+    raw.phase = 'overhaul-update-docs';
+    raw.track = 'overhaul';
+    raw.validation = { docsUpdated: true };
+    raw._checkpoint.phase = 'overhaul-update-docs';
+    await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+    const result = await handleNextAction({ featureId: 'refactor-na-overhaul-docs' }, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.action).toBe('AUTO:refactor-synthesize');
+  });
+
+  it('synthesize_HumanCheckpoint_ReturnsWait', async () => {
+    await handleInit({ featureId: 'refactor-na-synth', workflowType: 'refactor' }, tmpDir);
+
+    // Advance to synthesize via direct state manipulation
+    const stateFile = path.join(tmpDir, 'refactor-na-synth.state.json');
+    const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+    raw.phase = 'synthesize';
+    raw._checkpoint.phase = 'synthesize';
+    await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+    const result = await handleNextAction({ featureId: 'refactor-na-synth' }, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.action).toBe('WAIT:human-checkpoint:synthesize');
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/next-action.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/next-action.ts
@@ -54,8 +54,7 @@ export const PHASE_ACTION_MAP: Record<string, Record<string, string>> = {
     'hotfix-implement': 'AUTO:debug-validate',
   },
   refactor: {
-    explore: 'AUTO:refactor-explore',
-    brief: 'AUTO:refactor-brief',
+    explore: 'AUTO:refactor-brief',
     'polish-implement': 'AUTO:refactor-validate',
     'polish-validate': 'AUTO:refactor-update-docs',
     'overhaul-plan': 'AUTO:refactor-delegate',

--- a/rules/workflow-auto-resume.md
+++ b/rules/workflow-auto-resume.md
@@ -34,13 +34,12 @@ The `mcp__exarchos__exarchos_workflow_next_action` tool returns one of:
 
 | Response | Meaning | Action |
 |----------|---------|--------|
-| `AUTO:plan:<design-path>` | Auto-continue to plan | Invoke `/plan` |
-| `AUTO:plan:--revise <design-path>` | Plan has gaps, revise | Invoke `/plan --revise` with gap context |
-| `AUTO:plan-review:<plan-path>` | Auto-continue to plan review | Run plan-design delta analysis |
-| `AUTO:delegate:<path>` | Auto-continue to delegate | Invoke `/delegate` |
-| `AUTO:review:<path>` | Auto-continue to review | Invoke `/review` |
-| `AUTO:synthesize:<feature>` | Auto-continue to synthesize | Invoke `/synthesize` |
-| `AUTO:delegate:--fixes <path>` | Auto-continue fix cycle | Invoke `/delegate --fixes` |
+| `AUTO:plan` | Auto-continue to plan | Invoke `/plan` |
+| `AUTO:plan-review` | Auto-continue to plan review | Run plan-design delta analysis |
+| `AUTO:delegate` | Auto-continue to delegate | Invoke `/delegate` |
+| `AUTO:review` | Auto-continue to review | Invoke `/review` |
+| `AUTO:synthesize` | Auto-continue to synthesize | Invoke `/synthesize` |
+| `AUTO:delegate:--fixes` | Auto-continue fix cycle | Invoke `/delegate --fixes` |
 
 #### Debug Workflow Actions
 
@@ -58,15 +57,14 @@ The `mcp__exarchos__exarchos_workflow_next_action` tool returns one of:
 
 | Response | Meaning | Action |
 |----------|---------|--------|
-| `AUTO:refactor-explore` | Continue exploration | Resume scope assessment |
-| `AUTO:refactor-brief` | Capture brief | Continue brief phase |
-| `AUTO:refactor-implement` | Polish track implement | Continue direct implementation |
-| `AUTO:refactor-validate` | Polish track validate | Run validation checks |
-| `AUTO:refactor-update-docs` | Update documentation | Continue doc updates |
-| `AUTO:refactor-plan` | Overhaul track plan | Invoke `/plan` |
-| `AUTO:refactor-delegate` | Overhaul track delegate | Invoke `/delegate` |
-| `AUTO:refactor-review` | Overhaul track review | Invoke `/review` |
-| `AUTO:refactor-synthesize` | Overhaul track synthesize | Invoke `/synthesize` |
+| `AUTO:refactor-brief` | Explore complete, proceed to brief | Continue to brief phase |
+| `AUTO:polish-implement` | Brief complete (polish track) | Continue direct implementation |
+| `AUTO:overhaul-plan` | Brief complete (overhaul track) | Invoke `/plan` |
+| `AUTO:refactor-validate` | Polish implement complete | Run validation checks |
+| `AUTO:refactor-update-docs` | Validation passed or overhaul review passed | Continue doc updates |
+| `AUTO:refactor-delegate` | Overhaul plan complete | Invoke `/delegate` |
+| `AUTO:refactor-review` | Overhaul delegate complete | Invoke `/review` |
+| `AUTO:refactor-synthesize` | Overhaul update-docs complete | Invoke `/synthesize` |
 
 #### Wait/Done States
 
@@ -74,6 +72,7 @@ The `mcp__exarchos__exarchos_workflow_next_action` tool returns one of:
 |----------|---------|--------|
 | `WAIT:human-checkpoint:*` | Human input required | Display status, wait |
 | `WAIT:in-progress:*` | Work in progress | Check task status, continue |
+| `BLOCKED:circuit-open:<compoundId>` | Fix cycle limit reached | Display error, escalate to user |
 | `DONE` | Workflow complete | No action needed |
 
 ### Step 4: Execute Auto-Continue

--- a/skills/debug/references/state-schema.md
+++ b/skills/debug/references/state-schema.md
@@ -8,13 +8,13 @@ Debug workflows extend the standard workflow state with additional fields.
 
 ```json
 {
-  "version": "1.0",
+  "version": "1.1",
   "featureId": "debug-<issue-slug>",
   "workflowType": "debug",
   "createdAt": "ISO8601",
   "updatedAt": "ISO8601",
   "track": "hotfix | thorough",
-  "phase": "triage | investigate | rca | design | implement | validate | review | synthesize | completed",
+  "phase": "triage | investigate | rca | design | debug-implement | debug-validate | debug-review | hotfix-implement | hotfix-validate | synthesize | completed | cancelled | blocked",
 
   "urgency": {
     "level": "P0 | P1 | P2",
@@ -65,7 +65,7 @@ Debug workflows extend the standard workflow state with additional fields.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `version` | string | Schema version, currently "1.0" |
+| `version` | string | Schema version, currently "1.1" |
 | `featureId` | string | Unique identifier, format: `debug-<issue-slug>` |
 | `workflowType` | string | Always "debug" for debug workflows |
 | `createdAt` | ISO8601 | When workflow was created |
@@ -77,8 +77,8 @@ Debug workflows extend the standard workflow state with additional fields.
 
 | Track    | Valid Phases                                                                          |
 |----------|-----------------------------------------------------------------------------------------|
-| Hotfix   | triage → investigate → implement → validate → completed                                 |
-| Thorough | triage → investigate → rca → design → implement → validate → review → synthesize → completed |
+| Hotfix   | triage → investigate → hotfix-implement → hotfix-validate → completed                                 |
+| Thorough | triage → investigate → rca → design → debug-implement → debug-validate → debug-review → synthesize → completed |
 
 Note: Thorough track may skip `rca` and `design` phases if root cause is straightforward.
 
@@ -181,11 +181,11 @@ Note: Thorough track may skip `rca` and `design` phases if root cause is straigh
 ### Hotfix Track
 
 ```text
-triage → investigate → implement → validate → completed
-   │          │            │           │          │
-   │          │            │           │          └─ Human checkpoint: merge
-   │          │            │           └─ Run smoke tests
-   │          │            └─ Apply minimal fix
+triage → investigate → hotfix-implement → hotfix-validate → completed
+   │          │               │                 │                │
+   │          │               │                 │                └─ Human checkpoint: merge
+   │          │               │                 └─ Run smoke tests
+   │          │               └─ Apply minimal fix
    │          └─ Find root cause (15 min max)
    └─ Gather context, select track
 ```
@@ -193,12 +193,12 @@ triage → investigate → implement → validate → completed
 ### Thorough Track
 
 ```text
-triage → investigate → rca → design → implement → review → synthesize → completed
-   │          │         │       │          │          │          │          │
-   │          │         │       │          │          │          │          └─ Merge
-   │          │         │       │          │          │          └─ Create PR
-   │          │         │       │          │          └─ Spec review
-   │          │         │       │          └─ TDD implementation
+triage → investigate → rca → design → debug-implement → debug-review → synthesize → completed
+   │          │         │       │            │                │              │          │
+   │          │         │       │            │                │              │          └─ Merge
+   │          │         │       │            │                │              └─ Create PR
+   │          │         │       │            │                └─ Spec review
+   │          │         │       │            └─ TDD implementation
    │          │         │       └─ Brief fix approach
    │          │         └─ Full RCA document
    │          └─ Systematic investigation
@@ -211,13 +211,13 @@ triage → investigate → rca → design → implement → review → synthesiz
 
 ```json
 {
-  "version": "1.0",
+  "version": "1.1",
   "featureId": "debug-login-500",
   "workflowType": "debug",
   "createdAt": "2026-01-27T10:00:00Z",
   "updatedAt": "2026-01-27T10:12:00Z",
   "track": "hotfix",
-  "phase": "implement",
+  "phase": "hotfix-implement",
   "urgency": {
     "level": "P0",
     "justification": "Production login broken"
@@ -253,7 +253,7 @@ triage → investigate → rca → design → implement → review → synthesiz
 
 ```json
 {
-  "version": "1.0",
+  "version": "1.1",
   "featureId": "debug-cart-total-wrong",
   "workflowType": "debug",
   "createdAt": "2026-01-26T14:00:00Z",

--- a/skills/debug/references/state-schema.md
+++ b/skills/debug/references/state-schema.md
@@ -193,11 +193,12 @@ triage → investigate → hotfix-implement → hotfix-validate → completed
 ### Thorough Track
 
 ```text
-triage → investigate → rca → design → debug-implement → debug-review → synthesize → completed
-   │          │         │       │            │                │              │          │
-   │          │         │       │            │                │              │          └─ Merge
-   │          │         │       │            │                │              └─ Create PR
-   │          │         │       │            │                └─ Spec review
+triage → investigate → rca → design → debug-implement → debug-validate → debug-review → synthesize → completed
+   │          │         │       │            │                 │              │              │          │
+   │          │         │       │            │                 │              │              │          └─ Merge
+   │          │         │       │            │                 │              │              └─ Create PR
+   │          │         │       │            │                 │              └─ Spec review
+   │          │         │       │            │                 └─ Run validation
    │          │         │       │            └─ TDD implementation
    │          │         │       └─ Brief fix approach
    │          │         └─ Full RCA document

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -324,7 +324,7 @@ Initialize refactor workflow using `mcp__exarchos__exarchos_workflow_init` with 
 Full state schema:
 ```json
 {
-  "version": "1.0",
+  "version": "1.1",
   "featureId": "refactor-<slug>",
   "workflowType": "refactor",
   "track": "polish | overhaul",
@@ -374,10 +374,10 @@ explore -> brief -> polish-implement -> polish-validate -> polish-update-docs ->
 
 **Next actions:**
 - `AUTO:refactor-brief` after explore
-- `AUTO:refactor-implement` after brief
+- `AUTO:polish-implement` after brief
 - `AUTO:refactor-validate` after polish-implement
 - `AUTO:refactor-update-docs` after polish-validate
-- `WAIT:human-checkpoint:polish-complete` after polish-update-docs
+- `WAIT:human-checkpoint:polish-update-docs` after polish-update-docs
 
 ### Overhaul Auto-Chain
 
@@ -388,12 +388,12 @@ explore -> brief -> overhaul-plan -> overhaul-delegate -> overhaul-review -> ove
 
 **Next actions:**
 - `AUTO:refactor-brief` after explore
-- `AUTO:plan:<brief>` after brief
-- `AUTO:delegate:<plan>` after overhaul-plan
-- `AUTO:review:<path>` after overhaul-delegate
+- `AUTO:overhaul-plan` after brief
+- `AUTO:refactor-delegate` after overhaul-plan
+- `AUTO:refactor-review` after overhaul-delegate
 - `AUTO:refactor-update-docs` after overhaul-review
-- `AUTO:synthesize:<feature>` after overhaul-update-docs
-- `WAIT:human-checkpoint:overhaul-merge` after synthesize
+- `AUTO:refactor-synthesize` after overhaul-update-docs
+- `WAIT:human-checkpoint:synthesize` after synthesize
 
 ## Track Switching
 
@@ -451,16 +451,16 @@ Refactor phases map to auto-resume actions:
 | HSM Phase | Next Action |
 |-----------|-------------|
 | `explore` (completed) | `AUTO:refactor-brief` |
-| `brief` (completed, polish) | `AUTO:refactor-implement` |
-| `brief` (completed, overhaul) | `AUTO:plan:<brief>` |
+| `brief` (completed, polish) | `AUTO:polish-implement` |
+| `brief` (completed, overhaul) | `AUTO:overhaul-plan` |
 | `polish-implement` (completed) | `AUTO:refactor-validate` |
 | `polish-validate` (completed) | `AUTO:refactor-update-docs` |
-| `polish-update-docs` (completed) | `WAIT:human-checkpoint:polish-complete` |
-| `overhaul-plan` (completed) | `AUTO:delegate:<plan>` |
-| `overhaul-delegate` (completed) | `AUTO:review:<path>` |
+| `polish-update-docs` (completed) | `WAIT:human-checkpoint:polish-update-docs` |
+| `overhaul-plan` (completed) | `AUTO:refactor-delegate` |
+| `overhaul-delegate` (completed) | `AUTO:refactor-review` |
 | `overhaul-review` (completed) | `AUTO:refactor-update-docs` |
-| `overhaul-update-docs` (completed) | `AUTO:synthesize:<feature>` |
-| `synthesize` (completed) | `WAIT:human-checkpoint:overhaul-merge` |
+| `overhaul-update-docs` (completed) | `AUTO:refactor-synthesize` |
+| `synthesize` (completed) | `WAIT:human-checkpoint:synthesize` |
 
 ## Completion Criteria
 

--- a/skills/refactor/phases/auto-chain.md
+++ b/skills/refactor/phases/auto-chain.md
@@ -41,7 +41,7 @@ Returns: AUTO:refactor-brief
 
 # After brief
 Use mcp__exarchos__exarchos_workflow_next_action with the featureId.
-Returns: AUTO:refactor-implement
+Returns: AUTO:polish-implement
 
 # After implement
 Use mcp__exarchos__exarchos_workflow_next_action with the featureId.
@@ -53,7 +53,7 @@ Returns: AUTO:refactor-update-docs
 
 # After update-docs
 Use mcp__exarchos__exarchos_workflow_next_action with the featureId.
-Returns: WAIT:human-checkpoint:polish-complete
+Returns: WAIT:human-checkpoint:polish-update-docs
 ```
 
 ### Polish Checkpoint
@@ -108,7 +108,7 @@ Use `mcp__exarchos__exarchos_workflow_next_action` with the featureId after each
 Returns: AUTO:refactor-brief
 
 # After brief
-Returns: AUTO:refactor-plan
+Returns: AUTO:overhaul-plan
 
 # After plan
 Returns: AUTO:refactor-delegate
@@ -126,7 +126,7 @@ Returns: AUTO:refactor-delegate:--fixes
 Returns: AUTO:refactor-synthesize
 
 # After synthesize
-Returns: WAIT:human-checkpoint:overhaul-merge
+Returns: WAIT:human-checkpoint:synthesize
 ```
 
 ### Overhaul Checkpoint
@@ -175,7 +175,7 @@ updates: { "track": "overhaul" }
 
 # Next action returns
 Use mcp__exarchos__exarchos_workflow_next_action with the featureId.
-Returns: AUTO:refactor-plan
+Returns: AUTO:overhaul-plan
 ```
 
 ## Failure Handling
@@ -235,12 +235,11 @@ The auto-chain actions are handled by workflow-auto-resume.md rules.
 
 | Action | Skill Invocation |
 |--------|------------------|
-| AUTO:refactor-explore | Resume scope assessment (inline) |
 | AUTO:refactor-brief | Continue to brief capture (inline) |
-| AUTO:refactor-implement | Continue to implement phase (inline - orchestrator implements) |
+| AUTO:polish-implement | Continue to implement phase (inline - orchestrator implements) |
 | AUTO:refactor-validate | Continue to validate phase (inline) |
 | AUTO:refactor-update-docs | Continue to update-docs phase (inline) |
-| AUTO:refactor-plan | `Skill({ skill: "plan", args: "--refactor <state-file>" })` |
+| AUTO:overhaul-plan | `Skill({ skill: "plan", args: "--refactor <state-file>" })` |
 | AUTO:refactor-delegate | `Skill({ skill: "delegate", args: "<state-file>" })` |
 | AUTO:refactor-delegate:--fixes | `Skill({ skill: "delegate", args: "--fixes <state-file>" })` |
 | AUTO:refactor-review | `Skill({ skill: "review", args: "<state-file>" })` |

--- a/skills/refactor/phases/polish-implement.md
+++ b/skills/refactor/phases/polish-implement.md
@@ -309,7 +309,7 @@ Use mcp__exarchos__exarchos_workflow_set with featureId:
   phase: "plan"
 ```
 
-Next action: `AUTO:plan:<brief>`
+Next action: `AUTO:overhaul-plan`
 
 ## Anti-Patterns
 

--- a/skills/refactor/phases/polish-validate.md
+++ b/skills/refactor/phases/polish-validate.md
@@ -193,7 +193,7 @@ On successful validation:
 - Automatically proceeds to update documentation
 
 On failed validation:
-- Next action: `AUTO:refactor-implement` (return to fix issues)
+- Next action: `AUTO:polish-implement` (return to fix issues)
 - Does not proceed until validation passes
 
 ## Common Issues

--- a/skills/workflow-state/SKILL.md
+++ b/skills/workflow-state/SKILL.md
@@ -45,6 +45,8 @@ Use the `mcp__exarchos__exarchos_workflow_set` tool with jq filters:
 - **Mark task complete**: `filter: '(.tasks[] | select(.id == "001")).status = "complete"'`
 - **Add worktree**: `filter: '.worktrees[".worktrees/001-types"] = {"branch": "feature/001-types", "taskId": "001", "status": "active"}'`
 
+Worktree status values: `'active' | 'merged' | 'removed'`
+
 ### Get Summary
 
 For context restoration after summarization, use the `mcp__exarchos__exarchos_workflow_summary` tool with the state file path. This outputs a minimal summary suitable for rebuilding orchestrator context.
@@ -106,8 +108,9 @@ On task complete:
 See `docs/schemas/workflow-state.schema.json` for full schema.
 
 Key sections:
-- `version`: Schema version (currently "1.0")
+- `version`: Schema version (currently "1.1")
 - `featureId`: Unique workflow identifier
+- `workflowType`: Required. One of "feature", "debug", or "refactor"
 - `phase`: Current workflow phase
 - `artifacts`: Paths to design, plan, PR
 - `tasks`: Task list with status


### PR DESCRIPTION
## Summary

Audited all Exarchos MCP instruction files against the actual server implementation and fixed 10 discrepancies. Agents routinely hit validation errors from wrong enum values (worktree `in_progress` vs `active`) and followed phantom `next_action` formats that don't exist. Two server bugs in the refactor `PHASE_ACTION_MAP` compounded the problem — fixed those and added 11 tests covering all refactor `next_action` phases.

## Changes

- **PHASE_ACTION_MAP** — Fixed `explore` entry to use target-phase naming (`AUTO:refactor-brief`), removed `brief` entry so fallback produces track-aware values (`AUTO:polish-implement` / `AUTO:overhaul-plan`)
- **Next-action tests** — Added 11 tests covering all refactor phases including both `brief` track paths, human checkpoints, and overhaul transitions
- **workflow-auto-resume.md** — Removed phantom path suffixes from feature actions, removed phantom `AUTO:plan:--revise`, rewrote refactor action table, documented `BLOCKED:circuit-open`
- **Refactor skills** — Corrected all action values and human checkpoint suffixes across SKILL.md, auto-chain.md, polish-validate.md, polish-implement.md
- **Debug state-schema** — Added track prefixes to phase names, fixed thorough track ASCII diagram, updated version to 1.1
- **workflow-state SKILL** — Documented all worktree status values (`active`/`merged`/`removed`), marked `workflowType` as required, updated version

## Test Plan

All 722 tests pass including 11 new refactor `next_action` tests. Verified zero phantom values remain across all instruction files.

---

**Results:** Tests 722 ✓ · Typecheck 0 errors
**Plan:** [2026-02-11-mcp-consistency.md](docs/plans/2026-02-11-mcp-consistency.md)
**Related:** Stacked on #76