### PR TITLE
refactor: deduplicate ToolResult interface across modules

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
@@ -1,16 +1,8 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { EventStore, SequenceConflictError } from './store.js';
-import type { WorkflowEvent, EventType } from './schemas.js';
-import { formatResult } from '../format.js';
-
-// ─── Tool Result Type ───────────────────────────────────────────────────────
-
-interface ToolResult {
-  success: boolean;
-  data?: WorkflowEvent | WorkflowEvent[];
-  error?: { code: string; message: string };
-}
+import type { EventType } from './schemas.js';
+import { formatResult, type ToolResult } from '../format.js';
 
 // ─── Shared Store Instance Cache ────────────────────────────────────────────
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
@@ -3,15 +3,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { EventStore } from '../event-store/store.js';
-import { formatResult } from '../format.js';
-
-// ─── Tool Result Type ──────────────────────────────────────────────────────
-
-interface ToolResult {
-  success: boolean;
-  data?: unknown;
-  error?: { code: string; message: string };
-}
+import { formatResult, type ToolResult } from '../format.js';
 
 // ─── Shared Store Cache ────────────────────────────────────────────────────
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/team/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/team/tools.ts
@@ -5,15 +5,7 @@ import { z } from 'zod';
 import { EventStore } from '../event-store/store.js';
 import { TeamCoordinator } from './coordinator.js';
 import { ROLES } from './roles.js';
-import { formatResult } from '../format.js';
-
-// ─── Tool Result Type ──────────────────────────────────────────────────────
-
-interface ToolResult {
-  success: boolean;
-  data?: unknown;
-  error?: { code: string; message: string };
-}
+import { formatResult, type ToolResult } from '../format.js';
 
 // ─── Shared Coordinator + Store Cache ──────────────────────────────────────
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/tools.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { EventStore } from '../event-store/store.js';
-import { formatResult } from '../format.js';
+import { formatResult, type ToolResult } from '../format.js';
 import { ViewMaterializer } from './materializer.js';
 import { SnapshotStore } from './snapshot-store.js';
 import {
@@ -26,14 +26,6 @@ import {
   PIPELINE_VIEW,
 } from './pipeline-view.js';
 import type { PipelineViewState } from './pipeline-view.js';
-
-// ─── Tool Result Type ──────────────────────────────────────────────────────
-
-interface ToolResult {
-  success: boolean;
-  data?: unknown;
-  error?: { code: string; message: string };
-}
 
 // ─── Helper: create a materializer with all projections registered ─────────
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/cancel.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/cancel.ts
@@ -2,7 +2,6 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type {
   CancelInput,
-  CheckpointMeta,
   WorkflowState,
 } from './types.js';
 import { ErrorCode } from './schemas.js';
@@ -18,17 +17,8 @@ import {
 import { appendEvent } from './events.js';
 import { getHSMDefinition, executeTransition } from './state-machine.js';
 import { executeCompensation } from './compensation.js';
-import { formatResult } from '../format.js';
+import { formatResult, type ToolResult } from '../format.js';
 import * as path from 'node:path';
-
-// ─── Tool Result Interface ──────────────────────────────────────────────────
-
-export interface ToolResult {
-  readonly success: boolean;
-  readonly data?: unknown;
-  readonly error?: { code: string; message: string; validTargets?: readonly string[] };
-  readonly _meta?: CheckpointMeta;
-}
 
 // ─── handleCancel ──────────────────────────────────────────────────────────
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/next-action.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/next-action.ts
@@ -2,7 +2,6 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type {
   NextActionInput,
-  CheckpointMeta,
   WorkflowState,
 } from './types.js';
 import { ErrorCode } from './schemas.js';
@@ -13,17 +12,8 @@ import {
 import { buildCheckpointMeta } from './checkpoint.js';
 import { getHSMDefinition } from './state-machine.js';
 import { getCircuitBreakerState } from './circuit-breaker.js';
-import { formatResult } from '../format.js';
+import { formatResult, type ToolResult } from '../format.js';
 import * as path from 'node:path';
-
-// ─── Tool Result Interface ──────────────────────────────────────────────────
-
-export interface ToolResult {
-  readonly success: boolean;
-  readonly data?: unknown;
-  readonly error?: { code: string; message: string; validTargets?: readonly string[] };
-  readonly _meta?: CheckpointMeta;
-}
 
 // ─── Human Checkpoint Phases ────────────────────────────────────────────────
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/query.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/query.ts
@@ -4,7 +4,6 @@ import type {
   SummaryInput,
   ReconcileInput,
   TransitionsInput,
-  CheckpointMeta,
   WorkflowState,
 } from './types.js';
 import { ErrorCode } from './schemas.js';
@@ -16,18 +15,9 @@ import { buildCheckpointMeta } from './checkpoint.js';
 import { getRecentEvents } from './events.js';
 import { getHSMDefinition } from './state-machine.js';
 import { getCircuitBreakerState } from './circuit-breaker.js';
-import { formatResult } from '../format.js';
+import { formatResult, type ToolResult } from '../format.js';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
-
-// ─── Tool Result Interface ──────────────────────────────────────────────────
-
-export interface ToolResult {
-  readonly success: boolean;
-  readonly data?: unknown;
-  readonly error?: { code: string; message: string; validTargets?: readonly string[] };
-  readonly _meta?: CheckpointMeta;
-}
 
 // ─── Compound State Lookup ──────────────────────────────────────────────────
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
@@ -6,7 +6,6 @@ import type {
   GetInput,
   SetInput,
   CheckpointInput,
-  CheckpointMeta,
   WorkflowState,
 } from './types.js';
 import { ErrorCode, isReservedField } from './schemas.js';
@@ -26,22 +25,13 @@ import {
 } from './checkpoint.js';
 import { appendEvent } from './events.js';
 import { getHSMDefinition, executeTransition } from './state-machine.js';
-import { formatResult } from '../format.js';
+import { formatResult, type ToolResult } from '../format.js';
 import * as path from 'node:path';
 
 // Re-export from dedicated modules for backward compatibility
 export { handleNextAction } from './next-action.js';
 export { handleCancel } from './cancel.js';
 export { handleSummary, handleReconcile, handleTransitions } from './query.js';
-
-// ─── Tool Result Interface ──────────────────────────────────────────────────
-
-export interface ToolResult {
-  readonly success: boolean;
-  readonly data?: unknown;
-  readonly error?: { code: string; message: string; validTargets?: readonly string[] };
-  readonly _meta?: CheckpointMeta;
-}
 
 // ─── handleInit ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Removes 8 duplicate `ToolResult` interface declarations across MCP server modules, consolidating on the canonical export in `format.ts`. Part of the optimization sweep to reduce token waste in workflow responses.

## Changes

- **format.ts** — Canonical `ToolResult` interface (unchanged, already exported)
- **workflow/tools.ts, query.ts, next-action.ts, cancel.ts** — Replace local `ToolResult` with import from `format.ts`
- **event-store/tools.ts, team/tools.ts, tasks/tools.ts, views/tools.ts** — Replace local `ToolResult` with import from `format.ts`

## Test Plan

All 728 existing tests pass unchanged — type compatibility validated by full suite.

---

**Results:** Tests 728 ✓ · Build 0 errors
**Plan:** [optimization-sweep.md](docs/plans/2026-02-11-optimization-sweep.md)
**Related:** Stack 1/3 of Group A (Token Optimization)