### PR TITLE
refactor: persist EventStore sequence counters in .seq files

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/store.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/store.test.ts
@@ -315,3 +315,78 @@ describe('EventStore Optimistic Concurrency', () => {
     }
   });
 });
+
+// ─── B1: Persist Sequence Counters ──────────────────────────────────────────
+
+describe('EventStore Sequence Persistence', () => {
+  it('EventStore_Append_WritesSeqFile: after append, .seq file exists with correct sequence', async () => {
+    const store = new EventStore(tempDir);
+
+    await store.append('my-workflow', { type: 'workflow.started' });
+
+    const seqPath = path.join(tempDir, 'my-workflow.seq');
+    const content = await fs.readFile(seqPath, 'utf-8');
+    const parsed = JSON.parse(content);
+    expect(parsed.sequence).toBe(1);
+
+    // Append another and verify sequence increments
+    await store.append('my-workflow', { type: 'team.formed' });
+    const content2 = await fs.readFile(seqPath, 'utf-8');
+    const parsed2 = JSON.parse(content2);
+    expect(parsed2.sequence).toBe(2);
+  });
+
+  it('EventStore_NewInstance_ReadsSeqFile: new store continues from persisted sequence', async () => {
+    const store1 = new EventStore(tempDir);
+    await store1.append('my-workflow', { type: 'workflow.started' });
+    await store1.append('my-workflow', { type: 'team.formed' });
+    await store1.append('my-workflow', { type: 'phase.transitioned' });
+
+    // Create a NEW store instance (simulating server restart)
+    const store2 = new EventStore(tempDir);
+    const event = await store2.append('my-workflow', { type: 'task.assigned' });
+
+    // Should continue at 4, reading from .seq file (O(1)) instead of line counting
+    expect(event.sequence).toBe(4);
+
+    // Verify .seq file was read (not line counting) by checking .seq exists
+    const seqPath = path.join(tempDir, 'my-workflow.seq');
+    const content = await fs.readFile(seqPath, 'utf-8');
+    const parsed = JSON.parse(content);
+    expect(parsed.sequence).toBe(4);
+  });
+
+  it('EventStore_SeqFileMissing_FallsBackToLineCount: works when .seq file is deleted', async () => {
+    const store1 = new EventStore(tempDir);
+    await store1.append('my-workflow', { type: 'workflow.started' });
+    await store1.append('my-workflow', { type: 'team.formed' });
+
+    // Delete the .seq file to simulate missing file
+    const seqPath = path.join(tempDir, 'my-workflow.seq');
+    await fs.unlink(seqPath);
+
+    // Create a new store — should fall back to line counting
+    const store2 = new EventStore(tempDir);
+    const event = await store2.append('my-workflow', { type: 'phase.transitioned' });
+
+    // Should still continue from correct sequence by counting JSONL lines
+    expect(event.sequence).toBe(3);
+  });
+
+  it('EventStore_SeqFileCorrupt_FallsBackToLineCount: works when .seq file has garbage', async () => {
+    const store1 = new EventStore(tempDir);
+    await store1.append('my-workflow', { type: 'workflow.started' });
+    await store1.append('my-workflow', { type: 'team.formed' });
+
+    // Write garbage to the .seq file
+    const seqPath = path.join(tempDir, 'my-workflow.seq');
+    await fs.writeFile(seqPath, 'not-valid-json!!!', 'utf-8');
+
+    // Create a new store — should fall back to line counting
+    const store2 = new EventStore(tempDir);
+    const event = await store2.append('my-workflow', { type: 'phase.transitioned' });
+
+    // Should still continue from correct sequence by counting JSONL lines
+    expect(event.sequence).toBe(3);
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { EventStore, SequenceConflictError } from '../../event-store/store.js';
+import { EventStore, SequenceConflictError } from './store.js';
 
 let tempDir: string;
 
@@ -319,7 +319,8 @@ describe('EventStore Optimistic Concurrency', () => {
 // ─── B1: Persist Sequence Counters ──────────────────────────────────────────
 
 describe('EventStore Sequence Persistence', () => {
-  it('EventStore_Append_WritesSeqFile: after append, .seq file exists with correct sequence', async () => {
+  // After append, .seq file exists with correct sequence
+  it('EventStore_Append_WritesSeqFile', async () => {
     const store = new EventStore(tempDir);
 
     await store.append('my-workflow', { type: 'workflow.started' });
@@ -336,7 +337,8 @@ describe('EventStore Sequence Persistence', () => {
     expect(parsed2.sequence).toBe(2);
   });
 
-  it('EventStore_NewInstance_ReadsSeqFile: new store continues from persisted sequence', async () => {
+  // New store continues from persisted sequence
+  it('EventStore_NewInstance_ReadsSeqFile', async () => {
     const store1 = new EventStore(tempDir);
     await store1.append('my-workflow', { type: 'workflow.started' });
     await store1.append('my-workflow', { type: 'team.formed' });
@@ -356,7 +358,8 @@ describe('EventStore Sequence Persistence', () => {
     expect(parsed.sequence).toBe(4);
   });
 
-  it('EventStore_SeqFileMissing_FallsBackToLineCount: works when .seq file is deleted', async () => {
+  // Works when .seq file is deleted
+  it('EventStore_SeqFileMissing_FallsBackToLineCount', async () => {
     const store1 = new EventStore(tempDir);
     await store1.append('my-workflow', { type: 'workflow.started' });
     await store1.append('my-workflow', { type: 'team.formed' });
@@ -373,7 +376,35 @@ describe('EventStore Sequence Persistence', () => {
     expect(event.sequence).toBe(3);
   });
 
-  it('EventStore_SeqFileCorrupt_FallsBackToLineCount: works when .seq file has garbage', async () => {
+  // Append succeeds even when .seq write fails
+  it('EventStore_SeqWriteFails_AppendStillSucceeds', async () => {
+    const store = new EventStore(tempDir);
+
+    // First append succeeds normally
+    await store.append('my-workflow', { type: 'workflow.started' });
+
+    // Make the .seq file path a directory so writeFile will fail
+    const seqPath = path.join(tempDir, 'my-workflow.seq');
+    await fs.rm(seqPath, { force: true });
+    await fs.mkdir(seqPath);
+
+    // Second append should still succeed despite .seq write failure
+    const event = await store.append('my-workflow', { type: 'team.formed' });
+    expect(event.sequence).toBe(2);
+    expect(event.type).toBe('team.formed');
+
+    // Verify the JSONL file has both events (source of truth)
+    const filePath = path.join(tempDir, 'my-workflow.events.jsonl');
+    const content = await fs.readFile(filePath, 'utf-8');
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(2);
+
+    // Clean up: remove the directory so afterEach can clean up
+    await fs.rm(seqPath, { recursive: true, force: true });
+  });
+
+  // Works when .seq file has garbage
+  it('EventStore_SeqFileCorrupt_FallsBackToLineCount', async () => {
     const store1 = new EventStore(tempDir);
     await store1.append('my-workflow', { type: 'workflow.started' });
     await store1.append('my-workflow', { type: 'team.formed' });

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
@@ -122,11 +122,16 @@ export class EventStore {
       // Append as JSONL
       await fs.appendFile(filePath, JSON.stringify(fullEvent) + '\n', 'utf-8');
 
-      // Write sequence counter atomically
+      // Write sequence counter atomically (best-effort: JSONL is source of truth)
       const seqPath = this.getSeqFilePath(streamId);
       const tmpPath = `${seqPath}.tmp`;
-      await fs.writeFile(tmpPath, JSON.stringify({ sequence }), 'utf-8');
-      await fs.rename(tmpPath, seqPath);
+      try {
+        await fs.writeFile(tmpPath, JSON.stringify({ sequence }), 'utf-8');
+        await fs.rename(tmpPath, seqPath);
+      } catch {
+        // Best-effort: JSONL is source of truth, .seq is just a cache
+        await fs.rm(tmpPath, { force: true }).catch(() => {});
+      }
 
       return fullEvent;
     });

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
@@ -75,6 +75,11 @@ export class EventStore {
     return path.join(this.stateDir, `${streamId}.events.jsonl`);
   }
 
+  private getSeqFilePath(streamId: string): string {
+    validateStreamId(streamId);
+    return path.join(this.stateDir, `${streamId}.seq`);
+  }
+
   async append(
     streamId: string,
     event: Partial<Omit<WorkflowEvent, 'sequence' | 'streamId'>> & { type: string },
@@ -116,6 +121,12 @@ export class EventStore {
 
       // Append as JSONL
       await fs.appendFile(filePath, JSON.stringify(fullEvent) + '\n', 'utf-8');
+
+      // Write sequence counter atomically
+      const seqPath = this.getSeqFilePath(streamId);
+      const tmpPath = `${seqPath}.tmp`;
+      await fs.writeFile(tmpPath, JSON.stringify({ sequence }), 'utf-8');
+      await fs.rename(tmpPath, seqPath);
 
       return fullEvent;
     });
@@ -162,6 +173,20 @@ export class EventStore {
   }
 
   private async initializeSequence(streamId: string): Promise<void> {
+    // Try .seq file first (O(1))
+    const seqPath = this.getSeqFilePath(streamId);
+    try {
+      const content = await fs.readFile(seqPath, 'utf-8');
+      const parsed = JSON.parse(content);
+      if (typeof parsed.sequence === 'number' && parsed.sequence >= 0) {
+        this.sequenceCounters.set(streamId, parsed.sequence);
+        return;
+      }
+    } catch {
+      // Fall through to line counting
+    }
+
+    // Fallback: count lines in JSONL file (O(n))
     const filePath = this.getEventFilePath(streamId);
     try {
       const content = await fs.readFile(filePath, 'utf-8');


### PR DESCRIPTION
## Summary

Adds `.seq` file persistence for EventStore sequence counters, enabling O(1) initialization instead of O(n) line-counting on server restart. Part of the optimization sweep improving event architecture performance.

## Changes

- **event-store/store.ts** — Atomic `.seq` file writes (tmp + rename) after each append; `initializeSequence()` reads `.seq` first with line-count fallback
- **event-store/store.ts** — Handles corrupt/missing `.seq` files gracefully

## Test Plan

New tests: `EventStore_Append_WritesSeqFile`, `EventStore_NewInstance_ReadsSeqFile`, `EventStore_SeqFileMissing_FallsBackToLineCount`, `EventStore_SeqFileCorrupt_FallsBackToLineCount`.

---

**Results:** Tests 745 ✓ · Build 0 errors
**Plan:** [optimization-sweep.md](docs/plans/2026-02-11-optimization-sweep.md)
**Related:** Stack 1/5 of Group B (Event Architecture + Performance)