### PR TITLE
refactor: introduce EventAck type and minimal response pattern

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/tools.test.ts
@@ -89,6 +89,83 @@ describe('handleEventAppend', () => {
     expect(result.data!.sequence).toBe(2);
   });
 
+  it('should return an EventAck with only streamId, sequence, type keys', async () => {
+    const result = await handleEventAppend(
+      {
+        stream: 'my-workflow',
+        event: {
+          type: 'workflow.started',
+          data: { featureId: 'test-feature' },
+          correlationId: 'corr-1',
+          agentId: 'agent-1',
+        },
+      },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+
+    // Ack should contain ONLY these three keys
+    const keys = Object.keys(result.data as Record<string, unknown>).sort();
+    expect(keys).toEqual(['sequence', 'streamId', 'type']);
+
+    // Must NOT contain full event fields
+    const data = result.data as Record<string, unknown>;
+    expect(data).not.toHaveProperty('correlationId');
+    expect(data).not.toHaveProperty('causationId');
+    expect(data).not.toHaveProperty('agentId');
+    expect(data).not.toHaveProperty('data');
+    expect(data).not.toHaveProperty('agentRole');
+    expect(data).not.toHaveProperty('source');
+    expect(data).not.toHaveProperty('timestamp');
+    expect(data).not.toHaveProperty('schemaVersion');
+  });
+
+  it('should return ack with correct streamId, sequence, and type values', async () => {
+    const result = await handleEventAppend(
+      {
+        stream: 'my-workflow',
+        event: { type: 'workflow.started' },
+      },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    const ack = result.data as { streamId: string; sequence: number; type: string };
+    expect(ack.streamId).toBe('my-workflow');
+    expect(ack.sequence).toBe(1);
+    expect(ack.type).toBe('workflow.started');
+  });
+
+  it('should still persist full event to JSONL despite returning ack', async () => {
+    await handleEventAppend(
+      {
+        stream: 'my-workflow',
+        event: {
+          type: 'workflow.started',
+          data: { featureId: 'test-feature' },
+          correlationId: 'corr-1',
+          agentId: 'agent-1',
+        },
+      },
+      tempDir,
+    );
+
+    // Query the store to verify the full event is persisted
+    const queryResult = await handleEventQuery({ stream: 'my-workflow' }, tempDir);
+    expect(queryResult.success).toBe(true);
+
+    const events = queryResult.data as Array<Record<string, unknown>>;
+    expect(events).toHaveLength(1);
+    expect(events[0].streamId).toBe('my-workflow');
+    expect(events[0].sequence).toBe(1);
+    expect(events[0].type).toBe('workflow.started');
+    expect(events[0].data).toEqual({ featureId: 'test-feature' });
+    expect(events[0].correlationId).toBe('corr-1');
+    expect(events[0].agentId).toBe('agent-1');
+  });
+
   it('should return conflict error for stale expectedSequence', async () => {
     await handleEventAppend(
       { stream: 'my-workflow', event: { type: 'workflow.started' } },

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/stack/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/stack/tools.test.ts
@@ -130,6 +130,18 @@ describe('handleStackPlace', () => {
     );
   });
 
+  it('success returns EventAck with only streamId, sequence, type keys', async () => {
+    const result = await handleStackPlace(
+      { streamId: 'wf-001', position: 1, taskId: 't1', branch: 'feature/t1' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+    const keys = Object.keys(result.data as Record<string, unknown>).sort();
+    expect(keys).toEqual(['sequence', 'streamId', 'type']);
+  });
+
   it('missing streamId returns error', async () => {
     const result = await handleStackPlace(
       { streamId: '', position: 1, taskId: 't1' },

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
@@ -74,6 +74,18 @@ describe('handleTaskClaim', () => {
     expect(result.error?.message).toBe('agentId is required');
   });
 
+  it('success returns EventAck with only streamId, sequence, type keys', async () => {
+    const result = await handleTaskClaim(
+      { taskId: 't1', agentId: 'agent-1', streamId: 'wf-001' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+    const keys = Object.keys(result.data as Record<string, unknown>).sort();
+    expect(keys).toEqual(['sequence', 'streamId', 'type']);
+  });
+
   it('store.append() failure returns CLAIM_FAILED error', async () => {
     const result = await handleTaskClaim(
       { taskId: 't1', agentId: 'agent-1', streamId: 'wf-001' },
@@ -169,6 +181,18 @@ describe('handleTaskComplete', () => {
     expect((events[0].data as Record<string, unknown>).duration).toBeUndefined();
   });
 
+  it('success returns EventAck with only streamId, sequence, type keys', async () => {
+    const result = await handleTaskComplete(
+      { taskId: 't1', streamId: 'wf-001' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+    const keys = Object.keys(result.data as Record<string, unknown>).sort();
+    expect(keys).toEqual(['sequence', 'streamId', 'type']);
+  });
+
   it('store.append() failure returns COMPLETE_FAILED error', async () => {
     const result = await handleTaskComplete(
       { taskId: 't1', streamId: 'wf-001' },
@@ -253,6 +277,18 @@ describe('handleTaskFail', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('INVALID_INPUT');
     expect(result.error?.message).toBe('streamId is required');
+  });
+
+  it('success returns EventAck with only streamId, sequence, type keys', async () => {
+    const result = await handleTaskFail(
+      { taskId: 't1', error: 'Compilation error', streamId: 'wf-001' },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeDefined();
+    const keys = Object.keys(result.data as Record<string, unknown>).sort();
+    expect(keys).toEqual(['sequence', 'streamId', 'type']);
   });
 
   it('store.append() failure returns FAIL_FAILED error', async () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { EventStore, SequenceConflictError } from './store.js';
 import type { EventType } from './schemas.js';
-import { formatResult, type ToolResult } from '../format.js';
+import { formatResult, toEventAck, type ToolResult } from '../format.js';
 
 // ─── Shared Store Instance Cache ────────────────────────────────────────────
 
@@ -62,7 +62,7 @@ export async function handleEventAppend(
         : undefined,
     );
 
-    return { success: true, data: event };
+    return { success: true, data: toEventAck(event) };
   } catch (err) {
     if (err instanceof SequenceConflictError) {
       return {

--- a/plugins/exarchos/servers/exarchos-mcp/src/format.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/format.ts
@@ -7,6 +7,20 @@ export interface ToolResult {
   readonly _meta?: unknown;
 }
 
+// ─── Event Acknowledgement ──────────────────────────────────────────────────
+
+export interface EventAck {
+  readonly streamId: string;
+  readonly sequence: number;
+  readonly type: string;
+}
+
+export function toEventAck(event: { streamId: string; sequence: number; type: string }): EventAck {
+  return { streamId: event.streamId, sequence: event.sequence, type: event.type };
+}
+
+// ─── Result Formatting ──────────────────────────────────────────────────────
+
 export function formatResult(result: ToolResult) {
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(result) }],

--- a/plugins/exarchos/servers/exarchos-mcp/src/stack/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/stack/tools.ts
@@ -3,7 +3,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { EventStore } from '../event-store/store.js';
-import { formatResult, type ToolResult } from '../format.js';
+import { formatResult, toEventAck, type ToolResult } from '../format.js';
 
 // ─── Shared Store Cache ────────────────────────────────────────────────────
 
@@ -125,7 +125,7 @@ export async function handleStackPlace(
       data,
     });
 
-    return { success: true, data: event };
+    return { success: true, data: toEventAck(event) };
   } catch (err) {
     return {
       success: false,

--- a/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
@@ -3,7 +3,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { EventStore } from '../event-store/store.js';
-import { formatResult, type ToolResult } from '../format.js';
+import { formatResult, toEventAck, type ToolResult } from '../format.js';
 
 // ─── Shared Store Cache ────────────────────────────────────────────────────
 
@@ -62,7 +62,7 @@ export async function handleTaskClaim(
       agentId: args.agentId,
     });
 
-    return { success: true, data: event };
+    return { success: true, data: toEventAck(event) };
   } catch (err) {
     return {
       success: false,
@@ -116,7 +116,7 @@ export async function handleTaskComplete(
       data,
     });
 
-    return { success: true, data: event };
+    return { success: true, data: toEventAck(event) };
   } catch (err) {
     return {
       success: false,
@@ -177,7 +177,7 @@ export async function handleTaskFail(
       data,
     });
 
-    return { success: true, data: event };
+    return { success: true, data: toEventAck(event) };
   } catch (err) {
     return {
       success: false,


### PR DESCRIPTION
## Summary

Introduces the `EventAck` type and `toEventAck()` helper to return minimal `{streamId, sequence, type}` responses from event-writing tools instead of full event objects. Reduces token overhead for `event_append`, task tools, and `stack_place`.

## Changes

- **format.ts** — New `EventAck` interface and `toEventAck()` helper
- **event-store/tools.ts** — `event_append` returns EventAck
- **tasks/tools.ts** — `task_claim`, `task_complete`, `task_fail` return EventAck
- **stack/tools.ts** — `stack_place` returns EventAck

## Test Plan

7 new tests verify ack-only response shape and full event still persisted.

---

**Results:** Tests pass · Build 0 errors