### PR TITLE
refactor: add field projection and view filtering

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/tools.test.ts
@@ -251,6 +251,112 @@ describe('handleViewTasks', () => {
   });
 });
 
+// ─── Task 7: handleViewTasks limit ──────────────────────────────────────────
+
+describe('handleViewTasks limit', () => {
+  it('handleViewTasks_WithLimit_ReturnsLimitedResults', async () => {
+    // Arrange: create 3 tasks
+    await store.append('wf-limit', {
+      type: 'task.assigned',
+      data: { taskId: 't1', title: 'Task 1', branch: 'feat/t1' },
+    });
+    await store.append('wf-limit', {
+      type: 'task.assigned',
+      data: { taskId: 't2', title: 'Task 2', branch: 'feat/t2' },
+    });
+    await store.append('wf-limit', {
+      type: 'task.assigned',
+      data: { taskId: 't3', title: 'Task 3', branch: 'feat/t3' },
+    });
+
+    // Act
+    const result = await handleViewTasks(
+      { workflowId: 'wf-limit', limit: 2 },
+      tempDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    const data = result.data as Array<Record<string, unknown>>;
+    expect(data).toHaveLength(2);
+  });
+
+  it('handleViewTasks_WithFilter_ReturnsOnlyMatching', async () => {
+    // Arrange: create tasks with different statuses
+    await store.append('wf-filter-verify', {
+      type: 'task.assigned',
+      data: { taskId: 't1', title: 'Task 1', branch: 'feat/t1' },
+    });
+    await store.append('wf-filter-verify', {
+      type: 'task.assigned',
+      data: { taskId: 't2', title: 'Task 2', branch: 'feat/t2' },
+    });
+    await store.append('wf-filter-verify', {
+      type: 'task.completed',
+      data: { taskId: 't1', artifacts: ['a.ts'], duration: 30 },
+    });
+
+    // Act
+    const result = await handleViewTasks(
+      { workflowId: 'wf-filter-verify', filter: { status: 'completed' } },
+      tempDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    const data = result.data as Array<Record<string, unknown>>;
+    expect(data).toHaveLength(1);
+    expect(data[0].taskId).toBe('t1');
+  });
+
+  it('handleViewTasks_FilterAndLimit_AppliesBoth', async () => {
+    // Arrange: create 4 tasks, complete 3 of them
+    await store.append('wf-both', {
+      type: 'task.assigned',
+      data: { taskId: 't1', title: 'Task 1', branch: 'feat/t1' },
+    });
+    await store.append('wf-both', {
+      type: 'task.assigned',
+      data: { taskId: 't2', title: 'Task 2', branch: 'feat/t2' },
+    });
+    await store.append('wf-both', {
+      type: 'task.assigned',
+      data: { taskId: 't3', title: 'Task 3', branch: 'feat/t3' },
+    });
+    await store.append('wf-both', {
+      type: 'task.assigned',
+      data: { taskId: 't4', title: 'Task 4', branch: 'feat/t4' },
+    });
+    await store.append('wf-both', {
+      type: 'task.completed',
+      data: { taskId: 't1', artifacts: [], duration: 10 },
+    });
+    await store.append('wf-both', {
+      type: 'task.completed',
+      data: { taskId: 't2', artifacts: [], duration: 20 },
+    });
+    await store.append('wf-both', {
+      type: 'task.completed',
+      data: { taskId: 't3', artifacts: [], duration: 30 },
+    });
+
+    // Act: filter for completed (3 tasks) then limit to 2
+    const result = await handleViewTasks(
+      { workflowId: 'wf-both', filter: { status: 'completed' }, limit: 2 },
+      tempDir,
+    );
+
+    // Assert: filter applied first (3 completed), then limit caps at 2
+    expect(result.success).toBe(true);
+    const data = result.data as Array<Record<string, unknown>>;
+    expect(data).toHaveLength(2);
+    // All returned should be completed
+    for (const task of data) {
+      expect(task.status).toBe('completed');
+    }
+  });
+});
+
 describe('handleViewPipeline', () => {
   it('should aggregate pipeline data across workflows', async () => {
     await populateWorkflow('wf-001');

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -1822,3 +1822,100 @@ describe('Store-Based Event Consumers', () => {
     expect(recent[2].type).toBe('task.completed');
   });
 });
+
+// ─── Task 6: handleGet fields projection ─────────────────────────────────────
+
+describe('handleGet fields projection', () => {
+  it('handleGet_WithFields_ReturnsSingleField', async () => {
+    // Arrange
+    await handleInit({ featureId: 'fields-single', workflowType: 'feature' }, tmpDir);
+
+    // Act
+    const result = await handleGet(
+      { featureId: 'fields-single', fields: ['phase'] },
+      tmpDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(Object.keys(data)).toEqual(['phase']);
+    expect(data.phase).toBe('ideate');
+  });
+
+  it('handleGet_WithFields_ReturnsMultipleFields', async () => {
+    // Arrange
+    await handleInit({ featureId: 'fields-multi', workflowType: 'feature' }, tmpDir);
+
+    // Act
+    const result = await handleGet(
+      { featureId: 'fields-multi', fields: ['phase', 'featureId', 'workflowType'] },
+      tmpDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(Object.keys(data).sort()).toEqual(['featureId', 'phase', 'workflowType']);
+    expect(data.phase).toBe('ideate');
+    expect(data.featureId).toBe('fields-multi');
+    expect(data.workflowType).toBe('feature');
+  });
+
+  it('handleGet_WithFields_DotPathFieldsWork', async () => {
+    // Arrange
+    await handleInit({ featureId: 'fields-dot', workflowType: 'feature' }, tmpDir);
+    await handleSet(
+      { featureId: 'fields-dot', updates: { 'artifacts.design': 'my-design.md' } },
+      tmpDir,
+    );
+
+    // Act
+    const result = await handleGet(
+      { featureId: 'fields-dot', fields: ['artifacts.design'] },
+      tmpDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data['artifacts.design']).toBe('my-design.md');
+    expect(Object.keys(data)).toEqual(['artifacts.design']);
+  });
+
+  it('handleGet_WithFields_NonexistentFieldOmitted', async () => {
+    // Arrange
+    await handleInit({ featureId: 'fields-missing', workflowType: 'feature' }, tmpDir);
+
+    // Act
+    const result = await handleGet(
+      { featureId: 'fields-missing', fields: ['phase', 'nonexistent'] },
+      tmpDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(Object.keys(data)).toEqual(['phase']);
+    expect(data.phase).toBe('ideate');
+  });
+
+  it('handleGet_WithFields_InternalFieldsExcluded', async () => {
+    // Arrange
+    await handleInit({ featureId: 'fields-internal', workflowType: 'feature' }, tmpDir);
+
+    // Act
+    const result = await handleGet(
+      { featureId: 'fields-internal', fields: ['phase', '_history', '_events'] },
+      tmpDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(Object.keys(data)).toEqual(['phase']);
+    expect(data.phase).toBe('ideate');
+    expect(data._history).toBeUndefined();
+    expect(data._events).toBeUndefined();
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/tools.ts
@@ -166,7 +166,7 @@ export async function handleViewTeamStatus(
 // ─── View Tasks Handler ────────────────────────────────────────────────────
 
 export async function handleViewTasks(
-  args: { workflowId?: string; filter?: Record<string, unknown> },
+  args: { workflowId?: string; filter?: Record<string, unknown>; limit?: number },
   stateDir: string,
 ): Promise<ToolResult> {
   try {
@@ -194,6 +194,11 @@ export async function handleViewTasks(
         }
         return true;
       });
+    }
+
+    // Apply optional limit (after filter)
+    if (args.limit !== undefined) {
+      tasks = tasks.slice(0, args.limit);
     }
 
     return { success: true, data: tasks };
@@ -257,10 +262,11 @@ export function registerViewTools(server: McpServer, stateDir: string): void {
 
   server.tool(
     'exarchos_view_tasks',
-    'Get CQRS task detail view with optional filtering by workflowId and task properties',
+    'Get CQRS task detail view with optional filtering by workflowId and task properties, and optional limit',
     {
       workflowId: z.string().optional(),
       filter: z.record(z.string(), z.unknown()).optional(),
+      limit: z.number().int().positive().optional(),
     },
     async (args) => formatResult(await handleViewTasks(args, stateDir)),
   );

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/schemas.ts
@@ -229,6 +229,7 @@ export const ListInputSchema = z.object({});
 export const GetInputSchema = z.object({
   featureId: FeatureIdSchema,
   query: z.string().optional(),
+  fields: z.array(z.string()).optional(),
 });
 
 export const SetInputSchema = z.object({

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
@@ -162,6 +162,21 @@ export async function handleGet(
 
   const meta = buildCheckpointMeta(state._checkpoint);
 
+  // Fields projection: return only requested fields (skips internal fields)
+  if (input.fields && !input.query) {
+    const stateObj = state as unknown as Record<string, unknown>;
+    const projected: Record<string, unknown> = {};
+    for (const field of input.fields) {
+      // Skip internal fields
+      if (field.startsWith('_')) continue;
+      const value = resolveDotPath(stateObj, field);
+      if (value !== undefined) {
+        projected[field] = value;
+      }
+    }
+    return { success: true, data: projected, _meta: meta };
+  }
+
   if (!input.query) {
     const strippedState = stripInternalFields(state as unknown as Record<string, unknown>);
     return {
@@ -430,8 +445,8 @@ export function registerWorkflowTools(server: McpServer, stateDir: string): void
 
   server.tool(
     'exarchos_workflow_get',
-    'Query a field via dot-path (e.g. query:"phase") or get full state if no query',
-    { featureId: featureIdParam, query: z.string().optional() },
+    'Query a field via dot-path (e.g. query:"phase"), project specific fields (fields:["phase","featureId"]), or get full state if neither',
+    { featureId: featureIdParam, query: z.string().optional(), fields: z.array(z.string()).optional() },
     async (args) => formatResult(await handleGet(args, stateDir)),
   );
 


### PR DESCRIPTION
## Summary

Adds selective field projection to `workflow_get` and limit parameter to `view_tasks`, enabling callers to request only the data they need.

## Changes

- **workflow/tools.ts** — `workflow_get` accepts `fields` param for selective projection; excludes internal `_*` fields
- **views/tools.ts** — `view_tasks` accepts `limit` param pushed into materialization

## Test Plan

8 new tests cover single/multi field projection, dot-path fields, internal field exclusion, and limit+filter combinations.

---

**Results:** Tests pass · Build 0 errors