### PR TITLE
refactor: sparse responses and guaranteed event-first ordering

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -1158,6 +1158,98 @@ describe('Query Tools', () => {
   });
 });
 
+// ─── handleTransitions Sparse Responses ──────────────────────────────────────
+
+describe('handleTransitions sparse responses', () => {
+  it('handleTransitions_NoEffects_OmitsEffectsField', async () => {
+    // Arrange — get feature transitions, find one with no effects
+    const result = await handleTransitions({ workflowType: 'feature' }, tmpDir);
+    expect(result.success).toBe(true);
+
+    const data = result.data as Record<string, unknown>;
+    const transitions = data.transitions as Array<Record<string, unknown>>;
+
+    // Act — find a transition that should have empty effects (e.g. ideate->plan)
+    const ideateToPlan = transitions.find(
+      (t) => t.from === 'ideate' && t.to === 'plan',
+    );
+
+    // Assert — the transition object should NOT have an `effects` key at all
+    expect(ideateToPlan).toBeDefined();
+    expect('effects' in ideateToPlan!).toBe(false);
+  });
+
+  it('handleTransitions_IsFixCycleFalse_StillPresent', async () => {
+    // Arrange — get feature transitions
+    const result = await handleTransitions({ workflowType: 'feature' }, tmpDir);
+    expect(result.success).toBe(true);
+
+    const data = result.data as Record<string, unknown>;
+    const transitions = data.transitions as Array<Record<string, unknown>>;
+
+    // Act — find a non-fix-cycle transition (most of them)
+    const ideateToPlan = transitions.find(
+      (t) => t.from === 'ideate' && t.to === 'plan',
+    );
+
+    // Assert — isFixCycle: false should still be present (it's a meaningful boolean)
+    expect(ideateToPlan).toBeDefined();
+    expect('isFixCycle' in ideateToPlan!).toBe(true);
+    expect(ideateToPlan!.isFixCycle).toBe(false);
+  });
+
+  it('handleTransitions_WithEffects_KeepsEffectsField', async () => {
+    // Arrange — get feature transitions
+    const result = await handleTransitions({ workflowType: 'feature' }, tmpDir);
+    expect(result.success).toBe(true);
+
+    const data = result.data as Record<string, unknown>;
+    const transitions = data.transitions as Array<Record<string, unknown>>;
+
+    // Act — find the review->delegate fix-cycle transition which has effects
+    const fixCycle = transitions.find(
+      (t) => t.from === 'review' && t.to === 'delegate' && t.isFixCycle === true,
+    );
+
+    // Assert — effects should be present when non-empty
+    expect(fixCycle).toBeDefined();
+    expect('effects' in fixCycle!).toBe(true);
+    expect(fixCycle!.effects).toEqual(['increment-fix-cycle']);
+  });
+
+  it('handleTransitions_NullParent_OmitsParentField', async () => {
+    // Arrange — get feature states, find one with no parent (like ideate)
+    const result = await handleTransitions({ workflowType: 'feature' }, tmpDir);
+    expect(result.success).toBe(true);
+
+    const data = result.data as Record<string, unknown>;
+    const states = data.states as Array<Record<string, unknown>>;
+
+    // Act — find a state that has no parent (top-level atomic states like 'ideate')
+    const ideateState = states.find((s) => s.id === 'ideate');
+
+    // Assert — the state object should NOT have a `parent` key
+    expect(ideateState).toBeDefined();
+    expect('parent' in ideateState!).toBe(false);
+  });
+
+  it('handleTransitions_NullInitial_OmitsInitialField', async () => {
+    // Arrange — get feature states, find an atomic state (no initial sub-state)
+    const result = await handleTransitions({ workflowType: 'feature' }, tmpDir);
+    expect(result.success).toBe(true);
+
+    const data = result.data as Record<string, unknown>;
+    const states = data.states as Array<Record<string, unknown>>;
+
+    // Act — find an atomic state (should not have 'initial')
+    const ideateState = states.find((s) => s.id === 'ideate');
+
+    // Assert — atomic state should NOT have `initial` key
+    expect(ideateState).toBeDefined();
+    expect('initial' in ideateState!).toBe(false);
+  });
+});
+
 // ─── Integration Tests for Bug Fixes ────────────────────────────────────────
 
 describe('ToolSet_DynamicFields_SurviveRoundTrip', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -1831,6 +1831,68 @@ describe('External Event Store Bridge', () => {
   });
 });
 
+// ─── Guaranteed Event Append (Task 9) ──────────────────────────────────────
+
+describe('Guaranteed Event Append', () => {
+  it('handleSet_EventAppendFails_ReturnsError', async () => {
+    // Arrange — create a mock EventStore whose append method throws
+    const eventStore = new EventStore(tmpDir);
+    const appendSpy = vi.spyOn(eventStore, 'append').mockRejectedValue(
+      new Error('Disk full'),
+    );
+    configureWorkflowEventStore(eventStore);
+
+    await handleInit({ featureId: 'event-fail', workflowType: 'feature' }, tmpDir);
+    await handleSet(
+      { featureId: 'event-fail', updates: { 'artifacts.design': 'docs/test.md' } },
+      tmpDir,
+    );
+
+    // Act — attempt a phase transition that triggers event append
+    const result = await handleSet(
+      { featureId: 'event-fail', phase: 'plan' },
+      tmpDir,
+    );
+
+    // Assert — should return error with EVENT_APPEND_FAILED code
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error?.code).toBe('EVENT_APPEND_FAILED');
+    expect(result.error?.message).toContain('Disk full');
+
+    // State should NOT have been mutated (event-first guarantee)
+    const state = await readStateFile(path.join(tmpDir, 'event-fail.state.json'));
+    expect(state.phase).toBe('ideate');
+
+    appendSpy.mockRestore();
+  });
+
+  it('handleCheckpoint_EventAppendFails_ReturnsError', async () => {
+    // Arrange — create a mock EventStore whose append method throws
+    const eventStore = new EventStore(tmpDir);
+    const appendSpy = vi.spyOn(eventStore, 'append').mockRejectedValue(
+      new Error('Permission denied'),
+    );
+    configureWorkflowEventStore(eventStore);
+
+    await handleInit({ featureId: 'ckpt-event-fail', workflowType: 'feature' }, tmpDir);
+
+    // Act — attempt a checkpoint that triggers event append
+    const result = await handleCheckpoint(
+      { featureId: 'ckpt-event-fail', summary: 'test' },
+      tmpDir,
+    );
+
+    // Assert — should return error with EVENT_APPEND_FAILED code
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error?.code).toBe('EVENT_APPEND_FAILED');
+    expect(result.error?.message).toContain('Permission denied');
+
+    appendSpy.mockRestore();
+  });
+});
+
 describe('B5: Event-First Mutation Ordering', () => {
   it('handleSet_EventAppendedBeforeStateMutation: event store receives event for transition', async () => {
     const eventStore = new EventStore(tmpDir);

--- a/plugins/exarchos/servers/exarchos-mcp/src/format.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/format.ts
@@ -28,6 +28,20 @@ export function formatResult(result: ToolResult) {
   };
 }
 
+/**
+ * Strip null, undefined, and empty-array values from a flat object.
+ * Preserves false, 0, and other falsy-but-meaningful values.
+ */
+export function stripNullish(obj: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === null || value === undefined) continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    result[key] = value;
+  }
+  return result;
+}
+
 export function stubResult() {
   return formatResult({
     success: false,

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/query.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/query.ts
@@ -16,7 +16,7 @@ import { getRecentEventsFromStore } from './events.js';
 import { getHSMDefinition } from './state-machine.js';
 import { checkCircuitBreakerFromStore } from './circuit-breaker.js';
 import type { EventStore } from '../event-store/store.js';
-import { formatResult, type ToolResult } from '../format.js';
+import { formatResult, stripNullish, type ToolResult } from '../format.js';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 
@@ -195,13 +195,15 @@ export async function handleTransitions(
 ): Promise<ToolResult> {
   const hsm = getHSMDefinition(input.workflowType);
 
-  // Build states list
-  const states = Object.values(hsm.states).map((s) => ({
-    id: s.id,
-    type: s.type,
-    parent: s.parent ?? null,
-    initial: s.initial ?? null,
-  }));
+  // Build states list (sparse: omit null/empty fields)
+  const states = Object.values(hsm.states).map((s) =>
+    stripNullish({
+      id: s.id,
+      type: s.type,
+      parent: s.parent ?? null,
+      initial: s.initial ?? null,
+    }),
+  );
 
   // Build transitions list, optionally filtered by fromPhase
   let transitions = hsm.transitions;
@@ -209,14 +211,16 @@ export async function handleTransitions(
     transitions = transitions.filter((t) => t.from === input.fromPhase);
   }
 
-  const transitionData = transitions.map((t) => ({
-    from: t.from,
-    to: t.to,
-    guardDescription: t.guard?.description ?? null,
-    guardId: t.guard?.id ?? null,
-    isFixCycle: t.isFixCycle ?? false,
-    effects: t.effects ?? [],
-  }));
+  const transitionData = transitions.map((t) =>
+    stripNullish({
+      from: t.from,
+      to: t.to,
+      guardDescription: t.guard?.description ?? null,
+      guardId: t.guard?.id ?? null,
+      isFixCycle: t.isFixCycle ?? false,
+      effects: t.effects ?? [],
+    }),
+  );
 
   return {
     success: true,

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/schemas.ts
@@ -296,6 +296,7 @@ export const ErrorCode = {
   ALREADY_CANCELLED: 'ALREADY_CANCELLED',
   COMPENSATION_PARTIAL: 'COMPENSATION_PARTIAL',
   FILE_IO_ERROR: 'FILE_IO_ERROR',
+  EVENT_APPEND_FAILED: 'EVENT_APPEND_FAILED',
 } as const;
 
 // ─── Reserved Field Validation ──────────────────────────────────────────────

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
@@ -260,7 +260,7 @@ export async function handleSet(
     }
 
     if (!result.idempotent && result.newPhase) {
-      // Event-first: emit to external event store BEFORE mutating state (best-effort)
+      // Event-first: emit to external event store BEFORE mutating state (guaranteed)
       if (moduleEventStore) {
         try {
           for (const transitionEvent of result.events) {
@@ -275,8 +275,14 @@ export async function handleSet(
               },
             });
           }
-        } catch {
-          // External store is supplementary; JSONL append failure must not break workflow
+        } catch (err) {
+          return {
+            success: false,
+            error: {
+              code: ErrorCode.EVENT_APPEND_FAILED,
+              message: `Event append failed: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          };
         }
       }
 
@@ -359,7 +365,7 @@ export async function handleCheckpoint(
     input.summary,
   );
 
-  // Emit checkpoint event to external store (event-first, best-effort)
+  // Emit checkpoint event to external store (event-first, guaranteed)
   if (moduleEventStore) {
     try {
       await moduleEventStore.append(input.featureId, {
@@ -370,8 +376,14 @@ export async function handleCheckpoint(
           featureId: input.featureId,
         },
       });
-    } catch {
-      // External store is supplementary; JSONL append failure must not break workflow
+    } catch (err) {
+      return {
+        success: false,
+        error: {
+          code: ErrorCode.EVENT_APPEND_FAILED,
+          message: `Event append failed: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      };
     }
   }
 


### PR DESCRIPTION
## Summary

Omits empty/null fields from tool responses and promotes event-first ordering from best-effort to guaranteed — event append failures now propagate as structured errors.

## Changes

- **format.ts** — `stripNullish()` utility removes null/undefined/empty-array fields
- **workflow/query.ts** — `handleTransitions` applies sparse responses
- **workflow/tools.ts** — `handleSet` and `handleCheckpoint` propagate `EVENT_APPEND_FAILED` errors
- **workflow/schemas.ts** — New `EVENT_APPEND_FAILED` error code

## Test Plan

7 new tests verify sparse field omission and event failure propagation with state-not-mutated assertions.

---

**Results:** Tests pass · Build 0 errors