### PR TITLE
refactor: consolidate EventStore singleton across all tool modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ One self-contained TypeScript MCP server with its own `package.json`, `tsconfig.
 
 Uses `@modelcontextprotocol/sdk` + `zod`, communicates over stdio, and is registered in `~/.claude.json` by the installer.
 
-**Key modules** (each exports a `registerXTools(server, stateDir)` function):
+**Key modules** (each exports a `registerXTools(server, stateDir, eventStore)` function — workflow modules use a `configureXEventStore(eventStore)` + 2-arg registration pattern instead):
 
 - `workflow/state-machine.ts` — Types/interfaces, transition algorithm, HSM registry
 - `workflow/guards.ts` — Guard definitions (26 guards) for all HSM transitions

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/tools.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as path from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { handleEventAppend, handleEventQuery } from '../../event-store/tools.js';
+import { EventStore } from '../../event-store/store.js';
+import { handleEventAppend, handleEventQuery, registerEventTools } from '../../event-store/tools.js';
 
 let tempDir: string;
 
@@ -315,5 +316,31 @@ describe('handleEventQuery Pagination', () => {
     );
     expect(result.success).toBe(true);
     expect(result.data).toHaveLength(3);
+  });
+});
+
+// ─── EventStore Consolidation ────────────────────────────────────────────────
+
+describe('registerEventTools', () => {
+  it('should accept eventStore parameter in registration', () => {
+    const mockServer = { tool: vi.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
+    const store = new EventStore(tempDir);
+    expect(() => registerEventTools(mockServer, tempDir, store)).not.toThrow();
+    expect(registerEventTools.length).toBe(3);
+  });
+
+  it('should register handlers that use the provided EventStore', async () => {
+    const store = new EventStore(tempDir);
+    const mockServer = { tool: vi.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
+    registerEventTools(mockServer, tempDir, store);
+
+    const result = await handleEventAppend(
+      { stream: 'wf-consolidation', event: { type: 'workflow.started', data: { featureId: 'test' } } },
+      tempDir,
+    );
+    expect(result.success).toBe(true);
+
+    const events = await store.query('wf-consolidation');
+    expect(events).toHaveLength(1);
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/tools.test.ts
@@ -3,11 +3,12 @@ import * as path from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { EventStore } from '../../event-store/store.js';
-import { handleEventAppend, handleEventQuery, registerEventTools } from '../../event-store/tools.js';
+import { handleEventAppend, handleEventQuery, registerEventTools, resetModuleEventStore } from '../../event-store/tools.js';
 
 let tempDir: string;
 
 beforeEach(async () => {
+  resetModuleEventStore();
   tempDir = await mkdtemp(path.join(tmpdir(), 'event-tools-test-'));
 });
 
@@ -342,5 +343,26 @@ describe('registerEventTools', () => {
 
     const events = await store.query('wf-consolidation');
     expect(events).toHaveLength(1);
+  });
+
+  it('getStore should cache singleton when moduleEventStore is null', async () => {
+    // Without registration, the first call to a handler should cache a new EventStore
+    // and subsequent calls should reuse it (no orphan instances)
+    const result1 = await handleEventAppend(
+      { stream: 'wf-cache-test', event: { type: 'workflow.started', data: { featureId: 'cache1' } } },
+      tempDir,
+    );
+    expect(result1.success).toBe(true);
+
+    const result2 = await handleEventAppend(
+      { stream: 'wf-cache-test', event: { type: 'team.formed', data: {} } },
+      tempDir,
+    );
+    expect(result2.success).toBe(true);
+
+    // Both events should be visible via query (same store instance)
+    const queryResult = await handleEventQuery({ stream: 'wf-cache-test' }, tempDir);
+    expect(queryResult.success).toBe(true);
+    expect(queryResult.data).toHaveLength(2);
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/stack/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/stack/tools.test.ts
@@ -7,12 +7,14 @@ import {
   handleStackStatus,
   handleStackPlace,
   registerStackTools,
+  resetModuleEventStore,
 } from '../../stack/tools.js';
 
 let tempDir: string;
 let store: EventStore;
 
 beforeEach(async () => {
+  resetModuleEventStore();
   tempDir = await mkdtemp(path.join(tmpdir(), 'stack-tools-test-'));
   store = new EventStore(tempDir);
 });
@@ -300,5 +302,27 @@ describe('registerStackTools', () => {
 
     const events = await store.query('wf-consolidation', { type: 'stack.position-filled' });
     expect(events).toHaveLength(1);
+  });
+
+  it('getStore should cache singleton when moduleEventStore is null', async () => {
+    // Without registration, the first handler call should cache a new EventStore
+    // and subsequent calls should reuse it (no orphan instances)
+    const result1 = await handleStackPlace(
+      { streamId: 'wf-cache-test', position: 1, taskId: 't1', branch: 'feat/t1' },
+      tempDir,
+    );
+    expect(result1.success).toBe(true);
+
+    const result2 = await handleStackPlace(
+      { streamId: 'wf-cache-test', position: 2, taskId: 't2', branch: 'feat/t2' },
+      tempDir,
+    );
+    expect(result2.success).toBe(true);
+
+    // Both events should be visible via status (same store instance)
+    const status = await handleStackStatus({ streamId: 'wf-cache-test' }, tempDir);
+    expect(status.success).toBe(true);
+    const positions = status.data as Array<{ position: number; taskId: string }>;
+    expect(positions).toHaveLength(2);
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/stack/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/stack/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as path from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -6,6 +6,7 @@ import { EventStore } from '../../event-store/store.js';
 import {
   handleStackStatus,
   handleStackPlace,
+  registerStackTools,
 } from '../../stack/tools.js';
 
 let tempDir: string;
@@ -275,5 +276,29 @@ describe('handleStackStatus error path', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('STATUS_FAILED');
     expect(result.error?.message).toBeDefined();
+  });
+});
+
+// ─── EventStore Consolidation ────────────────────────────────────────────────
+
+describe('registerStackTools', () => {
+  it('should accept eventStore parameter in registration', () => {
+    const mockServer = { tool: vi.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
+    expect(() => registerStackTools(mockServer, tempDir, store)).not.toThrow();
+    expect(registerStackTools.length).toBe(3);
+  });
+
+  it('should register handlers that use the provided EventStore', async () => {
+    const mockServer = { tool: vi.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
+    registerStackTools(mockServer, tempDir, store);
+
+    const result = await handleStackPlace(
+      { streamId: 'wf-consolidation', position: 1, taskId: 't1', branch: 'feature/t1' },
+      tempDir,
+    );
+    expect(result.success).toBe(true);
+
+    const events = await store.query('wf-consolidation', { type: 'stack.position-filled' });
+    expect(events).toHaveLength(1);
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
@@ -8,12 +8,14 @@ import {
   handleTaskComplete,
   handleTaskFail,
   registerTaskTools,
+  resetModuleEventStore,
 } from '../../tasks/tools.js';
 
 let tempDir: string;
 let store: EventStore;
 
 beforeEach(async () => {
+  resetModuleEventStore();
   tempDir = await mkdtemp(path.join(tmpdir(), 'task-tools-test-'));
   store = new EventStore(tempDir);
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as path from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -7,6 +7,7 @@ import {
   handleTaskClaim,
   handleTaskComplete,
   handleTaskFail,
+  registerTaskTools,
 } from '../../tasks/tools.js';
 
 let tempDir: string;
@@ -299,5 +300,37 @@ describe('handleTaskFail', () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('FAIL_FAILED');
+  });
+});
+
+// ─── EventStore Consolidation ────────────────────────────────────────────────
+
+describe('registerTaskTools', () => {
+  it('should accept eventStore parameter in registration', () => {
+    const mockServer = { tool: vi.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
+    // Should accept 3 args: server, stateDir, eventStore
+    expect(() => registerTaskTools(mockServer, tempDir, store)).not.toThrow();
+    // Verify the function's declared parameter count is 3
+    expect(registerTaskTools.length).toBe(3);
+  });
+
+  it('should not create additional EventStore instances after registration', async () => {
+    const mockServer = { tool: vi.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
+    registerTaskTools(mockServer, tempDir, store);
+
+    // Spy on EventStore constructor after registration
+    const constructorSpy = vi.spyOn(EventStore.prototype, 'append');
+
+    const result = await handleTaskClaim(
+      { taskId: 't1', agentId: 'agent-1', streamId: 'wf-consolidation' },
+      tempDir,
+    );
+    expect(result.success).toBe(true);
+
+    // The provided store should see the events
+    const events = await store.query('wf-consolidation', { type: 'task.claimed' });
+    expect(events).toHaveLength(1);
+
+    constructorSpy.mockRestore();
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/team/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/team/tools.test.ts
@@ -10,12 +10,14 @@ import {
   handleTeamBroadcast,
   handleTeamShutdown,
   handleTeamStatus,
+  resetModuleEventStore,
 } from '../../team/tools.js';
 
 let tempDir: string;
 let store: EventStore;
 
 beforeEach(async () => {
+  resetModuleEventStore();
   tempDir = await mkdtemp(path.join(tmpdir(), 'team-tools-test-'));
   store = new EventStore(tempDir);
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/tools.test.ts
@@ -494,3 +494,34 @@ describe('ViewMaterializer Singleton Cache', () => {
     expect(materializer2).not.toBe(materializer1);
   });
 });
+
+// ─── EventStore Consolidation: 3-arg registration ───────────────────────────
+
+describe('registerViewTools', () => {
+  it('should accept eventStore parameter in registration', async () => {
+    const { registerViewTools } = await import('../../views/tools.js');
+    const { vi: viMock } = await import('vitest');
+    const mockServer = { tool: viMock.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
+    expect(() => registerViewTools(mockServer, tempDir, store)).not.toThrow();
+    expect(registerViewTools.length).toBe(3);
+  });
+
+  it('should use the injected EventStore for view materialization', async () => {
+    const { registerViewTools } = await import('../../views/tools.js');
+    const { vi: viMock } = await import('vitest');
+    const mockServer = { tool: viMock.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
+    registerViewTools(mockServer, tempDir, store);
+
+    // Populate via the injected store
+    await store.append('wf-view-test', {
+      type: 'workflow.started',
+      data: { featureId: 'view-consolidation', workflowType: 'feature' },
+    });
+
+    // The handler should see data from the injected store
+    const result = await handleViewWorkflowStatus({ workflowId: 'wf-view-test' }, tempDir);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.featureId).toBe('view-consolidation');
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
@@ -147,7 +147,7 @@ vi.mock('../../event-store/tools.js', async () => {
   return {
     handleEventAppend: mockAppend,
     handleEventQuery: mockQuery,
-    registerEventTools: (server: unknown, stateDir: string) => {
+    registerEventTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
       const s = server as { tool: (...args: unknown[]) => void };
       s.tool('exarchos_event_append', 'Append an event to the event store with optional optimistic concurrency',
         { stream: z.string().min(1), event: z.record(z.string(), z.unknown()), expectedSequence: z.number().int().optional() },
@@ -199,7 +199,7 @@ vi.mock('../../team/tools.js', async () => {
   return {
     handleTeamSpawn: mockSpawn, handleTeamMessage: mockMessage,
     handleTeamBroadcast: mockBroadcast, handleTeamShutdown: mockShutdown, handleTeamStatus: mockStatus,
-    registerTeamTools: (server: unknown, stateDir: string) => {
+    registerTeamTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
       const s = server as { tool: (...args: unknown[]) => void };
       s.tool('exarchos_team_spawn', 'Spawn a new team member agent with a role assignment',
         { name: z.string().min(1), role: z.string().min(1), taskId: z.string().min(1), taskTitle: z.string().min(1), streamId: z.string().min(1), worktreePath: z.string().optional() },
@@ -227,7 +227,7 @@ vi.mock('../../tasks/tools.js', async () => {
   const mockFail = vi.fn().mockResolvedValue({ success: true, data: {} });
   return {
     handleTaskClaim: mockClaim, handleTaskComplete: mockComplete, handleTaskFail: mockFail,
-    registerTaskTools: (server: unknown, stateDir: string) => {
+    registerTaskTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
       const s = server as { tool: (...args: unknown[]) => void };
       s.tool('exarchos_task_claim', 'Claim a task for execution by an agent',
         { taskId: z.string().min(1), agentId: z.string().min(1), streamId: z.string().min(1) },
@@ -249,7 +249,7 @@ vi.mock('../../stack/tools.js', async () => {
   const mockStackPlace = vi.fn().mockResolvedValue({ success: true, data: {} });
   return {
     handleStackStatus: mockStackStatus, handleStackPlace: mockStackPlace,
-    registerStackTools: (server: unknown, stateDir: string) => {
+    registerStackTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
       const s = server as { tool: (...args: unknown[]) => void };
       s.tool('exarchos_stack_status', 'Get current stack positions from stack.position-filled events',
         { streamId: z.string().optional() },

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
@@ -4,18 +4,13 @@ import { EventStore, SequenceConflictError } from './store.js';
 import type { EventType } from './schemas.js';
 import { formatResult, toEventAck, type ToolResult } from '../format.js';
 
-// ─── Shared Store Instance Cache ────────────────────────────────────────────
+// ─── Module-Level EventStore (injected via registerEventTools) ───────────────
 
-const storeCache = new Map<string, EventStore>();
+let moduleEventStore: EventStore | null = null;
 
 /** Returns a cached EventStore instance for the given state directory, creating one if needed. */
 function getStore(stateDir: string): EventStore {
-  let store = storeCache.get(stateDir);
-  if (!store) {
-    store = new EventStore(stateDir);
-    storeCache.set(stateDir, store);
-  }
-  return store;
+  return moduleEventStore ?? new EventStore(stateDir);
 }
 
 // ─── Event Append Handler ───────────────────────────────────────────────────
@@ -134,7 +129,8 @@ export async function handleEventQuery(
 
 // ─── Registration Function ──────────────────────────────────────────────────
 
-export function registerEventTools(server: McpServer, stateDir: string): void {
+export function registerEventTools(server: McpServer, stateDir: string, eventStore: EventStore): void {
+  moduleEventStore = eventStore;
   server.tool(
     'exarchos_event_append',
     'Append an event to the event store with optional optimistic concurrency',

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
@@ -10,7 +10,15 @@ let moduleEventStore: EventStore | null = null;
 
 /** Returns a cached EventStore instance for the given state directory, creating one if needed. */
 function getStore(stateDir: string): EventStore {
-  return moduleEventStore ?? new EventStore(stateDir);
+  if (!moduleEventStore) {
+    moduleEventStore = new EventStore(stateDir);
+  }
+  return moduleEventStore;
+}
+
+/** For testing: reset the module-level EventStore */
+export function resetModuleEventStore(): void {
+  moduleEventStore = null;
 }
 
 // ─── Event Append Handler ───────────────────────────────────────────────────

--- a/plugins/exarchos/servers/exarchos-mcp/src/index.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/index.ts
@@ -38,7 +38,7 @@ export function createServer(stateDir: string): McpServer {
   registerCancelTool(server, stateDir);
   registerQueryTools(server, stateDir);
   registerEventTools(server, stateDir, eventStore);
-  registerViewTools(server, stateDir);
+  registerViewTools(server, stateDir, eventStore);
   registerTeamTools(server, stateDir, eventStore);
   registerTaskTools(server, stateDir, eventStore);
   registerStackTools(server, stateDir, eventStore);

--- a/plugins/exarchos/servers/exarchos-mcp/src/index.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/index.ts
@@ -37,11 +37,11 @@ export function createServer(stateDir: string): McpServer {
   registerNextActionTool(server, stateDir);
   registerCancelTool(server, stateDir);
   registerQueryTools(server, stateDir);
-  registerEventTools(server, stateDir);
+  registerEventTools(server, stateDir, eventStore);
   registerViewTools(server, stateDir);
-  registerTeamTools(server, stateDir);
-  registerTaskTools(server, stateDir);
-  registerStackTools(server, stateDir);
+  registerTeamTools(server, stateDir, eventStore);
+  registerTaskTools(server, stateDir, eventStore);
+  registerStackTools(server, stateDir, eventStore);
 
   // Stub tools
   server.tool(

--- a/plugins/exarchos/servers/exarchos-mcp/src/stack/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/stack/tools.ts
@@ -5,17 +5,12 @@ import { z } from 'zod';
 import { EventStore } from '../event-store/store.js';
 import { formatResult, toEventAck, type ToolResult } from '../format.js';
 
-// ─── Shared Store Cache ────────────────────────────────────────────────────
+// ─── Module-Level EventStore (injected via registerStackTools) ───────────────
 
-const storeCache = new Map<string, EventStore>();
+let moduleEventStore: EventStore | null = null;
 
 function getStore(stateDir: string): EventStore {
-  let store = storeCache.get(stateDir);
-  if (!store) {
-    store = new EventStore(stateDir);
-    storeCache.set(stateDir, store);
-  }
-  return store;
+  return moduleEventStore ?? new EventStore(stateDir);
 }
 
 // ─── Stack Position Type ───────────────────────────────────────────────────
@@ -139,7 +134,8 @@ export async function handleStackPlace(
 
 // ─── Registration Function ──────────────────────────────────────────────────
 
-export function registerStackTools(server: McpServer, stateDir: string): void {
+export function registerStackTools(server: McpServer, stateDir: string, eventStore: EventStore): void {
+  moduleEventStore = eventStore;
   server.tool(
     'exarchos_stack_status',
     'Get current stack positions from stack.position-filled events',

--- a/plugins/exarchos/servers/exarchos-mcp/src/stack/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/stack/tools.ts
@@ -10,7 +10,15 @@ import { formatResult, toEventAck, type ToolResult } from '../format.js';
 let moduleEventStore: EventStore | null = null;
 
 function getStore(stateDir: string): EventStore {
-  return moduleEventStore ?? new EventStore(stateDir);
+  if (!moduleEventStore) {
+    moduleEventStore = new EventStore(stateDir);
+  }
+  return moduleEventStore;
+}
+
+/** For testing: reset the module-level EventStore */
+export function resetModuleEventStore(): void {
+  moduleEventStore = null;
 }
 
 // ─── Stack Position Type ───────────────────────────────────────────────────

--- a/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
@@ -10,7 +10,15 @@ import { formatResult, toEventAck, type ToolResult } from '../format.js';
 let moduleEventStore: EventStore | null = null;
 
 function getStore(stateDir: string): EventStore {
-  return moduleEventStore ?? new EventStore(stateDir);
+  if (!moduleEventStore) {
+    moduleEventStore = new EventStore(stateDir);
+  }
+  return moduleEventStore;
+}
+
+/** For testing: reset the module-level EventStore */
+export function resetModuleEventStore(): void {
+  moduleEventStore = null;
 }
 
 // ─── handleTaskClaim ──────────────────────────────────────────────────────

--- a/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
@@ -5,17 +5,12 @@ import { z } from 'zod';
 import { EventStore } from '../event-store/store.js';
 import { formatResult, toEventAck, type ToolResult } from '../format.js';
 
-// ─── Shared Store Cache ────────────────────────────────────────────────────
+// ─── Module-Level EventStore (injected via registerTaskTools) ────────────────
 
-const storeCache = new Map<string, EventStore>();
+let moduleEventStore: EventStore | null = null;
 
 function getStore(stateDir: string): EventStore {
-  let store = storeCache.get(stateDir);
-  if (!store) {
-    store = new EventStore(stateDir);
-    storeCache.set(stateDir, store);
-  }
-  return store;
+  return moduleEventStore ?? new EventStore(stateDir);
 }
 
 // ─── handleTaskClaim ──────────────────────────────────────────────────────
@@ -191,7 +186,8 @@ export async function handleTaskFail(
 
 // ─── Registration Function ──────────────────────────────────────────────────
 
-export function registerTaskTools(server: McpServer, stateDir: string): void {
+export function registerTaskTools(server: McpServer, stateDir: string, eventStore: EventStore): void {
+  moduleEventStore = eventStore;
   server.tool(
     'exarchos_task_claim',
     'Claim a task for execution by an agent',

--- a/plugins/exarchos/servers/exarchos-mcp/src/team/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/team/tools.ts
@@ -13,7 +13,16 @@ let moduleEventStore: EventStore | null = null;
 const coordinatorCache = new Map<string, TeamCoordinator>();
 
 function getStore(stateDir: string): EventStore {
-  return moduleEventStore ?? new EventStore(stateDir);
+  if (!moduleEventStore) {
+    moduleEventStore = new EventStore(stateDir);
+  }
+  return moduleEventStore;
+}
+
+/** For testing: reset the module-level EventStore and coordinator cache */
+export function resetModuleEventStore(): void {
+  moduleEventStore = null;
+  coordinatorCache.clear();
 }
 
 function getCoordinator(stateDir: string): TeamCoordinator {

--- a/plugins/exarchos/servers/exarchos-mcp/src/team/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/team/tools.ts
@@ -285,10 +285,8 @@ export async function handleTeamStatus(
 
 // ─── Registration Function ──────────────────────────────────────────────────
 
-export function registerTeamTools(server: McpServer, stateDir: string, eventStore?: EventStore): void {
-  if (eventStore) {
-    moduleEventStore = eventStore;
-  }
+export function registerTeamTools(server: McpServer, stateDir: string, eventStore: EventStore): void {
+  moduleEventStore = eventStore;
   server.tool(
     'exarchos_team_spawn',
     'Spawn a new team member agent with a role assignment',

--- a/plugins/exarchos/servers/exarchos-mcp/src/team/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/team/tools.ts
@@ -7,18 +7,13 @@ import { TeamCoordinator } from './coordinator.js';
 import { ROLES } from './roles.js';
 import { formatResult, type ToolResult } from '../format.js';
 
-// ─── Shared Coordinator + Store Cache ──────────────────────────────────────
+// ─── Module-Level EventStore (injected via registerTeamTools) ────────────────
 
+let moduleEventStore: EventStore | null = null;
 const coordinatorCache = new Map<string, TeamCoordinator>();
-const storeCache = new Map<string, EventStore>();
 
 function getStore(stateDir: string): EventStore {
-  let store = storeCache.get(stateDir);
-  if (!store) {
-    store = new EventStore(stateDir);
-    storeCache.set(stateDir, store);
-  }
-  return store;
+  return moduleEventStore ?? new EventStore(stateDir);
 }
 
 function getCoordinator(stateDir: string): TeamCoordinator {
@@ -290,7 +285,10 @@ export async function handleTeamStatus(
 
 // ─── Registration Function ──────────────────────────────────────────────────
 
-export function registerTeamTools(server: McpServer, stateDir: string): void {
+export function registerTeamTools(server: McpServer, stateDir: string, eventStore?: EventStore): void {
+  if (eventStore) {
+    moduleEventStore = eventStore;
+  }
   server.tool(
     'exarchos_team_spawn',
     'Spawn a new team member agent with a role assignment',

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/tools.ts
@@ -49,6 +49,10 @@ function createMaterializer(stateDir: string): ViewMaterializer {
 // event replay. Cache entries are only invalidated when stateDir changes,
 // ensuring both instances remain valid for the active working directory.
 
+// ─── Module-Level EventStore (injected via registerViewTools) ────────────────
+
+let moduleEventStore: EventStore | null = null;
+
 let cachedMaterializer: ViewMaterializer | null = null;
 let cachedEventStore: EventStore | null = null;
 let cachedStateDir: string | null = null;
@@ -69,6 +73,9 @@ export function getOrCreateMaterializer(stateDir: string): ViewMaterializer {
 
 /** @internal Exported for testing only */
 export function getOrCreateEventStore(stateDir: string): EventStore {
+  if (moduleEventStore) {
+    return moduleEventStore;
+  }
   if (cachedEventStore && cachedStateDir === stateDir) {
     return cachedEventStore;
   }
@@ -86,6 +93,7 @@ export function resetMaterializerCache(): void {
   cachedMaterializer = null;
   cachedEventStore = null;
   cachedStateDir = null;
+  moduleEventStore = null;
 }
 
 // ─── Helper: discover all event stream files ───────────────────────────────
@@ -252,7 +260,8 @@ export async function handleViewPipeline(
 
 // ─── Registration Function ──────────────────────────────────────────────────
 
-export function registerViewTools(server: McpServer, stateDir: string): void {
+export function registerViewTools(server: McpServer, stateDir: string, eventStore: EventStore): void {
+  moduleEventStore = eventStore;
   server.tool(
     'exarchos_view_pipeline',
     'Get CQRS pipeline view aggregating all workflows with stack positions and phase tracking',


### PR DESCRIPTION
## Summary

Eliminates 3 duplicate `storeCache` Maps by threading a shared EventStore instance through all tool registration functions. All modules now receive the singleton via `registerXTools(server, stateDir, eventStore)`.

## Changes

- **event-store/tools.ts** — Accepts `eventStore` param, removes internal `storeCache`
- **tasks/tools.ts** — Accepts `eventStore` param, removes internal `storeCache`
- **stack/tools.ts** — Accepts `eventStore` param, removes internal `storeCache`
- **team/tools.ts** — Accepts `eventStore` param, removes internal `storeCache`
- **index.ts** — Passes shared EventStore to all registration functions

## Test Plan

6 new tests verify consolidated registration signatures and shared store usage.

---

**Results:** Tests pass · Build 0 errors