### PR TITLE
docs: add JSDoc docstrings to event-store and format modules

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
@@ -38,6 +38,7 @@ export interface QueryFilters {
 
 const SAFE_STREAM_ID_PATTERN = /^[a-z0-9-]+$/;
 
+/** Validates that a stream ID matches the safe pattern (lowercase alphanumeric and hyphens). */
 function validateStreamId(streamId: string): void {
   if (!SAFE_STREAM_ID_PATTERN.test(streamId)) {
     throw new Error(
@@ -48,6 +49,10 @@ function validateStreamId(streamId: string): void {
 
 // ─── Pagination Helper ──────────────────────────────────────────────────────
 
+/**
+ * Applies offset/limit pagination to an array of items.
+ * Called after filtering; values are pre-validated by Zod schemas at the tool boundary.
+ */
 function applyPagination<T>(items: T[], offset?: number, limit?: number): T[] {
   const start = offset ?? 0;
   const end = limit !== undefined ? start + limit : undefined;

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
@@ -8,6 +8,7 @@ import { formatResult, toEventAck, type ToolResult } from '../format.js';
 
 const storeCache = new Map<string, EventStore>();
 
+/** Returns a cached EventStore instance for the given state directory, creating one if needed. */
 function getStore(stateDir: string): EventStore {
   let store = storeCache.get(stateDir);
   if (!store) {
@@ -19,6 +20,7 @@ function getStore(stateDir: string): EventStore {
 
 // ─── Event Append Handler ───────────────────────────────────────────────────
 
+/** Handles the event_append tool: validates input, appends an event to the store, and returns an EventAck. */
 export async function handleEventAppend(
   args: {
     stream: string;
@@ -85,6 +87,7 @@ export async function handleEventAppend(
 
 // ─── Event Query Handler ────────────────────────────────────────────────────
 
+/** Handles the event_query tool: validates input, queries events with optional filters and pagination. */
 export async function handleEventQuery(
   args: {
     stream?: string;

--- a/plugins/exarchos/servers/exarchos-mcp/src/format.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/format.ts
@@ -15,12 +15,14 @@ export interface EventAck {
   readonly type: string;
 }
 
+/** Extracts a minimal acknowledgement (streamId, sequence, type) from a full event to reduce response payload size. */
 export function toEventAck(event: { streamId: string; sequence: number; type: string }): EventAck {
   return { streamId: event.streamId, sequence: event.sequence, type: event.type };
 }
 
 // ─── Result Formatting ──────────────────────────────────────────────────────
 
+/** Converts a ToolResult into the MCP content format expected by the SDK. */
 export function formatResult(result: ToolResult) {
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(result) }],
@@ -42,6 +44,7 @@ export function stripNullish(obj: Record<string, unknown>): Record<string, unkno
   return result;
 }
 
+/** Returns a NOT_IMPLEMENTED error result for placeholder tool registrations. */
 export function stubResult() {
   return formatResult({
     success: false,


### PR DESCRIPTION
## Summary

Addresses the docstring coverage warning (75% < 80% threshold) flagged by CodeRabbit on PR #103. Adds concise JSDoc docstrings to 8 undocumented functions across the event-store and format modules.

## Changes

- **format.ts** — Added docstrings to `toEventAck`, `formatResult`, and `stubResult`
- **event-store/store.ts** — Added docstrings to `validateStreamId` and `applyPagination`
- **event-store/tools.ts** — Added docstrings to `getStore`, `handleEventAppend`, and `handleEventQuery`

## Test Plan

Existing test suite passes (798 tests). Build compiles with zero errors. No logic changes — docstrings only.

---

**Results:** Tests 798 ✓ · Build 0 errors
**Related:** Addresses feedback from #103