### PR TITLE
fix: rewrite CI to run actual test suites based on changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,3 @@
-# CI Workflow for Exarchos SDLC workflow automation
-#
-# Features:
-# - YAML/JSON validation
-# - Shell script syntax checking
-# - Terraform validation
-# - Test suite execution
-# - Path-based filtering (jobs only run when relevant files change)
-#
-# Uses Blacksmith runners for fast builds
-
 name: CI
 
 on:
@@ -19,116 +8,64 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
-  # Detect which paths have changed to enable selective job execution
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      azd: ${{ steps.filter.outputs.azd }}
-      ci-templates: ${{ steps.filter.outputs.ci-templates }}
-      renovate: ${{ steps.filter.outputs.renovate }}
-      validate: ${{ steps.filter.outputs.validate }}
+      root: ${{ steps.filter.outputs.root }}
+      mcp: ${{ steps.filter.outputs.mcp }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Check paths
-        uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
-            azd:
-              - 'azd-templates/**'
+            root:
+              - 'src/**'
+              - 'package.json'
+              - 'tsconfig.json'
               - '.github/workflows/ci.yml'
-            ci-templates:
-              - 'ci-templates/**'
-              - '.github/workflows/ci.yml'
-            renovate:
-              - 'renovate-config/**'
-              - 'renovate-config.js'
-              - 'renovate.json'
-              - '.github/workflows/ci.yml'
-            validate:
-              - 'scripts/**'
-              - 'azd-templates/**'
-              - 'ci-templates/**'
-              - 'renovate-config/**'
+            mcp:
+              - 'plugins/exarchos/servers/exarchos-mcp/**'
               - '.github/workflows/ci.yml'
 
-  validate:
-    name: Validate Templates
+  test-root:
+    name: Root Package
     needs: changes
-    if: ${{ needs.changes.outputs.validate == 'true' }}
+    if: ${{ needs.changes.outputs.root == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-node@v4
         with:
-          python-version: '3.14'
+          node-version: '20'
+          cache: npm
 
-      - name: Install validation tools
-        run: pip install pyyaml
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run test:run
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+  test-mcp:
+    name: Exarchos MCP Server
+    needs: changes
+    if: ${{ needs.changes.outputs.mcp == 'true' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    defaults:
+      run:
+        working-directory: plugins/exarchos/servers/exarchos-mcp
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
-          terraform_version: '1.9.0'
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: plugins/exarchos/servers/exarchos-mcp/package-lock.json
 
-      - name: Run template validation
-        run: ./scripts/validate-templates.sh --verbose
-
-  test-azd:
-    name: Test azd Templates
-    needs: changes
-    if: ${{ needs.changes.outputs.azd == 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2204
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: '1.9.0'
-
-      - name: Run azd tests
-        run: ./azd-templates/azd.test.sh
-
-      - name: Run infra tests
-        run: ./azd-templates/infra/infra.test.sh
-
-      - name: Run hooks tests
-        run: ./azd-templates/infra/scripts/hooks.test.sh
-
-  test-ci-templates:
-    name: Test CI Templates
-    needs: changes
-    if: ${{ needs.changes.outputs.ci-templates == 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2204
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run coverage-gate tests
-        run: ./ci-templates/coverage-gate/coverage-gate.test.sh
-
-      - name: Run cd-azure workflow tests
-        run: ./ci-templates/workflows/cd-azure.yml.test.sh
-
-  test-renovate:
-    name: Test Renovate Config
-    needs: changes
-    if: ${{ needs.changes.outputs.renovate == 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2204
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run renovate tests
-        run: ./renovate-config/renovate.test.sh
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm run test:run


### PR DESCRIPTION
## Summary

The existing CI workflow filtered on paths that no longer exist in this repo (`azd-templates/`, `ci-templates/`, `renovate-config/`, `scripts/`), so every job was skipped on every PR. No tests were ever running.

## Changes

- **ci.yml** — Replaced dead path filters with two jobs that actually run the codebase test suites:
  - **Root Package** — `npm run typecheck` + `npm run test:run` when `src/`, `package.json`, or `tsconfig.json` change
  - **Exarchos MCP Server** — `tsc --noEmit` + `npm run test:run` when anything under `plugins/exarchos/servers/exarchos-mcp/` changes
  - Both jobs trigger on CI workflow changes

## Test Plan

CI workflow itself triggers on `.github/workflows/ci.yml` changes, so this PR will self-test.

---

**Related:** Unblocks #98, #99, #100, #101, #102