### PR TITLE
refactor: add pagination, field projection, and StackView CQRS

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/stack/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/stack/tools.test.ts
@@ -7,19 +7,20 @@ import {
   handleStackStatus,
   handleStackPlace,
   registerStackTools,
-  resetModuleEventStore,
 } from '../../stack/tools.js';
+import { resetMaterializerCache } from '../../views/tools.js';
 
 let tempDir: string;
 let store: EventStore;
 
 beforeEach(async () => {
-  resetModuleEventStore();
+  resetMaterializerCache();
   tempDir = await mkdtemp(path.join(tmpdir(), 'stack-tools-test-'));
   store = new EventStore(tempDir);
 });
 
 afterEach(async () => {
+  resetMaterializerCache();
   await rm(tempDir, { recursive: true, force: true });
 });
 
@@ -281,6 +282,48 @@ describe('handleStackStatus error path', () => {
   });
 });
 
+// ─── Task 005: StackView CQRS Rewire ─────────────────────────────────────────
+// These tests intentionally duplicate scenarios from the handleStackStatus suite
+// above (same assertions, different streamId). They exist as explicit regression
+// documentation for the Task 005 CQRS rewire: they verify that the materializer-
+// based code path produces identical results to the prior direct EventStore access
+// implementation, ensuring the refactor introduced no behavioral changes.
+
+describe('handleStackStatus CQRS rewire', () => {
+  it('handleStackStatus_AfterRewire_ReturnsCorrectPositions', async () => {
+    // Arrange: place positions via store (simulating the event-sourced path)
+    await store.append('wf-rewire', {
+      type: 'stack.position-filled',
+      data: { position: 1, taskId: 't1', branch: 'feature/t1' },
+    });
+    await store.append('wf-rewire', {
+      type: 'stack.position-filled',
+      data: { position: 2, taskId: 't2', branch: 'feature/t2', prUrl: 'https://github.com/pr/2' },
+    });
+
+    // Act
+    const result = await handleStackStatus({ streamId: 'wf-rewire' }, tempDir);
+
+    // Assert: same results as before the rewire
+    expect(result.success).toBe(true);
+    const positions = result.data as Array<{ position: number; taskId: string; branch?: string; prUrl?: string }>;
+    expect(positions).toHaveLength(2);
+    expect(positions[0]).toEqual(
+      expect.objectContaining({ position: 1, taskId: 't1', branch: 'feature/t1' }),
+    );
+    expect(positions[1]).toEqual(
+      expect.objectContaining({ position: 2, taskId: 't2', branch: 'feature/t2', prUrl: 'https://github.com/pr/2' }),
+    );
+  });
+
+  it('handleStackStatus_NoStreamId_ReturnsEmpty', async () => {
+    const result = await handleStackStatus({}, tempDir);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual([]);
+  });
+});
+
 // ─── EventStore Consolidation ────────────────────────────────────────────────
 
 describe('registerStackTools', () => {
@@ -304,9 +347,9 @@ describe('registerStackTools', () => {
     expect(events).toHaveLength(1);
   });
 
-  it('getStore should cache singleton when moduleEventStore is null', async () => {
-    // Without registration, the first handler call should cache a new EventStore
-    // and subsequent calls should reuse it (no orphan instances)
+  it('both handlers share the same EventStore via getOrCreateEventStore', async () => {
+    // Without registration, both handlers use getOrCreateEventStore which caches
+    // a singleton — events written by handleStackPlace should be visible to handleStackStatus
     const result1 = await handleStackPlace(
       { streamId: 'wf-cache-test', position: 1, taskId: 't1', branch: 'feat/t1' },
       tempDir,
@@ -319,7 +362,7 @@ describe('registerStackTools', () => {
     );
     expect(result2.success).toBe(true);
 
-    // Both events should be visible via status (same store instance)
+    // Both events should be visible via status (same cached store instance)
     const status = await handleStackStatus({ streamId: 'wf-cache-test' }, tempDir);
     expect(status.success).toBe(true);
     const positions = status.data as Array<{ position: number; taskId: string }>;

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/tools.test.ts
@@ -357,6 +357,119 @@ describe('handleViewTasks limit', () => {
   });
 });
 
+// ─── Task 002: handleViewTasks offset and fields projection ────────────────
+
+describe('handleViewTasks offset and fields', () => {
+  it('handleViewTasks_WithOffset_SkipsTasks', async () => {
+    // Arrange: create 3 tasks
+    await store.append('wf-offset', {
+      type: 'task.assigned',
+      data: { taskId: 't1', title: 'Task 1', branch: 'feat/t1' },
+    });
+    await store.append('wf-offset', {
+      type: 'task.assigned',
+      data: { taskId: 't2', title: 'Task 2', branch: 'feat/t2' },
+    });
+    await store.append('wf-offset', {
+      type: 'task.assigned',
+      data: { taskId: 't3', title: 'Task 3', branch: 'feat/t3' },
+    });
+
+    // Act: query with offset=1
+    const result = await handleViewTasks(
+      { workflowId: 'wf-offset', offset: 1 },
+      tempDir,
+    );
+
+    // Assert: should skip first, return 2
+    expect(result.success).toBe(true);
+    const data = result.data as Array<Record<string, unknown>>;
+    expect(data).toHaveLength(2);
+  });
+
+  it('handleViewTasks_WithFields_ReturnsOnlyRequestedFields', async () => {
+    // Arrange: create a task with multiple fields
+    await store.append('wf-fields', {
+      type: 'task.assigned',
+      data: { taskId: 't1', title: 'Task 1', branch: 'feat/t1', worktree: '/tmp/wt1' },
+    });
+
+    // Act: query with fields=["taskId", "status"]
+    const result = await handleViewTasks(
+      { workflowId: 'wf-fields', fields: ['taskId', 'status'] },
+      tempDir,
+    );
+
+    // Assert: each result should only have taskId and status keys
+    expect(result.success).toBe(true);
+    const data = result.data as Array<Record<string, unknown>>;
+    expect(data).toHaveLength(1);
+    const keys = Object.keys(data[0]);
+    expect(keys).toEqual(expect.arrayContaining(['taskId', 'status']));
+    expect(keys).toHaveLength(2);
+    expect(data[0].taskId).toBe('t1');
+    expect(data[0].status).toBe('assigned');
+  });
+
+  it('handleViewTasks_WithFieldsAndFilter_AppliesBoth', async () => {
+    // Arrange: create tasks with different statuses
+    await store.append('wf-ff', {
+      type: 'task.assigned',
+      data: { taskId: 't1', title: 'Task 1', branch: 'feat/t1' },
+    });
+    await store.append('wf-ff', {
+      type: 'task.assigned',
+      data: { taskId: 't2', title: 'Task 2', branch: 'feat/t2' },
+    });
+    await store.append('wf-ff', {
+      type: 'task.completed',
+      data: { taskId: 't1', artifacts: ['a.ts'], duration: 30 },
+    });
+
+    // Act: filter for completed, project to taskId + status
+    const result = await handleViewTasks(
+      { workflowId: 'wf-ff', filter: { status: 'completed' }, fields: ['taskId', 'status'] },
+      tempDir,
+    );
+
+    // Assert: only 1 completed task, only requested fields
+    expect(result.success).toBe(true);
+    const data = result.data as Array<Record<string, unknown>>;
+    expect(data).toHaveLength(1);
+    expect(data[0].taskId).toBe('t1');
+    expect(data[0].status).toBe('completed');
+    const keys = Object.keys(data[0]);
+    expect(keys).toHaveLength(2);
+  });
+
+  it('handleViewTasks_WithOffsetAndLimit_PaginatesCorrectly', async () => {
+    // Arrange: create 3 tasks
+    await store.append('wf-ol', {
+      type: 'task.assigned',
+      data: { taskId: 't1', title: 'Task 1', branch: 'feat/t1' },
+    });
+    await store.append('wf-ol', {
+      type: 'task.assigned',
+      data: { taskId: 't2', title: 'Task 2', branch: 'feat/t2' },
+    });
+    await store.append('wf-ol', {
+      type: 'task.assigned',
+      data: { taskId: 't3', title: 'Task 3', branch: 'feat/t3' },
+    });
+
+    // Act: offset=1, limit=1 — should return exactly the second task
+    const result = await handleViewTasks(
+      { workflowId: 'wf-ol', offset: 1, limit: 1 },
+      tempDir,
+    );
+
+    // Assert: exactly 1 task
+    expect(result.success).toBe(true);
+    const data = result.data as Array<Record<string, unknown>>;
+    expect(data).toHaveLength(1);
+  });
+});
+
 describe('handleViewPipeline', () => {
   it('should aggregate pipeline data across workflows', async () => {
     await populateWorkflow('wf-001');
@@ -393,6 +506,106 @@ describe('handleViewPipeline', () => {
     const data = result.data as Record<string, unknown>;
     const workflows = data.workflows as Array<Record<string, unknown>>;
     expect(workflows).toHaveLength(0);
+  });
+
+  it('handleViewPipeline_WithLimit_ReturnsLimitedWorkflows', async () => {
+    // Arrange: create 3 event streams
+    await store.append('wf-p1', {
+      type: 'workflow.started',
+      data: { featureId: 'feat-1', workflowType: 'feature' },
+    });
+    await store.append('wf-p2', {
+      type: 'workflow.started',
+      data: { featureId: 'feat-2', workflowType: 'feature' },
+    });
+    await store.append('wf-p3', {
+      type: 'workflow.started',
+      data: { featureId: 'feat-3', workflowType: 'debug' },
+    });
+
+    // Act: query with limit=2
+    const result = await handleViewPipeline({ limit: 2 }, tempDir);
+
+    // Assert
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const workflows = data.workflows as Array<Record<string, unknown>>;
+    expect(workflows).toHaveLength(2);
+  });
+
+  it('handleViewPipeline_WithOffset_SkipsWorkflows', async () => {
+    // Arrange: create 3 event streams
+    await store.append('wf-p1', {
+      type: 'workflow.started',
+      data: { featureId: 'feat-1', workflowType: 'feature' },
+    });
+    await store.append('wf-p2', {
+      type: 'workflow.started',
+      data: { featureId: 'feat-2', workflowType: 'feature' },
+    });
+    await store.append('wf-p3', {
+      type: 'workflow.started',
+      data: { featureId: 'feat-3', workflowType: 'debug' },
+    });
+
+    // Act: query with offset=1
+    const result = await handleViewPipeline({ offset: 1 }, tempDir);
+
+    // Assert: should skip first, return 2
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const workflows = data.workflows as Array<Record<string, unknown>>;
+    expect(workflows).toHaveLength(2);
+  });
+
+  it('handleViewPipeline_WithLimitAndOffset_ReturnsSlice', async () => {
+    // Arrange: create 3 event streams
+    await store.append('wf-p1', {
+      type: 'workflow.started',
+      data: { featureId: 'feat-1', workflowType: 'feature' },
+    });
+    await store.append('wf-p2', {
+      type: 'workflow.started',
+      data: { featureId: 'feat-2', workflowType: 'feature' },
+    });
+    await store.append('wf-p3', {
+      type: 'workflow.started',
+      data: { featureId: 'feat-3', workflowType: 'debug' },
+    });
+
+    // Act: query with limit=1, offset=1
+    const result = await handleViewPipeline({ limit: 1, offset: 1 }, tempDir);
+
+    // Assert: should return exactly 1 (the second workflow)
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const workflows = data.workflows as Array<Record<string, unknown>>;
+    expect(workflows).toHaveLength(1);
+  });
+
+  it('handleViewPipeline_NoParams_ReturnsAll', async () => {
+    // Arrange: create 3 event streams
+    await store.append('wf-p1', {
+      type: 'workflow.started',
+      data: { featureId: 'feat-1', workflowType: 'feature' },
+    });
+    await store.append('wf-p2', {
+      type: 'workflow.started',
+      data: { featureId: 'feat-2', workflowType: 'feature' },
+    });
+    await store.append('wf-p3', {
+      type: 'workflow.started',
+      data: { featureId: 'feat-3', workflowType: 'debug' },
+    });
+
+    // Act: query with no params (existing behavior)
+    const result = await handleViewPipeline({}, tempDir);
+
+    // Assert: all 3 returned
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const workflows = data.workflows as Array<Record<string, unknown>>;
+    expect(workflows).toHaveLength(3);
   });
 
   it('should return VIEW_ERROR when discovered stream has invalid ID', async () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/format.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/format.ts
@@ -51,3 +51,16 @@ export function stubResult() {
     error: { code: 'NOT_IMPLEMENTED', message: 'Coming soon' },
   });
 }
+
+// ─── Field Projection ──────────────────────────────────────────────────────
+
+/** Picks only the specified fields from an object, returning a partial copy. */
+export function pickFields<T extends Record<string, unknown>>(obj: T, fields: string[]): Partial<T> {
+  const result: Partial<T> = {};
+  for (const field of fields) {
+    if (field in obj) {
+      (result as Record<string, unknown>)[field] = obj[field];
+    }
+  }
+  return result;
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/stack/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/stack/tools.ts
@@ -2,33 +2,11 @@
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { EventStore } from '../event-store/store.js';
+import type { EventStore } from '../event-store/store.js';
 import { formatResult, toEventAck, type ToolResult } from '../format.js';
-
-// ─── Module-Level EventStore (injected via registerStackTools) ───────────────
-
-let moduleEventStore: EventStore | null = null;
-
-function getStore(stateDir: string): EventStore {
-  if (!moduleEventStore) {
-    moduleEventStore = new EventStore(stateDir);
-  }
-  return moduleEventStore;
-}
-
-/** For testing: reset the module-level EventStore */
-export function resetModuleEventStore(): void {
-  moduleEventStore = null;
-}
-
-// ─── Stack Position Type ───────────────────────────────────────────────────
-
-interface StackPosition {
-  position: number;
-  taskId: string;
-  branch?: string;
-  prUrl?: string;
-}
+import { getOrCreateMaterializer, getOrCreateEventStore } from '../views/tools.js';
+import { STACK_VIEW } from '../views/stack-view.js';
+import type { StackViewState } from '../views/stack-view.js';
 
 // ─── handleStackStatus ─────────────────────────────────────────────────────
 
@@ -42,27 +20,15 @@ export async function handleStackStatus(
     return { success: true, data: [] };
   }
 
-  const store = getStore(stateDir);
-
   try {
-    const events = await store.query(args.streamId, { type: 'stack.position-filled' });
+    const store = getOrCreateEventStore(stateDir);
+    const materializer = getOrCreateMaterializer(stateDir);
 
-    const positions: StackPosition[] = events.map((event) => {
-      const data = event.data as Record<string, unknown>;
-      const position: StackPosition = {
-        position: data.position as number,
-        taskId: data.taskId as string,
-      };
-      if (data.branch !== undefined) {
-        position.branch = data.branch as string;
-      }
-      if (data.prUrl !== undefined) {
-        position.prUrl = data.prUrl as string;
-      }
-      return position;
-    });
+    await materializer.loadFromSnapshot(args.streamId, STACK_VIEW);
+    const events = await store.query(args.streamId);
+    const view = materializer.materialize<StackViewState>(args.streamId, STACK_VIEW, events);
 
-    return { success: true, data: positions };
+    return { success: true, data: view.positions };
   } catch (err) {
     return {
       success: false,
@@ -107,7 +73,7 @@ export async function handleStackPlace(
     };
   }
 
-  const store = getStore(stateDir);
+  const store = getOrCreateEventStore(stateDir);
 
   const data: Record<string, unknown> = {
     position: args.position,
@@ -142,8 +108,7 @@ export async function handleStackPlace(
 
 // ─── Registration Function ──────────────────────────────────────────────────
 
-export function registerStackTools(server: McpServer, stateDir: string, eventStore: EventStore): void {
-  moduleEventStore = eventStore;
+export function registerStackTools(server: McpServer, stateDir: string, _eventStore: EventStore): void {
   server.tool(
     'exarchos_stack_status',
     'Get current stack positions from stack.position-filled events',

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/stack-view.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/stack-view.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ViewMaterializer } from './materializer.js';
+import {
+  stackViewProjection,
+  STACK_VIEW,
+} from './stack-view.js';
+import type { StackViewState } from './stack-view.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+
+function makeEvent(
+  seq: number,
+  type: string,
+  data?: Record<string, unknown>,
+  streamId = 'wf-001',
+): WorkflowEvent {
+  return {
+    streamId,
+    sequence: seq,
+    timestamp: new Date().toISOString(),
+    type,
+    schemaVersion: '1.0',
+    data,
+  };
+}
+
+describe('StackView', () => {
+  let materializer: ViewMaterializer;
+
+  beforeEach(() => {
+    materializer = new ViewMaterializer();
+    materializer.register(STACK_VIEW, stackViewProjection);
+  });
+
+  it('stackViewProjection_Init_ReturnsEmptyPositions', () => {
+    const view = materializer.materialize<StackViewState>(
+      'wf-001',
+      STACK_VIEW,
+      [],
+    );
+
+    expect(view.positions).toEqual([]);
+  });
+
+  it('stackViewProjection_Apply_StackPositionFilled_AddsPosition', () => {
+    const events = [
+      makeEvent(1, 'stack.position-filled', {
+        position: 1,
+        taskId: 't1',
+        branch: 'feat/t1',
+        prUrl: 'https://github.com/pr/1',
+      }),
+    ];
+
+    const view = materializer.materialize<StackViewState>(
+      'wf-001',
+      STACK_VIEW,
+      events,
+    );
+
+    expect(view.positions).toHaveLength(1);
+    expect(view.positions[0]).toEqual({
+      position: 1,
+      taskId: 't1',
+      branch: 'feat/t1',
+      prUrl: 'https://github.com/pr/1',
+    });
+  });
+
+  it('stackViewProjection_Apply_MultiplePositions_AccumulatesAll', () => {
+    const events = [
+      makeEvent(1, 'stack.position-filled', { position: 1, taskId: 't1', branch: 'feat/t1' }),
+      makeEvent(2, 'stack.position-filled', { position: 2, taskId: 't2', branch: 'feat/t2' }),
+      makeEvent(3, 'stack.position-filled', { position: 3, taskId: 't3' }),
+    ];
+
+    const view = materializer.materialize<StackViewState>(
+      'wf-001',
+      STACK_VIEW,
+      events,
+    );
+
+    expect(view.positions).toHaveLength(3);
+    expect(view.positions[0].position).toBe(1);
+    expect(view.positions[1].position).toBe(2);
+    expect(view.positions[2].position).toBe(3);
+    expect(view.positions[2].taskId).toBe('t3');
+  });
+
+  it('stackViewProjection_Apply_UnrelatedEvent_ReturnsUnchanged', () => {
+    const events = [
+      makeEvent(1, 'task.assigned', { taskId: 't1', title: 'Task 1' }),
+      makeEvent(2, 'task.completed', { taskId: 't1' }),
+    ];
+
+    const view = materializer.materialize<StackViewState>(
+      'wf-001',
+      STACK_VIEW,
+      events,
+    );
+
+    expect(view.positions).toEqual([]);
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/stack-view.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/stack-view.ts
@@ -1,0 +1,47 @@
+import type { ViewProjection } from './materializer.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+
+// ─── View Name Constant ────────────────────────────────────────────────────
+
+export const STACK_VIEW = 'stack';
+
+// ─── Stack Position ────────────────────────────────────────────────────────
+
+export interface StackPosition {
+  position: number;
+  taskId: string;
+  branch?: string;
+  prUrl?: string;
+}
+
+// ─── View State ────────────────────────────────────────────────────────────
+
+export interface StackViewState {
+  positions: StackPosition[];
+}
+
+// ─── Projection ────────────────────────────────────────────────────────────
+
+export const stackViewProjection: ViewProjection<StackViewState> = {
+  init: () => ({ positions: [] }),
+
+  apply: (view, event) => {
+    if (event.type !== 'stack.position-filled') return view;
+
+    const data = event.data as
+      | { position?: number; taskId?: string; branch?: string; prUrl?: string }
+      | undefined;
+
+    if (data?.position === undefined || !data?.taskId) return view;
+
+    const pos: StackPosition = {
+      position: data.position,
+      taskId: data.taskId,
+    };
+
+    if (data.branch !== undefined) pos.branch = data.branch;
+    if (data.prUrl !== undefined) pos.prUrl = data.prUrl;
+
+    return { positions: [...view.positions, pos] };
+  },
+};

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/tools.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { EventStore } from '../event-store/store.js';
-import { formatResult, type ToolResult } from '../format.js';
+import { formatResult, pickFields, type ToolResult } from '../format.js';
 import { ViewMaterializer } from './materializer.js';
 import { SnapshotStore } from './snapshot-store.js';
 import {
@@ -26,6 +26,10 @@ import {
   PIPELINE_VIEW,
 } from './pipeline-view.js';
 import type { PipelineViewState } from './pipeline-view.js';
+import {
+  stackViewProjection,
+  STACK_VIEW,
+} from './stack-view.js';
 
 // ─── Helper: create a materializer with all projections registered ─────────
 
@@ -36,6 +40,7 @@ function createMaterializer(stateDir: string): ViewMaterializer {
   materializer.register(TEAM_STATUS_VIEW, teamStatusProjection);
   materializer.register(TASK_DETAIL_VIEW, taskDetailProjection);
   materializer.register(PIPELINE_VIEW, pipelineProjection);
+  materializer.register(STACK_VIEW, stackViewProjection);
   return materializer;
 }
 
@@ -174,7 +179,13 @@ export async function handleViewTeamStatus(
 // ─── View Tasks Handler ────────────────────────────────────────────────────
 
 export async function handleViewTasks(
-  args: { workflowId?: string; filter?: Record<string, unknown>; limit?: number },
+  args: {
+    workflowId?: string;
+    filter?: Record<string, unknown>;
+    limit?: number;
+    offset?: number;
+    fields?: string[];
+  },
   stateDir: string,
 ): Promise<ToolResult> {
   try {
@@ -204,9 +215,22 @@ export async function handleViewTasks(
       });
     }
 
-    // Apply optional limit (after filter)
+    // Apply optional offset (before limit)
+    if (args.offset !== undefined) {
+      tasks = tasks.slice(args.offset);
+    }
+
+    // Apply optional limit (after filter and offset)
     if (args.limit !== undefined) {
       tasks = tasks.slice(0, args.limit);
+    }
+
+    // Apply optional fields projection
+    if (args.fields) {
+      const projected = tasks.map(
+        (t) => pickFields(t as unknown as Record<string, unknown>, args.fields!),
+      );
+      return { success: true, data: projected };
     }
 
     return { success: true, data: tasks };
@@ -224,7 +248,7 @@ export async function handleViewTasks(
 // ─── View Pipeline Handler ─────────────────────────────────────────────────
 
 export async function handleViewPipeline(
-  args: Record<string, unknown>,
+  args: { limit?: number; offset?: number },
   stateDir: string,
 ): Promise<ToolResult> {
   try {
@@ -246,7 +270,12 @@ export async function handleViewPipeline(
       workflows.push(view);
     }
 
-    return { success: true, data: { workflows } };
+    // Apply pagination
+    const start = args.offset ?? 0;
+    const end = args.limit !== undefined ? start + args.limit : undefined;
+    const paginated = workflows.slice(start, end);
+
+    return { success: true, data: { workflows: paginated } };
   } catch (err) {
     return {
       success: false,
@@ -265,17 +294,22 @@ export function registerViewTools(server: McpServer, stateDir: string, eventStor
   server.tool(
     'exarchos_view_pipeline',
     'Get CQRS pipeline view aggregating all workflows with stack positions and phase tracking',
-    {},
+    {
+      limit: z.number().int().positive().optional(),
+      offset: z.number().int().nonnegative().optional(),
+    },
     async (args) => formatResult(await handleViewPipeline(args, stateDir)),
   );
 
   server.tool(
     'exarchos_view_tasks',
-    'Get CQRS task detail view with optional filtering by workflowId and task properties, and optional limit',
+    'Get CQRS task detail view with optional filtering by workflowId and task properties, pagination, and field projection',
     {
       workflowId: z.string().optional(),
       filter: z.record(z.string(), z.unknown()).optional(),
       limit: z.number().int().positive().optional(),
+      offset: z.number().int().nonnegative().optional(),
+      fields: z.array(z.string()).optional(),
     },
     async (args) => formatResult(await handleViewTasks(args, stateDir)),
   );


### PR DESCRIPTION
Tasks 001, 002, 004, 005:
- handleViewPipeline: limit/offset pagination
- handleViewTasks: offset and fields projection via pickFields helper
- New StackView CQRS projection replaces inline event aggregation
- handleStackStatus rewired to use materializer