### PR TITLE
refactor: add team summary mode and shutdown events

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/team/coordinator.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/team/coordinator.test.ts
@@ -168,9 +168,81 @@ describe('TeamCoordinator shutdown', () => {
     // The coordinator emits an agent.message or we just verify it's gone
   });
 
+  it('shutdown emits agent.message shutdown event', async () => {
+    await coordinator.shutdown('agent-1', 'stream');
+
+    const events = await eventStore.query('stream', { type: 'agent.message' });
+    const shutdownEvents = events.filter(
+      (e) => (e.data as Record<string, unknown>)?.messageType === 'shutdown',
+    );
+    expect(shutdownEvents).toHaveLength(1);
+    expect(shutdownEvents[0].data).toEqual(
+      expect.objectContaining({
+        from: 'system',
+        to: 'agent-1',
+        content: 'shutdown',
+        messageType: 'shutdown',
+      }),
+    );
+  });
+
+  it('shutdownAll emits event for each teammate', async () => {
+    await coordinator.spawn('agent-3', ROLES.implementer, { taskId: 't3', title: 'Task 3' }, 'stream');
+
+    await coordinator.shutdownAll('stream');
+
+    const status = coordinator.getStatus();
+    expect(status.teammates).toHaveLength(0);
+    expect(status.activeCount).toBe(0);
+
+    const events = await eventStore.query('stream', { type: 'agent.message' });
+    const shutdownEvents = events.filter(
+      (e) => (e.data as Record<string, unknown>)?.messageType === 'shutdown',
+    );
+    expect(shutdownEvents).toHaveLength(3);
+    const targets = shutdownEvents.map(
+      (e) => (e.data as Record<string, unknown>)?.to,
+    );
+    expect(targets).toContain('agent-1');
+    expect(targets).toContain('agent-2');
+    expect(targets).toContain('agent-3');
+  });
+
+  it('shutdown non-existent member throws without emitting event', async () => {
+    await expect(
+      coordinator.shutdown('unknown-agent', 'stream'),
+    ).rejects.toThrow(/not found/i);
+
+    const events = await eventStore.query('stream', { type: 'agent.message' });
+    const shutdownEvents = events.filter(
+      (e) => (e.data as Record<string, unknown>)?.messageType === 'shutdown',
+    );
+    expect(shutdownEvents).toHaveLength(0);
+  });
+
   it('shutdownAll cleans up all teammates', async () => {
     await coordinator.shutdownAll('stream');
 
+    const status = coordinator.getStatus();
+    expect(status.teammates).toHaveLength(0);
+    expect(status.activeCount).toBe(0);
+  });
+
+  it('shutdownAll clears teammates even when eventStore.append throws', async () => {
+    let callCount = 0;
+    const originalAppend = eventStore.append.bind(eventStore);
+    vi.spyOn(eventStore, 'append').mockImplementation(async (...args) => {
+      callCount++;
+      if (callCount > 1) {
+        throw new Error('EventStore write failure');
+      }
+      return originalAppend(...args);
+    });
+
+    // shutdownAll should throw because append fails on second teammate
+    await expect(coordinator.shutdownAll('stream')).rejects.toThrow('EventStore write failure');
+
+    // But teammates map must still be cleared (try/finally guarantee)
     const status = coordinator.getStatus();
     expect(status.teammates).toHaveLength(0);
     expect(status.activeCount).toBe(0);

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/team/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/team/tools.test.ts
@@ -385,4 +385,56 @@ describe('handleTeamStatus', () => {
     expect(data.activeCount).toBe(2);
     expect(data.staleCount).toBe(0);
   });
+
+  it('summary=true returns counts only without teammates array', async () => {
+    await handleTeamSpawn(
+      { name: 'agent-1', role: 'implementer', taskId: 't1', taskTitle: 'Task 1', streamId: 'wf-001' },
+      tempDir,
+    );
+    await handleTeamSpawn(
+      { name: 'agent-2', role: 'reviewer', taskId: 't2', taskTitle: 'Task 2', streamId: 'wf-001' },
+      tempDir,
+    );
+
+    const result = await handleTeamStatus({ summary: true }, tempDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.activeCount).toBe(2);
+    expect(data.staleCount).toBe(0);
+    expect(data).not.toHaveProperty('teammates');
+  });
+
+  it('summary=false returns full teammates array', async () => {
+    await handleTeamSpawn(
+      { name: 'agent-1', role: 'implementer', taskId: 't1', taskTitle: 'Task 1', streamId: 'wf-001' },
+      tempDir,
+    );
+    await handleTeamSpawn(
+      { name: 'agent-2', role: 'reviewer', taskId: 't2', taskTitle: 'Task 2', streamId: 'wf-001' },
+      tempDir,
+    );
+
+    const result = await handleTeamStatus({ summary: false }, tempDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as { teammates: unknown[]; activeCount: number; staleCount: number };
+    expect(data.teammates).toHaveLength(2);
+    expect(data.activeCount).toBe(2);
+    expect(data.staleCount).toBe(0);
+  });
+
+  it('default (no summary param) returns full teammates array', async () => {
+    await handleTeamSpawn(
+      { name: 'agent-1', role: 'implementer', taskId: 't1', taskTitle: 'Task 1', streamId: 'wf-001' },
+      tempDir,
+    );
+
+    const result = await handleTeamStatus({}, tempDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as { teammates: unknown[]; activeCount: number };
+    expect(data.teammates).toHaveLength(1);
+    expect(data).toHaveProperty('teammates');
+  });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/team/coordinator.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/team/coordinator.ts
@@ -125,16 +125,36 @@ export class TeamCoordinator {
     });
   }
 
-  async shutdown(name: string, _streamId?: string): Promise<void> {
+  async shutdown(name: string, streamId?: string): Promise<void> {
     if (!this.teammates.has(name)) {
       throw new Error(`Teammate '${name}' not found`);
+    }
+
+    if (streamId) {
+      await this.eventStore.append(streamId, {
+        type: 'agent.message',
+        data: { from: 'system', to: name, content: 'shutdown', messageType: 'shutdown' },
+        agentId: 'system',
+      });
     }
 
     this.teammates.delete(name);
   }
 
-  async shutdownAll(_streamId?: string): Promise<void> {
-    this.teammates.clear();
+  async shutdownAll(streamId?: string): Promise<void> {
+    try {
+      if (streamId) {
+        for (const [name] of this.teammates) {
+          await this.eventStore.append(streamId, {
+            type: 'agent.message',
+            data: { from: 'system', to: name, content: 'shutdown', messageType: 'shutdown' },
+            agentId: 'system',
+          });
+        }
+      }
+    } finally {
+      this.teammates.clear();
+    }
   }
 
   checkHealth(staleAfterMinutes: number = 30): TeammateInfo[] {

--- a/plugins/exarchos/servers/exarchos-mcp/src/team/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/team/tools.ts
@@ -273,13 +273,16 @@ export async function handleTeamShutdown(
 // ─── handleTeamStatus ─────────────────────────────────────────────────────
 
 export async function handleTeamStatus(
-  args: Record<string, unknown>,
+  args: { summary?: boolean },
   stateDir: string,
 ): Promise<ToolResult> {
   const coordinator = getCoordinator(stateDir);
 
   try {
     const status = coordinator.getStatus();
+    if (args.summary) {
+      return { success: true, data: { activeCount: status.activeCount, staleCount: status.staleCount } };
+    }
     return { success: true, data: status };
   } catch (err) {
     return {
@@ -347,7 +350,9 @@ export function registerTeamTools(server: McpServer, stateDir: string, eventStor
   server.tool(
     'exarchos_team_status',
     'Get status of all team members with health information',
-    {},
+    {
+      summary: z.boolean().optional().describe('When true, returns only activeCount and staleCount without full teammate details'),
+    },
     async (args) => formatResult(await handleTeamStatus(args, stateDir)),
   );
 }


### PR DESCRIPTION
Tasks 003, 009:
- handleTeamStatus: summary=true returns counts only
- TeamCoordinator shutdown/shutdownAll emit agent.message events