### PR TITLE
refactor: streaming EventStore query and event field projection

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/tools.test.ts
@@ -320,6 +320,132 @@ describe('handleEventQuery Pagination', () => {
   });
 });
 
+// ─── handleEventQuery Fields Projection ──────────────────────────────────────
+
+describe('handleEventQuery Fields Projection', () => {
+  it('handleEventQuery_WithFields_ReturnsOnlyRequestedFields', async () => {
+    await handleEventAppend(
+      {
+        stream: 'my-workflow',
+        event: {
+          type: 'workflow.started',
+          data: { featureId: 'test' },
+          correlationId: 'corr-1',
+          agentId: 'agent-1',
+        },
+      },
+      tempDir,
+    );
+
+    const result = await handleEventQuery(
+      { stream: 'my-workflow', fields: ['type', 'sequence'] },
+      tempDir,
+    );
+    expect(result.success).toBe(true);
+    const events = result.data as Record<string, unknown>[];
+    expect(events).toHaveLength(1);
+
+    // Only requested fields should be present
+    const keys = Object.keys(events[0]).sort();
+    expect(keys).toEqual(['sequence', 'type']);
+    expect(events[0].type).toBe('workflow.started');
+    expect(events[0].sequence).toBe(1);
+  });
+
+  it('handleEventQuery_WithFieldsTypeTimestamp_ReturnsMinimalEvents', async () => {
+    await handleEventAppend(
+      {
+        stream: 'my-workflow',
+        event: {
+          type: 'workflow.started',
+          data: { featureId: 'test' },
+          agentId: 'agent-1',
+        },
+      },
+      tempDir,
+    );
+    await handleEventAppend(
+      {
+        stream: 'my-workflow',
+        event: {
+          type: 'team.formed',
+          data: { teamId: 'team-1' },
+        },
+      },
+      tempDir,
+    );
+
+    const result = await handleEventQuery(
+      { stream: 'my-workflow', fields: ['type', 'timestamp'] },
+      tempDir,
+    );
+    expect(result.success).toBe(true);
+    const events = result.data as Record<string, unknown>[];
+    expect(events).toHaveLength(2);
+
+    for (const event of events) {
+      const keys = Object.keys(event).sort();
+      expect(keys).toEqual(['timestamp', 'type']);
+      expect(event).not.toHaveProperty('sequence');
+      expect(event).not.toHaveProperty('streamId');
+      expect(event).not.toHaveProperty('data');
+      expect(event).not.toHaveProperty('agentId');
+    }
+  });
+
+  it('handleEventQuery_WithoutFields_ReturnsFullEvents', async () => {
+    await handleEventAppend(
+      {
+        stream: 'my-workflow',
+        event: {
+          type: 'workflow.started',
+          data: { featureId: 'test' },
+          correlationId: 'corr-1',
+        },
+      },
+      tempDir,
+    );
+
+    const result = await handleEventQuery(
+      { stream: 'my-workflow' },
+      tempDir,
+    );
+    expect(result.success).toBe(true);
+    const events = result.data as Record<string, unknown>[];
+    expect(events).toHaveLength(1);
+
+    // Full events should have standard fields
+    expect(events[0]).toHaveProperty('type');
+    expect(events[0]).toHaveProperty('sequence');
+    expect(events[0]).toHaveProperty('streamId');
+    expect(events[0]).toHaveProperty('timestamp');
+    expect(events[0]).toHaveProperty('data');
+    expect(events[0]).toHaveProperty('correlationId');
+  });
+
+  it('handleEventQuery_WithFieldsAndNonexistentField_SkipsMissingFields', async () => {
+    await handleEventAppend(
+      {
+        stream: 'my-workflow',
+        event: { type: 'workflow.started' },
+      },
+      tempDir,
+    );
+
+    const result = await handleEventQuery(
+      { stream: 'my-workflow', fields: ['type', 'nonexistent'] },
+      tempDir,
+    );
+    expect(result.success).toBe(true);
+    const events = result.data as Record<string, unknown>[];
+    expect(events).toHaveLength(1);
+
+    // Only 'type' should be present; 'nonexistent' is skipped
+    const keys = Object.keys(events[0]);
+    expect(keys).toEqual(['type']);
+  });
+});
+
 // ─── EventStore Consolidation ────────────────────────────────────────────────
 
 describe('registerEventTools', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.test.ts
@@ -384,6 +384,95 @@ describe('EventStore Query Pagination', () => {
   });
 });
 
+// ─── Streaming Query Optimization ───────────────────────────────────────────
+
+describe('EventStore Streaming Query', () => {
+  it('query_WithSinceSequence_ReturnsOnlyLaterEvents', async () => {
+    const store = new EventStore(tempDir);
+    for (let i = 0; i < 10; i++) {
+      await store.append('my-workflow', { type: 'task.assigned' });
+    }
+
+    const events = await store.query('my-workflow', { sinceSequence: 7 });
+    expect(events).toHaveLength(3);
+    expect(events[0].sequence).toBe(8);
+    expect(events[1].sequence).toBe(9);
+    expect(events[2].sequence).toBe(10);
+  });
+
+  it('query_WithSinceSequenceAndLimit_CombinesFilters', async () => {
+    const store = new EventStore(tempDir);
+    for (let i = 0; i < 10; i++) {
+      await store.append('my-workflow', { type: 'task.assigned' });
+    }
+
+    const events = await store.query('my-workflow', { sinceSequence: 5, limit: 2 });
+    expect(events).toHaveLength(2);
+    expect(events[0].sequence).toBe(6);
+    expect(events[1].sequence).toBe(7);
+  });
+
+  it('query_WithTypeFilterAndLimit_CombinesCorrectly', async () => {
+    const store = new EventStore(tempDir);
+    // Append mixed types
+    await store.append('my-workflow', { type: 'workflow.started' });
+    await store.append('my-workflow', { type: 'task.assigned' });
+    await store.append('my-workflow', { type: 'workflow.started' });
+    await store.append('my-workflow', { type: 'task.assigned' });
+    await store.append('my-workflow', { type: 'workflow.started' });
+    await store.append('my-workflow', { type: 'task.assigned' });
+
+    const events = await store.query('my-workflow', { type: 'task.assigned', limit: 2 });
+    expect(events).toHaveLength(2);
+    expect(events.every(e => e.type === 'task.assigned')).toBe(true);
+    expect(events[0].sequence).toBe(2);
+    expect(events[1].sequence).toBe(4);
+  });
+
+  it('query_WithSinceSequenceAndTypeAndLimit_CombinesAllFilters', async () => {
+    const store = new EventStore(tempDir);
+    await store.append('my-workflow', { type: 'workflow.started' });
+    await store.append('my-workflow', { type: 'task.assigned' });
+    await store.append('my-workflow', { type: 'workflow.started' });
+    await store.append('my-workflow', { type: 'task.assigned' });
+    await store.append('my-workflow', { type: 'workflow.started' });
+    await store.append('my-workflow', { type: 'task.assigned' });
+
+    // sinceSequence=3 means events 4,5,6; type=task.assigned filters to 4,6; limit=1 gives only 4
+    const events = await store.query('my-workflow', {
+      sinceSequence: 3,
+      type: 'task.assigned',
+      limit: 1,
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].sequence).toBe(4);
+    expect(events[0].type).toBe('task.assigned');
+  });
+
+  it('query_WithOffsetAndLimit_InStreamingMode', async () => {
+    const store = new EventStore(tempDir);
+    for (let i = 0; i < 10; i++) {
+      await store.append('my-workflow', { type: 'task.assigned' });
+    }
+
+    // offset=3, limit=2 should return events at positions 4 and 5 (sequences 4,5)
+    const events = await store.query('my-workflow', { offset: 3, limit: 2 });
+    expect(events).toHaveLength(2);
+    expect(events[0].sequence).toBe(4);
+    expect(events[1].sequence).toBe(5);
+  });
+
+  it('query_EmptyFile_ReturnsEmpty', async () => {
+    const store = new EventStore(tempDir);
+    // Create an empty JSONL file
+    const filePath = path.join(tempDir, 'empty-stream.events.jsonl');
+    await fs.writeFile(filePath, '', 'utf-8');
+
+    const events = await store.query('empty-stream');
+    expect(events).toEqual([]);
+  });
+});
+
 // ─── B1: Persist Sequence Counters ──────────────────────────────────────────
 
 describe('EventStore Sequence Persistence', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
@@ -1,4 +1,6 @@
 import * as fs from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
 import * as path from 'node:path';
 import { WorkflowEventBase } from './schemas.js';
 import type { WorkflowEvent } from './schemas.js';
@@ -45,18 +47,6 @@ function validateStreamId(streamId: string): void {
       `Invalid streamId "${streamId}": must match ${SAFE_STREAM_ID_PATTERN} (lowercase alphanumeric and hyphens only)`,
     );
   }
-}
-
-// ─── Pagination Helper ──────────────────────────────────────────────────────
-
-/**
- * Applies offset/limit pagination to an array of items.
- * Called after filtering; values are pre-validated by Zod schemas at the tool boundary.
- */
-function applyPagination<T>(items: T[], offset?: number, limit?: number): T[] {
-  const start = offset ?? 0;
-  const end = limit !== undefined ? start + limit : undefined;
-  return items.slice(start, end);
 }
 
 // ─── Event Store ────────────────────────────────────────────────────────────
@@ -156,37 +146,47 @@ export class EventStore {
   async query(streamId: string, filters?: QueryFilters): Promise<WorkflowEvent[]> {
     const filePath = this.getEventFilePath(streamId);
 
-    let content: string;
+    // Check if file exists
     try {
-      content = await fs.readFile(filePath, 'utf-8');
+      await fs.access(filePath);
     } catch {
       return [];
     }
 
-    const lines = content.trim().split('\n').filter(Boolean);
-    let events: WorkflowEvent[] = lines.map((line) => JSON.parse(line) as WorkflowEvent);
+    const events: WorkflowEvent[] = [];
+    const input = createReadStream(filePath, { encoding: 'utf-8' });
+    const rl = createInterface({ input, crlfDelay: Infinity });
 
-    if (!filters) {
-      return events;
+    let skipped = 0;
+    const offset = filters?.offset ?? 0;
+    const limit = filters?.limit;
+
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+
+      const event = JSON.parse(line) as WorkflowEvent;
+
+      // Apply filters
+      if (filters?.sinceSequence !== undefined && event.sequence <= filters.sinceSequence) continue;
+      if (filters?.type && event.type !== filters.type) continue;
+      if (filters?.since && event.timestamp < filters.since) continue;
+      if (filters?.until && event.timestamp > filters.until) continue;
+
+      // Apply offset
+      if (skipped < offset) {
+        skipped++;
+        continue;
+      }
+
+      events.push(event);
+
+      // Early termination on limit
+      if (limit !== undefined && events.length >= limit) {
+        rl.close();
+        input.destroy();
+        break;
+      }
     }
-
-    if (filters.type) {
-      events = events.filter((e) => e.type === filters.type);
-    }
-
-    if (filters.sinceSequence !== undefined) {
-      events = events.filter((e) => e.sequence > filters.sinceSequence!);
-    }
-
-    if (filters.since) {
-      events = events.filter((e) => e.timestamp >= filters.since!);
-    }
-
-    if (filters.until) {
-      events = events.filter((e) => e.timestamp <= filters.until!);
-    }
-
-    events = applyPagination(events, filters.offset, filters.limit);
 
     return events;
   }

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as path from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { EventStore } from './store.js';
+import { handleEventQuery, resetModuleEventStore } from './tools.js';
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(path.join(tmpdir(), 'event-tools-test-'));
+  resetModuleEventStore();
+});
+
+afterEach(async () => {
+  resetModuleEventStore();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+// ─── Prototype Pollution Prevention ─────────────────────────────────────────
+
+describe('handleEventQuery field projection', () => {
+  it('should filter out __proto__ from fields', async () => {
+    const store = new EventStore(tempDir);
+    await store.append('my-workflow', { type: 'workflow.started', data: { foo: 'bar' } });
+
+    const result = await handleEventQuery(
+      { stream: 'my-workflow', fields: ['type', '__proto__', 'sequence'] },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    const projected = result.data as Record<string, unknown>[];
+    expect(projected).toHaveLength(1);
+    expect(projected[0]).toHaveProperty('type', 'workflow.started');
+    expect(projected[0]).toHaveProperty('sequence', 1);
+    expect(projected[0]).not.toHaveProperty('__proto__');
+  });
+
+  it('should filter out constructor from fields', async () => {
+    const store = new EventStore(tempDir);
+    await store.append('my-workflow', { type: 'workflow.started' });
+
+    const result = await handleEventQuery(
+      { stream: 'my-workflow', fields: ['type', 'constructor'] },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    const projected = result.data as Record<string, unknown>[];
+    expect(projected).toHaveLength(1);
+    expect(projected[0]).toHaveProperty('type', 'workflow.started');
+    expect(projected[0]).not.toHaveProperty('constructor');
+  });
+
+  it('should filter out prototype from fields', async () => {
+    const store = new EventStore(tempDir);
+    await store.append('my-workflow', { type: 'workflow.started' });
+
+    const result = await handleEventQuery(
+      { stream: 'my-workflow', fields: ['type', 'prototype'] },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    const projected = result.data as Record<string, unknown>[];
+    expect(projected).toHaveLength(1);
+    expect(projected[0]).toHaveProperty('type', 'workflow.started');
+    expect(projected[0]).not.toHaveProperty('prototype');
+  });
+
+  it('should return empty projection when all fields are unsafe', async () => {
+    const store = new EventStore(tempDir);
+    await store.append('my-workflow', { type: 'workflow.started' });
+
+    const result = await handleEventQuery(
+      { stream: 'my-workflow', fields: ['__proto__', 'constructor', 'prototype'] },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    const projected = result.data as Record<string, unknown>[];
+    expect(projected).toHaveLength(1);
+    expect(Object.keys(projected[0])).toHaveLength(0);
+  });
+
+  it('should allow safe fields through', async () => {
+    const store = new EventStore(tempDir);
+    await store.append('my-workflow', {
+      type: 'workflow.started',
+      data: { featureId: 'test' },
+    });
+
+    const result = await handleEventQuery(
+      { stream: 'my-workflow', fields: ['type', 'sequence', 'streamId', 'timestamp'] },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    const projected = result.data as Record<string, unknown>[];
+    expect(projected).toHaveLength(1);
+    expect(projected[0]).toHaveProperty('type');
+    expect(projected[0]).toHaveProperty('sequence');
+    expect(projected[0]).toHaveProperty('streamId');
+    expect(projected[0]).toHaveProperty('timestamp');
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { EventStore, SequenceConflictError } from './store.js';
 import type { EventType } from './schemas.js';
-import { formatResult, toEventAck, type ToolResult } from '../format.js';
+import { formatResult, pickFields, toEventAck, type ToolResult } from '../format.js';
 
 // ─── Module-Level EventStore (injected via registerEventTools) ───────────────
 
@@ -97,6 +97,7 @@ export async function handleEventQuery(
     filter?: Record<string, unknown>;
     limit?: number;
     offset?: number;
+    fields?: string[];
   },
   stateDir: string,
 ): Promise<ToolResult> {
@@ -123,6 +124,18 @@ export async function handleEventQuery(
 
   try {
     const events = await store.query(args.stream, filters);
+
+    // Apply field projection if requested
+    if (args.fields && args.fields.length > 0) {
+      const safeFields = args.fields.filter(
+        (field) => !['__proto__', 'constructor', 'prototype'].includes(field),
+      );
+      const projected = events.map((event) =>
+        pickFields(event as unknown as Record<string, unknown>, safeFields),
+      );
+      return { success: true, data: projected };
+    }
+
     return { success: true, data: events };
   } catch (err) {
     return {
@@ -152,12 +165,13 @@ export function registerEventTools(server: McpServer, stateDir: string, eventSto
 
   server.tool(
     'exarchos_event_query',
-    'Query events from the event store with optional filters (type, sinceSequence, since, until) and pagination (limit, offset)',
+    'Query events from the event store with optional filters (type, sinceSequence, since, until), pagination (limit, offset), and field projection (fields)',
     {
       stream: z.string().min(1),
       filter: z.record(z.string(), z.unknown()).optional(),
       limit: z.number().int().positive().optional(),
       offset: z.number().int().nonnegative().optional(),
+      fields: z.array(z.string()).optional(),
     },
     async (args) => formatResult(await handleEventQuery(args, stateDir)),
   );


### PR DESCRIPTION
Tasks 006, 010:
- EventStore.query() uses readline streaming with early termination
- handleEventQuery: fields param for field projection