### PR TITLE
refactor: add LRU eviction to ViewMaterializer cache

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/views/materializer.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/materializer.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ViewMaterializer, type ViewProjection } from './materializer.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+
+// ─── Test Helpers ──────────────────────────────────────────────────────────
+
+/** Simple counter projection for testing. */
+const counterProjection: ViewProjection<number> = {
+  init: () => 0,
+  apply: (view: number, _event: WorkflowEvent) => view + 1,
+};
+
+/** Create a minimal WorkflowEvent with a given sequence number. */
+function makeEvent(sequence: number, streamId = 'stream-1'): WorkflowEvent {
+  return {
+    streamId,
+    sequence,
+    timestamp: new Date().toISOString(),
+    type: 'workflow.started',
+    schemaVersion: '1.0',
+    data: {},
+  } as WorkflowEvent;
+}
+
+// ─── LRU Eviction Tests ───────────────────────────────────────────────────
+
+describe('ViewMaterializer LRU Eviction', () => {
+  const VIEW_NAME = 'counter';
+
+  describe('materialize_ExceedsMaxCacheSize_EvictsLeastRecentlyUsed', () => {
+    it('should evict the least recently used entry when cache exceeds maxCacheEntries', () => {
+      const materializer = new ViewMaterializer({ maxCacheEntries: 3 });
+      materializer.register(VIEW_NAME, counterProjection);
+
+      // Materialize 4 different streams — cache limit is 3
+      materializer.materialize('stream-a', VIEW_NAME, [makeEvent(1, 'stream-a')]);
+      materializer.materialize('stream-b', VIEW_NAME, [makeEvent(1, 'stream-b')]);
+      materializer.materialize('stream-c', VIEW_NAME, [makeEvent(1, 'stream-c')]);
+      materializer.materialize('stream-d', VIEW_NAME, [makeEvent(1, 'stream-d')]);
+
+      // stream-a should have been evicted (LRU — first inserted, never re-accessed)
+      expect(materializer.getState('stream-a', VIEW_NAME)).toBeUndefined();
+
+      // stream-b, stream-c, stream-d should still be present
+      expect(materializer.getState('stream-b', VIEW_NAME)).toBeDefined();
+      expect(materializer.getState('stream-c', VIEW_NAME)).toBeDefined();
+      expect(materializer.getState('stream-d', VIEW_NAME)).toBeDefined();
+    });
+  });
+
+  describe('materialize_WithinMaxCacheSize_KeepsAllEntries', () => {
+    it('should keep all entries when cache is within maxCacheEntries limit', () => {
+      const materializer = new ViewMaterializer({ maxCacheEntries: 5 });
+      materializer.register(VIEW_NAME, counterProjection);
+
+      materializer.materialize('stream-a', VIEW_NAME, [makeEvent(1, 'stream-a')]);
+      materializer.materialize('stream-b', VIEW_NAME, [makeEvent(1, 'stream-b')]);
+      materializer.materialize('stream-c', VIEW_NAME, [makeEvent(1, 'stream-c')]);
+
+      // All 3 should be present (cache limit is 5)
+      expect(materializer.getState('stream-a', VIEW_NAME)).toBeDefined();
+      expect(materializer.getState('stream-b', VIEW_NAME)).toBeDefined();
+      expect(materializer.getState('stream-c', VIEW_NAME)).toBeDefined();
+    });
+  });
+
+  describe('materialize_AfterEviction_ReinitializesFromProjection', () => {
+    it('should rebuild view from scratch when re-materializing an evicted entry', () => {
+      const materializer = new ViewMaterializer({ maxCacheEntries: 2 });
+      materializer.register(VIEW_NAME, counterProjection);
+
+      // Materialize stream-a with 2 events (counter = 2)
+      materializer.materialize('stream-a', VIEW_NAME, [
+        makeEvent(1, 'stream-a'),
+        makeEvent(2, 'stream-a'),
+      ]);
+
+      // Fill cache to evict stream-a
+      materializer.materialize('stream-b', VIEW_NAME, [makeEvent(1, 'stream-b')]);
+      materializer.materialize('stream-c', VIEW_NAME, [makeEvent(1, 'stream-c')]);
+
+      // stream-a should be evicted
+      expect(materializer.getState('stream-a', VIEW_NAME)).toBeUndefined();
+
+      // Re-materialize stream-a with same events — should rebuild from init()
+      const result = materializer.materialize<number>('stream-a', VIEW_NAME, [
+        makeEvent(1, 'stream-a'),
+        makeEvent(2, 'stream-a'),
+      ]);
+
+      // Counter should be 2 (rebuilt from scratch: init=0, +1, +1)
+      expect(result).toBe(2);
+      expect(materializer.getState<number>('stream-a', VIEW_NAME)?.view).toBe(2);
+    });
+  });
+
+  describe('materialize_AccessRefreshesLRUOrder', () => {
+    it('should evict the correct entry based on LRU order after access refresh', () => {
+      const materializer = new ViewMaterializer({ maxCacheEntries: 3 });
+      materializer.register(VIEW_NAME, counterProjection);
+
+      // Materialize A, B, C (in that insertion order)
+      materializer.materialize('stream-a', VIEW_NAME, [makeEvent(1, 'stream-a')]);
+      materializer.materialize('stream-b', VIEW_NAME, [makeEvent(1, 'stream-b')]);
+      materializer.materialize('stream-c', VIEW_NAME, [makeEvent(1, 'stream-c')]);
+
+      // Re-access A by materializing with a new event — this should move A to most-recent
+      materializer.materialize('stream-a', VIEW_NAME, [
+        makeEvent(1, 'stream-a'),
+        makeEvent(2, 'stream-a'),
+      ]);
+
+      // Now add D — should evict B (the actual LRU), not A
+      materializer.materialize('stream-d', VIEW_NAME, [makeEvent(1, 'stream-d')]);
+
+      // B should be evicted (LRU after A was refreshed)
+      expect(materializer.getState('stream-b', VIEW_NAME)).toBeUndefined();
+
+      // A, C, D should still be present
+      expect(materializer.getState('stream-a', VIEW_NAME)).toBeDefined();
+      expect(materializer.getState('stream-c', VIEW_NAME)).toBeDefined();
+      expect(materializer.getState('stream-d', VIEW_NAME)).toBeDefined();
+    });
+  });
+
+  describe('getState_AccessRefreshesLRUOrder', () => {
+    it('should refresh LRU order when getState is called', () => {
+      const materializer = new ViewMaterializer({ maxCacheEntries: 3 });
+      materializer.register(VIEW_NAME, counterProjection);
+
+      // Materialize A, B, C
+      materializer.materialize('stream-a', VIEW_NAME, [makeEvent(1, 'stream-a')]);
+      materializer.materialize('stream-b', VIEW_NAME, [makeEvent(1, 'stream-b')]);
+      materializer.materialize('stream-c', VIEW_NAME, [makeEvent(1, 'stream-c')]);
+
+      // Read A via getState — should refresh its LRU position
+      materializer.getState('stream-a', VIEW_NAME);
+
+      // Add D — should evict B (not A, since A was just accessed)
+      materializer.materialize('stream-d', VIEW_NAME, [makeEvent(1, 'stream-d')]);
+
+      expect(materializer.getState('stream-b', VIEW_NAME)).toBeUndefined();
+      expect(materializer.getState('stream-a', VIEW_NAME)).toBeDefined();
+      expect(materializer.getState('stream-c', VIEW_NAME)).toBeDefined();
+      expect(materializer.getState('stream-d', VIEW_NAME)).toBeDefined();
+    });
+  });
+
+  describe('loadState_ExceedsCacheCap_EvictsToWithinLimit', () => {
+    it('should evict entries when loadState exceeds cache cap', () => {
+      const materializer = new ViewMaterializer({ maxCacheEntries: 2 });
+      materializer.register(VIEW_NAME, counterProjection);
+
+      // Load 4 states via loadState — cache limit is 2
+      materializer.loadState('stream-a', VIEW_NAME, 1, 1);
+      materializer.loadState('stream-b', VIEW_NAME, 2, 1);
+      materializer.loadState('stream-c', VIEW_NAME, 3, 1);
+      materializer.loadState('stream-d', VIEW_NAME, 4, 1);
+
+      // Only 2 entries should remain (the most recently loaded)
+      expect(materializer.getState('stream-a', VIEW_NAME)).toBeUndefined();
+      expect(materializer.getState('stream-b', VIEW_NAME)).toBeUndefined();
+      expect(materializer.getState('stream-c', VIEW_NAME)).toBeDefined();
+      expect(materializer.getState('stream-d', VIEW_NAME)).toBeDefined();
+    });
+  });
+
+  describe('loadFromSnapshot_ExceedsCacheCap_EvictsToWithinLimit', () => {
+    it('should evict entries when loadFromSnapshot exceeds cache cap', async () => {
+      const mockSnapshotStore = {
+        save: async () => {},
+        load: async (_streamId: string, _viewName: string) => ({
+          view: 42,
+          highWaterMark: 10,
+        }),
+        delete: async () => {},
+      };
+      const materializer = new ViewMaterializer({
+        maxCacheEntries: 2,
+        snapshotStore: mockSnapshotStore,
+      });
+      materializer.register(VIEW_NAME, counterProjection);
+
+      // Load 3 snapshots — cache limit is 2
+      await materializer.loadFromSnapshot('stream-a', VIEW_NAME);
+      await materializer.loadFromSnapshot('stream-b', VIEW_NAME);
+      await materializer.loadFromSnapshot('stream-c', VIEW_NAME);
+
+      // Only 2 entries should remain
+      expect(materializer.getState('stream-a', VIEW_NAME)).toBeUndefined();
+      expect(materializer.getState('stream-b', VIEW_NAME)).toBeDefined();
+      expect(materializer.getState('stream-c', VIEW_NAME)).toBeDefined();
+    });
+  });
+
+  describe('evictIfNeeded_DrainsMultipleExcessEntries', () => {
+    it('should drain all excess entries with while loop, not just one', () => {
+      const materializer = new ViewMaterializer({ maxCacheEntries: 2 });
+      materializer.register(VIEW_NAME, counterProjection);
+
+      // Pre-load 4 entries via loadState (bypasses eviction in current code)
+      materializer.loadState('stream-a', VIEW_NAME, 1, 1);
+      materializer.loadState('stream-b', VIEW_NAME, 2, 1);
+      materializer.loadState('stream-c', VIEW_NAME, 3, 1);
+      materializer.loadState('stream-d', VIEW_NAME, 4, 1);
+
+      // Now materialize a 5th — this triggers evictIfNeeded via materialize
+      // With an `if` (single eviction), cache would still be 4 after removing 1 = 4
+      // With a `while` loop, it should drain down to maxCacheEntries = 2
+      materializer.materialize('stream-e', VIEW_NAME, [makeEvent(1, 'stream-e')]);
+
+      // Only the 2 most recent should remain: stream-d (LRU refreshed last via loadState)
+      // and stream-e (just materialized). All others should be evicted.
+      expect(materializer.getState('stream-a', VIEW_NAME)).toBeUndefined();
+      expect(materializer.getState('stream-b', VIEW_NAME)).toBeUndefined();
+      expect(materializer.getState('stream-c', VIEW_NAME)).toBeUndefined();
+      expect(materializer.getState('stream-d', VIEW_NAME)).toBeDefined();
+      expect(materializer.getState('stream-e', VIEW_NAME)).toBeDefined();
+    });
+  });
+
+  describe('materialize_DefaultMaxCacheEntries_Is100', () => {
+    it('should default to 100 max cache entries when not specified', () => {
+      const materializer = new ViewMaterializer();
+      materializer.register(VIEW_NAME, counterProjection);
+
+      // Materialize 101 streams — cache limit should be 100
+      for (let i = 1; i <= 101; i++) {
+        materializer.materialize(`stream-${i}`, VIEW_NAME, [
+          makeEvent(1, `stream-${i}`),
+        ]);
+      }
+
+      // stream-1 should have been evicted (LRU) when stream-101 was added
+      expect(materializer.getState('stream-1', VIEW_NAME)).toBeUndefined();
+
+      // stream-2 through stream-101 should still be present
+      expect(materializer.getState('stream-2', VIEW_NAME)).toBeDefined();
+      expect(materializer.getState('stream-101', VIEW_NAME)).toBeDefined();
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/materializer.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/materializer.ts
@@ -22,11 +22,13 @@ interface ViewState<T = unknown> {
 export interface MaterializerOptions {
   readonly snapshotStore?: SnapshotStore;
   readonly snapshotInterval?: number;
+  readonly maxCacheEntries?: number;
 }
 
 // ─── Default Snapshot Interval ─────────────────────────────────────────────
 
 const DEFAULT_SNAPSHOT_INTERVAL = 50;
+const DEFAULT_MAX_CACHE_ENTRIES = 100;
 
 // ─── View Materializer ─────────────────────────────────────────────────────
 
@@ -39,10 +41,12 @@ export class ViewMaterializer {
 
   private readonly snapshotStore?: SnapshotStore;
   private readonly snapshotInterval: number;
+  private readonly maxCacheEntries: number;
 
   constructor(options?: MaterializerOptions) {
     this.snapshotStore = options?.snapshotStore;
     this.snapshotInterval = options?.snapshotInterval ?? DEFAULT_SNAPSHOT_INTERVAL;
+    this.maxCacheEntries = options?.maxCacheEntries ?? DEFAULT_MAX_CACHE_ENTRIES;
   }
 
   /**
@@ -91,7 +95,12 @@ export class ViewMaterializer {
       highWaterMark: maxSequence,
     };
 
+    // LRU: delete and re-insert to move to end (most recently used)
+    this.states.delete(stateKey);
     this.states.set(stateKey, updatedState as ViewState);
+
+    // Evict least recently used if over limit
+    this.evictIfNeeded();
 
     // Trigger snapshot if interval crossed
     if (this.snapshotStore && newEvents.length > 0) {
@@ -124,6 +133,7 @@ export class ViewMaterializer {
       highWaterMark: snapshot.highWaterMark,
     });
     this.lastSnapshotHwm.set(stateKey, snapshot.highWaterMark);
+    this.evictIfNeeded();
     return true;
   }
 
@@ -133,7 +143,13 @@ export class ViewMaterializer {
    */
   getState<T>(streamId: string, viewName: string): ViewState<T> | undefined {
     const stateKey = `${viewName}:${streamId}`;
-    return this.states.get(stateKey) as ViewState<T> | undefined;
+    const state = this.states.get(stateKey);
+    if (state) {
+      // Refresh LRU order: delete and re-insert to move to end
+      this.states.delete(stateKey);
+      this.states.set(stateKey, state);
+    }
+    return state as ViewState<T> | undefined;
   }
 
   /**
@@ -142,6 +158,7 @@ export class ViewMaterializer {
   loadState<T>(streamId: string, viewName: string, view: T, highWaterMark: number): void {
     const stateKey = `${viewName}:${streamId}`;
     this.states.set(stateKey, { view, highWaterMark });
+    this.evictIfNeeded();
   }
 
   /**
@@ -156,5 +173,18 @@ export class ViewMaterializer {
    */
   getProjection<T>(viewName: string): ViewProjection<T> | undefined {
     return this.projections.get(viewName) as ViewProjection<T> | undefined;
+  }
+
+  /**
+   * Evict the least recently used cache entry if the cache exceeds maxCacheEntries.
+   * Uses Map insertion order: the first key is the least recently used.
+   */
+  private evictIfNeeded(): void {
+    while (this.states.size > this.maxCacheEntries) {
+      const oldest = this.states.keys().next().value;
+      if (oldest === undefined) break;
+      this.states.delete(oldest);
+      this.lastSnapshotHwm.delete(oldest);
+    }
   }
 }


### PR DESCRIPTION
Task 007:
- maxCacheEntries option (default 100)
- LRU via Map delete+re-insert pattern
- getState refreshes LRU order