### PR TITLE
refactor: add claim guard to handleTaskClaim

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
@@ -98,6 +98,54 @@ describe('handleTaskClaim', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('CLAIM_FAILED');
   });
+
+  it('already claimed taskId rejects with ALREADY_CLAIMED error', async () => {
+    // First claim succeeds
+    const first = await handleTaskClaim(
+      { taskId: 't1', agentId: 'agent-1', streamId: 'wf-001' },
+      tempDir,
+    );
+    expect(first.success).toBe(true);
+
+    // Second claim for the same taskId is rejected
+    const second = await handleTaskClaim(
+      { taskId: 't1', agentId: 'agent-2', streamId: 'wf-001' },
+      tempDir,
+    );
+    expect(second.success).toBe(false);
+    expect(second.error?.code).toBe('ALREADY_CLAIMED');
+    expect(second.error?.message).toContain('t1');
+  });
+
+  it('different taskIds can be claimed independently', async () => {
+    const first = await handleTaskClaim(
+      { taskId: 'task-1', agentId: 'agent-1', streamId: 'wf-001' },
+      tempDir,
+    );
+    expect(first.success).toBe(true);
+
+    const second = await handleTaskClaim(
+      { taskId: 'task-2', agentId: 'agent-2', streamId: 'wf-001' },
+      tempDir,
+    );
+    expect(second.success).toBe(true);
+  });
+
+  it('same agent re-claiming same taskId rejects with ALREADY_CLAIMED', async () => {
+    const first = await handleTaskClaim(
+      { taskId: 't1', agentId: 'agent-1', streamId: 'wf-001' },
+      tempDir,
+    );
+    expect(first.success).toBe(true);
+
+    // Even the same agent cannot re-claim
+    const second = await handleTaskClaim(
+      { taskId: 't1', agentId: 'agent-1', streamId: 'wf-001' },
+      tempDir,
+    );
+    expect(second.success).toBe(false);
+    expect(second.error?.code).toBe('ALREADY_CLAIMED');
+  });
 });
 
 describe('handleTaskComplete', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
@@ -55,6 +55,21 @@ export async function handleTaskClaim(
   const store = getStore(stateDir);
 
   try {
+    // Guard: check if task is already claimed
+    const existingEvents = await store.query(args.streamId, { type: 'task.claimed' });
+    const alreadyClaimed = existingEvents.some(
+      (e) => (e.data as Record<string, unknown>)?.taskId === args.taskId,
+    );
+    if (alreadyClaimed) {
+      return {
+        success: false,
+        error: {
+          code: 'ALREADY_CLAIMED',
+          message: `Task '${args.taskId}' is already claimed`,
+        },
+      };
+    }
+
     const event = await store.append(args.streamId, {
       type: 'task.claimed',
       data: {


### PR DESCRIPTION
Task 008:
- Query prior task.claimed events before emitting
- Return ALREADY_CLAIMED error if task already claimed