### PR TITLE
chore: add --publish --merge-when-ready to all gt submit calls

### DIFF
--- a/commands/synthesize.md
+++ b/commands/synthesize.md
@@ -39,7 +39,7 @@ Follow `@rules/pr-descriptions.md` for concise format.
 **Always use Graphite** to submit stacked PRs:
 ```typescript
 mcp__graphite__run_gt_cmd({
-  args: ["submit", "--no-interactive", "--stack"],
+  args: ["submit", "--no-interactive", "--publish", "--merge-when-ready", "--stack"],
   cwd: "<repo-root>"
 })
 ```

--- a/rules/mcp-tool-guidance.md
+++ b/rules/mcp-tool-guidance.md
@@ -138,8 +138,8 @@ Stacked PR management and merge queue. **Use for all PR stacking and submission.
 
 | Instead of | Use |
 |------------|-----|
-| `git commit` + `git push` | `gt create -m "message"` then `gt submit --no-interactive` |
-| `gh pr create` | `gt submit --no-interactive` (creates stacked PRs automatically) |
+| `git commit` + `git push` | `gt create -m "message"` then `gt submit --no-interactive --publish --merge-when-ready` |
+| `gh pr create` | `gt submit --no-interactive --publish --merge-when-ready` (creates stacked PRs automatically) |
 | Manual rebasing | `gt restack` (rebases all PRs in the stack) |
 | `git checkout <branch>` | `gt checkout` (interactive branch selection) |
 
@@ -164,7 +164,7 @@ When deciding which tool to use:
 1. **Workflow tracking** — Always use Exarchos MCP for state, never manual JSON files
 2. **Code structure** — Prefer Serena's `find_symbol` / `get_symbols_overview` over grep for understanding code architecture
 3. **GitHub operations** — **Always use GitHub MCP tools** for ALL GitHub operations: PR reading/listing/searching (`pull_request_read`, `list_pull_requests`, `search_pull_requests`), issue operations (`issue_read`, `issue_write`, `search_issues`), commit history (`list_commits`, `get_commit`), and merging (`merge_pull_request`). NEVER use `gh pr view`, `gh pr list`, `gh pr checks`, `gh api`, or any `gh` subcommand when an MCP tool covers the operation
-4. **PR creation** — **Always use Graphite MCP** (`gt submit --no-interactive`) for all PR creation. NEVER use `create_pull_request`, `gh pr create`, or any other non-Graphite PR creation path
+4. **PR creation** — **Always use Graphite MCP** (`gt submit --no-interactive --publish --merge-when-ready`) for all PR creation. NEVER use `create_pull_request`, `gh pr create`, or any other non-Graphite PR creation path
 5. **Library docs** — Use Context7 before web search for library documentation
 6. **Microsoft tech** — Use Microsoft Docs MCP for any Azure/.NET/Microsoft question
 
@@ -174,7 +174,7 @@ When deciding which tool to use:
 |-------|------------|
 | Grep for class definitions | Use Serena `find_symbol` |
 | Ask user to paste PR content | Use GitHub `pull_request_read` |
-| Use `gh pr create` or `create_pull_request` | Use Graphite `gt submit --no-interactive` for ALL PR creation |
+| Use `gh pr create` or `create_pull_request` | Use Graphite `gt submit --no-interactive --publish --merge-when-ready` for ALL PR creation |
 | Use `gh pr view` | Use GitHub `pull_request_read` with method `get` |
 | Use `gh pr list` | Use GitHub `list_pull_requests` or `search_pull_requests` |
 | Use `gh pr diff` | Use GitHub `pull_request_read` with method `get_diff` |
@@ -188,7 +188,7 @@ When deciding which tool to use:
 | Manually edit workflow state JSON | Use `workflow_set` MCP tool |
 | Web search for .NET API reference | Use Microsoft Learn `search` |
 | Read entire files to find a function | Use Serena `get_symbols_overview` then `find_symbol` with `include_body` |
-| Use `git commit` or `git push` | Use `gt create` + `gt submit --no-interactive` |
+| Use `git commit` or `git push` | Use `gt create` + `gt submit --no-interactive --publish --merge-when-ready` |
 | Use grep/rg to search code patterns | Use Serena `search_for_pattern` for regex search |
 | Use sed/awk for code replacement | Use Serena `replace_content` or `replace_symbol_body` |
 | Read entire files to understand structure | Use Serena `get_symbols_overview` then `find_symbol` with `include_body` |

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -312,7 +312,7 @@ Create PR via Graphite MCP:
 mcp__graphite__run_gt_cmd({ args: ["create", "-m", "fix: <issue summary>"], cwd: "<repo-root>" })
 
 # Submit to create the PR
-mcp__graphite__run_gt_cmd({ args: ["submit", "--no-interactive"], cwd: "<repo-root>" })
+mcp__graphite__run_gt_cmd({ args: ["submit", "--no-interactive", "--publish", "--merge-when-ready"], cwd: "<repo-root>" })
 ```
 
 Then update the PR description using GitHub MCP:

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -150,7 +150,7 @@ npm run typecheck
 # Stage and commit via Graphite
 git add shared/types/src/generated/ shared/validation/src/generated/ apps/ares-elite-web/src/api/generated/
 gt create chore/schema-sync -m "chore: regenerate TypeScript types from OpenAPI"
-gt submit --no-interactive
+gt submit --no-interactive --publish --merge-when-ready
 ```
 
 **NEVER use `git commit` or `git push`** — always use `gt create` and `gt submit`.

--- a/skills/delegation/references/implementer-prompt.md
+++ b/skills/delegation/references/implementer-prompt.md
@@ -121,7 +121,7 @@ After completing each logical task within your assignment:
 3. Continue to the next task (you are now on a new branch stacked on the previous)
 
 After all tasks are complete:
-4. Submit the full stack: `gt submit --no-interactive --stack`
+4. Submit the full stack: `gt submit --no-interactive --publish --merge-when-ready --stack`
 
 **IMPORTANT:** When using Graphite, never use `git commit` or `git push`. Always use `gt create` and `gt submit`.
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -304,7 +304,7 @@ The `/synthesize` skill creates the PR via Graphite MCP:
 
 ```typescript
 // Submit the stack to create PRs
-mcp__graphite__run_gt_cmd({ args: ["submit", "--no-interactive"], cwd: "<repo-root>" })
+mcp__graphite__run_gt_cmd({ args: ["submit", "--no-interactive", "--publish", "--merge-when-ready"], cwd: "<repo-root>" })
 ```
 
 Then update the PR description using GitHub MCP:

--- a/skills/refactor/phases/polish-implement.md
+++ b/skills/refactor/phases/polish-implement.md
@@ -105,7 +105,7 @@ gt create refactor/<brief-name> -m "refactor: <description>"
 
 After all changes are complete:
 ```bash
-gt submit --no-interactive --stack
+gt submit --no-interactive --publish --merge-when-ready --stack
 ```
 
 **NEVER use `git commit` or `git push`** — always use `gt create` and `gt submit`.

--- a/skills/sync-schemas/SKILL.md
+++ b/skills/sync-schemas/SKILL.md
@@ -161,7 +161,7 @@ If CI fails on schema-check, run `/sync-schemas` locally and commit the results.
 # Verify and commit via Graphite
 git add shared/ apps/ares-elite-web/src/api/generated/
 gt create chore/schema-sync -m "chore: regenerate TypeScript types from OpenAPI"
-gt submit --no-interactive
+gt submit --no-interactive --publish --merge-when-ready
 ```
 
 **NEVER use `git commit` or `git push`** — always use `gt create` and `gt submit`.

--- a/skills/synthesis/SKILL.md
+++ b/skills/synthesis/SKILL.md
@@ -67,7 +67,7 @@ Submit the entire stack to create stacked PRs:
 
 ```
 mcp__graphite__run_gt_cmd({
-  args: ["submit", "--no-interactive"],
+  args: ["submit", "--no-interactive", "--publish", "--merge-when-ready"],
   cwd: "<repo-root>",
   why: "Submit stacked PRs for all task branches"
 })
@@ -196,7 +196,7 @@ If the user receives PR review comments:
    ```
 
 3. Creates fix tasks from review comments
-4. After fixes, amend the stack with `mcp__graphite__run_gt_cmd` using `["modify", "-m", "fix: <description>"]` and resubmit with `["submit", "--no-interactive"]`
+4. After fixes, amend the stack with `mcp__graphite__run_gt_cmd` using `["modify", "-m", "fix: <description>"]` and resubmit with `["submit", "--no-interactive", "--publish", "--merge-when-ready"]`
 5. Return to merge confirmation
 
 ## Transition


### PR DESCRIPTION
Never create draft PRs. Always enable Graphite merge queue
automatically so stacks merge without manual intervention.