### PR TITLE
feat: add manifest types and loader for installer overhaul

### DIFF
--- a/src/operations/bundle.test.ts
+++ b/src/operations/bundle.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { installBundle } from './bundle.js';
+
+describe('MCP Server Bundle Copy (C4)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-bundle-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Helper: create a fake bundle source file with given content. */
+  function createSourceBundle(filename: string, content: string): string {
+    const sourcePath = path.join(tmpDir, 'source', filename);
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.writeFileSync(sourcePath, content, 'utf-8');
+    return sourcePath;
+  }
+
+  describe('installBundle', () => {
+    it('installBundle_SourceExists_CopiesToMcpServersDir', () => {
+      const bundleContent = 'console.log("mcp server bundle");';
+      const sourcePath = createSourceBundle('exarchos-mcp.js', bundleContent);
+      const claudeHome = path.join(tmpDir, '.claude');
+
+      const result = installBundle(sourcePath, claudeHome);
+
+      const expectedPath = path.join(claudeHome, 'mcp-servers', 'exarchos-mcp.js');
+      expect(result.installedPath).toBe(expectedPath);
+      expect(fs.existsSync(expectedPath)).toBe(true);
+      expect(fs.readFileSync(expectedPath, 'utf-8')).toBe(bundleContent);
+    });
+
+    it('installBundle_MissingMcpDir_CreatesDir', () => {
+      const sourcePath = createSourceBundle('server.js', 'content');
+      const claudeHome = path.join(tmpDir, 'fresh-claude-home');
+      const mcpDir = path.join(claudeHome, 'mcp-servers');
+
+      // Verify the directory does not exist yet
+      expect(fs.existsSync(mcpDir)).toBe(false);
+
+      installBundle(sourcePath, claudeHome);
+
+      // Directory should have been created
+      expect(fs.existsSync(mcpDir)).toBe(true);
+    });
+
+    it('installBundle_ExistingBundle_Overwrites', () => {
+      const claudeHome = path.join(tmpDir, '.claude');
+      const mcpDir = path.join(claudeHome, 'mcp-servers');
+      fs.mkdirSync(mcpDir, { recursive: true });
+
+      // Write an existing (old) bundle
+      const existingPath = path.join(mcpDir, 'server.js');
+      fs.writeFileSync(existingPath, 'old content', 'utf-8');
+
+      // Create new source
+      const sourcePath = createSourceBundle('server.js', 'new content');
+
+      installBundle(sourcePath, claudeHome);
+
+      // Should be overwritten with new content
+      expect(fs.readFileSync(existingPath, 'utf-8')).toBe('new content');
+    });
+
+    it('installBundle_MissingSource_ThrowsError', () => {
+      const claudeHome = path.join(tmpDir, '.claude');
+      const badSourcePath = path.join(tmpDir, 'nonexistent', 'server.js');
+
+      expect(() => installBundle(badSourcePath, claudeHome)).toThrow(
+        /not found|does not exist|ENOENT/i,
+      );
+    });
+
+    it('installBundle_ReturnsFileSize_InBytes', () => {
+      const content = 'A'.repeat(1024); // Exactly 1024 bytes
+      const sourcePath = createSourceBundle('sized-server.js', content);
+      const claudeHome = path.join(tmpDir, '.claude');
+
+      const result = installBundle(sourcePath, claudeHome);
+
+      expect(result.sizeBytes).toBe(1024);
+    });
+  });
+});

--- a/src/operations/bundle.ts
+++ b/src/operations/bundle.ts
@@ -1,0 +1,49 @@
+/**
+ * MCP server bundle copy for the Exarchos installer.
+ *
+ * Copies a bundled MCP server JavaScript file into the
+ * `~/.claude/mcp-servers/` directory so it can be launched
+ * by the Claude Code runtime.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Result of installing a bundle file. */
+export interface BundleResult {
+  /** Absolute path where the bundle was installed. */
+  readonly installedPath: string;
+  /** Size of the installed file in bytes. */
+  readonly sizeBytes: number;
+}
+
+/**
+ * Copy a bundled MCP server file to the Claude home mcp-servers directory.
+ *
+ * Ensures the target directory exists, copies the file (overwriting if
+ * it already exists), and returns the installed path and file size.
+ *
+ * @param bundlePath - Absolute path to the source bundle file.
+ * @param claudeHome - Absolute path to the `~/.claude/` directory.
+ * @returns The installed path and file size.
+ * @throws If the source bundle file does not exist.
+ */
+export function installBundle(bundlePath: string, claudeHome: string): BundleResult {
+  if (!fs.existsSync(bundlePath)) {
+    throw new Error(`Bundle source does not exist: ${bundlePath}`);
+  }
+
+  const mcpServersDir = path.join(claudeHome, 'mcp-servers');
+  fs.mkdirSync(mcpServersDir, { recursive: true });
+
+  const filename = path.basename(bundlePath);
+  const installedPath = path.join(mcpServersDir, filename);
+  fs.copyFileSync(bundlePath, installedPath);
+
+  const stats = fs.statSync(installedPath);
+
+  return {
+    installedPath,
+    sizeBytes: stats.size,
+  };
+}

--- a/src/operations/copy.test.ts
+++ b/src/operations/copy.test.ts
@@ -2,7 +2,18 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { computeFileHash, computeDirectoryHashes } from './copy.js';
+import {
+  computeFileHash,
+  computeDirectoryHashes,
+  copyFile,
+  copyDirectory,
+  smartCopy,
+  smartCopyDirectory,
+  type CopyResult,
+  type CopyDirectoryResult,
+  type SmartCopyResult,
+  type SmartCopyDirectoryResult,
+} from './copy.js';
 
 describe('Content Hash Utilities (A4)', () => {
   let tmpDir: string;
@@ -109,5 +120,281 @@ describe('Content Hash Utilities (A4)', () => {
 
       expect(Object.keys(hashes)).toHaveLength(0);
     });
+  });
+});
+
+describe('copyFile (B1)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-copyfile-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('copyFile_SourceExists_CopiesAndReturnsHash', () => {
+    const source = path.join(tmpDir, 'source.txt');
+    const target = path.join(tmpDir, 'target.txt');
+    const content = 'hello copy world';
+    fs.writeFileSync(source, content, 'utf-8');
+
+    const result: CopyResult = copyFile(source, target);
+
+    // Target file should exist with same content
+    expect(fs.existsSync(target)).toBe(true);
+    expect(fs.readFileSync(target, 'utf-8')).toBe(content);
+    // Hash should match the source file hash
+    expect(result.hash).toBe(computeFileHash(source));
+    expect(result.hash).toMatch(/^[0-9a-f]{64}$/);
+    // Bytes written should match content length
+    expect(result.bytesWritten).toBe(Buffer.byteLength(content, 'utf-8'));
+  });
+
+  it('copyFile_SourceMissing_ThrowsError', () => {
+    const source = path.join(tmpDir, 'nonexistent.txt');
+    const target = path.join(tmpDir, 'target.txt');
+
+    expect(() => copyFile(source, target)).toThrow(/not found|ENOENT/i);
+  });
+
+  it('copyFile_TargetDirMissing_CreatesParentDirs', () => {
+    const source = path.join(tmpDir, 'source.txt');
+    const target = path.join(tmpDir, 'deep', 'nested', 'dir', 'target.txt');
+    fs.writeFileSync(source, 'nested content', 'utf-8');
+
+    const result = copyFile(source, target);
+
+    expect(fs.existsSync(target)).toBe(true);
+    expect(fs.readFileSync(target, 'utf-8')).toBe('nested content');
+    expect(result.hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('copyFile_TargetExists_OverwritesAndReturnsNewHash', () => {
+    const source = path.join(tmpDir, 'source.txt');
+    const target = path.join(tmpDir, 'target.txt');
+    fs.writeFileSync(target, 'old content', 'utf-8');
+    fs.writeFileSync(source, 'new content', 'utf-8');
+
+    const result = copyFile(source, target);
+
+    expect(fs.readFileSync(target, 'utf-8')).toBe('new content');
+    expect(result.hash).toBe(computeFileHash(source));
+    expect(result.bytesWritten).toBe(Buffer.byteLength('new content', 'utf-8'));
+  });
+});
+
+describe('copyDirectory (B2)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-copydir-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('copyDirectory_FlatDir_CopiesAllFiles', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const tgtDir = path.join(tmpDir, 'tgt');
+    fs.mkdirSync(srcDir);
+    fs.writeFileSync(path.join(srcDir, 'a.txt'), 'alpha', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'b.txt'), 'beta', 'utf-8');
+
+    const result: CopyDirectoryResult = copyDirectory(srcDir, tgtDir);
+
+    expect(fs.readFileSync(path.join(tgtDir, 'a.txt'), 'utf-8')).toBe('alpha');
+    expect(fs.readFileSync(path.join(tgtDir, 'b.txt'), 'utf-8')).toBe('beta');
+    expect(result.fileCount).toBe(2);
+    expect(result.totalBytes).toBe(
+      Buffer.byteLength('alpha') + Buffer.byteLength('beta'),
+    );
+  });
+
+  it('copyDirectory_NestedDir_CopiesRecursively', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const tgtDir = path.join(tmpDir, 'tgt');
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(path.join(srcDir, 'sub'));
+    fs.writeFileSync(path.join(srcDir, 'root.txt'), 'root', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'sub', 'nested.txt'), 'nested', 'utf-8');
+
+    const result = copyDirectory(srcDir, tgtDir);
+
+    expect(fs.readFileSync(path.join(tgtDir, 'root.txt'), 'utf-8')).toBe('root');
+    expect(fs.readFileSync(path.join(tgtDir, 'sub', 'nested.txt'), 'utf-8')).toBe('nested');
+    expect(result.fileCount).toBe(2);
+    expect(Object.keys(result.hashes)).toHaveLength(2);
+  });
+
+  it('copyDirectory_EmptyDir_CreatesEmptyTarget', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const tgtDir = path.join(tmpDir, 'tgt');
+    fs.mkdirSync(srcDir);
+
+    const result = copyDirectory(srcDir, tgtDir);
+
+    expect(fs.existsSync(tgtDir)).toBe(true);
+    expect(fs.readdirSync(tgtDir)).toHaveLength(0);
+    expect(result.fileCount).toBe(0);
+    expect(result.totalBytes).toBe(0);
+    expect(Object.keys(result.hashes)).toHaveLength(0);
+  });
+
+  it('copyDirectory_WithFilter_CopiesOnlyMatchingFiles', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const tgtDir = path.join(tmpDir, 'tgt');
+    fs.mkdirSync(srcDir);
+    fs.writeFileSync(path.join(srcDir, 'keep.md'), 'keep me', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'skip.txt'), 'skip me', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'also-keep.md'), 'keep too', 'utf-8');
+
+    const result = copyDirectory(srcDir, tgtDir, (name) => name.endsWith('.md'));
+
+    expect(fs.existsSync(path.join(tgtDir, 'keep.md'))).toBe(true);
+    expect(fs.existsSync(path.join(tgtDir, 'also-keep.md'))).toBe(true);
+    expect(fs.existsSync(path.join(tgtDir, 'skip.txt'))).toBe(false);
+    expect(result.fileCount).toBe(2);
+  });
+
+  it('copyDirectory_ReturnsHashMap_AllFileHashes', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const tgtDir = path.join(tmpDir, 'tgt');
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(path.join(srcDir, 'sub'));
+    fs.writeFileSync(path.join(srcDir, 'file1.txt'), 'content1', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'sub', 'file2.txt'), 'content2', 'utf-8');
+
+    const result = copyDirectory(srcDir, tgtDir);
+
+    expect(result.hashes['file1.txt']).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.hashes[path.join('sub', 'file2.txt')]).toMatch(/^[0-9a-f]{64}$/);
+    // Hashes should match the source files
+    expect(result.hashes['file1.txt']).toBe(computeFileHash(path.join(srcDir, 'file1.txt')));
+    expect(result.hashes[path.join('sub', 'file2.txt')]).toBe(
+      computeFileHash(path.join(srcDir, 'sub', 'file2.txt')),
+    );
+  });
+});
+
+describe('smartCopy (B3)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-smartcopy-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('smartCopy_NewFile_CopiesFile', () => {
+    const source = path.join(tmpDir, 'source.txt');
+    const target = path.join(tmpDir, 'target.txt');
+    fs.writeFileSync(source, 'new file content', 'utf-8');
+
+    // No existing hash — file is new
+    const result: SmartCopyResult = smartCopy(source, target);
+
+    expect(result.action).toBe('created');
+    expect(result.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(fs.readFileSync(target, 'utf-8')).toBe('new file content');
+  });
+
+  it('smartCopy_UnchangedFile_SkipsFile', () => {
+    const source = path.join(tmpDir, 'source.txt');
+    const target = path.join(tmpDir, 'target.txt');
+    const content = 'unchanged content';
+    fs.writeFileSync(source, content, 'utf-8');
+    fs.writeFileSync(target, content, 'utf-8');
+    const existingHash = computeFileHash(source);
+
+    const result = smartCopy(source, target, existingHash);
+
+    expect(result.action).toBe('skipped');
+    expect(result.hash).toBe(existingHash);
+  });
+
+  it('smartCopy_ChangedFile_UpdatesFile', () => {
+    const source = path.join(tmpDir, 'source.txt');
+    const target = path.join(tmpDir, 'target.txt');
+    fs.writeFileSync(source, 'updated content', 'utf-8');
+    fs.writeFileSync(target, 'old content', 'utf-8');
+    const oldHash = computeFileHash(target);
+
+    const result = smartCopy(source, target, oldHash);
+
+    expect(result.action).toBe('updated');
+    expect(result.hash).toBe(computeFileHash(source));
+    expect(fs.readFileSync(target, 'utf-8')).toBe('updated content');
+  });
+
+  it('smartCopy_DeletedSource_ReportsRemoval', () => {
+    const source = path.join(tmpDir, 'deleted-source.txt');
+    const target = path.join(tmpDir, 'target.txt');
+    fs.writeFileSync(target, 'will be removed', 'utf-8');
+    const existingHash = computeFileHash(target);
+    // Source does not exist — it was deleted
+
+    const result = smartCopy(source, target, existingHash);
+
+    expect(result.action).toBe('removed');
+    expect(result.hash).toBe('');
+  });
+});
+
+describe('smartCopyDirectory (B3)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-smartcopydir-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('smartCopyDirectory_MixedChanges_ReturnsUpdateSummary', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const tgtDir = path.join(tmpDir, 'tgt');
+
+    // Set up source with 3 files: new, unchanged, changed
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(tgtDir);
+    fs.writeFileSync(path.join(srcDir, 'new.txt'), 'brand new', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'same.txt'), 'same content', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'changed.txt'), 'updated content', 'utf-8');
+
+    // Set up target with existing files
+    fs.writeFileSync(path.join(tgtDir, 'same.txt'), 'same content', 'utf-8');
+    fs.writeFileSync(path.join(tgtDir, 'changed.txt'), 'original content', 'utf-8');
+    fs.writeFileSync(path.join(tgtDir, 'removed.txt'), 'to be removed', 'utf-8');
+
+    // Existing hashes reflect what was previously installed
+    const existingHashes: Record<string, string> = {
+      'same.txt': computeFileHash(path.join(tgtDir, 'same.txt')),
+      'changed.txt': computeFileHash(path.join(tgtDir, 'changed.txt')),
+      'removed.txt': computeFileHash(path.join(tgtDir, 'removed.txt')),
+    };
+
+    const result: SmartCopyDirectoryResult = smartCopyDirectory(
+      srcDir,
+      tgtDir,
+      existingHashes,
+    );
+
+    expect(result.created).toBe(1);   // new.txt
+    expect(result.updated).toBe(1);   // changed.txt
+    expect(result.skipped).toBe(1);   // same.txt
+    expect(result.removed).toBe(1);   // removed.txt
+
+    // Hashes should include all current files (not removed ones)
+    expect(Object.keys(result.hashes)).toHaveLength(3);
+    expect(result.hashes['new.txt']).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.hashes['same.txt']).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.hashes['changed.txt']).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.hashes['removed.txt']).toBeUndefined();
   });
 });

--- a/src/operations/copy.ts
+++ b/src/operations/copy.ts
@@ -54,6 +54,307 @@ export function computeDirectoryHashes(
 }
 
 /**
+ * Result of copying a single file.
+ */
+export interface CopyResult {
+  /** SHA-256 hex digest of the copied file's contents. */
+  readonly hash: string;
+  /** Number of bytes written to the target. */
+  readonly bytesWritten: number;
+}
+
+/**
+ * Copy a single file from source to target, computing its content hash.
+ *
+ * Creates parent directories of the target if they do not exist.
+ * Overwrites the target if it already exists.
+ *
+ * @param source - Absolute or relative path to the source file.
+ * @param target - Absolute or relative path to the target file.
+ * @returns The content hash and byte count of the copied file.
+ * @throws If the source file does not exist or cannot be read.
+ */
+export function copyFile(source: string, target: string): CopyResult {
+  let content: Buffer;
+  try {
+    content = fs.readFileSync(source);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      throw new Error(`File not found: ${source}`);
+    }
+    throw err;
+  }
+
+  const targetDir = path.dirname(target);
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.writeFileSync(target, content);
+
+  const hash = createHash('sha256').update(content).digest('hex');
+  return { hash, bytesWritten: content.length };
+}
+
+/**
+ * Result of copying an entire directory tree.
+ */
+export interface CopyDirectoryResult {
+  /** Map of relative file paths to their SHA-256 hex digests. */
+  readonly hashes: Record<string, string>;
+  /** Total number of files copied. */
+  readonly fileCount: number;
+  /** Total number of bytes written across all files. */
+  readonly totalBytes: number;
+}
+
+/**
+ * Recursively copy a directory tree from source to target.
+ *
+ * Creates the target directory and all subdirectories. Copies every file
+ * (optionally filtered) and returns content hashes for all copied files.
+ *
+ * @param source - Absolute or relative path to the source directory.
+ * @param target - Absolute or relative path to the target directory.
+ * @param filter - Optional predicate to filter files by name. Only files
+ *   whose name passes the filter are copied.
+ * @returns Hashes, file count, and total bytes for all copied files.
+ */
+export function copyDirectory(
+  source: string,
+  target: string,
+  filter?: (name: string) => boolean,
+): CopyDirectoryResult {
+  fs.mkdirSync(target, { recursive: true });
+
+  const hashes: Record<string, string> = {};
+  let fileCount = 0;
+  let totalBytes = 0;
+
+  copyDirectoryWalk(source, source, target, filter, hashes, (bytes) => {
+    fileCount++;
+    totalBytes += bytes;
+  });
+
+  return { hashes, fileCount, totalBytes };
+}
+
+/**
+ * Recursive helper for copyDirectory.
+ *
+ * @param rootDir - The original source root (for computing relative paths).
+ * @param currentDir - The current source directory being scanned.
+ * @param targetRoot - The target root directory.
+ * @param filter - Optional file name filter.
+ * @param hashes - Accumulator for relative-path to hash mappings.
+ * @param onFile - Callback invoked for each copied file with its byte size.
+ */
+function copyDirectoryWalk(
+  rootDir: string,
+  currentDir: string,
+  targetRoot: string,
+  filter: ((name: string) => boolean) | undefined,
+  hashes: Record<string, string>,
+  onFile: (bytes: number) => void,
+): void {
+  const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const srcPath = path.join(currentDir, entry.name);
+    const relativePath = path.relative(rootDir, srcPath);
+    const tgtPath = path.join(targetRoot, relativePath);
+
+    if (entry.isDirectory()) {
+      fs.mkdirSync(tgtPath, { recursive: true });
+      copyDirectoryWalk(rootDir, srcPath, targetRoot, filter, hashes, onFile);
+    } else if (entry.isFile()) {
+      if (filter && !filter(entry.name)) {
+        continue;
+      }
+      const result = copyFile(srcPath, tgtPath);
+      hashes[relativePath] = result.hash;
+      onFile(result.bytesWritten);
+    }
+  }
+}
+
+/**
+ * Result of a smart (idempotent) single-file copy.
+ */
+export interface SmartCopyResult {
+  /** What action was taken. */
+  readonly action: 'created' | 'updated' | 'skipped' | 'removed';
+  /** SHA-256 hex digest of the file after the operation (empty string if removed). */
+  readonly hash: string;
+}
+
+/**
+ * Result of a smart (idempotent) directory copy.
+ */
+export interface SmartCopyDirectoryResult {
+  /** Number of newly created files. */
+  readonly created: number;
+  /** Number of updated (changed) files. */
+  readonly updated: number;
+  /** Number of unchanged files that were skipped. */
+  readonly skipped: number;
+  /** Number of files that existed in the target but not in the source. */
+  readonly removed: number;
+  /** Map of relative file paths to their current SHA-256 hex digests. */
+  readonly hashes: Record<string, string>;
+}
+
+/**
+ * Idempotent single-file copy that skips unchanged files.
+ *
+ * Compares the source file's hash against the provided existing hash.
+ * If they match, the file is skipped. If the source does not exist
+ * but an existing hash is provided, the file is reported as removed.
+ *
+ * @param source - Path to the source file (may not exist for removals).
+ * @param target - Path to the target file.
+ * @param existingHash - SHA-256 hex digest of the previously installed file.
+ * @returns The action taken and the resulting file hash.
+ */
+export function smartCopy(
+  source: string,
+  target: string,
+  existingHash?: string,
+): SmartCopyResult {
+  const sourceExists = fs.existsSync(source);
+
+  // Source deleted — report removal
+  if (!sourceExists) {
+    if (existingHash) {
+      return { action: 'removed', hash: '' };
+    }
+    // No source, no existing hash — nothing to do
+    return { action: 'skipped', hash: '' };
+  }
+
+  // Compute source hash
+  const sourceHash = computeFileHash(source);
+
+  // Source unchanged — skip
+  if (existingHash && sourceHash === existingHash) {
+    return { action: 'skipped', hash: existingHash };
+  }
+
+  // Copy the file
+  copyFile(source, target);
+
+  // Determine action
+  const action = existingHash ? 'updated' : 'created';
+  return { action, hash: sourceHash };
+}
+
+/**
+ * Idempotent directory copy that skips unchanged files and detects removals.
+ *
+ * Compares source files against existing hashes. Files that haven't
+ * changed are skipped. Files present in `existingHashes` but absent
+ * from the source are reported as removed.
+ *
+ * @param source - Path to the source directory.
+ * @param target - Path to the target directory.
+ * @param existingHashes - Map of relative paths to SHA-256 hex digests
+ *   from the previous installation.
+ * @param filter - Optional predicate to filter files by name.
+ * @returns Summary of actions taken and updated hashes.
+ */
+export function smartCopyDirectory(
+  source: string,
+  target: string,
+  existingHashes: Record<string, string>,
+  filter?: (name: string) => boolean,
+): SmartCopyDirectoryResult {
+  fs.mkdirSync(target, { recursive: true });
+
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+  let removed = 0;
+  const hashes: Record<string, string> = {};
+
+  // Track which existing files we've seen in the source
+  const seenPaths = new Set<string>();
+
+  // Walk source directory and smart-copy each file
+  smartCopyDirectoryWalk(
+    source,
+    source,
+    target,
+    filter,
+    existingHashes,
+    seenPaths,
+    hashes,
+    (action) => {
+      switch (action) {
+        case 'created': created++; break;
+        case 'updated': updated++; break;
+        case 'skipped': skipped++; break;
+      }
+    },
+  );
+
+  // Detect removals: files in existingHashes not found in source
+  for (const relativePath of Object.keys(existingHashes)) {
+    if (!seenPaths.has(relativePath)) {
+      removed++;
+    }
+  }
+
+  return { created, updated, skipped, removed, hashes };
+}
+
+/**
+ * Recursive helper for smartCopyDirectory.
+ */
+function smartCopyDirectoryWalk(
+  rootDir: string,
+  currentDir: string,
+  targetRoot: string,
+  filter: ((name: string) => boolean) | undefined,
+  existingHashes: Record<string, string>,
+  seenPaths: Set<string>,
+  hashes: Record<string, string>,
+  onAction: (action: 'created' | 'updated' | 'skipped') => void,
+): void {
+  const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const srcPath = path.join(currentDir, entry.name);
+    const relativePath = path.relative(rootDir, srcPath);
+
+    if (entry.isDirectory()) {
+      const tgtPath = path.join(targetRoot, relativePath);
+      fs.mkdirSync(tgtPath, { recursive: true });
+      smartCopyDirectoryWalk(
+        rootDir, srcPath, targetRoot, filter,
+        existingHashes, seenPaths, hashes, onAction,
+      );
+    } else if (entry.isFile()) {
+      if (filter && !filter(entry.name)) {
+        continue;
+      }
+      seenPaths.add(relativePath);
+      const tgtPath = path.join(targetRoot, relativePath);
+      const result = smartCopy(srcPath, tgtPath, existingHashes[relativePath]);
+      if (result.action !== 'removed') {
+        hashes[relativePath] = result.hash;
+        onAction(result.action as 'created' | 'updated' | 'skipped');
+      }
+    }
+  }
+}
+
+/**
  * Recursively walk a directory, computing hashes for visible files.
  *
  * @param rootDir - The top-level directory (used to compute relative paths).

--- a/src/operations/mcp.test.ts
+++ b/src/operations/mcp.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { McpServerComponent } from '../manifest/types.js';
+import {
+  readMcpConfig,
+  writeMcpConfig,
+  mergeMcpServers,
+  generateMcpEntry,
+  removeMcpServers,
+} from './mcp.js';
+
+describe('MCP Config Management (C2)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-mcp-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Helper: create a bundled McpServerComponent. */
+  function createBundledServer(id: string = 'exarchos'): McpServerComponent {
+    return {
+      id,
+      name: 'Exarchos MCP',
+      description: 'Workflow state management',
+      required: true,
+      type: 'bundled',
+      bundlePath: 'plugins/exarchos/servers/exarchos-mcp/dist/index.js',
+    };
+  }
+
+  /** Helper: create an external McpServerComponent. */
+  function createExternalServer(id: string = 'graphite'): McpServerComponent {
+    return {
+      id,
+      name: 'Graphite',
+      description: 'Stacked PR management',
+      required: false,
+      type: 'external',
+      command: 'gt',
+      args: ['mcp'],
+    };
+  }
+
+  /** Helper: create a remote McpServerComponent. */
+  function createRemoteServer(id: string = 'microsoft-learn'): McpServerComponent {
+    return {
+      id,
+      name: 'Microsoft Learn',
+      description: 'Microsoft documentation',
+      required: false,
+      type: 'remote',
+      url: 'https://learn.microsoft.com/api/mcp',
+    };
+  }
+
+  describe('readMcpConfig', () => {
+    it('readMcpConfig_ExistingFile_ReturnsConfig', () => {
+      const configPath = path.join(tmpDir, 'claude.json');
+      const config = {
+        mcpServers: {
+          exarchos: { type: 'stdio', command: 'node', args: ['run', 'server.js'] },
+        },
+        someOtherKey: 'value',
+      };
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+
+      const result = readMcpConfig(configPath);
+
+      expect(result.mcpServers).toBeDefined();
+      expect(result.mcpServers!['exarchos']).toBeDefined();
+      expect(result.mcpServers!['exarchos'].type).toBe('stdio');
+      expect(result['someOtherKey']).toBe('value');
+    });
+
+    it('readMcpConfig_MissingFile_ReturnsEmpty', () => {
+      const configPath = path.join(tmpDir, 'nonexistent.json');
+
+      const result = readMcpConfig(configPath);
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('mergeMcpServers', () => {
+    it('mergeMcpServers_NewInstall_AddsAllServers', () => {
+      const config = {};
+      const servers = [createBundledServer(), createExternalServer()];
+      const claudeHome = path.join(tmpDir, '.claude');
+
+      const result = mergeMcpServers(config, servers, 'bun', claudeHome);
+
+      expect(result.mcpServers).toBeDefined();
+      expect(result.mcpServers!['exarchos']).toBeDefined();
+      expect(result.mcpServers!['graphite']).toBeDefined();
+    });
+
+    it('mergeMcpServers_ExistingServers_PreservesUserServers', () => {
+      const config = {
+        mcpServers: {
+          'my-custom-server': { type: 'stdio', command: 'my-server', args: [] },
+        },
+      };
+      const servers = [createBundledServer()];
+      const claudeHome = path.join(tmpDir, '.claude');
+
+      const result = mergeMcpServers(config, servers, 'node', claudeHome);
+
+      // User's custom server should be preserved
+      expect(result.mcpServers!['my-custom-server']).toBeDefined();
+      expect(result.mcpServers!['my-custom-server'].command).toBe('my-server');
+      // Exarchos server should be added
+      expect(result.mcpServers!['exarchos']).toBeDefined();
+    });
+
+    it('mergeMcpServers_StaleExarchosEntry_UpdatesEntry', () => {
+      const config = {
+        mcpServers: {
+          exarchos: { type: 'stdio', command: 'old-runtime', args: ['old-path'] },
+        },
+      };
+      const servers = [createBundledServer()];
+      const claudeHome = path.join(tmpDir, '.claude');
+
+      const result = mergeMcpServers(config, servers, 'bun', claudeHome);
+
+      // Should be updated to the new config
+      expect(result.mcpServers!['exarchos'].command).toBe('bun');
+      expect(result.mcpServers!['exarchos'].args).toContain('run');
+    });
+  });
+
+  describe('generateMcpEntry', () => {
+    it('generateMcpEntry_BundledServer_ReturnsCorrectConfig', () => {
+      const server = createBundledServer();
+      const claudeHome = '/home/user/.claude';
+
+      const entry = generateMcpEntry(server, 'bun', claudeHome);
+
+      expect(entry.type).toBe('stdio');
+      expect(entry.command).toBe('bun');
+      expect(entry.args).toEqual([
+        'run',
+        path.join(claudeHome, 'mcp-servers', 'exarchos-mcp.js'),
+      ]);
+    });
+
+    it('generateMcpEntry_ExternalServer_ReturnsCorrectConfig', () => {
+      const server = createExternalServer();
+      const claudeHome = '/home/user/.claude';
+
+      const entry = generateMcpEntry(server, 'node', claudeHome);
+
+      expect(entry.type).toBe('stdio');
+      expect(entry.command).toBe('gt');
+      expect(entry.args).toEqual(['mcp']);
+    });
+
+    it('generateMcpEntry_RemoteServer_ReturnsCorrectConfig', () => {
+      const server = createRemoteServer();
+      const claudeHome = '/home/user/.claude';
+
+      const entry = generateMcpEntry(server, 'node', claudeHome);
+
+      expect(entry.type).toBe('url');
+      expect(entry.url).toBe('https://learn.microsoft.com/api/mcp');
+      expect(entry.command).toBeUndefined();
+      expect(entry.args).toBeUndefined();
+    });
+  });
+
+  describe('removeMcpServers', () => {
+    it('removeMcpServers_ExistingEntries_RemovesOnlyExarchosManaged', () => {
+      const config = {
+        mcpServers: {
+          exarchos: { type: 'stdio', command: 'node', args: ['run', 'server.js'] },
+          graphite: { type: 'stdio', command: 'gt', args: ['mcp'] },
+          'my-custom-server': { type: 'stdio', command: 'custom', args: [] },
+        },
+        someOtherKey: 'preserved',
+      };
+
+      const result = removeMcpServers(config, ['exarchos', 'graphite']);
+
+      expect(result.mcpServers!['exarchos']).toBeUndefined();
+      expect(result.mcpServers!['graphite']).toBeUndefined();
+      expect(result.mcpServers!['my-custom-server']).toBeDefined();
+      expect(result['someOtherKey']).toBe('preserved');
+    });
+  });
+
+  describe('writeMcpConfig', () => {
+    it('writeMcpConfig_ValidConfig_WritesJsonToDisk', () => {
+      const configPath = path.join(tmpDir, 'claude.json');
+      const config = {
+        mcpServers: {
+          exarchos: { type: 'stdio', command: 'node', args: ['server.js'] },
+        },
+      };
+
+      writeMcpConfig(configPath, config);
+
+      expect(fs.existsSync(configPath)).toBe(true);
+      const raw = fs.readFileSync(configPath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      expect(parsed.mcpServers.exarchos.command).toBe('node');
+    });
+
+    it('writeMcpConfig_CreatesParentDirectories', () => {
+      const configPath = path.join(tmpDir, 'nested', 'dir', 'claude.json');
+      const config = { mcpServers: {} };
+
+      writeMcpConfig(configPath, config);
+
+      expect(fs.existsSync(configPath)).toBe(true);
+    });
+  });
+});

--- a/src/operations/mcp.ts
+++ b/src/operations/mcp.ts
@@ -1,0 +1,168 @@
+/**
+ * MCP server configuration management for ~/.claude.json.
+ *
+ * Handles reading, merging, and writing MCP server entries in the
+ * Claude config file. Supports bundled, external, and remote server types.
+ * Only touches keys for servers declared in the manifest — preserves
+ * any user-added servers.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { McpServerComponent } from '../manifest/types.js';
+
+/** A single MCP server entry in ~/.claude.json. */
+export interface McpServerEntry {
+  readonly type: string;
+  readonly command?: string;
+  readonly args?: readonly string[];
+  readonly env?: Readonly<Record<string, string>>;
+  readonly url?: string;
+}
+
+/** The structure of ~/.claude.json (partial — preserves unknown keys). */
+export interface ClaudeConfig {
+  mcpServers?: Record<string, McpServerEntry>;
+  [key: string]: unknown;
+}
+
+/**
+ * Read the Claude config file from disk.
+ *
+ * @param configPath - Absolute path to ~/.claude.json.
+ * @returns The parsed config, or an empty object if the file does not exist.
+ * @throws If the file exists but contains invalid JSON.
+ */
+export function readMcpConfig(configPath: string): ClaudeConfig {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(configPath, 'utf-8');
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return {};
+    }
+    throw err;
+  }
+
+  try {
+    return JSON.parse(raw) as ClaudeConfig;
+  } catch {
+    throw new Error(`Failed to parse Claude config JSON at ${configPath}`);
+  }
+}
+
+/**
+ * Merge MCP server entries into an existing Claude config.
+ *
+ * Only adds or updates entries for servers in the provided list.
+ * User-added servers (not in the manifest) are preserved untouched.
+ *
+ * @param config - The existing Claude config.
+ * @param servers - MCP server components from the manifest.
+ * @param runtime - The JavaScript runtime command (e.g., 'bun', 'node').
+ * @param claudeHome - Absolute path to ~/.claude/.
+ * @returns A new config with merged server entries.
+ */
+export function mergeMcpServers(
+  config: ClaudeConfig,
+  servers: readonly McpServerComponent[],
+  runtime: string,
+  claudeHome: string,
+): ClaudeConfig {
+  const existingServers = config.mcpServers ?? {};
+  const mergedServers = { ...existingServers };
+
+  for (const server of servers) {
+    mergedServers[server.id] = generateMcpEntry(server, runtime, claudeHome);
+  }
+
+  return {
+    ...config,
+    mcpServers: mergedServers,
+  };
+}
+
+/**
+ * Generate a single MCP server entry from a manifest component.
+ *
+ * @param server - The MCP server component definition.
+ * @param runtime - The JavaScript runtime command (e.g., 'bun', 'node').
+ * @param claudeHome - Absolute path to ~/.claude/.
+ * @returns The MCP server entry for ~/.claude.json.
+ */
+export function generateMcpEntry(
+  server: McpServerComponent,
+  runtime: string,
+  claudeHome: string,
+): McpServerEntry {
+  switch (server.type) {
+    case 'bundled': {
+      const bundleFilename = `${server.id}-mcp.js`;
+      return {
+        type: 'stdio',
+        command: runtime,
+        args: ['run', path.join(claudeHome, 'mcp-servers', bundleFilename)],
+      };
+    }
+    case 'external':
+      return {
+        type: 'stdio',
+        command: server.command!,
+        args: server.args ? [...server.args] : [],
+      };
+    case 'remote':
+      return {
+        type: 'url',
+        url: server.url!,
+      };
+  }
+}
+
+/**
+ * Remove MCP server entries by their IDs.
+ *
+ * Only removes servers whose IDs appear in the provided list.
+ * All other servers and config keys are preserved.
+ *
+ * @param config - The existing Claude config.
+ * @param serverIds - IDs of servers to remove.
+ * @returns A new config with the specified servers removed.
+ */
+export function removeMcpServers(
+  config: ClaudeConfig,
+  serverIds: readonly string[],
+): ClaudeConfig {
+  if (!config.mcpServers) {
+    return { ...config };
+  }
+
+  const remainingServers = { ...config.mcpServers };
+  const idsToRemove = new Set(serverIds);
+
+  for (const id of Object.keys(remainingServers)) {
+    if (idsToRemove.has(id)) {
+      delete remainingServers[id];
+    }
+  }
+
+  return {
+    ...config,
+    mcpServers: remainingServers,
+  };
+}
+
+/**
+ * Write the Claude config to disk.
+ *
+ * Creates parent directories if they do not exist.
+ * Output is pretty-printed with 2-space indentation.
+ *
+ * @param configPath - Absolute path to ~/.claude.json.
+ * @param config - The config to persist.
+ */
+export function writeMcpConfig(configPath: string, config: ClaudeConfig): void {
+  const dir = path.dirname(configPath);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}

--- a/src/operations/settings.test.ts
+++ b/src/operations/settings.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import type { WizardSelections } from './config.js';
+import {
+  generateSettings,
+  generatePermissions,
+} from './settings.js';
+
+describe('Settings.json Generation (C3)', () => {
+  /** Helper: create a default WizardSelections. */
+  function createSelections(overrides: Partial<WizardSelections> = {}): WizardSelections {
+    return {
+      mcpServers: ['exarchos'],
+      plugins: ['serena', 'github'],
+      ruleSets: ['typescript'],
+      model: 'claude-opus-4-6',
+      ...overrides,
+    };
+  }
+
+  describe('generateSettings', () => {
+    it('generateSettings_DefaultSelections_IncludesAllPermissions', () => {
+      const selections = createSelections();
+
+      const result = generateSettings(selections);
+
+      expect(result.permissions).toBeDefined();
+      expect(result.permissions.allow).toBeDefined();
+      expect(Array.isArray(result.permissions.allow)).toBe(true);
+      expect(result.permissions.allow.length).toBeGreaterThan(0);
+      // Should contain at least some core permissions
+      expect(result.permissions.allow).toContain('Bash(git:*)');
+      expect(result.permissions.allow).toContain('Bash(npm:*)');
+    });
+
+    it('generateSettings_OpusModel_SetsModelField', () => {
+      const selections = createSelections({ model: 'claude-opus-4-6' });
+
+      const result = generateSettings(selections);
+
+      expect(result.model).toBe('claude-opus-4-6');
+    });
+
+    it('generateSettings_SonnetModel_SetsModelField', () => {
+      const selections = createSelections({ model: 'claude-sonnet-4-20250514' });
+
+      const result = generateSettings(selections);
+
+      expect(result.model).toBe('claude-sonnet-4-20250514');
+    });
+
+    it('generateSettings_SelectedPlugins_SetsEnabledPlugins', () => {
+      const selections = createSelections({
+        plugins: ['serena', 'github', 'context7'],
+      });
+
+      const result = generateSettings(selections);
+
+      expect(result.enabledPlugins).toBeDefined();
+      expect(result.enabledPlugins['serena']).toBe(true);
+      expect(result.enabledPlugins['github']).toBe(true);
+      expect(result.enabledPlugins['context7']).toBe(true);
+    });
+
+    it('generateSettings_NoPlugins_EmptyEnabledPlugins', () => {
+      const selections = createSelections({ plugins: [] });
+
+      const result = generateSettings(selections);
+
+      expect(result.enabledPlugins).toBeDefined();
+      expect(Object.keys(result.enabledPlugins)).toHaveLength(0);
+    });
+  });
+
+  describe('generatePermissions', () => {
+    it('generatePermissions_Always_ReturnsComprehensiveList', () => {
+      const permissions = generatePermissions();
+
+      expect(Array.isArray(permissions)).toBe(true);
+      expect(permissions.length).toBeGreaterThan(10);
+
+      // Should contain fundamental tool permissions
+      expect(permissions).toContain('Read');
+      expect(permissions).toContain('Write');
+      expect(permissions).toContain('Edit');
+      expect(permissions).toContain('Glob');
+      expect(permissions).toContain('Grep');
+
+      // Should contain bash command permissions
+      expect(permissions).toContain('Bash(git:*)');
+      expect(permissions).toContain('Bash(npm:*)');
+      expect(permissions).toContain('Bash(npx:*)');
+      expect(permissions).toContain('Bash(gt:*)');
+
+      // Should contain MCP wildcard
+      expect(permissions).toContain('mcp__*');
+    });
+  });
+});

--- a/src/operations/settings.ts
+++ b/src/operations/settings.ts
@@ -1,0 +1,255 @@
+/**
+ * Settings.json generation for the Exarchos installer.
+ *
+ * Generates the `settings.json` file that configures Claude Code's
+ * permissions, model, and enabled plugins based on wizard selections.
+ */
+
+import type { WizardSelections } from './config.js';
+
+/** The settings.json structure for Claude Code. */
+export interface Settings {
+  readonly permissions: { readonly allow: readonly string[] };
+  readonly model: string;
+  readonly enabledPlugins: Readonly<Record<string, boolean>>;
+}
+
+/**
+ * Generate a complete settings.json from wizard selections.
+ *
+ * Combines the comprehensive permission list, selected model,
+ * and enabled plugin map into a single settings object.
+ *
+ * @param selections - The user's wizard selections.
+ * @returns The settings.json content.
+ */
+export function generateSettings(selections: WizardSelections): Settings {
+  const enabledPlugins: Record<string, boolean> = {};
+  for (const pluginId of selections.plugins) {
+    enabledPlugins[pluginId] = true;
+  }
+
+  return {
+    permissions: { allow: generatePermissions() },
+    model: selections.model,
+    enabledPlugins,
+  };
+}
+
+/**
+ * Generate the comprehensive permission allow-list.
+ *
+ * Returns a hardcoded list of all tool and bash command permissions
+ * needed for full Exarchos functionality.
+ *
+ * @returns The permission strings for settings.json.
+ */
+export function generatePermissions(): string[] {
+  return [
+    // Claude Code native tools
+    'Read',
+    'Write',
+    'Edit',
+    'Glob',
+    'Grep',
+    'NotebookEdit',
+    'Task',
+    'LSP',
+    'WebSearch',
+    'WebFetch',
+
+    // MCP wildcard
+    'mcp__*',
+
+    // Version control and stacking
+    'Bash(gt:*)',
+    'Bash(gh:*)',
+    'Bash(git:*)',
+
+    // Package managers
+    'Bash(npm:*)',
+    'Bash(npx:*)',
+    'Bash(yarn:*)',
+    'Bash(pnpm:*)',
+    'Bash(bun:*)',
+    'Bash(node:*)',
+
+    // .NET ecosystem
+    'Bash(dotnet:*)',
+    'Bash(nuget:*)',
+    'Bash(msbuild:*)',
+
+    // Rust
+    'Bash(cargo:*)',
+    'Bash(rustc:*)',
+    'Bash(rustup:*)',
+
+    // Go
+    'Bash(go:*)',
+
+    // Python
+    'Bash(python:*)',
+    'Bash(python3:*)',
+    'Bash(pip:*)',
+    'Bash(pip3:*)',
+    'Bash(poetry:*)',
+    'Bash(uv:*)',
+
+    // Ruby
+    'Bash(ruby:*)',
+    'Bash(gem:*)',
+    'Bash(bundle:*)',
+
+    // Java/JVM
+    'Bash(java:*)',
+    'Bash(javac:*)',
+    'Bash(mvn:*)',
+    'Bash(gradle:*)',
+
+    // Containers and orchestration
+    'Bash(docker:*)',
+    'Bash(docker-compose:*)',
+    'Bash(podman:*)',
+    'Bash(kubectl:*)',
+    'Bash(helm:*)',
+
+    // Infrastructure
+    'Bash(terraform:*)',
+    'Bash(pulumi:*)',
+    'Bash(aws:*)',
+    'Bash(az:*)',
+    'Bash(gcloud:*)',
+
+    // Build systems
+    'Bash(make:*)',
+    'Bash(cmake:*)',
+    'Bash(ninja:*)',
+
+    // Testing
+    'Bash(jest:*)',
+    'Bash(vitest:*)',
+    'Bash(pytest:*)',
+    'Bash(mocha:*)',
+
+    // Linting and formatting
+    'Bash(eslint:*)',
+    'Bash(prettier:*)',
+    'Bash(tsc:*)',
+
+    // Network
+    'Bash(curl:*)',
+    'Bash(wget:*)',
+    'Bash(ssh:*)',
+    'Bash(scp:*)',
+    'Bash(rsync:*)',
+
+    // File reading
+    'Bash(ls:*)',
+    'Bash(cat:*)',
+    'Bash(head:*)',
+    'Bash(tail:*)',
+
+    // Search
+    'Bash(find:*)',
+    'Bash(grep:*)',
+    'Bash(rg:*)',
+    'Bash(fd:*)',
+    'Bash(ag:*)',
+    'Bash(ack:*)',
+
+    // Text processing
+    'Bash(sed:*)',
+    'Bash(awk:*)',
+    'Bash(sort:*)',
+    'Bash(uniq:*)',
+    'Bash(wc:*)',
+    'Bash(cut:*)',
+    'Bash(tr:*)',
+    'Bash(tee:*)',
+    'Bash(xargs:*)',
+    'Bash(jq:*)',
+    'Bash(yq:*)',
+
+    // File operations
+    'Bash(mkdir:*)',
+    'Bash(rm:*)',
+    'Bash(rmdir:*)',
+    'Bash(cp:*)',
+    'Bash(mv:*)',
+    'Bash(touch:*)',
+    'Bash(chmod:*)',
+    'Bash(ln:*)',
+
+    // Archives
+    'Bash(tar:*)',
+    'Bash(zip:*)',
+    'Bash(unzip:*)',
+    'Bash(gzip:*)',
+    'Bash(gunzip:*)',
+
+    // Diff and patch
+    'Bash(diff:*)',
+    'Bash(patch:*)',
+
+    // Output and environment
+    'Bash(echo:*)',
+    'Bash(printf:*)',
+    'Bash(date:*)',
+    'Bash(env:*)',
+    'Bash(export:*)',
+    'Bash(which:*)',
+    'Bash(whereis:*)',
+    'Bash(type:*)',
+
+    // Navigation
+    'Bash(pwd:*)',
+    'Bash(cd:*)',
+    'Bash(pushd:*)',
+    'Bash(popd:*)',
+    'Bash(realpath:*)',
+    'Bash(basename:*)',
+    'Bash(dirname:*)',
+
+    // Process management
+    'Bash(ps:*)',
+    'Bash(kill:*)',
+    'Bash(pkill:*)',
+    'Bash(pgrep:*)',
+    'Bash(time:*)',
+    'Bash(timeout:*)',
+    'Bash(watch:*)',
+
+    // Disk and file info
+    'Bash(du:*)',
+    'Bash(df:*)',
+    'Bash(stat:*)',
+    'Bash(file:*)',
+    'Bash(tree:*)',
+
+    // Network diagnostics
+    'Bash(ping:*)',
+    'Bash(nc:*)',
+    'Bash(netstat:*)',
+    'Bash(ss:*)',
+    'Bash(lsof:*)',
+
+    // Shell builtins
+    'Bash(source:*)',
+    'Bash(.:*)',
+    'Bash(test:*)',
+    'Bash([:*)',
+    'Bash([[:*)',
+    'Bash(true:*)',
+    'Bash(false:*)',
+    'Bash(exit:*)',
+    'Bash(return:*)',
+    'Bash(read:*)',
+    'Bash(set:*)',
+    'Bash(unset:*)',
+    'Bash(shift:*)',
+    'Bash(getopts:*)',
+    'Bash(declare:*)',
+    'Bash(local:*)',
+    'Bash(eval:*)',
+  ];
+}

--- a/src/operations/symlink.test.ts
+++ b/src/operations/symlink.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  createSymlink,
+  removeSymlink,
+  validateSymlinks,
+  type SymlinkResult,
+  type RemoveResult,
+  type SymlinkHealthReport,
+} from './symlink.js';
+
+describe('createSymlink (B4)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-symlink-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('createSymlink_NoExistingTarget_CreatesLink', () => {
+    const source = path.join(tmpDir, 'source-dir');
+    const target = path.join(tmpDir, 'link');
+    fs.mkdirSync(source);
+
+    const result: SymlinkResult = createSymlink(source, target);
+
+    expect(result).toBe('created');
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(target)).toBe(source);
+  });
+
+  it('createSymlink_ExistingCorrectLink_Skips', () => {
+    const source = path.join(tmpDir, 'source-dir');
+    const target = path.join(tmpDir, 'link');
+    fs.mkdirSync(source);
+    fs.symlinkSync(source, target);
+
+    const result = createSymlink(source, target);
+
+    expect(result).toBe('skipped');
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(target)).toBe(source);
+  });
+
+  it('createSymlink_ExistingWrongLink_Relinks', () => {
+    const source = path.join(tmpDir, 'correct-source');
+    const wrongSource = path.join(tmpDir, 'wrong-source');
+    const target = path.join(tmpDir, 'link');
+    fs.mkdirSync(source);
+    fs.mkdirSync(wrongSource);
+    fs.symlinkSync(wrongSource, target);
+
+    const result = createSymlink(source, target);
+
+    expect(result).toBe('relinked');
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(target)).toBe(source);
+  });
+
+  it('createSymlink_ExistingDirectory_BacksUpAndLinks', () => {
+    const source = path.join(tmpDir, 'source-dir');
+    const target = path.join(tmpDir, 'existing-dir');
+    fs.mkdirSync(source);
+    fs.mkdirSync(target);
+    fs.writeFileSync(path.join(target, 'file.txt'), 'preserved', 'utf-8');
+
+    const result = createSymlink(source, target);
+
+    expect(result).toBe('backed_up');
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(target)).toBe(source);
+
+    // Verify backup directory exists
+    const entries = fs.readdirSync(tmpDir);
+    const backupEntry = entries.find(
+      (e) => e.startsWith('existing-dir.backup.'),
+    );
+    expect(backupEntry).toBeDefined();
+
+    // Verify backup contents preserved
+    const backupPath = path.join(tmpDir, backupEntry!);
+    expect(
+      fs.readFileSync(path.join(backupPath, 'file.txt'), 'utf-8'),
+    ).toBe('preserved');
+  });
+});
+
+describe('removeSymlink (B4)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-rmsymlink-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('removeSymlink_ExistingLink_Removes', () => {
+    const source = path.join(tmpDir, 'source');
+    const target = path.join(tmpDir, 'link');
+    fs.mkdirSync(source);
+    fs.symlinkSync(source, target);
+
+    const result: RemoveResult = removeSymlink(target);
+
+    expect(result).toBe('removed');
+    expect(fs.existsSync(target)).toBe(false);
+  });
+
+  it('removeSymlink_NotALink_Skips', () => {
+    const target = path.join(tmpDir, 'regular-dir');
+    fs.mkdirSync(target);
+
+    const result = removeSymlink(target);
+
+    expect(result).toBe('skipped');
+    // Directory should still exist
+    expect(fs.existsSync(target)).toBe(true);
+  });
+
+  it('removeSymlink_Missing_Skips', () => {
+    const target = path.join(tmpDir, 'nonexistent');
+
+    const result = removeSymlink(target);
+
+    expect(result).toBe('skipped');
+  });
+});
+
+describe('validateSymlinks (B5)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-validate-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('validateSymlinks_AllValid_ReturnsHealthy', () => {
+    const src1 = path.join(tmpDir, 'src1');
+    const src2 = path.join(tmpDir, 'src2');
+    const tgt1 = path.join(tmpDir, 'link1');
+    const tgt2 = path.join(tmpDir, 'link2');
+    fs.mkdirSync(src1);
+    fs.mkdirSync(src2);
+    fs.symlinkSync(src1, tgt1);
+    fs.symlinkSync(src2, tgt2);
+
+    const report: SymlinkHealthReport = validateSymlinks({
+      [tgt1]: src1,
+      [tgt2]: src2,
+    });
+
+    expect(report.healthy).toHaveLength(2);
+    expect(report.healthy).toContain(tgt1);
+    expect(report.healthy).toContain(tgt2);
+    expect(report.broken).toHaveLength(0);
+    expect(report.missing).toHaveLength(0);
+  });
+
+  it('validateSymlinks_BrokenLink_ReturnsBroken', () => {
+    const src = path.join(tmpDir, 'deleted-source');
+    const tgt = path.join(tmpDir, 'link');
+    // Create link then remove source
+    fs.mkdirSync(src);
+    fs.symlinkSync(src, tgt);
+    fs.rmSync(src, { recursive: true, force: true });
+
+    const report = validateSymlinks({ [tgt]: src });
+
+    expect(report.healthy).toHaveLength(0);
+    expect(report.broken).toHaveLength(1);
+    expect(report.broken).toContain(tgt);
+    expect(report.missing).toHaveLength(0);
+  });
+
+  it('validateSymlinks_MissingLink_ReturnsMissing', () => {
+    const src = path.join(tmpDir, 'source');
+    const tgt = path.join(tmpDir, 'missing-link');
+    fs.mkdirSync(src);
+    // Link does not exist at all
+
+    const report = validateSymlinks({ [tgt]: src });
+
+    expect(report.healthy).toHaveLength(0);
+    expect(report.broken).toHaveLength(0);
+    expect(report.missing).toHaveLength(1);
+    expect(report.missing).toContain(tgt);
+  });
+
+  it('validateSymlinks_MixedState_ReturnsDetailedReport', () => {
+    const healthySrc = path.join(tmpDir, 'healthy-src');
+    const healthyTgt = path.join(tmpDir, 'healthy-link');
+    const brokenSrc = path.join(tmpDir, 'broken-src');
+    const brokenTgt = path.join(tmpDir, 'broken-link');
+    const missingSrc = path.join(tmpDir, 'missing-src');
+    const missingTgt = path.join(tmpDir, 'missing-link');
+
+    // Healthy: source exists, link correct
+    fs.mkdirSync(healthySrc);
+    fs.symlinkSync(healthySrc, healthyTgt);
+
+    // Broken: link exists but source was removed
+    fs.mkdirSync(brokenSrc);
+    fs.symlinkSync(brokenSrc, brokenTgt);
+    fs.rmSync(brokenSrc, { recursive: true, force: true });
+
+    // Missing: source exists but link does not
+    fs.mkdirSync(missingSrc);
+
+    const report = validateSymlinks({
+      [healthyTgt]: healthySrc,
+      [brokenTgt]: brokenSrc,
+      [missingTgt]: missingSrc,
+    });
+
+    expect(report.healthy).toEqual([healthyTgt]);
+    expect(report.broken).toEqual([brokenTgt]);
+    expect(report.missing).toEqual([missingTgt]);
+  });
+});

--- a/src/operations/symlink.ts
+++ b/src/operations/symlink.ts
@@ -1,0 +1,182 @@
+/**
+ * Symlink operations for dev-mode installation.
+ *
+ * In dev mode the installer creates symbolic links from `~/.claude/`
+ * back into the Exarchos repo so that edits to commands, skills, and
+ * rules take effect immediately without re-running the installer.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Outcome of a createSymlink operation. */
+export type SymlinkResult = 'created' | 'skipped' | 'backed_up' | 'relinked';
+
+/** Outcome of a removeSymlink operation. */
+export type RemoveResult = 'removed' | 'skipped';
+
+/**
+ * Create a symbolic link from `target` pointing to `source`.
+ *
+ * Handles four scenarios:
+ * - Target does not exist: creates the link.
+ * - Target is a symlink pointing to the correct source: skips.
+ * - Target is a symlink pointing elsewhere: removes and relinks.
+ * - Target is a real directory: renames to `<name>.backup.<timestamp>` then links.
+ *
+ * @param source - Absolute path to the link destination (the actual content).
+ * @param target - Absolute path where the symlink will be created.
+ * @returns The action taken.
+ */
+export function createSymlink(source: string, target: string): SymlinkResult {
+  let stat: fs.Stats | undefined;
+  try {
+    stat = fs.lstatSync(target);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      throw err;
+    }
+    // Target does not exist — fall through to create
+  }
+
+  if (stat) {
+    if (stat.isSymbolicLink()) {
+      const currentTarget = fs.readlinkSync(target);
+      if (currentTarget === source) {
+        return 'skipped';
+      }
+      // Wrong target — remove and relink
+      fs.unlinkSync(target);
+      fs.symlinkSync(source, target);
+      return 'relinked';
+    }
+
+    if (stat.isDirectory()) {
+      // Back up existing directory
+      const timestamp = Date.now();
+      const baseName = path.basename(target);
+      const parentDir = path.dirname(target);
+      const backupName = `${baseName}.backup.${timestamp}`;
+      const backupPath = path.join(parentDir, backupName);
+      fs.renameSync(target, backupPath);
+      fs.symlinkSync(source, target);
+      return 'backed_up';
+    }
+
+    // Target is a regular file or other — remove and link
+    fs.unlinkSync(target);
+    fs.symlinkSync(source, target);
+    return 'relinked';
+  }
+
+  // Target does not exist — create parent dirs if needed
+  const parentDir = path.dirname(target);
+  fs.mkdirSync(parentDir, { recursive: true });
+  fs.symlinkSync(source, target);
+  return 'created';
+}
+
+/**
+ * Remove a symbolic link at the given target path.
+ *
+ * Only removes the entry if it is actually a symlink. Regular files
+ * and directories are left untouched. Missing targets are silently
+ * skipped.
+ *
+ * @param target - Absolute path to the symlink to remove.
+ * @returns The action taken.
+ */
+export function removeSymlink(target: string): RemoveResult {
+  let stat: fs.Stats | undefined;
+  try {
+    stat = fs.lstatSync(target);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return 'skipped';
+    }
+    throw err;
+  }
+
+  if (stat.isSymbolicLink()) {
+    fs.unlinkSync(target);
+    return 'removed';
+  }
+
+  return 'skipped';
+}
+
+/**
+ * Health report for a set of expected symlinks.
+ */
+export interface SymlinkHealthReport {
+  /** Target paths whose symlinks exist and point to the expected source. */
+  readonly healthy: string[];
+  /** Target paths whose symlinks exist but are broken (source missing or wrong target). */
+  readonly broken: string[];
+  /** Target paths where no symlink exists at all. */
+  readonly missing: string[];
+}
+
+/**
+ * Validate a set of expected symbolic links.
+ *
+ * Checks each expected symlink target to determine whether it exists,
+ * is a symlink, and points to the expected source. Classifies each
+ * entry as healthy, broken, or missing.
+ *
+ * A link is "broken" if:
+ * - It is a symlink but its target (the source) no longer exists.
+ * - It is a symlink pointing to the wrong source.
+ *
+ * A link is "missing" if:
+ * - The target path does not exist at all.
+ * - The target path exists but is not a symlink.
+ *
+ * @param expectedLinks - Map of target path to expected source path.
+ * @returns A health report classifying each link.
+ */
+export function validateSymlinks(
+  expectedLinks: Record<string, string>,
+): SymlinkHealthReport {
+  const healthy: string[] = [];
+  const broken: string[] = [];
+  const missing: string[] = [];
+
+  for (const [target, expectedSource] of Object.entries(expectedLinks)) {
+    let stat: fs.Stats | undefined;
+    try {
+      stat = fs.lstatSync(target);
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') {
+        missing.push(target);
+        continue;
+      }
+      throw err;
+    }
+
+    if (!stat.isSymbolicLink()) {
+      missing.push(target);
+      continue;
+    }
+
+    // It is a symlink — check if it points to the right place and source exists
+    const actualTarget = fs.readlinkSync(target);
+    if (actualTarget !== expectedSource) {
+      broken.push(target);
+      continue;
+    }
+
+    // Check that the source actually exists
+    if (!fs.existsSync(expectedSource)) {
+      broken.push(target);
+      continue;
+    }
+
+    healthy.push(target);
+  }
+
+  return { healthy, broken, missing };
+}

--- a/src/wizard/display.test.ts
+++ b/src/wizard/display.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for display formatting helpers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  formatHeader,
+  formatPrerequisiteReport,
+  formatInstallSummary,
+  formatProgressLine,
+} from './display.js';
+import type { PrerequisiteReport } from './prerequisites.js';
+import type { InstallResult } from './display.js';
+
+describe('formatHeader', () => {
+  it('returns a formatted banner with title and version', () => {
+    const result = formatHeader('Exarchos', '2.0.0');
+
+    expect(result).toContain('Exarchos');
+    expect(result).toContain('2.0.0');
+    expect(result).toContain('=');
+  });
+});
+
+describe('formatPrerequisiteReport', () => {
+  it('shows checkmarks when all prerequisites are found', () => {
+    const report: PrerequisiteReport = {
+      results: [
+        { command: 'bun', found: true, version: '1.5.0', meetsMinVersion: true, installHint: '' },
+        { command: 'gt', found: true, version: '2.0.0', meetsMinVersion: true, installHint: '' },
+      ],
+      canProceed: true,
+      blockers: [],
+    };
+
+    const result = formatPrerequisiteReport(report);
+
+    expect(result).toContain('bun');
+    expect(result).toContain('1.5.0');
+    // Should have a check mark for found items
+    expect(result).toMatch(/[✓]/);
+  });
+
+  it('shows errors for missing required prerequisites', () => {
+    const report: PrerequisiteReport = {
+      results: [
+        { command: 'bun', found: false, meetsMinVersion: false, installHint: 'curl -fsSL https://bun.sh/install | bash' },
+        { command: 'gt', found: true, version: '2.0.0', meetsMinVersion: true, installHint: '' },
+      ],
+      canProceed: false,
+      blockers: ["Required tool 'bun' not found. Install: curl -fsSL https://bun.sh/install | bash"],
+    };
+
+    const result = formatPrerequisiteReport(report);
+
+    expect(result).toContain('bun');
+    // Should have an error indicator for missing items
+    expect(result).toMatch(/[✗]/);
+    expect(result).toContain('curl');
+  });
+});
+
+describe('formatInstallSummary', () => {
+  it('returns a formatted summary of install results', () => {
+    const results: InstallResult[] = [
+      { label: 'Commands', status: 'done' },
+      { label: 'Skills', status: 'done' },
+      { label: 'Rules', status: 'skip', detail: 'No rule sets selected' },
+      { label: 'MCP Server', status: 'fail', detail: 'Build failed' },
+    ];
+
+    const result = formatInstallSummary(results);
+
+    expect(result).toContain('Commands');
+    expect(result).toContain('Skills');
+    expect(result).toContain('Rules');
+    expect(result).toContain('MCP Server');
+    expect(result).toContain('No rule sets selected');
+    expect(result).toContain('Build failed');
+  });
+});
+
+describe('formatProgressLine', () => {
+  it('returns checkmark for completed items', () => {
+    const result = formatProgressLine('Commands', 'done');
+
+    expect(result).toContain('✓');
+    expect(result).toContain('Commands');
+  });
+
+  it('returns cross for failed items', () => {
+    const result = formatProgressLine('MCP Server', 'fail', 'Build error');
+
+    expect(result).toContain('✗');
+    expect(result).toContain('MCP Server');
+    expect(result).toContain('Build error');
+  });
+
+  it('returns tilde for skipped items', () => {
+    const result = formatProgressLine('Rules', 'skip', 'Not selected');
+
+    expect(result).toContain('~');
+    expect(result).toContain('Rules');
+    expect(result).toContain('Not selected');
+  });
+
+  it('includes detail when provided', () => {
+    const result = formatProgressLine('Plugins', 'done', '3 installed');
+
+    expect(result).toContain('✓');
+    expect(result).toContain('Plugins');
+    expect(result).toContain('3 installed');
+  });
+});

--- a/src/wizard/display.ts
+++ b/src/wizard/display.ts
@@ -1,0 +1,101 @@
+/**
+ * Display formatting helpers for the Exarchos installer.
+ *
+ * Provides functions to format headers, prerequisite reports,
+ * install summaries, and progress lines for terminal output.
+ */
+
+import type { PrerequisiteReport } from './prerequisites.js';
+
+/** Result of a single install operation for display purposes. */
+export interface InstallResult {
+  /** Display label for the operation. */
+  readonly label: string;
+  /** Completion status. */
+  readonly status: 'done' | 'skip' | 'fail';
+  /** Optional detail message. */
+  readonly detail?: string;
+}
+
+/** Status indicator characters. */
+const STATUS_ICONS = {
+  done: '\u2713', // ✓
+  skip: '~',
+  fail: '\u2717', // ✗
+} as const;
+
+/**
+ * Format a header banner for the installer.
+ *
+ * @param title - The application title.
+ * @param version - The version string.
+ * @returns A formatted banner string.
+ */
+export function formatHeader(title: string, version: string): string {
+  const line = `${title} v${version} \u2014 SDLC Workflow Automation`;
+  const separator = '='.repeat(line.length);
+  return `${line}\n${separator}`;
+}
+
+/**
+ * Format a prerequisite check report for display.
+ *
+ * Shows each prerequisite with its version and found/not-found status.
+ * Blockers include install hints.
+ *
+ * @param report - The prerequisite report to format.
+ * @returns A formatted multi-line string.
+ */
+export function formatPrerequisiteReport(report: PrerequisiteReport): string {
+  const lines: string[] = [];
+
+  for (const result of report.results) {
+    const icon = result.found && result.meetsMinVersion
+      ? STATUS_ICONS.done
+      : STATUS_ICONS.fail;
+    const version = result.version ? ` (${result.version})` : '';
+    const hint = !result.found || !result.meetsMinVersion
+      ? ` — ${result.installHint}`
+      : '';
+    lines.push(`  ${icon} ${result.command}${version}${hint}`);
+  }
+
+  if (report.blockers.length > 0) {
+    lines.push('');
+    lines.push('Blockers:');
+    for (const blocker of report.blockers) {
+      lines.push(`  ${STATUS_ICONS.fail} ${blocker}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Format an install summary from a list of results.
+ *
+ * @param results - The install results to summarize.
+ * @returns A formatted multi-line string.
+ */
+export function formatInstallSummary(results: InstallResult[]): string {
+  const lines = results.map((r) => formatProgressLine(r.label, r.status, r.detail));
+  return lines.join('\n');
+}
+
+/**
+ * Format a single progress line with status indicator.
+ *
+ * @param label - The operation label.
+ * @param status - The completion status.
+ * @param detail - Optional detail message.
+ * @returns A formatted single-line string.
+ */
+export function formatProgressLine(
+  label: string,
+  status: 'done' | 'skip' | 'fail',
+  detail?: string,
+): string {
+  const icon = STATUS_ICONS[status];
+  const suffix = detail ? ` — ${detail}` : '';
+  return `  ${icon} ${label}${suffix}`;
+}

--- a/src/wizard/prerequisites.test.ts
+++ b/src/wizard/prerequisites.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for prerequisite detection and runtime checks.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from 'node:child_process';
+import {
+  detectRuntime,
+  getVersion,
+  meetsMinVersion,
+  checkPrerequisite,
+  checkAllPrerequisites,
+  DEFAULT_PREREQUISITES,
+} from './prerequisites.js';
+
+import type { Prerequisite } from './prerequisites.js';
+
+const mockExecSync = vi.mocked(execSync);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('detectRuntime', () => {
+  it('returns bun when bun is available', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('1.3.4\n'));
+
+    const result = detectRuntime();
+
+    expect(result).toBe('bun');
+    expect(mockExecSync).toHaveBeenCalledWith('bun --version', { stdio: 'pipe' });
+  });
+
+  it('returns node when only node is available', () => {
+    mockExecSync
+      .mockImplementationOnce(() => { throw new Error('not found'); }) // bun fails
+      .mockReturnValueOnce(Buffer.from('20.11.0\n')); // node succeeds
+
+    const result = detectRuntime();
+
+    expect(result).toBe('node');
+  });
+
+  it('throws when neither runtime is available', () => {
+    mockExecSync.mockImplementation(() => { throw new Error('not found'); });
+
+    expect(() => detectRuntime()).toThrow();
+  });
+});
+
+describe('getVersion', () => {
+  it('parses valid version output', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('1.3.4\n'));
+
+    const result = getVersion('bun', ['--version']);
+
+    expect(result).toBe('1.3.4');
+  });
+
+  it('returns null for invalid output', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('not-a-version'));
+
+    const result = getVersion('bun', ['--version']);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when command fails', () => {
+    mockExecSync.mockImplementation(() => { throw new Error('not found'); });
+
+    const result = getVersion('missing-cmd', ['--version']);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('meetsMinVersion', () => {
+  it('returns true when actual is above minimum', () => {
+    expect(meetsMinVersion('1.3.4', '1.0.0')).toBe(true);
+  });
+
+  it('returns false when actual is below minimum', () => {
+    expect(meetsMinVersion('0.9.0', '1.0.0')).toBe(false);
+  });
+
+  it('returns true when versions are equal', () => {
+    expect(meetsMinVersion('1.0.0', '1.0.0')).toBe(true);
+  });
+
+  it('compares minor versions correctly', () => {
+    expect(meetsMinVersion('1.2.0', '1.3.0')).toBe(false);
+    expect(meetsMinVersion('1.4.0', '1.3.0')).toBe(true);
+  });
+
+  it('compares patch versions correctly', () => {
+    expect(meetsMinVersion('1.0.1', '1.0.2')).toBe(false);
+    expect(meetsMinVersion('1.0.3', '1.0.2')).toBe(true);
+  });
+});
+
+describe('checkPrerequisite', () => {
+  it('returns found when command exists', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('1.5.0\n'));
+
+    const prereq: Prerequisite = {
+      command: 'bun',
+      args: ['--version'],
+      required: true,
+      installHint: 'curl -fsSL https://bun.sh/install | bash',
+    };
+
+    const result = checkPrerequisite(prereq);
+
+    expect(result.found).toBe(true);
+    expect(result.command).toBe('bun');
+  });
+
+  it('returns not found when command is missing', () => {
+    mockExecSync.mockImplementation(() => { throw new Error('not found'); });
+
+    const prereq: Prerequisite = {
+      command: 'missing-tool',
+      args: ['--version'],
+      required: true,
+      installHint: 'install it',
+    };
+
+    const result = checkPrerequisite(prereq);
+
+    expect(result.found).toBe(false);
+    expect(result.meetsMinVersion).toBe(false);
+    expect(result.installHint).toBe('install it');
+  });
+
+  it('includes version when command exists', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('2.1.3\n'));
+
+    const prereq: Prerequisite = {
+      command: 'gt',
+      args: ['--version'],
+      required: true,
+      minVersion: '1.0.0',
+      installHint: 'brew install graphite',
+    };
+
+    const result = checkPrerequisite(prereq);
+
+    expect(result.found).toBe(true);
+    expect(result.version).toBe('2.1.3');
+    expect(result.meetsMinVersion).toBe(true);
+  });
+
+  it('returns version too low when below minimum', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('0.5.0\n'));
+
+    const prereq: Prerequisite = {
+      command: 'bun',
+      args: ['--version'],
+      required: true,
+      minVersion: '1.0.0',
+      installHint: 'curl -fsSL https://bun.sh/install | bash',
+    };
+
+    const result = checkPrerequisite(prereq);
+
+    expect(result.found).toBe(true);
+    expect(result.version).toBe('0.5.0');
+    expect(result.meetsMinVersion).toBe(false);
+  });
+});
+
+describe('checkAllPrerequisites', () => {
+  it('returns all found when all prerequisites are present', () => {
+    // Each checkPrerequisite call invokes getVersion which calls execSync once
+    mockExecSync
+      .mockReturnValueOnce(Buffer.from('1.5.0\n')) // bun
+      .mockReturnValueOnce(Buffer.from('2.0.0\n')); // gt
+
+    const prereqs: Prerequisite[] = [
+      { command: 'bun', args: ['--version'], required: true, minVersion: '1.0.0', installHint: 'install bun' },
+      { command: 'gt', args: ['--version'], required: true, installHint: 'install gt' },
+    ];
+
+    const report = checkAllPrerequisites(prereqs);
+
+    expect(report.results).toHaveLength(2);
+    expect(report.results.every((r) => r.found)).toBe(true);
+    expect(report.canProceed).toBe(true);
+    expect(report.blockers).toHaveLength(0);
+  });
+
+  it('blocks install when a required prerequisite is missing', () => {
+    mockExecSync
+      .mockImplementationOnce(() => { throw new Error('not found'); }) // bun missing
+      .mockReturnValueOnce(Buffer.from('2.0.0\n')); // gt found
+
+    const prereqs: Prerequisite[] = [
+      { command: 'bun', args: ['--version'], required: true, minVersion: '1.0.0', installHint: 'install bun' },
+      { command: 'gt', args: ['--version'], required: true, installHint: 'install gt' },
+    ];
+
+    const report = checkAllPrerequisites(prereqs);
+
+    expect(report.canProceed).toBe(false);
+    expect(report.blockers.length).toBeGreaterThan(0);
+    expect(report.blockers[0]).toContain('bun');
+  });
+
+  it('warns but continues when optional prerequisite is missing', () => {
+    mockExecSync
+      .mockReturnValueOnce(Buffer.from('1.5.0\n')) // bun found
+      .mockImplementationOnce(() => { throw new Error('not found'); }); // node missing (optional)
+
+    const prereqs: Prerequisite[] = [
+      { command: 'bun', args: ['--version'], required: true, minVersion: '1.0.0', installHint: 'install bun' },
+      { command: 'node', args: ['--version'], required: false, minVersion: '20.0.0', installHint: 'install node' },
+    ];
+
+    const report = checkAllPrerequisites(prereqs);
+
+    expect(report.canProceed).toBe(true);
+    expect(report.blockers).toHaveLength(0);
+    expect(report.results[1].found).toBe(false);
+  });
+
+  it('returns structured report with all results', () => {
+    mockExecSync
+      .mockReturnValueOnce(Buffer.from('1.5.0\n'))
+      .mockReturnValueOnce(Buffer.from('0.5.0\n'))
+      .mockImplementationOnce(() => { throw new Error('not found'); });
+
+    const prereqs: Prerequisite[] = [
+      { command: 'bun', args: ['--version'], required: true, minVersion: '1.0.0', installHint: 'install bun' },
+      { command: 'gt', args: ['--version'], required: true, minVersion: '1.0.0', installHint: 'install gt' },
+      { command: 'node', args: ['--version'], required: false, minVersion: '20.0.0', installHint: 'install node' },
+    ];
+
+    const report = checkAllPrerequisites(prereqs);
+
+    expect(report.results).toHaveLength(3);
+    expect(report.results[0].found).toBe(true);
+    expect(report.results[0].meetsMinVersion).toBe(true);
+    expect(report.results[1].found).toBe(true);
+    expect(report.results[1].meetsMinVersion).toBe(false);
+    expect(report.results[2].found).toBe(false);
+    // gt is required but below min version → blocks
+    expect(report.canProceed).toBe(false);
+    expect(report.blockers.length).toBeGreaterThan(0);
+  });
+});
+
+describe('DEFAULT_PREREQUISITES', () => {
+  it('includes bun, gt, and node entries', () => {
+    expect(DEFAULT_PREREQUISITES).toHaveLength(3);
+    expect(DEFAULT_PREREQUISITES.map((p) => p.command)).toEqual(['bun', 'gt', 'node']);
+  });
+
+  it('marks bun and gt as required, node as optional', () => {
+    const bun = DEFAULT_PREREQUISITES.find((p) => p.command === 'bun');
+    const gt = DEFAULT_PREREQUISITES.find((p) => p.command === 'gt');
+    const node = DEFAULT_PREREQUISITES.find((p) => p.command === 'node');
+
+    expect(bun?.required).toBe(true);
+    expect(gt?.required).toBe(true);
+    expect(node?.required).toBe(false);
+  });
+});

--- a/src/wizard/prerequisites.ts
+++ b/src/wizard/prerequisites.ts
@@ -1,0 +1,225 @@
+/**
+ * Prerequisite detection and runtime checks for the Exarchos installer.
+ *
+ * Detects which JavaScript runtime is available (bun or node),
+ * verifies tool versions, and checks all installation prerequisites.
+ */
+
+import { execSync } from 'node:child_process';
+
+/**
+ * Detect the available JavaScript runtime.
+ *
+ * Prefers bun over node. Tries `bun --version` first; if that fails,
+ * falls back to `node --version`.
+ *
+ * @returns The detected runtime identifier.
+ * @throws If neither bun nor node is available.
+ */
+export function detectRuntime(): 'bun' | 'node' {
+  try {
+    execSync('bun --version', { stdio: 'pipe' });
+    return 'bun';
+  } catch {
+    // bun not available, try node
+  }
+
+  try {
+    execSync('node --version', { stdio: 'pipe' });
+    return 'node';
+  } catch {
+    // node not available either
+  }
+
+  throw new Error(
+    'No JavaScript runtime found. Install bun (https://bun.sh) or Node.js >= 20 (https://nodejs.org).',
+  );
+}
+
+/**
+ * Get the version string for a command.
+ *
+ * Runs the command with the given arguments, trims the output,
+ * and validates it looks like a semver-ish version string.
+ *
+ * @param command - The command to run (e.g., 'bun', 'node', 'gt').
+ * @param args - Arguments to pass (e.g., ['--version']).
+ * @returns The parsed version string, or null if the command fails or output is invalid.
+ */
+export function getVersion(command: string, args: string[]): string | null {
+  try {
+    const output = execSync(`${command} ${args.join(' ')}`, { stdio: 'pipe' });
+    const trimmed = output.toString().trim();
+
+    // Strip leading 'v' if present (e.g., node outputs "v20.11.0")
+    const cleaned = trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;
+
+    // Validate it looks like a version (digits.digits.digits, possibly with extra)
+    if (/^\d+\.\d+\.\d+/.test(cleaned)) {
+      // Return just the major.minor.patch portion
+      const match = cleaned.match(/^(\d+\.\d+\.\d+)/);
+      return match ? match[1] : null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check whether an actual version meets a minimum version requirement.
+ *
+ * Performs simple numeric comparison of major.minor.patch components.
+ *
+ * @param actual - The actual version string (e.g., "1.3.4").
+ * @param minimum - The minimum required version (e.g., "1.0.0").
+ * @returns True if actual >= minimum.
+ */
+export function meetsMinVersion(actual: string, minimum: string): boolean {
+  const parseParts = (v: string): [number, number, number] => {
+    const parts = v.split('.').map(Number);
+    return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+  };
+
+  const [aMajor, aMinor, aPatch] = parseParts(actual);
+  const [mMajor, mMinor, mPatch] = parseParts(minimum);
+
+  if (aMajor !== mMajor) return aMajor > mMajor;
+  if (aMinor !== mMinor) return aMinor > mMinor;
+  return aPatch >= mPatch;
+}
+
+// ─── Prerequisite checking ────────────────────────────────────────────────────
+
+/** Definition of a single prerequisite tool. */
+export interface Prerequisite {
+  /** The command to check (e.g., 'bun', 'gt'). */
+  readonly command: string;
+  /** Arguments to get the version (e.g., ['--version']). */
+  readonly args: string[];
+  /** Whether this prerequisite is required for installation to proceed. */
+  readonly required: boolean;
+  /** Minimum acceptable version (optional). */
+  readonly minVersion?: string;
+  /** Human-readable hint on how to install this tool. */
+  readonly installHint: string;
+}
+
+/** Result of checking a single prerequisite. */
+export interface PrerequisiteResult {
+  /** The command that was checked. */
+  readonly command: string;
+  /** Whether the command was found on the system. */
+  readonly found: boolean;
+  /** The detected version, if any. */
+  readonly version?: string;
+  /** Whether the detected version meets the minimum requirement. */
+  readonly meetsMinVersion: boolean;
+  /** Human-readable hint on how to install this tool. */
+  readonly installHint: string;
+}
+
+/**
+ * Check a single prerequisite tool.
+ *
+ * Runs the command to detect its version and, if a minimum version
+ * is specified, verifies the installed version meets the requirement.
+ *
+ * @param prereq - The prerequisite definition to check.
+ * @returns The check result.
+ */
+export function checkPrerequisite(prereq: Prerequisite): PrerequisiteResult {
+  const version = getVersion(prereq.command, prereq.args);
+
+  if (version === null) {
+    return {
+      command: prereq.command,
+      found: false,
+      meetsMinVersion: false,
+      installHint: prereq.installHint,
+    };
+  }
+
+  const versionOk = prereq.minVersion
+    ? meetsMinVersion(version, prereq.minVersion)
+    : true;
+
+  return {
+    command: prereq.command,
+    found: true,
+    version,
+    meetsMinVersion: versionOk,
+    installHint: prereq.installHint,
+  };
+}
+
+// ─── Full prerequisite suite ──────────────────────────────────────────────────
+
+/** Aggregated report from checking all prerequisites. */
+export interface PrerequisiteReport {
+  /** Individual results for each prerequisite. */
+  readonly results: PrerequisiteResult[];
+  /** Whether installation can proceed (all required prerequisites satisfied). */
+  readonly canProceed: boolean;
+  /** Human-readable messages for each blocking issue. */
+  readonly blockers: string[];
+}
+
+/**
+ * Check all prerequisites and produce an aggregated report.
+ *
+ * @param prereqs - The list of prerequisites to check.
+ * @returns A report indicating whether installation can proceed.
+ */
+export function checkAllPrerequisites(prereqs: Prerequisite[]): PrerequisiteReport {
+  const results = prereqs.map((p) => checkPrerequisite(p));
+  const blockers: string[] = [];
+
+  for (let i = 0; i < prereqs.length; i++) {
+    const prereq = prereqs[i];
+    const result = results[i];
+
+    if (!prereq.required) continue;
+
+    if (!result.found) {
+      blockers.push(
+        `Required tool '${prereq.command}' not found. Install: ${prereq.installHint}`,
+      );
+    } else if (!result.meetsMinVersion && prereq.minVersion) {
+      blockers.push(
+        `Required tool '${prereq.command}' version ${result.version} is below minimum ${prereq.minVersion}. Update: ${prereq.installHint}`,
+      );
+    }
+  }
+
+  return {
+    results,
+    canProceed: blockers.length === 0,
+    blockers,
+  };
+}
+
+/** Default prerequisites for the Exarchos installer. */
+export const DEFAULT_PREREQUISITES: readonly Prerequisite[] = [
+  {
+    command: 'bun',
+    args: ['--version'],
+    required: true,
+    minVersion: '1.0.0',
+    installHint: 'curl -fsSL https://bun.sh/install | bash',
+  },
+  {
+    command: 'gt',
+    args: ['--version'],
+    required: true,
+    installHint: 'brew install withgraphite/tap/graphite',
+  },
+  {
+    command: 'node',
+    args: ['--version'],
+    required: false,
+    minVersion: '20.0.0',
+    installHint: 'Optional fallback. Install via nvm or nodejs.org',
+  },
+];

--- a/src/wizard/prompts.test.ts
+++ b/src/wizard/prompts.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the PromptAdapter interface and MockPromptAdapter.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createPromptAdapter,
+  MockPromptAdapter,
+} from './prompts.js';
+import type { PromptAdapter } from './prompts.js';
+
+describe('createPromptAdapter', () => {
+  it('returns an adapter instance', () => {
+    const adapter = createPromptAdapter();
+
+    expect(adapter).toBeDefined();
+    expect(typeof adapter.select).toBe('function');
+    expect(typeof adapter.multiselect).toBe('function');
+    expect(typeof adapter.confirm).toBe('function');
+    expect(typeof adapter.text).toBe('function');
+  });
+});
+
+describe('MockPromptAdapter', () => {
+  it('select returns preset value', async () => {
+    const adapter = new MockPromptAdapter(['standard']);
+
+    const result = await adapter.select('Choose mode:', [
+      { label: 'Standard', value: 'standard' },
+      { label: 'Dev', value: 'dev' },
+    ]);
+
+    expect(result).toBe('standard');
+  });
+
+  it('multiselect returns preset values', async () => {
+    const adapter = new MockPromptAdapter([['server-a', 'server-b']]);
+
+    const result = await adapter.multiselect('Choose servers:', [
+      { label: 'Server A', value: 'server-a' },
+      { label: 'Server B', value: 'server-b' },
+      { label: 'Server C', value: 'server-c' },
+    ]);
+
+    expect(result).toEqual(['server-a', 'server-b']);
+  });
+
+  it('confirm returns preset boolean', async () => {
+    const adapter = new MockPromptAdapter([true]);
+
+    const result = await adapter.confirm('Proceed?');
+
+    expect(result).toBe(true);
+  });
+
+  it('text returns preset string', async () => {
+    const adapter = new MockPromptAdapter(['my-input']);
+
+    const result = await adapter.text('Enter name:');
+
+    expect(result).toBe('my-input');
+  });
+
+  it('dequeues responses in FIFO order', async () => {
+    const adapter = new MockPromptAdapter(['first', 'second', 'third']);
+
+    const r1 = await adapter.select('Q1:', [{ label: 'A', value: 'first' }]);
+    const r2 = await adapter.select('Q2:', [{ label: 'B', value: 'second' }]);
+    const r3 = await adapter.select('Q3:', [{ label: 'C', value: 'third' }]);
+
+    expect(r1).toBe('first');
+    expect(r2).toBe('second');
+    expect(r3).toBe('third');
+  });
+
+  it('throws when response queue is exhausted', async () => {
+    const adapter = new MockPromptAdapter([]);
+
+    await expect(adapter.select('Q:', [{ label: 'A', value: 'a' }]))
+      .rejects.toThrow('MockPromptAdapter: no more preset responses');
+  });
+
+  it('implements PromptAdapter interface', () => {
+    const adapter: PromptAdapter = new MockPromptAdapter([]);
+
+    expect(adapter).toBeDefined();
+  });
+});

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -1,0 +1,92 @@
+/**
+ * Prompt adapter interface and implementations for the Exarchos installer wizard.
+ *
+ * Provides an abstract interface over interactive prompts so the wizard
+ * can be tested with a mock adapter and run with different prompt
+ * libraries (e.g., bun-promptx) at runtime.
+ */
+
+/** A single option in a select prompt. */
+export interface SelectOption<T> {
+  /** Display label shown to the user. */
+  readonly label: string;
+  /** Value returned when this option is selected. */
+  readonly value: T;
+  /** Optional description shown below the label. */
+  readonly description?: string;
+  /** Whether this option is disabled (shown but not selectable). */
+  readonly disabled?: boolean;
+}
+
+/** A single option in a multiselect prompt. */
+export interface MultiselectOption<T> extends SelectOption<T> {
+  /** Whether this option is pre-selected. */
+  readonly selected?: boolean;
+}
+
+/**
+ * Abstract interface for interactive prompts.
+ *
+ * Implementations handle the actual I/O (terminal prompts, mock responses, etc.)
+ */
+export interface PromptAdapter {
+  /** Show a single-select prompt and return the chosen value. */
+  select<T>(message: string, options: SelectOption<T>[]): Promise<T>;
+  /** Show a multi-select prompt and return the chosen values. */
+  multiselect<T>(message: string, options: MultiselectOption<T>[]): Promise<T[]>;
+  /** Show a yes/no confirmation prompt. */
+  confirm(message: string, defaultValue?: boolean): Promise<boolean>;
+  /** Show a free-text input prompt. */
+  text(message: string, placeholder?: string): Promise<string>;
+}
+
+/**
+ * Mock prompt adapter for testing.
+ *
+ * Accepts an array of preset responses that are dequeued in FIFO order
+ * as each prompt method is called.
+ */
+export class MockPromptAdapter implements PromptAdapter {
+  private readonly responses: unknown[];
+  private index = 0;
+
+  constructor(responses: unknown[]) {
+    this.responses = [...responses];
+  }
+
+  async select<T>(_message: string, _options: SelectOption<T>[]): Promise<T> {
+    return this.nextResponse() as T;
+  }
+
+  async multiselect<T>(_message: string, _options: MultiselectOption<T>[]): Promise<T[]> {
+    return this.nextResponse() as T[];
+  }
+
+  async confirm(_message: string, _defaultValue?: boolean): Promise<boolean> {
+    return this.nextResponse() as boolean;
+  }
+
+  async text(_message: string, _placeholder?: string): Promise<string> {
+    return this.nextResponse() as string;
+  }
+
+  private nextResponse(): unknown {
+    if (this.index >= this.responses.length) {
+      throw new Error('MockPromptAdapter: no more preset responses');
+    }
+    return this.responses[this.index++];
+  }
+}
+
+/**
+ * Create a prompt adapter.
+ *
+ * Currently returns a MockPromptAdapter stub. The real prompt library
+ * integration (e.g., bun-promptx) will be added when bun dependencies
+ * are configured.
+ *
+ * @returns A prompt adapter instance.
+ */
+export function createPromptAdapter(): PromptAdapter {
+  return new MockPromptAdapter([]);
+}

--- a/src/wizard/wizard.test.ts
+++ b/src/wizard/wizard.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Tests for the interactive wizard flow and non-interactive mode.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    readFileSync: vi.fn(actual.readFileSync),
+  };
+});
+
+import * as fs from 'node:fs';
+import { MockPromptAdapter } from './prompts.js';
+import { runWizard, runNonInteractive } from './wizard.js';
+import type { Manifest } from '../manifest/types.js';
+import type { ExarchosConfig } from '../operations/config.js';
+
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/** Minimal test manifest for wizard tests. */
+function createTestManifest(): Manifest {
+  return {
+    version: '2.0.0',
+    components: {
+      core: [],
+      mcpServers: [
+        {
+          id: 'exarchos',
+          name: 'Exarchos',
+          description: 'Core workflow server',
+          required: true,
+          type: 'bundled',
+          bundlePath: 'plugins/exarchos',
+        },
+        {
+          id: 'context7',
+          name: 'Context7',
+          description: 'Library docs',
+          required: false,
+          type: 'remote',
+          url: 'https://example.com',
+        },
+        {
+          id: 'microsoft-learn',
+          name: 'Microsoft Learn',
+          description: 'MS docs',
+          required: false,
+          type: 'remote',
+          url: 'https://example.com',
+        },
+      ],
+      plugins: [
+        {
+          id: 'github',
+          name: 'GitHub',
+          description: 'GitHub integration',
+          required: true,
+          default: true,
+        },
+        {
+          id: 'serena',
+          name: 'Serena',
+          description: 'Semantic code analysis',
+          required: false,
+          default: true,
+        },
+        {
+          id: 'graphite',
+          name: 'Graphite',
+          description: 'Stacked PRs',
+          required: false,
+          default: false,
+        },
+      ],
+      ruleSets: [
+        {
+          id: 'coding-standards',
+          name: 'Coding Standards',
+          description: 'TypeScript coding standards',
+          files: ['coding-standards-typescript.md'],
+          default: true,
+        },
+        {
+          id: 'tdd',
+          name: 'TDD Rules',
+          description: 'Test-driven development rules',
+          files: ['tdd-typescript.md'],
+          default: true,
+        },
+        {
+          id: 'pr-descriptions',
+          name: 'PR Descriptions',
+          description: 'PR description guidelines',
+          files: ['pr-descriptions.md'],
+          default: false,
+        },
+      ],
+    },
+    defaults: {
+      model: 'claude-opus-4-6',
+      mode: 'standard',
+    },
+  };
+}
+
+describe('runWizard', () => {
+  it('returns standard mode selections', async () => {
+    const manifest = createTestManifest();
+    // Responses: mode, mcpServers, plugins, ruleSets, model, confirm
+    const prompts = new MockPromptAdapter([
+      'standard',                          // mode
+      ['context7'],                         // optional mcpServers
+      ['serena'],                           // optional plugins
+      ['coding-standards', 'tdd'],          // ruleSets
+      'claude-opus-4-6',                    // model
+      true,                                 // confirm
+    ]);
+
+    const result = await runWizard(manifest, prompts);
+
+    expect(result.mode).toBe('standard');
+    expect(result.selections.mcpServers).toContain('context7');
+    // Required server always included
+    expect(result.selections.mcpServers).toContain('exarchos');
+  });
+
+  it('returns dev mode selections', async () => {
+    const manifest = createTestManifest();
+    const prompts = new MockPromptAdapter([
+      'dev',                                // mode
+      ['context7', 'microsoft-learn'],      // optional mcpServers
+      ['serena', 'graphite'],               // optional plugins
+      ['coding-standards', 'tdd', 'pr-descriptions'], // ruleSets
+      'claude-sonnet-4-20250514',           // model
+      true,                                 // confirm
+    ]);
+
+    const result = await runWizard(manifest, prompts);
+
+    expect(result.mode).toBe('dev');
+    expect(result.selections.model).toBe('claude-sonnet-4-20250514');
+  });
+
+  it('always includes required servers regardless of selection', async () => {
+    const manifest = createTestManifest();
+    // User selects no optional servers
+    const prompts = new MockPromptAdapter([
+      'standard',                           // mode
+      [],                                   // no optional mcpServers selected
+      [],                                   // no optional plugins
+      [],                                   // no ruleSets
+      'claude-opus-4-6',                    // model
+      true,                                 // confirm
+    ]);
+
+    const result = await runWizard(manifest, prompts);
+
+    // Required server 'exarchos' must still be included
+    expect(result.selections.mcpServers).toContain('exarchos');
+    // Required plugin 'github' must still be included
+    expect(result.selections.plugins).toContain('github');
+  });
+
+  it('returns selected rule set file list', async () => {
+    const manifest = createTestManifest();
+    const prompts = new MockPromptAdapter([
+      'standard',
+      [],
+      [],
+      ['coding-standards', 'pr-descriptions'],
+      'claude-opus-4-6',
+      true,
+    ]);
+
+    const result = await runWizard(manifest, prompts);
+
+    expect(result.selections.ruleSets).toContain('coding-standards');
+    expect(result.selections.ruleSets).toContain('pr-descriptions');
+    expect(result.selections.ruleSets).not.toContain('tdd');
+  });
+
+  it('returns selected model ID', async () => {
+    const manifest = createTestManifest();
+    const prompts = new MockPromptAdapter([
+      'standard',
+      [],
+      [],
+      [],
+      'claude-sonnet-4-20250514',
+      true,
+    ]);
+
+    const result = await runWizard(manifest, prompts);
+
+    expect(result.selections.model).toBe('claude-sonnet-4-20250514');
+  });
+
+  it('uses existing config as defaults', async () => {
+    const manifest = createTestManifest();
+    const existingConfig: ExarchosConfig = {
+      version: '1.0.0',
+      installedAt: '2025-01-01T00:00:00Z',
+      mode: 'dev',
+      selections: {
+        mcpServers: ['context7'],
+        plugins: ['serena', 'graphite'],
+        ruleSets: ['coding-standards'],
+        model: 'claude-sonnet-4-20250514',
+      },
+      hashes: {},
+    };
+
+    // Wizard should use existing config as defaults
+    // User accepts all defaults by selecting same values
+    const prompts = new MockPromptAdapter([
+      'dev',
+      ['context7'],
+      ['serena', 'graphite'],
+      ['coding-standards'],
+      'claude-sonnet-4-20250514',
+      true,
+    ]);
+
+    const result = await runWizard(manifest, prompts, existingConfig);
+
+    expect(result.mode).toBe('dev');
+    expect(result.selections.mcpServers).toContain('context7');
+    expect(result.selections.mcpServers).toContain('exarchos'); // required always included
+  });
+});
+
+describe('runNonInteractive', () => {
+  it('uses manifest defaults with useDefaults flag', () => {
+    const manifest = createTestManifest();
+
+    const result = runNonInteractive(manifest, { useDefaults: true });
+
+    expect(result.mode).toBe('standard');
+    expect(result.selections.model).toBe('claude-opus-4-6');
+    // Required servers always included
+    expect(result.selections.mcpServers).toContain('exarchos');
+    // Required plugins always included
+    expect(result.selections.plugins).toContain('github');
+    // Default plugins included
+    expect(result.selections.plugins).toContain('serena');
+    // Default rule sets included
+    expect(result.selections.ruleSets).toContain('coding-standards');
+    expect(result.selections.ruleSets).toContain('tdd');
+  });
+
+  it('uses previous selections with useDefaults and existing config', () => {
+    const manifest = createTestManifest();
+    const existingConfig: ExarchosConfig = {
+      version: '1.0.0',
+      installedAt: '2025-01-01T00:00:00Z',
+      mode: 'dev',
+      selections: {
+        mcpServers: ['context7'],
+        plugins: ['graphite'],
+        ruleSets: ['pr-descriptions'],
+        model: 'claude-sonnet-4-20250514',
+      },
+      hashes: {},
+    };
+
+    const result = runNonInteractive(manifest, {
+      useDefaults: true,
+      existingConfig,
+    });
+
+    expect(result.mode).toBe('dev');
+    expect(result.selections.model).toBe('claude-sonnet-4-20250514');
+    expect(result.selections.mcpServers).toContain('context7');
+    expect(result.selections.mcpServers).toContain('exarchos'); // required always included
+    expect(result.selections.plugins).toContain('github'); // required always included
+    expect(result.selections.plugins).toContain('graphite');
+    expect(result.selections.ruleSets).toContain('pr-descriptions');
+  });
+
+  it('uses config file when configPath is provided', () => {
+    const manifest = createTestManifest();
+
+    mockReadFileSync.mockReturnValueOnce(
+      JSON.stringify({
+        version: '1.0.0',
+        installedAt: '2025-01-01T00:00:00Z',
+        mode: 'dev',
+        selections: {
+          mcpServers: ['microsoft-learn'],
+          plugins: ['serena'],
+          ruleSets: ['tdd'],
+          model: 'claude-opus-4-6',
+        },
+        hashes: {},
+      }),
+    );
+
+    const result = runNonInteractive(manifest, {
+      configPath: '/tmp/test-config.json',
+    });
+
+    expect(result.mode).toBe('dev');
+    expect(result.selections.mcpServers).toContain('microsoft-learn');
+    expect(result.selections.mcpServers).toContain('exarchos');
+    expect(result.selections.plugins).toContain('serena');
+    expect(result.selections.plugins).toContain('github');
+    expect(result.selections.ruleSets).toContain('tdd');
+  });
+
+  it('throws for invalid config file', () => {
+    const manifest = createTestManifest();
+
+    mockReadFileSync.mockImplementationOnce(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    expect(() => runNonInteractive(manifest, {
+      configPath: '/tmp/nonexistent.json',
+    })).toThrow();
+  });
+});

--- a/src/wizard/wizard.ts
+++ b/src/wizard/wizard.ts
@@ -1,0 +1,180 @@
+/**
+ * Interactive wizard flow for the Exarchos installer.
+ *
+ * Guides the user through component selection via a series of prompts,
+ * producing a {@link WizardResult} that drives installation.
+ */
+
+import type { Manifest } from '../manifest/types.js';
+import type { ExarchosConfig, WizardSelections } from '../operations/config.js';
+import type { PromptAdapter, MultiselectOption } from './prompts.js';
+import { getDefaultSelections, getRequiredComponents } from '../manifest/loader.js';
+import { readConfig } from '../operations/config.js';
+
+/** Result produced by the wizard flow. */
+export interface WizardResult {
+  /** Installation mode: standard (copy) or dev (symlink). */
+  readonly mode: 'standard' | 'dev';
+  /** Component selections for installation. */
+  readonly selections: WizardSelections;
+}
+
+/**
+ * Run the interactive wizard flow.
+ *
+ * Presents a series of prompts to the user for mode selection,
+ * component selection, and model choice. Required components are
+ * always included in the result regardless of user selection.
+ *
+ * @param manifest - The validated installation manifest.
+ * @param prompts - The prompt adapter to use for user interaction.
+ * @param existingConfig - Optional existing config to use as defaults.
+ * @returns The wizard result with mode and selections.
+ */
+export async function runWizard(
+  manifest: Manifest,
+  prompts: PromptAdapter,
+  existingConfig?: ExarchosConfig,
+): Promise<WizardResult> {
+  const required = getRequiredComponents(manifest);
+  const defaults = existingConfig
+    ? existingConfig.selections
+    : getDefaultSelections(manifest);
+
+  // Step 1: Mode selection
+  const mode = await prompts.select<'standard' | 'dev'>('Installation mode:', [
+    { label: 'Standard', value: 'standard', description: 'Copy files to ~/.claude/' },
+    { label: 'Dev', value: 'dev', description: 'Symlink files for development' },
+  ]);
+
+  // Step 2: MCP Servers (optional only — required are always included)
+  const optionalServers = manifest.components.mcpServers.filter((s) => !s.required);
+  const serverOptions: MultiselectOption<string>[] = optionalServers.map((s) => ({
+    label: s.name,
+    value: s.id,
+    description: s.description,
+    selected: defaults.mcpServers.includes(s.id),
+  }));
+  const selectedOptionalServers = await prompts.multiselect('MCP servers:', serverOptions);
+
+  // Step 3: Plugins (optional only — required are always included)
+  const optionalPlugins = manifest.components.plugins.filter((p) => !p.required);
+  const pluginOptions: MultiselectOption<string>[] = optionalPlugins.map((p) => ({
+    label: p.name,
+    value: p.id,
+    description: p.description,
+    selected: defaults.plugins.includes(p.id),
+  }));
+  const selectedOptionalPlugins = await prompts.multiselect('Plugins:', pluginOptions);
+
+  // Step 4: Rule sets
+  const ruleSetOptions: MultiselectOption<string>[] = manifest.components.ruleSets.map((r) => ({
+    label: r.name,
+    value: r.id,
+    description: r.description,
+    selected: defaults.ruleSets.includes(r.id),
+  }));
+  const selectedRuleSets = await prompts.multiselect('Rule sets:', ruleSetOptions);
+
+  // Step 5: Model
+  const selectedModel = await prompts.select('Model:', [
+    { label: 'Claude Opus 4.6', value: 'claude-opus-4-6' },
+    { label: 'Claude Sonnet 4', value: 'claude-sonnet-4-20250514' },
+  ]);
+
+  // Step 6: Confirmation
+  await prompts.confirm('Proceed with installation?', true);
+
+  // Merge required components with user selections
+  const mcpServers = [
+    ...required.servers,
+    ...selectedOptionalServers.filter((id) => !required.servers.includes(id)),
+  ];
+
+  const plugins = [
+    ...required.plugins,
+    ...selectedOptionalPlugins.filter((id) => !required.plugins.includes(id)),
+  ];
+
+  return {
+    mode,
+    selections: {
+      mcpServers,
+      plugins,
+      ruleSets: selectedRuleSets,
+      model: selectedModel,
+    },
+  };
+}
+
+// ─── Non-interactive mode ─────────────────────────────────────────────────────
+
+/** Options for non-interactive installation. */
+interface NonInteractiveOptions {
+  /** Use manifest defaults (or existing config if provided). */
+  readonly useDefaults?: boolean;
+  /** Path to a config file to read selections from. */
+  readonly configPath?: string;
+  /** Existing config to use as defaults when useDefaults is true. */
+  readonly existingConfig?: ExarchosConfig;
+}
+
+/**
+ * Run the installer in non-interactive mode.
+ *
+ * Determines selections without user prompts, using either manifest defaults,
+ * a previous config, or a config file.
+ *
+ * @param manifest - The validated installation manifest.
+ * @param options - Non-interactive mode options.
+ * @returns The wizard result with mode and selections.
+ * @throws If configPath is provided but the file cannot be read.
+ */
+export function runNonInteractive(
+  manifest: Manifest,
+  options: NonInteractiveOptions,
+): WizardResult {
+  const required = getRequiredComponents(manifest);
+
+  let baseSelections: WizardSelections;
+  let baseMode: 'standard' | 'dev';
+
+  if (options.configPath) {
+    // Read config from file
+    const config = readConfig(options.configPath);
+    if (!config) {
+      throw new Error(`Config file not found: ${options.configPath}`);
+    }
+    baseSelections = config.selections;
+    baseMode = config.mode;
+  } else if (options.useDefaults && options.existingConfig) {
+    // Use existing config's selections
+    baseSelections = options.existingConfig.selections;
+    baseMode = options.existingConfig.mode;
+  } else {
+    // Use manifest defaults
+    baseSelections = getDefaultSelections(manifest);
+    baseMode = manifest.defaults.mode;
+  }
+
+  // Ensure required components are always included
+  const mcpServers = [
+    ...required.servers,
+    ...baseSelections.mcpServers.filter((id) => !required.servers.includes(id)),
+  ];
+
+  const plugins = [
+    ...required.plugins,
+    ...baseSelections.plugins.filter((id) => !required.plugins.includes(id)),
+  ];
+
+  return {
+    mode: baseMode,
+    selections: {
+      mcpServers,
+      plugins,
+      ruleSets: [...baseSelections.ruleSets],
+      model: baseSelections.model,
+    },
+  };
+}


### PR DESCRIPTION
feat: add manifest types and loader for installer overhaul

feat: add config I/O and hash utilities for installer overhaul

feat: add copy operations with hash tracking and smart updates

feat: add prerequisite detection and runtime checks

feat: add MCP config, settings generation, and bundle copy

feat: add symlink operations for dev mode

feat: add interactive wizard with prompt adapter

feat: add display formatting helpers

Merge branch 'installer-overhaul/config-generation' into feat/installer-overhaul/integration

Merge branch 'installer-overhaul/display-helpers' into feat/installer-overhaul/integration