### PR TITLE
docs: align instruction sets with optimize-mcp codebase audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Most of this repo is structured Markdown, not executable code:
 
 One self-contained TypeScript MCP server with its own `package.json`, `tsconfig.json`, and test suite:
 
-- **exarchos** (`plugins/exarchos/servers/exarchos-mcp/`) — Unified server combining workflow HSM (state machine transitions), append-only event store (JSONL), CQRS materialized views, and agent team coordination (spawn/message/shutdown). Persists to `docs/workflow-state/`. Exposes 27 MCP tools via a per-module registration pattern.
+- **exarchos** (`plugins/exarchos/servers/exarchos-mcp/`) — Unified server combining workflow HSM (state machine transitions), append-only event store (JSONL), CQRS materialized views, and agent team coordination (spawn/message/shutdown). Persists to `docs/workflow-state/`. Exposes 26 MCP tools via a per-module registration pattern.
 
 Uses `@modelcontextprotocol/sdk` + `zod`, communicates over stdio, and is registered in `~/.claude.json` by the installer.
 
@@ -65,7 +65,7 @@ Uses `@modelcontextprotocol/sdk` + `zod`, communicates over stdio, and is regist
 - `workflow/cancel.ts` — Saga compensation and workflow cancellation
 - `workflow/query.ts` — Summary, reconcile, and transitions handlers
 - `event-store/` — Zod event schemas (24 types including workflow.transition, workflow.fix-cycle), JSONL store with `.seq` files for O(1) sequence initialization, append/query tools
-- `views/` — CQRS materializer (cached singleton per server lifecycle), 5 view types (pipeline, tasks, workflow status, team status, task detail)
+- `views/` — CQRS materializer (cached singleton per server lifecycle), 6 view types (pipeline, tasks, workflow status, team status, task detail, stack)
 - `team/` — Coordinator lifecycle, roles, composition, spawn/message/broadcast/shutdown tools
 - `tasks/` — Task claim/complete/fail tools
 - `stack/` — Stack status/place tools

--- a/docs/plans/2026-02-12-optimize-mcp-docs-gaps.md
+++ b/docs/plans/2026-02-12-optimize-mcp-docs-gaps.md
@@ -1,0 +1,152 @@
+# Documentation Gaps: optimize-mcp Refactor
+
+**Context:** The `refactor-optimize-mcp` workflow added pagination, field projection, summary mode, claim guards, and other optimizations to the Exarchos MCP server. PRs #121 (merged) and #122-#127 (in Graphite merge pipeline) deliver these capabilities, but agent-facing documentation was not updated. Without these updates, agents will not use the new capabilities, negating the token economy benefits.
+
+**Audit method:** Cross-referenced actual Zod schemas and handler signatures against all instruction files (rules, skills, CLAUDE.md) to identify gaps.
+
+## 1. Wrong Parameter Names — `skills/workflow-state/SKILL.md`
+
+**File:** `skills/workflow-state/SKILL.md`
+**Lines:** 33-46
+
+**Problem:** The skill documents incorrect parameter names for `workflow_get` and `workflow_set`. Agents following this skill will pass parameters that don't match the actual Zod schemas.
+
+**Current (wrong):**
+```text
+- Full state: Call with just the `file` parameter
+- Specific field: Call with `file` and `path` parameters (e.g., `path: ".phase"`)
+- Update phase: `filter: '.phase = "delegate"'`
+```
+
+**Actual API:**
+```text
+- workflow_get: { featureId: string, query?: string, fields?: string[] }
+- workflow_set: { featureId: string, updates?: Record<string, unknown>, phase?: string }
+```
+
+**Fix:** Replace all `file`/`path`/jq filter references with correct `featureId`/`query`/`fields`/`updates`/`phase` parameters.
+
+**Severity:** Critical — agents using this skill will fail silently or get unexpected results.
+
+## 2. Phantom `repair: true` — `rules/mcp-tool-guidance.md`
+
+**File:** `rules/mcp-tool-guidance.md`
+**Line:** 18
+
+**Problem:** The `workflow_reconcile` entry claims `repair: true` auto-fixes corruption. No `repair` parameter exists in the Zod schema — only `featureId` is accepted. Agents will pass an invalid parameter.
+
+**Fix:** Remove the `repair: true` claim. Document reconcile as verification-only.
+
+**Severity:** High — agents will pass invalid parameters expecting auto-repair.
+
+## 3. Missing 16 Tools — `rules/mcp-tool-guidance.md`
+
+**File:** `rules/mcp-tool-guidance.md`
+**Section:** Exarchos tool table (lines 11-22)
+
+**Problem:** The Exarchos table lists only 10 workflow tools. The server exposes 26 tools total. Missing tools:
+
+| Category | Missing Tools |
+|----------|--------------|
+| Event Store | `event_append`, `event_query` |
+| Views | `view_pipeline`, `view_tasks`, `view_workflow_status`, `view_team_status` |
+| Team | `team_spawn`, `team_message`, `team_broadcast`, `team_shutdown`, `team_status` |
+| Tasks | `task_claim`, `task_complete`, `task_fail` |
+| Stack | `stack_status`, `stack_place` |
+
+**Fix:** Add all missing tools with usage guidance including new parameters (pagination, fields, summary).
+
+**Severity:** High — agents can only use tools they know about from the guidance table.
+
+## 4. Undocumented Optimizations — `rules/mcp-tool-guidance.md`
+
+**File:** `rules/mcp-tool-guidance.md`
+
+**Problem:** Existing and incoming optimization parameters are not documented anywhere in the guidance:
+
+| Tool | Parameter | Status | Purpose |
+|------|-----------|--------|---------|
+| `workflow_get` | `fields` | On main (#121) | Field projection to reduce response size |
+| `view_pipeline` | `limit`, `offset` | On main (#121) | Pagination for large workflow sets |
+| `view_tasks` | `fields`, `limit`, `offset`, `filter` | On main (#121) | Field projection + pagination + filtering |
+| `event_query` | `limit`, `offset` | On main (#103) | Pagination for event streams |
+| `event_query` | `fields` | Incoming (#123) | Field projection for events |
+| `team_status` | `summary` | Incoming (#122) | Counts-only mode for token savings |
+| `task_claim` | Claim guard | Incoming (#125) | Returns `ALREADY_CLAIMED` error |
+
+**Fix:** Document all parameters in the tool guidance table with usage examples.
+
+**Severity:** High — the whole point of the optimization work is lost without agent-facing documentation.
+
+## 5. Broken Zod Schema — `team_status` tool
+
+**File:** `plugins/exarchos/servers/exarchos-mcp/src/team/tools.ts`
+**Line:** 350 (registration schema)
+
+**Problem:** PR #122 adds summary mode to the handler, but the Zod registration schema remains `{}` (empty). MCP tool introspection exposes the schema to Claude Code — an empty schema means the `summary` parameter is invisible.
+
+**Fix:** Change the registration schema from `{}` to:
+```typescript
+{ summary: z.boolean().optional().describe('If true, return counts only (activeCount, staleCount) instead of full teammate details') }
+```
+
+**Severity:** Critical — summary mode was built specifically to reduce token cost. Without schema exposure, no agent will ever send `summary: true`.
+
+**Note:** This is a code change that should go as a new PR on top of the current Graphite stack (#127).
+
+## 6. Quality Review — field projection examples
+
+**File:** `skills/quality-review/SKILL.md`
+**Line:** 434
+
+**Problem:** The review skill references `exarchos_view_tasks` for combined task + gate view but uses the default all-fields call pattern. It should demonstrate efficient querying.
+
+**Fix:** Update the Exarchos Integration section to show field projection:
+```text
+Use exarchos_view_tasks with fields: ['taskId', 'status', 'title'] and limit: 20
+```
+
+**Severity:** Medium — missed optimization opportunity in a token-intensive phase.
+
+## 7. Delegation Skill — claim guard and efficient queries
+
+**File:** `skills/delegation/SKILL.md`
+
+**Problem A:** With the incoming claim guard (#125), concurrent agents claiming the same task will get `ALREADY_CLAIMED`. The skill doesn't document this error.
+
+**Problem B:** The skill uses `workflow_get` with `query: "tasks"` but doesn't mention `fields` projection for efficient status checks.
+
+**Fix:** Add a claim guard error handling note and efficient query examples.
+
+**Severity:** Medium — error handling gap for concurrent agents.
+
+## 8. CLAUDE.md — tool and view counts
+
+**File:** `CLAUDE.md`
+**Line:** 54, 68
+
+**Problem:** States "27 MCP tools" — actual count is 26. States "5 view types" — StackView (#121) brings this to 6.
+
+**Fix:** Update counts to match reality.
+
+**Severity:** Low — minor inaccuracy.
+
+## Priority Order
+
+| # | Item | Severity | Effort |
+|---|------|----------|--------|
+| 1 | Fix `workflow-state/SKILL.md` parameter names | Critical | 10 min |
+| 2 | Fix `team_status` Zod schema (code change, new PR) | Critical | 5 min |
+| 3 | Remove phantom `repair: true` from guidance | High | 2 min |
+| 4 | Add 16 missing tools to guidance table | High | 15 min |
+| 5 | Document optimization parameters in guidance | High | 10 min |
+| 6 | Update `quality-review/SKILL.md` field projection | Medium | 5 min |
+| 7 | Update `delegation/SKILL.md` claim guard + queries | Medium | 5 min |
+| 8 | Fix `CLAUDE.md` counts | Low | 2 min |
+
+## Implementation Strategy
+
+Items 1, 3-8 are documentation fixes that can be applied directly to main.
+Item 2 is a code change that needs a new Graphite PR on top of the #122-#127 stack.
+
+All documentation fixes should land before the optimization PRs merge, so agents have guidance ready when the features arrive.

--- a/rules/mcp-tool-guidance.md
+++ b/rules/mcp-tool-guidance.md
@@ -6,20 +6,63 @@ Proactively use the installed MCP servers. Don't fall back to generic approaches
 
 ### Exarchos (`mcp__exarchos__*`)
 
-Unified MCP server for workflow orchestration, event sourcing, CQRS views, and team coordination. **Always use for workflow tracking.**
+Unified MCP server for workflow orchestration, event sourcing, CQRS views, and team coordination. **Always use for workflow tracking.** Exposes 26 tools across 6 modules.
+
+#### Workflow Tools
 
 | Tool | When to Use |
 |------|-------------|
 | `workflow_init` | Starting any `/ideate`, `/debug`, or `/refactor` workflow |
-| `workflow_get` | Restoring context, checking phase, reading task details |
-| `workflow_set` | Updating phase, recording artifacts, marking tasks complete |
+| `workflow_get` | Restoring context, checking phase, reading task details. Use `query` for dot-path lookup (e.g., `query: "phase"`), or `fields` array for projection (e.g., `fields: ["phase", "tasks"]`) to reduce token cost |
+| `workflow_set` | Updating phase (`phase: "delegate"`), recording artifacts, marking tasks complete. Use `updates` for field changes and `phase` for transitions |
 | `workflow_summary` | Quick context restoration after session restart |
 | `workflow_next_action` | Determining what to auto-continue after phase completion |
-| `workflow_reconcile` | Verifying state matches git reality on resume; with `repair: true`, auto-fixes common corruption (missing `_events`, invalid `_eventSequence`, null `_checkpoint`, bad task statuses) |
+| `workflow_reconcile` | Verifying state matches git reality on resume. Verification only — reports discrepancies but does not auto-fix |
 | `workflow_checkpoint` | Saving progress before likely context exhaustion |
-| `workflow_cancel` | Cleaning up abandoned workflows |
-| `workflow_transitions` | Checking valid phase transitions |
+| `workflow_cancel` | Cleaning up abandoned workflows. Supports `dryRun: true` to preview cleanup actions |
+| `workflow_transitions` | Checking valid phase transitions for a `workflowType`. Use `fromPhase` to filter |
 | `workflow_list` | Finding active workflows at session start |
+
+#### Event Store Tools
+
+| Tool | When to Use |
+|------|-------------|
+| `event_append` | Recording workflow events (task.assigned, team.formed, gate.executed, etc.). Use `expectedSequence` for optimistic concurrency |
+| `event_query` | Reading event history. Use `filter` for type/time filtering, `limit`/`offset` for pagination |
+
+#### View Tools (CQRS)
+
+| Tool | When to Use |
+|------|-------------|
+| `view_pipeline` | Aggregated view of all workflows with stack positions. Use `limit`/`offset` for pagination |
+| `view_tasks` | Task detail view with filtering and projection. Use `workflowId` to scope, `filter` for property matching, `fields` for projection (e.g., `fields: ["taskId", "status", "title"]`), `limit`/`offset` for pagination |
+| `view_workflow_status` | Workflow phase, task counts, and metadata. Use `workflowId` to scope |
+| `view_team_status` | Teammate composition and task assignments. Use `workflowId` to scope |
+
+#### Team Tools
+
+| Tool | When to Use |
+|------|-------------|
+| `team_spawn` | Register a new agent with role assignment. Always pair with Task tool for subprocess |
+| `team_message` | Send a direct message to a specific teammate |
+| `team_broadcast` | Broadcast a message to all active teammates |
+| `team_shutdown` | Shut down a teammate agent. Emits shutdown event |
+| `team_status` | Get health status of all teammates. Use `summary: true` for counts-only response during orchestration |
+
+#### Task Tools
+
+| Tool | When to Use |
+|------|-------------|
+| `task_claim` | Claim a task for execution. Returns `ALREADY_CLAIMED` if previously claimed — handle gracefully |
+| `task_complete` | Mark a task complete with optional `result` (artifacts, duration) |
+| `task_fail` | Mark a task failed with `error` message and optional `diagnostics` |
+
+#### Stack Tools
+
+| Tool | When to Use |
+|------|-------------|
+| `stack_status` | Get current stack positions from events. Use `streamId` to scope |
+| `stack_place` | Record a stack position with `position`, `taskId`, `branch`, optional `prUrl` |
 
 ### GitHub (`mcp__plugin_github_github__*`)
 

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -273,7 +273,7 @@ This skill tracks task progress in workflow state for context persistence.
 
 ### Read Tasks from State
 
-Instead of re-parsing plan, read task list using `mcp__exarchos__exarchos_workflow_get` with query `tasks`.
+Instead of re-parsing plan, read task list using `mcp__exarchos__exarchos_workflow_get` with `query: "tasks"`. For status checks during monitoring, use `fields: ["tasks"]` to reduce response size.
 
 ### On Task Dispatch
 
@@ -394,7 +394,7 @@ When Exarchos MCP tools are available, emit events during delegation:
 2. **After team composition:** Call `mcp__exarchos__exarchos_event_append` with event type `team.formed` including teammates array
 3. **For each task dispatch:** Use `mcp__exarchos__exarchos_team_spawn` to register the agent with the team coordinator, then use the Task tool to launch the subagent. `team_spawn` handles role assignment, event emission, and health tracking; the Task tool handles actual subprocess execution. Both are always used together — `team_spawn` does not replace the Task tool
 4. **For each task assignment:** Call `mcp__exarchos__exarchos_event_append` with event type `task.assigned` including taskId, title, branch, worktree
-5. **Monitor progress:** Use `mcp__exarchos__exarchos_view_workflow_status` to check task completion status
+5. **Monitor progress:** Use `mcp__exarchos__exarchos_view_workflow_status` to check task completion status. For lightweight checks, use `mcp__exarchos__exarchos_workflow_get` with `fields: ["tasks"]`
 6. **On task completion — Graphite stacking:**
    Subagents handle stacking directly using `gt create` (per implementer prompt template).
    When a multi-task agent completes, it will have created a Graphite stack with one branch per logical review unit.
@@ -402,3 +402,9 @@ When Exarchos MCP tools are available, emit events during delegation:
    - Call `mcp__exarchos__exarchos_stack_place` with position, taskId, and branch to record each stack position
    - Verify the stack was submitted by checking for PRs: `mcp__graphite__run_gt_cmd({ args: ["--no-interactive", "ls"], cwd: "<worktree-path>" })`
 7. **On all tasks complete:** Call `mcp__exarchos__exarchos_event_append` with event type `phase.transitioned` from delegate to next phase
+
+### Claim Guard
+
+`task_claim` prevents double-claims. If an agent receives an `ALREADY_CLAIMED` error, it means another agent already claimed that task. The orchestrator should:
+- Skip the task (it's being handled)
+- Check task status via `mcp__exarchos__exarchos_view_tasks` with `filter: { "taskId": "<id>" }` before re-dispatching

--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -431,5 +431,5 @@ When Exarchos MCP tools are available, emit gate events during review:
    - `layer`: "per-pr" or "per-stack"
    - `passed`: boolean
    - `duration`: milliseconds (if available)
-3. **Read unified status:** Use `exarchos_view_tasks` for combined task + gate view
+3. **Read unified status:** Use `exarchos_view_tasks` with `fields: ["taskId", "status", "title"]` and `limit: 20` for combined task + gate view with minimal token cost
 4. **When all per-PR gates pass:** Apply `stack-ready` label to the PR

--- a/skills/workflow-state/SKILL.md
+++ b/skills/workflow-state/SKILL.md
@@ -26,34 +26,41 @@ State files are gitignored - they persist locally but are not committed.
 
 ### Initialize State
 
-At the start of `/ideate`, use the `mcp__exarchos__exarchos_workflow_init` tool with the feature ID as the `id` parameter. This creates a new state file with phase "ideate".
+At the start of `/ideate`, use `mcp__exarchos__exarchos_workflow_init` with:
+- `featureId`: the workflow identifier (e.g., `"user-authentication"`)
+- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`
+
+This creates a new state file with phase "ideate".
 
 ### Read State
 
-To restore context, use the `mcp__exarchos__exarchos_workflow_get` tool:
+Use `mcp__exarchos__exarchos_workflow_get` with `featureId`:
 
-- **Full state**: Call with just the `file` parameter (the state file path)
-- **Specific field**: Call with `file` and `path` parameters (e.g., `path: ".phase"`)
-- **Task list**: Call with `file` and `path: ".tasks"`
+- **Full state**: Call with just `featureId`
+- **Specific field**: Add `query` for dot-path lookup (e.g., `query: "phase"`, `query: "tasks"`)
+- **Multiple fields**: Add `fields` array for projection (e.g., `fields: ["phase", "featureId", "tasks"]`)
+
+Field projection via `fields` returns only the requested top-level keys, reducing token cost.
 
 ### Update State
 
-Use the `mcp__exarchos__exarchos_workflow_set` tool with jq filters:
+Use `mcp__exarchos__exarchos_workflow_set` with `featureId` and either `updates`, `phase`, or both:
 
-- **Update phase**: `filter: '.phase = "delegate"'`
-- **Set artifact path**: `filter: '.artifacts.design = "docs/designs/2026-01-05-feature.md"'`
-- **Mark task complete**: `filter: '(.tasks[] | select(.id == "001")).status = "complete"'`
-- **Add worktree**: `filter: '.worktrees[".worktrees/001-types"] = {"branch": "feature/001-types", "taskId": "001", "status": "active"}'`
+- **Update phase**: `phase: "delegate"`
+- **Set artifact path**: `updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }`
+- **Mark task complete**: `updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }`
+- **Add worktree**: `updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }`
+- **Phase + updates together**: `phase: "delegate"`, `updates: { "artifacts.plan": "docs/plans/plan.md" }`
 
 Worktree status values: `'active' | 'merged' | 'removed'`
 
 ### Get Summary
 
-For context restoration after summarization, use the `mcp__exarchos__exarchos_workflow_summary` tool with the state file path. This outputs a minimal summary suitable for rebuilding orchestrator context.
+For context restoration after summarization, use `mcp__exarchos__exarchos_workflow_summary` with `featureId`. This outputs a minimal summary suitable for rebuilding orchestrator context.
 
 ### Reconcile State
 
-To verify state matches git reality, use the `mcp__exarchos__exarchos_workflow_reconcile` tool with the state file path. This checks that worktrees and branches referenced in state actually exist.
+To verify state matches git reality, use `mcp__exarchos__exarchos_workflow_reconcile` with `featureId`. This checks that worktrees and branches referenced in state actually exist.
 
 ## Integration Points
 
@@ -129,12 +136,13 @@ Key sections:
 
 ## Example Workflow
 
-1. **Start new workflow**: Use `mcp__exarchos__exarchos_workflow_init` with `id: "user-authentication"`
+1. **Start new workflow**: Use `mcp__exarchos__exarchos_workflow_init` with `featureId: "user-authentication"`, `workflowType: "feature"`
 
 2. **After design phase**: Use `mcp__exarchos__exarchos_workflow_set` with:
-   - `file: "docs/workflow-state/user-authentication.state.json"`
-   - `filter: '.artifacts.design = "docs/designs/2026-01-05-user-auth.md" | .phase = "plan"'`
+   - `featureId: "user-authentication"`
+   - `phase: "plan"`
+   - `updates: { "artifacts.design": "docs/designs/2026-01-05-user-auth.md" }`
 
-3. **Check state**: Use `mcp__exarchos__exarchos_workflow_summary` with the state file path
+3. **Check state**: Use `mcp__exarchos__exarchos_workflow_summary` with `featureId: "user-authentication"`
 
-4. **Resume after context loss**: Use `mcp__exarchos__exarchos_workflow_summary` with the state file path to get context restoration output
+4. **Resume after context loss**: Use `mcp__exarchos__exarchos_workflow_summary` with `featureId: "user-authentication"` to get context restoration output


### PR DESCRIPTION
Cross-referenced Zod schemas and handler signatures against all instruction
files. Fixes wrong parameter names in workflow-state skill, removes phantom
repair:true from guidance, adds 16 missing tools to Exarchos table, and
documents pagination/fields/summary optimization params across skills.