### PR TITLE
feat: add installer foundation modules

### DIFF
--- a/src/manifest/loader.test.ts
+++ b/src/manifest/loader.test.ts
@@ -15,7 +15,7 @@ import {
   getDefaultSelections,
   getRequiredComponents,
 } from './loader.js';
-import type { WizardSelections } from './loader.js';
+import type { WizardSelections } from '../operations/config.js';
 
 // ─── A1: Type definition tests ───────────────────────────────────────────────
 
@@ -264,5 +264,69 @@ describe('Manifest Loader (A2)', () => {
       // No plugins have required: true in our fixture
       expect(required.plugins).toEqual([]);
     });
+  });
+});
+
+// ─── E5: Real manifest.json tests ────────────────────────────────────────────
+
+describe('Real Manifest File (E5)', () => {
+  const repoRoot = path.join(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+  const manifestPath = path.join(repoRoot, 'manifest.json');
+  const pkgPath = path.join(repoRoot, 'package.json');
+
+  it('manifest_Exists_IsValidJson', () => {
+    expect(fs.existsSync(manifestPath)).toBe(true);
+    const content = fs.readFileSync(manifestPath, 'utf-8');
+    expect(() => JSON.parse(content)).not.toThrow();
+  });
+
+  it('manifest_ContainsAllCoreComponents', () => {
+    const manifest = loadManifest(manifestPath);
+    const coreIds = manifest.components.core.map((c) => c.id);
+    expect(coreIds).toContain('commands');
+    expect(coreIds).toContain('skills');
+    expect(coreIds).toContain('scripts');
+    expect(coreIds).toContain('hooks');
+  });
+
+  it('manifest_ContainsRequiredServers', () => {
+    const manifest = loadManifest(manifestPath);
+    const required = getRequiredComponents(manifest);
+    expect(required.servers).toContain('exarchos');
+    expect(required.servers).toContain('graphite');
+  });
+
+  it('manifest_ContainsAllPlugins', () => {
+    const manifest = loadManifest(manifestPath);
+    const pluginIds = manifest.components.plugins.map((p) => p.id);
+    expect(pluginIds).toContain('github@claude-plugins-official');
+    expect(pluginIds).toContain('serena@claude-plugins-official');
+    expect(pluginIds).toContain('context7@claude-plugins-official');
+  });
+
+  it('manifest_ContainsAllRuleSets', () => {
+    const manifest = loadManifest(manifestPath);
+    const ruleSetIds = manifest.components.ruleSets.map((r) => r.id);
+    expect(ruleSetIds).toContain('typescript');
+    expect(ruleSetIds).toContain('csharp');
+    expect(ruleSetIds).toContain('workflow');
+  });
+
+  it('manifest_RuleSetFiles_AllExist', () => {
+    const manifest = loadManifest(manifestPath);
+    const rulesDir = path.join(repoRoot, 'rules');
+
+    for (const ruleSet of manifest.components.ruleSets) {
+      for (const file of ruleSet.files) {
+        const filePath = path.join(rulesDir, file);
+        expect(fs.existsSync(filePath), `Rule file missing: ${file} (in ruleSet '${ruleSet.id}')`).toBe(true);
+      }
+    }
+  });
+
+  it('manifest_Version_MatchesPackageJson', () => {
+    const manifest = loadManifest(manifestPath);
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    expect(manifest.version).toBe(pkg.version);
   });
 });

--- a/src/manifest/loader.ts
+++ b/src/manifest/loader.ts
@@ -11,23 +11,7 @@ import type {
   ManifestComponents,
   ManifestDefaults,
 } from './types.js';
-
-/**
- * User selections from the installation wizard.
- *
- * Captures which optional components the user chose to install
- * and their preferred model.
- */
-export interface WizardSelections {
-  /** IDs of selected MCP servers (excludes required servers). */
-  readonly mcpServers: string[];
-  /** IDs of selected plugins. */
-  readonly plugins: string[];
-  /** IDs of selected rule sets. */
-  readonly ruleSets: string[];
-  /** Selected Claude model identifier. */
-  readonly model: string;
-}
+import type { WizardSelections } from '../operations/config.js';
 
 /**
  * Load and validate a manifest file from disk.

--- a/src/operations/bundle.test.ts
+++ b/src/operations/bundle.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { installBundle } from './bundle.js';
+
+describe('MCP Server Bundle Copy (C4)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-bundle-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Helper: create a fake bundle source file with given content. */
+  function createSourceBundle(filename: string, content: string): string {
+    const sourcePath = path.join(tmpDir, 'source', filename);
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.writeFileSync(sourcePath, content, 'utf-8');
+    return sourcePath;
+  }
+
+  describe('installBundle', () => {
+    it('installBundle_SourceExists_CopiesToMcpServersDir', () => {
+      const bundleContent = 'console.log("mcp server bundle");';
+      const sourcePath = createSourceBundle('exarchos-mcp.js', bundleContent);
+      const claudeHome = path.join(tmpDir, '.claude');
+
+      const result = installBundle(sourcePath, claudeHome);
+
+      const expectedPath = path.join(claudeHome, 'mcp-servers', 'exarchos-mcp.js');
+      expect(result.installedPath).toBe(expectedPath);
+      expect(fs.existsSync(expectedPath)).toBe(true);
+      expect(fs.readFileSync(expectedPath, 'utf-8')).toBe(bundleContent);
+    });
+
+    it('installBundle_MissingMcpDir_CreatesDir', () => {
+      const sourcePath = createSourceBundle('server.js', 'content');
+      const claudeHome = path.join(tmpDir, 'fresh-claude-home');
+      const mcpDir = path.join(claudeHome, 'mcp-servers');
+
+      // Verify the directory does not exist yet
+      expect(fs.existsSync(mcpDir)).toBe(false);
+
+      installBundle(sourcePath, claudeHome);
+
+      // Directory should have been created
+      expect(fs.existsSync(mcpDir)).toBe(true);
+    });
+
+    it('installBundle_ExistingBundle_Overwrites', () => {
+      const claudeHome = path.join(tmpDir, '.claude');
+      const mcpDir = path.join(claudeHome, 'mcp-servers');
+      fs.mkdirSync(mcpDir, { recursive: true });
+
+      // Write an existing (old) bundle
+      const existingPath = path.join(mcpDir, 'server.js');
+      fs.writeFileSync(existingPath, 'old content', 'utf-8');
+
+      // Create new source
+      const sourcePath = createSourceBundle('server.js', 'new content');
+
+      installBundle(sourcePath, claudeHome);
+
+      // Should be overwritten with new content
+      expect(fs.readFileSync(existingPath, 'utf-8')).toBe('new content');
+    });
+
+    it('installBundle_MissingSource_ThrowsError', () => {
+      const claudeHome = path.join(tmpDir, '.claude');
+      const badSourcePath = path.join(tmpDir, 'nonexistent', 'server.js');
+
+      expect(() => installBundle(badSourcePath, claudeHome)).toThrow(
+        /not found|does not exist|ENOENT/i,
+      );
+    });
+
+    it('installBundle_ReturnsFileSize_InBytes', () => {
+      const content = 'A'.repeat(1024); // Exactly 1024 bytes
+      const sourcePath = createSourceBundle('sized-server.js', content);
+      const claudeHome = path.join(tmpDir, '.claude');
+
+      const result = installBundle(sourcePath, claudeHome);
+
+      expect(result.sizeBytes).toBe(1024);
+    });
+  });
+});

--- a/src/operations/bundle.ts
+++ b/src/operations/bundle.ts
@@ -1,0 +1,49 @@
+/**
+ * MCP server bundle copy for the Exarchos installer.
+ *
+ * Copies a bundled MCP server JavaScript file into the
+ * `~/.claude/mcp-servers/` directory so it can be launched
+ * by the Claude Code runtime.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Result of installing a bundle file. */
+export interface BundleResult {
+  /** Absolute path where the bundle was installed. */
+  readonly installedPath: string;
+  /** Size of the installed file in bytes. */
+  readonly sizeBytes: number;
+}
+
+/**
+ * Copy a bundled MCP server file to the Claude home mcp-servers directory.
+ *
+ * Ensures the target directory exists, copies the file (overwriting if
+ * it already exists), and returns the installed path and file size.
+ *
+ * @param bundlePath - Absolute path to the source bundle file.
+ * @param claudeHome - Absolute path to the `~/.claude/` directory.
+ * @returns The installed path and file size.
+ * @throws If the source bundle file does not exist.
+ */
+export function installBundle(bundlePath: string, claudeHome: string): BundleResult {
+  if (!fs.existsSync(bundlePath)) {
+    throw new Error(`Bundle source does not exist: ${bundlePath}`);
+  }
+
+  const mcpServersDir = path.join(claudeHome, 'mcp-servers');
+  fs.mkdirSync(mcpServersDir, { recursive: true });
+
+  const filename = path.basename(bundlePath);
+  const installedPath = path.join(mcpServersDir, filename);
+  fs.copyFileSync(bundlePath, installedPath);
+
+  const stats = fs.statSync(installedPath);
+
+  return {
+    installedPath,
+    sizeBytes: stats.size,
+  };
+}

--- a/src/operations/copy.test.ts
+++ b/src/operations/copy.test.ts
@@ -2,7 +2,18 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { computeFileHash, computeDirectoryHashes } from './copy.js';
+import {
+  computeFileHash,
+  computeDirectoryHashes,
+  copyFile,
+  copyDirectory,
+  smartCopy,
+  smartCopyDirectory,
+  type CopyResult,
+  type CopyDirectoryResult,
+  type SmartCopyResult,
+  type SmartCopyDirectoryResult,
+} from './copy.js';
 
 describe('Content Hash Utilities (A4)', () => {
   let tmpDir: string;
@@ -109,5 +120,281 @@ describe('Content Hash Utilities (A4)', () => {
 
       expect(Object.keys(hashes)).toHaveLength(0);
     });
+  });
+});
+
+describe('copyFile (B1)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-copyfile-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('copyFile_SourceExists_CopiesAndReturnsHash', () => {
+    const source = path.join(tmpDir, 'source.txt');
+    const target = path.join(tmpDir, 'target.txt');
+    const content = 'hello copy world';
+    fs.writeFileSync(source, content, 'utf-8');
+
+    const result: CopyResult = copyFile(source, target);
+
+    // Target file should exist with same content
+    expect(fs.existsSync(target)).toBe(true);
+    expect(fs.readFileSync(target, 'utf-8')).toBe(content);
+    // Hash should match the source file hash
+    expect(result.hash).toBe(computeFileHash(source));
+    expect(result.hash).toMatch(/^[0-9a-f]{64}$/);
+    // Bytes written should match content length
+    expect(result.bytesWritten).toBe(Buffer.byteLength(content, 'utf-8'));
+  });
+
+  it('copyFile_SourceMissing_ThrowsError', () => {
+    const source = path.join(tmpDir, 'nonexistent.txt');
+    const target = path.join(tmpDir, 'target.txt');
+
+    expect(() => copyFile(source, target)).toThrow(/not found|ENOENT/i);
+  });
+
+  it('copyFile_TargetDirMissing_CreatesParentDirs', () => {
+    const source = path.join(tmpDir, 'source.txt');
+    const target = path.join(tmpDir, 'deep', 'nested', 'dir', 'target.txt');
+    fs.writeFileSync(source, 'nested content', 'utf-8');
+
+    const result = copyFile(source, target);
+
+    expect(fs.existsSync(target)).toBe(true);
+    expect(fs.readFileSync(target, 'utf-8')).toBe('nested content');
+    expect(result.hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('copyFile_TargetExists_OverwritesAndReturnsNewHash', () => {
+    const source = path.join(tmpDir, 'source.txt');
+    const target = path.join(tmpDir, 'target.txt');
+    fs.writeFileSync(target, 'old content', 'utf-8');
+    fs.writeFileSync(source, 'new content', 'utf-8');
+
+    const result = copyFile(source, target);
+
+    expect(fs.readFileSync(target, 'utf-8')).toBe('new content');
+    expect(result.hash).toBe(computeFileHash(source));
+    expect(result.bytesWritten).toBe(Buffer.byteLength('new content', 'utf-8'));
+  });
+});
+
+describe('copyDirectory (B2)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-copydir-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('copyDirectory_FlatDir_CopiesAllFiles', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const tgtDir = path.join(tmpDir, 'tgt');
+    fs.mkdirSync(srcDir);
+    fs.writeFileSync(path.join(srcDir, 'a.txt'), 'alpha', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'b.txt'), 'beta', 'utf-8');
+
+    const result: CopyDirectoryResult = copyDirectory(srcDir, tgtDir);
+
+    expect(fs.readFileSync(path.join(tgtDir, 'a.txt'), 'utf-8')).toBe('alpha');
+    expect(fs.readFileSync(path.join(tgtDir, 'b.txt'), 'utf-8')).toBe('beta');
+    expect(result.fileCount).toBe(2);
+    expect(result.totalBytes).toBe(
+      Buffer.byteLength('alpha') + Buffer.byteLength('beta'),
+    );
+  });
+
+  it('copyDirectory_NestedDir_CopiesRecursively', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const tgtDir = path.join(tmpDir, 'tgt');
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(path.join(srcDir, 'sub'));
+    fs.writeFileSync(path.join(srcDir, 'root.txt'), 'root', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'sub', 'nested.txt'), 'nested', 'utf-8');
+
+    const result = copyDirectory(srcDir, tgtDir);
+
+    expect(fs.readFileSync(path.join(tgtDir, 'root.txt'), 'utf-8')).toBe('root');
+    expect(fs.readFileSync(path.join(tgtDir, 'sub', 'nested.txt'), 'utf-8')).toBe('nested');
+    expect(result.fileCount).toBe(2);
+    expect(Object.keys(result.hashes)).toHaveLength(2);
+  });
+
+  it('copyDirectory_EmptyDir_CreatesEmptyTarget', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const tgtDir = path.join(tmpDir, 'tgt');
+    fs.mkdirSync(srcDir);
+
+    const result = copyDirectory(srcDir, tgtDir);
+
+    expect(fs.existsSync(tgtDir)).toBe(true);
+    expect(fs.readdirSync(tgtDir)).toHaveLength(0);
+    expect(result.fileCount).toBe(0);
+    expect(result.totalBytes).toBe(0);
+    expect(Object.keys(result.hashes)).toHaveLength(0);
+  });
+
+  it('copyDirectory_WithFilter_CopiesOnlyMatchingFiles', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const tgtDir = path.join(tmpDir, 'tgt');
+    fs.mkdirSync(srcDir);
+    fs.writeFileSync(path.join(srcDir, 'keep.md'), 'keep me', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'skip.txt'), 'skip me', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'also-keep.md'), 'keep too', 'utf-8');
+
+    const result = copyDirectory(srcDir, tgtDir, (name) => name.endsWith('.md'));
+
+    expect(fs.existsSync(path.join(tgtDir, 'keep.md'))).toBe(true);
+    expect(fs.existsSync(path.join(tgtDir, 'also-keep.md'))).toBe(true);
+    expect(fs.existsSync(path.join(tgtDir, 'skip.txt'))).toBe(false);
+    expect(result.fileCount).toBe(2);
+  });
+
+  it('copyDirectory_ReturnsHashMap_AllFileHashes', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const tgtDir = path.join(tmpDir, 'tgt');
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(path.join(srcDir, 'sub'));
+    fs.writeFileSync(path.join(srcDir, 'file1.txt'), 'content1', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'sub', 'file2.txt'), 'content2', 'utf-8');
+
+    const result = copyDirectory(srcDir, tgtDir);
+
+    expect(result.hashes['file1.txt']).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.hashes[path.join('sub', 'file2.txt')]).toMatch(/^[0-9a-f]{64}$/);
+    // Hashes should match the source files
+    expect(result.hashes['file1.txt']).toBe(computeFileHash(path.join(srcDir, 'file1.txt')));
+    expect(result.hashes[path.join('sub', 'file2.txt')]).toBe(
+      computeFileHash(path.join(srcDir, 'sub', 'file2.txt')),
+    );
+  });
+});
+
+describe('smartCopy (B3)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-smartcopy-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('smartCopy_NewFile_CopiesFile', () => {
+    const source = path.join(tmpDir, 'source.txt');
+    const target = path.join(tmpDir, 'target.txt');
+    fs.writeFileSync(source, 'new file content', 'utf-8');
+
+    // No existing hash — file is new
+    const result: SmartCopyResult = smartCopy(source, target);
+
+    expect(result.action).toBe('created');
+    expect(result.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(fs.readFileSync(target, 'utf-8')).toBe('new file content');
+  });
+
+  it('smartCopy_UnchangedFile_SkipsFile', () => {
+    const source = path.join(tmpDir, 'source.txt');
+    const target = path.join(tmpDir, 'target.txt');
+    const content = 'unchanged content';
+    fs.writeFileSync(source, content, 'utf-8');
+    fs.writeFileSync(target, content, 'utf-8');
+    const existingHash = computeFileHash(source);
+
+    const result = smartCopy(source, target, existingHash);
+
+    expect(result.action).toBe('skipped');
+    expect(result.hash).toBe(existingHash);
+  });
+
+  it('smartCopy_ChangedFile_UpdatesFile', () => {
+    const source = path.join(tmpDir, 'source.txt');
+    const target = path.join(tmpDir, 'target.txt');
+    fs.writeFileSync(source, 'updated content', 'utf-8');
+    fs.writeFileSync(target, 'old content', 'utf-8');
+    const oldHash = computeFileHash(target);
+
+    const result = smartCopy(source, target, oldHash);
+
+    expect(result.action).toBe('updated');
+    expect(result.hash).toBe(computeFileHash(source));
+    expect(fs.readFileSync(target, 'utf-8')).toBe('updated content');
+  });
+
+  it('smartCopy_DeletedSource_ReportsRemoval', () => {
+    const source = path.join(tmpDir, 'deleted-source.txt');
+    const target = path.join(tmpDir, 'target.txt');
+    fs.writeFileSync(target, 'will be removed', 'utf-8');
+    const existingHash = computeFileHash(target);
+    // Source does not exist — it was deleted
+
+    const result = smartCopy(source, target, existingHash);
+
+    expect(result.action).toBe('removed');
+    expect(result.hash).toBe('');
+  });
+});
+
+describe('smartCopyDirectory (B3)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-smartcopydir-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('smartCopyDirectory_MixedChanges_ReturnsUpdateSummary', () => {
+    const srcDir = path.join(tmpDir, 'src');
+    const tgtDir = path.join(tmpDir, 'tgt');
+
+    // Set up source with 3 files: new, unchanged, changed
+    fs.mkdirSync(srcDir);
+    fs.mkdirSync(tgtDir);
+    fs.writeFileSync(path.join(srcDir, 'new.txt'), 'brand new', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'same.txt'), 'same content', 'utf-8');
+    fs.writeFileSync(path.join(srcDir, 'changed.txt'), 'updated content', 'utf-8');
+
+    // Set up target with existing files
+    fs.writeFileSync(path.join(tgtDir, 'same.txt'), 'same content', 'utf-8');
+    fs.writeFileSync(path.join(tgtDir, 'changed.txt'), 'original content', 'utf-8');
+    fs.writeFileSync(path.join(tgtDir, 'removed.txt'), 'to be removed', 'utf-8');
+
+    // Existing hashes reflect what was previously installed
+    const existingHashes: Record<string, string> = {
+      'same.txt': computeFileHash(path.join(tgtDir, 'same.txt')),
+      'changed.txt': computeFileHash(path.join(tgtDir, 'changed.txt')),
+      'removed.txt': computeFileHash(path.join(tgtDir, 'removed.txt')),
+    };
+
+    const result: SmartCopyDirectoryResult = smartCopyDirectory(
+      srcDir,
+      tgtDir,
+      existingHashes,
+    );
+
+    expect(result.created).toBe(1);   // new.txt
+    expect(result.updated).toBe(1);   // changed.txt
+    expect(result.skipped).toBe(1);   // same.txt
+    expect(result.removed).toBe(1);   // removed.txt
+
+    // Hashes should include all current files (not removed ones)
+    expect(Object.keys(result.hashes)).toHaveLength(3);
+    expect(result.hashes['new.txt']).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.hashes['same.txt']).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.hashes['changed.txt']).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.hashes['removed.txt']).toBeUndefined();
   });
 });

--- a/src/operations/copy.ts
+++ b/src/operations/copy.ts
@@ -54,6 +54,307 @@ export function computeDirectoryHashes(
 }
 
 /**
+ * Result of copying a single file.
+ */
+export interface CopyResult {
+  /** SHA-256 hex digest of the copied file's contents. */
+  readonly hash: string;
+  /** Number of bytes written to the target. */
+  readonly bytesWritten: number;
+}
+
+/**
+ * Copy a single file from source to target, computing its content hash.
+ *
+ * Creates parent directories of the target if they do not exist.
+ * Overwrites the target if it already exists.
+ *
+ * @param source - Absolute or relative path to the source file.
+ * @param target - Absolute or relative path to the target file.
+ * @returns The content hash and byte count of the copied file.
+ * @throws If the source file does not exist or cannot be read.
+ */
+export function copyFile(source: string, target: string): CopyResult {
+  let content: Buffer;
+  try {
+    content = fs.readFileSync(source);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      throw new Error(`File not found: ${source}`);
+    }
+    throw err;
+  }
+
+  const targetDir = path.dirname(target);
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.writeFileSync(target, content);
+
+  const hash = createHash('sha256').update(content).digest('hex');
+  return { hash, bytesWritten: content.length };
+}
+
+/**
+ * Result of copying an entire directory tree.
+ */
+export interface CopyDirectoryResult {
+  /** Map of relative file paths to their SHA-256 hex digests. */
+  readonly hashes: Record<string, string>;
+  /** Total number of files copied. */
+  readonly fileCount: number;
+  /** Total number of bytes written across all files. */
+  readonly totalBytes: number;
+}
+
+/**
+ * Recursively copy a directory tree from source to target.
+ *
+ * Creates the target directory and all subdirectories. Copies every file
+ * (optionally filtered) and returns content hashes for all copied files.
+ *
+ * @param source - Absolute or relative path to the source directory.
+ * @param target - Absolute or relative path to the target directory.
+ * @param filter - Optional predicate to filter files by name. Only files
+ *   whose name passes the filter are copied.
+ * @returns Hashes, file count, and total bytes for all copied files.
+ */
+export function copyDirectory(
+  source: string,
+  target: string,
+  filter?: (name: string) => boolean,
+): CopyDirectoryResult {
+  fs.mkdirSync(target, { recursive: true });
+
+  const hashes: Record<string, string> = {};
+  let fileCount = 0;
+  let totalBytes = 0;
+
+  copyDirectoryWalk(source, source, target, filter, hashes, (bytes) => {
+    fileCount++;
+    totalBytes += bytes;
+  });
+
+  return { hashes, fileCount, totalBytes };
+}
+
+/**
+ * Recursive helper for copyDirectory.
+ *
+ * @param rootDir - The original source root (for computing relative paths).
+ * @param currentDir - The current source directory being scanned.
+ * @param targetRoot - The target root directory.
+ * @param filter - Optional file name filter.
+ * @param hashes - Accumulator for relative-path to hash mappings.
+ * @param onFile - Callback invoked for each copied file with its byte size.
+ */
+function copyDirectoryWalk(
+  rootDir: string,
+  currentDir: string,
+  targetRoot: string,
+  filter: ((name: string) => boolean) | undefined,
+  hashes: Record<string, string>,
+  onFile: (bytes: number) => void,
+): void {
+  const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const srcPath = path.join(currentDir, entry.name);
+    const relativePath = path.relative(rootDir, srcPath);
+    const tgtPath = path.join(targetRoot, relativePath);
+
+    if (entry.isDirectory()) {
+      fs.mkdirSync(tgtPath, { recursive: true });
+      copyDirectoryWalk(rootDir, srcPath, targetRoot, filter, hashes, onFile);
+    } else if (entry.isFile()) {
+      if (filter && !filter(entry.name)) {
+        continue;
+      }
+      const result = copyFile(srcPath, tgtPath);
+      hashes[relativePath] = result.hash;
+      onFile(result.bytesWritten);
+    }
+  }
+}
+
+/**
+ * Result of a smart (idempotent) single-file copy.
+ */
+export interface SmartCopyResult {
+  /** What action was taken. */
+  readonly action: 'created' | 'updated' | 'skipped' | 'removed';
+  /** SHA-256 hex digest of the file after the operation (empty string if removed). */
+  readonly hash: string;
+}
+
+/**
+ * Result of a smart (idempotent) directory copy.
+ */
+export interface SmartCopyDirectoryResult {
+  /** Number of newly created files. */
+  readonly created: number;
+  /** Number of updated (changed) files. */
+  readonly updated: number;
+  /** Number of unchanged files that were skipped. */
+  readonly skipped: number;
+  /** Number of files that existed in the target but not in the source. */
+  readonly removed: number;
+  /** Map of relative file paths to their current SHA-256 hex digests. */
+  readonly hashes: Record<string, string>;
+}
+
+/**
+ * Idempotent single-file copy that skips unchanged files.
+ *
+ * Compares the source file's hash against the provided existing hash.
+ * If they match, the file is skipped. If the source does not exist
+ * but an existing hash is provided, the file is reported as removed.
+ *
+ * @param source - Path to the source file (may not exist for removals).
+ * @param target - Path to the target file.
+ * @param existingHash - SHA-256 hex digest of the previously installed file.
+ * @returns The action taken and the resulting file hash.
+ */
+export function smartCopy(
+  source: string,
+  target: string,
+  existingHash?: string,
+): SmartCopyResult {
+  const sourceExists = fs.existsSync(source);
+
+  // Source deleted — report removal
+  if (!sourceExists) {
+    if (existingHash) {
+      return { action: 'removed', hash: '' };
+    }
+    // No source, no existing hash — nothing to do
+    return { action: 'skipped', hash: '' };
+  }
+
+  // Compute source hash
+  const sourceHash = computeFileHash(source);
+
+  // Source unchanged — skip
+  if (existingHash && sourceHash === existingHash) {
+    return { action: 'skipped', hash: existingHash };
+  }
+
+  // Copy the file
+  copyFile(source, target);
+
+  // Determine action
+  const action = existingHash ? 'updated' : 'created';
+  return { action, hash: sourceHash };
+}
+
+/**
+ * Idempotent directory copy that skips unchanged files and detects removals.
+ *
+ * Compares source files against existing hashes. Files that haven't
+ * changed are skipped. Files present in `existingHashes` but absent
+ * from the source are reported as removed.
+ *
+ * @param source - Path to the source directory.
+ * @param target - Path to the target directory.
+ * @param existingHashes - Map of relative paths to SHA-256 hex digests
+ *   from the previous installation.
+ * @param filter - Optional predicate to filter files by name.
+ * @returns Summary of actions taken and updated hashes.
+ */
+export function smartCopyDirectory(
+  source: string,
+  target: string,
+  existingHashes: Record<string, string>,
+  filter?: (name: string) => boolean,
+): SmartCopyDirectoryResult {
+  fs.mkdirSync(target, { recursive: true });
+
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+  let removed = 0;
+  const hashes: Record<string, string> = {};
+
+  // Track which existing files we've seen in the source
+  const seenPaths = new Set<string>();
+
+  // Walk source directory and smart-copy each file
+  smartCopyDirectoryWalk(
+    source,
+    source,
+    target,
+    filter,
+    existingHashes,
+    seenPaths,
+    hashes,
+    (action) => {
+      switch (action) {
+        case 'created': created++; break;
+        case 'updated': updated++; break;
+        case 'skipped': skipped++; break;
+      }
+    },
+  );
+
+  // Detect removals: files in existingHashes not found in source
+  for (const relativePath of Object.keys(existingHashes)) {
+    if (!seenPaths.has(relativePath)) {
+      removed++;
+    }
+  }
+
+  return { created, updated, skipped, removed, hashes };
+}
+
+/**
+ * Recursive helper for smartCopyDirectory.
+ */
+function smartCopyDirectoryWalk(
+  rootDir: string,
+  currentDir: string,
+  targetRoot: string,
+  filter: ((name: string) => boolean) | undefined,
+  existingHashes: Record<string, string>,
+  seenPaths: Set<string>,
+  hashes: Record<string, string>,
+  onAction: (action: 'created' | 'updated' | 'skipped') => void,
+): void {
+  const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const srcPath = path.join(currentDir, entry.name);
+    const relativePath = path.relative(rootDir, srcPath);
+
+    if (entry.isDirectory()) {
+      const tgtPath = path.join(targetRoot, relativePath);
+      fs.mkdirSync(tgtPath, { recursive: true });
+      smartCopyDirectoryWalk(
+        rootDir, srcPath, targetRoot, filter,
+        existingHashes, seenPaths, hashes, onAction,
+      );
+    } else if (entry.isFile()) {
+      if (filter && !filter(entry.name)) {
+        continue;
+      }
+      seenPaths.add(relativePath);
+      const tgtPath = path.join(targetRoot, relativePath);
+      const result = smartCopy(srcPath, tgtPath, existingHashes[relativePath]);
+      if (result.action !== 'removed') {
+        hashes[relativePath] = result.hash;
+        onAction(result.action as 'created' | 'updated' | 'skipped');
+      }
+    }
+  }
+}
+
+/**
  * Recursively walk a directory, computing hashes for visible files.
  *
  * @param rootDir - The top-level directory (used to compute relative paths).

--- a/src/operations/mcp.test.ts
+++ b/src/operations/mcp.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { McpServerComponent } from '../manifest/types.js';
+import {
+  readMcpConfig,
+  writeMcpConfig,
+  mergeMcpServers,
+  generateMcpEntry,
+  removeMcpServers,
+} from './mcp.js';
+
+describe('MCP Config Management (C2)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-mcp-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Helper: create a bundled McpServerComponent. */
+  function createBundledServer(id: string = 'exarchos'): McpServerComponent {
+    return {
+      id,
+      name: 'Exarchos MCP',
+      description: 'Workflow state management',
+      required: true,
+      type: 'bundled',
+      bundlePath: 'plugins/exarchos/servers/exarchos-mcp/dist/index.js',
+    };
+  }
+
+  /** Helper: create an external McpServerComponent. */
+  function createExternalServer(id: string = 'graphite'): McpServerComponent {
+    return {
+      id,
+      name: 'Graphite',
+      description: 'Stacked PR management',
+      required: false,
+      type: 'external',
+      command: 'gt',
+      args: ['mcp'],
+    };
+  }
+
+  /** Helper: create a remote McpServerComponent. */
+  function createRemoteServer(id: string = 'microsoft-learn'): McpServerComponent {
+    return {
+      id,
+      name: 'Microsoft Learn',
+      description: 'Microsoft documentation',
+      required: false,
+      type: 'remote',
+      url: 'https://learn.microsoft.com/api/mcp',
+    };
+  }
+
+  describe('readMcpConfig', () => {
+    it('readMcpConfig_ExistingFile_ReturnsConfig', () => {
+      const configPath = path.join(tmpDir, 'claude.json');
+      const config = {
+        mcpServers: {
+          exarchos: { type: 'stdio', command: 'node', args: ['run', 'server.js'] },
+        },
+        someOtherKey: 'value',
+      };
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+
+      const result = readMcpConfig(configPath);
+
+      expect(result.mcpServers).toBeDefined();
+      expect(result.mcpServers!['exarchos']).toBeDefined();
+      expect(result.mcpServers!['exarchos'].type).toBe('stdio');
+      expect(result['someOtherKey']).toBe('value');
+    });
+
+    it('readMcpConfig_MissingFile_ReturnsEmpty', () => {
+      const configPath = path.join(tmpDir, 'nonexistent.json');
+
+      const result = readMcpConfig(configPath);
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('mergeMcpServers', () => {
+    it('mergeMcpServers_NewInstall_AddsAllServers', () => {
+      const config = {};
+      const servers = [createBundledServer(), createExternalServer()];
+      const claudeHome = path.join(tmpDir, '.claude');
+
+      const result = mergeMcpServers(config, servers, 'bun', claudeHome);
+
+      expect(result.mcpServers).toBeDefined();
+      expect(result.mcpServers!['exarchos']).toBeDefined();
+      expect(result.mcpServers!['graphite']).toBeDefined();
+    });
+
+    it('mergeMcpServers_ExistingServers_PreservesUserServers', () => {
+      const config = {
+        mcpServers: {
+          'my-custom-server': { type: 'stdio', command: 'my-server', args: [] },
+        },
+      };
+      const servers = [createBundledServer()];
+      const claudeHome = path.join(tmpDir, '.claude');
+
+      const result = mergeMcpServers(config, servers, 'node', claudeHome);
+
+      // User's custom server should be preserved
+      expect(result.mcpServers!['my-custom-server']).toBeDefined();
+      expect(result.mcpServers!['my-custom-server'].command).toBe('my-server');
+      // Exarchos server should be added
+      expect(result.mcpServers!['exarchos']).toBeDefined();
+    });
+
+    it('mergeMcpServers_StaleExarchosEntry_UpdatesEntry', () => {
+      const config = {
+        mcpServers: {
+          exarchos: { type: 'stdio', command: 'old-runtime', args: ['old-path'] },
+        },
+      };
+      const servers = [createBundledServer()];
+      const claudeHome = path.join(tmpDir, '.claude');
+
+      const result = mergeMcpServers(config, servers, 'bun', claudeHome);
+
+      // Should be updated to the new config
+      expect(result.mcpServers!['exarchos'].command).toBe('bun');
+      expect(result.mcpServers!['exarchos'].args).toContain('run');
+    });
+  });
+
+  describe('generateMcpEntry', () => {
+    it('generateMcpEntry_BundledServer_ReturnsCorrectConfig', () => {
+      const server = createBundledServer();
+      const claudeHome = '/home/user/.claude';
+
+      const entry = generateMcpEntry(server, 'bun', claudeHome);
+
+      expect(entry.type).toBe('stdio');
+      expect(entry.command).toBe('bun');
+      expect(entry.args).toEqual([
+        'run',
+        path.join(claudeHome, 'mcp-servers', 'exarchos-mcp.js'),
+      ]);
+    });
+
+    it('generateMcpEntry_ExternalServer_ReturnsCorrectConfig', () => {
+      const server = createExternalServer();
+      const claudeHome = '/home/user/.claude';
+
+      const entry = generateMcpEntry(server, 'node', claudeHome);
+
+      expect(entry.type).toBe('stdio');
+      expect(entry.command).toBe('gt');
+      expect(entry.args).toEqual(['mcp']);
+    });
+
+    it('generateMcpEntry_RemoteServer_ReturnsCorrectConfig', () => {
+      const server = createRemoteServer();
+      const claudeHome = '/home/user/.claude';
+
+      const entry = generateMcpEntry(server, 'node', claudeHome);
+
+      expect(entry.type).toBe('http');
+      expect(entry.url).toBe('https://learn.microsoft.com/api/mcp');
+      expect(entry.command).toBeUndefined();
+      expect(entry.args).toBeUndefined();
+    });
+  });
+
+  describe('removeMcpServers', () => {
+    it('removeMcpServers_ExistingEntries_RemovesOnlyExarchosManaged', () => {
+      const config = {
+        mcpServers: {
+          exarchos: { type: 'stdio', command: 'node', args: ['run', 'server.js'] },
+          graphite: { type: 'stdio', command: 'gt', args: ['mcp'] },
+          'my-custom-server': { type: 'stdio', command: 'custom', args: [] },
+        },
+        someOtherKey: 'preserved',
+      };
+
+      const result = removeMcpServers(config, ['exarchos', 'graphite']);
+
+      expect(result.mcpServers!['exarchos']).toBeUndefined();
+      expect(result.mcpServers!['graphite']).toBeUndefined();
+      expect(result.mcpServers!['my-custom-server']).toBeDefined();
+      expect(result['someOtherKey']).toBe('preserved');
+    });
+  });
+
+  describe('writeMcpConfig', () => {
+    it('writeMcpConfig_ValidConfig_WritesJsonToDisk', () => {
+      const configPath = path.join(tmpDir, 'claude.json');
+      const config = {
+        mcpServers: {
+          exarchos: { type: 'stdio', command: 'node', args: ['server.js'] },
+        },
+      };
+
+      writeMcpConfig(configPath, config);
+
+      expect(fs.existsSync(configPath)).toBe(true);
+      const raw = fs.readFileSync(configPath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      expect(parsed.mcpServers.exarchos.command).toBe('node');
+    });
+
+    it('writeMcpConfig_CreatesParentDirectories', () => {
+      const configPath = path.join(tmpDir, 'nested', 'dir', 'claude.json');
+      const config = { mcpServers: {} };
+
+      writeMcpConfig(configPath, config);
+
+      expect(fs.existsSync(configPath)).toBe(true);
+    });
+  });
+});

--- a/src/operations/mcp.ts
+++ b/src/operations/mcp.ts
@@ -1,0 +1,168 @@
+/**
+ * MCP server configuration management for ~/.claude.json.
+ *
+ * Handles reading, merging, and writing MCP server entries in the
+ * Claude config file. Supports bundled, external, and remote server types.
+ * Only touches keys for servers declared in the manifest — preserves
+ * any user-added servers.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { McpServerComponent } from '../manifest/types.js';
+
+/** A single MCP server entry in ~/.claude.json. */
+export interface McpServerEntry {
+  readonly type: string;
+  readonly command?: string;
+  readonly args?: readonly string[];
+  readonly env?: Readonly<Record<string, string>>;
+  readonly url?: string;
+}
+
+/** The structure of ~/.claude.json (partial — preserves unknown keys). */
+export interface ClaudeConfig {
+  mcpServers?: Record<string, McpServerEntry>;
+  [key: string]: unknown;
+}
+
+/**
+ * Read the Claude config file from disk.
+ *
+ * @param configPath - Absolute path to ~/.claude.json.
+ * @returns The parsed config, or an empty object if the file does not exist.
+ * @throws If the file exists but contains invalid JSON.
+ */
+export function readMcpConfig(configPath: string): ClaudeConfig {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(configPath, 'utf-8');
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return {};
+    }
+    throw err;
+  }
+
+  try {
+    return JSON.parse(raw) as ClaudeConfig;
+  } catch {
+    throw new Error(`Failed to parse Claude config JSON at ${configPath}`);
+  }
+}
+
+/**
+ * Merge MCP server entries into an existing Claude config.
+ *
+ * Only adds or updates entries for servers in the provided list.
+ * User-added servers (not in the manifest) are preserved untouched.
+ *
+ * @param config - The existing Claude config.
+ * @param servers - MCP server components from the manifest.
+ * @param runtime - The JavaScript runtime command (e.g., 'bun', 'node').
+ * @param claudeHome - Absolute path to ~/.claude/.
+ * @returns A new config with merged server entries.
+ */
+export function mergeMcpServers(
+  config: ClaudeConfig,
+  servers: readonly McpServerComponent[],
+  runtime: string,
+  claudeHome: string,
+): ClaudeConfig {
+  const existingServers = config.mcpServers ?? {};
+  const mergedServers = { ...existingServers };
+
+  for (const server of servers) {
+    mergedServers[server.id] = generateMcpEntry(server, runtime, claudeHome);
+  }
+
+  return {
+    ...config,
+    mcpServers: mergedServers,
+  };
+}
+
+/**
+ * Generate a single MCP server entry from a manifest component.
+ *
+ * @param server - The MCP server component definition.
+ * @param runtime - The JavaScript runtime command (e.g., 'bun', 'node').
+ * @param claudeHome - Absolute path to ~/.claude/.
+ * @returns The MCP server entry for ~/.claude.json.
+ */
+export function generateMcpEntry(
+  server: McpServerComponent,
+  runtime: string,
+  claudeHome: string,
+): McpServerEntry {
+  switch (server.type) {
+    case 'bundled': {
+      const bundleFilename = `${server.id}-mcp.js`;
+      return {
+        type: 'stdio',
+        command: runtime,
+        args: ['run', path.join(claudeHome, 'mcp-servers', bundleFilename)],
+      };
+    }
+    case 'external':
+      return {
+        type: 'stdio',
+        command: server.command!,
+        args: server.args ? [...server.args] : [],
+      };
+    case 'remote':
+      return {
+        type: 'http',
+        url: server.url!,
+      };
+  }
+}
+
+/**
+ * Remove MCP server entries by their IDs.
+ *
+ * Only removes servers whose IDs appear in the provided list.
+ * All other servers and config keys are preserved.
+ *
+ * @param config - The existing Claude config.
+ * @param serverIds - IDs of servers to remove.
+ * @returns A new config with the specified servers removed.
+ */
+export function removeMcpServers(
+  config: ClaudeConfig,
+  serverIds: readonly string[],
+): ClaudeConfig {
+  if (!config.mcpServers) {
+    return { ...config };
+  }
+
+  const remainingServers = { ...config.mcpServers };
+  const idsToRemove = new Set(serverIds);
+
+  for (const id of Object.keys(remainingServers)) {
+    if (idsToRemove.has(id)) {
+      delete remainingServers[id];
+    }
+  }
+
+  return {
+    ...config,
+    mcpServers: remainingServers,
+  };
+}
+
+/**
+ * Write the Claude config to disk.
+ *
+ * Creates parent directories if they do not exist.
+ * Output is pretty-printed with 2-space indentation.
+ *
+ * @param configPath - Absolute path to ~/.claude.json.
+ * @param config - The config to persist.
+ */
+export function writeMcpConfig(configPath: string, config: ClaudeConfig): void {
+  const dir = path.dirname(configPath);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}

--- a/src/operations/migration.test.ts
+++ b/src/operations/migration.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { detectV1Install, migrateV1, getV1RepoPath } from './migration.js';
+
+describe('V1 Migration', () => {
+  let tmpDir: string;
+  let claudeHome: string;
+  let fakeRepoRoot: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-test-'));
+    claudeHome = path.join(tmpDir, '.claude');
+    fakeRepoRoot = path.join(tmpDir, 'exarchos-repo');
+    fs.mkdirSync(claudeHome, { recursive: true });
+    fs.mkdirSync(fakeRepoRoot, { recursive: true });
+    // Create fake repo content directories
+    fs.mkdirSync(path.join(fakeRepoRoot, 'skills'), { recursive: true });
+    fs.mkdirSync(path.join(fakeRepoRoot, 'commands'), { recursive: true });
+    fs.mkdirSync(path.join(fakeRepoRoot, 'rules'), { recursive: true });
+    fs.mkdirSync(path.join(fakeRepoRoot, 'scripts'), { recursive: true });
+    fs.writeFileSync(path.join(fakeRepoRoot, 'settings.json'), '{}');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('detectV1Install', () => {
+    it('detectV1Install_SymlinkedSkills_ReturnsTrue', () => {
+      // Create symlink from claudeHome/skills -> fakeRepoRoot/skills (v1 pattern)
+      fs.symlinkSync(
+        path.join(fakeRepoRoot, 'skills'),
+        path.join(claudeHome, 'skills'),
+      );
+
+      const result = detectV1Install(claudeHome);
+
+      expect(result.isV1).toBe(true);
+      expect(result.repoPath).not.toBeNull();
+    });
+
+    it('detectV1Install_CopiedSkills_ReturnsFalse', () => {
+      // Create a real directory (not a symlink) — v2 standard mode
+      fs.mkdirSync(path.join(claudeHome, 'skills'), { recursive: true });
+      fs.writeFileSync(
+        path.join(claudeHome, 'skills', 'test.md'),
+        'content',
+      );
+
+      const result = detectV1Install(claudeHome);
+
+      expect(result.isV1).toBe(false);
+      expect(result.repoPath).toBeNull();
+    });
+
+    it('detectV1Install_NoSkills_ReturnsFalse', () => {
+      // No skills directory at all
+      const result = detectV1Install(claudeHome);
+
+      expect(result.isV1).toBe(false);
+      expect(result.repoPath).toBeNull();
+    });
+  });
+
+  describe('getV1RepoPath', () => {
+    it('getV1RepoPath_FromSymlink_ReturnsRepoRoot', () => {
+      // Symlink skills -> fakeRepoRoot/skills
+      fs.symlinkSync(
+        path.join(fakeRepoRoot, 'skills'),
+        path.join(claudeHome, 'skills'),
+      );
+
+      const result = getV1RepoPath(claudeHome);
+
+      // Should resolve to fakeRepoRoot (parent of 'skills')
+      expect(result).toBe(fakeRepoRoot);
+    });
+
+    it('getV1RepoPath_NoSymlink_ReturnsNull', () => {
+      const result = getV1RepoPath(claudeHome);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('migrateV1', () => {
+    it('migrateV1_RemovesSymlinks_ReturnsRemovedPaths', () => {
+      // Create v1 symlinks
+      const symlinkDirs = ['skills', 'commands', 'rules', 'scripts'];
+      for (const dir of symlinkDirs) {
+        fs.symlinkSync(
+          path.join(fakeRepoRoot, dir),
+          path.join(claudeHome, dir),
+        );
+      }
+      fs.symlinkSync(
+        path.join(fakeRepoRoot, 'settings.json'),
+        path.join(claudeHome, 'settings.json'),
+      );
+
+      const result = migrateV1(claudeHome);
+
+      expect(result.removedSymlinks.length).toBeGreaterThanOrEqual(5);
+      // Verify symlinks are actually gone
+      for (const dir of symlinkDirs) {
+        const targetPath = path.join(claudeHome, dir);
+        expect(fs.existsSync(targetPath)).toBe(false);
+      }
+      expect(fs.existsSync(path.join(claudeHome, 'settings.json'))).toBe(false);
+      expect(result.repoPath).toBe(fakeRepoRoot);
+    });
+
+    it('migrateV1_PreservesNonExarchosFiles_InClaudeDir', () => {
+      // Create v1 symlinks
+      fs.symlinkSync(
+        path.join(fakeRepoRoot, 'skills'),
+        path.join(claudeHome, 'skills'),
+      );
+
+      // Create non-Exarchos files that should be preserved
+      fs.mkdirSync(path.join(claudeHome, 'projects'), { recursive: true });
+      fs.writeFileSync(
+        path.join(claudeHome, 'projects', 'user-config.json'),
+        '{"user": true}',
+      );
+      fs.writeFileSync(
+        path.join(claudeHome, 'custom-file.txt'),
+        'preserve me',
+      );
+
+      migrateV1(claudeHome);
+
+      // Verify non-Exarchos files are preserved
+      expect(
+        fs.existsSync(path.join(claudeHome, 'projects', 'user-config.json')),
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(claudeHome, 'custom-file.txt')),
+      ).toBe(true);
+    });
+  });
+});

--- a/src/operations/migration.ts
+++ b/src/operations/migration.ts
@@ -1,0 +1,138 @@
+/**
+ * V1 migration detection and execution for the Exarchos installer.
+ *
+ * The v1 installer created symlinks from `~/.claude/` directly into the
+ * Exarchos repo (skills, commands, rules, scripts, settings.json). The
+ * v2 installer uses either copy (standard) or symlink (dev) mode with
+ * a config file. This module detects v1 installs and cleanly removes
+ * old symlinks before v2 installation proceeds.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { removeSymlink } from './symlink.js';
+
+/** Result of detecting a v1 installation. */
+export interface V1Detection {
+  /** Whether a v1 installation was detected. */
+  readonly isV1: boolean;
+  /** Absolute path to the Exarchos repo (resolved from symlink), or null. */
+  readonly repoPath: string | null;
+}
+
+/** Result of running a v1 migration. */
+export interface MigrationResult {
+  /** Absolute paths of symlinks that were removed. */
+  readonly removedSymlinks: string[];
+  /** Absolute paths of non-Exarchos files/dirs that were preserved. */
+  readonly preservedFiles: string[];
+  /** Absolute path to the Exarchos repo (resolved from symlink), or null. */
+  readonly repoPath: string | null;
+}
+
+/** Known Exarchos v1 symlink names within ~/.claude/. */
+const V1_SYMLINK_NAMES = ['skills', 'commands', 'rules', 'scripts', 'settings.json'] as const;
+
+/**
+ * Detect whether a v1 Exarchos installation exists.
+ *
+ * Checks if `~/.claude/skills` is a symbolic link, which is the
+ * primary indicator of a v1 install (v2 standard mode copies files,
+ * v2 dev mode also creates symlinks but writes an exarchos.json config).
+ *
+ * @param claudeHome - Absolute path to the `~/.claude/` directory.
+ * @returns Detection result with v1 flag and resolved repo path.
+ */
+export function detectV1Install(claudeHome: string): V1Detection {
+  const skillsPath = path.join(claudeHome, 'skills');
+
+  let stat: fs.Stats | undefined;
+  try {
+    stat = fs.lstatSync(skillsPath);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return { isV1: false, repoPath: null };
+    }
+    throw err;
+  }
+
+  if (!stat.isSymbolicLink()) {
+    return { isV1: false, repoPath: null };
+  }
+
+  // It's a symlink — resolve the repo root
+  const repoPath = getV1RepoPath(claudeHome);
+  return { isV1: true, repoPath };
+}
+
+/**
+ * Resolve the Exarchos repo root from a v1 symlink.
+ *
+ * Reads the `skills` symlink target and resolves its parent directory
+ * as the repo root.
+ *
+ * @param claudeHome - Absolute path to the `~/.claude/` directory.
+ * @returns The absolute repo root path, or null if no symlink exists.
+ */
+export function getV1RepoPath(claudeHome: string): string | null {
+  const skillsPath = path.join(claudeHome, 'skills');
+
+  let stat: fs.Stats | undefined;
+  try {
+    stat = fs.lstatSync(skillsPath);
+  } catch {
+    return null;
+  }
+
+  if (!stat.isSymbolicLink()) {
+    return null;
+  }
+
+  const symlinkTarget = fs.readlinkSync(skillsPath);
+  // The symlink target is e.g. /path/to/exarchos/skills
+  // The repo root is the parent of that
+  return path.dirname(symlinkTarget);
+}
+
+/**
+ * Migrate a v1 installation by removing Exarchos symlinks.
+ *
+ * Removes all known v1 symlinks (skills, commands, rules, scripts,
+ * settings.json) while preserving any non-Exarchos files and directories
+ * in `~/.claude/`.
+ *
+ * @param claudeHome - Absolute path to the `~/.claude/` directory.
+ * @returns Migration result with removed and preserved paths.
+ */
+export function migrateV1(claudeHome: string): MigrationResult {
+  const repoPath = getV1RepoPath(claudeHome);
+  const removedSymlinks: string[] = [];
+  const preservedFiles: string[] = [];
+
+  // Remove known Exarchos v1 symlinks
+  for (const name of V1_SYMLINK_NAMES) {
+    const targetPath = path.join(claudeHome, name);
+    const result = removeSymlink(targetPath);
+    if (result === 'removed') {
+      removedSymlinks.push(targetPath);
+    }
+  }
+
+  // Enumerate remaining items to report preserved files
+  try {
+    const entries = fs.readdirSync(claudeHome, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(claudeHome, entry.name);
+      // Skip anything we just removed
+      if (removedSymlinks.includes(entryPath)) {
+        continue;
+      }
+      preservedFiles.push(entryPath);
+    }
+  } catch {
+    // If claudeHome doesn't exist or can't be read, nothing to preserve
+  }
+
+  return { removedSymlinks, preservedFiles, repoPath };
+}

--- a/src/operations/settings.test.ts
+++ b/src/operations/settings.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import type { WizardSelections } from './config.js';
+import {
+  generateSettings,
+  generatePermissions,
+} from './settings.js';
+
+describe('Settings.json Generation (C3)', () => {
+  /** Helper: create a default WizardSelections. */
+  function createSelections(overrides: Partial<WizardSelections> = {}): WizardSelections {
+    return {
+      mcpServers: ['exarchos'],
+      plugins: ['serena', 'github'],
+      ruleSets: ['typescript'],
+      model: 'claude-opus-4-6',
+      ...overrides,
+    };
+  }
+
+  describe('generateSettings', () => {
+    it('generateSettings_DefaultSelections_IncludesAllPermissions', () => {
+      const selections = createSelections();
+
+      const result = generateSettings(selections);
+
+      expect(result.permissions).toBeDefined();
+      expect(result.permissions.allow).toBeDefined();
+      expect(Array.isArray(result.permissions.allow)).toBe(true);
+      expect(result.permissions.allow.length).toBeGreaterThan(0);
+      // Should contain at least some core permissions
+      expect(result.permissions.allow).toContain('Bash(git:*)');
+      expect(result.permissions.allow).toContain('Bash(npm:*)');
+    });
+
+    it('generateSettings_OpusModel_SetsModelField', () => {
+      const selections = createSelections({ model: 'claude-opus-4-6' });
+
+      const result = generateSettings(selections);
+
+      expect(result.model).toBe('claude-opus-4-6');
+    });
+
+    it('generateSettings_SonnetModel_SetsModelField', () => {
+      const selections = createSelections({ model: 'claude-sonnet-4-20250514' });
+
+      const result = generateSettings(selections);
+
+      expect(result.model).toBe('claude-sonnet-4-20250514');
+    });
+
+    it('generateSettings_SelectedPlugins_SetsEnabledPlugins', () => {
+      const selections = createSelections({
+        plugins: ['serena', 'github', 'context7'],
+      });
+
+      const result = generateSettings(selections);
+
+      expect(result.enabledPlugins).toBeDefined();
+      expect(result.enabledPlugins['serena']).toBe(true);
+      expect(result.enabledPlugins['github']).toBe(true);
+      expect(result.enabledPlugins['context7']).toBe(true);
+    });
+
+    it('generateSettings_NoPlugins_EmptyEnabledPlugins', () => {
+      const selections = createSelections({ plugins: [] });
+
+      const result = generateSettings(selections);
+
+      expect(result.enabledPlugins).toBeDefined();
+      expect(Object.keys(result.enabledPlugins)).toHaveLength(0);
+    });
+  });
+
+  describe('generatePermissions', () => {
+    it('generatePermissions_Always_ReturnsComprehensiveList', () => {
+      const permissions = generatePermissions();
+
+      expect(Array.isArray(permissions)).toBe(true);
+      expect(permissions.length).toBeGreaterThan(10);
+
+      // Should contain fundamental tool permissions
+      expect(permissions).toContain('Read');
+      expect(permissions).toContain('Write');
+      expect(permissions).toContain('Edit');
+      expect(permissions).toContain('Glob');
+      expect(permissions).toContain('Grep');
+
+      // Should contain bash command permissions
+      expect(permissions).toContain('Bash(git:*)');
+      expect(permissions).toContain('Bash(npm:*)');
+      expect(permissions).toContain('Bash(npx:*)');
+      expect(permissions).toContain('Bash(gt:*)');
+
+      // Should contain MCP wildcard
+      expect(permissions).toContain('mcp__*');
+    });
+  });
+});

--- a/src/operations/settings.ts
+++ b/src/operations/settings.ts
@@ -1,0 +1,255 @@
+/**
+ * Settings.json generation for the Exarchos installer.
+ *
+ * Generates the `settings.json` file that configures Claude Code's
+ * permissions, model, and enabled plugins based on wizard selections.
+ */
+
+import type { WizardSelections } from './config.js';
+
+/** The settings.json structure for Claude Code. */
+export interface Settings {
+  readonly permissions: { readonly allow: readonly string[] };
+  readonly model: string;
+  readonly enabledPlugins: Readonly<Record<string, boolean>>;
+}
+
+/**
+ * Generate a complete settings.json from wizard selections.
+ *
+ * Combines the comprehensive permission list, selected model,
+ * and enabled plugin map into a single settings object.
+ *
+ * @param selections - The user's wizard selections.
+ * @returns The settings.json content.
+ */
+export function generateSettings(selections: WizardSelections): Settings {
+  const enabledPlugins: Record<string, boolean> = {};
+  for (const pluginId of selections.plugins) {
+    enabledPlugins[pluginId] = true;
+  }
+
+  return {
+    permissions: { allow: generatePermissions() },
+    model: selections.model,
+    enabledPlugins,
+  };
+}
+
+/**
+ * Generate the comprehensive permission allow-list.
+ *
+ * Returns a hardcoded list of all tool and bash command permissions
+ * needed for full Exarchos functionality.
+ *
+ * @returns The permission strings for settings.json.
+ */
+export function generatePermissions(): string[] {
+  return [
+    // Claude Code native tools
+    'Read',
+    'Write',
+    'Edit',
+    'Glob',
+    'Grep',
+    'NotebookEdit',
+    'Task',
+    'LSP',
+    'WebSearch',
+    'WebFetch',
+
+    // MCP wildcard
+    'mcp__*',
+
+    // Version control and stacking
+    'Bash(gt:*)',
+    'Bash(gh:*)',
+    'Bash(git:*)',
+
+    // Package managers
+    'Bash(npm:*)',
+    'Bash(npx:*)',
+    'Bash(yarn:*)',
+    'Bash(pnpm:*)',
+    'Bash(bun:*)',
+    'Bash(node:*)',
+
+    // .NET ecosystem
+    'Bash(dotnet:*)',
+    'Bash(nuget:*)',
+    'Bash(msbuild:*)',
+
+    // Rust
+    'Bash(cargo:*)',
+    'Bash(rustc:*)',
+    'Bash(rustup:*)',
+
+    // Go
+    'Bash(go:*)',
+
+    // Python
+    'Bash(python:*)',
+    'Bash(python3:*)',
+    'Bash(pip:*)',
+    'Bash(pip3:*)',
+    'Bash(poetry:*)',
+    'Bash(uv:*)',
+
+    // Ruby
+    'Bash(ruby:*)',
+    'Bash(gem:*)',
+    'Bash(bundle:*)',
+
+    // Java/JVM
+    'Bash(java:*)',
+    'Bash(javac:*)',
+    'Bash(mvn:*)',
+    'Bash(gradle:*)',
+
+    // Containers and orchestration
+    'Bash(docker:*)',
+    'Bash(docker-compose:*)',
+    'Bash(podman:*)',
+    'Bash(kubectl:*)',
+    'Bash(helm:*)',
+
+    // Infrastructure
+    'Bash(terraform:*)',
+    'Bash(pulumi:*)',
+    'Bash(aws:*)',
+    'Bash(az:*)',
+    'Bash(gcloud:*)',
+
+    // Build systems
+    'Bash(make:*)',
+    'Bash(cmake:*)',
+    'Bash(ninja:*)',
+
+    // Testing
+    'Bash(jest:*)',
+    'Bash(vitest:*)',
+    'Bash(pytest:*)',
+    'Bash(mocha:*)',
+
+    // Linting and formatting
+    'Bash(eslint:*)',
+    'Bash(prettier:*)',
+    'Bash(tsc:*)',
+
+    // Network
+    'Bash(curl:*)',
+    'Bash(wget:*)',
+    'Bash(ssh:*)',
+    'Bash(scp:*)',
+    'Bash(rsync:*)',
+
+    // File reading
+    'Bash(ls:*)',
+    'Bash(cat:*)',
+    'Bash(head:*)',
+    'Bash(tail:*)',
+
+    // Search
+    'Bash(find:*)',
+    'Bash(grep:*)',
+    'Bash(rg:*)',
+    'Bash(fd:*)',
+    'Bash(ag:*)',
+    'Bash(ack:*)',
+
+    // Text processing
+    'Bash(sed:*)',
+    'Bash(awk:*)',
+    'Bash(sort:*)',
+    'Bash(uniq:*)',
+    'Bash(wc:*)',
+    'Bash(cut:*)',
+    'Bash(tr:*)',
+    'Bash(tee:*)',
+    'Bash(xargs:*)',
+    'Bash(jq:*)',
+    'Bash(yq:*)',
+
+    // File operations
+    'Bash(mkdir:*)',
+    'Bash(rm:*)',
+    'Bash(rmdir:*)',
+    'Bash(cp:*)',
+    'Bash(mv:*)',
+    'Bash(touch:*)',
+    'Bash(chmod:*)',
+    'Bash(ln:*)',
+
+    // Archives
+    'Bash(tar:*)',
+    'Bash(zip:*)',
+    'Bash(unzip:*)',
+    'Bash(gzip:*)',
+    'Bash(gunzip:*)',
+
+    // Diff and patch
+    'Bash(diff:*)',
+    'Bash(patch:*)',
+
+    // Output and environment
+    'Bash(echo:*)',
+    'Bash(printf:*)',
+    'Bash(date:*)',
+    'Bash(env:*)',
+    'Bash(export:*)',
+    'Bash(which:*)',
+    'Bash(whereis:*)',
+    'Bash(type:*)',
+
+    // Navigation
+    'Bash(pwd:*)',
+    'Bash(cd:*)',
+    'Bash(pushd:*)',
+    'Bash(popd:*)',
+    'Bash(realpath:*)',
+    'Bash(basename:*)',
+    'Bash(dirname:*)',
+
+    // Process management
+    'Bash(ps:*)',
+    'Bash(kill:*)',
+    'Bash(pkill:*)',
+    'Bash(pgrep:*)',
+    'Bash(time:*)',
+    'Bash(timeout:*)',
+    'Bash(watch:*)',
+
+    // Disk and file info
+    'Bash(du:*)',
+    'Bash(df:*)',
+    'Bash(stat:*)',
+    'Bash(file:*)',
+    'Bash(tree:*)',
+
+    // Network diagnostics
+    'Bash(ping:*)',
+    'Bash(nc:*)',
+    'Bash(netstat:*)',
+    'Bash(ss:*)',
+    'Bash(lsof:*)',
+
+    // Shell builtins
+    'Bash(source:*)',
+    'Bash(.:*)',
+    'Bash(test:*)',
+    'Bash([:*)',
+    'Bash([[:*)',
+    'Bash(true:*)',
+    'Bash(false:*)',
+    'Bash(exit:*)',
+    'Bash(return:*)',
+    'Bash(read:*)',
+    'Bash(set:*)',
+    'Bash(unset:*)',
+    'Bash(shift:*)',
+    'Bash(getopts:*)',
+    'Bash(declare:*)',
+    'Bash(local:*)',
+    'Bash(eval:*)',
+  ];
+}

--- a/src/operations/symlink.test.ts
+++ b/src/operations/symlink.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  createSymlink,
+  removeSymlink,
+  validateSymlinks,
+  type SymlinkResult,
+  type RemoveResult,
+  type SymlinkHealthReport,
+} from './symlink.js';
+
+describe('createSymlink (B4)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-symlink-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('createSymlink_NoExistingTarget_CreatesLink', () => {
+    const source = path.join(tmpDir, 'source-dir');
+    const target = path.join(tmpDir, 'link');
+    fs.mkdirSync(source);
+
+    const result: SymlinkResult = createSymlink(source, target);
+
+    expect(result).toBe('created');
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(target)).toBe(source);
+  });
+
+  it('createSymlink_ExistingCorrectLink_Skips', () => {
+    const source = path.join(tmpDir, 'source-dir');
+    const target = path.join(tmpDir, 'link');
+    fs.mkdirSync(source);
+    fs.symlinkSync(source, target);
+
+    const result = createSymlink(source, target);
+
+    expect(result).toBe('skipped');
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(target)).toBe(source);
+  });
+
+  it('createSymlink_ExistingWrongLink_Relinks', () => {
+    const source = path.join(tmpDir, 'correct-source');
+    const wrongSource = path.join(tmpDir, 'wrong-source');
+    const target = path.join(tmpDir, 'link');
+    fs.mkdirSync(source);
+    fs.mkdirSync(wrongSource);
+    fs.symlinkSync(wrongSource, target);
+
+    const result = createSymlink(source, target);
+
+    expect(result).toBe('relinked');
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(target)).toBe(source);
+  });
+
+  it('createSymlink_ExistingDirectory_BacksUpAndLinks', () => {
+    const source = path.join(tmpDir, 'source-dir');
+    const target = path.join(tmpDir, 'existing-dir');
+    fs.mkdirSync(source);
+    fs.mkdirSync(target);
+    fs.writeFileSync(path.join(target, 'file.txt'), 'preserved', 'utf-8');
+
+    const result = createSymlink(source, target);
+
+    expect(result).toBe('backed_up');
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(fs.readlinkSync(target)).toBe(source);
+
+    // Verify backup directory exists
+    const entries = fs.readdirSync(tmpDir);
+    const backupEntry = entries.find(
+      (e) => e.startsWith('existing-dir.backup.'),
+    );
+    expect(backupEntry).toBeDefined();
+
+    // Verify backup contents preserved
+    const backupPath = path.join(tmpDir, backupEntry!);
+    expect(
+      fs.readFileSync(path.join(backupPath, 'file.txt'), 'utf-8'),
+    ).toBe('preserved');
+  });
+});
+
+describe('removeSymlink (B4)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-rmsymlink-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('removeSymlink_ExistingLink_Removes', () => {
+    const source = path.join(tmpDir, 'source');
+    const target = path.join(tmpDir, 'link');
+    fs.mkdirSync(source);
+    fs.symlinkSync(source, target);
+
+    const result: RemoveResult = removeSymlink(target);
+
+    expect(result).toBe('removed');
+    expect(fs.existsSync(target)).toBe(false);
+  });
+
+  it('removeSymlink_NotALink_Skips', () => {
+    const target = path.join(tmpDir, 'regular-dir');
+    fs.mkdirSync(target);
+
+    const result = removeSymlink(target);
+
+    expect(result).toBe('skipped');
+    // Directory should still exist
+    expect(fs.existsSync(target)).toBe(true);
+  });
+
+  it('removeSymlink_Missing_Skips', () => {
+    const target = path.join(tmpDir, 'nonexistent');
+
+    const result = removeSymlink(target);
+
+    expect(result).toBe('skipped');
+  });
+});
+
+describe('validateSymlinks (B5)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-validate-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('validateSymlinks_AllValid_ReturnsHealthy', () => {
+    const src1 = path.join(tmpDir, 'src1');
+    const src2 = path.join(tmpDir, 'src2');
+    const tgt1 = path.join(tmpDir, 'link1');
+    const tgt2 = path.join(tmpDir, 'link2');
+    fs.mkdirSync(src1);
+    fs.mkdirSync(src2);
+    fs.symlinkSync(src1, tgt1);
+    fs.symlinkSync(src2, tgt2);
+
+    const report: SymlinkHealthReport = validateSymlinks({
+      [tgt1]: src1,
+      [tgt2]: src2,
+    });
+
+    expect(report.healthy).toHaveLength(2);
+    expect(report.healthy).toContain(tgt1);
+    expect(report.healthy).toContain(tgt2);
+    expect(report.broken).toHaveLength(0);
+    expect(report.missing).toHaveLength(0);
+  });
+
+  it('validateSymlinks_BrokenLink_ReturnsBroken', () => {
+    const src = path.join(tmpDir, 'deleted-source');
+    const tgt = path.join(tmpDir, 'link');
+    // Create link then remove source
+    fs.mkdirSync(src);
+    fs.symlinkSync(src, tgt);
+    fs.rmSync(src, { recursive: true, force: true });
+
+    const report = validateSymlinks({ [tgt]: src });
+
+    expect(report.healthy).toHaveLength(0);
+    expect(report.broken).toHaveLength(1);
+    expect(report.broken).toContain(tgt);
+    expect(report.missing).toHaveLength(0);
+  });
+
+  it('validateSymlinks_MissingLink_ReturnsMissing', () => {
+    const src = path.join(tmpDir, 'source');
+    const tgt = path.join(tmpDir, 'missing-link');
+    fs.mkdirSync(src);
+    // Link does not exist at all
+
+    const report = validateSymlinks({ [tgt]: src });
+
+    expect(report.healthy).toHaveLength(0);
+    expect(report.broken).toHaveLength(0);
+    expect(report.missing).toHaveLength(1);
+    expect(report.missing).toContain(tgt);
+  });
+
+  it('validateSymlinks_MixedState_ReturnsDetailedReport', () => {
+    const healthySrc = path.join(tmpDir, 'healthy-src');
+    const healthyTgt = path.join(tmpDir, 'healthy-link');
+    const brokenSrc = path.join(tmpDir, 'broken-src');
+    const brokenTgt = path.join(tmpDir, 'broken-link');
+    const missingSrc = path.join(tmpDir, 'missing-src');
+    const missingTgt = path.join(tmpDir, 'missing-link');
+
+    // Healthy: source exists, link correct
+    fs.mkdirSync(healthySrc);
+    fs.symlinkSync(healthySrc, healthyTgt);
+
+    // Broken: link exists but source was removed
+    fs.mkdirSync(brokenSrc);
+    fs.symlinkSync(brokenSrc, brokenTgt);
+    fs.rmSync(brokenSrc, { recursive: true, force: true });
+
+    // Missing: source exists but link does not
+    fs.mkdirSync(missingSrc);
+
+    const report = validateSymlinks({
+      [healthyTgt]: healthySrc,
+      [brokenTgt]: brokenSrc,
+      [missingTgt]: missingSrc,
+    });
+
+    expect(report.healthy).toEqual([healthyTgt]);
+    expect(report.broken).toEqual([brokenTgt]);
+    expect(report.missing).toEqual([missingTgt]);
+  });
+});

--- a/src/operations/symlink.ts
+++ b/src/operations/symlink.ts
@@ -1,0 +1,182 @@
+/**
+ * Symlink operations for dev-mode installation.
+ *
+ * In dev mode the installer creates symbolic links from `~/.claude/`
+ * back into the Exarchos repo so that edits to commands, skills, and
+ * rules take effect immediately without re-running the installer.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Outcome of a createSymlink operation. */
+export type SymlinkResult = 'created' | 'skipped' | 'backed_up' | 'relinked';
+
+/** Outcome of a removeSymlink operation. */
+export type RemoveResult = 'removed' | 'skipped';
+
+/**
+ * Create a symbolic link from `target` pointing to `source`.
+ *
+ * Handles four scenarios:
+ * - Target does not exist: creates the link.
+ * - Target is a symlink pointing to the correct source: skips.
+ * - Target is a symlink pointing elsewhere: removes and relinks.
+ * - Target is a real directory: renames to `<name>.backup.<timestamp>` then links.
+ *
+ * @param source - Absolute path to the link destination (the actual content).
+ * @param target - Absolute path where the symlink will be created.
+ * @returns The action taken.
+ */
+export function createSymlink(source: string, target: string): SymlinkResult {
+  let stat: fs.Stats | undefined;
+  try {
+    stat = fs.lstatSync(target);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      throw err;
+    }
+    // Target does not exist — fall through to create
+  }
+
+  if (stat) {
+    if (stat.isSymbolicLink()) {
+      const currentTarget = fs.readlinkSync(target);
+      if (currentTarget === source) {
+        return 'skipped';
+      }
+      // Wrong target — remove and relink
+      fs.unlinkSync(target);
+      fs.symlinkSync(source, target);
+      return 'relinked';
+    }
+
+    if (stat.isDirectory()) {
+      // Back up existing directory
+      const timestamp = Date.now();
+      const baseName = path.basename(target);
+      const parentDir = path.dirname(target);
+      const backupName = `${baseName}.backup.${timestamp}`;
+      const backupPath = path.join(parentDir, backupName);
+      fs.renameSync(target, backupPath);
+      fs.symlinkSync(source, target);
+      return 'backed_up';
+    }
+
+    // Target is a regular file or other — remove and link
+    fs.unlinkSync(target);
+    fs.symlinkSync(source, target);
+    return 'relinked';
+  }
+
+  // Target does not exist — create parent dirs if needed
+  const parentDir = path.dirname(target);
+  fs.mkdirSync(parentDir, { recursive: true });
+  fs.symlinkSync(source, target);
+  return 'created';
+}
+
+/**
+ * Remove a symbolic link at the given target path.
+ *
+ * Only removes the entry if it is actually a symlink. Regular files
+ * and directories are left untouched. Missing targets are silently
+ * skipped.
+ *
+ * @param target - Absolute path to the symlink to remove.
+ * @returns The action taken.
+ */
+export function removeSymlink(target: string): RemoveResult {
+  let stat: fs.Stats | undefined;
+  try {
+    stat = fs.lstatSync(target);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return 'skipped';
+    }
+    throw err;
+  }
+
+  if (stat.isSymbolicLink()) {
+    fs.unlinkSync(target);
+    return 'removed';
+  }
+
+  return 'skipped';
+}
+
+/**
+ * Health report for a set of expected symlinks.
+ */
+export interface SymlinkHealthReport {
+  /** Target paths whose symlinks exist and point to the expected source. */
+  readonly healthy: string[];
+  /** Target paths whose symlinks exist but are broken (source missing or wrong target). */
+  readonly broken: string[];
+  /** Target paths where no symlink exists at all. */
+  readonly missing: string[];
+}
+
+/**
+ * Validate a set of expected symbolic links.
+ *
+ * Checks each expected symlink target to determine whether it exists,
+ * is a symlink, and points to the expected source. Classifies each
+ * entry as healthy, broken, or missing.
+ *
+ * A link is "broken" if:
+ * - It is a symlink but its target (the source) no longer exists.
+ * - It is a symlink pointing to the wrong source.
+ *
+ * A link is "missing" if:
+ * - The target path does not exist at all.
+ * - The target path exists but is not a symlink.
+ *
+ * @param expectedLinks - Map of target path to expected source path.
+ * @returns A health report classifying each link.
+ */
+export function validateSymlinks(
+  expectedLinks: Record<string, string>,
+): SymlinkHealthReport {
+  const healthy: string[] = [];
+  const broken: string[] = [];
+  const missing: string[] = [];
+
+  for (const [target, expectedSource] of Object.entries(expectedLinks)) {
+    let stat: fs.Stats | undefined;
+    try {
+      stat = fs.lstatSync(target);
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') {
+        missing.push(target);
+        continue;
+      }
+      throw err;
+    }
+
+    if (!stat.isSymbolicLink()) {
+      missing.push(target);
+      continue;
+    }
+
+    // It is a symlink — check if it points to the right place and source exists
+    const actualTarget = fs.readlinkSync(target);
+    if (actualTarget !== expectedSource) {
+      broken.push(target);
+      continue;
+    }
+
+    // Check that the source actually exists
+    if (!fs.existsSync(expectedSource)) {
+      broken.push(target);
+      continue;
+    }
+
+    healthy.push(target);
+  }
+
+  return { healthy, broken, missing };
+}


### PR DESCRIPTION
## Summary

Adds the foundational type system and utility modules for the new manifest-driven installer. These modules replace the monolithic symlink approach with modular, testable operations for file copying, symlink management, MCP config merging, settings generation, and v1 migration.

## Changes

- **Manifest Types + Loader** — `Manifest`, `CoreComponent`, `McpServerComponent`, `PluginComponent`, `RuleSetComponent` interfaces with validation and default extraction
- **Config I/O** — `ExarchosConfig` read/write with `WizardSelections` type and content hash storage
- **Copy Operations** — Single file copy, recursive directory copy, and smart copy (skip unchanged via SHA-256 hash comparison)
- **Symlink Operations** — Create/remove/validate symlinks with health checking for dev mode self-healing
- **MCP Config** — Read/merge/write `~/.claude.json` preserving user servers; supports bundled, external, and remote server types
- **Settings Generation** — Generate `settings.json` from wizard selections with 130+ hardcoded permissions
- **Bundle Copy** — Install MCP server bundle to `~/.claude/mcp-servers/`
- **V1 Migration** — Detect symlink-based v1 installs, extract repo path, migrate to copy-based

## Test Plan

111 unit tests across 8 test files covering all modules. Tests use temp directories for file operations isolation.

---

**Results:** Tests 189 ✓ · Build 0 errors
**Design:** [2026-02-12-installer-overhaul.md](docs/designs/2026-02-12-installer-overhaul.md)
**Related:** Stack 1/3