### PR TITLE
feat: add interactive wizard with prerequisite detection

### DIFF
--- a/src/wizard/display.test.ts
+++ b/src/wizard/display.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for display formatting helpers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  formatHeader,
+  formatPrerequisiteReport,
+  formatInstallSummary,
+  formatProgressLine,
+} from './display.js';
+import type { PrerequisiteReport } from './prerequisites.js';
+import type { InstallResult } from './display.js';
+
+describe('formatHeader', () => {
+  it('returns a formatted banner with title and version', () => {
+    const result = formatHeader('Exarchos', '2.0.0');
+
+    expect(result).toContain('Exarchos');
+    expect(result).toContain('2.0.0');
+    expect(result).toContain('=');
+  });
+});
+
+describe('formatPrerequisiteReport', () => {
+  it('shows checkmarks when all prerequisites are found', () => {
+    const report: PrerequisiteReport = {
+      results: [
+        { command: 'bun', found: true, version: '1.5.0', meetsMinVersion: true, installHint: '' },
+        { command: 'gt', found: true, version: '2.0.0', meetsMinVersion: true, installHint: '' },
+      ],
+      canProceed: true,
+      blockers: [],
+    };
+
+    const result = formatPrerequisiteReport(report);
+
+    expect(result).toContain('bun');
+    expect(result).toContain('1.5.0');
+    // Should have a check mark for found items
+    expect(result).toMatch(/[✓]/);
+  });
+
+  it('shows errors for missing required prerequisites', () => {
+    const report: PrerequisiteReport = {
+      results: [
+        { command: 'bun', found: false, meetsMinVersion: false, installHint: 'curl -fsSL https://bun.sh/install | bash' },
+        { command: 'gt', found: true, version: '2.0.0', meetsMinVersion: true, installHint: '' },
+      ],
+      canProceed: false,
+      blockers: ["Required tool 'bun' not found. Install: curl -fsSL https://bun.sh/install | bash"],
+    };
+
+    const result = formatPrerequisiteReport(report);
+
+    expect(result).toContain('bun');
+    // Should have an error indicator for missing items
+    expect(result).toMatch(/[✗]/);
+    expect(result).toContain('curl');
+  });
+});
+
+describe('formatInstallSummary', () => {
+  it('returns a formatted summary of install results', () => {
+    const results: InstallResult[] = [
+      { label: 'Commands', status: 'done' },
+      { label: 'Skills', status: 'done' },
+      { label: 'Rules', status: 'skip', detail: 'No rule sets selected' },
+      { label: 'MCP Server', status: 'fail', detail: 'Build failed' },
+    ];
+
+    const result = formatInstallSummary(results);
+
+    expect(result).toContain('Commands');
+    expect(result).toContain('Skills');
+    expect(result).toContain('Rules');
+    expect(result).toContain('MCP Server');
+    expect(result).toContain('No rule sets selected');
+    expect(result).toContain('Build failed');
+  });
+});
+
+describe('formatProgressLine', () => {
+  it('returns checkmark for completed items', () => {
+    const result = formatProgressLine('Commands', 'done');
+
+    expect(result).toContain('✓');
+    expect(result).toContain('Commands');
+  });
+
+  it('returns cross for failed items', () => {
+    const result = formatProgressLine('MCP Server', 'fail', 'Build error');
+
+    expect(result).toContain('✗');
+    expect(result).toContain('MCP Server');
+    expect(result).toContain('Build error');
+  });
+
+  it('returns tilde for skipped items', () => {
+    const result = formatProgressLine('Rules', 'skip', 'Not selected');
+
+    expect(result).toContain('~');
+    expect(result).toContain('Rules');
+    expect(result).toContain('Not selected');
+  });
+
+  it('includes detail when provided', () => {
+    const result = formatProgressLine('Plugins', 'done', '3 installed');
+
+    expect(result).toContain('✓');
+    expect(result).toContain('Plugins');
+    expect(result).toContain('3 installed');
+  });
+});

--- a/src/wizard/display.ts
+++ b/src/wizard/display.ts
@@ -1,0 +1,101 @@
+/**
+ * Display formatting helpers for the Exarchos installer.
+ *
+ * Provides functions to format headers, prerequisite reports,
+ * install summaries, and progress lines for terminal output.
+ */
+
+import type { PrerequisiteReport } from './prerequisites.js';
+
+/** Result of a single install operation for display purposes. */
+export interface InstallResult {
+  /** Display label for the operation. */
+  readonly label: string;
+  /** Completion status. */
+  readonly status: 'done' | 'skip' | 'fail';
+  /** Optional detail message. */
+  readonly detail?: string;
+}
+
+/** Status indicator characters. */
+const STATUS_ICONS = {
+  done: '\u2713', // ✓
+  skip: '~',
+  fail: '\u2717', // ✗
+} as const;
+
+/**
+ * Format a header banner for the installer.
+ *
+ * @param title - The application title.
+ * @param version - The version string.
+ * @returns A formatted banner string.
+ */
+export function formatHeader(title: string, version: string): string {
+  const line = `${title} v${version} \u2014 SDLC Workflow Automation`;
+  const separator = '='.repeat(line.length);
+  return `${line}\n${separator}`;
+}
+
+/**
+ * Format a prerequisite check report for display.
+ *
+ * Shows each prerequisite with its version and found/not-found status.
+ * Blockers include install hints.
+ *
+ * @param report - The prerequisite report to format.
+ * @returns A formatted multi-line string.
+ */
+export function formatPrerequisiteReport(report: PrerequisiteReport): string {
+  const lines: string[] = [];
+
+  for (const result of report.results) {
+    const icon = result.found && result.meetsMinVersion
+      ? STATUS_ICONS.done
+      : STATUS_ICONS.fail;
+    const version = result.version ? ` (${result.version})` : '';
+    const hint = !result.found || !result.meetsMinVersion
+      ? ` — ${result.installHint}`
+      : '';
+    lines.push(`  ${icon} ${result.command}${version}${hint}`);
+  }
+
+  if (report.blockers.length > 0) {
+    lines.push('');
+    lines.push('Blockers:');
+    for (const blocker of report.blockers) {
+      lines.push(`  ${STATUS_ICONS.fail} ${blocker}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Format an install summary from a list of results.
+ *
+ * @param results - The install results to summarize.
+ * @returns A formatted multi-line string.
+ */
+export function formatInstallSummary(results: InstallResult[]): string {
+  const lines = results.map((r) => formatProgressLine(r.label, r.status, r.detail));
+  return lines.join('\n');
+}
+
+/**
+ * Format a single progress line with status indicator.
+ *
+ * @param label - The operation label.
+ * @param status - The completion status.
+ * @param detail - Optional detail message.
+ * @returns A formatted single-line string.
+ */
+export function formatProgressLine(
+  label: string,
+  status: 'done' | 'skip' | 'fail',
+  detail?: string,
+): string {
+  const icon = STATUS_ICONS[status];
+  const suffix = detail ? ` — ${detail}` : '';
+  return `  ${icon} ${label}${suffix}`;
+}

--- a/src/wizard/prerequisites.test.ts
+++ b/src/wizard/prerequisites.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for prerequisite detection and runtime checks.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from 'node:child_process';
+import {
+  detectRuntime,
+  getVersion,
+  meetsMinVersion,
+  checkPrerequisite,
+  checkAllPrerequisites,
+  DEFAULT_PREREQUISITES,
+} from './prerequisites.js';
+
+import type { Prerequisite } from './prerequisites.js';
+
+const mockExecSync = vi.mocked(execSync);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('detectRuntime', () => {
+  it('returns bun when bun is available', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('1.3.4\n'));
+
+    const result = detectRuntime();
+
+    expect(result).toBe('bun');
+    expect(mockExecSync).toHaveBeenCalledWith('bun --version', { stdio: 'pipe' });
+  });
+
+  it('returns node when only node is available', () => {
+    mockExecSync
+      .mockImplementationOnce(() => { throw new Error('not found'); }) // bun fails
+      .mockReturnValueOnce(Buffer.from('20.11.0\n')); // node succeeds
+
+    const result = detectRuntime();
+
+    expect(result).toBe('node');
+  });
+
+  it('throws when neither runtime is available', () => {
+    mockExecSync.mockImplementation(() => { throw new Error('not found'); });
+
+    expect(() => detectRuntime()).toThrow();
+  });
+});
+
+describe('getVersion', () => {
+  it('parses valid version output', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('1.3.4\n'));
+
+    const result = getVersion('bun', ['--version']);
+
+    expect(result).toBe('1.3.4');
+  });
+
+  it('returns null for invalid output', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('not-a-version'));
+
+    const result = getVersion('bun', ['--version']);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when command fails', () => {
+    mockExecSync.mockImplementation(() => { throw new Error('not found'); });
+
+    const result = getVersion('missing-cmd', ['--version']);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('meetsMinVersion', () => {
+  it('returns true when actual is above minimum', () => {
+    expect(meetsMinVersion('1.3.4', '1.0.0')).toBe(true);
+  });
+
+  it('returns false when actual is below minimum', () => {
+    expect(meetsMinVersion('0.9.0', '1.0.0')).toBe(false);
+  });
+
+  it('returns true when versions are equal', () => {
+    expect(meetsMinVersion('1.0.0', '1.0.0')).toBe(true);
+  });
+
+  it('compares minor versions correctly', () => {
+    expect(meetsMinVersion('1.2.0', '1.3.0')).toBe(false);
+    expect(meetsMinVersion('1.4.0', '1.3.0')).toBe(true);
+  });
+
+  it('compares patch versions correctly', () => {
+    expect(meetsMinVersion('1.0.1', '1.0.2')).toBe(false);
+    expect(meetsMinVersion('1.0.3', '1.0.2')).toBe(true);
+  });
+});
+
+describe('checkPrerequisite', () => {
+  it('returns found when command exists', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('1.5.0\n'));
+
+    const prereq: Prerequisite = {
+      command: 'bun',
+      args: ['--version'],
+      required: true,
+      installHint: 'curl -fsSL https://bun.sh/install | bash',
+    };
+
+    const result = checkPrerequisite(prereq);
+
+    expect(result.found).toBe(true);
+    expect(result.command).toBe('bun');
+  });
+
+  it('returns not found when command is missing', () => {
+    mockExecSync.mockImplementation(() => { throw new Error('not found'); });
+
+    const prereq: Prerequisite = {
+      command: 'missing-tool',
+      args: ['--version'],
+      required: true,
+      installHint: 'install it',
+    };
+
+    const result = checkPrerequisite(prereq);
+
+    expect(result.found).toBe(false);
+    expect(result.meetsMinVersion).toBe(false);
+    expect(result.installHint).toBe('install it');
+  });
+
+  it('includes version when command exists', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('2.1.3\n'));
+
+    const prereq: Prerequisite = {
+      command: 'gt',
+      args: ['--version'],
+      required: true,
+      minVersion: '1.0.0',
+      installHint: 'brew install graphite',
+    };
+
+    const result = checkPrerequisite(prereq);
+
+    expect(result.found).toBe(true);
+    expect(result.version).toBe('2.1.3');
+    expect(result.meetsMinVersion).toBe(true);
+  });
+
+  it('returns version too low when below minimum', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('0.5.0\n'));
+
+    const prereq: Prerequisite = {
+      command: 'bun',
+      args: ['--version'],
+      required: true,
+      minVersion: '1.0.0',
+      installHint: 'curl -fsSL https://bun.sh/install | bash',
+    };
+
+    const result = checkPrerequisite(prereq);
+
+    expect(result.found).toBe(true);
+    expect(result.version).toBe('0.5.0');
+    expect(result.meetsMinVersion).toBe(false);
+  });
+});
+
+describe('checkAllPrerequisites', () => {
+  it('returns all found when all prerequisites are present', () => {
+    // Each checkPrerequisite call invokes getVersion which calls execSync once
+    mockExecSync
+      .mockReturnValueOnce(Buffer.from('1.5.0\n')) // bun
+      .mockReturnValueOnce(Buffer.from('2.0.0\n')); // gt
+
+    const prereqs: Prerequisite[] = [
+      { command: 'bun', args: ['--version'], required: true, minVersion: '1.0.0', installHint: 'install bun' },
+      { command: 'gt', args: ['--version'], required: true, installHint: 'install gt' },
+    ];
+
+    const report = checkAllPrerequisites(prereqs);
+
+    expect(report.results).toHaveLength(2);
+    expect(report.results.every((r) => r.found)).toBe(true);
+    expect(report.canProceed).toBe(true);
+    expect(report.blockers).toHaveLength(0);
+  });
+
+  it('blocks install when a required prerequisite is missing', () => {
+    mockExecSync
+      .mockImplementationOnce(() => { throw new Error('not found'); }) // bun missing
+      .mockReturnValueOnce(Buffer.from('2.0.0\n')); // gt found
+
+    const prereqs: Prerequisite[] = [
+      { command: 'bun', args: ['--version'], required: true, minVersion: '1.0.0', installHint: 'install bun' },
+      { command: 'gt', args: ['--version'], required: true, installHint: 'install gt' },
+    ];
+
+    const report = checkAllPrerequisites(prereqs);
+
+    expect(report.canProceed).toBe(false);
+    expect(report.blockers.length).toBeGreaterThan(0);
+    expect(report.blockers[0]).toContain('bun');
+  });
+
+  it('warns but continues when optional prerequisite is missing', () => {
+    mockExecSync
+      .mockReturnValueOnce(Buffer.from('1.5.0\n')) // bun found
+      .mockImplementationOnce(() => { throw new Error('not found'); }); // node missing (optional)
+
+    const prereqs: Prerequisite[] = [
+      { command: 'bun', args: ['--version'], required: true, minVersion: '1.0.0', installHint: 'install bun' },
+      { command: 'node', args: ['--version'], required: false, minVersion: '20.0.0', installHint: 'install node' },
+    ];
+
+    const report = checkAllPrerequisites(prereqs);
+
+    expect(report.canProceed).toBe(true);
+    expect(report.blockers).toHaveLength(0);
+    expect(report.results[1].found).toBe(false);
+  });
+
+  it('returns structured report with all results', () => {
+    mockExecSync
+      .mockReturnValueOnce(Buffer.from('1.5.0\n'))
+      .mockReturnValueOnce(Buffer.from('0.5.0\n'))
+      .mockImplementationOnce(() => { throw new Error('not found'); });
+
+    const prereqs: Prerequisite[] = [
+      { command: 'bun', args: ['--version'], required: true, minVersion: '1.0.0', installHint: 'install bun' },
+      { command: 'gt', args: ['--version'], required: true, minVersion: '1.0.0', installHint: 'install gt' },
+      { command: 'node', args: ['--version'], required: false, minVersion: '20.0.0', installHint: 'install node' },
+    ];
+
+    const report = checkAllPrerequisites(prereqs);
+
+    expect(report.results).toHaveLength(3);
+    expect(report.results[0].found).toBe(true);
+    expect(report.results[0].meetsMinVersion).toBe(true);
+    expect(report.results[1].found).toBe(true);
+    expect(report.results[1].meetsMinVersion).toBe(false);
+    expect(report.results[2].found).toBe(false);
+    // gt is required but below min version → blocks
+    expect(report.canProceed).toBe(false);
+    expect(report.blockers.length).toBeGreaterThan(0);
+  });
+});
+
+describe('DEFAULT_PREREQUISITES', () => {
+  it('includes bun, gt, and node entries', () => {
+    expect(DEFAULT_PREREQUISITES).toHaveLength(3);
+    expect(DEFAULT_PREREQUISITES.map((p) => p.command)).toEqual(['bun', 'gt', 'node']);
+  });
+
+  it('marks bun and gt as required, node as optional', () => {
+    const bun = DEFAULT_PREREQUISITES.find((p) => p.command === 'bun');
+    const gt = DEFAULT_PREREQUISITES.find((p) => p.command === 'gt');
+    const node = DEFAULT_PREREQUISITES.find((p) => p.command === 'node');
+
+    expect(bun?.required).toBe(true);
+    expect(gt?.required).toBe(true);
+    expect(node?.required).toBe(false);
+  });
+});

--- a/src/wizard/prerequisites.ts
+++ b/src/wizard/prerequisites.ts
@@ -1,0 +1,225 @@
+/**
+ * Prerequisite detection and runtime checks for the Exarchos installer.
+ *
+ * Detects which JavaScript runtime is available (bun or node),
+ * verifies tool versions, and checks all installation prerequisites.
+ */
+
+import { execSync } from 'node:child_process';
+
+/**
+ * Detect the available JavaScript runtime.
+ *
+ * Prefers bun over node. Tries `bun --version` first; if that fails,
+ * falls back to `node --version`.
+ *
+ * @returns The detected runtime identifier.
+ * @throws If neither bun nor node is available.
+ */
+export function detectRuntime(): 'bun' | 'node' {
+  try {
+    execSync('bun --version', { stdio: 'pipe' });
+    return 'bun';
+  } catch {
+    // bun not available, try node
+  }
+
+  try {
+    execSync('node --version', { stdio: 'pipe' });
+    return 'node';
+  } catch {
+    // node not available either
+  }
+
+  throw new Error(
+    'No JavaScript runtime found. Install bun (https://bun.sh) or Node.js >= 20 (https://nodejs.org).',
+  );
+}
+
+/**
+ * Get the version string for a command.
+ *
+ * Runs the command with the given arguments, trims the output,
+ * and validates it looks like a semver-ish version string.
+ *
+ * @param command - The command to run (e.g., 'bun', 'node', 'gt').
+ * @param args - Arguments to pass (e.g., ['--version']).
+ * @returns The parsed version string, or null if the command fails or output is invalid.
+ */
+export function getVersion(command: string, args: string[]): string | null {
+  try {
+    const output = execSync(`${command} ${args.join(' ')}`, { stdio: 'pipe' });
+    const trimmed = output.toString().trim();
+
+    // Strip leading 'v' if present (e.g., node outputs "v20.11.0")
+    const cleaned = trimmed.startsWith('v') ? trimmed.slice(1) : trimmed;
+
+    // Validate it looks like a version (digits.digits.digits, possibly with extra)
+    if (/^\d+\.\d+\.\d+/.test(cleaned)) {
+      // Return just the major.minor.patch portion
+      const match = cleaned.match(/^(\d+\.\d+\.\d+)/);
+      return match ? match[1] : null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check whether an actual version meets a minimum version requirement.
+ *
+ * Performs simple numeric comparison of major.minor.patch components.
+ *
+ * @param actual - The actual version string (e.g., "1.3.4").
+ * @param minimum - The minimum required version (e.g., "1.0.0").
+ * @returns True if actual >= minimum.
+ */
+export function meetsMinVersion(actual: string, minimum: string): boolean {
+  const parseParts = (v: string): [number, number, number] => {
+    const parts = v.split('.').map(Number);
+    return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+  };
+
+  const [aMajor, aMinor, aPatch] = parseParts(actual);
+  const [mMajor, mMinor, mPatch] = parseParts(minimum);
+
+  if (aMajor !== mMajor) return aMajor > mMajor;
+  if (aMinor !== mMinor) return aMinor > mMinor;
+  return aPatch >= mPatch;
+}
+
+// ─── Prerequisite checking ────────────────────────────────────────────────────
+
+/** Definition of a single prerequisite tool. */
+export interface Prerequisite {
+  /** The command to check (e.g., 'bun', 'gt'). */
+  readonly command: string;
+  /** Arguments to get the version (e.g., ['--version']). */
+  readonly args: string[];
+  /** Whether this prerequisite is required for installation to proceed. */
+  readonly required: boolean;
+  /** Minimum acceptable version (optional). */
+  readonly minVersion?: string;
+  /** Human-readable hint on how to install this tool. */
+  readonly installHint: string;
+}
+
+/** Result of checking a single prerequisite. */
+export interface PrerequisiteResult {
+  /** The command that was checked. */
+  readonly command: string;
+  /** Whether the command was found on the system. */
+  readonly found: boolean;
+  /** The detected version, if any. */
+  readonly version?: string;
+  /** Whether the detected version meets the minimum requirement. */
+  readonly meetsMinVersion: boolean;
+  /** Human-readable hint on how to install this tool. */
+  readonly installHint: string;
+}
+
+/**
+ * Check a single prerequisite tool.
+ *
+ * Runs the command to detect its version and, if a minimum version
+ * is specified, verifies the installed version meets the requirement.
+ *
+ * @param prereq - The prerequisite definition to check.
+ * @returns The check result.
+ */
+export function checkPrerequisite(prereq: Prerequisite): PrerequisiteResult {
+  const version = getVersion(prereq.command, prereq.args);
+
+  if (version === null) {
+    return {
+      command: prereq.command,
+      found: false,
+      meetsMinVersion: false,
+      installHint: prereq.installHint,
+    };
+  }
+
+  const versionOk = prereq.minVersion
+    ? meetsMinVersion(version, prereq.minVersion)
+    : true;
+
+  return {
+    command: prereq.command,
+    found: true,
+    version,
+    meetsMinVersion: versionOk,
+    installHint: prereq.installHint,
+  };
+}
+
+// ─── Full prerequisite suite ──────────────────────────────────────────────────
+
+/** Aggregated report from checking all prerequisites. */
+export interface PrerequisiteReport {
+  /** Individual results for each prerequisite. */
+  readonly results: PrerequisiteResult[];
+  /** Whether installation can proceed (all required prerequisites satisfied). */
+  readonly canProceed: boolean;
+  /** Human-readable messages for each blocking issue. */
+  readonly blockers: string[];
+}
+
+/**
+ * Check all prerequisites and produce an aggregated report.
+ *
+ * @param prereqs - The list of prerequisites to check.
+ * @returns A report indicating whether installation can proceed.
+ */
+export function checkAllPrerequisites(prereqs: Prerequisite[]): PrerequisiteReport {
+  const results = prereqs.map((p) => checkPrerequisite(p));
+  const blockers: string[] = [];
+
+  for (let i = 0; i < prereqs.length; i++) {
+    const prereq = prereqs[i];
+    const result = results[i];
+
+    if (!prereq.required) continue;
+
+    if (!result.found) {
+      blockers.push(
+        `Required tool '${prereq.command}' not found. Install: ${prereq.installHint}`,
+      );
+    } else if (!result.meetsMinVersion && prereq.minVersion) {
+      blockers.push(
+        `Required tool '${prereq.command}' version ${result.version} is below minimum ${prereq.minVersion}. Update: ${prereq.installHint}`,
+      );
+    }
+  }
+
+  return {
+    results,
+    canProceed: blockers.length === 0,
+    blockers,
+  };
+}
+
+/** Default prerequisites for the Exarchos installer. */
+export const DEFAULT_PREREQUISITES: readonly Prerequisite[] = [
+  {
+    command: 'bun',
+    args: ['--version'],
+    required: true,
+    minVersion: '1.0.0',
+    installHint: 'curl -fsSL https://bun.sh/install | bash',
+  },
+  {
+    command: 'gt',
+    args: ['--version'],
+    required: true,
+    installHint: 'brew install withgraphite/tap/graphite',
+  },
+  {
+    command: 'node',
+    args: ['--version'],
+    required: false,
+    minVersion: '20.0.0',
+    installHint: 'Optional fallback. Install via nvm or nodejs.org',
+  },
+];

--- a/src/wizard/prompts.test.ts
+++ b/src/wizard/prompts.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the PromptAdapter interface and MockPromptAdapter.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createPromptAdapter,
+  MockPromptAdapter,
+} from './prompts.js';
+import type { PromptAdapter } from './prompts.js';
+
+describe('createPromptAdapter', () => {
+  it('returns an adapter instance', () => {
+    const adapter = createPromptAdapter();
+
+    expect(adapter).toBeDefined();
+    expect(typeof adapter.select).toBe('function');
+    expect(typeof adapter.multiselect).toBe('function');
+    expect(typeof adapter.confirm).toBe('function');
+    expect(typeof adapter.text).toBe('function');
+  });
+});
+
+describe('MockPromptAdapter', () => {
+  it('select returns preset value', async () => {
+    const adapter = new MockPromptAdapter(['standard']);
+
+    const result = await adapter.select('Choose mode:', [
+      { label: 'Standard', value: 'standard' },
+      { label: 'Dev', value: 'dev' },
+    ]);
+
+    expect(result).toBe('standard');
+  });
+
+  it('multiselect returns preset values', async () => {
+    const adapter = new MockPromptAdapter([['server-a', 'server-b']]);
+
+    const result = await adapter.multiselect('Choose servers:', [
+      { label: 'Server A', value: 'server-a' },
+      { label: 'Server B', value: 'server-b' },
+      { label: 'Server C', value: 'server-c' },
+    ]);
+
+    expect(result).toEqual(['server-a', 'server-b']);
+  });
+
+  it('confirm returns preset boolean', async () => {
+    const adapter = new MockPromptAdapter([true]);
+
+    const result = await adapter.confirm('Proceed?');
+
+    expect(result).toBe(true);
+  });
+
+  it('text returns preset string', async () => {
+    const adapter = new MockPromptAdapter(['my-input']);
+
+    const result = await adapter.text('Enter name:');
+
+    expect(result).toBe('my-input');
+  });
+
+  it('dequeues responses in FIFO order', async () => {
+    const adapter = new MockPromptAdapter(['first', 'second', 'third']);
+
+    const r1 = await adapter.select('Q1:', [{ label: 'A', value: 'first' }]);
+    const r2 = await adapter.select('Q2:', [{ label: 'B', value: 'second' }]);
+    const r3 = await adapter.select('Q3:', [{ label: 'C', value: 'third' }]);
+
+    expect(r1).toBe('first');
+    expect(r2).toBe('second');
+    expect(r3).toBe('third');
+  });
+
+  it('throws when response queue is exhausted', async () => {
+    const adapter = new MockPromptAdapter([]);
+
+    await expect(adapter.select('Q:', [{ label: 'A', value: 'a' }]))
+      .rejects.toThrow('MockPromptAdapter: no more preset responses');
+  });
+
+  it('implements PromptAdapter interface', () => {
+    const adapter: PromptAdapter = new MockPromptAdapter([]);
+
+    expect(adapter).toBeDefined();
+  });
+});

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -1,0 +1,92 @@
+/**
+ * Prompt adapter interface and implementations for the Exarchos installer wizard.
+ *
+ * Provides an abstract interface over interactive prompts so the wizard
+ * can be tested with a mock adapter and run with different prompt
+ * libraries (e.g., bun-promptx) at runtime.
+ */
+
+/** A single option in a select prompt. */
+export interface SelectOption<T> {
+  /** Display label shown to the user. */
+  readonly label: string;
+  /** Value returned when this option is selected. */
+  readonly value: T;
+  /** Optional description shown below the label. */
+  readonly description?: string;
+  /** Whether this option is disabled (shown but not selectable). */
+  readonly disabled?: boolean;
+}
+
+/** A single option in a multiselect prompt. */
+export interface MultiselectOption<T> extends SelectOption<T> {
+  /** Whether this option is pre-selected. */
+  readonly selected?: boolean;
+}
+
+/**
+ * Abstract interface for interactive prompts.
+ *
+ * Implementations handle the actual I/O (terminal prompts, mock responses, etc.)
+ */
+export interface PromptAdapter {
+  /** Show a single-select prompt and return the chosen value. */
+  select<T>(message: string, options: SelectOption<T>[]): Promise<T>;
+  /** Show a multi-select prompt and return the chosen values. */
+  multiselect<T>(message: string, options: MultiselectOption<T>[]): Promise<T[]>;
+  /** Show a yes/no confirmation prompt. */
+  confirm(message: string, defaultValue?: boolean): Promise<boolean>;
+  /** Show a free-text input prompt. */
+  text(message: string, placeholder?: string): Promise<string>;
+}
+
+/**
+ * Mock prompt adapter for testing.
+ *
+ * Accepts an array of preset responses that are dequeued in FIFO order
+ * as each prompt method is called.
+ */
+export class MockPromptAdapter implements PromptAdapter {
+  private readonly responses: unknown[];
+  private index = 0;
+
+  constructor(responses: unknown[]) {
+    this.responses = [...responses];
+  }
+
+  async select<T>(_message: string, _options: SelectOption<T>[]): Promise<T> {
+    return this.nextResponse() as T;
+  }
+
+  async multiselect<T>(_message: string, _options: MultiselectOption<T>[]): Promise<T[]> {
+    return this.nextResponse() as T[];
+  }
+
+  async confirm(_message: string, _defaultValue?: boolean): Promise<boolean> {
+    return this.nextResponse() as boolean;
+  }
+
+  async text(_message: string, _placeholder?: string): Promise<string> {
+    return this.nextResponse() as string;
+  }
+
+  private nextResponse(): unknown {
+    if (this.index >= this.responses.length) {
+      throw new Error('MockPromptAdapter: no more preset responses');
+    }
+    return this.responses[this.index++];
+  }
+}
+
+/**
+ * Create a prompt adapter.
+ *
+ * Currently returns a MockPromptAdapter stub. The real prompt library
+ * integration (e.g., bun-promptx) will be added when bun dependencies
+ * are configured.
+ *
+ * @returns A prompt adapter instance.
+ */
+export function createPromptAdapter(): PromptAdapter {
+  return new MockPromptAdapter([]);
+}

--- a/src/wizard/wizard.test.ts
+++ b/src/wizard/wizard.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Tests for the interactive wizard flow and non-interactive mode.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    readFileSync: vi.fn(actual.readFileSync),
+  };
+});
+
+import * as fs from 'node:fs';
+import { MockPromptAdapter } from './prompts.js';
+import { runWizard, runNonInteractive } from './wizard.js';
+import type { Manifest } from '../manifest/types.js';
+import type { ExarchosConfig } from '../operations/config.js';
+
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/** Minimal test manifest for wizard tests. */
+function createTestManifest(): Manifest {
+  return {
+    version: '2.0.0',
+    components: {
+      core: [],
+      mcpServers: [
+        {
+          id: 'exarchos',
+          name: 'Exarchos',
+          description: 'Core workflow server',
+          required: true,
+          type: 'bundled',
+          bundlePath: 'plugins/exarchos',
+        },
+        {
+          id: 'context7',
+          name: 'Context7',
+          description: 'Library docs',
+          required: false,
+          type: 'remote',
+          url: 'https://example.com',
+        },
+        {
+          id: 'microsoft-learn',
+          name: 'Microsoft Learn',
+          description: 'MS docs',
+          required: false,
+          type: 'remote',
+          url: 'https://example.com',
+        },
+      ],
+      plugins: [
+        {
+          id: 'github',
+          name: 'GitHub',
+          description: 'GitHub integration',
+          required: true,
+          default: true,
+        },
+        {
+          id: 'serena',
+          name: 'Serena',
+          description: 'Semantic code analysis',
+          required: false,
+          default: true,
+        },
+        {
+          id: 'graphite',
+          name: 'Graphite',
+          description: 'Stacked PRs',
+          required: false,
+          default: false,
+        },
+      ],
+      ruleSets: [
+        {
+          id: 'coding-standards',
+          name: 'Coding Standards',
+          description: 'TypeScript coding standards',
+          files: ['coding-standards-typescript.md'],
+          default: true,
+        },
+        {
+          id: 'tdd',
+          name: 'TDD Rules',
+          description: 'Test-driven development rules',
+          files: ['tdd-typescript.md'],
+          default: true,
+        },
+        {
+          id: 'pr-descriptions',
+          name: 'PR Descriptions',
+          description: 'PR description guidelines',
+          files: ['pr-descriptions.md'],
+          default: false,
+        },
+      ],
+    },
+    defaults: {
+      model: 'claude-opus-4-6',
+      mode: 'standard',
+    },
+  };
+}
+
+describe('runWizard', () => {
+  it('returns standard mode selections', async () => {
+    const manifest = createTestManifest();
+    // Responses: mode, mcpServers, plugins, ruleSets, model, confirm
+    const prompts = new MockPromptAdapter([
+      'standard',                          // mode
+      ['context7'],                         // optional mcpServers
+      ['serena'],                           // optional plugins
+      ['coding-standards', 'tdd'],          // ruleSets
+      'claude-opus-4-6',                    // model
+      true,                                 // confirm
+    ]);
+
+    const result = await runWizard(manifest, prompts);
+
+    expect(result.mode).toBe('standard');
+    expect(result.selections.mcpServers).toContain('context7');
+    // Required server always included
+    expect(result.selections.mcpServers).toContain('exarchos');
+  });
+
+  it('returns dev mode selections', async () => {
+    const manifest = createTestManifest();
+    const prompts = new MockPromptAdapter([
+      'dev',                                // mode
+      ['context7', 'microsoft-learn'],      // optional mcpServers
+      ['serena', 'graphite'],               // optional plugins
+      ['coding-standards', 'tdd', 'pr-descriptions'], // ruleSets
+      'claude-sonnet-4-20250514',           // model
+      true,                                 // confirm
+    ]);
+
+    const result = await runWizard(manifest, prompts);
+
+    expect(result.mode).toBe('dev');
+    expect(result.selections.model).toBe('claude-sonnet-4-20250514');
+  });
+
+  it('always includes required servers regardless of selection', async () => {
+    const manifest = createTestManifest();
+    // User selects no optional servers
+    const prompts = new MockPromptAdapter([
+      'standard',                           // mode
+      [],                                   // no optional mcpServers selected
+      [],                                   // no optional plugins
+      [],                                   // no ruleSets
+      'claude-opus-4-6',                    // model
+      true,                                 // confirm
+    ]);
+
+    const result = await runWizard(manifest, prompts);
+
+    // Required server 'exarchos' must still be included
+    expect(result.selections.mcpServers).toContain('exarchos');
+    // Required plugin 'github' must still be included
+    expect(result.selections.plugins).toContain('github');
+  });
+
+  it('returns selected rule set file list', async () => {
+    const manifest = createTestManifest();
+    const prompts = new MockPromptAdapter([
+      'standard',
+      [],
+      [],
+      ['coding-standards', 'pr-descriptions'],
+      'claude-opus-4-6',
+      true,
+    ]);
+
+    const result = await runWizard(manifest, prompts);
+
+    expect(result.selections.ruleSets).toContain('coding-standards');
+    expect(result.selections.ruleSets).toContain('pr-descriptions');
+    expect(result.selections.ruleSets).not.toContain('tdd');
+  });
+
+  it('returns selected model ID', async () => {
+    const manifest = createTestManifest();
+    const prompts = new MockPromptAdapter([
+      'standard',
+      [],
+      [],
+      [],
+      'claude-sonnet-4-20250514',
+      true,
+    ]);
+
+    const result = await runWizard(manifest, prompts);
+
+    expect(result.selections.model).toBe('claude-sonnet-4-20250514');
+  });
+
+  it('uses existing config as defaults', async () => {
+    const manifest = createTestManifest();
+    const existingConfig: ExarchosConfig = {
+      version: '1.0.0',
+      installedAt: '2025-01-01T00:00:00Z',
+      mode: 'dev',
+      selections: {
+        mcpServers: ['context7'],
+        plugins: ['serena', 'graphite'],
+        ruleSets: ['coding-standards'],
+        model: 'claude-sonnet-4-20250514',
+      },
+      hashes: {},
+    };
+
+    // Wizard should use existing config as defaults
+    // User accepts all defaults by selecting same values
+    const prompts = new MockPromptAdapter([
+      'dev',
+      ['context7'],
+      ['serena', 'graphite'],
+      ['coding-standards'],
+      'claude-sonnet-4-20250514',
+      true,
+    ]);
+
+    const result = await runWizard(manifest, prompts, existingConfig);
+
+    expect(result.mode).toBe('dev');
+    expect(result.selections.mcpServers).toContain('context7');
+    expect(result.selections.mcpServers).toContain('exarchos'); // required always included
+  });
+});
+
+describe('runNonInteractive', () => {
+  it('uses manifest defaults with useDefaults flag', () => {
+    const manifest = createTestManifest();
+
+    const result = runNonInteractive(manifest, { useDefaults: true });
+
+    expect(result.mode).toBe('standard');
+    expect(result.selections.model).toBe('claude-opus-4-6');
+    // Required servers always included
+    expect(result.selections.mcpServers).toContain('exarchos');
+    // Required plugins always included
+    expect(result.selections.plugins).toContain('github');
+    // Default plugins included
+    expect(result.selections.plugins).toContain('serena');
+    // Default rule sets included
+    expect(result.selections.ruleSets).toContain('coding-standards');
+    expect(result.selections.ruleSets).toContain('tdd');
+  });
+
+  it('uses previous selections with useDefaults and existing config', () => {
+    const manifest = createTestManifest();
+    const existingConfig: ExarchosConfig = {
+      version: '1.0.0',
+      installedAt: '2025-01-01T00:00:00Z',
+      mode: 'dev',
+      selections: {
+        mcpServers: ['context7'],
+        plugins: ['graphite'],
+        ruleSets: ['pr-descriptions'],
+        model: 'claude-sonnet-4-20250514',
+      },
+      hashes: {},
+    };
+
+    const result = runNonInteractive(manifest, {
+      useDefaults: true,
+      existingConfig,
+    });
+
+    expect(result.mode).toBe('dev');
+    expect(result.selections.model).toBe('claude-sonnet-4-20250514');
+    expect(result.selections.mcpServers).toContain('context7');
+    expect(result.selections.mcpServers).toContain('exarchos'); // required always included
+    expect(result.selections.plugins).toContain('github'); // required always included
+    expect(result.selections.plugins).toContain('graphite');
+    expect(result.selections.ruleSets).toContain('pr-descriptions');
+  });
+
+  it('uses config file when configPath is provided', () => {
+    const manifest = createTestManifest();
+
+    mockReadFileSync.mockReturnValueOnce(
+      JSON.stringify({
+        version: '1.0.0',
+        installedAt: '2025-01-01T00:00:00Z',
+        mode: 'dev',
+        selections: {
+          mcpServers: ['microsoft-learn'],
+          plugins: ['serena'],
+          ruleSets: ['tdd'],
+          model: 'claude-opus-4-6',
+        },
+        hashes: {},
+      }),
+    );
+
+    const result = runNonInteractive(manifest, {
+      configPath: '/tmp/test-config.json',
+    });
+
+    expect(result.mode).toBe('dev');
+    expect(result.selections.mcpServers).toContain('microsoft-learn');
+    expect(result.selections.mcpServers).toContain('exarchos');
+    expect(result.selections.plugins).toContain('serena');
+    expect(result.selections.plugins).toContain('github');
+    expect(result.selections.ruleSets).toContain('tdd');
+  });
+
+  it('throws for invalid config file', () => {
+    const manifest = createTestManifest();
+
+    mockReadFileSync.mockImplementationOnce(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    expect(() => runNonInteractive(manifest, {
+      configPath: '/tmp/nonexistent.json',
+    })).toThrow();
+  });
+});

--- a/src/wizard/wizard.ts
+++ b/src/wizard/wizard.ts
@@ -1,0 +1,180 @@
+/**
+ * Interactive wizard flow for the Exarchos installer.
+ *
+ * Guides the user through component selection via a series of prompts,
+ * producing a {@link WizardResult} that drives installation.
+ */
+
+import type { Manifest } from '../manifest/types.js';
+import type { ExarchosConfig, WizardSelections } from '../operations/config.js';
+import type { PromptAdapter, MultiselectOption } from './prompts.js';
+import { getDefaultSelections, getRequiredComponents } from '../manifest/loader.js';
+import { readConfig } from '../operations/config.js';
+
+/** Result produced by the wizard flow. */
+export interface WizardResult {
+  /** Installation mode: standard (copy) or dev (symlink). */
+  readonly mode: 'standard' | 'dev';
+  /** Component selections for installation. */
+  readonly selections: WizardSelections;
+}
+
+/**
+ * Run the interactive wizard flow.
+ *
+ * Presents a series of prompts to the user for mode selection,
+ * component selection, and model choice. Required components are
+ * always included in the result regardless of user selection.
+ *
+ * @param manifest - The validated installation manifest.
+ * @param prompts - The prompt adapter to use for user interaction.
+ * @param existingConfig - Optional existing config to use as defaults.
+ * @returns The wizard result with mode and selections.
+ */
+export async function runWizard(
+  manifest: Manifest,
+  prompts: PromptAdapter,
+  existingConfig?: ExarchosConfig,
+): Promise<WizardResult> {
+  const required = getRequiredComponents(manifest);
+  const defaults = existingConfig
+    ? existingConfig.selections
+    : getDefaultSelections(manifest);
+
+  // Step 1: Mode selection
+  const mode = await prompts.select<'standard' | 'dev'>('Installation mode:', [
+    { label: 'Standard', value: 'standard', description: 'Copy files to ~/.claude/' },
+    { label: 'Dev', value: 'dev', description: 'Symlink files for development' },
+  ]);
+
+  // Step 2: MCP Servers (optional only — required are always included)
+  const optionalServers = manifest.components.mcpServers.filter((s) => !s.required);
+  const serverOptions: MultiselectOption<string>[] = optionalServers.map((s) => ({
+    label: s.name,
+    value: s.id,
+    description: s.description,
+    selected: defaults.mcpServers.includes(s.id),
+  }));
+  const selectedOptionalServers = await prompts.multiselect('MCP servers:', serverOptions);
+
+  // Step 3: Plugins (optional only — required are always included)
+  const optionalPlugins = manifest.components.plugins.filter((p) => !p.required);
+  const pluginOptions: MultiselectOption<string>[] = optionalPlugins.map((p) => ({
+    label: p.name,
+    value: p.id,
+    description: p.description,
+    selected: defaults.plugins.includes(p.id),
+  }));
+  const selectedOptionalPlugins = await prompts.multiselect('Plugins:', pluginOptions);
+
+  // Step 4: Rule sets
+  const ruleSetOptions: MultiselectOption<string>[] = manifest.components.ruleSets.map((r) => ({
+    label: r.name,
+    value: r.id,
+    description: r.description,
+    selected: defaults.ruleSets.includes(r.id),
+  }));
+  const selectedRuleSets = await prompts.multiselect('Rule sets:', ruleSetOptions);
+
+  // Step 5: Model
+  const selectedModel = await prompts.select('Model:', [
+    { label: 'Claude Opus 4.6', value: 'claude-opus-4-6' },
+    { label: 'Claude Sonnet 4', value: 'claude-sonnet-4-20250514' },
+  ]);
+
+  // Step 6: Confirmation
+  await prompts.confirm('Proceed with installation?', true);
+
+  // Merge required components with user selections
+  const mcpServers = [
+    ...required.servers,
+    ...selectedOptionalServers.filter((id) => !required.servers.includes(id)),
+  ];
+
+  const plugins = [
+    ...required.plugins,
+    ...selectedOptionalPlugins.filter((id) => !required.plugins.includes(id)),
+  ];
+
+  return {
+    mode,
+    selections: {
+      mcpServers,
+      plugins,
+      ruleSets: selectedRuleSets,
+      model: selectedModel,
+    },
+  };
+}
+
+// ─── Non-interactive mode ─────────────────────────────────────────────────────
+
+/** Options for non-interactive installation. */
+interface NonInteractiveOptions {
+  /** Use manifest defaults (or existing config if provided). */
+  readonly useDefaults?: boolean;
+  /** Path to a config file to read selections from. */
+  readonly configPath?: string;
+  /** Existing config to use as defaults when useDefaults is true. */
+  readonly existingConfig?: ExarchosConfig;
+}
+
+/**
+ * Run the installer in non-interactive mode.
+ *
+ * Determines selections without user prompts, using either manifest defaults,
+ * a previous config, or a config file.
+ *
+ * @param manifest - The validated installation manifest.
+ * @param options - Non-interactive mode options.
+ * @returns The wizard result with mode and selections.
+ * @throws If configPath is provided but the file cannot be read.
+ */
+export function runNonInteractive(
+  manifest: Manifest,
+  options: NonInteractiveOptions,
+): WizardResult {
+  const required = getRequiredComponents(manifest);
+
+  let baseSelections: WizardSelections;
+  let baseMode: 'standard' | 'dev';
+
+  if (options.configPath) {
+    // Read config from file
+    const config = readConfig(options.configPath);
+    if (!config) {
+      throw new Error(`Config file not found: ${options.configPath}`);
+    }
+    baseSelections = config.selections;
+    baseMode = config.mode;
+  } else if (options.useDefaults && options.existingConfig) {
+    // Use existing config's selections
+    baseSelections = options.existingConfig.selections;
+    baseMode = options.existingConfig.mode;
+  } else {
+    // Use manifest defaults
+    baseSelections = getDefaultSelections(manifest);
+    baseMode = manifest.defaults.mode;
+  }
+
+  // Ensure required components are always included
+  const mcpServers = [
+    ...required.servers,
+    ...baseSelections.mcpServers.filter((id) => !required.servers.includes(id)),
+  ];
+
+  const plugins = [
+    ...required.plugins,
+    ...baseSelections.plugins.filter((id) => !required.plugins.includes(id)),
+  ];
+
+  return {
+    mode: baseMode,
+    selections: {
+      mcpServers,
+      plugins,
+      ruleSets: [...baseSelections.ruleSets],
+      model: baseSelections.model,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds the interactive installation wizard with prerequisite detection, prompt abstraction, and display formatting. The wizard guides users through mode selection, MCP server configuration, plugin choices, rule sets, and model preferences with support for both interactive and non-interactive (`--yes`, `--config`) modes.

## Changes

- **Prerequisites** — Runtime detection (prefer bun, fallback node), version parsing, min version checks, structured prerequisite reporting with blocking vs warning semantics
- **PromptAdapter** — Abstract interface for `select`, `multiselect`, `confirm`, `text` operations with `MockPromptAdapter` for testing and `createPromptAdapter` factory
- **Wizard Flow** — 6-step interactive flow (mode → servers → plugins → rules → model → confirm) with required items pinned, existing config as defaults for re-install
- **Non-Interactive Mode** — `runNonInteractive()` for `--yes` (use defaults) and `--config <path>` (use saved selections)
- **Display Helpers** — Terminal formatting for headers, prerequisite reports, install summaries, and progress lines with Unicode status indicators

## Test Plan

78 unit tests across 4 test files. Wizard tests use MockPromptAdapter with preset responses for deterministic coverage of all flow paths.

---

**Results:** Tests 189 ✓ · Build 0 errors
**Design:** [2026-02-12-installer-overhaul.md](docs/designs/2026-02-12-installer-overhaul.md)
**Related:** Stack 2/3, depends on #156