### PR TITLE
perf: lazy pagination in handleViewPipeline

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/tools.test.ts
@@ -608,6 +608,63 @@ describe('handleViewPipeline', () => {
     expect(workflows).toHaveLength(3);
   });
 
+  it('handleViewPipeline_WithLimit_OnlyMaterializesSubset', async () => {
+    // Arrange: create 5 event streams
+    for (let i = 1; i <= 5; i++) {
+      await store.append(`wf-lazy-${i}`, {
+        type: 'workflow.started',
+        data: { featureId: `feat-lazy-${i}`, workflowType: 'feature' },
+      });
+    }
+
+    // Act: request only 2
+    const result = await handleViewPipeline({ limit: 2 }, tempDir);
+
+    // Assert: exactly 2 workflows returned, total is 5
+    expect(result.success).toBe(true);
+    const data = result.data as { workflows: Array<Record<string, unknown>>; total: number };
+    expect(data.workflows).toHaveLength(2);
+    expect(data.total).toBe(5);
+  });
+
+  it('handleViewPipeline_WithOffsetAndLimit_ReturnsCorrectSlice', async () => {
+    // Arrange: create 5 event streams
+    for (let i = 1; i <= 5; i++) {
+      await store.append(`wf-slice-${i}`, {
+        type: 'workflow.started',
+        data: { featureId: `feat-slice-${i}`, workflowType: 'feature' },
+      });
+    }
+
+    // Act: request offset=2, limit=2 (should return streams 3 and 4)
+    const result = await handleViewPipeline({ offset: 2, limit: 2 }, tempDir);
+
+    // Assert: exactly 2 workflows returned from the middle, total is 5
+    expect(result.success).toBe(true);
+    const data = result.data as { workflows: Array<Record<string, unknown>>; total: number };
+    expect(data.workflows).toHaveLength(2);
+    expect(data.total).toBe(5);
+  });
+
+  it('handleViewPipeline_ReturnsTotal', async () => {
+    // Arrange: create 3 event streams
+    for (let i = 1; i <= 3; i++) {
+      await store.append(`wf-total-${i}`, {
+        type: 'workflow.started',
+        data: { featureId: `feat-total-${i}`, workflowType: 'feature' },
+      });
+    }
+
+    // Act: no pagination params — should return all with total
+    const result = await handleViewPipeline({}, tempDir);
+
+    // Assert: total field is present and equals stream count
+    expect(result.success).toBe(true);
+    const data = result.data as { workflows: Array<Record<string, unknown>>; total: number };
+    expect(data.total).toBe(3);
+    expect(data.workflows).toHaveLength(3);
+  });
+
   it('should return VIEW_ERROR when discovered stream has invalid ID', async () => {
     // Create an events file with uppercase characters in the name,
     // which will cause assertSafeId to throw in SnapshotStore

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/tools.ts
@@ -255,11 +255,17 @@ export async function handleViewPipeline(
     const store = getOrCreateEventStore(stateDir);
     const materializer = getOrCreateMaterializer(stateDir);
 
-    // Discover all streams and materialize pipeline view for each
+    // Discover all streams and paginate IDs before materialization
     const streamIds = await discoverStreams(stateDir);
+    const total = streamIds.length;
+    const start = args.offset ?? 0;
+    const end = args.limit !== undefined ? start + args.limit : undefined;
+    const paginatedIds = streamIds.slice(start, end);
+
+    // Only materialize the paginated subset
     const workflows: PipelineViewState[] = [];
 
-    for (const streamId of streamIds) {
+    for (const streamId of paginatedIds) {
       await materializer.loadFromSnapshot(streamId, PIPELINE_VIEW);
       const events = await store.query(streamId);
       const view = materializer.materialize<PipelineViewState>(
@@ -270,12 +276,7 @@ export async function handleViewPipeline(
       workflows.push(view);
     }
 
-    // Apply pagination
-    const start = args.offset ?? 0;
-    const end = args.limit !== undefined ? start + args.limit : undefined;
-    const paginated = workflows.slice(start, end);
-
-    return { success: true, data: { workflows: paginated } };
+    return { success: true, data: { workflows, total } };
   } catch (err) {
     return {
       success: false,


### PR DESCRIPTION
## Summary

The `handleViewPipeline` function materialized ALL workflow event streams before slicing for pagination. Requesting `limit=3` out of 100 workflows caused all 100 to be materialized. This change applies pagination to stream IDs before the materialization loop, so only the requested page is processed. A `total` field is added to the response for pagination awareness.

## Changes

- **handleViewPipeline** — Moved offset/limit slicing before the materialization loop so only the paginated subset of streams is materialized
- **Response shape** — Added `total` field to pipeline view response data alongside `workflows`
- **Tests** — Added 3 tests verifying lazy pagination, offset+limit slicing, and total field presence

## Test Plan

Added unit tests for limit-only, offset+limit, and no-params scenarios. Full suite passes at 874 tests (871 baseline + 3 new).

---

**Results:** Tests 874 ✓ · Build 0 errors