### PR TITLE
perf: add pagination to handleStackStatus

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/stack/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/stack/tools.test.ts
@@ -282,6 +282,107 @@ describe('handleStackStatus error path', () => {
   });
 });
 
+// ─── Pagination ─────────────────────────────────────────────────────────────
+
+describe('handleStackStatus pagination', () => {
+  async function seedPositions(streamId: string, count: number): Promise<void> {
+    for (let i = 1; i <= count; i++) {
+      await store.append(streamId, {
+        type: 'stack.position-filled',
+        data: { position: i, taskId: `t${i}`, branch: `feature/t${i}` },
+      });
+    }
+  }
+
+  it('with limit returns subset of positions', async () => {
+    // Arrange
+    await seedPositions('wf-paginate', 10);
+
+    // Act
+    const result = await handleStackStatus(
+      { streamId: 'wf-paginate', limit: 3 },
+      tempDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    const positions = result.data as Array<{ position: number; taskId: string }>;
+    expect(positions).toHaveLength(3);
+    expect(positions[0].taskId).toBe('t1');
+    expect(positions[1].taskId).toBe('t2');
+    expect(positions[2].taskId).toBe('t3');
+  });
+
+  it('with offset and limit skips and returns correct positions', async () => {
+    // Arrange
+    await seedPositions('wf-paginate-offset', 10);
+
+    // Act
+    const result = await handleStackStatus(
+      { streamId: 'wf-paginate-offset', offset: 5, limit: 3 },
+      tempDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    const positions = result.data as Array<{ position: number; taskId: string }>;
+    expect(positions).toHaveLength(3);
+    expect(positions[0].taskId).toBe('t6');
+    expect(positions[1].taskId).toBe('t7');
+    expect(positions[2].taskId).toBe('t8');
+  });
+
+  it('without pagination params returns all positions', async () => {
+    // Arrange
+    await seedPositions('wf-paginate-all', 10);
+
+    // Act
+    const result = await handleStackStatus(
+      { streamId: 'wf-paginate-all' },
+      tempDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    const positions = result.data as Array<{ position: number; taskId: string }>;
+    expect(positions).toHaveLength(10);
+  });
+
+  it('with offset beyond array length returns empty', async () => {
+    // Arrange
+    await seedPositions('wf-paginate-beyond', 5);
+
+    // Act
+    const result = await handleStackStatus(
+      { streamId: 'wf-paginate-beyond', offset: 10 },
+      tempDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    const positions = result.data as Array<{ position: number; taskId: string }>;
+    expect(positions).toHaveLength(0);
+  });
+
+  it('with only offset returns remaining positions', async () => {
+    // Arrange
+    await seedPositions('wf-paginate-offset-only', 5);
+
+    // Act
+    const result = await handleStackStatus(
+      { streamId: 'wf-paginate-offset-only', offset: 3 },
+      tempDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    const positions = result.data as Array<{ position: number; taskId: string }>;
+    expect(positions).toHaveLength(2);
+    expect(positions[0].taskId).toBe('t4');
+    expect(positions[1].taskId).toBe('t5');
+  });
+});
+
 // ─── Task 005: StackView CQRS Rewire ─────────────────────────────────────────
 // These tests intentionally duplicate scenarios from the handleStackStatus suite
 // above (same assertions, different streamId). They exist as explicit regression

--- a/plugins/exarchos/servers/exarchos-mcp/src/stack/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/stack/tools.ts
@@ -13,6 +13,8 @@ import type { StackViewState } from '../views/stack-view.js';
 export async function handleStackStatus(
   args: {
     streamId?: string;
+    limit?: number;
+    offset?: number;
   },
   stateDir: string,
 ): Promise<ToolResult> {
@@ -28,7 +30,19 @@ export async function handleStackStatus(
     const events = await store.query(args.streamId);
     const view = materializer.materialize<StackViewState>(args.streamId, STACK_VIEW, events);
 
-    return { success: true, data: view.positions };
+    let positions = view.positions;
+
+    // Apply optional offset (before limit)
+    if (args.offset !== undefined) {
+      positions = positions.slice(args.offset);
+    }
+
+    // Apply optional limit (after offset)
+    if (args.limit !== undefined) {
+      positions = positions.slice(0, args.limit);
+    }
+
+    return { success: true, data: positions };
   } catch (err) {
     return {
       success: false,
@@ -112,7 +126,11 @@ export function registerStackTools(server: McpServer, stateDir: string, _eventSt
   server.tool(
     'exarchos_stack_status',
     'Get current stack positions from stack.position-filled events',
-    { streamId: z.string().optional() },
+    {
+      streamId: z.string().optional(),
+      limit: z.number().int().positive().optional(),
+      offset: z.number().int().nonnegative().optional(),
+    },
     async (args) => formatResult(await handleStackStatus(args, stateDir)),
   );
 


### PR DESCRIPTION
## Summary

The `handleStackStatus` handler returned all stack positions with no pagination, wasting tokens for large stacks. This adds optional `limit` and `offset` parameters following the same pagination convention already used in `views/tools.ts`.

## Changes

- **stack/tools.ts** — Added `limit` and `offset` optional parameters to handler args type and Zod schema; applies offset-then-limit slicing to materialized positions
- **stack/tools.test.ts** — Added 5 pagination tests covering limit-only, offset+limit, no-params backward compat, offset-beyond-bounds, and offset-only scenarios

## Test Plan

TDD workflow: wrote 5 failing tests first, implemented minimum code to pass, verified all 876 tests pass with no regressions.

---

**Results:** Tests 876 ✓ · Build 0 errors
**Related:** Part of exarchos-mcp optimization sweep