### PR TITLE
fix: add checkpoint resume for idempotent compensation

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/compensation.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/compensation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Event } from '../../workflow/types.js';
 import type {
   CompensationAction,
+  CompensationCheckpoint,
   CompensationOptions,
   CompensationActionResult,
   CompensationResult,
@@ -1003,6 +1004,121 @@ describe('Compensation', () => {
       for (let i = 1; i < result.events.length; i++) {
         expect(result.events[i].sequence).toBeGreaterThan(result.events[i - 1].sequence);
       }
+    });
+  });
+
+  describe('ExecuteCompensation_WithCheckpoint_SkipsCompletedActions', () => {
+    it('should skip actions already recorded in the checkpoint', async () => {
+      const state = makeState({ phase: 'synthesize' });
+      const events = makeEvents(2);
+
+      // Provide a checkpoint indicating 'synthesize:close-pr' already completed
+      const checkpoint: CompensationCheckpoint = {
+        completedActions: ['synthesize:close-pr'],
+      };
+
+      const result = await executeCompensation(state, 'synthesize', events, 2, {
+        dryRun: false,
+        checkpoint,
+      });
+
+      // The close-pr action should be skipped with checkpoint message
+      const closePrAction = result.actions.find((a) => a.actionId === 'synthesize:close-pr');
+      expect(closePrAction).toBeDefined();
+      expect(closePrAction!.status).toBe('skipped');
+      expect(closePrAction!.message).toContain('Already completed (checkpoint)');
+
+      // Other actions (delegate phase) should still execute normally
+      const delegateActions = result.actions.filter((a) => a.actionId.startsWith('delegate:'));
+      expect(delegateActions.length).toBeGreaterThan(0);
+      for (const action of delegateActions) {
+        // Delegate actions should be executed or skipped-by-condition (not checkpoint-skipped)
+        expect(action.message).not.toContain('Already completed (checkpoint)');
+      }
+
+      // The gh close command should NOT have been called since close-pr was checkpointed
+      const ghCloseCalls = mockedExecFile.mock.calls.filter((call) => {
+        const args = call[1] as string[] | undefined;
+        return call[0] === 'gh' && args?.includes('close');
+      });
+      expect(ghCloseCalls.length).toBe(0);
+    });
+  });
+
+  describe('ExecuteCompensation_ReturnsCheckpoint', () => {
+    it('should return a checkpoint with IDs of all executed and skipped actions', async () => {
+      const state = makeState({ phase: 'delegate' });
+      const events = makeEvents(1);
+
+      const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: false });
+
+      // Result should include checkpoint
+      expect(result.checkpoint).toBeDefined();
+      expect(Array.isArray(result.checkpoint.completedActions)).toBe(true);
+
+      // All actions that were executed or skipped should appear in checkpoint
+      for (const action of result.actions) {
+        if (action.status === 'executed' || action.status === 'skipped') {
+          expect(result.checkpoint.completedActions).toContain(action.actionId);
+        }
+      }
+
+      // Failed actions should NOT appear in checkpoint
+      const failedActions = result.actions.filter((a) => a.status === 'failed');
+      for (const action of failedActions) {
+        expect(result.checkpoint.completedActions).not.toContain(action.actionId);
+      }
+    });
+  });
+
+  describe('ExecuteCompensation_WithEmptyCheckpoint_ExecutesAll', () => {
+    it('should execute all actions when checkpoint has no completed actions', async () => {
+      const state = makeState({ phase: 'synthesize' });
+      const events = makeEvents(2);
+
+      // Empty checkpoint — no previously completed actions
+      const checkpoint: CompensationCheckpoint = {
+        completedActions: [],
+      };
+
+      const result = await executeCompensation(state, 'synthesize', events, 2, {
+        dryRun: false,
+        checkpoint,
+      });
+
+      // No actions should be checkpoint-skipped
+      for (const action of result.actions) {
+        expect(action.message).not.toContain('Already completed (checkpoint)');
+      }
+
+      // Actions should still execute or be condition-skipped as normal
+      expect(result.actions.length).toBeGreaterThan(0);
+
+      // Checkpoint should be returned with all executed/skipped action IDs
+      expect(result.checkpoint).toBeDefined();
+      expect(result.checkpoint.completedActions.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('ExecuteCompensation_WithoutCheckpoint_ExecutesAll', () => {
+    it('should execute all actions when no checkpoint option is provided', async () => {
+      const state = makeState({ phase: 'synthesize' });
+      const events = makeEvents(2);
+
+      // No checkpoint in options at all (backward compatibility)
+      const result = await executeCompensation(state, 'synthesize', events, 2, { dryRun: false });
+
+      // No actions should be checkpoint-skipped
+      for (const action of result.actions) {
+        expect(action.message).not.toContain('Already completed (checkpoint)');
+      }
+
+      // Actions should still execute or be condition-skipped as normal
+      expect(result.actions.length).toBeGreaterThan(0);
+
+      // Checkpoint should still be returned in the result
+      expect(result.checkpoint).toBeDefined();
+      expect(Array.isArray(result.checkpoint.completedActions)).toBe(true);
     });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/compensation.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/compensation.ts
@@ -28,9 +28,14 @@ export interface CompensationAction {
   ) => Promise<CompensationActionResult>;
 }
 
+export interface CompensationCheckpoint {
+  readonly completedActions: readonly string[];
+}
+
 export interface CompensationOptions {
   readonly dryRun: boolean;
   readonly stateDir?: string;
+  readonly checkpoint?: CompensationCheckpoint;
 }
 
 export interface CompensationActionResult {
@@ -44,6 +49,7 @@ export interface CompensationResult {
   readonly events: readonly Event[];
   readonly success: boolean;
   readonly errorCode?: string;
+  readonly checkpoint: CompensationCheckpoint;
 }
 
 // ─── Phase Order (reverse compensation order) ───────────────────────────────
@@ -303,14 +309,28 @@ export async function executeCompensation(
   const compensationEvents: Event[] = [];
   let currentSequence = eventSequence;
   let hasFailure = false;
+  const completedSet = new Set(options.checkpoint?.completedActions ?? []);
 
   for (const action of orderedActions) {
-    const result = await action.execute(state, options);
-    results.push(result);
+    let result: CompensationActionResult;
 
-    if (result.status === 'failed') {
-      hasFailure = true;
+    // Skip already-completed actions from a previous checkpoint
+    if (completedSet.has(action.id)) {
+      result = { actionId: action.id, status: 'skipped', message: 'Already completed (checkpoint)' };
+    } else {
+      result = await action.execute(state, options);
+
+      if (result.status === 'failed') {
+        hasFailure = true;
+      }
+
+      // Track successfully completed actions for the checkpoint
+      if (result.status === 'executed' || result.status === 'skipped') {
+        completedSet.add(action.id);
+      }
     }
+
+    results.push(result);
 
     // Log a compensation event for each action
     const { eventSequence: nextSeq, event } = appendEvent(
@@ -336,5 +356,6 @@ export async function executeCompensation(
     events: compensationEvents,
     success: !hasFailure,
     ...(hasFailure && { errorCode: ErrorCode.COMPENSATION_PARTIAL }),
+    checkpoint: { completedActions: [...completedSet] },
   };
 }


### PR DESCRIPTION
## Summary

Adds a `CompensationCheckpoint` mechanism to `executeCompensation` so that retried compensation runs skip actions that already succeeded. Previously, all compensation actions re-executed on every retry, causing noisy failures or unintended side effects for actions like closing PRs that had already been closed.

## Changes

- **CompensationCheckpoint interface** — New `readonly completedActions: readonly string[]` type tracking which actions finished successfully
- **CompensationOptions** — Added optional `checkpoint` field for passing in prior checkpoint state on retry
- **executeCompensation** — Skips actions found in checkpoint's `completedActions` set; tracks newly completed actions; returns updated checkpoint in result
- **CompensationResult** — Added required `checkpoint` field so callers can persist and reuse it on retry

## Test Plan

Added 4 new test cases covering checkpoint skip, checkpoint return, empty checkpoint, and no-checkpoint backward compatibility. All 875 tests pass (871 baseline + 4 new). TypeScript type check passes cleanly.

---

**Results:** Tests 875 ✓ · Build 0 errors