### PR TITLE
fix: persist idempotency key in JSONL event data

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -49,6 +49,7 @@ export const WorkflowEventBase = z.object({
   source: z.string().optional(),
   schemaVersion: z.string().default('1.0'),
   data: z.record(z.string(), z.unknown()).optional(),
+  idempotencyKey: z.string().optional(),
 });
 
 // ─── Workflow-Level Event Data ──────────────────────────────────────────────

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.test.ts
@@ -713,3 +713,124 @@ describe('EventStore Append Idempotency', () => {
     expect(events).toHaveLength(102);
   });
 });
+
+// ─── Idempotency Key Persistence ────────────────────────────────────────────
+
+describe('EventStore Idempotency Persistence', () => {
+  it('should persist idempotencyKey in JSONL event data', async () => {
+    const store = new EventStore(tempDir);
+
+    await store.append(
+      'my-workflow',
+      { type: 'task.claimed' },
+      { idempotencyKey: 'claim-abc' },
+    );
+
+    // Read the raw JSONL file and verify the idempotencyKey is present
+    const filePath = path.join(tempDir, 'my-workflow.events.jsonl');
+    const content = await fs.readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(content.trim());
+
+    expect(parsed.idempotencyKey).toBe('claim-abc');
+  });
+
+  it('should not include idempotencyKey when none is provided', async () => {
+    const store = new EventStore(tempDir);
+
+    await store.append('my-workflow', { type: 'task.claimed' });
+
+    // Read the raw JSONL file — idempotencyKey should be absent
+    const filePath = path.join(tempDir, 'my-workflow.events.jsonl');
+    const content = await fs.readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(content.trim());
+
+    expect(parsed.idempotencyKey).toBeUndefined();
+  });
+
+  it('should rebuild idempotency cache from persisted events on new instance', async () => {
+    const store1 = new EventStore(tempDir);
+
+    const original = await store1.append(
+      'my-workflow',
+      { type: 'task.claimed' },
+      { idempotencyKey: 'claim-xyz' },
+    );
+
+    // Create a new store instance (simulating server restart)
+    const store2 = new EventStore(tempDir);
+
+    // Retry the same idempotencyKey — should return the cached event, not a new one
+    const retried = await store2.append(
+      'my-workflow',
+      { type: 'task.claimed' },
+      { idempotencyKey: 'claim-xyz' },
+    );
+
+    // Should return the same event (dedup across restart)
+    expect(retried.sequence).toBe(original.sequence);
+    expect(retried.streamId).toBe(original.streamId);
+
+    // Only one event should exist in the stream
+    const events = await store2.query('my-workflow');
+    expect(events).toHaveLength(1);
+  });
+
+  it('should only rebuild cache once per stream per lifecycle', async () => {
+    const store1 = new EventStore(tempDir);
+
+    // Append several events with keys
+    await store1.append('my-workflow', { type: 'task.claimed' }, { idempotencyKey: 'k1' });
+    await store1.append('my-workflow', { type: 'task.assigned' }, { idempotencyKey: 'k2' });
+    await store1.append('my-workflow', { type: 'task.completed' }, { idempotencyKey: 'k3' });
+
+    // New instance
+    const store2 = new EventStore(tempDir);
+
+    // First dedup check triggers rebuild
+    const r1 = await store2.append('my-workflow', { type: 'task.claimed' }, { idempotencyKey: 'k1' });
+    expect(r1.sequence).toBe(1); // deduped
+
+    // Subsequent checks use the already-rebuilt cache
+    const r2 = await store2.append('my-workflow', { type: 'task.assigned' }, { idempotencyKey: 'k2' });
+    expect(r2.sequence).toBe(2); // deduped
+
+    const r3 = await store2.append('my-workflow', { type: 'task.completed' }, { idempotencyKey: 'k3' });
+    expect(r3.sequence).toBe(3); // deduped
+
+    // Still only 3 events total
+    const events = await store2.query('my-workflow');
+    expect(events).toHaveLength(3);
+  });
+
+  it('should respect MAX_IDEMPOTENCY_KEYS when rebuilding from JSONL', async () => {
+    const store1 = new EventStore(tempDir);
+
+    // Append 105 events with unique keys (cache max is 100)
+    for (let i = 0; i < 105; i++) {
+      await store1.append(
+        'my-workflow',
+        { type: 'task.assigned' },
+        { idempotencyKey: `key-${i}` },
+      );
+    }
+
+    // New instance — rebuild should only load the last 100 keys
+    const store2 = new EventStore(tempDir);
+
+    // Key from the first 5 events should NOT be in cache (evicted during rebuild)
+    const retried = await store2.append(
+      'my-workflow',
+      { type: 'task.assigned' },
+      { idempotencyKey: 'key-0' },
+    );
+    expect(retried.sequence).toBe(106); // new event, not deduped
+
+    // Key from a recent event should still be cached
+    const deduped = await store2.append(
+      'my-workflow',
+      { type: 'task.assigned' },
+      { idempotencyKey: 'key-104' },
+    );
+    expect(deduped.sequence).toBe(105); // deduped
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
@@ -60,6 +60,9 @@ export class EventStore {
   private idempotencyCache: Map<string, Map<string, WorkflowEvent>> = new Map();
   private static readonly MAX_IDEMPOTENCY_KEYS = 100;
 
+  /** Tracks which streams have had their idempotency cache rebuilt from JSONL */
+  private idempotencyCacheInitialized: Set<string> = new Set();
+
   constructor(private readonly stateDir: string) {}
 
   private async withLock<T>(streamId: string, fn: () => Promise<T>): Promise<T> {
@@ -96,6 +99,11 @@ export class EventStore {
     options?: AppendOptions,
   ): Promise<WorkflowEvent> {
     return this.withLock(streamId, async () => {
+      // Rebuild idempotency cache from JSONL on first access per stream
+      if (options?.idempotencyKey && !this.idempotencyCacheInitialized.has(streamId)) {
+        await this.rebuildIdempotencyCache(streamId);
+      }
+
       // Idempotency check: return cached event if key was already seen
       if (options?.idempotencyKey) {
         const streamCache = this.idempotencyCache.get(streamId);
@@ -129,6 +137,7 @@ export class EventStore {
         streamId,
         sequence,
         timestamp: event.timestamp || new Date().toISOString(),
+        idempotencyKey: options?.idempotencyKey,
       });
 
       // Ensure directory exists
@@ -232,6 +241,43 @@ export class EventStore {
 
   async refreshSequence(streamId: string): Promise<void> {
     await this.initializeSequence(streamId);
+  }
+
+  private async rebuildIdempotencyCache(streamId: string): Promise<void> {
+    if (this.idempotencyCacheInitialized.has(streamId)) return;
+    this.idempotencyCacheInitialized.add(streamId);
+
+    const filePath = this.getEventFilePath(streamId);
+    try {
+      await fs.access(filePath);
+    } catch {
+      return; // No events file yet
+    }
+
+    const input = createReadStream(filePath, { encoding: 'utf-8' });
+    const rl = createInterface({ input, crlfDelay: Infinity });
+
+    // Collect all events with idempotency keys
+    const keyed: Array<{ key: string; event: WorkflowEvent }> = [];
+
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+      const event = JSON.parse(line) as WorkflowEvent;
+      if (event.idempotencyKey) {
+        keyed.push({ key: event.idempotencyKey, event });
+      }
+    }
+
+    // Take only the last MAX_IDEMPOTENCY_KEYS entries
+    const toCache = keyed.slice(-EventStore.MAX_IDEMPOTENCY_KEYS);
+
+    if (toCache.length > 0) {
+      const streamCache = new Map<string, WorkflowEvent>();
+      for (const { key, event } of toCache) {
+        streamCache.set(key, event);
+      }
+      this.idempotencyCache.set(streamId, streamCache);
+    }
   }
 
   private async initializeSequence(streamId: string): Promise<void> {


### PR DESCRIPTION
## Summary

Persists idempotency keys in the JSONL event data so deduplication survives server restarts. Previously keys were in-memory only — after restart, retry protection was lost.

## Changes

- **event-store/schemas.ts** — Added `idempotencyKey` to `WorkflowEventBase`
- **event-store/store.ts** — Include key in event parse, add `rebuildIdempotencyCache()` for lazy cache rebuild on first access

## Test Plan

Added 5 persistence tests covering JSONL write, cross-restart dedup, and bounded rebuild. All 917 tests pass.

---

**Results:** Tests 917 ✓ · Build 0 errors
**Related:** Continues #174