### PR TITLE
feat: add composite handler for exarchos_event

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/composite.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/composite.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ToolResult } from '../format.js';
+
+vi.mock('./tools.js', () => ({
+  handleEventAppend: vi.fn().mockResolvedValue({
+    success: true,
+    data: { streamId: 'test', sequence: 1, type: 'test.event' },
+  } satisfies ToolResult),
+  handleEventQuery: vi.fn().mockResolvedValue({
+    success: true,
+    data: [{ streamId: 'test', sequence: 1, type: 'test.event' }],
+  } satisfies ToolResult),
+}));
+
+import { handleEvent } from './composite.js';
+import { handleEventAppend, handleEventQuery } from './tools.js';
+
+describe('handleEvent', () => {
+  const stateDir = '/tmp/test-state';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('append action', () => {
+    it('should delegate to handleEventAppend', async () => {
+      // Arrange
+      const args = {
+        action: 'append',
+        stream: 'workflow-123',
+        event: { type: 'task.assigned', data: { taskId: 't1' } },
+        expectedSequence: 5,
+        idempotencyKey: 'key-1',
+      };
+
+      // Act
+      const result = await handleEvent(args, stateDir);
+
+      // Assert
+      expect(handleEventAppend).toHaveBeenCalledWith(
+        {
+          stream: 'workflow-123',
+          event: { type: 'task.assigned', data: { taskId: 't1' } },
+          expectedSequence: 5,
+          idempotencyKey: 'key-1',
+        },
+        stateDir,
+      );
+      expect(result).toEqual({
+        success: true,
+        data: { streamId: 'test', sequence: 1, type: 'test.event' },
+      });
+    });
+  });
+
+  describe('query action', () => {
+    it('should delegate to handleEventQuery', async () => {
+      // Arrange
+      const args = {
+        action: 'query',
+        stream: 'workflow-123',
+        filter: { type: 'task.assigned' },
+        limit: 10,
+        offset: 0,
+        fields: ['type', 'data'],
+      };
+
+      // Act
+      const result = await handleEvent(args, stateDir);
+
+      // Assert
+      expect(handleEventQuery).toHaveBeenCalledWith(
+        {
+          stream: 'workflow-123',
+          filter: { type: 'task.assigned' },
+          limit: 10,
+          offset: 0,
+          fields: ['type', 'data'],
+        },
+        stateDir,
+      );
+      expect(result).toEqual({
+        success: true,
+        data: [{ streamId: 'test', sequence: 1, type: 'test.event' }],
+      });
+    });
+  });
+
+  describe('unknown action', () => {
+    it('should return error for unknown action', async () => {
+      // Arrange
+      const args = { action: 'delete' };
+
+      // Act
+      const result = await handleEvent(args, stateDir);
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error: {
+          code: 'UNKNOWN_ACTION',
+          message: 'Unknown action: delete. Valid actions: append, query',
+        },
+      });
+      expect(handleEventAppend).not.toHaveBeenCalled();
+      expect(handleEventQuery).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/composite.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/composite.ts
@@ -1,0 +1,38 @@
+import type { ToolResult } from '../format.js';
+import { handleEventAppend, handleEventQuery } from './tools.js';
+
+const VALID_ACTIONS = ['append', 'query'] as const;
+type EventAction = (typeof VALID_ACTIONS)[number];
+
+/** Composite handler that routes `action` to the appropriate event-store handler. */
+export async function handleEvent(
+  args: Record<string, unknown>,
+  stateDir: string,
+): Promise<ToolResult> {
+  const action = args.action as string | undefined;
+
+  switch (action as EventAction) {
+    case 'append': {
+      const { action: _, ...rest } = args;
+      return handleEventAppend(
+        rest as Parameters<typeof handleEventAppend>[0],
+        stateDir,
+      );
+    }
+    case 'query': {
+      const { action: _, ...rest } = args;
+      return handleEventQuery(
+        rest as Parameters<typeof handleEventQuery>[0],
+        stateDir,
+      );
+    }
+    default:
+      return {
+        success: false,
+        error: {
+          code: 'UNKNOWN_ACTION',
+          message: `Unknown action: ${action}. Valid actions: ${VALID_ACTIONS.join(', ')}`,
+        },
+      };
+  }
+}


### PR DESCRIPTION
## Summary

Adds a composite handler that routes `action` to existing event-store handler functions (`handleEventAppend`, `handleEventQuery`). This replaces 2 individual MCP tools with a single `handleEvent` entry point, supporting the progressive disclosure hooks design.

## Changes

- **composite.ts** — Composite `handleEvent` function that switches on `action` and delegates to the appropriate handler, stripping the `action` field before forwarding args
- **composite.test.ts** — 3 tests covering append delegation, query delegation, and unknown action error handling

## Test Plan

TDD workflow: wrote tests first (RED), implemented handler (GREEN), verified full suite (REFACTOR). All 935 tests pass including 3 new composite handler tests.

---

**Results:** Tests 935 ✓ · Build 0 errors
**Related:** Progressive disclosure hooks design