### PR TITLE
feat: add CLI framework for hook entry points

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/cli.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parseStdinJson, outputJson, routeCommand } from './cli.js';
+
+describe('CLI Framework', () => {
+  describe('parseStdinJson', () => {
+    it('should parse valid JSON string into an object', () => {
+      // Arrange
+      const input = '{"tool_name": "exarchos_workflow", "action": "init"}';
+
+      // Act
+      const result = parseStdinJson(input);
+
+      // Assert
+      expect(result).toEqual({ tool_name: 'exarchos_workflow', action: 'init' });
+    });
+
+    it('should return empty object for empty string input', () => {
+      // Arrange
+      const input = '';
+
+      // Act
+      const result = parseStdinJson(input);
+
+      // Assert
+      expect(result).toEqual({});
+    });
+
+    it('should return empty object for whitespace-only input', () => {
+      // Arrange
+      const input = '   \n\t  ';
+
+      // Act
+      const result = parseStdinJson(input);
+
+      // Assert
+      expect(result).toEqual({});
+    });
+
+    it('should throw for invalid JSON', () => {
+      // Arrange
+      const input = '{ not valid json }';
+
+      // Act & Assert
+      expect(() => parseStdinJson(input)).toThrow();
+    });
+
+    it('should handle nested JSON objects', () => {
+      // Arrange
+      const input = JSON.stringify({
+        tool_name: 'exarchos_orchestrate',
+        tool_input: { action: 'task_claim', taskId: 'T1' },
+      });
+
+      // Act
+      const result = parseStdinJson(input);
+
+      // Assert
+      expect(result).toEqual({
+        tool_name: 'exarchos_orchestrate',
+        tool_input: { action: 'task_claim', taskId: 'T1' },
+      });
+    });
+  });
+
+  describe('outputJson', () => {
+    let writtenData: string;
+
+    beforeEach(() => {
+      writtenData = '';
+      vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+        writtenData += typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+        return true;
+      });
+    });
+
+    it('should write valid JSON to stdout', () => {
+      // Arrange
+      const obj = { success: true, data: 'test' };
+
+      // Act
+      outputJson(obj);
+
+      // Assert
+      const parsed = JSON.parse(writtenData);
+      expect(parsed).toEqual({ success: true, data: 'test' });
+    });
+
+    it('should write a trailing newline', () => {
+      // Arrange
+      const obj = { ok: true };
+
+      // Act
+      outputJson(obj);
+
+      // Assert
+      expect(writtenData.endsWith('\n')).toBe(true);
+    });
+
+    it('should handle null value', () => {
+      // Act
+      outputJson(null);
+
+      // Assert
+      expect(JSON.parse(writtenData)).toBeNull();
+    });
+
+    it('should handle array value', () => {
+      // Arrange
+      const arr = [1, 2, 3];
+
+      // Act
+      outputJson(arr);
+
+      // Assert
+      expect(JSON.parse(writtenData)).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('routeCommand', () => {
+    it('should route pre-compact command to handler', async () => {
+      // Act
+      const result = await routeCommand('pre-compact', {});
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('error');
+    });
+
+    it('should route session-start command to handler', async () => {
+      // Act
+      const result = await routeCommand('session-start', {});
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('error');
+    });
+
+    it('should route guard command to handler', async () => {
+      // Act
+      const result = await routeCommand('guard', {});
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('error');
+    });
+
+    it('should route task-gate command to handler', async () => {
+      // Act
+      const result = await routeCommand('task-gate', {});
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('error');
+    });
+
+    it('should route teammate-gate command to handler', async () => {
+      // Act
+      const result = await routeCommand('teammate-gate', {});
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('error');
+    });
+
+    it('should route subagent-context command to handler', async () => {
+      // Act
+      const result = await routeCommand('subagent-context', {});
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('error');
+    });
+
+    it('should return error for unknown command', async () => {
+      // Act
+      const result = await routeCommand('nonexistent', {});
+
+      // Assert
+      expect(result).toEqual({
+        error: {
+          code: 'UNKNOWN_COMMAND',
+          message: 'Unknown command: nonexistent',
+        },
+      });
+    });
+
+    it('should pass stdin data to command handlers', async () => {
+      // Arrange
+      const stdinData = { tool_name: 'exarchos_workflow', tool_input: { action: 'init' } };
+
+      // Act
+      const result = await routeCommand('guard', stdinData);
+
+      // Assert — stub returns not-implemented but should not crash
+      expect(result).toBeDefined();
+    });
+
+    it('should return not-implemented error for stubbed commands', async () => {
+      // Act
+      const result = await routeCommand('pre-compact', {});
+
+      // Assert
+      expect(result).toEqual({
+        error: {
+          code: 'NOT_IMPLEMENTED',
+          message: 'pre-compact handler not yet implemented',
+        },
+      });
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+// ─── CLI Entry Point for Claude Code Hooks ──────────────────────────────────
+//
+// All hook scripts call: node dist/cli.js <command>
+// JSON is piped via stdin, JSON result is written to stdout.
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Result returned by command handlers. */
+export interface CommandResult {
+  readonly error?: { readonly code: string; readonly message: string };
+  readonly [key: string]: unknown;
+}
+
+/** A command handler receives parsed stdin data and returns a result. */
+type CommandHandler = (stdinData: Record<string, unknown>) => Promise<CommandResult>;
+
+// ─── Known Commands ─────────────────────────────────────────────────────────
+
+const KNOWN_COMMANDS = [
+  'pre-compact',
+  'session-start',
+  'guard',
+  'task-gate',
+  'teammate-gate',
+  'subagent-context',
+] as const;
+
+type KnownCommand = (typeof KNOWN_COMMANDS)[number];
+
+function isKnownCommand(command: string): command is KnownCommand {
+  return (KNOWN_COMMANDS as readonly string[]).includes(command);
+}
+
+// ─── Stub Handlers ──────────────────────────────────────────────────────────
+
+function createStubHandler(command: string): CommandHandler {
+  return async (_stdinData: Record<string, unknown>): Promise<CommandResult> => ({
+    error: {
+      code: 'NOT_IMPLEMENTED',
+      message: `${command} handler not yet implemented`,
+    },
+  });
+}
+
+const commandHandlers: Record<KnownCommand, CommandHandler> = {
+  'pre-compact': createStubHandler('pre-compact'),
+  'session-start': createStubHandler('session-start'),
+  'guard': createStubHandler('guard'),
+  'task-gate': createStubHandler('task-gate'),
+  'teammate-gate': createStubHandler('teammate-gate'),
+  'subagent-context': createStubHandler('subagent-context'),
+};
+
+// ─── Stdin Parsing ──────────────────────────────────────────────────────────
+
+/**
+ * Parse a JSON string into a record. Returns an empty object for empty or
+ * whitespace-only input. Throws on invalid JSON.
+ */
+export function parseStdinJson(input: string): Record<string, unknown> {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    return {};
+  }
+  return JSON.parse(trimmed) as Record<string, unknown>;
+}
+
+// ─── Stdout Output ──────────────────────────────────────────────────────────
+
+/** Write a value as JSON to stdout with a trailing newline. */
+export function outputJson(obj: unknown): void {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+// ─── Stdin Reader ───────────────────────────────────────────────────────────
+
+/** Read all data from stdin into a string. */
+export function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on('data', (chunk: Buffer) => chunks.push(chunk));
+    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    process.stdin.on('error', reject);
+  });
+}
+
+// ─── Command Router ─────────────────────────────────────────────────────────
+
+/**
+ * Route a command string to the appropriate handler. Returns the handler's
+ * result, or an error object for unknown commands.
+ */
+export async function routeCommand(
+  command: string,
+  stdinData: Record<string, unknown>,
+): Promise<CommandResult> {
+  if (!isKnownCommand(command)) {
+    return {
+      error: {
+        code: 'UNKNOWN_COMMAND',
+        message: `Unknown command: ${command}`,
+      },
+    };
+  }
+
+  return commandHandlers[command](stdinData);
+}
+
+// ─── Main Entry Point ───────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const command = process.argv[2];
+
+  if (!command) {
+    outputJson({
+      error: {
+        code: 'MISSING_COMMAND',
+        message: 'Usage: cli.js <command>',
+      },
+    });
+    process.exitCode = 1;
+    return;
+  }
+
+  const rawInput = await readStdin();
+  const stdinData = parseStdinJson(rawInput);
+  const result = await routeCommand(command, stdinData);
+
+  outputJson(result);
+
+  if (result.error) {
+    process.exitCode = 1;
+  }
+}
+
+// Only run main when executed directly (not when imported for testing)
+const isDirectExecution =
+  process.argv[1] &&
+  (import.meta.url.endsWith(process.argv[1]) ||
+    import.meta.url.endsWith(process.argv[1].replace(/\.ts$/, '.js')));
+
+if (isDirectExecution) {
+  main().catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    outputJson({
+      error: {
+        code: 'FATAL',
+        message,
+      },
+    });
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

Adds the shared CLI entry point that all Claude Code hooks will use. Hook scripts call `node dist/cli.js <command>` and pipe JSON via stdin. The CLI parses stdin JSON, routes to the appropriate command handler, and writes JSON results to stdout. All six command handlers (pre-compact, session-start, guard, task-gate, teammate-gate, subagent-context) are stubbed for implementation in later tasks.

## Changes

- **cli.ts** -- Standalone CLI entry point with shebang, stdin JSON parsing, stdout JSON output, command routing via typed handler map, and direct-execution guard
- **cli.test.ts** -- 18 unit tests covering JSON parsing (valid, empty, whitespace, invalid, nested), stdout output (objects, null, arrays, newline), and command routing (all 6 known commands, unknown command error, stdin passthrough, stub error format)

## Test Plan

18 Vitest tests verify all CLI framework behavior. Full suite (950 tests) passes with no regressions.

---

**Results:** Tests 950 ✓ · Build 0 new errors (pre-existing registry.ts type issue)
**Design:** [progressive-disclosure-hooks.md](docs/designs/2026-02-12-progressive-disclosure-hooks.md)