### PR TITLE
feat: add quality gate CLI commands for task and teammate hooks

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ExecSyncOptions } from 'node:child_process';
+
+// Mock child_process before importing the module under test
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from 'node:child_process';
+import { handleTaskGate, handleTeammateGate, runQualityChecks } from './gates.js';
+import type { CommandResult } from '../cli.js';
+
+const mockExecSync = vi.mocked(execSync);
+
+describe('Quality Gate Commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('handleTaskGate', () => {
+    it('should parse TaskCompleted input with task_subject correctly', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(Buffer.from(''));
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'Implement user auth',
+        task_output: 'All tests pass',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTaskGate(input);
+
+      // Assert — should not error on valid input
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should return continue true when all checks pass', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(Buffer.from(''));
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'Add feature X',
+        task_output: 'Done',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTaskGate(input);
+
+      // Assert
+      expect(result).toEqual({ continue: true });
+    });
+
+    it('should return GATE_FAILED error when typecheck fails', async () => {
+      // Arrange
+      const typecheckError = new Error('Type checking failed');
+      (typecheckError as NodeJS.ErrnoException).status = 1;
+      (typecheckError as unknown as { stdout: Buffer }).stdout = Buffer.from('');
+      (typecheckError as unknown as { stderr: Buffer }).stderr = Buffer.from(
+        "src/foo.ts(5,3): error TS2322: Type 'string' is not assignable to type 'number'.",
+      );
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('typecheck')) {
+          throw typecheckError;
+        }
+        return Buffer.from('');
+      });
+
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'Add feature X',
+        task_output: 'Done',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTaskGate(input);
+
+      // Assert
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('GATE_FAILED');
+      expect(result.error!.message).toContain('typecheck');
+    });
+
+    it('should return GATE_FAILED error when tests fail', async () => {
+      // Arrange
+      const testError = new Error('Tests failed');
+      (testError as NodeJS.ErrnoException).status = 1;
+      (testError as unknown as { stdout: Buffer }).stdout = Buffer.from('FAIL src/foo.test.ts');
+      (testError as unknown as { stderr: Buffer }).stderr = Buffer.from('');
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('test:run')) {
+          throw testError;
+        }
+        return Buffer.from('');
+      });
+
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'Add feature X',
+        task_output: 'Done',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTaskGate(input);
+
+      // Assert
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('GATE_FAILED');
+      expect(result.error!.message).toContain('test');
+    });
+
+    it('should return GATE_FAILED error when worktree has uncommitted changes', async () => {
+      // Arrange
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('git status')) {
+          return Buffer.from(' M src/foo.ts\n?? src/bar.ts\n');
+        }
+        return Buffer.from('');
+      });
+
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'Add feature X',
+        task_output: 'Done',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTaskGate(input);
+
+      // Assert
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('GATE_FAILED');
+      expect(result.error!.message).toContain('uncommitted');
+    });
+
+    it('should return INVALID_INPUT error when cwd is missing', async () => {
+      // Arrange
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'Add feature X',
+        task_output: 'Done',
+      };
+
+      // Act
+      const result = await handleTaskGate(input);
+
+      // Assert
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('INVALID_INPUT');
+    });
+
+    it('should run checks in the cwd from stdin', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(Buffer.from(''));
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'task',
+        task_output: 'output',
+        cwd: '/my/specific/worktree',
+      };
+
+      // Act
+      await handleTaskGate(input);
+
+      // Assert — verify execSync was called with the correct cwd
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringContaining('typecheck'),
+        expect.objectContaining({ cwd: '/my/specific/worktree' }),
+      );
+    });
+  });
+
+  describe('handleTeammateGate', () => {
+    it('should parse TeammateIdle input with teammate_name correctly', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(Buffer.from(''));
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTeammateGate(input);
+
+      // Assert — should not error on valid input
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should return continue true when all checks pass', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(Buffer.from(''));
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTeammateGate(input);
+
+      // Assert
+      expect(result).toEqual({ continue: true });
+    });
+
+    it('should return INVALID_INPUT error when cwd is missing', async () => {
+      // Arrange
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+      };
+
+      // Act
+      const result = await handleTeammateGate(input);
+
+      // Assert
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('INVALID_INPUT');
+    });
+  });
+
+  describe('runQualityChecks', () => {
+    it('should run typecheck, tests, and git status in order', async () => {
+      // Arrange
+      const callOrder: string[] = [];
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string') {
+          if (cmd.includes('typecheck')) callOrder.push('typecheck');
+          else if (cmd.includes('test:run')) callOrder.push('test');
+          else if (cmd.includes('git status')) callOrder.push('git-status');
+        }
+        return Buffer.from('');
+      });
+
+      // Act
+      const result = await runQualityChecks('/tmp/worktree');
+
+      // Assert
+      expect(callOrder).toEqual(['typecheck', 'test', 'git-status']);
+      expect(result).toEqual({ continue: true });
+    });
+
+    it('should stop at first failure and not run subsequent checks', async () => {
+      // Arrange
+      const callOrder: string[] = [];
+      const typecheckError = new Error('fail');
+      (typecheckError as NodeJS.ErrnoException).status = 1;
+      (typecheckError as unknown as { stderr: Buffer }).stderr = Buffer.from('type error');
+      (typecheckError as unknown as { stdout: Buffer }).stdout = Buffer.from('');
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string') {
+          if (cmd.includes('typecheck')) {
+            callOrder.push('typecheck');
+            throw typecheckError;
+          }
+          if (cmd.includes('test:run')) callOrder.push('test');
+          if (cmd.includes('git status')) callOrder.push('git-status');
+        }
+        return Buffer.from('');
+      });
+
+      // Act
+      const result = await runQualityChecks('/tmp/worktree');
+
+      // Assert
+      expect(callOrder).toEqual(['typecheck']);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should use appropriate timeouts for each check', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(Buffer.from(''));
+
+      // Act
+      await runQualityChecks('/tmp/worktree');
+
+      // Assert — verify typecheck has 30s timeout
+      const typecheckCall = mockExecSync.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('typecheck'),
+      );
+      expect(typecheckCall).toBeDefined();
+      expect((typecheckCall![1] as ExecSyncOptions)?.timeout).toBe(30_000);
+
+      // Assert — verify test has 120s timeout
+      const testCall = mockExecSync.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('test:run'),
+      );
+      expect(testCall).toBeDefined();
+      expect((testCall![1] as ExecSyncOptions)?.timeout).toBe(120_000);
+    });
+
+    it('should handle command timeout as a failure', async () => {
+      // Arrange
+      const timeoutError = new Error('Command timed out');
+      (timeoutError as NodeJS.ErrnoException).code = 'ETIMEDOUT';
+      (timeoutError as unknown as { killed: boolean }).killed = true;
+      (timeoutError as unknown as { stderr: Buffer }).stderr = Buffer.from('');
+      (timeoutError as unknown as { stdout: Buffer }).stdout = Buffer.from('');
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('test:run')) {
+          throw timeoutError;
+        }
+        return Buffer.from('');
+      });
+
+      // Act
+      const result = await runQualityChecks('/tmp/worktree');
+
+      // Assert
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('GATE_FAILED');
+      expect(result.error!.message).toContain('test');
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.ts
@@ -1,0 +1,172 @@
+// ─── Quality Gate CLI Commands ──────────────────────────────────────────────
+//
+// Gates run at task/teammate lifecycle boundaries to enforce quality standards.
+// They execute configurable checks in the task's working directory.
+//
+// Exit semantics (managed by the CLI framework, not this module):
+//   - continue: true  → exit 0 (gate passed, allow continuation)
+//   - error returned   → exit 2 (gate blocked, feedback on stderr)
+
+import { execSync } from 'node:child_process';
+import type { CommandResult } from '../cli.js';
+
+// ─── Check Definitions ─────────────────────────────────────────────────────
+
+interface QualityCheck {
+  readonly name: string;
+  readonly command: string;
+  readonly timeoutMs: number;
+  readonly failureLabel: string;
+}
+
+const QUALITY_CHECKS: readonly QualityCheck[] = [
+  {
+    name: 'typecheck',
+    command: 'npm run typecheck',
+    timeoutMs: 30_000,
+    failureLabel: 'typecheck failed',
+  },
+  {
+    name: 'test',
+    command: 'npm run test:run',
+    timeoutMs: 120_000,
+    failureLabel: 'tests failed',
+  },
+  {
+    name: 'clean-worktree',
+    command: 'git status --porcelain',
+    timeoutMs: 10_000,
+    failureLabel: 'uncommitted changes detected',
+  },
+];
+
+// ─── Core Quality Check Runner ─────────────────────────────────────────────
+
+/**
+ * Run all quality checks sequentially in the given working directory.
+ * Stops at the first failure and returns a GATE_FAILED error.
+ * Returns `{ continue: true }` when all checks pass.
+ */
+export async function runQualityChecks(cwd: string): Promise<CommandResult> {
+  for (const check of QUALITY_CHECKS) {
+    try {
+      const output = execSync(check.command, {
+        cwd,
+        timeout: check.timeoutMs,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        encoding: 'buffer',
+      });
+
+      // Special case: git status --porcelain returns empty when clean
+      if (check.name === 'clean-worktree') {
+        const statusOutput = output.toString('utf-8').trim();
+        if (statusOutput.length > 0) {
+          return {
+            error: {
+              code: 'GATE_FAILED',
+              message: `${check.failureLabel}:\n${statusOutput}`,
+            },
+          };
+        }
+      }
+    } catch (err: unknown) {
+      const stderr = extractStderr(err);
+      const stdout = extractStdout(err);
+      const detail = stderr || stdout || (err instanceof Error ? err.message : String(err));
+
+      return {
+        error: {
+          code: 'GATE_FAILED',
+          message: `${check.failureLabel}:\n${detail}`,
+        },
+      };
+    }
+  }
+
+  return { continue: true };
+}
+
+// ─── Input Validation ──────────────────────────────────────────────────────
+
+function validateCwd(input: Record<string, unknown>): CommandResult | null {
+  if (typeof input.cwd !== 'string' || input.cwd.length === 0) {
+    return {
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'Missing required field: cwd',
+      },
+    };
+  }
+  return null;
+}
+
+// ─── Gate Handlers ─────────────────────────────────────────────────────────
+
+/**
+ * Task gate handler for TaskCompleted hook events.
+ *
+ * Expected stdin shape:
+ * ```json
+ * {
+ *   "hook_event_name": "TaskCompleted",
+ *   "task_subject": "...",
+ *   "task_output": "...",
+ *   "cwd": "/path/to/worktree"
+ * }
+ * ```
+ */
+export async function handleTaskGate(
+  input: Record<string, unknown>,
+): Promise<CommandResult> {
+  const validationError = validateCwd(input);
+  if (validationError) return validationError;
+
+  return runQualityChecks(input.cwd as string);
+}
+
+/**
+ * Teammate gate handler for TeammateIdle hook events.
+ *
+ * Expected stdin shape:
+ * ```json
+ * {
+ *   "hook_event_name": "TeammateIdle",
+ *   "teammate_name": "...",
+ *   "cwd": "/path/to/worktree"
+ * }
+ * ```
+ */
+export async function handleTeammateGate(
+  input: Record<string, unknown>,
+): Promise<CommandResult> {
+  const validationError = validateCwd(input);
+  if (validationError) return validationError;
+
+  return runQualityChecks(input.cwd as string);
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function extractStderr(err: unknown): string {
+  if (
+    err !== null &&
+    typeof err === 'object' &&
+    'stderr' in err &&
+    Buffer.isBuffer((err as { stderr: unknown }).stderr)
+  ) {
+    return ((err as { stderr: Buffer }).stderr).toString('utf-8').trim();
+  }
+  return '';
+}
+
+function extractStdout(err: unknown): string {
+  if (
+    err !== null &&
+    typeof err === 'object' &&
+    'stdout' in err &&
+    Buffer.isBuffer((err as { stdout: unknown }).stdout)
+  ) {
+    return ((err as { stdout: Buffer }).stdout).toString('utf-8').trim();
+  }
+  return '';
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parseStdinJson, outputJson, routeCommand } from './cli.js';
+
+describe('CLI Framework', () => {
+  describe('parseStdinJson', () => {
+    it('should parse valid JSON string into an object', () => {
+      // Arrange
+      const input = '{"tool_name": "exarchos_workflow", "action": "init"}';
+
+      // Act
+      const result = parseStdinJson(input);
+
+      // Assert
+      expect(result).toEqual({ tool_name: 'exarchos_workflow', action: 'init' });
+    });
+
+    it('should return empty object for empty string input', () => {
+      // Arrange
+      const input = '';
+
+      // Act
+      const result = parseStdinJson(input);
+
+      // Assert
+      expect(result).toEqual({});
+    });
+
+    it('should return empty object for whitespace-only input', () => {
+      // Arrange
+      const input = '   \n\t  ';
+
+      // Act
+      const result = parseStdinJson(input);
+
+      // Assert
+      expect(result).toEqual({});
+    });
+
+    it('should throw for invalid JSON', () => {
+      // Arrange
+      const input = '{ not valid json }';
+
+      // Act & Assert
+      expect(() => parseStdinJson(input)).toThrow();
+    });
+
+    it('should handle nested JSON objects', () => {
+      // Arrange
+      const input = JSON.stringify({
+        tool_name: 'exarchos_orchestrate',
+        tool_input: { action: 'task_claim', taskId: 'T1' },
+      });
+
+      // Act
+      const result = parseStdinJson(input);
+
+      // Assert
+      expect(result).toEqual({
+        tool_name: 'exarchos_orchestrate',
+        tool_input: { action: 'task_claim', taskId: 'T1' },
+      });
+    });
+  });
+
+  describe('outputJson', () => {
+    let writtenData: string;
+
+    beforeEach(() => {
+      writtenData = '';
+      vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+        writtenData += typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+        return true;
+      });
+    });
+
+    it('should write valid JSON to stdout', () => {
+      // Arrange
+      const obj = { success: true, data: 'test' };
+
+      // Act
+      outputJson(obj);
+
+      // Assert
+      const parsed = JSON.parse(writtenData);
+      expect(parsed).toEqual({ success: true, data: 'test' });
+    });
+
+    it('should write a trailing newline', () => {
+      // Arrange
+      const obj = { ok: true };
+
+      // Act
+      outputJson(obj);
+
+      // Assert
+      expect(writtenData.endsWith('\n')).toBe(true);
+    });
+
+    it('should handle null value', () => {
+      // Act
+      outputJson(null);
+
+      // Assert
+      expect(JSON.parse(writtenData)).toBeNull();
+    });
+
+    it('should handle array value', () => {
+      // Arrange
+      const arr = [1, 2, 3];
+
+      // Act
+      outputJson(arr);
+
+      // Assert
+      expect(JSON.parse(writtenData)).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('routeCommand', () => {
+    it('should route pre-compact command to handler', async () => {
+      // Act
+      const result = await routeCommand('pre-compact', {});
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('error');
+    });
+
+    it('should route session-start command to handler', async () => {
+      // Act
+      const result = await routeCommand('session-start', {});
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('error');
+    });
+
+    it('should route guard command to handler', async () => {
+      // Act
+      const result = await routeCommand('guard', {});
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('error');
+    });
+
+    it('should route task-gate command to handler', async () => {
+      // Act
+      const result = await routeCommand('task-gate', {});
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('error');
+    });
+
+    it('should route teammate-gate command to handler', async () => {
+      // Act
+      const result = await routeCommand('teammate-gate', {});
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('error');
+    });
+
+    it('should route subagent-context command to handler', async () => {
+      // Act
+      const result = await routeCommand('subagent-context', {});
+
+      // Assert
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('error');
+    });
+
+    it('should return error for unknown command', async () => {
+      // Act
+      const result = await routeCommand('nonexistent', {});
+
+      // Assert
+      expect(result).toEqual({
+        error: {
+          code: 'UNKNOWN_COMMAND',
+          message: 'Unknown command: nonexistent',
+        },
+      });
+    });
+
+    it('should pass stdin data to command handlers', async () => {
+      // Arrange
+      const stdinData = { tool_name: 'exarchos_workflow', tool_input: { action: 'init' } };
+
+      // Act
+      const result = await routeCommand('guard', stdinData);
+
+      // Assert — stub returns not-implemented but should not crash
+      expect(result).toBeDefined();
+    });
+
+    it('should return not-implemented error for stubbed commands', async () => {
+      // Act
+      const result = await routeCommand('pre-compact', {});
+
+      // Assert
+      expect(result).toEqual({
+        error: {
+          code: 'NOT_IMPLEMENTED',
+          message: 'pre-compact handler not yet implemented',
+        },
+      });
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
@@ -5,6 +5,8 @@
 // All hook scripts call: node dist/cli.js <command>
 // JSON is piped via stdin, JSON result is written to stdout.
 
+import { handleTaskGate, handleTeammateGate } from './cli-commands/gates.js';
+
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 /** Result returned by command handlers. */
@@ -48,8 +50,8 @@ const commandHandlers: Record<KnownCommand, CommandHandler> = {
   'pre-compact': createStubHandler('pre-compact'),
   'session-start': createStubHandler('session-start'),
   'guard': createStubHandler('guard'),
-  'task-gate': createStubHandler('task-gate'),
-  'teammate-gate': createStubHandler('teammate-gate'),
+  'task-gate': handleTaskGate,
+  'teammate-gate': handleTeammateGate,
   'subagent-context': createStubHandler('subagent-context'),
 };
 
@@ -131,7 +133,9 @@ async function main(): Promise<void> {
   outputJson(result);
 
   if (result.error) {
-    process.exitCode = 1;
+    // Gate commands use exit code 2 to signal "blocked" to the hook runner
+    const isGateCommand = command === 'task-gate' || command === 'teammate-gate';
+    process.exitCode = isGateCommand && result.error.code === 'GATE_FAILED' ? 2 : 1;
   }
 }
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+// ─── CLI Entry Point for Claude Code Hooks ──────────────────────────────────
+//
+// All hook scripts call: node dist/cli.js <command>
+// JSON is piped via stdin, JSON result is written to stdout.
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Result returned by command handlers. */
+export interface CommandResult {
+  readonly error?: { readonly code: string; readonly message: string };
+  readonly [key: string]: unknown;
+}
+
+/** A command handler receives parsed stdin data and returns a result. */
+type CommandHandler = (stdinData: Record<string, unknown>) => Promise<CommandResult>;
+
+// ─── Known Commands ─────────────────────────────────────────────────────────
+
+const KNOWN_COMMANDS = [
+  'pre-compact',
+  'session-start',
+  'guard',
+  'task-gate',
+  'teammate-gate',
+  'subagent-context',
+] as const;
+
+type KnownCommand = (typeof KNOWN_COMMANDS)[number];
+
+function isKnownCommand(command: string): command is KnownCommand {
+  return (KNOWN_COMMANDS as readonly string[]).includes(command);
+}
+
+// ─── Stub Handlers ──────────────────────────────────────────────────────────
+
+function createStubHandler(command: string): CommandHandler {
+  return async (_stdinData: Record<string, unknown>): Promise<CommandResult> => ({
+    error: {
+      code: 'NOT_IMPLEMENTED',
+      message: `${command} handler not yet implemented`,
+    },
+  });
+}
+
+const commandHandlers: Record<KnownCommand, CommandHandler> = {
+  'pre-compact': createStubHandler('pre-compact'),
+  'session-start': createStubHandler('session-start'),
+  'guard': createStubHandler('guard'),
+  'task-gate': createStubHandler('task-gate'),
+  'teammate-gate': createStubHandler('teammate-gate'),
+  'subagent-context': createStubHandler('subagent-context'),
+};
+
+// ─── Stdin Parsing ──────────────────────────────────────────────────────────
+
+/**
+ * Parse a JSON string into a record. Returns an empty object for empty or
+ * whitespace-only input. Throws on invalid JSON.
+ */
+export function parseStdinJson(input: string): Record<string, unknown> {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    return {};
+  }
+  return JSON.parse(trimmed) as Record<string, unknown>;
+}
+
+// ─── Stdout Output ──────────────────────────────────────────────────────────
+
+/** Write a value as JSON to stdout with a trailing newline. */
+export function outputJson(obj: unknown): void {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+// ─── Stdin Reader ───────────────────────────────────────────────────────────
+
+/** Read all data from stdin into a string. */
+export function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    process.stdin.on('data', (chunk: Buffer) => chunks.push(chunk));
+    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    process.stdin.on('error', reject);
+  });
+}
+
+// ─── Command Router ─────────────────────────────────────────────────────────
+
+/**
+ * Route a command string to the appropriate handler. Returns the handler's
+ * result, or an error object for unknown commands.
+ */
+export async function routeCommand(
+  command: string,
+  stdinData: Record<string, unknown>,
+): Promise<CommandResult> {
+  if (!isKnownCommand(command)) {
+    return {
+      error: {
+        code: 'UNKNOWN_COMMAND',
+        message: `Unknown command: ${command}`,
+      },
+    };
+  }
+
+  return commandHandlers[command](stdinData);
+}
+
+// ─── Main Entry Point ───────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const command = process.argv[2];
+
+  if (!command) {
+    outputJson({
+      error: {
+        code: 'MISSING_COMMAND',
+        message: 'Usage: cli.js <command>',
+      },
+    });
+    process.exitCode = 1;
+    return;
+  }
+
+  const rawInput = await readStdin();
+  const stdinData = parseStdinJson(rawInput);
+  const result = await routeCommand(command, stdinData);
+
+  outputJson(result);
+
+  if (result.error) {
+    process.exitCode = 1;
+  }
+}
+
+// Only run main when executed directly (not when imported for testing)
+const isDirectExecution =
+  process.argv[1] &&
+  (import.meta.url.endsWith(process.argv[1]) ||
+    import.meta.url.endsWith(process.argv[1].replace(/\.ts$/, '.js')));
+
+if (isDirectExecution) {
+  main().catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    outputJson({
+      error: {
+        code: 'FATAL',
+        message,
+      },
+    });
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

Implements `task-gate` and `teammate-gate` CLI command handlers that run configurable quality checks at task/teammate lifecycle boundaries. These gates enforce that code compiles, tests pass, and the worktree is clean before allowing task completion or teammate idle transitions.

## Changes

- **gates.ts** — Core quality gate logic with three sequential checks: typecheck (30s timeout), test suite (120s timeout), and clean worktree verification. Shared `runQualityChecks` runner with fail-fast behavior and actionable error messages
- **gates.test.ts** — 14 unit tests covering input parsing, pass/fail paths, check ordering, timeout handling, and error extraction via mocked `child_process.execSync`
- **cli.ts** — Wire real gate handlers replacing stubs, add exit code 2 for `GATE_FAILED` errors on gate commands

## Test Plan

14 new tests verify both gate handlers and the shared quality check runner. Full suite passes (964 tests). Pre-existing typecheck error in `registry.ts` is unrelated (confirmed on main).

---

**Results:** Tests 964 ✓ · Build 0 new errors
**Related:** Part of progressive disclosure hooks feature