### PR TITLE
feat: add generate-docs script for tool registry documentation

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/scripts/generate-docs.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/scripts/generate-docs.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { generateDocsMarkdown } from './generate-docs.js';
+
+describe('generateDocsMarkdown', () => {
+  const output = generateDocsMarkdown();
+
+  it('should produce markdown with a composite tools table header', () => {
+    expect(output).toContain('| Tool |');
+    expect(output).toContain('| Description |');
+  });
+
+  it('should include all 5 composite tool names', () => {
+    const expectedComposites = [
+      'exarchos_workflow',
+      'exarchos_event',
+      'exarchos_orchestrate',
+      'exarchos_view',
+      'exarchos_sync',
+    ];
+
+    for (const name of expectedComposites) {
+      expect(output).toContain(name);
+    }
+  });
+
+  it('should list all 21 action names', () => {
+    const expectedActions = [
+      // workflow (4)
+      'init',
+      'get',
+      'set',
+      'cancel',
+      // event (2)
+      'append',
+      'query',
+      // orchestrate (8)
+      'team_spawn',
+      'team_message',
+      'team_broadcast',
+      'team_shutdown',
+      'team_status',
+      'task_claim',
+      'task_complete',
+      'task_fail',
+      // view (6)
+      'pipeline',
+      'tasks',
+      'workflow_status',
+      'team_status',
+      'stack_status',
+      'stack_place',
+      // sync (1)
+      'now',
+    ];
+
+    for (const action of expectedActions) {
+      expect(output, `action '${action}' should appear in output`).toContain(
+        `\`${action}\``,
+      );
+    }
+  });
+
+  it('should include a phase mappings section with all phases', () => {
+    expect(output).toContain('## Phase Mappings');
+
+    const expectedPhases = [
+      'ideate',
+      'plan',
+      'plan-review',
+      'delegate',
+      'review',
+      'synthesize',
+    ];
+
+    for (const phase of expectedPhases) {
+      expect(
+        output,
+        `phase '${phase}' should appear in phase mappings`,
+      ).toContain(phase);
+    }
+  });
+
+  it('should produce valid markdown tables with consistent column counts', () => {
+    const lines = output.split('\n');
+
+    // Collect contiguous table blocks
+    const tables: string[][] = [];
+    let currentTable: string[] = [];
+
+    for (const line of lines) {
+      if (line.startsWith('|')) {
+        currentTable.push(line);
+      } else if (currentTable.length > 0) {
+        tables.push(currentTable);
+        currentTable = [];
+      }
+    }
+    if (currentTable.length > 0) {
+      tables.push(currentTable);
+    }
+
+    // Verify we found tables
+    expect(tables.length).toBeGreaterThan(0);
+
+    // Each table should have consistent column counts across all rows
+    for (const table of tables) {
+      const columnCounts = table.map(
+        (row) => row.split('|').filter((_, i, arr) => i > 0 && i < arr.length - 1).length,
+      );
+      const expectedColumns = columnCounts[0];
+      for (let i = 1; i < columnCounts.length; i++) {
+        expect(
+          columnCounts[i],
+          `Table row ${i} has ${columnCounts[i]} columns, expected ${expectedColumns}: "${table[i]}"`,
+        ).toBe(expectedColumns);
+      }
+    }
+  });
+
+  it('should include the auto-generated header notice', () => {
+    expect(output).toContain('Auto-generated');
+    expect(output).toContain('# Exarchos MCP Tool Reference');
+  });
+
+  it('should include action details sections for each composite', () => {
+    expect(output).toContain('## Action Details');
+    expect(output).toContain('### exarchos_workflow');
+    expect(output).toContain('### exarchos_event');
+    expect(output).toContain('### exarchos_orchestrate');
+    expect(output).toContain('### exarchos_view');
+    expect(output).toContain('### exarchos_sync');
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/scripts/generate-docs.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/scripts/generate-docs.ts
@@ -1,0 +1,121 @@
+import { TOOL_REGISTRY } from '../src/registry.js';
+import type { CompositeTool } from '../src/registry.js';
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const ALL_PHASES = ['ideate', 'plan', 'plan-review', 'delegate', 'review', 'synthesize'] as const;
+
+// ─── Markdown Generation ────────────────────────────────────────────────────
+
+function formatPhases(phases: ReadonlySet<string>): string {
+  const hasAll = ALL_PHASES.every((p) => phases.has(p));
+  if (hasAll) return 'all';
+  return [...phases].join(', ');
+}
+
+function formatRoles(roles: ReadonlySet<string>): string {
+  return [...roles].join(', ');
+}
+
+function generateCompositeTable(registry: readonly CompositeTool[]): string {
+  const lines: string[] = [
+    '## Composite Tools',
+    '',
+    '| Tool | Description | Actions |',
+    '|------|-------------|---------|',
+  ];
+
+  for (const composite of registry) {
+    const actionNames = composite.actions.map((a) => a.name).join(', ');
+    lines.push(`| \`${composite.name}\` | ${composite.description} | ${actionNames} |`);
+  }
+
+  return lines.join('\n');
+}
+
+function generateActionDetails(registry: readonly CompositeTool[]): string {
+  const sections: string[] = ['## Action Details'];
+
+  for (const composite of registry) {
+    sections.push('');
+    sections.push(`### ${composite.name}`);
+    sections.push('');
+    sections.push('| Action | Description | Phases | Roles |');
+    sections.push('|--------|-------------|--------|-------|');
+
+    for (const action of composite.actions) {
+      sections.push(
+        `| \`${action.name}\` | ${action.description} | ${formatPhases(action.phases)} | ${formatRoles(action.roles)} |`,
+      );
+    }
+  }
+
+  return sections.join('\n');
+}
+
+function generatePhaseMappings(registry: readonly CompositeTool[]): string {
+  // Build a map of phase -> list of "composite:action" strings
+  const phaseMap = new Map<string, string[]>();
+  for (const phase of ALL_PHASES) {
+    phaseMap.set(phase, []);
+  }
+
+  for (const composite of registry) {
+    const shortName = composite.name.replace('exarchos_', '');
+    for (const action of composite.actions) {
+      for (const phase of action.phases) {
+        const list = phaseMap.get(phase);
+        if (list) {
+          list.push(`${shortName}:${action.name}`);
+        }
+      }
+    }
+  }
+
+  const lines: string[] = [
+    '## Phase Mappings',
+    '',
+    '| Phase | Available Actions |',
+    '|-------|-------------------|',
+  ];
+
+  for (const phase of ALL_PHASES) {
+    const actions = phaseMap.get(phase) ?? [];
+    lines.push(`| ${phase} | ${actions.join(', ')} |`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Generates Markdown documentation from the TOOL_REGISTRY.
+ * Exported for testability; the script's main entrypoint writes to stdout.
+ */
+export function generateDocsMarkdown(): string {
+  const sections: string[] = [
+    '# Exarchos MCP Tool Reference',
+    '',
+    '> Auto-generated from tool registry. Do not edit manually.',
+    '',
+    generateCompositeTable(TOOL_REGISTRY),
+    '',
+    generateActionDetails(TOOL_REGISTRY),
+    '',
+    generatePhaseMappings(TOOL_REGISTRY),
+    '',
+  ];
+
+  return sections.join('\n');
+}
+
+// ─── CLI Entrypoint ─────────────────────────────────────────────────────────
+
+// Only run when executed directly (not imported by tests)
+const isDirectRun =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  (process.argv[1].endsWith('generate-docs.ts') || process.argv[1].endsWith('generate-docs.js'));
+
+if (isDirectRun) {
+  process.stdout.write(generateDocsMarkdown());
+}

--- a/plugins/exarchos/servers/exarchos-mcp/vitest.config.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: false,
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
Build script that generates Markdown reference docs from TOOL_REGISTRY,
producing composite tool tables, action details, and phase mappings.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>