### PR TITLE
feat: add subagent-context CLI command for SubagentStart hook

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  filterToolsForPhaseAndRole,
+  formatToolGuidance,
+  findActiveWorkflowPhase,
+  type FilteredComposite,
+} from './subagent-context.js';
+
+// ─── Test Helpers ────────────────────────────────────────────────────────────
+
+async function createTempStateDir(): Promise<string> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'subagent-ctx-'));
+  return tmpDir;
+}
+
+async function writeStateFile(
+  stateDir: string,
+  featureId: string,
+  phase: string,
+): Promise<void> {
+  const stateFile = path.join(stateDir, `${featureId}.state.json`);
+  const state = {
+    version: 2,
+    featureId,
+    workflowType: 'feature',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    phase,
+    artifacts: { design: null, plan: null, pr: null },
+    tasks: [],
+    worktrees: {},
+    reviews: {},
+    synthesis: {
+      integrationBranch: null,
+      mergeOrder: [],
+      mergedBranches: [],
+      prUrl: null,
+      prFeedback: [],
+    },
+    _version: 1,
+    _history: {},
+    _checkpoint: {
+      timestamp: new Date().toISOString(),
+      phase,
+      summary: 'Test state',
+      operationsSince: 0,
+      fixCycleCount: 0,
+      lastActivityTimestamp: new Date().toISOString(),
+      staleAfterMinutes: 120,
+    },
+  };
+  await fs.writeFile(stateFile, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+async function cleanupDir(dir: string): Promise<void> {
+  try {
+    await fs.rm(dir, { recursive: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('subagent-context', () => {
+  describe('filterToolsForPhaseAndRole', () => {
+    it('should return task actions for delegate phase with teammate role', () => {
+      // Arrange
+      const phase = 'delegate';
+      const role = 'teammate';
+
+      // Act
+      const result = filterToolsForPhaseAndRole(phase, role);
+
+      // Assert — should include task_claim, task_complete, task_fail from exarchos_orchestrate
+      const orchestrate = result.available.find((c) => c.name === 'exarchos_orchestrate');
+      expect(orchestrate).toBeDefined();
+      expect(orchestrate!.actions).toContain('task_claim');
+      expect(orchestrate!.actions).toContain('task_complete');
+      expect(orchestrate!.actions).toContain('task_fail');
+    });
+
+    it('should exclude lead-only actions for delegate phase with teammate role', () => {
+      // Arrange
+      const phase = 'delegate';
+      const role = 'teammate';
+
+      // Act
+      const result = filterToolsForPhaseAndRole(phase, role);
+
+      // Assert — team_spawn, team_message, etc. should be in denied list
+      const deniedOrchestrate = result.denied.find(
+        (c) => c.name === 'exarchos_orchestrate',
+      );
+      expect(deniedOrchestrate).toBeDefined();
+      expect(deniedOrchestrate!.actions).toContain('team_spawn');
+      expect(deniedOrchestrate!.actions).toContain('team_message');
+      expect(deniedOrchestrate!.actions).toContain('team_broadcast');
+      expect(deniedOrchestrate!.actions).toContain('team_shutdown');
+      expect(deniedOrchestrate!.actions).toContain('team_status');
+    });
+
+    it('should include event actions for delegate phase with teammate role', () => {
+      // Arrange
+      const phase = 'delegate';
+      const role = 'teammate';
+
+      // Act
+      const result = filterToolsForPhaseAndRole(phase, role);
+
+      // Assert
+      const event = result.available.find((c) => c.name === 'exarchos_event');
+      expect(event).toBeDefined();
+      expect(event!.actions).toContain('append');
+      expect(event!.actions).toContain('query');
+    });
+
+    it('should include view actions for review phase with teammate role', () => {
+      // Arrange
+      const phase = 'review';
+      const role = 'teammate';
+
+      // Act
+      const result = filterToolsForPhaseAndRole(phase, role);
+
+      // Assert — view tools should be available in review phase
+      const view = result.available.find((c) => c.name === 'exarchos_view');
+      expect(view).toBeDefined();
+      expect(view!.actions).toContain('pipeline');
+      expect(view!.actions).toContain('tasks');
+      expect(view!.actions).toContain('workflow_status');
+      expect(view!.actions).toContain('team_status');
+    });
+
+    it('should exclude orchestrate actions for review phase with teammate role', () => {
+      // Arrange
+      const phase = 'review';
+      const role = 'teammate';
+
+      // Act
+      const result = filterToolsForPhaseAndRole(phase, role);
+
+      // Assert — all orchestrate actions should be denied (delegate phase only)
+      const deniedOrchestrate = result.denied.find(
+        (c) => c.name === 'exarchos_orchestrate',
+      );
+      expect(deniedOrchestrate).toBeDefined();
+      // All 8 orchestrate actions should be denied in review phase
+      expect(deniedOrchestrate!.actions.length).toBe(8);
+    });
+
+    it('should deny workflow init and cancel for teammate role', () => {
+      // Arrange
+      const phase = 'delegate';
+      const role = 'teammate';
+
+      // Act
+      const result = filterToolsForPhaseAndRole(phase, role);
+
+      // Assert — init and cancel are lead-only
+      const deniedWorkflow = result.denied.find((c) => c.name === 'exarchos_workflow');
+      expect(deniedWorkflow).toBeDefined();
+      expect(deniedWorkflow!.actions).toContain('init');
+      expect(deniedWorkflow!.actions).toContain('cancel');
+    });
+
+    it('should allow workflow get for teammate role in any phase', () => {
+      // Arrange
+      const phase = 'delegate';
+      const role = 'teammate';
+
+      // Act
+      const result = filterToolsForPhaseAndRole(phase, role);
+
+      // Assert — get is role: any
+      const availWorkflow = result.available.find((c) => c.name === 'exarchos_workflow');
+      expect(availWorkflow).toBeDefined();
+      expect(availWorkflow!.actions).toContain('get');
+    });
+  });
+
+  describe('formatToolGuidance', () => {
+    it('should format available tools section', () => {
+      // Arrange
+      const available: FilteredComposite[] = [
+        { name: 'exarchos_orchestrate', actions: ['task_claim', 'task_complete', 'task_fail'] },
+        { name: 'exarchos_event', actions: ['append', 'query'] },
+      ];
+      const denied: FilteredComposite[] = [
+        { name: 'exarchos_workflow', actions: ['init', 'set', 'cancel'] },
+      ];
+
+      // Act
+      const output = formatToolGuidance(available, denied);
+
+      // Assert
+      expect(output).toContain('Your available Exarchos tools:');
+      expect(output).toContain('exarchos_orchestrate');
+      expect(output).toContain('task_claim');
+      expect(output).toContain('task_complete');
+      expect(output).toContain('task_fail');
+      expect(output).toContain('exarchos_event');
+      expect(output).toContain('append');
+      expect(output).toContain('query');
+    });
+
+    it('should format denied tools section', () => {
+      // Arrange
+      const available: FilteredComposite[] = [
+        { name: 'exarchos_event', actions: ['append', 'query'] },
+      ];
+      const denied: FilteredComposite[] = [
+        { name: 'exarchos_orchestrate', actions: ['team_spawn', 'team_message'] },
+        { name: 'exarchos_workflow', actions: ['init', 'cancel'] },
+      ];
+
+      // Act
+      const output = formatToolGuidance(available, denied);
+
+      // Assert
+      expect(output).toContain('Do NOT call:');
+      expect(output).toContain('exarchos_orchestrate');
+      expect(output).toContain('team_spawn');
+      expect(output).toContain('exarchos_workflow');
+      expect(output).toContain('init');
+      expect(output).toContain('cancel');
+    });
+
+    it('should output empty string when no available and no denied', () => {
+      // Act
+      const output = formatToolGuidance([], []);
+
+      // Assert
+      expect(output).toBe('');
+    });
+  });
+
+  describe('findActiveWorkflowPhase', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await createTempStateDir();
+    });
+
+    afterEach(async () => {
+      await cleanupDir(tempDir);
+    });
+
+    it('should return phase for an active workflow', async () => {
+      // Arrange
+      await writeStateFile(tempDir, 'my-feature', 'delegate');
+
+      // Act
+      const result = await findActiveWorkflowPhase(tempDir);
+
+      // Assert
+      expect(result).toBe('delegate');
+    });
+
+    it('should return null when no state files exist', async () => {
+      // Act (tempDir is empty)
+      const result = await findActiveWorkflowPhase(tempDir);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should return null when state directory does not exist', async () => {
+      // Act
+      const result = await findActiveWorkflowPhase('/nonexistent/path/nowhere');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should skip completed workflows and find active one', async () => {
+      // Arrange
+      await writeStateFile(tempDir, 'old-feature', 'completed');
+      await writeStateFile(tempDir, 'active-feature', 'review');
+
+      // Act
+      const result = await findActiveWorkflowPhase(tempDir);
+
+      // Assert
+      expect(result).toBe('review');
+    });
+
+    it('should return null when all workflows are completed', async () => {
+      // Arrange
+      await writeStateFile(tempDir, 'done-1', 'completed');
+      await writeStateFile(tempDir, 'done-2', 'completed');
+
+      // Act
+      const result = await findActiveWorkflowPhase(tempDir);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.ts
@@ -1,0 +1,171 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { TOOL_REGISTRY } from '../registry.js';
+import type { CommandResult } from '../cli.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface FilteredComposite {
+  readonly name: string;
+  readonly actions: readonly string[];
+}
+
+export interface FilterResult {
+  readonly available: readonly FilteredComposite[];
+  readonly denied: readonly FilteredComposite[];
+}
+
+// ─── Phase + Role Filtering ────────────────────────────────────────────────
+
+/**
+ * Filter the TOOL_REGISTRY actions by phase and role.
+ *
+ * An action is "available" when:
+ *   - action.phases.has(currentPhase)
+ *   - action.roles.has(role) OR action.roles.has('any')
+ *
+ * Everything else is "denied".
+ */
+export function filterToolsForPhaseAndRole(
+  phase: string,
+  role: string,
+): FilterResult {
+  const available: FilteredComposite[] = [];
+  const denied: FilteredComposite[] = [];
+
+  for (const composite of TOOL_REGISTRY) {
+    const availActions: string[] = [];
+    const deniedActions: string[] = [];
+
+    for (const action of composite.actions) {
+      const phaseMatch = action.phases.has(phase);
+      const roleMatch = action.roles.has(role) || action.roles.has('any');
+
+      if (phaseMatch && roleMatch) {
+        availActions.push(action.name);
+      } else {
+        deniedActions.push(action.name);
+      }
+    }
+
+    if (availActions.length > 0) {
+      available.push({ name: composite.name, actions: availActions });
+    }
+    if (deniedActions.length > 0) {
+      denied.push({ name: composite.name, actions: deniedActions });
+    }
+  }
+
+  return { available, denied };
+}
+
+// ─── Output Formatting ─────────────────────────────────────────────────────
+
+/**
+ * Format tool guidance as human-readable plain text for SubagentStart injection.
+ */
+export function formatToolGuidance(
+  available: readonly FilteredComposite[],
+  denied: readonly FilteredComposite[],
+): string {
+  if (available.length === 0 && denied.length === 0) {
+    return '';
+  }
+
+  const lines: string[] = [];
+
+  if (available.length > 0) {
+    lines.push('Your available Exarchos tools:');
+    for (const composite of available) {
+      lines.push(`- ${composite.name}: ${composite.actions.join(', ')}`);
+    }
+  }
+
+  if (denied.length > 0) {
+    if (lines.length > 0) {
+      lines.push('');
+    }
+    lines.push('Do NOT call:');
+    for (const composite of denied) {
+      lines.push(`- ${composite.name}: ${composite.actions.join(', ')}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ─── Active Workflow Discovery ─────────────────────────────────────────────
+
+/**
+ * Scan the state directory for the first non-completed workflow and return its phase.
+ * Returns null if no active workflow is found.
+ *
+ * Uses lightweight JSON parsing (no full Zod validation) since we only need the phase field.
+ */
+export async function findActiveWorkflowPhase(
+  stateDir: string,
+): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(stateDir);
+  } catch {
+    return null;
+  }
+
+  const stateFiles = entries.filter((f) => f.endsWith('.state.json'));
+
+  for (const file of stateFiles) {
+    try {
+      const raw = await fs.readFile(path.join(stateDir, file), 'utf-8');
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const phase = parsed.phase;
+
+      if (typeof phase === 'string' && phase !== 'completed') {
+        return phase;
+      }
+    } catch {
+      // Skip corrupt files
+      continue;
+    }
+  }
+
+  return null;
+}
+
+// ─── Command Handler ───────────────────────────────────────────────────────
+
+/**
+ * Resolve the workflow state directory from environment or default.
+ */
+function resolveStateDir(): string {
+  const envDir = process.env.WORKFLOW_STATE_DIR;
+  if (envDir) return envDir;
+
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
+  return path.join(home, '.claude', 'workflow-state');
+}
+
+/**
+ * SubagentStart hook handler.
+ *
+ * Reads the active workflow's phase, filters tools by phase + teammate role,
+ * and outputs plain-text guidance to stdout.
+ *
+ * Degrades gracefully: outputs nothing if no active workflow exists.
+ */
+export async function handleSubagentContext(
+  _stdinData: Record<string, unknown>,
+): Promise<CommandResult> {
+  const stateDir = resolveStateDir();
+  const phase = await findActiveWorkflowPhase(stateDir);
+
+  if (!phase) {
+    // Graceful degradation: no active workflow, output empty guidance
+    return { guidance: '' };
+  }
+
+  const { available, denied } = filterToolsForPhaseAndRole(phase, 'teammate');
+  const guidance = formatToolGuidance(available, denied);
+
+  return { guidance };
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli.test.ts
@@ -162,13 +162,13 @@ describe('CLI Framework', () => {
       expect(result).toHaveProperty('error');
     });
 
-    it('should route subagent-context command to handler', async () => {
+    it('should route subagent-context command to real handler', async () => {
       // Act
       const result = await routeCommand('subagent-context', {});
 
-      // Assert
+      // Assert — real handler returns guidance (not an error)
       expect(result).toBeDefined();
-      expect(result).toHaveProperty('error');
+      expect(result).toHaveProperty('guidance');
     });
 
     it('should return error for unknown command', async () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
@@ -5,6 +5,8 @@
 // All hook scripts call: node dist/cli.js <command>
 // JSON is piped via stdin, JSON result is written to stdout.
 
+import { handleSubagentContext } from './cli-commands/subagent-context.js';
+
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 /** Result returned by command handlers. */
@@ -50,7 +52,7 @@ const commandHandlers: Record<KnownCommand, CommandHandler> = {
   'guard': createStubHandler('guard'),
   'task-gate': createStubHandler('task-gate'),
   'teammate-gate': createStubHandler('teammate-gate'),
-  'subagent-context': createStubHandler('subagent-context'),
+  'subagent-context': handleSubagentContext,
 };
 
 // ─── Stdin Parsing ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements the `subagent-context` CLI command — a SubagentStart hook that injects phase-specific tool guidance when a subagent is spawned. Subagents only learn about tools relevant to their current workflow phase and role, reducing confusion and preventing unauthorized tool usage.

## Changes

- **subagent-context.ts** — Core command with three exported functions: `filterToolsForPhaseAndRole` (filters TOOL_REGISTRY by phase + role), `formatToolGuidance` (formats available/denied tools as plain text), and `findActiveWorkflowPhase` (lightweight state directory scan)
- **subagent-context.test.ts** — 15 tests covering delegate phase filtering, review phase filtering, lead-only exclusions, output formatting, and graceful degradation when no active workflow exists
- **cli.ts** — Wires real `handleSubagentContext` handler replacing the stub, with import from `cli-commands/` module
- **cli.test.ts** — Updated route test to verify real handler returns `guidance` instead of `NOT_IMPLEMENTED` error

## Test Plan

15 unit tests covering all filtering scenarios: delegate phase teammate access, review phase view access, lead-only action exclusion, formatting output, empty/missing state directory handling, and completed workflow skipping. Full suite: 965 tests passing.

---

**Results:** Tests 965 ✓ · Build 0 errors (pre-existing type issue in registry.ts)
**Related:** Builds on #190 (CLI framework)