### PR TITLE
feat: add composite handler for exarchos_event

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/composite.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/composite.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ToolResult } from '../format.js';
+
+vi.mock('./tools.js', () => ({
+  handleEventAppend: vi.fn().mockResolvedValue({
+    success: true,
+    data: { streamId: 'test', sequence: 1, type: 'test.event' },
+  } satisfies ToolResult),
+  handleEventQuery: vi.fn().mockResolvedValue({
+    success: true,
+    data: [{ streamId: 'test', sequence: 1, type: 'test.event' }],
+  } satisfies ToolResult),
+}));
+
+import { handleEvent } from './composite.js';
+import { handleEventAppend, handleEventQuery } from './tools.js';
+
+describe('handleEvent', () => {
+  const stateDir = '/tmp/test-state';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('append action', () => {
+    it('should delegate to handleEventAppend', async () => {
+      // Arrange
+      const args = {
+        action: 'append',
+        stream: 'workflow-123',
+        event: { type: 'task.assigned', data: { taskId: 't1' } },
+        expectedSequence: 5,
+        idempotencyKey: 'key-1',
+      };
+
+      // Act
+      const result = await handleEvent(args, stateDir);
+
+      // Assert
+      expect(handleEventAppend).toHaveBeenCalledWith(
+        {
+          stream: 'workflow-123',
+          event: { type: 'task.assigned', data: { taskId: 't1' } },
+          expectedSequence: 5,
+          idempotencyKey: 'key-1',
+        },
+        stateDir,
+      );
+      expect(result).toEqual({
+        success: true,
+        data: { streamId: 'test', sequence: 1, type: 'test.event' },
+      });
+    });
+  });
+
+  describe('query action', () => {
+    it('should delegate to handleEventQuery', async () => {
+      // Arrange
+      const args = {
+        action: 'query',
+        stream: 'workflow-123',
+        filter: { type: 'task.assigned' },
+        limit: 10,
+        offset: 0,
+        fields: ['type', 'data'],
+      };
+
+      // Act
+      const result = await handleEvent(args, stateDir);
+
+      // Assert
+      expect(handleEventQuery).toHaveBeenCalledWith(
+        {
+          stream: 'workflow-123',
+          filter: { type: 'task.assigned' },
+          limit: 10,
+          offset: 0,
+          fields: ['type', 'data'],
+        },
+        stateDir,
+      );
+      expect(result).toEqual({
+        success: true,
+        data: [{ streamId: 'test', sequence: 1, type: 'test.event' }],
+      });
+    });
+  });
+
+  describe('unknown action', () => {
+    it('should return error for unknown action', async () => {
+      // Arrange
+      const args = { action: 'delete' };
+
+      // Act
+      const result = await handleEvent(args, stateDir);
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error: {
+          code: 'UNKNOWN_ACTION',
+          message: 'Unknown action: delete. Valid actions: append, query',
+        },
+      });
+      expect(handleEventAppend).not.toHaveBeenCalled();
+      expect(handleEventQuery).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/composite.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/composite.ts
@@ -1,0 +1,38 @@
+import type { ToolResult } from '../format.js';
+import { handleEventAppend, handleEventQuery } from './tools.js';
+
+const VALID_ACTIONS = ['append', 'query'] as const;
+type EventAction = (typeof VALID_ACTIONS)[number];
+
+/** Composite handler that routes `action` to the appropriate event-store handler. */
+export async function handleEvent(
+  args: Record<string, unknown>,
+  stateDir: string,
+): Promise<ToolResult> {
+  const action = args.action as string | undefined;
+
+  switch (action as EventAction) {
+    case 'append': {
+      const { action: _, ...rest } = args;
+      return handleEventAppend(
+        rest as Parameters<typeof handleEventAppend>[0],
+        stateDir,
+      );
+    }
+    case 'query': {
+      const { action: _, ...rest } = args;
+      return handleEventQuery(
+        rest as Parameters<typeof handleEventQuery>[0],
+        stateDir,
+      );
+    }
+    default:
+      return {
+        success: false,
+        error: {
+          code: 'UNKNOWN_ACTION',
+          message: `Unknown action: ${action}. Valid actions: ${VALID_ACTIONS.join(', ')}`,
+        },
+      };
+  }
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/orchestrate/composite.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/orchestrate/composite.test.ts
@@ -1,0 +1,240 @@
+// ─── Composite Orchestrate Handler Tests ────────────────────────────────────
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ToolResult } from '../format.js';
+
+// ─── Mock team handler functions ────────────────────────────────────────────
+
+vi.mock('../team/tools.js', () => ({
+  handleTeamSpawn: vi.fn(),
+  handleTeamMessage: vi.fn(),
+  handleTeamBroadcast: vi.fn(),
+  handleTeamShutdown: vi.fn(),
+  handleTeamStatus: vi.fn(),
+}));
+
+// ─── Mock task handler functions ────────────────────────────────────────────
+
+vi.mock('../tasks/tools.js', () => ({
+  handleTaskClaim: vi.fn(),
+  handleTaskComplete: vi.fn(),
+  handleTaskFail: vi.fn(),
+}));
+
+import { handleTeamSpawn, handleTeamMessage, handleTeamBroadcast, handleTeamShutdown, handleTeamStatus } from '../team/tools.js';
+import { handleTaskClaim, handleTaskComplete, handleTaskFail } from '../tasks/tools.js';
+import { handleOrchestrate } from './composite.js';
+
+const STATE_DIR = '/tmp/test-state';
+
+function successResult(data: unknown): ToolResult {
+  return { success: true, data };
+}
+
+describe('handleOrchestrate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── Team Actions ───────────────────────────────────────────────────────
+
+  describe('team actions', () => {
+    it('handleOrchestrate_TeamSpawn_DelegatesToHandleTeamSpawn', async () => {
+      // Arrange
+      const expected = successResult({ name: 'agent-1' });
+      vi.mocked(handleTeamSpawn).mockResolvedValue(expected);
+      const args = {
+        action: 'team_spawn',
+        name: 'agent-1',
+        role: 'implementer',
+        taskId: 't1',
+        taskTitle: 'Do stuff',
+        streamId: 's1',
+      };
+
+      // Act
+      const result = await handleOrchestrate(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleTeamSpawn).toHaveBeenCalledWith(
+        { name: 'agent-1', role: 'implementer', taskId: 't1', taskTitle: 'Do stuff', streamId: 's1' },
+        STATE_DIR,
+      );
+    });
+
+    it('handleOrchestrate_TeamMessage_DelegatesToHandleTeamMessage', async () => {
+      // Arrange
+      const expected = successResult({ sent: true });
+      vi.mocked(handleTeamMessage).mockResolvedValue(expected);
+      const args = {
+        action: 'team_message',
+        from: 'orchestrator',
+        to: 'agent-1',
+        content: 'hello',
+        streamId: 's1',
+      };
+
+      // Act
+      const result = await handleOrchestrate(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleTeamMessage).toHaveBeenCalledWith(
+        { from: 'orchestrator', to: 'agent-1', content: 'hello', streamId: 's1' },
+        STATE_DIR,
+      );
+    });
+
+    it('handleOrchestrate_TeamBroadcast_DelegatesToHandleTeamBroadcast', async () => {
+      // Arrange
+      const expected = successResult({ broadcast: true });
+      vi.mocked(handleTeamBroadcast).mockResolvedValue(expected);
+      const args = {
+        action: 'team_broadcast',
+        from: 'orchestrator',
+        content: 'attention all',
+        streamId: 's1',
+      };
+
+      // Act
+      const result = await handleOrchestrate(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleTeamBroadcast).toHaveBeenCalledWith(
+        { from: 'orchestrator', content: 'attention all', streamId: 's1' },
+        STATE_DIR,
+      );
+    });
+
+    it('handleOrchestrate_TeamShutdown_DelegatesToHandleTeamShutdown', async () => {
+      // Arrange
+      const expected = successResult({ shutdown: true });
+      vi.mocked(handleTeamShutdown).mockResolvedValue(expected);
+      const args = {
+        action: 'team_shutdown',
+        name: 'agent-1',
+        streamId: 's1',
+      };
+
+      // Act
+      const result = await handleOrchestrate(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleTeamShutdown).toHaveBeenCalledWith(
+        { name: 'agent-1', streamId: 's1' },
+        STATE_DIR,
+      );
+    });
+
+    it('handleOrchestrate_TeamStatus_DelegatesToHandleTeamStatus', async () => {
+      // Arrange
+      const expected = successResult({ activeCount: 2, staleCount: 0 });
+      vi.mocked(handleTeamStatus).mockResolvedValue(expected);
+      const args = {
+        action: 'team_status',
+        summary: true,
+      };
+
+      // Act
+      const result = await handleOrchestrate(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleTeamStatus).toHaveBeenCalledWith(
+        { summary: true },
+        STATE_DIR,
+      );
+    });
+  });
+
+  // ─── Task Actions ───────────────────────────────────────────────────────
+
+  describe('task actions', () => {
+    it('handleOrchestrate_TaskClaim_DelegatesToHandleTaskClaim', async () => {
+      // Arrange
+      const expected = successResult({ streamId: 's1', sequence: 1, type: 'task.claimed' });
+      vi.mocked(handleTaskClaim).mockResolvedValue(expected);
+      const args = {
+        action: 'task_claim',
+        taskId: 't1',
+        agentId: 'agent-1',
+        streamId: 's1',
+      };
+
+      // Act
+      const result = await handleOrchestrate(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleTaskClaim).toHaveBeenCalledWith(
+        { taskId: 't1', agentId: 'agent-1', streamId: 's1' },
+        STATE_DIR,
+      );
+    });
+
+    it('handleOrchestrate_TaskComplete_DelegatesToHandleTaskComplete', async () => {
+      // Arrange
+      const expected = successResult({ streamId: 's1', sequence: 2, type: 'task.completed' });
+      vi.mocked(handleTaskComplete).mockResolvedValue(expected);
+      const args = {
+        action: 'task_complete',
+        taskId: 't1',
+        result: { artifacts: ['file.ts'] },
+        streamId: 's1',
+      };
+
+      // Act
+      const result = await handleOrchestrate(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleTaskComplete).toHaveBeenCalledWith(
+        { taskId: 't1', result: { artifacts: ['file.ts'] }, streamId: 's1' },
+        STATE_DIR,
+      );
+    });
+
+    it('handleOrchestrate_TaskFail_DelegatesToHandleTaskFail', async () => {
+      // Arrange
+      const expected = successResult({ streamId: 's1', sequence: 3, type: 'task.failed' });
+      vi.mocked(handleTaskFail).mockResolvedValue(expected);
+      const args = {
+        action: 'task_fail',
+        taskId: 't1',
+        error: 'something broke',
+        diagnostics: { log: 'details' },
+        streamId: 's1',
+      };
+
+      // Act
+      const result = await handleOrchestrate(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleTaskFail).toHaveBeenCalledWith(
+        { taskId: 't1', error: 'something broke', diagnostics: { log: 'details' }, streamId: 's1' },
+        STATE_DIR,
+      );
+    });
+  });
+
+  // ─── Error Handling ─────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('handleOrchestrate_UnknownAction_ReturnsError', async () => {
+      // Arrange
+      const args = { action: 'unknown_action' };
+
+      // Act
+      const result = await handleOrchestrate(args, STATE_DIR);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('UNKNOWN_ACTION');
+      expect(result.error?.message).toContain('unknown_action');
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -1,0 +1,79 @@
+// ─── Composite Orchestrate Handler ──────────────────────────────────────────
+//
+// Routes an `action` field to the appropriate team or task handler function,
+// replacing 8 individual MCP tools with a single `exarchos_orchestrate` tool.
+// ────────────────────────────────────────────────────────────────────────────
+
+import type { ToolResult } from '../format.js';
+
+// ─── Team Handlers ──────────────────────────────────────────────────────────
+
+import {
+  handleTeamSpawn,
+  handleTeamMessage,
+  handleTeamBroadcast,
+  handleTeamShutdown,
+  handleTeamStatus,
+} from '../team/tools.js';
+
+// ─── Task Handlers ──────────────────────────────────────────────────────────
+
+import {
+  handleTaskClaim,
+  handleTaskComplete,
+  handleTaskFail,
+} from '../tasks/tools.js';
+
+// ─── Action Router ──────────────────────────────────────────────────────────
+
+type ActionHandler = (args: Record<string, unknown>, stateDir: string) => Promise<ToolResult>;
+
+const TEAM_ACTIONS: Readonly<Record<string, ActionHandler>> = {
+  team_spawn: handleTeamSpawn as ActionHandler,
+  team_message: handleTeamMessage as ActionHandler,
+  team_broadcast: handleTeamBroadcast as ActionHandler,
+  team_shutdown: handleTeamShutdown as ActionHandler,
+  team_status: handleTeamStatus as ActionHandler,
+};
+
+const TASK_ACTIONS: Readonly<Record<string, ActionHandler>> = {
+  task_claim: handleTaskClaim as ActionHandler,
+  task_complete: handleTaskComplete as ActionHandler,
+  task_fail: handleTaskFail as ActionHandler,
+};
+
+const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
+  ...TEAM_ACTIONS,
+  ...TASK_ACTIONS,
+};
+
+// ─── Composite Handler ──────────────────────────────────────────────────────
+
+/**
+ * Routes the `action` field from args to the corresponding team or task handler.
+ *
+ * The `action` field is consumed by this router and stripped from the args
+ * forwarded to the underlying handler.
+ */
+export async function handleOrchestrate(
+  args: Record<string, unknown>,
+  stateDir: string,
+): Promise<ToolResult> {
+  const action = args.action as string | undefined;
+
+  const handler = action ? ACTION_HANDLERS[action] : undefined;
+  if (!handler) {
+    return {
+      success: false,
+      error: {
+        code: 'UNKNOWN_ACTION',
+        message: `Unknown orchestrate action '${String(action)}'. Valid actions: ${Object.keys(ACTION_HANDLERS).join(', ')}`,
+      },
+    };
+  }
+
+  // Strip the `action` field before forwarding to the underlying handler
+  const { action: _action, ...handlerArgs } = args;
+
+  return handler(handlerArgs as Record<string, unknown>, stateDir);
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/composite.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/composite.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the view tools module
+vi.mock('./tools.js', () => ({
+  handleViewPipeline: vi.fn(),
+  handleViewTasks: vi.fn(),
+  handleViewWorkflowStatus: vi.fn(),
+  handleViewTeamStatus: vi.fn(),
+}));
+
+// Mock the stack tools module
+vi.mock('../stack/tools.js', () => ({
+  handleStackStatus: vi.fn(),
+  handleStackPlace: vi.fn(),
+}));
+
+import { handleView } from './composite.js';
+import {
+  handleViewPipeline,
+  handleViewTasks,
+  handleViewWorkflowStatus,
+  handleViewTeamStatus,
+} from './tools.js';
+import { handleStackStatus, handleStackPlace } from '../stack/tools.js';
+
+const STATE_DIR = '/tmp/test-state';
+
+describe('handleView', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('pipeline', () => {
+    it('should delegate to handleViewPipeline', async () => {
+      // Arrange
+      const expected = { success: true, data: { workflows: [], total: 0 } };
+      vi.mocked(handleViewPipeline).mockResolvedValue(expected);
+      const args = { action: 'pipeline', limit: 10, offset: 0 };
+
+      // Act
+      const result = await handleView(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleViewPipeline).toHaveBeenCalledWith(
+        { limit: 10, offset: 0 },
+        STATE_DIR,
+      );
+    });
+  });
+
+  describe('tasks', () => {
+    it('should delegate to handleViewTasks', async () => {
+      // Arrange
+      const expected = { success: true, data: [] };
+      vi.mocked(handleViewTasks).mockResolvedValue(expected);
+      const args = {
+        action: 'tasks',
+        workflowId: 'wf-1',
+        filter: { status: 'done' },
+        limit: 5,
+        offset: 2,
+        fields: ['taskId', 'status'],
+      };
+
+      // Act
+      const result = await handleView(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleViewTasks).toHaveBeenCalledWith(
+        {
+          workflowId: 'wf-1',
+          filter: { status: 'done' },
+          limit: 5,
+          offset: 2,
+          fields: ['taskId', 'status'],
+        },
+        STATE_DIR,
+      );
+    });
+  });
+
+  describe('workflow_status', () => {
+    it('should delegate to handleViewWorkflowStatus', async () => {
+      // Arrange
+      const expected = { success: true, data: { phase: 'delegate' } };
+      vi.mocked(handleViewWorkflowStatus).mockResolvedValue(expected);
+      const args = { action: 'workflow_status', workflowId: 'wf-2' };
+
+      // Act
+      const result = await handleView(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleViewWorkflowStatus).toHaveBeenCalledWith(
+        { workflowId: 'wf-2' },
+        STATE_DIR,
+      );
+    });
+  });
+
+  describe('team_status', () => {
+    it('should delegate to handleViewTeamStatus', async () => {
+      // Arrange
+      const expected = { success: true, data: { teammates: [] } };
+      vi.mocked(handleViewTeamStatus).mockResolvedValue(expected);
+      const args = { action: 'team_status', workflowId: 'wf-3' };
+
+      // Act
+      const result = await handleView(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleViewTeamStatus).toHaveBeenCalledWith(
+        { workflowId: 'wf-3' },
+        STATE_DIR,
+      );
+    });
+  });
+
+  describe('stack_status', () => {
+    it('should delegate to handleStackStatus', async () => {
+      // Arrange
+      const expected = { success: true, data: [] };
+      vi.mocked(handleStackStatus).mockResolvedValue(expected);
+      const args = {
+        action: 'stack_status',
+        streamId: 'stream-1',
+        limit: 3,
+        offset: 1,
+      };
+
+      // Act
+      const result = await handleView(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleStackStatus).toHaveBeenCalledWith(
+        { streamId: 'stream-1', limit: 3, offset: 1 },
+        STATE_DIR,
+      );
+    });
+  });
+
+  describe('stack_place', () => {
+    it('should delegate to handleStackPlace', async () => {
+      // Arrange
+      const expected = {
+        success: true,
+        data: { streamId: 's1', sequence: 1, type: 'stack.position-filled' },
+      };
+      vi.mocked(handleStackPlace).mockResolvedValue(expected);
+      const args = {
+        action: 'stack_place',
+        streamId: 'stream-1',
+        position: 2,
+        taskId: 'task-A',
+        branch: 'feat/foo',
+        prUrl: 'https://github.com/org/repo/pull/1',
+      };
+
+      // Act
+      const result = await handleView(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleStackPlace).toHaveBeenCalledWith(
+        {
+          streamId: 'stream-1',
+          position: 2,
+          taskId: 'task-A',
+          branch: 'feat/foo',
+          prUrl: 'https://github.com/org/repo/pull/1',
+        },
+        STATE_DIR,
+      );
+    });
+  });
+
+  describe('unknown action', () => {
+    it('should return error for unknown action', async () => {
+      // Arrange
+      const args = { action: 'nonexistent' };
+
+      // Act
+      const result = await handleView(args, STATE_DIR);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('UNKNOWN_ACTION');
+      expect(result.error?.message).toContain('nonexistent');
+    });
+  });
+
+  describe('missing action', () => {
+    it('should return error when action is not provided', async () => {
+      // Arrange
+      const args = {};
+
+      // Act
+      const result = await handleView(args, STATE_DIR);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('UNKNOWN_ACTION');
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/composite.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/composite.ts
@@ -1,0 +1,91 @@
+// ─── Composite View Handler ─────────────────────────────────────────────────
+//
+// Routes `action` to the appropriate view or stack handler, replacing 6
+// individual MCP tools with a single `exarchos_view` entry point.
+
+import type { ToolResult } from '../format.js';
+import {
+  handleViewPipeline,
+  handleViewTasks,
+  handleViewWorkflowStatus,
+  handleViewTeamStatus,
+} from './tools.js';
+import { handleStackStatus, handleStackPlace } from '../stack/tools.js';
+
+/**
+ * Composite handler that dispatches to existing view/stack handlers
+ * based on the `action` field in args.
+ */
+export async function handleView(
+  args: Record<string, unknown>,
+  stateDir: string,
+): Promise<ToolResult> {
+  const { action, ...rest } = args;
+
+  switch (action) {
+    case 'pipeline':
+      return handleViewPipeline(
+        rest as { limit?: number; offset?: number },
+        stateDir,
+      );
+
+    case 'tasks':
+      return handleViewTasks(
+        rest as {
+          workflowId?: string;
+          filter?: Record<string, unknown>;
+          limit?: number;
+          offset?: number;
+          fields?: string[];
+        },
+        stateDir,
+      );
+
+    case 'workflow_status':
+      return handleViewWorkflowStatus(
+        rest as { workflowId?: string },
+        stateDir,
+      );
+
+    case 'team_status':
+      return handleViewTeamStatus(
+        rest as { workflowId?: string },
+        stateDir,
+      );
+
+    case 'stack_status':
+      return handleStackStatus(
+        rest as { streamId?: string; limit?: number; offset?: number },
+        stateDir,
+      );
+
+    case 'stack_place':
+      return handleStackPlace(
+        rest as {
+          streamId: string;
+          position: number;
+          taskId: string;
+          branch?: string;
+          prUrl?: string;
+        },
+        stateDir,
+      );
+
+    default:
+      return {
+        success: false,
+        error: {
+          code: 'UNKNOWN_ACTION',
+          message: `Unknown view action: ${String(action)}`,
+          validTargets: [
+            'pipeline',
+            'tasks',
+            'workflow_status',
+            'team_status',
+            'stack_status',
+            'stack_place',
+          ] as const,
+        },
+      };
+  }
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/composite.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/composite.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./tools.js', () => ({
+  handleInit: vi.fn().mockResolvedValue({ success: true, data: { phase: 'init-result' } }),
+  handleGet: vi.fn().mockResolvedValue({ success: true, data: { phase: 'get-result' } }),
+  handleSet: vi.fn().mockResolvedValue({ success: true, data: { phase: 'set-result' } }),
+}));
+
+vi.mock('./cancel.js', () => ({
+  handleCancel: vi.fn().mockResolvedValue({ success: true, data: { phase: 'cancel-result' } }),
+}));
+
+import { handleWorkflow } from './composite.js';
+import { handleInit, handleGet, handleSet } from './tools.js';
+import { handleCancel } from './cancel.js';
+
+describe('handleWorkflow', () => {
+  const stateDir = '/tmp/test-state';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('init action', () => {
+    it('should delegate to handleInit with correct args', async () => {
+      const args = { action: 'init', featureId: 'test', workflowType: 'feature' };
+
+      const result = await handleWorkflow(args, stateDir);
+
+      expect(handleInit).toHaveBeenCalledWith(
+        { featureId: 'test', workflowType: 'feature' },
+        stateDir,
+      );
+      expect(result).toEqual({ success: true, data: { phase: 'init-result' } });
+    });
+  });
+
+  describe('get action', () => {
+    it('should delegate to handleGet with correct args', async () => {
+      const args = { action: 'get', featureId: 'test', query: 'phase' };
+
+      const result = await handleWorkflow(args, stateDir);
+
+      expect(handleGet).toHaveBeenCalledWith(
+        { featureId: 'test', query: 'phase' },
+        stateDir,
+      );
+      expect(result).toEqual({ success: true, data: { phase: 'get-result' } });
+    });
+  });
+
+  describe('set action', () => {
+    it('should delegate to handleSet with correct args', async () => {
+      const args = { action: 'set', featureId: 'test', phase: 'delegate', updates: { track: 'polish' } };
+
+      const result = await handleWorkflow(args, stateDir);
+
+      expect(handleSet).toHaveBeenCalledWith(
+        { featureId: 'test', phase: 'delegate', updates: { track: 'polish' } },
+        stateDir,
+      );
+      expect(result).toEqual({ success: true, data: { phase: 'set-result' } });
+    });
+  });
+
+  describe('cancel action', () => {
+    it('should delegate to handleCancel with correct args', async () => {
+      const args = { action: 'cancel', featureId: 'test', reason: 'no longer needed' };
+
+      const result = await handleWorkflow(args, stateDir);
+
+      expect(handleCancel).toHaveBeenCalledWith(
+        { featureId: 'test', reason: 'no longer needed' },
+        stateDir,
+      );
+      expect(result).toEqual({ success: true, data: { phase: 'cancel-result' } });
+    });
+  });
+
+  describe('unknown action', () => {
+    it('should return error for unknown action', async () => {
+      const args = { action: 'invalid' };
+
+      const result = await handleWorkflow(args, stateDir);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('UNKNOWN_ACTION');
+      expect(result.error!.message).toContain('invalid');
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/composite.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/composite.ts
@@ -1,0 +1,33 @@
+import { handleInit, handleGet, handleSet } from './tools.js';
+import { handleCancel } from './cancel.js';
+import type { ToolResult } from '../format.js';
+
+/**
+ * Composite handler that routes `action` to the appropriate workflow handler.
+ * Replaces individual init/get/set/cancel tools with a single discriminated-union tool.
+ */
+export async function handleWorkflow(
+  args: Record<string, unknown>,
+  stateDir: string,
+): Promise<ToolResult> {
+  const { action, ...rest } = args;
+
+  switch (action) {
+    case 'init':
+      return handleInit(rest as Parameters<typeof handleInit>[0], stateDir);
+    case 'get':
+      return handleGet(rest as Parameters<typeof handleGet>[0], stateDir);
+    case 'set':
+      return handleSet(rest as Parameters<typeof handleSet>[0], stateDir);
+    case 'cancel':
+      return handleCancel(rest as Parameters<typeof handleCancel>[0], stateDir);
+    default:
+      return {
+        success: false,
+        error: {
+          code: 'UNKNOWN_ACTION',
+          message: `Unknown action: ${String(action)}. Valid actions: init, get, set, cancel`,
+        },
+      };
+  }
+}


### PR DESCRIPTION
feat: add composite handler for exarchos_event

Routes action (append, query) to existing event-store handler
functions, replacing 2 individual MCP tools with a single
composite tool entry point.

feat: add composite handler for exarchos_workflow

Routes action discriminator to existing handleInit, handleGet, handleSet,
and handleCancel handlers. Returns structured error for unknown actions.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

feat: add composite handler for exarchos_orchestrate

Routes action field to existing team and task handler functions,
replacing 8 individual MCP tools with a single composite entry point.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

feat: add composite handler for exarchos_view

Routes action parameter to existing view and stack handlers,
replacing 6 individual MCP tools with a single entry point.
Supports: pipeline, tasks, workflow_status, team_status,
stack_status, stack_place.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Merge branches 'feat/progressive-disclosure/b1-composite-workflow', '02-13-feat_add_composite_handler_for_exarchos_event', 'feat/progressive-disclosure/b3-composite-orchestrate' and 'feat/progressive-disclosure/b4-composite-view' into feat/progressive-disclosure/b5-index-registration