### PR TITLE
feat: register 5 composite tools replacing 27 individual tools

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
@@ -4,24 +4,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const {
   toolRegistrations,
-  mockHandleInit, mockHandleList, mockHandleGet, mockHandleSet, mockHandleCheckpoint,
-  mockHandleNextAction, mockHandleCancel,
-  mockHandleSummary, mockHandleReconcile, mockHandleTransitions,
+  mockHandleWorkflow, mockHandleEvent, mockHandleOrchestrate, mockHandleView,
 } = vi.hoisted(() => ({
   toolRegistrations: new Map<
     string,
     { description: string; schema: unknown; handler: (...args: unknown[]) => unknown }
   >(),
-  mockHandleInit: vi.fn().mockResolvedValue({ success: true, data: { phase: 'ideate' } }),
-  mockHandleList: vi.fn().mockResolvedValue({ success: true, data: [] }),
-  mockHandleGet: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleSet: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleCheckpoint: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleNextAction: vi.fn().mockResolvedValue({ success: true, data: { action: 'DONE' } }),
-  mockHandleCancel: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleSummary: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleReconcile: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleTransitions: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  mockHandleWorkflow: vi.fn().mockResolvedValue({ success: true, data: { phase: 'ideate' } }),
+  mockHandleEvent: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  mockHandleOrchestrate: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  mockHandleView: vi.fn().mockResolvedValue({ success: true, data: {} }),
 }));
 
 // ─── Module Mocks ────────────────────────────────────────────────────────────
@@ -46,220 +38,44 @@ vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
   StdioServerTransport: vi.fn(),
 }));
 
-// Mock workflow/tools.js - provide both handlers and registration function
-vi.mock('../../workflow/tools.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const featureIdParam = z.string().min(1).regex(/^[a-z0-9-]+$/);
-  const workflowTypeParam = z.enum(['feature', 'debug', 'refactor']);
-  return {
-    handleInit: mockHandleInit,
-    handleList: mockHandleList,
-    handleGet: mockHandleGet,
-    handleSet: mockHandleSet,
-    handleCheckpoint: mockHandleCheckpoint,
-    handleNextAction: mockHandleNextAction,
-    handleCancel: mockHandleCancel,
-    handleSummary: mockHandleSummary,
-    handleReconcile: mockHandleReconcile,
-    handleTransitions: mockHandleTransitions,
-    configureWorkflowEventStore: vi.fn(),
-    registerWorkflowTools: (server: unknown, stateDir: string) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_workflow_init', 'Initialize a new workflow state file for a feature/debug/refactor workflow',
-        { featureId: featureIdParam, workflowType: workflowTypeParam },
-        async (args: unknown) => formatResult(await mockHandleInit(args, stateDir)));
-      s.tool('exarchos_workflow_list', 'List all active workflow state files with staleness information',
-        {},
-        async (args: unknown) => formatResult(await mockHandleList(args, stateDir)));
-      s.tool('exarchos_workflow_get', 'Query a field via dot-path (e.g. query:"phase") or get full state if no query',
-        { featureId: featureIdParam, query: z.string().optional() },
-        async (args: unknown) => formatResult(await mockHandleGet(args, stateDir)));
-      s.tool('exarchos_workflow_set', 'Update fields and/or transition phase. Returns {phase, updatedAt}',
-        { featureId: featureIdParam, updates: z.record(z.string(), z.unknown()).optional(), phase: z.string().optional() },
-        async (args: unknown) => formatResult(await mockHandleSet(args, stateDir)));
-      s.tool('exarchos_workflow_checkpoint', 'Create an explicit checkpoint, resetting the operation counter',
-        { featureId: featureIdParam, summary: z.string().optional() },
-        async (args: unknown) => formatResult(await mockHandleCheckpoint(args, stateDir)));
-    },
-  };
-});
+// Mock EventStore
+vi.mock('../../event-store/store.js', () => ({
+  EventStore: vi.fn().mockImplementation(() => ({})),
+}));
 
-vi.mock('../../workflow/next-action.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  return {
-    handleNextAction: mockHandleNextAction,
-    configureNextActionEventStore: vi.fn(),
-    registerNextActionTool: (server: unknown, stateDir: string) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_workflow_next_action', 'Determine the next auto-continue action based on current phase and guards',
-        { featureId: z.string().min(1).regex(/^[a-z0-9-]+$/) },
-        async (args: unknown) => formatResult(await mockHandleNextAction(args, stateDir)));
-    },
-  };
-});
+// Mock configure functions — still called by createServer
+vi.mock('../../workflow/tools.js', () => ({
+  configureWorkflowEventStore: vi.fn(),
+}));
 
-vi.mock('../../workflow/cancel.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  return {
-    handleCancel: mockHandleCancel,
-    configureCancelEventStore: vi.fn(),
-    registerCancelTool: (server: unknown, stateDir: string) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_workflow_cancel', 'Cancel a workflow with saga compensation and cleanup',
-        { featureId: z.string().min(1).regex(/^[a-z0-9-]+$/), reason: z.string().optional(), dryRun: z.boolean().optional() },
-        async (args: unknown) => formatResult(await mockHandleCancel(args, stateDir)));
-    },
-  };
-});
+vi.mock('../../workflow/next-action.js', () => ({
+  configureNextActionEventStore: vi.fn(),
+}));
 
-vi.mock('../../workflow/query.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const featureIdParam = z.string().min(1).regex(/^[a-z0-9-]+$/);
-  return {
-    handleSummary: mockHandleSummary,
-    handleReconcile: mockHandleReconcile,
-    handleTransitions: mockHandleTransitions,
-    configureQueryEventStore: vi.fn(),
-    registerQueryTools: (server: unknown, stateDir: string) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_workflow_summary', 'Get structured summary of workflow progress, events, and circuit breaker status',
-        { featureId: featureIdParam },
-        async (args: unknown) => formatResult(await mockHandleSummary(args, stateDir)));
-      s.tool('exarchos_workflow_reconcile', 'Verify worktree paths and branches match state file',
-        { featureId: featureIdParam },
-        async (args: unknown) => formatResult(await mockHandleReconcile(args, stateDir)));
-      s.tool('exarchos_workflow_transitions', 'Get available state machine transitions for a workflow type',
-        { workflowType: z.enum(['feature', 'debug', 'refactor']), fromPhase: z.string().optional() },
-        async (args: unknown) => formatResult(await mockHandleTransitions(args, stateDir)));
-    },
-  };
-});
+vi.mock('../../workflow/cancel.js', () => ({
+  configureCancelEventStore: vi.fn(),
+}));
 
-vi.mock('../../event-store/tools.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const mockAppend = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockQuery = vi.fn().mockResolvedValue({ success: true, data: [] });
-  return {
-    handleEventAppend: mockAppend,
-    handleEventQuery: mockQuery,
-    registerEventTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_event_append', 'Append an event to the event store with optional optimistic concurrency',
-        { stream: z.string().min(1), event: z.record(z.string(), z.unknown()), expectedSequence: z.number().int().optional() },
-        async (args: unknown) => formatResult(await mockAppend(args, stateDir)));
-      s.tool('exarchos_event_query', 'Query events from the event store with optional filters (type, sinceSequence, since, until)',
-        { stream: z.string().min(1), filter: z.record(z.string(), z.unknown()).optional() },
-        async (args: unknown) => formatResult(await mockQuery(args, stateDir)));
-    },
-  };
-});
+vi.mock('../../workflow/query.js', () => ({
+  configureQueryEventStore: vi.fn(),
+}));
 
-vi.mock('../../views/tools.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const mockPipeline = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockTasks = vi.fn().mockResolvedValue({ success: true, data: [] });
-  const mockWorkflowStatus = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockTeamStatus = vi.fn().mockResolvedValue({ success: true, data: {} });
-  return {
-    handleViewPipeline: mockPipeline,
-    handleViewTasks: mockTasks,
-    handleViewWorkflowStatus: mockWorkflowStatus,
-    handleViewTeamStatus: mockTeamStatus,
-    registerViewTools: (server: unknown, stateDir: string) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_view_pipeline', 'Get CQRS pipeline view aggregating all workflows with stack positions and phase tracking',
-        {}, async (args: unknown) => formatResult(await mockPipeline(args, stateDir)));
-      s.tool('exarchos_view_tasks', 'Get CQRS task detail view with optional filtering by workflowId and task properties',
-        { workflowId: z.string().optional(), filter: z.record(z.string(), z.unknown()).optional() },
-        async (args: unknown) => formatResult(await mockTasks(args, stateDir)));
-      s.tool('exarchos_view_workflow_status', 'Get CQRS workflow status view with phase, task counts, and feature metadata',
-        { workflowId: z.string().optional() },
-        async (args: unknown) => formatResult(await mockWorkflowStatus(args, stateDir)));
-      s.tool('exarchos_view_team_status', 'Get CQRS team status view with teammate composition and current task assignments',
-        { workflowId: z.string().optional() },
-        async (args: unknown) => formatResult(await mockTeamStatus(args, stateDir)));
-    },
-  };
-});
+// Mock composite handlers
+vi.mock('../../workflow/composite.js', () => ({
+  handleWorkflow: mockHandleWorkflow,
+}));
 
-vi.mock('../../team/tools.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const mockSpawn = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockMessage = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockBroadcast = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockShutdown = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockStatus = vi.fn().mockResolvedValue({ success: true, data: {} });
-  return {
-    handleTeamSpawn: mockSpawn, handleTeamMessage: mockMessage,
-    handleTeamBroadcast: mockBroadcast, handleTeamShutdown: mockShutdown, handleTeamStatus: mockStatus,
-    registerTeamTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_team_spawn', 'Spawn a new team member agent with a role assignment',
-        { name: z.string().min(1), role: z.string().min(1), taskId: z.string().min(1), taskTitle: z.string().min(1), streamId: z.string().min(1), worktreePath: z.string().optional() },
-        async (args: unknown) => formatResult(await mockSpawn(args, stateDir)));
-      s.tool('exarchos_team_message', 'Send a direct message to a team member',
-        { from: z.string().min(1), to: z.string().min(1), content: z.string().min(1), streamId: z.string().min(1), messageType: z.string().optional() },
-        async (args: unknown) => formatResult(await mockMessage(args, stateDir)));
-      s.tool('exarchos_team_broadcast', 'Broadcast a message to all team members',
-        { from: z.string().min(1), content: z.string().min(1), streamId: z.string().min(1) },
-        async (args: unknown) => formatResult(await mockBroadcast(args, stateDir)));
-      s.tool('exarchos_team_shutdown', 'Shutdown a team member agent',
-        { name: z.string().min(1), streamId: z.string().min(1) },
-        async (args: unknown) => formatResult(await mockShutdown(args, stateDir)));
-      s.tool('exarchos_team_status', 'Get status of all team members with health information',
-        {}, async (args: unknown) => formatResult(await mockStatus(args, stateDir)));
-    },
-  };
-});
+vi.mock('../../event-store/composite.js', () => ({
+  handleEvent: mockHandleEvent,
+}));
 
-vi.mock('../../tasks/tools.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const mockClaim = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockComplete = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockFail = vi.fn().mockResolvedValue({ success: true, data: {} });
-  return {
-    handleTaskClaim: mockClaim, handleTaskComplete: mockComplete, handleTaskFail: mockFail,
-    registerTaskTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_task_claim', 'Claim a task for execution by an agent',
-        { taskId: z.string().min(1), agentId: z.string().min(1), streamId: z.string().min(1) },
-        async (args: unknown) => formatResult(await mockClaim(args, stateDir)));
-      s.tool('exarchos_task_complete', 'Mark a task as complete with optional artifacts',
-        { taskId: z.string().min(1), result: z.record(z.string(), z.unknown()).optional(), streamId: z.string().min(1) },
-        async (args: unknown) => formatResult(await mockComplete(args, stateDir)));
-      s.tool('exarchos_task_fail', 'Mark a task as failed with error details and optional diagnostics',
-        { taskId: z.string().min(1), error: z.string().min(1), diagnostics: z.record(z.string(), z.unknown()).optional(), streamId: z.string().min(1) },
-        async (args: unknown) => formatResult(await mockFail(args, stateDir)));
-    },
-  };
-});
+vi.mock('../../orchestrate/composite.js', () => ({
+  handleOrchestrate: mockHandleOrchestrate,
+}));
 
-vi.mock('../../stack/tools.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const mockStackStatus = vi.fn().mockResolvedValue({ success: true, data: [] });
-  const mockStackPlace = vi.fn().mockResolvedValue({ success: true, data: {} });
-  return {
-    handleStackStatus: mockStackStatus, handleStackPlace: mockStackPlace,
-    registerStackTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_stack_status', 'Get current stack positions from stack.position-filled events',
-        { streamId: z.string().optional() },
-        async (args: unknown) => formatResult(await mockStackStatus(args, stateDir)));
-      s.tool('exarchos_stack_place', 'Place an item on the stack by emitting a stack.position-filled event',
-        { streamId: z.string().min(1), position: z.number().int(), taskId: z.string().min(1), branch: z.string().optional(), prUrl: z.string().optional() },
-        async (args: unknown) => formatResult(await mockStackPlace(args, stateDir)));
-    },
-  };
-});
+vi.mock('../../views/composite.js', () => ({
+  handleView: mockHandleView,
+}));
 
 // Import after mocks are set up
 import { createServer } from '../../index.js';
@@ -273,25 +89,18 @@ describe('MCP Server Entry Point', () => {
   });
 
   describe('createServer', () => {
-    it('should register all 27 tools with correct names', () => {
+    it('should register exactly 5 composite tools', () => {
       createServer('/tmp/test-state-dir');
 
       const expectedTools = [
-        'exarchos_workflow_init', 'exarchos_workflow_list', 'exarchos_workflow_get',
-        'exarchos_workflow_set', 'exarchos_workflow_summary', 'exarchos_workflow_reconcile',
-        'exarchos_workflow_next_action', 'exarchos_workflow_transitions',
-        'exarchos_workflow_cancel', 'exarchos_workflow_checkpoint',
-        'exarchos_event_append', 'exarchos_event_query',
-        'exarchos_view_pipeline', 'exarchos_view_tasks',
-        'exarchos_view_workflow_status', 'exarchos_view_team_status',
-        'exarchos_team_spawn', 'exarchos_team_message', 'exarchos_team_broadcast',
-        'exarchos_team_shutdown', 'exarchos_team_status',
-        'exarchos_task_claim', 'exarchos_task_complete', 'exarchos_task_fail',
-        'exarchos_stack_status', 'exarchos_stack_place',
-        'exarchos_sync_now',
+        'exarchos_workflow',
+        'exarchos_event',
+        'exarchos_orchestrate',
+        'exarchos_view',
+        'exarchos_sync',
       ];
 
-      expect(toolRegistrations.size).toBe(27);
+      expect(toolRegistrations.size).toBe(5);
 
       for (const toolName of expectedTools) {
         expect(toolRegistrations.has(toolName)).toBe(true);
@@ -316,14 +125,16 @@ describe('MCP Server Entry Point', () => {
     });
   });
 
-  describe('tool handler routing', () => {
-    it('should route exarchos_workflow_init to handleInit', async () => {
+  describe('composite handler routing', () => {
+    it('should route exarchos_workflow to handleWorkflow', async () => {
       createServer('/tmp/test-state-dir');
-      const handler = toolRegistrations.get('exarchos_workflow_init')!.handler;
-      const result = await handler({ featureId: 'test-feat', workflowType: 'feature' });
+      const handler = toolRegistrations.get('exarchos_workflow')!.handler;
+      const result = await handler({ action: 'init', featureId: 'test-feat', workflowType: 'feature' });
 
-      expect(mockHandleInit).toHaveBeenCalledWith(
-        { featureId: 'test-feat', workflowType: 'feature' }, '/tmp/test-state-dir');
+      expect(mockHandleWorkflow).toHaveBeenCalledWith(
+        { action: 'init', featureId: 'test-feat', workflowType: 'feature' },
+        '/tmp/test-state-dir',
+      );
 
       const typedResult = result as { content: Array<{ type: string; text: string }>; isError: boolean };
       expect(typedResult.content).toHaveLength(1);
@@ -332,68 +143,53 @@ describe('MCP Server Entry Point', () => {
       expect(JSON.parse(typedResult.content[0].text).success).toBe(true);
     });
 
-    it('should route exarchos_workflow_list to handleList', async () => {
+    it('should route exarchos_event to handleEvent', async () => {
       createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_list')!.handler({});
-      expect(mockHandleList).toHaveBeenCalledWith({}, '/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_event')!.handler({
+        action: 'append', stream: 'workflow-123', event: { type: 'test' },
+      });
+      expect(mockHandleEvent).toHaveBeenCalledWith(
+        { action: 'append', stream: 'workflow-123', event: { type: 'test' } },
+        '/tmp/test-state-dir',
+      );
     });
 
-    it('should route exarchos_workflow_get to handleGet', async () => {
+    it('should route exarchos_orchestrate to handleOrchestrate', async () => {
       createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_get')!.handler({ featureId: 'my-feat', query: '.phase' });
-      expect(mockHandleGet).toHaveBeenCalledWith({ featureId: 'my-feat', query: '.phase' }, '/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_orchestrate')!.handler({
+        action: 'team_spawn', name: 'agent-1', role: 'implementer',
+        taskId: 'task-1', taskTitle: 'Build it', streamId: 'wf-123',
+      });
+      expect(mockHandleOrchestrate).toHaveBeenCalledWith(
+        {
+          action: 'team_spawn', name: 'agent-1', role: 'implementer',
+          taskId: 'task-1', taskTitle: 'Build it', streamId: 'wf-123',
+        },
+        '/tmp/test-state-dir',
+      );
     });
 
-    it('should route exarchos_workflow_set to handleSet', async () => {
+    it('should route exarchos_view to handleView', async () => {
       createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_set')!.handler({ featureId: 'my-feat', phase: 'plan' });
-      expect(mockHandleSet).toHaveBeenCalledWith({ featureId: 'my-feat', phase: 'plan' }, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_summary to handleSummary', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_summary')!.handler({ featureId: 'my-feat' });
-      expect(mockHandleSummary).toHaveBeenCalledWith({ featureId: 'my-feat' }, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_reconcile to handleReconcile', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_reconcile')!.handler({ featureId: 'my-feat' });
-      expect(mockHandleReconcile).toHaveBeenCalledWith({ featureId: 'my-feat' }, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_next_action to handleNextAction', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_next_action')!.handler({ featureId: 'my-feat' });
-      expect(mockHandleNextAction).toHaveBeenCalledWith({ featureId: 'my-feat' }, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_transitions to handleTransitions', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_transitions')!.handler({ workflowType: 'feature' });
-      expect(mockHandleTransitions).toHaveBeenCalledWith({ workflowType: 'feature' }, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_cancel to handleCancel', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_cancel')!.handler({ featureId: 'my-feat', reason: 'no longer needed' });
-      expect(mockHandleCancel).toHaveBeenCalledWith({ featureId: 'my-feat', reason: 'no longer needed' }, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_checkpoint to handleCheckpoint', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_checkpoint')!.handler({ featureId: 'my-feat', summary: 'mid-delegation' });
-      expect(mockHandleCheckpoint).toHaveBeenCalledWith({ featureId: 'my-feat', summary: 'mid-delegation' }, '/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_view')!.handler({
+        action: 'pipeline', limit: 10,
+      });
+      expect(mockHandleView).toHaveBeenCalledWith(
+        { action: 'pipeline', limit: 10 },
+        '/tmp/test-state-dir',
+      );
     });
 
     it('should set isError to true when handler returns success: false', async () => {
-      mockHandleInit.mockResolvedValueOnce({
+      mockHandleWorkflow.mockResolvedValueOnce({
         success: false,
         error: { code: 'STATE_ALREADY_EXISTS', message: 'Already exists' },
       });
 
       createServer('/tmp/test-state-dir');
-      const result = await toolRegistrations.get('exarchos_workflow_init')!.handler({ featureId: 'dup', workflowType: 'feature' });
+      const result = await toolRegistrations.get('exarchos_workflow')!.handler({
+        action: 'init', featureId: 'dup', workflowType: 'feature',
+      });
 
       const typedResult = result as { content: Array<{ type: string; text: string }>; isError: boolean };
       expect(typedResult.isError).toBe(true);
@@ -404,9 +200,9 @@ describe('MCP Server Entry Point', () => {
   });
 
   describe('stub tools', () => {
-    it('should return NOT_IMPLEMENTED for stub tools', async () => {
+    it('should return NOT_IMPLEMENTED for exarchos_sync', async () => {
       createServer('/tmp/test-state-dir');
-      const result = await toolRegistrations.get('exarchos_sync_now')!.handler({});
+      const result = await toolRegistrations.get('exarchos_sync')!.handler({ action: 'now' });
 
       const typedResult = result as { content: Array<{ type: string; text: string }>; isError: boolean };
       expect(typedResult.isError).toBe(true);
@@ -414,22 +210,6 @@ describe('MCP Server Entry Point', () => {
       expect(parsed.success).toBe(false);
       expect(parsed.error.code).toBe('NOT_IMPLEMENTED');
       expect(parsed.error.message).toBe('Coming soon');
-    });
-
-    it('should register implemented team and task tools', () => {
-      createServer('/tmp/test-state-dir');
-      const implementedTools = [
-        'exarchos_team_spawn', 'exarchos_team_message', 'exarchos_team_broadcast',
-        'exarchos_team_shutdown', 'exarchos_team_status',
-        'exarchos_task_claim', 'exarchos_task_complete', 'exarchos_task_fail',
-        'exarchos_stack_status', 'exarchos_stack_place',
-      ];
-      for (const toolName of implementedTools) {
-        expect(toolRegistrations.has(toolName)).toBe(true);
-        const reg = toolRegistrations.get(toolName)!;
-        expect(reg.handler).toBeDefined();
-        expect(typeof reg.handler).toBe('function');
-      }
     });
   });
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/index.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/index.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Track server.tool() calls
+const toolCalls: Array<{ name: string; description: string }> = [];
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: vi.fn().mockImplementation(() => ({
+    tool: vi.fn(
+      (name: string, description: string, _schema: unknown, _handler: unknown) => {
+        toolCalls.push({ name, description });
+      },
+    ),
+  })),
+}));
+
+// Mock EventStore to prevent filesystem access
+vi.mock('./event-store/store.js', () => ({
+  EventStore: vi.fn().mockImplementation(() => ({})),
+}));
+
+// Mock all module registration / configuration functions that index.ts imports.
+// The configure* functions are no-ops; the register* functions are stubs that
+// call server.tool() internally — but since we already mock McpServer, any calls
+// they make will just be captured by our tracker above.
+vi.mock('./workflow/tools.js', () => ({
+  configureWorkflowEventStore: vi.fn(),
+  registerWorkflowTools: vi.fn(),
+}));
+
+vi.mock('./workflow/next-action.js', () => ({
+  configureNextActionEventStore: vi.fn(),
+  registerNextActionTool: vi.fn(),
+}));
+
+vi.mock('./workflow/cancel.js', () => ({
+  configureCancelEventStore: vi.fn(),
+  registerCancelTool: vi.fn(),
+}));
+
+vi.mock('./workflow/query.js', () => ({
+  configureQueryEventStore: vi.fn(),
+  registerQueryTools: vi.fn(),
+}));
+
+vi.mock('./event-store/tools.js', () => ({
+  registerEventTools: vi.fn(),
+}));
+
+vi.mock('./views/tools.js', () => ({
+  registerViewTools: vi.fn(),
+}));
+
+vi.mock('./team/tools.js', () => ({
+  registerTeamTools: vi.fn(),
+}));
+
+vi.mock('./tasks/tools.js', () => ({
+  registerTaskTools: vi.fn(),
+}));
+
+vi.mock('./stack/tools.js', () => ({
+  registerStackTools: vi.fn(),
+}));
+
+// Mock composite handlers (will be used after implementation)
+vi.mock('./workflow/composite.js', () => ({
+  handleWorkflow: vi.fn(),
+}));
+
+vi.mock('./event-store/composite.js', () => ({
+  handleEvent: vi.fn(),
+}));
+
+vi.mock('./orchestrate/composite.js', () => ({
+  handleOrchestrate: vi.fn(),
+}));
+
+vi.mock('./views/composite.js', () => ({
+  handleView: vi.fn(),
+}));
+
+import { createServer } from './index.js';
+import { configureWorkflowEventStore } from './workflow/tools.js';
+import { configureNextActionEventStore } from './workflow/next-action.js';
+import { configureCancelEventStore } from './workflow/cancel.js';
+import { configureQueryEventStore } from './workflow/query.js';
+
+describe('createServer', () => {
+  beforeEach(() => {
+    toolCalls.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('should register exactly 5 tools', () => {
+    createServer('/tmp/test-state');
+
+    expect(toolCalls).toHaveLength(5);
+  });
+
+  it('should register the expected composite tool names', () => {
+    createServer('/tmp/test-state');
+
+    const names = toolCalls.map((c) => c.name);
+    expect(names).toEqual([
+      'exarchos_workflow',
+      'exarchos_event',
+      'exarchos_orchestrate',
+      'exarchos_view',
+      'exarchos_sync',
+    ]);
+  });
+
+  it('should include descriptions for each composite tool', () => {
+    createServer('/tmp/test-state');
+
+    for (const call of toolCalls) {
+      expect(call.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('should still configure EventStore instances for modules', () => {
+    createServer('/tmp/test-state');
+
+    expect(configureWorkflowEventStore).toHaveBeenCalledTimes(1);
+    expect(configureNextActionEventStore).toHaveBeenCalledTimes(1);
+    expect(configureCancelEventStore).toHaveBeenCalledTimes(1);
+    expect(configureQueryEventStore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/index.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/index.ts
@@ -2,24 +2,36 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
-import { stubResult } from './format.js';
-import { registerWorkflowTools, configureWorkflowEventStore } from './workflow/tools.js';
-import { registerNextActionTool, configureNextActionEventStore } from './workflow/next-action.js';
-import { registerCancelTool, configureCancelEventStore } from './workflow/cancel.js';
-import { registerQueryTools, configureQueryEventStore } from './workflow/query.js';
-import { registerEventTools } from './event-store/tools.js';
+import { formatResult, stubResult, type ToolResult } from './format.js';
+import { configureWorkflowEventStore } from './workflow/tools.js';
+import { configureNextActionEventStore } from './workflow/next-action.js';
+import { configureCancelEventStore } from './workflow/cancel.js';
+import { configureQueryEventStore } from './workflow/query.js';
 import { EventStore } from './event-store/store.js';
-import { registerViewTools } from './views/tools.js';
-import { registerTeamTools } from './team/tools.js';
-import { registerTaskTools } from './tasks/tools.js';
-import { registerStackTools } from './stack/tools.js';
+import { TOOL_REGISTRY } from './registry.js';
+import { handleWorkflow } from './workflow/composite.js';
+import { handleEvent } from './event-store/composite.js';
+import { handleOrchestrate } from './orchestrate/composite.js';
+import { handleView } from './views/composite.js';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 export const SERVER_NAME = 'exarchos-mcp';
 export const SERVER_VERSION = '1.0.0';
+
+// ─── Composite Handler Map ──────────────────────────────────────────────────
+
+type CompositeHandler = (args: Record<string, unknown>, stateDir: string) => Promise<ToolResult>;
+
+const COMPOSITE_HANDLERS: Readonly<Record<string, CompositeHandler>> = {
+  exarchos_workflow: handleWorkflow,
+  exarchos_event: handleEvent,
+  exarchos_orchestrate: handleOrchestrate,
+  exarchos_view: handleView,
+};
 
 // ─── Server Factory ──────────────────────────────────────────────────────────
 
@@ -33,24 +45,34 @@ export function createServer(stateDir: string): McpServer {
   configureCancelEventStore(eventStore);
   configureQueryEventStore(eventStore);
 
-  // Register all tool modules
-  registerWorkflowTools(server, stateDir);
-  registerNextActionTool(server, stateDir);
-  registerCancelTool(server, stateDir);
-  registerQueryTools(server, stateDir);
-  registerEventTools(server, stateDir, eventStore);
-  registerViewTools(server, stateDir, eventStore);
-  registerTeamTools(server, stateDir, eventStore);
-  registerTaskTools(server, stateDir, eventStore);
-  registerStackTools(server, stateDir, eventStore);
+  // Register composite tools from the registry
+  for (const composite of TOOL_REGISTRY) {
+    const handler = COMPOSITE_HANDLERS[composite.name];
 
-  // Stub tools
-  server.tool(
-    'exarchos_sync_now',
-    'Trigger immediate sync with remote',
-    {},
-    async () => stubResult(),
-  );
+    if (handler) {
+      // Real composite — route through the composite handler
+      server.tool(
+        composite.name,
+        composite.description,
+        { action: z.string(), ...Object.fromEntries(
+          // Collect all possible fields from all actions as optional z.unknown()
+          // so the SDK schema passes through all args to the handler
+          composite.actions.flatMap((a) =>
+            Object.keys(a.schema.shape).map((k) => [k, z.unknown().optional()]),
+          ),
+        ) },
+        async (args) => formatResult(await handler(args as Record<string, unknown>, stateDir)),
+      );
+    } else {
+      // Stub composite (exarchos_sync) — return NOT_IMPLEMENTED for any action
+      server.tool(
+        composite.name,
+        composite.description,
+        { action: z.string() },
+        async () => stubResult(),
+      );
+    }
+  }
 
   return server;
 }


### PR DESCRIPTION
Replace 9 individual registerXTools() calls in createServer() with a
registry-driven loop over TOOL_REGISTRY that registers exactly 5
composite tools (workflow, event, orchestrate, view, sync).

- Import composite handlers and TOOL_REGISTRY from registry module
- Route 4 composites through their handlers, sync remains a stub
- Build permissive schemas from action field names for SDK compatibility
- Preserve EventStore configuration calls for module-level instances
- Update existing index integration test to test 5 composites
- Add co-located index.test.ts with focused registration tests