### PR TITLE
feat: add phase guardrail CLI command for PreToolUse hook

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/guard.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/guard.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { handleGuard } from './guard.js';
+
+// ─── Test Helpers ───────────────────────────────────────────────────────────
+
+/** Create a minimal valid state file JSON for a given phase. */
+function makeStateJson(featureId: string, phase: string): string {
+  const now = new Date().toISOString();
+  return JSON.stringify({
+    version: '1.1',
+    featureId,
+    workflowType: 'feature',
+    createdAt: now,
+    updatedAt: now,
+    phase,
+    artifacts: { design: null, plan: null, pr: null },
+    tasks: [],
+    worktrees: {},
+    reviews: {},
+    integration: null,
+    synthesis: {
+      integrationBranch: null,
+      mergeOrder: [],
+      mergedBranches: [],
+      prUrl: null,
+      prFeedback: [],
+    },
+    _version: 1,
+    _history: {},
+    _checkpoint: {
+      timestamp: now,
+      phase,
+      summary: 'Test state',
+      operationsSince: 0,
+      fixCycleCount: 0,
+      lastActivityTimestamp: now,
+      staleAfterMinutes: 120,
+    },
+  });
+}
+
+/** Build stdin data that mimics a PreToolUse hook invocation. */
+function makePreToolUseInput(
+  mcpToolName: string,
+  action: string,
+): Record<string, unknown> {
+  return {
+    hook_event_name: 'PreToolUse',
+    tool_name: mcpToolName,
+    tool_input: { action },
+  };
+}
+
+describe('guard command', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'guard-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // ─── Allow Cases ────────────────────────────────────────────────────────
+
+  describe('allow decisions', () => {
+    it('should allow workflow "set" action in ideate phase', async () => {
+      // Arrange
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'ideate'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_workflow', 'set');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert — empty object means allow
+      expect(result).toEqual({});
+    });
+
+    it('should allow view "tasks" action in delegate phase', async () => {
+      // Arrange
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'delegate'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_view', 'tasks');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert
+      expect(result).toEqual({});
+    });
+
+    it('should allow orchestrate "task_claim" action in delegate phase', async () => {
+      // Arrange
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'delegate'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_orchestrate', 'task_claim');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert
+      expect(result).toEqual({});
+    });
+  });
+
+  // ─── Deny Cases ─────────────────────────────────────────────────────────
+
+  describe('deny decisions', () => {
+    it('should deny orchestrate "team_spawn" action in ideate phase', async () => {
+      // Arrange
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'ideate'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_orchestrate', 'team_spawn');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert
+      expect(result).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          reason: expect.stringContaining('team_spawn'),
+        },
+      });
+    });
+
+    it('should deny orchestrate "team_spawn" action in review phase', async () => {
+      // Arrange
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'review'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_orchestrate', 'team_spawn');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert
+      expect(result).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          reason: expect.stringContaining('team_spawn'),
+        },
+      });
+    });
+  });
+
+  // ─── Deny Format Verification ──────────────────────────────────────────
+
+  describe('deny output format', () => {
+    it('should return correct PreToolUse deny JSON structure', async () => {
+      // Arrange
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'ideate'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_orchestrate', 'team_spawn');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert — verify exact structure
+      expect(result).toHaveProperty('hookSpecificOutput');
+      const output = (result as { hookSpecificOutput: Record<string, unknown> }).hookSpecificOutput;
+      expect(output).toHaveProperty('hookEventName', 'PreToolUse');
+      expect(output).toHaveProperty('permissionDecision', 'deny');
+      expect(output).toHaveProperty('reason');
+      expect(typeof output.reason).toBe('string');
+      expect(output.reason as string).toMatch(/team_spawn/);
+      expect(output.reason as string).toMatch(/ideate/);
+      expect(output.reason as string).toMatch(/delegate/);
+    });
+  });
+
+  // ─── Graceful Degradation ──────────────────────────────────────────────
+
+  describe('graceful degradation', () => {
+    it('should allow when no active workflow exists', async () => {
+      // Arrange — tmpDir is empty, no state files
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_orchestrate', 'team_spawn');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert — allow when no workflow to guard
+      expect(result).toEqual({});
+    });
+
+    it('should allow when state directory does not exist', async () => {
+      // Arrange — nonexistent directory
+      const nonExistentDir = path.join(tmpDir, 'does-not-exist');
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_orchestrate', 'team_spawn');
+
+      // Act
+      const result = await handleGuard(input, nonExistentDir);
+
+      // Assert
+      expect(result).toEqual({});
+    });
+
+    it('should allow when tool_name is not an exarchos MCP tool', async () => {
+      // Arrange
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'ideate'));
+      const input = {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'some_other_tool',
+        tool_input: { action: 'do_something' },
+      };
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert — not an exarchos tool, allow
+      expect(result).toEqual({});
+    });
+
+    it('should allow when action is not found in registry', async () => {
+      // Arrange
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'ideate'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_workflow', 'nonexistent_action');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert — unknown action, allow (graceful degradation)
+      expect(result).toEqual({});
+    });
+
+    it('should allow when composite tool is not found in registry', async () => {
+      // Arrange
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'ideate'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_unknown', 'some_action');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert — unknown composite tool, allow
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/guard.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/guard.ts
@@ -1,0 +1,153 @@
+import { TOOL_REGISTRY } from '../registry.js';
+import { listStateFiles } from '../workflow/state-store.js';
+import { resolveStateDir } from '../workflow/state-store.js';
+import type { CommandResult } from '../cli.js';
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const MCP_TOOL_PREFIX = 'mcp__exarchos__';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface PreToolUseDenyOutput {
+  readonly hookEventName: 'PreToolUse';
+  readonly permissionDecision: 'deny';
+  readonly reason: string;
+}
+
+// ─── Tool Name Extraction ───────────────────────────────────────────────────
+
+/**
+ * Extract the composite tool name from a full MCP tool name.
+ * e.g. "mcp__exarchos__exarchos_workflow" -> "exarchos_workflow"
+ * Returns null if the tool name doesn't match the exarchos prefix.
+ */
+function extractCompositeToolName(mcpToolName: string): string | null {
+  if (!mcpToolName.startsWith(MCP_TOOL_PREFIX)) {
+    return null;
+  }
+  return mcpToolName.slice(MCP_TOOL_PREFIX.length);
+}
+
+// ─── Registry Lookup ────────────────────────────────────────────────────────
+
+/**
+ * Look up valid phases for a given composite tool name and action name.
+ * Returns the set of valid phases, or null if the tool/action is not found.
+ */
+function lookupActionPhases(
+  compositeToolName: string,
+  actionName: string,
+): ReadonlySet<string> | null {
+  const composite = TOOL_REGISTRY.find((c) => c.name === compositeToolName);
+  if (!composite) return null;
+
+  const action = composite.actions.find((a) => a.name === actionName);
+  if (!action) return null;
+
+  return action.phases;
+}
+
+// ─── Deny Response Builder ──────────────────────────────────────────────────
+
+function buildDenyResult(actionName: string, currentPhase: string, validPhases: ReadonlySet<string>): CommandResult {
+  const validPhaseList = [...validPhases].sort().join(', ');
+  const hookSpecificOutput: PreToolUseDenyOutput = {
+    hookEventName: 'PreToolUse',
+    permissionDecision: 'deny',
+    reason: `Action '${actionName}' is not valid in phase '${currentPhase}'. Valid phases: ${validPhaseList}`,
+  };
+  return { hookSpecificOutput };
+}
+
+// ─── Allow Response ─────────────────────────────────────────────────────────
+
+function buildAllowResult(): CommandResult {
+  return {};
+}
+
+// ─── Active Workflow Phase ──────────────────────────────────────────────────
+
+/**
+ * Find the current phase of the active workflow.
+ * Returns null if no active workflow exists or the directory is missing.
+ */
+async function findActiveWorkflowPhase(stateDir: string): Promise<string | null> {
+  let stateFiles;
+  try {
+    stateFiles = await listStateFiles(stateDir);
+  } catch {
+    // State directory doesn't exist or is unreadable
+    return null;
+  }
+
+  if (stateFiles.length === 0) {
+    return null;
+  }
+
+  // Use the first active (non-completed) workflow, or fall back to the first workflow
+  const activeWorkflow = stateFiles.find((sf) => sf.state.phase !== 'completed') ?? stateFiles[0];
+  return activeWorkflow.state.phase;
+}
+
+// ─── Guard Handler ──────────────────────────────────────────────────────────
+
+/**
+ * Handle the guard CLI command (PreToolUse hook).
+ *
+ * Checks if the tool+action combination is valid for the current workflow phase.
+ * Returns an empty object to allow, or a deny object with reason.
+ *
+ * Graceful degradation: allows the call if no active workflow, unknown tool,
+ * or unknown action is encountered.
+ */
+export async function handleGuard(
+  stdinData: Record<string, unknown>,
+  stateDirOverride?: string,
+): Promise<CommandResult> {
+  // Extract tool name and action from stdin
+  const toolName = stdinData.tool_name;
+  if (typeof toolName !== 'string') {
+    return buildAllowResult();
+  }
+
+  // Extract composite tool name from the MCP prefix
+  const compositeToolName = extractCompositeToolName(toolName);
+  if (compositeToolName === null) {
+    // Not an exarchos MCP tool — allow
+    return buildAllowResult();
+  }
+
+  // Extract action from tool_input
+  const toolInput = stdinData.tool_input;
+  if (typeof toolInput !== 'object' || toolInput === null) {
+    return buildAllowResult();
+  }
+  const actionName = (toolInput as Record<string, unknown>).action;
+  if (typeof actionName !== 'string') {
+    return buildAllowResult();
+  }
+
+  // Look up valid phases for this tool+action
+  const validPhases = lookupActionPhases(compositeToolName, actionName);
+  if (validPhases === null) {
+    // Unknown tool or action — allow (graceful degradation)
+    return buildAllowResult();
+  }
+
+  // Find the current workflow phase
+  const stateDir = stateDirOverride ?? resolveStateDir();
+  const currentPhase = await findActiveWorkflowPhase(stateDir);
+  if (currentPhase === null) {
+    // No active workflow — allow
+    return buildAllowResult();
+  }
+
+  // Check if current phase is in the valid phases for this action
+  if (validPhases.has(currentPhase)) {
+    return buildAllowResult();
+  }
+
+  // Deny — current phase is not valid for this action
+  return buildDenyResult(actionName, currentPhase, validPhases);
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli.test.ts
@@ -136,12 +136,12 @@ describe('CLI Framework', () => {
     });
 
     it('should route guard command to handler', async () => {
-      // Act
+      // Act — empty stdin data means no tool_name, so guard allows
       const result = await routeCommand('guard', {});
 
-      // Assert
+      // Assert — guard returns empty object (allow) for missing tool_name
       expect(result).toBeDefined();
-      expect(result).toHaveProperty('error');
+      expect(result).toEqual({});
     });
 
     it('should route task-gate command to handler', async () => {
@@ -185,13 +185,13 @@ describe('CLI Framework', () => {
     });
 
     it('should pass stdin data to command handlers', async () => {
-      // Arrange
+      // Arrange — tool_name without mcp__exarchos__ prefix, so guard allows
       const stdinData = { tool_name: 'exarchos_workflow', tool_input: { action: 'init' } };
 
       // Act
       const result = await routeCommand('guard', stdinData);
 
-      // Assert — stub returns not-implemented but should not crash
+      // Assert — guard allows (not an exarchos MCP tool name)
       expect(result).toBeDefined();
     });
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
@@ -7,6 +7,7 @@
 
 import { handlePreCompact } from './cli-commands/pre-compact.js';
 import { handleSessionStart } from './cli-commands/session-start.js';
+import { handleGuard } from './cli-commands/guard.js';
 import { resolveStateDir } from './workflow/state-store.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -48,10 +49,12 @@ function createStubHandler(command: string): CommandHandler {
   });
 }
 
+// ─── Command Handler Registry ───────────────────────────────────────────────
+
 const commandHandlers: Record<KnownCommand, CommandHandler> = {
   'pre-compact': async (stdinData) => handlePreCompact(stdinData, resolveStateDir()),
   'session-start': async (stdinData) => handleSessionStart(stdinData, resolveStateDir()),
-  'guard': createStubHandler('guard'),
+  'guard': handleGuard,
   'task-gate': createStubHandler('task-gate'),
   'teammate-gate': createStubHandler('teammate-gate'),
   'subagent-context': createStubHandler('subagent-context'),


### PR DESCRIPTION
Implements the `guard` CLI command that enforces workflow phase
constraints as a PreToolUse hook. When an Exarchos MCP tool is invoked,
the guard extracts the composite tool name and action, looks up valid
phases from TOOL_REGISTRY, and checks against the active workflow's
current phase. Returns allow (empty object) or deny with reason.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>