### PR TITLE
feat: add quality gate CLI commands for task and teammate hooks

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ExecSyncOptions } from 'node:child_process';
+
+// Mock child_process before importing the module under test
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from 'node:child_process';
+import { handleTaskGate, handleTeammateGate, runQualityChecks } from './gates.js';
+import type { CommandResult } from '../cli.js';
+
+const mockExecSync = vi.mocked(execSync);
+
+describe('Quality Gate Commands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('handleTaskGate', () => {
+    it('should parse TaskCompleted input with task_subject correctly', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(Buffer.from(''));
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'Implement user auth',
+        task_output: 'All tests pass',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTaskGate(input);
+
+      // Assert — should not error on valid input
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should return continue true when all checks pass', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(Buffer.from(''));
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'Add feature X',
+        task_output: 'Done',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTaskGate(input);
+
+      // Assert
+      expect(result).toEqual({ continue: true });
+    });
+
+    it('should return GATE_FAILED error when typecheck fails', async () => {
+      // Arrange
+      const typecheckError = new Error('Type checking failed');
+      (typecheckError as NodeJS.ErrnoException).status = 1;
+      (typecheckError as unknown as { stdout: Buffer }).stdout = Buffer.from('');
+      (typecheckError as unknown as { stderr: Buffer }).stderr = Buffer.from(
+        "src/foo.ts(5,3): error TS2322: Type 'string' is not assignable to type 'number'.",
+      );
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('typecheck')) {
+          throw typecheckError;
+        }
+        return Buffer.from('');
+      });
+
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'Add feature X',
+        task_output: 'Done',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTaskGate(input);
+
+      // Assert
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('GATE_FAILED');
+      expect(result.error!.message).toContain('typecheck');
+    });
+
+    it('should return GATE_FAILED error when tests fail', async () => {
+      // Arrange
+      const testError = new Error('Tests failed');
+      (testError as NodeJS.ErrnoException).status = 1;
+      (testError as unknown as { stdout: Buffer }).stdout = Buffer.from('FAIL src/foo.test.ts');
+      (testError as unknown as { stderr: Buffer }).stderr = Buffer.from('');
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('test:run')) {
+          throw testError;
+        }
+        return Buffer.from('');
+      });
+
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'Add feature X',
+        task_output: 'Done',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTaskGate(input);
+
+      // Assert
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('GATE_FAILED');
+      expect(result.error!.message).toContain('test');
+    });
+
+    it('should return GATE_FAILED error when worktree has uncommitted changes', async () => {
+      // Arrange
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('git status')) {
+          return Buffer.from(' M src/foo.ts\n?? src/bar.ts\n');
+        }
+        return Buffer.from('');
+      });
+
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'Add feature X',
+        task_output: 'Done',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTaskGate(input);
+
+      // Assert
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('GATE_FAILED');
+      expect(result.error!.message).toContain('uncommitted');
+    });
+
+    it('should return INVALID_INPUT error when cwd is missing', async () => {
+      // Arrange
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'Add feature X',
+        task_output: 'Done',
+      };
+
+      // Act
+      const result = await handleTaskGate(input);
+
+      // Assert
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('INVALID_INPUT');
+    });
+
+    it('should run checks in the cwd from stdin', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(Buffer.from(''));
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TaskCompleted',
+        task_subject: 'task',
+        task_output: 'output',
+        cwd: '/my/specific/worktree',
+      };
+
+      // Act
+      await handleTaskGate(input);
+
+      // Assert — verify execSync was called with the correct cwd
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringContaining('typecheck'),
+        expect.objectContaining({ cwd: '/my/specific/worktree' }),
+      );
+    });
+  });
+
+  describe('handleTeammateGate', () => {
+    it('should parse TeammateIdle input with teammate_name correctly', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(Buffer.from(''));
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTeammateGate(input);
+
+      // Assert — should not error on valid input
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should return continue true when all checks pass', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(Buffer.from(''));
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+        cwd: '/tmp/worktree',
+      };
+
+      // Act
+      const result = await handleTeammateGate(input);
+
+      // Assert
+      expect(result).toEqual({ continue: true });
+    });
+
+    it('should return INVALID_INPUT error when cwd is missing', async () => {
+      // Arrange
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+      };
+
+      // Act
+      const result = await handleTeammateGate(input);
+
+      // Assert
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('INVALID_INPUT');
+    });
+  });
+
+  describe('runQualityChecks', () => {
+    it('should run typecheck, tests, and git status in order', async () => {
+      // Arrange
+      const callOrder: string[] = [];
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string') {
+          if (cmd.includes('typecheck')) callOrder.push('typecheck');
+          else if (cmd.includes('test:run')) callOrder.push('test');
+          else if (cmd.includes('git status')) callOrder.push('git-status');
+        }
+        return Buffer.from('');
+      });
+
+      // Act
+      const result = await runQualityChecks('/tmp/worktree');
+
+      // Assert
+      expect(callOrder).toEqual(['typecheck', 'test', 'git-status']);
+      expect(result).toEqual({ continue: true });
+    });
+
+    it('should stop at first failure and not run subsequent checks', async () => {
+      // Arrange
+      const callOrder: string[] = [];
+      const typecheckError = new Error('fail');
+      (typecheckError as NodeJS.ErrnoException).status = 1;
+      (typecheckError as unknown as { stderr: Buffer }).stderr = Buffer.from('type error');
+      (typecheckError as unknown as { stdout: Buffer }).stdout = Buffer.from('');
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string') {
+          if (cmd.includes('typecheck')) {
+            callOrder.push('typecheck');
+            throw typecheckError;
+          }
+          if (cmd.includes('test:run')) callOrder.push('test');
+          if (cmd.includes('git status')) callOrder.push('git-status');
+        }
+        return Buffer.from('');
+      });
+
+      // Act
+      const result = await runQualityChecks('/tmp/worktree');
+
+      // Assert
+      expect(callOrder).toEqual(['typecheck']);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should use appropriate timeouts for each check', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(Buffer.from(''));
+
+      // Act
+      await runQualityChecks('/tmp/worktree');
+
+      // Assert — verify typecheck has 30s timeout
+      const typecheckCall = mockExecSync.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('typecheck'),
+      );
+      expect(typecheckCall).toBeDefined();
+      expect((typecheckCall![1] as ExecSyncOptions)?.timeout).toBe(30_000);
+
+      // Assert — verify test has 120s timeout
+      const testCall = mockExecSync.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('test:run'),
+      );
+      expect(testCall).toBeDefined();
+      expect((testCall![1] as ExecSyncOptions)?.timeout).toBe(120_000);
+    });
+
+    it('should handle command timeout as a failure', async () => {
+      // Arrange
+      const timeoutError = new Error('Command timed out');
+      (timeoutError as NodeJS.ErrnoException).code = 'ETIMEDOUT';
+      (timeoutError as unknown as { killed: boolean }).killed = true;
+      (timeoutError as unknown as { stderr: Buffer }).stderr = Buffer.from('');
+      (timeoutError as unknown as { stdout: Buffer }).stdout = Buffer.from('');
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('test:run')) {
+          throw timeoutError;
+        }
+        return Buffer.from('');
+      });
+
+      // Act
+      const result = await runQualityChecks('/tmp/worktree');
+
+      // Assert
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('GATE_FAILED');
+      expect(result.error!.message).toContain('test');
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.ts
@@ -1,0 +1,172 @@
+// ─── Quality Gate CLI Commands ──────────────────────────────────────────────
+//
+// Gates run at task/teammate lifecycle boundaries to enforce quality standards.
+// They execute configurable checks in the task's working directory.
+//
+// Exit semantics (managed by the CLI framework, not this module):
+//   - continue: true  → exit 0 (gate passed, allow continuation)
+//   - error returned   → exit 2 (gate blocked, feedback on stderr)
+
+import { execSync } from 'node:child_process';
+import type { CommandResult } from '../cli.js';
+
+// ─── Check Definitions ─────────────────────────────────────────────────────
+
+interface QualityCheck {
+  readonly name: string;
+  readonly command: string;
+  readonly timeoutMs: number;
+  readonly failureLabel: string;
+}
+
+const QUALITY_CHECKS: readonly QualityCheck[] = [
+  {
+    name: 'typecheck',
+    command: 'npm run typecheck',
+    timeoutMs: 30_000,
+    failureLabel: 'typecheck failed',
+  },
+  {
+    name: 'test',
+    command: 'npm run test:run',
+    timeoutMs: 120_000,
+    failureLabel: 'tests failed',
+  },
+  {
+    name: 'clean-worktree',
+    command: 'git status --porcelain',
+    timeoutMs: 10_000,
+    failureLabel: 'uncommitted changes detected',
+  },
+];
+
+// ─── Core Quality Check Runner ─────────────────────────────────────────────
+
+/**
+ * Run all quality checks sequentially in the given working directory.
+ * Stops at the first failure and returns a GATE_FAILED error.
+ * Returns `{ continue: true }` when all checks pass.
+ */
+export async function runQualityChecks(cwd: string): Promise<CommandResult> {
+  for (const check of QUALITY_CHECKS) {
+    try {
+      const output = execSync(check.command, {
+        cwd,
+        timeout: check.timeoutMs,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        encoding: 'buffer',
+      });
+
+      // Special case: git status --porcelain returns empty when clean
+      if (check.name === 'clean-worktree') {
+        const statusOutput = output.toString('utf-8').trim();
+        if (statusOutput.length > 0) {
+          return {
+            error: {
+              code: 'GATE_FAILED',
+              message: `${check.failureLabel}:\n${statusOutput}`,
+            },
+          };
+        }
+      }
+    } catch (err: unknown) {
+      const stderr = extractStderr(err);
+      const stdout = extractStdout(err);
+      const detail = stderr || stdout || (err instanceof Error ? err.message : String(err));
+
+      return {
+        error: {
+          code: 'GATE_FAILED',
+          message: `${check.failureLabel}:\n${detail}`,
+        },
+      };
+    }
+  }
+
+  return { continue: true };
+}
+
+// ─── Input Validation ──────────────────────────────────────────────────────
+
+function validateCwd(input: Record<string, unknown>): CommandResult | null {
+  if (typeof input.cwd !== 'string' || input.cwd.length === 0) {
+    return {
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'Missing required field: cwd',
+      },
+    };
+  }
+  return null;
+}
+
+// ─── Gate Handlers ─────────────────────────────────────────────────────────
+
+/**
+ * Task gate handler for TaskCompleted hook events.
+ *
+ * Expected stdin shape:
+ * ```json
+ * {
+ *   "hook_event_name": "TaskCompleted",
+ *   "task_subject": "...",
+ *   "task_output": "...",
+ *   "cwd": "/path/to/worktree"
+ * }
+ * ```
+ */
+export async function handleTaskGate(
+  input: Record<string, unknown>,
+): Promise<CommandResult> {
+  const validationError = validateCwd(input);
+  if (validationError) return validationError;
+
+  return runQualityChecks(input.cwd as string);
+}
+
+/**
+ * Teammate gate handler for TeammateIdle hook events.
+ *
+ * Expected stdin shape:
+ * ```json
+ * {
+ *   "hook_event_name": "TeammateIdle",
+ *   "teammate_name": "...",
+ *   "cwd": "/path/to/worktree"
+ * }
+ * ```
+ */
+export async function handleTeammateGate(
+  input: Record<string, unknown>,
+): Promise<CommandResult> {
+  const validationError = validateCwd(input);
+  if (validationError) return validationError;
+
+  return runQualityChecks(input.cwd as string);
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function extractStderr(err: unknown): string {
+  if (
+    err !== null &&
+    typeof err === 'object' &&
+    'stderr' in err &&
+    Buffer.isBuffer((err as { stderr: unknown }).stderr)
+  ) {
+    return ((err as { stderr: Buffer }).stderr).toString('utf-8').trim();
+  }
+  return '';
+}
+
+function extractStdout(err: unknown): string {
+  if (
+    err !== null &&
+    typeof err === 'object' &&
+    'stdout' in err &&
+    Buffer.isBuffer((err as { stdout: unknown }).stdout)
+  ) {
+    return ((err as { stdout: Buffer }).stdout).toString('utf-8').trim();
+  }
+  return '';
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
@@ -8,6 +8,7 @@
 import { handlePreCompact } from './cli-commands/pre-compact.js';
 import { handleSessionStart } from './cli-commands/session-start.js';
 import { handleGuard } from './cli-commands/guard.js';
+import { handleTaskGate, handleTeammateGate } from './cli-commands/gates.js';
 import { resolveStateDir } from './workflow/state-store.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -55,8 +56,8 @@ const commandHandlers: Record<KnownCommand, CommandHandler> = {
   'pre-compact': async (stdinData) => handlePreCompact(stdinData, resolveStateDir()),
   'session-start': async (stdinData) => handleSessionStart(stdinData, resolveStateDir()),
   'guard': handleGuard,
-  'task-gate': createStubHandler('task-gate'),
-  'teammate-gate': createStubHandler('teammate-gate'),
+  'task-gate': handleTaskGate,
+  'teammate-gate': handleTeammateGate,
   'subagent-context': createStubHandler('subagent-context'),
 };
 
@@ -138,7 +139,9 @@ async function main(): Promise<void> {
   outputJson(result);
 
   if (result.error) {
-    process.exitCode = 1;
+    // Gate commands use exit code 2 to signal "blocked" to the hook runner
+    const isGateCommand = command === 'task-gate' || command === 'teammate-gate';
+    process.exitCode = isGateCommand && result.error.code === 'GATE_FAILED' ? 2 : 1;
   }
 }
 


### PR DESCRIPTION
Implement task-gate and teammate-gate handlers that run configurable
quality checks (typecheck, tests, clean worktree) in the task's working
directory. Gates return continue:true on pass or GATE_FAILED error on
failure, with exit code 2 for blocked gates.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>