### PR TITLE
feat: add hooks.json with 6 Claude Code hook definitions

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -1,12 +1,75 @@
 {
+  "description": "Exarchos progressive disclosure and lifecycle hooks",
   "hooks": {
-    "PreToolUse": [
+    "PreCompact": [
       {
-        "matcher": "Bash",
+        "matcher": "auto",
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/scripts/validate-rm.sh"
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/servers/exarchos-mcp/dist/cli.js\" pre-compact",
+            "timeout": 30,
+            "statusMessage": "Saving workflow checkpoint..."
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/servers/exarchos-mcp/dist/cli.js\" session-start",
+            "timeout": 10,
+            "statusMessage": "Checking for active workflows..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "mcp__exarchos__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/servers/exarchos-mcp/dist/cli.js\" guard",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/servers/exarchos-mcp/dist/cli.js\" task-gate",
+            "timeout": 120,
+            "statusMessage": "Running quality gates..."
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/servers/exarchos-mcp/dist/cli.js\" teammate-gate",
+            "timeout": 120,
+            "statusMessage": "Verifying teammate work..."
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/servers/exarchos-mcp/dist/cli.js\" subagent-context",
+            "timeout": 5
           }
         ]
       }

--- a/manifest.json
+++ b/manifest.json
@@ -64,7 +64,6 @@
           "orchestrator-constraints.md",
           "pr-descriptions.md",
           "primary-workflows.md",
-          "workflow-auto-resume.md",
           "mcp-tool-guidance.md",
           "skill-path-resolution.md",
           "rm-safety.md"

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -1067,3 +1067,48 @@ describe('printHelp', () => {
     expect(typeof mod.printHelp).toBe('function');
   });
 });
+
+describe('hooks.json', () => {
+  const hooksPath = join(repoRoot, 'hooks.json');
+
+  it('hooksJson_IsValidJson', () => {
+    expect(existsSync(hooksPath)).toBe(true);
+    const content = readFileSync(hooksPath, 'utf-8');
+    expect(() => JSON.parse(content)).not.toThrow();
+  });
+
+  it('hooksJson_HasSixHookEvents', () => {
+    const hooks = JSON.parse(readFileSync(hooksPath, 'utf-8'));
+    const eventTypes = Object.keys(hooks.hooks);
+    expect(eventTypes).toContain('PreCompact');
+    expect(eventTypes).toContain('SessionStart');
+    expect(eventTypes).toContain('PreToolUse');
+    expect(eventTypes).toContain('TaskCompleted');
+    expect(eventTypes).toContain('TeammateIdle');
+    expect(eventTypes).toContain('SubagentStart');
+    expect(eventTypes).toHaveLength(6);
+  });
+
+  it('hooksJson_AllCommandsReferenceCliJs', () => {
+    const hooks = JSON.parse(readFileSync(hooksPath, 'utf-8'));
+    for (const [eventType, entries] of Object.entries(hooks.hooks)) {
+      for (const entry of entries as Array<{ hooks: Array<{ command: string }> }>) {
+        for (const hook of entry.hooks) {
+          expect(hook.command, `${eventType} hook command should reference cli.js`).toContain('cli.js');
+        }
+      }
+    }
+  });
+});
+
+describe('manifest.json workflow ruleset', () => {
+  it('manifest_WorkflowRuleSet_ExcludesAutoResume', () => {
+    const manifestPath = join(repoRoot, 'manifest.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    const workflowRuleSet = manifest.components.ruleSets.find(
+      (rs: { id: string }) => rs.id === 'workflow',
+    );
+    expect(workflowRuleSet).toBeDefined();
+    expect(workflowRuleSet.files).not.toContain('workflow-auto-resume.md');
+  });
+});


### PR DESCRIPTION
Replace the single PreToolUse/Bash hook with all 6 lifecycle hooks
(PreCompact, SessionStart, PreToolUse, TaskCompleted, TeammateIdle,
SubagentStart) that wire CLI commands to Claude Code events. Remove
workflow-auto-resume.md from manifest workflow ruleset since the
SessionStart hook replaces it.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>