### PR TITLE
feat: migrate prompt files to composite tool names

### DIFF
--- a/commands/checkpoint.md
+++ b/commands/checkpoint.md
@@ -22,9 +22,7 @@ Use `/checkpoint` when:
 
 ### Step 1: Identify Active Workflow
 
-Find the current state file using `mcp__exarchos__exarchos_workflow_list` (no parameters required).
-
-Or if you know the feature, check the state directory:
+The SessionStart hook automatically discovers active workflows on session start. If you need to locate the state file manually, check the state directory:
 
 ```bash
 ls docs/workflow-state/*.state.json
@@ -40,8 +38,7 @@ Update state file with latest progress:
 
 ### Step 3: Reconcile State
 
-Verify state matches reality using `mcp__exarchos__exarchos_workflow_reconcile`:
-- Set `featureId` to the feature identifier
+The SessionStart hook automatically verifies state matches git reality on resume. If manual reconciliation is needed, review state file contents against actual worktree and branch state.
 
 Fix any discrepancies.
 

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -65,11 +65,11 @@ Switch from hotfix to thorough track during investigation.
 
 ### Step 1: Initialize State
 
-Initialize workflow state using `mcp__exarchos__exarchos_workflow_init`:
+Initialize workflow state using `mcp__exarchos__exarchos_workflow` with `action: "init"`:
 - Set `featureId` to `debug-<issue-slug>`
 - Set `workflowType` to "debug"
 
-Then update the track using `mcp__exarchos__exarchos_workflow_set`:
+Then update the track using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 - Set `track` to "hotfix" or "thorough" based on triage
 
 ### Step 2: Triage

--- a/commands/ideate.md
+++ b/commands/ideate.md
@@ -52,9 +52,9 @@ After user selects approach:
 
 ## State Management
 
-Initialize workflow state at the start using `mcp__exarchos__exarchos_workflow_init` with the featureId.
+Initialize workflow state at the start using `mcp__exarchos__exarchos_workflow` with `action: "init"` and the featureId.
 
-After saving design, update state using `mcp__exarchos__exarchos_workflow_set`:
+After saving design, update state using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 - Set `artifacts.design` to the design path
 - Set `phase` to "plan"
 
@@ -66,7 +66,7 @@ Save design to `docs/designs/YYYY-MM-DD-<feature>.md` and capture the path as `$
 
 After saving the design document, **auto-continue to planning** (no user confirmation here):
 
-1. Update state with design path and phase using `mcp__exarchos__exarchos_workflow_set`:
+1. Update state with design path and phase using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
    - Set `artifacts.design` to the design document path
    - Set `phase` to "plan"
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -71,7 +71,7 @@ Write to `docs/plans/YYYY-MM-DD-<feature>.md`
 
 ## State Management
 
-After saving plan, update state with tasks using `mcp__exarchos__exarchos_workflow_set`:
+After saving plan, update state with tasks using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 - Set `artifacts.plan` to the plan path
 - Set `tasks` to an array of task objects (id, title, status, branch)
 - Set `phase` to "plan-review"
@@ -117,7 +117,7 @@ Plan-review performs delta analysis and **auto-loops** back to `/plan` if gaps a
 
 If plan-review finds missing coverage:
 
-1. Update state with gaps using `mcp__exarchos__exarchos_workflow_set`:
+1. Update state with gaps using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
    - Set `planReview.gapsFound` to true
    - Set `planReview.gaps` to an array of gap descriptions
 
@@ -138,7 +138,7 @@ If plan-review finds complete coverage:
 
 2. **PAUSE for user input**: "Plan covers all design requirements. Approve and continue to delegation? (yes/no)"
 
-3. **On approval**, use `mcp__exarchos__exarchos_workflow_set`:
+3. **On approval**, use `mcp__exarchos__exarchos_workflow` with `action: "set"`:
    - Set `planReview.approved` to true
    - Set `phase` to "delegate"
 

--- a/commands/refactor.md
+++ b/commands/refactor.md
@@ -63,7 +63,7 @@ Switch from polish to overhaul if scope expands.
 
 ### Step 1: Initialize State
 
-Initialize workflow state using `mcp__exarchos__exarchos_workflow_init` with featureId `refactor-<slug>` and workflowType `refactor`.
+Initialize workflow state using `mcp__exarchos__exarchos_workflow` with `action: "init"`, featureId `refactor-<slug>`, and workflowType `refactor`.
 
 ### Step 2: Explore
 

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -21,19 +21,19 @@ Restore workflow context after:
 
 ### Step 1: Locate State File
 
-If no argument provided, list available workflows using `mcp__exarchos__exarchos_workflow_list` (no parameters required).
+If no argument provided, the SessionStart hook automatically discovers active workflows on session start. To manually locate state files, check the state directory:
+
+```bash
+ls docs/workflow-state/*.state.json
+```
 
 ### Step 2: Reconcile State
 
-Verify state matches git reality using `mcp__exarchos__exarchos_workflow_reconcile`:
-- Set `featureId` to the feature identifier
-
-Report any discrepancies (missing worktrees, branches).
+The SessionStart hook automatically verifies state matches git reality on resume. Review reported discrepancies (missing worktrees, branches).
 
 ### Step 3: Load Context Summary
 
-Generate minimal context restoration prompt using `mcp__exarchos__exarchos_workflow_summary`:
-- Set `featureId` to the feature identifier
+The SessionStart hook provides workflow context automatically. Read the state file using `mcp__exarchos__exarchos_workflow` with `action: "get"` and the featureId for detailed state.
 
 ### Step 4: Display Context
 
@@ -109,7 +109,7 @@ The resume process is designed to be context-efficient:
 ERROR: State file not found: <path>
 
 Available workflows:
-  <list from mcp__exarchos__exarchos_workflow_list>
+  <list from workflow state directory>
 ```
 
 ### Reconciliation Issues

--- a/commands/synthesize.md
+++ b/commands/synthesize.md
@@ -90,7 +90,7 @@ After PR is created, this is a **human checkpoint** - user confirmation required
 
 ### Save State
 
-Update state using `mcp__exarchos__exarchos_workflow_set` with the `featureId`:
+Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` and the `featureId`:
 - Set `artifacts.pr` to the PR URL
 - Set `synthesis.prUrl` to the PR URL
 

--- a/rules/mcp-tool-guidance.md
+++ b/rules/mcp-tool-guidance.md
@@ -6,61 +6,60 @@ Proactively use the installed MCP servers. Don't fall back to generic approaches
 
 ### Exarchos (`mcp__exarchos__*`)
 
-Unified MCP server for workflow orchestration, event sourcing, CQRS views, and team coordination. **Always use for workflow tracking.** Exposes 26 tools across 6 modules.
+Unified MCP server for workflow orchestration, event sourcing, CQRS views, and team coordination. **Always use for workflow tracking.** Exposes 5 composite tools with action discriminators.
 
-#### Workflow Tools
+#### Composite Tools
 
-| Tool | When to Use |
-|------|-------------|
-| `workflow_init` | Starting any `/ideate`, `/debug`, or `/refactor` workflow |
-| `workflow_get` | Restoring context, checking phase, reading task details. Use `query` for dot-path lookup (e.g., `query: "phase"`), or `fields` array for projection (e.g., `fields: ["phase", "tasks"]`) to reduce token cost |
-| `workflow_set` | Updating phase (`phase: "delegate"`), recording artifacts, marking tasks complete. Use `updates` for field changes and `phase` for transitions |
-| `workflow_summary` | Quick context restoration after session restart |
-| `workflow_next_action` | Determining what to auto-continue after phase completion |
-| `workflow_reconcile` | Verifying state matches git reality on resume. Verification only — reports discrepancies but does not auto-fix |
-| `workflow_checkpoint` | Saving progress before likely context exhaustion |
-| `workflow_cancel` | Cleaning up abandoned workflows. Supports `dryRun: true` to preview cleanup actions |
-| `workflow_transitions` | Checking valid phase transitions for a `workflowType`. Use `fromPhase` to filter |
-| `workflow_list` | Finding active workflows at session start |
+| Tool | Actions | When to Use |
+|------|---------|-------------|
+| `exarchos_workflow` | `init`, `get`, `set`, `cancel` | Workflow CRUD: starting workflows, reading/updating state, cancelling abandoned workflows |
+| `exarchos_event` | `append`, `query` | Event sourcing: recording workflow events, reading event history |
+| `exarchos_orchestrate` | `team_spawn`, `team_message`, `team_broadcast`, `team_shutdown`, `team_status`, `task_claim`, `task_complete`, `task_fail` | Team coordination and task lifecycle |
+| `exarchos_view` | `pipeline`, `tasks`, `workflow_status`, `team_status`, `stack_status`, `stack_place` | CQRS materialized views for read-optimized queries |
+| `exarchos_sync` | `now` | Force sync of materialized views |
 
-#### Event Store Tools
+#### Workflow Tool Actions
 
-| Tool | When to Use |
-|------|-------------|
-| `event_append` | Recording workflow events (task.assigned, team.formed, gate.executed, etc.). Use `expectedSequence` for optimistic concurrency |
-| `event_query` | Reading event history. Use `filter` for type/time filtering, `limit`/`offset` for pagination |
+| Action | When to Use |
+|--------|-------------|
+| `init` | Starting any `/ideate`, `/debug`, or `/refactor` workflow |
+| `get` | Restoring context, checking phase, reading task details. Use `query` for dot-path lookup (e.g., `query: "phase"`), or `fields` array for projection (e.g., `fields: ["phase", "tasks"]`) to reduce token cost |
+| `set` | Updating phase (`phase: "delegate"`), recording artifacts, marking tasks complete. Use `updates` for field changes and `phase` for transitions |
+| `cancel` | Cleaning up abandoned workflows. Supports `dryRun: true` to preview cleanup actions |
 
-#### View Tools (CQRS)
+**Hooks (automatic, no tool call needed):**
+- **SessionStart hook** — Discovers active workflows, restores context, determines next action, and verifies state on resume (replaces former `workflow_list`, `workflow_summary`, `workflow_next_action`, `workflow_reconcile` tools)
+- **PreCompact hook** — Saves checkpoints before context exhaustion (replaces former `workflow_checkpoint` tool)
+- Valid phase transitions are documented statically (replaces former `workflow_transitions` tool)
 
-| Tool | When to Use |
-|------|-------------|
-| `view_pipeline` | Aggregated view of all workflows with stack positions. Use `limit`/`offset` for pagination |
-| `view_tasks` | Task detail view with filtering and projection. Use `workflowId` to scope, `filter` for property matching, `fields` for projection (e.g., `fields: ["taskId", "status", "title"]`), `limit`/`offset` for pagination |
-| `view_workflow_status` | Workflow phase, task counts, and metadata. Use `workflowId` to scope |
-| `view_team_status` | Teammate composition and task assignments. Use `workflowId` to scope |
+#### Event Tool Actions
 
-#### Team Tools
+| Action | When to Use |
+|--------|-------------|
+| `append` | Recording workflow events (task.assigned, team.formed, gate.executed, etc.). Use `expectedSequence` for optimistic concurrency |
+| `query` | Reading event history. Use `filter` for type/time filtering, `limit`/`offset` for pagination |
 
-| Tool | When to Use |
-|------|-------------|
+#### Orchestrate Tool Actions
+
+| Action | When to Use |
+|--------|-------------|
 | `team_spawn` | Register a new agent with role assignment. Always pair with Task tool for subprocess |
 | `team_message` | Send a direct message to a specific teammate |
 | `team_broadcast` | Broadcast a message to all active teammates |
 | `team_shutdown` | Shut down a teammate agent. Emits shutdown event |
 | `team_status` | Get health status of all teammates. Use `summary: true` for counts-only response during orchestration |
-
-#### Task Tools
-
-| Tool | When to Use |
-|------|-------------|
 | `task_claim` | Claim a task for execution. Returns `ALREADY_CLAIMED` if previously claimed — handle gracefully |
 | `task_complete` | Mark a task complete with optional `result` (artifacts, duration) |
 | `task_fail` | Mark a task failed with `error` message and optional `diagnostics` |
 
-#### Stack Tools
+#### View Tool Actions
 
-| Tool | When to Use |
-|------|-------------|
+| Action | When to Use |
+|--------|-------------|
+| `pipeline` | Aggregated view of all workflows with stack positions. Use `limit`/`offset` for pagination |
+| `tasks` | Task detail view with filtering and projection. Use `workflowId` to scope, `filter` for property matching, `fields` for projection (e.g., `fields: ["taskId", "status", "title"]`), `limit`/`offset` for pagination |
+| `workflow_status` | Workflow phase, task counts, and metadata. Use `workflowId` to scope |
+| `team_status` | Teammate composition and task assignments. Use `workflowId` to scope |
 | `stack_status` | Get current stack positions from events. Use `streamId` to scope |
 | `stack_place` | Record a stack position with `position`, `taskId`, `branch`, optional `prUrl` |
 
@@ -185,7 +184,7 @@ When deciding which tool to use:
 | Use `gh issue view` or `gh issue list` | Use GitHub `issue_read` or `list_issues` / `search_issues` |
 | Use `gh pr view --json` for structured data | Use GitHub MCP tools which return structured data natively |
 | Guess library APIs from memory | Use Context7 `query-docs` |
-| Manually edit workflow state JSON | Use `workflow_set` MCP tool |
+| Manually edit workflow state JSON | Use `exarchos_workflow` with `action: "set"` |
 | Web search for .NET API reference | Use Microsoft Learn `search` |
 | Read entire files to find a function | Use Serena `get_symbols_overview` then `find_symbol` with `include_body` |
 | Use `git commit` or `git push` | Use `gt create` + `gt submit --no-interactive --publish --merge-when-ready` |
@@ -194,4 +193,4 @@ When deciding which tool to use:
 | Read entire files to understand structure | Use Serena `get_symbols_overview` then `find_symbol` with `include_body` |
 | Generate diffs with shell commands | Use GitHub `pull_request_read` or Graphite `gt diff` |
 | Manually parse PR comments | Use GitHub `pull_request_read` for structured review data |
-| Skip state reconciliation on resume | Always call `workflow_reconcile` before resuming |
+| Skip state reconciliation on resume | The SessionStart hook handles reconciliation automatically |

--- a/rules/orchestrator-constraints.md
+++ b/rules/orchestrator-constraints.md
@@ -42,7 +42,7 @@ If any trigger fires, stop and run:
 ```
 
 **Verification:**
-Before starting implementation, verify using `mcp__exarchos__exarchos_workflow_get`:
+Before starting implementation, verify using `mcp__exarchos__exarchos_workflow` with `action: "get"`:
 1. Track is "polish" in state file (query: `.track`)
 2. Phase is "implement" (query: `.phase`)
 3. Brief goals are captured

--- a/rules/workflow-auto-resume.md
+++ b/rules/workflow-auto-resume.md
@@ -8,7 +8,7 @@ This rule ensures autonomous workflow continuation after context compaction.
 
 ## Session Start Detection
 
-At the START of every session, BEFORE responding to any user request, silently check for active workflows using `mcp__exarchos__exarchos_workflow_list`.
+At the START of every session, the **SessionStart hook** automatically detects active workflows, restores context, determines the next action, and verifies state matches git reality. This replaces the former manual tool calls (`workflow_list`, `workflow_summary`, `workflow_next_action`, `workflow_reconcile`).
 
 If an active (non-completed) workflow exists, auto-restore and continue.
 
@@ -16,19 +16,20 @@ If an active (non-completed) workflow exists, auto-restore and continue.
 
 ### Step 1: Detect Active Workflow
 
-Use `mcp__exarchos__exarchos_workflow_list` to find state files with phase != "completed".
+The SessionStart hook discovers active workflow state files with phase != "completed".
 
 ### Step 2: Restore Context
 
-If active workflow found, use:
-- `mcp__exarchos__exarchos_workflow_summary` with the featureId
-- `mcp__exarchos__exarchos_workflow_next_action` with the featureId
+If active workflow found, the SessionStart hook:
+- Provides workflow context (phase, tasks, artifacts)
+- Determines the next action to take
+- Verifies state matches git reality (worktrees, branches)
 
-Display a brief context restoration message.
+A brief context restoration message is displayed.
 
 ### Step 3: Determine Next Action
 
-The `mcp__exarchos__exarchos_workflow_next_action` tool returns one of:
+The SessionStart hook returns one of:
 
 #### Feature Workflow Actions
 

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -111,13 +111,13 @@ This skill manages workflow state for context persistence.
 
 ### On Start (before Phase 1)
 
-Initialize workflow state using `mcp__exarchos__exarchos_workflow_init` with the featureId.
+Initialize workflow state using `mcp__exarchos__exarchos_workflow` with `action: "init"` and the featureId.
 
 This creates a state file tracked by the MCP server.
 
 ### On Design Save (after Phase 3)
 
-Update state with design artifact using `mcp__exarchos__exarchos_workflow_set`:
+Update state with design artifact using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 - Set `artifacts.design` to the design path
 - Set `phase` to "plan"
 
@@ -134,7 +134,7 @@ Update state with design artifact using `mcp__exarchos__exarchos_workflow_set`:
 
 After brainstorming completes, **auto-continue to planning** (no user confirmation):
 
-1. Update state with design path and phase using `mcp__exarchos__exarchos_workflow_set`:
+1. Update state with design path and phase using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
    - Set `artifacts.design` to the design path
    - Set `phase` to "plan"
 
@@ -153,4 +153,4 @@ This is NOT a human checkpoint. The human checkpoint occurs at plan-review (plan
 
 When Exarchos MCP tools are available:
 
-1. **At workflow start:** Call `exarchos_event_append` with event type `workflow.started` including featureId and workflowType
+1. **At workflow start:** Call `mcp__exarchos__exarchos_event` with `action: "append"` and event type `workflow.started` including featureId and workflowType

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -99,10 +99,10 @@ Use `@skills/debug/references/triage-questions.md` to gather:
 - Urgency justification
 - Affected area
 
-Update state using `mcp__exarchos__exarchos_workflow_set`:
+Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 
 ```
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "triage": {
       "symptom": "<symptom>",
@@ -127,17 +127,17 @@ Use `@skills/debug/references/investigation-checklist.md`.
 - Root cause found -> Continue to implement
 - Root cause NOT found -> Switch to thorough track
 
-Record findings using `mcp__exarchos__exarchos_workflow_set`:
+Record findings using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 
 ```
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "investigation.findings": ["<finding>"] }
 ```
 
 When root cause found:
 
 ```
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "investigation.rootCause": "<root cause>",
     "investigation.completedAt": "<ISO8601>"
@@ -153,7 +153,7 @@ Apply minimal fix directly (no worktree):
 - Record fix approach in state
 
 ```
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "artifacts.fixDesign": "<brief fix description>" }
   phase: "validate"
 ```
@@ -168,7 +168,7 @@ npm run test:run -- <affected-test-files>
 If tests pass:
 
 ```
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "followUp.rcaRequired": true }
   phase: "completed"
 ```
@@ -220,7 +220,7 @@ Triage → Investigate → RCA → Design → Implement → Review → Synthesiz
 Same as hotfix, but set track to "thorough":
 
 ```
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "track": "thorough" }
   phase: "investigate"
 ```
@@ -243,7 +243,7 @@ Save to: `docs/rca/YYYY-MM-DD-<issue-slug>.md`
 Update state:
 
 ```
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "artifacts.rca": "docs/rca/YYYY-MM-DD-<issue-slug>.md" }
   phase: "design"
 ```
@@ -255,7 +255,7 @@ Brief fix approach (NOT a full design document).
 2-3 paragraphs max in state file:
 
 ```
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "artifacts.fixDesign": "<fix approach description>" }
   phase: "implement"
 ```
@@ -276,7 +276,7 @@ cd .worktrees/debug-<issue-slug> && npm install
 Update state:
 
 ```
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "worktrees.\".worktrees/debug-<issue-slug>\"": {
       "branch": "feature/debug-<issue-slug>",
@@ -299,7 +299,7 @@ Verify:
 Update state:
 
 ```
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   phase: "synthesize"
 ```
 
@@ -332,7 +332,7 @@ mcp__plugin_github_github__update_pull_request({
 If during hotfix investigation root cause is not found in 15 minutes:
 
 ```
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "track": "thorough",
     "investigation.findings": ["Switched to thorough track: root cause not found in 15 min"]
@@ -346,7 +346,7 @@ Continue investigation without time constraint.
 If fix requires architectural changes:
 
 ```
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "investigation.findings": ["Escalated: requires architectural changes"] }
   phase: "blocked"
 ```
@@ -375,10 +375,10 @@ triage → investigate → rca → design → implement → review → synthesiz
 
 ## State Management
 
-Initialize debug workflow using `mcp__exarchos__exarchos_workflow_init`:
+Initialize debug workflow using `mcp__exarchos__exarchos_workflow` with `action: "init"`:
 
 ```
-Use mcp__exarchos__exarchos_workflow_init with featureId `debug-<issue-slug>` and workflowType `debug`.
+Use mcp__exarchos__exarchos_workflow with action: "init", featureId `debug-<issue-slug>`, and workflowType `debug`.
 ```
 
 See `@skills/debug/references/state-schema.md` for full schema.
@@ -402,8 +402,8 @@ Debug workflows resume like feature workflows:
 
 Extended to support:
 - `workflowType: "debug"` field
-- Debug-specific phases in `mcp__exarchos__exarchos_workflow_next_action` response
-- Debug context in `mcp__exarchos__exarchos_workflow_summary` output
+- Debug-specific phases handled by the SessionStart hook (which determines next action on resume)
+- Debug context provided by the SessionStart hook on session start
 
 ## Completion Criteria
 
@@ -437,9 +437,9 @@ Extended to support:
 
 When Exarchos MCP tools are available, emit events throughout the debug workflow:
 
-1. **At workflow start (triage):** `exarchos_event_append` → `workflow.started` with workflowType "debug", urgency
-2. **On track selection:** `exarchos_event_append` → `phase.transitioned` with selected track (hotfix/thorough)
-3. **On each phase transition:** `exarchos_event_append` → `phase.transitioned` from→to
+1. **At workflow start (triage):** `mcp__exarchos__exarchos_event` with `action: "append"` → `workflow.started` with workflowType "debug", urgency
+2. **On track selection:** `mcp__exarchos__exarchos_event` with `action: "append"` → `phase.transitioned` with selected track (hotfix/thorough)
+3. **On each phase transition:** `mcp__exarchos__exarchos_event` with `action: "append"` → `phase.transitioned` from→to
 4. **Thorough track stacking:** Handled by `/synthesize` (Graphite stack submission)
 5. **Hotfix track commit:** Single `gt create -m "fix: <description>"` — no multi-branch stacking needed
-6. **On complete:** `exarchos_event_append` → `phase.transitioned` to "completed"
+6. **On complete:** `mcp__exarchos__exarchos_event` with `action: "append"` → `phase.transitioned` to "completed"

--- a/skills/debug/references/investigation-checklist.md
+++ b/skills/debug/references/investigation-checklist.md
@@ -106,15 +106,15 @@ If any answer is "no" -> switch to thorough track.
 
 ### Switching to Thorough Track
 
-Use `mcp__exarchos__exarchos_workflow_set` to update state:
+Use `mcp__exarchos__exarchos_workflow` with `action: "set"` to update state:
 
 ```text
 # Update track
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "track": "thorough" }
 
 # Record investigation findings so far
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "investigation.findings": ["Investigated for 15 min, narrowed to auth module but root cause unclear"]
   }
@@ -174,23 +174,23 @@ git blame -L 50,60 src/auth/login.ts
 
 ## Recording Findings
 
-Update state with investigation progress using `mcp__exarchos__exarchos_workflow_set`:
+Update state with investigation progress using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 
 ```text
 # Add finding
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "investigation.findings": ["Error occurs in handleLogin when session is null"]
   }
 
 # Record root cause when found
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "investigation.rootCause": "Session cookie not being set due to SameSite attribute mismatch"
   }
 
 # Mark investigation complete
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "investigation.completedAt": "2026-01-27T10:30:00Z"
   }

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -236,7 +236,7 @@ Before dispatching ANY implementer:
 
 ### Worktree State Tracking
 
-Track worktrees in the workflow state file using `mcp__exarchos__exarchos_workflow_set`:
+Track worktrees in the workflow state file using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 - Set `worktrees.<worktree-id>` to an object containing `branch`, `status`, and either `taskId` (single task) or `tasks` (array of task IDs for multi-task worktrees)
 
 ### Implementer Prompt Requirements
@@ -273,11 +273,11 @@ This skill tracks task progress in workflow state for context persistence.
 
 ### Read Tasks from State
 
-Instead of re-parsing plan, read task list using `mcp__exarchos__exarchos_workflow_get` with `query: "tasks"`. For status checks during monitoring, use `fields: ["tasks"]` to reduce response size.
+Instead of re-parsing plan, read task list using `mcp__exarchos__exarchos_workflow` with `action: "get"` with `query: "tasks"`. For status checks during monitoring, use `fields: ["tasks"]` to reduce response size.
 
 ### On Task Dispatch
 
-Update task status when dispatched using `mcp__exarchos__exarchos_workflow_set`:
+Update task status when dispatched using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 - Update the task's status to "in_progress"
 - Set the task's startedAt timestamp
 
@@ -285,13 +285,13 @@ If creating worktree, also set the worktree entry with branch, status, and eithe
 
 ### On Task Complete
 
-Update task status when subagent reports completion using `mcp__exarchos__exarchos_workflow_set`:
+Update task status when subagent reports completion using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 - Update the task's status to "complete"
 - Set the task's completedAt timestamp
 
 ### On All Tasks Complete
 
-Update phase using `mcp__exarchos__exarchos_workflow_set`:
+Update phase using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 - Set `phase` to "review"
 
 ## Fix Mode (--fixes)
@@ -308,7 +308,7 @@ Or auto-invoked after review failures.
 
 ### Fix Mode Process
 
-1. **Read failure details** from state using `mcp__exarchos__exarchos_workflow_get`:
+1. **Read failure details** from state using `mcp__exarchos__exarchos_workflow` with `action: "get"`:
    - Query `reviews` for review failures
 
 2. **Extract fix tasks** from failure reports:
@@ -390,21 +390,21 @@ State is saved, enabling recovery after context compaction.
 
 When Exarchos MCP tools are available, emit events during delegation:
 
-1. **At delegation start:** Call `mcp__exarchos__exarchos_event_append` with event type `workflow.started` (if not already emitted for this workflow)
-2. **After team composition:** Call `mcp__exarchos__exarchos_event_append` with event type `team.formed` including teammates array
-3. **For each task dispatch:** Use `mcp__exarchos__exarchos_team_spawn` to register the agent with the team coordinator, then use the Task tool to launch the subagent. `team_spawn` handles role assignment, event emission, and health tracking; the Task tool handles actual subprocess execution. Both are always used together — `team_spawn` does not replace the Task tool
-4. **For each task assignment:** Call `mcp__exarchos__exarchos_event_append` with event type `task.assigned` including taskId, title, branch, worktree
-5. **Monitor progress:** Use `mcp__exarchos__exarchos_view_workflow_status` to check task completion status. For lightweight checks, use `mcp__exarchos__exarchos_workflow_get` with `fields: ["tasks"]`
+1. **At delegation start:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `workflow.started` (if not already emitted for this workflow)
+2. **After team composition:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `team.formed` including teammates array
+3. **For each task dispatch:** Use `mcp__exarchos__exarchos_orchestrate` with `action: "team_spawn"` to register the agent with the team coordinator, then use the Task tool to launch the subagent. `team_spawn` handles role assignment, event emission, and health tracking; the Task tool handles actual subprocess execution. Both are always used together — `team_spawn` does not replace the Task tool
+4. **For each task assignment:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `task.assigned` including taskId, title, branch, worktree
+5. **Monitor progress:** Use `mcp__exarchos__exarchos_view` with `action: "workflow_status"` to check task completion status. For lightweight checks, use `mcp__exarchos__exarchos_workflow` with `action: "get"` with `fields: ["tasks"]`
 6. **On task completion — Graphite stacking:**
    Subagents handle stacking directly using `gt create` (per implementer prompt template).
    When a multi-task agent completes, it will have created a Graphite stack with one branch per logical review unit.
    The orchestrator should:
-   - Call `mcp__exarchos__exarchos_stack_place` with position, taskId, and branch to record each stack position
+   - Call `mcp__exarchos__exarchos_view` with `action: "stack_place"` with position, taskId, and branch to record each stack position
    - Verify the stack was submitted by checking for PRs: `mcp__graphite__run_gt_cmd({ args: ["--no-interactive", "ls"], cwd: "<worktree-path>" })`
-7. **On all tasks complete:** Call `mcp__exarchos__exarchos_event_append` with event type `phase.transitioned` from delegate to next phase
+7. **On all tasks complete:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `phase.transitioned` from delegate to next phase
 
 ### Claim Guard
 
-`task_claim` prevents double-claims. If an agent receives an `ALREADY_CLAIMED` error, it means another agent already claimed that task. The orchestrator should:
+`task_claim` action prevents double-claims. If an agent receives an `ALREADY_CLAIMED` error, it means another agent already claimed that task. The orchestrator should:
 - Skip the task (it's being handled)
-- Check task status via `mcp__exarchos__exarchos_view_tasks` with `filter: { "taskId": "<id>" }` before re-dispatching
+- Check task status via `mcp__exarchos__exarchos_view` with `action: "tasks"` with `filter: { "taskId": "<id>" }` before re-dispatching

--- a/skills/implementation-planning/SKILL.md
+++ b/skills/implementation-planning/SKILL.md
@@ -19,11 +19,11 @@ Activate this skill when:
 When invoked with `--revise`, plan-review found gaps in the previous plan. The state file contains `.planReview.gaps` with specific missing items.
 
 **Revision workflow:**
-1. Read gaps from state using `mcp__exarchos__exarchos_workflow_get` with query `planReview.gaps`
+1. Read gaps from state using `mcp__exarchos__exarchos_workflow` with `action: "get"` with query `planReview.gaps`
 2. Re-read design document
 3. Add tasks to address each gap
 4. Update existing plan file (append new tasks)
-5. Clear gaps using `mcp__exarchos__exarchos_workflow_set` (set `planReview.gaps` to empty array, `planReview.gapsFound` to false)
+5. Clear gaps using `mcp__exarchos__exarchos_workflow` with `action: "set"` (set `planReview.gaps` to empty array, `planReview.gapsFound` to false)
 
 ## The Iron Law
 
@@ -238,7 +238,7 @@ This skill updates workflow state with plan details.
 
 ### On Plan Save
 
-Update state with plan artifact and tasks using `mcp__exarchos__exarchos_workflow_set`:
+Update state with plan artifact and tasks using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 - Set `artifacts.plan` to the plan path
 - Set `tasks` to the array of task objects (id, title, status, branch)
 - Set `phase` to "plan-review"
@@ -286,4 +286,4 @@ Skill({ skill: "delegate", args: "<plan-path>" })
 
 When Exarchos MCP tools are available:
 
-1. **On plan completion:** Call `exarchos_event_append` with event type `phase.transitioned` from plan to plan-review
+1. **On plan completion:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `phase.transitioned` from plan to plan-review

--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -353,21 +353,21 @@ Task({
 
 ## State Management
 
-Update workflow state with review results using `mcp__exarchos__exarchos_workflow_set`.
+Update workflow state with review results using `mcp__exarchos__exarchos_workflow` with `action: "set"`.
 
 ### On Review Complete
 
 ```text
 # Update task review status - for approved
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "tasks[id=<task-id>].reviewStatus.qualityReview": "approved" }
 
 # Or if needs fixes:
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "tasks[id=<task-id>].reviewStatus.qualityReview": "needs_fixes" }
 
 # Add review details
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "reviews.<task-id>.qualityReview": {"status": "approved", "highPriority": [], "mediumPriority": []}
   }
@@ -378,7 +378,7 @@ Use mcp__exarchos__exarchos_workflow_set with featureId:
 Update phase for synthesis:
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   phase: "synthesize"
 ```
 
@@ -426,10 +426,10 @@ This is NOT a human checkpoint - workflow continues autonomously.
 When Exarchos MCP tools are available, emit gate events during review:
 
 1. **Read CI status:** Use `mcp__plugin_github_github__pull_request_read` with `method: "get_status"` to get CI gate results
-2. **For each CI check:** Call `exarchos_event_append` with event type `gate.executed` including:
+2. **For each CI check:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `gate.executed` including:
    - `gateName`: The CI check name
    - `layer`: "per-pr" or "per-stack"
    - `passed`: boolean
    - `duration`: milliseconds (if available)
-3. **Read unified status:** Use `exarchos_view_tasks` with `fields: ["taskId", "status", "title"]` and `limit: 20` for combined task + gate view with minimal token cost
+3. **Read unified status:** Use `mcp__exarchos__exarchos_view` with `action: "tasks"` with `fields: ["taskId", "status", "title"]` and `limit: 20` for combined task + gate view with minimal token cost
 4. **When all per-PR gates pass:** Apply `stack-ready` label to the PR

--- a/skills/refactor/COMMAND.md
+++ b/skills/refactor/COMMAND.md
@@ -54,10 +54,10 @@ The command triggers the refactor skill which:
 
 ## State Initialization
 
-When invoked, initializes refactor workflow state using `mcp__exarchos__exarchos_workflow_init`:
+When invoked, initializes refactor workflow state using `mcp__exarchos__exarchos_workflow` with `action: "init"`:
 
 ```text
-Use mcp__exarchos__exarchos_workflow_init with featureId `refactor-<feature-id>` and workflowType `refactor`.
+Use mcp__exarchos__exarchos_workflow with action: "init", featureId `refactor-<feature-id>` and workflowType `refactor`.
 ```
 
 ## See Also

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -97,10 +97,10 @@ Use `@skills/refactor/references/explore-checklist.md` to assess:
 - Confirm polish is appropriate
 
 Update state using MCP tools:
-1. Use `mcp__exarchos__exarchos_workflow_init` with featureId `refactor-<slug>` and workflowType `refactor`
-2. Use `mcp__exarchos__exarchos_workflow_set` to set track, phase, and explore scope assessment
+1. Use `mcp__exarchos__exarchos_workflow` with `action: "init"` with featureId `refactor-<slug>` and workflowType `refactor`
+2. Use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set track, phase, and explore scope assessment
 
-On completion, use `mcp__exarchos__exarchos_workflow_set` to set `explore.completedAt` and `phase` to "brief".
+On completion, use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `explore.completedAt` and `phase` to "brief".
 
 #### 2. Brief Phase
 
@@ -114,7 +114,7 @@ Use `@skills/refactor/references/brief-template.md` to structure:
 - Success criteria
 - Docs to update
 
-Update state using `mcp__exarchos__exarchos_workflow_set` to set the `brief` object and `phase` to "polish-implement".
+Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set the `brief` object and `phase` to "polish-implement".
 
 #### 3. Implement Phase
 
@@ -130,7 +130,7 @@ When done, commit via Graphite:
 mcp__graphite__run_gt_cmd({ args: ["create", "-m", "refactor: <description>"], cwd: "<repo-root>" })
 ```
 
-Update state on completion using `mcp__exarchos__exarchos_workflow_set` to set `phase` to "polish-validate".
+Update state on completion using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `phase` to "polish-validate".
 
 #### 4. Validate Phase
 
@@ -147,7 +147,7 @@ npm run lint  # or equivalent
 npm run typecheck  # if TypeScript
 ```
 
-Update state using `mcp__exarchos__exarchos_workflow_set` to set `validation` object and `phase` to "polish-update-docs".
+Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `validation` object and `phase` to "polish-update-docs".
 
 #### 5. Update Docs Phase
 
@@ -161,7 +161,7 @@ Use `@skills/refactor/references/doc-update-checklist.md` to update:
 
 If `docsToUpdate` is empty, verify no docs need updating.
 
-Update state using `mcp__exarchos__exarchos_workflow_set` to set `validation.docsUpdated` to true, `artifacts.updatedDocs` array, and `phase` to "completed".
+Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `validation.docsUpdated` to true, `artifacts.updatedDocs` array, and `phase` to "completed".
 
 > **Note:** The HSM transitions directly from `polish-update-docs` to `completed`. There is no `synthesize` phase for polish track.
 
@@ -199,16 +199,16 @@ Thorough scope assessment using `@skills/refactor/references/explore-checklist.m
 - Map dependencies and impact
 
 Update state using MCP tools:
-1. Use `mcp__exarchos__exarchos_workflow_init` with featureId `refactor-<slug>` and workflowType `refactor`
-2. Use `mcp__exarchos__exarchos_workflow_set` to set track to "overhaul", phase, and explore scope assessment
+1. Use `mcp__exarchos__exarchos_workflow` with `action: "init"` with featureId `refactor-<slug>` and workflowType `refactor`
+2. Use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set track to "overhaul", phase, and explore scope assessment
 
-On completion, use `mcp__exarchos__exarchos_workflow_set` to set `explore.completedAt` and `phase` to "brief".
+On completion, use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `explore.completedAt` and `phase` to "brief".
 
 #### 2. Brief Phase
 
 Detailed capture of refactor intent (more thorough than polish).
 
-Update state using `mcp__exarchos__exarchos_workflow_set` to set the `brief` object and `phase` to "overhaul-plan".
+Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set the `brief` object and `phase` to "overhaul-plan".
 
 Then auto-invoke plan:
 ```typescript
@@ -229,7 +229,7 @@ The `/plan` skill:
 - Each task leaves code in working state
 - Dependency order matters more for refactors
 
-Update state on completion using `mcp__exarchos__exarchos_workflow_set` to set `artifacts.plan` and `phase` to "overhaul-delegate".
+Update state on completion using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `artifacts.plan` and `phase` to "overhaul-delegate".
 
 > **Note:** There is no `plan-review` phase in the refactor HSM. Overhaul goes directly `overhaul-plan` → `overhaul-delegate`.
 
@@ -253,7 +253,7 @@ The `/delegate` skill:
 - Parallel execution where dependencies allow
 - Tracks progress in state file
 
-Update state on completion using `mcp__exarchos__exarchos_workflow_set` to set `phase` to "overhaul-review".
+Update state on completion using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `phase` to "overhaul-review".
 
 Then auto-invoke review:
 ```typescript
@@ -273,7 +273,7 @@ The `/review` skill:
 - Refactors are high regression risk
 - Verifies structure matches brief goals
 
-Update state on completion using `mcp__exarchos__exarchos_workflow_set` to set `phase` to "overhaul-update-docs".
+Update state on completion using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `phase` to "overhaul-update-docs".
 
 #### 6. Update Docs Phase
 
@@ -285,7 +285,7 @@ For overhaul, typically includes:
 - Migration guides if public interfaces changed
 - Updated diagrams
 
-Update state using `mcp__exarchos__exarchos_workflow_set` to set `validation.docsUpdated` to true, `artifacts.updatedDocs` array, and `phase` to "synthesize".
+Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `validation.docsUpdated` to true, `artifacts.updatedDocs` array, and `phase` to "synthesize".
 
 Then auto-invoke synthesize:
 ```typescript
@@ -319,7 +319,7 @@ mcp__plugin_github_github__update_pull_request({
 
 ## State Management
 
-Initialize refactor workflow using `mcp__exarchos__exarchos_workflow_init` with featureId `refactor-<slug>` and workflowType `refactor`.
+Initialize refactor workflow using `mcp__exarchos__exarchos_workflow` with `action: "init"` with featureId `refactor-<slug>` and workflowType `refactor`.
 
 Full state schema:
 ```json
@@ -399,7 +399,7 @@ explore -> brief -> overhaul-plan -> overhaul-delegate -> overhaul-review -> ove
 
 ### Polish -> Overhaul
 
-If scope expands beyond polish limits during explore or brief phase, use `mcp__exarchos__exarchos_workflow_set` to set `track` to "overhaul" and update `explore.scopeAssessment.recommendedTrack`.
+If scope expands beyond polish limits during explore or brief phase, use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `track` to "overhaul" and update `explore.scopeAssessment.recommendedTrack`.
 
 **Indicators to switch:**
 - More than 5 files affected
@@ -441,8 +441,8 @@ Task({
 
 The workflow-state MCP server supports:
 - `workflowType: "refactor"` field
-- Refactor-specific phases in `mcp__exarchos__exarchos_workflow_next_action` output
-- Refactor context in `mcp__exarchos__exarchos_workflow_summary` output
+- Refactor-specific phases handled by the SessionStart hook (which determines next action on resume)
+- Refactor context provided by the SessionStart hook on session start
 
 ### With workflow-auto-resume.md
 
@@ -500,9 +500,9 @@ Refactor phases map to auto-resume actions:
 
 When Exarchos MCP tools are available, emit events throughout the refactor workflow:
 
-1. **At workflow start (explore):** `exarchos_event_append` → `workflow.started` with workflowType "refactor"
-2. **On track selection:** `exarchos_event_append` → `phase.transitioned` with selected track (polish/overhaul)
-3. **On each phase transition:** `exarchos_event_append` → `phase.transitioned` from→to
+1. **At workflow start (explore):** `mcp__exarchos__exarchos_event` with `action: "append"` → `workflow.started` with workflowType "refactor"
+2. **On track selection:** `mcp__exarchos__exarchos_event` with `action: "append"` → `phase.transitioned` with selected track (polish/overhaul)
+3. **On each phase transition:** `mcp__exarchos__exarchos_event` with `action: "append"` → `phase.transitioned` from→to
 4. **Overhaul track stacking:** Handled by `/delegate` (subagents use `gt create` per implementer prompt)
 5. **Polish track commit:** Single `gt create -m "refactor: <description>"` — no multi-branch stacking needed
-6. **On complete:** `exarchos_event_append` → `phase.transitioned` to "completed"
+6. **On complete:** `mcp__exarchos__exarchos_event` with `action: "append"` → `phase.transitioned` to "completed"

--- a/skills/refactor/phases/auto-chain.md
+++ b/skills/refactor/phases/auto-chain.md
@@ -32,27 +32,27 @@ explore → brief → implement → validate → update-docs → CHECKPOINT
 
 ### Polish Auto-Chain Commands
 
-After each phase, use `mcp__exarchos__exarchos_workflow_next_action` with the featureId to determine the next action:
+After each phase, use the SessionStart hook with the featureId to determine the next action:
 
 ```text
 # After explore
-Use mcp__exarchos__exarchos_workflow_next_action with the featureId.
+The SessionStart hook determines the next action automatically.
 Returns: AUTO:refactor-brief
 
 # After brief
-Use mcp__exarchos__exarchos_workflow_next_action with the featureId.
+The SessionStart hook determines the next action automatically.
 Returns: AUTO:polish-implement
 
 # After implement
-Use mcp__exarchos__exarchos_workflow_next_action with the featureId.
+The SessionStart hook determines the next action automatically.
 Returns: AUTO:refactor-validate
 
 # After validate (passed)
-Use mcp__exarchos__exarchos_workflow_next_action with the featureId.
+The SessionStart hook determines the next action automatically.
 Returns: AUTO:refactor-update-docs
 
 # After update-docs
-Use mcp__exarchos__exarchos_workflow_next_action with the featureId.
+The SessionStart hook determines the next action automatically.
 Returns: WAIT:human-checkpoint:polish-update-docs
 ```
 
@@ -101,7 +101,7 @@ explore → brief → plan → delegate → review → update-docs → synthesiz
 
 ### Overhaul Auto-Chain Commands
 
-Use `mcp__exarchos__exarchos_workflow_next_action` with the featureId after each phase:
+Use the SessionStart hook with the featureId after each phase:
 
 ```text
 # After explore
@@ -165,7 +165,7 @@ polish:implement → [scope expands] → overhaul:plan
 Auto-chain handles this via MCP tools:
 
 ```text
-# When scope expands during implement, use mcp__exarchos__exarchos_workflow_set:
+# When scope expands during implement, use mcp__exarchos__exarchos_workflow with action: "set":
 # 1. First call: Set updates
 updates: { "implement.switchReason": "<reason>", "implement.switchedAt": "<ISO8601>" }
 
@@ -174,7 +174,7 @@ phase: "plan"
 updates: { "track": "overhaul" }
 
 # Next action returns
-Use mcp__exarchos__exarchos_workflow_next_action with the featureId.
+The SessionStart hook determines the next action automatically.
 Returns: AUTO:overhaul-plan
 ```
 

--- a/skills/refactor/phases/brief.md
+++ b/skills/refactor/phases/brief.md
@@ -108,11 +108,11 @@ Based on exploration, preparing brief for <polish|overhaul> track.
 
 ## State Update
 
-Use `mcp__exarchos__exarchos_workflow_set` with the featureId:
+Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with the featureId:
 
 ```
 # First call: Set brief data
-Use mcp__exarchos__exarchos_workflow_set:
+Use mcp__exarchos__exarchos_workflow with action: "set":
   updates: {
     "brief": {
       "problem": "<problem statement>",
@@ -127,7 +127,7 @@ Use mcp__exarchos__exarchos_workflow_set:
   }
 
 # Second call: Transition phase
-Use mcp__exarchos__exarchos_workflow_set:
+Use mcp__exarchos__exarchos_workflow with action: "set":
   phase: "<implement|plan>"
 ```
 

--- a/skills/refactor/phases/explore.md
+++ b/skills/refactor/phases/explore.md
@@ -79,10 +79,10 @@ Significant doc updates → overhaul track indicator.
 
 ## Output
 
-Update workflow state with assessment using `mcp__exarchos__exarchos_workflow_set`:
+Update workflow state with assessment using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "explore": {
       "filesAffected": <count>,

--- a/skills/refactor/phases/overhaul-delegate.md
+++ b/skills/refactor/phases/overhaul-delegate.md
@@ -76,19 +76,19 @@ See `overhaul-review.md` for detailed criteria.
 
 ## State Updates
 
-Use `mcp__exarchos__exarchos_workflow_set` with the featureId for state updates:
+Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with the featureId for state updates:
 
 ```text
 # After delegation complete
-Use mcp__exarchos__exarchos_workflow_set:
+Use mcp__exarchos__exarchos_workflow with action: "set":
   phase: "review"
 
 # After review passes
-Use mcp__exarchos__exarchos_workflow_set:
+Use mcp__exarchos__exarchos_workflow with action: "set":
   phase: "update-docs"
 
 # After review fails - dispatch fix tasks, loop back
-Use mcp__exarchos__exarchos_workflow_set:
+Use mcp__exarchos__exarchos_workflow with action: "set":
   updates: { "reviews.<id>.status": "failed", "reviews.<id>.findings": ["<issue1>"] }
 ```
 

--- a/skills/refactor/phases/overhaul-plan.md
+++ b/skills/refactor/phases/overhaul-plan.md
@@ -244,15 +244,15 @@ After all tasks complete:
 
 ### On Plan Completion
 
-Use `mcp__exarchos__exarchos_workflow_set` with the featureId:
+Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with the featureId:
 
 ```text
 # Set plan artifact path
-Use mcp__exarchos__exarchos_workflow_set:
+Use mcp__exarchos__exarchos_workflow with action: "set":
   updates: { "artifacts.plan": "docs/plans/YYYY-MM-DD-<refactor>.md" }
 
 # Add tasks to state (single call with all tasks)
-Use mcp__exarchos__exarchos_workflow_set:
+Use mcp__exarchos__exarchos_workflow with action: "set":
   updates: {
     "tasks": [
       {"id": "001", "title": "Task description", "status": "pending", "working_state_verified": false},
@@ -261,7 +261,7 @@ Use mcp__exarchos__exarchos_workflow_set:
   }
 
 # Transition to delegate phase (separate call)
-Use mcp__exarchos__exarchos_workflow_set:
+Use mcp__exarchos__exarchos_workflow with action: "set":
   phase: "delegate"
 ```
 

--- a/skills/refactor/phases/overhaul-review.md
+++ b/skills/refactor/phases/overhaul-review.md
@@ -239,11 +239,11 @@ Every goal from the brief must be verified as achieved.
 
 ### On Review Complete
 
-Use `mcp__exarchos__exarchos_workflow_set` with the featureId:
+Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with the featureId:
 
 ```text
 # Record review results
-Use mcp__exarchos__exarchos_workflow_set:
+Use mcp__exarchos__exarchos_workflow with action: "set":
   updates: {
     "reviews.overhaul": {
       "status": "approved",
@@ -258,14 +258,14 @@ Use mcp__exarchos__exarchos_workflow_set:
 ### On Approval
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set:
+Use mcp__exarchos__exarchos_workflow with action: "set":
   phase: "synthesize"
 ```
 
 ### On Needs Fixes
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set:
+Use mcp__exarchos__exarchos_workflow with action: "set":
   updates: {
     "reviews.overhaul.status": "needs_fixes",
     "reviews.overhaul.issues": ["<issue1>", "<issue2>"]

--- a/skills/refactor/phases/polish-implement.md
+++ b/skills/refactor/phases/polish-implement.md
@@ -33,17 +33,17 @@ If any condition is violated, switch to overhaul track.
 
 ## Entry Conditions
 
-Before starting implementation, verify using `mcp__exarchos__exarchos_workflow_get`:
+Before starting implementation, verify using `mcp__exarchos__exarchos_workflow` with `action: "get"`:
 
 ```text
 # Read state to confirm prerequisites
-Use mcp__exarchos__exarchos_workflow_get with featureId and query: ".track"
+Use mcp__exarchos__exarchos_workflow with action: "get", featureId and query: ".track"
 # Must return: "polish"
 
-Use mcp__exarchos__exarchos_workflow_get with featureId and query: ".phase"
+Use mcp__exarchos__exarchos_workflow with action: "get", featureId and query: ".phase"
 # Must return: "implement"
 
-Use mcp__exarchos__exarchos_workflow_get with featureId and query: ".brief.goals"
+Use mcp__exarchos__exarchos_workflow with action: "get", featureId and query: ".brief.goals"
 # Must return: populated array
 ```
 
@@ -71,10 +71,10 @@ npm run test:run
 
 **Gate:** Tests must pass. If tests fail before implementation, stop and investigate. Do not implement on top of a failing test suite.
 
-Capture baseline in state using `mcp__exarchos__exarchos_workflow_set`:
+Capture baseline in state using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "implement": {
       "startedAt": "<ISO8601>",
@@ -110,10 +110,10 @@ gt submit --no-interactive --publish --merge-when-ready --stack
 
 **NEVER use `git commit` or `git push`** — always use `gt create` and `gt submit`.
 
-Log the change using `mcp__exarchos__exarchos_workflow_set`:
+Log the change using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "implement.changesLog": [{"file": "<path>", "description": "<what changed>"}]
   }
@@ -135,7 +135,7 @@ After all changes, verify each goal from brief:
 
 ```text
 # Read goals
-Use mcp__exarchos__exarchos_workflow_get with featureId and query: ".brief.goals"
+Use mcp__exarchos__exarchos_workflow with action: "get", featureId and query: ".brief.goals"
 ```
 
 For each goal, confirm it's addressed. If a goal cannot be addressed within polish scope, trigger track switch.
@@ -189,18 +189,18 @@ echo "Switching to overhaul track recommended."
 ### Switch Protocol
 
 1. **Commit current work** - Don't lose progress
-2. **Update state** using `mcp__exarchos__exarchos_workflow_set`:
+2. **Update state** using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 
 ```text
 # First call: Record switch info
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "implement.switchReason": "<reason for switch>",
     "implement.switchedAt": "<ISO8601>"
   }
 
 # Second call: Change track and phase
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "track": "overhaul" }
   phase: "plan"
 ```
@@ -227,7 +227,7 @@ Current progress has been committed. Continue? (Y/n)
 
 ### Implementation Start
 
-Use `mcp__exarchos__exarchos_workflow_set` with the featureId:
+Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with the featureId:
 
 ```text
 updates: {
@@ -291,7 +291,7 @@ Implementation phase exits when:
 - Less than or equal to 5 files changed
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   phase: "validate"
 ```
 
@@ -304,7 +304,7 @@ Next action: `AUTO:refactor-validate`
 - Current work committed
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "track": "overhaul" }
   phase: "plan"
 ```

--- a/skills/refactor/phases/polish-validate.md
+++ b/skills/refactor/phases/polish-validate.md
@@ -36,8 +36,8 @@ If tests fail:
 Review each goal from the brief and verify completion:
 
 ```text
-# Read goals from state using mcp__exarchos__exarchos_workflow_get
-Use mcp__exarchos__exarchos_workflow_get with featureId and query: ".brief.goals"
+# Read goals from state using mcp__exarchos__exarchos_workflow with action: "get"
+Use mcp__exarchos__exarchos_workflow with action: "get" with featureId and query: ".brief.goals"
 ```
 
 **For each goal:**
@@ -45,10 +45,10 @@ Use mcp__exarchos__exarchos_workflow_get with featureId and query: ".brief.goals
 - [ ] Evidence of completion is clear (code change, metric improvement, etc.)
 - [ ] Goal was not partially implemented
 
-Document verified goals in state using `mcp__exarchos__exarchos_workflow_set`:
+Document verified goals in state using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "validation.goalsVerified": ["<goal text>"] }
 ```
 
@@ -111,7 +111,7 @@ Manual review of key changes:
 
 ### Record Validation Start
 
-Use `mcp__exarchos__exarchos_workflow_set` with the featureId:
+Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with the featureId:
 
 ```text
 updates: {
@@ -130,21 +130,21 @@ On successful validation:
 
 ```text
 # First call: Record results
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "validation.testsPass": true,
     "validation.completedAt": "<ISO8601>"
   }
 
 # Second call: Transition phase
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   phase: "update-docs"
 ```
 
 On failed validation:
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "validation.testsPass": false,
     "validation.failureReason": "<reason>"

--- a/skills/refactor/phases/update-docs.md
+++ b/skills/refactor/phases/update-docs.md
@@ -30,10 +30,10 @@ The `docsToUpdate` field in the brief identifies documents requiring updates. If
 
 ### Step 1: Review Documentation List
 
-Read the brief's `docsToUpdate` field using `mcp__exarchos__exarchos_workflow_get`:
+Read the brief's `docsToUpdate` field using `mcp__exarchos__exarchos_workflow` with `action: "get"`:
 
 ```text
-Use mcp__exarchos__exarchos_workflow_get with featureId and query: ".brief.docsToUpdate"
+Use mcp__exarchos__exarchos_workflow with action: "get", featureId and query: ".brief.docsToUpdate"
 ```
 
 If the list is empty, proceed to Step 4 (Verification).
@@ -134,23 +134,23 @@ Update when:
 
 ## State Updates
 
-Record updated documents using `mcp__exarchos__exarchos_workflow_set`:
+Record updated documents using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 
 ```text
 # Add each updated document
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "artifacts.updatedDocs": ["docs/architecture/modules.md"] }
 
 # Mark docs updated
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "validation.docsUpdated": true }
 
 # Update phase - Polish track
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   phase: "completed"
 
 # Update phase - Overhaul track
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   phase: "synthesize"
 ```
 
@@ -188,7 +188,7 @@ After completing documentation updates:
 4. **Auto-chain to synthesize phase**
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   phase: "synthesize"
 ```
 

--- a/skills/refactor/references/brief-template.md
+++ b/skills/refactor/references/brief-template.md
@@ -52,11 +52,11 @@ List documentation files that need updating after refactor.
 
 ## State Update
 
-Use `mcp__exarchos__exarchos_workflow_set` with the featureId:
+Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with the featureId:
 
 ```text
 # First call: Set brief data
-Use mcp__exarchos__exarchos_workflow_set:
+Use mcp__exarchos__exarchos_workflow with action: "set":
   updates: {
     "brief": {
       "problem": "<problem statement>",
@@ -70,7 +70,7 @@ Use mcp__exarchos__exarchos_workflow_set:
   }
 
 # Second call: Transition phase
-Use mcp__exarchos__exarchos_workflow_set:
+Use mcp__exarchos__exarchos_workflow with action: "set":
   phase: "implement" (polish) or "plan" (overhaul)
 ```
 

--- a/skills/refactor/references/doc-update-checklist.md
+++ b/skills/refactor/references/doc-update-checklist.md
@@ -64,10 +64,10 @@ After updating documentation:
 
 ## State Update
 
-After documentation is updated, use `mcp__exarchos__exarchos_workflow_set`:
+After documentation is updated, use `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "validation.docsUpdated": true,
     "artifacts.updatedDocs": ["<doc1>", "<doc2>"]
@@ -84,7 +84,7 @@ If `docsToUpdate` is empty, verify this is correct:
 4. Document verification in state:
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "validation.docsUpdated": true,
     "artifacts.updatedDocs": []

--- a/skills/refactor/references/explore-checklist.md
+++ b/skills/refactor/references/explore-checklist.md
@@ -40,10 +40,10 @@
 
 ## Output
 
-After exploration, update state with scope assessment using `mcp__exarchos__exarchos_workflow_set`:
+After exploration, update state with scope assessment using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 
 ```text
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "explore.scopeAssessment": {
       "filesAffected": ["<list>"],

--- a/skills/shared/prompts/context-reading.md
+++ b/skills/shared/prompts/context-reading.md
@@ -10,10 +10,10 @@ If given a state file path, read task details using MCP tools:
 
 ```text
 # Get your task
-Use mcp__exarchos__exarchos_workflow_get with featureId and query: ".tasks[] | select(.id == \"<task-id>\")"
+Use mcp__exarchos__exarchos_workflow with action: "get", featureId and query: ".tasks[] | select(.id == \"<task-id>\")"
 
 # Get plan path
-Use mcp__exarchos__exarchos_workflow_get with featureId and query: ".artifacts.plan"
+Use mcp__exarchos__exarchos_workflow with action: "get", featureId and query: ".artifacts.plan"
 ```
 
 Then read the specific task section:
@@ -36,7 +36,7 @@ If you need design context:
 
 ```text
 # Get design path from state
-Use mcp__exarchos__exarchos_workflow_get with featureId and query: ".artifacts.design"
+Use mcp__exarchos__exarchos_workflow with action: "get", featureId and query: ".artifacts.design"
 
 # Then read the design file
 Read({ file_path: "<design-path>" })

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -234,21 +234,21 @@ Task({
 
 ## State Management
 
-Update workflow state with review results using `mcp__exarchos__exarchos_workflow_set`.
+Update workflow state with review results using `mcp__exarchos__exarchos_workflow` with `action: "set"`.
 
 ### On Review Complete
 
 ```text
 # Update task review status - for pass
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "tasks[id=<task-id>].reviewStatus.specReview": "pass" }
 
 # Or if failed:
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: { "tasks[id=<task-id>].reviewStatus.specReview": "fail" }
 
 # Add review details
-Use mcp__exarchos__exarchos_workflow_set with featureId:
+Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
   updates: {
     "reviews.<task-id>.specReview": {"status": "pass", "issues": []}
   }

--- a/skills/synthesis/SKILL.md
+++ b/skills/synthesis/SKILL.md
@@ -124,7 +124,7 @@ If tests fail during synthesis (they passed in review):
 
 ## State Management
 
-This skill tracks synthesis progress in workflow state using `mcp__exarchos__exarchos_workflow_get` and `mcp__exarchos__exarchos_workflow_set`.
+This skill tracks synthesis progress in workflow state using `mcp__exarchos__exarchos_workflow` with `action: "get"` and `mcp__exarchos__exarchos_workflow` with `action: "set"`.
 
 ### Read Task State
 
@@ -218,6 +218,6 @@ Options:
 
 When Exarchos MCP tools are available:
 
-1. **After stack submission:** Call `mcp__exarchos__exarchos_event_append` with event type `stack.enqueued` including PR numbers from `gt log --short`
+1. **After stack submission:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `stack.enqueued` including PR numbers from `gt log --short`
 2. **Monitor merge status:** Use `mcp__graphite__run_gt_cmd` with `["log", "--short"]` to check stack/PR status
-3. **On successful merge:** Call `mcp__exarchos__exarchos_event_append` with event type `phase.transitioned` to mark workflow complete
+3. **On successful merge:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `phase.transitioned` to mark workflow complete

--- a/skills/workflow-state/SKILL.md
+++ b/skills/workflow-state/SKILL.md
@@ -26,7 +26,7 @@ State files are gitignored - they persist locally but are not committed.
 
 ### Initialize State
 
-At the start of `/ideate`, use `mcp__exarchos__exarchos_workflow_init` with:
+At the start of `/ideate`, use `mcp__exarchos__exarchos_workflow` with `action: "init"` with:
 - `featureId`: the workflow identifier (e.g., `"user-authentication"`)
 - `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`
 
@@ -34,7 +34,7 @@ This creates a new state file with phase "ideate".
 
 ### Read State
 
-Use `mcp__exarchos__exarchos_workflow_get` with `featureId`:
+Use `mcp__exarchos__exarchos_workflow` with `action: "get"` and `featureId`:
 
 - **Full state**: Call with just `featureId`
 - **Specific field**: Add `query` for dot-path lookup (e.g., `query: "phase"`, `query: "tasks"`)
@@ -44,7 +44,7 @@ Field projection via `fields` returns only the requested top-level keys, reducin
 
 ### Update State
 
-Use `mcp__exarchos__exarchos_workflow_set` with `featureId` and either `updates`, `phase`, or both:
+Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with `featureId` and either `updates`, `phase`, or both:
 
 - **Update phase**: `phase: "delegate"`
 - **Set artifact path**: `updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }`
@@ -56,11 +56,11 @@ Worktree status values: `'active' | 'merged' | 'removed'`
 
 ### Get Summary
 
-For context restoration after summarization, use `mcp__exarchos__exarchos_workflow_summary` with `featureId`. This outputs a minimal summary suitable for rebuilding orchestrator context.
+For context restoration after summarization, use `mcp__exarchos__exarchos_workflow` with `action: "get"` and `featureId`. This outputs a minimal summary suitable for rebuilding orchestrator context.
 
 ### Reconcile State
 
-To verify state matches git reality, use `mcp__exarchos__exarchos_workflow_reconcile` with `featureId`. This checks that worktrees and branches referenced in state actually exist.
+To verify state matches git reality, the SessionStart hook automatically reconciles on resume. This checks that worktrees and branches referenced in state actually exist.
 
 ## Integration Points
 
@@ -136,13 +136,13 @@ Key sections:
 
 ## Example Workflow
 
-1. **Start new workflow**: Use `mcp__exarchos__exarchos_workflow_init` with `featureId: "user-authentication"`, `workflowType: "feature"`
+1. **Start new workflow**: Use `mcp__exarchos__exarchos_workflow` with `action: "init"` with `featureId: "user-authentication"`, `workflowType: "feature"`
 
-2. **After design phase**: Use `mcp__exarchos__exarchos_workflow_set` with:
+2. **After design phase**: Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with:
    - `featureId: "user-authentication"`
    - `phase: "plan"`
    - `updates: { "artifacts.design": "docs/designs/2026-01-05-user-auth.md" }`
 
-3. **Check state**: Use `mcp__exarchos__exarchos_workflow_summary` with `featureId: "user-authentication"`
+3. **Check state**: Use `mcp__exarchos__exarchos_workflow` with `action: "get"` with `featureId: "user-authentication"`
 
-4. **Resume after context loss**: Use `mcp__exarchos__exarchos_workflow_summary` with `featureId: "user-authentication"` to get context restoration output
+4. **Resume after context loss**: Use `mcp__exarchos__exarchos_workflow` with `action: "get"` with `featureId: "user-authentication"` to get context restoration output


### PR DESCRIPTION
Update all 34 Markdown prompt files (commands, skills, rules) to use
the new 5 composite tool + action discriminator format instead of the
former 27 individual tool names.

Mapping:
- Individual workflow tools -> exarchos_workflow with action
- Individual event tools -> exarchos_event with action
- Individual team/task tools -> exarchos_orchestrate with action
- Individual view/stack tools -> exarchos_view with action
- sync_now -> exarchos_sync with action

Eliminated tools replaced by hooks:
- workflow_list, workflow_summary, workflow_next_action,
  workflow_reconcile -> SessionStart hook
- workflow_checkpoint -> PreCompact hook
- workflow_transitions -> static documentation

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>