### PR TITLE
refactor: bundle CLI and merge hooks into settings.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Exarchos is local agent governance for Claude Code. It provides event-sourced SD
 
 ```bash
 # Root installer
-npm run build          # tsc → dist/install.js
+npm run build          # tsc + bun → dist/install.js, dist/exarchos-mcp.js, dist/exarchos-cli.js
 npm run test:run       # vitest single run
 npm run test           # vitest watch mode
 npm run typecheck      # tsc --noEmit
@@ -35,9 +35,9 @@ The installer (`src/install.ts`) creates symlinks from this repo into `~/.claude
 - `commands/` → slash commands (`/ideate`, `/plan`, `/delegate`, etc.)
 - `skills/` → reusable workflow logic referenced by commands
 - `rules/` → coding standards and behavior constraints
-- `settings.json` → permissions and plugin config
+- `settings.json` → permissions, plugin config, and hooks with resolved CLI paths
 
-It also builds and registers MCP servers in `~/.claude.json`.
+It also builds and registers MCP servers in `~/.claude.json`. Hooks from `hooks.json` are resolved with mode-dependent CLI paths and merged into `settings.json` (not copied as a separate file).
 
 ### Content Layers (no runtime code)
 

--- a/hooks.json
+++ b/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/servers/exarchos-mcp/dist/cli.js\" pre-compact",
+            "command": "node \"{{CLI_PATH}}\" pre-compact",
             "timeout": 30,
             "statusMessage": "Saving workflow checkpoint..."
           }
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/servers/exarchos-mcp/dist/cli.js\" session-start",
+            "command": "node \"{{CLI_PATH}}\" session-start",
             "timeout": 10,
             "statusMessage": "Checking for active workflows..."
           }
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/servers/exarchos-mcp/dist/cli.js\" guard",
+            "command": "node \"{{CLI_PATH}}\" guard",
             "timeout": 5
           }
         ]
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/servers/exarchos-mcp/dist/cli.js\" task-gate",
+            "command": "node \"{{CLI_PATH}}\" task-gate",
             "timeout": 120,
             "statusMessage": "Running quality gates..."
           }
@@ -56,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/servers/exarchos-mcp/dist/cli.js\" teammate-gate",
+            "command": "node \"{{CLI_PATH}}\" teammate-gate",
             "timeout": 120,
             "statusMessage": "Verifying teammate work..."
           }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/servers/exarchos-mcp/dist/cli.js\" subagent-context",
+            "command": "node \"{{CLI_PATH}}\" subagent-context",
             "timeout": 5
           }
         ]

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,8 @@
         "required": true,
         "type": "bundled",
         "bundlePath": "dist/exarchos-mcp.js",
-        "devEntryPoint": "plugins/exarchos/servers/exarchos-mcp/dist/index.js"
+        "devEntryPoint": "plugins/exarchos/servers/exarchos-mcp/dist/index.js",
+        "cliBundlePath": "dist/exarchos-cli.js"
       },
       {
         "id": "graphite",

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,7 @@
     "core": [
       { "id": "commands", "source": "commands", "target": "commands", "type": "directory" },
       { "id": "skills", "source": "skills", "target": "skills", "type": "directory" },
-      { "id": "scripts", "source": "scripts", "target": "scripts", "type": "directory" },
-      { "id": "hooks", "source": "hooks.json", "target": "hooks.json", "type": "file" }
+      { "id": "scripts", "source": "scripts", "target": "scripts", "type": "directory" }
     ],
     "mcpServers": [
       {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "!**/src"
   ],
   "scripts": {
-    "build": "tsc && bun run build:mcp",
+    "build": "tsc && bun run build:mcp && bun run build:cli",
+    "build:cli": "bun build plugins/exarchos/servers/exarchos-mcp/src/cli.ts --outfile dist/exarchos-cli.js --target node",
     "build:mcp": "bun build plugins/exarchos/servers/exarchos-mcp/src/index.ts --outfile dist/exarchos-mcp.js --target bun --minify",
     "prepare": "npm run build",
     "test": "vitest",

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -29,6 +29,13 @@ describe('Project Configuration', () => {
       expect(pkg.scripts['test:run']).toBeDefined();
     });
 
+    it('packageJson_HasBuildCliScript', () => {
+      const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8'));
+
+      expect(pkg.scripts['build:cli']).toBeDefined();
+      expect(pkg.scripts['build:cli']).toContain('exarchos-cli.js');
+    });
+
     it('should have correct name and version', () => {
       const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8'));
       expect(pkg.name).toBe('@lvlup-sw/exarchos');
@@ -1089,15 +1096,24 @@ describe('hooks.json', () => {
     expect(eventTypes).toHaveLength(6);
   });
 
-  it('hooksJson_AllCommandsReferenceCliJs', () => {
+  it('hooksJson_AllCommandsReferenceCliPath', () => {
     const hooks = JSON.parse(readFileSync(hooksPath, 'utf-8'));
     for (const [eventType, entries] of Object.entries(hooks.hooks)) {
       for (const entry of entries as Array<{ hooks: Array<{ command: string }> }>) {
         for (const hook of entry.hooks) {
-          expect(hook.command, `${eventType} hook command should reference cli.js`).toContain('cli.js');
+          expect(hook.command, `${eventType} hook command should reference {{CLI_PATH}}`).toContain('{{CLI_PATH}}');
         }
       }
     }
+  });
+
+  it('hooksJson_AllCommands_UseCliPathPlaceholder', () => {
+    const hooksContent = readFileSync(hooksPath, 'utf-8');
+
+    // Should use placeholder
+    expect(hooksContent).toContain('{{CLI_PATH}}');
+    // Should NOT contain old hardcoded path
+    expect(hooksContent).not.toContain('${CLAUDE_PLUGIN_ROOT}');
   });
 });
 

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -1027,6 +1027,33 @@ describe('Uninstall Orchestrator (E4)', () => {
     ).resolves.not.toThrow();
   });
 
+  it('uninstall_WithConfig_RemovesCliBundleToo', async () => {
+    const { uninstall } = await import('./install.js');
+
+    mkdirSync(join(claudeHome, 'mcp-servers'), { recursive: true });
+    writeFileSync(join(claudeHome, 'mcp-servers', 'exarchos-mcp.js'), 'mcp code');
+    writeFileSync(join(claudeHome, 'mcp-servers', 'exarchos-cli.js'), 'cli code');
+
+    const config = {
+      version: '2.0.0',
+      installedAt: new Date().toISOString(),
+      mode: 'standard' as const,
+      selections: {
+        mcpServers: ['exarchos', 'graphite'],
+        plugins: [],
+        ruleSets: [],
+        model: 'claude-opus-4-6',
+      },
+      hashes: {},
+    };
+    writeFileSync(join(claudeHome, 'exarchos.json'), JSON.stringify(config));
+
+    await uninstall({ claudeHome, claudeConfigPath });
+
+    expect(existsSync(join(claudeHome, 'mcp-servers', 'exarchos-mcp.js'))).toBe(false);
+    expect(existsSync(join(claudeHome, 'mcp-servers', 'exarchos-cli.js'))).toBe(false);
+  });
+
   it('uninstall_DevMode_RemovesSymlinks', async () => {
     const { uninstall } = await import('./install.js');
 
@@ -1138,6 +1165,22 @@ describe('resolveHooks', () => {
 
   afterEach(() => {
     rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('resolveHooks_MalformedJson_ThrowsDescriptiveError', async () => {
+    const { resolveHooks } = await import('./install.js');
+    writeFileSync(join(fakeRepoRoot, 'hooks.json'), '{ not valid json!!!');
+
+    expect(() => resolveHooks(join(fakeRepoRoot, 'hooks.json'), '/some/path'))
+      .toThrow(/Failed to parse hooks file/);
+  });
+
+  it('resolveHooks_MissingHooksKey_ThrowsDescriptiveError', async () => {
+    const { resolveHooks } = await import('./install.js');
+    writeFileSync(join(fakeRepoRoot, 'hooks.json'), JSON.stringify({ notHooks: {} }));
+
+    expect(() => resolveHooks(join(fakeRepoRoot, 'hooks.json'), '/some/path'))
+      .toThrow(/missing 'hooks' key/);
   });
 
   it('resolveHooks_WithCliPath_ReplacesPlaceholder', async () => {

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -1117,6 +1117,220 @@ describe('hooks.json', () => {
   });
 });
 
+describe('resolveHooks', () => {
+  let tempDir: string;
+  let fakeRepoRoot: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'hooks-test-'));
+    fakeRepoRoot = join(tempDir, 'repo');
+    mkdirSync(fakeRepoRoot, { recursive: true });
+
+    // Create a hooks.json with placeholder
+    const hooksTemplate = {
+      hooks: {
+        PreCompact: [{ matcher: 'auto', hooks: [{ type: 'command', command: 'node "{{CLI_PATH}}" pre-compact' }] }],
+        SessionStart: [{ matcher: 'startup|resume', hooks: [{ type: 'command', command: 'node "{{CLI_PATH}}" session-start' }] }],
+      },
+    };
+    writeFileSync(join(fakeRepoRoot, 'hooks.json'), JSON.stringify(hooksTemplate, null, 2));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('resolveHooks_WithCliPath_ReplacesPlaceholder', async () => {
+    const { resolveHooks } = await import('./install.js');
+    const cliPath = '/home/user/.claude/mcp-servers/exarchos-cli.js';
+
+    const result = resolveHooks(join(fakeRepoRoot, 'hooks.json'), cliPath);
+
+    // Verify placeholder was replaced
+    const preCompactCmd = (result.PreCompact[0] as { hooks: { command: string }[] }).hooks[0].command;
+    expect(preCompactCmd).toContain(cliPath);
+    expect(preCompactCmd).not.toContain('{{CLI_PATH}}');
+
+    const sessionStartCmd = (result.SessionStart[0] as { hooks: { command: string }[] }).hooks[0].command;
+    expect(sessionStartCmd).toContain(cliPath);
+    expect(sessionStartCmd).not.toContain('{{CLI_PATH}}');
+  });
+});
+
+describe('Install Orchestrator - Hooks Integration', () => {
+  let tempDir: string;
+  let claudeHome: string;
+  let fakeRepoRoot: string;
+  let manifestPath: string;
+  let claudeConfigPath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'hooks-install-test-'));
+    claudeHome = join(tempDir, '.claude');
+    fakeRepoRoot = join(tempDir, 'repo');
+    manifestPath = join(fakeRepoRoot, 'manifest.json');
+    claudeConfigPath = join(tempDir, '.claude.json');
+    mkdirSync(claudeHome, { recursive: true });
+    mkdirSync(fakeRepoRoot, { recursive: true });
+
+    // Create fake repo content directories
+    mkdirSync(join(fakeRepoRoot, 'commands'), { recursive: true });
+    writeFileSync(join(fakeRepoRoot, 'commands', 'ideate.md'), '# Ideate');
+    mkdirSync(join(fakeRepoRoot, 'skills'), { recursive: true });
+    writeFileSync(join(fakeRepoRoot, 'skills', 'brainstorming.md'), '# Brainstorming');
+    mkdirSync(join(fakeRepoRoot, 'scripts'), { recursive: true });
+    writeFileSync(join(fakeRepoRoot, 'scripts', 'run.sh'), '#!/bin/bash');
+    mkdirSync(join(fakeRepoRoot, 'rules'), { recursive: true });
+    writeFileSync(join(fakeRepoRoot, 'rules', 'coding-standards-typescript.md'), '# TS Rules');
+    writeFileSync(join(fakeRepoRoot, 'rules', 'tdd-typescript.md'), '# TDD');
+
+    // Create fake bundle file
+    mkdirSync(join(fakeRepoRoot, 'dist'), { recursive: true });
+    writeFileSync(join(fakeRepoRoot, 'dist', 'exarchos-mcp.js'), 'console.log("mcp")');
+
+    // Create manifest (with cliBundlePath)
+    const manifest = {
+      version: '2.0.0',
+      components: {
+        core: [
+          { id: 'commands', source: 'commands', target: 'commands', type: 'directory' },
+          { id: 'skills', source: 'skills', target: 'skills', type: 'directory' },
+          { id: 'scripts', source: 'scripts', target: 'scripts', type: 'directory' },
+        ],
+        mcpServers: [
+          {
+            id: 'exarchos', name: 'Exarchos',
+            description: 'Workflow orchestration',
+            required: true, type: 'bundled', bundlePath: 'dist/exarchos-mcp.js',
+            devEntryPoint: 'plugins/exarchos/servers/exarchos-mcp/dist/index.js',
+            cliBundlePath: 'dist/exarchos-cli.js',
+          },
+          {
+            id: 'graphite', name: 'Graphite',
+            description: 'Stacked PRs',
+            required: true, type: 'external',
+            command: 'gt', args: ['mcp'], prerequisite: 'gt',
+          },
+        ],
+        plugins: [
+          { id: 'github@claude-plugins-official', name: 'GitHub', description: 'PRs', required: false, default: true },
+        ],
+        ruleSets: [
+          { id: 'typescript', name: 'TypeScript', description: 'TS rules', files: ['coding-standards-typescript.md', 'tdd-typescript.md'], default: true },
+        ],
+      },
+      defaults: { model: 'claude-opus-4-6', mode: 'standard' },
+    };
+    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('install_StandardMode_InstallsCliBundleWhenCliBundlePath', async () => {
+    const { install } = await import('./install.js');
+    const { MockPromptAdapter } = await import('./wizard/prompts.js');
+
+    // Create CLI bundle
+    writeFileSync(join(fakeRepoRoot, 'dist', 'exarchos-cli.js'), 'console.log("cli")');
+
+    // Create hooks.json with placeholder
+    writeFileSync(join(fakeRepoRoot, 'hooks.json'), JSON.stringify({
+      hooks: {
+        PreCompact: [{ matcher: 'auto', hooks: [{ type: 'command', command: 'node "{{CLI_PATH}}" pre-compact' }] }],
+      },
+    }));
+
+    const prompts = new MockPromptAdapter([
+      'standard', ['github@claude-plugins-official'],
+      ['typescript'], true,
+    ]);
+
+    await install({
+      claudeHome,
+      repoRoot: fakeRepoRoot,
+      manifestPath,
+      claudeConfigPath,
+      prompts,
+      args: { action: 'install' },
+    });
+
+    // CLI bundle should be installed alongside MCP bundle
+    expect(existsSync(join(claudeHome, 'mcp-servers', 'exarchos-cli.js'))).toBe(true);
+  });
+
+  it('install_StandardMode_SettingsContainsHooksWithBundlePaths', async () => {
+    const { install } = await import('./install.js');
+    const { MockPromptAdapter } = await import('./wizard/prompts.js');
+
+    // Create CLI bundle and hooks.json
+    writeFileSync(join(fakeRepoRoot, 'dist', 'exarchos-cli.js'), 'console.log("cli")');
+    writeFileSync(join(fakeRepoRoot, 'hooks.json'), JSON.stringify({
+      hooks: {
+        PreCompact: [{ matcher: 'auto', hooks: [{ type: 'command', command: 'node "{{CLI_PATH}}" pre-compact' }] }],
+      },
+    }));
+
+    const prompts = new MockPromptAdapter([
+      'standard', ['github@claude-plugins-official'],
+      ['typescript'], true,
+    ]);
+
+    await install({
+      claudeHome,
+      repoRoot: fakeRepoRoot,
+      manifestPath,
+      claudeConfigPath,
+      prompts,
+      args: { action: 'install' },
+    });
+
+    const settings = JSON.parse(readFileSync(join(claudeHome, 'settings.json'), 'utf-8'));
+    expect(settings.hooks).toBeDefined();
+    expect(settings.hooks.PreCompact).toBeDefined();
+    // The CLI path should be the installed bundle path
+    const cmd = settings.hooks.PreCompact[0].hooks[0].command;
+    expect(cmd).toContain(join(claudeHome, 'mcp-servers', 'exarchos-cli.js'));
+    expect(cmd).not.toContain('{{CLI_PATH}}');
+  });
+
+  it('install_DevMode_SettingsContainsHooksWithRepoPaths', async () => {
+    const { install } = await import('./install.js');
+    const { MockPromptAdapter } = await import('./wizard/prompts.js');
+
+    // Create hooks.json in fake repo
+    writeFileSync(join(fakeRepoRoot, 'hooks.json'), JSON.stringify({
+      hooks: {
+        PreCompact: [{ matcher: 'auto', hooks: [{ type: 'command', command: 'node "{{CLI_PATH}}" pre-compact' }] }],
+      },
+    }));
+
+    const prompts = new MockPromptAdapter([
+      'dev', ['github@claude-plugins-official'],
+      ['typescript'], true,
+    ]);
+
+    await install({
+      claudeHome,
+      repoRoot: fakeRepoRoot,
+      manifestPath,
+      claudeConfigPath,
+      prompts,
+      args: { action: 'install' },
+    });
+
+    const settings = JSON.parse(readFileSync(join(claudeHome, 'settings.json'), 'utf-8'));
+    expect(settings.hooks).toBeDefined();
+    expect(settings.hooks.PreCompact).toBeDefined();
+    // Dev mode should use repo path
+    const cmd = settings.hooks.PreCompact[0].hooks[0].command;
+    expect(cmd).toContain(fakeRepoRoot);
+    expect(cmd).toContain('plugins/exarchos/servers/exarchos-mcp/dist/cli.js');
+    expect(cmd).not.toContain('{{CLI_PATH}}');
+  });
+});
+
 describe('manifest.json workflow ruleset', () => {
   it('manifest_WorkflowRuleSet_ExcludesAutoResume', () => {
     const manifestPath = join(repoRoot, 'manifest.json');

--- a/src/install.ts
+++ b/src/install.ts
@@ -238,6 +238,25 @@ const legacyRemoveSymlink = async (target: string): Promise<RemoveResult> => {
 
 export { legacyCreateSymlink as createSymlink, legacyRemoveSymlink as removeSymlink };
 
+// ─── Hook resolution ─────────────────────────────────────────────────────────
+
+/**
+ * Read hooks.json and resolve the {{CLI_PATH}} placeholder.
+ *
+ * @param hooksPath - Absolute path to hooks.json.
+ * @param cliPath - Absolute path to the CLI binary.
+ * @returns The hooks object with resolved paths, ready for settings.json.
+ */
+export function resolveHooks(
+  hooksPath: string,
+  cliPath: string,
+): Record<string, unknown[]> {
+  const raw = fs.readFileSync(hooksPath, 'utf-8');
+  const resolved = raw.replace(/\{\{CLI_PATH\}\}/g, cliPath);
+  const parsed = JSON.parse(resolved) as { hooks: Record<string, unknown[]> };
+  return parsed.hooks;
+}
+
 // ─── Install dependencies interface ────────────────────────────────────────
 
 export interface InstallDeps {
@@ -331,8 +350,31 @@ async function installStandard(
     installBundle(bundlePath, claudeHome);
   }
 
+  // 3a. Install CLI bundles
+  for (const server of bundledServers) {
+    if (server.cliBundlePath) {
+      const cliBundlePath = join(repoRoot, server.cliBundlePath);
+      if (fs.existsSync(cliBundlePath)) {
+        installBundle(cliBundlePath, claudeHome);
+      }
+    }
+  }
+
+  // 3b. Resolve hooks
+  const hooksPath = join(repoRoot, 'hooks.json');
+  let resolvedHooks: Record<string, unknown[]> | undefined;
+  if (fs.existsSync(hooksPath)) {
+    const exarchosServer = manifest.components.mcpServers.find(
+      (s) => s.type === 'bundled' && s.cliBundlePath,
+    );
+    if (exarchosServer) {
+      const cliPath = join(claudeHome, 'mcp-servers', basename(exarchosServer.cliBundlePath!));
+      resolvedHooks = resolveHooks(hooksPath, cliPath);
+    }
+  }
+
   // 4. Generate and write settings.json
-  const settings = generateSettings(selections);
+  const settings = generateSettings(selections, resolvedHooks);
   const settingsPath = join(claudeHome, 'settings.json');
   fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
 
@@ -383,8 +425,22 @@ async function installDev(
   const rulesTarget = join(claudeHome, 'rules');
   symlinkCreate(rulesSource, rulesTarget);
 
+  // 2a. Resolve hooks for dev mode
+  const hooksPath = join(repoRoot, 'hooks.json');
+  let resolvedHooks: Record<string, unknown[]> | undefined;
+  if (fs.existsSync(hooksPath)) {
+    const exarchosServer = manifest.components.mcpServers.find(
+      (s) => s.type === 'bundled' && s.cliBundlePath,
+    );
+    if (exarchosServer) {
+      // In dev mode, point to the repo's built CLI entry point
+      const cliPath = join(repoRoot, 'plugins/exarchos/servers/exarchos-mcp/dist/cli.js');
+      resolvedHooks = resolveHooks(hooksPath, cliPath);
+    }
+  }
+
   // 3. Generate and write settings.json
-  const settings = generateSettings(selections);
+  const settings = generateSettings(selections, resolvedHooks);
   const settingsPath = join(claudeHome, 'settings.json');
   fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -253,8 +253,44 @@ export function resolveHooks(
 ): Record<string, unknown[]> {
   const raw = fs.readFileSync(hooksPath, 'utf-8');
   const resolved = raw.replace(/\{\{CLI_PATH\}\}/g, cliPath);
-  const parsed = JSON.parse(resolved) as { hooks: Record<string, unknown[]> };
-  return parsed.hooks;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(resolved);
+  } catch {
+    throw new Error(`Failed to parse hooks file: ${hooksPath}`);
+  }
+
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('hooks' in parsed) ||
+    typeof (parsed as Record<string, unknown>).hooks !== 'object'
+  ) {
+    throw new Error(`Invalid hooks file: missing 'hooks' key in ${hooksPath}`);
+  }
+
+  return (parsed as { hooks: Record<string, unknown[]> }).hooks;
+}
+
+/**
+ * Resolve hooks from hooks.json for the given install mode.
+ * Returns undefined if hooks.json doesn't exist or no bundled server has cliBundlePath.
+ */
+function resolveHooksForMode(
+  repoRoot: string,
+  manifest: Manifest,
+  cliPath: string,
+): Record<string, unknown[]> | undefined {
+  const hooksPath = join(repoRoot, 'hooks.json');
+  if (!fs.existsSync(hooksPath)) return undefined;
+
+  const server = manifest.components.mcpServers.find(
+    (s) => s.type === 'bundled' && s.cliBundlePath,
+  );
+  if (!server?.cliBundlePath) return undefined;
+
+  return resolveHooks(hooksPath, cliPath);
 }
 
 // ─── Install dependencies interface ────────────────────────────────────────
@@ -354,24 +390,23 @@ async function installStandard(
   for (const server of bundledServers) {
     if (server.cliBundlePath) {
       const cliBundlePath = join(repoRoot, server.cliBundlePath);
-      if (fs.existsSync(cliBundlePath)) {
-        installBundle(cliBundlePath, claudeHome);
+      if (!fs.existsSync(cliBundlePath)) {
+        throw new Error(
+          `CLI bundle not found: ${cliBundlePath}\n` +
+          `Run 'npm run build' to generate the bundle before installing.`,
+        );
       }
+      installBundle(cliBundlePath, claudeHome);
     }
   }
 
   // 3b. Resolve hooks
-  const hooksPath = join(repoRoot, 'hooks.json');
-  let resolvedHooks: Record<string, unknown[]> | undefined;
-  if (fs.existsSync(hooksPath)) {
-    const exarchosServer = manifest.components.mcpServers.find(
-      (s) => s.type === 'bundled' && s.cliBundlePath,
-    );
-    if (exarchosServer) {
-      const cliPath = join(claudeHome, 'mcp-servers', basename(exarchosServer.cliBundlePath!));
-      resolvedHooks = resolveHooks(hooksPath, cliPath);
-    }
-  }
+  const exarchosServer = manifest.components.mcpServers.find(
+    (s) => s.type === 'bundled' && s.cliBundlePath,
+  );
+  const resolvedHooks = exarchosServer?.cliBundlePath
+    ? resolveHooksForMode(repoRoot, manifest, join(claudeHome, 'mcp-servers', basename(exarchosServer.cliBundlePath)))
+    : undefined;
 
   // 4. Generate and write settings.json
   const settings = generateSettings(selections, resolvedHooks);
@@ -426,18 +461,11 @@ async function installDev(
   symlinkCreate(rulesSource, rulesTarget);
 
   // 2a. Resolve hooks for dev mode
-  const hooksPath = join(repoRoot, 'hooks.json');
-  let resolvedHooks: Record<string, unknown[]> | undefined;
-  if (fs.existsSync(hooksPath)) {
-    const exarchosServer = manifest.components.mcpServers.find(
-      (s) => s.type === 'bundled' && s.cliBundlePath,
-    );
-    if (exarchosServer) {
-      // In dev mode, point to the repo's built CLI entry point
-      const cliPath = join(repoRoot, 'plugins/exarchos/servers/exarchos-mcp/dist/cli.js');
-      resolvedHooks = resolveHooks(hooksPath, cliPath);
-    }
-  }
+  const resolvedHooks = resolveHooksForMode(
+    repoRoot,
+    manifest,
+    join(repoRoot, 'plugins/exarchos/servers/exarchos-mcp/dist/cli.js'),
+  );
 
   // 3. Generate and write settings.json
   const settings = generateSettings(selections, resolvedHooks);
@@ -583,7 +611,7 @@ export async function uninstall(deps: UninstallDeps): Promise<void> {
     // Remove known bundle files
     const bundleFiles = fs.readdirSync(mcpServersDir);
     for (const file of bundleFiles) {
-      if (file.endsWith('-mcp.js')) {
+      if (file.endsWith('-mcp.js') || file.endsWith('-cli.js')) {
         fs.unlinkSync(join(mcpServersDir, file));
       }
     }

--- a/src/manifest/loader.test.ts
+++ b/src/manifest/loader.test.ts
@@ -286,7 +286,6 @@ describe('Real Manifest File (E5)', () => {
     expect(coreIds).toContain('commands');
     expect(coreIds).toContain('skills');
     expect(coreIds).toContain('scripts');
-    expect(coreIds).toContain('hooks');
   });
 
   it('manifest_ContainsRequiredServers', () => {
@@ -335,5 +334,11 @@ describe('Real Manifest File (E5)', () => {
     const exarchos = manifest.components.mcpServers.find((s) => s.id === 'exarchos');
     expect(exarchos).toBeDefined();
     expect(exarchos!.cliBundlePath).toBe('dist/exarchos-cli.js');
+  });
+
+  it('manifest_CoreComponents_DoesNotIncludeHooks', () => {
+    const manifest = loadManifest(manifestPath);
+    const coreIds = manifest.components.core.map((c) => c.id);
+    expect(coreIds).not.toContain('hooks');
   });
 });

--- a/src/manifest/loader.test.ts
+++ b/src/manifest/loader.test.ts
@@ -329,4 +329,11 @@ describe('Real Manifest File (E5)', () => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     expect(manifest.version).toBe(pkg.version);
   });
+
+  it('manifest_ExarchosMcpServer_HasCliBundlePath', () => {
+    const manifest = loadManifest(manifestPath);
+    const exarchos = manifest.components.mcpServers.find((s) => s.id === 'exarchos');
+    expect(exarchos).toBeDefined();
+    expect(exarchos!.cliBundlePath).toBe('dist/exarchos-cli.js');
+  });
 });

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -64,6 +64,8 @@ export interface McpServerComponent {
   readonly bundlePath?: string;
   /** Relative path to the compiled entry point for dev mode (type = 'bundled'). */
   readonly devEntryPoint?: string;
+  /** Relative path to the bundled CLI entry point (type = 'bundled'). */
+  readonly cliBundlePath?: string;
   /** Executable command to launch the server (type = 'external'). */
   readonly command?: string;
   /** Arguments passed to `command` (type = 'external'). */

--- a/src/operations/settings.test.ts
+++ b/src/operations/settings.test.ts
@@ -69,6 +69,40 @@ describe('Settings.json Generation (C3)', () => {
       expect(result.enabledPlugins).toBeDefined();
       expect(Object.keys(result.enabledPlugins)).toHaveLength(0);
     });
+
+    it('generateSettings_WithHooks_IncludesHooksInOutput', () => {
+      const selections = createSelections();
+      const hooks = {
+        PreCompact: [{ matcher: 'auto', hooks: [{ type: 'command', command: 'node cli.js pre-compact' }] }],
+      };
+
+      const result = generateSettings(selections, hooks);
+
+      expect(result.hooks).toBeDefined();
+      expect(result.hooks).toEqual(hooks);
+    });
+
+    it('generateSettings_WithoutHooks_OmitsHooksKey', () => {
+      const selections = createSelections();
+
+      const result = generateSettings(selections);
+
+      expect(result.hooks).toBeUndefined();
+    });
+
+    it('generateSettings_HooksStructure_PreservesEventEntries', () => {
+      const selections = createSelections();
+      const hooks = {
+        PreCompact: [{ matcher: 'auto', hooks: [{ type: 'command', command: 'node cli.js pre-compact', timeout: 30 }] }],
+        SessionStart: [{ matcher: 'startup|resume', hooks: [{ type: 'command', command: 'node cli.js session-start', timeout: 10 }] }],
+      };
+
+      const result = generateSettings(selections, hooks);
+
+      expect(result.hooks).toBeDefined();
+      expect(result.hooks!.PreCompact).toHaveLength(1);
+      expect(result.hooks!.SessionStart).toHaveLength(1);
+    });
   });
 
   describe('generatePermissions', () => {

--- a/src/operations/settings.ts
+++ b/src/operations/settings.ts
@@ -12,28 +12,40 @@ export interface Settings {
   readonly permissions: { readonly allow: readonly string[] };
   readonly model: string;
   readonly enabledPlugins: Readonly<Record<string, boolean>>;
+  readonly hooks?: Readonly<Record<string, unknown[]>>;
 }
 
 /**
  * Generate a complete settings.json from wizard selections.
  *
  * Combines the comprehensive permission list, selected model,
- * and enabled plugin map into a single settings object.
+ * and enabled plugin map into a single settings object. Optionally
+ * includes Claude Code hook definitions when provided.
  *
  * @param selections - The user's wizard selections.
+ * @param hooks - Optional hook definitions keyed by event name.
  * @returns The settings.json content.
  */
-export function generateSettings(selections: WizardSelections): Settings {
+export function generateSettings(
+  selections: WizardSelections,
+  hooks?: Record<string, unknown[]>,
+): Settings {
   const enabledPlugins: Record<string, boolean> = {};
   for (const pluginId of selections.plugins) {
     enabledPlugins[pluginId] = true;
   }
 
-  return {
+  const settings: Settings = {
     permissions: { allow: generatePermissions() },
     model: selections.model,
     enabledPlugins,
   };
+
+  if (hooks && Object.keys(hooks).length > 0) {
+    return { ...settings, hooks };
+  }
+
+  return settings;
 }
 
 /**


### PR DESCRIPTION
## Summary

Refactors the hooks installation pipeline so hooks are resolved with mode-dependent CLI paths and merged into `settings.json` instead of being copied as a separate file. The CLI entry point is now bundled with bun alongside the MCP server bundle, enabling self-contained hook execution.

## Changes

- **package.json** — Added `build:cli` script producing `dist/exarchos-cli.js`; build chain now outputs both MCP and CLI bundles
- **hooks.json** — Replaced 6 hardcoded `${CLAUDE_PLUGIN_ROOT}` paths with `{{CLI_PATH}}` placeholder for installer resolution
- **manifest.json** — Added `cliBundlePath` to exarchos server entry; removed hooks from core components array
- **McpServerComponent** — Extended type with optional `cliBundlePath` field
- **Settings / generateSettings** — Extended to accept and include optional hooks in output
- **Installer** — Added `resolveHooks` and `resolveHooksForMode` helpers; standard mode installs CLI bundle and resolves paths to `~/.claude/mcp-servers/`; dev mode resolves to repo source path
- **Uninstall** — Now cleans up both `*-mcp.js` and `*-cli.js` bundles
- **CLAUDE.md** — Updated build commands and architecture description

## Test Plan

Added 14 new tests covering hook resolution (placeholder replacement, malformed JSON, missing keys), CLI bundle installation in both modes, settings.json hooks integration, manifest schema changes, and uninstall cleanup. Full suite: 223 tests passing.

---

**Results:** Tests 223 ✓ · Build 0 errors
**Plan:** [refactor-hooks-installer-bundling.plan.md](docs/plans/2026-02-14-refactor-hooks-installer-bundling.plan.md)