### PR TITLE
refactor: split quality-review skill into SKILL.md + references

### DIFF
--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -1,3 +1,19 @@
+---
+name: quality-review
+description: |
+  Two-stage code review: spec compliance then code quality analysis.
+  Use when the user says "review code", "check quality", "code review",
+  or runs /review. Stage 1 verifies design alignment. Stage 2 checks
+  SOLID principles, DRY, security, and test quality.
+  Do NOT use for plan-design delta analysis -- use spec-review instead.
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: review
+---
+
 # Quality Review Skill
 
 ## Overview
@@ -18,38 +34,31 @@ Activate this skill when:
 
 This skill runs in a SUBAGENT spawned by the orchestrator, not inline.
 
-The orchestrator provides:
-- State file path (preferred) OR design/plan paths
-- Diff output from `~/.claude/scripts/review-diff.sh` (context-efficient)
-- Task ID being reviewed
-- Spec review results (must be PASS)
+The orchestrator provides the state file path, diff output from `~/.claude/scripts/review-diff.sh`, task ID, and spec review results (must be PASS).
 
-The subagent:
-- Reads state file to get artifact paths
-- Uses diff output instead of reading full files
-- Runs static analysis
-- Performs code walkthrough
-- Generates report
-- Returns verdict to orchestrator
+The subagent reads the state file for artifact paths, uses the diff output instead of full files, runs static analysis, performs a code walkthrough, generates a report, and returns the verdict.
 
 ### Context-Efficient Input
 
-Instead of reading full files, receive the stack diff:
+Instead of reading full files, receive the integrated diff:
 
 ```bash
-# Generate diff for review (Graphite stack vs main)
+# Generate integrated diff for review (Graphite stack vs main)
 gt diff main > /tmp/stack-diff.patch
+
+# Alternative: git diff main...integration-branch for complete picture
+git diff main...integration > /tmp/integration-diff.patch
 
 # Alternative: use GitHub MCP to get PR diff
 # mcp__plugin_github_github__pull_request_read({ owner, repo, pullNumber, method: "get_diff" })
 ```
 
-This provides the complete picture of all changes across all tasks and reduces context consumption by 80-90%.
+This reduces context consumption by 80-90% while providing the complete picture.
 
 ### Review Scope: Combined Changes
 
 After delegation completes, quality review examines:
-- The **complete stack diff** (all task branches vs main)
+- The **complete stack diff** (all task branches vs main), or the **feature/integration-branch** diff when using integration branches
 - All changes across all tasks in one view
 - The full picture of combined code quality
 
@@ -72,183 +81,6 @@ This enables catching:
 - Functional completeness (spec review)
 - TDD compliance (spec review)
 
-## Review Criteria
-
-### 1. Code Quality
-
-| Aspect | Check For |
-|--------|-----------|
-| Readability | Clear variable/function names |
-| Complexity | Functions <30 lines, single responsibility |
-| Duplication | DRY - no copy-paste code |
-| Comments | Only where logic isn't self-evident |
-| Formatting | Consistent with project style |
-
-### 1.1 DRY Enforcement
-
-| Pattern | Threshold | Priority |
-|---------|-----------|----------|
-| Identical code blocks | 3+ occurrences OR 5+ lines | HIGH (3+), MEDIUM (2) |
-| Similar code (literals differ) | 3+ occurrences | MEDIUM |
-| Repeated validation logic | 2+ locations | HIGH |
-| Repeated business rules | 2+ locations | HIGH |
-| Copy-pasted tests | 3+ similar tests | LOW |
-| Magic literals | Same value 3+ times | MEDIUM |
-
-**Detection approach (prefer MCP tools):**
-- Use `mcp__plugin_serena_serena__search_for_pattern` to find duplicate code blocks
-- Use `mcp__plugin_serena_serena__find_referencing_symbols` to trace dependency usage
-- Use `mcp__plugin_serena_serena__get_symbols_overview` to understand module structure before deep-reading
-
-**Detection checklist:**
-- [ ] Search for identical multi-line blocks (5+ lines duplicated)
-- [ ] Flag validation code outside designated validation layer
-- [ ] Trace business rule conditionals - must have single source
-- [ ] Check for repeated string/number literals without constants
-
-### 2. SOLID Principles
-
-| Principle | Verify | Specific Checks |
-|-----------|--------|-----------------|
-| **S**RP | One reason to change | Max 1 public type/file; class name matches responsibility |
-| **O**CP | Extensible without modification | No switch/if-else on types; uses strategy/polymorphism |
-| **L**SP | Subtypes substitutable | No `NotImplementedException`; no precondition strengthening |
-| **I**SP | No forced dependencies | Interface <= 5 methods; no empty implementations |
-| **D**IP | Depend on abstractions | No `new` for services; constructor injection only |
-
-#### ISP Violation Patterns
-
-| Pattern | Detection | Priority |
-|---------|-----------|----------|
-| Fat interface (> 5 methods) | Count methods on interface | MEDIUM |
-| Mixed read/write interface | Check for getters + mutators together | MEDIUM |
-| Empty/throw implementations | Scan for `NotImplementedException`, empty bodies | HIGH |
-| Vague interface names | `IService`, `IManager`, `IHandler` without qualifier | LOW |
-| Partial interface usage | Client uses < 50% of interface methods | MEDIUM |
-
-**ISP Checklist:**
-- [ ] No interface has more than 5 methods
-- [ ] Interfaces are role-specific (IReadable, IWritable, not IDataAccess)
-- [ ] No classes implement interfaces with NotImplementedException
-- [ ] Interface names describe a single capability
-
-### 2.1 Control Flow Standards
-
-| Standard | Check For |
-|----------|-----------|
-| Guard clauses | Validate at method entry, not nested |
-| Early returns | Exit as soon as result is known |
-| No arrow code | Deeply nested if/else is a smell |
-| Conditional abstraction | Large switch/if-else extracted to helper |
-
-#### Guard Clause Pattern
-
-**Preferred:**
-```
-if (input == null) return;
-// Main logic flat
-```
-
-**Avoid:**
-```
-if (input != null) {
-  // Entire body nested
-}
-```
-
-### 2.2 Structural Standards
-
-| Standard | Check For | Priority |
-|----------|-----------|----------|
-| One responsibility per file | Public types in dedicated files | HIGH |
-| Composition over inheritance | See checklist below | MEDIUM-HIGH |
-| Sealed by default | `sealed` unless designed for extension | LOW |
-
-#### Composition Over Inheritance Checklist
-
-| Smell | Detection | Priority | Fix |
-|-------|-----------|----------|-----|
-| Inheritance depth > 2 | Count class hierarchy levels | MEDIUM | Refactor to delegation |
-| Base class with multiple concerns | Base has unrelated methods | MEDIUM | Split into interfaces + composition |
-| `protected` for code sharing | Many protected methods (> 2/class) | MEDIUM | Extract to utility or inject strategy |
-| Override that only extends | `super.method()` + additions | MEDIUM | Use decorator pattern |
-| Inherit for one method | Extends to reuse single method | HIGH | Compose with delegation |
-| Missing `sealed` | Non-sealed without extension design | LOW | Add `sealed` (C#) |
-
-**Composition Checklist:**
-- [ ] Inheritance represents true "is-a" relationship, not code reuse
-- [ ] Class hierarchy depth <= 2
-- [ ] `protected` methods are rare (< 2 per class)
-- [ ] No override methods that just call super + add logic
-- [ ] C# classes are `sealed` unless explicitly designed for inheritance
-
-**Language-specific rules:** See `~/.claude/rules/coding-standards-{language}.md`
-
-### 3. Error Handling
-
-| Check | Verify |
-|-------|--------|
-| Errors caught | Try/catch where needed |
-| Errors meaningful | Clear error messages |
-| Errors propagated | Proper error bubbling |
-| No silent failures | All errors handled or logged |
-| Input validation | At system boundaries |
-
-### 4. Test Quality
-
-| Aspect | Verify |
-|--------|--------|
-| Arrange-Act-Assert | Clear test structure |
-| Test isolation | No shared state issues |
-| Meaningful assertions | Not just "expect(true)" |
-| Edge cases | Boundary conditions tested |
-| Error paths | Failure scenarios covered |
-
-### 5. Performance
-
-| Check | Verify |
-|-------|--------|
-| No N+1 queries | Batch operations used |
-| Efficient algorithms | No obvious O(n^2) when O(n) works |
-| Memory management | No leaks, proper cleanup |
-| Async patterns | Proper await usage |
-
-### 6. Security Basics
-
-| Check | Verify |
-|-------|--------|
-| Input sanitization | User input validated |
-| No secrets in code | Use environment variables |
-| SQL injection | Parameterized queries |
-| XSS prevention | Output encoding |
-
-### 7. Frontend Aesthetics (if applicable)
-
-For frontend code (React, Vue, HTML/CSS, etc.), verify distinctive design:
-
-| Check | Verify |
-|-------|--------|
-| Distinctive typography | Not using Inter, Roboto, Arial, or system defaults |
-| Intentional color palette | CSS variables defined, not ad-hoc colors |
-| Purposeful motion | Orchestrated animations, not scattered micro-interactions |
-| Atmospheric backgrounds | Layered/textured, not flat solid colors |
-| Overall distinctiveness | Doesn't exhibit "AI slop" patterns |
-
-**Anti-patterns to flag:**
-- Purple gradients on white backgrounds
-- Perfectly centered symmetric layouts
-- Generic font choices
-- Flat #f5f5f5 or pure white/black backgrounds
-- Animation without purpose
-
-## Priority Levels
-
-| Priority | Action | Examples |
-|----------|--------|----------|
-| **HIGH** | Must fix before merge | Security issues, data loss risks |
-| **MEDIUM** | Should fix, may defer | SOLID violations, complexity |
-| **LOW** | Nice to have | Style preferences, minor refactors |
-
 ## Review Process
 
 ### Step 1: Static Analysis
@@ -264,81 +96,30 @@ npm run quality-check
 
 ### Step 2: Code Walkthrough
 
-Read each modified file and assess:
-- Function/class structure
-- Error handling patterns
-- Test quality
+Assess each modified file against the quality checklists:
+- Consult `references/code-quality-checklist.md` for code quality, SOLID, DRY, and structural criteria
+- Consult `references/security-checklist.md` for security review criteria
 
 ### Step 3: Generate Report
 
-```markdown
-## Quality Review Report
+Use the template from `references/review-report-template.md` to structure the review output.
 
-### Summary
-- Status: [APPROVED | NEEDS_FIXES | BLOCKED]
-- Reviewed: [timestamp]
-- Reviewer: Claude Code
+## Priority Levels
 
-### Findings
-
-#### HIGH Priority
-1. [Finding title]
-   - File: `path/to/file.ts:42`
-   - Issue: [Description]
-   - Fix: [Required change]
-
-#### MEDIUM Priority
-1. [Finding title]
-   - File: `path/to/file.ts:88`
-   - Issue: [Description]
-   - Suggestion: [Recommended change]
-
-#### LOW Priority
-1. [Finding title]
-   - File: `path/to/file.ts:15`
-   - Note: [Observation]
-
-### Verdict
-[APPROVED] Ready for synthesis
-[NEEDS_FIXES] Fix HIGH priority items, then re-review
-[BLOCKED] Critical issues require design discussion
-```
+| Priority | Action | Examples |
+|----------|--------|----------|
+| **HIGH** | Must fix before merge | Security issues, data loss risks |
+| **MEDIUM** | Should fix, may defer | SOLID violations, complexity |
+| **LOW** | Nice to have | Style preferences, minor refactors |
 
 ## Fix Loop for HIGH Priority
 
 If HIGH priority issues found:
 
-1. Create fix task with specific issues
-2. Dispatch to implementer
+1. Create fix task listing each HIGH finding with file, issue, and required fix
+2. Dispatch to implementer subagent
 3. Re-review quality after fixes
-4. Only mark APPROVED when HIGH items resolved
-
-```typescript
-// Return for quality fixes
-Task({
-  model: "opus",
-  description: "Fix quality review issues",
-  prompt: `
-# Fix Required: Quality Review Issues
-
-## HIGH Priority (Must Fix)
-1. SQL Injection vulnerability
-   - File: src/api/users.ts:42
-   - Issue: Raw string interpolation in query
-   - Fix: Use parameterized query
-
-2. Unhandled promise rejection
-   - File: src/services/email.ts:88
-   - Issue: Missing await/catch
-   - Fix: Add try/catch with error logging
-
-## Success Criteria
-- All HIGH priority items resolved
-- Tests still pass
-- No new issues introduced
-`
-})
-```
+4. Only mark APPROVED when all HIGH items resolved and tests pass
 
 ## Anti-Patterns
 
@@ -353,34 +134,10 @@ Task({
 
 ## State Management
 
-Update workflow state with review results using `mcp__exarchos__exarchos_workflow` with `action: "set"`.
+Update workflow state with review results using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 
-### On Review Complete
-
-```text
-# Update task review status - for approved
-Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
-  updates: { "tasks[id=<task-id>].reviewStatus.qualityReview": "approved" }
-
-# Or if needs fixes:
-Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
-  updates: { "tasks[id=<task-id>].reviewStatus.qualityReview": "needs_fixes" }
-
-# Add review details
-Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
-  updates: {
-    "reviews.<task-id>.qualityReview": {"status": "approved", "highPriority": [], "mediumPriority": []}
-  }
-```
-
-### On All Reviews Pass
-
-Update phase for synthesis:
-
-```text
-Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
-  phase: "synthesize"
-```
+- **On review complete:** Set `tasks[id=<task-id>].reviewStatus.qualityReview` to `"approved"` or `"needs_fixes"`, and add review details to `reviews.<task-id>.qualityReview`
+- **On all reviews pass:** Set `phase: "synthesize"` to advance the workflow
 
 ## Completion Criteria
 
@@ -425,11 +182,7 @@ This is NOT a human checkpoint - workflow continues autonomously.
 
 When Exarchos MCP tools are available, emit gate events during review:
 
-1. **Read CI status:** Use `mcp__plugin_github_github__pull_request_read` with `method: "get_status"` to get CI gate results
-2. **For each CI check:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `gate.executed` including:
-   - `gateName`: The CI check name
-   - `layer`: "per-pr" or "per-stack"
-   - `passed`: boolean
-   - `duration`: milliseconds (if available)
-3. **Read unified status:** Use `mcp__exarchos__exarchos_view` with `action: "tasks"` with `fields: ["taskId", "status", "title"]` and `limit: 20` for combined task + gate view with minimal token cost
-4. **When all per-PR gates pass:** Apply `stack-ready` label to the PR
+1. **Read CI status** via `pull_request_read` with `method: "get_status"`
+2. **Emit gate events** via `exarchos_event` with `action: "append"`, type `gate.executed` (include `gateName`, `layer`, `passed`, `duration`)
+3. **Read unified status** via `exarchos_view` with `action: "tasks"`, `fields: ["taskId", "status", "title"]`, `limit: 20`
+4. **When all per-PR gates pass**, apply `stack-ready` label to the PR

--- a/skills/quality-review/references/code-quality-checklist.md
+++ b/skills/quality-review/references/code-quality-checklist.md
@@ -1,0 +1,159 @@
+# Code Quality Checklist
+
+Detailed review criteria for code quality, SOLID principles, DRY enforcement, and structural standards. Used during Step 2 of the quality review process.
+
+## 1. Code Quality
+
+| Aspect | Check For |
+|--------|-----------|
+| Readability | Clear variable/function names |
+| Complexity | Functions <30 lines, single responsibility |
+| Duplication | DRY - no copy-paste code |
+| Comments | Only where logic isn't self-evident |
+| Formatting | Consistent with project style |
+
+## 1.1 DRY Enforcement
+
+| Pattern | Threshold | Priority |
+|---------|-----------|----------|
+| Identical code blocks | 3+ occurrences OR 5+ lines | HIGH (3+), MEDIUM (2) |
+| Similar code (literals differ) | 3+ occurrences | MEDIUM |
+| Repeated validation logic | 2+ locations | HIGH |
+| Repeated business rules | 2+ locations | HIGH |
+| Copy-pasted tests | 3+ similar tests | LOW |
+| Magic literals | Same value 3+ times | MEDIUM |
+
+**Detection approach (prefer MCP tools):**
+- Use `search_for_pattern` to find duplicate code blocks
+- Use `find_referencing_symbols` to trace dependency usage
+- Use `get_symbols_overview` to understand module structure
+
+**Detection checklist:**
+- [ ] Search for identical multi-line blocks (5+ lines duplicated)
+- [ ] Flag validation code outside designated validation layer
+- [ ] Trace business rule conditionals - must have single source
+- [ ] Check for repeated string/number literals without constants
+
+## 2. SOLID Principles
+
+| Principle | Verify | Specific Checks |
+|-----------|--------|-----------------|
+| **S**RP | One reason to change | Max 1 public type/file; class name matches responsibility |
+| **O**CP | Extensible without modification | No switch/if-else on types; uses strategy/polymorphism |
+| **L**SP | Subtypes substitutable | No `NotImplementedException`; no precondition strengthening |
+| **I**SP | No forced dependencies | Interface <= 5 methods; no empty implementations |
+| **D**IP | Depend on abstractions | No `new` for services; constructor injection only |
+
+### ISP Violation Patterns
+
+| Pattern | Detection | Priority |
+|---------|-----------|----------|
+| Fat interface (> 5 methods) | Count methods on interface | MEDIUM |
+| Mixed read/write interface | Check for getters + mutators together | MEDIUM |
+| Empty/throw implementations | Scan for `NotImplementedException`, empty bodies | HIGH |
+| Vague interface names | `IService`, `IManager`, `IHandler` without qualifier | LOW |
+| Partial interface usage | Client uses < 50% of interface methods | MEDIUM |
+
+**ISP Checklist:**
+- [ ] No interface has more than 5 methods
+- [ ] Interfaces are role-specific (IReadable, IWritable, not IDataAccess)
+- [ ] No classes implement interfaces with NotImplementedException
+- [ ] Interface names describe a single capability
+
+## 2.1 Control Flow Standards
+
+| Standard | Check For |
+|----------|-----------|
+| Guard clauses | Validate at method entry, not nested |
+| Early returns | Exit as soon as result is known |
+| No arrow code | Deeply nested if/else is a smell |
+| Conditional abstraction | Large switch/if-else extracted to helper |
+
+### Guard Clause Pattern
+
+**Preferred:**
+```
+if (input == null) return;
+// Main logic flat
+```
+
+**Avoid:**
+```
+if (input != null) {
+  // Entire body nested
+}
+```
+
+## 2.2 Structural Standards
+
+| Standard | Check For | Priority |
+|----------|-----------|----------|
+| One responsibility per file | Public types in dedicated files | HIGH |
+| Composition over inheritance | See checklist below | MEDIUM-HIGH |
+| Sealed by default | `sealed` unless designed for extension | LOW |
+
+### Composition Over Inheritance Checklist
+
+| Smell | Detection | Priority | Fix |
+|-------|-----------|----------|-----|
+| Inheritance depth > 2 | Count hierarchy levels | MEDIUM | Refactor to delegation |
+| Base class, multiple concerns | Base has unrelated methods | MEDIUM | Split into interfaces + composition |
+| `protected` for code sharing | Many protected methods (> 2/class) | MEDIUM | Extract to utility or inject strategy |
+| Override that only extends | `super.method()` + additions | MEDIUM | Use decorator pattern |
+| Inherit for one method | Extends to reuse single method | HIGH | Compose with delegation |
+
+**Composition Checklist:**
+- [ ] Inheritance represents true "is-a" relationship, not code reuse
+- [ ] Class hierarchy depth <= 2
+- [ ] `protected` methods rare (< 2 per class)
+- [ ] No override methods that just call super + add logic
+
+**Language-specific rules:** See `~/.claude/rules/coding-standards-{language}.md`
+
+## 3. Error Handling
+
+| Check | Verify |
+|-------|--------|
+| Errors caught | Try/catch where needed |
+| Errors meaningful | Clear error messages |
+| Errors propagated | Proper error bubbling |
+| No silent failures | All errors handled or logged |
+| Input validation | At system boundaries |
+
+## 4. Test Quality
+
+| Aspect | Verify |
+|--------|--------|
+| Arrange-Act-Assert | Clear test structure |
+| Test isolation | No shared state issues |
+| Meaningful assertions | Not just "expect(true)" |
+| Edge cases | Boundary conditions tested |
+| Error paths | Failure scenarios covered |
+
+## 5. Performance
+
+| Check | Verify |
+|-------|--------|
+| No N+1 queries | Batch operations used |
+| Efficient algorithms | No obvious O(n^2) when O(n) works |
+| Memory management | No leaks, proper cleanup |
+| Async patterns | Proper await usage |
+
+## 6. Frontend Aesthetics (if applicable)
+
+For frontend code (React, Vue, HTML/CSS, etc.), verify distinctive design:
+
+| Check | Verify |
+|-------|--------|
+| Distinctive typography | Not using Inter, Roboto, Arial, or system defaults |
+| Intentional color palette | CSS variables defined, not ad-hoc colors |
+| Purposeful motion | Orchestrated animations, not scattered micro-interactions |
+| Atmospheric backgrounds | Layered/textured, not flat solid colors |
+| Overall distinctiveness | Doesn't exhibit "AI slop" patterns |
+
+**Anti-patterns to flag:**
+- Purple gradients on white backgrounds
+- Perfectly centered symmetric layouts
+- Generic font choices
+- Flat #f5f5f5 or pure white/black backgrounds
+- Animation without purpose

--- a/skills/quality-review/references/review-report-template.md
+++ b/skills/quality-review/references/review-report-template.md
@@ -1,0 +1,54 @@
+# Quality Review Report Template
+
+Use this template to structure the output of Step 3 (Generate Report) in the quality review process.
+
+## Template
+
+```markdown
+## Quality Review Report
+
+### Summary
+- Status: [APPROVED | NEEDS_FIXES | BLOCKED]
+- Reviewed: [timestamp]
+- Reviewer: Claude Code
+
+### Findings
+
+#### HIGH Priority
+1. [Finding title]
+   - File: `path/to/file.ts:42`
+   - Issue: [Description]
+   - Fix: [Required change]
+
+#### MEDIUM Priority
+1. [Finding title]
+   - File: `path/to/file.ts:88`
+   - Issue: [Description]
+   - Suggestion: [Recommended change]
+
+#### LOW Priority
+1. [Finding title]
+   - File: `path/to/file.ts:15`
+   - Note: [Observation]
+
+### Verdict
+[APPROVED] Ready for synthesis
+[NEEDS_FIXES] Fix HIGH priority items, then re-review
+[BLOCKED] Critical issues require design discussion
+```
+
+## Verdict Criteria
+
+| Verdict | Condition |
+|---------|-----------|
+| **APPROVED** | No HIGH priority findings; MEDIUM/LOW acceptable |
+| **NEEDS_FIXES** | One or more HIGH priority findings that must be resolved |
+| **BLOCKED** | Critical architectural or security issues requiring design discussion |
+
+## Report Guidelines
+
+- List every finding with file path and line number
+- HIGH priority findings must include a concrete fix description
+- MEDIUM priority findings should include a suggested approach
+- LOW priority findings are observations for future improvement
+- The verdict drives the next workflow transition (synthesize, fix loop, or redesign)

--- a/skills/quality-review/references/security-checklist.md
+++ b/skills/quality-review/references/security-checklist.md
@@ -1,0 +1,62 @@
+# Security Review Checklist
+
+Security review criteria based on OWASP Top 10 patterns. Used during Step 2 of the quality review process.
+
+## Security Basics
+
+| Check | Verify |
+|-------|--------|
+| Input sanitization | User input validated |
+| No secrets in code | Use environment variables |
+| SQL injection | Parameterized queries |
+| XSS prevention | Output encoding |
+
+## OWASP Top 10 Patterns
+
+When reviewing code that handles user input, authentication, or data access, check for these common vulnerability patterns:
+
+### Injection (A03)
+- SQL queries use parameterized statements, never string concatenation
+- Shell commands use safe APIs, never template strings with user input
+- LDAP/XPath queries are parameterized
+
+### Broken Authentication (A07)
+- Passwords are hashed with bcrypt/argon2, never stored in plaintext
+- Session tokens have sufficient entropy
+- Rate limiting on authentication endpoints
+
+### Sensitive Data Exposure (A02)
+- No secrets, API keys, or credentials in source code
+- Sensitive data encrypted at rest and in transit
+- PII properly handled per data classification
+
+### Broken Access Control (A01)
+- Authorization checks on every endpoint
+- No direct object references without access validation
+- Default deny for permissions
+
+### Security Misconfiguration (A05)
+- No debug mode in production config
+- Error messages don't leak stack traces or internal details
+- Security headers configured (CORS, CSP, HSTS)
+
+### Cross-Site Scripting (A03)
+- Output encoding applied to all user-controlled data
+- Content Security Policy headers set
+- DOM manipulation uses safe APIs
+
+### Insecure Deserialization (A08)
+- User input is validated before deserialization
+- Type checking enforced on deserialized objects
+- No eval() or equivalent on untrusted data
+
+## Detection Checklist
+
+- [ ] No hardcoded secrets or API keys
+- [ ] All user input validated at system boundaries
+- [ ] SQL/NoSQL queries use parameterized statements
+- [ ] Output encoding applied for XSS prevention
+- [ ] Authentication uses secure hashing algorithms
+- [ ] Authorization checks present on all endpoints
+- [ ] Error messages do not expose internal details
+- [ ] Dependencies checked for known vulnerabilities


### PR DESCRIPTION
## Summary

Splits the monolithic quality-review SKILL.md (2,057 words) into a focused workflow overview plus three reference files. Adds YAML frontmatter for machine-readable skill metadata. This reduces the main skill file to 800 words while preserving all review criteria in dedicated checklists.

## Changes

- **SKILL.md** -- Restructured to workflow overview (~800 words) with YAML frontmatter, condensed State Management and Fix Loop sections, added explicit references to checklist files at appropriate review steps
- **references/code-quality-checklist.md** -- Extracted Code Quality, DRY Enforcement, SOLID Principles, ISP Violations, Control Flow, Structural Standards, Error Handling, Test Quality, Performance, and Frontend Aesthetics criteria (~982 words)
- **references/security-checklist.md** -- Extracted Security Basics table plus expanded OWASP Top 10 pattern coverage (~347 words)
- **references/review-report-template.md** -- Extracted report template with verdict criteria and guidelines (~210 words)

## Test Plan

Frontmatter validation passes via `validate-frontmatter.sh`. Existing `SKILL.md.test.sh` backward compatibility preserved (all 5 grep assertions pass). Word counts verified within targets.

---

**Results:** Frontmatter validation PASS, existing test PASS, body 800 words
**Related:** Continues skills-content-mod stack