### PR TITLE
feat: add frontmatter and troubleshooting to 4 MCP-heavy skills

### DIFF
--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,3 +1,27 @@
+---
+name: debug
+description: |-
+  Bug investigation and fix workflow with hotfix and thorough tracks.
+  Use when the user says "debug", "fix bug", "investigate issue",
+  "something is broken", or runs /debug. Hotfix track for quick fixes,
+  thorough track for complex bugs requiring root cause analysis.
+  Do NOT use for code improvement — use refactor instead.
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity:
+    - triage
+    - investigate
+    - rca
+    - design
+    - implement
+    - validate
+    - review
+    - synthesize
+---
+
 # Debug Workflow Skill
 
 ## Overview
@@ -432,6 +456,33 @@ Extended to support:
 | Exceed 15 min on hotfix investigation | Switch to thorough track |
 | Add features during bug fix | Scope creep - only fix the bug |
 | Skip tests because "it's just a fix" | Fixes need tests to prevent regression |
+
+## Troubleshooting
+
+### MCP Tool Call Failed
+If an Exarchos MCP tool returns an error:
+1. Check the error message — it usually contains specific guidance
+2. Verify the workflow state exists: call `exarchos_workflow` with `action: "get"` and the featureId
+3. If "version mismatch": another process updated state — retry the operation
+4. If state is corrupted: call `exarchos_workflow` with `action: "cancel"` and `dryRun: true`
+
+### State Desync
+If workflow state doesn't match git reality:
+1. The SessionStart hook runs reconciliation automatically on resume
+2. If manual check needed: compare state file with `git log` and branch state
+3. Update state via `exarchos_workflow` with `action: "set"` to match git truth
+
+### Investigation Timeout (Hotfix Track)
+If 15-minute investigation timer expires without root cause:
+1. The workflow auto-switches to thorough track
+2. All investigation findings are preserved in state
+3. Continue investigation without time constraint
+
+### Track Switching
+If hotfix track reveals complexity requiring thorough investigation:
+1. Call `exarchos_workflow` with `action: "set"` to update track to "thorough"
+2. Previous investigation findings carry over
+3. RCA phase begins after investigation completes
 
 ## Exarchos Integration
 

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -1,3 +1,20 @@
+---
+name: delegation
+description: |-
+  Dispatch implementation tasks to agent teammates in git worktrees.
+  Use when the user says "delegate", "dispatch tasks", "assign work",
+  or runs /delegate. Spawns teammates, creates worktrees, monitors
+  progress, and collects results. Supports --fixes flag for review
+  finding remediation.
+  Do NOT use for direct implementation — orchestrator delegates only.
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: delegate
+---
+
 # Delegation Skill
 
 ## Overview
@@ -385,6 +402,10 @@ After all tasks complete, **auto-continue immediately** (no user confirmation):
 
 This is NOT a human checkpoint - workflow continues autonomously.
 State is saved, enabling recovery after context compaction.
+
+## Troubleshooting
+
+See `@skills/delegation/references/troubleshooting.md` for detailed troubleshooting covering MCP tool failures, state desync, worktree creation, teammate spawn timeouts, and task claim conflicts.
 
 ## Exarchos Integration
 

--- a/skills/delegation/references/troubleshooting.md
+++ b/skills/delegation/references/troubleshooting.md
@@ -1,0 +1,33 @@
+# Delegation Troubleshooting
+
+## MCP Tool Call Failed
+If an Exarchos MCP tool returns an error:
+1. Check the error message — it usually contains specific guidance
+2. Verify the workflow state exists: call `exarchos_workflow` with `action: "get"` and the featureId
+3. If "version mismatch": another process updated state — retry the operation
+4. If state is corrupted: call `exarchos_workflow` with `action: "cancel"` and `dryRun: true`
+
+## State Desync
+If workflow state doesn't match git reality:
+1. The SessionStart hook runs reconciliation automatically on resume
+2. If manual check needed: compare state file with `git log` and branch state
+3. Update state via `exarchos_workflow` with `action: "set"` to match git truth
+
+## Worktree Creation Failed
+If `git worktree add` fails:
+1. Check if the branch already exists: `git branch --list <branch-name>`
+2. Check if a worktree already exists at the path: `git worktree list`
+3. If stale worktree: `git worktree prune` then retry
+4. If branch conflict: use a unique branch name
+
+## Teammate Spawn Timeout
+If a spawned teammate doesn't respond:
+1. Check teammate status: call `exarchos_orchestrate` with `action: "team_status"`
+2. If teammate shows as active but idle: send a message via `exarchos_orchestrate` with `action: "team_message"`
+3. If teammate is missing: shut down and re-spawn
+
+## Task Claim Conflict
+If `exarchos_orchestrate` with `action: "task_claim"` returns ALREADY_CLAIMED:
+1. Another agent already claimed this task — skip it
+2. Check task status via `exarchos_view` with `action: "tasks"` and `filter: { "taskId": "<id>" }`
+3. Do not re-dispatch — the other agent is handling it

--- a/skills/synthesis/SKILL.md
+++ b/skills/synthesis/SKILL.md
@@ -1,3 +1,19 @@
+---
+name: synthesis
+description: |-
+  Create pull request from completed feature branch using Graphite
+  stacked PRs. Use when the user says "create PR", "submit for review",
+  "synthesize", or runs /synthesize. Validates branch readiness, creates
+  PR with structured description, and manages merge queue.
+  Do NOT use before /review has passed.
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: synthesize
+---
+
 # Synthesis Skill
 
 ## Overview
@@ -213,6 +229,40 @@ Options:
 - **'yes'**: Merge PR, update state to "completed"
 - **'feedback'**: Auto-continue to `/delegate --pr-fixes` to address comments, then return here
 - **'no'**: Pause workflow, can resume later with `/resume`
+
+## Troubleshooting
+
+### MCP Tool Call Failed
+If an Exarchos MCP tool returns an error:
+1. Check the error message — it usually contains specific guidance
+2. Verify the workflow state exists: call `exarchos_workflow` with `action: "get"` and the featureId
+3. If "version mismatch": another process updated state — retry the operation
+4. If state is corrupted: call `exarchos_workflow` with `action: "cancel"` and `dryRun: true`
+
+### State Desync
+If workflow state doesn't match git reality:
+1. The SessionStart hook runs reconciliation automatically on resume
+2. If manual check needed: compare state file with `git log` and branch state
+3. Update state via `exarchos_workflow` with `action: "set"` to match git truth
+
+### PR Creation Failed
+If `gt submit` fails:
+1. Check the error output for specific guidance
+2. Run `gt log` to verify the stack state
+3. If rebase conflict: run `gt restack` to resolve
+4. If authentication issue: check GitHub token permissions
+
+### Stack Rebase Conflict
+If `gt restack` encounters conflicts:
+1. Resolve conflicts manually in each affected file
+2. Run `git add <resolved-files>` then `gt continue`
+3. After resolution, re-run `gt submit --no-interactive --publish --merge-when-ready`
+
+### Merge Queue Rejection
+If the merge queue rejects a PR:
+1. Check CI status via GitHub MCP: `pull_request_read` with method `get_status`
+2. Fix failing checks
+3. Push fixes and re-enqueue
 
 ## Exarchos Integration
 

--- a/skills/workflow-state/SKILL.md
+++ b/skills/workflow-state/SKILL.md
@@ -1,3 +1,23 @@
+---
+name: workflow-state
+description: |-
+  Checkpoint and resume workflow state for context persistence across
+  sessions. Use when the user says "save progress", "checkpoint",
+  "I need to stop", or runs /checkpoint or /resume. Saves current
+  workflow phase, task progress, and artifacts for later resumption.
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: utility
+  phase-affinity:
+    - ideate
+    - plan
+    - delegate
+    - review
+    - synthesize
+---
+
 # Workflow State Management Skill
 
 ## Overview
@@ -133,6 +153,39 @@ Key sections:
 3. **Reconcile on resume** - Always verify state matches git state
 4. **Checkpoint at boundaries** - Save state before likely context exhaustion
 5. **Read state, don't remember** - After summarization, read from state file
+
+## Troubleshooting
+
+### MCP Tool Call Failed
+If an Exarchos MCP tool returns an error:
+1. Check the error message — it usually contains specific guidance
+2. Verify the workflow state exists: call `exarchos_workflow` with `action: "get"` and the featureId
+3. If "version mismatch": another process updated state — retry the operation
+4. If state is corrupted: call `exarchos_workflow` with `action: "cancel"` and `dryRun: true`
+
+### State Desync
+If workflow state doesn't match git reality:
+1. The SessionStart hook runs reconciliation automatically on resume
+2. If manual check needed: compare state file with `git log` and branch state
+3. Update state via `exarchos_workflow` with `action: "set"` to match git truth
+
+### Checkpoint File Missing
+If the PreCompact hook can't find state to checkpoint:
+1. Verify a workflow is active: call `exarchos_workflow` with `action: "get"` and the featureId
+2. If no active workflow: the hook will silently skip (expected behavior)
+3. If workflow exists but checkpoint fails: check disk space and permissions
+
+### Resume Finds Stale State
+If state references branches or worktrees that no longer exist:
+1. The SessionStart hook handles reconciliation automatically
+2. It updates state to reflect current git reality
+3. Missing branches are flagged in the session-start output
+
+### Multiple Active Workflows
+If multiple workflow state files exist:
+1. The system uses the most recently updated active (non-completed) workflow
+2. Use `exarchos_workflow` with `action: "cancel"` and `dryRun: true` on stale workflows to preview cleanup
+3. Cancel stale workflows before starting new ones
 
 ## Example Workflow
 


### PR DESCRIPTION
## Summary

Adds YAML frontmatter metadata and troubleshooting sections to the 4 skills that coordinate MCP calls: debug, delegation, synthesis, and workflow-state. Frontmatter enables semantic discovery and phase-affinity matching. Troubleshooting sections use composite tool names throughout and reference SessionStart/PreCompact hooks where appropriate.

## Changes

- **Debug skill** — Added frontmatter with 8 phase affinities and inline troubleshooting covering MCP failures, state desync, investigation timeouts, and track switching
- **Delegation skill** — Added frontmatter with delegate phase affinity and extracted troubleshooting to `references/troubleshooting.md` (body exceeded 2000-word limit inline) covering worktree creation, teammate spawning, and task claim conflicts
- **Synthesis skill** — Added frontmatter with synthesize phase affinity and inline troubleshooting covering PR creation failures, stack rebase conflicts, and merge queue rejections
- **Workflow-state skill** — Added frontmatter with 5 phase affinities and inline troubleshooting covering checkpoint failures, stale state on resume, and multiple active workflows

## Test Plan

All 4 skills pass `validate-frontmatter.sh` (frontmatter structure, name matching, no XML tags, word count under 2000, reference file existence). Existing `SKILL.md.test.sh` scripts for delegation and synthesis verified.

---

**Results:** Frontmatter validation 4/4 pass · Delegation test pass · Body word counts: debug 1713, delegation 1809, synthesis 1095, workflow-state 954
**Related:** Continues skills-content-mod series