### PR TITLE
refactor: condense rules and migrate full versions to skill references

### DIFF
--- a/rules/orchestrator-constraints.md
+++ b/rules/orchestrator-constraints.md
@@ -15,51 +15,6 @@ The orchestrator SHOULD:
 4. **Chain phases** — Invoke next skill when phase completes
 5. **Handle failures** — Route failures back to appropriate phase
 
-## Exceptions
+**Exception:** For `/refactor --polish` only, the orchestrator MAY write code directly during `implement` phase (small scope, single concern).
 
-### Polish Track Refactors
-
-For `/refactor --polish` (polish track) ONLY, the orchestrator MAY write implementation code directly during the `implement` phase.
-
-**Rationale:** Polish refactors are small enough (≤5 files, single concern) that delegation overhead exceeds benefit. Setting up worktrees and dispatching subagents for a simple rename or extraction adds ceremony without value.
-
-**Guardrails:**
-1. **Only during implement phase** — Not during explore, brief, validate, or update-docs
-2. **Only for polish track** — Overhaul track MUST use delegation
-3. **Stay within brief scope** — If scope expands beyond brief, switch to overhaul track
-4. **Must follow TDD** — Write/update tests first if changing behavior
-5. **Commit incrementally** — Commit after each logical change
-
-**Scope Expansion Triggers:**
-- More than 5 files need modification
-- Changes cross module boundaries
-- Test coverage gaps discovered
-- Architectural decisions needed
-
-If any trigger fires, stop and run:
-```bash
-/refactor --switch-overhaul
-```
-
-**Verification:**
-Before starting implementation, verify using `mcp__exarchos__exarchos_workflow` with `action: "get"`:
-1. Track is "polish" in state file (query: `.track`)
-2. Phase is "implement" (query: `.phase`)
-3. Brief goals are captured
-
-## Rationale
-
-The orchestrator acts as a coordinator, not an implementer. This separation:
-- Preserves context window for coordination tasks
-- Enables parallel execution via worktrees
-- Creates clear boundaries for recovery after context compaction
-- Ensures all changes are testable and reviewable
-
-## Enforcement
-
-When tempted to write code directly, ask:
-1. Can this be delegated to a subagent?
-2. Is this a coordination task or implementation task?
-3. Will this consume significant context?
-
-If in doubt, delegate.
+For exceptions (polish track), guardrails, and verification steps, see `skills/delegation/references/orchestrator-constraints.md`.

--- a/rules/pr-descriptions.md
+++ b/rules/pr-descriptions.md
@@ -1,87 +1,34 @@
 # PR Description Guidelines
 
-Write PR descriptions that help reviewers understand the change quickly. Aim for ~120-200 words. CodeRabbit adds detailed analysis—focus on motivation and high-level changes.
+Write PR descriptions that help reviewers understand the change quickly. Aim for ~120-200 words.
 
 ## Title Format
 
 `<type>: <what>` (max 72 chars)
 
-Examples:
-- `feat: Add knowledge ingestion workflow`
-- `fix: Resolve null state in workflow steps`
-- `refactor: Simplify token ledger interface`
-
 ## Body Structure
 
-### Summary (required)
-2-3 sentences explaining what changed and why it matters. Include the motivation—what problem does this solve?
-
-### Changes (required)
-Scannable list of key changes. Use `**Bold**` for component names and `—` (em-dash) as separator.
-
-### Test Plan (required)
-Brief description of testing approach. What was tested and how?
-
-### Footer (required)
-Separated by `---`. Contains results, design doc, and related PRs.
+- **Summary** (required) — 2-3 sentences: what changed, why it matters
+- **Changes** (required) — Scannable list with `**Bold**` component names and `—` separator
+- **Test Plan** (required) — Testing approach and coverage summary
+- **Footer** (required) — Separated by `---`: results, design doc, related PRs
 
 ## Template
 
 ```markdown
 ## Summary
-
 [2-3 sentences: What changed, why it matters, what problem it solves]
 
 ## Changes
-
-- **Component 1** — Brief description of what changed
-- **Component 2** — Brief description of what changed
-- **Component 3** — Brief description of what changed
+- **Component** — Brief description of what changed
 
 ## Test Plan
-
 [1-2 sentences: Testing approach and coverage summary]
 
 ---
-
 **Results:** Tests X ✓ · Build 0 errors
-**Design:** [design-doc.md](docs/path/design-doc.md)
-**Related:** #123, Continues #456
+**Design:** [doc](docs/path/design-doc.md)
+**Related:** #123
 ```
 
-## Example
-
-```markdown
-## Summary
-
-Completes the Knowledge System foundation for RAG-based agent workflows. The platform needs to ingest documents, extract semantic concepts, and build a linked knowledge graph—this PR delivers that infrastructure.
-
-## Changes
-
-- **LLM Inference** — vLLM client with streaming SSE and LoRA adapter support
-- **Token Accounting** — Multi-dimensional ledger tracking usage across categories
-- **Vector Collections** — Registry with schema versioning for embedding spaces
-- **Knowledge Models** — Core types for representing extracted knowledge
-- **Ingestion Workflow** — 11-step pipeline from parsing to knowledge graph commit
-
-## Test Plan
-
-Added ~180 unit tests covering all new components. Integration tests verify the complete workflow with mocked dependencies.
-
----
-
-**Results:** Tests 3462 ✓ · Build 0 errors
-**Design:** [shared-infrastructure.md](docs/adrs/workflow-designs/shared-infrastructure.md)
-**Related:** Continues #5
-```
-
-## Anti-Patterns
-
-Avoid these—they bloat descriptions without adding value:
-
-- Bullet lists of every file changed
-- Repeating commit messages in the body
-- Low-level implementation details (class names, method signatures)
-- "Generated with..." footers
-- Phase-by-phase breakdowns
-- Detailed test counts by project
+For detailed guidelines, examples, and anti-patterns, see `skills/synthesis/references/pr-descriptions.md`.

--- a/skills/delegation/references/orchestrator-constraints.md
+++ b/skills/delegation/references/orchestrator-constraints.md
@@ -1,0 +1,65 @@
+# Orchestrator Constraints
+
+The orchestrator (main Claude Code session) MUST NOT:
+
+1. **Write implementation code** — All code changes via subagents
+2. **Fix review findings directly** — Dispatch fixer subagents
+3. **Run tests inline** — Tests run in subagent worktrees or during review
+4. **Work in main project root** — All implementation in worktrees
+
+The orchestrator SHOULD:
+
+1. **Parse and extract** — Read plans, extract task details
+2. **Dispatch and monitor** — Launch subagents, track progress
+3. **Manage state** — Update workflow state file
+4. **Chain phases** — Invoke next skill when phase completes
+5. **Handle failures** — Route failures back to appropriate phase
+
+## Exceptions
+
+### Polish Track Refactors
+
+For `/refactor --polish` (polish track) ONLY, the orchestrator MAY write implementation code directly during the `implement` phase.
+
+**Rationale:** Polish refactors are small enough (≤5 files, single concern) that delegation overhead exceeds benefit. Setting up worktrees and dispatching subagents for a simple rename or extraction adds ceremony without value.
+
+**Guardrails:**
+1. **Only during implement phase** — Not during explore, brief, validate, or update-docs
+2. **Only for polish track** — Overhaul track MUST use delegation
+3. **Stay within brief scope** — If scope expands beyond brief, switch to overhaul track
+4. **Must follow TDD** — Write/update tests first if changing behavior
+5. **Commit incrementally** — Commit after each logical change
+
+**Scope Expansion Triggers:**
+- More than 5 files need modification
+- Changes cross module boundaries
+- Test coverage gaps discovered
+- Architectural decisions needed
+
+If any trigger fires, stop and run:
+```bash
+/refactor --switch-overhaul
+```
+
+**Verification:**
+Before starting implementation, verify using `mcp__exarchos__exarchos_workflow` with `action: "get"`:
+1. Track is "polish" in state file (query: `.track`)
+2. Phase is "implement" (query: `.phase`)
+3. Brief goals are captured
+
+## Rationale
+
+The orchestrator acts as a coordinator, not an implementer. This separation:
+- Preserves context window for coordination tasks
+- Enables parallel execution via worktrees
+- Creates clear boundaries for recovery after context compaction
+- Ensures all changes are testable and reviewable
+
+## Enforcement
+
+When tempted to write code directly, ask:
+1. Can this be delegated to a subagent?
+2. Is this a coordination task or implementation task?
+3. Will this consume significant context?
+
+If in doubt, delegate.

--- a/skills/synthesis/references/pr-descriptions.md
+++ b/skills/synthesis/references/pr-descriptions.md
@@ -1,0 +1,87 @@
+# PR Description Guidelines
+
+Write PR descriptions that help reviewers understand the change quickly. Aim for ~120-200 words. CodeRabbit adds detailed analysis—focus on motivation and high-level changes.
+
+## Title Format
+
+`<type>: <what>` (max 72 chars)
+
+Examples:
+- `feat: Add knowledge ingestion workflow`
+- `fix: Resolve null state in workflow steps`
+- `refactor: Simplify token ledger interface`
+
+## Body Structure
+
+### Summary (required)
+2-3 sentences explaining what changed and why it matters. Include the motivation—what problem does this solve?
+
+### Changes (required)
+Scannable list of key changes. Use `**Bold**` for component names and `—` (em-dash) as separator.
+
+### Test Plan (required)
+Brief description of testing approach. What was tested and how?
+
+### Footer (required)
+Separated by `---`. Contains results, design doc, and related PRs.
+
+## Template
+
+```markdown
+## Summary
+
+[2-3 sentences: What changed, why it matters, what problem it solves]
+
+## Changes
+
+- **Component 1** — Brief description of what changed
+- **Component 2** — Brief description of what changed
+- **Component 3** — Brief description of what changed
+
+## Test Plan
+
+[1-2 sentences: Testing approach and coverage summary]
+
+---
+
+**Results:** Tests X ✓ · Build 0 errors
+**Design:** [design-doc.md](docs/path/design-doc.md)
+**Related:** #123, Continues #456
+```
+
+## Example
+
+```markdown
+## Summary
+
+Completes the Knowledge System foundation for RAG-based agent workflows. The platform needs to ingest documents, extract semantic concepts, and build a linked knowledge graph—this PR delivers that infrastructure.
+
+## Changes
+
+- **LLM Inference** — vLLM client with streaming SSE and LoRA adapter support
+- **Token Accounting** — Multi-dimensional ledger tracking usage across categories
+- **Vector Collections** — Registry with schema versioning for embedding spaces
+- **Knowledge Models** — Core types for representing extracted knowledge
+- **Ingestion Workflow** — 11-step pipeline from parsing to knowledge graph commit
+
+## Test Plan
+
+Added ~180 unit tests covering all new components. Integration tests verify the complete workflow with mocked dependencies.
+
+---
+
+**Results:** Tests 3462 ✓ · Build 0 errors
+**Design:** [shared-infrastructure.md](docs/adrs/workflow-designs/shared-infrastructure.md)
+**Related:** Continues #5
+```
+
+## Anti-Patterns
+
+Avoid these—they bloat descriptions without adding value:
+
+- Bullet lists of every file changed
+- Repeating commit messages in the body
+- Low-level implementation details (class names, method signatures)
+- "Generated with..." footers
+- Phase-by-phase breakdowns
+- Detailed test counts by project


### PR DESCRIPTION
## Summary

Moves detailed PR description guidelines and orchestrator constraints into skill reference files for progressive disclosure. Rules retain brief pointers; full content loads only when the relevant skill is invoked, reducing always-loaded context overhead by ~1,300 tokens.

## Changes

- **rules/pr-descriptions.md** — Condensed from 88 to 34 lines; full version migrated to `skills/synthesis/references/`
- **rules/orchestrator-constraints.md** — Condensed from 66 to 20 lines; full version migrated to `skills/delegation/references/`
- **skills/synthesis/references/pr-descriptions.md** — New reference with complete PR description guide
- **skills/delegation/references/orchestrator-constraints.md** — New reference with full orchestrator constraints

## Test Plan

Manual verification: condensed rules retain essential guidance, reference files preserve full original content, pointer paths are correct.

---

**Design:** [skills-content-modernization.md](docs/designs/2026-02-13-skills-content-modernization.md)
**Related:** Part of skills-content-modernization stack (Task 008/009)