### PR TITLE
fix: correct token budget ADR with measured word counts

### DIFF
--- a/docs/adrs/context-token-budget.md
+++ b/docs/adrs/context-token-budget.md
@@ -13,8 +13,8 @@ Rules load into every Claude Code session as system prompt context. Minimizing f
 | coding-standards-csharp.md | 1,610 | ~2,093 | Yes | `**/*.cs` |
 | coding-standards-typescript.md | 400 | ~520 | Yes | `**/*.ts`, `**/*.tsx` |
 | mcp-tool-guidance.md | 1,164 | ~1,513 | No | always loaded |
-| orchestrator-constraints.md | 362 | ~471 | No | always loaded |
-| pr-descriptions.md | 364 | ~473 | No | always loaded |
+| orchestrator-constraints.md | 132 | ~172 | No | always loaded (condensed; full in skill reference) |
+| pr-descriptions.md | 133 | ~173 | No | always loaded (condensed; full in skill reference) |
 | primary-workflows.md | 48 | ~62 | No | always loaded |
 | rm-safety.md | 228 | ~296 | No | always loaded |
 | skill-path-resolution.md | 225 | ~293 | No | always loaded |
@@ -31,25 +31,26 @@ Rules load into every Claude Code session as system prompt context. Minimizing f
 
 | Metric | Before | After | Reduction |
 |--------|--------|-------|-----------|
-| Always-loaded rule tokens | ~11,000 | ~3,108 | ~72% |
-| With TypeScript scoping | ~11,000 | ~3,904 | ~65% |
+| Always-loaded rule tokens | ~8,791 | ~2,508 | ~71% |
+| With TypeScript scoping | ~8,791 | ~3,304 | ~62% |
+| With C# scoping | ~8,791 | ~4,998 | ~43% |
 
-"Before" = all original rules including workflow-auto-resume.md loaded always (no scoping, no pruning).
+"Before" = all original rules including workflow-auto-resume.md loaded always (no scoping, no pruning). Measured via `wc -w` on `main` branch × 1.3.
 "After" = post-optimization with scoping, condensing, and pruning.
 
-For "Before" values, these known word counts were used:
-- workflow-auto-resume.md: ~1,700 words (~2,210 tokens) — removed entirely
-- mcp-tool-guidance.md (original): ~2,460 words (~3,200 tokens) — pruned Exarchos sections
-- primary-workflows.md (original): ~258 words (~336 tokens) — condensed to 3-line table
-- pr-descriptions.md (original): ~518 words (~674 tokens)
-- orchestrator-constraints.md (original): ~485 words (~630 tokens)
-- tdd-typescript.md: ~335 words (~436 tokens) — now scoped
-- coding-standards-typescript.md: ~520 words (~676 tokens) — now scoped
-- rm-safety.md: ~295 words (~384 tokens)
-- skill-path-resolution.md: ~315 words (~410 tokens)
-- coding-standards-csharp.md: ~2,300 words (~2,990 tokens) — now scoped
-- tdd-csharp.md: ~370 words (~481 tokens) — now scoped
-Total before: ~9,556 words (~12,427 tokens)
+Before values (measured on `main` via `wc -w`):
+- workflow-auto-resume.md: 1,090 words (~1,417 tokens) — removed entirely
+- mcp-tool-guidance.md (original): 1,754 words (~2,280 tokens) — pruned Exarchos sections
+- primary-workflows.md (original): 215 words (~280 tokens) — condensed to 3-line table
+- pr-descriptions.md (original): 364 words (~473 tokens) — condensed, full in skill reference
+- orchestrator-constraints.md (original): 362 words (~471 tokens) — condensed, full in skill reference
+- tdd-typescript.md: 212 words (~276 tokens) — now scoped
+- coding-standards-typescript.md: 400 words (~520 tokens) — now scoped
+- rm-safety.md: 228 words (~296 tokens)
+- skill-path-resolution.md: 225 words (~293 tokens)
+- coding-standards-csharp.md: 1,610 words (~2,093 tokens) — now scoped
+- tdd-csharp.md: 305 words (~397 tokens) — now scoped
+Total before: 6,765 words (~8,791 tokens)
 
 ## Guidance for New Rules
 - Budget: aim for total always-loaded overhead ≤ 5,000 tokens


### PR DESCRIPTION
## Summary

Corrects the context token budget ADR with actual `wc -w` measurements from `main` instead of estimated values from the design document. The original ADR used inflated estimates that overstated the before-optimization baseline.

## Changes

- **docs/adrs/context-token-budget.md** — Replace estimated word counts with measured values; correct before/after reduction from 72% to 71%; update per-rule "After" values for condensed rules (pr-descriptions, orchestrator-constraints); add C# scoping row

## Test Plan

Verified all word counts via `wc -w` on `main` branch pre-optimization files.

---

**Related:** Follow-up to #241