### PR TITLE
fix: address CodeRabbit feedback from skills-content-modernization PRs

### DIFF
--- a/docs/adrs/context-token-budget.md
+++ b/docs/adrs/context-token-budget.md
@@ -35,7 +35,7 @@ Rules load into every Claude Code session as system prompt context. Minimizing f
 | With TypeScript scoping | ~8,791 | ~3,304 | ~62% |
 | With C# scoping | ~8,791 | ~4,998 | ~43% |
 
-"Before" = all original rules including workflow-auto-resume.md loaded always (no scoping, no pruning). Measured via `wc -w` on `main` branch × 1.3.
+"Before" = all original rules including workflow-auto-resume.md always loaded (no scoping, no pruning). Measured via `wc -w` on `main` branch × 1.3.
 "After" = post-optimization with scoping, condensing, and pruning.
 
 Before values (measured on `main` via `wc -w`):

--- a/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
@@ -95,20 +95,48 @@ export function buildToolDescription(tool: CompositeTool): string {
 // ─── Shared Constants ───────────────────────────────────────────────────────
 
 const ALL_PHASES: ReadonlySet<string> = new Set([
+  // Feature workflow
   'ideate',
   'plan',
   'plan-review',
   'delegate',
   'review',
   'synthesize',
+  // Debug workflow
+  'triage',
+  'investigate',
+  'rca',
+  'design',
+  'debug-implement',
+  'debug-validate',
+  'debug-review',
+  'hotfix-implement',
+  'hotfix-validate',
+  // Refactor workflow
+  'explore',
+  'brief',
+  'polish-implement',
+  'polish-validate',
+  'polish-update-docs',
+  'overhaul-plan',
+  'overhaul-delegate',
+  'overhaul-review',
+  'overhaul-update-docs',
 ]);
 
 const ROLE_ANY: ReadonlySet<string> = new Set(['any']);
 const ROLE_LEAD: ReadonlySet<string> = new Set(['lead']);
 const ROLE_TEAMMATE: ReadonlySet<string> = new Set(['teammate']);
 
-const DELEGATE_PHASES: ReadonlySet<string> = new Set(['delegate']);
-const STACK_PHASES: ReadonlySet<string> = new Set(['synthesize', 'delegate']);
+const DELEGATE_PHASES: ReadonlySet<string> = new Set([
+  'delegate',
+  'overhaul-delegate',
+]);
+const STACK_PHASES: ReadonlySet<string> = new Set([
+  'synthesize',
+  'delegate',
+  'overhaul-delegate',
+]);
 
 // ─── Shared Schema Fragments ────────────────────────────────────────────────
 

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -462,15 +462,15 @@ Extended to support:
 ### MCP Tool Call Failed
 If an Exarchos MCP tool returns an error:
 1. Check the error message — it usually contains specific guidance
-2. Verify the workflow state exists: call `exarchos_workflow` with `action: "get"` and the featureId
+2. Verify the workflow state exists: call `mcp__exarchos__exarchos_workflow` with `action: "get"` and the featureId
 3. If "version mismatch": another process updated state — retry the operation
-4. If state is corrupted: call `exarchos_workflow` with `action: "cancel"` and `dryRun: true`
+4. If state is corrupted: call `mcp__exarchos__exarchos_workflow` with `action: "cancel"` and `dryRun: true`
 
 ### State Desync
 If workflow state doesn't match git reality:
 1. The SessionStart hook runs reconciliation automatically on resume
 2. If manual check needed: compare state file with `git log` and branch state
-3. Update state via `exarchos_workflow` with `action: "set"` to match git truth
+3. Update state via `mcp__exarchos__exarchos_workflow` with `action: "set"` to match git truth
 
 ### Investigation Timeout (Hotfix Track)
 If 15-minute investigation timer expires without root cause:
@@ -480,7 +480,7 @@ If 15-minute investigation timer expires without root cause:
 
 ### Track Switching
 If hotfix track reveals complexity requiring thorough investigation:
-1. Call `exarchos_workflow` with `action: "set"` to update track to "thorough"
+1. Call `mcp__exarchos__exarchos_workflow` with `action: "set"` to update track to "thorough"
 2. Previous investigation findings carry over
 3. RCA phase begins after investigation completes
 

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -372,7 +372,7 @@ Each fix task extracted should include:
 Fix mode goes back to the integration phase after fixes are applied,
 then re-enters review to re-integrate and re-verify:
 
-```
+```text
 /delegate --fixes -> [fixes applied] -> re-integrate -> /review
 ```
 

--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -46,8 +46,8 @@ Instead of reading full files, receive the integrated diff:
 # Generate integrated diff for review (Graphite stack vs main)
 gt diff main > /tmp/stack-diff.patch
 
-# Alternative: git diff main...integration-branch for complete picture
-git diff main...integration > /tmp/integration-diff.patch
+# Alternative: git diff for integration branch
+git diff main...integration-branch > /tmp/integration-diff.patch
 
 # Alternative: use GitHub MCP to get PR diff
 # mcp__plugin_github_github__pull_request_read({ owner, repo, pullNumber, method: "get_diff" })
@@ -112,9 +112,9 @@ Use the template from `references/review-report-template.md` to structure the re
 | **MEDIUM** | Should fix, may defer | SOLID violations, complexity |
 | **LOW** | Nice to have | Style preferences, minor refactors |
 
-## Fix Loop for HIGH Priority
+## Fix Loop for HIGH-Priority
 
-If HIGH priority issues found:
+If HIGH-priority issues found:
 
 1. Create fix task listing each HIGH finding with file, issue, and required fix
 2. Dispatch to implementer subagent
@@ -142,7 +142,7 @@ Update workflow state with review results using `mcp__exarchos__exarchos_workflo
 ## Completion Criteria
 
 - [ ] Static analysis passes
-- [ ] All HIGH priority issues fixed
+- [ ] All HIGH-priority issues fixed
 - [ ] No security vulnerabilities
 - [ ] Test quality acceptable
 - [ ] Code is maintainable
@@ -162,7 +162,7 @@ All transitions happen **immediately** without user confirmation:
 
 ### If NEEDS_FIXES:
 1. Update state with failed issues
-2. Output: "Quality review found [N] HIGH priority issues. Auto-continuing to fixes..."
+2. Output: "Quality review found [N] HIGH-priority issues. Auto-continuing to fixes..."
 3. Auto-invoke delegate with fix tasks:
    ```typescript
    Skill({ skill: "delegate", args: "--fixes <plan-path>" })

--- a/skills/quality-review/references/code-quality-checklist.md
+++ b/skills/quality-review/references/code-quality-checklist.md
@@ -72,13 +72,13 @@ Detailed review criteria for code quality, SOLID principles, DRY enforcement, an
 ### Guard Clause Pattern
 
 **Preferred:**
-```
+```typescript
 if (input == null) return;
 // Main logic flat
 ```
 
 **Avoid:**
-```
+```typescript
 if (input != null) {
   // Entire body nested
 }

--- a/skills/quality-review/references/review-report-template.md
+++ b/skills/quality-review/references/review-report-template.md
@@ -12,28 +12,39 @@ Use this template to structure the output of Step 3 (Generate Report) in the qua
 - Reviewed: [timestamp]
 - Reviewer: Claude Code
 
-### Findings
+### Findings Summary
 
-#### HIGH Priority
+| Severity | Category | File:Line | Issue |
+|----------|----------|-----------|-------|
+| HIGH | [category] | `path/to/file.ts:42` | [Brief description] |
+| MEDIUM | [category] | `path/to/file.ts:88` | [Brief description] |
+| LOW | [category] | `path/to/file.ts:15` | [Brief description] |
+
+### Findings Detail
+
+#### HIGH-Priority
 1. [Finding title]
    - File: `path/to/file.ts:42`
-   - Issue: [Description]
+   - Category: [security | correctness | performance | maintainability]
+   - Current: [What the code does now]
    - Fix: [Required change]
 
-#### MEDIUM Priority
+#### MEDIUM-Priority
 1. [Finding title]
    - File: `path/to/file.ts:88`
-   - Issue: [Description]
+   - Category: [security | correctness | performance | maintainability]
+   - Current: [What the code does now]
    - Suggestion: [Recommended change]
 
-#### LOW Priority
+#### LOW-Priority
 1. [Finding title]
    - File: `path/to/file.ts:15`
+   - Category: [style | documentation | optimization]
    - Note: [Observation]
 
 ### Verdict
 [APPROVED] Ready for synthesis
-[NEEDS_FIXES] Fix HIGH priority items, then re-review
+[NEEDS_FIXES] Fix HIGH-priority items, then re-review
 [BLOCKED] Critical issues require design discussion
 ```
 
@@ -41,14 +52,14 @@ Use this template to structure the output of Step 3 (Generate Report) in the qua
 
 | Verdict | Condition |
 |---------|-----------|
-| **APPROVED** | No HIGH priority findings; MEDIUM/LOW acceptable |
-| **NEEDS_FIXES** | One or more HIGH priority findings that must be resolved |
+| **APPROVED** | No HIGH-priority findings; MEDIUM/LOW acceptable |
+| **NEEDS_FIXES** | One or more HIGH-priority findings that must be resolved |
 | **BLOCKED** | Critical architectural or security issues requiring design discussion |
 
 ## Report Guidelines
 
 - List every finding with file path and line number
-- HIGH priority findings must include a concrete fix description
+- HIGH-priority findings must include a concrete fix description
 - MEDIUM priority findings should include a suggested approach
 - LOW priority findings are observations for future improvement
 - The verdict drives the next workflow transition (synthesize, fix loop, or redesign)

--- a/skills/quality-review/references/security-checklist.md
+++ b/skills/quality-review/references/security-checklist.md
@@ -11,44 +11,61 @@ Security review criteria based on OWASP Top 10 patterns. Used during Step 2 of t
 | SQL injection | Parameterized queries |
 | XSS prevention | Output encoding |
 
-## OWASP Top 10 Patterns
+## OWASP Top 10 (2021) Patterns
 
 When reviewing code that handles user input, authentication, or data access, check for these common vulnerability patterns:
-
-### Injection (A03)
-- SQL queries use parameterized statements, never string concatenation
-- Shell commands use safe APIs, never template strings with user input
-- LDAP/XPath queries are parameterized
-
-### Broken Authentication (A07)
-- Passwords are hashed with bcrypt/argon2, never stored in plaintext
-- Session tokens have sufficient entropy
-- Rate limiting on authentication endpoints
-
-### Sensitive Data Exposure (A02)
-- No secrets, API keys, or credentials in source code
-- Sensitive data encrypted at rest and in transit
-- PII properly handled per data classification
 
 ### Broken Access Control (A01)
 - Authorization checks on every endpoint
 - No direct object references without access validation
 - Default deny for permissions
 
+### Cryptographic Failures (A02)
+- No secrets, API keys, or credentials in source code
+- Sensitive data encrypted at rest and in transit
+- PII properly handled per data classification
+
+### Injection (A03)
+- SQL queries use parameterized statements, never string concatenation
+- Shell commands use safe APIs, never template strings with user input
+- Output encoding applied to all user-controlled data (XSS)
+- Content Security Policy headers set
+
+### Insecure Design (A04)
+- Threat modeling performed for critical flows
+- Business logic validated server-side
+- Rate limiting and resource controls in place
+
 ### Security Misconfiguration (A05)
 - No debug mode in production config
 - Error messages don't leak stack traces or internal details
 - Security headers configured (CORS, CSP, HSTS)
 
-### Cross-Site Scripting (A03)
-- Output encoding applied to all user-controlled data
-- Content Security Policy headers set
-- DOM manipulation uses safe APIs
+### Vulnerable and Outdated Components (A06)
+- Dependencies checked for known vulnerabilities
+- No end-of-life frameworks or libraries
+- Component versions tracked and updated
 
-### Insecure Deserialization (A08)
+### Identification and Authentication Failures (A07)
+- Passwords are hashed with bcrypt/argon2, never stored in plaintext
+- Session tokens have sufficient entropy
+- Rate limiting on authentication endpoints
+
+### Software and Data Integrity Failures (A08)
 - User input is validated before deserialization
 - Type checking enforced on deserialized objects
 - No eval() or equivalent on untrusted data
+- CI/CD pipeline integrity verified
+
+### Security Logging and Monitoring Failures (A09)
+- Security-relevant events are logged
+- Logs do not contain sensitive data
+- Alerting configured for suspicious activity
+
+### Server-Side Request Forgery (A10)
+- URL inputs validated against allowlists
+- Internal network access restricted from user-controlled requests
+- DNS rebinding protections in place
 
 ## Detection Checklist
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -82,7 +82,7 @@ Activate this skill when:
 | Worktree | No (direct) | Yes (isolated) |
 | Delegation | No | Yes (full workflow) |
 | Documentation | Mandatory update phase | Mandatory update phase |
-| Human Checkpoints | 1 (completion) | 1 (merge) |
+| Human Checkpoints | 0 | 1 (merge) |
 
 ## Polish Track
 
@@ -181,8 +181,6 @@ If `docsToUpdate` is empty, verify no docs need updating.
 Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `validation.docsUpdated` to true, `artifacts.updatedDocs` array, and `phase` to "completed".
 
 > **Note:** The HSM transitions directly from `polish-update-docs` to `completed`. There is no `synthesize` phase for polish track.
-
-**Human checkpoint:** Confirm refactor complete.
 
 ## Overhaul Track
 
@@ -371,7 +369,7 @@ Both tracks have ONE human checkpoint: completion/merge confirmation.
 
 ```
 explore -> brief -> polish-implement -> polish-validate -> polish-update-docs -> completed
-           (auto)   (auto)              (auto)             (auto)                [HUMAN]
+           (auto)   (auto)              (auto)             (auto)                (auto)
 ```
 
 **Next actions:**
@@ -379,7 +377,7 @@ explore -> brief -> polish-implement -> polish-validate -> polish-update-docs ->
 - `AUTO:polish-implement` after brief
 - `AUTO:refactor-validate` after polish-implement
 - `AUTO:refactor-update-docs` after polish-validate
-- `WAIT:human-checkpoint:polish-update-docs` after polish-update-docs
+- `AUTO:completed` after polish-update-docs
 
 ### Overhaul Auto-Chain
 
@@ -410,7 +408,7 @@ If scope expands beyond polish limits during explore or brief phase, use `mcp__e
 - Test coverage gaps require new tests
 - Architectural documentation needed
 
-Output: "Scope expanded beyond polish limits. Switching to overhaul track. Continue? (Y/n)"
+Output: "Scope expanded beyond polish limits. Switching to overhaul track."
 
 ## Integration Points
 

--- a/skills/synthesis/SKILL.md
+++ b/skills/synthesis/SKILL.md
@@ -264,15 +264,15 @@ Options:
 ### MCP Tool Call Failed
 If an Exarchos MCP tool returns an error:
 1. Check the error message — it usually contains specific guidance
-2. Verify the workflow state exists: call `exarchos_workflow` with `action: "get"` and the featureId
+2. Verify the workflow state exists: call `mcp__exarchos__exarchos_workflow` with `action: "get"` and the featureId
 3. If "version mismatch": another process updated state — retry the operation
-4. If state is corrupted: call `exarchos_workflow` with `action: "cancel"` and `dryRun: true`
+4. If state is corrupted: call `mcp__exarchos__exarchos_workflow` with `action: "cancel"` and `dryRun: true`
 
 ### State Desync
 If workflow state doesn't match git reality:
 1. The SessionStart hook runs reconciliation automatically on resume
 2. If manual check needed: compare state file with `git log` and branch state
-3. Update state via `exarchos_workflow` with `action: "set"` to match git truth
+3. Update state via `mcp__exarchos__exarchos_workflow` with `action: "set"` to match git truth
 
 ### PR Creation Failed
 If `gt submit` fails:

--- a/skills/validate-all-skills.sh
+++ b/skills/validate-all-skills.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VALIDATOR="${SCRIPT_DIR}/validate-frontmatter.sh"
 SKILLS_DIR="${SCRIPT_DIR}"
+shopt -s nullglob
 
 # Colors
 GREEN='\033[0;32m'
@@ -38,12 +39,12 @@ for skill_file in "${SKILLS_DIR}"/*/SKILL.md; do
 
   if [[ "$validation_exit" -eq 0 ]]; then
     PASS_COUNT=$((PASS_COUNT + 1))
-    printf "Validating %-30s ${GREEN}PASS${RESET}\n" "${folder_name}..."
+    printf "%b" "Validating $(printf '%-30s' "${folder_name}...") ${GREEN}PASS${RESET}\n"
   else
     FAIL_COUNT=$((FAIL_COUNT + 1))
     # Extract the first error for the summary line
     first_error=$(echo "$validation_output" | head -n 1 | sed 's/^ERROR: //')
-    printf "Validating %-30s ${RED}FAIL${RESET} (%s)\n" "${folder_name}..." "$first_error"
+    printf "%b" "Validating $(printf '%-30s' "${folder_name}...") ${RED}FAIL${RESET} (${first_error})\n"
   fi
 done
 

--- a/skills/validate-frontmatter.sh
+++ b/skills/validate-frontmatter.sh
@@ -63,7 +63,7 @@ check_frontmatter_exists() {
   # Extract body (everything after closing delimiter)
   local body_start=$((closing_line + 1))
   local total_lines
-  total_lines=$(wc -l < "$SKILL_FILE" | tr -d ' ')
+  total_lines=$(awk 'END {print NR}' "$SKILL_FILE")
   if [[ "$body_start" -le "$total_lines" ]]; then
     BODY=$(tail -n +"$body_start" "$SKILL_FILE")
   else

--- a/skills/workflow-state/SKILL.md
+++ b/skills/workflow-state/SKILL.md
@@ -159,19 +159,19 @@ Key sections:
 ### MCP Tool Call Failed
 If an Exarchos MCP tool returns an error:
 1. Check the error message — it usually contains specific guidance
-2. Verify the workflow state exists: call `exarchos_workflow` with `action: "get"` and the featureId
+2. Verify the workflow state exists: call `mcp__exarchos__exarchos_workflow` with `action: "get"` and the featureId
 3. If "version mismatch": another process updated state — retry the operation
-4. If state is corrupted: call `exarchos_workflow` with `action: "cancel"` and `dryRun: true`
+4. If state is corrupted: call `mcp__exarchos__exarchos_workflow` with `action: "cancel"` and `dryRun: true`
 
 ### State Desync
 If workflow state doesn't match git reality:
 1. The SessionStart hook runs reconciliation automatically on resume
 2. If manual check needed: compare state file with `git log` and branch state
-3. Update state via `exarchos_workflow` with `action: "set"` to match git truth
+3. Update state via `mcp__exarchos__exarchos_workflow` with `action: "set"` to match git truth
 
 ### Checkpoint File Missing
 If the PreCompact hook can't find state to checkpoint:
-1. Verify a workflow is active: call `exarchos_workflow` with `action: "get"` and the featureId
+1. Verify a workflow is active: call `mcp__exarchos__exarchos_workflow` with `action: "get"` and the featureId
 2. If no active workflow: the hook will silently skip (expected behavior)
 3. If workflow exists but checkpoint fails: check disk space and permissions
 
@@ -184,7 +184,7 @@ If state references branches or worktrees that no longer exist:
 ### Multiple Active Workflows
 If multiple workflow state files exist:
 1. The system uses the most recently updated active (non-completed) workflow
-2. Use `exarchos_workflow` with `action: "cancel"` and `dryRun: true` on stale workflows to preview cleanup
+2. Use `mcp__exarchos__exarchos_workflow` with `action: "cancel"` and `dryRun: true` on stale workflows to preview cleanup
 3. Cancel stale workflows before starting new ones
 
 ## Example Workflow


### PR DESCRIPTION
## Summary

Consolidates and resolves all unaddressed CodeRabbit feedback from the skills-content-modernization workflow (PRs #227, #229, #234, #235, #238, #241). Also fixes a blocking bug in the MCP tool registry that prevented refactor and debug workflows from using Exarchos tools.

## Changes

- **Troubleshooting sections** — Add `mcp__exarchos__` prefix to bare `exarchos_workflow` tool references in debug, synthesis, and workflow-state skills
- **Refactor SKILL** — Remove unauthorized human checkpoint from polish track completion and "Continue?" prompt from scope switching
- **Security checklist** — Update OWASP Top 10 from 2017 to 2021 edition with all 10 categories (A01–A10)
- **Review report template** — Add structured findings summary table with Severity, Category, File:Line, and Issue columns
- **Validation scripts** — Fix `wc -l` undercount for files without trailing newline, add `shopt -s nullglob`, use `printf %b` for ANSI escapes
- **Style fixes** — Hyphenate compound adjectives, add language identifiers to code fences, fix adverb order, standardize terminology
- **Tool registry** — Add refactor and debug workflow phases to `ALL_PHASES`, `DELEGATE_PHASES`, and `STACK_PHASES` constants

## Test Plan

All existing tests pass (223 root + 1,051 MCP server). Skill frontmatter validation passes for all 12 skills.

---

**Results:** Tests 1274 ✓ · Build 0 errors · Validation 12/12 skills pass
**Related:** Fixes #252