### PR TITLE
fix: harden guard registry for all workflow types

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/guard.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/guard.test.ts
@@ -108,6 +108,132 @@ describe('guard command', () => {
     });
   });
 
+  // ─── Init Enforcement ──────────────────────────────────────────────────
+
+  describe('init enforcement', () => {
+    it('should deny init when an active workflow exists in any phase', async () => {
+      // Arrange — active workflow in delegate phase
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'delegate'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_workflow', 'init');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert — init has empty phases set, always denied when active workflow exists
+      expect(result).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          reason: expect.stringContaining('init'),
+        },
+      });
+    });
+
+    it('should deny init even when active workflow is in ideate phase', async () => {
+      // Arrange — prevents creating duplicate workflows
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'ideate'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_workflow', 'init');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert — init should be denied to prevent duplicate workflows
+      expect(result).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          reason: expect.stringContaining('init'),
+        },
+      });
+    });
+
+    it('should allow init when no active workflow exists', async () => {
+      // Arrange — empty state directory
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_workflow', 'init');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert — null phase means no active workflow, allow
+      expect(result).toEqual({});
+    });
+  });
+
+  // ─── Blocked Phase ────────────────────────────────────────────────────
+
+  describe('blocked phase', () => {
+    it('should allow workflow get in blocked phase', async () => {
+      // Arrange — workflow is blocked, should still be inspectable
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'blocked'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_workflow', 'get');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert — must be able to read blocked workflows
+      expect(result).toEqual({});
+    });
+
+    it('should allow workflow set in blocked phase', async () => {
+      // Arrange — need set to transition out of blocked
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'blocked'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_workflow', 'set');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert — must be able to unblock workflows
+      expect(result).toEqual({});
+    });
+
+    it('should allow workflow cancel in blocked phase', async () => {
+      // Arrange — need cancel to clean up blocked workflows
+      const stateFile = path.join(tmpDir, 'test-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('test-feature', 'blocked'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_workflow', 'cancel');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert
+      expect(result).toEqual({});
+    });
+  });
+
+  // ─── Debug Workflow Phases ────────────────────────────────────────────
+
+  describe('debug workflow phases', () => {
+    it('should allow team_spawn in debug-implement phase', async () => {
+      // Arrange — debug thorough track uses team coordination
+      const stateFile = path.join(tmpDir, 'debug-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('debug-feature', 'debug-implement'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_orchestrate', 'team_spawn');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert — debug-implement is in DELEGATE_PHASES
+      expect(result).toEqual({});
+    });
+
+    it('should allow task_claim in debug-implement phase', async () => {
+      // Arrange
+      const stateFile = path.join(tmpDir, 'debug-feature.state.json');
+      await fs.writeFile(stateFile, makeStateJson('debug-feature', 'debug-implement'));
+      const input = makePreToolUseInput('mcp__exarchos__exarchos_orchestrate', 'task_claim');
+
+      // Act
+      const result = await handleGuard(input, tmpDir);
+
+      // Assert
+      expect(result).toEqual({});
+    });
+  });
+
   // ─── Deny Cases ─────────────────────────────────────────────────────────
 
   describe('deny decisions', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.test.ts
@@ -324,5 +324,41 @@ describe('subagent-context', () => {
       // Assert
       expect(result).toBeNull();
     });
+
+    it('should skip cancelled workflows and find active one', async () => {
+      // Arrange
+      await writeStateFile(tempDir, 'cancelled-feature', 'cancelled');
+      await writeStateFile(tempDir, 'active-feature', 'delegate');
+
+      // Act
+      const result = await findActiveWorkflowPhase(tempDir);
+
+      // Assert
+      expect(result).toBe('delegate');
+    });
+
+    it('should return null when all workflows are cancelled', async () => {
+      // Arrange
+      await writeStateFile(tempDir, 'cancelled-1', 'cancelled');
+      await writeStateFile(tempDir, 'cancelled-2', 'cancelled');
+
+      // Act
+      const result = await findActiveWorkflowPhase(tempDir);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should return null when workflows are mix of completed and cancelled', async () => {
+      // Arrange
+      await writeStateFile(tempDir, 'done', 'completed');
+      await writeStateFile(tempDir, 'stopped', 'cancelled');
+
+      // Act
+      const result = await findActiveWorkflowPhase(tempDir);
+
+      // Assert
+      expect(result).toBeNull();
+    });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.ts
@@ -120,7 +120,7 @@ export async function findActiveWorkflowPhase(
       const parsed = JSON.parse(raw) as Record<string, unknown>;
       const phase = parsed.phase;
 
-      if (typeof phase === 'string' && phase !== 'completed') {
+      if (typeof phase === 'string' && phase !== 'completed' && phase !== 'cancelled') {
         return phase;
       }
     } catch {

--- a/plugins/exarchos/servers/exarchos-mcp/src/registry.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/registry.test.ts
@@ -111,13 +111,25 @@ describe('TOOL_REGISTRY', () => {
     });
   });
 
-  it('should have non-empty phases for every action', () => {
+  it('should have non-empty phases for every action except init', () => {
+    // init has empty phases by design — it relies on the guard's null-check
+    // (no active workflow) rather than phase matching
+    const EMPTY_PHASE_ACTIONS = new Set(['exarchos_workflow.init']);
+
     for (const composite of TOOL_REGISTRY) {
       for (const action of composite.actions) {
-        expect(
-          action.phases.size,
-          `${composite.name}.${action.name} should have at least one phase`,
-        ).toBeGreaterThan(0);
+        const key = `${composite.name}.${action.name}`;
+        if (EMPTY_PHASE_ACTIONS.has(key)) {
+          expect(
+            action.phases.size,
+            `${key} should have empty phases (guard null-check only)`,
+          ).toBe(0);
+        } else {
+          expect(
+            action.phases.size,
+            `${key} should have at least one phase`,
+          ).toBeGreaterThan(0);
+        }
       }
     }
   });

--- a/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
@@ -122,6 +122,8 @@ const ALL_PHASES: ReadonlySet<string> = new Set([
   'overhaul-delegate',
   'overhaul-review',
   'overhaul-update-docs',
+  // Shared
+  'blocked',
 ]);
 
 const ROLE_ANY: ReadonlySet<string> = new Set(['any']);
@@ -131,11 +133,13 @@ const ROLE_TEAMMATE: ReadonlySet<string> = new Set(['teammate']);
 const DELEGATE_PHASES: ReadonlySet<string> = new Set([
   'delegate',
   'overhaul-delegate',
+  'debug-implement',
 ]);
 const STACK_PHASES: ReadonlySet<string> = new Set([
   'synthesize',
   'delegate',
   'overhaul-delegate',
+  'debug-implement',
 ]);
 
 // ─── Shared Schema Fragments ────────────────────────────────────────────────
@@ -152,7 +156,7 @@ const workflowActions: readonly ToolAction[] = [
       featureId: featureIdSchema,
       workflowType: z.enum(['feature', 'debug', 'refactor']),
     }),
-    phases: new Set(['ideate']),
+    phases: new Set<string>(),
     roles: ROLE_LEAD,
   },
   {


### PR DESCRIPTION
## Summary

Fixes four guard registry bugs discovered while testing the refactor workflow (#253). Blocked workflows were permanently stuck, init could create duplicates, debug thorough track couldn't use team tools, and cancelled workflows leaked stale context to subagents.

## Changes

- **ALL_PHASES** — Add `blocked` phase so workflows in blocked state can be inspected, unblocked, and cancelled via MCP tools
- **init phases** — Empty the phase set to prevent duplicate workflow creation; the guard's null-check already handles the no-active-workflow case correctly
- **DELEGATE_PHASES / STACK_PHASES** — Add `debug-implement` so debug thorough track can use team coordination and stack tools for larger efforts
- **subagent-context** — Filter `cancelled` workflows alongside `completed` to prevent stale tool guidance injection

## Test Plan

Added 11 new tests covering all four fixes: init enforcement (3), blocked phase access (3), debug-implement delegation (2), and cancelled workflow filtering (3). Full suite passes: 1,062 MCP tests.

---

**Results:** Tests 1062 ✓ · Build 0 errors
**Related:** Follow-up to #253