### PR TITLE
fix: harden merge gates with CI aggregator and required reviews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,6 @@ jobs:
       - run: npm run typecheck
       - run: npm run test:run
 
-  test-mcp-skip:
-    name: Exarchos MCP Server
-    needs: changes
-    if: ${{ needs.changes.outputs.mcp != 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "No MCP changes, skipping"
-
   test-mcp:
     name: Exarchos MCP Server
     needs: changes
@@ -79,3 +71,30 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
       - run: npm run test:run
+
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    needs: [changes, test-root, test-mcp]
+    if: always()
+    steps:
+      - name: Evaluate results
+        run: |
+          echo "changes=${{ needs.changes.result }}"
+          echo "test-root=${{ needs.test-root.result }}"
+          echo "test-mcp=${{ needs.test-mcp.result }}"
+
+          if [[ "${{ needs.changes.result }}" =~ ^(failure|cancelled)$ ]]; then
+            echo "::error::Change detection: ${{ needs.changes.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.test-root.result }}" =~ ^(failure|cancelled)$ ]]; then
+            echo "::error::Root package tests: ${{ needs.test-root.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.test-mcp.result }}" =~ ^(failure|cancelled)$ ]]; then
+            echo "::error::MCP server tests: ${{ needs.test-mcp.result }}"
+            exit 1
+          fi
+
+          echo "All checks passed (skipped jobs are OK)"


### PR DESCRIPTION
## Summary

PRs were auto-merging via the Graphite merge queue despite CI failures and CodeRabbit `CHANGES_REQUESTED` reviews. Three interacting gaps — a meaningless status check, zero required reviews, and SKIPPED jobs satisfying required checks — meant no gate actually blocked merging.

## Changes

- **CI Workflow** — Added always-running `ci-gate` aggregator job that fails only on actual failures (treats SKIPPED as OK), removed the `test-mcp-skip` workaround
- **Branch Ruleset** — Replaced `Exarchos MCP Server` + `CodeRabbit` required status checks with `CI Gate`
- **Branch Ruleset** — Set `required_approving_review_count` from 0 to 1, making `CHANGES_REQUESTED` reviews actually block merging

## Test Plan

Ruleset changes are live and can be verified by inspecting the [ruleset configuration](https://github.com/lvlup-sw/exarchos/rules/11581356). CI gate behavior will be validated by this PR's own check run — `CI Gate` should appear and pass.

---

**Related:** Closes #257, follows up on 9ced175