### PR TITLE
fix: migrate all workflows from ubuntu-latest to Blacksmith runners

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   update-prs:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     outputs:
       root: ${{ steps.filter.outputs.root }}
       mcp: ${{ steps.filter.outputs.mcp }}
@@ -74,7 +74,7 @@ jobs:
 
   ci-gate:
     name: CI Gate
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     needs: [changes, test-root, test-mcp]
     if: always()
     steps:

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -26,7 +26,7 @@ jobs:
   # ============================================================
   label-sync:
     if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions:
       issues: write
     steps:
@@ -108,7 +108,7 @@ jobs:
   # ============================================================
   auto-triage:
     if: github.event_name == 'issues' && github.event.action == 'opened'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions:
       issues: write
     steps:
@@ -154,7 +154,7 @@ jobs:
   # ============================================================
   auto-assign-author:
     if: github.event_name == 'pull_request' && github.event.action == 'opened' && github.event.pull_request.user.type != 'Bot'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions:
       pull-requests: write
     steps:
@@ -172,7 +172,7 @@ jobs:
     if: |
       (github.event_name == 'issues' && github.event.action == 'opened') ||
       (github.event_name == 'pull_request' && github.event.action == 'opened')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:
       - name: Add to project
         uses: actions/add-to-project@v1.0.2
@@ -188,7 +188,7 @@ jobs:
     if: |
       (github.event_name == 'issues' && github.event.action == 'opened') ||
       (github.event_name == 'pull_request' && github.event.action == 'opened')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:
       - name: Initialize project fields
         uses: actions/github-script@v8
@@ -368,7 +368,7 @@ jobs:
     if: |
       github.event_name == 'issues' ||
       github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:
       - name: Update project status
         uses: actions/github-script@v8
@@ -476,7 +476,7 @@ jobs:
   # ============================================================
   stale:
     if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions:
       issues: write
     steps:
@@ -501,7 +501,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       github.event.pull_request.user.login == 'renovate[bot]'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions:
       contents: write
       pull-requests: write
@@ -517,7 +517,7 @@ jobs:
   # ============================================================
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     permissions:
       contents: write
     steps:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   renovate:
     name: Renovate
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

GitHub Actions minutes exhausted (3000/3000 on Team plan), causing all `ubuntu-latest` jobs to fail immediately with no runner provisioning. Migrates every workflow job to Blacksmith runners to eliminate GitHub-hosted runner dependency entirely.

## Changes

- **CI workflow** — `Detect Changes` and `CI Gate` moved from `ubuntu-latest` to `blacksmith-2vcpu-ubuntu-2204`
- **Project Automation** — All 10 jobs (label-sync, auto-triage, auto-assign, project-sync, etc.) moved to `blacksmith-2vcpu-ubuntu-2204`
- **Auto Update PRs** — Moved to `blacksmith-2vcpu-ubuntu-2204`
- **Renovate** — Moved to `blacksmith-2vcpu-ubuntu-2204`

## Test Plan

CI for this PR will itself validate the fix — if `Detect Changes` and `CI Gate` run successfully on Blacksmith, the migration works. Test jobs (`Root Package`, `Exarchos MCP Server`) already use `blacksmith-4vcpu-ubuntu-2204`.

---

**Related:** Follows #258, #257