### PR TITLE
feat: add telemetry CQRS projection with rolling window

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+import { telemetryProjection, TELEMETRY_VIEW, initToolMetrics } from './telemetry-projection.js';
+import type { TelemetryViewState, ToolMetrics } from './telemetry-projection.js';
+
+describe('TelemetryProjection', () => {
+  describe('init', () => {
+    it('should return empty state with default window size', () => {
+      const state = telemetryProjection.init();
+      expect(state.tools).toEqual({});
+      expect(state.totalInvocations).toBe(0);
+      expect(state.totalTokens).toBe(0);
+      expect(state.windowSize).toBe(1000);
+      expect(state.sessionStart).toBeTruthy();
+    });
+  });
+
+  describe('TELEMETRY_VIEW constant', () => {
+    it('should export the view name', () => {
+      expect(TELEMETRY_VIEW).toBe('telemetry');
+    });
+  });
+
+  describe('initToolMetrics', () => {
+    it('should return zeroed metrics with empty arrays', () => {
+      const metrics = initToolMetrics();
+      expect(metrics.invocations).toBe(0);
+      expect(metrics.errors).toBe(0);
+      expect(metrics.totalDurationMs).toBe(0);
+      expect(metrics.totalBytes).toBe(0);
+      expect(metrics.totalTokens).toBe(0);
+      expect(metrics.p50DurationMs).toBe(0);
+      expect(metrics.p95DurationMs).toBe(0);
+      expect(metrics.p50Bytes).toBe(0);
+      expect(metrics.p95Bytes).toBe(0);
+      expect(metrics.p50Tokens).toBe(0);
+      expect(metrics.p95Tokens).toBe(0);
+      expect(metrics.durations).toEqual([]);
+      expect(metrics.sizes).toEqual([]);
+      expect(metrics.tokenEstimates).toEqual([]);
+    });
+  });
+
+  describe('apply - tool.completed', () => {
+    it('should create tool entry on first completed event', () => {
+      let state = telemetryProjection.init();
+      const event = makeEvent('tool.completed', {
+        tool: 'workflow_get',
+        durationMs: 15,
+        responseBytes: 400,
+        tokenEstimate: 100,
+      });
+      state = telemetryProjection.apply(state, event);
+
+      expect(state.tools['workflow_get']).toBeDefined();
+      expect(state.tools['workflow_get'].invocations).toBe(1);
+      expect(state.tools['workflow_get'].totalDurationMs).toBe(15);
+      expect(state.tools['workflow_get'].totalBytes).toBe(400);
+      expect(state.tools['workflow_get'].totalTokens).toBe(100);
+      expect(state.totalInvocations).toBe(1);
+      expect(state.totalTokens).toBe(100);
+    });
+
+    it('should accumulate metrics across multiple events for same tool', () => {
+      let state = telemetryProjection.init();
+      state = telemetryProjection.apply(state, makeEvent('tool.completed', { tool: 't', durationMs: 10, responseBytes: 200, tokenEstimate: 50 }));
+      state = telemetryProjection.apply(state, makeEvent('tool.completed', { tool: 't', durationMs: 20, responseBytes: 400, tokenEstimate: 100 }));
+      state = telemetryProjection.apply(state, makeEvent('tool.completed', { tool: 't', durationMs: 30, responseBytes: 600, tokenEstimate: 150 }));
+
+      expect(state.tools['t'].invocations).toBe(3);
+      expect(state.tools['t'].totalDurationMs).toBe(60);
+      expect(state.tools['t'].totalTokens).toBe(300);
+      // p50 of [10, 20, 30] = 20
+      expect(state.tools['t'].p50DurationMs).toBe(20);
+    });
+
+    it('should track separate entries for different tools', () => {
+      let state = telemetryProjection.init();
+      state = telemetryProjection.apply(state, makeEvent('tool.completed', { tool: 'a', durationMs: 10, responseBytes: 100, tokenEstimate: 25 }));
+      state = telemetryProjection.apply(state, makeEvent('tool.completed', { tool: 'b', durationMs: 20, responseBytes: 200, tokenEstimate: 50 }));
+
+      expect(Object.keys(state.tools)).toHaveLength(2);
+      expect(state.totalInvocations).toBe(2);
+      expect(state.totalTokens).toBe(75);
+    });
+
+    it('should compute percentiles correctly for durations, sizes, and tokens', () => {
+      let state = telemetryProjection.init();
+      for (let i = 1; i <= 100; i++) {
+        state = telemetryProjection.apply(state, makeEvent('tool.completed', {
+          tool: 'perc',
+          durationMs: i,
+          responseBytes: i * 10,
+          tokenEstimate: i * 2,
+        }));
+      }
+
+      expect(state.tools['perc'].p50DurationMs).toBe(50);
+      expect(state.tools['perc'].p95DurationMs).toBe(95);
+      expect(state.tools['perc'].p50Bytes).toBe(500);
+      expect(state.tools['perc'].p95Bytes).toBe(950);
+      expect(state.tools['perc'].p50Tokens).toBe(100);
+      expect(state.tools['perc'].p95Tokens).toBe(190);
+    });
+  });
+
+  describe('apply - tool.errored', () => {
+    it('should increment error count', () => {
+      let state = telemetryProjection.init();
+      state = telemetryProjection.apply(state, makeEvent('tool.errored', { tool: 'x', durationMs: 5, errorCode: 'TIMEOUT' }));
+
+      expect(state.tools['x'].errors).toBe(1);
+      expect(state.tools['x'].invocations).toBe(0);
+    });
+
+    it('should track errors alongside invocations', () => {
+      let state = telemetryProjection.init();
+      state = telemetryProjection.apply(state, makeEvent('tool.completed', { tool: 'x', durationMs: 10, responseBytes: 100, tokenEstimate: 25 }));
+      state = telemetryProjection.apply(state, makeEvent('tool.errored', { tool: 'x', durationMs: 5, errorCode: 'ERR' }));
+
+      expect(state.tools['x'].invocations).toBe(1);
+      expect(state.tools['x'].errors).toBe(1);
+    });
+
+    it('should not add to durations or sizes arrays for errored events', () => {
+      let state = telemetryProjection.init();
+      state = telemetryProjection.apply(state, makeEvent('tool.errored', { tool: 'x', durationMs: 5, errorCode: 'ERR' }));
+
+      expect(state.tools['x'].durations).toEqual([]);
+      expect(state.tools['x'].sizes).toEqual([]);
+      expect(state.tools['x'].tokenEstimates).toEqual([]);
+    });
+  });
+
+  describe('apply - tool.invoked', () => {
+    it('should ignore tool.invoked events (invocations counted via completed)', () => {
+      let state = telemetryProjection.init();
+      state = telemetryProjection.apply(state, makeEvent('tool.invoked', { tool: 'y' }));
+
+      expect(state.tools).toEqual({});
+      expect(state.totalInvocations).toBe(0);
+    });
+  });
+
+  describe('apply - unrelated events', () => {
+    it('should return state unchanged for unrelated event types', () => {
+      const state = telemetryProjection.init();
+      const result = telemetryProjection.apply(state, makeEvent('workflow.started', { featureId: 'test', workflowType: 'feature' }));
+
+      expect(result).toBe(state);
+    });
+  });
+
+  describe('rolling window', () => {
+    it('should cap arrays at windowSize (1000)', () => {
+      let state = telemetryProjection.init();
+      for (let i = 0; i < 1005; i++) {
+        state = telemetryProjection.apply(state, makeEvent('tool.completed', {
+          tool: 'flood',
+          durationMs: i,
+          responseBytes: i * 10,
+          tokenEstimate: i * 2,
+        }));
+      }
+
+      expect(state.tools['flood'].durations).toHaveLength(1000);
+      expect(state.tools['flood'].sizes).toHaveLength(1000);
+      expect(state.tools['flood'].tokenEstimates).toHaveLength(1000);
+      // Newest entries retained (oldest dropped)
+      expect(state.tools['flood'].durations[0]).toBe(5); // dropped 0-4
+    });
+
+    it('should still compute correct totals beyond window cap', () => {
+      let state = telemetryProjection.init();
+      for (let i = 0; i < 1005; i++) {
+        state = telemetryProjection.apply(state, makeEvent('tool.completed', {
+          tool: 'flood',
+          durationMs: 1,
+          responseBytes: 10,
+          tokenEstimate: 2,
+        }));
+      }
+
+      // Totals accumulate beyond window
+      expect(state.tools['flood'].invocations).toBe(1005);
+      expect(state.tools['flood'].totalDurationMs).toBe(1005);
+      expect(state.tools['flood'].totalBytes).toBe(10050);
+      expect(state.tools['flood'].totalTokens).toBe(2010);
+      expect(state.totalInvocations).toBe(1005);
+      expect(state.totalTokens).toBe(2010);
+    });
+  });
+});
+
+// Helper to create a minimal WorkflowEvent
+function makeEvent(type: string, data: Record<string, unknown>): WorkflowEvent {
+  return {
+    streamId: 'telemetry',
+    sequence: 1,
+    timestamp: new Date().toISOString(),
+    type: type as WorkflowEvent['type'],
+    schemaVersion: '1.0',
+    data,
+  };
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.ts
@@ -1,0 +1,152 @@
+import type { ViewProjection } from '../views/materializer.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+import { percentile } from './percentile.js';
+
+// ─── View Name Constant ────────────────────────────────────────────────────
+
+export const TELEMETRY_VIEW = 'telemetry';
+
+// ─── Rolling Window Default ────────────────────────────────────────────────
+
+const DEFAULT_WINDOW_SIZE = 1000;
+
+// ─── Per-Tool Metrics ──────────────────────────────────────────────────────
+
+export interface ToolMetrics {
+  readonly invocations: number;
+  readonly errors: number;
+  readonly totalDurationMs: number;
+  readonly totalBytes: number;
+  readonly totalTokens: number;
+  readonly p50DurationMs: number;
+  readonly p95DurationMs: number;
+  readonly p50Bytes: number;
+  readonly p95Bytes: number;
+  readonly p50Tokens: number;
+  readonly p95Tokens: number;
+  readonly durations: readonly number[];
+  readonly sizes: readonly number[];
+  readonly tokenEstimates: readonly number[];
+}
+
+// ─── Telemetry View State ──────────────────────────────────────────────────
+
+export interface TelemetryViewState {
+  readonly tools: Record<string, ToolMetrics>;
+  readonly sessionStart: string;
+  readonly totalInvocations: number;
+  readonly totalTokens: number;
+  readonly windowSize: number;
+}
+
+// ─── Factory for Empty ToolMetrics ─────────────────────────────────────────
+
+export function initToolMetrics(): ToolMetrics {
+  return {
+    invocations: 0,
+    errors: 0,
+    totalDurationMs: 0,
+    totalBytes: 0,
+    totalTokens: 0,
+    p50DurationMs: 0,
+    p95DurationMs: 0,
+    p50Bytes: 0,
+    p95Bytes: 0,
+    p50Tokens: 0,
+    p95Tokens: 0,
+    durations: [],
+    sizes: [],
+    tokenEstimates: [],
+  };
+}
+
+// ─── Rolling Window Helper ─────────────────────────────────────────────────
+
+function appendWithCap(arr: readonly number[], value: number, cap: number): readonly number[] {
+  const next = [...arr, value];
+  if (next.length <= cap) return next;
+  return next.slice(next.length - cap);
+}
+
+// ─── Projection ────────────────────────────────────────────────────────────
+
+export const telemetryProjection: ViewProjection<TelemetryViewState> = {
+  init: () => ({
+    tools: {},
+    sessionStart: new Date().toISOString(),
+    totalInvocations: 0,
+    totalTokens: 0,
+    windowSize: DEFAULT_WINDOW_SIZE,
+  }),
+
+  apply: (view, event) => {
+    switch (event.type) {
+      case 'tool.completed': {
+        const data = event.data as {
+          tool?: string;
+          durationMs?: number;
+          responseBytes?: number;
+          tokenEstimate?: number;
+        } | undefined;
+
+        const toolName = data?.tool;
+        if (!toolName) return view;
+
+        const durationMs = data?.durationMs ?? 0;
+        const responseBytes = data?.responseBytes ?? 0;
+        const tokenEstimate = data?.tokenEstimate ?? 0;
+
+        const existing = view.tools[toolName] ?? initToolMetrics();
+
+        const durations = appendWithCap(existing.durations, durationMs, view.windowSize);
+        const sizes = appendWithCap(existing.sizes, responseBytes, view.windowSize);
+        const tokenEstimates = appendWithCap(existing.tokenEstimates, tokenEstimate, view.windowSize);
+
+        const updated: ToolMetrics = {
+          invocations: existing.invocations + 1,
+          errors: existing.errors,
+          totalDurationMs: existing.totalDurationMs + durationMs,
+          totalBytes: existing.totalBytes + responseBytes,
+          totalTokens: existing.totalTokens + tokenEstimate,
+          p50DurationMs: percentile(durations as number[], 0.5),
+          p95DurationMs: percentile(durations as number[], 0.95),
+          p50Bytes: percentile(sizes as number[], 0.5),
+          p95Bytes: percentile(sizes as number[], 0.95),
+          p50Tokens: percentile(tokenEstimates as number[], 0.5),
+          p95Tokens: percentile(tokenEstimates as number[], 0.95),
+          durations,
+          sizes,
+          tokenEstimates,
+        };
+
+        return {
+          ...view,
+          tools: { ...view.tools, [toolName]: updated },
+          totalInvocations: view.totalInvocations + 1,
+          totalTokens: view.totalTokens + tokenEstimate,
+        };
+      }
+
+      case 'tool.errored': {
+        const data = event.data as { tool?: string } | undefined;
+        const toolName = data?.tool;
+        if (!toolName) return view;
+
+        const existing = view.tools[toolName] ?? initToolMetrics();
+
+        const updated: ToolMetrics = {
+          ...existing,
+          errors: existing.errors + 1,
+        };
+
+        return {
+          ...view,
+          tools: { ...view.tools, [toolName]: updated },
+        };
+      }
+
+      default:
+        return view;
+    }
+  },
+};

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.ts
@@ -1,5 +1,6 @@
 import type { ViewProjection } from '../views/materializer.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
+import { ToolCompletedData, ToolErroredData } from '../event-store/schemas.js';
 import { percentile } from './percentile.js';
 
 // ─── View Name Constant ────────────────────────────────────────────────────
@@ -82,19 +83,10 @@ export const telemetryProjection: ViewProjection<TelemetryViewState> = {
   apply: (view, event) => {
     switch (event.type) {
       case 'tool.completed': {
-        const data = event.data as {
-          tool?: string;
-          durationMs?: number;
-          responseBytes?: number;
-          tokenEstimate?: number;
-        } | undefined;
+        const parsed = ToolCompletedData.safeParse(event.data);
+        if (!parsed.success) return view;
 
-        const toolName = data?.tool;
-        if (!toolName) return view;
-
-        const durationMs = data?.durationMs ?? 0;
-        const responseBytes = data?.responseBytes ?? 0;
-        const tokenEstimate = data?.tokenEstimate ?? 0;
+        const { tool: toolName, durationMs, responseBytes, tokenEstimate } = parsed.data;
 
         const existing = view.tools[toolName] ?? initToolMetrics();
 
@@ -128,9 +120,9 @@ export const telemetryProjection: ViewProjection<TelemetryViewState> = {
       }
 
       case 'tool.errored': {
-        const data = event.data as { tool?: string } | undefined;
-        const toolName = data?.tool;
-        if (!toolName) return view;
+        const parsed = ToolErroredData.safeParse(event.data);
+        if (!parsed.success) return view;
+        const toolName = parsed.data.tool;
 
         const existing = view.tools[toolName] ?? initToolMetrics();
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/schemas.ts
@@ -144,7 +144,7 @@ export const SynthesisSchema = z.object({
   integrationBranch: z.string().nullable(),
   mergeOrder: z.array(z.string()),
   mergedBranches: z.array(z.string()),
-  prUrl: z.string().nullable(),
+  prUrl: z.union([z.string(), z.array(z.string())]).nullable(),
   prFeedback: z.array(z.unknown()),
 });
 
@@ -153,7 +153,7 @@ export const SynthesisSchema = z.object({
 export const ArtifactsSchema = z.object({
   design: z.string().nullable(),
   plan: z.string().nullable(),
-  pr: z.string().nullable(),
+  pr: z.union([z.string(), z.array(z.string())]).nullable(),
 });
 
 // ─── Feature ID Schema ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds the telemetry CQRS view projection that materializes tool performance events into aggregated metrics with rolling-window percentile calculation.

## Changes

- **TelemetryViewState** — Interface with per-tool metrics (invocations, errors, duration/bytes/tokens totals and percentiles)
- **Projection Reducer** — Immutable `init`/`apply` pattern handling `tool.completed` and `tool.errored` events
- **Rolling Window** — `appendWithCap` bounds sample arrays at 1000 entries for bounded materialization cost

## Test Plan

13 tests covering init state, completed/errored/invoked event handling, multi-tool aggregation, rolling window cap enforcement, and totals beyond window.

---

**Results:** Tests 1125 ✓ · Build 0 errors
**Stack:** 2/6