### PR TITLE
feat: add telemetry instrumentation middleware and registrar

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -264,7 +264,7 @@ export const ToolCompletedData = z.object({
 export const ToolErroredData = z.object({
   tool: z.string(),
   durationMs: z.number(),
-  errorCode: z.string(),
+  errorMessage: z.string(),
 });
 
 // ─── TypeScript Types ───────────────────────────────────────────────────────

--- a/plugins/exarchos/servers/exarchos-mcp/src/format.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/format.ts
@@ -20,6 +20,18 @@ export function toEventAck(event: { streamId: string; sequence: number; type: st
   return { streamId: event.streamId, sequence: event.sequence, type: event.type };
 }
 
+// ─── MCP Wire Format Types ──────────────────────────────────────────────────
+
+export interface McpToolContent {
+  readonly type: string;
+  readonly text: string;
+}
+
+export interface McpToolResult {
+  readonly content: readonly McpToolContent[];
+  readonly isError: boolean;
+}
+
 // ─── Result Formatting ──────────────────────────────────────────────────────
 
 /** Converts a ToolResult into the MCP content format expected by the SDK. */

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/foundation.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/foundation.test.ts
@@ -38,7 +38,7 @@ describe('Telemetry Event Types', () => {
   it('should accept tool.errored event with error info', async () => {
     const event = await store.append(TELEMETRY_STREAM, {
       type: 'tool.errored',
-      data: { tool: 'test_tool', durationMs: 5, errorCode: 'TIMEOUT' },
+      data: { tool: 'test_tool', durationMs: 5, errorMessage: 'TIMEOUT' },
     });
     expect(event.type).toBe('tool.errored');
   });
@@ -46,7 +46,7 @@ describe('Telemetry Event Types', () => {
   it('should query telemetry stream and return all 3 events', async () => {
     await store.append(TELEMETRY_STREAM, { type: 'tool.invoked', data: { tool: 't' } });
     await store.append(TELEMETRY_STREAM, { type: 'tool.completed', data: { tool: 't', durationMs: 1, responseBytes: 10, tokenEstimate: 3 } });
-    await store.append(TELEMETRY_STREAM, { type: 'tool.errored', data: { tool: 't', durationMs: 1, errorCode: 'ERR' } });
+    await store.append(TELEMETRY_STREAM, { type: 'tool.errored', data: { tool: 't', durationMs: 1, errorMessage: 'ERR' } });
 
     const events = await store.query(TELEMETRY_STREAM);
     expect(events).toHaveLength(3);

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/middleware.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/middleware.test.ts
@@ -100,7 +100,7 @@ describe('withTelemetry', () => {
       expect(events[1].type).toBe('tool.errored');
       const errorData = events[1].data as Record<string, unknown>;
       expect(errorData.tool).toBe('fail_tool');
-      expect(errorData.errorCode).toContain('Handler failed');
+      expect(errorData.errorMessage).toContain('Handler failed');
     });
   });
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/middleware.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/middleware.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { withTelemetry, createInstrumentedRegistrar } from './middleware.js';
+import { EventStore } from '../event-store/store.js';
+import { TELEMETRY_STREAM } from './constants.js';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+describe('withTelemetry', () => {
+  let tmpDir: string;
+  let eventStore: EventStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'middleware-test-'));
+    eventStore = new EventStore(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('successful handler', () => {
+    it('should emit tool.invoked and tool.completed events', async () => {
+      // Arrange
+      const handler = async () => ({
+        content: [{ type: 'text' as const, text: JSON.stringify({ success: true, data: { key: 'val' } }) }],
+        isError: false,
+      });
+
+      // Act
+      const wrapped = withTelemetry(handler, 'test_tool', eventStore);
+      await wrapped({});
+
+      // Assert
+      const events = await eventStore.query(TELEMETRY_STREAM);
+      expect(events).toHaveLength(2);
+      expect(events[0].type).toBe('tool.invoked');
+      expect((events[0].data as Record<string, unknown>).tool).toBe('test_tool');
+      expect(events[1].type).toBe('tool.completed');
+      const completedData = events[1].data as Record<string, unknown>;
+      expect(completedData.tool).toBe('test_tool');
+      expect(completedData.durationMs).toBeGreaterThanOrEqual(0);
+      expect(completedData.responseBytes).toBeGreaterThan(0);
+      expect(completedData.tokenEstimate).toBeGreaterThan(0);
+    });
+
+    it('should inject _perf field into response', async () => {
+      // Arrange
+      const handler = async () => ({
+        content: [{ type: 'text' as const, text: JSON.stringify({ success: true, data: { key: 'val' } }) }],
+        isError: false,
+      });
+
+      // Act
+      const wrapped = withTelemetry(handler, 'test_tool', eventStore);
+      const result = await wrapped({});
+      const parsed = JSON.parse(result.content[0].text);
+
+      // Assert
+      expect(parsed._perf).toBeDefined();
+      expect(parsed._perf.ms).toBeGreaterThanOrEqual(0);
+      expect(parsed._perf.bytes).toBeGreaterThan(0);
+      expect(parsed._perf.tokens).toBeGreaterThan(0);
+      // Original data preserved
+      expect(parsed.data.key).toBe('val');
+    });
+
+    it('should preserve _meta field if present', async () => {
+      // Arrange
+      const handler = async () => ({
+        content: [{ type: 'text' as const, text: JSON.stringify({ success: true, _meta: { hint: 'test' } }) }],
+        isError: false,
+      });
+
+      // Act
+      const wrapped = withTelemetry(handler, 'test_tool', eventStore);
+      const result = await wrapped({});
+      const parsed = JSON.parse(result.content[0].text);
+
+      // Assert
+      expect(parsed._meta).toEqual({ hint: 'test' });
+      expect(parsed._perf).toBeDefined();
+    });
+  });
+
+  describe('failing handler', () => {
+    it('should emit tool.errored event and re-throw', async () => {
+      // Arrange
+      const handler = async () => {
+        throw new Error('Handler failed');
+      };
+
+      // Act & Assert
+      const wrapped = withTelemetry(handler, 'fail_tool', eventStore);
+      await expect(wrapped({})).rejects.toThrow('Handler failed');
+
+      const events = await eventStore.query(TELEMETRY_STREAM);
+      expect(events).toHaveLength(2);
+      expect(events[0].type).toBe('tool.invoked');
+      expect(events[1].type).toBe('tool.errored');
+      const errorData = events[1].data as Record<string, unknown>;
+      expect(errorData.tool).toBe('fail_tool');
+      expect(errorData.errorCode).toContain('Handler failed');
+    });
+  });
+
+  describe('telemetry failure resilience', () => {
+    it('should succeed even when telemetry append fails', async () => {
+      // Arrange - Create a store pointing to a non-existent dir
+      const brokenStore = new EventStore('/nonexistent/path/that/wont/work');
+
+      const handler = async () => ({
+        content: [{ type: 'text' as const, text: JSON.stringify({ success: true, data: {} }) }],
+        isError: false,
+      });
+
+      // Act
+      const wrapped = withTelemetry(handler, 'test_tool', brokenStore);
+      // Should not throw even though telemetry fails
+      const result = await wrapped({});
+
+      // Assert
+      expect(result.content[0]).toBeDefined();
+      // _perf may be absent when telemetry fails (graceful degradation)
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(true);
+    });
+  });
+});
+
+describe('createInstrumentedRegistrar', () => {
+  let tmpDir: string;
+  let eventStore: EventStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'registrar-test-'));
+    eventStore = new EventStore(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should return a function', () => {
+    // Arrange
+    const mockServer = { tool: () => {} };
+
+    // Act
+    const registrar = createInstrumentedRegistrar(mockServer as unknown as { tool: (...args: unknown[]) => void }, eventStore);
+
+    // Assert
+    expect(typeof registrar).toBe('function');
+  });
+
+  it('should call server.tool with wrapped handler', () => {
+    // Arrange
+    let registeredName: string | undefined;
+    let registeredHandler: ((...args: unknown[]) => unknown) | undefined;
+    const mockServer = {
+      tool: (name: string, _desc: string, _schema: unknown, handler: (...args: unknown[]) => unknown) => {
+        registeredName = name;
+        registeredHandler = handler;
+      },
+    };
+
+    const registrar = createInstrumentedRegistrar(mockServer as unknown as { tool: (...args: unknown[]) => void }, eventStore);
+    const originalHandler = async () => ({
+      content: [{ type: 'text' as const, text: '{}' }],
+      isError: false,
+    });
+
+    // Act
+    registrar('my_tool', 'My tool description', {}, originalHandler);
+
+    // Assert
+    expect(registeredName).toBe('my_tool');
+    expect(registeredHandler).toBeDefined();
+    // The registered handler should NOT be the original (it's wrapped)
+    expect(registeredHandler).not.toBe(originalHandler);
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/middleware.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/middleware.ts
@@ -1,0 +1,129 @@
+import { EventStore } from '../event-store/store.js';
+import { TELEMETRY_STREAM } from './constants.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface McpToolContent {
+  readonly type: string;
+  readonly text: string;
+}
+
+interface McpToolResult {
+  content: McpToolContent[];
+  isError: boolean;
+}
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<McpToolResult>;
+
+// ─── Perf Injection ─────────────────────────────────────────────────────────
+
+interface PerfMetrics {
+  readonly ms: number;
+  readonly bytes: number;
+  readonly tokens: number;
+}
+
+/** Injects `_perf` into the JSON payload of the first content entry. Fails silently if text is not valid JSON. */
+function injectPerf(result: McpToolResult, perf: PerfMetrics): McpToolResult {
+  const entry = result.content[0];
+  if (!entry?.text) return result;
+
+  try {
+    const parsed = JSON.parse(entry.text) as Record<string, unknown>;
+    parsed._perf = perf;
+    return {
+      ...result,
+      content: [{ ...entry, text: JSON.stringify(parsed) }, ...result.content.slice(1)],
+    };
+  } catch {
+    // Not valid JSON — return unchanged
+    return result;
+  }
+}
+
+// ─── withTelemetry HOF ──────────────────────────────────────────────────────
+
+/**
+ * Wraps an MCP tool handler with telemetry instrumentation.
+ *
+ * Emits `tool.invoked` before execution, `tool.completed` after success (with
+ * duration, response size, and token estimate), or `tool.errored` on failure.
+ *
+ * Telemetry failures are swallowed — they never break the underlying handler.
+ */
+export function withTelemetry(
+  handler: ToolHandler,
+  toolName: string,
+  eventStore: EventStore,
+): ToolHandler {
+  return async (args) => {
+    // Emit invoked (fire-and-forget, swallow failures)
+    const invokePromise = eventStore
+      .append(TELEMETRY_STREAM, {
+        type: 'tool.invoked',
+        data: { tool: toolName },
+      })
+      .catch(() => {});
+
+    const start = performance.now();
+
+    try {
+      const result = await handler(args);
+      const durationMs = Math.round(performance.now() - start);
+      const responseText = result.content[0]?.text ?? '';
+      const responseBytes = Buffer.byteLength(responseText, 'utf-8');
+      const tokenEstimate = Math.ceil(responseBytes / 4);
+
+      // Wait for invoke event to settle before emitting completed
+      await invokePromise;
+
+      // Emit completed (swallow failures)
+      await eventStore
+        .append(TELEMETRY_STREAM, {
+          type: 'tool.completed',
+          data: { tool: toolName, durationMs, responseBytes, tokenEstimate },
+        })
+        .catch(() => {});
+
+      return injectPerf(result, { ms: durationMs, bytes: responseBytes, tokens: tokenEstimate });
+    } catch (error) {
+      const durationMs = Math.round(performance.now() - start);
+
+      // Wait for invoke event to settle before emitting errored
+      await invokePromise;
+
+      // Emit errored (swallow failures)
+      await eventStore
+        .append(TELEMETRY_STREAM, {
+          type: 'tool.errored',
+          data: {
+            tool: toolName,
+            durationMs,
+            errorCode: error instanceof Error ? error.message : String(error),
+          },
+        })
+        .catch(() => {});
+
+      throw error;
+    }
+  };
+}
+
+// ─── Instrumented Registrar ─────────────────────────────────────────────────
+
+interface McpServer {
+  tool: (...args: unknown[]) => void;
+}
+
+/**
+ * Creates a registration function that transparently wraps MCP tool handlers
+ * with telemetry instrumentation before delegating to `server.tool()`.
+ */
+export function createInstrumentedRegistrar(
+  server: McpServer,
+  eventStore: EventStore,
+) {
+  return (name: string, description: string, schema: unknown, handler: ToolHandler) => {
+    server.tool(name, description, schema, withTelemetry(handler, name, eventStore));
+  };
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/middleware.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/middleware.ts
@@ -1,17 +1,8 @@
 import { EventStore } from '../event-store/store.js';
+import type { McpToolResult } from '../format.js';
 import { TELEMETRY_STREAM } from './constants.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
-
-interface McpToolContent {
-  readonly type: string;
-  readonly text: string;
-}
-
-interface McpToolResult {
-  content: McpToolContent[];
-  isError: boolean;
-}
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<McpToolResult>;
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/middleware.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/middleware.ts
@@ -90,7 +90,7 @@ export function withTelemetry(
           data: {
             tool: toolName,
             durationMs,
-            errorCode: error instanceof Error ? error.message : String(error),
+            errorMessage: error instanceof Error ? error.message : String(error),
           },
         })
         .catch(() => {});

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts
@@ -107,7 +107,7 @@ describe('TelemetryProjection', () => {
   describe('apply - tool.errored', () => {
     it('should increment error count', () => {
       let state = telemetryProjection.init();
-      state = telemetryProjection.apply(state, makeEvent('tool.errored', { tool: 'x', durationMs: 5, errorCode: 'TIMEOUT' }));
+      state = telemetryProjection.apply(state, makeEvent('tool.errored', { tool: 'x', durationMs: 5, errorMessage: 'TIMEOUT' }));
 
       expect(state.tools['x'].errors).toBe(1);
       expect(state.tools['x'].invocations).toBe(0);
@@ -116,7 +116,7 @@ describe('TelemetryProjection', () => {
     it('should track errors alongside invocations', () => {
       let state = telemetryProjection.init();
       state = telemetryProjection.apply(state, makeEvent('tool.completed', { tool: 'x', durationMs: 10, responseBytes: 100, tokenEstimate: 25 }));
-      state = telemetryProjection.apply(state, makeEvent('tool.errored', { tool: 'x', durationMs: 5, errorCode: 'ERR' }));
+      state = telemetryProjection.apply(state, makeEvent('tool.errored', { tool: 'x', durationMs: 5, errorMessage: 'ERR' }));
 
       expect(state.tools['x'].invocations).toBe(1);
       expect(state.tools['x'].errors).toBe(1);
@@ -124,7 +124,7 @@ describe('TelemetryProjection', () => {
 
     it('should not add to durations or sizes arrays for errored events', () => {
       let state = telemetryProjection.init();
-      state = telemetryProjection.apply(state, makeEvent('tool.errored', { tool: 'x', durationMs: 5, errorCode: 'ERR' }));
+      state = telemetryProjection.apply(state, makeEvent('tool.errored', { tool: 'x', durationMs: 5, errorMessage: 'ERR' }));
 
       expect(state.tools['x'].durations).toEqual([]);
       expect(state.tools['x'].sizes).toEqual([]);


### PR DESCRIPTION
## Summary

Adds the `withTelemetry` higher-order function that wraps MCP tool handlers to emit timing/sizing events and inject `_perf` metadata into responses, plus the `createInstrumentedRegistrar` factory for bulk instrumentation.

## Changes

- **withTelemetry HOF** — Wraps handlers to emit `tool.invoked`/`tool.completed`/`tool.errored` events with `performance.now()` timing and `bytes/4` token estimation
- **_perf Injection** — Adds `{ ms, bytes, tokens }` field to every tool response for runtime agent guidance
- **Failure Resilience** — Telemetry append failures are swallowed; instrumentation never breaks tool functionality
- **Registrar Factory** — `createInstrumentedRegistrar` for wrapping handlers at registration time

## Test Plan

6 tests covering success/error paths, telemetry resilience (broken store), `_perf` injection, `_meta` preservation, and registrar factory.

---

**Results:** Tests 1125 ✓ · Build 0 errors
**Stack:** 3/6