### PR TITLE
feat: add threshold-based hint generation rules

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/hints.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/hints.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { generateHints } from './hints.js';
+import type { Hint } from './hints.js';
+import type { TelemetryViewState, ToolMetrics } from './telemetry-projection.js';
+import { initToolMetrics } from './telemetry-projection.js';
+
+function makeState(tools: Record<string, Partial<ToolMetrics>>): TelemetryViewState {
+  const fullTools: Record<string, ToolMetrics> = {};
+  for (const [name, partial] of Object.entries(tools)) {
+    fullTools[name] = { ...initToolMetrics(), ...partial };
+  }
+  return {
+    tools: fullTools,
+    sessionStart: new Date().toISOString(),
+    totalInvocations: 0,
+    totalTokens: 0,
+    windowSize: 1000,
+  };
+}
+
+describe('generateHints', () => {
+  describe('view_tasks hints', () => {
+    it('should suggest fields projection when p95Bytes > 1200', () => {
+      const state = makeState({ view_tasks: { p95Bytes: 1500 } });
+      const hints = generateHints(state);
+      expect(hints).toHaveLength(1);
+      expect(hints[0].tool).toBe('view_tasks');
+      expect(hints[0].hint).toContain('fields');
+    });
+
+    it('should not hint when p95Bytes < 800', () => {
+      const state = makeState({ view_tasks: { p95Bytes: 600 } });
+      const hints = generateHints(state);
+      expect(hints).toHaveLength(0);
+    });
+  });
+
+  describe('workflow_get hints', () => {
+    it('should suggest query parameter when p95Bytes > 600', () => {
+      const state = makeState({ workflow_get: { p95Bytes: 800 } });
+      const hints = generateHints(state);
+      expect(hints).toHaveLength(1);
+      expect(hints[0].tool).toBe('workflow_get');
+      expect(hints[0].hint).toContain('query');
+    });
+
+    it('should not hint when p95Bytes < 400', () => {
+      const state = makeState({ workflow_get: { p95Bytes: 300 } });
+      const hints = generateHints(state);
+      expect(hints).toHaveLength(0);
+    });
+  });
+
+  describe('event_query hints', () => {
+    it('should suggest limit parameter when p95Bytes > 2000', () => {
+      const state = makeState({ event_query: { p95Bytes: 2500 } });
+      const hints = generateHints(state);
+      expect(hints).toHaveLength(1);
+      expect(hints[0].tool).toBe('event_query');
+      expect(hints[0].hint).toContain('limit');
+    });
+
+    it('should not hint when p95Bytes < 800', () => {
+      const state = makeState({ event_query: { p95Bytes: 500 } });
+      const hints = generateHints(state);
+      expect(hints).toHaveLength(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return empty array for empty tools map', () => {
+      const state = makeState({});
+      const hints = generateHints(state);
+      expect(hints).toEqual([]);
+    });
+
+    it('should return empty array when all tools have low metrics', () => {
+      const state = makeState({
+        view_tasks: { p95Bytes: 100 },
+        workflow_get: { p95Bytes: 50 },
+        event_query: { p95Bytes: 200 },
+      });
+      const hints = generateHints(state);
+      expect(hints).toEqual([]);
+    });
+
+    it('should return hints for multiple tools at once', () => {
+      const state = makeState({
+        view_tasks: { p95Bytes: 1500 },
+        workflow_get: { p95Bytes: 800 },
+        event_query: { p95Bytes: 2500 },
+      });
+      const hints = generateHints(state);
+      expect(hints).toHaveLength(3);
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/hints.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/hints.ts
@@ -1,0 +1,54 @@
+import type { TelemetryViewState, ToolMetrics } from './telemetry-projection.js';
+
+// ─── Hint Interface ──────────────────────────────────────────────────────────
+
+export interface Hint {
+  readonly tool: string;
+  readonly hint: string;
+}
+
+// ─── Threshold Constants ─────────────────────────────────────────────────────
+
+const VIEW_TASKS_BYTES_THRESHOLD = 1200;
+const WORKFLOW_GET_BYTES_THRESHOLD = 600;
+const EVENT_QUERY_BYTES_THRESHOLD = 2000;
+
+// ─── Rule Type ───────────────────────────────────────────────────────────────
+
+type HintRule = (metrics: ToolMetrics, toolName: string) => Hint | null;
+
+// ─── Rules ───────────────────────────────────────────────────────────────────
+
+const rules: readonly HintRule[] = [
+  (metrics, toolName) => {
+    if (toolName === 'view_tasks' && metrics.p95Bytes > VIEW_TASKS_BYTES_THRESHOLD) {
+      return { tool: toolName, hint: 'Consider using fields projection to reduce response size' };
+    }
+    return null;
+  },
+  (metrics, toolName) => {
+    if (toolName === 'workflow_get' && metrics.p95Bytes > WORKFLOW_GET_BYTES_THRESHOLD) {
+      return { tool: toolName, hint: 'Consider using query parameter for targeted field access' };
+    }
+    return null;
+  },
+  (metrics, toolName) => {
+    if (toolName === 'event_query' && metrics.p95Bytes > EVENT_QUERY_BYTES_THRESHOLD) {
+      return { tool: toolName, hint: 'Consider using limit parameter to cap event results' };
+    }
+    return null;
+  },
+];
+
+// ─── Generator ───────────────────────────────────────────────────────────────
+
+export function generateHints(state: TelemetryViewState): Hint[] {
+  const hints: Hint[] = [];
+  for (const [toolName, metrics] of Object.entries(state.tools)) {
+    for (const rule of rules) {
+      const hint = rule(metrics, toolName);
+      if (hint) hints.push(hint);
+    }
+  }
+  return hints;
+}


### PR DESCRIPTION
## Summary

Adds agent guidance hints that analyze telemetry metrics and suggest optimal tool usage patterns when thresholds indicate suboptimal behavior.

## Changes

- **Hint Interface** — `{ tool: string; hint: string }` for structured suggestions
- **Three Rules** — `view_tasks` fields projection, `workflow_get` query parameter, `event_query` limit parameter
- **Threshold Constants** — Extracted for configurability (token thresholds per tool)

## Test Plan

9 tests covering all three rules, empty state, low metrics (no hints), and multi-tool scenarios.

---

**Results:** Tests 1125 ✓ · Build 0 errors
**Stack:** 4/6