### PR TITLE
feat: add telemetry tool handler and server wiring

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
@@ -4,19 +4,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const {
   toolRegistrations,
-  mockHandleWorkflow,
-  mockHandleEvent,
-  mockHandleOrchestrate,
-  mockHandleView,
+  mockHandleInit, mockHandleList, mockHandleGet, mockHandleSet, mockHandleCheckpoint,
+  mockHandleNextAction, mockHandleCancel,
+  mockHandleSummary, mockHandleReconcile, mockHandleTransitions,
 } = vi.hoisted(() => ({
   toolRegistrations: new Map<
     string,
     { description: string; schema: unknown; handler: (...args: unknown[]) => unknown }
   >(),
-  mockHandleWorkflow: vi.fn().mockResolvedValue({ success: true, data: { phase: 'ideate' } }),
-  mockHandleEvent: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleOrchestrate: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleView: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  mockHandleInit: vi.fn().mockResolvedValue({ success: true, data: { phase: 'ideate' } }),
+  mockHandleList: vi.fn().mockResolvedValue({ success: true, data: [] }),
+  mockHandleGet: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  mockHandleSet: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  mockHandleCheckpoint: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  mockHandleNextAction: vi.fn().mockResolvedValue({ success: true, data: { action: 'DONE' } }),
+  mockHandleCancel: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  mockHandleSummary: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  mockHandleReconcile: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  mockHandleTransitions: vi.fn().mockResolvedValue({ success: true, data: {} }),
 }));
 
 // ─── Module Mocks ────────────────────────────────────────────────────────────
@@ -54,47 +59,223 @@ vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
   StdioServerTransport: vi.fn(),
 }));
 
-// Mock composite handlers
-vi.mock('../../workflow/composite.js', () => ({
-  handleWorkflow: mockHandleWorkflow,
-}));
+// Mock workflow/tools.js - provide both handlers and registration function
+vi.mock('../../workflow/tools.js', async () => {
+  const { z } = await import('zod');
+  const { formatResult } = await import('../../format.js');
+  const featureIdParam = z.string().min(1).regex(/^[a-z0-9-]+$/);
+  const workflowTypeParam = z.enum(['feature', 'debug', 'refactor']);
+  return {
+    handleInit: mockHandleInit,
+    handleList: mockHandleList,
+    handleGet: mockHandleGet,
+    handleSet: mockHandleSet,
+    handleCheckpoint: mockHandleCheckpoint,
+    handleNextAction: mockHandleNextAction,
+    handleCancel: mockHandleCancel,
+    handleSummary: mockHandleSummary,
+    handleReconcile: mockHandleReconcile,
+    handleTransitions: mockHandleTransitions,
+    configureWorkflowEventStore: vi.fn(),
+    registerWorkflowTools: (server: unknown, stateDir: string) => {
+      const s = server as { tool: (...args: unknown[]) => void };
+      s.tool('exarchos_workflow_init', 'Initialize a new workflow state file for a feature/debug/refactor workflow',
+        { featureId: featureIdParam, workflowType: workflowTypeParam },
+        async (args: unknown) => formatResult(await mockHandleInit(args, stateDir)));
+      s.tool('exarchos_workflow_list', 'List all active workflow state files with staleness information',
+        {},
+        async (args: unknown) => formatResult(await mockHandleList(args, stateDir)));
+      s.tool('exarchos_workflow_get', 'Query a field via dot-path (e.g. query:"phase") or get full state if no query',
+        { featureId: featureIdParam, query: z.string().optional() },
+        async (args: unknown) => formatResult(await mockHandleGet(args, stateDir)));
+      s.tool('exarchos_workflow_set', 'Update fields and/or transition phase. Returns {phase, updatedAt}',
+        { featureId: featureIdParam, updates: z.record(z.string(), z.unknown()).optional(), phase: z.string().optional() },
+        async (args: unknown) => formatResult(await mockHandleSet(args, stateDir)));
+      s.tool('exarchos_workflow_checkpoint', 'Create an explicit checkpoint, resetting the operation counter',
+        { featureId: featureIdParam, summary: z.string().optional() },
+        async (args: unknown) => formatResult(await mockHandleCheckpoint(args, stateDir)));
+    },
+  };
+});
 
-vi.mock('../../event-store/composite.js', () => ({
-  handleEvent: mockHandleEvent,
-}));
+vi.mock('../../workflow/next-action.js', async () => {
+  const { z } = await import('zod');
+  const { formatResult } = await import('../../format.js');
+  return {
+    handleNextAction: mockHandleNextAction,
+    configureNextActionEventStore: vi.fn(),
+    registerNextActionTool: (server: unknown, stateDir: string) => {
+      const s = server as { tool: (...args: unknown[]) => void };
+      s.tool('exarchos_workflow_next_action', 'Determine the next auto-continue action based on current phase and guards',
+        { featureId: z.string().min(1).regex(/^[a-z0-9-]+$/) },
+        async (args: unknown) => formatResult(await mockHandleNextAction(args, stateDir)));
+    },
+  };
+});
 
-vi.mock('../../orchestrate/composite.js', () => ({
-  handleOrchestrate: mockHandleOrchestrate,
-}));
+vi.mock('../../workflow/cancel.js', async () => {
+  const { z } = await import('zod');
+  const { formatResult } = await import('../../format.js');
+  return {
+    handleCancel: mockHandleCancel,
+    configureCancelEventStore: vi.fn(),
+    registerCancelTool: (server: unknown, stateDir: string) => {
+      const s = server as { tool: (...args: unknown[]) => void };
+      s.tool('exarchos_workflow_cancel', 'Cancel a workflow with saga compensation and cleanup',
+        { featureId: z.string().min(1).regex(/^[a-z0-9-]+$/), reason: z.string().optional(), dryRun: z.boolean().optional() },
+        async (args: unknown) => formatResult(await mockHandleCancel(args, stateDir)));
+    },
+  };
+});
 
-vi.mock('../../views/composite.js', () => ({
-  handleView: mockHandleView,
-}));
+vi.mock('../../workflow/query.js', async () => {
+  const { z } = await import('zod');
+  const { formatResult } = await import('../../format.js');
+  const featureIdParam = z.string().min(1).regex(/^[a-z0-9-]+$/);
+  return {
+    handleSummary: mockHandleSummary,
+    handleReconcile: mockHandleReconcile,
+    handleTransitions: mockHandleTransitions,
+    configureQueryEventStore: vi.fn(),
+    registerQueryTools: (server: unknown, stateDir: string) => {
+      const s = server as { tool: (...args: unknown[]) => void };
+      s.tool('exarchos_workflow_summary', 'Get structured summary of workflow progress, events, and circuit breaker status',
+        { featureId: featureIdParam },
+        async (args: unknown) => formatResult(await mockHandleSummary(args, stateDir)));
+      s.tool('exarchos_workflow_reconcile', 'Verify worktree paths and branches match state file',
+        { featureId: featureIdParam },
+        async (args: unknown) => formatResult(await mockHandleReconcile(args, stateDir)));
+      s.tool('exarchos_workflow_transitions', 'Get available state machine transitions for a workflow type',
+        { workflowType: z.enum(['feature', 'debug', 'refactor']), fromPhase: z.string().optional() },
+        async (args: unknown) => formatResult(await mockHandleTransitions(args, stateDir)));
+    },
+  };
+});
 
-// Mock EventStore configuration (workflow modules require explicit injection)
-vi.mock('../../workflow/tools.js', () => ({
-  configureWorkflowEventStore: vi.fn(),
-}));
+vi.mock('../../event-store/tools.js', async () => {
+  const { z } = await import('zod');
+  const { formatResult } = await import('../../format.js');
+  const mockAppend = vi.fn().mockResolvedValue({ success: true, data: {} });
+  const mockQuery = vi.fn().mockResolvedValue({ success: true, data: [] });
+  return {
+    handleEventAppend: mockAppend,
+    handleEventQuery: mockQuery,
+    registerEventTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
+      const s = server as { tool: (...args: unknown[]) => void };
+      s.tool('exarchos_event_append', 'Append an event to the event store with optional optimistic concurrency',
+        { stream: z.string().min(1), event: z.record(z.string(), z.unknown()), expectedSequence: z.number().int().optional() },
+        async (args: unknown) => formatResult(await mockAppend(args, stateDir)));
+      s.tool('exarchos_event_query', 'Query events from the event store with optional filters (type, sinceSequence, since, until)',
+        { stream: z.string().min(1), filter: z.record(z.string(), z.unknown()).optional() },
+        async (args: unknown) => formatResult(await mockQuery(args, stateDir)));
+    },
+  };
+});
 
-vi.mock('../../workflow/next-action.js', () => ({
-  configureNextActionEventStore: vi.fn(),
-}));
+vi.mock('../../views/tools.js', async () => {
+  const { z } = await import('zod');
+  const { formatResult } = await import('../../format.js');
+  const mockPipeline = vi.fn().mockResolvedValue({ success: true, data: {} });
+  const mockTasks = vi.fn().mockResolvedValue({ success: true, data: [] });
+  const mockWorkflowStatus = vi.fn().mockResolvedValue({ success: true, data: {} });
+  const mockTeamStatus = vi.fn().mockResolvedValue({ success: true, data: {} });
+  return {
+    handleViewPipeline: mockPipeline,
+    handleViewTasks: mockTasks,
+    handleViewWorkflowStatus: mockWorkflowStatus,
+    handleViewTeamStatus: mockTeamStatus,
+    registerViewTools: (server: unknown, stateDir: string) => {
+      const s = server as { tool: (...args: unknown[]) => void };
+      s.tool('exarchos_view_pipeline', 'Get CQRS pipeline view aggregating all workflows with stack positions and phase tracking',
+        {}, async (args: unknown) => formatResult(await mockPipeline(args, stateDir)));
+      s.tool('exarchos_view_tasks', 'Get CQRS task detail view with optional filtering by workflowId and task properties',
+        { workflowId: z.string().optional(), filter: z.record(z.string(), z.unknown()).optional() },
+        async (args: unknown) => formatResult(await mockTasks(args, stateDir)));
+      s.tool('exarchos_view_workflow_status', 'Get CQRS workflow status view with phase, task counts, and feature metadata',
+        { workflowId: z.string().optional() },
+        async (args: unknown) => formatResult(await mockWorkflowStatus(args, stateDir)));
+      s.tool('exarchos_view_team_status', 'Get CQRS team status view with teammate composition and current task assignments',
+        { workflowId: z.string().optional() },
+        async (args: unknown) => formatResult(await mockTeamStatus(args, stateDir)));
+    },
+  };
+});
 
-vi.mock('../../workflow/cancel.js', () => ({
-  configureCancelEventStore: vi.fn(),
-}));
+vi.mock('../../team/tools.js', async () => {
+  const { z } = await import('zod');
+  const { formatResult } = await import('../../format.js');
+  const mockSpawn = vi.fn().mockResolvedValue({ success: true, data: {} });
+  const mockMessage = vi.fn().mockResolvedValue({ success: true, data: {} });
+  const mockBroadcast = vi.fn().mockResolvedValue({ success: true, data: {} });
+  const mockShutdown = vi.fn().mockResolvedValue({ success: true, data: {} });
+  const mockStatus = vi.fn().mockResolvedValue({ success: true, data: {} });
+  return {
+    handleTeamSpawn: mockSpawn, handleTeamMessage: mockMessage,
+    handleTeamBroadcast: mockBroadcast, handleTeamShutdown: mockShutdown, handleTeamStatus: mockStatus,
+    registerTeamTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
+      const s = server as { tool: (...args: unknown[]) => void };
+      s.tool('exarchos_team_spawn', 'Spawn a new team member agent with a role assignment',
+        { name: z.string().min(1), role: z.string().min(1), taskId: z.string().min(1), taskTitle: z.string().min(1), streamId: z.string().min(1), worktreePath: z.string().optional() },
+        async (args: unknown) => formatResult(await mockSpawn(args, stateDir)));
+      s.tool('exarchos_team_message', 'Send a direct message to a team member',
+        { from: z.string().min(1), to: z.string().min(1), content: z.string().min(1), streamId: z.string().min(1), messageType: z.string().optional() },
+        async (args: unknown) => formatResult(await mockMessage(args, stateDir)));
+      s.tool('exarchos_team_broadcast', 'Broadcast a message to all team members',
+        { from: z.string().min(1), content: z.string().min(1), streamId: z.string().min(1) },
+        async (args: unknown) => formatResult(await mockBroadcast(args, stateDir)));
+      s.tool('exarchos_team_shutdown', 'Shutdown a team member agent',
+        { name: z.string().min(1), streamId: z.string().min(1) },
+        async (args: unknown) => formatResult(await mockShutdown(args, stateDir)));
+      s.tool('exarchos_team_status', 'Get status of all team members with health information',
+        {}, async (args: unknown) => formatResult(await mockStatus(args, stateDir)));
+    },
+  };
+});
 
-vi.mock('../../workflow/query.js', () => ({
-  configureQueryEventStore: vi.fn(),
-}));
+vi.mock('../../tasks/tools.js', async () => {
+  const { z } = await import('zod');
+  const { formatResult } = await import('../../format.js');
+  const mockClaim = vi.fn().mockResolvedValue({ success: true, data: {} });
+  const mockComplete = vi.fn().mockResolvedValue({ success: true, data: {} });
+  const mockFail = vi.fn().mockResolvedValue({ success: true, data: {} });
+  return {
+    handleTaskClaim: mockClaim, handleTaskComplete: mockComplete, handleTaskFail: mockFail,
+    registerTaskTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
+      const s = server as { tool: (...args: unknown[]) => void };
+      s.tool('exarchos_task_claim', 'Claim a task for execution by an agent',
+        { taskId: z.string().min(1), agentId: z.string().min(1), streamId: z.string().min(1) },
+        async (args: unknown) => formatResult(await mockClaim(args, stateDir)));
+      s.tool('exarchos_task_complete', 'Mark a task as complete with optional artifacts',
+        { taskId: z.string().min(1), result: z.record(z.string(), z.unknown()).optional(), streamId: z.string().min(1) },
+        async (args: unknown) => formatResult(await mockComplete(args, stateDir)));
+      s.tool('exarchos_task_fail', 'Mark a task as failed with error details and optional diagnostics',
+        { taskId: z.string().min(1), error: z.string().min(1), diagnostics: z.record(z.string(), z.unknown()).optional(), streamId: z.string().min(1) },
+        async (args: unknown) => formatResult(await mockFail(args, stateDir)));
+    },
+  };
+});
 
-vi.mock('../../event-store/store.js', () => ({
-  EventStore: vi.fn(),
-}));
+vi.mock('../../stack/tools.js', async () => {
+  const { z } = await import('zod');
+  const { formatResult } = await import('../../format.js');
+  const mockStackStatus = vi.fn().mockResolvedValue({ success: true, data: [] });
+  const mockStackPlace = vi.fn().mockResolvedValue({ success: true, data: {} });
+  return {
+    handleStackStatus: mockStackStatus, handleStackPlace: mockStackPlace,
+    registerStackTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
+      const s = server as { tool: (...args: unknown[]) => void };
+      s.tool('exarchos_stack_status', 'Get current stack positions from stack.position-filled events',
+        { streamId: z.string().optional() },
+        async (args: unknown) => formatResult(await mockStackStatus(args, stateDir)));
+      s.tool('exarchos_stack_place', 'Place an item on the stack by emitting a stack.position-filled event',
+        { streamId: z.string().min(1), position: z.number().int(), taskId: z.string().min(1), branch: z.string().optional(), prUrl: z.string().optional() },
+        async (args: unknown) => formatResult(await mockStackPlace(args, stateDir)));
+    },
+  };
+});
 
 // Import after mocks are set up
 import { createServer } from '../../index.js';
-import { TOOL_REGISTRY } from '../../registry.js';
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
@@ -105,29 +286,29 @@ describe('MCP Server Entry Point', () => {
   });
 
   describe('createServer', () => {
-    it('should register exactly 5 composite tools', () => {
+    it('should register all 28 tools with correct names', () => {
       createServer('/tmp/test-state-dir');
 
       const expectedTools = [
-        'exarchos_workflow',
-        'exarchos_event',
-        'exarchos_orchestrate',
-        'exarchos_view',
-        'exarchos_sync',
+        'exarchos_workflow_init', 'exarchos_workflow_list', 'exarchos_workflow_get',
+        'exarchos_workflow_set', 'exarchos_workflow_summary', 'exarchos_workflow_reconcile',
+        'exarchos_workflow_next_action', 'exarchos_workflow_transitions',
+        'exarchos_workflow_cancel', 'exarchos_workflow_checkpoint',
+        'exarchos_event_append', 'exarchos_event_query',
+        'exarchos_view_pipeline', 'exarchos_view_tasks',
+        'exarchos_view_workflow_status', 'exarchos_view_team_status',
+        'exarchos_view_telemetry',
+        'exarchos_team_spawn', 'exarchos_team_message', 'exarchos_team_broadcast',
+        'exarchos_team_shutdown', 'exarchos_team_status',
+        'exarchos_task_claim', 'exarchos_task_complete', 'exarchos_task_fail',
+        'exarchos_stack_status', 'exarchos_stack_place',
+        'exarchos_sync_now',
       ];
 
-      expect(toolRegistrations.size).toBe(5);
+      expect(toolRegistrations.size).toBe(28);
 
       for (const toolName of expectedTools) {
         expect(toolRegistrations.has(toolName)).toBe(true);
-      }
-    });
-
-    it('should register one tool per registry entry', () => {
-      createServer('/tmp/test-state-dir');
-
-      for (const tool of TOOL_REGISTRY) {
-        expect(toolRegistrations.has(tool.name)).toBe(true);
       }
     });
 
@@ -140,18 +321,7 @@ describe('MCP Server Entry Point', () => {
       }
     });
 
-    it('should include action signatures in descriptions', () => {
-      createServer('/tmp/test-state-dir');
-
-      const workflow = toolRegistrations.get('exarchos_workflow')!;
-      expect(workflow.description).toContain('Actions:');
-      expect(workflow.description).toContain('init(');
-      expect(workflow.description).toContain('get(');
-      expect(workflow.description).toContain('set(');
-      expect(workflow.description).toContain('cancel(');
-    });
-
-    it('should register tools with schemas containing action field', () => {
+    it('should register tools with schemas', () => {
       createServer('/tmp/test-state-dir');
       for (const [, registration] of toolRegistrations) {
         expect(registration.schema).toBeDefined();
@@ -162,61 +332,14 @@ describe('MCP Server Entry Point', () => {
     });
   });
 
-  describe('composite handler routing', () => {
-    it('should route exarchos_workflow to handleWorkflow', async () => {
+  describe('tool handler routing', () => {
+    it('should route exarchos_workflow_init to handleInit', async () => {
       createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow')!.handler({
-        action: 'init', featureId: 'test-feat', workflowType: 'feature',
-      });
+      const handler = toolRegistrations.get('exarchos_workflow_init')!.handler;
+      const result = await handler({ featureId: 'test-feat', workflowType: 'feature' });
 
-      expect(mockHandleWorkflow).toHaveBeenCalledWith(
-        { action: 'init', featureId: 'test-feat', workflowType: 'feature' },
-        '/tmp/test-state-dir',
-      );
-    });
-
-    it('should route exarchos_event to handleEvent', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_event')!.handler({
-        action: 'append', stream: 'my-stream', event: { type: 'test' },
-      });
-
-      expect(mockHandleEvent).toHaveBeenCalledWith(
-        { action: 'append', stream: 'my-stream', event: { type: 'test' } },
-        '/tmp/test-state-dir',
-      );
-    });
-
-    it('should route exarchos_orchestrate to handleOrchestrate', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_orchestrate')!.handler({
-        action: 'team_spawn', name: 'agent-1', role: 'implementer',
-        taskId: 'T1', taskTitle: 'Implement feature', streamId: 'feat-1',
-      });
-
-      expect(mockHandleOrchestrate).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'team_spawn', name: 'agent-1' }),
-        '/tmp/test-state-dir',
-      );
-    });
-
-    it('should route exarchos_view to handleView', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_view')!.handler({
-        action: 'pipeline',
-      });
-
-      expect(mockHandleView).toHaveBeenCalledWith(
-        { action: 'pipeline' },
-        '/tmp/test-state-dir',
-      );
-    });
-
-    it('should wrap results with formatResult', async () => {
-      createServer('/tmp/test-state-dir');
-      const result = await toolRegistrations.get('exarchos_workflow')!.handler({
-        action: 'init', featureId: 'test-feat', workflowType: 'feature',
-      });
+      expect(mockHandleInit).toHaveBeenCalledWith(
+        { featureId: 'test-feat', workflowType: 'feature' }, '/tmp/test-state-dir');
 
       const typedResult = result as { content: Array<{ type: string; text: string }>; isError: boolean };
       expect(typedResult.content).toHaveLength(1);
@@ -225,16 +348,68 @@ describe('MCP Server Entry Point', () => {
       expect(JSON.parse(typedResult.content[0].text).success).toBe(true);
     });
 
+    it('should route exarchos_workflow_list to handleList', async () => {
+      createServer('/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_workflow_list')!.handler({});
+      expect(mockHandleList).toHaveBeenCalledWith({}, '/tmp/test-state-dir');
+    });
+
+    it('should route exarchos_workflow_get to handleGet', async () => {
+      createServer('/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_workflow_get')!.handler({ featureId: 'my-feat', query: '.phase' });
+      expect(mockHandleGet).toHaveBeenCalledWith({ featureId: 'my-feat', query: '.phase' }, '/tmp/test-state-dir');
+    });
+
+    it('should route exarchos_workflow_set to handleSet', async () => {
+      createServer('/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_workflow_set')!.handler({ featureId: 'my-feat', phase: 'plan' });
+      expect(mockHandleSet).toHaveBeenCalledWith({ featureId: 'my-feat', phase: 'plan' }, '/tmp/test-state-dir');
+    });
+
+    it('should route exarchos_workflow_summary to handleSummary', async () => {
+      createServer('/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_workflow_summary')!.handler({ featureId: 'my-feat' });
+      expect(mockHandleSummary).toHaveBeenCalledWith({ featureId: 'my-feat' }, '/tmp/test-state-dir');
+    });
+
+    it('should route exarchos_workflow_reconcile to handleReconcile', async () => {
+      createServer('/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_workflow_reconcile')!.handler({ featureId: 'my-feat' });
+      expect(mockHandleReconcile).toHaveBeenCalledWith({ featureId: 'my-feat' }, '/tmp/test-state-dir');
+    });
+
+    it('should route exarchos_workflow_next_action to handleNextAction', async () => {
+      createServer('/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_workflow_next_action')!.handler({ featureId: 'my-feat' });
+      expect(mockHandleNextAction).toHaveBeenCalledWith({ featureId: 'my-feat' }, '/tmp/test-state-dir');
+    });
+
+    it('should route exarchos_workflow_transitions to handleTransitions', async () => {
+      createServer('/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_workflow_transitions')!.handler({ workflowType: 'feature' });
+      expect(mockHandleTransitions).toHaveBeenCalledWith({ workflowType: 'feature' }, '/tmp/test-state-dir');
+    });
+
+    it('should route exarchos_workflow_cancel to handleCancel', async () => {
+      createServer('/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_workflow_cancel')!.handler({ featureId: 'my-feat', reason: 'no longer needed' });
+      expect(mockHandleCancel).toHaveBeenCalledWith({ featureId: 'my-feat', reason: 'no longer needed' }, '/tmp/test-state-dir');
+    });
+
+    it('should route exarchos_workflow_checkpoint to handleCheckpoint', async () => {
+      createServer('/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_workflow_checkpoint')!.handler({ featureId: 'my-feat', summary: 'mid-delegation' });
+      expect(mockHandleCheckpoint).toHaveBeenCalledWith({ featureId: 'my-feat', summary: 'mid-delegation' }, '/tmp/test-state-dir');
+    });
+
     it('should set isError to true when handler returns success: false', async () => {
-      mockHandleWorkflow.mockResolvedValueOnce({
+      mockHandleInit.mockResolvedValueOnce({
         success: false,
         error: { code: 'STATE_ALREADY_EXISTS', message: 'Already exists' },
       });
 
       createServer('/tmp/test-state-dir');
-      const result = await toolRegistrations.get('exarchos_workflow')!.handler({
-        action: 'init', featureId: 'dup', workflowType: 'feature',
-      });
+      const result = await toolRegistrations.get('exarchos_workflow_init')!.handler({ featureId: 'dup', workflowType: 'feature' });
 
       const typedResult = result as { content: Array<{ type: string; text: string }>; isError: boolean };
       expect(typedResult.isError).toBe(true);
@@ -245,11 +420,9 @@ describe('MCP Server Entry Point', () => {
   });
 
   describe('stub tools', () => {
-    it('should return NOT_IMPLEMENTED for exarchos_sync', async () => {
+    it('should return NOT_IMPLEMENTED for stub tools', async () => {
       createServer('/tmp/test-state-dir');
-      const result = await toolRegistrations.get('exarchos_sync')!.handler({
-        action: 'now',
-      });
+      const result = await toolRegistrations.get('exarchos_sync_now')!.handler({});
 
       const typedResult = result as { content: Array<{ type: string; text: string }>; isError: boolean };
       expect(typedResult.isError).toBe(true);
@@ -257,6 +430,22 @@ describe('MCP Server Entry Point', () => {
       expect(parsed.success).toBe(false);
       expect(parsed.error.code).toBe('NOT_IMPLEMENTED');
       expect(parsed.error.message).toBe('Coming soon');
+    });
+
+    it('should register implemented team and task tools', () => {
+      createServer('/tmp/test-state-dir');
+      const implementedTools = [
+        'exarchos_team_spawn', 'exarchos_team_message', 'exarchos_team_broadcast',
+        'exarchos_team_shutdown', 'exarchos_team_status',
+        'exarchos_task_claim', 'exarchos_task_complete', 'exarchos_task_fail',
+        'exarchos_stack_status', 'exarchos_stack_place',
+      ];
+      for (const toolName of implementedTools) {
+        expect(toolRegistrations.has(toolName)).toBe(true);
+        const reg = toolRegistrations.get(toolName)!;
+        expect(reg.handler).toBeDefined();
+        expect(typeof reg.handler).toBe('function');
+      }
     });
   });
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
@@ -4,24 +4,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const {
   toolRegistrations,
-  mockHandleInit, mockHandleList, mockHandleGet, mockHandleSet, mockHandleCheckpoint,
-  mockHandleNextAction, mockHandleCancel,
-  mockHandleSummary, mockHandleReconcile, mockHandleTransitions,
+  mockHandleWorkflow,
+  mockHandleEvent,
+  mockHandleOrchestrate,
+  mockHandleView,
 } = vi.hoisted(() => ({
   toolRegistrations: new Map<
     string,
     { description: string; schema: unknown; handler: (...args: unknown[]) => unknown }
   >(),
-  mockHandleInit: vi.fn().mockResolvedValue({ success: true, data: { phase: 'ideate' } }),
-  mockHandleList: vi.fn().mockResolvedValue({ success: true, data: [] }),
-  mockHandleGet: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleSet: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleCheckpoint: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleNextAction: vi.fn().mockResolvedValue({ success: true, data: { action: 'DONE' } }),
-  mockHandleCancel: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleSummary: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleReconcile: vi.fn().mockResolvedValue({ success: true, data: {} }),
-  mockHandleTransitions: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  mockHandleWorkflow: vi.fn().mockResolvedValue({ success: true, data: { phase: 'ideate' } }),
+  mockHandleEvent: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  mockHandleOrchestrate: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  mockHandleView: vi.fn().mockResolvedValue({ success: true, data: {} }),
 }));
 
 // ─── Module Mocks ────────────────────────────────────────────────────────────
@@ -59,223 +54,52 @@ vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
   StdioServerTransport: vi.fn(),
 }));
 
-// Mock workflow/tools.js - provide both handlers and registration function
-vi.mock('../../workflow/tools.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const featureIdParam = z.string().min(1).regex(/^[a-z0-9-]+$/);
-  const workflowTypeParam = z.enum(['feature', 'debug', 'refactor']);
-  return {
-    handleInit: mockHandleInit,
-    handleList: mockHandleList,
-    handleGet: mockHandleGet,
-    handleSet: mockHandleSet,
-    handleCheckpoint: mockHandleCheckpoint,
-    handleNextAction: mockHandleNextAction,
-    handleCancel: mockHandleCancel,
-    handleSummary: mockHandleSummary,
-    handleReconcile: mockHandleReconcile,
-    handleTransitions: mockHandleTransitions,
-    configureWorkflowEventStore: vi.fn(),
-    registerWorkflowTools: (server: unknown, stateDir: string) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_workflow_init', 'Initialize a new workflow state file for a feature/debug/refactor workflow',
-        { featureId: featureIdParam, workflowType: workflowTypeParam },
-        async (args: unknown) => formatResult(await mockHandleInit(args, stateDir)));
-      s.tool('exarchos_workflow_list', 'List all active workflow state files with staleness information',
-        {},
-        async (args: unknown) => formatResult(await mockHandleList(args, stateDir)));
-      s.tool('exarchos_workflow_get', 'Query a field via dot-path (e.g. query:"phase") or get full state if no query',
-        { featureId: featureIdParam, query: z.string().optional() },
-        async (args: unknown) => formatResult(await mockHandleGet(args, stateDir)));
-      s.tool('exarchos_workflow_set', 'Update fields and/or transition phase. Returns {phase, updatedAt}',
-        { featureId: featureIdParam, updates: z.record(z.string(), z.unknown()).optional(), phase: z.string().optional() },
-        async (args: unknown) => formatResult(await mockHandleSet(args, stateDir)));
-      s.tool('exarchos_workflow_checkpoint', 'Create an explicit checkpoint, resetting the operation counter',
-        { featureId: featureIdParam, summary: z.string().optional() },
-        async (args: unknown) => formatResult(await mockHandleCheckpoint(args, stateDir)));
-    },
-  };
-});
+// Mock composite handlers
+vi.mock('../../workflow/composite.js', () => ({
+  handleWorkflow: mockHandleWorkflow,
+}));
 
-vi.mock('../../workflow/next-action.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  return {
-    handleNextAction: mockHandleNextAction,
-    configureNextActionEventStore: vi.fn(),
-    registerNextActionTool: (server: unknown, stateDir: string) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_workflow_next_action', 'Determine the next auto-continue action based on current phase and guards',
-        { featureId: z.string().min(1).regex(/^[a-z0-9-]+$/) },
-        async (args: unknown) => formatResult(await mockHandleNextAction(args, stateDir)));
-    },
-  };
-});
+vi.mock('../../event-store/composite.js', () => ({
+  handleEvent: mockHandleEvent,
+}));
 
-vi.mock('../../workflow/cancel.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  return {
-    handleCancel: mockHandleCancel,
-    configureCancelEventStore: vi.fn(),
-    registerCancelTool: (server: unknown, stateDir: string) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_workflow_cancel', 'Cancel a workflow with saga compensation and cleanup',
-        { featureId: z.string().min(1).regex(/^[a-z0-9-]+$/), reason: z.string().optional(), dryRun: z.boolean().optional() },
-        async (args: unknown) => formatResult(await mockHandleCancel(args, stateDir)));
-    },
-  };
-});
+vi.mock('../../orchestrate/composite.js', () => ({
+  handleOrchestrate: mockHandleOrchestrate,
+}));
 
-vi.mock('../../workflow/query.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const featureIdParam = z.string().min(1).regex(/^[a-z0-9-]+$/);
-  return {
-    handleSummary: mockHandleSummary,
-    handleReconcile: mockHandleReconcile,
-    handleTransitions: mockHandleTransitions,
-    configureQueryEventStore: vi.fn(),
-    registerQueryTools: (server: unknown, stateDir: string) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_workflow_summary', 'Get structured summary of workflow progress, events, and circuit breaker status',
-        { featureId: featureIdParam },
-        async (args: unknown) => formatResult(await mockHandleSummary(args, stateDir)));
-      s.tool('exarchos_workflow_reconcile', 'Verify worktree paths and branches match state file',
-        { featureId: featureIdParam },
-        async (args: unknown) => formatResult(await mockHandleReconcile(args, stateDir)));
-      s.tool('exarchos_workflow_transitions', 'Get available state machine transitions for a workflow type',
-        { workflowType: z.enum(['feature', 'debug', 'refactor']), fromPhase: z.string().optional() },
-        async (args: unknown) => formatResult(await mockHandleTransitions(args, stateDir)));
-    },
-  };
-});
+vi.mock('../../views/composite.js', () => ({
+  handleView: mockHandleView,
+}));
 
-vi.mock('../../event-store/tools.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const mockAppend = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockQuery = vi.fn().mockResolvedValue({ success: true, data: [] });
-  return {
-    handleEventAppend: mockAppend,
-    handleEventQuery: mockQuery,
-    registerEventTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_event_append', 'Append an event to the event store with optional optimistic concurrency',
-        { stream: z.string().min(1), event: z.record(z.string(), z.unknown()), expectedSequence: z.number().int().optional() },
-        async (args: unknown) => formatResult(await mockAppend(args, stateDir)));
-      s.tool('exarchos_event_query', 'Query events from the event store with optional filters (type, sinceSequence, since, until)',
-        { stream: z.string().min(1), filter: z.record(z.string(), z.unknown()).optional() },
-        async (args: unknown) => formatResult(await mockQuery(args, stateDir)));
-    },
-  };
-});
+// Mock EventStore configuration (workflow modules require explicit injection)
+vi.mock('../../workflow/tools.js', () => ({
+  configureWorkflowEventStore: vi.fn(),
+}));
 
-vi.mock('../../views/tools.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const mockPipeline = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockTasks = vi.fn().mockResolvedValue({ success: true, data: [] });
-  const mockWorkflowStatus = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockTeamStatus = vi.fn().mockResolvedValue({ success: true, data: {} });
-  return {
-    handleViewPipeline: mockPipeline,
-    handleViewTasks: mockTasks,
-    handleViewWorkflowStatus: mockWorkflowStatus,
-    handleViewTeamStatus: mockTeamStatus,
-    registerViewTools: (server: unknown, stateDir: string) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_view_pipeline', 'Get CQRS pipeline view aggregating all workflows with stack positions and phase tracking',
-        {}, async (args: unknown) => formatResult(await mockPipeline(args, stateDir)));
-      s.tool('exarchos_view_tasks', 'Get CQRS task detail view with optional filtering by workflowId and task properties',
-        { workflowId: z.string().optional(), filter: z.record(z.string(), z.unknown()).optional() },
-        async (args: unknown) => formatResult(await mockTasks(args, stateDir)));
-      s.tool('exarchos_view_workflow_status', 'Get CQRS workflow status view with phase, task counts, and feature metadata',
-        { workflowId: z.string().optional() },
-        async (args: unknown) => formatResult(await mockWorkflowStatus(args, stateDir)));
-      s.tool('exarchos_view_team_status', 'Get CQRS team status view with teammate composition and current task assignments',
-        { workflowId: z.string().optional() },
-        async (args: unknown) => formatResult(await mockTeamStatus(args, stateDir)));
-    },
-  };
-});
+vi.mock('../../workflow/next-action.js', () => ({
+  configureNextActionEventStore: vi.fn(),
+}));
 
-vi.mock('../../team/tools.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const mockSpawn = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockMessage = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockBroadcast = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockShutdown = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockStatus = vi.fn().mockResolvedValue({ success: true, data: {} });
-  return {
-    handleTeamSpawn: mockSpawn, handleTeamMessage: mockMessage,
-    handleTeamBroadcast: mockBroadcast, handleTeamShutdown: mockShutdown, handleTeamStatus: mockStatus,
-    registerTeamTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_team_spawn', 'Spawn a new team member agent with a role assignment',
-        { name: z.string().min(1), role: z.string().min(1), taskId: z.string().min(1), taskTitle: z.string().min(1), streamId: z.string().min(1), worktreePath: z.string().optional() },
-        async (args: unknown) => formatResult(await mockSpawn(args, stateDir)));
-      s.tool('exarchos_team_message', 'Send a direct message to a team member',
-        { from: z.string().min(1), to: z.string().min(1), content: z.string().min(1), streamId: z.string().min(1), messageType: z.string().optional() },
-        async (args: unknown) => formatResult(await mockMessage(args, stateDir)));
-      s.tool('exarchos_team_broadcast', 'Broadcast a message to all team members',
-        { from: z.string().min(1), content: z.string().min(1), streamId: z.string().min(1) },
-        async (args: unknown) => formatResult(await mockBroadcast(args, stateDir)));
-      s.tool('exarchos_team_shutdown', 'Shutdown a team member agent',
-        { name: z.string().min(1), streamId: z.string().min(1) },
-        async (args: unknown) => formatResult(await mockShutdown(args, stateDir)));
-      s.tool('exarchos_team_status', 'Get status of all team members with health information',
-        {}, async (args: unknown) => formatResult(await mockStatus(args, stateDir)));
-    },
-  };
-});
+vi.mock('../../workflow/cancel.js', () => ({
+  configureCancelEventStore: vi.fn(),
+}));
 
-vi.mock('../../tasks/tools.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const mockClaim = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockComplete = vi.fn().mockResolvedValue({ success: true, data: {} });
-  const mockFail = vi.fn().mockResolvedValue({ success: true, data: {} });
-  return {
-    handleTaskClaim: mockClaim, handleTaskComplete: mockComplete, handleTaskFail: mockFail,
-    registerTaskTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_task_claim', 'Claim a task for execution by an agent',
-        { taskId: z.string().min(1), agentId: z.string().min(1), streamId: z.string().min(1) },
-        async (args: unknown) => formatResult(await mockClaim(args, stateDir)));
-      s.tool('exarchos_task_complete', 'Mark a task as complete with optional artifacts',
-        { taskId: z.string().min(1), result: z.record(z.string(), z.unknown()).optional(), streamId: z.string().min(1) },
-        async (args: unknown) => formatResult(await mockComplete(args, stateDir)));
-      s.tool('exarchos_task_fail', 'Mark a task as failed with error details and optional diagnostics',
-        { taskId: z.string().min(1), error: z.string().min(1), diagnostics: z.record(z.string(), z.unknown()).optional(), streamId: z.string().min(1) },
-        async (args: unknown) => formatResult(await mockFail(args, stateDir)));
-    },
-  };
-});
+vi.mock('../../workflow/query.js', () => ({
+  configureQueryEventStore: vi.fn(),
+}));
 
-vi.mock('../../stack/tools.js', async () => {
-  const { z } = await import('zod');
-  const { formatResult } = await import('../../format.js');
-  const mockStackStatus = vi.fn().mockResolvedValue({ success: true, data: [] });
-  const mockStackPlace = vi.fn().mockResolvedValue({ success: true, data: {} });
-  return {
-    handleStackStatus: mockStackStatus, handleStackPlace: mockStackPlace,
-    registerStackTools: (server: unknown, stateDir: string, _eventStore?: unknown) => {
-      const s = server as { tool: (...args: unknown[]) => void };
-      s.tool('exarchos_stack_status', 'Get current stack positions from stack.position-filled events',
-        { streamId: z.string().optional() },
-        async (args: unknown) => formatResult(await mockStackStatus(args, stateDir)));
-      s.tool('exarchos_stack_place', 'Place an item on the stack by emitting a stack.position-filled event',
-        { streamId: z.string().min(1), position: z.number().int(), taskId: z.string().min(1), branch: z.string().optional(), prUrl: z.string().optional() },
-        async (args: unknown) => formatResult(await mockStackPlace(args, stateDir)));
-    },
-  };
-});
+vi.mock('../../event-store/store.js', () => ({
+  EventStore: vi.fn(),
+}));
+
+// Mock telemetry middleware (pass-through by default)
+vi.mock('../../telemetry/middleware.js', () => ({
+  withTelemetry: vi.fn((handler: unknown) => handler),
+}));
 
 // Import after mocks are set up
 import { createServer } from '../../index.js';
+import { TOOL_REGISTRY } from '../../registry.js';
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
@@ -286,29 +110,29 @@ describe('MCP Server Entry Point', () => {
   });
 
   describe('createServer', () => {
-    it('should register all 28 tools with correct names', () => {
+    it('should register exactly 5 composite tools', () => {
       createServer('/tmp/test-state-dir');
 
       const expectedTools = [
-        'exarchos_workflow_init', 'exarchos_workflow_list', 'exarchos_workflow_get',
-        'exarchos_workflow_set', 'exarchos_workflow_summary', 'exarchos_workflow_reconcile',
-        'exarchos_workflow_next_action', 'exarchos_workflow_transitions',
-        'exarchos_workflow_cancel', 'exarchos_workflow_checkpoint',
-        'exarchos_event_append', 'exarchos_event_query',
-        'exarchos_view_pipeline', 'exarchos_view_tasks',
-        'exarchos_view_workflow_status', 'exarchos_view_team_status',
-        'exarchos_view_telemetry',
-        'exarchos_team_spawn', 'exarchos_team_message', 'exarchos_team_broadcast',
-        'exarchos_team_shutdown', 'exarchos_team_status',
-        'exarchos_task_claim', 'exarchos_task_complete', 'exarchos_task_fail',
-        'exarchos_stack_status', 'exarchos_stack_place',
-        'exarchos_sync_now',
+        'exarchos_workflow',
+        'exarchos_event',
+        'exarchos_orchestrate',
+        'exarchos_view',
+        'exarchos_sync',
       ];
 
-      expect(toolRegistrations.size).toBe(28);
+      expect(toolRegistrations.size).toBe(5);
 
       for (const toolName of expectedTools) {
         expect(toolRegistrations.has(toolName)).toBe(true);
+      }
+    });
+
+    it('should register one tool per registry entry', () => {
+      createServer('/tmp/test-state-dir');
+
+      for (const tool of TOOL_REGISTRY) {
+        expect(toolRegistrations.has(tool.name)).toBe(true);
       }
     });
 
@@ -321,7 +145,18 @@ describe('MCP Server Entry Point', () => {
       }
     });
 
-    it('should register tools with schemas', () => {
+    it('should include action signatures in descriptions', () => {
+      createServer('/tmp/test-state-dir');
+
+      const workflow = toolRegistrations.get('exarchos_workflow')!;
+      expect(workflow.description).toContain('Actions:');
+      expect(workflow.description).toContain('init(');
+      expect(workflow.description).toContain('get(');
+      expect(workflow.description).toContain('set(');
+      expect(workflow.description).toContain('cancel(');
+    });
+
+    it('should register tools with schemas containing action field', () => {
       createServer('/tmp/test-state-dir');
       for (const [, registration] of toolRegistrations) {
         expect(registration.schema).toBeDefined();
@@ -330,16 +165,80 @@ describe('MCP Server Entry Point', () => {
         expect(schema.shape).toHaveProperty('action');
       }
     });
+
+    it('should include telemetry action in exarchos_view', () => {
+      createServer('/tmp/test-state-dir');
+
+      const viewTool = TOOL_REGISTRY.find((t) => t.name === 'exarchos_view');
+      expect(viewTool).toBeDefined();
+
+      const actionNames = viewTool!.actions.map((a) => a.name);
+      expect(actionNames).toContain('telemetry');
+    });
+
+    it('should mention telemetry in exarchos_view description', () => {
+      createServer('/tmp/test-state-dir');
+
+      const viewReg = toolRegistrations.get('exarchos_view')!;
+      expect(viewReg.description).toContain('telemetry');
+    });
   });
 
-  describe('tool handler routing', () => {
-    it('should route exarchos_workflow_init to handleInit', async () => {
+  describe('composite handler routing', () => {
+    it('should route exarchos_workflow to handleWorkflow', async () => {
       createServer('/tmp/test-state-dir');
-      const handler = toolRegistrations.get('exarchos_workflow_init')!.handler;
-      const result = await handler({ featureId: 'test-feat', workflowType: 'feature' });
+      await toolRegistrations.get('exarchos_workflow')!.handler({
+        action: 'init', featureId: 'test-feat', workflowType: 'feature',
+      });
 
-      expect(mockHandleInit).toHaveBeenCalledWith(
-        { featureId: 'test-feat', workflowType: 'feature' }, '/tmp/test-state-dir');
+      expect(mockHandleWorkflow).toHaveBeenCalledWith(
+        { action: 'init', featureId: 'test-feat', workflowType: 'feature' },
+        '/tmp/test-state-dir',
+      );
+    });
+
+    it('should route exarchos_event to handleEvent', async () => {
+      createServer('/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_event')!.handler({
+        action: 'append', stream: 'my-stream', event: { type: 'test' },
+      });
+
+      expect(mockHandleEvent).toHaveBeenCalledWith(
+        { action: 'append', stream: 'my-stream', event: { type: 'test' } },
+        '/tmp/test-state-dir',
+      );
+    });
+
+    it('should route exarchos_orchestrate to handleOrchestrate', async () => {
+      createServer('/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_orchestrate')!.handler({
+        action: 'team_spawn', name: 'agent-1', role: 'implementer',
+        taskId: 'T1', taskTitle: 'Implement feature', streamId: 'feat-1',
+      });
+
+      expect(mockHandleOrchestrate).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'team_spawn', name: 'agent-1' }),
+        '/tmp/test-state-dir',
+      );
+    });
+
+    it('should route exarchos_view to handleView', async () => {
+      createServer('/tmp/test-state-dir');
+      await toolRegistrations.get('exarchos_view')!.handler({
+        action: 'pipeline',
+      });
+
+      expect(mockHandleView).toHaveBeenCalledWith(
+        { action: 'pipeline' },
+        '/tmp/test-state-dir',
+      );
+    });
+
+    it('should wrap results with formatResult', async () => {
+      createServer('/tmp/test-state-dir');
+      const result = await toolRegistrations.get('exarchos_workflow')!.handler({
+        action: 'init', featureId: 'test-feat', workflowType: 'feature',
+      });
 
       const typedResult = result as { content: Array<{ type: string; text: string }>; isError: boolean };
       expect(typedResult.content).toHaveLength(1);
@@ -348,68 +247,16 @@ describe('MCP Server Entry Point', () => {
       expect(JSON.parse(typedResult.content[0].text).success).toBe(true);
     });
 
-    it('should route exarchos_workflow_list to handleList', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_list')!.handler({});
-      expect(mockHandleList).toHaveBeenCalledWith({}, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_get to handleGet', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_get')!.handler({ featureId: 'my-feat', query: '.phase' });
-      expect(mockHandleGet).toHaveBeenCalledWith({ featureId: 'my-feat', query: '.phase' }, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_set to handleSet', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_set')!.handler({ featureId: 'my-feat', phase: 'plan' });
-      expect(mockHandleSet).toHaveBeenCalledWith({ featureId: 'my-feat', phase: 'plan' }, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_summary to handleSummary', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_summary')!.handler({ featureId: 'my-feat' });
-      expect(mockHandleSummary).toHaveBeenCalledWith({ featureId: 'my-feat' }, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_reconcile to handleReconcile', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_reconcile')!.handler({ featureId: 'my-feat' });
-      expect(mockHandleReconcile).toHaveBeenCalledWith({ featureId: 'my-feat' }, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_next_action to handleNextAction', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_next_action')!.handler({ featureId: 'my-feat' });
-      expect(mockHandleNextAction).toHaveBeenCalledWith({ featureId: 'my-feat' }, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_transitions to handleTransitions', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_transitions')!.handler({ workflowType: 'feature' });
-      expect(mockHandleTransitions).toHaveBeenCalledWith({ workflowType: 'feature' }, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_cancel to handleCancel', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_cancel')!.handler({ featureId: 'my-feat', reason: 'no longer needed' });
-      expect(mockHandleCancel).toHaveBeenCalledWith({ featureId: 'my-feat', reason: 'no longer needed' }, '/tmp/test-state-dir');
-    });
-
-    it('should route exarchos_workflow_checkpoint to handleCheckpoint', async () => {
-      createServer('/tmp/test-state-dir');
-      await toolRegistrations.get('exarchos_workflow_checkpoint')!.handler({ featureId: 'my-feat', summary: 'mid-delegation' });
-      expect(mockHandleCheckpoint).toHaveBeenCalledWith({ featureId: 'my-feat', summary: 'mid-delegation' }, '/tmp/test-state-dir');
-    });
-
     it('should set isError to true when handler returns success: false', async () => {
-      mockHandleInit.mockResolvedValueOnce({
+      mockHandleWorkflow.mockResolvedValueOnce({
         success: false,
         error: { code: 'STATE_ALREADY_EXISTS', message: 'Already exists' },
       });
 
       createServer('/tmp/test-state-dir');
-      const result = await toolRegistrations.get('exarchos_workflow_init')!.handler({ featureId: 'dup', workflowType: 'feature' });
+      const result = await toolRegistrations.get('exarchos_workflow')!.handler({
+        action: 'init', featureId: 'dup', workflowType: 'feature',
+      });
 
       const typedResult = result as { content: Array<{ type: string; text: string }>; isError: boolean };
       expect(typedResult.isError).toBe(true);
@@ -420,9 +267,11 @@ describe('MCP Server Entry Point', () => {
   });
 
   describe('stub tools', () => {
-    it('should return NOT_IMPLEMENTED for stub tools', async () => {
+    it('should return NOT_IMPLEMENTED for exarchos_sync', async () => {
       createServer('/tmp/test-state-dir');
-      const result = await toolRegistrations.get('exarchos_sync_now')!.handler({});
+      const result = await toolRegistrations.get('exarchos_sync')!.handler({
+        action: 'now',
+      });
 
       const typedResult = result as { content: Array<{ type: string; text: string }>; isError: boolean };
       expect(typedResult.isError).toBe(true);
@@ -431,20 +280,19 @@ describe('MCP Server Entry Point', () => {
       expect(parsed.error.code).toBe('NOT_IMPLEMENTED');
       expect(parsed.error.message).toBe('Coming soon');
     });
+  });
 
-    it('should register implemented team and task tools', () => {
-      createServer('/tmp/test-state-dir');
-      const implementedTools = [
-        'exarchos_team_spawn', 'exarchos_team_message', 'exarchos_team_broadcast',
-        'exarchos_team_shutdown', 'exarchos_team_status',
-        'exarchos_task_claim', 'exarchos_task_complete', 'exarchos_task_fail',
-        'exarchos_stack_status', 'exarchos_stack_place',
-      ];
-      for (const toolName of implementedTools) {
-        expect(toolRegistrations.has(toolName)).toBe(true);
-        const reg = toolRegistrations.get(toolName)!;
-        expect(reg.handler).toBeDefined();
-        expect(typeof reg.handler).toBe('function');
+  describe('telemetry integration', () => {
+    it('should wrap handlers with withTelemetry when EXARCHOS_TELEMETRY is not false', async () => {
+      const { withTelemetry } = await import('../../telemetry/middleware.js');
+      const originalEnv = process.env.EXARCHOS_TELEMETRY;
+      try {
+        delete process.env.EXARCHOS_TELEMETRY;
+        createServer('/tmp/test-state-dir');
+        expect(withTelemetry).toHaveBeenCalled();
+      } finally {
+        if (originalEnv === undefined) { delete process.env.EXARCHOS_TELEMETRY; }
+        else { process.env.EXARCHOS_TELEMETRY = originalEnv; }
       }
     });
   });

--- a/plugins/exarchos/servers/exarchos-mcp/src/format.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/format.ts
@@ -23,13 +23,15 @@ export function toEventAck(event: { streamId: string; sequence: number; type: st
 // ─── MCP Wire Format Types ──────────────────────────────────────────────────
 
 export interface McpToolContent {
-  readonly type: string;
+  readonly type: 'text';
   readonly text: string;
+  readonly [key: string]: unknown;
 }
 
 export interface McpToolResult {
-  readonly content: readonly McpToolContent[];
-  readonly isError: boolean;
+  content: McpToolContent[];
+  isError: boolean;
+  [key: string]: unknown;
 }
 
 // ─── Result Formatting ──────────────────────────────────────────────────────

--- a/plugins/exarchos/servers/exarchos-mcp/src/index.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/index.ts
@@ -4,46 +4,23 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
-
-import { TOOL_REGISTRY, buildRegistrationSchema, buildToolDescription } from './registry.js';
-import { formatResult, type ToolResult } from './format.js';
-
-// Composite handlers
-import { handleWorkflow } from './workflow/composite.js';
-import { handleEvent } from './event-store/composite.js';
-import { handleOrchestrate } from './orchestrate/composite.js';
-import { handleView } from './views/composite.js';
-
-// EventStore configuration — workflow modules require explicit injection
-// (non-workflow modules use lazy init via getStore())
-import { configureWorkflowEventStore } from './workflow/tools.js';
-import { configureNextActionEventStore } from './workflow/next-action.js';
-import { configureCancelEventStore } from './workflow/cancel.js';
-import { configureQueryEventStore } from './workflow/query.js';
+import { stubResult } from './format.js';
+import { registerWorkflowTools, configureWorkflowEventStore } from './workflow/tools.js';
+import { registerNextActionTool, configureNextActionEventStore } from './workflow/next-action.js';
+import { registerCancelTool, configureCancelEventStore } from './workflow/cancel.js';
+import { registerQueryTools, configureQueryEventStore } from './workflow/query.js';
+import { registerEventTools } from './event-store/tools.js';
 import { EventStore } from './event-store/store.js';
+import { registerViewTools } from './views/tools.js';
+import { registerTeamTools } from './team/tools.js';
+import { registerTaskTools } from './tasks/tools.js';
+import { registerStackTools } from './stack/tools.js';
+import { registerTelemetryTools } from './telemetry/tools.js';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 export const SERVER_NAME = 'exarchos-mcp';
 export const SERVER_VERSION = '1.0.0';
-
-// ─── Composite Handler Map ──────────────────────────────────────────────────
-
-type CompositeHandler = (
-  args: Record<string, unknown>,
-  stateDir: string,
-) => Promise<ToolResult>;
-
-const COMPOSITE_HANDLERS: Readonly<Record<string, CompositeHandler>> = {
-  exarchos_workflow: handleWorkflow,
-  exarchos_event: handleEvent,
-  exarchos_orchestrate: handleOrchestrate,
-  exarchos_view: handleView,
-  exarchos_sync: async () => ({
-    success: false,
-    error: { code: 'NOT_IMPLEMENTED', message: 'Coming soon' },
-  }),
-};
 
 // ─── Server Factory ──────────────────────────────────────────────────────────
 
@@ -51,16 +28,23 @@ export function createServer(stateDir: string): McpServer {
   const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
   const eventStore = new EventStore(stateDir);
 
-  // Configure module-level EventStore for workflow modules (no lazy init)
+  // Configure module-level EventStore instances before registration
   configureWorkflowEventStore(eventStore);
   configureNextActionEventStore(eventStore);
   configureCancelEventStore(eventStore);
   configureQueryEventStore(eventStore);
 
-  // Register composite tools from registry
-  for (const tool of TOOL_REGISTRY) {
-    const handler = COMPOSITE_HANDLERS[tool.name];
-    if (!handler) continue;
+  // Register all tool modules
+  registerWorkflowTools(server, stateDir);
+  registerNextActionTool(server, stateDir);
+  registerCancelTool(server, stateDir);
+  registerQueryTools(server, stateDir);
+  registerEventTools(server, stateDir, eventStore);
+  registerViewTools(server, stateDir, eventStore);
+  registerTeamTools(server, stateDir, eventStore);
+  registerTaskTools(server, stateDir, eventStore);
+  registerStackTools(server, stateDir, eventStore);
+  registerTelemetryTools(server, stateDir, eventStore);
 
     const inputSchema = buildRegistrationSchema(tool.actions);
     const description = buildToolDescription(tool);

--- a/plugins/exarchos/servers/exarchos-mcp/src/index.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/index.ts
@@ -4,23 +4,49 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
-import { stubResult } from './format.js';
-import { registerWorkflowTools, configureWorkflowEventStore } from './workflow/tools.js';
-import { registerNextActionTool, configureNextActionEventStore } from './workflow/next-action.js';
-import { registerCancelTool, configureCancelEventStore } from './workflow/cancel.js';
-import { registerQueryTools, configureQueryEventStore } from './workflow/query.js';
-import { registerEventTools } from './event-store/tools.js';
+
+import { TOOL_REGISTRY, buildRegistrationSchema, buildToolDescription } from './registry.js';
+import { formatResult, type ToolResult } from './format.js';
+
+// Composite handlers
+import { handleWorkflow } from './workflow/composite.js';
+import { handleEvent } from './event-store/composite.js';
+import { handleOrchestrate } from './orchestrate/composite.js';
+import { handleView } from './views/composite.js';
+
+// EventStore configuration — workflow modules require explicit injection
+// (non-workflow modules use lazy init via getStore())
+import { configureWorkflowEventStore } from './workflow/tools.js';
+import { configureNextActionEventStore } from './workflow/next-action.js';
+import { configureCancelEventStore } from './workflow/cancel.js';
+import { configureQueryEventStore } from './workflow/query.js';
 import { EventStore } from './event-store/store.js';
-import { registerViewTools } from './views/tools.js';
-import { registerTeamTools } from './team/tools.js';
-import { registerTaskTools } from './tasks/tools.js';
-import { registerStackTools } from './stack/tools.js';
-import { registerTelemetryTools } from './telemetry/tools.js';
+
+// Telemetry middleware
+import { withTelemetry } from './telemetry/middleware.js';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 export const SERVER_NAME = 'exarchos-mcp';
 export const SERVER_VERSION = '1.0.0';
+
+// ─── Composite Handler Map ──────────────────────────────────────────────────
+
+type CompositeHandler = (
+  args: Record<string, unknown>,
+  stateDir: string,
+) => Promise<ToolResult>;
+
+const COMPOSITE_HANDLERS: Readonly<Record<string, CompositeHandler>> = {
+  exarchos_workflow: handleWorkflow,
+  exarchos_event: handleEvent,
+  exarchos_orchestrate: handleOrchestrate,
+  exarchos_view: handleView,
+  exarchos_sync: async () => ({
+    success: false,
+    error: { code: 'NOT_IMPLEMENTED', message: 'Coming soon' },
+  }),
+};
 
 // ─── Server Factory ──────────────────────────────────────────────────────────
 
@@ -28,26 +54,24 @@ export function createServer(stateDir: string): McpServer {
   const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
   const eventStore = new EventStore(stateDir);
 
-  // Configure module-level EventStore instances before registration
+  // Configure module-level EventStore for workflow modules (no lazy init)
   configureWorkflowEventStore(eventStore);
   configureNextActionEventStore(eventStore);
   configureCancelEventStore(eventStore);
   configureQueryEventStore(eventStore);
 
-  // Register all tool modules
-  registerWorkflowTools(server, stateDir);
-  registerNextActionTool(server, stateDir);
-  registerCancelTool(server, stateDir);
-  registerQueryTools(server, stateDir);
-  registerEventTools(server, stateDir, eventStore);
-  registerViewTools(server, stateDir, eventStore);
-  registerTeamTools(server, stateDir, eventStore);
-  registerTaskTools(server, stateDir, eventStore);
-  registerStackTools(server, stateDir, eventStore);
-  registerTelemetryTools(server, stateDir, eventStore);
+  // Register composite tools from registry
+  const enableTelemetry = process.env.EXARCHOS_TELEMETRY !== 'false';
+
+  for (const tool of TOOL_REGISTRY) {
+    const handler = COMPOSITE_HANDLERS[tool.name];
+    if (!handler) continue;
 
     const inputSchema = buildRegistrationSchema(tool.actions);
     const description = buildToolDescription(tool);
+
+    const baseHandler = async (args: Record<string, unknown>) =>
+      formatResult(await handler(args, stateDir));
 
     // Use registerTool() so the strict ZodObject is passed as inputSchema
     // directly, preserving .strict() validation that rejects unrecognized keys.
@@ -55,8 +79,9 @@ export function createServer(stateDir: string): McpServer {
     server.registerTool(
       tool.name,
       { description, inputSchema },
-      async (args) =>
-        formatResult(await handler(args as Record<string, unknown>, stateDir)),
+      enableTelemetry
+        ? withTelemetry(baseHandler, tool.name, eventStore)
+        : baseHandler,
     );
   }
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
@@ -391,6 +391,18 @@ const viewActions: readonly ToolAction[] = [
     phases: STACK_PHASES,
     roles: ROLE_ANY,
   },
+  {
+    name: 'telemetry',
+    description: 'Get telemetry metrics with per-tool performance data and optimization hints',
+    schema: z.object({
+      compact: z.boolean().optional(),
+      tool: z.string().optional(),
+      sort: z.enum(['tokens', 'invocations', 'duration']).optional(),
+      limit: z.number().int().positive().optional(),
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_ANY,
+  },
 ];
 
 // ─── Composite Tool: exarchos_sync ──────────────────────────────────────────
@@ -425,7 +437,7 @@ export const TOOL_REGISTRY: readonly CompositeTool[] = [
   },
   {
     name: 'exarchos_view',
-    description: 'CQRS materialized views — pipeline, tasks, workflow status, team status, and stack',
+    description: 'CQRS materialized views — pipeline, tasks, workflow status, team status, stack, and telemetry',
     actions: viewActions,
   },
   {

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/tools.test.ts
@@ -3,10 +3,9 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { EventStore } from '../event-store/store.js';
-import { handleViewTelemetry, registerTelemetryTools } from './tools.js';
+import { handleViewTelemetry } from './tools.js';
 import { getOrCreateMaterializer, resetMaterializerCache } from '../views/tools.js';
 import { TELEMETRY_VIEW } from './telemetry-projection.js';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 // ─── Test Helpers ────────────────────────────────────────────────────────────
 
@@ -297,21 +296,3 @@ describe('Telemetry projection registered in materializer', () => {
   });
 });
 
-describe('registerTelemetryTools', () => {
-  it('should register exarchos_view_telemetry tool on the server', () => {
-    // Arrange
-    const toolNames: string[] = [];
-    const mockServer = {
-      tool: (name: string, ..._rest: unknown[]) => {
-        toolNames.push(name);
-      },
-    } as unknown as McpServer;
-    const store = new EventStore('/tmp/test-reg');
-
-    // Act
-    registerTelemetryTools(mockServer, '/tmp/test-reg', store);
-
-    // Assert
-    expect(toolNames).toContain('exarchos_view_telemetry');
-  });
-});

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/tools.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { EventStore } from '../event-store/store.js';
+import { handleViewTelemetry, registerTelemetryTools } from './tools.js';
+import { getOrCreateMaterializer, resetMaterializerCache } from '../views/tools.js';
+import { TELEMETRY_VIEW } from './telemetry-projection.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// ─── Test Helpers ────────────────────────────────────────────────────────────
+
+async function createTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'telemetry-tools-test-'));
+}
+
+async function seedTelemetryEvents(
+  stateDir: string,
+  events: Array<{
+    tool: string;
+    durationMs: number;
+    responseBytes: number;
+    tokenEstimate: number;
+  }>,
+): Promise<void> {
+  const store = new EventStore(stateDir);
+  for (const e of events) {
+    await store.append('telemetry', {
+      type: 'tool.completed',
+      data: e,
+    });
+  }
+}
+
+describe('handleViewTelemetry', () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await createTempDir();
+    resetMaterializerCache();
+  });
+
+  describe('compact mode (default)', () => {
+    it('should return summary without rolling window arrays', async () => {
+      // Arrange
+      await seedTelemetryEvents(stateDir, [
+        { tool: 'workflow_get', durationMs: 10, responseBytes: 200, tokenEstimate: 50 },
+        { tool: 'workflow_get', durationMs: 20, responseBytes: 400, tokenEstimate: 100 },
+      ]);
+
+      // Act
+      const result = await handleViewTelemetry({}, stateDir);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        session: { start: string; totalInvocations: number; totalTokens: number };
+        tools: Array<Record<string, unknown>>;
+        hints: unknown[];
+      };
+      expect(data.session.totalInvocations).toBe(2);
+      expect(data.session.totalTokens).toBe(150);
+      expect(data.tools).toHaveLength(1);
+      expect(data.tools[0].tool).toBe('workflow_get');
+      expect(data.tools[0].invocations).toBe(2);
+      // Compact mode: rolling window arrays should be stripped
+      expect(data.tools[0]).not.toHaveProperty('durations');
+      expect(data.tools[0]).not.toHaveProperty('sizes');
+      expect(data.tools[0]).not.toHaveProperty('tokenEstimates');
+    });
+  });
+
+  describe('full mode', () => {
+    it('should include durations/sizes/tokenEstimates arrays', async () => {
+      // Arrange
+      await seedTelemetryEvents(stateDir, [
+        { tool: 'event_query', durationMs: 15, responseBytes: 300, tokenEstimate: 75 },
+      ]);
+
+      // Act
+      const result = await handleViewTelemetry({ compact: false }, stateDir);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        tools: Array<Record<string, unknown>>;
+      };
+      expect(data.tools[0]).toHaveProperty('durations');
+      expect(data.tools[0]).toHaveProperty('sizes');
+      expect(data.tools[0]).toHaveProperty('tokenEstimates');
+      expect(data.tools[0].durations).toEqual([15]);
+      expect(data.tools[0].sizes).toEqual([300]);
+      expect(data.tools[0].tokenEstimates).toEqual([75]);
+    });
+  });
+
+  describe('filter by tool', () => {
+    it('should return only the specified tool', async () => {
+      // Arrange
+      await seedTelemetryEvents(stateDir, [
+        { tool: 'workflow_get', durationMs: 10, responseBytes: 200, tokenEstimate: 50 },
+        { tool: 'event_query', durationMs: 20, responseBytes: 400, tokenEstimate: 100 },
+        { tool: 'view_tasks', durationMs: 30, responseBytes: 600, tokenEstimate: 150 },
+      ]);
+
+      // Act
+      const result = await handleViewTelemetry({ tool: 'event_query' }, stateDir);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        tools: Array<{ tool: string }>;
+      };
+      expect(data.tools).toHaveLength(1);
+      expect(data.tools[0].tool).toBe('event_query');
+    });
+  });
+
+  describe('sort by tokens', () => {
+    it('should sort tools descending by total tokens', async () => {
+      // Arrange
+      await seedTelemetryEvents(stateDir, [
+        { tool: 'small', durationMs: 5, responseBytes: 100, tokenEstimate: 25 },
+        { tool: 'large', durationMs: 10, responseBytes: 800, tokenEstimate: 200 },
+        { tool: 'medium', durationMs: 8, responseBytes: 400, tokenEstimate: 100 },
+      ]);
+
+      // Act
+      const result = await handleViewTelemetry({ sort: 'tokens' }, stateDir);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        tools: Array<{ tool: string; totalTokens: number }>;
+      };
+      expect(data.tools[0].tool).toBe('large');
+      expect(data.tools[1].tool).toBe('medium');
+      expect(data.tools[2].tool).toBe('small');
+    });
+  });
+
+  describe('sort by invocations', () => {
+    it('should sort tools descending by invocation count', async () => {
+      // Arrange
+      await seedTelemetryEvents(stateDir, [
+        { tool: 'few', durationMs: 5, responseBytes: 100, tokenEstimate: 25 },
+        { tool: 'many', durationMs: 5, responseBytes: 100, tokenEstimate: 25 },
+        { tool: 'many', durationMs: 5, responseBytes: 100, tokenEstimate: 25 },
+        { tool: 'many', durationMs: 5, responseBytes: 100, tokenEstimate: 25 },
+        { tool: 'some', durationMs: 5, responseBytes: 100, tokenEstimate: 25 },
+        { tool: 'some', durationMs: 5, responseBytes: 100, tokenEstimate: 25 },
+      ]);
+
+      // Act
+      const result = await handleViewTelemetry({ sort: 'invocations' }, stateDir);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        tools: Array<{ tool: string; invocations: number }>;
+      };
+      expect(data.tools[0].tool).toBe('many');
+      expect(data.tools[0].invocations).toBe(3);
+      expect(data.tools[1].tool).toBe('some');
+      expect(data.tools[1].invocations).toBe(2);
+      expect(data.tools[2].tool).toBe('few');
+      expect(data.tools[2].invocations).toBe(1);
+    });
+  });
+
+  describe('sort by duration', () => {
+    it('should sort tools descending by total duration', async () => {
+      // Arrange
+      await seedTelemetryEvents(stateDir, [
+        { tool: 'fast', durationMs: 5, responseBytes: 100, tokenEstimate: 25 },
+        { tool: 'slow', durationMs: 100, responseBytes: 100, tokenEstimate: 25 },
+        { tool: 'mid', durationMs: 50, responseBytes: 100, tokenEstimate: 25 },
+      ]);
+
+      // Act
+      const result = await handleViewTelemetry({ sort: 'duration' }, stateDir);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        tools: Array<{ tool: string; totalDurationMs: number }>;
+      };
+      expect(data.tools[0].tool).toBe('slow');
+      expect(data.tools[1].tool).toBe('mid');
+      expect(data.tools[2].tool).toBe('fast');
+    });
+  });
+
+  describe('limit results', () => {
+    it('should return only top N tools', async () => {
+      // Arrange
+      await seedTelemetryEvents(stateDir, [
+        { tool: 'a', durationMs: 10, responseBytes: 100, tokenEstimate: 25 },
+        { tool: 'b', durationMs: 20, responseBytes: 200, tokenEstimate: 50 },
+        { tool: 'c', durationMs: 30, responseBytes: 300, tokenEstimate: 75 },
+        { tool: 'd', durationMs: 40, responseBytes: 400, tokenEstimate: 100 },
+      ]);
+
+      // Act
+      const result = await handleViewTelemetry(
+        { sort: 'tokens', limit: 2 },
+        stateDir,
+      );
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        tools: Array<{ tool: string }>;
+      };
+      expect(data.tools).toHaveLength(2);
+      expect(data.tools[0].tool).toBe('d');
+      expect(data.tools[1].tool).toBe('c');
+    });
+  });
+
+  describe('empty state', () => {
+    it('should return empty tools when no events exist', async () => {
+      // Act
+      const result = await handleViewTelemetry({}, stateDir);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        session: { totalInvocations: number; totalTokens: number };
+        tools: unknown[];
+        hints: unknown[];
+      };
+      expect(data.session.totalInvocations).toBe(0);
+      expect(data.session.totalTokens).toBe(0);
+      expect(data.tools).toHaveLength(0);
+      expect(data.hints).toHaveLength(0);
+    });
+  });
+
+  describe('hints included', () => {
+    it('should include hints when thresholds are exceeded', async () => {
+      // Arrange — seed with large responses to trigger view_tasks hint
+      const largeEvents = Array.from({ length: 5 }, () => ({
+        tool: 'view_tasks',
+        durationMs: 10,
+        responseBytes: 2000,
+        tokenEstimate: 500,
+      }));
+      await seedTelemetryEvents(stateDir, largeEvents);
+
+      // Act
+      const result = await handleViewTelemetry({}, stateDir);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        hints: Array<{ tool: string; hint: string }>;
+      };
+      expect(data.hints.length).toBeGreaterThan(0);
+      expect(data.hints[0].tool).toBe('view_tasks');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should return error result when materializer throws', async () => {
+      // Arrange — create a materializer that will fail by corrupting event data
+      const badDir = await createTempDir();
+      resetMaterializerCache();
+
+      // Write a corrupt JSONL file that will fail JSON.parse during query
+      const corruptFile = path.join(badDir, 'telemetry.events.jsonl');
+      await fs.mkdir(badDir, { recursive: true });
+      await fs.writeFile(corruptFile, '{not valid json\n', 'utf-8');
+
+      // Act
+      const result = await handleViewTelemetry({}, badDir);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(result.error?.code).toBe('VIEW_ERROR');
+    });
+  });
+});
+
+describe('Telemetry projection registered in materializer', () => {
+  beforeEach(() => {
+    resetMaterializerCache();
+  });
+
+  it('should have telemetry view registered after materializer creation', () => {
+    // Act — create a materializer (which calls createMaterializer internally)
+    const materializer = getOrCreateMaterializer('/tmp/test-mat-telemetry');
+
+    // Assert
+    expect(materializer.hasProjection(TELEMETRY_VIEW)).toBe(true);
+  });
+});
+
+describe('registerTelemetryTools', () => {
+  it('should register exarchos_view_telemetry tool on the server', () => {
+    // Arrange
+    const toolNames: string[] = [];
+    const mockServer = {
+      tool: (name: string, ..._rest: unknown[]) => {
+        toolNames.push(name);
+      },
+    } as unknown as McpServer;
+    const store = new EventStore('/tmp/test-reg');
+
+    // Act
+    registerTelemetryTools(mockServer, '/tmp/test-reg', store);
+
+    // Assert
+    expect(toolNames).toContain('exarchos_view_telemetry');
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -37,6 +37,10 @@ describe('handleViewTelemetry', () => {
   beforeEach(async () => {
     stateDir = await createTempDir();
     resetMaterializerCache();
+  });
+
+  afterEach(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
   });
 
   describe('compact mode (default)', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/tools.ts
@@ -1,5 +1,6 @@
 // ─── Telemetry MCP Tool Handler ──────────────────────────────────────────────
 
+import { z } from 'zod';
 import type { ToolResult } from '../format.js';
 import { getOrCreateMaterializer, getOrCreateEventStore } from '../views/tools.js';
 import { TELEMETRY_VIEW } from './telemetry-projection.js';
@@ -9,12 +10,14 @@ import { generateHints } from './hints.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-interface ViewTelemetryArgs {
-  compact?: boolean;
-  tool?: string;
-  sort?: 'tokens' | 'invocations' | 'duration';
-  limit?: number;
-}
+const ViewTelemetryArgsSchema = z.object({
+  compact: z.boolean().optional(),
+  tool: z.string().optional(),
+  sort: z.enum(['tokens', 'invocations', 'duration']).optional(),
+  limit: z.number().int().positive().optional(),
+});
+
+type ViewTelemetryArgs = z.infer<typeof ViewTelemetryArgsSchema>;
 
 interface CompactToolEntry {
   readonly tool: string;
@@ -48,9 +51,21 @@ const SORT_FIELDS: Record<string, keyof ToolMetrics> = {
 // ─── Handler ────────────────────────────────────────────────────────────────
 
 export async function handleViewTelemetry(
-  args: ViewTelemetryArgs,
+  args: unknown,
   stateDir: string,
 ): Promise<ToolResult> {
+  const parseResult = ViewTelemetryArgsSchema.safeParse(args);
+  if (!parseResult.success) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: parseResult.error.issues.map((i) => i.message).join('; '),
+      },
+    };
+  }
+  const validated = parseResult.data;
+
   try {
     const store = getOrCreateEventStore(stateDir);
     const materializer = getOrCreateMaterializer(stateDir);
@@ -66,17 +81,17 @@ export async function handleViewTelemetry(
 
     // Convert tools map to array of { tool, ...metrics } entries
     let toolEntries = Object.entries(view.tools).map(([name, metrics]) =>
-      toToolEntry(name, metrics, args.compact !== false),
+      toToolEntry(name, metrics, validated.compact !== false),
     );
 
     // Apply tool filter
-    if (args.tool) {
-      toolEntries = toolEntries.filter((entry) => entry.tool === args.tool);
+    if (validated.tool) {
+      toolEntries = toolEntries.filter((entry) => entry.tool === validated.tool);
     }
 
     // Apply sort (descending)
-    if (args.sort) {
-      const sortField = SORT_FIELDS[args.sort];
+    if (validated.sort) {
+      const sortField = SORT_FIELDS[validated.sort];
       if (sortField) {
         toolEntries.sort((a, b) => {
           const aVal = (a as unknown as Record<string, number>)[sortField] ?? 0;
@@ -87,8 +102,8 @@ export async function handleViewTelemetry(
     }
 
     // Apply limit
-    if (args.limit !== undefined) {
-      toolEntries = toolEntries.slice(0, args.limit);
+    if (validated.limit !== undefined) {
+      toolEntries = toolEntries.slice(0, validated.limit);
     }
 
     // Generate hints
@@ -150,4 +165,3 @@ function toToolEntry(
     tokenEstimates: metrics.tokenEstimates,
   };
 }
-

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/tools.ts
@@ -1,0 +1,179 @@
+// ─── Telemetry MCP Tool Handler ──────────────────────────────────────────────
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { EventStore } from '../event-store/store.js';
+import { formatResult, type ToolResult } from '../format.js';
+import { getOrCreateMaterializer, getOrCreateEventStore } from '../views/tools.js';
+import { TELEMETRY_VIEW } from './telemetry-projection.js';
+import type { TelemetryViewState, ToolMetrics } from './telemetry-projection.js';
+import { TELEMETRY_STREAM } from './constants.js';
+import { generateHints } from './hints.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface ViewTelemetryArgs {
+  compact?: boolean;
+  tool?: string;
+  sort?: 'tokens' | 'invocations' | 'duration';
+  limit?: number;
+}
+
+interface CompactToolEntry {
+  readonly tool: string;
+  readonly invocations: number;
+  readonly errors: number;
+  readonly totalDurationMs: number;
+  readonly totalBytes: number;
+  readonly totalTokens: number;
+  readonly p50DurationMs: number;
+  readonly p95DurationMs: number;
+  readonly p50Bytes: number;
+  readonly p95Bytes: number;
+  readonly p50Tokens: number;
+  readonly p95Tokens: number;
+}
+
+interface FullToolEntry extends CompactToolEntry {
+  readonly durations: readonly number[];
+  readonly sizes: readonly number[];
+  readonly tokenEstimates: readonly number[];
+}
+
+// ─── Sort Field Mapping ─────────────────────────────────────────────────────
+
+const SORT_FIELDS: Record<string, keyof ToolMetrics> = {
+  tokens: 'totalTokens',
+  invocations: 'invocations',
+  duration: 'totalDurationMs',
+};
+
+// ─── Handler ────────────────────────────────────────────────────────────────
+
+export async function handleViewTelemetry(
+  args: ViewTelemetryArgs,
+  stateDir: string,
+): Promise<ToolResult> {
+  try {
+    const store = getOrCreateEventStore(stateDir);
+    const materializer = getOrCreateMaterializer(stateDir);
+
+    // Materialize the telemetry view from the telemetry stream
+    await materializer.loadFromSnapshot(TELEMETRY_STREAM, TELEMETRY_VIEW);
+    const events = await store.query(TELEMETRY_STREAM);
+    const view = materializer.materialize<TelemetryViewState>(
+      TELEMETRY_STREAM,
+      TELEMETRY_VIEW,
+      events,
+    );
+
+    // Convert tools map to array of { tool, ...metrics } entries
+    let toolEntries = Object.entries(view.tools).map(([name, metrics]) =>
+      toToolEntry(name, metrics, args.compact !== false),
+    );
+
+    // Apply tool filter
+    if (args.tool) {
+      toolEntries = toolEntries.filter((entry) => entry.tool === args.tool);
+    }
+
+    // Apply sort (descending)
+    if (args.sort) {
+      const sortField = SORT_FIELDS[args.sort];
+      if (sortField) {
+        toolEntries.sort((a, b) => {
+          const aVal = (a as unknown as Record<string, number>)[sortField] ?? 0;
+          const bVal = (b as unknown as Record<string, number>)[sortField] ?? 0;
+          return bVal - aVal;
+        });
+      }
+    }
+
+    // Apply limit
+    if (args.limit !== undefined) {
+      toolEntries = toolEntries.slice(0, args.limit);
+    }
+
+    // Generate hints
+    const hints = generateHints(view);
+
+    return {
+      success: true,
+      data: {
+        session: {
+          start: view.sessionStart,
+          totalInvocations: view.totalInvocations,
+          totalTokens: view.totalTokens,
+        },
+        tools: toolEntries,
+        hints,
+      },
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: {
+        code: 'VIEW_ERROR',
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+}
+
+// ─── Entry Builder ──────────────────────────────────────────────────────────
+
+function toToolEntry(
+  name: string,
+  metrics: ToolMetrics,
+  compact: boolean,
+): CompactToolEntry | FullToolEntry {
+  const base: CompactToolEntry = {
+    tool: name,
+    invocations: metrics.invocations,
+    errors: metrics.errors,
+    totalDurationMs: metrics.totalDurationMs,
+    totalBytes: metrics.totalBytes,
+    totalTokens: metrics.totalTokens,
+    p50DurationMs: metrics.p50DurationMs,
+    p95DurationMs: metrics.p95DurationMs,
+    p50Bytes: metrics.p50Bytes,
+    p95Bytes: metrics.p95Bytes,
+    p50Tokens: metrics.p50Tokens,
+    p95Tokens: metrics.p95Tokens,
+  };
+
+  if (compact) {
+    return base;
+  }
+
+  return {
+    ...base,
+    durations: metrics.durations,
+    sizes: metrics.sizes,
+    tokenEstimates: metrics.tokenEstimates,
+  };
+}
+
+// ─── Registration Function ──────────────────────────────────────────────────
+//
+// NOTE: Wiring createInstrumentedRegistrar to replace direct server.tool()
+// calls is deferred to a future task to avoid breaking existing tool
+// registrations and their test suites.
+
+export function registerTelemetryTools(
+  server: McpServer,
+  stateDir: string,
+  _eventStore: EventStore,
+): void {
+  server.tool(
+    'exarchos_view_telemetry',
+    'Get telemetry view with per-tool metrics, percentiles, and optimization hints. Supports compact/full modes, filtering, sorting, and limiting.',
+    {
+      compact: z.boolean().optional().describe('Strip rolling window arrays (default: true)'),
+      tool: z.string().optional().describe('Filter to a single tool name'),
+      sort: z.enum(['tokens', 'invocations', 'duration']).optional().describe('Sort descending by field'),
+      limit: z.number().int().positive().optional().describe('Return top N tools'),
+    },
+    async (args) => formatResult(await handleViewTelemetry(args, stateDir)),
+  );
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/tools.ts
@@ -1,9 +1,6 @@
 // ─── Telemetry MCP Tool Handler ──────────────────────────────────────────────
 
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
-import type { EventStore } from '../event-store/store.js';
-import { formatResult, type ToolResult } from '../format.js';
+import type { ToolResult } from '../format.js';
 import { getOrCreateMaterializer, getOrCreateEventStore } from '../views/tools.js';
 import { TELEMETRY_VIEW } from './telemetry-projection.js';
 import type { TelemetryViewState, ToolMetrics } from './telemetry-projection.js';
@@ -154,26 +151,3 @@ function toToolEntry(
   };
 }
 
-// ─── Registration Function ──────────────────────────────────────────────────
-//
-// NOTE: Wiring createInstrumentedRegistrar to replace direct server.tool()
-// calls is deferred to a future task to avoid breaking existing tool
-// registrations and their test suites.
-
-export function registerTelemetryTools(
-  server: McpServer,
-  stateDir: string,
-  _eventStore: EventStore,
-): void {
-  server.tool(
-    'exarchos_view_telemetry',
-    'Get telemetry view with per-tool metrics, percentiles, and optimization hints. Supports compact/full modes, filtering, sorting, and limiting.',
-    {
-      compact: z.boolean().optional().describe('Strip rolling window arrays (default: true)'),
-      tool: z.string().optional().describe('Filter to a single tool name'),
-      sort: z.enum(['tokens', 'invocations', 'duration']).optional().describe('Sort descending by field'),
-      limit: z.number().int().positive().optional().describe('Return top N tools'),
-    },
-    async (args) => formatResult(await handleViewTelemetry(args, stateDir)),
-  );
-}

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/composite.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/composite.test.ts
@@ -14,6 +14,11 @@ vi.mock('../stack/tools.js', () => ({
   handleStackPlace: vi.fn(),
 }));
 
+// Mock the telemetry tools module
+vi.mock('../telemetry/tools.js', () => ({
+  handleViewTelemetry: vi.fn(),
+}));
+
 import { handleView } from './composite.js';
 import {
   handleViewPipeline,
@@ -22,6 +27,7 @@ import {
   handleViewTeamStatus,
 } from './tools.js';
 import { handleStackStatus, handleStackPlace } from '../stack/tools.js';
+import { handleViewTelemetry } from '../telemetry/tools.js';
 
 const STATE_DIR = '/tmp/test-state';
 
@@ -173,6 +179,28 @@ describe('handleView', () => {
           branch: 'feat/foo',
           prUrl: 'https://github.com/org/repo/pull/1',
         },
+        STATE_DIR,
+      );
+    });
+  });
+
+  describe('telemetry', () => {
+    it('should delegate to handleViewTelemetry', async () => {
+      // Arrange
+      const expected = {
+        success: true,
+        data: { session: { totalInvocations: 5 }, tools: [], hints: [] },
+      };
+      vi.mocked(handleViewTelemetry).mockResolvedValue(expected);
+      const args = { action: 'telemetry', compact: true, tool: 'workflow_get' };
+
+      // Act
+      const result = await handleView(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleViewTelemetry).toHaveBeenCalledWith(
+        { compact: true, tool: 'workflow_get' },
         STATE_DIR,
       );
     });

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/composite.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/composite.ts
@@ -11,6 +11,7 @@ import {
   handleViewTeamStatus,
 } from './tools.js';
 import { handleStackStatus, handleStackPlace } from '../stack/tools.js';
+import { handleViewTelemetry } from '../telemetry/tools.js';
 
 /**
  * Composite handler that dispatches to existing view/stack handlers
@@ -71,6 +72,17 @@ export async function handleView(
         stateDir,
       );
 
+    case 'telemetry':
+      return handleViewTelemetry(
+        rest as {
+          compact?: boolean;
+          tool?: string;
+          sort?: 'tokens' | 'invocations' | 'duration';
+          limit?: number;
+        },
+        stateDir,
+      );
+
     default:
       return {
         success: false,
@@ -84,6 +96,7 @@ export async function handleView(
             'team_status',
             'stack_status',
             'stack_place',
+            'telemetry',
           ] as const,
         },
       };

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/tools.ts
@@ -30,6 +30,10 @@ import {
   stackViewProjection,
   STACK_VIEW,
 } from './stack-view.js';
+import {
+  telemetryProjection,
+  TELEMETRY_VIEW,
+} from '../telemetry/telemetry-projection.js';
 
 // ─── Helper: create a materializer with all projections registered ─────────
 
@@ -41,6 +45,7 @@ function createMaterializer(stateDir: string): ViewMaterializer {
   materializer.register(TASK_DETAIL_VIEW, taskDetailProjection);
   materializer.register(PIPELINE_VIEW, pipelineProjection);
   materializer.register(STACK_VIEW, stackViewProjection);
+  materializer.register(TELEMETRY_VIEW, telemetryProjection);
   return materializer;
 }
 


### PR DESCRIPTION
## Summary

Wires all telemetry components together: registers the telemetry projection in the materializer, adds the `telemetry` action to the `exarchos_view` composite tool, and instruments all existing tool handlers via `withTelemetry` in `index.ts`.

## Changes

- **Telemetry Tool Handler** — `handleViewTelemetry` with compact/full modes, filter by tool, sort (tokens/invocations/duration), and limit
- **Composite Integration** — `telemetry` action added to `exarchos_view` composite router
- **Server Wiring** — `index.ts` wraps all tool handlers with `withTelemetry` (conditional via `EXARCHOS_TELEMETRY` env var)
- **Registry Update** — Telemetry tool metadata added to central registry

## Test Plan

10 tests covering compact/full modes, filtering, sorting (3 variants), limiting, empty state, hints integration, error handling, and projection registration.

---

**Results:** Tests 1125 ✓ · Build 0 errors
**Stack:** 5/6