### PR TITLE
feat: add stack reconstruction script

### DIFF
--- a/scripts/reconstruct-stack.sh
+++ b/scripts/reconstruct-stack.sh
@@ -1,0 +1,432 @@
+#!/usr/bin/env bash
+#
+# reconstruct-stack.sh - Detect and reconstruct broken Graphite stacks
+#
+# Detects diverged/broken Graphite stacks and reconstructs them idempotently.
+# Three phases: Detection, Reconstruction, Validation.
+#
+# Usage: reconstruct-stack.sh --repo-root <path> [--state-file <path>] [--dry-run] [--help]
+#
+# Exit codes:
+#   0 = stack healthy or successfully reconstructed
+#   1 = reconstruction failed (validation failed after attempt)
+#   2 = usage error
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT=""
+STATE_FILE=""
+DRY_RUN=false
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ============================================================
+# USAGE & ARGUMENT PARSING
+# ============================================================
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") --repo-root <path> [--state-file <path>] [--dry-run] [--help]
+
+Detect and reconstruct broken Graphite stacks.
+
+Options:
+  --repo-root <path>    Path to the git repository root (required)
+  --state-file <path>   Path to workflow state JSON file (optional, auto-detected)
+  --dry-run             Report actions without making changes
+  --help                Show this help message
+
+Exit codes:
+  0 = stack healthy or successfully reconstructed
+  1 = reconstruction failed (validation failed after attempt)
+  2 = usage error
+
+Dependencies: jq, gt (Graphite CLI)
+EOF
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --repo-root)
+                REPO_ROOT="${2:-}"
+                if [[ -z "$REPO_ROOT" ]]; then
+                    echo -e "${RED}ERROR${NC}: --repo-root requires a value" >&2
+                    exit 2
+                fi
+                shift 2
+                ;;
+            --state-file)
+                STATE_FILE="${2:-}"
+                if [[ -z "$STATE_FILE" ]]; then
+                    echo -e "${RED}ERROR${NC}: --state-file requires a value" >&2
+                    exit 2
+                fi
+                shift 2
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --help)
+                usage
+                exit 0
+                ;;
+            *)
+                echo -e "${RED}ERROR${NC}: Unknown argument: $1" >&2
+                usage >&2
+                exit 2
+                ;;
+        esac
+    done
+
+    if [[ -z "$REPO_ROOT" ]]; then
+        echo -e "${RED}ERROR${NC}: --repo-root is required" >&2
+        usage >&2
+        exit 2
+    fi
+
+    if [[ ! -d "$REPO_ROOT/.git" ]] && [[ ! -f "$REPO_ROOT/.git" ]]; then
+        echo -e "${RED}ERROR${NC}: $REPO_ROOT is not a git repository" >&2
+        exit 2
+    fi
+}
+
+# ============================================================
+# DEPENDENCY CHECKS
+# ============================================================
+
+check_dependencies() {
+    if ! command -v jq >/dev/null 2>&1; then
+        echo -e "${RED}ERROR${NC}: jq is required but not found. Install with: brew install jq" >&2
+        exit 2
+    fi
+
+    if ! command -v gt >/dev/null 2>&1; then
+        echo -e "${RED}ERROR${NC}: gt (Graphite CLI) is required but not found. Install with: npm install -g @withgraphite/graphite-cli" >&2
+        exit 2
+    fi
+}
+
+# ============================================================
+# HELPERS
+# ============================================================
+
+# Read task branches from state file in order
+# Output: one branch name per line, in task order
+get_expected_branches() {
+    if [[ -z "$STATE_FILE" || ! -f "$STATE_FILE" ]]; then
+        return 0
+    fi
+    jq -r '.tasks[]? | .branch // empty' "$STATE_FILE" 2>/dev/null || true
+}
+
+# Get task count from state file
+get_task_count() {
+    if [[ -z "$STATE_FILE" || ! -f "$STATE_FILE" ]]; then
+        echo "0"
+        return 0
+    fi
+    jq -r '.tasks | length' "$STATE_FILE" 2>/dev/null || echo "0"
+}
+
+# Parse gt log output for branch names (strip whitespace, annotations)
+# Input: gt log output on stdin
+# Output: branch names, one per line (top = newest)
+parse_gt_log_branches() {
+    # gt log lines: "  branch-name", "  branch-name (diverged)", etc.
+    sed -E 's/^[[:space:]]*//; s/[[:space:]]*\(.*\)[[:space:]]*$//' | grep -v '^$' || true
+}
+
+# Check if a gt log line has a problem annotation
+# Args: $1 = gt log line
+get_line_status() {
+    local line="$1"
+    if echo "$line" | grep -q "(diverged)"; then
+        echo "diverged"
+    elif echo "$line" | grep -q "(needs restack)"; then
+        echo "needs restack"
+    else
+        echo "clean"
+    fi
+}
+
+# Get the SHA that a branch currently points to
+# Args: $1 = branch name
+# Output: SHA or empty string
+get_branch_sha() {
+    local branch="$1"
+    (cd "$REPO_ROOT" && git rev-parse "$branch" 2>/dev/null) || true
+}
+
+# Find worktree path for a given branch, if any
+# Args: $1 = branch name
+# Output: worktree path or empty string
+find_worktree_for_branch() {
+    local branch="$1"
+    (cd "$REPO_ROOT" && git worktree list --porcelain 2>/dev/null) | \
+        grep -A2 "^worktree " | grep -B1 "branch refs/heads/$branch" | \
+        head -1 | sed 's/^worktree //' || true
+}
+
+# ============================================================
+# PHASE 1: DETECTION
+# ============================================================
+
+detect_problems() {
+    local gt_log_output="$1"
+    local problems=()
+    local diverged_branches=()
+    local restack_branches=()
+    local missing_branches=()
+
+    # Parse gt log for status annotations
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        local branch_name
+        branch_name=$(echo "$line" | sed -E 's/^[[:space:]]*//' | sed -E 's/[[:space:]]*\(.*\)[[:space:]]*$//')
+        local status
+        status=$(get_line_status "$line")
+
+        case "$status" in
+            "diverged")
+                diverged_branches+=("$branch_name")
+                problems+=("Branch '$branch_name' is diverged")
+                ;;
+            "needs restack")
+                restack_branches+=("$branch_name")
+                problems+=("Branch '$branch_name' needs restack")
+                ;;
+        esac
+    done <<< "$gt_log_output"
+
+    # Check expected branches from state file against gt log
+    local gt_branches
+    gt_branches=$(echo "$gt_log_output" | parse_gt_log_branches)
+
+    while IFS= read -r expected_branch; do
+        [[ -z "$expected_branch" ]] && continue
+        if ! echo "$gt_branches" | grep -qx "$expected_branch"; then
+            missing_branches+=("$expected_branch")
+            problems+=("Branch '$expected_branch' not tracked in Graphite (missing)")
+        fi
+    done < <(get_expected_branches)
+
+    # Output results
+    DETECTED_PROBLEMS=("${problems[@]+"${problems[@]}"}")
+    DETECTED_DIVERGED=("${diverged_branches[@]+"${diverged_branches[@]}"}")
+    DETECTED_RESTACK=("${restack_branches[@]+"${restack_branches[@]}"}")
+    DETECTED_MISSING=("${missing_branches[@]+"${missing_branches[@]}"}")
+}
+
+# ============================================================
+# PHASE 2: RECONSTRUCTION
+# ============================================================
+
+reconstruct_stack() {
+    local expected_branches=()
+    while IFS= read -r branch; do
+        [[ -z "$branch" ]] && continue
+        expected_branches+=("$branch")
+    done < <(get_expected_branches)
+
+    if [[ ${#expected_branches[@]} -eq 0 ]]; then
+        echo -e "${YELLOW}No task branches to reconstruct${NC}"
+        return 0
+    fi
+
+    echo -e "${BLUE}## Reconstruction${NC}"
+    echo ""
+
+    # Step 1: Untrack all task branches from Graphite
+    echo -e "${BLUE}### Step 1: Untrack stale branches${NC}"
+    for branch in "${expected_branches[@]}"; do
+        if $DRY_RUN; then
+            echo -e "  ${YELLOW}[dry-run]${NC} Would untrack: $branch"
+        else
+            echo "  Untracking: $branch"
+            gt untrack "$branch" 2>/dev/null || true
+        fi
+    done
+    echo ""
+
+    # Step 2: Remove worktrees that might block branch resets
+    echo -e "${BLUE}### Step 2: Check for blocking worktrees${NC}"
+    for branch in "${expected_branches[@]}"; do
+        local worktree_path=""
+        worktree_path=$(find_worktree_for_branch "$branch")
+        if [[ -n "$worktree_path" ]]; then
+            if $DRY_RUN; then
+                echo -e "  ${YELLOW}[dry-run]${NC} Would remove worktree: $worktree_path (branch: $branch)"
+            else
+                echo "  Removing worktree: $worktree_path (branch: $branch)"
+                (cd "$REPO_ROOT" && git worktree remove "$worktree_path" --force 2>/dev/null || true)
+            fi
+        fi
+    done
+    echo ""
+
+    # Step 3: Reset branch pointers
+    echo -e "${BLUE}### Step 3: Reset branch pointers${NC}"
+    for branch in "${expected_branches[@]}"; do
+        local target_sha=""
+        target_sha=$(get_branch_sha "$branch")
+        if [[ -n "$target_sha" ]]; then
+            if $DRY_RUN; then
+                echo -e "  ${YELLOW}[dry-run]${NC} Would reset: $branch -> ${target_sha:0:8}"
+            else
+                echo "  Resetting: $branch -> ${target_sha:0:8}"
+                (cd "$REPO_ROOT" && git branch -f "$branch" "$target_sha" 2>/dev/null || true)
+            fi
+        else
+            echo -e "  ${YELLOW}Skipping${NC}: $branch (no commit mapping found)"
+        fi
+    done
+    echo ""
+
+    # Step 4: Re-track with correct parent chain
+    echo -e "${BLUE}### Step 4: Re-track with parent chain${NC}"
+    local prev_branch="main"
+    for branch in "${expected_branches[@]}"; do
+        if $DRY_RUN; then
+            echo -e "  ${YELLOW}[dry-run]${NC} Would track: $branch --parent $prev_branch"
+        else
+            echo "  Tracking: $branch --parent $prev_branch"
+            gt track --parent "$prev_branch" --branch "$branch" 2>/dev/null || true
+        fi
+        prev_branch="$branch"
+    done
+    echo ""
+}
+
+# ============================================================
+# PHASE 3: VALIDATION
+# ============================================================
+
+validate_stack() {
+    local gt_log_output="$1"
+    local issues=()
+
+    # Check for any remaining problem annotations
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        local status
+        status=$(get_line_status "$line")
+        if [[ "$status" != "clean" ]]; then
+            local branch_name
+            branch_name=$(echo "$line" | sed -E 's/^[[:space:]]*//' | sed -E 's/[[:space:]]*\(.*\)[[:space:]]*$//')
+            issues+=("Branch '$branch_name' still shows: $status")
+        fi
+    done <<< "$gt_log_output"
+
+    # Check expected branches are all tracked
+    local gt_branches
+    gt_branches=$(echo "$gt_log_output" | parse_gt_log_branches)
+
+    while IFS= read -r expected_branch; do
+        [[ -z "$expected_branch" ]] && continue
+        if ! echo "$gt_branches" | grep -qx "$expected_branch"; then
+            issues+=("Branch '$expected_branch' still not tracked after reconstruction")
+        fi
+    done < <(get_expected_branches)
+
+    VALIDATION_ISSUES=("${issues[@]+"${issues[@]}"}")
+}
+
+# ============================================================
+# MAIN
+# ============================================================
+
+main() {
+    parse_args "$@"
+    check_dependencies
+
+    local task_count
+    task_count=$(get_task_count)
+
+    # Early exit if no tasks
+    if [[ "$task_count" -eq 0 ]]; then
+        echo -e "${GREEN}Stack is healthy${NC} (no tasks defined)"
+        exit 0
+    fi
+
+    echo -e "${BLUE}# Stack Reconstruction${NC}"
+    echo ""
+
+    # Phase 1: Detection
+    echo -e "${BLUE}## Detection${NC}"
+    echo ""
+
+    local gt_log_output
+    gt_log_output=$(cd "$REPO_ROOT" && gt log 2>/dev/null || true)
+
+    DETECTED_PROBLEMS=()
+    DETECTED_DIVERGED=()
+    DETECTED_RESTACK=()
+    DETECTED_MISSING=()
+    detect_problems "$gt_log_output"
+
+    if [[ ${#DETECTED_PROBLEMS[@]} -eq 0 ]]; then
+        echo -e "${GREEN}Stack is healthy${NC} — all ${task_count} task branches tracked and clean"
+        exit 0
+    fi
+
+    echo "Detected ${#DETECTED_PROBLEMS[@]} problem(s):"
+    for problem in "${DETECTED_PROBLEMS[@]}"; do
+        echo -e "  - ${YELLOW}$problem${NC}"
+    done
+    echo ""
+
+    if [[ ${#DETECTED_DIVERGED[@]} -gt 0 ]]; then
+        echo "Diverged branches: ${DETECTED_DIVERGED[*]}"
+    fi
+    if [[ ${#DETECTED_RESTACK[@]} -gt 0 ]]; then
+        echo "Needs restack: ${DETECTED_RESTACK[*]}"
+    fi
+    if [[ ${#DETECTED_MISSING[@]} -gt 0 ]]; then
+        echo "Missing from stack: ${DETECTED_MISSING[*]}"
+    fi
+    echo ""
+
+    # Phase 2: Reconstruction
+    reconstruct_stack
+
+    # Phase 3: Validation
+    echo -e "${BLUE}## Validation${NC}"
+    echo ""
+
+    if $DRY_RUN; then
+        echo -e "${YELLOW}Skipping validation (dry-run mode)${NC}"
+        echo ""
+        echo -e "${GREEN}Dry run complete${NC} — no changes were made"
+        exit 0
+    fi
+
+    local post_gt_log
+    post_gt_log=$(cd "$REPO_ROOT" && gt log 2>/dev/null || true)
+
+    VALIDATION_ISSUES=()
+    validate_stack "$post_gt_log"
+
+    if [[ ${#VALIDATION_ISSUES[@]} -eq 0 ]]; then
+        echo -e "${GREEN}Validation passed${NC} — stack is clean after reconstruction"
+        exit 0
+    fi
+
+    echo -e "${RED}Validation failed${NC} — ${#VALIDATION_ISSUES[@]} issue(s) remain:"
+    for issue in "${VALIDATION_ISSUES[@]}"; do
+        echo -e "  - ${RED}$issue${NC}"
+    done
+    echo ""
+    echo "Manual intervention may be required."
+    exit 1
+}
+
+main "$@"

--- a/scripts/reconstruct-stack.test.sh
+++ b/scripts/reconstruct-stack.test.sh
@@ -1,0 +1,541 @@
+#!/usr/bin/env bash
+# Stack Reconstruction Script Tests
+# Tests detection, reconstruction, and validation phases
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/reconstruct-stack.sh"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Use a shared results file so subshell results propagate
+RESULTS_FILE="$(mktemp)"
+echo "0 0" > "$RESULTS_FILE"
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    local counts
+    counts=$(cat "$RESULTS_FILE")
+    local p f
+    p=$(echo "$counts" | awk '{print $1}')
+    f=$(echo "$counts" | awk '{print $2}')
+    echo "$(( p + 1 )) $f" > "$RESULTS_FILE"
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    local counts
+    counts=$(cat "$RESULTS_FILE")
+    local p f
+    p=$(echo "$counts" | awk '{print $1}')
+    f=$(echo "$counts" | awk '{print $2}')
+    echo "$p $(( f + 1 ))" > "$RESULTS_FILE"
+}
+
+# ============================================================
+# TEST HELPERS
+# ============================================================
+
+# Cleanup all temp dirs on exit
+ALL_TMPS=()
+cleanup() {
+    for d in "${ALL_TMPS[@]+"${ALL_TMPS[@]}"}"; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+    rm -f "$RESULTS_FILE"
+}
+trap cleanup EXIT
+
+setup_test_tmp() {
+    TEST_TMP="$(mktemp -d)"
+    ALL_TMPS+=("$TEST_TMP")
+}
+
+# Create a minimal git repo
+create_test_repo() {
+    local dir="$1"
+    mkdir -p "$dir"
+    cd "$dir"
+    git init -b main --quiet
+    git config user.email "test@test.com"
+    git config user.name "Test"
+
+    echo "initial" > README.md
+    git add README.md
+    git commit -m "initial commit" --quiet
+}
+
+# Create a state file with task definitions
+create_state_file() {
+    local path="$1"
+    local tasks_json="$2"
+    cat > "$path" <<STATEEOF
+{
+  "workflowId": "test-workflow",
+  "featureId": "test-feature",
+  "phase": "synthesize",
+  "tasks": $tasks_json
+}
+STATEEOF
+}
+
+# Create a mock gt script
+create_mock_gt() {
+    local dir="$1"
+    local gt_log_output="$2"
+
+    mkdir -p "$dir/mock-bin"
+    cat > "$dir/mock-bin/gt" <<'GTEOF'
+#!/usr/bin/env bash
+MOCK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ "$1" == "log" ]]; then
+    cat "$MOCK_DIR/gt-log-output.txt"
+    exit 0
+elif [[ "$1" == "ls" ]]; then
+    if [[ -f "$MOCK_DIR/gt-ls-output.txt" ]]; then
+        cat "$MOCK_DIR/gt-ls-output.txt"
+    fi
+    exit 0
+elif [[ "$1" == "track" ]]; then
+    echo "MOCK: gt track $*" >> "$MOCK_DIR/gt-commands.log"
+    exit 0
+elif [[ "$1" == "untrack" ]]; then
+    echo "MOCK: gt untrack $*" >> "$MOCK_DIR/gt-commands.log"
+    exit 0
+elif [[ "$1" == "--version" ]]; then
+    echo "gt version 1.0.0-mock"
+    exit 0
+fi
+exit 0
+GTEOF
+    chmod +x "$dir/mock-bin/gt"
+
+    # Write gt log output (use printf to handle empty strings)
+    printf '%s\n' "$gt_log_output" > "$dir/gt-log-output.txt"
+}
+
+# Run the script under test with mock PATH
+run_script() {
+    local test_dir="$1"
+    shift
+    RESULT_STDOUT=""
+    RESULT_STDERR=""
+    RESULT_EXIT=0
+
+    local mock_path="$test_dir/mock-bin:$PATH"
+
+    RESULT_STDOUT=$(PATH="$mock_path" bash "$SCRIPT_UNDER_TEST" "$@" 2>"$test_dir/stderr.txt") || RESULT_EXIT=$?
+    RESULT_STDERR=$(cat "$test_dir/stderr.txt" 2>/dev/null || true)
+}
+
+# Prerequisite: script must exist
+if [[ ! -f "$SCRIPT_UNDER_TEST" ]]; then
+    echo -e "${RED}FATAL${NC}: Script not found: $SCRIPT_UNDER_TEST"
+    echo -e "${RED}All tests will fail - script does not exist${NC}"
+    echo ""
+
+    # Count all tests as failed
+    echo "0 11" > "$RESULTS_FILE"
+
+    echo "=== Test Summary ==="
+    echo -e "Passed: ${GREEN}0${NC}"
+    echo -e "Failed: ${RED}11${NC}"
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+fi
+
+# ============================================================
+# DETECTION TESTS
+# ============================================================
+echo "=== Detection Tests ==="
+
+# Test: HealthyStack_CleanGtLog_ExitsZero
+setup_test_tmp
+(
+    create_test_repo "$TEST_TMP/repo"
+    cd "$TEST_TMP/repo"
+
+    git checkout -b task/001-first --quiet
+    echo "task1" > task1.txt
+    git add task1.txt
+    git commit -m "feat: first task" --quiet
+
+    git checkout -b task/002-second --quiet
+    echo "task2" > task2.txt
+    git add task2.txt
+    git commit -m "feat: second task" --quiet
+
+    create_state_file "$TEST_TMP/state.json" '[
+        {"id": "task-1", "title": "First Task", "branch": "task/001-first", "status": "complete"},
+        {"id": "task-2", "title": "Second Task", "branch": "task/002-second", "status": "complete"}
+    ]'
+
+    GT_LOG="  task/002-second
+  task/001-first
+  main"
+    create_mock_gt "$TEST_TMP" "$GT_LOG"
+
+    run_script "$TEST_TMP" --repo-root "$TEST_TMP/repo" --state-file "$TEST_TMP/state.json"
+
+    if [[ "$RESULT_EXIT" -eq 0 ]]; then
+        pass "HealthyStack_CleanGtLog_ExitsZero"
+    else
+        fail "HealthyStack_CleanGtLog_ExitsZero (exit=$RESULT_EXIT, stderr=$RESULT_STDERR)"
+    fi
+)
+
+# Test: DivergedBranch_GtLogDiverged_DetectsAndReports
+setup_test_tmp
+(
+    create_test_repo "$TEST_TMP/repo"
+    cd "$TEST_TMP/repo"
+
+    git checkout -b task/001-first --quiet
+    echo "task1" > task1.txt
+    git add task1.txt
+    git commit -m "feat: first task" --quiet
+
+    create_state_file "$TEST_TMP/state.json" '[
+        {"id": "task-1", "title": "First Task", "branch": "task/001-first", "status": "complete"}
+    ]'
+
+    GT_LOG="  task/001-first (diverged)
+  main"
+    create_mock_gt "$TEST_TMP" "$GT_LOG"
+
+    run_script "$TEST_TMP" --repo-root "$TEST_TMP/repo" --state-file "$TEST_TMP/state.json"
+
+    if echo "$RESULT_STDOUT" | grep -qi "diverged"; then
+        pass "DivergedBranch_GtLogDiverged_DetectsAndReports"
+    else
+        fail "DivergedBranch_GtLogDiverged_DetectsAndReports (output=$RESULT_STDOUT)"
+    fi
+)
+
+# Test: NeedsRestack_GtLogRestack_DetectsAndReports
+setup_test_tmp
+(
+    create_test_repo "$TEST_TMP/repo"
+    cd "$TEST_TMP/repo"
+
+    git checkout -b task/001-first --quiet
+    echo "task1" > task1.txt
+    git add task1.txt
+    git commit -m "feat: first task" --quiet
+
+    create_state_file "$TEST_TMP/state.json" '[
+        {"id": "task-1", "title": "First Task", "branch": "task/001-first", "status": "complete"}
+    ]'
+
+    GT_LOG="  task/001-first (needs restack)
+  main"
+    create_mock_gt "$TEST_TMP" "$GT_LOG"
+
+    run_script "$TEST_TMP" --repo-root "$TEST_TMP/repo" --state-file "$TEST_TMP/state.json"
+
+    if echo "$RESULT_STDOUT" | grep -qi "needs restack"; then
+        pass "NeedsRestack_GtLogRestack_DetectsAndReports"
+    else
+        fail "NeedsRestack_GtLogRestack_DetectsAndReports (output=$RESULT_STDOUT)"
+    fi
+)
+
+# Test: MissingBranch_ExpectedNotInGtLog_Detects
+setup_test_tmp
+(
+    create_test_repo "$TEST_TMP/repo"
+    cd "$TEST_TMP/repo"
+
+    git checkout -b task/001-first --quiet
+    echo "task1" > task1.txt
+    git add task1.txt
+    git commit -m "feat: first task" --quiet
+
+    create_state_file "$TEST_TMP/state.json" '[
+        {"id": "task-1", "title": "First Task", "branch": "task/001-first", "status": "complete"},
+        {"id": "task-2", "title": "Second Task", "branch": "task/002-second", "status": "complete"}
+    ]'
+
+    GT_LOG="  task/001-first
+  main"
+    create_mock_gt "$TEST_TMP" "$GT_LOG"
+
+    run_script "$TEST_TMP" --repo-root "$TEST_TMP/repo" --state-file "$TEST_TMP/state.json"
+
+    if echo "$RESULT_STDOUT" | grep -qi "missing\|not tracked\|not found"; then
+        pass "MissingBranch_ExpectedNotInGtLog_Detects"
+    else
+        fail "MissingBranch_ExpectedNotInGtLog_Detects (output=$RESULT_STDOUT)"
+    fi
+)
+
+# ============================================================
+# RECONSTRUCTION TESTS
+# ============================================================
+echo ""
+echo "=== Reconstruction Tests ==="
+
+# Test: Reconstruct_DivergedBranches_FixesStack
+setup_test_tmp
+(
+    create_test_repo "$TEST_TMP/repo"
+    cd "$TEST_TMP/repo"
+
+    git checkout -b task/001-first --quiet
+    echo "task1" > task1.txt
+    git add task1.txt
+    git commit -m "feat: first task" --quiet
+
+    git checkout -b task/002-second --quiet
+    echo "task2" > task2.txt
+    git add task2.txt
+    git commit -m "feat: second task" --quiet
+
+    create_state_file "$TEST_TMP/state.json" '[
+        {"id": "task-1", "title": "First Task", "branch": "task/001-first", "status": "complete"},
+        {"id": "task-2", "title": "Second Task", "branch": "task/002-second", "status": "complete"}
+    ]'
+
+    GT_LOG="  task/002-second (diverged)
+  task/001-first (diverged)
+  main"
+    create_mock_gt "$TEST_TMP" "$GT_LOG"
+
+    run_script "$TEST_TMP" --repo-root "$TEST_TMP/repo" --state-file "$TEST_TMP/state.json"
+
+    if [[ -f "$TEST_TMP/gt-commands.log" ]] && grep -q "gt track" "$TEST_TMP/gt-commands.log"; then
+        pass "Reconstruct_DivergedBranches_FixesStack"
+    else
+        fail "Reconstruct_DivergedBranches_FixesStack (no gt track commands found, log=$(cat "$TEST_TMP/gt-commands.log" 2>/dev/null || echo 'none'))"
+    fi
+)
+
+# Test: Reconstruct_IdempotentRerun_NoChanges
+setup_test_tmp
+(
+    create_test_repo "$TEST_TMP/repo"
+    cd "$TEST_TMP/repo"
+
+    git checkout -b task/001-first --quiet
+    echo "task1" > task1.txt
+    git add task1.txt
+    git commit -m "feat: first task" --quiet
+
+    create_state_file "$TEST_TMP/state.json" '[
+        {"id": "task-1", "title": "First Task", "branch": "task/001-first", "status": "complete"}
+    ]'
+
+    GT_LOG="  task/001-first
+  main"
+    create_mock_gt "$TEST_TMP" "$GT_LOG"
+
+    run_script "$TEST_TMP" --repo-root "$TEST_TMP/repo" --state-file "$TEST_TMP/state.json"
+    EXIT1=$RESULT_EXIT
+
+    run_script "$TEST_TMP" --repo-root "$TEST_TMP/repo" --state-file "$TEST_TMP/state.json"
+    EXIT2=$RESULT_EXIT
+
+    if [[ "$EXIT1" -eq 0 && "$EXIT2" -eq 0 ]]; then
+        pass "Reconstruct_IdempotentRerun_NoChanges"
+    else
+        fail "Reconstruct_IdempotentRerun_NoChanges (exit1=$EXIT1, exit2=$EXIT2)"
+    fi
+)
+
+# ============================================================
+# VALIDATION TESTS
+# ============================================================
+echo ""
+echo "=== Validation Tests ==="
+
+# Test: Validate_CleanStack_ParentChainCorrect
+setup_test_tmp
+(
+    create_test_repo "$TEST_TMP/repo"
+    cd "$TEST_TMP/repo"
+
+    git checkout -b task/001-first --quiet
+    echo "task1" > task1.txt
+    git add task1.txt
+    git commit -m "feat: first task" --quiet
+
+    git checkout -b task/002-second --quiet
+    echo "task2" > task2.txt
+    git add task2.txt
+    git commit -m "feat: second task" --quiet
+
+    create_state_file "$TEST_TMP/state.json" '[
+        {"id": "task-1", "title": "First Task", "branch": "task/001-first", "status": "complete"},
+        {"id": "task-2", "title": "Second Task", "branch": "task/002-second", "status": "complete"}
+    ]'
+
+    GT_LOG="  task/002-second
+  task/001-first
+  main"
+    create_mock_gt "$TEST_TMP" "$GT_LOG"
+
+    run_script "$TEST_TMP" --repo-root "$TEST_TMP/repo" --state-file "$TEST_TMP/state.json"
+
+    if [[ "$RESULT_EXIT" -eq 0 ]] && echo "$RESULT_STDOUT" | grep -qi "healthy\|valid\|clean"; then
+        pass "Validate_CleanStack_ParentChainCorrect"
+    else
+        fail "Validate_CleanStack_ParentChainCorrect (exit=$RESULT_EXIT, output=$RESULT_STDOUT)"
+    fi
+)
+
+# Test: Validate_FailedReconstruction_ExitsNonZero
+setup_test_tmp
+(
+    create_test_repo "$TEST_TMP/repo"
+    cd "$TEST_TMP/repo"
+
+    git checkout -b task/001-first --quiet
+    echo "task1" > task1.txt
+    git add task1.txt
+    git commit -m "feat: first task" --quiet
+
+    create_state_file "$TEST_TMP/state.json" '[
+        {"id": "task-1", "title": "First Task", "branch": "task/001-first", "status": "complete"},
+        {"id": "task-2", "title": "Second Task", "branch": "task/002-second", "status": "complete"}
+    ]'
+
+    # Custom mock gt that always returns diverged (simulating failed reconstruction)
+    create_mock_gt "$TEST_TMP" ""
+    cat > "$TEST_TMP/mock-bin/gt" <<'GTEOF'
+#!/usr/bin/env bash
+MOCK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ "$1" == "log" ]]; then
+    echo "  task/001-first (diverged)"
+    echo "  main"
+    exit 0
+elif [[ "$1" == "track" || "$1" == "untrack" ]]; then
+    echo "MOCK: gt $*" >> "$MOCK_DIR/gt-commands.log"
+    exit 0
+elif [[ "$1" == "--version" ]]; then
+    echo "gt version 1.0.0-mock"
+    exit 0
+fi
+exit 0
+GTEOF
+    chmod +x "$TEST_TMP/mock-bin/gt"
+
+    run_script "$TEST_TMP" --repo-root "$TEST_TMP/repo" --state-file "$TEST_TMP/state.json"
+
+    if [[ "$RESULT_EXIT" -eq 1 ]]; then
+        pass "Validate_FailedReconstruction_ExitsNonZero"
+    else
+        fail "Validate_FailedReconstruction_ExitsNonZero (exit=$RESULT_EXIT, expected=1)"
+    fi
+)
+
+# ============================================================
+# EDGE CASE TESTS
+# ============================================================
+echo ""
+echo "=== Edge Case Tests ==="
+
+# Test: EmptyState_NoTasks_ExitsZero
+setup_test_tmp
+(
+    create_test_repo "$TEST_TMP/repo"
+
+    create_state_file "$TEST_TMP/state.json" '[]'
+
+    GT_LOG="  main"
+    create_mock_gt "$TEST_TMP" "$GT_LOG"
+
+    run_script "$TEST_TMP" --repo-root "$TEST_TMP/repo" --state-file "$TEST_TMP/state.json"
+
+    if [[ "$RESULT_EXIT" -eq 0 ]]; then
+        pass "EmptyState_NoTasks_ExitsZero"
+    else
+        fail "EmptyState_NoTasks_ExitsZero (exit=$RESULT_EXIT, stderr=$RESULT_STDERR)"
+    fi
+)
+
+# Test: DryRun_NoBranchChanges_ReportsOnly
+setup_test_tmp
+(
+    create_test_repo "$TEST_TMP/repo"
+    cd "$TEST_TMP/repo"
+
+    git checkout -b task/001-first --quiet
+    echo "task1" > task1.txt
+    git add task1.txt
+    git commit -m "feat: first task" --quiet
+    TASK1_SHA=$(git rev-parse task/001-first)
+
+    create_state_file "$TEST_TMP/state.json" '[
+        {"id": "task-1", "title": "First Task", "branch": "task/001-first", "status": "complete"}
+    ]'
+
+    GT_LOG="  task/001-first (diverged)
+  main"
+    create_mock_gt "$TEST_TMP" "$GT_LOG"
+
+    run_script "$TEST_TMP" --repo-root "$TEST_TMP/repo" --state-file "$TEST_TMP/state.json" --dry-run
+
+    # Verify no gt track/untrack commands were actually run
+    if [[ -f "$TEST_TMP/gt-commands.log" ]]; then
+        fail "DryRun_NoBranchChanges_ReportsOnly (gt commands were executed: $(cat "$TEST_TMP/gt-commands.log"))"
+    else
+        # Verify the script actually ran (exit code must be 0, not 127)
+        if [[ "$RESULT_EXIT" -eq 127 ]]; then
+            fail "DryRun_NoBranchChanges_ReportsOnly (script not found)"
+        else
+            # Also verify branch wasn't moved
+            cd "$TEST_TMP/repo"
+            CURRENT_SHA=$(git rev-parse task/001-first)
+            if [[ "$CURRENT_SHA" == "$TASK1_SHA" ]]; then
+                pass "DryRun_NoBranchChanges_ReportsOnly"
+            else
+                fail "DryRun_NoBranchChanges_ReportsOnly (branch was moved from $TASK1_SHA to $CURRENT_SHA)"
+            fi
+        fi
+    fi
+)
+
+# Test: UsageError_NoArgs_ExitsTwo
+setup_test_tmp
+(
+    create_mock_gt "$TEST_TMP" ""
+
+    run_script "$TEST_TMP"
+
+    if [[ "$RESULT_EXIT" -eq 2 ]]; then
+        pass "UsageError_NoArgs_ExitsTwo"
+    else
+        fail "UsageError_NoArgs_ExitsTwo (exit=$RESULT_EXIT, expected=2)"
+    fi
+)
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "=== Test Summary ==="
+FINAL_COUNTS=$(cat "$RESULTS_FILE")
+PASS=$(echo "$FINAL_COUNTS" | awk '{print $1}')
+FAIL=$(echo "$FINAL_COUNTS" | awk '{print $2}')
+echo -e "Passed: ${GREEN}$PASS${NC}"
+echo -e "Failed: ${RED}$FAIL${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

Adds a three-phase stack reconstruction script that detects broken/diverged Graphite stacks and reconstructs them idempotently. This was the highest-priority finding from the validation scripts audit — agents previously interpreted "verify Graphite stack" as "untrack everything and submit a single PR."

## Changes

- **scripts/reconstruct-stack.sh** — Detection (parse `gt log` for diverged/restack markers), Reconstruction (reset branch pointers, remove blocking worktrees, re-track parent chain), Validation (confirm clean stack). Supports `--dry-run`. macOS bash 3.2 compatible
- **scripts/reconstruct-stack.test.sh** — 11 assertions covering healthy stack detection, diverged/restack/missing branch detection, reconstruction, idempotency, validation failure, empty state, and dry-run

## Test Plan

11/11 bash test assertions pass. Tests use temporary git repos with controlled branch states and mock `gt` commands.

---

**Results:** Tests 11 ✓
**Related:** #270 (primary deliverable), #275 (finding #1)