### PR TITLE
fix: reject unrecognized parameters in composite tool schemas

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
@@ -33,6 +33,19 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
         toolRegistrations.set(name, { description, schema, handler });
       },
     ),
+    registerTool: vi.fn(
+      (
+        name: string,
+        config: { description: string; inputSchema: unknown },
+        handler: (...args: unknown[]) => unknown,
+      ) => {
+        toolRegistrations.set(name, {
+          description: config.description,
+          schema: config.inputSchema,
+          handler,
+        });
+      },
+    ),
     connect: vi.fn().mockResolvedValue(undefined),
   })),
 }));
@@ -142,8 +155,9 @@ describe('MCP Server Entry Point', () => {
       createServer('/tmp/test-state-dir');
       for (const [, registration] of toolRegistrations) {
         expect(registration.schema).toBeDefined();
-        const schema = registration.schema as Record<string, unknown>;
-        expect(schema).toHaveProperty('action');
+        // Schema is a strict ZodObject; check the shape for the action field
+        const schema = registration.schema as { shape: Record<string, unknown> };
+        expect(schema.shape).toHaveProperty('action');
       }
     });
   });

--- a/plugins/exarchos/servers/exarchos-mcp/src/index.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/index.ts
@@ -62,11 +62,17 @@ export function createServer(stateDir: string): McpServer {
     const handler = COMPOSITE_HANDLERS[tool.name];
     if (!handler) continue;
 
-    const schema = buildRegistrationSchema(tool.actions);
+    const inputSchema = buildRegistrationSchema(tool.actions);
     const description = buildToolDescription(tool);
 
-    server.tool(tool.name, description, schema, async (args) =>
-      formatResult(await handler(args as Record<string, unknown>, stateDir)),
+    // Use registerTool() so the strict ZodObject is passed as inputSchema
+    // directly, preserving .strict() validation that rejects unrecognized keys.
+    // The server.tool() overload treats ZodObjects as annotations, not schemas.
+    server.registerTool(
+      tool.name,
+      { description, inputSchema },
+      async (args) =>
+        formatResult(await handler(args as Record<string, unknown>, stateDir)),
     );
   }
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/registry.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
-import { buildCompositeSchema, TOOL_REGISTRY } from './registry.js';
+import { buildCompositeSchema, buildRegistrationSchema, TOOL_REGISTRY } from './registry.js';
 import type { ToolAction } from './registry.js';
 
 describe('buildCompositeSchema', () => {
@@ -39,6 +39,65 @@ describe('buildCompositeSchema', () => {
     // Should reject an invalid action
     const invalidResult = schema.safeParse({ action: 'invalid' });
     expect(invalidResult.success).toBe(false);
+  });
+});
+
+describe('buildRegistrationSchema', () => {
+  const testActions: readonly ToolAction[] = [
+    {
+      name: 'append',
+      description: 'Append an event',
+      schema: z.object({
+        stream: z.string().min(1),
+        event: z.record(z.string(), z.unknown()),
+      }),
+      phases: new Set(['ideate']),
+      roles: new Set(['any']),
+    },
+    {
+      name: 'query',
+      description: 'Query events',
+      schema: z.object({
+        stream: z.string().min(1),
+        limit: z.number().optional(),
+      }),
+      phases: new Set(['ideate']),
+      roles: new Set(['any']),
+    },
+  ];
+
+  it('should reject unrecognized parameters with a clear error', () => {
+    const schema = buildRegistrationSchema(testActions);
+
+    // "streamId" is a typo for "stream" — should be rejected, not silently dropped
+    const result = schema.safeParse({
+      action: 'append',
+      streamId: 'workflow-123',
+      event: { type: 'test' },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const errorMessage = result.error.message;
+      expect(errorMessage).toContain('streamId');
+    }
+  });
+
+  it('should accept valid parameters', () => {
+    const schema = buildRegistrationSchema(testActions);
+
+    const result = schema.safeParse({
+      action: 'append',
+      stream: 'workflow-123',
+      event: { type: 'test' },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should return a ZodObject, not a raw shape', () => {
+    const schema = buildRegistrationSchema(testActions);
+    expect(schema).toBeInstanceOf(z.ZodObject);
   });
 });
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
@@ -45,7 +45,7 @@ export function buildCompositeSchema(
 }
 
 /**
- * Builds a flat Zod raw shape for MCP SDK tool registration.
+ * Builds a strict Zod object schema for MCP SDK tool registration.
  *
  * The MCP SDK's `normalizeObjectSchema` cannot generate JSON Schema from
  * discriminated unions, so we flatten the composite schema into a single
@@ -53,10 +53,14 @@ export function buildCompositeSchema(
  *
  * The composite handler performs action-level routing and the underlying
  * handlers validate required fields per action.
+ *
+ * The returned schema uses `.strict()` so that unrecognized parameter names
+ * (e.g., `streamId` instead of `stream`) produce clear validation errors
+ * instead of being silently dropped.
  */
 export function buildRegistrationSchema(
   actions: readonly ToolAction[],
-): z.ZodRawShape {
+): z.ZodObject<z.ZodRawShape> {
   const actionNames = actions.map((a) => a.name) as [string, ...string[]];
   const shape: z.ZodRawShape = {
     action: z.enum(actionNames),
@@ -73,7 +77,7 @@ export function buildRegistrationSchema(
     }
   }
 
-  return shape;
+  return z.object(shape).strict();
 }
 
 /**


### PR DESCRIPTION
## Summary

Composite tool schemas in the Exarchos MCP server silently dropped unrecognized parameter names because `z.object()` was used without `.strict()`. This caused typos like `streamId` instead of `stream` to produce misleading validation errors about unrelated required fields, rather than flagging the unrecognized key directly.

## Changes

- **registry.ts** — Changed `buildRegistrationSchema` to return a `z.ZodObject` with `.strict()` instead of a plain `ZodRawShape`, so Zod rejects unrecognized keys with clear error messages
- **index.ts** — Switched from `server.tool()` to `server.registerTool()` for tool registration, because the MCP SDK's `tool()` overload misidentifies `ZodObject` instances as annotations rather than input schemas
- **registry.test.ts** — Added 3 tests verifying strict schema validation: rejects unrecognized params with clear errors, accepts valid params, and confirms the return type is a `ZodObject`
- **index.test.ts** — Updated mock to include `registerTool` and adjusted schema assertion to check `.shape` property on the `ZodObject`

## Test Plan

All 1086 MCP server tests pass, including 3 new tests for strict schema validation. Root-level tests (223) also pass. TypeScript typecheck clean.

---

**Results:** Tests 1086 + 223 = 1309 passing | Build 0 errors