### PR TITLE
feat: add refactor validation scripts (#275 Phase 4)

### DIFF
--- a/scripts/assess-refactor-scope.sh
+++ b/scripts/assess-refactor-scope.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# Assess Refactor Scope
+# Assesses scope and recommends track (polish vs overhaul).
+# Replaces explore phase scope assessment prose with deterministic validation.
+#
+# Usage: assess-refactor-scope.sh --files <file1,file2,...> | --state-file <path>
+#
+# Exit codes:
+#   0 = polish recommended
+#   1 = overhaul recommended
+#   2 = usage error (missing required args)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ============================================================
+# ARGUMENT PARSING
+# ============================================================
+
+FILES=""
+STATE_FILE=""
+
+usage() {
+    cat << 'USAGE'
+Usage: assess-refactor-scope.sh --files <file1,file2,...> | --state-file <path>
+
+Required (one of):
+  --files <file1,file2,...>   Comma-separated list of affected files
+  --state-file <path>        Path to workflow state JSON (reads explore.scopeAssessment.filesAffected)
+
+Optional:
+  --help                     Show this help message
+
+Exit codes:
+  0  Polish recommended (<=5 files, single module, good test coverage)
+  1  Overhaul recommended (scope exceeds polish limits)
+  2  Usage error (missing required args)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --files)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --files requires a comma-separated list" >&2
+                exit 2
+            fi
+            FILES="$2"
+            shift 2
+            ;;
+        --state-file)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --state-file requires a path argument" >&2
+                exit 2
+            fi
+            STATE_FILE="$2"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$FILES" && -z "$STATE_FILE" ]]; then
+    echo "Error: --files or --state-file is required" >&2
+    usage >&2
+    exit 2
+fi
+
+# ============================================================
+# DEPENDENCY CHECK
+# ============================================================
+
+if [[ -n "$STATE_FILE" ]]; then
+    if ! command -v jq &>/dev/null; then
+        echo "Error: jq is required but not installed" >&2
+        exit 2
+    fi
+fi
+
+# ============================================================
+# PARSE FILES
+# ============================================================
+
+FILE_LIST=()
+
+if [[ -n "$STATE_FILE" ]]; then
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo "Error: State file not found: $STATE_FILE" >&2
+        exit 2
+    fi
+    # Read files from state file
+    while IFS= read -r line; do
+        FILE_LIST+=("$line")
+    done < <(jq -r '.explore.scopeAssessment.filesAffected[]' "$STATE_FILE" 2>/dev/null)
+elif [[ -n "$FILES" ]]; then
+    IFS=',' read -ra FILE_LIST <<< "$FILES"
+fi
+
+FILE_COUNT=${#FILE_LIST[@]}
+
+# ============================================================
+# ASSESS SCOPE
+# ============================================================
+
+CHECK_PASS=0
+CHECK_FAIL=0
+RESULTS=()
+
+check_pass() {
+    local name="$1"
+    RESULTS+=("- **PASS**: $name")
+    CHECK_PASS=$((CHECK_PASS + 1))
+}
+
+check_fail() {
+    local name="$1"
+    local detail="${2:-}"
+    if [[ -n "$detail" ]]; then
+        RESULTS+=("- **FAIL**: $name — $detail")
+    else
+        RESULTS+=("- **FAIL**: $name")
+    fi
+    CHECK_FAIL=$((CHECK_FAIL + 1))
+}
+
+# Check 1: File count (<=5 for polish)
+if [[ $FILE_COUNT -le 5 ]]; then
+    check_pass "File count within polish limit ($FILE_COUNT <= 5)"
+else
+    check_fail "File count exceeds polish limit" "$FILE_COUNT files (max 5)"
+fi
+
+# Check 2: Cross-module span
+# Extract unique top-level directories (Bash 3 compatible — no associative arrays)
+MODULE_LIST=""
+for f in "${FILE_LIST[@]}"; do
+    top_dir="$(echo "$f" | cut -d'/' -f1)"
+    # Add to list if not already present
+    if ! echo "$MODULE_LIST" | grep -qF "|$top_dir|"; then
+        MODULE_LIST="${MODULE_LIST}|$top_dir|"
+    fi
+done
+# Count unique modules
+MODULE_COUNT=0
+MODULE_NAMES=""
+if [[ -n "$MODULE_LIST" ]]; then
+    MODULE_NAMES="$(echo "$MODULE_LIST" | tr '|' '\n' | sort -u | grep -v '^$' | tr '\n' ' ')"
+    MODULE_COUNT="$(echo "$MODULE_LIST" | tr '|' '\n' | sort -u | grep -vc '^$' || true)"
+fi
+
+if [[ $MODULE_COUNT -le 1 ]]; then
+    check_pass "Single module scope ($MODULE_NAMES)"
+else
+    check_fail "Cross-module span detected" "$MODULE_COUNT modules: $MODULE_NAMES"
+fi
+
+# Check 3: Test coverage (check if .test.ts/.test.sh files exist for affected files)
+MISSING_TESTS=()
+for f in "${FILE_LIST[@]}"; do
+    # Skip files that are already test files
+    if [[ "$f" == *.test.ts || "$f" == *.test.sh ]]; then
+        continue
+    fi
+    # Skip non-source files
+    if [[ "$f" != *.ts && "$f" != *.sh ]]; then
+        continue
+    fi
+    # Derive expected test file name
+    if [[ "$f" == *.ts ]]; then
+        test_file="${f%.ts}.test.ts"
+    elif [[ "$f" == *.sh ]]; then
+        test_file="${f%.sh}.test.sh"
+    fi
+    # We can only check existence if we have a reference directory,
+    # but for scope assessment we just note the expected test counterparts
+    MISSING_TESTS+=("$test_file")
+done
+
+# For scope assessment purposes, having test counterparts is informational
+if [[ ${#MISSING_TESTS[@]} -eq 0 ]]; then
+    check_pass "Test coverage assessment (all source files have known patterns)"
+else
+    # This is informational, not a hard fail for track decision
+    check_pass "Test coverage assessment (${#MISSING_TESTS[@]} test counterparts to verify)"
+fi
+
+# ============================================================
+# DETERMINE RECOMMENDATION
+# ============================================================
+
+RECOMMENDATION="polish"
+if [[ $FILE_COUNT -gt 5 ]]; then
+    RECOMMENDATION="overhaul"
+fi
+if [[ $MODULE_COUNT -gt 1 ]]; then
+    RECOMMENDATION="overhaul"
+fi
+
+# ============================================================
+# STRUCTURED OUTPUT
+# ============================================================
+
+echo "## Scope Assessment Report"
+echo ""
+echo "**Files affected:** $FILE_COUNT"
+echo "**Modules:** ${MODULE_NAMES:-}"
+echo "**Recommendation:** $RECOMMENDATION"
+echo ""
+
+for result in "${RESULTS[@]}"; do
+    echo "$result"
+done
+
+echo ""
+echo "---"
+echo ""
+
+if [[ "$RECOMMENDATION" == "polish" ]]; then
+    echo "**Result: POLISH** — Scope is within polish limits"
+    exit 0
+else
+    echo "**Result: OVERHAUL** — Scope exceeds polish limits"
+    exit 1
+fi

--- a/scripts/assess-refactor-scope.test.sh
+++ b/scripts/assess-refactor-scope.test.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Assess Refactor Scope — Test Suite
+# Validates scope assessment and track recommendation logic.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/assess-refactor-scope.sh"
+PASS=0
+FAIL=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAIL=$((FAIL + 1))
+}
+
+# ============================================================
+# TEST FIXTURES
+# ============================================================
+
+TMPDIR_ROOT=""
+
+setup() {
+    TMPDIR_ROOT="$(mktemp -d)"
+}
+
+teardown() {
+    if [[ -n "$TMPDIR_ROOT" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+
+# Create a minimal project structure for testing
+create_project() {
+    local dir="$1"
+    local project="$dir/project"
+    mkdir -p "$project/src" "$project/tests"
+
+    # Create some source files
+    echo 'export function foo() {}' > "$project/src/foo.ts"
+    echo 'export function bar() {}' > "$project/src/bar.ts"
+    echo 'export function baz() {}' > "$project/src/baz.ts"
+
+    # Create test files for foo and bar only
+    echo 'test("foo", () => {})' > "$project/src/foo.test.ts"
+    echo 'test("bar", () => {})' > "$project/src/bar.test.ts"
+
+    echo "$project"
+}
+
+# Create a state file with scope assessment
+create_state_with_files() {
+    local dir="$1"
+    shift
+    local files_json="["
+    local first=true
+    for f in "$@"; do
+        if [[ "$first" == true ]]; then
+            first=false
+        else
+            files_json+=","
+        fi
+        files_json+="\"$f\""
+    done
+    files_json+="]"
+
+    cat > "$dir/test.state.json" << EOF
+{
+  "version": "1.1",
+  "featureId": "refactor-test",
+  "workflowType": "refactor",
+  "phase": "explore",
+  "explore": {
+    "scopeAssessment": {
+      "filesAffected": $files_json
+    }
+  }
+}
+EOF
+    echo "$dir/test.state.json"
+}
+
+# ============================================================
+# TEST CASES
+# ============================================================
+
+echo "=== Assess Refactor Scope Tests ==="
+echo ""
+
+# --------------------------------------------------
+# Test 1: FewFiles_SingleModule_RecommendsPolish_ExitsZero
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --files "src/foo.ts,src/bar.ts,src/baz.ts" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "FewFiles_SingleModule_RecommendsPolish_ExitsZero"
+else
+    fail "FewFiles_SingleModule_RecommendsPolish_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 2: ManyFiles_RecommendsOverhaul_ExitsOne
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --files "src/a.ts,src/b.ts,src/c.ts,src/d.ts,src/e.ts,src/f.ts" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "ManyFiles_RecommendsOverhaul_ExitsOne"
+else
+    fail "ManyFiles_RecommendsOverhaul_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 3: CrossModule_RecommendsOverhaul_ExitsOne
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --files "src/foo.ts,plugins/bar.ts,commands/baz.ts" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "CrossModule_RecommendsOverhaul_ExitsOne"
+else
+    fail "CrossModule_RecommendsOverhaul_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 4: FilesFlag_ParsesCommaSeparated
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --files "src/a.ts,src/b.ts" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+# Should contain file count of 2
+if echo "$OUTPUT" | grep -q "2"; then
+    pass "FilesFlag_ParsesCommaSeparated"
+else
+    fail "FilesFlag_ParsesCommaSeparated (output does not mention file count 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 5: StateFileFlag_ReadsFromState
+# --------------------------------------------------
+setup
+STATE_FILE="$(create_state_with_files "$TMPDIR_ROOT" "src/foo.ts" "src/bar.ts")"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --state-file "$STATE_FILE" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "StateFileFlag_ReadsFromState"
+else
+    fail "StateFileFlag_ReadsFromState (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 6: UsageError_NoArgs_ExitsTwo
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "UsageError_NoArgs_ExitsTwo"
+else
+    fail "UsageError_NoArgs_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 7: OutputContainsScopeAssessment
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --files "src/foo.ts,src/bar.ts" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+# Check for key assessment components in output
+if echo "$OUTPUT" | grep -qi "scope\|assessment\|recommendation\|file"; then
+    pass "OutputContainsScopeAssessment"
+else
+    fail "OutputContainsScopeAssessment (output missing scope assessment info)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "=== Test Summary ==="
+echo -e "Passed: ${GREEN}$PASS${NC}"
+echo -e "Failed: ${RED}$FAIL${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/scripts/check-polish-scope.sh
+++ b/scripts/check-polish-scope.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Check Polish Scope
+# Checks if polish scope has expanded beyond limits.
+# Replaces "Scope Expansion Triggers" prose with deterministic validation.
+#
+# Usage: check-polish-scope.sh --repo-root <path> [--base-branch main]
+#
+# Exit codes:
+#   0 = scope OK (stay polish)
+#   1 = scope expanded (switch to overhaul)
+#   2 = usage error (missing required args)
+
+set -euo pipefail
+
+# ============================================================
+# ARGUMENT PARSING
+# ============================================================
+
+REPO_ROOT=""
+BASE_BRANCH="main"
+
+usage() {
+    cat << 'USAGE'
+Usage: check-polish-scope.sh --repo-root <path> [--base-branch main]
+
+Required:
+  --repo-root <path>      Path to the git repository root
+
+Optional:
+  --base-branch <branch>  Base branch to diff against (default: main)
+  --help                  Show this help message
+
+Exit codes:
+  0  Scope OK — within polish limits
+  1  Scope expanded — switch to overhaul
+  2  Usage error (missing required args)
+
+Expansion triggers checked:
+  - File count > 5 (modified files via git diff)
+  - Module boundaries crossed (>2 top-level dirs modified)
+  - New test files needed (impl files without test counterparts)
+  - Architectural docs needed (detected heuristically)
+
+  Note: Assumes co-located tests (foo.test.ts alongside foo.ts)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo-root)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --repo-root requires a path argument" >&2
+                exit 2
+            fi
+            REPO_ROOT="$2"
+            shift 2
+            ;;
+        --base-branch)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --base-branch requires a branch name" >&2
+                exit 2
+            fi
+            BASE_BRANCH="$2"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$REPO_ROOT" ]]; then
+    echo "Error: --repo-root is required" >&2
+    usage >&2
+    exit 2
+fi
+
+# ============================================================
+# DEPENDENCY CHECK
+# ============================================================
+
+if ! command -v git &>/dev/null; then
+    echo "Error: git is required but not installed" >&2
+    exit 2
+fi
+
+# ============================================================
+# CHECK FUNCTIONS
+# ============================================================
+
+CHECK_PASS=0
+CHECK_FAIL=0
+RESULTS=()
+TRIGGERS_FIRED=()
+
+check_pass() {
+    local name="$1"
+    RESULTS+=("- **PASS**: $name")
+    CHECK_PASS=$((CHECK_PASS + 1))
+}
+
+check_fail() {
+    local name="$1"
+    local detail="${2:-}"
+    if [[ -n "$detail" ]]; then
+        RESULTS+=("- **FAIL**: $name — $detail")
+    else
+        RESULTS+=("- **FAIL**: $name")
+    fi
+    CHECK_FAIL=$((CHECK_FAIL + 1))
+}
+
+# ============================================================
+# GET MODIFIED FILES
+# ============================================================
+
+cd "$REPO_ROOT"
+
+# Get list of files modified compared to base branch
+MODIFIED_FILES=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && MODIFIED_FILES+=("$line")
+done < <(git diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null || git diff --name-only "$BASE_BRANCH" HEAD 2>/dev/null || true)
+
+FILE_COUNT=${#MODIFIED_FILES[@]}
+
+# ============================================================
+# TRIGGER 1: File count > 5
+# ============================================================
+
+if [[ $FILE_COUNT -le 5 ]]; then
+    check_pass "File count within limit ($FILE_COUNT <= 5)"
+else
+    check_fail "File count exceeds limit" "$FILE_COUNT files modified (max 5)"
+    TRIGGERS_FIRED+=("File count ($FILE_COUNT) exceeds limit of 5")
+fi
+
+# ============================================================
+# TRIGGER 2: Module boundaries crossed (>2 top-level dirs)
+# ============================================================
+
+# Bash 3 compatible — no associative arrays
+MODULE_LIST=""
+for f in "${MODIFIED_FILES[@]}"; do
+    top_dir="$(echo "$f" | cut -d'/' -f1)"
+    if ! echo "$MODULE_LIST" | grep -qF "|$top_dir|"; then
+        MODULE_LIST="${MODULE_LIST}|$top_dir|"
+    fi
+done
+MODULE_COUNT=0
+MODULE_NAMES=""
+if [[ -n "$MODULE_LIST" ]]; then
+    MODULE_NAMES="$(echo "$MODULE_LIST" | tr '|' '\n' | sort -u | grep -v '^$' | tr '\n' ' ')"
+    MODULE_COUNT="$(echo "$MODULE_LIST" | tr '|' '\n' | sort -u | grep -vc '^$' || true)"
+fi
+
+if [[ $MODULE_COUNT -le 2 ]]; then
+    check_pass "Module boundaries OK ($MODULE_COUNT top-level dirs)"
+else
+    check_fail "Module boundaries crossed" "$MODULE_COUNT top-level dirs: $MODULE_NAMES"
+    TRIGGERS_FIRED+=("Module boundaries crossed ($MODULE_COUNT dirs: $MODULE_NAMES)")
+fi
+
+# ============================================================
+# TRIGGER 3: New test files needed
+# ============================================================
+
+MISSING_TESTS=()
+for f in "${MODIFIED_FILES[@]}"; do
+    # Only check .ts implementation files
+    if [[ "$f" == *.ts && "$f" != *.test.ts && "$f" != *.d.ts ]]; then
+        test_file="${f%.ts}.test.ts"
+        if [[ ! -f "$test_file" ]]; then
+            MISSING_TESTS+=("$f")
+        fi
+    fi
+done
+
+if [[ ${#MISSING_TESTS[@]} -eq 0 ]]; then
+    check_pass "Test coverage OK (all impl files have test counterparts)"
+else
+    check_fail "New test files needed" "${#MISSING_TESTS[@]} impl files without tests: ${MISSING_TESTS[*]}"
+    TRIGGERS_FIRED+=("New test files needed for ${#MISSING_TESTS[@]} files")
+fi
+
+# ============================================================
+# TRIGGER 4: Architectural docs needed (heuristic)
+# ============================================================
+
+NEEDS_ARCH_DOCS=false
+for f in "${MODIFIED_FILES[@]}"; do
+    # Heuristic: if modifying files in multiple top-level dirs with structural changes
+    if [[ "$f" == *"index.ts" || "$f" == *"types.ts" || "$f" == *"interface"* ]]; then
+        if [[ $MODULE_COUNT -gt 1 ]]; then
+            NEEDS_ARCH_DOCS=true
+            break
+        fi
+    fi
+done
+
+if [[ "$NEEDS_ARCH_DOCS" == false ]]; then
+    check_pass "No architectural docs needed"
+else
+    check_fail "Architectural documentation likely needed" "Structural files modified across modules"
+    TRIGGERS_FIRED+=("Architectural documentation needed")
+fi
+
+# ============================================================
+# STRUCTURED OUTPUT
+# ============================================================
+
+echo "## Polish Scope Check Report"
+echo ""
+echo "**Repository:** \`$REPO_ROOT\`"
+echo "**Base branch:** $BASE_BRANCH"
+echo "**Files modified:** $FILE_COUNT"
+echo "**Modules touched:** $MODULE_COUNT (${MODULE_NAMES:-none})"
+echo ""
+
+for result in "${RESULTS[@]}"; do
+    echo "$result"
+done
+
+echo ""
+echo "---"
+echo ""
+
+if [[ ${#TRIGGERS_FIRED[@]} -eq 0 ]]; then
+    echo "**Result: SCOPE OK** — All within polish limits"
+    exit 0
+else
+    echo "**Result: SCOPE EXPANDED** — Switch to overhaul track"
+    echo ""
+    echo "Triggers fired:"
+    for trigger in "${TRIGGERS_FIRED[@]}"; do
+        echo "  - $trigger"
+    done
+    exit 1
+fi

--- a/scripts/check-polish-scope.test.sh
+++ b/scripts/check-polish-scope.test.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Check Polish Scope — Test Suite
+# Validates scope expansion detection during polish track.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/check-polish-scope.sh"
+PASS=0
+FAIL=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAIL=$((FAIL + 1))
+}
+
+# ============================================================
+# TEST FIXTURES
+# ============================================================
+
+TMPDIR_ROOT=""
+
+setup() {
+    TMPDIR_ROOT="$(mktemp -d)"
+}
+
+teardown() {
+    if [[ -n "$TMPDIR_ROOT" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+
+# Create a git repo with a given number of modified files in specified directories
+create_git_repo() {
+    local dir="$1"
+    shift
+    local files=("$@")
+
+    mkdir -p "$dir"
+    cd "$dir"
+    git init -q
+    git checkout -q -b main
+
+    # Create initial commit with package.json
+    echo '{}' > package.json
+    git add package.json
+    git commit -q -m "initial"
+
+    # Create feature branch
+    git checkout -q -b feature
+
+    # Create modified files
+    for f in "${files[@]}"; do
+        mkdir -p "$(dirname "$f")"
+        echo "modified" > "$f"
+        # Also create test file if it's a .ts file (for test coverage check)
+        local test_file="${f%.ts}.test.ts"
+        if [[ "$f" == *.ts && ! "$f" == *.test.ts ]]; then
+            # Don't create test file — let the test decide
+            :
+        fi
+        git add "$f"
+    done
+    git commit -q -m "feature changes"
+
+    cd - > /dev/null
+    echo "$dir"
+}
+
+# Create test counterpart files
+add_test_files() {
+    local dir="$1"
+    shift
+    for f in "$@"; do
+        local test_file="${f%.ts}.test.ts"
+        mkdir -p "$dir/$(dirname "$test_file")"
+        echo "test" > "$dir/$test_file"
+        cd "$dir"
+        git add "$test_file"
+        git commit -q -m "add test for $f"
+        cd - > /dev/null
+    done
+}
+
+# ============================================================
+# TEST CASES
+# ============================================================
+
+echo "=== Check Polish Scope Tests ==="
+echo ""
+
+# --------------------------------------------------
+# Test 1: WithinLimits_ExitsZero
+# --------------------------------------------------
+setup
+# Create only 2 source files with their test counterparts in a single commit (4 files total, <= 5)
+REPO="$(create_git_repo "$TMPDIR_ROOT/repo1" "src/foo.ts" "src/bar.ts")"
+add_test_files "$REPO" "src/foo.ts" "src/bar.ts"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --repo-root "$REPO" --base-branch main 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "WithinLimits_ExitsZero"
+else
+    fail "WithinLimits_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 2: TooManyFiles_ExitsOne
+# --------------------------------------------------
+setup
+REPO="$(create_git_repo "$TMPDIR_ROOT/repo2" "src/a.ts" "src/b.ts" "src/c.ts" "src/d.ts" "src/e.ts" "src/f.ts")"
+add_test_files "$REPO" "src/a.ts" "src/b.ts" "src/c.ts" "src/d.ts" "src/e.ts" "src/f.ts"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --repo-root "$REPO" --base-branch main 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "TooManyFiles_ExitsOne"
+else
+    fail "TooManyFiles_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 3: CrossModuleBoundary_ExitsOne
+# --------------------------------------------------
+setup
+REPO="$(create_git_repo "$TMPDIR_ROOT/repo3" "src/foo.ts" "plugins/bar.ts" "commands/baz.ts")"
+add_test_files "$REPO" "src/foo.ts" "plugins/bar.ts" "commands/baz.ts"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --repo-root "$REPO" --base-branch main 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "CrossModuleBoundary_ExitsOne"
+else
+    fail "CrossModuleBoundary_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 4: MissingTestFiles_ExitsOne
+# --------------------------------------------------
+setup
+REPO="$(create_git_repo "$TMPDIR_ROOT/repo4" "src/foo.ts" "src/bar.ts")"
+# Don't add test files — triggers "new test files needed"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --repo-root "$REPO" --base-branch main 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "MissingTestFiles_ExitsOne"
+else
+    fail "MissingTestFiles_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 5: OutputShowsTrigger
+# --------------------------------------------------
+setup
+REPO="$(create_git_repo "$TMPDIR_ROOT/repo5" "src/a.ts" "src/b.ts" "src/c.ts" "src/d.ts" "src/e.ts" "src/f.ts")"
+add_test_files "$REPO" "src/a.ts" "src/b.ts" "src/c.ts" "src/d.ts" "src/e.ts" "src/f.ts"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --repo-root "$REPO" --base-branch main 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+# Output should mention the trigger that fired
+if echo "$OUTPUT" | grep -qi "file count\|files modified\|trigger\|exceeds"; then
+    pass "OutputShowsTrigger"
+else
+    fail "OutputShowsTrigger (output missing trigger info)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 6: UsageError_ExitsTwo
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "UsageError_ExitsTwo"
+else
+    fail "UsageError_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "=== Test Summary ==="
+echo -e "Passed: ${GREEN}$PASS${NC}"
+echo -e "Failed: ${RED}$FAIL${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/scripts/validate-refactor.sh
+++ b/scripts/validate-refactor.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Validate Refactor
+# Runs tests/lint/typecheck with structured pass/fail output.
+# Replaces validate phase prose checklist with deterministic validation.
+#
+# Usage: validate-refactor.sh --repo-root <path> [--skip-lint] [--skip-typecheck]
+#
+# Exit codes:
+#   0 = all checks pass
+#   1 = one or more checks failed
+#   2 = usage error (missing required args)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ============================================================
+# ARGUMENT PARSING
+# ============================================================
+
+REPO_ROOT=""
+SKIP_LINT=false
+SKIP_TYPECHECK=false
+
+usage() {
+    cat << 'USAGE'
+Usage: validate-refactor.sh --repo-root <path> [--skip-lint] [--skip-typecheck]
+
+Required:
+  --repo-root <path>    Path to the repository root (must contain package.json)
+
+Optional:
+  --skip-lint           Skip lint check
+  --skip-typecheck      Skip typecheck
+  --help                Show this help message
+
+Exit codes:
+  0  All checks pass
+  1  One or more checks failed
+  2  Usage error (missing required args)
+
+Checks performed:
+  - npm run test:run (required)
+  - npm run lint (skipped if missing or --skip-lint)
+  - npm run typecheck (skipped if missing or --skip-typecheck)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo-root)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --repo-root requires a path argument" >&2
+                exit 2
+            fi
+            REPO_ROOT="$2"
+            shift 2
+            ;;
+        --skip-lint)
+            SKIP_LINT=true
+            shift
+            ;;
+        --skip-typecheck)
+            SKIP_TYPECHECK=true
+            shift
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$REPO_ROOT" ]]; then
+    echo "Error: --repo-root is required" >&2
+    usage >&2
+    exit 2
+fi
+
+# ============================================================
+# CHECK FUNCTIONS
+# ============================================================
+
+CHECK_PASS=0
+CHECK_FAIL=0
+RESULTS=()
+
+check_pass() {
+    local name="$1"
+    RESULTS+=("- **PASS**: $name")
+    CHECK_PASS=$((CHECK_PASS + 1))
+}
+
+check_fail() {
+    local name="$1"
+    local detail="${2:-}"
+    if [[ -n "$detail" ]]; then
+        RESULTS+=("- **FAIL**: $name — $detail")
+    else
+        RESULTS+=("- **FAIL**: $name")
+    fi
+    CHECK_FAIL=$((CHECK_FAIL + 1))
+}
+
+check_skip() {
+    local name="$1"
+    RESULTS+=("- **SKIP**: $name")
+}
+
+# ============================================================
+# HELPER: Check if npm script exists in package.json
+# ============================================================
+
+has_npm_script() {
+    local script_name="$1"
+    if [[ -f "$REPO_ROOT/package.json" ]]; then
+        # Use node or jq to check; fall back to grep
+        if command -v jq &>/dev/null; then
+            jq -e ".scripts[\"$script_name\"]" "$REPO_ROOT/package.json" &>/dev/null
+            return $?
+        else
+            grep -q "\"$script_name\"" "$REPO_ROOT/package.json" 2>/dev/null
+            return $?
+        fi
+    fi
+    return 1
+}
+
+# ============================================================
+# CHECK 1: Tests (npm run test:run)
+# ============================================================
+
+check_tests() {
+    local output
+    if ! output="$(cd "$REPO_ROOT" && npm run test:run 2>&1)"; then
+        check_fail "Tests (npm run test:run)" "Tests failed"
+        return 1
+    fi
+    check_pass "Tests (npm run test:run)"
+    return 0
+}
+
+# ============================================================
+# CHECK 2: Lint (npm run lint)
+# ============================================================
+
+check_lint() {
+    if [[ "$SKIP_LINT" == true ]]; then
+        check_skip "Lint (--skip-lint)"
+        return 0
+    fi
+
+    if ! has_npm_script "lint"; then
+        check_skip "Lint (no lint script in package.json)"
+        return 0
+    fi
+
+    local output
+    if ! output="$(cd "$REPO_ROOT" && npm run lint 2>&1)"; then
+        check_fail "Lint (npm run lint)" "Lint errors found"
+        return 1
+    fi
+    check_pass "Lint (npm run lint)"
+    return 0
+}
+
+# ============================================================
+# CHECK 3: Typecheck (npm run typecheck)
+# ============================================================
+
+check_typecheck() {
+    if [[ "$SKIP_TYPECHECK" == true ]]; then
+        check_skip "Typecheck (--skip-typecheck)"
+        return 0
+    fi
+
+    if ! has_npm_script "typecheck"; then
+        check_skip "Typecheck (no typecheck script in package.json)"
+        return 0
+    fi
+
+    local output
+    if ! output="$(cd "$REPO_ROOT" && npm run typecheck 2>&1)"; then
+        check_fail "Typecheck (npm run typecheck)" "Type errors found"
+        return 1
+    fi
+    check_pass "Typecheck (npm run typecheck)"
+    return 0
+}
+
+# ============================================================
+# EXECUTE CHECKS
+# ============================================================
+
+check_tests || true
+check_lint || true
+check_typecheck || true
+
+# ============================================================
+# STRUCTURED OUTPUT
+# ============================================================
+
+echo "## Refactor Validation Report"
+echo ""
+echo "**Repository:** \`$REPO_ROOT\`"
+echo ""
+
+for result in "${RESULTS[@]}"; do
+    echo "$result"
+done
+
+echo ""
+TOTAL=$((CHECK_PASS + CHECK_FAIL))
+echo "---"
+echo ""
+
+if [[ $CHECK_FAIL -eq 0 ]]; then
+    echo "**Result: PASS** ($CHECK_PASS/$TOTAL checks passed)"
+    exit 0
+else
+    echo "**Result: FAIL** ($CHECK_FAIL/$TOTAL checks failed)"
+    exit 1
+fi

--- a/scripts/validate-refactor.test.sh
+++ b/scripts/validate-refactor.test.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# Validate Refactor — Test Suite
+# Validates test/lint/typecheck execution with structured output.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/validate-refactor.sh"
+PASS=0
+FAIL=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAIL=$((FAIL + 1))
+}
+
+# ============================================================
+# TEST FIXTURES
+# ============================================================
+
+TMPDIR_ROOT=""
+
+setup() {
+    TMPDIR_ROOT="$(mktemp -d)"
+    MOCK_BIN="$TMPDIR_ROOT/mock-bin"
+    mkdir -p "$MOCK_BIN"
+}
+
+teardown() {
+    if [[ -n "$TMPDIR_ROOT" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+
+# Create a repo root with package.json containing all scripts
+create_repo_all_pass() {
+    local dir="$1"
+    mkdir -p "$dir"
+
+    # Create package.json with all scripts
+    cat > "$dir/package.json" << 'EOF'
+{
+  "scripts": {
+    "test:run": "echo tests passed",
+    "lint": "echo lint passed",
+    "typecheck": "echo typecheck passed"
+  }
+}
+EOF
+
+    # Mock npm that reads package.json and succeeds for all scripts
+    cat > "$MOCK_BIN/npm" << 'MOCKEOF'
+#!/usr/bin/env bash
+# Simulate npm run — always succeeds
+exit 0
+MOCKEOF
+    chmod +x "$MOCK_BIN/npm"
+
+    echo "$dir"
+}
+
+# Create repo where tests fail
+create_repo_tests_fail() {
+    local dir="$1"
+    mkdir -p "$dir"
+
+    cat > "$dir/package.json" << 'EOF'
+{
+  "scripts": {
+    "test:run": "echo tests failed && exit 1",
+    "lint": "echo lint passed",
+    "typecheck": "echo typecheck passed"
+  }
+}
+EOF
+
+    cat > "$MOCK_BIN/npm" << 'MOCKEOF'
+#!/usr/bin/env bash
+# test:run fails, others succeed
+if [[ "${2:-}" == "test:run" ]]; then
+    echo "FAIL: some tests failed" >&2
+    exit 1
+fi
+exit 0
+MOCKEOF
+    chmod +x "$MOCK_BIN/npm"
+
+    echo "$dir"
+}
+
+# Create repo where lint fails
+create_repo_lint_fail() {
+    local dir="$1"
+    mkdir -p "$dir"
+
+    cat > "$dir/package.json" << 'EOF'
+{
+  "scripts": {
+    "test:run": "echo tests passed",
+    "lint": "echo lint failed && exit 1",
+    "typecheck": "echo typecheck passed"
+  }
+}
+EOF
+
+    cat > "$MOCK_BIN/npm" << 'MOCKEOF'
+#!/usr/bin/env bash
+if [[ "${2:-}" == "lint" ]]; then
+    echo "FAIL: lint errors found" >&2
+    exit 1
+fi
+exit 0
+MOCKEOF
+    chmod +x "$MOCK_BIN/npm"
+
+    echo "$dir"
+}
+
+# Create repo with no lint script
+create_repo_no_lint() {
+    local dir="$1"
+    mkdir -p "$dir"
+
+    cat > "$dir/package.json" << 'EOF'
+{
+  "scripts": {
+    "test:run": "echo tests passed",
+    "typecheck": "echo typecheck passed"
+  }
+}
+EOF
+
+    cat > "$MOCK_BIN/npm" << 'MOCKEOF'
+#!/usr/bin/env bash
+# No lint script — npm run lint would fail with "missing script"
+if [[ "${2:-}" == "lint" ]]; then
+    echo "npm ERR! Missing script: \"lint\"" >&2
+    exit 1
+fi
+exit 0
+MOCKEOF
+    chmod +x "$MOCK_BIN/npm"
+
+    echo "$dir"
+}
+
+# ============================================================
+# TEST CASES
+# ============================================================
+
+echo "=== Validate Refactor Tests ==="
+echo ""
+
+# --------------------------------------------------
+# Test 1: AllPass_ExitsZero
+# --------------------------------------------------
+setup
+REPO="$(create_repo_all_pass "$TMPDIR_ROOT/repo1")"
+OUTPUT="$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_UNDER_TEST" --repo-root "$REPO" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "AllPass_ExitsZero"
+else
+    fail "AllPass_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 2: TestsFail_ExitsOne
+# --------------------------------------------------
+setup
+REPO="$(create_repo_tests_fail "$TMPDIR_ROOT/repo2")"
+OUTPUT="$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_UNDER_TEST" --repo-root "$REPO" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "TestsFail_ExitsOne"
+else
+    fail "TestsFail_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 3: LintFails_ExitsOne
+# --------------------------------------------------
+setup
+REPO="$(create_repo_lint_fail "$TMPDIR_ROOT/repo3")"
+OUTPUT="$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_UNDER_TEST" --repo-root "$REPO" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "LintFails_ExitsOne"
+else
+    fail "LintFails_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 4: SkipLint_Works
+# --------------------------------------------------
+setup
+REPO="$(create_repo_lint_fail "$TMPDIR_ROOT/repo4")"
+OUTPUT="$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_UNDER_TEST" --repo-root "$REPO" --skip-lint 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "SkipLint_Works"
+else
+    fail "SkipLint_Works (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+# Verify SKIP marker in output
+if echo "$OUTPUT" | grep -qi "SKIP.*lint"; then
+    pass "SkipLint_ShowsSkipMarker"
+else
+    fail "SkipLint_ShowsSkipMarker (no SKIP marker for lint in output)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 5: SkipTypecheck_Works
+# --------------------------------------------------
+setup
+REPO="$(create_repo_all_pass "$TMPDIR_ROOT/repo5")"
+OUTPUT="$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_UNDER_TEST" --repo-root "$REPO" --skip-typecheck 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "SkipTypecheck_Works"
+else
+    fail "SkipTypecheck_Works (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+# Verify SKIP marker in output
+if echo "$OUTPUT" | grep -qi "SKIP.*typecheck"; then
+    pass "SkipTypecheck_ShowsSkipMarker"
+else
+    fail "SkipTypecheck_ShowsSkipMarker (no SKIP marker for typecheck in output)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 6: MissingScript_Skipped
+# --------------------------------------------------
+setup
+REPO="$(create_repo_no_lint "$TMPDIR_ROOT/repo6")"
+OUTPUT="$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_UNDER_TEST" --repo-root "$REPO" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+# Should pass (exit 0) because missing lint script is skipped, not failed
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "MissingScript_Skipped"
+else
+    fail "MissingScript_Skipped (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+# Verify SKIP marker for lint
+if echo "$OUTPUT" | grep -qi "SKIP.*lint"; then
+    pass "MissingScript_ShowsSkipMarker"
+else
+    fail "MissingScript_ShowsSkipMarker (no SKIP marker for missing lint in output)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 7: UsageError_ExitsTwo
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "UsageError_ExitsTwo"
+else
+    fail "UsageError_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 8: StructuredOutput_HasPassFailMarkers
+# --------------------------------------------------
+setup
+REPO="$(create_repo_all_pass "$TMPDIR_ROOT/repo8")"
+OUTPUT="$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_UNDER_TEST" --repo-root "$REPO" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if echo "$OUTPUT" | grep -qE "(PASS|FAIL)"; then
+    pass "StructuredOutput_HasPassFailMarkers"
+else
+    fail "StructuredOutput_HasPassFailMarkers (no PASS/FAIL markers)"
+    echo "  Output: $OUTPUT"
+fi
+# Check for markdown heading
+if echo "$OUTPUT" | grep -qE "^## "; then
+    pass "StructuredOutput_HasMarkdownHeading"
+else
+    fail "StructuredOutput_HasMarkdownHeading (no markdown heading)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "=== Test Summary ==="
+echo -e "Passed: ${GREEN}$PASS${NC}"
+echo -e "Failed: ${RED}$FAIL${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/scripts/verify-doc-links.sh
+++ b/scripts/verify-doc-links.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# Verify Doc Links
+# Checks that internal markdown links resolve to existing files.
+# Replaces manual documentation link verification with deterministic validation.
+#
+# Usage: verify-doc-links.sh --doc-file <path> | --docs-dir <path>
+#
+# Exit codes:
+#   0 = all links valid
+#   1 = broken links found
+#   2 = usage error (missing required args)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ============================================================
+# ARGUMENT PARSING
+# ============================================================
+
+DOC_FILE=""
+DOCS_DIR=""
+
+usage() {
+    cat << 'USAGE'
+Usage: verify-doc-links.sh --doc-file <path> | --docs-dir <path>
+
+Required (one of):
+  --doc-file <path>    Single markdown file to check
+  --docs-dir <path>    Directory to check recursively (all .md files)
+
+Optional:
+  --help               Show this help message
+
+Exit codes:
+  0  All internal links resolve to existing files
+  1  One or more broken links found
+  2  Usage error (missing required args)
+
+Notes:
+  - External URLs (http://, https://) are skipped
+  - Anchor-only links (#section) are skipped
+  - Links with anchors (file.md#section) check the file part only
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --doc-file)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --doc-file requires a path argument" >&2
+                exit 2
+            fi
+            DOC_FILE="$2"
+            shift 2
+            ;;
+        --docs-dir)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --docs-dir requires a path argument" >&2
+                exit 2
+            fi
+            DOCS_DIR="$2"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$DOC_FILE" && -z "$DOCS_DIR" ]]; then
+    echo "Error: --doc-file or --docs-dir is required" >&2
+    usage >&2
+    exit 2
+fi
+
+# ============================================================
+# LINK CHECKING
+# ============================================================
+
+BROKEN_COUNT=0
+CHECKED_COUNT=0
+SKIPPED_COUNT=0
+BROKEN_LINKS=()
+
+check_file() {
+    local file="$1"
+    local file_dir
+    file_dir="$(dirname "$file")"
+    local line_num=0
+
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+
+        # Extract markdown links: [text](target)
+        # Use grep to find all link targets on this line
+        while IFS= read -r target; do
+            [[ -z "$target" ]] && continue
+
+            # Skip external URLs
+            if [[ "$target" == http://* || "$target" == https://* ]]; then
+                SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+                continue
+            fi
+
+            # Skip anchor-only links
+            if [[ "$target" == \#* ]]; then
+                SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+                continue
+            fi
+
+            # Strip anchor from target (file.md#section -> file.md)
+            local file_target="${target%%#*}"
+
+            # Skip if empty after stripping anchor
+            if [[ -z "$file_target" ]]; then
+                SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+                continue
+            fi
+
+            CHECKED_COUNT=$((CHECKED_COUNT + 1))
+
+            # Resolve relative to the file's directory (or use as-is if absolute)
+            local resolved_path
+            if [[ "$file_target" == /* ]]; then
+                resolved_path="$file_target"
+            else
+                resolved_path="$file_dir/$file_target"
+            fi
+
+            if [[ ! -e "$resolved_path" ]]; then
+                BROKEN_COUNT=$((BROKEN_COUNT + 1))
+                BROKEN_LINKS+=("$file:$line_num -> $target (resolved: $resolved_path)")
+            fi
+        done < <(echo "$line" | grep -oE '\[[^]]*\]\([^)]+\)' | sed -E 's/\[[^]]*\]\(([^)]+)\)/\1/g' || true)
+    done < "$file"
+}
+
+# ============================================================
+# COLLECT FILES TO CHECK
+# ============================================================
+
+FILES_TO_CHECK=()
+
+if [[ -n "$DOC_FILE" ]]; then
+    if [[ ! -f "$DOC_FILE" ]]; then
+        echo "Error: File not found: $DOC_FILE" >&2
+        exit 2
+    fi
+    FILES_TO_CHECK+=("$DOC_FILE")
+elif [[ -n "$DOCS_DIR" ]]; then
+    if [[ ! -d "$DOCS_DIR" ]]; then
+        echo "Error: Directory not found: $DOCS_DIR" >&2
+        exit 2
+    fi
+    while IFS= read -r f; do
+        FILES_TO_CHECK+=("$f")
+    done < <(find "$DOCS_DIR" -name "*.md" -type f 2>/dev/null | sort)
+fi
+
+# ============================================================
+# EXECUTE CHECKS
+# ============================================================
+
+for f in "${FILES_TO_CHECK[@]}"; do
+    check_file "$f"
+done
+
+# ============================================================
+# STRUCTURED OUTPUT
+# ============================================================
+
+echo "## Documentation Link Verification Report"
+echo ""
+echo "**Files checked:** ${#FILES_TO_CHECK[@]}"
+echo "**Links checked:** $CHECKED_COUNT"
+echo "**Links skipped:** $SKIPPED_COUNT (external URLs, anchors)"
+echo "**Broken links:** $BROKEN_COUNT"
+echo ""
+
+if [[ $BROKEN_COUNT -gt 0 ]]; then
+    echo "### Broken Links"
+    echo ""
+    for link in "${BROKEN_LINKS[@]}"; do
+        echo "- \`$link\`"
+    done
+    echo ""
+fi
+
+echo "---"
+echo ""
+
+if [[ $BROKEN_COUNT -eq 0 ]]; then
+    echo "**Result: PASS** — All internal links resolve to existing files"
+    exit 0
+else
+    echo "**Result: FAIL** — $BROKEN_COUNT broken link(s) found"
+    exit 1
+fi

--- a/scripts/verify-doc-links.test.sh
+++ b/scripts/verify-doc-links.test.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Verify Doc Links — Test Suite
+# Validates internal markdown link resolution.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/verify-doc-links.sh"
+PASS=0
+FAIL=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAIL=$((FAIL + 1))
+}
+
+# ============================================================
+# TEST FIXTURES
+# ============================================================
+
+TMPDIR_ROOT=""
+
+setup() {
+    TMPDIR_ROOT="$(mktemp -d)"
+}
+
+teardown() {
+    if [[ -n "$TMPDIR_ROOT" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+
+# ============================================================
+# TEST CASES
+# ============================================================
+
+echo "=== Verify Doc Links Tests ==="
+echo ""
+
+# --------------------------------------------------
+# Test 1: AllLinksValid_ExitsZero
+# --------------------------------------------------
+setup
+mkdir -p "$TMPDIR_ROOT/docs"
+echo "some content" > "$TMPDIR_ROOT/docs/other.md"
+cat > "$TMPDIR_ROOT/docs/test.md" << 'EOF'
+# Test Doc
+
+See [other doc](other.md) for details.
+Also check [same dir](./other.md).
+EOF
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --doc-file "$TMPDIR_ROOT/docs/test.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "AllLinksValid_ExitsZero"
+else
+    fail "AllLinksValid_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 2: BrokenLink_ExitsOne
+# --------------------------------------------------
+setup
+mkdir -p "$TMPDIR_ROOT/docs"
+cat > "$TMPDIR_ROOT/docs/test.md" << 'EOF'
+# Test Doc
+
+See [missing doc](nonexistent.md) for details.
+EOF
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --doc-file "$TMPDIR_ROOT/docs/test.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "BrokenLink_ExitsOne"
+else
+    fail "BrokenLink_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+# Check that output mentions the broken link
+if echo "$OUTPUT" | grep -q "nonexistent.md"; then
+    pass "BrokenLink_OutputMentionsTarget"
+else
+    fail "BrokenLink_OutputMentionsTarget (output does not mention broken target)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 3: ExternalUrlSkipped_ExitsZero
+# --------------------------------------------------
+setup
+mkdir -p "$TMPDIR_ROOT/docs"
+cat > "$TMPDIR_ROOT/docs/test.md" << 'EOF'
+# Test Doc
+
+See [Google](https://google.com) and [HTTP site](http://example.com).
+Also [relative](nonexistent-but-external.md) is missing, but let's test external only.
+EOF
+# Create the relative file so only externals are tested
+echo "exists" > "$TMPDIR_ROOT/docs/nonexistent-but-external.md"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --doc-file "$TMPDIR_ROOT/docs/test.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "ExternalUrlSkipped_ExitsZero"
+else
+    fail "ExternalUrlSkipped_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 4: AnchorOnlySkipped_ExitsZero
+# --------------------------------------------------
+setup
+mkdir -p "$TMPDIR_ROOT/docs"
+cat > "$TMPDIR_ROOT/docs/test.md" << 'EOF'
+# Test Doc
+
+See [section below](#some-section) for details.
+And [another anchor](#another) too.
+EOF
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --doc-file "$TMPDIR_ROOT/docs/test.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "AnchorOnlySkipped_ExitsZero"
+else
+    fail "AnchorOnlySkipped_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 5: RecursiveDir_ChecksAllFiles
+# --------------------------------------------------
+setup
+mkdir -p "$TMPDIR_ROOT/docs/sub"
+echo "exists" > "$TMPDIR_ROOT/docs/exists.md"
+cat > "$TMPDIR_ROOT/docs/good.md" << 'EOF'
+[link](exists.md)
+EOF
+cat > "$TMPDIR_ROOT/docs/sub/bad.md" << 'EOF'
+[broken](../missing.md)
+EOF
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --docs-dir "$TMPDIR_ROOT/docs" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "RecursiveDir_ChecksAllFiles"
+else
+    fail "RecursiveDir_ChecksAllFiles (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+# Verify broken link from sub/ is reported
+if echo "$OUTPUT" | grep -q "missing.md"; then
+    pass "RecursiveDir_ReportsBrokenFromSubdir"
+else
+    fail "RecursiveDir_ReportsBrokenFromSubdir (output missing broken link from subdir)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 6: UsageError_ExitsTwo
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "UsageError_ExitsTwo"
+else
+    fail "UsageError_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "=== Test Summary ==="
+echo -e "Passed: ${GREEN}$PASS${NC}"
+echo -e "Failed: ${RED}$FAIL${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -106,16 +106,31 @@ Explore -> Brief -> Implement -> Validate -> Update Docs -> Complete
 
 #### 1. Explore Phase
 
-Use `@skills/refactor/references/explore-checklist.md` to assess:
-- Current code structure
-- Files/modules affected (must be <=5 for polish)
-- Test coverage of affected areas
-- Documentation that needs updates
-- Confirm polish is appropriate
+Use `@skills/refactor/references/explore-checklist.md` to assess current code structure, then run the scope assessment script to determine the recommended track:
+
+```bash
+# Assess scope from a comma-separated file list
+scripts/assess-refactor-scope.sh --files "src/foo.ts,src/bar.ts,src/baz.ts"
+
+# Or read files from workflow state (requires jq)
+scripts/assess-refactor-scope.sh --state-file ~/.claude/workflow-state/<feature>.state.json
+```
+
+> **Dependency:** The `--state-file` option requires `jq` to parse the workflow state JSON. The script will exit with an error if `jq` is not installed.
+
+**What it validates:**
+- File count (<=5 for polish)
+- Cross-module span (files in different top-level directories)
+- Test coverage assessment (test counterparts for source files)
+
+**Exit code routing:**
+- Exit 0 = polish recommended (proceed with polish track)
+- Exit 1 = overhaul recommended (switch to overhaul track)
+- Exit 2 = usage error
 
 Update state using MCP tools:
 1. Use `mcp__exarchos__exarchos_workflow` with `action: "init"` with featureId `refactor-<slug>` and workflowType `refactor`
-2. Use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set track, phase, and explore scope assessment
+2. Use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set track (based on script recommendation), phase, and explore scope assessment
 
 On completion, use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `explore.completedAt` and `phase` to "brief".
 
@@ -151,18 +166,27 @@ Update state on completion using `mcp__exarchos__exarchos_workflow` with `action
 
 #### 4. Validate Phase
 
-Verify refactor goals are met:
-- [ ] All existing tests pass
-- [ ] Each goal in brief is addressed
-- [ ] No new lint/type errors introduced
-- [ ] Code quality improved per brief
+Run the validation script to verify refactor goals are met:
 
-Run validation:
 ```bash
-npm run test:run
-npm run lint  # or equivalent
-npm run typecheck  # if TypeScript
+# Run all checks (tests, lint, typecheck)
+scripts/validate-refactor.sh --repo-root <path>
+
+# Skip optional checks
+scripts/validate-refactor.sh --repo-root <path> --skip-lint --skip-typecheck
 ```
+
+**What it validates:**
+- `npm run test:run` passes (required)
+- `npm run lint` passes (skipped if missing or `--skip-lint`)
+- `npm run typecheck` passes (skipped if missing or `--skip-typecheck`)
+
+**Exit code routing:**
+- Exit 0 = all checks pass (proceed to update-docs)
+- Exit 1 = one or more checks failed (fix before proceeding)
+- Exit 2 = usage error
+
+Additionally verify each goal in brief is addressed and code quality improved per brief (manual review).
 
 Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `validation` object and `phase` to "polish-update-docs".
 
@@ -177,6 +201,26 @@ Use `@skills/refactor/references/doc-update-checklist.md` to update:
 - Inline comments if complex logic moved
 
 If `docsToUpdate` is empty, verify no docs need updating.
+
+After updating documentation, verify all internal links resolve:
+
+```bash
+# Check a single doc file
+scripts/verify-doc-links.sh --doc-file docs/designs/my-design.md
+
+# Check all docs recursively
+scripts/verify-doc-links.sh --docs-dir docs/
+```
+
+**What it validates:**
+- All `[text](path)` markdown links resolve to existing files
+- External URLs (http/https) are skipped
+- Anchor-only links (#section) are skipped
+
+**Exit code routing:**
+- Exit 0 = all internal links valid (proceed)
+- Exit 1 = broken links found (fix before proceeding)
+- Exit 2 = usage error
 
 Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `validation.docsUpdated` to true, `artifacts.updatedDocs` array, and `phase` to "completed".
 
@@ -399,14 +443,24 @@ explore -> brief -> overhaul-plan -> overhaul-delegate -> overhaul-review -> ove
 
 ### Polish -> Overhaul
 
-If scope expands beyond polish limits during explore or brief phase, use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `track` to "overhaul" and update `explore.scopeAssessment.recommendedTrack`.
+During the implement phase, run the scope check script to detect expansion triggers:
 
-**Indicators to switch:**
-- More than 5 files affected
-- Multiple concerns identified
-- Cross-module changes needed
-- Test coverage gaps require new tests
-- Architectural documentation needed
+```bash
+scripts/check-polish-scope.sh --repo-root <path> --base-branch main
+```
+
+**What it validates (expansion triggers):**
+- File count > 5 (modified files via git diff)
+- Module boundaries crossed (>2 top-level dirs modified)
+- New test files needed (impl files without test counterparts)
+- Architectural docs needed (structural files across modules)
+
+**Exit code routing:**
+- Exit 0 = scope OK (stay on polish track)
+- Exit 1 = scope expanded (switch to overhaul track)
+- Exit 2 = usage error
+
+If exit 1, use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `track` to "overhaul" and update `explore.scopeAssessment.recommendedTrack`.
 
 Output: "Scope expanded beyond polish limits. Switching to overhaul track."
 


### PR DESCRIPTION
## Summary

Replaces 4 prose checklist steps in the refactor skill with deterministic validation scripts. Covers scope assessment, polish-track expansion triggers, validate-phase checks, and documentation link verification.

## Changes

- **assess-refactor-scope.sh** — Analyzes file count, module span, and cross-boundary changes to recommend polish vs overhaul track
- **check-polish-scope.sh** — Detects scope expansion triggers (file count, module boundaries, test gaps) during polish-track refactors
- **validate-refactor.sh** — Runs lint, typecheck, and tests to verify refactor correctness post-implementation
- **verify-doc-links.sh** — Checks markdown files for broken internal links (relative and absolute paths)
- **refactor/SKILL.md** — Updated to invoke scripts instead of prose checklists

## Test Plan

4 co-located test files covering scope thresholds, expansion triggers, validation passes/failures, and link checking.

---

**Results:** Script tests pass · Build 0 errors
**Related:** #275 (Phase 4), stack 4/8