### PR TITLE
feat: add planning validation scripts (#275 Phase 5)

### DIFF
--- a/scripts/check-coverage-thresholds.sh
+++ b/scripts/check-coverage-thresholds.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Check Coverage Thresholds
+# Parse test coverage output (Vitest/Istanbul JSON format) and compare against thresholds.
+#
+# Usage: check-coverage-thresholds.sh --coverage-file <path> [--line-threshold 80] [--branch-threshold 70] [--function-threshold 100]
+#
+# Exit codes:
+#   0 = all thresholds met
+#   1 = below threshold
+#   2 = usage error (missing required args, missing file)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ============================================================
+# ARGUMENT PARSING
+# ============================================================
+
+COVERAGE_FILE=""
+LINE_THRESHOLD=80
+BRANCH_THRESHOLD=70
+FUNCTION_THRESHOLD=100
+
+usage() {
+    cat << 'USAGE'
+Usage: check-coverage-thresholds.sh --coverage-file <path> [--line-threshold 80] [--branch-threshold 70] [--function-threshold 100]
+
+Required:
+  --coverage-file <path>       Path to coverage JSON file (Istanbul/Vitest format)
+
+Optional:
+  --line-threshold <num>       Line coverage threshold percentage (default: 80)
+  --branch-threshold <num>     Branch coverage threshold percentage (default: 70)
+  --function-threshold <num>   Function coverage threshold percentage (default: 100)
+  --help                       Show this help message
+
+Exit codes:
+  0  All thresholds met
+  1  Below threshold
+  2  Usage error (missing required args, missing file)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --coverage-file)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --coverage-file requires a path argument" >&2
+                exit 2
+            fi
+            COVERAGE_FILE="$2"
+            shift 2
+            ;;
+        --line-threshold)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --line-threshold requires a number argument" >&2
+                exit 2
+            fi
+            LINE_THRESHOLD="$2"
+            shift 2
+            ;;
+        --branch-threshold)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --branch-threshold requires a number argument" >&2
+                exit 2
+            fi
+            BRANCH_THRESHOLD="$2"
+            shift 2
+            ;;
+        --function-threshold)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --function-threshold requires a number argument" >&2
+                exit 2
+            fi
+            FUNCTION_THRESHOLD="$2"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$COVERAGE_FILE" ]]; then
+    echo "Error: --coverage-file is required" >&2
+    usage >&2
+    exit 2
+fi
+
+if [[ ! -f "$COVERAGE_FILE" ]]; then
+    echo "Error: Coverage file not found: $COVERAGE_FILE" >&2
+    exit 2
+fi
+
+# ============================================================
+# DEPENDENCY CHECK
+# ============================================================
+
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required but not installed" >&2
+    exit 2
+fi
+
+# ============================================================
+# PARSE COVERAGE DATA
+# ============================================================
+
+# Validate JSON
+if ! jq empty "$COVERAGE_FILE" 2>/dev/null; then
+    echo "Error: Invalid JSON in coverage file: $COVERAGE_FILE" >&2
+    exit 2
+fi
+
+# Extract percentages from Istanbul/Vitest coverage-summary.json format
+LINE_PCT="$(jq '.total.lines.pct // 0' "$COVERAGE_FILE")"
+BRANCH_PCT="$(jq '.total.branches.pct // 0' "$COVERAGE_FILE")"
+FUNCTION_PCT="$(jq '.total.functions.pct // 0' "$COVERAGE_FILE")"
+
+# ============================================================
+# CHECK THRESHOLDS
+# ============================================================
+
+CHECK_PASS=0
+CHECK_FAIL=0
+RESULTS=()
+
+check_threshold() {
+    local name="$1"
+    local actual="$2"
+    local threshold="$3"
+
+    # Use awk for floating-point comparison
+    if awk "BEGIN { exit !($actual >= $threshold) }"; then
+        RESULTS+=("- **PASS**: $name — ${actual}% >= ${threshold}%")
+        CHECK_PASS=$((CHECK_PASS + 1))
+    else
+        RESULTS+=("- **FAIL**: $name — ${actual}% < ${threshold}%")
+        CHECK_FAIL=$((CHECK_FAIL + 1))
+    fi
+}
+
+check_threshold "lines" "$LINE_PCT" "$LINE_THRESHOLD"
+check_threshold "branches" "$BRANCH_PCT" "$BRANCH_THRESHOLD"
+check_threshold "functions" "$FUNCTION_PCT" "$FUNCTION_THRESHOLD"
+
+# ============================================================
+# STRUCTURED OUTPUT
+# ============================================================
+
+echo "## Coverage Threshold Report"
+echo ""
+echo "**Coverage file:** \`$COVERAGE_FILE\`"
+echo ""
+
+echo "### Thresholds"
+echo ""
+echo "| Metric | Actual | Threshold | Status |"
+echo "|--------|--------|-----------|--------|"
+echo "| lines | ${LINE_PCT}% | ${LINE_THRESHOLD}% | $(awk "BEGIN { print ($LINE_PCT >= $LINE_THRESHOLD) ? \"PASS\" : \"FAIL\" }") |"
+echo "| branches | ${BRANCH_PCT}% | ${BRANCH_THRESHOLD}% | $(awk "BEGIN { print ($BRANCH_PCT >= $BRANCH_THRESHOLD) ? \"PASS\" : \"FAIL\" }") |"
+echo "| functions | ${FUNCTION_PCT}% | ${FUNCTION_THRESHOLD}% | $(awk "BEGIN { print ($FUNCTION_PCT >= $FUNCTION_THRESHOLD) ? \"PASS\" : \"FAIL\" }") |"
+echo ""
+
+echo "### Check Results"
+echo ""
+for result in "${RESULTS[@]}"; do
+    echo "$result"
+done
+
+echo ""
+TOTAL=$((CHECK_PASS + CHECK_FAIL))
+echo "---"
+echo ""
+
+if [[ $CHECK_FAIL -eq 0 ]]; then
+    echo "**Result: PASS** ($CHECK_PASS/$TOTAL metrics meet thresholds)"
+    exit 0
+else
+    echo "**Result: FAIL** ($CHECK_FAIL/$TOTAL metrics below threshold)"
+    exit 1
+fi

--- a/scripts/check-coverage-thresholds.test.sh
+++ b/scripts/check-coverage-thresholds.test.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# check-coverage-thresholds.sh — Test Suite
+# Validates coverage threshold checking against test output.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/check-coverage-thresholds.sh"
+PASS=0
+FAIL=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAIL=$((FAIL + 1))
+}
+
+# ============================================================
+# TEST FIXTURES
+# ============================================================
+
+TMPDIR_ROOT=""
+
+setup() {
+    TMPDIR_ROOT="$(mktemp -d)"
+}
+
+teardown() {
+    if [[ -n "$TMPDIR_ROOT" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+
+# Istanbul/Vitest JSON coverage summary format — above defaults
+create_above_threshold_coverage() {
+    local dir="$1"
+    cat > "$dir/coverage-summary.json" << 'EOF'
+{
+  "total": {
+    "lines": { "total": 100, "covered": 90, "skipped": 0, "pct": 90 },
+    "statements": { "total": 100, "covered": 90, "skipped": 0, "pct": 90 },
+    "functions": { "total": 20, "covered": 20, "skipped": 0, "pct": 100 },
+    "branches": { "total": 30, "covered": 24, "skipped": 0, "pct": 80 }
+  }
+}
+EOF
+    echo "$dir/coverage-summary.json"
+}
+
+# Coverage below default thresholds
+create_below_threshold_coverage() {
+    local dir="$1"
+    cat > "$dir/coverage-summary.json" << 'EOF'
+{
+  "total": {
+    "lines": { "total": 100, "covered": 50, "skipped": 0, "pct": 50 },
+    "statements": { "total": 100, "covered": 50, "skipped": 0, "pct": 50 },
+    "functions": { "total": 20, "covered": 10, "skipped": 0, "pct": 50 },
+    "branches": { "total": 30, "covered": 12, "skipped": 0, "pct": 40 }
+  }
+}
+EOF
+    echo "$dir/coverage-summary.json"
+}
+
+# Coverage that passes custom thresholds but fails defaults
+create_custom_threshold_coverage() {
+    local dir="$1"
+    cat > "$dir/coverage-summary.json" << 'EOF'
+{
+  "total": {
+    "lines": { "total": 100, "covered": 65, "skipped": 0, "pct": 65 },
+    "statements": { "total": 100, "covered": 65, "skipped": 0, "pct": 65 },
+    "functions": { "total": 20, "covered": 12, "skipped": 0, "pct": 60 },
+    "branches": { "total": 30, "covered": 15, "skipped": 0, "pct": 50 }
+  }
+}
+EOF
+    echo "$dir/coverage-summary.json"
+}
+
+# ============================================================
+# TEST CASES
+# ============================================================
+
+echo "=== Coverage Thresholds Check Tests ==="
+echo ""
+
+# --------------------------------------------------
+# Test 1: AboveThreshold_ExitsZero
+# --------------------------------------------------
+setup
+COV="$(create_above_threshold_coverage "$TMPDIR_ROOT")"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --coverage-file "$COV" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "AboveThreshold_ExitsZero"
+else
+    fail "AboveThreshold_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 2: BelowThreshold_ExitsOne
+# --------------------------------------------------
+setup
+COV="$(create_below_threshold_coverage "$TMPDIR_ROOT")"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --coverage-file "$COV" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "BelowThreshold_ExitsOne"
+else
+    fail "BelowThreshold_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 3: CustomThresholds_Applied
+# --------------------------------------------------
+setup
+COV="$(create_custom_threshold_coverage "$TMPDIR_ROOT")"
+# Use low custom thresholds that the coverage meets
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --coverage-file "$COV" --line-threshold 60 --branch-threshold 50 --function-threshold 60 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "CustomThresholds_Applied_PassesWithLowerThresholds"
+else
+    fail "CustomThresholds_Applied_PassesWithLowerThresholds (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+# Now verify the same file FAILS with default thresholds
+OUTPUT2="$(bash "$SCRIPT_UNDER_TEST" --coverage-file "$COV" 2>&1)" && EXIT_CODE2=$? || EXIT_CODE2=$?
+if [[ $EXIT_CODE2 -eq 1 ]]; then
+    pass "CustomThresholds_Applied_FailsWithDefaults"
+else
+    fail "CustomThresholds_Applied_FailsWithDefaults (exit=$EXIT_CODE2, expected 1)"
+    echo "  Output: $OUTPUT2"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 4: MissingCoverageFile_ExitsTwo
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --coverage-file "/nonexistent/coverage.json" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "MissingCoverageFile_ExitsTwo"
+else
+    fail "MissingCoverageFile_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 5: UsageError_MissingArgs_ExitsTwo
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "UsageError_MissingArgs_ExitsTwo"
+else
+    fail "UsageError_MissingArgs_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 6: HelpFlag_ShowsUsage_ExitsZero
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --help 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "HelpFlag_ShowsUsage_ExitsZero"
+else
+    fail "HelpFlag_ShowsUsage_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+if echo "$OUTPUT" | grep -q "coverage-file"; then
+    pass "HelpFlag_ShowsUsageText"
+else
+    fail "HelpFlag_ShowsUsageText (no usage text in output)"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 7: StructuredOutput_ContainsSummary
+# --------------------------------------------------
+setup
+COV="$(create_above_threshold_coverage "$TMPDIR_ROOT")"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --coverage-file "$COV" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if echo "$OUTPUT" | grep -qE "PASS|lines|branches|functions"; then
+    pass "StructuredOutput_ContainsSummary"
+else
+    fail "StructuredOutput_ContainsSummary (no summary metrics in output)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "=== Test Summary ==="
+echo -e "Passed: ${GREEN}$PASS${NC}"
+echo -e "Failed: ${RED}$FAIL${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/scripts/check-tdd-compliance.sh
+++ b/scripts/check-tdd-compliance.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# Check TDD Compliance
+# Verify test-first git history order for commits on a branch.
+#
+# Usage: check-tdd-compliance.sh --repo-root <path> --branch <name> [--base-branch main]
+#
+# Exit codes:
+#   0 = compliant (test files committed before or alongside implementation)
+#   1 = violations found (implementation committed without test)
+#   2 = usage error (missing required args)
+
+set -euo pipefail
+
+# ============================================================
+# ARGUMENT PARSING
+# ============================================================
+
+REPO_ROOT=""
+BRANCH=""
+BASE_BRANCH="main"
+
+usage() {
+    cat << 'USAGE'
+Usage: check-tdd-compliance.sh --repo-root <path> --branch <name> [--base-branch main]
+
+Required:
+  --repo-root <path>     Repository root directory
+  --branch <name>        Branch to check
+
+Optional:
+  --base-branch <name>   Base branch to compare against (default: main)
+  --help                 Show this help message
+
+Exit codes:
+  0  Compliant (test files committed before or alongside implementation)
+  1  Violations found (implementation without test in same/prior commit)
+  2  Usage error (missing required args)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo-root)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --repo-root requires a path argument" >&2
+                exit 2
+            fi
+            REPO_ROOT="$2"
+            shift 2
+            ;;
+        --branch)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --branch requires a name argument" >&2
+                exit 2
+            fi
+            BRANCH="$2"
+            shift 2
+            ;;
+        --base-branch)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --base-branch requires a name argument" >&2
+                exit 2
+            fi
+            BASE_BRANCH="$2"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$REPO_ROOT" || -z "$BRANCH" ]]; then
+    echo "Error: --repo-root and --branch are required" >&2
+    usage >&2
+    exit 2
+fi
+
+if [[ ! -d "$REPO_ROOT/.git" ]]; then
+    echo "Error: Not a git repository: $REPO_ROOT" >&2
+    exit 2
+fi
+
+# ============================================================
+# HELPER: Classify a file as test or implementation
+# ============================================================
+
+is_test_file() {
+    local file="$1"
+    case "$file" in
+        *.test.ts|*.test.sh|*.spec.ts|*.test.js|*.spec.js|*.test.tsx|*.spec.tsx)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+is_impl_file() {
+    local file="$1"
+    # Implementation files: source code that isn't a test, config, or docs
+    case "$file" in
+        *.ts|*.js|*.tsx|*.jsx|*.sh)
+            # Exclude test files
+            if is_test_file "$file"; then
+                return 1
+            fi
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# ============================================================
+# ANALYZE COMMITS
+# ============================================================
+
+CHECK_PASS=0
+CHECK_FAIL=0
+VIOLATIONS=()
+RESULTS=()
+
+# Track test files seen across all commits (cumulative)
+# Use a delimiter-separated string for bash 3.x compatibility (no associative arrays)
+TESTS_SEEN=""
+
+# Get commits from base..branch in chronological order (oldest first)
+cd "$REPO_ROOT"
+COMMITS=()
+while IFS= read -r commit_hash; do
+    [[ -n "$commit_hash" ]] && COMMITS+=("$commit_hash")
+done < <(git log --reverse --format="%H" "${BASE_BRANCH}..${BRANCH}" 2>/dev/null)
+
+if [[ ${#COMMITS[@]} -eq 0 ]]; then
+    echo "## TDD Compliance Report"
+    echo ""
+    echo "**Branch:** $BRANCH"
+    echo "**Base:** $BASE_BRANCH"
+    echo ""
+    echo "No commits found between $BASE_BRANCH and $BRANCH"
+    echo ""
+    echo "---"
+    echo ""
+    echo "**Result: PASS** (no commits to check)"
+    exit 0
+fi
+
+for commit_hash in "${COMMITS[@]}"; do
+    commit_msg="$(git log -1 --format="%s" "$commit_hash")"
+    commit_short="$(git log -1 --format="%h" "$commit_hash")"
+
+    # Get files changed in this commit
+    FILES_IN_COMMIT=()
+    while IFS= read -r file; do
+        [[ -n "$file" ]] && FILES_IN_COMMIT+=("$file")
+    done < <(git diff-tree --no-commit-id --name-only -r "$commit_hash" 2>/dev/null)
+
+    # Classify files in this commit
+    HAS_TEST=false
+    HAS_IMPL=false
+    IMPL_FILES=()
+    TEST_FILES=()
+
+    for file in "${FILES_IN_COMMIT[@]}"; do
+        if is_test_file "$file"; then
+            HAS_TEST=true
+            TEST_FILES+=("$file")
+            TESTS_SEEN="${TESTS_SEEN}|${file}"
+        elif is_impl_file "$file"; then
+            HAS_IMPL=true
+            IMPL_FILES+=("$file")
+        fi
+    done
+
+    # A commit with implementation files is compliant if:
+    # 1. It also contains test files (mixed commit), OR
+    # 2. Corresponding test files were seen in prior commits
+    if [[ "$HAS_IMPL" == true ]]; then
+        if [[ "$HAS_TEST" == true ]]; then
+            # Mixed commit: test and impl together — OK
+            RESULTS+=("- **PASS**: \`$commit_short\` — $commit_msg (test+impl)")
+            CHECK_PASS=$((CHECK_PASS + 1))
+        else
+            # Check if test files were seen before this commit
+            FOUND_PRIOR_TEST=false
+            for impl_file in "${IMPL_FILES[@]}"; do
+                # Derive expected test file name(s)
+                base="${impl_file%.*}"
+                ext="${impl_file##*.}"
+                test_candidate_test="${base}.test.${ext}"
+                test_candidate_spec="${base}.spec.${ext}"
+
+                if echo "$TESTS_SEEN" | grep -qF "|${test_candidate_test}" || \
+                   echo "$TESTS_SEEN" | grep -qF "|${test_candidate_spec}"; then
+                    FOUND_PRIOR_TEST=true
+                    break
+                fi
+            done
+
+            if [[ "$FOUND_PRIOR_TEST" == true ]]; then
+                RESULTS+=("- **PASS**: \`$commit_short\` — $commit_msg (test in prior commit)")
+                CHECK_PASS=$((CHECK_PASS + 1))
+            else
+                RESULTS+=("- **FAIL**: \`$commit_short\` — $commit_msg (implementation without test)")
+                VIOLATIONS+=("$commit_short: $commit_msg")
+                CHECK_FAIL=$((CHECK_FAIL + 1))
+            fi
+        fi
+    elif [[ "$HAS_TEST" == true ]]; then
+        # Test-only commit — always compliant
+        RESULTS+=("- **PASS**: \`$commit_short\` — $commit_msg (test-only)")
+        CHECK_PASS=$((CHECK_PASS + 1))
+    else
+        # Non-code commit (docs, config, etc.) — skip
+        RESULTS+=("- **SKIP**: \`$commit_short\` — $commit_msg (non-code)")
+    fi
+done
+
+# ============================================================
+# STRUCTURED OUTPUT
+# ============================================================
+
+echo "## TDD Compliance Report"
+echo ""
+echo "**Branch:** $BRANCH"
+echo "**Base:** $BASE_BRANCH"
+echo "**Commits analyzed:** ${#COMMITS[@]}"
+echo ""
+
+echo "### Per-commit Analysis"
+echo ""
+for result in "${RESULTS[@]}"; do
+    echo "$result"
+done
+echo ""
+
+if [[ ${#VIOLATIONS[@]} -gt 0 ]]; then
+    echo "### Violations"
+    echo ""
+    for v in "${VIOLATIONS[@]}"; do
+        echo "- $v"
+    done
+    echo ""
+fi
+
+TOTAL=$((CHECK_PASS + CHECK_FAIL))
+echo "---"
+echo ""
+
+if [[ $CHECK_FAIL -eq 0 ]]; then
+    echo "**Result: PASS** ($CHECK_PASS/$TOTAL commits compliant)"
+    exit 0
+else
+    echo "**Result: FAIL** ($CHECK_FAIL/$TOTAL commits have violations)"
+    exit 1
+fi

--- a/scripts/check-tdd-compliance.sh
+++ b/scripts/check-tdd-compliance.sh
@@ -162,7 +162,7 @@ for commit_hash in "${COMMITS[@]}"; do
     FILES_IN_COMMIT=()
     while IFS= read -r file; do
         [[ -n "$file" ]] && FILES_IN_COMMIT+=("$file")
-    done < <(git diff-tree --no-commit-id --name-only -r "$commit_hash" 2>/dev/null)
+    done < <(git diff-tree --no-commit-id --name-only --diff-filter=ACMRT -r "$commit_hash" 2>/dev/null)
 
     # Classify files in this commit
     HAS_TEST=false
@@ -174,7 +174,7 @@ for commit_hash in "${COMMITS[@]}"; do
         if is_test_file "$file"; then
             HAS_TEST=true
             TEST_FILES+=("$file")
-            TESTS_SEEN="${TESTS_SEEN}|${file}"
+            TESTS_SEEN="${TESTS_SEEN}|${file}|"
         elif is_impl_file "$file"; then
             HAS_IMPL=true
             IMPL_FILES+=("$file")
@@ -199,8 +199,8 @@ for commit_hash in "${COMMITS[@]}"; do
                 test_candidate_test="${base}.test.${ext}"
                 test_candidate_spec="${base}.spec.${ext}"
 
-                if echo "$TESTS_SEEN" | grep -qF "|${test_candidate_test}" || \
-                   echo "$TESTS_SEEN" | grep -qF "|${test_candidate_spec}"; then
+                if echo "$TESTS_SEEN" | grep -qF "|${test_candidate_test}|" || \
+                   echo "$TESTS_SEEN" | grep -qF "|${test_candidate_spec}|"; then
                     FOUND_PRIOR_TEST=true
                     break
                 fi

--- a/scripts/check-tdd-compliance.test.sh
+++ b/scripts/check-tdd-compliance.test.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# check-tdd-compliance.sh — Test Suite
+# Validates test-first git history order checking.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/check-tdd-compliance.sh"
+PASS=0
+FAIL=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAIL=$((FAIL + 1))
+}
+
+# ============================================================
+# TEST FIXTURES
+# ============================================================
+
+TMPDIR_ROOT=""
+
+setup() {
+    TMPDIR_ROOT="$(mktemp -d)"
+
+    # Create a git repo with controlled commit history
+    cd "$TMPDIR_ROOT"
+    git init -b main --quiet
+    git config user.email "test@test.com"
+    git config user.name "Test"
+
+    # Initial commit on main
+    echo "# README" > README.md
+    git add README.md
+    git commit -m "initial commit" --quiet
+}
+
+teardown() {
+    if [[ -n "$TMPDIR_ROOT" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+
+# Create a compliant branch: test file committed before/with implementation
+create_compliant_branch() {
+    cd "$TMPDIR_ROOT"
+    git checkout -b feature/compliant --quiet
+
+    # Commit 1: test file first
+    mkdir -p src
+    echo "// test" > src/widget.test.ts
+    git add src/widget.test.ts
+    git commit -m "test: add widget tests" --quiet
+
+    # Commit 2: implementation
+    echo "// impl" > src/widget.ts
+    git add src/widget.ts
+    git commit -m "feat: add widget" --quiet
+}
+
+# Create a violating branch: implementation committed without any test
+create_violating_branch() {
+    cd "$TMPDIR_ROOT"
+    git checkout -b feature/violating --quiet
+
+    # Commit 1: implementation only (no test)
+    mkdir -p src
+    echo "// impl" > src/api.ts
+    git add src/api.ts
+    git commit -m "feat: add api" --quiet
+
+    # Commit 2: test added later
+    echo "// test" > src/api.test.ts
+    git add src/api.test.ts
+    git commit -m "test: add api tests" --quiet
+}
+
+# Create a mixed-commit branch: test and impl in same commit (OK)
+create_mixed_commit_branch() {
+    cd "$TMPDIR_ROOT"
+    git checkout -b feature/mixed --quiet
+
+    # Single commit with both test and implementation
+    mkdir -p src
+    echo "// test" > src/util.test.ts
+    echo "// impl" > src/util.ts
+    git add src/util.test.ts src/util.ts
+    git commit -m "feat: add util with tests" --quiet
+}
+
+# ============================================================
+# TEST CASES
+# ============================================================
+
+echo "=== TDD Compliance Check Tests ==="
+echo ""
+
+# --------------------------------------------------
+# Test 1: TestFirst_Compliant_ExitsZero
+# --------------------------------------------------
+setup
+create_compliant_branch
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --repo-root "$TMPDIR_ROOT" --branch "feature/compliant" --base-branch "main" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "TestFirst_Compliant_ExitsZero"
+else
+    fail "TestFirst_Compliant_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 2: ImplFirst_Violation_ExitsOne
+# --------------------------------------------------
+setup
+create_violating_branch
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --repo-root "$TMPDIR_ROOT" --branch "feature/violating" --base-branch "main" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "ImplFirst_Violation_ExitsOne"
+else
+    fail "ImplFirst_Violation_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+# Verify output mentions the violation
+if echo "$OUTPUT" | grep -qi "violation\|FAIL"; then
+    pass "ImplFirst_Violation_ReportsViolation"
+else
+    fail "ImplFirst_Violation_ReportsViolation (no violation reported)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 3: MixedCommit_TestAndImpl_ExitsZero
+# --------------------------------------------------
+setup
+create_mixed_commit_branch
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --repo-root "$TMPDIR_ROOT" --branch "feature/mixed" --base-branch "main" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "MixedCommit_TestAndImpl_ExitsZero"
+else
+    fail "MixedCommit_TestAndImpl_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 4: UsageError_MissingArgs_ExitsTwo
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "UsageError_MissingArgs_ExitsTwo"
+else
+    fail "UsageError_MissingArgs_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 5: HelpFlag_ShowsUsage_ExitsZero
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --help 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "HelpFlag_ShowsUsage_ExitsZero"
+else
+    fail "HelpFlag_ShowsUsage_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+if echo "$OUTPUT" | grep -q "repo-root"; then
+    pass "HelpFlag_ShowsUsageText"
+else
+    fail "HelpFlag_ShowsUsageText (no usage text in output)"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 6: StructuredOutput_ContainsPerCommitReport
+# --------------------------------------------------
+setup
+create_compliant_branch
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --repo-root "$TMPDIR_ROOT" --branch "feature/compliant" --base-branch "main" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if echo "$OUTPUT" | grep -qE "##.*Compliance|commit"; then
+    pass "StructuredOutput_ContainsPerCommitReport"
+else
+    fail "StructuredOutput_ContainsPerCommitReport (no per-commit report)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "=== Test Summary ==="
+echo -e "Passed: ${GREEN}$PASS${NC}"
+echo -e "Failed: ${RED}$FAIL${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/scripts/generate-traceability.sh
+++ b/scripts/generate-traceability.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Generate Traceability Matrix
+# Pre-populate traceability matrix from design and plan headers.
+#
+# Usage: generate-traceability.sh --design-file <path> --plan-file <path> [--output <path>]
+#
+# Exit codes:
+#   0 = generated successfully
+#   1 = parse error (no sections found)
+#   2 = usage error (missing required args, missing files)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ============================================================
+# ARGUMENT PARSING
+# ============================================================
+
+DESIGN_FILE=""
+PLAN_FILE=""
+OUTPUT_FILE=""
+
+usage() {
+    cat << 'USAGE'
+Usage: generate-traceability.sh --design-file <path> --plan-file <path> [--output <path>]
+
+Required:
+  --design-file <path>   Path to the design document markdown file
+  --plan-file <path>     Path to the implementation plan markdown file
+
+Optional:
+  --output <path>        Write output to file instead of stdout
+  --help                 Show this help message
+
+Exit codes:
+  0  Generated successfully
+  1  Parse error (no sections found in design)
+  2  Usage error (missing required args, missing files)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --design-file)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --design-file requires a path argument" >&2
+                exit 2
+            fi
+            DESIGN_FILE="$2"
+            shift 2
+            ;;
+        --plan-file)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --plan-file requires a path argument" >&2
+                exit 2
+            fi
+            PLAN_FILE="$2"
+            shift 2
+            ;;
+        --output)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --output requires a path argument" >&2
+                exit 2
+            fi
+            OUTPUT_FILE="$2"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$DESIGN_FILE" || -z "$PLAN_FILE" ]]; then
+    echo "Error: --design-file and --plan-file are required" >&2
+    usage >&2
+    exit 2
+fi
+
+if [[ ! -f "$DESIGN_FILE" ]]; then
+    echo "Error: Design file not found: $DESIGN_FILE" >&2
+    exit 2
+fi
+
+if [[ ! -f "$PLAN_FILE" ]]; then
+    echo "Error: Plan file not found: $PLAN_FILE" >&2
+    exit 2
+fi
+
+# ============================================================
+# EXTRACT DESIGN SECTIONS (## and ### headers)
+# ============================================================
+
+DESIGN_SECTIONS=()
+DESIGN_LEVELS=()
+
+while IFS= read -r line; do
+    if [[ "$line" =~ ^(#{2,3})[[:space:]]+(.+) ]]; then
+        level="${BASH_REMATCH[1]}"
+        section_name="${BASH_REMATCH[2]}"
+        section_name="$(echo "$section_name" | sed 's/[[:space:]]*$//')"
+        DESIGN_SECTIONS+=("$section_name")
+        DESIGN_LEVELS+=("$level")
+    fi
+done < "$DESIGN_FILE"
+
+if [[ ${#DESIGN_SECTIONS[@]} -eq 0 ]]; then
+    echo "Error: No ## or ### headers found in design document" >&2
+    exit 1
+fi
+
+# ============================================================
+# EXTRACT PLAN TASKS (### Task headers)
+# ============================================================
+
+PLAN_TASKS=()
+PLAN_TASK_IDS=()
+
+while IFS= read -r line; do
+    if [[ "$line" =~ ^###[[:space:]]+Task[[:space:]]+([0-9]+) ]]; then
+        task_id="${BASH_REMATCH[1]}"
+        # Extract the full task title
+        task_title="${line#*: }"
+        if [[ -n "$task_title" && "$task_title" != "$line" ]]; then
+            PLAN_TASKS+=("$task_title")
+        else
+            PLAN_TASKS+=("$line")
+        fi
+        PLAN_TASK_IDS+=("$task_id")
+    fi
+done < "$PLAN_FILE"
+
+# Read full plan content for matching
+PLAN_CONTENT="$(cat "$PLAN_FILE")"
+
+# ============================================================
+# GENERATE TRACEABILITY TABLE
+# ============================================================
+
+generate_table() {
+    echo "## Spec Traceability"
+    echo ""
+    echo "### Traceability Matrix"
+    echo ""
+    echo "| Design Section | Key Requirements | Task ID(s) | Status |"
+    echo "|----------------|-----------------|------------|--------|"
+
+    for i in "${!DESIGN_SECTIONS[@]}"; do
+        section="${DESIGN_SECTIONS[$i]}"
+        level="${DESIGN_LEVELS[$i]}"
+
+        # Find matching tasks
+        matched_ids=()
+        for j in "${!PLAN_TASKS[@]}"; do
+            task="${PLAN_TASKS[$j]}"
+            tid="${PLAN_TASK_IDS[$j]}"
+            if echo "$task" | grep -qiF "$section"; then
+                matched_ids+=("$tid")
+            fi
+        done
+
+        # Also check plan body
+        if [[ ${#matched_ids[@]} -eq 0 ]]; then
+            if echo "$PLAN_CONTENT" | grep -qiF "$section"; then
+                matched_ids+=("?")
+            fi
+        fi
+
+        # Format output
+        if [[ ${#matched_ids[@]} -gt 0 ]]; then
+            ids="$(printf '%s, ' "${matched_ids[@]}")"
+            ids="${ids%, }"
+            echo "| $section | (to be filled) | $ids | Covered |"
+        else
+            echo "| $section | (to be filled) | — | Uncovered |"
+        fi
+    done
+    echo ""
+    echo "### Scope Declaration"
+    echo ""
+    echo "**Target:** (to be filled)"
+    echo "**Excluded:** (to be filled)"
+}
+
+# ============================================================
+# OUTPUT
+# ============================================================
+
+if [[ -n "$OUTPUT_FILE" ]]; then
+    generate_table > "$OUTPUT_FILE"
+    echo "Traceability matrix written to: $OUTPUT_FILE"
+else
+    generate_table
+fi
+
+exit 0

--- a/scripts/generate-traceability.test.sh
+++ b/scripts/generate-traceability.test.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# generate-traceability.sh — Test Suite
+# Validates traceability matrix generation from design and plan documents.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/generate-traceability.sh"
+PASS=0
+FAIL=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAIL=$((FAIL + 1))
+}
+
+# ============================================================
+# TEST FIXTURES
+# ============================================================
+
+TMPDIR_ROOT=""
+
+setup() {
+    TMPDIR_ROOT="$(mktemp -d)"
+}
+
+teardown() {
+    if [[ -n "$TMPDIR_ROOT" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+
+create_valid_inputs() {
+    local dir="$1"
+    cat > "$dir/design.md" << 'EOF'
+# Feature Design
+
+## Problem Statement
+
+Build a widget system.
+
+## Technical Design
+
+### Widget Component
+
+Renders the main UI.
+
+### API Client
+
+Handles data fetching.
+
+## Testing Strategy
+
+Unit tests for all.
+EOF
+
+    cat > "$dir/plan.md" << 'EOF'
+# Implementation Plan
+
+## Tasks
+
+### Task 001: Create Widget Component
+
+Widget rendering layer.
+
+### Task 002: Create API Client
+
+API integration layer.
+
+### Task 003: Add unit tests
+
+Testing coverage.
+EOF
+    echo "$dir"
+}
+
+create_empty_design() {
+    local dir="$1"
+    cat > "$dir/design.md" << 'EOF'
+EOF
+    cat > "$dir/plan.md" << 'EOF'
+# Plan
+### Task 001: Something
+EOF
+    echo "$dir"
+}
+
+# ============================================================
+# TEST CASES
+# ============================================================
+
+echo "=== Generate Traceability Tests ==="
+echo ""
+
+# --------------------------------------------------
+# Test 1: ValidInputs_GeneratesMarkdownTable
+# --------------------------------------------------
+setup
+DIR="$(create_valid_inputs "$TMPDIR_ROOT")"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "$DIR/design.md" --plan-file "$DIR/plan.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "ValidInputs_GeneratesMarkdownTable_ExitsZero"
+else
+    fail "ValidInputs_GeneratesMarkdownTable_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+# Verify markdown table structure (pipe-delimited rows)
+if echo "$OUTPUT" | grep -qE "\|.*Design Section.*\|.*Task"; then
+    pass "ValidInputs_GeneratesMarkdownTable_HasTableHeader"
+else
+    fail "ValidInputs_GeneratesMarkdownTable_HasTableHeader (no table header in output)"
+    echo "  Output: $OUTPUT"
+fi
+# Verify design sections appear in output
+if echo "$OUTPUT" | grep -q "Widget Component" && echo "$OUTPUT" | grep -q "API Client"; then
+    pass "ValidInputs_GeneratesMarkdownTable_ContainsSections"
+else
+    fail "ValidInputs_GeneratesMarkdownTable_ContainsSections (missing design sections)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 2: OutputToFile_CreatesFile
+# --------------------------------------------------
+setup
+DIR="$(create_valid_inputs "$TMPDIR_ROOT")"
+OUTFILE="$TMPDIR_ROOT/traceability.md"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "$DIR/design.md" --plan-file "$DIR/plan.md" --output "$OUTFILE" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "OutputToFile_CreatesFile_ExitsZero"
+else
+    fail "OutputToFile_CreatesFile_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+if [[ -f "$OUTFILE" ]]; then
+    pass "OutputToFile_CreatesFile_FileExists"
+else
+    fail "OutputToFile_CreatesFile_FileExists (file not created)"
+fi
+# Verify file contains table
+if [[ -f "$OUTFILE" ]] && grep -qE "\|.*Design Section" "$OUTFILE"; then
+    pass "OutputToFile_CreatesFile_HasContent"
+else
+    fail "OutputToFile_CreatesFile_HasContent (file missing table content)"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 3: EmptyDesign_ParseError_ExitsOne
+# --------------------------------------------------
+setup
+DIR="$(create_empty_design "$TMPDIR_ROOT")"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "$DIR/design.md" --plan-file "$DIR/plan.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "EmptyDesign_ParseError_ExitsOne"
+else
+    fail "EmptyDesign_ParseError_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 4: UsageError_MissingArgs_ExitsTwo
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "UsageError_MissingArgs_ExitsTwo"
+else
+    fail "UsageError_MissingArgs_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 5: HelpFlag_ShowsUsage_ExitsZero
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --help 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "HelpFlag_ShowsUsage_ExitsZero"
+else
+    fail "HelpFlag_ShowsUsage_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+if echo "$OUTPUT" | grep -q "design-file"; then
+    pass "HelpFlag_ShowsUsageText"
+else
+    fail "HelpFlag_ShowsUsageText (no usage text in output)"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 6: MissingDesignFile_ExitsTwo
+# --------------------------------------------------
+setup
+cat > "$TMPDIR_ROOT/plan.md" << 'EOF'
+# Plan
+### Task 001: Something
+EOF
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "/nonexistent/design.md" --plan-file "$TMPDIR_ROOT/plan.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "MissingDesignFile_ExitsTwo"
+else
+    fail "MissingDesignFile_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "=== Test Summary ==="
+echo -e "Passed: ${GREEN}$PASS${NC}"
+echo -e "Failed: ${RED}$FAIL${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/scripts/spec-coverage-check.sh
+++ b/scripts/spec-coverage-check.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Spec Coverage Check
+# Verify test coverage for spec compliance. Replaces spec-review "Compare to Spec" prose.
+#
+# Usage: spec-coverage-check.sh --plan-file <path> --repo-root <path> [--skip-run]
+#
+# Exit codes:
+#   0 = coverage met (all planned tests exist and pass)
+#   1 = gaps found (missing test files or test failures)
+#   2 = usage error (missing required args)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ============================================================
+# ARGUMENT PARSING
+# ============================================================
+
+PLAN_FILE=""
+REPO_ROOT=""
+SKIP_RUN=false
+
+usage() {
+    cat << 'USAGE'
+Usage: spec-coverage-check.sh --plan-file <path> --repo-root <path> [--skip-run]
+
+Required:
+  --plan-file <path>    Path to the implementation plan markdown file
+  --repo-root <path>    Repository root directory
+
+Optional:
+  --skip-run            Skip running tests (only check file existence)
+  --help                Show this help message
+
+Exit codes:
+  0  Coverage met (all planned tests exist and pass)
+  1  Gaps found (missing test files or test failures)
+  2  Usage error (missing required args)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --plan-file)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --plan-file requires a path argument" >&2
+                exit 2
+            fi
+            PLAN_FILE="$2"
+            shift 2
+            ;;
+        --repo-root)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --repo-root requires a path argument" >&2
+                exit 2
+            fi
+            REPO_ROOT="$2"
+            shift 2
+            ;;
+        --skip-run)
+            SKIP_RUN=true
+            shift
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$PLAN_FILE" || -z "$REPO_ROOT" ]]; then
+    echo "Error: --plan-file and --repo-root are required" >&2
+    usage >&2
+    exit 2
+fi
+
+if [[ ! -f "$PLAN_FILE" ]]; then
+    echo "Error: Plan file not found: $PLAN_FILE" >&2
+    exit 2
+fi
+
+# ============================================================
+# CHECK FUNCTIONS
+# ============================================================
+
+CHECK_PASS=0
+CHECK_FAIL=0
+RESULTS=()
+
+check_pass() {
+    local name="$1"
+    RESULTS+=("- **PASS**: $name")
+    CHECK_PASS=$((CHECK_PASS + 1))
+}
+
+check_fail() {
+    local name="$1"
+    local detail="${2:-}"
+    if [[ -n "$detail" ]]; then
+        RESULTS+=("- **FAIL**: $name — $detail")
+    else
+        RESULTS+=("- **FAIL**: $name")
+    fi
+    CHECK_FAIL=$((CHECK_FAIL + 1))
+}
+
+check_skip() {
+    local name="$1"
+    RESULTS+=("- **SKIP**: $name")
+}
+
+# ============================================================
+# EXTRACT TEST FILES FROM PLAN
+# ============================================================
+
+# Extract test file paths from **Test file:** lines in the plan
+TEST_FILES=()
+while IFS= read -r line; do
+    # Match lines like: **Test file:** `src/widget.test.ts`
+    if [[ "$line" =~ \*\*Test\ file:\*\*[[:space:]]*\`([^\`]+)\` ]]; then
+        TEST_FILES+=("${BASH_REMATCH[1]}")
+    fi
+done < "$PLAN_FILE"
+
+# ============================================================
+# CHECK: Test files referenced in plan
+# ============================================================
+
+if [[ ${#TEST_FILES[@]} -eq 0 ]]; then
+    check_fail "Test files in plan" "No test files referenced in plan document"
+fi
+
+# ============================================================
+# CHECK: Each test file exists on disk
+# ============================================================
+
+FOUND=0
+MISSING=0
+MISSING_LIST=()
+
+for test_file in "${TEST_FILES[@]}"; do
+    full_path="$REPO_ROOT/$test_file"
+    if [[ -f "$full_path" ]]; then
+        check_pass "Test file exists: $test_file"
+        FOUND=$((FOUND + 1))
+    else
+        check_fail "Test file exists: $test_file" "Not found at $full_path"
+        MISSING=$((MISSING + 1))
+        MISSING_LIST+=("$test_file")
+    fi
+done
+
+# ============================================================
+# CHECK: Tests pass (unless --skip-run)
+# ============================================================
+
+if [[ "$SKIP_RUN" == true ]]; then
+    check_skip "Test execution (--skip-run)"
+elif [[ ${#TEST_FILES[@]} -gt 0 && $MISSING -eq 0 ]]; then
+    for test_file in "${TEST_FILES[@]}"; do
+        if ! npx vitest run "$REPO_ROOT/$test_file" >/dev/null 2>&1; then
+            check_fail "Test passes: $test_file"
+        else
+            check_pass "Test passes: $test_file"
+        fi
+    done
+fi
+
+# ============================================================
+# STRUCTURED OUTPUT
+# ============================================================
+
+echo "## Spec Coverage Report"
+echo ""
+echo "**Plan file:** \`$PLAN_FILE\`"
+echo "**Repo root:** \`$REPO_ROOT\`"
+echo ""
+
+TOTAL_TESTS=${#TEST_FILES[@]}
+echo "### Coverage Summary"
+echo ""
+echo "- Planned test files: $TOTAL_TESTS"
+echo "- Found on disk: $FOUND"
+echo "- Missing: $MISSING"
+echo ""
+
+if [[ ${#MISSING_LIST[@]} -gt 0 ]]; then
+    echo "### Missing Test Files"
+    echo ""
+    for f in "${MISSING_LIST[@]}"; do
+        echo "- \`$f\`"
+    done
+    echo ""
+fi
+
+echo "### Check Results"
+echo ""
+for result in "${RESULTS[@]}"; do
+    echo "$result"
+done
+
+echo ""
+TOTAL=$((CHECK_PASS + CHECK_FAIL))
+echo "---"
+echo ""
+
+if [[ $CHECK_FAIL -eq 0 && $TOTAL_TESTS -gt 0 ]]; then
+    echo "**Result: PASS** ($CHECK_PASS/$TOTAL checks passed)"
+    exit 0
+else
+    echo "**Result: FAIL** ($CHECK_FAIL/$TOTAL checks failed)"
+    exit 1
+fi

--- a/scripts/spec-coverage-check.sh
+++ b/scripts/spec-coverage-check.sh
@@ -91,6 +91,11 @@ if [[ ! -f "$PLAN_FILE" ]]; then
     exit 2
 fi
 
+if [[ ! -d "$REPO_ROOT" ]]; then
+    echo "Error: Repo root directory not found: $REPO_ROOT" >&2
+    exit 2
+fi
+
 # ============================================================
 # CHECK FUNCTIONS
 # ============================================================
@@ -170,7 +175,7 @@ if [[ "$SKIP_RUN" == true ]]; then
     check_skip "Test execution (--skip-run)"
 elif [[ ${#TEST_FILES[@]} -gt 0 && $MISSING -eq 0 ]]; then
     for test_file in "${TEST_FILES[@]}"; do
-        if ! npx vitest run "$REPO_ROOT/$test_file" >/dev/null 2>&1; then
+        if ! npx vitest run --root "$REPO_ROOT" "$test_file" >/dev/null 2>&1; then
             check_fail "Test passes: $test_file"
         else
             check_pass "Test passes: $test_file"

--- a/scripts/spec-coverage-check.test.sh
+++ b/scripts/spec-coverage-check.test.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# spec-coverage-check.sh — Test Suite
+# Validates spec coverage checking for plan compliance.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/spec-coverage-check.sh"
+PASS=0
+FAIL=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAIL=$((FAIL + 1))
+}
+
+# ============================================================
+# TEST FIXTURES
+# ============================================================
+
+TMPDIR_ROOT=""
+
+setup() {
+    TMPDIR_ROOT="$(mktemp -d)"
+    MOCK_BIN="$TMPDIR_ROOT/mock-bin"
+    mkdir -p "$MOCK_BIN"
+
+    # Mock npx vitest run: always succeeds by default
+    cat > "$MOCK_BIN/npx" << 'MOCKEOF'
+#!/usr/bin/env bash
+# Default mock: print coverage summary and exit 0
+echo "Test Files  3 passed"
+echo "Tests  12 passed"
+echo "Coverage: 85%"
+exit 0
+MOCKEOF
+    chmod +x "$MOCK_BIN/npx"
+}
+
+teardown() {
+    if [[ -n "$TMPDIR_ROOT" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+
+# Create a plan file with test references
+create_plan_with_tests() {
+    local dir="$1"
+    mkdir -p "$dir/src"
+    # Create actual test files on disk
+    echo "// test" > "$dir/src/widget.test.ts"
+    echo "// test" > "$dir/src/api.test.ts"
+
+    cat > "$dir/plan.md" << 'EOF'
+# Implementation Plan
+
+### Task 001: Create widget component
+
+**Test file:** `src/widget.test.ts`
+
+### Task 002: Create API client
+
+**Test file:** `src/api.test.ts`
+EOF
+    echo "$dir/plan.md"
+}
+
+# Create a plan referencing a missing test file
+create_plan_with_missing_test() {
+    local dir="$1"
+    mkdir -p "$dir/src"
+    echo "// test" > "$dir/src/widget.test.ts"
+    # Note: src/missing.test.ts does NOT exist
+
+    cat > "$dir/plan.md" << 'EOF'
+# Implementation Plan
+
+### Task 001: Create widget component
+
+**Test file:** `src/widget.test.ts`
+
+### Task 002: Create missing module
+
+**Test file:** `src/missing.test.ts`
+EOF
+    echo "$dir/plan.md"
+}
+
+# Create a plan with no test references
+create_plan_no_tests() {
+    local dir="$1"
+    cat > "$dir/plan.md" << 'EOF'
+# Implementation Plan
+
+### Task 001: Setup configuration
+
+No test files referenced.
+EOF
+    echo "$dir/plan.md"
+}
+
+# ============================================================
+# TEST CASES
+# ============================================================
+
+echo "=== Spec Coverage Check Tests ==="
+echo ""
+
+# --------------------------------------------------
+# Test 1: AllTestsExist_ExitsZero
+# --------------------------------------------------
+setup
+PLAN="$(create_plan_with_tests "$TMPDIR_ROOT")"
+OUTPUT="$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_UNDER_TEST" --plan-file "$PLAN" --repo-root "$TMPDIR_ROOT" --skip-run 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "AllTestsExist_ExitsZero"
+else
+    fail "AllTestsExist_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 2: MissingTestFile_ExitsOne
+# --------------------------------------------------
+setup
+PLAN="$(create_plan_with_missing_test "$TMPDIR_ROOT")"
+OUTPUT="$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_UNDER_TEST" --plan-file "$PLAN" --repo-root "$TMPDIR_ROOT" --skip-run 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "MissingTestFile_ExitsOne"
+else
+    fail "MissingTestFile_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 3: SkipRun_Flag_SkipsExecution
+# --------------------------------------------------
+setup
+PLAN="$(create_plan_with_tests "$TMPDIR_ROOT")"
+# Create a failing npx mock — if --skip-run works, it won't be called
+cat > "$MOCK_BIN/npx" << 'MOCKEOF'
+#!/usr/bin/env bash
+echo "npx SHOULD NOT RUN" >&2
+exit 1
+MOCKEOF
+chmod +x "$MOCK_BIN/npx"
+OUTPUT="$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_UNDER_TEST" --plan-file "$PLAN" --repo-root "$TMPDIR_ROOT" --skip-run 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "SkipRun_Flag_SkipsExecution"
+else
+    fail "SkipRun_Flag_SkipsExecution (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+if echo "$OUTPUT" | grep -q "npx SHOULD NOT RUN"; then
+    fail "SkipRun_Flag_NpxNotCalled (npx was called despite --skip-run)"
+else
+    pass "SkipRun_Flag_NpxNotCalled"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 4: NoTestsInPlan_ExitsOne
+# --------------------------------------------------
+setup
+PLAN="$(create_plan_no_tests "$TMPDIR_ROOT")"
+OUTPUT="$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_UNDER_TEST" --plan-file "$PLAN" --repo-root "$TMPDIR_ROOT" --skip-run 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "NoTestsInPlan_ExitsOne"
+else
+    fail "NoTestsInPlan_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 5: UsageError_MissingArgs_ExitsTwo
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "UsageError_MissingArgs_ExitsTwo"
+else
+    fail "UsageError_MissingArgs_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 6: StructuredOutput_ContainsReport
+# --------------------------------------------------
+setup
+PLAN="$(create_plan_with_tests "$TMPDIR_ROOT")"
+OUTPUT="$(PATH="$MOCK_BIN:$PATH" bash "$SCRIPT_UNDER_TEST" --plan-file "$PLAN" --repo-root "$TMPDIR_ROOT" --skip-run 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if echo "$OUTPUT" | grep -qE "## |Coverage"; then
+    pass "StructuredOutput_ContainsReport"
+else
+    fail "StructuredOutput_ContainsReport (no report structure in output)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 7: HelpFlag_ShowsUsage_ExitsZero
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --help 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "HelpFlag_ShowsUsage_ExitsZero"
+else
+    fail "HelpFlag_ShowsUsage_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+if echo "$OUTPUT" | grep -q "plan-file"; then
+    pass "HelpFlag_ShowsUsageText"
+else
+    fail "HelpFlag_ShowsUsageText (no usage text in output)"
+fi
+teardown
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "=== Test Summary ==="
+echo -e "Passed: ${GREEN}$PASS${NC}"
+echo -e "Failed: ${RED}$FAIL${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/scripts/verify-plan-coverage.sh
+++ b/scripts/verify-plan-coverage.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Verify Plan Coverage
+# Cross-reference design document sections to plan tasks. Replaces "Plan Verification" prose.
+#
+# Usage: verify-plan-coverage.sh --design-file <path> --plan-file <path>
+#
+# Exit codes:
+#   0 = complete coverage (every Technical Design subsection maps to >= 1 task)
+#   1 = gaps found (unmapped sections)
+#   2 = usage error (missing required args, empty design, missing files)
+
+set -euo pipefail
+
+# ============================================================
+# ARGUMENT PARSING
+# ============================================================
+
+DESIGN_FILE=""
+PLAN_FILE=""
+
+usage() {
+    cat << 'USAGE'
+Usage: verify-plan-coverage.sh --design-file <path> --plan-file <path>
+
+Required:
+  --design-file <path>   Path to the design document markdown file
+  --plan-file <path>     Path to the implementation plan markdown file
+
+Optional:
+  --help                 Show this help message
+
+Exit codes:
+  0  Complete coverage (all Technical Design subsections mapped to tasks)
+  1  Gaps found (unmapped design sections)
+  2  Usage error (missing required args, empty design, missing files)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --design-file)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --design-file requires a path argument" >&2
+                exit 2
+            fi
+            DESIGN_FILE="$2"
+            shift 2
+            ;;
+        --plan-file)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --plan-file requires a path argument" >&2
+                exit 2
+            fi
+            PLAN_FILE="$2"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$DESIGN_FILE" || -z "$PLAN_FILE" ]]; then
+    echo "Error: --design-file and --plan-file are required" >&2
+    usage >&2
+    exit 2
+fi
+
+if [[ ! -f "$DESIGN_FILE" ]]; then
+    echo "Error: Design file not found: $DESIGN_FILE" >&2
+    exit 2
+fi
+
+if [[ ! -f "$PLAN_FILE" ]]; then
+    echo "Error: Plan file not found: $PLAN_FILE" >&2
+    exit 2
+fi
+
+# ============================================================
+# EXTRACT DESIGN SECTIONS
+# ============================================================
+
+# Extract ### subsections under ## Technical Design
+# We look for "## Technical Design" then collect all ### headers until the next ## header
+DESIGN_SECTIONS=()
+IN_TECH_DESIGN=false
+
+while IFS= read -r line; do
+    # Detect start of Technical Design section
+    if [[ "$line" =~ ^##[[:space:]]+Technical[[:space:]]+Design ]]; then
+        IN_TECH_DESIGN=true
+        continue
+    fi
+
+    # Detect next ## section (end of Technical Design)
+    if [[ "$IN_TECH_DESIGN" == true && "$line" =~ ^##[[:space:]] && ! "$line" =~ ^###[[:space:]] ]]; then
+        IN_TECH_DESIGN=false
+        continue
+    fi
+
+    # Collect ### subsection headers within Technical Design
+    if [[ "$IN_TECH_DESIGN" == true && "$line" =~ ^###[[:space:]]+(.+) ]]; then
+        section_name="${BASH_REMATCH[1]}"
+        # Trim trailing whitespace
+        section_name="$(echo "$section_name" | sed 's/[[:space:]]*$//')"
+        DESIGN_SECTIONS+=("$section_name")
+    fi
+done < "$DESIGN_FILE"
+
+# Validate we found sections
+if [[ ${#DESIGN_SECTIONS[@]} -eq 0 ]]; then
+    echo "Error: No Technical Design subsections found in design document" >&2
+    echo "Expected ### headers under '## Technical Design'" >&2
+    exit 2
+fi
+
+# ============================================================
+# EXTRACT PLAN TASKS
+# ============================================================
+
+# Extract ### Task headers from plan
+PLAN_TASKS=()
+while IFS= read -r line; do
+    if [[ "$line" =~ ^###[[:space:]]+Task[[:space:]]+[0-9]+ ]]; then
+        # Extract the full task title (everything after "### Task NNN: ")
+        task_title="${line#*: }"
+        if [[ -n "$task_title" && "$task_title" != "$line" ]]; then
+            PLAN_TASKS+=("$task_title")
+        else
+            PLAN_TASKS+=("$line")
+        fi
+    fi
+done < "$PLAN_FILE"
+
+# Also read the full plan content for free-text matching
+PLAN_CONTENT="$(cat "$PLAN_FILE")"
+
+# ============================================================
+# CROSS-REFERENCE: Design sections to plan tasks
+# ============================================================
+
+CHECK_PASS=0
+CHECK_FAIL=0
+GAPS=()
+MATRIX_ROWS=()
+
+for section in "${DESIGN_SECTIONS[@]}"; do
+    # Check if any task title or plan content references this design section
+    MATCHED_TASKS=()
+
+    for task in "${PLAN_TASKS[@]}"; do
+        # Case-insensitive substring match
+        if echo "$task" | grep -qiF "$section"; then
+            MATCHED_TASKS+=("$task")
+        fi
+    done
+
+    # If no task title matches, check the full plan content for the section name
+    if [[ ${#MATCHED_TASKS[@]} -eq 0 ]]; then
+        if echo "$PLAN_CONTENT" | grep -qiF "$section"; then
+            MATCHED_TASKS+=("(referenced in plan body)")
+        fi
+    fi
+
+    if [[ ${#MATCHED_TASKS[@]} -gt 0 ]]; then
+        task_list="$(printf '%s, ' "${MATCHED_TASKS[@]}")"
+        task_list="${task_list%, }"
+        MATRIX_ROWS+=("| $section | $task_list | Covered |")
+        CHECK_PASS=$((CHECK_PASS + 1))
+    else
+        MATRIX_ROWS+=("| $section | — | **GAP** |")
+        GAPS+=("$section")
+        CHECK_FAIL=$((CHECK_FAIL + 1))
+    fi
+done
+
+# ============================================================
+# STRUCTURED OUTPUT
+# ============================================================
+
+echo "## Plan Coverage Report"
+echo ""
+echo "**Design file:** \`$DESIGN_FILE\`"
+echo "**Plan file:** \`$PLAN_FILE\`"
+echo ""
+
+echo "### Coverage Matrix"
+echo ""
+echo "| Design Section | Task(s) | Status |"
+echo "|----------------|---------|--------|"
+for row in "${MATRIX_ROWS[@]}"; do
+    echo "$row"
+done
+echo ""
+
+TOTAL=$((CHECK_PASS + CHECK_FAIL))
+echo "### Summary"
+echo ""
+echo "- Design sections: $TOTAL"
+echo "- Covered: $CHECK_PASS"
+echo "- Gaps: $CHECK_FAIL"
+echo ""
+
+if [[ ${#GAPS[@]} -gt 0 ]]; then
+    echo "### Unmapped Sections"
+    echo ""
+    for gap in "${GAPS[@]}"; do
+        echo "- **$gap** — No task maps to this design section"
+    done
+    echo ""
+fi
+
+echo "---"
+echo ""
+
+if [[ $CHECK_FAIL -eq 0 ]]; then
+    echo "**Result: PASS** (${CHECK_PASS}/${TOTAL} sections covered)"
+    exit 0
+else
+    echo "**Result: FAIL** (${CHECK_FAIL}/${TOTAL} sections have gaps)"
+    exit 1
+fi

--- a/scripts/verify-plan-coverage.test.sh
+++ b/scripts/verify-plan-coverage.test.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# verify-plan-coverage.sh — Test Suite
+# Validates cross-referencing of design sections to plan tasks.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/verify-plan-coverage.sh"
+PASS=0
+FAIL=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAIL=$((FAIL + 1))
+}
+
+# ============================================================
+# TEST FIXTURES
+# ============================================================
+
+TMPDIR_ROOT=""
+
+setup() {
+    TMPDIR_ROOT="$(mktemp -d)"
+}
+
+teardown() {
+    if [[ -n "$TMPDIR_ROOT" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+
+# Design with Technical Design subsections all mapped to tasks
+create_full_coverage_files() {
+    local dir="$1"
+    cat > "$dir/design.md" << 'EOF'
+# Feature Design
+
+## Problem Statement
+
+We need to build a widget system.
+
+## Chosen Approach
+
+Use component-based architecture.
+
+## Technical Design
+
+### Widget Component
+
+Renders the main UI.
+
+### API Client
+
+Handles data fetching.
+
+### State Manager
+
+Manages application state.
+
+## Testing Strategy
+
+Unit tests for all components.
+EOF
+
+    cat > "$dir/plan.md" << 'EOF'
+# Implementation Plan
+
+## Tasks
+
+### Task 001: Create Widget Component
+
+Build the widget rendering layer.
+Design section: Widget Component
+
+### Task 002: Create API Client
+
+Build the API integration.
+Design section: API Client
+
+### Task 003: Create State Manager
+
+Build the state management module.
+Design section: State Manager
+EOF
+    echo "$dir"
+}
+
+# Design with a section NOT mapped to any task
+create_gap_files() {
+    local dir="$1"
+    cat > "$dir/design.md" << 'EOF'
+# Feature Design
+
+## Problem Statement
+
+We need a full system.
+
+## Technical Design
+
+### Widget Component
+
+Renders the main UI.
+
+### API Client
+
+Handles data fetching.
+
+### Cache Layer
+
+Caching for performance.
+
+## Testing Strategy
+
+Unit tests needed.
+EOF
+
+    cat > "$dir/plan.md" << 'EOF'
+# Implementation Plan
+
+## Tasks
+
+### Task 001: Create Widget Component
+
+Design section: Widget Component
+
+### Task 002: Create API Client
+
+Design section: API Client
+EOF
+    # Note: Cache Layer has no corresponding task
+    echo "$dir"
+}
+
+# Empty design file
+create_empty_design() {
+    local dir="$1"
+    cat > "$dir/design.md" << 'EOF'
+EOF
+    cat > "$dir/plan.md" << 'EOF'
+# Implementation Plan
+
+## Tasks
+
+### Task 001: Something
+
+Some task.
+EOF
+    echo "$dir"
+}
+
+# ============================================================
+# TEST CASES
+# ============================================================
+
+echo "=== Verify Plan Coverage Tests ==="
+echo ""
+
+# --------------------------------------------------
+# Test 1: FullCoverage_AllSectionsMapped_ExitsZero
+# --------------------------------------------------
+setup
+DIR="$(create_full_coverage_files "$TMPDIR_ROOT")"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "$DIR/design.md" --plan-file "$DIR/plan.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "FullCoverage_AllSectionsMapped_ExitsZero"
+else
+    fail "FullCoverage_AllSectionsMapped_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 2: GapFound_MissingSection_ExitsOne
+# --------------------------------------------------
+setup
+DIR="$(create_gap_files "$TMPDIR_ROOT")"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "$DIR/design.md" --plan-file "$DIR/plan.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "GapFound_MissingSection_ExitsOne"
+else
+    fail "GapFound_MissingSection_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+# Verify the gap identifies Cache Layer
+if echo "$OUTPUT" | grep -qi "Cache Layer"; then
+    pass "GapFound_IdentifiesMissingSection"
+else
+    fail "GapFound_IdentifiesMissingSection (expected 'Cache Layer' in output)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 3: EmptyDesign_ExitsTwo
+# --------------------------------------------------
+setup
+DIR="$(create_empty_design "$TMPDIR_ROOT")"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "$DIR/design.md" --plan-file "$DIR/plan.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "EmptyDesign_ExitsTwo"
+else
+    fail "EmptyDesign_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 4: OutputContainsCoverageMatrix
+# --------------------------------------------------
+setup
+DIR="$(create_full_coverage_files "$TMPDIR_ROOT")"
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "$DIR/design.md" --plan-file "$DIR/plan.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if echo "$OUTPUT" | grep -qE "Design Section.*Task"; then
+    pass "OutputContainsCoverageMatrix"
+else
+    fail "OutputContainsCoverageMatrix (no coverage matrix in output)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 5: UsageError_MissingArgs_ExitsTwo
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "UsageError_MissingArgs_ExitsTwo"
+else
+    fail "UsageError_MissingArgs_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 6: HelpFlag_ShowsUsage_ExitsZero
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --help 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "HelpFlag_ShowsUsage_ExitsZero"
+else
+    fail "HelpFlag_ShowsUsage_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+if echo "$OUTPUT" | grep -q "design-file"; then
+    pass "HelpFlag_ShowsUsageText"
+else
+    fail "HelpFlag_ShowsUsageText (no usage text in output)"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 7: MissingDesignFile_ExitsTwo
+# --------------------------------------------------
+setup
+cat > "$TMPDIR_ROOT/plan.md" << 'EOF'
+# Plan
+### Task 001: Something
+EOF
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "/nonexistent/design.md" --plan-file "$TMPDIR_ROOT/plan.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "MissingDesignFile_ExitsTwo"
+else
+    fail "MissingDesignFile_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "=== Test Summary ==="
+echo -e "Passed: ${GREEN}$PASS${NC}"
+echo -e "Failed: ${RED}$FAIL${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/skills/implementation-planning/SKILL.md
+++ b/skills/implementation-planning/SKILL.md
@@ -38,6 +38,19 @@ Every implementation task MUST:
 2. Specify the expected failure reason
 3. Only then implement minimum code to pass
 
+**Verify TDD compliance** in git history after implementation:
+
+```bash
+scripts/check-tdd-compliance.sh \
+  --repo-root . \
+  --branch feature/<name> \
+  --base-branch main
+```
+
+- **exit 0** — All commits have test files before or alongside implementation
+- **exit 1** — Violations found; commits have implementation without corresponding tests
+- **exit 2** — Usage error; check arguments
+
 ## Planning Process
 
 ### Step 1: Analyze Design Document
@@ -54,6 +67,19 @@ Read the design document thoroughly. For each major section, extract:
 
 Create a traceability matrix mapping design sections to planned tasks.
 Consult `references/spec-tracing-guide.md` for the methodology and template.
+
+**Pre-populate the matrix** using the traceability generator script:
+
+```bash
+scripts/generate-traceability.sh \
+  --design-file docs/designs/<feature>.md \
+  --plan-file docs/plans/<date>-<feature>.md \
+  --output docs/plans/<date>-<feature>-traceability.md
+```
+
+- **exit 0** — Matrix generated; review and fill in "Key Requirements" column
+- **exit 1** — Parse error; design document may lack expected `##`/`###` headers
+- **exit 2** — Usage error; check arguments
 
 ### Step 2: Decompose into Tasks
 
@@ -81,7 +107,34 @@ Use the template from `references/plan-document-template.md`.
 
 ### Step 5: Plan Verification
 
-Follow the coverage checklist and delta analysis in `references/spec-tracing-guide.md`.
+Run deterministic verification scripts instead of manual checklist review.
+
+**5a. Design-to-plan coverage** — verify every Technical Design subsection maps to a task:
+
+```bash
+scripts/verify-plan-coverage.sh \
+  --design-file docs/designs/<feature>.md \
+  --plan-file docs/plans/<date>-<feature>.md
+```
+
+- **exit 0** — All design sections covered; proceed to 5b
+- **exit 1** — Gaps found; add tasks for uncovered sections or defer with rationale
+- **exit 2** — Usage error or empty design; check arguments
+
+**5b. Spec coverage check** — verify planned test files exist and pass:
+
+```bash
+scripts/spec-coverage-check.sh \
+  --plan-file docs/plans/<date>-<feature>.md \
+  --repo-root . \
+  --threshold 80
+```
+
+- **exit 0** — All planned tests found and passing; plan verification complete
+- **exit 1** — Missing test files or test failures; create missing tests or fix failures
+- **exit 2** — Usage error; check arguments
+
+For reference, consult `references/spec-tracing-guide.md` for the underlying methodology.
 
 ## Anti-Patterns
 
@@ -113,13 +166,24 @@ On plan save, update state via `mcp__exarchos__exarchos_workflow` `action: "set"
 ## Completion Criteria
 
 - [ ] Design document read and understood
-- [ ] Spec traceability table created
+- [ ] Spec traceability table created (`scripts/generate-traceability.sh`)
 - [ ] Scope declared (full or partial with rationale)
 - [ ] Tasks decomposed to 2-5 min granularity
 - [ ] Each task starts with failing test
 - [ ] Dependencies mapped
 - [ ] Parallel groups identified
-- [ ] Plan verification passed (Step 5)
+- [ ] Plan verification passed — `scripts/verify-plan-coverage.sh` exit 0
+- [ ] Spec coverage check passed — `scripts/spec-coverage-check.sh` exit 0
+- [ ] Coverage thresholds met — `scripts/check-coverage-thresholds.sh` exit 0:
+
+```bash
+scripts/check-coverage-thresholds.sh \
+  --coverage-file coverage/coverage-summary.json \
+  --line-threshold 80 \
+  --branch-threshold 70 \
+  --function-threshold 100
+```
+
 - [ ] Plan saved to `docs/plans/`
 - [ ] State file updated with plan path and tasks
 


### PR DESCRIPTION
## Summary

Replaces 5 prose checklist steps in the implementation-planning skill with deterministic validation scripts. Covers spec tracing, plan coverage, traceability matrix generation, TDD compliance, and coverage threshold verification.

## Changes

- **spec-coverage-check.sh** — Verifies design spec sections have corresponding test files and those tests pass
- **verify-plan-coverage.sh** — Checks that every design section is covered by at least one plan task
- **generate-traceability.sh** — Produces a traceability matrix mapping design sections to plan tasks with coverage status
- **check-tdd-compliance.sh** — Validates commit ordering follows TDD red-green-refactor by checking test-before-implementation patterns
- **check-coverage-thresholds.sh** — Verifies test coverage meets configurable thresholds for lines, branches, and functions
- **implementation-planning/SKILL.md** — Updated to invoke scripts instead of prose checklists

## Test Plan

5 co-located test files covering spec matching, plan coverage gaps, traceability generation, TDD ordering violations, and threshold edge cases.

---

**Results:** Script tests pass · Build 0 errors
**Related:** #275 (Phase 5), stack 6/8