### PR TITLE
feat: add agent event metadata validation helper

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { validateAgentEvent, AGENT_EVENT_TYPES } from './schemas.js';
+
+describe('validateAgentEvent', () => {
+  describe('agent event types', () => {
+    it('should reject task.claimed when agentId is missing', () => {
+      expect(() =>
+        validateAgentEvent({ type: 'task.claimed', source: 'test' }),
+      ).toThrow();
+    });
+
+    it('should reject task.claimed when source is missing', () => {
+      expect(() =>
+        validateAgentEvent({ type: 'task.claimed', agentId: 'agent-1' }),
+      ).toThrow();
+    });
+
+    it('should reject agent.message when agentId and source are both missing', () => {
+      expect(() =>
+        validateAgentEvent({ type: 'agent.message' }),
+      ).toThrow();
+    });
+
+    it('should reject agent.handoff when agentId is missing', () => {
+      expect(() =>
+        validateAgentEvent({ type: 'agent.handoff', source: 'test' }),
+      ).toThrow();
+    });
+
+    it('should reject task.progressed when source is missing', () => {
+      expect(() =>
+        validateAgentEvent({ type: 'task.progressed', agentId: 'agent-1' }),
+      ).toThrow();
+    });
+
+    it('should pass task.claimed when both agentId and source are present', () => {
+      expect(
+        validateAgentEvent({ type: 'task.claimed', agentId: 'agent-1', source: 'test' }),
+      ).toBe(true);
+    });
+
+    it('should pass agent.message when both agentId and source are present', () => {
+      expect(
+        validateAgentEvent({ type: 'agent.message', agentId: 'agent-1', source: 'orchestrator' }),
+      ).toBe(true);
+    });
+
+    it('should pass agent.handoff when both agentId and source are present', () => {
+      expect(
+        validateAgentEvent({ type: 'agent.handoff', agentId: 'agent-1', source: 'test' }),
+      ).toBe(true);
+    });
+
+    it('should pass task.progressed when both agentId and source are present', () => {
+      expect(
+        validateAgentEvent({ type: 'task.progressed', agentId: 'agent-1', source: 'test' }),
+      ).toBe(true);
+    });
+  });
+
+  describe('system event types', () => {
+    it('should pass workflow.started without agentId or source', () => {
+      expect(
+        validateAgentEvent({ type: 'workflow.started' }),
+      ).toBe(true);
+    });
+
+    it('should pass phase.transitioned without agentId or source', () => {
+      expect(
+        validateAgentEvent({ type: 'phase.transitioned' }),
+      ).toBe(true);
+    });
+
+    it('should pass task.assigned without agentId or source', () => {
+      expect(
+        validateAgentEvent({ type: 'task.assigned' }),
+      ).toBe(true);
+    });
+
+    it('should pass team.formed without agentId or source', () => {
+      expect(
+        validateAgentEvent({ type: 'team.formed' }),
+      ).toBe(true);
+    });
+  });
+
+  describe('AGENT_EVENT_TYPES constant', () => {
+    it('should contain exactly the four agent event types', () => {
+      expect(AGENT_EVENT_TYPES).toEqual([
+        'task.claimed',
+        'task.progressed',
+        'agent.message',
+        'agent.handoff',
+      ]);
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -301,3 +301,50 @@ export type WorkflowCircuitOpen = z.infer<typeof WorkflowCircuitOpenData>;
 export type ToolInvoked = z.infer<typeof ToolInvokedData>;
 export type ToolCompleted = z.infer<typeof ToolCompletedData>;
 export type ToolErrored = z.infer<typeof ToolErroredData>;
+
+// ─── Agent Event Validation ──────────────────────────────────────────────────
+
+/** Event types that require agentId and source metadata. */
+export const AGENT_EVENT_TYPES = [
+  'task.claimed',
+  'task.progressed',
+  'agent.message',
+  'agent.handoff',
+] as const;
+
+export type AgentEventType = typeof AGENT_EVENT_TYPES[number];
+
+/**
+ * Validates that agent event types include required metadata fields.
+ *
+ * Agent events (`task.claimed`, `task.progressed`, `agent.message`, `agent.handoff`)
+ * must have both `agentId` and `source` set. System events pass through without
+ * validation.
+ *
+ * @returns `true` if validation passes
+ * @throws Error if an agent event is missing `agentId` or `source`
+ */
+export function validateAgentEvent(event: {
+  type: string;
+  agentId?: string;
+  source?: string;
+}): true {
+  const isAgentEvent = (AGENT_EVENT_TYPES as readonly string[]).includes(event.type);
+  if (!isAgentEvent) {
+    return true;
+  }
+
+  if (!event.agentId) {
+    throw new Error(
+      `Agent event '${event.type}' requires agentId but none was provided`,
+    );
+  }
+
+  if (!event.source) {
+    throw new Error(
+      `Agent event '${event.type}' requires source but none was provided`,
+    );
+  }
+
+  return true;
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
@@ -3,6 +3,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { EventStore, SequenceConflictError } from '../event-store/store.js';
+import { validateAgentEvent } from '../event-store/schemas.js';
 import { formatResult, toEventAck, type ToolResult } from '../format.js';
 import { getOrCreateMaterializer, getOrCreateEventStore } from '../views/tools.js';
 import { TASK_DETAIL_VIEW } from '../views/task-detail-view.js';
@@ -127,17 +128,23 @@ async function attemptTaskClaim(
     }
   }
 
+  const claimEvent = {
+    type: 'task.claimed' as const,
+    data: {
+      taskId: args.taskId,
+      agentId: args.agentId,
+      claimedAt: new Date().toISOString(),
+    },
+    agentId: args.agentId,
+    source: 'exarchos-mcp',
+  };
+
+  // Validate agent event metadata before appending
+  validateAgentEvent(claimEvent);
+
   const event = await store.append(
     args.streamId,
-    {
-      type: 'task.claimed',
-      data: {
-        taskId: args.taskId,
-        agentId: args.agentId,
-        claimedAt: new Date().toISOString(),
-      },
-      agentId: args.agentId,
-    },
+    claimEvent,
     { expectedSequence: currentSequence },
   );
 


### PR DESCRIPTION
## Summary

Adds a `validateAgentEvent` helper that enforces `agentId` and `source` metadata on agent-originated events (`task.claimed`, `task.progressed`, `agent.message`, `agent.handoff`). System events pass through without validation. Wired into `handleTaskClaim` to confirm the contract at append time.

## Changes

- **`event-store/schemas.ts`** — New `AGENT_EVENT_TYPES` constant and `validateAgentEvent()` function
- **`event-store/schemas.test.ts`** (new) — 14 tests covering rejection, pass-through, and constant validation
- **`tasks/tools.ts`** — Wire `validateAgentEvent` before `store.append`; add `source: 'exarchos-mcp'` to claim events

## Test Plan

14 new unit tests for the validation helper covering all agent and system event types.

---

**Results:** Tests 1162 ✓ · Build 0 errors
**Related:** Part of refactor-optimize-prompt-staleness (2/7)