### PR TITLE
refactor: extract track-specific content from oversized skills to references

### DIFF
--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -151,79 +151,11 @@ bash scripts/post-delegation-check.sh \
 
 ### Step 7: Schema Sync (Auto-Detection)
 
-After all tasks complete, run the schema sync detection script:
-
-```bash
-bash scripts/needs-schema-sync.sh \
-  --repo-root <project-root> \
-  [--base-branch main] \
-  [--diff-file <path-to-diff>]
-```
-
-**Validates:** Git diff for API file patterns that trigger schema regeneration:
-- `*Endpoints.cs`
-- `Models/*.cs`
-- `Requests/*.cs`
-- `Responses/*.cs`
-- `Dtos/*.cs`
-
-**On exit 0:** No sync needed. No API files were modified. Proceed to review phase.
-
-**On exit 1:** Sync needed. The output lists modified API files. Run schema sync:
-
-```bash
-# Run schema sync from monorepo root
-npm run sync:schemas
-
-# Verify types
-npm run typecheck
-
-# Stage and commit via Graphite
-git add shared/types/src/generated/ shared/validation/src/generated/ apps/ares-elite-web/src/api/generated/
-gt create chore/schema-sync -m "chore: regenerate TypeScript types from OpenAPI"
-gt submit --no-interactive --publish
-```
-
-**NEVER use `git commit` or `git push`** — always use `gt create` and `gt submit`.
-
-**Skill Reference:** `@skills/sync-schemas/SKILL.md`
+After all tasks complete, check for modified API files (`*Endpoints.cs`, `Models/*.cs`, `Requests/*.cs`, `Responses/*.cs`, `Dtos/*.cs`). If found, run `npm run sync:schemas` and commit via Graphite. See `@skills/sync-schemas/SKILL.md`.
 
 ## Parallel Execution Strategy
 
-### Identifying Parallel Groups
-
-From implementation plan:
-```markdown
-## Parallel Groups
-
-Group A (can run simultaneously):
-- Task 001: Types
-- Task 002: Interfaces
-
-Group B (depends on Group A):
-- Task 003: Implementation
-- Task 004: API handlers
-```
-
-### Dispatching Parallel Tasks
-
-**Critical:** Use single message with multiple Task calls:
-
-```typescript
-// CORRECT: Single message, parallel execution
-Task({ model: "opus", description: "Task 001", prompt: "..." })
-Task({ model: "opus", description: "Task 002", prompt: "..." })
-
-// WRONG: Separate messages = sequential
-```
-
-### Waiting for Parallel Completion
-
-```typescript
-// Wait for all background tasks
-TaskOutput({ task_id: "task-001-id" })
-TaskOutput({ task_id: "task-002-id" })
-```
+Dispatch parallel tasks in a single message with multiple Task calls. See `@skills/delegation/references/parallel-strategy.md` for group identification, dispatching patterns, and model selection.
 
 ## Worktree Enforcement (MANDATORY)
 
@@ -286,15 +218,6 @@ Include in ALL implementer prompts:
 | Forget to track in TodoWrite | Update status for every task |
 | Skip TDD requirements | Include TDD instructions in prompt |
 
-## Model Selection Guide
-
-| Task Type | Model | Reason |
-|-----------|-------|--------|
-| Code implementation | `opus` | Best quality for coding |
-| Code review | `opus` | Thorough analysis |
-| File search/exploration | (default) | Speed over quality |
-| Simple queries | `haiku` | Fast, low cost |
-
 ## State Management
 
 This skill tracks task progress in workflow state for context persistence.
@@ -324,83 +247,9 @@ Update phase using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
 
 ## Fix Mode (--fixes)
 
-When invoked with `--fixes`, delegation handles review failures instead of initial implementation.
+When invoked with `--fixes`, delegation handles review failures instead of initial implementation. Uses fixer-prompt template, dispatches fix tasks per issue, then re-invokes review.
 
-### Trigger
-
-```bash
-/delegate --fixes docs/plans/YYYY-MM-DD-feature.md
-```
-
-Or auto-invoked after review failures.
-
-### Fix Mode Process
-
-1. **Read failure details** from state using `mcp__exarchos__exarchos_workflow` with `action: "get"`:
-   - Query `reviews` for review failures
-
-2. **Extract fix tasks** using the extraction script:
-
-   ```bash
-   bash scripts/extract-fix-tasks.sh \
-     --state-file <path-to-state.json> \
-     [--review-report <path-to-report.json>] \
-     [--repo-root <project-root>]
-   ```
-
-   **Validates:**
-   - Findings parsed from state file reviews (or external report file)
-   - Each finding mapped to file path and line number
-   - File-to-worktree ownership determined from task worktree assignments
-
-   **On exit 0:** Outputs JSON array of fix tasks with fields: `id`, `file`, `line`, `worktree`, `description`, `severity`. Use this output to create fix task dispatches.
-
-   **On exit 1:** Parse error. Check that the state file or review report contains valid JSON with the expected structure.
-
-3. **Create fix tasks** for each extracted issue:
-   - Use `fixer-prompt.md` template
-   - Include full issue context from the extracted JSON
-   - Specify target worktree from the extraction output
-
-4. **Dispatch fixers** (same as implementers, different prompt):
-   ```typescript
-   Task({
-     subagent_type: "general-purpose",
-     model: "opus",
-     description: "Fix: [issue summary]",
-     prompt: "[fixer-prompt template with issue details]"
-   })
-   ```
-
-5. **Re-review after fixes**:
-   After all fix tasks complete, auto-invoke review phase:
-   ```typescript
-   Skill({ skill: "review", args: "<state-file>" })
-   ```
-
-### Fix Task Structure
-
-Each fix task extracted should include:
-
-| Field | Description |
-|-------|-------------|
-| issue | Problem description from review |
-| file | File path needing fix |
-| line | Line number (if known) |
-| worktree | Which worktree to fix in |
-| branch | Which branch owns this fix |
-| priority | HIGH / MEDIUM / LOW |
-
-### Transition After Fixes
-
-Fix mode goes back to the integration phase after fixes are applied,
-then re-enters review to re-integrate and re-verify:
-
-```text
-/delegate --fixes -> [fixes applied] -> re-integrate -> /review
-```
-
-This ensures fixed code is re-verified.
+For detailed fix mode process, task structure, and transition flow, see `@skills/delegation/references/fix-mode.md`.
 
 ## Completion Criteria
 
@@ -434,29 +283,16 @@ See `@skills/delegation/references/troubleshooting.md` for detailed troubleshoot
 
 ## Exarchos Integration
 
-When Exarchos MCP tools are available, emit events during delegation:
+Emit events at each delegation milestone using Exarchos MCP tools:
 
-1. **At delegation start:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `workflow.started` (if not already emitted for this workflow)
-2. **After team composition:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `team.formed` including teammates array
-3. **For each task dispatch:** Use `mcp__exarchos__exarchos_orchestrate` with `action: "team_spawn"` to register the agent with the team coordinator, then use the Task tool to launch the subagent. `team_spawn` handles role assignment, event emission, and health tracking; the Task tool handles actual subprocess execution. Both are always used together — `team_spawn` does not replace the Task tool
-4. **For each task assignment:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `task.assigned` including taskId, title, branch, worktree
-5. **Monitor progress:** Use `mcp__exarchos__exarchos_view` with `action: "workflow_status"` to check task completion status. For lightweight checks, use `mcp__exarchos__exarchos_workflow` with `action: "get"` with `fields: ["tasks"]`
-6. **On task completion — Graphite stacking:**
-   Subagents handle stacking directly using `gt create` (per implementer prompt template).
-   When a multi-task agent completes, it will have created a Graphite stack with one branch per logical review unit.
-   The orchestrator should:
-   - Call `mcp__exarchos__exarchos_view` with `action: "stack_place"` with position, taskId, and branch to record each stack position
-   - Verify the stack was submitted by checking for PRs: `mcp__graphite__run_gt_cmd({ args: ["--no-interactive", "ls"], cwd: "<worktree-path>" })`
-7. **On all tasks complete:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `phase.transitioned` from delegate to next phase
+1. **Delegation start:** `exarchos_event` append `workflow.started` (if not already emitted)
+2. **Team composition:** `exarchos_event` append `team.formed` with teammates array
+3. **Task dispatch:** `exarchos_orchestrate` `team_spawn` to register agent, then Task tool to launch. Both are always used together -- `team_spawn` does not replace Task tool
+4. **Task assignment:** `exarchos_event` append `task.assigned` with taskId, title, branch, worktree
+5. **Monitor:** `exarchos_view` `workflow_status` or `exarchos_workflow` `get` with `fields: ["tasks"]`
+6. **Task completion:** Record stack positions via `exarchos_view` `stack_place`. Subagents handle Graphite stacking via `gt create`
+7. **All complete:** `exarchos_event` append `phase.transitioned` from delegate to next phase
 
 ### Claim Guard
 
-Use `mcp__exarchos__exarchos_orchestrate` with `action: "task_claim"` to claim tasks. This action prevents double-claims via optimistic concurrency. If an agent receives an `ALREADY_CLAIMED` error, another agent already claimed that task. The orchestrator should:
-- Skip the task (it's being handled)
-- Check task status via `mcp__exarchos__exarchos_view` with `action: "tasks"` with `filter: { "taskId": "<id>" }` before re-dispatching
-
-## Performance Notes
-
-- Complete each step fully before advancing — quality over speed
-- Do not skip validation checks even when the change appears trivial
-- Verify each task dispatch before proceeding to next. Do not batch dispatches without confirming worktree readiness.
+Use `exarchos_orchestrate` `task_claim` for optimistic concurrency. On `ALREADY_CLAIMED`, skip the task and check status via `exarchos_view` `tasks` before re-dispatching.

--- a/skills/delegation/references/fix-mode.md
+++ b/skills/delegation/references/fix-mode.md
@@ -1,0 +1,66 @@
+# Fix Mode (--fixes)
+
+When invoked with `--fixes`, delegation handles review failures instead of initial implementation.
+
+## Trigger
+
+```bash
+/delegate --fixes docs/plans/YYYY-MM-DD-feature.md
+```
+
+Or auto-invoked after review failures.
+
+## Fix Mode Process
+
+1. **Read failure details** from state using `mcp__exarchos__exarchos_workflow` with `action: "get"`:
+   - Query `reviews` for review failures
+
+2. **Extract fix tasks** from failure reports:
+   - Parse issue descriptions
+   - Identify file paths and line numbers
+   - Determine which worktree/branch owns the fix
+
+3. **Create fix tasks** for each issue:
+   - Use `fixer-prompt.md` template
+   - Include full issue context
+   - Specify target worktree
+
+4. **Dispatch fixers** (same as implementers, different prompt):
+   ```typescript
+   Task({
+     subagent_type: "general-purpose",
+     model: "opus",
+     description: "Fix: [issue summary]",
+     prompt: "[fixer-prompt template with issue details]"
+   })
+   ```
+
+5. **Re-review after fixes**:
+   After all fix tasks complete, auto-invoke review phase:
+   ```typescript
+   Skill({ skill: "review", args: "<state-file>" })
+   ```
+
+## Fix Task Structure
+
+Each fix task extracted should include:
+
+| Field | Description |
+|-------|-------------|
+| issue | Problem description from review |
+| file | File path needing fix |
+| line | Line number (if known) |
+| worktree | Which worktree to fix in |
+| branch | Which branch owns this fix |
+| priority | HIGH / MEDIUM / LOW |
+
+## Transition After Fixes
+
+Fix mode goes back to the integration phase after fixes are applied,
+then re-enters review to re-integrate and re-verify:
+
+```text
+/delegate --fixes -> [fixes applied] -> re-integrate -> /review
+```
+
+This ensures fixed code is re-verified.

--- a/skills/delegation/references/parallel-strategy.md
+++ b/skills/delegation/references/parallel-strategy.md
@@ -1,0 +1,45 @@
+# Parallel Execution Strategy
+
+## Identifying Parallel Groups
+
+From implementation plan:
+```markdown
+## Parallel Groups
+
+Group A (can run simultaneously):
+- Task 001: Types
+- Task 002: Interfaces
+
+Group B (depends on Group A):
+- Task 003: Implementation
+- Task 004: API handlers
+```
+
+## Dispatching Parallel Tasks
+
+**Critical:** Use single message with multiple Task calls:
+
+```typescript
+// CORRECT: Single message, parallel execution
+Task({ model: "opus", description: "Task 001", prompt: "..." })
+Task({ model: "opus", description: "Task 002", prompt: "..." })
+
+// WRONG: Separate messages = sequential
+```
+
+## Waiting for Parallel Completion
+
+```typescript
+// Wait for all background tasks
+TaskOutput({ task_id: "task-001-id" })
+TaskOutput({ task_id: "task-002-id" })
+```
+
+## Model Selection Guide
+
+| Task Type | Model | Reason |
+|-----------|-------|--------|
+| Code implementation | `opus` | Best quality for coding |
+| Code review | `opus` | Thorough analysis |
+| File search/exploration | (default) | Speed over quality |
+| Simple queries | `haiku` | Fast, low cost |

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -86,280 +86,19 @@ Activate this skill when:
 
 ## Polish Track
 
-### Purpose
+Fast path for small, contained refactors (<=5 files, single concern). Orchestrator may write code directly (exception to orchestrator constraints). No worktree, no delegation.
 
-Fast path for small, contained refactors. Single session, minimal ceremony. Orchestrator may write implementation code directly (exception to orchestrator constraints).
+Phases: Explore -> Brief -> Implement -> Validate -> Update Docs -> Complete
 
-### Phases
-
-```
-Explore -> Brief -> Implement -> Validate -> Update Docs -> Complete
-   |         |          |           |             |
-   |         |          |           |             +-- Update affected documentation
-   |         |          |           +-- Run tests, verify goals met
-   |         |          +-- Direct implementation (no worktree)
-   |         +-- Capture goals and approach in state
-   +-- Quick scope assessment, confirm polish-appropriate
-```
-
-### Phase Details
-
-#### 1. Explore Phase
-
-Use `@skills/refactor/references/explore-checklist.md` to assess current code structure, then run the scope assessment script to determine the recommended track:
-
-```bash
-# Assess scope from a comma-separated file list
-scripts/assess-refactor-scope.sh --files "src/foo.ts,src/bar.ts,src/baz.ts"
-
-# Or read files from workflow state (requires jq)
-scripts/assess-refactor-scope.sh --state-file ~/.claude/workflow-state/<feature>.state.json
-```
-
-> **Dependency:** The `--state-file` option requires `jq` to parse the workflow state JSON. The script will exit with an error if `jq` is not installed.
-
-**What it validates:**
-- File count (<=5 for polish)
-- Cross-module span (files in different top-level directories)
-- Test coverage assessment (test counterparts for source files)
-
-**Exit code routing:**
-- Exit 0 = polish recommended (proceed with polish track)
-- Exit 1 = overhaul recommended (switch to overhaul track)
-- Exit 2 = usage error
-
-Update state using MCP tools:
-1. Use `mcp__exarchos__exarchos_workflow` with `action: "init"` with featureId `refactor-<slug>` and workflowType `refactor`
-2. Use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set track (based on script recommendation), phase, and explore scope assessment
-
-On completion, use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `explore.completedAt` and `phase` to "brief".
-
-#### 2. Brief Phase
-
-Capture refactor intent and approach in state (not separate document).
-
-Use `@skills/refactor/references/brief-template.md` to structure:
-- Problem statement (2-3 sentences)
-- Specific goals (bulleted list)
-- High-level approach
-- Out of scope items
-- Success criteria
-- Docs to update
-
-Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set the `brief` object and `phase` to "polish-implement".
-
-#### 3. Implement Phase
-
-**Orchestrator may write code directly** (polish track exception).
-
-Constraints:
-- Follow TDD (write/update test first if behavior changes)
-- Commit after each logical change
-- Stop if scope expands beyond brief
-
-When done, commit via Graphite:
-```typescript
-mcp__graphite__run_gt_cmd({ args: ["create", "-m", "refactor: <description>"], cwd: "<repo-root>" })
-```
-
-Update state on completion using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `phase` to "polish-validate".
-
-#### 4. Validate Phase
-
-Run the validation script to verify refactor goals are met:
-
-```bash
-# Run all checks (tests, lint, typecheck)
-scripts/validate-refactor.sh --repo-root <path>
-
-# Skip optional checks
-scripts/validate-refactor.sh --repo-root <path> --skip-lint --skip-typecheck
-```
-
-**What it validates:**
-- `npm run test:run` passes (required)
-- `npm run lint` passes (skipped if missing or `--skip-lint`)
-- `npm run typecheck` passes (skipped if missing or `--skip-typecheck`)
-
-**Exit code routing:**
-- Exit 0 = all checks pass (proceed to update-docs)
-- Exit 1 = one or more checks failed (fix before proceeding)
-- Exit 2 = usage error
-
-Additionally verify each goal in brief is addressed and code quality improved per brief (manual review).
-
-Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `validation` object and `phase` to "polish-update-docs".
-
-#### 5. Update Docs Phase
-
-**Mandatory** - documentation must reflect new architecture.
-
-Use `@skills/refactor/references/doc-update-checklist.md` to update:
-- Architecture docs if structure changed
-- API docs if interfaces changed
-- README if setup/usage changed
-- Inline comments if complex logic moved
-
-If `docsToUpdate` is empty, verify no docs need updating.
-
-After updating documentation, verify all internal links resolve:
-
-```bash
-# Check a single doc file
-scripts/verify-doc-links.sh --doc-file docs/designs/my-design.md
-
-# Check all docs recursively
-scripts/verify-doc-links.sh --docs-dir docs/
-```
-
-**What it validates:**
-- All `[text](path)` markdown links resolve to existing files
-- External URLs (http/https) are skipped
-- Anchor-only links (#section) are skipped
-
-**Exit code routing:**
-- Exit 0 = all internal links valid (proceed)
-- Exit 1 = broken links found (fix before proceeding)
-- Exit 2 = usage error
-
-Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `validation.docsUpdated` to true, `artifacts.updatedDocs` array, and `phase` to "completed".
-
-> **Note:** The HSM transitions directly from `polish-update-docs` to `completed`. There is no `synthesize` phase for polish track.
+For detailed phase instructions, state management, and auto-chain behavior, see `@skills/refactor/references/polish-track.md`.
 
 ## Overhaul Track
 
-### Purpose
-
 Rigorous path for architectural changes, migrations, and multi-file restructuring. Uses full delegation model with worktree isolation.
 
-### Phases
+Phases: Explore -> Brief -> Plan -> Delegate -> Review -> Update Docs -> Synthesize
 
-```
-Explore -> Brief -> Plan -> Delegate -> Review -> Update Docs -> Synthesize
-   |         |        |         |          |            |             |
-   |         |        |         |          |            |             +-- PR creation
-   |         |        |         |          |            +-- Update architecture docs
-   |         |        |         |          +-- Quality review (emphasized)
-   |         |        |         +-- TDD implementation in worktrees
-   |         |        +-- Extract tasks from brief
-   |         +-- Detailed goals, approach, affected areas
-   +-- Thorough scope assessment, identify affected systems
-```
-
-### Phase Details
-
-#### 1. Explore Phase
-
-Thorough scope assessment using `@skills/refactor/references/explore-checklist.md`:
-- Read affected code to understand current structure
-- Identify ALL files/modules that will change
-- Assess test coverage of affected areas
-- Identify documentation that will need updates
-- Map dependencies and impact
-
-Update state using MCP tools:
-1. Use `mcp__exarchos__exarchos_workflow` with `action: "init"` with featureId `refactor-<slug>` and workflowType `refactor`
-2. Use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set track to "overhaul", phase, and explore scope assessment
-
-On completion, use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `explore.completedAt` and `phase` to "brief".
-
-#### 2. Brief Phase
-
-Detailed capture of refactor intent (more thorough than polish).
-
-Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set the `brief` object and `phase` to "overhaul-plan".
-
-Then auto-invoke plan:
-```typescript
-Skill({ skill: "plan", args: "--refactor ~/.claude/workflow-state/<feature>.state.json" })
-```
-
-#### 3. Plan Phase
-
-Invoke `/plan` skill with explicit Skill tool call:
-
-```typescript
-Skill({ skill: "plan", args: "--refactor ~/.claude/workflow-state/<feature>.state.json" })
-```
-
-The `/plan` skill:
-- Extracts tasks from the brief
-- Focuses on incremental, testable changes
-- Each task leaves code in working state
-- Dependency order matters more for refactors
-
-Update state on completion using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `artifacts.plan` and `phase` to "overhaul-delegate".
-
-> **Note:** There is no `plan-review` phase in the refactor HSM. Overhaul goes directly `overhaul-plan` → `overhaul-delegate`.
-
-Then auto-invoke delegate:
-```typescript
-Skill({ skill: "delegate", args: "~/.claude/workflow-state/<feature>.state.json" })
-```
-
-#### 4. Delegate Phase
-
-Invoke `/delegate` skill for TDD implementation in worktrees:
-
-```typescript
-Skill({ skill: "delegate", args: "~/.claude/workflow-state/<feature>.state.json" })
-```
-
-The `/delegate` skill:
-- Creates worktrees for each task
-- Dispatches subagents via Task tool with `model: "opus"`
-- Uses implementer prompt template for full context
-- Parallel execution where dependencies allow
-- Tracks progress in state file
-
-Update state on completion using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `phase` to "overhaul-review".
-
-Then auto-invoke review:
-```typescript
-Skill({ skill: "review", args: "~/.claude/workflow-state/<feature>.state.json" })
-```
-
-#### 5. Review Phase
-
-Invoke `/review` skill with emphasis on quality:
-
-```typescript
-Skill({ skill: "review", args: "~/.claude/workflow-state/<feature>.state.json" })
-```
-
-The `/review` skill:
-- Quality review is emphasized for refactors
-- Refactors are high regression risk
-- Verifies structure matches brief goals
-
-Update state on completion using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `phase` to "overhaul-update-docs".
-
-#### 6. Update Docs Phase
-
-**Mandatory** - documentation must reflect new architecture.
-
-For overhaul, typically includes:
-- Architecture documentation updates
-- API documentation changes
-- Migration guides if public interfaces changed
-- Updated diagrams
-
-Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `validation.docsUpdated` to true, `artifacts.updatedDocs` array, and `phase` to "synthesize".
-
-Then auto-invoke synthesize:
-```typescript
-Skill({ skill: "synthesize", args: "<feature-name>" })
-```
-
-#### 7. Synthesize Phase
-
-Invoke `/synthesize` skill:
-
-```typescript
-Skill({ skill: "synthesize", args: "<feature-name>" })
-```
-
-Creates PR via Graphite, updates description via GitHub MCP. **Human checkpoint:** Confirm merge.
+For detailed phase instructions, skill invocations, and auto-chain behavior, see `@skills/refactor/references/overhaul-track.md`.
 
 ## State Management
 
@@ -405,70 +144,21 @@ Full state schema:
 }
 ```
 
-## Auto-Chain Behavior
-
-Both tracks have ONE human checkpoint: completion/merge confirmation.
-
-### Polish Auto-Chain
-
-```
-explore -> brief -> polish-implement -> polish-validate -> polish-update-docs -> completed
-           (auto)   (auto)              (auto)             (auto)                (auto)
-```
-
-**Next actions:**
-- `AUTO:refactor-brief` after explore
-- `AUTO:polish-implement` after brief
-- `AUTO:refactor-validate` after polish-implement
-- `AUTO:refactor-update-docs` after polish-validate
-- `AUTO:completed` after polish-update-docs
-
-### Overhaul Auto-Chain
-
-```
-explore -> brief -> overhaul-plan -> overhaul-delegate -> overhaul-review -> overhaul-update-docs -> synthesize -> completed
-           (auto)   (auto)          (auto)               (auto)             (auto)                  (auto)        [HUMAN]
-```
-
-**Next actions:**
-- `AUTO:refactor-brief` after explore
-- `AUTO:overhaul-plan` after brief
-- `AUTO:refactor-delegate` after overhaul-plan
-- `AUTO:refactor-review` after overhaul-delegate
-- `AUTO:refactor-update-docs` after overhaul-review
-- `AUTO:refactor-synthesize` after overhaul-update-docs
-- `WAIT:human-checkpoint:synthesize` after synthesize
-
 ## Track Switching
 
-### Polish -> Overhaul
+If scope expands beyond polish limits during explore or brief phase, use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `track` to "overhaul" and update `explore.scopeAssessment.recommendedTrack`.
 
-During the implement phase, run the scope check script to detect expansion triggers:
-
-```bash
-scripts/check-polish-scope.sh --repo-root <path> --base-branch main
-```
-
-**What it validates (expansion triggers):**
-- File count > 5 (modified files via git diff)
-- Module boundaries crossed (>2 top-level dirs modified)
-- New test files needed (impl files without test counterparts)
-- Architectural docs needed (structural files across modules)
-
-**Exit code routing:**
-- Exit 0 = scope OK (stay on polish track)
-- Exit 1 = scope expanded (switch to overhaul track)
-- Exit 2 = usage error
-
-If exit 1, use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `track` to "overhaul" and update `explore.scopeAssessment.recommendedTrack`.
+**Indicators to switch:**
+- More than 5 files affected
+- Multiple concerns identified
+- Cross-module changes needed
+- Test coverage gaps require new tests
 
 Output: "Scope expanded beyond polish limits. Switching to overhaul track."
 
 ## Integration Points
 
-### With Existing Skills
-
-**CRITICAL:** All skill invocations MUST use explicit `Skill()` tool calls to ensure they actually execute:
+**CRITICAL:** All skill invocations MUST use explicit `Skill()` tool calls:
 
 | Skill | Invocation | Usage |
 |-------|------------|-------|
@@ -476,45 +166,6 @@ Output: "Scope expanded beyond polish limits. Switching to overhaul track."
 | `/delegate` | `Skill({ skill: "delegate", args: "<state-file>" })` | Subagent dispatch for TDD |
 | `/review` | `Skill({ skill: "review", args: "<state-file>" })` | Quality review |
 | `/synthesize` | `Skill({ skill: "synthesize", args: "<feature>" })` | PR creation |
-
-The `/delegate` skill dispatches subagents using:
-```typescript
-Task({
-  subagent_type: "general-purpose",
-  model: "opus",  // REQUIRED for coding tasks
-  description: "Implement task N",
-  prompt: "[Full implementer prompt with TDD requirements]"
-})
-```
-
-### With Workflow State MCP
-
-The workflow-state MCP server supports:
-- `workflowType: "refactor"` field
-- Refactor-specific phases handled by the SessionStart hook (which determines next action on resume)
-- Refactor context provided by the SessionStart hook on session start
-
-## Completion Criteria
-
-### Polish Complete
-
-- [ ] Scope assessment completed (<=5 files)
-- [ ] Brief goals captured
-- [ ] Implementation complete
-- [ ] All tests pass
-- [ ] Each goal verified
-- [ ] Documentation updated
-- [ ] User confirmed completion
-
-### Overhaul Complete
-
-- [ ] Full exploration done
-- [ ] Detailed brief captured
-- [ ] Plan created
-- [ ] All tasks delegated and complete
-- [ ] Quality review passed
-- [ ] Documentation updated
-- [ ] PR merged
 
 ## Anti-Patterns
 

--- a/skills/refactor/references/overhaul-track.md
+++ b/skills/refactor/references/overhaul-track.md
@@ -1,0 +1,158 @@
+# Overhaul Track — Detailed Phase Guide
+
+## Purpose
+
+Rigorous path for architectural changes, migrations, and multi-file restructuring. Uses full delegation model with worktree isolation.
+
+## Phases
+
+```
+Explore -> Brief -> Plan -> Delegate -> Review -> Update Docs -> Synthesize
+   |         |        |         |          |            |             |
+   |         |        |         |          |            |             +-- PR creation
+   |         |        |         |          |            +-- Update architecture docs
+   |         |        |         |          +-- Quality review (emphasized)
+   |         |        |         +-- TDD implementation in worktrees
+   |         |        +-- Extract tasks from brief
+   |         +-- Detailed goals, approach, affected areas
+   +-- Thorough scope assessment, identify affected systems
+```
+
+### 1. Explore Phase
+
+Thorough scope assessment using `@skills/refactor/references/explore-checklist.md`:
+- Read affected code to understand current structure
+- Identify ALL files/modules that will change
+- Assess test coverage of affected areas
+- Identify documentation that will need updates
+- Map dependencies and impact
+
+Update state using MCP tools:
+1. Use `mcp__exarchos__exarchos_workflow` with `action: "init"` with featureId `refactor-<slug>` and workflowType `refactor`
+2. Use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set track to "overhaul", phase, and explore scope assessment
+
+On completion, use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `explore.completedAt` and `phase` to "brief".
+
+### 2. Brief Phase
+
+Detailed capture of refactor intent (more thorough than polish).
+
+Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set the `brief` object and `phase` to "overhaul-plan".
+
+Then auto-invoke plan:
+```typescript
+Skill({ skill: "plan", args: "--refactor ~/.claude/workflow-state/<feature>.state.json" })
+```
+
+### 3. Plan Phase
+
+Invoke `/plan` skill with explicit Skill tool call:
+
+```typescript
+Skill({ skill: "plan", args: "--refactor ~/.claude/workflow-state/<feature>.state.json" })
+```
+
+The `/plan` skill:
+- Extracts tasks from the brief
+- Focuses on incremental, testable changes
+- Each task leaves code in working state
+- Dependency order matters more for refactors
+
+Update state on completion using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `artifacts.plan` and `phase` to "overhaul-delegate".
+
+> **Note:** There is no `plan-review` phase in the refactor HSM. Overhaul goes directly `overhaul-plan` -> `overhaul-delegate`.
+
+Then auto-invoke delegate:
+```typescript
+Skill({ skill: "delegate", args: "~/.claude/workflow-state/<feature>.state.json" })
+```
+
+### 4. Delegate Phase
+
+Invoke `/delegate` skill for TDD implementation in worktrees:
+
+```typescript
+Skill({ skill: "delegate", args: "~/.claude/workflow-state/<feature>.state.json" })
+```
+
+The `/delegate` skill:
+- Creates worktrees for each task
+- Dispatches subagents via Task tool with `model: "opus"`
+- Uses implementer prompt template for full context
+- Parallel execution where dependencies allow
+- Tracks progress in state file
+
+Update state on completion using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `phase` to "overhaul-review".
+
+Then auto-invoke review:
+```typescript
+Skill({ skill: "review", args: "~/.claude/workflow-state/<feature>.state.json" })
+```
+
+### 5. Review Phase
+
+Invoke `/review` skill with emphasis on quality:
+
+```typescript
+Skill({ skill: "review", args: "~/.claude/workflow-state/<feature>.state.json" })
+```
+
+The `/review` skill:
+- Quality review is emphasized for refactors
+- Refactors are high regression risk
+- Verifies structure matches brief goals
+
+Update state on completion using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `phase` to "overhaul-update-docs".
+
+### 6. Update Docs Phase
+
+**Mandatory** - documentation must reflect new architecture.
+
+For overhaul, typically includes:
+- Architecture documentation updates
+- API documentation changes
+- Migration guides if public interfaces changed
+- Updated diagrams
+
+Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `validation.docsUpdated` to true, `artifacts.updatedDocs` array, and `phase` to "synthesize".
+
+Then auto-invoke synthesize:
+```typescript
+Skill({ skill: "synthesize", args: "<feature-name>" })
+```
+
+### 7. Synthesize Phase
+
+Invoke `/synthesize` skill:
+
+```typescript
+Skill({ skill: "synthesize", args: "<feature-name>" })
+```
+
+Creates PR via Graphite, updates description via GitHub MCP. **Human checkpoint:** Confirm merge.
+
+## Auto-Chain
+
+```
+explore -> brief -> overhaul-plan -> overhaul-delegate -> overhaul-review -> overhaul-update-docs -> synthesize -> completed
+           (auto)   (auto)          (auto)               (auto)             (auto)                  (auto)        [HUMAN]
+```
+
+**Next actions:**
+- `AUTO:refactor-brief` after explore
+- `AUTO:overhaul-plan` after brief
+- `AUTO:refactor-delegate` after overhaul-plan
+- `AUTO:refactor-review` after overhaul-delegate
+- `AUTO:refactor-update-docs` after overhaul-review
+- `AUTO:refactor-synthesize` after overhaul-update-docs
+- `WAIT:human-checkpoint:synthesize` after synthesize
+
+## Completion Criteria
+
+- [ ] Full exploration done
+- [ ] Detailed brief captured
+- [ ] Plan created
+- [ ] All tasks delegated and complete
+- [ ] Quality review passed
+- [ ] Documentation updated
+- [ ] PR merged

--- a/skills/refactor/references/polish-track.md
+++ b/skills/refactor/references/polish-track.md
@@ -1,0 +1,119 @@
+# Polish Track — Detailed Phase Guide
+
+## Purpose
+
+Fast path for small, contained refactors. Single session, minimal ceremony. Orchestrator may write implementation code directly (exception to orchestrator constraints).
+
+## Phases
+
+```
+Explore -> Brief -> Implement -> Validate -> Update Docs -> Complete
+   |         |          |           |             |
+   |         |          |           |             +-- Update affected documentation
+   |         |          |           +-- Run tests, verify goals met
+   |         |          +-- Direct implementation (no worktree)
+   |         +-- Capture goals and approach in state
+   +-- Quick scope assessment, confirm polish-appropriate
+```
+
+### 1. Explore Phase
+
+Use `@skills/refactor/references/explore-checklist.md` to assess:
+- Current code structure
+- Files/modules affected (must be <=5 for polish)
+- Test coverage of affected areas
+- Documentation that needs updates
+- Confirm polish is appropriate
+
+Update state using MCP tools:
+1. Use `mcp__exarchos__exarchos_workflow` with `action: "init"` with featureId `refactor-<slug>` and workflowType `refactor`
+2. Use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set track, phase, and explore scope assessment
+
+On completion, use `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `explore.completedAt` and `phase` to "brief".
+
+### 2. Brief Phase
+
+Capture refactor intent and approach in state (not separate document).
+
+Use `@skills/refactor/references/brief-template.md` to structure:
+- Problem statement (2-3 sentences)
+- Specific goals (bulleted list)
+- High-level approach
+- Out of scope items
+- Success criteria
+- Docs to update
+
+Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set the `brief` object and `phase` to "polish-implement".
+
+### 3. Implement Phase
+
+**Orchestrator may write code directly** (polish track exception).
+
+Constraints:
+- Follow TDD (write/update test first if behavior changes)
+- Commit after each logical change
+- Stop if scope expands beyond brief
+
+When done, commit via Graphite:
+```typescript
+mcp__graphite__run_gt_cmd({ args: ["create", "-m", "refactor: <description>"], cwd: "<repo-root>" })
+```
+
+Update state on completion using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `phase` to "polish-validate".
+
+### 4. Validate Phase
+
+Verify refactor goals are met:
+- [ ] All existing tests pass
+- [ ] Each goal in brief is addressed
+- [ ] No new lint/type errors introduced
+- [ ] Code quality improved per brief
+
+Run validation:
+```bash
+npm run test:run
+npm run lint  # or equivalent
+npm run typecheck  # if TypeScript
+```
+
+Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `validation` object and `phase` to "polish-update-docs".
+
+### 5. Update Docs Phase
+
+**Mandatory** - documentation must reflect new architecture.
+
+Use `@skills/refactor/references/doc-update-checklist.md` to update:
+- Architecture docs if structure changed
+- API docs if interfaces changed
+- README if setup/usage changed
+- Inline comments if complex logic moved
+
+If `docsToUpdate` is empty, verify no docs need updating.
+
+Update state using `mcp__exarchos__exarchos_workflow` with `action: "set"` to set `validation.docsUpdated` to true, `artifacts.updatedDocs` array, and `phase` to "completed".
+
+> **Note:** The HSM transitions directly from `polish-update-docs` to `completed`. There is no `synthesize` phase for polish track.
+
+## Auto-Chain
+
+```
+explore -> brief -> polish-implement -> polish-validate -> polish-update-docs -> completed
+           (auto)   (auto)              (auto)             (auto)                (auto)
+```
+
+**Next actions:**
+- `AUTO:refactor-brief` after explore
+- `AUTO:polish-implement` after brief
+- `AUTO:refactor-validate` after polish-implement
+- `AUTO:refactor-update-docs` after polish-validate
+- `AUTO:completed` after polish-update-docs
+
+## Completion Criteria
+
+- [ ] Scope assessment completed (<=5 files)
+- [ ] Brief goals captured
+- [ ] Implementation complete
+- [ ] All tests pass
+- [ ] Each goal verified
+- [ ] Documentation updated
+- [ ] User confirmed completion


### PR DESCRIPTION
## Summary

Extracts track-specific content from the refactor and delegation skills into reference files, reducing always-loaded token overhead. The main SKILL.md files now contain summaries with progressive disclosure links to detailed references.

## Changes

- **`skills/refactor/SKILL.md`** — 2,065w → 860w; polish/overhaul track details extracted
- **`skills/refactor/references/polish-track.md`** (new) — Full polish track phase guide (540w)
- **`skills/refactor/references/overhaul-track.md`** (new) — Full overhaul track phase guide (660w)
- **`skills/delegation/SKILL.md`** — 1,927w → 1,263w; parallel strategy and fix mode extracted
- **`skills/delegation/references/parallel-strategy.md`** (new) — Group dispatch patterns (162w)
- **`skills/delegation/references/fix-mode.md`** (new) — Fix mode process and transitions (247w)

## Test Plan

Word count validation: both skills under 1,500w target. All 223 existing tests pass.

---

**Results:** Tests 223 ✓ · Build 0 errors
**Related:** Part of refactor-optimize-prompt-staleness (4/7)