### PR TITLE
docs: update CLAUDE.md and ADR to reflect sync handler and CQRS task claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Uses `@modelcontextprotocol/sdk` + `zod`, communicates over stdio, and is regist
 | `exarchos_event` | `append`, `query` | Event sourcing |
 | `exarchos_orchestrate` | `team_spawn`, `team_message`, `team_broadcast`, `team_shutdown`, `team_status`, `task_claim`, `task_complete`, `task_fail` | Team coordination |
 | `exarchos_view` | `pipeline`, `tasks`, `workflow_status`, `team_status`, `stack_status`, `stack_place` | CQRS read views |
-| `exarchos_sync` | `now` | Remote sync (stub) |
+| `exarchos_sync` | `now` | Outbox drain (no-op sender until remote wired) |
 
 **Key modules:**
 
@@ -106,7 +106,7 @@ Uses `@modelcontextprotocol/sdk` + `zod`, communicates over stdio, and is regist
 - `event-store/` — Zod event schemas (24 types including workflow.transition, workflow.fix-cycle), JSONL store with `.seq` files for O(1) sequence initialization, append/query tools. Supports idempotency keys (persisted in JSONL, cache rebuilt on restart) and pre-parse sequence filtering for fast queries
 - `views/` — CQRS materializer (cached singleton per server lifecycle, LRU-bounded), 6 view types (pipeline, tasks, workflow status, team status, task detail, stack). Pipeline view uses lazy pagination (materializes only the requested subset)
 - `team/` — Coordinator lifecycle, roles, composition, spawn/message/broadcast/shutdown tools
-- `tasks/` — Task claim/complete/fail tools with optimistic concurrency (expectedSequence) for atomic claims
+- `tasks/` — Task claim/complete/fail tools with CQRS materializer for claim-status checks and optimistic concurrency (expectedSequence) for atomic claims
 - `stack/` — Stack status/place tools with offset/limit pagination
 - `format.ts` — Canonical `ToolResult` interface (all modules import from here) and shared formatting helpers
 

--- a/docs/adrs/distributed-sdlc-pipeline.md
+++ b/docs/adrs/distributed-sdlc-pipeline.md
@@ -284,9 +284,9 @@ All teammates and the lead access these tools via the shared MCP server instance
 
 | Tool | Purpose | Access | Module |
 |------|---------|--------|--------|
-| `exarchos_sync_now` | Trigger immediate sync with Basileus (stub) | Lead only | `index.ts` |
+| `exarchos_sync_now` | Discover outbox streams and drain (no-op sender until remote wired) | Lead only | `sync/composite.ts` |
 
-> **Note:** `exarchos_sync_now` is currently a stub returning `NOT_IMPLEMENTED`. Remote sync will be implemented in Phase 4.
+> **Note:** `exarchos_sync_now` discovers local outbox streams and drains them via a no-op sender. Full remote sync (Basileus HTTP client) will be implemented in Phase 4.
 
 > **Note:** `exarchos_task_complete` is enhanced to trigger stack placement evaluation — when a teammate marks a task complete, the lead evaluates whether the completed work can be placed into the Graphite stack at its designated position.
 
@@ -1714,7 +1714,7 @@ All concerns are handled by the unified `exarchos-mcp` server (the originally-en
 | Teammate lifecycle | `exarchos_team_spawn`, `exarchos_team_message`, `exarchos_team_broadcast`, `exarchos_team_shutdown`, `exarchos_team_status` | `team/tools.ts` |
 | Task management | `exarchos_task_claim`, `exarchos_task_complete`, `exarchos_task_fail` | `tasks/tools.ts` |
 | Stack management | `exarchos_stack_status`, `exarchos_stack_place` | `stack/tools.ts` |
-| Sync with Basileus | `exarchos_sync_now` (stub) | `index.ts` |
+| Sync with Basileus | `exarchos_sync_now` (no-op sender) | `sync/composite.ts` |
 
 ### Skill Mapping
 
@@ -1864,10 +1864,10 @@ The autonomous invocation path (Path B) integrates with CI/CD systems:
 | Phase 1: Foundation | **Complete** | Unified exarchos-mcp server with 27 MCP tools, local JSONL event store (19 event types), Zod schemas, HSM state machine with 26 guards across feature/debug/refactor workflows |
 | Phase 2: Team Coordinator | **Complete** | Team spawn/message/broadcast/shutdown/status lifecycle, task claim/complete/fail, role definitions and composition strategy |
 | Phase 3: Materialized Views | **Complete** | CQRS views (PipelineView, UnifiedTaskView, WorkflowStatusView, TeamStatusView, TaskDetailView), view materialization from event sequences, snapshot persistence |
-| Phase 4: Remote Projection | **Planned** | Basileus HTTP client, outbox delivery, event schema mapping, `sync_now` implementation, Task Router score-based routing |
+| Phase 4: Remote Projection | **Planned** | Basileus HTTP client, outbox delivery with real sender, event schema mapping, Task Router score-based routing |
 | Phase 5: Bidirectional Sync | **Planned** | Remote event polling, conflict resolution, cross-session coordination, dual-write mode, Agentic Coder container dispatching |
 
-> **Note:** Phases 1-3 are fully implemented and operational in local mode. The `exarchos_sync_now` tool exists as a stub. Remote-only event types (`ContainerProvisioned`, `CodingAttemptStarted`, `CodingAttemptCompleted`, `ContainerDestroyed`, `DependencyBlocked`, `DependencyResolved`, `RemediationAttempted`, `RemediationExhausted`) will be added to the event schema when Phases 4-5 are implemented.
+> **Note:** Phases 1-3 are fully implemented and operational in local mode. The `exarchos_sync_now` tool has plumbing in place (stream discovery, outbox drain) but uses a no-op sender until the Basileus remote client is implemented in Phase 4. Remote-only event types (`ContainerProvisioned`, `CodingAttemptStarted`, `CodingAttemptCompleted`, `ContainerDestroyed`, `DependencyBlocked`, `DependencyResolved`, `RemediationAttempted`, `RemediationExhausted`) will be added to the event schema when Phases 4-5 are implemented.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates project documentation to reflect the sync handler implementation and CQRS materializer usage in task claims. The sync tool is no longer a stub, and the tasks module now uses materialized views.

## Changes

- **`CLAUDE.md`** — Update `exarchos_sync` description from "Remote sync (stub)" to "Outbox drain"; update tasks module description to mention CQRS materializer
- **`docs/adrs/distributed-sdlc-pipeline.md`** — Update sync tool references from stub to plumbing-only handler; update Phase 4 description

## Test Plan

Documentation-only changes. No code modified.

---

**Results:** Tests 1162 ✓ · Build 0 errors
**Related:** Part of refactor-optimize-prompt-staleness (7/7)