### PR TITLE
feat: harden event store with blank-line tolerance and tmpFile cleanup

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.test.ts
@@ -834,3 +834,63 @@ describe('EventStore Idempotency Persistence', () => {
     expect(deduped.sequence).toBe(105); // deduped
   });
 });
+
+// ─── Blank-line Tolerance ───────────────────────────────────────────────────
+
+describe('query_BlankLineTolerance', () => {
+  it('should correctly skip with sinceSequence when JSONL has blank lines', async () => {
+    // Arrange: append events normally, then manually inject blank lines into JSONL
+    const store = new EventStore(tempDir);
+
+    await store.append('my-workflow', { type: 'workflow.started', data: { featureId: 'test' } });
+    await store.append('my-workflow', { type: 'workflow.transition', data: { from: 'a', to: 'b' } });
+    await store.append('my-workflow', { type: 'task.claimed', data: { taskId: 't1' } });
+
+    // Manually inject blank lines between events in the JSONL file
+    const filePath = path.join(tempDir, 'my-workflow.events.jsonl');
+    const original = await fs.readFile(filePath, 'utf-8');
+    const lines = original.trim().split('\n');
+    // Insert blank lines: before first, between each, and after last
+    const corrupted = '\n' + lines[0] + '\n\n' + lines[1] + '\n\n\n' + lines[2] + '\n';
+    await fs.writeFile(filePath, corrupted, 'utf-8');
+
+    // Create a fresh store to avoid cached sequence counters
+    const freshStore = new EventStore(tempDir);
+
+    // Act: query with sinceSequence=1 (should return events 2 and 3)
+    const result = await freshStore.query('my-workflow', { sinceSequence: 1 });
+
+    // Assert: returns correct events (not off-by-one due to blank lines)
+    expect(result).toHaveLength(2);
+    expect(result[0].sequence).toBe(2);
+    expect(result[1].sequence).toBe(3);
+  });
+});
+
+// ─── Orphaned .seq.tmp Cleanup ──────────────────────────────────────────────
+
+describe('initializeSequence_CleansTmpFiles', () => {
+  it('should remove orphaned .seq.tmp files during initialization', async () => {
+    // Arrange: create a JSONL file so initializeSequence has something to read,
+    // plus an orphaned .seq.tmp that simulates a crash during atomic write.
+    const store = new EventStore(tempDir);
+    await store.append('my-workflow', { type: 'workflow.started', data: { featureId: 'test' } });
+
+    // Now create an orphaned .seq.tmp file (simulating a crash mid-write)
+    const tmpFilePath = path.join(tempDir, 'my-workflow.seq.tmp');
+    await fs.writeFile(tmpFilePath, JSON.stringify({ sequence: 999 }), 'utf-8');
+
+    // Act: trigger initializeSequence via refreshSequence (no append side effects)
+    const freshStore = new EventStore(tempDir);
+    await freshStore.refreshSequence('my-workflow');
+
+    // Assert: .seq.tmp file should be removed by initializeSequence
+    let tmpExists = true;
+    try {
+      await fs.access(tmpFilePath);
+    } catch {
+      tmpExists = false;
+    }
+    expect(tmpExists).toBe(false);
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
@@ -52,12 +52,25 @@ function validateStreamId(streamId: string): void {
 
 // ─── Event Store ────────────────────────────────────────────────────────────
 
+/**
+ * Append-only event store backed by JSONL files with .seq sequence caches.
+ *
+ * Uses in-memory promise-chain locks that only protect within a single Node.js process.
+ * Multiple EventStore instances sharing the same stateDir will corrupt data.
+ * The MCP server ensures a single EventStore per stateDir via the singleton in views/tools.ts.
+ */
 export class EventStore {
   private sequenceCounters: Map<string, number> = new Map();
   private locks: Map<string, Promise<void>> = new Map();
 
   /** In-memory dedup cache: streamId -> (idempotencyKey -> event) */
   private idempotencyCache: Map<string, Map<string, WorkflowEvent>> = new Map();
+  /**
+   * Maximum number of idempotency keys retained per stream.
+   * Keys older than this limit are evicted via FIFO.
+   * Retries with evicted keys will NOT be deduplicated.
+   * Acceptable because retries occur within the same session, not across long time spans.
+   */
   private static readonly MAX_IDEMPOTENCY_KEYS = 100;
 
   /** Tracks which streams have had their idempotency cache rebuilt from JSONL */
@@ -283,6 +296,9 @@ export class EventStore {
   private async initializeSequence(streamId: string): Promise<void> {
     // Try .seq file first (O(1))
     const seqPath = this.getSeqFilePath(streamId);
+    // Clean up orphaned .seq.tmp files left by crashed atomic writes
+    const tmpPath = `${seqPath}.tmp`;
+    await fs.rm(tmpPath, { force: true }).catch(() => {});
     try {
       const content = await fs.readFile(seqPath, 'utf-8');
       const parsed = JSON.parse(content);


### PR DESCRIPTION
## Summary
Addresses three event store operational hardening findings: blank-line tolerance in fast-skip queries, orphaned `.seq.tmp` file cleanup during initialization, and JSDoc documenting the idempotency cache eviction policy and single-instance assumption.

## Changes
- **store.ts** — Blank-line tolerance test for fast-skip, `.seq.tmp` cleanup in `initializeSequence()`, JSDoc on `MAX_IDEMPOTENCY_KEYS` and single-instance assumption
- **store.test.ts** — Tests for blank-line tolerance with `sinceSequence` and orphaned tmpFile cleanup

## Test Plan
TDD: blank-line tolerance verified with manually crafted JSONL, tmpFile cleanup verified with orphaned files. All 48 event store tests pass.

---
**Results:** Tests 1090 ✓ · Typecheck 0 errors
**Plan:** [docs/plans/2026-02-16-optimize-audit-refactor.md](docs/plans/2026-02-16-optimize-audit-refactor.md)
**Stack:** 5/6 in refactor-optimize-audit