### PR TITLE
feat: wire up guard-failed and circuit-open diagnostic event emission

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/events.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/events.test.ts
@@ -4,6 +4,7 @@ import {
   getFixCycleCount,
   getRecentEvents,
   getPhaseDuration,
+  mapInternalToExternalType,
   EVENT_LOG_MAX,
 } from '../../workflow/events.js';
 import type { Event, EventType } from '../../workflow/types.js';
@@ -403,6 +404,33 @@ describe('Event Log', () => {
   describe('EVENT_LOG_MAX', () => {
     it('should default to 100', () => {
       expect(EVENT_LOG_MAX).toBe(100);
+    });
+  });
+
+  describe('mapInternalToExternalType', () => {
+    it('should map compound-exit to workflow.compound-exit explicitly', () => {
+      expect(mapInternalToExternalType('compound-exit')).toBe('workflow.compound-exit');
+    });
+
+    it('should map circuit-open to workflow.circuit-open explicitly', () => {
+      expect(mapInternalToExternalType('circuit-open')).toBe('workflow.circuit-open');
+    });
+
+    it('should map all known internal types to correct external types', () => {
+      const expectedMappings: Record<string, string> = {
+        'transition': 'workflow.transition',
+        'fix-cycle': 'workflow.fix-cycle',
+        'guard-failed': 'workflow.guard-failed',
+        'checkpoint': 'workflow.checkpoint',
+        'compound-entry': 'workflow.compound-entry',
+        'compound-exit': 'workflow.compound-exit',
+        'circuit-open': 'workflow.circuit-open',
+        'cancel': 'workflow.cancel',
+      };
+
+      for (const [internal, external] of Object.entries(expectedMappings)) {
+        expect(mapInternalToExternalType(internal)).toBe(external);
+      }
     });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
@@ -1970,6 +1970,125 @@ describe('Guard edge cases', () => {
 
 // ─── Task: Missing state/edge case coverage ──────────────────────────────────
 
+// ─── Task: Diagnostic event emission on guard failure and circuit open ──────
+
+describe('Diagnostic Event Emission', () => {
+  describe('guard-failed events', () => {
+    it('should return guard-failed event when guard returns false', () => {
+      const hsm = getHSMDefinition('feature');
+      const state: Record<string, unknown> = {
+        phase: 'ideate',
+        artifacts: { design: null, plan: null, pr: null },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'plan');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+      expect(result.events.length).toBe(1);
+      expect(result.events[0].type).toBe('guard-failed');
+      expect(result.events[0].from).toBe('ideate');
+      expect(result.events[0].to).toBe('plan');
+      expect(result.events[0].metadata).toBeDefined();
+      expect(result.events[0].metadata!.guard).toBe('design-artifact-exists');
+    });
+
+    it('should return guard-failed event when guard throws exception', () => {
+      const hsm = getHSMDefinition('feature');
+      // Corrupt state that makes the allTasksComplete guard throw
+      const state: Record<string, unknown> = {
+        phase: 'delegate',
+        tasks: { length: 1, 0: { status: 'pending' } },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'review');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+      expect(result.events.length).toBe(1);
+      expect(result.events[0].type).toBe('guard-failed');
+      expect(result.events[0].from).toBe('delegate');
+      expect(result.events[0].to).toBe('review');
+      expect(result.events[0].metadata).toBeDefined();
+      expect(result.events[0].metadata!.guard).toBe('all-tasks-complete');
+    });
+  });
+
+  describe('circuit-open events', () => {
+    it('should return circuit-open event when fix-cycle limit reached', () => {
+      const hsm = getHSMDefinition('feature');
+
+      // Simulate 3 fix-cycle events within the implementation compound (maxFixCycles is 3)
+      const fixCycleEvents = Array.from({ length: 3 }, (_, i) => ({
+        sequence: i + 1,
+        version: '1.0' as const,
+        timestamp: new Date().toISOString(),
+        type: 'fix-cycle' as const,
+        from: 'review',
+        to: 'delegate',
+        trigger: 'test',
+        metadata: { compoundStateId: 'implementation' },
+      }));
+
+      const state: Record<string, unknown> = {
+        phase: 'review',
+        reviews: { spec: { status: 'fail' } },
+        _events: fixCycleEvents,
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'delegate');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('CIRCUIT_OPEN');
+      expect(result.events.length).toBe(1);
+      expect(result.events[0].type).toBe('circuit-open');
+      expect(result.events[0].from).toBe('review');
+      expect(result.events[0].to).toBe('delegate');
+      expect(result.events[0].metadata).toBeDefined();
+      expect(result.events[0].metadata!.compoundStateId).toBe('implementation');
+      expect(result.events[0].metadata!.fixCycleCount).toBe(3);
+      expect(result.events[0].metadata!.maxFixCycles).toBe(3);
+    });
+
+    it('should return circuit-open event for overhaul-track compound', () => {
+      const hsm = getHSMDefinition('refactor');
+
+      // Simulate 3 fix-cycle events within the overhaul-track compound (maxFixCycles is 3)
+      const fixCycleEvents = Array.from({ length: 3 }, (_, i) => ({
+        sequence: i + 1,
+        version: '1.0' as const,
+        timestamp: new Date().toISOString(),
+        type: 'fix-cycle' as const,
+        from: 'overhaul-review',
+        to: 'overhaul-delegate',
+        trigger: 'test',
+        metadata: { compoundStateId: 'overhaul-track' },
+      }));
+
+      const state: Record<string, unknown> = {
+        phase: 'overhaul-review',
+        track: 'overhaul',
+        reviews: { spec: { status: 'fail' } },
+        _events: fixCycleEvents,
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'overhaul-delegate');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('CIRCUIT_OPEN');
+      expect(result.events.length).toBe(1);
+      expect(result.events[0].type).toBe('circuit-open');
+      expect(result.events[0].metadata!.compoundStateId).toBe('overhaul-track');
+    });
+  });
+});
+
 describe('Missing _events and _history defaults', () => {
   it('handles missing _events gracefully (defaults to empty array)', () => {
     const hsm = getHSMDefinition('feature');

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -1862,6 +1862,117 @@ describe('External Event Store Bridge', () => {
   });
 });
 
+// ─── Diagnostic Event Emission (guard-failed, circuit-open) ────────────────
+
+describe('Diagnostic Event Emission', () => {
+  it('handleSet emits guard-failed event to event store on guard failure', async () => {
+    const eventStore = new EventStore(tmpDir);
+    configureWorkflowEventStore(eventStore);
+
+    // Create a feature workflow at ideate
+    await handleInit({ featureId: 'guard-diag', workflowType: 'feature' }, tmpDir);
+
+    // Try to transition from ideate to plan WITHOUT setting design artifact (guard will fail)
+    const result = await handleSet(
+      { featureId: 'guard-diag', phase: 'plan' },
+      tmpDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('GUARD_FAILED');
+
+    // Query external event store for workflow.guard-failed events
+    const events = await eventStore.query('guard-diag', { type: 'workflow.guard-failed' });
+    expect(events.length).toBe(1);
+    const data = events[0].data as Record<string, unknown>;
+    expect(data.guard).toBe('design-artifact-exists');
+    expect(data.from).toBe('ideate');
+    expect(data.to).toBe('plan');
+    expect(data.featureId).toBe('guard-diag');
+  });
+
+  it('handleSet emits circuit-open event to event store when circuit breaker trips', async () => {
+    const eventStore = new EventStore(tmpDir);
+    configureWorkflowEventStore(eventStore);
+
+    // Create a feature workflow
+    await handleInit({ featureId: 'circuit-diag', workflowType: 'feature' }, tmpDir);
+
+    // Advance to review phase — set up all the artifacts/state needed
+    await handleSet(
+      { featureId: 'circuit-diag', updates: { 'artifacts.design': 'docs/d.md' } },
+      tmpDir,
+    );
+    await handleSet({ featureId: 'circuit-diag', phase: 'plan' }, tmpDir);
+    await handleSet(
+      { featureId: 'circuit-diag', updates: { 'artifacts.plan': 'docs/p.md' } },
+      tmpDir,
+    );
+    await handleSet({ featureId: 'circuit-diag', phase: 'plan-review' }, tmpDir);
+    await handleSet(
+      { featureId: 'circuit-diag', updates: { 'planReview.approved': true } },
+      tmpDir,
+    );
+    await handleSet({ featureId: 'circuit-diag', phase: 'delegate' }, tmpDir);
+
+    // Complete tasks with proper task schema
+    await handleSet(
+      { featureId: 'circuit-diag', updates: { tasks: [{ id: 't1', title: 'Task 1', status: 'complete' }] } },
+      tmpDir,
+    );
+    await handleSet({ featureId: 'circuit-diag', phase: 'review' }, tmpDir);
+
+    // Now inject 3 fix-cycle events into internal state to trigger circuit breaker
+    // We need to write _events directly to the state file
+    const stateFile = path.join(tmpDir, 'circuit-diag.state.json');
+    const state = await readStateFile(stateFile);
+    const mutableState = state as unknown as Record<string, unknown>;
+    mutableState._events = Array.from({ length: 3 }, (_, i) => ({
+      sequence: i + 1,
+      version: '1.0',
+      timestamp: new Date().toISOString(),
+      type: 'fix-cycle',
+      from: 'review',
+      to: 'delegate',
+      trigger: 'test',
+      metadata: { compoundStateId: 'implementation' },
+    }));
+    // Set review to failed so the guard would pass for delegate transition
+    mutableState.reviews = { spec: { status: 'fail' } };
+    await writeStateFile(stateFile, mutableState as WorkflowState);
+
+    // Attempt fix cycle — should trigger circuit breaker
+    const result = await handleSet(
+      { featureId: 'circuit-diag', phase: 'delegate' },
+      tmpDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('CIRCUIT_OPEN');
+
+    // Query external event store for workflow.circuit-open events
+    const events = await eventStore.query('circuit-diag', { type: 'workflow.circuit-open' });
+    expect(events.length).toBe(1);
+    const data = events[0].data as Record<string, unknown>;
+    expect(data.featureId).toBe('circuit-diag');
+    expect(data.compoundId).toBe('implementation');
+  });
+
+  it('handleSet does not emit diagnostic events when no event store configured', async () => {
+    // No event store configured (default null)
+    await handleInit({ featureId: 'no-store', workflowType: 'feature' }, tmpDir);
+
+    // This should not throw even without event store
+    const result = await handleSet(
+      { featureId: 'no-store', phase: 'plan' },
+      tmpDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('GUARD_FAILED');
+  });
+});
+
 // ─── Guaranteed Event Append (Task 9) ──────────────────────────────────────
 
 describe('Guaranteed Event Append', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/events.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/events.ts
@@ -140,6 +140,8 @@ export function mapInternalToExternalType(internalType: string): string {
     'guard-failed': 'workflow.guard-failed',
     'checkpoint': 'workflow.checkpoint',
     'compound-entry': 'workflow.compound-entry',
+    'compound-exit': 'workflow.compound-exit',
+    'circuit-open': 'workflow.circuit-open',
     'cancel': 'workflow.cancel',
   };
   return typeMap[internalType] ?? `workflow.${internalType}`;

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/state-machine.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/state-machine.ts
@@ -142,6 +142,10 @@ export function getValidTransitions(
 /**
  * Execute a transition in the HSM. This is a PURE function that computes
  * what should happen but does not perform I/O. The caller handles persistence.
+ *
+ * Returns diagnostic events in `result.events` even on failure (guard-failed,
+ * circuit-open). The caller is responsible for emitting these to the event store
+ * before returning the error to the client.
  */
 export function executeTransition(
   hsm: HSMDefinition,
@@ -248,7 +252,13 @@ export function executeTransition(
         success: false,
         idempotent: false,
         effects: [],
-        events: [],
+        events: [{
+          type: 'guard-failed',
+          from: currentPhase,
+          to: targetPhase,
+          trigger: 'execute-transition',
+          metadata: { guard: transition.guard.id },
+        }],
         errorCode: 'GUARD_FAILED',
         errorMessage: `Guard '${transition.guard.id}' threw: ${(err as Error).message}`,
         guardDescription: transition.guard.description,
@@ -262,7 +272,13 @@ export function executeTransition(
         success: false,
         idempotent: false,
         effects: [],
-        events: [],
+        events: [{
+          type: 'guard-failed',
+          from: currentPhase,
+          to: targetPhase,
+          trigger: 'execute-transition',
+          metadata: { guard: transition.guard.id },
+        }],
         errorCode: 'GUARD_FAILED',
         errorMessage: guardReason
           ? `Guard '${transition.guard.id}' failed: ${guardReason}`
@@ -283,7 +299,18 @@ export function executeTransition(
           success: false,
           idempotent: false,
           effects: [],
-          events: [],
+          events: [{
+            type: 'circuit-open',
+            from: currentPhase,
+            to: targetPhase,
+            trigger: 'execute-transition',
+            metadata: {
+              compoundStateId: parent.id,
+              compoundId: parent.id,
+              fixCycleCount: fixCount,
+              maxFixCycles: parent.maxFixCycles,
+            },
+          }],
           errorCode: 'CIRCUIT_OPEN',
           errorMessage: `Fix cycle limit (${parent.maxFixCycles}) reached for compound '${parent.id}'`,
         };

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
@@ -212,6 +212,47 @@ export async function handleGet(
   };
 }
 
+// ─── Event Emission Helper ──────────────────────────────────────────────────
+
+interface TransitionEventRecord {
+  readonly type: string;
+  readonly from: string;
+  readonly to: string;
+  readonly trigger: string;
+  readonly metadata?: Record<string, unknown>;
+}
+
+/**
+ * Emit transition events to the external JSONL event store.
+ * Used by both the success path (after CAS write) and the failure path
+ * (diagnostic events like guard-failed, circuit-open).
+ *
+ * @returns Error message string on failure, undefined on success or when no events to emit.
+ */
+async function emitTransitionEvents(
+  featureId: string,
+  events: readonly TransitionEventRecord[],
+): Promise<string | undefined> {
+  if (!moduleEventStore || events.length === 0) return undefined;
+  try {
+    for (const evt of events) {
+      await moduleEventStore.append(featureId, {
+        type: mapInternalToExternalType(evt.type) as import('../event-store/schemas.js').EventType,
+        data: {
+          from: evt.from,
+          to: evt.to,
+          trigger: evt.trigger,
+          featureId,
+          ...(evt.metadata ?? {}),
+        },
+      });
+    }
+    return undefined;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
 // ─── handleSet ──────────────────────────────────────────────────────────────
 
 const MAX_CAS_RETRIES = 3;
@@ -267,19 +308,17 @@ export async function handleSet(
 
     // ─── Phase transition (guards evaluate against updated state) ──────
     // Collect transition events for deferred emission after CAS write succeeds
-    let pendingTransitionEvents: Array<{
-      type: string;
-      from: string;
-      to: string;
-      trigger: string;
-      metadata?: Record<string, unknown>;
-    }> = [];
+    let pendingTransitionEvents: TransitionEventRecord[] = [];
 
     if (input.phase) {
       const hsm = getHSMDefinition(state.workflowType);
       const result = executeTransition(hsm, mutableState, input.phase);
 
       if (!result.success) {
+        // Emit diagnostic events (guard-failed, circuit-open) before returning error.
+        // These are emitted BEFORE state write since no state change occurs on failure.
+        await emitTransitionEvents(input.featureId, result.events);
+
         const errorCode = result.errorCode ?? ErrorCode.INVALID_TRANSITION;
         return {
           success: false,
@@ -348,25 +387,10 @@ export async function handleSet(
     // AFTER the CAS write succeeds. This prevents duplicate events on CAS retry.
     // If event emission fails after a successful state write, we return success
     // with a warning — events are supplementary and the state is the source of truth.
-    let eventWarning: string | undefined;
-    if (moduleEventStore && pendingTransitionEvents.length > 0) {
-      try {
-        for (const transitionEvent of pendingTransitionEvents) {
-          await moduleEventStore.append(input.featureId, {
-            type: mapInternalToExternalType(transitionEvent.type) as import('../event-store/schemas.js').EventType,
-            data: {
-              from: transitionEvent.from,
-              to: transitionEvent.to,
-              trigger: transitionEvent.trigger,
-              featureId: input.featureId,
-              ...(transitionEvent.metadata ?? {}),
-            },
-          });
-        }
-      } catch (err) {
-        eventWarning = `Event append failed after state write: ${err instanceof Error ? err.message : String(err)}`;
-      }
-    }
+    const emitError = await emitTransitionEvents(input.featureId, pendingTransitionEvents);
+    const eventWarning = emitError
+      ? `Event append failed after state write: ${emitError}`
+      : undefined;
 
     return {
       success: true,


### PR DESCRIPTION
## Summary
Wire up HSM diagnostic events so guard failures and circuit breaker trips emit observability events to the JSONL store. The type mappings and external schemas already existed but `executeTransition()` returned empty events on failure and `handleSet()` returned early before the emission loop.

## Changes
- **workflow/state-machine.ts** — Return `guard-failed` and `circuit-open` events in `TransitionResult` even on failure
- **workflow/tools.ts** — Extract `emitTransitionEvents()` helper, add pre-state-write emission for diagnostic events on failure path
- **workflow/events.ts** — Add explicit `compound-exit` and `circuit-open` mappings in `mapInternalToExternalType()`
- **10 new tests** — Unit tests for event generation + integration tests for end-to-end emission

## Test Plan
1093 tests pass. Verified guard-failed emits on both guard-threw and guard-returned-false paths. Circuit-open emits with compound metadata.

---
**Results:** Tests 1093 ✓ · Build 0 errors
**Issue:** #368