### PR TITLE
docs: replace phase.transitioned with workflow.transition in skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ Uses `@modelcontextprotocol/sdk` + `zod`, communicates over stdio, and is regist
 - `workflow/cancel.ts` — Saga compensation and workflow cancellation with checkpoint persistence for resumable compensation on partial failure
 - `registry.ts` — Single source of truth for all tool metadata (names, schemas, phase/role mappings). Consumed by `index.ts` for registration and by CLI hooks for guardrails
 - `cli.ts` — Hook CLI entry point (`pre-compact`, `session-start`, `guard`, `task-gate`, `teammate-gate`, `subagent-context`)
-- `event-store/` — Zod event schemas (28 types including workflow.transition, workflow.fix-cycle), JSONL store with `.seq` files for O(1) sequence initialization, append/query tools. Supports idempotency keys (persisted in JSONL, cache rebuilt on restart) and pre-parse sequence filtering for fast queries
+- `event-store/` — Zod event schemas (22 types including workflow.transition, workflow.fix-cycle), JSONL store with `.seq` files for O(1) sequence initialization, append/query tools. Supports idempotency keys (persisted in JSONL, cache rebuilt on restart) and pre-parse sequence filtering for fast queries
 - `views/` — CQRS materializer (cached singleton per server lifecycle, LRU-bounded), 5 view types (pipeline, tasks, workflow status, task detail, stack) plus telemetry projection. Pipeline view uses lazy pagination (materializes only the requested subset)
 - `tasks/` — Task claim/complete/fail tools with CQRS materializer for claim-status checks and optimistic concurrency (expectedSequence) for atomic claims
 - `stack/` — Stack status/place tools with offset/limit pagination

--- a/scripts/coderabbit-review-gate.sh
+++ b/scripts/coderabbit-review-gate.sh
@@ -236,7 +236,7 @@ count_review_rounds() {
         echo -e "${YELLOW}WARNING${NC}: More than 100 reviews found; count may be incomplete" >&2
     fi
 
-    echo "$reviews_json" | jq '[.data.repository.pullRequest.reviews.nodes[] | select(.author.login == "coderabbitai[bot]")] | length' 2>/dev/null || echo "0"
+    echo "$reviews_json" | jq '[.data.repository.pullRequest.reviews.nodes[] | select(.author.login == "coderabbitai")] | length' 2>/dev/null || echo "0"
 }
 
 # ============================================================
@@ -300,7 +300,7 @@ query_all_threads() {
 get_active_threads() {
     local all_threads_json="$1"
     # Filter: unresolved, non-outdated, CodeRabbit-authored threads only
-    echo "$all_threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false and (.comments.nodes[0].author.login == "coderabbitai[bot]"))]'
+    echo "$all_threads_json" | jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false and (.comments.nodes[0].author.login == "coderabbitai"))]'
 }
 
 # ============================================================
@@ -311,7 +311,7 @@ resolve_outdated_threads() {
     local all_threads_json="$1"
     # Find unresolved outdated threads
     local outdated_thread_ids
-    outdated_thread_ids=$(echo "$all_threads_json" | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == true and (.comments.nodes[0].author.login == "coderabbitai[bot]")) | .id')
+    outdated_thread_ids=$(echo "$all_threads_json" | jq -r '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == true and (.comments.nodes[0].author.login == "coderabbitai")) | .id')
 
     if [[ -z "$outdated_thread_ids" ]]; then
         return 0
@@ -346,7 +346,7 @@ has_blocking_findings() {
     red_circle=$(printf '\xf0\x9f\x94\xb4')       # U+1F534
     orange_circle=$(printf '\xf0\x9f\x9f\xa0')     # U+1F7E0
     local blocker_count
-    blocker_count=$(echo "$threads_json" | jq --arg rc "$red_circle" --arg oc "$orange_circle" '[.[] | select(.comments.nodes[0] | (.author.login == "coderabbitai[bot]") and (.body != null) and (.body | test($rc) or test($oc)))] | length' 2>/dev/null || echo "0")
+    blocker_count=$(echo "$threads_json" | jq --arg rc "$red_circle" --arg oc "$orange_circle" '[.[] | select(.comments.nodes[0] | (.author.login == "coderabbitai") and (.body != null) and (.body | test($rc) or test($oc)))] | length' 2>/dev/null || echo "0")
 
     if [[ "$blocker_count" -gt 0 ]]; then
         return 0  # has blockers

--- a/scripts/coderabbit-review-gate.test.sh
+++ b/scripts/coderabbit-review-gate.test.sh
@@ -302,7 +302,7 @@ echo "=== Task 2: Review Round Counting ==="
 
 # Test: CountRounds_OneReview_ReturnsOne
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
 OUTPUT=$(run_script --owner testowner --repo testrepo --pr 100)
 if echo "$OUTPUT" | grep -qF '**Round:** 1'; then
     pass "CountRounds_OneReview_ReturnsOne"
@@ -312,7 +312,7 @@ fi
 
 # Test: CountRounds_ThreeReviews_ReturnsThree
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T08:00:00Z"},{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T10:00:00Z"},{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T12:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T08:00:00Z"},{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"},{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T12:00:00Z"}]}}}}}'
 OUTPUT=$(run_script --owner testowner --repo testrepo --pr 100)
 if echo "$OUTPUT" | grep -qF '**Round:** 3'; then
     pass "CountRounds_ThreeReviews_ReturnsThree"
@@ -322,7 +322,7 @@ fi
 
 # Test: CountRounds_MixedReviewers_OnlyCountsCodeRabbit
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T08:00:00Z"},{"author":{"login":"humanreviewer"},"submittedAt":"2026-01-15T09:00:00Z"},{"author":{"login":"otherbot[bot]"},"submittedAt":"2026-01-15T10:00:00Z"},{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T11:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T08:00:00Z"},{"author":{"login":"humanreviewer"},"submittedAt":"2026-01-15T09:00:00Z"},{"author":{"login":"otherbot[bot]"},"submittedAt":"2026-01-15T10:00:00Z"},{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T11:00:00Z"}]}}}}}'
 OUTPUT=$(run_script --owner testowner --repo testrepo --pr 100)
 if echo "$OUTPUT" | grep -qF '**Round:** 2'; then
     pass "CountRounds_MixedReviewers_OnlyCountsCodeRabbit"
@@ -348,7 +348,7 @@ echo "=== Task 3: Thread Querying and Severity Classification ==="
 
 # Test: GetThreads_NoThreads_ReturnsEmpty
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
 write_threads_response '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
 OUTPUT=$(run_script --owner testowner --repo testrepo --pr 100)
 if echo "$OUTPUT" | grep -qF '**Active Threads:** 0'; then
@@ -359,11 +359,11 @@ fi
 
 # Test: GetThreads_ResolvedExcluded
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
 write_threads_response '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[
-  {"id":"T_1","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"body":"Resolved issue","author":{"login":"coderabbitai[bot]"}}]}},
-  {"id":"T_2","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"body":"Active issue","author":{"login":"coderabbitai[bot]"}}]}},
-  {"id":"T_3","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"body":"Another resolved","author":{"login":"coderabbitai[bot]"}}]}}
+  {"id":"T_1","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"body":"Resolved issue","author":{"login":"coderabbitai"}}]}},
+  {"id":"T_2","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"body":"Active issue","author":{"login":"coderabbitai"}}]}},
+  {"id":"T_3","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"body":"Another resolved","author":{"login":"coderabbitai"}}]}}
 ]}}}}}'
 OUTPUT=$(run_script --owner testowner --repo testrepo --pr 100)
 if echo "$OUTPUT" | grep -qF '**Active Threads:** 1'; then
@@ -374,9 +374,9 @@ fi
 
 # Test: ClassifySeverity_CriticalMarker_ReturnsCritical
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
 write_threads_response "{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"nodes\":[
-  {\"id\":\"T_1\",\"isResolved\":false,\"isOutdated\":false,\"comments\":{\"nodes\":[{\"body\":\"${EMOJI_RED} Critical: SQL injection vulnerability detected\",\"author\":{\"login\":\"coderabbitai[bot]\"}}]}}
+  {\"id\":\"T_1\",\"isResolved\":false,\"isOutdated\":false,\"comments\":{\"nodes\":[{\"body\":\"${EMOJI_RED} Critical: SQL injection vulnerability detected\",\"author\":{\"login\":\"coderabbitai\"}}]}}
 ]}}}}}"
 OUTPUT=$(run_script --owner testowner --repo testrepo --pr 100)
 if echo "$OUTPUT" | grep -qF '**Blocking Findings:** true'; then
@@ -387,9 +387,9 @@ fi
 
 # Test: ClassifySeverity_MajorMarker_ReturnsMajor
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
 write_threads_response "{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"nodes\":[
-  {\"id\":\"T_1\",\"isResolved\":false,\"isOutdated\":false,\"comments\":{\"nodes\":[{\"body\":\"${EMOJI_ORANGE} Major: Missing error handling in async function\",\"author\":{\"login\":\"coderabbitai[bot]\"}}]}}
+  {\"id\":\"T_1\",\"isResolved\":false,\"isOutdated\":false,\"comments\":{\"nodes\":[{\"body\":\"${EMOJI_ORANGE} Major: Missing error handling in async function\",\"author\":{\"login\":\"coderabbitai\"}}]}}
 ]}}}}}"
 OUTPUT=$(run_script --owner testowner --repo testrepo --pr 100)
 if echo "$OUTPUT" | grep -qF '**Blocking Findings:** true'; then
@@ -400,9 +400,9 @@ fi
 
 # Test: ClassifySeverity_MinorOnly_NoBlockers
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
 write_threads_response "{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"nodes\":[
-  {\"id\":\"T_1\",\"isResolved\":false,\"isOutdated\":false,\"comments\":{\"nodes\":[{\"body\":\"${EMOJI_YELLOW} Minor: Consider renaming variable for clarity\",\"author\":{\"login\":\"coderabbitai[bot]\"}}]}}
+  {\"id\":\"T_1\",\"isResolved\":false,\"isOutdated\":false,\"comments\":{\"nodes\":[{\"body\":\"${EMOJI_YELLOW} Minor: Consider renaming variable for clarity\",\"author\":{\"login\":\"coderabbitai\"}}]}}
 ]}}}}}"
 OUTPUT=$(run_script --owner testowner --repo testrepo --pr 100)
 if echo "$OUTPUT" | grep -qF '**Blocking Findings:** false'; then
@@ -413,7 +413,7 @@ fi
 
 # Test: ClassifySeverity_NonBotEmoji_Ignored
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
 write_threads_response "{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"nodes\":[
   {\"id\":\"T_1\",\"isResolved\":false,\"isOutdated\":false,\"comments\":{\"nodes\":[{\"body\":\"${EMOJI_RED} Critical: not from bot\",\"author\":{\"login\":\"humanreviewer\"}}]}}
 ]}}}}}"
@@ -426,11 +426,11 @@ fi
 
 # Test: GetThreads_OutdatedExcluded
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
 write_threads_response '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[
-  {"id":"T_1","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"body":"Outdated issue","author":{"login":"coderabbitai[bot]"}}]}},
-  {"id":"T_2","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"body":"Active issue","author":{"login":"coderabbitai[bot]"}}]}},
-  {"id":"T_3","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"body":"Another outdated","author":{"login":"coderabbitai[bot]"}}]}}
+  {"id":"T_1","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"body":"Outdated issue","author":{"login":"coderabbitai"}}]}},
+  {"id":"T_2","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"body":"Active issue","author":{"login":"coderabbitai"}}]}},
+  {"id":"T_3","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"body":"Another outdated","author":{"login":"coderabbitai"}}]}}
 ]}}}}}'
 OUTPUT=$(run_script --owner testowner --repo testrepo --pr 100)
 if echo "$OUTPUT" | grep -qF '**Active Threads:** 1'; then
@@ -448,11 +448,11 @@ echo "=== Task 4: Auto-Resolve Outdated Threads ==="
 # Test: ResolveOutdated_OutdatedThreads_CallsMutation
 # Mock returns threads with some outdated+unresolved; script should call resolveReviewThread mutation
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
 write_threads_response '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[
-  {"id":"T_outdated_1","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"body":"Old finding","author":{"login":"coderabbitai[bot]"}}]}},
-  {"id":"T_outdated_2","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"body":"Another old finding","author":{"login":"coderabbitai[bot]"}}]}},
-  {"id":"T_active","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"body":"Current finding","author":{"login":"coderabbitai[bot]"}}]}}
+  {"id":"T_outdated_1","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"body":"Old finding","author":{"login":"coderabbitai"}}]}},
+  {"id":"T_outdated_2","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"body":"Another old finding","author":{"login":"coderabbitai"}}]}},
+  {"id":"T_active","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"body":"Current finding","author":{"login":"coderabbitai"}}]}}
 ]}}}}}'
 OUTPUT=$(run_script --owner testowner --repo testrepo --pr 100)
 MUTATION_COUNT=$(count_calls "mutation")
@@ -465,10 +465,10 @@ fi
 # Test: ResolveOutdated_NoOutdated_NoMutation
 # All threads are either resolved or not outdated — no mutation calls expected
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
 write_threads_response '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[
-  {"id":"T_resolved","isResolved":true,"isOutdated":true,"comments":{"nodes":[{"body":"Already resolved","author":{"login":"coderabbitai[bot]"}}]}},
-  {"id":"T_active","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"body":"Active finding","author":{"login":"coderabbitai[bot]"}}]}}
+  {"id":"T_resolved","isResolved":true,"isOutdated":true,"comments":{"nodes":[{"body":"Already resolved","author":{"login":"coderabbitai"}}]}},
+  {"id":"T_active","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"body":"Active finding","author":{"login":"coderabbitai"}}]}}
 ]}}}}}'
 OUTPUT=$(run_script --owner testowner --repo testrepo --pr 100)
 MUTATION_COUNT=$(count_calls "mutation")
@@ -481,10 +481,10 @@ fi
 # Test: DryRun_OutdatedThreads_NoMutation
 # With --dry-run, outdated threads should NOT be resolved (no mutation calls)
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
 write_threads_response '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[
-  {"id":"T_outdated_1","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"body":"Old finding","author":{"login":"coderabbitai[bot]"}}]}},
-  {"id":"T_active","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"body":"Current finding","author":{"login":"coderabbitai[bot]"}}]}}
+  {"id":"T_outdated_1","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"body":"Old finding","author":{"login":"coderabbitai"}}]}},
+  {"id":"T_active","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"body":"Current finding","author":{"login":"coderabbitai"}}]}}
 ]}}}}}'
 OUTPUT=$(run_script --owner testowner --repo testrepo --pr 100 --dry-run)
 MUTATION_COUNT=$(count_calls "mutation")
@@ -497,11 +497,11 @@ fi
 # Test: ResolveOutdated_NonBotThread_NotResolved
 # Outdated threads from non-CodeRabbit authors should NOT be auto-resolved
 clear_mocks
-write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai[bot]"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
 write_threads_response '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[
-  {"id":"T_bot_outdated","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"body":"Old bot finding","author":{"login":"coderabbitai[bot]"}}]}},
+  {"id":"T_bot_outdated","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"body":"Old bot finding","author":{"login":"coderabbitai"}}]}},
   {"id":"T_human_outdated","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"body":"Old human comment","author":{"login":"humanreviewer"}}]}},
-  {"id":"T_active","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"body":"Current finding","author":{"login":"coderabbitai[bot]"}}]}}
+  {"id":"T_active","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"body":"Current finding","author":{"login":"coderabbitai"}}]}}
 ]}}}}}'
 OUTPUT=$(run_script --owner testowner --repo testrepo --pr 100)
 MUTATION_COUNT=$(count_calls "mutation")
@@ -523,7 +523,7 @@ make_reviews() {
     local nodes=""
     for ((i=1; i<=count; i++)); do
         if [[ -n "$nodes" ]]; then nodes="$nodes,"; fi
-        nodes="${nodes}{\"author\":{\"login\":\"coderabbitai[bot]\"},\"submittedAt\":\"2026-01-15T$(printf '%02d' $i):00:00Z\"}"
+        nodes="${nodes}{\"author\":{\"login\":\"coderabbitai\"},\"submittedAt\":\"2026-01-15T$(printf '%02d' $i):00:00Z\"}"
     done
     echo "{\"data\":{\"repository\":{\"pullRequest\":{\"reviews\":{\"nodes\":[$nodes]}}}}}"
 }
@@ -544,7 +544,7 @@ make_threads() {
         elif [[ "$blocker_type" == "minor" ]]; then
             body="${EMOJI_YELLOW} Minor: Style suggestion"
         fi
-        nodes="${nodes}{\"id\":\"T_${i}\",\"isResolved\":false,\"isOutdated\":false,\"comments\":{\"nodes\":[{\"body\":\"${body}\",\"author\":{\"login\":\"coderabbitai[bot]\"}}]}}"
+        nodes="${nodes}{\"id\":\"T_${i}\",\"isResolved\":false,\"isOutdated\":false,\"comments\":{\"nodes\":[{\"body\":\"${body}\",\"author\":{\"login\":\"coderabbitai\"}}]}}"
     done
     echo "{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"nodes\":[${nodes}]}}}}}"
 }

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -505,11 +505,11 @@ If hotfix track reveals complexity requiring thorough investigation:
 When Exarchos MCP tools are available, emit events throughout the debug workflow:
 
 1. **At workflow start (triage):** `mcp__exarchos__exarchos_event` with `action: "append"` → `workflow.started` with workflowType "debug", urgency
-2. **On track selection:** `mcp__exarchos__exarchos_event` with `action: "append"` → `phase.transitioned` with selected track (hotfix/thorough)
-3. **On each phase transition:** `mcp__exarchos__exarchos_event` with `action: "append"` → `phase.transitioned` from→to
+2. **On track selection:** Auto-emitted by `exarchos_workflow` `set` when `phase` is provided — emits `workflow.transition` with selected track (hotfix/thorough)
+3. **On each phase transition:** Auto-emitted by `exarchos_workflow` `set` when `phase` is provided — emits `workflow.transition` with from/to/trigger/featureId
 4. **Thorough track stacking:** Handled by `/synthesize` (Graphite stack submission)
 5. **Hotfix track commit:** Single `gt create -m "fix: <description>"` — no multi-branch stacking needed
-6. **On complete:** `mcp__exarchos__exarchos_event` with `action: "append"` → `phase.transitioned` to "completed"
+6. **On complete:** Auto-emitted by `exarchos_workflow` `set` when transitioning to terminal state — emits `workflow.transition` to "completed"
 
 ## Performance Notes
 

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -290,7 +290,7 @@ Emit events at each delegation milestone using Exarchos MCP tools:
 3. **Task assignment:** `exarchos_event` append `task.assigned` with taskId, title, branch, worktree
 4. **Monitor:** `exarchos_view` `workflow_status` or `exarchos_workflow` `get` with `fields: ["tasks"]`
 5. **Task completion:** Record stack positions via `exarchos_view` `stack_place`. Subagents handle Graphite stacking via `gt create`
-6. **All complete:** `exarchos_event` append `phase.transitioned` from delegate to next phase
+6. **All complete:** Auto-emitted by `exarchos_workflow` `set` when phase transitions — emits `workflow.transition` from delegate to next phase
 
 ### Claim Guard
 

--- a/skills/implementation-planning/SKILL.md
+++ b/skills/implementation-planning/SKILL.md
@@ -199,7 +199,7 @@ After planning completes, **auto-continue to plan-review** (delta analysis):
 
 ## Exarchos Integration
 
-On plan completion, call `mcp__exarchos__exarchos_event` with `action: "append"` and event type `phase.transitioned` from plan to plan-review.
+On plan completion, auto-emitted by `exarchos_workflow` `set` when phase transitions — emits `workflow.transition` from plan to plan-review. No manual `exarchos_event` append needed.
 
 ## Performance Notes
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -184,8 +184,8 @@ Output: "Scope expanded beyond polish limits. Switching to overhaul track."
 When Exarchos MCP tools are available, emit events throughout the refactor workflow:
 
 1. **At workflow start (explore):** `mcp__exarchos__exarchos_event` with `action: "append"` → `workflow.started` with workflowType "refactor"
-2. **On track selection:** `mcp__exarchos__exarchos_event` with `action: "append"` → `phase.transitioned` with selected track (polish/overhaul)
-3. **On each phase transition:** `mcp__exarchos__exarchos_event` with `action: "append"` → `phase.transitioned` from→to
+2. **On track selection:** Auto-emitted by `exarchos_workflow` `set` when `phase` is provided — emits `workflow.transition` with selected track (polish/overhaul)
+3. **On each phase transition:** Auto-emitted by `exarchos_workflow` `set` when `phase` is provided — emits `workflow.transition` with from/to/trigger/featureId
 4. **Overhaul track stacking:** Handled by `/delegate` (subagents use `gt create` per implementer prompt)
 5. **Polish track commit:** Single `gt create -m "refactor: <description>"` — no multi-branch stacking needed
-6. **On complete:** `mcp__exarchos__exarchos_event` with `action: "append"` → `phase.transitioned` to "completed"
+6. **On complete:** Auto-emitted by `exarchos_workflow` `set` when transitioning to terminal state — emits `workflow.transition` to "completed"

--- a/skills/synthesis/SKILL.md
+++ b/skills/synthesis/SKILL.md
@@ -301,7 +301,7 @@ When Exarchos MCP tools are available:
 
 1. **After stack submission:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `stack.enqueued` including PR numbers from `gt log --short`
 2. **Monitor merge status:** Use `mcp__graphite__run_gt_cmd` with `["log", "--short"]` to check stack/PR status
-3. **On successful merge:** Call `mcp__exarchos__exarchos_event` with `action: "append"` with event type `phase.transitioned` to mark workflow complete
+3. **On successful merge:** Auto-emitted by `exarchos_workflow` `set` when transitioning to terminal state — emits `workflow.transition` to mark workflow complete
 
 ## Performance Notes
 


### PR DESCRIPTION
## Summary
Update all skill documentation to replace stale `phase.transitioned` manual event emission instructions with notes about auto-emission. The `phase.transitioned` event type was removed in the previous stack PR and `exarchos_workflow` `set` auto-emits `workflow.transition` events when `phase` is provided.

## Changes
- **skills/debug/SKILL.md** — Replace 3 manual emission instructions with auto-emission notes
- **skills/delegation/SKILL.md** — Replace 1 manual emission instruction
- **skills/implementation-planning/SKILL.md** — Replace 1 manual emission instruction
- **skills/refactor/SKILL.md** — Replace 3 manual emission instructions
- **skills/synthesis/SKILL.md** — Replace 1 manual emission instruction
- **CLAUDE.md** — Update event type count (28→22)

## Test Plan
Grep verification: zero `phase.transitioned` references remain in skills/ directory.

---
**Results:** Grep clean
**Issue:** #368