### PR TITLE
feat: add cleanup action for post-merge workflow resolution

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -391,6 +391,7 @@ describe('EventTypes', () => {
     expect(EventTypes).toContain('workflow.compound-entry');
     expect(EventTypes).toContain('workflow.compound-exit');
     expect(EventTypes).toContain('workflow.cancel');
+    expect(EventTypes).toContain('workflow.cleanup');
     expect(EventTypes).toContain('workflow.compensation');
     expect(EventTypes).toContain('workflow.circuit-open');
   });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -357,8 +357,8 @@ describe('StackEnqueuedData', () => {
 // ─── EventTypes Discriminated Union (A03) ───────────────────────────────────
 
 describe('EventTypes', () => {
-  it('should contain all 22 event types', () => {
-    expect(EventTypes).toHaveLength(22);
+  it('should contain all 23 event types', () => {
+    expect(EventTypes).toHaveLength(23);
   });
 
   it('should include workflow-level types', () => {
@@ -693,7 +693,7 @@ describe('Dead event types removed', () => {
     }
   });
 
-  it('should have exactly 22 event types', () => {
-    expect(EventTypes).toHaveLength(22);
+  it('should have exactly 23 event types', () => {
+    expect(EventTypes).toHaveLength(23);
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/cleanup.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/cleanup.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { handleCleanup, configureCleanupEventStore } from '../../workflow/cleanup.js';
+import { handleInit } from '../../workflow/tools.js';
+import { handleWorkflow } from '../../workflow/composite.js';
+import type { EventStore } from '../../event-store/store.js';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-cleanup-test-'));
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function readRawState(featureId: string): Promise<Record<string, unknown>> {
+  const stateFile = path.join(tmpDir, `${featureId}.state.json`);
+  return JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+}
+
+async function writeRawState(featureId: string, state: Record<string, unknown>): Promise<void> {
+  const stateFile = path.join(tmpDir, `${featureId}.state.json`);
+  await fs.writeFile(stateFile, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+describe('handleCleanup', () => {
+  describe('rejection paths', () => {
+    it('should return STATE_NOT_FOUND for non-existent feature', async () => {
+      const result = await handleCleanup({ featureId: 'nonexistent', mergeVerified: true }, tmpDir);
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('STATE_NOT_FOUND');
+    });
+
+    it('should return ALREADY_COMPLETED for completed workflow', async () => {
+      await handleInit({ featureId: 'already-done', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('already-done');
+      raw.phase = 'completed';
+      await writeRawState('already-done', raw);
+
+      const result = await handleCleanup({ featureId: 'already-done', mergeVerified: true }, tmpDir);
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('ALREADY_COMPLETED');
+    });
+
+    it('should return INVALID_TRANSITION for cancelled workflow', async () => {
+      await handleInit({ featureId: 'cancelled-wf', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('cancelled-wf');
+      raw.phase = 'cancelled';
+      await writeRawState('cancelled-wf', raw);
+
+      const result = await handleCleanup({ featureId: 'cancelled-wf', mergeVerified: true }, tmpDir);
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('INVALID_TRANSITION');
+    });
+
+    it('should return GUARD_FAILED when mergeVerified is false', async () => {
+      await handleInit({ featureId: 'not-merged', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('not-merged');
+      raw.phase = 'review';
+      await writeRawState('not-merged', raw);
+
+      const result = await handleCleanup({ featureId: 'not-merged', mergeVerified: false }, tmpDir);
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('GUARD_FAILED');
+    });
+  });
+
+  describe('happy path', () => {
+    it('should transition to completed from review phase', async () => {
+      await handleInit({ featureId: 'cleanup-review', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('cleanup-review');
+      raw.phase = 'review';
+      await writeRawState('cleanup-review', raw);
+
+      const result = await handleCleanup({
+        featureId: 'cleanup-review',
+        mergeVerified: true,
+        prUrl: 'https://github.com/test/pr/1',
+        mergedBranches: ['feature/task-1'],
+      }, tmpDir);
+
+      expect(result.success).toBe(true);
+      expect((result.data as Record<string, unknown>)?.phase).toBe('completed');
+    });
+
+    it('should backfill synthesis metadata from input', async () => {
+      await handleInit({ featureId: 'cleanup-synth', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('cleanup-synth');
+      raw.phase = 'review';
+      await writeRawState('cleanup-synth', raw);
+
+      await handleCleanup({
+        featureId: 'cleanup-synth',
+        mergeVerified: true,
+        prUrl: 'https://github.com/test/pr/1',
+        mergedBranches: ['feature/task-1', 'feature/task-2'],
+      }, tmpDir);
+
+      const state = await readRawState('cleanup-synth');
+      const synthesis = state.synthesis as Record<string, unknown>;
+      expect(synthesis.prUrl).toBe('https://github.com/test/pr/1');
+      expect(synthesis.mergedBranches).toEqual(['feature/task-1', 'feature/task-2']);
+    });
+
+    it('should force-resolve blocking review statuses', async () => {
+      await handleInit({ featureId: 'cleanup-reviews', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('cleanup-reviews');
+      raw.phase = 'review';
+      raw.reviews = {
+        'task-1': { status: 'in-progress' },
+        'task-2': { specReview: { status: 'fail' }, qualityReview: { status: 'needs_fixes' } },
+      };
+      await writeRawState('cleanup-reviews', raw);
+
+      await handleCleanup({
+        featureId: 'cleanup-reviews',
+        mergeVerified: true,
+      }, tmpDir);
+
+      const state = await readRawState('cleanup-reviews');
+      const reviews = state.reviews as Record<string, Record<string, unknown>>;
+      expect(reviews['task-1'].status).toBe('approved');
+      expect((reviews['task-2'].specReview as Record<string, unknown>).status).toBe('approved');
+      expect((reviews['task-2'].qualityReview as Record<string, unknown>).status).toBe('approved');
+    });
+
+    it('should return dryRun preview without modifying state', async () => {
+      await handleInit({ featureId: 'cleanup-dry', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('cleanup-dry');
+      raw.phase = 'review';
+      await writeRawState('cleanup-dry', raw);
+
+      const result = await handleCleanup({
+        featureId: 'cleanup-dry',
+        mergeVerified: true,
+        dryRun: true,
+      }, tmpDir);
+
+      expect(result.success).toBe(true);
+      expect((result.data as Record<string, unknown>)?.dryRun).toBe(true);
+
+      // State should NOT be modified
+      const state = await readRawState('cleanup-dry');
+      expect(state.phase).toBe('review');
+    });
+
+    it('should work from delegate phase (feature workflow)', async () => {
+      await handleInit({ featureId: 'cleanup-delegate', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('cleanup-delegate');
+      raw.phase = 'delegate';
+      await writeRawState('cleanup-delegate', raw);
+
+      const result = await handleCleanup({
+        featureId: 'cleanup-delegate',
+        mergeVerified: true,
+      }, tmpDir);
+
+      expect(result.success).toBe(true);
+      expect((result.data as Record<string, unknown>)?.phase).toBe('completed');
+      expect((result.data as Record<string, unknown>)?.previousPhase).toBe('delegate');
+    });
+
+    it('should work for debug workflow', async () => {
+      await handleInit({ featureId: 'cleanup-debug', workflowType: 'debug' }, tmpDir);
+      const raw = await readRawState('cleanup-debug');
+      raw.phase = 'investigate';
+      await writeRawState('cleanup-debug', raw);
+
+      const result = await handleCleanup({
+        featureId: 'cleanup-debug',
+        mergeVerified: true,
+      }, tmpDir);
+
+      expect(result.success).toBe(true);
+      expect((result.data as Record<string, unknown>)?.phase).toBe('completed');
+    });
+
+    it('should work for refactor workflow', async () => {
+      await handleInit({ featureId: 'cleanup-refactor', workflowType: 'refactor' }, tmpDir);
+      const raw = await readRawState('cleanup-refactor');
+      raw.phase = 'overhaul-review';
+      await writeRawState('cleanup-refactor', raw);
+
+      const result = await handleCleanup({
+        featureId: 'cleanup-refactor',
+        mergeVerified: true,
+      }, tmpDir);
+
+      expect(result.success).toBe(true);
+      expect((result.data as Record<string, unknown>)?.phase).toBe('completed');
+    });
+  });
+
+  describe('event store emission', () => {
+    it('should emit workflow.cleanup event when event store is configured', async () => {
+      const mockEventStore = {
+        append: vi.fn().mockResolvedValue({
+          sequence: 1,
+          timestamp: new Date().toISOString(),
+          type: 'workflow.transition',
+          streamId: 'cleanup-event-test',
+          schemaVersion: '1.0',
+        }),
+        query: vi.fn().mockResolvedValue([]),
+      } as unknown as EventStore;
+
+      configureCleanupEventStore(mockEventStore);
+
+      await handleInit({ featureId: 'cleanup-event-test', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('cleanup-event-test');
+      raw.phase = 'review';
+      await writeRawState('cleanup-event-test', raw);
+
+      const result = await handleCleanup({
+        featureId: 'cleanup-event-test',
+        mergeVerified: true,
+      }, tmpDir);
+
+      expect(result.success).toBe(true);
+      expect(mockEventStore.append).toHaveBeenCalledWith(
+        'cleanup-event-test',
+        expect.objectContaining({
+          data: expect.objectContaining({
+            featureId: 'cleanup-event-test',
+          }),
+        }),
+      );
+
+      configureCleanupEventStore(null);
+    });
+
+    it('should not break cleanup when event store append fails', async () => {
+      const mockEventStore = {
+        append: vi.fn().mockRejectedValue(new Error('store error')),
+        query: vi.fn().mockResolvedValue([]),
+      } as unknown as EventStore;
+
+      configureCleanupEventStore(mockEventStore);
+
+      await handleInit({ featureId: 'cleanup-store-fail', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('cleanup-store-fail');
+      raw.phase = 'review';
+      await writeRawState('cleanup-store-fail', raw);
+
+      const result = await handleCleanup({
+        featureId: 'cleanup-store-fail',
+        mergeVerified: true,
+      }, tmpDir);
+
+      expect(result.success).toBe(true);
+      expect((result.data as Record<string, unknown>)?.phase).toBe('completed');
+
+      configureCleanupEventStore(null);
+    });
+  });
+
+  describe('composite routing', () => {
+    it('should route cleanup action to handleCleanup', async () => {
+      await handleInit({ featureId: 'composite-test', workflowType: 'feature' }, tmpDir);
+
+      const result = await handleWorkflow({
+        action: 'cleanup',
+        featureId: 'composite-test',
+        mergeVerified: false,
+      }, tmpDir);
+
+      // Should fail with GUARD_FAILED (not UNKNOWN_ACTION)
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('GUARD_FAILED');
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
@@ -84,6 +84,10 @@ vi.mock('../../workflow/cancel.js', () => ({
   configureCancelEventStore: vi.fn(),
 }));
 
+vi.mock('../../workflow/cleanup.js', () => ({
+  configureCleanupEventStore: vi.fn(),
+}));
+
 vi.mock('../../workflow/query.js', () => ({
   configureQueryEventStore: vi.fn(),
 }));

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/schemas.test.ts
@@ -24,10 +24,13 @@ import {
   TransitionsInputSchema,
   CancelInputSchema,
   CheckpointInputSchema,
+  CleanupInputSchema,
   ErrorCode,
   isReservedField,
   WorkflowTypeSchema,
 } from '../../workflow/schemas.js';
+import { EventTypes } from '../../event-store/schemas.js';
+import { TOOL_REGISTRY } from '../../registry.js';
 
 // Helper to create a minimal valid checkpoint state
 function makeCheckpointState() {
@@ -798,5 +801,68 @@ describe('Workflow State Schemas', () => {
         expect((result.data as Record<string, unknown>).planReview).toEqual({ approved: true });
       }
     });
+  });
+});
+
+// ─── Task 3: CleanupInputSchema and workflow.cleanup event type ────────────────
+
+describe('CleanupInputSchema', () => {
+  it('should accept valid cleanup input', () => {
+    const input = {
+      featureId: 'test-feature',
+      mergeVerified: true,
+      prUrl: 'https://github.com/test/pr/1',
+      mergedBranches: ['feature/task-1', 'feature/task-2'],
+    };
+    const result = CleanupInputSchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it('should require featureId', () => {
+    const input = { mergeVerified: true };
+    const result = CleanupInputSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it('should require mergeVerified', () => {
+    const input = { featureId: 'test-feature' };
+    const result = CleanupInputSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept prUrl as string or array', () => {
+    const singleUrl = CleanupInputSchema.safeParse({
+      featureId: 'test', mergeVerified: true, prUrl: 'https://url',
+    });
+    const arrayUrl = CleanupInputSchema.safeParse({
+      featureId: 'test', mergeVerified: true, prUrl: ['https://url1', 'https://url2'],
+    });
+    expect(singleUrl.success).toBe(true);
+    expect(arrayUrl.success).toBe(true);
+  });
+
+  it('should accept optional dryRun', () => {
+    const result = CleanupInputSchema.safeParse({
+      featureId: 'test', mergeVerified: true, dryRun: true,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('workflow.cleanup event type', () => {
+  it('should be a valid event type', () => {
+    expect(EventTypes).toContain('workflow.cleanup');
+  });
+});
+
+// ─── Task 6: cleanup action registration ────────────────────────────────────
+
+describe('cleanup action registration', () => {
+  it('should include cleanup in exarchos_workflow actions', () => {
+    const workflowTool = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow');
+    expect(workflowTool).toBeDefined();
+    const cleanupAction = workflowTool!.actions.find(a => a.name === 'cleanup');
+    expect(cleanupAction).toBeDefined();
+    expect(cleanupAction!.schema).toBeDefined();
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
@@ -5,6 +5,7 @@ import {
   getValidTransitions,
 } from '../../workflow/state-machine.js';
 import type { HSMDefinition, State, Transition } from '../../workflow/state-machine.js';
+import { guards } from '../../workflow/guards.js';
 
 // ─── Task 003: HSM State/Transition Definitions ─────────────────────────────
 
@@ -2223,5 +2224,120 @@ describe('Leaf-state onEntry/onExit effects', () => {
     expect(result.newPhase).toBe('cancelled');
     // Should include the onExit effect from the alpha leaf state via cancel path
     expect(result.effects).toContain('log');
+  });
+});
+
+// ─── Task 1: mergeVerified guard ──────────────────────────────────────────────
+
+describe('mergeVerified guard', () => {
+  it('should pass when _cleanup.mergeVerified is true', () => {
+    const state = { _cleanup: { mergeVerified: true } } as Record<string, unknown>;
+    expect(guards.mergeVerified.evaluate(state)).toBe(true);
+  });
+
+  it('should fail with reason when _cleanup.mergeVerified is false', () => {
+    const state = { _cleanup: { mergeVerified: false } } as Record<string, unknown>;
+    const result = guards.mergeVerified.evaluate(state);
+    expect(typeof result).toBe('object');
+    expect((result as { passed: boolean; reason: string }).passed).toBe(false);
+    expect((result as { passed: boolean; reason: string }).reason).toBeTruthy();
+  });
+
+  it('should fail with reason when _cleanup is missing', () => {
+    const state = {} as Record<string, unknown>;
+    const result = guards.mergeVerified.evaluate(state);
+    expect(typeof result).toBe('object');
+    expect((result as { passed: boolean }).passed).toBe(false);
+  });
+});
+
+// ─── Task 2: Universal cleanup transition ─────────────────────────────────────
+
+describe('universal cleanup transition', () => {
+  it('should transition from review to completed when mergeVerified', () => {
+    const hsm = getHSMDefinition('feature');
+    const state = { phase: 'review', _cleanup: { mergeVerified: true }, _events: [], _history: {} };
+    const result = executeTransition(hsm, state as Record<string, unknown>, 'completed');
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('completed');
+  });
+
+  it('should transition from delegate to completed when mergeVerified', () => {
+    const hsm = getHSMDefinition('feature');
+    const state = { phase: 'delegate', _cleanup: { mergeVerified: true }, _events: [], _history: {} };
+    const result = executeTransition(hsm, state as Record<string, unknown>, 'completed');
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('completed');
+  });
+
+  it('should fall through to normal transition when mergeVerified is false', () => {
+    const hsm = getHSMDefinition('feature');
+    // review has no normal transition to completed, so this should fail
+    const state = { phase: 'review', _cleanup: { mergeVerified: false }, _events: [], _history: {} };
+    const result = executeTransition(hsm, state as Record<string, unknown>, 'completed');
+    expect(result.success).toBe(false);
+  });
+
+  it('should still allow normal synthesize to completed via prUrlExists', () => {
+    const hsm = getHSMDefinition('feature');
+    const state = {
+      phase: 'synthesize',
+      synthesis: { prUrl: 'https://github.com/test/pr/1' },
+      artifacts: { pr: 'https://github.com/test/pr/1' },
+      _events: [],
+      _history: {},
+    };
+    const result = executeTransition(hsm, state as Record<string, unknown>, 'completed');
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('completed');
+  });
+
+  it('should emit cleanup event type for cleanup transitions', () => {
+    const hsm = getHSMDefinition('feature');
+    const state = { phase: 'review', _cleanup: { mergeVerified: true }, _events: [], _history: {} };
+    const result = executeTransition(hsm, state as Record<string, unknown>, 'completed');
+    expect(result.events[0].type).toBe('cleanup');
+    expect(result.events[0].trigger).toBe('cleanup');
+  });
+
+  it('should work for debug workflow', () => {
+    const hsm = getHSMDefinition('debug');
+    const state = { phase: 'investigate', _cleanup: { mergeVerified: true }, _events: [], _history: {} };
+    const result = executeTransition(hsm, state as Record<string, unknown>, 'completed');
+    expect(result.success).toBe(true);
+  });
+
+  it('should work for refactor workflow', () => {
+    const hsm = getHSMDefinition('refactor');
+    const state = { phase: 'overhaul-review', _cleanup: { mergeVerified: true }, _events: [], _history: {} };
+    const result = executeTransition(hsm, state as Record<string, unknown>, 'completed');
+    expect(result.success).toBe(true);
+  });
+
+  it('should collect exit effects from compound parents', () => {
+    const hsm = getHSMDefinition('feature');
+    // delegate is inside 'implementation' compound
+    const state = { phase: 'delegate', _cleanup: { mergeVerified: true }, _events: [], _history: {} };
+    const result = executeTransition(hsm, state as Record<string, unknown>, 'completed');
+    expect(result.success).toBe(true);
+    // Should have exit effects from implementation compound
+    expect(result.effects.length).toBeGreaterThan(0);
+  });
+
+  it('should record history for compound states being exited', () => {
+    const hsm = getHSMDefinition('feature');
+    const state = { phase: 'delegate', _cleanup: { mergeVerified: true }, _events: [], _history: {} };
+    const result = executeTransition(hsm, state as Record<string, unknown>, 'completed');
+    expect(result.historyUpdates).toBeDefined();
+    expect(result.historyUpdates?.['implementation']).toBe('delegate');
+  });
+
+  it('should not transition from already completed state', () => {
+    const hsm = getHSMDefinition('feature');
+    const state = { phase: 'completed', _cleanup: { mergeVerified: true }, _events: [], _history: {} };
+    const result = executeTransition(hsm, state as Record<string, unknown>, 'completed');
+    // Should be idempotent
+    expect(result.success).toBe(true);
+    expect(result.idempotent).toBe(true);
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -20,6 +20,7 @@ export const EventTypes = [
   'workflow.compound-entry',
   'workflow.compound-exit',
   'workflow.cancel',
+  'workflow.cleanup',
   'workflow.compensation',
   'workflow.circuit-open',
   'tool.invoked',

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -157,6 +157,13 @@ export const WorkflowCompoundExitData = z.object({
   trigger: z.string().optional(),
 });
 
+export const WorkflowCleanupData = z.object({
+  from: z.string(),
+  to: z.string(),
+  trigger: z.string(),
+  featureId: z.string(),
+});
+
 export const WorkflowCancelData = z.object({
   from: z.string(),
   to: z.string(),
@@ -217,6 +224,7 @@ export type WorkflowGuardFailed = z.infer<typeof WorkflowGuardFailedData>;
 export type WorkflowCheckpoint = z.infer<typeof WorkflowCheckpointData>;
 export type WorkflowCompoundEntry = z.infer<typeof WorkflowCompoundEntryData>;
 export type WorkflowCompoundExit = z.infer<typeof WorkflowCompoundExitData>;
+export type WorkflowCleanup = z.infer<typeof WorkflowCleanupData>;
 export type WorkflowCancel = z.infer<typeof WorkflowCancelData>;
 export type WorkflowCompensation = z.infer<typeof WorkflowCompensationData>;
 export type WorkflowCircuitOpen = z.infer<typeof WorkflowCircuitOpenData>;

--- a/plugins/exarchos/servers/exarchos-mcp/src/index.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/index.ts
@@ -20,6 +20,7 @@ import { handleSync } from './sync/composite.js';
 import { configureWorkflowEventStore } from './workflow/tools.js';
 import { configureNextActionEventStore } from './workflow/next-action.js';
 import { configureCancelEventStore } from './workflow/cancel.js';
+import { configureCleanupEventStore } from './workflow/cleanup.js';
 import { configureQueryEventStore } from './workflow/query.js';
 import { EventStore } from './event-store/store.js';
 
@@ -56,6 +57,7 @@ export function createServer(stateDir: string): McpServer {
   configureWorkflowEventStore(eventStore);
   configureNextActionEventStore(eventStore);
   configureCancelEventStore(eventStore);
+  configureCleanupEventStore(eventStore);
   configureQueryEventStore(eventStore);
 
   // Register composite tools from registry

--- a/plugins/exarchos/servers/exarchos-mcp/src/registry.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/registry.test.ts
@@ -232,11 +232,11 @@ describe('TOOL_REGISTRY', () => {
   });
 
   describe('exarchos_workflow', () => {
-    it('should have 4 actions: init, get, set, cancel', () => {
+    it('should have 5 actions: init, get, set, cancel, cleanup', () => {
       const composite = findComposite('exarchos_workflow');
       expect(composite).toBeDefined();
       const actionNames = composite!.actions.map((a) => a.name);
-      expect(actionNames).toEqual(['init', 'get', 'set', 'cancel']);
+      expect(actionNames).toEqual(['init', 'get', 'set', 'cancel', 'cleanup']);
     });
   });
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
@@ -232,6 +232,19 @@ const workflowActions: readonly ToolAction[] = [
     phases: ALL_PHASES,
     roles: ROLE_LEAD,
   },
+  {
+    name: 'cleanup',
+    description: 'Resolve a merged workflow to completed. Verifies merge, backfills synthesis metadata, force-resolves reviews, transitions to completed. Auto-emits workflow.cleanup event',
+    schema: z.object({
+      featureId: featureIdSchema,
+      mergeVerified: z.boolean(),
+      prUrl: z.union([z.string(), z.array(z.string())]).optional(),
+      mergedBranches: z.array(z.string()).optional(),
+      dryRun: z.boolean().optional(),
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_LEAD,
+  },
 ];
 
 // ─── Composite Tool: exarchos_event ─────────────────────────────────────────
@@ -393,7 +406,7 @@ const syncActions: readonly ToolAction[] = [
 export const TOOL_REGISTRY: readonly CompositeTool[] = [
   {
     name: 'exarchos_workflow',
-    description: 'Workflow lifecycle management — init, read, update, and cancel workflows',
+    description: 'Workflow lifecycle management — init, read, update, cancel, and cleanup workflows',
     actions: workflowActions,
   },
   {

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/cleanup.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/cleanup.ts
@@ -161,26 +161,6 @@ export async function handleCleanup(
     };
   }
 
-  // Event-first: emit cleanup event BEFORE state write
-  if (moduleEventStore) {
-    try {
-      for (const transitionEvent of transitionResult.events) {
-        await moduleEventStore.append(input.featureId, {
-          type: mapInternalToExternalType(transitionEvent.type) as import('../event-store/schemas.js').EventType,
-          data: {
-            from: transitionEvent.from,
-            to: transitionEvent.to,
-            trigger: transitionEvent.trigger,
-            featureId: input.featureId,
-            ...(transitionEvent.metadata ?? {}),
-          },
-        });
-      }
-    } catch {
-      // External store is supplementary; append failure must not break cleanup
-    }
-  }
-
   // Mutate state
   mutableState.phase = 'completed';
 
@@ -208,8 +188,28 @@ export async function handleCleanup(
   // Clean up internal cleanup flag
   delete mutableState._cleanup;
 
-  // Write state
+  // Write state first — cleanup events are supplementary
   await writeStateFile(stateFile, mutableState as WorkflowState);
+
+  // Emit transition events after state write (best-effort)
+  if (moduleEventStore) {
+    try {
+      for (const transitionEvent of transitionResult.events) {
+        await moduleEventStore.append(input.featureId, {
+          type: mapInternalToExternalType(transitionEvent.type) as import('../event-store/schemas.js').EventType,
+          data: {
+            from: transitionEvent.from,
+            to: transitionEvent.to,
+            trigger: transitionEvent.trigger,
+            featureId: input.featureId,
+            ...(transitionEvent.metadata ?? {}),
+          },
+        });
+      }
+    } catch {
+      // External store is supplementary; append failure must not break cleanup
+    }
+  }
 
   return {
     success: true,

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/cleanup.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/cleanup.ts
@@ -1,0 +1,222 @@
+import type { CleanupInput, WorkflowState } from './types.js';
+import { ErrorCode } from './schemas.js';
+import {
+  readStateFile,
+  writeStateFile,
+  StateStoreError,
+} from './state-store.js';
+import {
+  buildCheckpointMeta,
+  resetCounter,
+} from './checkpoint.js';
+import { mapInternalToExternalType } from './events.js';
+import { getHSMDefinition, executeTransition } from './state-machine.js';
+import type { EventStore } from '../event-store/store.js';
+import type { ToolResult } from '../format.js';
+import * as path from 'node:path';
+
+// ─── Module-Level EventStore Configuration ──────────────────────────────────
+
+let moduleEventStore: EventStore | null = null;
+
+/** Configure the EventStore instance used by cleanup handlers. */
+export function configureCleanupEventStore(store: EventStore | null): void {
+  moduleEventStore = store;
+}
+
+// ─── handleCleanup ──────────────────────────────────────────────────────────
+
+export async function handleCleanup(
+  input: CleanupInput,
+  stateDir: string,
+): Promise<ToolResult> {
+  const stateFile = path.join(stateDir, `${input.featureId}.state.json`);
+
+  let state: WorkflowState;
+  try {
+    state = await readStateFile(stateFile);
+  } catch (err) {
+    if (err instanceof StateStoreError && err.code === ErrorCode.STATE_NOT_FOUND) {
+      return {
+        success: false,
+        error: {
+          code: ErrorCode.STATE_NOT_FOUND,
+          message: `State not found for feature: ${input.featureId}`,
+        },
+      };
+    }
+    throw err;
+  }
+
+  // Check if already completed
+  if (state.phase === 'completed') {
+    return {
+      success: false,
+      error: {
+        code: ErrorCode.ALREADY_COMPLETED,
+        message: `Workflow '${input.featureId}' is already completed`,
+      },
+    };
+  }
+
+  // Check if cancelled (cannot cleanup a cancelled workflow)
+  if (state.phase === 'cancelled') {
+    return {
+      success: false,
+      error: {
+        code: ErrorCode.INVALID_TRANSITION,
+        message: `Cannot cleanup cancelled workflow '${input.featureId}'`,
+      },
+    };
+  }
+
+  // Check merge verification
+  if (!input.mergeVerified) {
+    return {
+      success: false,
+      error: {
+        code: ErrorCode.GUARD_FAILED,
+        message: 'Cleanup requires mergeVerified: true — verify PRs are merged before invoking cleanup',
+      },
+    };
+  }
+
+  // ─── Happy path (Task 5) ──────────────────────────────────────────────
+
+  const mutableState = structuredClone(state) as Record<string, unknown>;
+  const currentPhase = state.phase;
+  const dryRun = input.dryRun ?? false;
+
+  // Backfill synthesis metadata
+  const synthesis = (mutableState.synthesis ?? {}) as Record<string, unknown>;
+  if (input.prUrl !== undefined) {
+    synthesis.prUrl = input.prUrl;
+  }
+  if (input.mergedBranches !== undefined) {
+    synthesis.mergedBranches = input.mergedBranches;
+  }
+  mutableState.synthesis = synthesis;
+
+  // Also set artifacts.pr for guards that check there
+  const artifacts = (mutableState.artifacts ?? {}) as Record<string, unknown>;
+  if (input.prUrl !== undefined && artifacts.pr == null) {
+    artifacts.pr = input.prUrl;
+  }
+  mutableState.artifacts = artifacts;
+
+  // Force-resolve all blocking review statuses
+  const reviews = mutableState.reviews as Record<string, unknown> | undefined;
+  if (reviews) {
+    for (const [, value] of Object.entries(reviews)) {
+      if (typeof value !== 'object' || value === null) continue;
+      const entry = value as Record<string, unknown>;
+      if (typeof entry.status === 'string') {
+        // Flat review: { status: "in-progress" } → { status: "approved" }
+        entry.status = 'approved';
+      } else {
+        // Nested: { specReview: { status: "fail" }, qualityReview: { status: "needs_fixes" } }
+        for (const [, subValue] of Object.entries(entry)) {
+          if (typeof subValue === 'object' && subValue !== null) {
+            const sub = subValue as Record<string, unknown>;
+            if (typeof sub.status === 'string') {
+              sub.status = 'approved';
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Set _cleanup.mergeVerified for the guard
+  mutableState._cleanup = { mergeVerified: true };
+
+  // Execute HSM transition to completed
+  const hsm = getHSMDefinition(state.workflowType);
+  const transitionResult = executeTransition(hsm, mutableState, 'completed');
+
+  if (!transitionResult.success) {
+    return {
+      success: false,
+      error: {
+        code: transitionResult.errorCode ?? ErrorCode.INVALID_TRANSITION,
+        message: transitionResult.errorMessage ?? 'Failed to transition to completed',
+      },
+    };
+  }
+
+  // dryRun: return preview without modifying state
+  if (dryRun) {
+    return {
+      success: true,
+      data: {
+        dryRun: true,
+        currentPhase,
+        wouldTransitionTo: 'completed',
+        synthesisBackfill: {
+          prUrl: input.prUrl ?? null,
+          mergedBranches: input.mergedBranches ?? null,
+        },
+      },
+      _meta: buildCheckpointMeta(state._checkpoint),
+    };
+  }
+
+  // Event-first: emit cleanup event BEFORE state write
+  if (moduleEventStore) {
+    try {
+      for (const transitionEvent of transitionResult.events) {
+        await moduleEventStore.append(input.featureId, {
+          type: mapInternalToExternalType(transitionEvent.type) as import('../event-store/schemas.js').EventType,
+          data: {
+            from: transitionEvent.from,
+            to: transitionEvent.to,
+            trigger: transitionEvent.trigger,
+            featureId: input.featureId,
+            ...(transitionEvent.metadata ?? {}),
+          },
+        });
+      }
+    } catch {
+      // External store is supplementary; append failure must not break cleanup
+    }
+  }
+
+  // Mutate state
+  mutableState.phase = 'completed';
+
+  // Apply history updates from transition
+  if (transitionResult.historyUpdates) {
+    const history = { ...(mutableState._history as Record<string, string>) };
+    for (const [key, value] of Object.entries(transitionResult.historyUpdates)) {
+      history[key] = value;
+    }
+    mutableState._history = history;
+  }
+
+  // Reset checkpoint counter
+  mutableState._checkpoint = resetCounter(
+    mutableState._checkpoint as WorkflowState['_checkpoint'],
+    'completed',
+    'Workflow completed via cleanup',
+  );
+
+  // Update timestamps
+  mutableState.updatedAt = new Date().toISOString();
+  const checkpoint = mutableState._checkpoint as Record<string, unknown>;
+  checkpoint.lastActivityTimestamp = new Date().toISOString();
+
+  // Clean up internal cleanup flag
+  delete mutableState._cleanup;
+
+  // Write state
+  await writeStateFile(stateFile, mutableState as WorkflowState);
+
+  return {
+    success: true,
+    data: {
+      phase: 'completed',
+      previousPhase: currentPhase,
+    },
+    _meta: buildCheckpointMeta(mutableState._checkpoint as WorkflowState['_checkpoint']),
+  };
+}

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/composite.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/composite.ts
@@ -1,5 +1,6 @@
 import { handleInit, handleGet, handleSet } from './tools.js';
 import { handleCancel } from './cancel.js';
+import { handleCleanup } from './cleanup.js';
 import type { ToolResult } from '../format.js';
 
 /**
@@ -21,12 +22,14 @@ export async function handleWorkflow(
       return handleSet(rest as Parameters<typeof handleSet>[0], stateDir);
     case 'cancel':
       return handleCancel(rest as Parameters<typeof handleCancel>[0], stateDir);
+    case 'cleanup':
+      return handleCleanup(rest as Parameters<typeof handleCleanup>[0], stateDir);
     default:
       return {
         success: false,
         error: {
           code: 'UNKNOWN_ACTION',
-          message: `Unknown action: ${String(action)}. Valid actions: init, get, set, cancel`,
+          message: `Unknown action: ${String(action)}. Valid actions: init, get, set, cancel, cleanup`,
         },
       };
   }

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/events.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/events.ts
@@ -143,6 +143,7 @@ export function mapInternalToExternalType(internalType: string): string {
     'compound-exit': 'workflow.compound-exit',
     'circuit-open': 'workflow.circuit-open',
     'cancel': 'workflow.cancel',
+    'cleanup': 'workflow.cleanup',
   };
   return typeMap[internalType] ?? `workflow.${internalType}`;
 }

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/guards.ts
@@ -335,6 +335,21 @@ export const guards = {
     },
   },
 
+  mergeVerified: {
+    id: 'merge-verified',
+    description: 'Merge must be verified by the orchestrator before cleanup',
+    evaluate: (state: Record<string, unknown>): GuardResult => {
+      const cleanup = state._cleanup as Record<string, unknown> | undefined;
+      if (!cleanup || cleanup.mergeVerified !== true) {
+        return {
+          passed: false,
+          reason: 'Cleanup requires mergeVerified flag — verify PRs are merged via GitHub API before invoking cleanup',
+        };
+      }
+      return true;
+    },
+  },
+
   always: {
     id: 'always',
     description: 'Always passes',

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/schemas.ts
@@ -12,6 +12,7 @@ export const EventTypeSchema = z.enum([
   'circuit-open',
   'compensation',
   'cancel',
+  'cleanup',
   'field-update',
 ]);
 
@@ -265,6 +266,14 @@ export const CancelInputSchema = z.object({
   dryRun: z.boolean().optional(),
 });
 
+export const CleanupInputSchema = z.object({
+  featureId: FeatureIdSchema,
+  mergeVerified: z.boolean(),
+  prUrl: z.union([z.string(), z.array(z.string())]).optional(),
+  mergedBranches: z.array(z.string()).optional(),
+  dryRun: z.boolean().optional(),
+});
+
 export const CheckpointInputSchema = z.object({
   featureId: FeatureIdSchema,
   summary: z.string().optional(),
@@ -282,6 +291,7 @@ export const ToolInputSchemas = {
   'next-action': NextActionInputSchema,
   transitions: TransitionsInputSchema,
   cancel: CancelInputSchema,
+  cleanup: CleanupInputSchema,
   checkpoint: CheckpointInputSchema,
 } as const;
 
@@ -298,6 +308,7 @@ export const ErrorCode = {
   INVALID_INPUT: 'INVALID_INPUT',
   RESERVED_FIELD: 'RESERVED_FIELD',
   ALREADY_CANCELLED: 'ALREADY_CANCELLED',
+  ALREADY_COMPLETED: 'ALREADY_COMPLETED',
   COMPENSATION_PARTIAL: 'COMPENSATION_PARTIAL',
   FILE_IO_ERROR: 'FILE_IO_ERROR',
   EVENT_APPEND_FAILED: 'EVENT_APPEND_FAILED',

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/state-machine.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/state-machine.ts
@@ -1,4 +1,5 @@
 import type { Guard, GuardResult } from './guards.js';
+import { guards } from './guards.js';
 import { createFeatureHSM, createDebugHSM, createRefactorHSM } from './hsm-definitions.js';
 
 // Re-export guard types for consumers
@@ -136,6 +137,11 @@ export function getValidTransitions(
     targets.push('cancelled');
   }
 
+  // Add universal cleanup (completed) if not already present
+  if (!targets.includes('completed') && hsm.states['completed']) {
+    targets.push('completed');
+  }
+
   return [...new Set(targets)];
 }
 
@@ -222,6 +228,55 @@ export function executeTransition(
       historyUpdates:
         Object.keys(historyUpdates).length > 0 ? historyUpdates : undefined,
     };
+  }
+
+  // Handle universal cleanup transition (mergeVerified → completed)
+  const isCleanup = targetPhase === 'completed' && hsm.states['completed']?.type === 'final';
+
+  if (isCleanup) {
+    // Evaluate mergeVerified guard
+    const guardResult = guards.mergeVerified.evaluate(state);
+    const guardPassed = typeof guardResult === 'boolean' ? guardResult : false;
+
+    if (guardPassed) {
+      const exitEffects: Effect[] = [];
+      const historyUpdates: Record<string, string> = {};
+
+      // Exit actions for current state and parent compounds (same pattern as cancel)
+      const currentAncestors = getCompoundAncestors(hsm, currentPhase);
+      if (currentState?.onExit) {
+        exitEffects.push(...currentState.onExit);
+      }
+      for (const ancestor of currentAncestors) {
+        if (ancestor.onExit) exitEffects.push(...ancestor.onExit);
+        historyUpdates[ancestor.id] = currentPhase;
+      }
+
+      // If current state is in a compound, record history
+      const parent = getParentCompound(hsm, currentPhase);
+      if (parent) {
+        historyUpdates[parent.id] = currentPhase;
+      }
+
+      return {
+        success: true,
+        idempotent: false,
+        newPhase: 'completed',
+        effects: exitEffects,
+        events: [
+          {
+            type: 'cleanup',
+            from: currentPhase,
+            to: 'completed',
+            trigger: 'cleanup',
+          },
+        ],
+        historyUpdates:
+          Object.keys(historyUpdates).length > 0 ? historyUpdates : undefined,
+      };
+    }
+    // If mergeVerified guard fails, fall through to normal transition lookup
+    // This allows existing transitions like synthesize → completed (prUrlExists) to work
   }
 
   // Find matching transition

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/types.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/types.ts
@@ -28,6 +28,7 @@ import type {
   NextActionInputSchema,
   TransitionsInputSchema,
   CancelInputSchema,
+  CleanupInputSchema,
   CheckpointInputSchema,
   ErrorCode,
 } from './schemas.js';
@@ -73,6 +74,7 @@ export type ReconcileInput = z.infer<typeof ReconcileInputSchema>;
 export type NextActionInput = z.infer<typeof NextActionInputSchema>;
 export type TransitionsInput = z.infer<typeof TransitionsInputSchema>;
 export type CancelInput = z.infer<typeof CancelInputSchema>;
+export type CleanupInput = z.infer<typeof CleanupInputSchema>;
 export type CheckpointInput = z.infer<typeof CheckpointInputSchema>;
 
 // ─── Error Code Type ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a `cleanup` action to the `exarchos_workflow` composite tool that resolves merged workflows to `completed` in a single operation. Previously, post-merge cleanup required ~8 manual tool calls with guard failures — now it's a single action with merge verification.

## Changes

- **HSM definitions** — Added cleanup transitions from any non-terminal state to `completed` for all 3 workflow types (feature, debug, refactor), gated by `mergeVerified` guard
- **Guards** — Added `mergeVerified` guard that checks the cleanup payload flag
- **cleanup.ts** — New `handleCleanup()` handler: validates merge verification, backfills synthesis metadata (prUrl, mergedBranches), force-resolves blocking review statuses, executes HSM transition, emits `workflow.cleanup` event
- **Event schemas** — Added `workflow.cleanup` event type to the event store schema
- **Registry + composite** — Registered cleanup action in tool registry and composite router
- **Tests** — 14 cleanup-specific tests covering happy path, rejection paths, all 3 workflow types, and event emission

## Test Plan

1135 MCP server tests passing, 223 root tests passing. Cleanup tests verify transitions from multiple starting phases across all workflow types.

---
**Results:** Tests 1135 ✓ · Build 0 errors
**Issue:** #375