### PR TITLE
docs: add /cleanup command and skill for post-merge workflow resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ Uses `@modelcontextprotocol/sdk` + `zod`, communicates over stdio, and is regist
 - `workflow/state-machine.ts` — Types/interfaces, transition algorithm, HSM registry
 - `workflow/guards.ts` — Guard definitions (26 guards) for all HSM transitions
 - `workflow/hsm-definitions.ts` — HSM definitions for feature/debug/refactor workflows
-- `workflow/tools.ts` — Handler functions for init, get, set. Uses CAS versioning (`_version` field) with retry loop to prevent lost updates on concurrent writes. Emits transition events to external JSONL store after successful state write (state-first, event-after). Responses strip internal fields (`_events`, `_history`) and include compact `_meta` summaries. Fast-path for simple queries (phase, featureId) skips full Zod validation.
+- `workflow/tools.ts` — Handler functions for init, get, set. Uses CAS versioning (`_version` field) with retry loop to prevent lost updates on concurrent writes. Event-first architecture: appends transition events to JSONL store BEFORE writing state file; idempotency keys prevent duplicates on CAS retry. Responses strip internal fields (`_events`, `_history`) and include compact `_meta` summaries. Fast-path for simple queries (phase, featureId) skips full Zod validation.
 - `workflow/composite.ts` — Composite router dispatching `action` to init/get/set/cancel handlers
 - `workflow/next-action.ts` — Auto-continue logic and phase-to-action mapping (used by CLI hooks)
 - `workflow/cancel.ts` — Saga compensation and workflow cancellation with checkpoint persistence for resumable compensation on partial failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Uses `@modelcontextprotocol/sdk` + `zod`, communicates over stdio, and is regist
 
 | Tool | Actions | Purpose |
 |------|---------|---------|
-| `exarchos_workflow` | `init`, `get`, `set`, `cancel` | Workflow CRUD |
+| `exarchos_workflow` | `init`, `get`, `set`, `cancel`, `cleanup` | Workflow CRUD + post-merge resolution |
 | `exarchos_event` | `append`, `query` | Event sourcing |
 | `exarchos_orchestrate` | `task_claim`, `task_complete`, `task_fail` | Task coordination |
 | `exarchos_view` | `pipeline`, `tasks`, `workflow_status`, `stack_status`, `stack_place` | CQRS read views |
@@ -114,7 +114,7 @@ Uses `@modelcontextprotocol/sdk` + `zod`, communicates over stdio, and is regist
 
 ### Three Workflow Types
 
-**Feature:** `/ideate` → `/plan` → plan-review → `/delegate` → `/review` → `/synthesize`
+**Feature:** `/ideate` → `/plan` → plan-review → `/delegate` → `/review` → `/synthesize` → merge → `/cleanup`
 **Debug:** `/debug` → triage → investigate → fix → validate (hotfix or thorough tracks)
 **Refactor:** `/refactor` → explore → brief → implement → validate (polish or overhaul tracks)
 

--- a/commands/cleanup.md
+++ b/commands/cleanup.md
@@ -1,0 +1,107 @@
+---
+description: Resolve merged workflow to completed state
+---
+
+# Cleanup
+
+Resolve merged workflow: "$ARGUMENTS"
+
+## Workflow Position
+
+```
+/ideate → [CONFIRM] → /plan → /delegate → /review → /synthesize → [CONFIRM] → merge → /cleanup
+                                                                                        ▲▲▲▲▲▲▲
+```
+
+This command is the **post-merge cleanup** entry point. Use after PR stack has merged to resolve workflow state to `completed`.
+
+## Skill Reference
+
+Follow the cleanup skill: `@skills/cleanup/SKILL.md`
+
+## Prerequisites
+
+- [ ] Workflow exists (any non-terminal phase)
+- [ ] All PRs in the stack are merged
+
+## Process
+
+### Step 1: Identify Workflow
+
+Read workflow state:
+```typescript
+mcp__exarchos__exarchos_workflow({ action: "get", featureId: "<feature-id>" })
+```
+
+If no `$ARGUMENTS` provided, list active workflows:
+```typescript
+mcp__exarchos__exarchos_view({ action: "pipeline" })
+```
+
+### Step 2: Verify PR Merge Status
+
+Query GitHub for merged PRs associated with this workflow:
+```typescript
+// For each PR URL in state
+mcp__plugin_github_github__pull_request_read({
+  owner: "lvlup-sw",
+  repo: "exarchos",
+  pullNumber: <number>
+})
+```
+
+Or use gh CLI as fallback:
+```bash
+gh pr view <number> --json state,mergedAt
+```
+
+Collect:
+- `prUrl` — PR URL(s) that were merged
+- `mergedBranches` — branch names that were merged
+
+### Step 3: Invoke Cleanup Action
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "cleanup",
+  featureId: "<feature-id>",
+  mergeVerified: true,
+  prUrl: "<collected-pr-url>",
+  mergedBranches: ["<branch-1>", "<branch-2>"]
+})
+```
+
+### Step 4: Worktree Cleanup
+
+Remove worktrees associated with the workflow:
+```bash
+# For each worktree in state
+git worktree remove .worktrees/<worktree-name>
+git worktree prune
+```
+
+### Step 5: Branch Sync
+
+Sync Graphite branches to remove merged ones:
+```bash
+gt sync --force
+```
+
+## Output
+
+When complete:
+```markdown
+## Cleanup Complete
+
+Feature: <featureId>
+Previous phase: <phase> → completed
+PRs merged: <count>
+Worktrees removed: <count>
+Branches synced: ✓
+```
+
+## Error Handling
+
+- **Workflow not found:** "No workflow found for '<featureId>'. Check active workflows with pipeline view."
+- **PRs not merged:** "Cannot cleanup — PR #<number> is not merged. Merge all PRs first or use `/cancel` to abandon."
+- **Already completed:** "Workflow '<featureId>' is already completed. No cleanup needed."

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: cleanup
+description: "Post-merge workflow resolution. Verifies PR merge status, backfills synthesis metadata, force-resolves review statuses, transitions to completed, and cleans up worktrees/branches. Use when the user says 'cleanup', 'resolve workflow', 'mark as done', or runs /cleanup. Do NOT use before PRs are merged."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: cleanup
+---
+
+# Cleanup Skill
+
+## Overview
+
+Resolve merged workflows to `completed` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
+
+## Triggers
+
+Activate this skill when:
+- User runs `/cleanup` command
+- User says "cleanup", "resolve workflow", "mark as done"
+- PR stack has merged and workflow needs resolution
+- User wants to close out a completed feature
+
+## Prerequisites
+
+- Active workflow in any non-terminal phase
+- All PRs merged on GitHub
+
+## Process
+
+### 1. Identify Target Workflow
+
+Read workflow state to get current phase and metadata:
+```typescript
+mcp__exarchos__exarchos_workflow({ action: "get", featureId: "<id>" })
+```
+
+If featureId not provided, use pipeline view to list active workflows:
+```typescript
+mcp__exarchos__exarchos_view({ action: "pipeline" })
+```
+
+### 2. Verify Merge Status
+
+For each PR associated with the workflow, verify it is merged.
+
+**Primary method** — GitHub MCP:
+```typescript
+mcp__plugin_github_github__pull_request_read({
+  owner: "lvlup-sw",
+  repo: "exarchos",
+  pullNumber: <number>
+})
+```
+
+**Fallback** — gh CLI:
+```bash
+gh pr view <number> --json state,mergedAt,headRefName
+```
+
+Collect from merged PRs:
+- `prUrl`: The PR URL (or array of URLs for stacked PRs)
+- `mergedBranches`: The head branch names that were merged
+
+**Safety check:** If ANY PR is not merged, abort with clear error message.
+
+For detailed verification guidance, see `references/merge-verification.md`.
+
+### 3. Invoke Cleanup Action
+
+Call the MCP cleanup action with collected data:
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "cleanup",
+  featureId: "<id>",
+  mergeVerified: true,
+  prUrl: "<url-or-array>",
+  mergedBranches: ["branch1", "branch2"]
+})
+```
+
+This single call:
+- Backfills `synthesis.prUrl` and `synthesis.mergedBranches`
+- Force-resolves all blocking review statuses to `approved`
+- Transitions to `completed` via universal cleanup path
+- Emits `workflow.cleanup` event to event store
+
+### 4. Worktree Cleanup
+
+Remove all worktrees associated with the workflow:
+```bash
+# Read worktrees from state (already captured in step 1)
+git worktree remove .worktrees/<name>
+git worktree prune
+```
+
+Handle gracefully if worktrees are already removed.
+
+### 5. Branch Sync
+
+Remove merged local branches:
+```bash
+gt sync --force
+```
+
+### 6. Report Completion
+
+Output summary:
+```markdown
+## Cleanup Complete
+
+**Feature:** <featureId>
+**Transition:** <previousPhase> → completed
+**PRs merged:** <count>
+**Worktrees removed:** <count>
+**Branches synced:** ✓
+```
+
+## Dry Run
+
+Use `dryRun: true` to preview what cleanup would do without modifying state:
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "cleanup",
+  featureId: "<id>",
+  mergeVerified: true,
+  dryRun: true
+})
+```
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| STATE_NOT_FOUND | Invalid featureId | Check pipeline view for active workflows |
+| ALREADY_COMPLETED | Workflow already done | No action needed |
+| INVALID_TRANSITION | Workflow is cancelled | Cannot cleanup cancelled workflows |
+| GUARD_FAILED | mergeVerified is false | Verify PRs are merged before cleanup |
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Use cleanup as escape hatch during implementation | Only use after PRs are merged |
+| Skip merge verification | Always verify via GitHub API |
+| Manually navigate HSM guards post-merge | Use /cleanup |
+| Leave worktrees after cleanup | Include worktree removal in process |
+
+## Exarchos Integration
+
+The cleanup action auto-emits events — do NOT manually emit:
+- `workflow.cleanup` — emitted by the MCP cleanup action for the phase change to completed

--- a/skills/cleanup/references/merge-verification.md
+++ b/skills/cleanup/references/merge-verification.md
@@ -1,3 +1,7 @@
+---
+name: merge-verification
+---
+
 # Merge Verification Guide
 
 ## Why Verify?

--- a/skills/cleanup/references/merge-verification.md
+++ b/skills/cleanup/references/merge-verification.md
@@ -1,0 +1,46 @@
+# Merge Verification Guide
+
+## Why Verify?
+
+The cleanup action trusts the `mergeVerified` flag — it does not query GitHub itself. The orchestrator (skill) is responsible for verification. This separation keeps the MCP server free of GitHub API dependencies.
+
+## Verification Methods
+
+### GitHub MCP (Preferred)
+
+```typescript
+const pr = await mcp__plugin_github_github__pull_request_read({
+  owner: "lvlup-sw",
+  repo: "exarchos",
+  pullNumber: 123
+});
+
+// Check: pr.state === "MERGED" or pr.merged === true
+```
+
+### gh CLI (Fallback)
+
+```bash
+gh pr view 123 --json state,mergedAt,headRefName
+# Check: .state == "MERGED" and .mergedAt is not null
+```
+
+### For Stacked PRs
+
+When verifying a Graphite stack, check ALL PRs in the stack:
+
+```bash
+# List PRs for the branch stack
+gh pr list --head "feature/*" --json number,state,headRefName
+```
+
+Collect from each merged PR:
+- `number` — for logging
+- `headRefName` — for `mergedBranches` array
+- PR URL — for `prUrl` (use array if multiple)
+
+## Edge Cases
+
+- **Partially merged stack:** If some PRs are merged and others are not, abort cleanup. All PRs must be merged.
+- **Squash-merged PRs:** The branch name may differ from what's in the worktree. Use the PR's `headRefName` field.
+- **Already-deleted branches:** GitHub may have auto-deleted branches after merge. This is fine — `gt sync` will handle it.


### PR DESCRIPTION
## Summary

Adds the `/cleanup` slash command and skill documentation for post-merge workflow resolution. This is the user-facing counterpart to the cleanup MCP action added in PR #389.

## Changes

- **commands/cleanup.md** — New slash command entry point with workflow position diagram and process steps
- **skills/cleanup/SKILL.md** — Full skill definition with triggers, process steps, and state management
- **skills/cleanup/references/merge-verification.md** — Detailed merge verification steps using GitHub API
- **CLAUDE.md** — Updated composite tools table with cleanup action

## Test Plan

Content-only changes (Markdown). Verified CLAUDE.md accuracy against implementation.

---
**Results:** Content only
**Issue:** #375