### PR TITLE
fix: use CAS versioning and deduplicate resolveStateDir in gates

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.test.ts
@@ -5,10 +5,46 @@ import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 
+// Shared state for CAS race simulation — accessible to the fs mock below
+const casRaceConfig = vi.hoisted(() => ({
+  targetPath: null as string | null,
+  readCount: 0,
+  concurrentState: null as Record<string, unknown> | null,
+}));
+
 // Mock child_process before importing the module under test
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
 }));
+
+// Wrap node:fs/promises readFile to support CAS race simulation.
+// All other functions pass through to the real implementation.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    readFile: async (...args: Parameters<typeof actual.readFile>) => {
+      const result = await actual.readFile(...args);
+      const filePath = typeof args[0] === 'string' ? args[0] : '';
+      if (
+        casRaceConfig.targetPath &&
+        filePath === casRaceConfig.targetPath &&
+        casRaceConfig.concurrentState
+      ) {
+        casRaceConfig.readCount += 1;
+        if (casRaceConfig.readCount === 1) {
+          // After the first read of the target state file, simulate a concurrent
+          // writer modifying the file on disk before the caller can write back.
+          await actual.writeFile(
+            casRaceConfig.targetPath,
+            JSON.stringify(casRaceConfig.concurrentState, null, 2),
+          );
+        }
+      }
+      return result;
+    },
+  };
+});
 
 import { execSync } from 'node:child_process';
 import { handleTaskGate, handleTeammateGate, runQualityChecks, findActiveWorkflowState } from './gates.js';
@@ -450,6 +486,66 @@ describe('Quality Gate Commands', () => {
         const updatedState = JSON.parse(updatedRaw);
         expect(updatedState.tasks[0].status).toBe('in_progress');
         expect(updatedState._version).toBe(1);
+      });
+
+      it('should not overwrite state when a concurrent write changes _version', async () => {
+        // Arrange — initial state at version 1
+        mockExecSync.mockReturnValue(Buffer.from(''));
+        const stateFilePath = path.join(tempDir, 'test-workflow.state.json');
+        const initialState = {
+          featureId: 'test-workflow',
+          phase: 'overhaul-delegate',
+          tasks: [
+            { id: 'task-001', title: 'Test task', status: 'in_progress', branch: 'feat/test' },
+          ],
+          worktrees: {
+            'wt-001': {
+              branch: 'feat/test',
+              status: 'active',
+              taskId: 'task-001',
+              path: '/tmp/worktree',
+            },
+          },
+          _version: 1,
+        };
+        await fsp.writeFile(stateFilePath, JSON.stringify(initialState));
+
+        // Configure the CAS race simulation: after the first readFile of the
+        // state file (done by findActiveWorkflowState), the mock will inject
+        // a concurrent write that bumps _version to 2 and changes task status.
+        casRaceConfig.targetPath = stateFilePath;
+        casRaceConfig.readCount = 0;
+        casRaceConfig.concurrentState = {
+          ...initialState,
+          _version: 2,
+          tasks: [
+            { id: 'task-001', title: 'Test task', status: 'claimed_by_other', branch: 'feat/test' },
+          ],
+        };
+
+        const input: Record<string, unknown> = {
+          hook_event_name: 'TeammateIdle',
+          teammate_name: 'worker-1',
+          cwd: '/tmp/worktree',
+        };
+
+        // Act
+        const result = await handleTeammateGate(input);
+
+        // Disable race simulation before reading final state
+        casRaceConfig.targetPath = null;
+        casRaceConfig.concurrentState = null;
+
+        // Assert — gate still returns success
+        expect(result).toEqual({ continue: true });
+
+        // Assert — the concurrent writer's state should be preserved, NOT overwritten
+        const finalRaw = await fsp.readFile(stateFilePath, 'utf-8');
+        const finalState = JSON.parse(finalRaw);
+        // The concurrent writer set _version=2 and status='claimed_by_other'
+        // updateTaskCompletion should detect the version mismatch and skip the write
+        expect(finalState._version).toBe(2);
+        expect(finalState.tasks[0].status).toBe('claimed_by_other');
       });
     });
   });

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.ts
@@ -11,6 +11,7 @@ import { execSync } from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import type { CommandResult } from '../cli.js';
+import { resolveStateDir } from '../workflow/state-store.js';
 
 // ─── Check Definitions ─────────────────────────────────────────────────────
 
@@ -180,19 +181,6 @@ export async function findActiveWorkflowState(
   return null;
 }
 
-// ─── State Directory Resolution ────────────────────────────────────────────
-
-function resolveStateDir(): string {
-  const envDir = process.env.WORKFLOW_STATE_DIR;
-  if (envDir) return envDir;
-
-  const home = process.env.HOME ?? process.env.USERPROFILE;
-  if (!home) {
-    throw new Error('Cannot determine home directory: HOME and USERPROFILE are both undefined');
-  }
-  return path.join(home, '.claude', 'workflow-state');
-}
-
 // ─── Gate Handlers ─────────────────────────────────────────────────────────
 
 /**
@@ -254,14 +242,24 @@ export async function handleTeammateGate(
 
 /**
  * Best-effort update: find the active workflow, match cwd to a worktree entry,
- * mark the corresponding task as complete, and write back. Silently swallows
- * all errors so the gate is never blocked by state issues.
+ * mark the corresponding task as complete, and write back atomically with CAS
+ * version checking. Silently swallows all errors so the gate is never blocked
+ * by state issues.
+ *
+ * CAS protocol:
+ * 1. Read state via findActiveWorkflowState (captures expectedVersion)
+ * 2. Mutate in memory
+ * 3. Re-read file to verify _version still matches expectedVersion
+ * 4. If mismatch (concurrent writer intervened), skip the update silently
+ * 5. Write atomically via tmp file + rename
  */
 async function updateTaskCompletion(cwd: string): Promise<void> {
   try {
     const stateDir = resolveStateDir();
     const active = await findActiveWorkflowState(stateDir);
     if (!active) return;
+
+    const expectedVersion = active.state._version;
 
     // Find the worktree entry whose path matches cwd
     const matchingWorktree = Object.values(active.state.worktrees).find(
@@ -278,8 +276,27 @@ async function updateTaskCompletion(cwd: string): Promise<void> {
     task.completedAt = new Date().toISOString();
     active.state._version += 1;
 
-    // Write updated state back
-    await fs.writeFile(active.filePath, JSON.stringify(active.state, null, 2));
+    // CAS check: re-read file and verify version hasn't changed
+    const currentRaw = await fs.readFile(active.filePath, 'utf-8');
+    const currentState = JSON.parse(currentRaw) as WorkflowState;
+    if (currentState._version !== expectedVersion) {
+      // Another writer intervened — skip this update (best-effort)
+      return;
+    }
+
+    // Atomic write: tmp file + rename
+    const tmpPath = `${active.filePath}.tmp.${process.pid}`;
+    try {
+      await fs.writeFile(tmpPath, JSON.stringify(active.state, null, 2));
+      await fs.rename(tmpPath, active.filePath);
+    } catch {
+      // Clean up tmp file on failure
+      try {
+        await fs.unlink(tmpPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
   } catch {
     // Best-effort: swallow errors so gate is never blocked
   }


### PR DESCRIPTION
Remove local resolveStateDir() from gates.ts, importing the canonical
version from state-store.ts instead. Replace raw fs.writeFile in
updateTaskCompletion with CAS version checking (re-read before write)
and atomic tmp+rename writes to prevent concurrent-write corruption.
Add CAS conflict test to verify race condition handling.