### PR TITLE
docs: add Agent Teams dispatch mode to delegation skill

### DIFF
--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -23,7 +23,21 @@ Activate this skill when:
 - User wants to parallelize work
 - Tasks are ready for execution
 
-## Delegation Mode
+## Delegation Modes
+
+### Dispatch Mode Selection
+
+| Mode | Mechanism | Visualization | Best for |
+|------|-----------|---------------|----------|
+| `subagent` (default) | `Task` tool with `run_in_background` | None — orchestrator polls `TaskOutput` | Quick tasks, CI, non-interactive |
+| `agent-team` | Natural language delegation to teammates | tmux split panes | Interactive sessions, complex coordination |
+
+**Auto-detection logic:**
+- If inside tmux AND Agent Teams enabled → default to `agent-team`
+- Otherwise → default to `subagent`
+- User can override via `/delegate --mode subagent` or `/delegate --mode agent-team`
+
+> **Verification:** Agent Teams availability is controlled by the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` environment variable in your session settings. Check `~/.claude/settings.json` for the `env` block.
 
 ### Task Tool (Subagents)
 
@@ -45,6 +59,26 @@ Task({
   prompt: `[Full implementer prompt from template]`
 })
 ```
+
+### Agent Teams (Teammates)
+
+**Use when:**
+- Running in tmux with Agent Teams enabled
+- Tasks benefit from visual monitoring
+- Complex coordination between tasks
+- Interactive development sessions
+
+**Mechanism:** Orchestrator delegates to named teammates via natural language
+
+**Dispatch flow:**
+1. Orchestrator creates an agent team with N teammates (one per parallel group)
+2. Each teammate gets a worktree path in its spawn prompt
+3. Orchestrator activates delegate mode (coordination only — no direct code)
+4. Teammates self-coordinate via shared task list
+5. `TeammateIdle` hook (see State Bridge section below) runs quality gates; updates Exarchos workflow state
+6. Orchestrator synthesizes results when all teammates finish
+
+**CRITICAL:** Always specify `model: "opus"` for coding tasks.
 
 ## Controller Responsibilities
 
@@ -150,6 +184,20 @@ After all tasks complete, **auto-continue immediately** (no user confirmation):
 This is NOT a human checkpoint - workflow continues autonomously.
 State is saved, enabling recovery after context compaction.
 
+## Known Limitations
+
+**Agent Teams mode:**
+- No session resumption with in-process teammates (`/resume` doesn't restore them)
+- Task status can lag — teammates sometimes fail to mark tasks complete
+- One team per session
+- No nested teams (teammates can't spawn sub-teammates)
+- Split panes require tmux or iTerm2 (not VS Code terminal, Windows Terminal, or Ghostty)
+
+**Task Tool mode:**
+- No visual monitoring
+- Individual context windows per task
+- Limited observability
+
 ## Troubleshooting
 
 See `@skills/delegation/references/troubleshooting.md` for detailed troubleshooting covering MCP tool failures, state desync, worktree creation, teammate spawn timeouts, and task claim conflicts.
@@ -168,3 +216,15 @@ Emit events at each delegation milestone using Exarchos MCP tools:
 ### Claim Guard
 
 Use `exarchos_orchestrate` `task_claim` for optimistic concurrency. On `ALREADY_CLAIMED`, skip the task and check status via `exarchos_view` `tasks` before re-dispatching.
+
+### State Bridge (TeammateIdle)
+
+When using Agent Teams mode, the `TeammateIdle` hook fires when a teammate completes its work and becomes idle, bridging real-time Agent Teams coordination with persistent Exarchos state:
+
+- **On quality pass:** Updates the matching task's status to "complete" in the workflow state file
+- **On quality fail:** Returns exit code 2 (sends feedback to teammate, keeps it working)
+- **Graceful degradation:** If no matching workflow/worktree found, gate still passes
+
+This implements a **layered coordination** model:
+- Agent Teams handles real-time dispatch and self-coordination
+- Exarchos handles persistent workflow state and event sourcing

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -78,7 +78,7 @@ Task({
 5. `TeammateIdle` hook (see State Bridge section below) runs quality gates; updates Exarchos workflow state
 6. Orchestrator synthesizes results when all teammates finish
 
-**CRITICAL:** Always specify `model: "opus"` for coding tasks.
+**CRITICAL:** Ensure your session is using the opus model for coding tasks. All teammates inherit the session model — use Task tool dispatch if you need per-task model selection.
 
 ## Controller Responsibilities
 

--- a/skills/delegation/references/parallel-strategy.md
+++ b/skills/delegation/references/parallel-strategy.md
@@ -27,6 +27,42 @@ Task({ model: "opus", description: "Task 002", prompt: "..." })
 // WRONG: Separate messages = sequential
 ```
 
+## Agent Teams Dispatch
+
+When using `--mode agent-team`, parallel execution uses named teammates instead of Task tool calls:
+
+### Creating the Team
+
+Orchestrator activates delegate mode and describes the parallel work:
+
+```text
+"Create a team with 3 teammates:
+- teammate-1: Work in /path/.worktrees/group-a on tasks 1-2 (settings)
+- teammate-2: Work in /path/.worktrees/group-b on tasks 3-5 (gate bridge)
+- teammate-3: Work in /path/.worktrees/group-c on tasks 6-8 (content)"
+```
+
+Each teammate receives the full implementer prompt content as context.
+
+### Self-Coordination
+
+Teammates use Claude Code's native shared task list for claim/complete tracking. When a teammate becomes idle after completing its tasks, the `TeammateIdle` quality gate hook fires automatically, running quality checks and updating Exarchos workflow state (see SKILL.md State Bridge section).
+
+### One Team Per Session
+
+Agent Teams supports one team per session. If you need more parallel groups than teammates, assign multiple tasks per teammate (sequential within the group).
+
+## Dispatch Mode Comparison
+
+| Aspect | Task Tool (Subagent) | Agent Teams (Teammate) |
+|--------|---------------------|----------------------|
+| Parallel dispatch | Multiple `Task()` in one message | Named teammates in agent team |
+| Waiting | `TaskOutput({ block: true })` | `TeammateIdle` hook (fires when teammate idle) |
+| Visibility | None (background) | tmux split panes |
+| Model control | `model: "opus"` per task | Session model for all |
+| Max parallelism | Unlimited | One team, N teammates |
+| Resume on crash | Task results preserved | Teammates lost (worktrees survive) |
+
 ## Waiting for Parallel Completion
 
 ```typescript
@@ -43,3 +79,5 @@ TaskOutput({ task_id: "task-002-id" })
 | Code review | `opus` | Thorough analysis |
 | File search/exploration | (default) | Speed over quality |
 | Simple queries | `haiku` | Fast, low cost |
+
+**Note:** When using Agent Teams, all teammates inherit the session's model. Use Task tool dispatch if you need per-task model selection (e.g., `haiku` for simple queries, `opus` for implementation).

--- a/skills/delegation/references/workflow-steps.md
+++ b/skills/delegation/references/workflow-steps.md
@@ -55,12 +55,30 @@ Task({
 })
 ```
 
+### Agent Teams Dispatch (alternative)
+
+When using `--mode agent-team`:
+1. Orchestrator activates delegate mode (Shift+Tab in Claude Code terminal)
+2. Describes each task to teammates via natural language (see parallel-strategy.md for example)
+3. Each teammate receives worktree path + implementer prompt content
+4. Teammates self-coordinate via shared task list
+
+**No `Task()` calls needed** — delegation happens through natural language.
+
 ## Step 5: Monitor Progress
 
 For background tasks:
 ```typescript
 TaskOutput({ task_id: "task-001-id", block: true })
 ```
+
+### Agent Teams Monitoring (alternative)
+
+When using `--mode agent-team`:
+- Teammates visible in tmux split panes
+- `TeammateIdle` hook auto-runs quality gates
+- Orchestrator observes progress via pane output
+- No `TaskOutput` polling needed
 
 ## Step 6: Collect Results
 
@@ -83,6 +101,14 @@ bash scripts/post-delegation-check.sh \
 **On exit 0:** All delegation results collected and verified. Update TodoWrite status, then check if schema sync is needed (Step 7) and proceed to review phase.
 
 **On exit 1:** Failures detected. Review the per-task status report. Address incomplete tasks or failing tests before proceeding.
+
+### Agent Teams Collection (alternative)
+
+When using `--mode agent-team`:
+- `TeammateIdle` hook updates Exarchos workflow state automatically
+- On quality gate pass: task marked "complete" in state
+- On quality gate fail: exit code 2 sends feedback, teammate continues
+- Run `post-delegation-check.sh` as usual after all teammates finish
 
 ## Step 7: Schema Sync (Auto-Detection)
 


### PR DESCRIPTION
Document dual dispatch modes (subagent vs agent-team) in delegation
SKILL.md, workflow-steps.md, and parallel-strategy.md. Adds mode
selection guidance, Agent Teams lifecycle documentation, and
parallel execution patterns for tmux-based teammate dispatch.