### PR TITLE
refactor: trim context budget — condense rules, CLAUDE.md, and extract spec-review checklists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,148 +1,38 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Exarchos is local agent governance for Claude Code — event-sourced SDLC workflows with agent team coordination. Installs commands, skills, rules, and MCP plugins to `~/.claude/` via symlinks. Workflows survive context compaction through persistent state and auto-resume.
 
-## What This Is
-
-Exarchos is local agent governance for Claude Code. It provides event-sourced SDLC workflows with agent team coordination, installing commands, skills, rules, and MCP plugins to `~/.claude/` via symlinks. Workflows survive context compaction through persistent state and auto-resume on session start.
-
-## Build & Test Commands
+## Build & Test
 
 ```bash
-# Root installer
-npm run build          # tsc + bun → dist/install.js, dist/exarchos-mcp.js, dist/exarchos-cli.js
+npm run build          # tsc + bun → dist/
 npm run test:run       # vitest single run
-npm run test           # vitest watch mode
 npm run typecheck      # tsc --noEmit
 
-# Exarchos MCP server (unified: workflow state + events + teams)
-cd plugins/exarchos/servers/exarchos-mcp
-npm run build          # tsc
-npm run test:run       # vitest single run
-npm run test:coverage  # vitest with coverage
-npm run dev            # tsx watch mode
-
-# Run a single test file (any package)
-npx vitest run src/install.test.ts                                           # root installer
-cd plugins/exarchos/servers/exarchos-mcp && npx vitest run src/__tests__/workflow/state-machine.test.ts
-```
-
-## Validation Scripts
-
-The `scripts/` directory contains deterministic validation scripts that replace prose checklists in skills. All scripts follow a consistent pattern: `set -euo pipefail`, exit codes (0=pass, 1=fail, 2=usage), and markdown output. Each has a co-located `.test.sh` integration test.
-
-| Category | Scripts |
-|----------|---------|
-| **Synthesis** | `pre-synthesis-check.sh`, `reconstruct-stack.sh`, `check-coderabbit.sh`, `coderabbit-review-gate.sh` |
-| **Delegation** | `setup-worktree.sh`, `post-delegation-check.sh`, `extract-fix-tasks.sh`, `needs-schema-sync.sh` |
-| **Git Worktrees** | `verify-worktree.sh`, `verify-worktree-baseline.sh` |
-| **Quality Review** | `review-verdict.sh`, `static-analysis-gate.sh`, `security-scan.sh` |
-| **Planning** | `spec-coverage-check.sh`, `verify-plan-coverage.sh`, `generate-traceability.sh`, `check-tdd-compliance.sh`, `check-coverage-thresholds.sh` |
-| **Refactor** | `assess-refactor-scope.sh`, `check-polish-scope.sh`, `validate-refactor.sh`, `verify-doc-links.sh` |
-| **Debug** | `investigation-timer.sh`, `select-debug-track.sh`, `debug-review-gate.sh` |
-| **Misc** | `verify-ideate-artifacts.sh`, `reconcile-state.sh`, `validate-dotnet-standards.sh` |
-
-**Integration tests** verify that each SKILL.md properly references its validation scripts:
-```bash
-# Run all skill integration tests
-for f in scripts/validate-*-skill.test.sh scripts/validate-misc-skills.test.sh; do
-  bash "$f"
-done
+# MCP server
+cd plugins/exarchos/servers/exarchos-mcp && npm run build && npm run test:run
 ```
 
 ## Architecture
 
-### Installation Model
+- **Installer** (`src/install.ts`) — Symlinks commands/skills/rules to `~/.claude/`, registers MCP servers in `~/.claude.json`
+- **Content layers** — Commands (`commands/*.md`), Skills (`skills/*/SKILL.md` with `references/`), Rules (`rules/*.md`). Structured Markdown, not executable code.
+- **MCP server** (`plugins/exarchos/servers/exarchos-mcp/`) — 5 composite tools (`exarchos_workflow`, `exarchos_event`, `exarchos_orchestrate`, `exarchos_view`, `exarchos_sync`). Uses `@modelcontextprotocol/sdk` + `zod` over stdio.
+- **Validation scripts** (`scripts/`) — Deterministic bash replacing prose checklists. Pattern: `set -euo pipefail`, exit codes 0/1/2, co-located `.test.sh`.
 
-The installer (`src/install.ts`) creates symlinks from this repo into `~/.claude/`:
-- `commands/` → slash commands (`/ideate`, `/plan`, `/delegate`, etc.)
-- `skills/` → reusable workflow logic referenced by commands
-- `rules/` → coding standards and behavior constraints
-- `settings.json` → permissions, plugin config, and hooks with resolved CLI paths
+## Workflows
 
-It also builds and registers MCP servers in `~/.claude.json`. Hooks from `hooks.json` are resolved with mode-dependent CLI paths and merged into `settings.json` (not copied as a separate file).
+- **Feature:** `/ideate` → `/plan` → `/delegate` → `/review` → `/synthesize` → `/cleanup`
+- **Debug:** `/debug` → triage → investigate → fix → validate
+- **Refactor:** `/refactor` → explore → brief → implement → validate
 
-### Content Layers (no runtime code)
-
-Most of this repo is structured Markdown, not executable code:
-
-- **Commands** (`commands/*.md`) — Entry points with YAML frontmatter. Each command references a skill via `@skills/<name>/SKILL.md` path and contains workflow position diagrams.
-- **Skills** (`skills/*/SKILL.md`) — Reusable workflow modules with templates in `references/` subdirectories. Skills define multi-step processes (brainstorming, delegation, review, etc.).
-  Skills use YAML frontmatter (`name`, `description`, `metadata`) following
-  Anthropic's skill format. The `description` field includes trigger phrases
-  for when the skill should activate. Larger skills use `references/`
-  subdirectories for progressive disclosure of detailed content.
-- **Rules** (`rules/*.md`) — Behavioral constraints applied globally. Some use `paths` frontmatter to scope to specific file patterns.
-
-### MCP Servers
-
-One self-contained TypeScript MCP server with its own `package.json`, `tsconfig.json`, and test suite:
-
-- **exarchos** (`plugins/exarchos/servers/exarchos-mcp/`) — Unified server combining workflow HSM (state machine transitions), append-only event store (JSONL), CQRS materialized views, and task coordination. Persists to `~/.claude/workflow-state/` (configurable via `WORKFLOW_STATE_DIR` env var). Exposes 5 composite MCP tools with `action` discriminators, registered from a central tool registry. Note: inter-agent messaging is handled by Claude Code's native Agent Teams, not by Exarchos.
-
-Uses `@modelcontextprotocol/sdk` + `zod`, communicates over stdio, and is registered in `~/.claude.json` by the installer.
-
-**Composite tools** (each routes to underlying handler functions via `action` field):
-
-| Tool | Actions | Purpose |
-|------|---------|---------|
-| `exarchos_workflow` | `init`, `get`, `set`, `cancel`, `cleanup` | Workflow CRUD + post-merge resolution |
-| `exarchos_event` | `append`, `query` | Event sourcing |
-| `exarchos_orchestrate` | `task_claim`, `task_complete`, `task_fail` | Task coordination |
-| `exarchos_view` | `pipeline`, `tasks`, `workflow_status`, `stack_status`, `stack_place` | CQRS read views |
-| `exarchos_sync` | `now` | Outbox drain (no-op sender until remote wired) |
-
-**Key modules:**
-
-- `workflow/state-machine.ts` — Types/interfaces, transition algorithm, HSM registry
-- `workflow/guards.ts` — Guard definitions (26 guards) for all HSM transitions
-- `workflow/hsm-definitions.ts` — HSM definitions for feature/debug/refactor workflows
-- `workflow/tools.ts` — Handler functions for init, get, set. Uses CAS versioning (`_version` field) with retry loop to prevent lost updates on concurrent writes. Event-first architecture: appends transition events to JSONL store BEFORE writing state file; idempotency keys prevent duplicates on CAS retry. Responses strip internal fields (`_events`, `_history`) and include compact `_meta` summaries. Fast-path for simple queries (phase, featureId) skips full Zod validation.
-- `workflow/composite.ts` — Composite router dispatching `action` to init/get/set/cancel handlers
-- `workflow/next-action.ts` — Auto-continue logic and phase-to-action mapping (used by CLI hooks)
-- `workflow/cancel.ts` — Saga compensation and workflow cancellation with checkpoint persistence for resumable compensation on partial failure
-- `registry.ts` — Single source of truth for all tool metadata (names, schemas, phase/role mappings). Consumed by `index.ts` for registration and by CLI hooks for guardrails
-- `cli.ts` — Hook CLI entry point (`pre-compact`, `session-start`, `guard`, `task-gate`, `teammate-gate`, `subagent-context`)
-- `event-store/` — Zod event schemas (22 types including workflow.transition, workflow.fix-cycle), JSONL store with `.seq` files for O(1) sequence initialization, append/query tools. Supports idempotency keys (persisted in JSONL, cache rebuilt on restart) and pre-parse sequence filtering for fast queries
-- `views/` — CQRS materializer (cached singleton per server lifecycle, LRU-bounded), 5 view types (pipeline, tasks, workflow status, task detail, stack) plus telemetry projection. Pipeline view uses lazy pagination (materializes only the requested subset)
-- `tasks/` — Task claim/complete/fail tools with CQRS materializer for claim-status checks and optimistic concurrency (expectedSequence) for atomic claims
-- `stack/` — Stack status/place tools with offset/limit pagination
-- `telemetry/` — Performance telemetry: projections, hints, middleware, percentile calculations, benchmarks
-- `sync/` — Remote sync state management (outbox drain, stub sender)
-- `orchestrate/` — Composite router for task coordination actions
-- `format.ts` — Canonical `ToolResult` interface (all modules import from here) and shared formatting helpers
-
-### Three Workflow Types
-
-**Feature:** `/ideate` → `/plan` → plan-review → `/delegate` → `/review` → `/synthesize` → merge → `/cleanup`
-**Debug:** `/debug` → triage → investigate → fix → validate (hotfix or thorough tracks)
-**Refactor:** `/refactor` → explore → brief → implement → validate (polish or overhaul tracks)
-
-Human checkpoints only at plan-review approval and merge confirmation. Everything else auto-continues via the SessionStart hook (which determines next action on resume).
-
-### Orchestrator Pattern
-
-The main Claude Code session coordinates but does not write implementation code (exception: polish-track refactors). All code changes go through agent teammates dispatched to git worktrees. This preserves context window for coordination.
+Human checkpoints at plan-review and merge only. Auto-continues via SessionStart hook.
 
 ## Key Conventions
 
-- **ESM throughout** — All packages use `"type": "module"` with NodeNext resolution
-- **Strict TypeScript** — `strict: true`, no `any`, use `unknown` with type guards
-- **Co-located tests** — `foo.test.ts` alongside `foo.ts`, not in separate `tests/` dir
-- **Vitest** — Import explicitly: `import { describe, it, expect, vi } from 'vitest'` (no globals)
-- **No runtime dependencies** for the root installer — only devDependencies
-- **Node >= 20** required across all packages
-- **Skill frontmatter** — Every `SKILL.md` has YAML frontmatter with `name`
-  (kebab-case, matches folder), `description` (<=1,024 chars, WHAT + WHEN +
-  triggers), and `metadata` (author, version, mcp-server, category, phase-affinity)
-
-## Docs Directory
-
-- `docs/designs/` — Feature design documents
-- `docs/plans/` — TDD implementation plans
-- `docs/adrs/` — Architecture Decision Records
-- `docs/rca/` — Root Cause Analysis documents
-- `docs/schemas/` — JSON schemas for state files
-- `docs/audits/` — Testing and quality audit findings
-- `docs/bugs/` — Bug reports and investigation notes
-- `docs/prompts/` — Prompt optimization templates
+- **ESM** — `"type": "module"`, NodeNext resolution
+- **Strict TypeScript** — `strict: true`, no `any`, `unknown` with type guards
+- **Co-located tests** — `foo.test.ts` alongside `foo.ts`
+- **Vitest** — `import { describe, it, expect, vi } from 'vitest'`
+- **No runtime deps** for root installer; **Node >= 20**
+- **Skill frontmatter** — `name` (kebab-case), `description` (<=1,024 chars), `metadata`

--- a/docs/prompts/optimize.md
+++ b/docs/prompts/optimize.md
@@ -76,7 +76,7 @@ Validate that all skills, commands, and rules follow Anthropic's official skill-
 - Do skills cleanly delegate to other skills where appropriate, or do they duplicate logic that belongs in a different skill?
 
 **Validation scripts:**
-- For skills with critical validation steps (gate checks, review criteria, quality thresholds), are those checks implemented as `scripts/` that run programmatically, or expressed only as prose instructions?
+- For skills with critical validation steps (gate checks, review criteria, quality thresholds), are those checks implemented as `scripts/` that run programmatically, or expressed only as prose instructions? (Note: skills should reference their validation scripts — either in SKILL.md body or `references/` subdirectories. Verified as of v2 audit.)
 - Code is deterministic; language interpretation is not. Identify validation steps that would benefit from a bundled script rather than relying on Claude to interpret prose criteria consistently.
 
 **Rule scoping:**
@@ -106,7 +106,7 @@ Every byte in a tool response or skill body consumes agent context window. Audit
 - Is `format.ts` enforcing a consistent, minimal `ToolResult` shape across all modules?
 
 **Skill token budget:**
-- Which `SKILL.md` files exceed 5,000 words? These degrade Claude's instruction-following and should be split into body + `references/`.
+- Which `SKILL.md` files exceed 5,000 words? These degrade Claude's instruction-following and should be split into body + `references/`. (Note: skills are expected to be under 1,300 words. Verified as of v2 audit.)
 - Are any skills loading large inline templates, checklists, or code blocks that could be moved to `references/` for on-demand access?
 - Do commands embed full skill content inline instead of referencing via `@skills/` paths?
 - Are any `references/` files loaded eagerly (mentioned at the top of SKILL.md as required reading) rather than linked for progressive discovery?

--- a/rules/mcp-tool-guidance.md
+++ b/rules/mcp-tool-guidance.md
@@ -1,21 +1,17 @@
+---
+name: mcp-tool-guidance
+description: "Prefer specialized MCP tools over generic CLI approaches."
+---
+
 # MCP Tool Guidance
 
-Proactively use installed MCP servers. Don't fall back to generic approaches when a specialized tool exists.
+Use specialized MCP tools over generic approaches:
 
-## Tool Selection Priority
+1. **Workflow state** — Exarchos MCP, never manual JSON
+2. **Code structure** — Serena (`find_symbol`, `get_symbols_overview`) over grep
+3. **GitHub operations** — GitHub MCP tools over `gh` CLI
+4. **PR creation** — Graphite MCP (`gt submit --no-interactive --publish --merge-when-ready`), never `gh pr create`
+5. **Library docs** — Context7 before web search
+6. **State management** — `exarchos_workflow` set/get, never edit JSON directly
 
-1. **Workflow state** — Use Exarchos MCP (`exarchos_workflow`, `exarchos_event`, `exarchos_orchestrate`, `exarchos_view`), never manual JSON files
-2. **Code structure** — Use Serena (`find_symbol`, `get_symbols_overview`, `find_referencing_symbols`) over grep for architecture questions
-3. **GitHub operations** — Use GitHub MCP tools for ALL GitHub operations (PRs, issues, commits, merging). NEVER use `gh` CLI when an MCP equivalent exists
-4. **PR creation** — Use Graphite MCP (`gt submit --no-interactive --publish --merge-when-ready`). NEVER use `gh pr create` or `create_pull_request`
-5. **Library docs** — Use Context7 (`resolve-library-id`, `query-docs`) before web search
-6. **Microsoft tech** — Use Microsoft Learn MCP for Azure/.NET/Microsoft questions
-
-## Key Rules
-
-- **GitHub MCP over gh CLI** — Use `pull_request_read` (not `gh pr view`), `list_pull_requests` (not `gh pr list`), `merge_pull_request` (not `gh pr merge`)
-- **Serena over grep** — Use `find_symbol` and `get_symbols_overview` before reading full files
-- **Graphite over git** — Use `gt create` + `gt submit` instead of `git commit` + `git push`
-- **Exarchos for state** — Use `exarchos_workflow` set/get, never edit state JSON directly
-
-For detailed tool actions, method mappings, and anti-patterns, see `@skills/workflow-state/references/mcp-tool-reference.md`.
+See `@skills/workflow-state/references/mcp-tool-reference.md` for detailed mappings.

--- a/rules/orchestrator-constraints.md
+++ b/rules/orchestrator-constraints.md
@@ -1,59 +1,18 @@
+---
+name: orchestrator-constraints
+description: "Main Claude Code session coordinates but does not write implementation code."
+---
+
 # Orchestrator Constraints
 
 The orchestrator (main Claude Code session) MUST NOT:
+1. Write implementation code — all code via subagents in worktrees
+2. Fix review findings directly — dispatch fixer subagents
+3. Run integration tests inline — tests in subagent worktrees
+4. Work in main project root — all implementation in worktrees
 
-1. **Write implementation code** — All code changes via subagents
-2. **Fix review findings directly** — Dispatch fixer subagents
-3. **Run integration tests inline** — Tests run in subagent worktrees or during review
-4. **Work in main project root** — All implementation in worktrees
+The orchestrator SHOULD: parse/extract plans, dispatch/monitor subagents, manage workflow state, chain phases, handle failures.
 
-The orchestrator SHOULD:
+## Exception: Polish Track Refactors
 
-1. **Parse and extract** — Read plans, extract task details
-2. **Dispatch and monitor** — Launch subagents, track progress
-3. **Manage state** — Update workflow state file
-4. **Chain phases** — Invoke next skill when phase completes
-5. **Handle failures** — Route failures back to appropriate phase
-
-## Exceptions
-
-### Polish Track Refactors
-
-For `/refactor --polish` (polish track) ONLY, the orchestrator MAY write implementation code directly during the `implement` phase.
-
-**Rationale:** Polish refactors are small enough (<=5 files, single concern) that delegation overhead exceeds benefit.
-
-**Guardrails:**
-1. **Only during implement phase** — Not during explore, brief, validate, or update-docs
-2. **Only for polish track** — Overhaul track MUST use delegation
-3. **Stay within brief scope** — If scope expands beyond brief, switch to overhaul track
-4. **Must follow TDD** — Write/update tests first if changing behavior
-5. **Commit incrementally** — Commit after each logical change
-
-**Scope Expansion Triggers** (switch to overhaul if any fire):
-- More than 5 files need modification
-- Changes cross module boundaries
-- Test coverage gaps discovered
-- Architectural decisions needed
-
-**Verification:** Before starting implementation, verify using `mcp__exarchos__exarchos_workflow` with `action: "get"`:
-1. Track is "polish" in state file (query: `.track`)
-2. Phase is "implement" (query: `.phase`)
-3. Brief goals are captured
-
-## Rationale
-
-The orchestrator acts as a coordinator, not an implementer. This separation:
-- Preserves context window for coordination tasks
-- Enables parallel execution via worktrees
-- Creates clear boundaries for recovery after context compaction
-- Ensures all changes are testable and reviewable
-
-## Enforcement
-
-When tempted to write code directly, ask:
-1. Can this be delegated to a subagent?
-2. Is this a coordination task or implementation task?
-3. Will this consume significant context?
-
-If in doubt, delegate.
+During `polish-implement` phase ONLY, the orchestrator MAY write code directly. Guardrails: only polish track, stay within brief scope, follow TDD if changing behavior. Switch to overhaul if >5 files or cross-module changes.

--- a/rules/orchestrator-constraints.md
+++ b/rules/orchestrator-constraints.md
@@ -1,4 +1,5 @@
 ---
+alwaysApply: true
 name: orchestrator-constraints
 description: "Main Claude Code session coordinates but does not write implementation code."
 ---

--- a/rules/pr-descriptions.md
+++ b/rules/pr-descriptions.md
@@ -1,34 +1,12 @@
-# PR Description Guidelines
-
-Write PR descriptions that help reviewers understand the change quickly. Aim for ~120-200 words.
-
-## Title Format
-
-`<type>: <what>` (max 72 chars)
-
-## Body Structure
-
-- **Summary** (required) — 2-3 sentences: what changed, why it matters
-- **Changes** (required) — Scannable list with `**Bold**` component names and `—` separator
-- **Test Plan** (required) — Testing approach and coverage summary
-- **Footer** (required) — Separated by `---`: results, design doc, related PRs
-
-## Template
-
-```markdown
-## Summary
-[2-3 sentences: What changed, why it matters, what problem it solves]
-
-## Changes
-- **Component** — Brief description of what changed
-
-## Test Plan
-[1-2 sentences: Testing approach and coverage summary]
-
 ---
-**Results:** Tests X ✓ · Build 0 errors
-**Design:** [doc](docs/path/design-doc.md)
-**Related:** #123
-```
+name: pr-descriptions
+description: "PR title and body format guidelines for Graphite stacked PRs."
+---
 
-For detailed guidelines, examples, and anti-patterns, see `skills/synthesis/references/pr-descriptions.md`.
+# PR Descriptions
+
+**Title:** `<type>: <what>` (max 72 chars)
+
+**Body:** Summary (2-3 sentences) → Changes (bulleted, `**Component** — description`) → Test Plan → Footer (`---` + results, design doc, related PRs). Aim for 120-200 words.
+
+See `skills/synthesis/references/pr-descriptions.md` for template and examples.

--- a/rules/rm-safety.md
+++ b/rules/rm-safety.md
@@ -2,47 +2,8 @@
 alwaysApply: true
 ---
 
-# rm Safety Guidelines
+# rm Safety
 
-When using `rm` commands, follow these safety practices:
+**NEVER:** `rm -rf /`, `rm -rf ~`, `rm -rf .` in home/root, rm with unset variables (`$UNSET_VAR/*`)
 
-## NEVER Execute
-
-- `rm -rf /` or `rm -rf /*` - destroys entire system
-- `rm -rf ~` or `rm -rf ~/*` - destroys home directory
-- `rm -rf .` in home or root directories
-- Any rm with variables that could expand dangerously (e.g., `rm -rf $UNSET_VAR/*`)
-
-## Always Prefer
-
-1. **Use specific paths** - never use broad wildcards at dangerous locations
-2. **List before deleting** - run `ls` first to verify what will be deleted
-3. **Use relative paths** - prefer `rm ./file` over absolute paths when possible
-4. **Avoid -f flag** - unless specifically needed, let rm prompt for protected files
-5. **Double-check recursion** - before `rm -r`, verify the target directory
-
-## Safe Patterns
-
-```bash
-# Good: specific file
-rm ./temp-file.txt
-
-# Good: specific directory contents
-rm -r ./build/
-
-# Good: with confirmation
-rm -i ./important-file
-
-# Dangerous: broad wildcard
-rm -rf /tmp/*  # Could delete important temp files
-
-# Dangerous: variable expansion
-rm -rf "${DIR}/"  # What if DIR is empty or /?
-```
-
-## When in Doubt
-
-If uncertain about an rm command's safety:
-1. First run with `echo` to see what would be deleted: `echo rm -rf ./path`
-2. Or use `ls` to preview: `ls ./path`
-3. Ask the user to confirm before executing
+**Always:** Use specific paths, `ls` before deleting, avoid `-f` unless needed, verify `-r` targets. When uncertain, preview with `echo rm ...` or ask the user.

--- a/rules/skill-path-resolution.md
+++ b/rules/skill-path-resolution.md
@@ -1,54 +1,10 @@
+---
+name: skill-path-resolution
+description: "Resolve @skills/<name>/SKILL.md paths to ~/.claude/skills/<name>/SKILL.md."
+---
+
 # Skill Path Resolution
 
-When commands or instructions reference skills using the `@skills/` prefix, resolve these paths to the user's global Claude skills directory.
+`@skills/<name>/SKILL.md` resolves to `~/.claude/skills/<name>/SKILL.md`.
 
-## Path Resolution
-
-| Reference | Resolves To |
-|-----------|-------------|
-| `@skills/` | `~/.claude/skills/` |
-| `@skills/brainstorming/SKILL.md` | `~/.claude/skills/brainstorming/SKILL.md` |
-| `@skills/<name>/SKILL.md` | `~/.claude/skills/<name>/SKILL.md` |
-
-## Implementation
-
-When you encounter a skill reference like `@skills/brainstorming/SKILL.md`:
-
-1. **Read the skill file** from `~/.claude/skills/brainstorming/SKILL.md`
-2. **Follow the skill's instructions** as documented in the SKILL.md file
-3. **Use skill-specific templates** from the skill's directory if available
-
-## Available Skills
-
-Skills are located in `~/.claude/skills/` and include:
-
-- `brainstorming/` - Design exploration and ideation
-- `implementation-planning/` - TDD implementation planning
-- `delegation/` - Task delegation to subagents
-- `integration/` - Branch integration and testing
-- `quality-review/` - Two-stage code review
-- `synthesis/` - PR creation and merge
-- `git-worktrees/` - Git worktree management
-- `workflow-state/` - Workflow state persistence
-
-## Example
-
-When a command says:
-
-```markdown
-Follow the brainstorming skill: `@skills/brainstorming/SKILL.md`
-```
-
-You must:
-
-1. Read `~/.claude/skills/brainstorming/SKILL.md`
-2. Follow all instructions in that file
-3. Use templates and patterns defined there
-
-## Failure Mode
-
-If a skill file is not found at the resolved path:
-
-1. Report the missing skill file to the user
-2. Fall back to inline instructions in the command if available
-3. Ask the user for guidance if neither is available
+When encountered: read the skill file, follow its instructions, use templates from its directory. If not found, report to user and fall back to inline instructions.

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -82,122 +82,14 @@ This enables catching:
 
 ## Review Checklist
 
-### 1. Functional Completeness
+For the full checklist with verification commands, tables, and report template, see `references/review-checklist.md`.
 
-| Check | Verify |
-|-------|--------|
-| All requirements implemented | Compare to spec/plan |
-| No missing features | Cross-reference task list |
-| Correct behavior | Run manual verification |
-| Edge cases handled | Check spec edge cases |
-
-### 2. TDD Compliance
-
-| Check | Verify |
-|-------|--------|
-| Tests exist for all features | Grep for test files |
-| Tests written first | Check git history order |
-| Tests are meaningful | Not just "expect true" |
-| Test naming convention | `Method_Scenario_Outcome` |
-
-**Verification Commands:**
+**Verification:**
 ```bash
-# Check test file exists
-ls src/**/*.test.ts
-
-# Run tests
 npm run test:run
-
-# Check coverage
 npm run test:coverage
-```
-
-### 3. Specification Alignment
-
-Compare implementation to:
-- Original design document
-- Implementation plan tasks
-- Acceptance criteria
-
-**Questions to answer:**
-- Does it do what was specified?
-- Does it do MORE than specified? (over-engineering)
-- Does it do LESS than specified? (incomplete)
-
-### 4. Test Coverage
-
-| Metric | Threshold |
-|--------|-----------|
-| Line coverage | >80% for new code |
-| Branch coverage | >70% for new code |
-| Function coverage | 100% for public APIs |
-
-## Review Process
-
-### Step 1: Gather Artifacts
-
-```markdown
-## Review Artifacts
-
-- Design: `docs/designs/YYYY-MM-DD-feature.md`
-- Plan: `docs/plans/YYYY-MM-DD-feature.md`
-- Implementation: `src/feature/`
-- Tests: `src/feature/*.test.ts`
-```
-
-### Step 2: Run Verification
-
-```bash
-# Run all tests
-npm run test:run
-
-# Check coverage
-npm run test:coverage
-
-# Run type check
 npm run typecheck
-```
-
-### Step 3: Compare to Spec
-
-Read design/plan and verify each requirement:
-
-```markdown
-## Spec Compliance
-
-| Requirement | Implemented | Test Exists | Notes |
-|-------------|-------------|-------------|-------|
-| User can login | YES | YES | |
-| Email validation | YES | YES | |
-| Rate limiting | NO | NO | MISSING |
-```
-
-### Step 4: Generate Report
-
-```markdown
-## Spec Review Report
-
-### Summary
-- Status: [PASS | FAIL | NEEDS_FIXES]
-- Tested: [timestamp]
-- Reviewer: Claude Code
-
-### Compliance Matrix
-[Table from Step 3]
-
-### Issues Found
-1. [Issue description]
-   - File: `path/to/file.ts`
-   - Expected: [spec requirement]
-   - Actual: [current behavior]
-   - Fix: [required change]
-
-### Missing Items
-- [ ] [Feature not implemented]
-
-### Verdict
-[PASS] Ready for quality review
-[FAIL] Return to implementer with fix list
+scripts/check-tdd-compliance.sh --repo-root <repo-root> --base-branch main
 ```
 
 ## Fix Loop
@@ -265,15 +157,6 @@ Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
     "reviews.<task-id>.specReview": {"status": "pass", "issues": []}
   }
 ```
-
-## Completion Criteria
-
-- [ ] All spec requirements verified
-- [ ] TDD compliance confirmed
-- [ ] Tests pass
-- [ ] Coverage meets thresholds
-- [ ] No missing functionality
-- [ ] State file updated with review results
 
 ## Transition
 

--- a/skills/spec-review/references/review-checklist.md
+++ b/skills/spec-review/references/review-checklist.md
@@ -1,0 +1,60 @@
+---
+name: spec-review-checklist
+description: "Validation script invocations and report template for spec compliance verification."
+---
+
+# Spec Review Checklist
+
+## Automated Verification
+
+Run these scripts as the authoritative checks:
+
+```bash
+# TDD compliance (test-first ordering, naming conventions, coverage)
+scripts/check-tdd-compliance.sh --repo-root <repo-root> --base-branch main
+
+# Full test suite
+npm run test:run
+
+# Coverage thresholds (line >80%, branch >70%, function 100% for public APIs)
+npm run test:coverage
+
+# Type safety
+npm run typecheck
+```
+
+## Manual Checks
+
+After scripts pass, verify:
+- All spec requirements implemented (compare to design/plan)
+- No over-engineering beyond spec
+- No missing edge cases
+
+## Report Template
+
+```markdown
+## Spec Review Report
+
+### Summary
+- Status: [PASS | FAIL | NEEDS_FIXES]
+- Tested: [timestamp]
+
+### Compliance Matrix
+| Requirement | Implemented | Test Exists | Notes |
+|-------------|-------------|-------------|-------|
+
+### Issues Found
+1. [Issue] — File: `path` — Fix: [required change]
+
+### Verdict
+[PASS] Ready for quality review
+[FAIL] Return to implementer with fix list
+```
+
+## Completion Criteria
+
+- [ ] `check-tdd-compliance.sh` passes
+- [ ] All tests pass
+- [ ] Coverage meets thresholds
+- [ ] All spec requirements verified
+- [ ] State file updated with review results


### PR DESCRIPTION
Reduce baseline context overhead by ~3,500 tokens (8-12% of 34k baseline):
- CLAUDE.md: 1,243→258 words (move architecture reference to progressive disclosure)
- 5 rule files condensed: rm-safety, skill-path-resolution, orchestrator-constraints, pr-descriptions, mcp-tool-guidance
- spec-review SKILL.md: extract checklists to references/review-checklist.md
- Add check-tdd-compliance.sh reference to spec-review verification

All behavioral constraints preserved. Reference material remains accessible
via filesystem or references/ directories (progressive disclosure per
Anthropic skill-building guide).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>