### PR TITLE
feat: detect orphaned team recovery in SessionStart

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -358,8 +358,8 @@ describe('StackEnqueuedData', () => {
 // ─── EventTypes Discriminated Union (A03) ───────────────────────────────────
 
 describe('EventTypes', () => {
-  it('should contain all 24 event types', () => {
-    expect(EventTypes).toHaveLength(24);
+  it('should contain all 30 event types', () => {
+    expect(EventTypes).toHaveLength(30);
   });
 
   it('should include workflow-level types', () => {
@@ -751,7 +751,7 @@ describe('Dead event types removed', () => {
     }
   });
 
-  it('should have exactly 24 event types', () => {
-    expect(EventTypes).toHaveLength(24);
+  it('should have exactly 30 event types', () => {
+    expect(EventTypes).toHaveLength(30);
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.test.ts
@@ -33,6 +33,7 @@ interface CheckpointData {
   readonly tasks: ReadonlyArray<{ id: string; status: string; title: string }>;
   readonly artifacts: Record<string, unknown>;
   readonly stateFile: string;
+  readonly teamState?: unknown;
 }
 
 /** Minimal valid workflow state file for testing. */
@@ -368,6 +369,109 @@ describe('session-start command', () => {
 
       // Assert — the malformed file should NOT be deleted (skipped before unlink)
       await expect(fs.access(filePath)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('orphaned team recovery detection', () => {
+    it('should include recovery info when delegate phase has active teammates', async () => {
+      // Arrange
+      const checkpoint = createCheckpointFile({
+        featureId: 'team-feature',
+        phase: 'delegate',
+        teamState: {
+          teammates: [{ name: 'w1', status: 'active' }],
+        },
+        tasks: [
+          { id: 'T1', status: 'complete', title: 'Done task' },
+          { id: 'T2', status: 'in_progress', title: 'Active task' },
+          { id: 'T3', status: 'pending', title: 'Pending task' },
+        ],
+      });
+      await fs.writeFile(
+        path.join(tmpDir, 'team-feature.checkpoint.json'),
+        JSON.stringify(checkpoint),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir);
+
+      // Assert
+      expect(result.workflows).toBeDefined();
+      const workflow = result.workflows!.find((w) => w.featureId === 'team-feature');
+      expect(workflow).toBeDefined();
+      expect(workflow!.recovery).toBeDefined();
+      expect(workflow!.recovery!.type).toBe('orphaned_team');
+      expect(workflow!.recovery!.remainingTasks).toBeGreaterThan(0);
+    });
+
+    it('should not include recovery info when delegate phase has no teamState', async () => {
+      // Arrange
+      const checkpoint = createCheckpointFile({
+        featureId: 'no-team',
+        phase: 'delegate',
+        // no teamState
+      });
+      await fs.writeFile(
+        path.join(tmpDir, 'no-team.checkpoint.json'),
+        JSON.stringify(checkpoint),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir);
+
+      // Assert
+      const workflow = result.workflows!.find((w) => w.featureId === 'no-team');
+      expect(workflow).toBeDefined();
+      expect(workflow!.recovery).toBeUndefined();
+    });
+
+    it('should not include recovery info when all teammates are completed', async () => {
+      // Arrange
+      const checkpoint = createCheckpointFile({
+        featureId: 'done-team',
+        phase: 'delegate',
+        teamState: {
+          teammates: [
+            { name: 'w1', status: 'completed' },
+            { name: 'w2', status: 'completed' },
+          ],
+        },
+      });
+      await fs.writeFile(
+        path.join(tmpDir, 'done-team.checkpoint.json'),
+        JSON.stringify(checkpoint),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir);
+
+      // Assert
+      const workflow = result.workflows!.find((w) => w.featureId === 'done-team');
+      expect(workflow).toBeDefined();
+      expect(workflow!.recovery).toBeUndefined();
+    });
+
+    it('should not include recovery info when review phase has teamState', async () => {
+      // Arrange
+      const checkpoint = createCheckpointFile({
+        featureId: 'review-team',
+        phase: 'review',
+        teamState: {
+          teammates: [{ name: 'w1', status: 'active' }],
+        },
+      });
+      await fs.writeFile(
+        path.join(tmpDir, 'review-team.checkpoint.json'),
+        JSON.stringify(checkpoint),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir);
+
+      // Assert
+      const workflow = result.workflows!.find((w) => w.featureId === 'review-team');
+      expect(workflow).toBeDefined();
+      expect(workflow!.recovery).toBeUndefined();
     });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.ts
@@ -15,6 +15,15 @@ interface CheckpointData {
   readonly tasks: ReadonlyArray<{ id: string; status: string; title: string }>;
   readonly artifacts: Record<string, unknown>;
   readonly stateFile: string;
+  readonly teamState?: unknown;
+}
+
+/** Recovery info attached when orphaned team state is detected. */
+interface RecoveryInfo {
+  readonly type: string;
+  readonly message: string;
+  readonly completedTasks: number;
+  readonly remainingTasks: number;
 }
 
 /** A discovered workflow for the session-start response. */
@@ -24,6 +33,7 @@ interface WorkflowInfo {
   readonly summary: string;
   readonly nextAction: string;
   readonly tasks?: ReadonlyArray<{ id: string; status: string; title: string }>;
+  readonly recovery?: RecoveryInfo;
 }
 
 /** Result from the session-start command. */
@@ -96,6 +106,42 @@ async function readAndDeleteCheckpoints(stateDir: string): Promise<CheckpointDat
   return results;
 }
 
+// ─── Orphaned Team Detection ────────────────────────────────────────────────
+
+/**
+ * Detect orphaned team state from a checkpoint.
+ * Returns recovery info if the checkpoint is in the delegate phase and has
+ * active (non-completed) teammates. Returns undefined otherwise.
+ */
+function detectOrphanedTeam(
+  checkpoint: CheckpointData,
+): RecoveryInfo | undefined {
+  if (checkpoint.phase !== 'delegate') return undefined;
+  if (!checkpoint.teamState || typeof checkpoint.teamState !== 'object') return undefined;
+
+  const ts = checkpoint.teamState as Record<string, unknown>;
+  const teammates = ts.teammates;
+  if (!Array.isArray(teammates) || teammates.length === 0) return undefined;
+
+  const activeTeammates = teammates.filter((t) => {
+    if (!t || typeof t !== 'object') return false;
+    const teammate = t as Record<string, unknown>;
+    return teammate.status === 'active';
+  });
+
+  if (activeTeammates.length === 0) return undefined;
+
+  const completedTasks = checkpoint.tasks.filter((t) => t.status === 'complete').length;
+  const remainingTasks = checkpoint.tasks.length - completedTasks;
+
+  return {
+    type: 'orphaned_team',
+    message: `${activeTeammates.length} active teammate(s) orphaned after compaction`,
+    completedTasks,
+    remainingTasks,
+  };
+}
+
 // ─── Handler ────────────────────────────────────────────────────────────────
 
 /**
@@ -117,13 +163,17 @@ export async function handleSessionStart(
     // Collect featureIds from checkpoints to exclude from state file discovery
     const checkpointFeatureIds = new Set(checkpoints.map((cp) => cp.featureId));
 
-    const workflows: WorkflowInfo[] = checkpoints.map((cp) => ({
-      featureId: cp.featureId,
-      phase: cp.phase,
-      summary: cp.summary,
-      nextAction: cp.nextAction,
-      tasks: cp.tasks.length > 0 ? cp.tasks : undefined,
-    }));
+    const workflows: WorkflowInfo[] = checkpoints.map((cp) => {
+      const recovery = detectOrphanedTeam(cp);
+      return {
+        featureId: cp.featureId,
+        phase: cp.phase,
+        summary: cp.summary,
+        nextAction: cp.nextAction,
+        tasks: cp.tasks.length > 0 ? cp.tasks : undefined,
+        ...(recovery !== undefined && { recovery }),
+      };
+    });
 
     // Also check for active state files not covered by checkpoints
     try {

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { validateAgentEvent, AGENT_EVENT_TYPES } from './schemas.js';
+import {
+  validateAgentEvent,
+  AGENT_EVENT_TYPES,
+  EventTypes,
+  TeamSpawnedData,
+  TeamTaskAssignedData,
+  TeamTaskCompletedData,
+  TeamTaskFailedData,
+  TeamDisbandedData,
+  TeamContextInjectedData,
+} from './schemas.js';
 
 describe('validateAgentEvent', () => {
   describe('agent event types', () => {
@@ -55,11 +65,103 @@ describe('validateAgentEvent', () => {
   });
 
   describe('AGENT_EVENT_TYPES constant', () => {
-    it('should contain exactly the two agent event types', () => {
+    it('should contain all agent event types', () => {
       expect(AGENT_EVENT_TYPES).toEqual([
         'task.claimed',
         'task.progressed',
+        'team.task.completed',
+        'team.task.failed',
       ]);
     });
+  });
+});
+
+describe('Team Event Data Schemas', () => {
+  describe('TeamSpawnedData', () => {
+    it('should parse valid payload successfully', () => {
+      const result = TeamSpawnedData.safeParse({
+        teamSize: 3,
+        teammateNames: ['a', 'b', 'c'],
+        taskCount: 5,
+        dispatchMode: 'agent-team',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('TeamTaskCompletedData', () => {
+    it('should parse valid payload successfully', () => {
+      const result = TeamTaskCompletedData.safeParse({
+        taskId: 'task-001',
+        teammateName: 'worker-1',
+        durationMs: 5000,
+        filesChanged: ['a.ts'],
+        testsPassed: true,
+        qualityGateResults: {},
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('TeamTaskFailedData', () => {
+    it('should parse valid payload successfully', () => {
+      const result = TeamTaskFailedData.safeParse({
+        taskId: 'task-001',
+        teammateName: 'worker-1',
+        failureReason: 'typecheck',
+        gateResults: {},
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('TeamDisbandedData', () => {
+    it('should parse valid payload successfully', () => {
+      const result = TeamDisbandedData.safeParse({
+        totalDurationMs: 60000,
+        tasksCompleted: 5,
+        tasksFailed: 0,
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('TeamContextInjectedData', () => {
+    it('should parse valid payload successfully', () => {
+      const result = TeamContextInjectedData.safeParse({
+        phase: 'delegate',
+        toolsAvailable: 3,
+        historicalHints: ['hint'],
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('TeamTaskAssignedData', () => {
+    it('should parse valid payload successfully', () => {
+      const result = TeamTaskAssignedData.safeParse({
+        taskId: 'task-001',
+        teammateName: 'worker-1',
+        worktreePath: '/tmp/wt',
+        modules: ['auth'],
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+});
+
+describe('EventTypes', () => {
+  it('should include all 6 team event types', () => {
+    const teamEventTypes = [
+      'team.spawned',
+      'team.task.assigned',
+      'team.task.completed',
+      'team.task.failed',
+      'team.disbanded',
+      'team.context.injected',
+    ];
+    for (const eventType of teamEventTypes) {
+      expect(EventTypes).toContain(eventType);
+    }
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -27,6 +27,12 @@ export const EventTypes = [
   'tool.completed',
   'tool.errored',
   'benchmark.completed',
+  'team.spawned',
+  'team.task.assigned',
+  'team.task.completed',
+  'team.task.failed',
+  'team.disbanded',
+  'team.context.injected',
 ] as const;
 
 export type EventType = typeof EventTypes[number];
@@ -221,6 +227,50 @@ export const BenchmarkCompletedData = z.object({
   })).min(1),
 });
 
+// ─── Team Event Data ────────────────────────────────────────────────────────
+
+export const TeamSpawnedData = z.object({
+  teamSize: z.number().int(),
+  teammateNames: z.array(z.string()),
+  taskCount: z.number().int(),
+  dispatchMode: z.string(),
+});
+
+export const TeamTaskAssignedData = z.object({
+  taskId: z.string(),
+  teammateName: z.string(),
+  worktreePath: z.string(),
+  modules: z.array(z.string()),
+});
+
+export const TeamTaskCompletedData = z.object({
+  taskId: z.string(),
+  teammateName: z.string(),
+  durationMs: z.number(),
+  filesChanged: z.array(z.string()),
+  testsPassed: z.boolean(),
+  qualityGateResults: z.record(z.string(), z.unknown()),
+});
+
+export const TeamTaskFailedData = z.object({
+  taskId: z.string(),
+  teammateName: z.string(),
+  failureReason: z.string(),
+  gateResults: z.record(z.string(), z.unknown()),
+});
+
+export const TeamDisbandedData = z.object({
+  totalDurationMs: z.number(),
+  tasksCompleted: z.number().int(),
+  tasksFailed: z.number().int(),
+});
+
+export const TeamContextInjectedData = z.object({
+  phase: z.string(),
+  toolsAvailable: z.number().int(),
+  historicalHints: z.array(z.string()),
+});
+
 // ─── TypeScript Types ───────────────────────────────────────────────────────
 
 export type WorkflowEvent = z.infer<typeof WorkflowEventBase>;
@@ -248,6 +298,12 @@ export type ToolInvoked = z.infer<typeof ToolInvokedData>;
 export type ToolCompleted = z.infer<typeof ToolCompletedData>;
 export type ToolErrored = z.infer<typeof ToolErroredData>;
 export type BenchmarkCompleted = z.infer<typeof BenchmarkCompletedData>;
+export type TeamSpawned = z.infer<typeof TeamSpawnedData>;
+export type TeamTaskAssigned = z.infer<typeof TeamTaskAssignedData>;
+export type TeamTaskCompleted = z.infer<typeof TeamTaskCompletedData>;
+export type TeamTaskFailed = z.infer<typeof TeamTaskFailedData>;
+export type TeamDisbanded = z.infer<typeof TeamDisbandedData>;
+export type TeamContextInjected = z.infer<typeof TeamContextInjectedData>;
 
 // ─── Agent Event Validation ──────────────────────────────────────────────────
 
@@ -255,6 +311,8 @@ export type BenchmarkCompleted = z.infer<typeof BenchmarkCompletedData>;
 export const AGENT_EVENT_TYPES = [
   'task.claimed',
   'task.progressed',
+  'team.task.completed',
+  'team.task.failed',
 ] as const;
 
 export type AgentEventType = typeof AGENT_EVENT_TYPES[number];


### PR DESCRIPTION
feat: detect orphaned team recovery in SessionStart

chore: cherry-pick team event schemas from Task 1