### PR TITLE
feat: emit rich team.task.completed events from TeammateIdle hook

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.test.ts
@@ -47,7 +47,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 });
 
 import { execSync } from 'node:child_process';
-import { handleTaskGate, handleTeammateGate, runQualityChecks, findActiveWorkflowState } from './gates.js';
+import { handleTaskGate, handleTeammateGate, runQualityChecks, findActiveWorkflowState, findUnblockedTasks, resetQualityRetries } from './gates.js';
 import type { CommandResult } from '../cli.js';
 
 const mockExecSync = vi.mocked(execSync);
@@ -753,6 +753,422 @@ describe('Quality Gate Commands', () => {
       expect(result.error).toBeDefined();
       expect(result.error!.code).toBe('GATE_FAILED');
       expect(result.error!.message).toContain('test');
+    });
+  });
+
+  // ─── Task 8: Team Event Emission ────────────────────────────────────────────
+
+  describe('team event emission', () => {
+    let tempDir: string;
+    const originalEnv = process.env.WORKFLOW_STATE_DIR;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-event-test-'));
+      process.env.WORKFLOW_STATE_DIR = tempDir;
+    });
+
+    afterEach(async () => {
+      process.env.WORKFLOW_STATE_DIR = originalEnv;
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    });
+
+    function createActiveState(overrides: {
+      taskId?: string;
+      taskStatus?: string;
+      cwdPath?: string;
+      startedAt?: string;
+    } = {}): Record<string, unknown> {
+      return {
+        featureId: 'event-test-workflow',
+        phase: 'overhaul-delegate',
+        tasks: [
+          {
+            id: overrides.taskId ?? 'task-evt-001',
+            title: 'Event test task',
+            status: overrides.taskStatus ?? 'in_progress',
+            branch: 'feat/event-test',
+            startedAt: overrides.startedAt ?? new Date(Date.now() - 5000).toISOString(),
+          },
+        ],
+        worktrees: {
+          'wt-evt-001': {
+            branch: 'feat/event-test',
+            status: 'active',
+            taskId: overrides.taskId ?? 'task-evt-001',
+            path: overrides.cwdPath ?? '/tmp/event-worktree',
+          },
+        },
+        _version: 1,
+      };
+    }
+
+    async function writeStateFile(state: Record<string, unknown>): Promise<void> {
+      await fsp.writeFile(
+        path.join(tempDir, `${state.featureId as string}.state.json`),
+        JSON.stringify(state),
+      );
+    }
+
+    async function readEventLines(): Promise<Record<string, unknown>[]> {
+      const eventFile = path.join(tempDir, 'event-test-workflow.events.jsonl');
+      try {
+        const content = await fsp.readFile(eventFile, 'utf-8');
+        return content
+          .trim()
+          .split('\n')
+          .filter(Boolean)
+          .map((line) => JSON.parse(line) as Record<string, unknown>);
+      } catch {
+        return [];
+      }
+    }
+
+    it('should emit team.task.completed event when quality checks pass', async () => {
+      // Arrange
+      mockExecSync.mockReturnValue(Buffer.from(''));
+      const state = createActiveState({ cwdPath: '/tmp/event-worktree' });
+      await writeStateFile(state);
+
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+        cwd: '/tmp/event-worktree',
+      };
+
+      // Act
+      await handleTeammateGate(input);
+
+      // Assert
+      const events = await readEventLines();
+      const completedEvents = events.filter((e) => e.type === 'team.task.completed');
+      expect(completedEvents).toHaveLength(1);
+
+      const event = completedEvents[0];
+      const data = event.data as Record<string, unknown>;
+      expect(data.taskId).toBe('task-evt-001');
+      expect(data.teammateName).toBe('worker-1');
+      expect(typeof data.durationMs).toBe('number');
+      expect((data.durationMs as number)).toBeGreaterThan(0);
+      expect(data.testsPassed).toBe(true);
+    });
+
+    it('should not emit team.task.completed event when quality checks fail', async () => {
+      // Arrange
+      const typecheckError = new Error('Type checking failed');
+      (typecheckError as NodeJS.ErrnoException).status = 1;
+      (typecheckError as unknown as { stdout: Buffer }).stdout = Buffer.from('');
+      (typecheckError as unknown as { stderr: Buffer }).stderr = Buffer.from('type error');
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('typecheck')) {
+          throw typecheckError;
+        }
+        return Buffer.from('');
+      });
+
+      const state = createActiveState({ cwdPath: '/tmp/event-worktree' });
+      await writeStateFile(state);
+
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+        cwd: '/tmp/event-worktree',
+      };
+
+      // Act
+      await handleTeammateGate(input);
+
+      // Assert — no team.task.completed event should be written
+      const events = await readEventLines();
+      const completedEvents = events.filter((e) => e.type === 'team.task.completed');
+      expect(completedEvents).toHaveLength(0);
+    });
+
+    it('should not emit event when no matching task for cwd', async () => {
+      // Arrange — state has a worktree at a different path
+      mockExecSync.mockReturnValue(Buffer.from(''));
+      const state = createActiveState({ cwdPath: '/tmp/other-worktree' });
+      await writeStateFile(state);
+
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+        cwd: '/tmp/event-worktree',
+      };
+
+      // Act
+      const result = await handleTeammateGate(input);
+
+      // Assert — no event written, but gate still passes
+      const events = await readEventLines();
+      expect(events).toHaveLength(0);
+      expect(result.continue).toBe(true);
+    });
+
+    it('should include changed files in team.task.completed event', async () => {
+      // Arrange — git diff returns a string (encoding: 'utf-8'), quality checks return Buffer
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('git diff --name-only')) {
+          return 'src/auth/login.ts\nsrc/api/routes.ts\n';
+        }
+        return Buffer.from('');
+      });
+
+      const state = createActiveState({ cwdPath: '/tmp/event-worktree' });
+      await writeStateFile(state);
+
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+        cwd: '/tmp/event-worktree',
+      };
+
+      // Act
+      await handleTeammateGate(input);
+
+      // Assert
+      const events = await readEventLines();
+      const completedEvents = events.filter((e) => e.type === 'team.task.completed');
+      expect(completedEvents).toHaveLength(1);
+
+      const data = completedEvents[0].data as Record<string, unknown>;
+      const filesChanged = data.filesChanged as string[];
+      expect(filesChanged).toContain('src/auth/login.ts');
+      expect(filesChanged).toContain('src/api/routes.ts');
+    });
+  });
+
+  // ─── Task 9: Follow-up Task Detection ──────────────────────────────────────
+
+  describe('follow-up task detection', () => {
+    it('should return dependents when completed task unblocks them', () => {
+      // Arrange
+      const tasks = [
+        { id: 'task-A', title: 'Task A', status: 'complete' },
+        { id: 'task-B', title: 'Task B', status: 'pending', blockedBy: ['task-A'] },
+      ];
+
+      // Act
+      const result = findUnblockedTasks(tasks, 'task-A');
+
+      // Assert
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('task-B');
+    });
+
+    it('should return empty when dependent is still blocked by another task', () => {
+      // Arrange
+      const tasks = [
+        { id: 'task-A', title: 'Task A', status: 'complete' },
+        { id: 'task-C', title: 'Task C', status: 'pending', blockedBy: ['task-A', 'task-D'] },
+        { id: 'task-D', title: 'Task D', status: 'in_progress' },
+      ];
+
+      // Act
+      const result = findUnblockedTasks(tasks, 'task-A');
+
+      // Assert
+      expect(result).toHaveLength(0);
+    });
+
+    it('should return empty when no tasks depend on completed task', () => {
+      // Arrange
+      const tasks = [
+        { id: 'task-A', title: 'Task A', status: 'complete' },
+        { id: 'task-B', title: 'Task B', status: 'pending' },
+      ];
+
+      // Act
+      const result = findUnblockedTasks(tasks, 'task-A');
+
+      // Assert
+      expect(result).toHaveLength(0);
+    });
+
+    it('should include unblockedTasks in handler result when tasks become unblocked', async () => {
+      // Arrange
+      const tempDir2 = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-unblock-test-'));
+      const originalEnv2 = process.env.WORKFLOW_STATE_DIR;
+      process.env.WORKFLOW_STATE_DIR = tempDir2;
+
+      mockExecSync.mockReturnValue(Buffer.from(''));
+      const state = {
+        featureId: 'unblock-test',
+        phase: 'overhaul-delegate',
+        tasks: [
+          { id: 'task-A', title: 'Task A', status: 'in_progress', branch: 'feat/a' },
+          { id: 'task-B', title: 'Task B', status: 'pending', branch: 'feat/b', blockedBy: ['task-A'] },
+        ],
+        worktrees: {
+          'wt-001': {
+            branch: 'feat/a',
+            status: 'active',
+            taskId: 'task-A',
+            path: '/tmp/unblock-worktree',
+          },
+        },
+        _version: 1,
+      };
+      await fsp.writeFile(
+        path.join(tempDir2, 'unblock-test.state.json'),
+        JSON.stringify(state),
+      );
+
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+        cwd: '/tmp/unblock-worktree',
+      };
+
+      // Act
+      const result = await handleTeammateGate(input);
+
+      // Cleanup
+      process.env.WORKFLOW_STATE_DIR = originalEnv2;
+      await fsp.rm(tempDir2, { recursive: true, force: true });
+
+      // Assert
+      expect(result.continue).toBe(true);
+      const unblockedTasks = result.unblockedTasks as Array<{ id: string }>;
+      expect(unblockedTasks).toBeDefined();
+      expect(unblockedTasks).toHaveLength(1);
+      expect(unblockedTasks[0].id).toBe('task-B');
+    });
+  });
+
+  // ─── Task 14: Retry Circuit Breaker ──────────────────────────────────────────
+
+  describe('retry circuit breaker', () => {
+    let tempDir: string;
+    const originalEnv = process.env.WORKFLOW_STATE_DIR;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gate-circuit-test-'));
+      process.env.WORKFLOW_STATE_DIR = tempDir;
+      // Reset the module-level retry counters between tests
+      resetQualityRetries('__all__');
+    });
+
+    afterEach(async () => {
+      process.env.WORKFLOW_STATE_DIR = originalEnv;
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    });
+
+    function makeQualityFail(): void {
+      const typecheckError = new Error('Type checking failed');
+      (typecheckError as NodeJS.ErrnoException).status = 1;
+      (typecheckError as unknown as { stdout: Buffer }).stdout = Buffer.from('');
+      (typecheckError as unknown as { stderr: Buffer }).stderr = Buffer.from('type error');
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('typecheck')) {
+          throw typecheckError;
+        }
+        return Buffer.from('');
+      });
+    }
+
+    it('should trip circuit breaker after repeated failures', async () => {
+      // Arrange
+      makeQualityFail();
+      const state = {
+        featureId: 'circuit-test',
+        phase: 'overhaul-delegate',
+        tasks: [
+          { id: 'task-001', title: 'Circuit test task', status: 'in_progress', branch: 'feat/circuit' },
+        ],
+        worktrees: {
+          'wt-001': {
+            branch: 'feat/circuit',
+            status: 'active',
+            taskId: 'task-001',
+            path: '/tmp/circuit-worktree',
+          },
+        },
+        _version: 1,
+      };
+      await fsp.writeFile(
+        path.join(tempDir, 'circuit-test.state.json'),
+        JSON.stringify(state),
+      );
+
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+        cwd: '/tmp/circuit-worktree',
+      };
+
+      // Act — call 3 times (MAX_QUALITY_RETRIES)
+      await handleTeammateGate(input);
+      await handleTeammateGate(input);
+      const result = await handleTeammateGate(input);
+
+      // Assert — circuit should be open
+      expect(result.error).toBeDefined();
+      expect(result.circuitOpen).toBe(true);
+    });
+
+    it('should reset counter on success', async () => {
+      // Arrange — fail once, then succeed
+      const typecheckError = new Error('Type checking failed');
+      (typecheckError as NodeJS.ErrnoException).status = 1;
+      (typecheckError as unknown as { stdout: Buffer }).stdout = Buffer.from('');
+      (typecheckError as unknown as { stderr: Buffer }).stderr = Buffer.from('type error');
+
+      let callCount = 0;
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('typecheck')) {
+          callCount++;
+          if (callCount <= 1) {
+            throw typecheckError;
+          }
+        }
+        return Buffer.from('');
+      });
+
+      const input: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+        cwd: '/tmp/circuit-reset-worktree',
+      };
+
+      // Act — fail once, then succeed
+      const failResult = await handleTeammateGate(input);
+      const passResult = await handleTeammateGate(input);
+
+      // Assert — circuit should NOT be tripped
+      expect(failResult.error).toBeDefined();
+      expect(passResult.error).toBeUndefined();
+      expect(passResult.circuitOpen).toBeUndefined();
+    });
+
+    it('should track different cwds independently', async () => {
+      // Arrange
+      makeQualityFail();
+
+      const inputA: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-1',
+        cwd: '/tmp/circuit-worktree-A',
+      };
+      const inputB: Record<string, unknown> = {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'worker-2',
+        cwd: '/tmp/circuit-worktree-B',
+      };
+
+      // Act — fail 2 times for A, 1 time for B
+      await handleTeammateGate(inputA);
+      await handleTeammateGate(inputA);
+      await handleTeammateGate(inputB);
+
+      // Neither should have tripped the circuit (A=2 < 3, B=1 < 3)
+      const resultA = await handleTeammateGate(inputA); // 3rd for A — should trip
+      const resultB = await handleTeammateGate(inputB); // 2nd for B — should NOT trip
+
+      // Assert
+      expect(resultA.circuitOpen).toBe(true);
+      expect(resultB.circuitOpen).toBeUndefined();
     });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/gates.ts
@@ -111,6 +111,8 @@ interface WorkflowTask {
   status: string;
   readonly branch: string;
   completedAt?: string;
+  readonly startedAt?: string;
+  readonly blockedBy?: string[];
 }
 
 interface WorkflowWorktree {
@@ -222,8 +224,13 @@ export async function handleTaskGate(
  * Teammate gate handler for TeammateIdle hook events.
  *
  * When quality checks pass, attempts to update the corresponding task's
- * status to "complete" in the workflow state file. This is best-effort:
- * failures in state update do not block the gate.
+ * status to "complete" in the workflow state file, emits a team.task.completed
+ * event, and detects newly unblocked follow-up tasks. This is best-effort:
+ * failures in state update or event emission do not block the gate.
+ *
+ * Includes a circuit breaker: after MAX_QUALITY_RETRIES consecutive failures
+ * for the same cwd, the gate returns circuitOpen: true to signal the
+ * orchestrator should stop retrying.
  *
  * Expected stdin shape:
  * ```json
@@ -241,28 +248,67 @@ export async function handleTeammateGate(
   if (validationError) return validationError;
 
   const cwd = input.cwd as string;
+  const teammateName = typeof input.teammate_name === 'string' ? input.teammate_name : 'unknown';
   const qualityResult = await runQualityChecks(cwd);
 
-  // Only attempt state update when quality checks pass
-  if (!qualityResult.error) {
-    await updateTaskCompletion(cwd);
+  if (qualityResult.error) {
+    // Track failure and check circuit breaker
+    const circuitOpen = trackQualityFailure(cwd);
+    if (circuitOpen) {
+      // Emit team.task.failed event on circuit open
+      await emitTeamTaskEvent(cwd, teammateName, false, qualityResult.error.message);
+      return { ...qualityResult, circuitOpen: true };
+    }
+    return qualityResult;
   }
 
-  return qualityResult;
+  // Quality passed — reset retry counter
+  resetQualityRetries(cwd);
+
+  // Attempt state update and event emission (best-effort)
+  const completionContext = await updateTaskCompletion(cwd);
+  if (completionContext) {
+    await emitTeamTaskEvent(
+      cwd,
+      teammateName,
+      true,
+      undefined,
+      completionContext.taskId,
+      completionContext.startedAt,
+      completionContext.featureId,
+    );
+
+    // Detect newly unblocked tasks
+    const unblockedTasks = findUnblockedTasks(completionContext.allTasks, completionContext.taskId);
+    if (unblockedTasks.length > 0) {
+      return { continue: true, unblockedTasks };
+    }
+  }
+
+  return { continue: true };
 }
 
 // ─── State Bridge ──────────────────────────────────────────────────────────
 
+/** Context returned by updateTaskCompletion for event emission and follow-up detection. */
+interface TaskCompletionContext {
+  readonly taskId: string;
+  readonly startedAt: string | undefined;
+  readonly featureId: string;
+  readonly allTasks: readonly WorkflowTask[];
+}
+
 /**
  * Best-effort update: find the active workflow, match cwd to a worktree entry,
- * mark the corresponding task as complete, and write back. Silently swallows
- * all errors so the gate is never blocked by state issues.
+ * mark the corresponding task as complete, and write back. Returns context
+ * for event emission if a task was matched, or null otherwise.
+ * Silently swallows all errors so the gate is never blocked by state issues.
  */
-async function updateTaskCompletion(cwd: string): Promise<void> {
+async function updateTaskCompletion(cwd: string): Promise<TaskCompletionContext | null> {
   try {
     const stateDir = resolveStateDir();
     const active = await findActiveWorkflowState(stateDir);
-    if (!active) return;
+    if (!active) return null;
 
     const expectedVersion = active.state._version;
 
@@ -270,11 +316,19 @@ async function updateTaskCompletion(cwd: string): Promise<void> {
     const matchingWorktree = Object.values(active.state.worktrees).find(
       (wt) => wt.path === cwd,
     );
-    if (!matchingWorktree) return;
+    if (!matchingWorktree) return null;
 
     // Find the corresponding task
     const task = active.state.tasks.find((t) => t.id === matchingWorktree.taskId);
-    if (!task) return;
+    if (!task) return null;
+
+    // Capture context before mutation
+    const context: TaskCompletionContext = {
+      taskId: task.id,
+      startedAt: task.startedAt,
+      featureId: active.featureId,
+      allTasks: active.state.tasks,
+    };
 
     // Update task status
     task.status = 'complete';
@@ -286,7 +340,8 @@ async function updateTaskCompletion(cwd: string): Promise<void> {
     const currentState = JSON.parse(currentRaw) as WorkflowState;
     if (currentState._version !== expectedVersion) {
       // Another writer intervened — skip this update (best-effort)
-      return;
+      // Still return context so event can be emitted
+      return context;
     }
 
     // Atomic write: tmp file + rename (with unique suffix to prevent same-process collisions)
@@ -302,8 +357,165 @@ async function updateTaskCompletion(cwd: string): Promise<void> {
         // Ignore cleanup errors
       }
     }
+
+    return context;
   } catch {
     // Best-effort: swallow errors so gate is never blocked
+    return null;
+  }
+}
+
+// ─── Team Event Emission ──────────────────────────────────────────────────
+
+/**
+ * Lightweight event append for CLI hooks (no full EventStore import).
+ * Appends a single JSON line to the JSONL file.
+ */
+async function appendTeamEvent(
+  stateDir: string,
+  streamId: string,
+  event: Record<string, unknown>,
+): Promise<void> {
+  const eventFile = path.join(stateDir, `${streamId}.events.jsonl`);
+  const line = JSON.stringify(event) + '\n';
+  await fs.appendFile(eventFile, line, 'utf-8');
+}
+
+/**
+ * Get changed files in the worktree using git diff.
+ */
+function getChangedFiles(cwd: string): string[] {
+  try {
+    const output = execSync('git diff --name-only HEAD~1', {
+      cwd,
+      timeout: 10_000,
+      encoding: 'utf-8',
+    });
+    return output.trim().split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Emit a team.task.completed or team.task.failed event to the JSONL event store.
+ * Best-effort: failures are silently swallowed.
+ */
+async function emitTeamTaskEvent(
+  cwd: string,
+  teammateName: string,
+  passed: boolean,
+  failureReason?: string,
+  taskId?: string,
+  startedAt?: string,
+  featureId?: string,
+): Promise<void> {
+  try {
+    const stateDir = resolveStateDir();
+    const streamId = featureId ?? (await resolveStreamId(stateDir));
+    if (!streamId) return;
+
+    if (passed) {
+      const filesChanged = getChangedFiles(cwd);
+      const durationMs = startedAt
+        ? Date.now() - new Date(startedAt).getTime()
+        : 0;
+
+      await appendTeamEvent(stateDir, streamId, {
+        streamId,
+        sequence: Date.now(),
+        timestamp: new Date().toISOString(),
+        type: 'team.task.completed',
+        data: {
+          taskId: taskId ?? 'unknown',
+          teammateName,
+          durationMs: durationMs > 0 ? durationMs : 1,
+          filesChanged,
+          testsPassed: true,
+          qualityGateResults: {},
+        },
+      });
+    } else {
+      await appendTeamEvent(stateDir, streamId, {
+        streamId,
+        sequence: Date.now(),
+        timestamp: new Date().toISOString(),
+        type: 'team.task.failed',
+        data: {
+          taskId: taskId ?? 'unknown',
+          teammateName,
+          failureReason: failureReason ?? 'quality gate failed',
+          gateResults: {},
+        },
+      });
+    }
+  } catch {
+    // Best-effort: swallow errors
+  }
+}
+
+/**
+ * Resolve the stream ID by finding the active workflow.
+ */
+async function resolveStreamId(stateDir: string): Promise<string | null> {
+  const active = await findActiveWorkflowState(stateDir);
+  return active?.featureId ?? null;
+}
+
+// ─── Follow-up Task Detection ─────────────────────────────────────────────
+
+interface BlockableTask {
+  readonly id: string;
+  readonly title: string;
+  readonly status: string;
+  readonly blockedBy?: string[];
+}
+
+/**
+ * Find tasks that become unblocked after a task completes.
+ * A task is unblocked when ALL its blockers are in 'complete' status.
+ */
+export function findUnblockedTasks(
+  tasks: readonly BlockableTask[],
+  completedTaskId: string,
+): BlockableTask[] {
+  return tasks.filter((task) => {
+    if (!task.blockedBy || task.blockedBy.length === 0) return false;
+    if (!task.blockedBy.includes(completedTaskId)) return false;
+    if (task.status !== 'pending') return false;
+    // Check ALL blockers are complete
+    return task.blockedBy.every((blockerId) => {
+      if (blockerId === completedTaskId) return true;
+      const blocker = tasks.find((t) => t.id === blockerId);
+      return blocker?.status === 'complete';
+    });
+  });
+}
+
+// ─── Retry Circuit Breaker ────────────────────────────────────────────────
+
+const MAX_QUALITY_RETRIES = 3;
+
+/** Module-level retry counter (persists across calls within same process). */
+const qualityRetryCounters = new Map<string, number>();
+
+/**
+ * Track quality gate failures per cwd. Returns true if circuit should open.
+ */
+function trackQualityFailure(cwd: string): boolean {
+  const current = (qualityRetryCounters.get(cwd) ?? 0) + 1;
+  qualityRetryCounters.set(cwd, current);
+  return current >= MAX_QUALITY_RETRIES;
+}
+
+/**
+ * Reset retry counter on success. Pass '__all__' to clear all counters (for testing).
+ */
+export function resetQualityRetries(cwd: string): void {
+  if (cwd === '__all__') {
+    qualityRetryCounters.clear();
+  } else {
+    qualityRetryCounters.delete(cwd);
   }
 }
 


### PR DESCRIPTION
Add team event emission to handleTeammateGate:
- appendTeamEvent() lightweight JSONL event writer for CLI hooks
- getChangedFiles() git diff helper for file change tracking
- emitTeamTaskEvent() emits team.task.completed/failed events
- findUnblockedTasks() detects follow-up tasks unblocked by completion
- Retry circuit breaker with trackQualityFailure/resetQualityRetries
- updateTaskCompletion returns TaskCompletionContext for enriched results

Includes 11 new test cases covering all three features.