### PR TITLE
feat: SubagentStart hook — live data only, skip sub-subagent injection

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.test.ts
@@ -10,6 +10,9 @@ import {
   queryModuleHistory,
   synthesizeIntelligence,
   extractModulesFromCwd,
+  readNativeTaskList,
+  isTeammateSubSubagent,
+  isAgentTeamMode,
   type FilteredComposite,
 } from './subagent-context.js';
 
@@ -572,6 +575,409 @@ describe('subagent-context', () => {
       expect(result.guidance).toBe('');
       expect(result.context).toBe('');
       expect(result.team).toBe('');
+    });
+  });
+
+  // ─── Task 005: Live Data Only (Deduplication) ──────────────────────────────
+
+  describe('readNativeTaskList', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'native-tasks-'));
+    });
+
+    afterEach(async () => {
+      await cleanupDir(tempDir);
+    });
+
+    it('should return task statuses from existing tasks directory', async () => {
+      // Arrange — create a tasks directory with JSON files
+      const tasksDir = path.join(tempDir, 'my-feature');
+      await fs.mkdir(tasksDir, { recursive: true });
+      await fs.writeFile(
+        path.join(tasksDir, 'task-001.json'),
+        JSON.stringify({ id: 'task-001', title: 'Implement auth', status: 'complete' }),
+        'utf-8',
+      );
+      await fs.writeFile(
+        path.join(tasksDir, 'task-002.json'),
+        JSON.stringify({ id: 'task-002', title: 'Implement api', status: 'in_progress' }),
+        'utf-8',
+      );
+      await fs.writeFile(
+        path.join(tasksDir, 'task-003.json'),
+        JSON.stringify({ id: 'task-003', title: 'Implement ui', status: 'pending' }),
+        'utf-8',
+      );
+
+      // Act
+      const result = await readNativeTaskList(tasksDir);
+
+      // Assert
+      expect(result).toHaveLength(3);
+      expect(result).toContainEqual(
+        expect.objectContaining({ id: 'task-001', status: 'complete' }),
+      );
+      expect(result).toContainEqual(
+        expect.objectContaining({ id: 'task-002', status: 'in_progress' }),
+      );
+      expect(result).toContainEqual(
+        expect.objectContaining({ id: 'task-003', status: 'pending' }),
+      );
+    });
+
+    it('should return empty array when tasks directory does not exist', async () => {
+      // Act
+      const result = await readNativeTaskList('/nonexistent/path/tasks');
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('isTeammateSubSubagent', () => {
+    it('should return true when cwd contains .worktrees/ and phase is delegate', () => {
+      // Arrange
+      const cwd = '/Users/dev/project/.worktrees/wt-auth-service/src';
+      const phase = 'delegate';
+
+      // Act
+      const result = isTeammateSubSubagent(cwd, phase);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('should return false when cwd does NOT contain .worktrees/', () => {
+      // Arrange — orchestrator cwd (no worktree)
+      const cwd = '/Users/dev/project/src';
+      const phase = 'delegate';
+
+      // Act
+      const result = isTeammateSubSubagent(cwd, phase);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+
+    it('should return false when cwd has .worktrees/ but phase is NOT delegate', () => {
+      // Arrange
+      const cwd = '/Users/dev/project/.worktrees/wt-auth-service/src';
+      const phase = 'review';
+
+      // Act
+      const result = isTeammateSubSubagent(cwd, phase);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isAgentTeamMode', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'teams-'));
+    });
+
+    afterEach(async () => {
+      await cleanupDir(tempDir);
+    });
+
+    it('should return true when team config directory exists', async () => {
+      // Arrange — create team config at {teamsDir}/{featureId}/config.json
+      const teamDir = path.join(tempDir, 'my-feature');
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({ teamSize: 3 }),
+        'utf-8',
+      );
+
+      // Act
+      const result = await isAgentTeamMode('my-feature', tempDir);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('should return true when team config flat file exists', async () => {
+      // Arrange — create team config at {teamsDir}/{featureId}.json
+      await fs.writeFile(
+        path.join(tempDir, 'my-feature.json'),
+        JSON.stringify({ teamSize: 3 }),
+        'utf-8',
+      );
+
+      // Act
+      const result = await isAgentTeamMode('my-feature', tempDir);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('should return false when no team config exists', async () => {
+      // Act — tempDir has no team config for this feature
+      const result = await isAgentTeamMode('nonexistent-feature', tempDir);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('handleSubagentContext agent-team mode', () => {
+    let tempDir: string;
+    let tempTeamsDir: string;
+    let tempTasksDir: string;
+    let originalStateDir: string | undefined;
+    let originalHome: string | undefined;
+
+    beforeEach(async () => {
+      tempDir = await createTempStateDir();
+      tempTeamsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'teams-'));
+      tempTasksDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tasks-'));
+      originalStateDir = process.env.WORKFLOW_STATE_DIR;
+      originalHome = process.env.HOME;
+      process.env.WORKFLOW_STATE_DIR = tempDir;
+      // We override HOME so the team/task resolution uses our temp dirs
+      // But the implementation uses HOME-based paths, so we set up the structure
+    });
+
+    afterEach(async () => {
+      if (originalStateDir !== undefined) {
+        process.env.WORKFLOW_STATE_DIR = originalStateDir;
+      } else {
+        delete process.env.WORKFLOW_STATE_DIR;
+      }
+      if (originalHome !== undefined) {
+        process.env.HOME = originalHome;
+      } else {
+        delete process.env.HOME;
+      }
+      await cleanupDir(tempDir);
+      await cleanupDir(tempTeamsDir);
+      await cleanupDir(tempTasksDir);
+    });
+
+    it('should not call queryModuleHistory in agent-team mode', async () => {
+      // Arrange — active workflow with team config present
+      const featureId = 'team-feature';
+      await writeStateFile(tempDir, featureId, 'delegate');
+
+      // Create team config directory structure under HOME
+      const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'home-'));
+      process.env.HOME = homeDir;
+      const teamDir = path.join(homeDir, '.claude', 'teams', featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({ teamSize: 3 }),
+        'utf-8',
+      );
+
+      // Add JSONL events that would be found if queryModuleHistory were called
+      const jsonlContent = [
+        `{"streamId":"${featureId}","sequence":1,"timestamp":"2026-01-01T00:00:00Z","type":"workflow.fix-cycle","data":{"compoundStateId":"auth-review","count":2,"featureId":"${featureId}"},"schemaVersion":"1.0"}`,
+      ].join('\n');
+      await fs.writeFile(
+        path.join(tempDir, `${featureId}.events.jsonl`),
+        jsonlContent,
+        'utf-8',
+      );
+
+      // Act
+      const result = await handleSubagentContext({ cwd: '/tmp/wt-auth-service/src' });
+
+      // Assert — context should be empty because historical intelligence is skipped
+      expect(result.context).toBe('');
+
+      await cleanupDir(homeDir);
+    });
+
+    it('should not inject static team context in agent-team mode', async () => {
+      // Arrange — active workflow with team config AND workflow tasks
+      const featureId = 'team-feature-2';
+      const stateFile = path.join(tempDir, `${featureId}.state.json`);
+      const state = {
+        version: 2,
+        featureId,
+        workflowType: 'feature',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        phase: 'delegate',
+        artifacts: { design: null, plan: null, pr: null },
+        tasks: [
+          { id: 'task-1', title: 'Implement auth', status: 'in_progress', branch: 'auth' },
+          { id: 'task-2', title: 'Implement api', status: 'complete', branch: 'api' },
+        ],
+        worktrees: {},
+        reviews: {},
+        synthesis: {
+          integrationBranch: null, mergeOrder: [], mergedBranches: [],
+          prUrl: null, prFeedback: [],
+        },
+        _version: 1, _history: {},
+        _checkpoint: {
+          timestamp: new Date().toISOString(), phase: 'delegate',
+          summary: 'Test', operationsSince: 0, fixCycleCount: 0,
+          lastActivityTimestamp: new Date().toISOString(), staleAfterMinutes: 120,
+        },
+      };
+      await fs.writeFile(stateFile, JSON.stringify(state, null, 2), 'utf-8');
+
+      // Create team config
+      const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'home-'));
+      process.env.HOME = homeDir;
+      const teamDir = path.join(homeDir, '.claude', 'teams', featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({ teamSize: 3 }),
+        'utf-8',
+      );
+
+      // Act
+      const result = await handleSubagentContext({ cwd: '/some/path' });
+
+      // Assert — team field should be empty (static team context suppressed)
+      expect(result.team).toBe('');
+
+      await cleanupDir(homeDir);
+    });
+
+    it('should inject live task status changes in agent-team mode', async () => {
+      // Arrange — active workflow with team config + native task files
+      const featureId = 'team-feature-3';
+      await writeStateFile(tempDir, featureId, 'delegate');
+
+      // Create team config + native tasks under HOME
+      const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'home-'));
+      process.env.HOME = homeDir;
+      const teamDir = path.join(homeDir, '.claude', 'teams', featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({ teamSize: 3 }),
+        'utf-8',
+      );
+      const tasksDir = path.join(homeDir, '.claude', 'tasks', featureId);
+      await fs.mkdir(tasksDir, { recursive: true });
+      await fs.writeFile(
+        path.join(tasksDir, 'task-001.json'),
+        JSON.stringify({ id: 'task-001', title: 'Implement auth', status: 'complete' }),
+        'utf-8',
+      );
+      await fs.writeFile(
+        path.join(tasksDir, 'task-002.json'),
+        JSON.stringify({ id: 'task-002', title: 'Implement api', status: 'in_progress' }),
+        'utf-8',
+      );
+
+      // Act
+      const result = await handleSubagentContext({ cwd: '/some/path' });
+
+      // Assert — liveTaskStatus field should contain task data
+      expect(result).toHaveProperty('liveTaskStatus');
+      expect(typeof result.liveTaskStatus).toBe('string');
+      expect((result.liveTaskStatus as string).length).toBeGreaterThan(0);
+      expect(result.liveTaskStatus as string).toContain('complete');
+
+      await cleanupDir(homeDir);
+    });
+
+    it('should retain historical intelligence in subagent mode (no team config)', async () => {
+      // Arrange — active workflow WITHOUT team config
+      const featureId = 'solo-feature';
+      await writeStateFile(tempDir, featureId, 'delegate');
+
+      // Ensure no team config exists
+      const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'home-'));
+      process.env.HOME = homeDir;
+
+      // Add JSONL events that should be found
+      const jsonlContent = [
+        `{"streamId":"${featureId}","sequence":1,"timestamp":"2026-01-01T00:00:00Z","type":"workflow.fix-cycle","data":{"compoundStateId":"auth-review","count":2,"featureId":"${featureId}"},"schemaVersion":"1.0"}`,
+      ].join('\n');
+      await fs.writeFile(
+        path.join(tempDir, `${featureId}.events.jsonl`),
+        jsonlContent,
+        'utf-8',
+      );
+
+      // Act
+      const result = await handleSubagentContext({ cwd: '/tmp/wt-auth-service/src' });
+
+      // Assert — context should be non-empty (historical intelligence preserved in subagent mode)
+      expect(typeof result.context).toBe('string');
+      expect((result.context as string).length).toBeGreaterThan(0);
+      expect(result.context as string).toContain('fix cycle');
+
+      await cleanupDir(homeDir);
+    });
+
+    it('should always retain tool guidance regardless of mode', async () => {
+      // Arrange — active workflow WITH team config
+      const featureId = 'guided-feature';
+      await writeStateFile(tempDir, featureId, 'delegate');
+
+      const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'home-'));
+      process.env.HOME = homeDir;
+      const teamDir = path.join(homeDir, '.claude', 'teams', featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({ teamSize: 3 }),
+        'utf-8',
+      );
+
+      // Act
+      const result = await handleSubagentContext({ cwd: '/some/path' });
+
+      // Assert — guidance should be present (tool filtering always applies)
+      expect(result).toHaveProperty('guidance');
+      expect(typeof result.guidance).toBe('string');
+      expect((result.guidance as string).length).toBeGreaterThan(0);
+
+      await cleanupDir(homeDir);
+    });
+
+    it('should skip all injection for teammate sub-subagents during delegate', async () => {
+      // Arrange — active workflow + team config + cwd in worktree + phase is delegate
+      const featureId = 'sub-sub-feature';
+      await writeStateFile(tempDir, featureId, 'delegate');
+
+      const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'home-'));
+      process.env.HOME = homeDir;
+      const teamDir = path.join(homeDir, '.claude', 'teams', featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({ teamSize: 3 }),
+        'utf-8',
+      );
+
+      // Add JSONL events
+      const jsonlContent = [
+        `{"streamId":"${featureId}","sequence":1,"timestamp":"2026-01-01T00:00:00Z","type":"workflow.fix-cycle","data":{"compoundStateId":"auth-review","count":2,"featureId":"${featureId}"},"schemaVersion":"1.0"}`,
+      ].join('\n');
+      await fs.writeFile(
+        path.join(tempDir, `${featureId}.events.jsonl`),
+        jsonlContent,
+        'utf-8',
+      );
+
+      // Act — cwd is inside a .worktrees/ directory (teammate sub-subagent)
+      const result = await handleSubagentContext({
+        cwd: '/Users/dev/project/.worktrees/wt-auth-service/src',
+      });
+
+      // Assert — all context should be empty (sub-subagent inherits from parent)
+      expect(result.guidance).toBe('');
+      expect(result.context).toBe('');
+      expect(result.team).toBe('');
+
+      await cleanupDir(homeDir);
     });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.ts
@@ -371,7 +371,116 @@ export function extractModulesFromCwd(cwd: string): string[] {
   return modules;
 }
 
+// ─── Agent Team Detection ─────────────────────────────────────────────────
+
+/**
+ * Read native task list from a tasks directory.
+ * Each JSON file in the directory represents a task with id, title, and status.
+ * Returns empty array if the directory does not exist or is unreadable.
+ */
+export async function readNativeTaskList(
+  tasksDir: string,
+): Promise<Array<Record<string, unknown>>> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(tasksDir);
+  } catch {
+    return [];
+  }
+
+  const jsonFiles = entries.filter((f) => f.endsWith('.json'));
+  const results: Array<Record<string, unknown>> = [];
+
+  for (const file of jsonFiles) {
+    try {
+      const raw = await fs.readFile(path.join(tasksDir, file), 'utf-8');
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      results.push(parsed);
+    } catch {
+      // Skip unparseable files
+      continue;
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Detect if the current SubagentStart event originates from a teammate's
+ * subprocess (sub-subagent). Detected by cwd being inside a `.worktrees/`
+ * directory during the delegate phase.
+ *
+ * Teammate sub-subagents (tests, formatting, etc.) inherit context from
+ * their parent teammate and should not receive additional injection.
+ */
+export function isTeammateSubSubagent(cwd: string, phase: string): boolean {
+  if (phase !== 'delegate') return false;
+
+  const normalized = cwd.replace(/\\/g, '/');
+  return normalized.includes('.worktrees/');
+}
+
+/**
+ * Check if the current workflow is running in agent-team mode.
+ * Agent-team mode is detected by the existence of a native team config at:
+ *   - `{teamsDir}/{featureId}/config.json` (directory-style)
+ *   - `{teamsDir}/{featureId}.json` (flat-file-style)
+ */
+export async function isAgentTeamMode(
+  featureId: string,
+  teamsDir: string,
+): Promise<boolean> {
+  // Check directory-style: {teamsDir}/{featureId}/config.json
+  try {
+    await fs.access(path.join(teamsDir, featureId, 'config.json'));
+    return true;
+  } catch {
+    // Not found, try flat-file
+  }
+
+  // Check flat-file-style: {teamsDir}/{featureId}.json
+  try {
+    await fs.access(path.join(teamsDir, `${featureId}.json`));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Format live task status changes as a human-readable summary.
+ * Shows current task statuses from the native task list.
+ */
+function formatLiveTaskStatus(
+  tasks: Array<Record<string, unknown>>,
+): string {
+  if (tasks.length === 0) return '';
+
+  const lines: string[] = ['Live task statuses:'];
+
+  for (const task of tasks) {
+    const id = typeof task.id === 'string' ? task.id : 'unknown';
+    const title = typeof task.title === 'string' ? task.title : '';
+    const status = typeof task.status === 'string' ? task.status : 'unknown';
+    const label = title ? `${id} (${title})` : id;
+    lines.push(`- ${label}: ${status}`);
+  }
+
+  return lines.join('\n');
+}
+
 // ─── Command Handler ───────────────────────────────────────────────────────
+
+/**
+ * Resolve the home directory from environment.
+ */
+function resolveHomeDir(): string {
+  const home = process.env.HOME ?? process.env.USERPROFILE;
+  if (!home) {
+    throw new Error('Cannot determine home directory: HOME and USERPROFILE are both undefined');
+  }
+  return home;
+}
 
 /**
  * Resolve the workflow state directory from environment or default.
@@ -380,11 +489,7 @@ function resolveStateDir(): string {
   const envDir = process.env.WORKFLOW_STATE_DIR;
   if (envDir) return envDir;
 
-  const home = process.env.HOME ?? process.env.USERPROFILE;
-  if (!home) {
-    throw new Error('Cannot determine home directory: HOME and USERPROFILE are both undefined');
-  }
-  return path.join(home, '.claude', 'workflow-state');
+  return path.join(resolveHomeDir(), '.claude', 'workflow-state');
 }
 
 /**
@@ -481,8 +586,19 @@ async function formatTeamContext(
  * SubagentStart hook handler.
  *
  * Reads the active workflow's phase, filters tools by phase + teammate role,
- * and outputs plain-text guidance to stdout. Also enriches with historical
- * intelligence and team context.
+ * and outputs plain-text guidance to stdout.
+ *
+ * In agent-team mode (native team config exists):
+ *   - Skips historical intelligence (already in spawn prompt)
+ *   - Skips static team context (already in spawn prompt)
+ *   - Injects live task status changes (data that changed since spawn)
+ *   - Retains tool guidance (not in spawn prompt)
+ *
+ * In subagent mode (no team config):
+ *   - Retains all existing behavior (historical intelligence, team context, tool guidance)
+ *
+ * For teammate sub-subagents during delegate phase:
+ *   - Skips all injection (inherits context from parent teammate)
  *
  * Degrades gracefully: outputs empty fields if no active workflow exists.
  */
@@ -503,12 +619,38 @@ export async function handleSubagentContext(
     return { guidance: '', context: '', team: '' };
   }
 
-  // Existing: tool guidance
+  const cwd = typeof stdinData.cwd === 'string' ? stdinData.cwd : '';
+
+  // Determine if we're in agent-team mode
+  const homeDir = resolveHomeDir();
+  const featureId = typeof activeState?.featureId === 'string'
+    ? activeState.featureId
+    : '';
+  const teamsDir = path.join(homeDir, '.claude', 'teams');
+  const teamMode = featureId.length > 0
+    ? await isAgentTeamMode(featureId, teamsDir)
+    : false;
+
+  // Skip all injection for teammate sub-subagents during delegate
+  if (teamMode && isTeammateSubSubagent(cwd, phase)) {
+    return { guidance: '', context: '', team: '' };
+  }
+
+  // Tool guidance — always present regardless of mode
   const { available, denied } = filterToolsForPhaseAndRole(phase, 'teammate');
   const guidance = formatToolGuidance(available, denied);
 
-  // Historical intelligence
-  const cwd = typeof stdinData.cwd === 'string' ? stdinData.cwd : '';
+  if (teamMode) {
+    // Agent-team mode: skip historical intelligence and static team context,
+    // inject live task status instead
+    const tasksDir = path.join(homeDir, '.claude', 'tasks', featureId);
+    const nativeTasks = await readNativeTaskList(tasksDir);
+    const liveTaskStatus = formatLiveTaskStatus(nativeTasks);
+
+    return { guidance, context: '', team: '', liveTaskStatus };
+  }
+
+  // Subagent mode: retain all existing behavior
   const modules = extractModulesFromCwd(cwd);
   const events = await queryModuleHistory(stateDir, modules);
   const context = synthesizeIntelligence(events);


### PR DESCRIPTION
## Summary

Deduplicate context injection in the SubagentStart hook when running in agent-team mode. Historical intelligence (~125 tokens) and static team context (~30 tokens) are already present in the spawn prompt, so the hook now skips them and injects only live task status changes and tool guidance. Teammate sub-subagents during delegate phase receive no injection at all.

## Changes

- **`readNativeTaskList`** -- Read task statuses from `~/.claude/tasks/{featureId}/` JSON files for live injection
- **`isTeammateSubSubagent`** -- Detect sub-subagents by cwd inside `.worktrees/` during delegate phase
- **`isAgentTeamMode`** -- Detect agent-team mode via team config at `~/.claude/teams/{featureId}/`
- **`handleSubagentContext`** -- Conditional paths: agent-team mode skips historical + team context, injects live task status; subagent mode retains all existing behavior; sub-subagents get empty context

## Test Plan

- [x] 12 new tests covering all new functions and both modes
- [x] All 43 subagent-context tests pass
- [x] Full MCP server test suite (1254 tests) passes with 0 regressions
- [x] TypeScript typecheck passes

---

Generated with Claude Code