### PR TITLE
feat: SessionStart hook — detect orphaned native team directories

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { handleSessionStart } from './session-start.js';
+import { handleSessionStart, detectNativeTeam } from './session-start.js';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -503,6 +503,377 @@ describe('session-start command', () => {
       const workflow = result.workflows!.find((w) => w.featureId === 'review-team');
       expect(workflow).toBeDefined();
       expect(workflow!.recovery).toBeUndefined();
+    });
+  });
+
+  // ─── Native Team Directory Detection ────────────────────────────────────────
+
+  describe('detectNativeTeam', () => {
+    let teamsDir: string;
+
+    beforeEach(async () => {
+      teamsDir = path.join(tmpDir, 'teams');
+      await fs.mkdir(teamsDir, { recursive: true });
+    });
+
+    it('should return team info when directory format config exists with members', async () => {
+      // Arrange — ~/.claude/teams/{featureId}/config.json
+      const featureId = 'my-feature';
+      const teamDir = path.join(teamsDir, featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({
+          members: [
+            { name: 'agent-auth', role: 'teammate' },
+            { name: 'agent-api', role: 'teammate' },
+          ],
+        }),
+      );
+
+      // Act
+      const result = await detectNativeTeam(featureId, teamsDir);
+
+      // Assert
+      expect(result).not.toBeNull();
+      expect(result!.memberCount).toBe(2);
+      expect(result!.memberNames).toContain('agent-auth');
+      expect(result!.memberNames).toContain('agent-api');
+    });
+
+    it('should return team info when flat file format exists with members', async () => {
+      // Arrange — ~/.claude/teams/{featureId}.json
+      const featureId = 'flat-feature';
+      await fs.writeFile(
+        path.join(teamsDir, `${featureId}.json`),
+        JSON.stringify({
+          members: [
+            { name: 'agent-ui', role: 'teammate' },
+          ],
+        }),
+      );
+
+      // Act
+      const result = await detectNativeTeam(featureId, teamsDir);
+
+      // Assert
+      expect(result).not.toBeNull();
+      expect(result!.memberCount).toBe(1);
+      expect(result!.memberNames).toContain('agent-ui');
+    });
+
+    it('should return null when no team directory or file exists', async () => {
+      // Arrange — nothing created
+
+      // Act
+      const result = await detectNativeTeam('nonexistent-feature', teamsDir);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should return null when config file is empty or malformed', async () => {
+      // Arrange — directory format with invalid JSON
+      const featureId = 'malformed-feature';
+      const teamDir = path.join(teamsDir, featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        '{ not valid json }',
+      );
+
+      // Act
+      const result = await detectNativeTeam(featureId, teamsDir);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should return null when config has no members array', async () => {
+      // Arrange — valid JSON but no members field
+      const featureId = 'no-members-feature';
+      const teamDir = path.join(teamsDir, featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({ name: 'some team' }),
+      );
+
+      // Act
+      const result = await detectNativeTeam(featureId, teamsDir);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should return null when members array is empty', async () => {
+      // Arrange
+      const featureId = 'empty-members-feature';
+      const teamDir = path.join(teamsDir, featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({ members: [] }),
+      );
+
+      // Act
+      const result = await detectNativeTeam(featureId, teamsDir);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it('should prefer directory format over flat file format', async () => {
+      // Arrange — both formats exist with different data
+      const featureId = 'both-formats';
+      const teamDir = path.join(teamsDir, featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({
+          members: [
+            { name: 'dir-agent-1', role: 'teammate' },
+            { name: 'dir-agent-2', role: 'teammate' },
+          ],
+        }),
+      );
+      await fs.writeFile(
+        path.join(teamsDir, `${featureId}.json`),
+        JSON.stringify({
+          members: [{ name: 'flat-agent-1', role: 'teammate' }],
+        }),
+      );
+
+      // Act
+      const result = await detectNativeTeam(featureId, teamsDir);
+
+      // Assert — directory format should take precedence
+      expect(result).not.toBeNull();
+      expect(result!.memberCount).toBe(2);
+      expect(result!.memberNames).toContain('dir-agent-1');
+    });
+
+    it('should return null when teams base directory does not exist', async () => {
+      // Act
+      const result = await detectNativeTeam('any-feature', '/nonexistent/teams');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── Native Team Cleanup Recommendations in handleSessionStart ─────────────
+
+  describe('native team cleanup recommendations', () => {
+    let teamsDir: string;
+
+    beforeEach(async () => {
+      teamsDir = path.join(tmpDir, 'teams');
+      await fs.mkdir(teamsDir, { recursive: true });
+    });
+
+    it('should include cleanup recommendation when native team exists and workflow is past delegation', async () => {
+      // Arrange — workflow in review phase + native team directory
+      const featureId = 'team-past-delegate';
+      const stateData = createValidStateFile({
+        featureId,
+        phase: 'review',
+      });
+      await fs.writeFile(
+        path.join(tmpDir, `${featureId}.state.json`),
+        JSON.stringify(stateData, null, 2),
+      );
+
+      const teamDir = path.join(teamsDir, featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({
+          members: [{ name: 'agent-1', role: 'teammate' }],
+        }),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir, teamsDir);
+
+      // Assert
+      expect(result.workflows).toBeDefined();
+      const workflow = result.workflows!.find((w) => w.featureId === featureId);
+      expect(workflow).toBeDefined();
+      expect(workflow!.nativeTeamCleanup).toBeDefined();
+      expect(workflow!.nativeTeamCleanup).toContain('Orphaned native team detected');
+      expect(workflow!.nativeTeamCleanup).toContain(featureId);
+      expect(workflow!.nativeTeamCleanup).toContain('TeamDelete');
+    });
+
+    it('should not warn when native team exists and workflow is in delegation phase', async () => {
+      // Arrange — workflow in delegate phase + native team
+      const featureId = 'team-in-delegate';
+      const stateData = createValidStateFile({
+        featureId,
+        phase: 'delegate',
+      });
+      await fs.writeFile(
+        path.join(tmpDir, `${featureId}.state.json`),
+        JSON.stringify(stateData, null, 2),
+      );
+
+      const teamDir = path.join(teamsDir, featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({
+          members: [{ name: 'agent-1', role: 'teammate' }],
+        }),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir, teamsDir);
+
+      // Assert
+      expect(result.workflows).toBeDefined();
+      const workflow = result.workflows!.find((w) => w.featureId === featureId);
+      expect(workflow).toBeDefined();
+      expect(workflow!.nativeTeamCleanup).toBeUndefined();
+    });
+
+    it('should warn about orphaned team when team exists but no workflow found', async () => {
+      // Arrange — native team directory exists, but no workflow state file
+      const featureId = 'orphaned-team-no-workflow';
+      const teamDir = path.join(teamsDir, featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({
+          members: [{ name: 'agent-orphan', role: 'teammate' }],
+        }),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir, teamsDir);
+
+      // Assert — should have a workflow entry for the orphaned team warning
+      expect(result.orphanedTeams).toBeDefined();
+      expect(result.orphanedTeams).toHaveLength(1);
+      expect(result.orphanedTeams![0]).toContain(featureId);
+      expect(result.orphanedTeams![0]).toContain('TeamDelete');
+    });
+
+    it('should not produce warnings when no native teams exist', async () => {
+      // Arrange — workflow exists but no team directories
+      const featureId = 'no-team-feature';
+      const stateData = createValidStateFile({
+        featureId,
+        phase: 'review',
+      });
+      await fs.writeFile(
+        path.join(tmpDir, `${featureId}.state.json`),
+        JSON.stringify(stateData, null, 2),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir, teamsDir);
+
+      // Assert
+      expect(result.workflows).toBeDefined();
+      const workflow = result.workflows!.find((w) => w.featureId === featureId);
+      expect(workflow).toBeDefined();
+      expect(workflow!.nativeTeamCleanup).toBeUndefined();
+      expect(result.orphanedTeams).toBeUndefined();
+    });
+
+    it('should include cleanup for synthesize phase workflow with native team', async () => {
+      // Arrange
+      const featureId = 'synth-team';
+      const stateData = createValidStateFile({
+        featureId,
+        phase: 'synthesize',
+      });
+      await fs.writeFile(
+        path.join(tmpDir, `${featureId}.state.json`),
+        JSON.stringify(stateData, null, 2),
+      );
+
+      const teamDir = path.join(teamsDir, featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({
+          members: [{ name: 'agent-synth', role: 'teammate' }],
+        }),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir, teamsDir);
+
+      // Assert
+      expect(result.workflows).toBeDefined();
+      const workflow = result.workflows!.find((w) => w.featureId === featureId);
+      expect(workflow).toBeDefined();
+      expect(workflow!.nativeTeamCleanup).toBeDefined();
+      expect(workflow!.nativeTeamCleanup).toContain('Orphaned native team detected');
+    });
+
+    it('should not warn for overhaul-delegate phase workflow with native team', async () => {
+      // Arrange — refactor workflow in overhaul-delegate phase (delegation active)
+      const featureId = 'overhaul-delegate-team';
+      const stateData = createValidStateFile({
+        featureId,
+        workflowType: 'refactor',
+        phase: 'overhaul-delegate',
+      });
+      await fs.writeFile(
+        path.join(tmpDir, `${featureId}.state.json`),
+        JSON.stringify(stateData, null, 2),
+      );
+
+      const teamDir = path.join(teamsDir, featureId);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({
+          members: [{ name: 'agent-overhaul', role: 'teammate' }],
+        }),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir, teamsDir);
+
+      // Assert
+      expect(result.workflows).toBeDefined();
+      const workflow = result.workflows!.find((w) => w.featureId === featureId);
+      expect(workflow).toBeDefined();
+      expect(workflow!.nativeTeamCleanup).toBeUndefined();
+    });
+
+    it('should detect orphaned teams from flat file format too', async () => {
+      // Arrange — flat file format team + workflow past delegation
+      const featureId = 'flat-file-team';
+      const stateData = createValidStateFile({
+        featureId,
+        phase: 'review',
+      });
+      await fs.writeFile(
+        path.join(tmpDir, `${featureId}.state.json`),
+        JSON.stringify(stateData, null, 2),
+      );
+
+      await fs.writeFile(
+        path.join(teamsDir, `${featureId}.json`),
+        JSON.stringify({
+          members: [{ name: 'flat-agent', role: 'teammate' }],
+        }),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir, teamsDir);
+
+      // Assert
+      expect(result.workflows).toBeDefined();
+      const workflow = result.workflows!.find((w) => w.featureId === featureId);
+      expect(workflow).toBeDefined();
+      expect(workflow!.nativeTeamCleanup).toBeDefined();
+      expect(workflow!.nativeTeamCleanup).toContain('Orphaned native team detected');
     });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.ts
@@ -263,8 +263,9 @@ async function listNativeTeamFeatureIds(teamsDir: string): Promise<string[]> {
 
 /**
  * Annotate workflows with native team cleanup recommendations.
- * Mutates the workflow objects in place by adding nativeTeamCleanup field
- * for workflows that are past the delegation phase but still have a native team.
+ * Replaces array elements with new WorkflowInfo objects containing the
+ * nativeTeamCleanup field for workflows past the delegation phase
+ * that still have a native team directory.
  */
 async function annotateNativeTeamCleanup(
   workflows: WorkflowInfo[],

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.ts
@@ -26,6 +26,12 @@ interface RecoveryInfo {
   readonly remainingTasks: number;
 }
 
+/** Info about a detected native Agent Teams directory. */
+export interface NativeTeamInfo {
+  readonly memberNames: ReadonlyArray<string>;
+  readonly memberCount: number;
+}
+
 /** A discovered workflow for the session-start response. */
 interface WorkflowInfo {
   readonly featureId: string;
@@ -34,11 +40,13 @@ interface WorkflowInfo {
   readonly nextAction: string;
   readonly tasks?: ReadonlyArray<{ id: string; status: string; title: string }>;
   readonly recovery?: RecoveryInfo;
+  readonly nativeTeamCleanup?: string;
 }
 
 /** Result from the session-start command. */
 export interface SessionStartResult extends CommandResult {
   readonly workflows?: ReadonlyArray<WorkflowInfo>;
+  readonly orphanedTeams?: ReadonlyArray<string>;
 }
 
 // ─── Terminal Phases ────────────────────────────────────────────────────────
@@ -143,7 +151,184 @@ function detectOrphanedTeam(
   };
 }
 
+// ─── Native Team Directory Detection ────────────────────────────────────────
+
+/**
+ * Try to parse a team config from raw JSON content.
+ * Returns a NativeTeamInfo if the config has a non-empty members array,
+ * or null if the content is malformed or has no members.
+ */
+function parseTeamConfig(raw: string): NativeTeamInfo | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  const obj = parsed as Record<string, unknown>;
+  if (!Array.isArray(obj.members) || obj.members.length === 0) return null;
+
+  const memberNames: string[] = [];
+  for (const member of obj.members) {
+    if (!member || typeof member !== 'object') continue;
+    const m = member as Record<string, unknown>;
+    if (typeof m.name === 'string') {
+      memberNames.push(m.name);
+    }
+  }
+
+  if (memberNames.length === 0) return null;
+
+  return {
+    memberNames,
+    memberCount: memberNames.length,
+  };
+}
+
+/**
+ * Detect a native Agent Teams directory for a given featureId.
+ *
+ * Checks two formats:
+ * 1. Directory format: `{teamsDir}/{featureId}/config.json`
+ * 2. Flat file format: `{teamsDir}/{featureId}.json`
+ *
+ * Directory format takes precedence. Returns NativeTeamInfo with member
+ * names and count, or null if no valid team config is found.
+ */
+export async function detectNativeTeam(
+  featureId: string,
+  teamsDir: string,
+): Promise<NativeTeamInfo | null> {
+  // Try directory format first: {teamsDir}/{featureId}/config.json
+  const dirConfigPath = path.join(teamsDir, featureId, 'config.json');
+  try {
+    const raw = await fs.readFile(dirConfigPath, 'utf-8');
+    const info = parseTeamConfig(raw);
+    if (info) return info;
+  } catch {
+    // File doesn't exist or is unreadable — fall through to flat file format
+  }
+
+  // Try flat file format: {teamsDir}/{featureId}.json
+  const flatFilePath = path.join(teamsDir, `${featureId}.json`);
+  try {
+    const raw = await fs.readFile(flatFilePath, 'utf-8');
+    return parseTeamConfig(raw);
+  } catch {
+    // File doesn't exist or is unreadable
+    return null;
+  }
+}
+
+/**
+ * List all feature IDs that have native team directories or files.
+ * Scans the teamsDir for both directory-format and flat-file-format teams.
+ */
+async function listNativeTeamFeatureIds(teamsDir: string): Promise<string[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(teamsDir);
+  } catch {
+    return [];
+  }
+
+  const featureIds = new Set<string>();
+
+  for (const entry of entries) {
+    // Flat file: {featureId}.json
+    if (entry.endsWith('.json')) {
+      featureIds.add(entry.replace(/\.json$/, ''));
+      continue;
+    }
+
+    // Directory: {featureId}/config.json — check if it's a directory
+    const entryPath = path.join(teamsDir, entry);
+    try {
+      const stat = await fs.stat(entryPath);
+      if (stat.isDirectory()) {
+        featureIds.add(entry);
+      }
+    } catch {
+      // Skip unreadable entries
+    }
+  }
+
+  return [...featureIds];
+}
+
 // ─── Handler ────────────────────────────────────────────────────────────────
+
+/**
+ * Annotate workflows with native team cleanup recommendations.
+ * Mutates the workflow objects in place by adding nativeTeamCleanup field
+ * for workflows that are past the delegation phase but still have a native team.
+ */
+async function annotateNativeTeamCleanup(
+  workflows: WorkflowInfo[],
+  teamsDir: string,
+): Promise<void> {
+  for (let i = 0; i < workflows.length; i++) {
+    const workflow = workflows[i];
+    const teamInfo = await detectNativeTeam(workflow.featureId, teamsDir);
+    if (!teamInfo) continue;
+
+    // If the workflow is in a delegation phase, the team is expected — no warning
+    if (DELEGATE_PHASES.has(workflow.phase)) continue;
+
+    // Workflow is past delegation but team still exists — recommend cleanup
+    workflows[i] = {
+      ...workflow,
+      nativeTeamCleanup: `Orphaned native team detected for ${workflow.featureId} (${teamInfo.memberCount} member(s): ${teamInfo.memberNames.join(', ')}). Run TeamDelete to clean up.`,
+    };
+  }
+}
+
+/**
+ * Detect native team directories that have no corresponding workflow.
+ * Returns cleanup recommendation strings for each orphaned team.
+ */
+async function detectOrphanedTeamsWithoutWorkflows(
+  workflowFeatureIds: Set<string>,
+  teamsDir: string,
+): Promise<string[]> {
+  const allTeamIds = await listNativeTeamFeatureIds(teamsDir);
+  const orphaned: string[] = [];
+
+  for (const teamId of allTeamIds) {
+    if (workflowFeatureIds.has(teamId)) continue;
+
+    const teamInfo = await detectNativeTeam(teamId, teamsDir);
+    if (!teamInfo) continue;
+
+    orphaned.push(
+      `Orphaned native team detected for ${teamId} (${teamInfo.memberCount} member(s): ${teamInfo.memberNames.join(', ')}). No active workflow found. Run TeamDelete to clean up.`,
+    );
+  }
+
+  return orphaned;
+}
+
+/**
+ * Apply native team detection to a set of workflows and return the final result.
+ * Handles both per-workflow cleanup annotations and orphaned team detection.
+ */
+async function applyNativeTeamDetection(
+  workflows: WorkflowInfo[],
+  teamsDir: string,
+): Promise<SessionStartResult> {
+  await annotateNativeTeamCleanup(workflows, teamsDir);
+
+  const allWorkflowIds = new Set(workflows.map((w) => w.featureId));
+  const orphanedTeams = await detectOrphanedTeamsWithoutWorkflows(allWorkflowIds, teamsDir);
+
+  if (workflows.length === 0 && orphanedTeams.length === 0) return {};
+  if (workflows.length === 0) return { orphanedTeams };
+  if (orphanedTeams.length > 0) return { workflows, orphanedTeams };
+  return { workflows };
+}
 
 /**
  * Handle the `session-start` CLI command.
@@ -152,10 +337,14 @@ function detectOrphanedTeam(
  * 1. If checkpoint files exist, return their resume context (and delete them).
  * 2. If no checkpoints, scan for active (non-terminal) workflow state files.
  * 3. If nothing found, return silently (no error, no workflows).
+ *
+ * Additionally, when teamsDir is provided, checks for orphaned native Agent
+ * Teams directories and includes cleanup recommendations.
  */
 export async function handleSessionStart(
   _stdinData: Record<string, unknown>,
   stateDir: string,
+  teamsDir?: string,
 ): Promise<SessionStartResult> {
   // Step 1: Check for checkpoint files (highest priority)
   const checkpoints = await readAndDeleteCheckpoints(stateDir);
@@ -194,6 +383,7 @@ export async function handleSessionStart(
       // Non-critical: if listing fails, we still have checkpoint data
     }
 
+    if (teamsDir) return applyNativeTeamDetection(workflows, teamsDir);
     return { workflows };
   }
 
@@ -204,10 +394,7 @@ export async function handleSessionStart(
       (entry) => !TERMINAL_PHASES.has(entry.state.phase),
     );
 
-    if (activeWorkflows.length === 0) {
-      // Silent: no active workflows
-      return {};
-    }
+    if (activeWorkflows.length === 0 && !teamsDir) return {};
 
     const workflows: WorkflowInfo[] = activeWorkflows.map((entry) => ({
       featureId: entry.featureId,
@@ -216,9 +403,12 @@ export async function handleSessionStart(
       nextAction: `WAIT:in-progress:${entry.state.phase}`,
     }));
 
+    if (teamsDir) return applyNativeTeamDetection(workflows, teamsDir);
+    if (workflows.length === 0) return {};
     return { workflows };
   } catch {
-    // If state dir doesn't exist or is unreadable, silent return
+    // If state dir doesn't exist or is unreadable, still check for orphaned teams
+    if (teamsDir) return applyNativeTeamDetection([], teamsDir);
     return {};
   }
 }

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli.ts
@@ -5,6 +5,8 @@
 // All hook scripts call: node dist/cli.js <command>
 // JSON is piped via stdin, JSON result is written to stdout.
 
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { handlePreCompact } from './cli-commands/pre-compact.js';
 import { handleSessionStart } from './cli-commands/session-start.js';
 import { handleGuard } from './cli-commands/guard.js';
@@ -44,7 +46,7 @@ function isKnownCommand(command: string): command is KnownCommand {
 
 const commandHandlers: Record<KnownCommand, CommandHandler> = {
   'pre-compact': async (stdinData) => handlePreCompact(stdinData, resolveStateDir()),
-  'session-start': async (stdinData) => handleSessionStart(stdinData, resolveStateDir()),
+  'session-start': async (stdinData) => handleSessionStart(stdinData, resolveStateDir(), path.join(os.homedir(), '.claude', 'teams')),
   'guard': handleGuard,
   'task-gate': handleTaskGate,
   'teammate-gate': handleTeammateGate,


### PR DESCRIPTION
## Summary

Add native Agent Teams directory detection to the SessionStart hook. The new `detectNativeTeam()` function reads team config from both directory format (`~/.claude/teams/{featureId}/config.json`) and flat file format (`~/.claude/teams/{featureId}.json`). When a team exists but the workflow has moved past the delegation phase, a cleanup recommendation is included in the session start output.

## Changes

- **`detectNativeTeam()`** — New exported function that tries directory format first, then flat file format. Uses a `parseTeamConfig()` helper with proper type guards. Returns `NativeTeamInfo` (member names + count) or null.
- **`handleSessionStart()` enhanced** — Accepts optional `teamsDir` parameter. When provided, annotates workflows past delegation with `nativeTeamCleanup` recommendations. Also detects fully orphaned teams (team exists, no workflow) via `orphanedTeams` result field.
- **Refactored** — Extracted `applyNativeTeamDetection()` to deduplicate native team checking across all code paths (checkpoint, state file discovery, error fallback).

## Test Plan

- [x] `detectNativeTeam` — directory format returns team info
- [x] `detectNativeTeam` — flat file format returns team info
- [x] `detectNativeTeam` — missing dir returns null
- [x] `detectNativeTeam` — empty/malformed config returns null
- [x] `detectNativeTeam` — empty members array returns null
- [x] `detectNativeTeam` — directory format preferred over flat file
- [x] `handleSessionStart` — orphaned team past delegation gets cleanup recommendation
- [x] `handleSessionStart` — active delegation phase produces no warning
- [x] `handleSessionStart` — orphaned team with no workflow detected
- [x] `handleSessionStart` — no false positives when no teams exist
- [x] All 1255 MCP server tests pass, typecheck clean

---

35 tests (15 new), 0 failures. `npm run test:run` and `tsc --noEmit` both clean.