### PR TITLE
feat: add native correlation fields, event schemas, and batch_append action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Exarchos is local agent governance for Claude Code. It provides event-sourced SD
 Single server at `plugins/exarchos/servers/exarchos-mcp/` exposing 5 composite tools:
 
 - **exarchos_workflow** — HSM-based workflow lifecycle (init/get/set/cancel)
-- **exarchos_event** — Append-only JSONL event store with 31 event types
+- **exarchos_event** — Append-only JSONL event store with 32 event types
 - **exarchos_orchestrate** — Agent team spawn/message/shutdown + task claim/complete/fail
 - **exarchos_view** — CQRS materialized views (pipeline, tasks, workflow status, team status, stack, telemetry)
 - **exarchos_sync** — Remote sync (stub)

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -358,7 +358,7 @@ describe('StackEnqueuedData', () => {
 // ─── EventTypes Discriminated Union (A03) ───────────────────────────────────
 
 describe('EventTypes', () => {
-  it('should contain all 30 event types', () => {
+  it('should contain all 32 event types', () => {
     expect(EventTypes).toHaveLength(32);
   });
 
@@ -751,7 +751,4 @@ describe('Dead event types removed', () => {
     }
   });
 
-  it('should have exactly 30 event types', () => {
-    expect(EventTypes).toHaveLength(32);
-  });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -359,7 +359,7 @@ describe('StackEnqueuedData', () => {
 
 describe('EventTypes', () => {
   it('should contain all 30 event types', () => {
-    expect(EventTypes).toHaveLength(30);
+    expect(EventTypes).toHaveLength(32);
   });
 
   it('should include workflow-level types', () => {
@@ -752,6 +752,6 @@ describe('Dead event types removed', () => {
   });
 
   it('should have exactly 30 event types', () => {
-    expect(EventTypes).toHaveLength(30);
+    expect(EventTypes).toHaveLength(32);
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/schemas.test.ts
@@ -580,6 +580,75 @@ describe('Workflow State Schemas', () => {
       const result = TaskSchema.safeParse(task);
       expect(result.success).toBe(false);
     });
+
+    it('TaskSchema_WithNativeTaskId_AcceptsOptionalString', () => {
+      const task = {
+        id: 'task-001',
+        title: 'Implement schemas',
+        status: 'pending',
+        nativeTaskId: 'abc',
+      };
+      const result = TaskSchema.safeParse(task);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.nativeTaskId).toBe('abc');
+      }
+    });
+
+    it('TaskSchema_WithTeammateName_AcceptsOptionalString', () => {
+      const task = {
+        id: 'task-001',
+        title: 'Implement schemas',
+        status: 'pending',
+        teammateName: 'worker-1',
+      };
+      const result = TaskSchema.safeParse(task);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.teammateName).toBe('worker-1');
+      }
+    });
+
+    it('TaskSchema_WithBlockedBy_AcceptsStringArray', () => {
+      const task = {
+        id: 'task-001',
+        title: 'Implement schemas',
+        status: 'pending',
+        blockedBy: ['task-001'],
+      };
+      const result = TaskSchema.safeParse(task);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.blockedBy).toEqual(['task-001']);
+      }
+    });
+
+    it('TaskSchema_WithBlockedBy_DefaultsToEmptyArray', () => {
+      const task = {
+        id: 'task-001',
+        title: 'Implement schemas',
+        status: 'pending',
+      };
+      const result = TaskSchema.safeParse(task);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.blockedBy).toEqual([]);
+      }
+    });
+
+    it('TaskSchema_WithWorktreePath_AcceptsOptionalString', () => {
+      const task = {
+        id: 'task-001',
+        title: 'Implement schemas',
+        status: 'pending',
+        worktreePath: '/path/.worktrees/foo',
+      };
+      const result = TaskSchema.safeParse(task);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.worktreePath).toBe('/path/.worktrees/foo');
+      }
+    });
   });
 
   describe('WorktreeSchema', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/composite.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/composite.test.ts
@@ -99,7 +99,7 @@ describe('handleEvent', () => {
         success: false,
         error: {
           code: 'UNKNOWN_ACTION',
-          message: 'Unknown action: delete. Valid actions: append, query',
+          message: 'Unknown action: delete. Valid actions: append, query, batch_append',
         },
       });
       expect(handleEventAppend).not.toHaveBeenCalled();

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/composite.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/composite.ts
@@ -1,7 +1,7 @@
 import type { ToolResult } from '../format.js';
-import { handleEventAppend, handleEventQuery } from './tools.js';
+import { handleEventAppend, handleEventQuery, handleBatchAppend } from './tools.js';
 
-const VALID_ACTIONS = ['append', 'query'] as const;
+const VALID_ACTIONS = ['append', 'query', 'batch_append'] as const;
 type EventAction = (typeof VALID_ACTIONS)[number];
 
 /** Composite handler that routes `action` to the appropriate event-store handler. */
@@ -23,6 +23,13 @@ export async function handleEvent(
       const { action: _, ...rest } = args;
       return handleEventQuery(
         rest as Parameters<typeof handleEventQuery>[0],
+        stateDir,
+      );
+    }
+    case 'batch_append': {
+      const { action: _, ...rest } = args;
+      return handleBatchAppend(
+        rest as Parameters<typeof handleBatchAppend>[0],
         stateDir,
       );
     }

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -154,7 +154,7 @@ describe('Team Event Data Schemas', () => {
 });
 
 describe('EventTypes', () => {
-  it('should include all 6 team event types', () => {
+  it('should include all 8 team event types', () => {
     const teamEventTypes = [
       'team.spawned',
       'team.task.assigned',
@@ -162,6 +162,8 @@ describe('EventTypes', () => {
       'team.task.failed',
       'team.disbanded',
       'team.context.injected',
+      'team.task.planned',
+      'team.teammate.dispatched',
     ];
     for (const eventType of teamEventTypes) {
       expect(EventTypes).toContain(eventType);

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -3,12 +3,15 @@ import {
   validateAgentEvent,
   AGENT_EVENT_TYPES,
   EventTypes,
+  WorkflowEventBase,
   TeamSpawnedData,
   TeamTaskAssignedData,
   TeamTaskCompletedData,
   TeamTaskFailedData,
   TeamDisbandedData,
   TeamContextInjectedData,
+  TeamTaskPlannedData,
+  TeamTeammateDispatchedData,
 } from './schemas.js';
 
 describe('validateAgentEvent', () => {
@@ -163,5 +166,99 @@ describe('EventTypes', () => {
     for (const eventType of teamEventTypes) {
       expect(EventTypes).toContain(eventType);
     }
+  });
+});
+
+// ─── Task 002: team.task.planned and team.teammate.dispatched ────────────────
+
+describe('TeamTaskPlannedData', () => {
+  it('EventSchema_TeamTaskPlanned_ValidatesPayload', () => {
+    const result = TeamTaskPlannedData.safeParse({
+      taskId: 'task-001',
+      title: 'Implement event store',
+      modules: ['event-store', 'schemas'],
+      blockedBy: ['task-000'],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.taskId).toBe('task-001');
+      expect(result.data.title).toBe('Implement event store');
+      expect(result.data.modules).toEqual(['event-store', 'schemas']);
+      expect(result.data.blockedBy).toEqual(['task-000']);
+    }
+  });
+
+  it('EventSchema_TeamTaskPlanned_RejectsWithoutTaskId', () => {
+    const result = TeamTaskPlannedData.safeParse({
+      title: 'Implement event store',
+      modules: ['event-store'],
+      blockedBy: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('EventSchema_TeamTaskPlanned_IncludedInEventTypeUnion', () => {
+    expect(EventTypes).toContain('team.task.planned');
+  });
+
+  it('EventSchema_TeamTaskPlanned_ParsesAsBaseEvent', () => {
+    const event = WorkflowEventBase.safeParse({
+      streamId: 'my-workflow',
+      sequence: 1,
+      type: 'team.task.planned',
+      data: {
+        taskId: 'task-001',
+        title: 'Implement event store',
+        modules: ['event-store'],
+        blockedBy: [],
+      },
+    });
+    expect(event.success).toBe(true);
+  });
+});
+
+describe('TeamTeammateDispatchedData', () => {
+  it('EventSchema_TeamTeammateDispatched_ValidatesPayload', () => {
+    const result = TeamTeammateDispatchedData.safeParse({
+      teammateName: 'worker-1',
+      worktreePath: '/path/.worktrees/wt-001',
+      assignedTaskIds: ['task-001', 'task-002'],
+      model: 'claude-sonnet-4-20250514',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.teammateName).toBe('worker-1');
+      expect(result.data.worktreePath).toBe('/path/.worktrees/wt-001');
+      expect(result.data.assignedTaskIds).toEqual(['task-001', 'task-002']);
+      expect(result.data.model).toBe('claude-sonnet-4-20250514');
+    }
+  });
+
+  it('EventSchema_TeamTeammateDispatched_RejectsWithoutTeammateName', () => {
+    const result = TeamTeammateDispatchedData.safeParse({
+      worktreePath: '/path/.worktrees/wt-001',
+      assignedTaskIds: ['task-001'],
+      model: 'claude-sonnet-4-20250514',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('EventSchema_TeamTeammateDispatched_IncludedInEventTypeUnion', () => {
+    expect(EventTypes).toContain('team.teammate.dispatched');
+  });
+
+  it('EventSchema_TeamTeammateDispatched_ParsesAsBaseEvent', () => {
+    const event = WorkflowEventBase.safeParse({
+      streamId: 'my-workflow',
+      sequence: 1,
+      type: 'team.teammate.dispatched',
+      data: {
+        teammateName: 'worker-1',
+        worktreePath: '/tmp/wt',
+        assignedTaskIds: ['task-001'],
+        model: 'claude-sonnet-4-20250514',
+      },
+    });
+    expect(event.success).toBe(true);
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -33,6 +33,8 @@ export const EventTypes = [
   'team.task.failed',
   'team.disbanded',
   'team.context.injected',
+  'team.task.planned',
+  'team.teammate.dispatched',
 ] as const;
 
 export type EventType = typeof EventTypes[number];
@@ -271,6 +273,20 @@ export const TeamContextInjectedData = z.object({
   historicalHints: z.array(z.string()),
 });
 
+export const TeamTaskPlannedData = z.object({
+  taskId: z.string(),
+  title: z.string(),
+  modules: z.array(z.string()),
+  blockedBy: z.array(z.string()),
+});
+
+export const TeamTeammateDispatchedData = z.object({
+  teammateName: z.string(),
+  worktreePath: z.string(),
+  assignedTaskIds: z.array(z.string()),
+  model: z.string(),
+});
+
 // ─── TypeScript Types ───────────────────────────────────────────────────────
 
 export type WorkflowEvent = z.infer<typeof WorkflowEventBase>;
@@ -304,6 +320,8 @@ export type TeamTaskCompleted = z.infer<typeof TeamTaskCompletedData>;
 export type TeamTaskFailed = z.infer<typeof TeamTaskFailedData>;
 export type TeamDisbanded = z.infer<typeof TeamDisbandedData>;
 export type TeamContextInjected = z.infer<typeof TeamContextInjectedData>;
+export type TeamTaskPlanned = z.infer<typeof TeamTaskPlannedData>;
+export type TeamTeammateDispatched = z.infer<typeof TeamTeammateDispatchedData>;
 
 // ─── Agent Event Validation ──────────────────────────────────────────────────
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
@@ -124,8 +124,6 @@ export class EventStore {
         if (cached) return cached;
       }
 
-      const filePath = this.getEventFilePath(streamId);
-
       // Initialize sequence from file if not cached
       if (!this.sequenceCounters.has(streamId)) {
         await this.initializeSequence(streamId);
@@ -153,42 +151,116 @@ export class EventStore {
         idempotencyKey: options?.idempotencyKey,
       });
 
-      // Ensure directory exists
-      await fs.mkdir(path.dirname(filePath), { recursive: true });
-
-      // Append as JSONL
-      await fs.appendFile(filePath, JSON.stringify(fullEvent) + '\n', 'utf-8');
-
-      // Write sequence counter atomically (best-effort: JSONL is source of truth)
-      const seqPath = this.getSeqFilePath(streamId);
-      const tmpPath = `${seqPath}.tmp`;
-      try {
-        await fs.writeFile(tmpPath, JSON.stringify({ sequence }), 'utf-8');
-        await fs.rename(tmpPath, seqPath);
-      } catch {
-        // Best-effort: JSONL is source of truth, .seq is just a cache
-        await fs.rm(tmpPath, { force: true }).catch(() => {});
-        await fs.rm(seqPath, { force: true }).catch(() => {});
-      }
-
-      // Cache the idempotency key after successful append
-      if (options?.idempotencyKey) {
-        let streamCache = this.idempotencyCache.get(streamId);
-        if (!streamCache) {
-          streamCache = new Map();
-          this.idempotencyCache.set(streamId, streamCache);
-        }
-        streamCache.set(options.idempotencyKey, fullEvent);
-
-        // FIFO eviction: remove oldest key when cache exceeds max
-        if (streamCache.size > EventStore.MAX_IDEMPOTENCY_KEYS) {
-          const oldest = streamCache.keys().next().value;
-          if (oldest) streamCache.delete(oldest);
-        }
-      }
+      await this.writeEvents(streamId, [fullEvent]);
+      this.cacheIdempotencyKey(streamId, fullEvent);
 
       return fullEvent;
     });
+  }
+
+  async batchAppend(
+    streamId: string,
+    events: Array<Partial<Omit<WorkflowEvent, 'sequence' | 'streamId'>> & { type: string; idempotencyKey?: string }>,
+  ): Promise<WorkflowEvent[]> {
+    return this.withLock(streamId, async () => {
+      // Rebuild idempotency cache if any event has an idempotency key
+      const hasIdempotencyKeys = events.some(e => e.idempotencyKey);
+      if (hasIdempotencyKeys && !this.idempotencyCacheInitialized.has(streamId)) {
+        await this.rebuildIdempotencyCache(streamId);
+      }
+
+      // Initialize sequence from file if not cached
+      if (!this.sequenceCounters.has(streamId)) {
+        await this.initializeSequence(streamId);
+      }
+
+      // Phase 1: Validate all events before writing any (atomic: all-or-nothing)
+      const toAppend: WorkflowEvent[] = [];
+      let nextSequence = (this.sequenceCounters.get(streamId) ?? 0) + 1;
+
+      for (const event of events) {
+        // Idempotency dedup within batch and against cache
+        if (event.idempotencyKey) {
+          const streamCache = this.idempotencyCache.get(streamId);
+          const cached = streamCache?.get(event.idempotencyKey);
+          if (cached) continue;
+
+          // Also check within this batch's toAppend list
+          const alreadyInBatch = toAppend.some(e => e.idempotencyKey === event.idempotencyKey);
+          if (alreadyInBatch) continue;
+        }
+
+        const fullEvent = WorkflowEventBase.parse({
+          ...event,
+          streamId,
+          sequence: nextSequence,
+          timestamp: event.timestamp || new Date().toISOString(),
+          idempotencyKey: event.idempotencyKey,
+        });
+        toAppend.push(fullEvent);
+        nextSequence++;
+      }
+
+      // Phase 2: Write all validated events in a single append
+      if (toAppend.length > 0) {
+        await this.writeEvents(streamId, toAppend);
+        for (const fullEvent of toAppend) {
+          this.cacheIdempotencyKey(streamId, fullEvent);
+        }
+      }
+
+      return toAppend;
+    });
+  }
+
+  // ─── Shared Helpers ────────────────────────────────────────────────────────
+
+  /** Writes events to JSONL and updates the .seq counter file. */
+  private async writeEvents(streamId: string, events: WorkflowEvent[]): Promise<void> {
+    if (events.length === 0) return;
+
+    const filePath = this.getEventFilePath(streamId);
+
+    // Ensure directory exists
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+
+    // Append as JSONL
+    const lines = events.map(e => JSON.stringify(e)).join('\n') + '\n';
+    await fs.appendFile(filePath, lines, 'utf-8');
+
+    // Update in-memory sequence counter
+    const finalSequence = events[events.length - 1].sequence;
+    this.sequenceCounters.set(streamId, finalSequence);
+
+    // Write sequence counter atomically (best-effort: JSONL is source of truth)
+    const seqPath = this.getSeqFilePath(streamId);
+    const tmpPath = `${seqPath}.tmp`;
+    try {
+      await fs.writeFile(tmpPath, JSON.stringify({ sequence: finalSequence }), 'utf-8');
+      await fs.rename(tmpPath, seqPath);
+    } catch {
+      // Best-effort: JSONL is source of truth, .seq is just a cache
+      await fs.rm(tmpPath, { force: true }).catch(() => {});
+      await fs.rm(seqPath, { force: true }).catch(() => {});
+    }
+  }
+
+  /** Caches an event's idempotency key with FIFO eviction. */
+  private cacheIdempotencyKey(streamId: string, event: WorkflowEvent): void {
+    if (!event.idempotencyKey) return;
+
+    let streamCache = this.idempotencyCache.get(streamId);
+    if (!streamCache) {
+      streamCache = new Map();
+      this.idempotencyCache.set(streamId, streamCache);
+    }
+    streamCache.set(event.idempotencyKey, event);
+
+    // FIFO eviction: remove oldest key when cache exceeds max
+    if (streamCache.size > EventStore.MAX_IDEMPOTENCY_KEYS) {
+      const oldest = streamCache.keys().next().value;
+      if (oldest) streamCache.delete(oldest);
+    }
   }
 
   async query(streamId: string, filters?: QueryFilters): Promise<WorkflowEvent[]> {

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/store.ts
@@ -176,6 +176,7 @@ export class EventStore {
 
       // Phase 1: Validate all events before writing any (atomic: all-or-nothing)
       const toAppend: WorkflowEvent[] = [];
+      const batchKeys = new Set<string>();
       let nextSequence = (this.sequenceCounters.get(streamId) ?? 0) + 1;
 
       for (const event of events) {
@@ -185,9 +186,9 @@ export class EventStore {
           const cached = streamCache?.get(event.idempotencyKey);
           if (cached) continue;
 
-          // Also check within this batch's toAppend list
-          const alreadyInBatch = toAppend.some(e => e.idempotencyKey === event.idempotencyKey);
-          if (alreadyInBatch) continue;
+          // Also check within this batch (O(1) Set lookup)
+          if (batchKeys.has(event.idempotencyKey)) continue;
+          batchKeys.add(event.idempotencyKey);
         }
 
         const fullEvent = WorkflowEventBase.parse({

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.test.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { EventStore } from './store.js';
-import { handleEventQuery, resetModuleEventStore } from './tools.js';
+import { handleEventQuery, handleBatchAppend, resetModuleEventStore } from './tools.js';
 
 let tempDir: string;
 
@@ -103,5 +103,165 @@ describe('handleEventQuery field projection', () => {
     expect(projected[0]).toHaveProperty('sequence');
     expect(projected[0]).toHaveProperty('streamId');
     expect(projected[0]).toHaveProperty('timestamp');
+  });
+});
+
+// ─── Task 003: batch_append action ───────────────────────────────────────────
+
+describe('handleBatchAppend', () => {
+  it('batchAppend_MultipleEvents_AppendsAllWithSequentialSequenceNumbers', async () => {
+    // Arrange: seed the stream with one event so we start from sequence 1
+    const store = new EventStore(tempDir);
+    await store.append('my-workflow', { type: 'workflow.started' });
+
+    // Act: batch append 3 events
+    const result = await handleBatchAppend(
+      {
+        stream: 'my-workflow',
+        events: [
+          { type: 'task.assigned', data: { taskId: 't1' } },
+          { type: 'task.assigned', data: { taskId: 't2' } },
+          { type: 'task.assigned', data: { taskId: 't3' } },
+        ],
+      },
+      tempDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    const sequences = result.data as Array<{ streamId: string; sequence: number; type: string }>;
+    expect(sequences).toHaveLength(3);
+    expect(sequences[0].sequence).toBe(2);
+    expect(sequences[1].sequence).toBe(3);
+    expect(sequences[2].sequence).toBe(4);
+
+    // Verify all events exist in the stream
+    const queryResult = await handleEventQuery({ stream: 'my-workflow' }, tempDir);
+    expect(queryResult.success).toBe(true);
+    expect(queryResult.data).toHaveLength(4);
+  });
+
+  it('batchAppend_EmptyArray_ReturnsError', async () => {
+    const result = await handleBatchAppend(
+      {
+        stream: 'my-workflow',
+        events: [],
+      },
+      tempDir,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('INVALID_INPUT');
+  });
+
+  it('batchAppend_IdempotencyKey_DeduplicatesAcrossBatch', async () => {
+    const result = await handleBatchAppend(
+      {
+        stream: 'my-workflow',
+        events: [
+          { type: 'task.assigned', data: { taskId: 't1' }, idempotencyKey: 'key-dup' },
+          { type: 'task.assigned', data: { taskId: 't2' }, idempotencyKey: 'key-dup' },
+        ],
+      },
+      tempDir,
+    );
+
+    expect(result.success).toBe(true);
+    const sequences = result.data as Array<{ streamId: string; sequence: number; type: string }>;
+    // Only 1 event should be appended — the second is a duplicate
+    expect(sequences).toHaveLength(1);
+
+    // Verify only 1 event in stream
+    const queryResult = await handleEventQuery({ stream: 'my-workflow' }, tempDir);
+    expect(queryResult.success).toBe(true);
+    expect(queryResult.data).toHaveLength(1);
+  });
+
+  it('batchAppend_ValidationFailure_AtomicRollback', async () => {
+    // Arrange: seed the stream
+    const store = new EventStore(tempDir);
+    await store.append('my-workflow', { type: 'workflow.started' });
+
+    // Act: batch with 1 invalid event (missing type)
+    const result = await handleBatchAppend(
+      {
+        stream: 'my-workflow',
+        events: [
+          { type: 'task.assigned', data: { taskId: 't1' } },
+          { type: 'INVALID_TYPE_DOES_NOT_EXIST' as string, data: {} },
+          { type: 'task.assigned', data: { taskId: 't3' } },
+        ],
+      },
+      tempDir,
+    );
+
+    // Assert: entire batch fails
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+
+    // Verify no new events were appended (only the seed event)
+    const queryResult = await handleEventQuery({ stream: 'my-workflow' }, tempDir);
+    expect(queryResult.success).toBe(true);
+    expect(queryResult.data).toHaveLength(1);
+  });
+
+  it('batchAppend_ConcurrentWrite_RespectsStreamLock', async () => {
+    // Arrange: two concurrent batch appends on the same stream
+    const batch1 = handleBatchAppend(
+      {
+        stream: 'my-workflow',
+        events: [
+          { type: 'task.assigned', data: { taskId: 'a1' } },
+          { type: 'task.assigned', data: { taskId: 'a2' } },
+          { type: 'task.assigned', data: { taskId: 'a3' } },
+        ],
+      },
+      tempDir,
+    );
+
+    const batch2 = handleBatchAppend(
+      {
+        stream: 'my-workflow',
+        events: [
+          { type: 'task.completed', data: { taskId: 'b1' } },
+          { type: 'task.completed', data: { taskId: 'b2' } },
+          { type: 'task.completed', data: { taskId: 'b3' } },
+        ],
+      },
+      tempDir,
+    );
+
+    // Act: run both concurrently
+    const [result1, result2] = await Promise.all([batch1, batch2]);
+
+    // Assert: both succeed
+    expect(result1.success).toBe(true);
+    expect(result2.success).toBe(true);
+
+    // Total 6 events, with sequential sequence numbers (no gaps, no interleaving)
+    const queryResult = await handleEventQuery({ stream: 'my-workflow' }, tempDir);
+    expect(queryResult.success).toBe(true);
+    const events = queryResult.data as Array<{ sequence: number; type: string }>;
+    expect(events).toHaveLength(6);
+
+    // Verify sequential numbering
+    for (let i = 0; i < events.length; i++) {
+      expect(events[i].sequence).toBe(i + 1);
+    }
+
+    // Verify no interleaving: events from each batch should be contiguous
+    const batch1Seqs = (result1.data as Array<{ sequence: number }>).map(e => e.sequence);
+    const batch2Seqs = (result2.data as Array<{ sequence: number }>).map(e => e.sequence);
+
+    // One batch should have sequences 1,2,3 and the other 4,5,6
+    const allSeqs = [...batch1Seqs, ...batch2Seqs].sort((a, b) => a - b);
+    expect(allSeqs).toEqual([1, 2, 3, 4, 5, 6]);
+
+    // Each batch's sequences should be contiguous (no interleaving)
+    expect(batch1Seqs[1] - batch1Seqs[0]).toBe(1);
+    expect(batch1Seqs[2] - batch1Seqs[1]).toBe(1);
+    expect(batch2Seqs[1] - batch2Seqs[0]).toBe(1);
+    expect(batch2Seqs[2] - batch2Seqs[1]).toBe(1);
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
@@ -92,6 +92,73 @@ export async function handleEventAppend(
   }
 }
 
+// ─── Batch Append Handler ───────────────────────────────────────────────────
+
+/** Handles the event batch_append tool: validates all events upfront, appends atomically, and returns EventAck[]. */
+export async function handleBatchAppend(
+  args: {
+    stream: string;
+    events: Array<Record<string, unknown>>;
+  },
+  stateDir: string,
+): Promise<ToolResult> {
+  if (!args.stream) {
+    return {
+      success: false,
+      error: { code: 'INVALID_INPUT', message: 'stream is required' },
+    };
+  }
+
+  if (!args.events || args.events.length === 0) {
+    return {
+      success: false,
+      error: { code: 'INVALID_INPUT', message: 'events array must be non-empty' },
+    };
+  }
+
+  // Validate all events have a type before passing to store
+  for (let i = 0; i < args.events.length; i++) {
+    const eventType = args.events[i]?.type as EventType | undefined;
+    if (!eventType) {
+      return {
+        success: false,
+        error: { code: 'INVALID_INPUT', message: `events[${i}].type is required` },
+      };
+    }
+  }
+
+  const store = getStore(stateDir);
+
+  try {
+    const storeEvents = args.events.map((event) => ({
+      type: event.type as string,
+      data: event.data as Record<string, unknown> | undefined,
+      correlationId: event.correlationId as string | undefined,
+      causationId: event.causationId as string | undefined,
+      agentId: event.agentId as string | undefined,
+      agentRole: event.agentRole as string | undefined,
+      source: event.source as string | undefined,
+      timestamp: event.timestamp as string | undefined,
+      idempotencyKey: event.idempotencyKey as string | undefined,
+    }));
+
+    const appended = await store.batchAppend(args.stream, storeEvents);
+
+    return {
+      success: true,
+      data: appended.map(toEventAck),
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: {
+        code: 'BATCH_APPEND_FAILED',
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+}
+
 // ─── Event Query Handler ────────────────────────────────────────────────────
 
 /** Handles the event_query tool: validates input, queries events with optional filters and pagination. */

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
@@ -132,14 +132,14 @@ export async function handleBatchAppend(
   try {
     const storeEvents = args.events.map((event) => ({
       type: event.type as string,
-      data: event.data as Record<string, unknown> | undefined,
-      correlationId: event.correlationId as string | undefined,
-      causationId: event.causationId as string | undefined,
-      agentId: event.agentId as string | undefined,
-      agentRole: event.agentRole as string | undefined,
-      source: event.source as string | undefined,
-      timestamp: event.timestamp as string | undefined,
-      idempotencyKey: event.idempotencyKey as string | undefined,
+      ...(event.data !== undefined && { data: event.data as Record<string, unknown> }),
+      ...(event.correlationId !== undefined && { correlationId: event.correlationId as string }),
+      ...(event.causationId !== undefined && { causationId: event.causationId as string }),
+      ...(event.agentId !== undefined && { agentId: event.agentId as string }),
+      ...(event.agentRole !== undefined && { agentRole: event.agentRole as string }),
+      ...(event.source !== undefined && { source: event.source as string }),
+      ...(event.timestamp !== undefined && { timestamp: event.timestamp as string }),
+      ...(event.idempotencyKey !== undefined && { idempotencyKey: event.idempotencyKey as string }),
     }));
 
     const appended = await store.batchAppend(args.stream, storeEvents);

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/tools.ts
@@ -131,7 +131,7 @@ export async function handleBatchAppend(
 
   try {
     const storeEvents = args.events.map((event) => ({
-      type: event.type as string,
+      type: event.type as EventType,
       ...(event.data !== undefined && { data: event.data as Record<string, unknown> }),
       ...(event.correlationId !== undefined && { correlationId: event.correlationId as string }),
       ...(event.causationId !== undefined && { causationId: event.causationId as string }),

--- a/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
@@ -310,6 +310,16 @@ const eventActions: readonly ToolAction[] = [
     phases: ALL_PHASES,
     roles: ROLE_ANY,
   },
+  {
+    name: 'batch_append',
+    description: 'Append multiple events to a stream atomically',
+    schema: z.object({
+      stream: z.string().min(1),
+      events: z.array(coercedRecord()),
+    }),
+    phases: DELEGATE_PHASES,
+    roles: ROLE_LEAD,
+  },
 ];
 
 // ─── Composite Tool: exarchos_orchestrate ───────────────────────────────────

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/schemas.ts
@@ -123,6 +123,10 @@ export const TaskSchema = z.object({
   branch: z.string().optional(),
   startedAt: z.string().datetime().optional(),
   completedAt: z.string().datetime().optional(),
+  nativeTaskId: z.string().optional(),
+  teammateName: z.string().optional(),
+  blockedBy: z.array(z.string()).default([]),
+  worktreePath: z.string().optional(),
 });
 
 // ─── Worktree Schema ────────────────────────────────────────────────────────


### PR DESCRIPTION
Task 001: Extend WorkflowTask schema with nativeTaskId, teammateName,
blockedBy, and worktreePath fields for native Agent Teams correlation.

Task 002: Add team.task.planned and team.teammate.dispatched event types
with typed data schemas to the event store discriminated union.

Task 003: Add batch_append action to exarchos_event composite tool with
atomic all-or-nothing semantics, per-event idempotency dedup, and stream
lock acquisition. Refactored EventStore to extract shared writeEvents and
cacheIdempotencyKey helpers.