### PR TITLE
feat: add verify-delegation-saga.sh validation script

### DIFF
--- a/scripts/verify-delegation-saga.sh
+++ b/scripts/verify-delegation-saga.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# verify-delegation-saga.sh — Verify saga step ordering in delegation event streams
+# Reads a JSONL event file and validates that delegation saga events appear in correct order.
+#
+# Usage: verify-delegation-saga.sh --feature-id <id> [--state-dir <path>]
+#
+# Exit codes:
+#   0 = valid saga (or no team events to validate)
+#   1 = violations found
+#   2 = usage error (missing args, no event file, empty stream)
+
+set -euo pipefail
+
+# ============================================================
+# ARGUMENT PARSING
+# ============================================================
+
+FEATURE_ID=""
+STATE_DIR="${HOME}/.claude/workflow-state"
+
+usage() {
+    cat >&2 << 'USAGE'
+Usage: verify-delegation-saga.sh --feature-id <id> [--state-dir <path>]
+
+Required:
+  --feature-id <id>    Feature identifier (used to locate events JSONL file)
+
+Optional:
+  --state-dir <path>   Directory containing event files (default: ~/.claude/workflow-state/)
+  --help               Show this help message
+
+Exit codes:
+  0  Valid saga ordering (or no team events to validate)
+  1  Saga ordering violations found
+  2  Usage error (missing args, no event file, empty stream)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --feature-id)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --feature-id requires a value" >&2
+                exit 2
+            fi
+            FEATURE_ID="$2"
+            shift 2
+            ;;
+        --state-dir)
+            if [[ -z "${2:-}" ]]; then
+                echo "Error: --state-dir requires a path argument" >&2
+                exit 2
+            fi
+            STATE_DIR="$2"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "$FEATURE_ID" ]]; then
+    echo "Error: --feature-id is required" >&2
+    usage
+    exit 2
+fi
+
+# ============================================================
+# DEPENDENCY CHECK
+# ============================================================
+
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required but not installed" >&2
+    exit 2
+fi
+
+# ============================================================
+# LOCATE EVENT FILE
+# ============================================================
+
+EVENT_FILE="${STATE_DIR}/${FEATURE_ID}.events.jsonl"
+
+if [[ ! -f "$EVENT_FILE" ]]; then
+    echo "Error: Event file not found: $EVENT_FILE" >&2
+    exit 2
+fi
+
+# Check for empty file
+if [[ ! -s "$EVENT_FILE" ]]; then
+    echo "Error: Event file is empty: $EVENT_FILE" >&2
+    exit 2
+fi
+
+# ============================================================
+# EXTRACT TEAM EVENTS
+# ============================================================
+
+# Filter to only team.* events, preserving order
+TEAM_EVENTS="$(jq -c 'select(.type | startswith("team."))' "$EVENT_FILE")"
+
+# If no team events exist, nothing to validate — exit clean
+if [[ -z "$TEAM_EVENTS" ]]; then
+    echo "No team events found in event stream. Skipping saga validation."
+    exit 0
+fi
+
+# ============================================================
+# VALIDATION STATE
+# ============================================================
+
+VIOLATIONS=()
+HAS_SPAWNED=false
+HAS_PLANNED=false
+HAS_DISBANDED=false
+DISBANDED_SEQUENCE=0
+
+# Track planned task IDs
+declare -a PLANNED_TASK_IDS=()
+
+# Track dispatched task IDs (from assignedTaskIds)
+declare -a DISPATCHED_TASK_IDS=()
+
+# ============================================================
+# RULE VALIDATION — Process events in sequence order
+# ============================================================
+
+while IFS= read -r event; do
+    event_type="$(echo "$event" | jq -r '.type')"
+    event_seq="$(echo "$event" | jq -r '.sequence')"
+
+    case "$event_type" in
+        team.spawned)
+            HAS_SPAWNED=true
+            ;;
+
+        team.task.planned)
+            # Rule 1: team.spawned must appear before any team.task.planned
+            if [[ "$HAS_SPAWNED" != true ]]; then
+                VIOLATIONS+=("VIOLATION: team.task.planned (seq $event_seq) appeared before team.spawned")
+            fi
+
+            # Rule 4: team.disbanded must be the last team event
+            if [[ "$HAS_DISBANDED" == true ]]; then
+                VIOLATIONS+=("VIOLATION: team.task.planned (seq $event_seq) appeared after team.disbanded (seq $DISBANDED_SEQUENCE)")
+            fi
+
+            # Track planned task ID
+            task_id="$(echo "$event" | jq -r '.data.taskId')"
+            PLANNED_TASK_IDS+=("$task_id")
+            HAS_PLANNED=true
+            ;;
+
+        team.teammate.dispatched)
+            # Rule 1: team.spawned must appear before dispatch
+            if [[ "$HAS_SPAWNED" != true ]]; then
+                VIOLATIONS+=("VIOLATION: team.teammate.dispatched (seq $event_seq) appeared before team.spawned")
+            fi
+
+            # Rule 2: team.task.planned must appear before any team.teammate.dispatched
+            if [[ "$HAS_PLANNED" != true ]]; then
+                VIOLATIONS+=("VIOLATION: team.teammate.dispatched (seq $event_seq) appeared before any team.task.planned")
+            fi
+
+            # Rule 4: team.disbanded must be the last team event
+            if [[ "$HAS_DISBANDED" == true ]]; then
+                VIOLATIONS+=("VIOLATION: team.teammate.dispatched (seq $event_seq) appeared after team.disbanded (seq $DISBANDED_SEQUENCE)")
+            fi
+
+            # Track dispatched task IDs for coverage check
+            while IFS= read -r tid; do
+                DISPATCHED_TASK_IDS+=("$tid")
+            done < <(echo "$event" | jq -r '.data.assignedTaskIds[]')
+            ;;
+
+        team.disbanded)
+            HAS_DISBANDED=true
+            DISBANDED_SEQUENCE="$event_seq"
+            ;;
+
+        # Other team.* events — no specific rules yet, but check disbanded constraint
+        team.*)
+            if [[ "$HAS_DISBANDED" == true && "$event_type" != "team.disbanded" ]]; then
+                VIOLATIONS+=("VIOLATION: $event_type (seq $event_seq) appeared after team.disbanded (seq $DISBANDED_SEQUENCE)")
+            fi
+            ;;
+    esac
+done <<< "$TEAM_EVENTS"
+
+# ============================================================
+# RULE 3: All dispatched task IDs must have been planned
+# ============================================================
+
+if [[ ${#DISPATCHED_TASK_IDS[@]} -gt 0 ]]; then
+    for dispatched_id in "${DISPATCHED_TASK_IDS[@]}"; do
+        found=false
+        if [[ ${#PLANNED_TASK_IDS[@]} -gt 0 ]]; then
+            for planned_id in "${PLANNED_TASK_IDS[@]}"; do
+                if [[ "$dispatched_id" == "$planned_id" ]]; then
+                    found=true
+                    break
+                fi
+            done
+        fi
+        if [[ "$found" != true ]]; then
+            VIOLATIONS+=("VIOLATION: Dispatched task '$dispatched_id' was never planned (no team.task.planned event with this taskId)")
+        fi
+    done
+fi
+
+# ============================================================
+# OUTPUT AND EXIT
+# ============================================================
+
+if [[ ${#VIOLATIONS[@]} -gt 0 ]]; then
+    echo "Delegation saga validation FAILED for feature '$FEATURE_ID':"
+    echo ""
+    for v in "${VIOLATIONS[@]}"; do
+        echo "  $v"
+    done
+    echo ""
+    echo "${#VIOLATIONS[@]} violation(s) found."
+    exit 1
+fi
+
+echo "Delegation saga validation PASSED for feature '$FEATURE_ID'."
+exit 0

--- a/scripts/verify-delegation-saga.sh
+++ b/scripts/verify-delegation-saga.sh
@@ -151,9 +151,10 @@ while IFS= read -r event; do
                 VIOLATIONS+=("VIOLATION: team.task.planned (seq $event_seq) appeared after team.disbanded (seq $DISBANDED_SEQUENCE)")
             fi
 
-            # Track planned task ID
-            task_id="$(echo "$event" | jq -r '.data.taskId')"
-            PLANNED_TASK_IDS+=("$task_id")
+            # Track planned task IDs — support both single taskId and batched taskIds[]
+            while IFS= read -r tid; do
+                PLANNED_TASK_IDS+=("$tid")
+            done < <(echo "$event" | jq -r '(.data.taskIds // [])[] // empty, (.data.taskId // empty)')
             HAS_PLANNED=true
             ;;
 
@@ -173,10 +174,10 @@ while IFS= read -r event; do
                 VIOLATIONS+=("VIOLATION: team.teammate.dispatched (seq $event_seq) appeared after team.disbanded (seq $DISBANDED_SEQUENCE)")
             fi
 
-            # Track dispatched task IDs for coverage check
+            # Track dispatched task IDs for coverage check (safe on missing/null field)
             while IFS= read -r tid; do
                 DISPATCHED_TASK_IDS+=("$tid")
-            done < <(echo "$event" | jq -r '.data.assignedTaskIds[]')
+            done < <(echo "$event" | jq -r '(.data.assignedTaskIds // [])[]')
             ;;
 
         team.disbanded)
@@ -186,7 +187,7 @@ while IFS= read -r event; do
 
         # Other team.* events — no specific rules yet, but check disbanded constraint
         team.*)
-            if [[ "$HAS_DISBANDED" == true && "$event_type" != "team.disbanded" ]]; then
+            if [[ "$HAS_DISBANDED" == true ]]; then
                 VIOLATIONS+=("VIOLATION: $event_type (seq $event_seq) appeared after team.disbanded (seq $DISBANDED_SEQUENCE)")
             fi
             ;;
@@ -219,15 +220,21 @@ fi
 # ============================================================
 
 if [[ ${#VIOLATIONS[@]} -gt 0 ]]; then
-    echo "Delegation saga validation FAILED for feature '$FEATURE_ID':"
+    echo "## Delegation Saga Validation"
+    echo ""
+    echo "**Status:** FAILED for feature \`$FEATURE_ID\`"
+    echo ""
+    echo "### Violations"
     echo ""
     for v in "${VIOLATIONS[@]}"; do
-        echo "  $v"
+        echo "- $v"
     done
     echo ""
-    echo "${#VIOLATIONS[@]} violation(s) found."
+    echo "**Total:** ${#VIOLATIONS[@]} violation(s) found."
     exit 1
 fi
 
-echo "Delegation saga validation PASSED for feature '$FEATURE_ID'."
+echo "## Delegation Saga Validation"
+echo ""
+echo "**Status:** PASSED for feature \`$FEATURE_ID\`"
 exit 0

--- a/scripts/verify-delegation-saga.test.sh
+++ b/scripts/verify-delegation-saga.test.sh
@@ -27,6 +27,7 @@ fail() {
 # ============================================================
 
 TMPDIR_ROOT=""
+STATE_DIR=""
 
 setup() {
     TMPDIR_ROOT="$(mktemp -d)"
@@ -272,6 +273,66 @@ if echo "$OUTPUT" | grep -qi "team.disbanded"; then
     pass "DisbandedNotLast_OutputMentionsViolation"
 else
     fail "DisbandedNotLast_OutputMentionsViolation (output does not mention team.disbanded)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 12: Batched taskIds[] in planned event — dispatched tasks covered -> exit 0
+# --------------------------------------------------
+setup
+write_events "batched-taskids" \
+    '{"streamId":"batched-taskids","sequence":1,"timestamp":"2026-02-18T00:00:00.000Z","type":"team.spawned","data":{"teamSize":1,"taskCount":3,"dispatchMode":"agent-team"}}' \
+    '{"streamId":"batched-taskids","sequence":2,"timestamp":"2026-02-18T00:00:01.000Z","type":"team.task.planned","data":{"taskIds":["task-A","task-B","task-C"],"title":"Batched plan","modules":["core"],"blockedBy":[]}}' \
+    '{"streamId":"batched-taskids","sequence":3,"timestamp":"2026-02-18T00:00:02.000Z","type":"team.teammate.dispatched","data":{"teammateName":"worker-1","worktreePath":"/path/wt1","assignedTaskIds":["task-A","task-B","task-C"],"model":"opus"}}'
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --feature-id batched-taskids --state-dir "$STATE_DIR" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "BatchedTaskIds_PlannedArray_ExitsZero"
+else
+    fail "BatchedTaskIds_PlannedArray_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 13: Batched taskIds[] with unplanned dispatch -> exit 1
+# --------------------------------------------------
+setup
+write_events "batched-taskids-unplanned" \
+    '{"streamId":"batched-taskids-unplanned","sequence":1,"timestamp":"2026-02-18T00:00:00.000Z","type":"team.spawned","data":{"teamSize":1,"taskCount":2,"dispatchMode":"agent-team"}}' \
+    '{"streamId":"batched-taskids-unplanned","sequence":2,"timestamp":"2026-02-18T00:00:01.000Z","type":"team.task.planned","data":{"taskIds":["task-A","task-B"],"title":"Batched plan","modules":["core"],"blockedBy":[]}}' \
+    '{"streamId":"batched-taskids-unplanned","sequence":3,"timestamp":"2026-02-18T00:00:02.000Z","type":"team.teammate.dispatched","data":{"teammateName":"worker-1","worktreePath":"/path/wt1","assignedTaskIds":["task-A","task-X"],"model":"opus"}}'
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --feature-id batched-taskids-unplanned --state-dir "$STATE_DIR" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "BatchedTaskIds_UnplannedDispatch_ExitsOne"
+else
+    fail "BatchedTaskIds_UnplannedDispatch_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+if echo "$OUTPUT" | grep -q "task-X"; then
+    pass "BatchedTaskIds_OutputMentionsUnplannedTaskId"
+else
+    fail "BatchedTaskIds_OutputMentionsUnplannedTaskId (output does not mention task-X)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 14: Missing assignedTaskIds field in dispatch — no crash -> exit 0
+# --------------------------------------------------
+setup
+write_events "missing-assigned" \
+    '{"streamId":"missing-assigned","sequence":1,"timestamp":"2026-02-18T00:00:00.000Z","type":"team.spawned","data":{"teamSize":1,"taskCount":1,"dispatchMode":"agent-team"}}' \
+    '{"streamId":"missing-assigned","sequence":2,"timestamp":"2026-02-18T00:00:01.000Z","type":"team.task.planned","data":{"taskId":"task-001","title":"Schema extension","modules":["workflow"],"blockedBy":[]}}' \
+    '{"streamId":"missing-assigned","sequence":3,"timestamp":"2026-02-18T00:00:02.000Z","type":"team.teammate.dispatched","data":{"teammateName":"worker-1","worktreePath":"/path/wt1","model":"opus"}}'
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --feature-id missing-assigned --state-dir "$STATE_DIR" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "MissingAssignedTaskIds_NoCrash_ExitsZero"
+else
+    fail "MissingAssignedTaskIds_NoCrash_ExitsZero (exit=$EXIT_CODE, expected 0)"
     echo "  Output: $OUTPUT"
 fi
 teardown

--- a/scripts/verify-delegation-saga.test.sh
+++ b/scripts/verify-delegation-saga.test.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# verify-delegation-saga.test.sh — Tests for verify-delegation-saga.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/verify-delegation-saga.sh"
+PASS=0
+FAIL=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAIL=$((FAIL + 1))
+}
+
+# ============================================================
+# TEST FIXTURES
+# ============================================================
+
+TMPDIR_ROOT=""
+
+setup() {
+    TMPDIR_ROOT="$(mktemp -d)"
+    STATE_DIR="$TMPDIR_ROOT/workflow-state"
+    mkdir -p "$STATE_DIR"
+}
+
+teardown() {
+    if [[ -n "$TMPDIR_ROOT" && -d "$TMPDIR_ROOT" ]]; then
+        rm -rf "$TMPDIR_ROOT"
+    fi
+}
+
+# Helper: write events to a JSONL file for a given feature-id
+write_events() {
+    local feature_id="$1"
+    shift
+    local file="$STATE_DIR/${feature_id}.events.jsonl"
+    for event in "$@"; do
+        echo "$event" >> "$file"
+    done
+}
+
+# ============================================================
+# TEST CASES
+# ============================================================
+
+echo "=== Verify Delegation Saga Tests ==="
+echo ""
+
+# --------------------------------------------------
+# Test 1: Valid saga — full lifecycle (spawned -> planned x N -> dispatched x N -> disbanded) -> exit 0
+# --------------------------------------------------
+setup
+write_events "valid-saga" \
+    '{"streamId":"valid-saga","sequence":1,"timestamp":"2026-02-18T00:00:00.000Z","type":"team.spawned","data":{"teamSize":2,"taskCount":2,"dispatchMode":"agent-team"}}' \
+    '{"streamId":"valid-saga","sequence":2,"timestamp":"2026-02-18T00:00:01.000Z","type":"team.task.planned","data":{"taskId":"task-001","title":"Schema extension","modules":["workflow"],"blockedBy":[]}}' \
+    '{"streamId":"valid-saga","sequence":3,"timestamp":"2026-02-18T00:00:02.000Z","type":"team.task.planned","data":{"taskId":"task-002","title":"API changes","modules":["api"],"blockedBy":["task-001"]}}' \
+    '{"streamId":"valid-saga","sequence":4,"timestamp":"2026-02-18T00:00:03.000Z","type":"team.teammate.dispatched","data":{"teammateName":"worker-1","worktreePath":"/path/wt1","assignedTaskIds":["task-001"],"model":"opus"}}' \
+    '{"streamId":"valid-saga","sequence":5,"timestamp":"2026-02-18T00:00:04.000Z","type":"team.teammate.dispatched","data":{"teammateName":"worker-2","worktreePath":"/path/wt2","assignedTaskIds":["task-002"],"model":"opus"}}' \
+    '{"streamId":"valid-saga","sequence":6,"timestamp":"2026-02-18T00:00:05.000Z","type":"team.disbanded","data":{"reason":"all tasks complete"}}'
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --feature-id valid-saga --state-dir "$STATE_DIR" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "ValidSaga_FullLifecycle_ExitsZero"
+else
+    fail "ValidSaga_FullLifecycle_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 2: Missing team.spawned before team.task.planned -> exit 1
+# --------------------------------------------------
+setup
+write_events "missing-spawn" \
+    '{"streamId":"missing-spawn","sequence":1,"timestamp":"2026-02-18T00:00:00.000Z","type":"team.task.planned","data":{"taskId":"task-001","title":"Schema extension","modules":["workflow"],"blockedBy":[]}}' \
+    '{"streamId":"missing-spawn","sequence":2,"timestamp":"2026-02-18T00:00:01.000Z","type":"team.teammate.dispatched","data":{"teammateName":"worker-1","worktreePath":"/path/wt1","assignedTaskIds":["task-001"],"model":"opus"}}'
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --feature-id missing-spawn --state-dir "$STATE_DIR" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "MissingSpawn_BeforePlanned_ExitsOne"
+else
+    fail "MissingSpawn_BeforePlanned_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+# Verify output mentions the violation
+if echo "$OUTPUT" | grep -qi "team.spawned"; then
+    pass "MissingSpawn_OutputMentionsViolation"
+else
+    fail "MissingSpawn_OutputMentionsViolation (output does not mention team.spawned)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 3: Missing team.task.planned before team.teammate.dispatched -> exit 1
+# --------------------------------------------------
+setup
+write_events "missing-plan" \
+    '{"streamId":"missing-plan","sequence":1,"timestamp":"2026-02-18T00:00:00.000Z","type":"team.spawned","data":{"teamSize":1,"taskCount":1,"dispatchMode":"agent-team"}}' \
+    '{"streamId":"missing-plan","sequence":2,"timestamp":"2026-02-18T00:00:01.000Z","type":"team.teammate.dispatched","data":{"teammateName":"worker-1","worktreePath":"/path/wt1","assignedTaskIds":["task-001"],"model":"opus"}}'
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --feature-id missing-plan --state-dir "$STATE_DIR" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "MissingPlan_BeforeDispatched_ExitsOne"
+else
+    fail "MissingPlan_BeforeDispatched_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+# Verify output mentions the violation
+if echo "$OUTPUT" | grep -qi "team.task.planned"; then
+    pass "MissingPlan_OutputMentionsViolation"
+else
+    fail "MissingPlan_OutputMentionsViolation (output does not mention team.task.planned)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 4: Batched team.task.planned events validate correctly -> exit 0
+# --------------------------------------------------
+setup
+write_events "batched-plans" \
+    '{"streamId":"batched-plans","sequence":1,"timestamp":"2026-02-18T00:00:00.000Z","type":"team.spawned","data":{"teamSize":3,"taskCount":4,"dispatchMode":"agent-team"}}' \
+    '{"streamId":"batched-plans","sequence":2,"timestamp":"2026-02-18T00:00:01.000Z","type":"team.task.planned","data":{"taskId":"task-001","title":"Types","modules":["types"],"blockedBy":[]}}' \
+    '{"streamId":"batched-plans","sequence":3,"timestamp":"2026-02-18T00:00:01.100Z","type":"team.task.planned","data":{"taskId":"task-002","title":"API","modules":["api"],"blockedBy":[]}}' \
+    '{"streamId":"batched-plans","sequence":4,"timestamp":"2026-02-18T00:00:01.200Z","type":"team.task.planned","data":{"taskId":"task-003","title":"Tests","modules":["test"],"blockedBy":["task-001"]}}' \
+    '{"streamId":"batched-plans","sequence":5,"timestamp":"2026-02-18T00:00:01.300Z","type":"team.task.planned","data":{"taskId":"task-004","title":"Docs","modules":["docs"],"blockedBy":[]}}' \
+    '{"streamId":"batched-plans","sequence":6,"timestamp":"2026-02-18T00:00:02.000Z","type":"team.teammate.dispatched","data":{"teammateName":"worker-1","worktreePath":"/path/wt1","assignedTaskIds":["task-001","task-003"],"model":"opus"}}' \
+    '{"streamId":"batched-plans","sequence":7,"timestamp":"2026-02-18T00:00:03.000Z","type":"team.teammate.dispatched","data":{"teammateName":"worker-2","worktreePath":"/path/wt2","assignedTaskIds":["task-002"],"model":"opus"}}' \
+    '{"streamId":"batched-plans","sequence":8,"timestamp":"2026-02-18T00:00:04.000Z","type":"team.teammate.dispatched","data":{"teammateName":"worker-3","worktreePath":"/path/wt3","assignedTaskIds":["task-004"],"model":"opus"}}'
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --feature-id batched-plans --state-dir "$STATE_DIR" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "BatchedPlans_SequentialSequences_ExitsZero"
+else
+    fail "BatchedPlans_SequentialSequences_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 5: Empty event stream -> exit 2
+# --------------------------------------------------
+setup
+# Create an empty JSONL file
+touch "$STATE_DIR/empty-stream.events.jsonl"
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --feature-id empty-stream --state-dir "$STATE_DIR" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "EmptyEventStream_ExitsTwo"
+else
+    fail "EmptyEventStream_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 6: No team events at all (only workflow events) -> exit 0
+# --------------------------------------------------
+setup
+write_events "no-team-events" \
+    '{"streamId":"no-team-events","sequence":1,"timestamp":"2026-02-18T00:00:00.000Z","type":"workflow.started","data":{"featureId":"no-team-events","workflow":"feature"}}' \
+    '{"streamId":"no-team-events","sequence":2,"timestamp":"2026-02-18T00:00:01.000Z","type":"workflow.transition","data":{"from":"planning","to":"delegating"}}'
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --feature-id no-team-events --state-dir "$STATE_DIR" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "NoTeamEvents_WorkflowOnly_ExitsZero"
+else
+    fail "NoTeamEvents_WorkflowOnly_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 7: Valid partial saga (spawned + planned but no dispatched yet) -> exit 0
+# --------------------------------------------------
+setup
+write_events "partial-saga" \
+    '{"streamId":"partial-saga","sequence":1,"timestamp":"2026-02-18T00:00:00.000Z","type":"team.spawned","data":{"teamSize":2,"taskCount":2,"dispatchMode":"agent-team"}}' \
+    '{"streamId":"partial-saga","sequence":2,"timestamp":"2026-02-18T00:00:01.000Z","type":"team.task.planned","data":{"taskId":"task-001","title":"Schema extension","modules":["workflow"],"blockedBy":[]}}' \
+    '{"streamId":"partial-saga","sequence":3,"timestamp":"2026-02-18T00:00:02.000Z","type":"team.task.planned","data":{"taskId":"task-002","title":"API changes","modules":["api"],"blockedBy":[]}}'
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --feature-id partial-saga --state-dir "$STATE_DIR" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "PartialSaga_SpawnedAndPlanned_ExitsZero"
+else
+    fail "PartialSaga_SpawnedAndPlanned_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 8: Usage error — missing feature-id -> exit 2
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "UsageError_MissingFeatureId_ExitsTwo"
+else
+    fail "UsageError_MissingFeatureId_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 9: Usage error — event file does not exist -> exit 2
+# --------------------------------------------------
+setup
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --feature-id nonexistent --state-dir "$STATE_DIR" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "UsageError_NoEventFile_ExitsTwo"
+else
+    fail "UsageError_NoEventFile_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 10: Unplanned task in dispatch — dispatched task-id not in planned events -> exit 1
+# --------------------------------------------------
+setup
+write_events "unplanned-dispatch" \
+    '{"streamId":"unplanned-dispatch","sequence":1,"timestamp":"2026-02-18T00:00:00.000Z","type":"team.spawned","data":{"teamSize":1,"taskCount":1,"dispatchMode":"agent-team"}}' \
+    '{"streamId":"unplanned-dispatch","sequence":2,"timestamp":"2026-02-18T00:00:01.000Z","type":"team.task.planned","data":{"taskId":"task-001","title":"Schema extension","modules":["workflow"],"blockedBy":[]}}' \
+    '{"streamId":"unplanned-dispatch","sequence":3,"timestamp":"2026-02-18T00:00:02.000Z","type":"team.teammate.dispatched","data":{"teammateName":"worker-1","worktreePath":"/path/wt1","assignedTaskIds":["task-001","task-999"],"model":"opus"}}'
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --feature-id unplanned-dispatch --state-dir "$STATE_DIR" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "UnplannedDispatch_TaskNotPlanned_ExitsOne"
+else
+    fail "UnplannedDispatch_TaskNotPlanned_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+# Verify output mentions the unplanned task
+if echo "$OUTPUT" | grep -q "task-999"; then
+    pass "UnplannedDispatch_OutputMentionsTaskId"
+else
+    fail "UnplannedDispatch_OutputMentionsTaskId (output does not mention task-999)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 11: team.disbanded not last team event -> exit 1
+# --------------------------------------------------
+setup
+write_events "disbanded-not-last" \
+    '{"streamId":"disbanded-not-last","sequence":1,"timestamp":"2026-02-18T00:00:00.000Z","type":"team.spawned","data":{"teamSize":1,"taskCount":1,"dispatchMode":"agent-team"}}' \
+    '{"streamId":"disbanded-not-last","sequence":2,"timestamp":"2026-02-18T00:00:01.000Z","type":"team.task.planned","data":{"taskId":"task-001","title":"Schema","modules":["workflow"],"blockedBy":[]}}' \
+    '{"streamId":"disbanded-not-last","sequence":3,"timestamp":"2026-02-18T00:00:02.000Z","type":"team.disbanded","data":{"reason":"complete"}}' \
+    '{"streamId":"disbanded-not-last","sequence":4,"timestamp":"2026-02-18T00:00:03.000Z","type":"team.teammate.dispatched","data":{"teammateName":"worker-1","worktreePath":"/path/wt1","assignedTaskIds":["task-001"],"model":"opus"}}'
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --feature-id disbanded-not-last --state-dir "$STATE_DIR" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "DisbandedNotLast_TeamEventAfter_ExitsOne"
+else
+    fail "DisbandedNotLast_TeamEventAfter_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+if echo "$OUTPUT" | grep -qi "team.disbanded"; then
+    pass "DisbandedNotLast_OutputMentionsViolation"
+else
+    fail "DisbandedNotLast_OutputMentionsViolation (output does not mention team.disbanded)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "=== Test Summary ==="
+echo -e "Passed: ${GREEN}$PASS${NC}"
+echo -e "Failed: ${RED}$FAIL${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

Adds a new validation script that verifies saga step ordering in delegation event streams. The script reads JSONL event files and validates that delegation saga events (`team.spawned`, `team.task.planned`, `team.teammate.dispatched`, `team.disbanded`) appear in the correct causal order.

## Changes

- **`scripts/verify-delegation-saga.sh`** -- Reads `{state-dir}/{feature-id}.events.jsonl` and enforces four ordering rules: spawned-before-planned, planned-before-dispatched, all dispatched tasks must have been planned, and disbanded must be the last team event. Handles batched planned events and partial (in-progress) sagas gracefully. Exit codes: 0 (valid), 1 (violations), 2 (usage error).
- **`scripts/verify-delegation-saga.test.sh`** -- 11 test cases covering valid full/partial sagas, missing spawned/planned violations, batched events, empty streams, non-team-event streams, unplanned dispatch detection, and disbanded-not-last detection. 15 assertions total.

## Test Plan

- [x] RED: Tests written first, verified all 15 assertions fail (script missing)
- [x] GREEN: Implementation created, all 15 assertions pass
- [x] REFACTOR: Fixed empty-array handling under `set -u`, tests stay green
- [x] Run: `bash scripts/verify-delegation-saga.test.sh` -- 15/15 pass

---

Generated with [Claude Code](https://claude.com/claude-code)