### PR TITLE
feat: delegation skill event-first saga and implementer prompt update

### DIFF
--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -68,17 +68,193 @@ Task({
 - Complex coordination between tasks
 - Interactive development sessions
 
-**Mechanism:** Orchestrator delegates to named teammates via natural language
+**Mechanism:** Event-first delegation saga. Every coordination action is preceded by an Exarchos event emission. The event stream is the authoritative record; native API calls are side effects.
 
-**Dispatch flow:**
-1. Orchestrator creates an agent team with N teammates (one per parallel group)
-2. Each teammate gets a worktree path in its spawn prompt
-3. Orchestrator activates delegate mode (coordination only — no direct code)
-4. Teammates self-coordinate via shared task list
-5. `TeammateIdle` hook (see State Bridge section below) runs quality gates; updates Exarchos workflow state
-6. Orchestrator synthesizes results when all teammates finish
+**Architectural principle:** Events record intent. Native API calls execute effects.
 
-**CRITICAL:** Ensure your session is using the opus model for coding tasks. All teammates inherit the session model — use Task tool dispatch if you need per-task model selection.
+#### Delegation Saga (6 Steps)
+
+The dispatch follows a saga pattern with compensable, pivot, and retryable transactions.
+
+**Step 1: Create Team** (COMPENSABLE)
+
+```
+# Emit event (source of truth)
+exarchos_event append:
+  stream: {featureId}
+  event:
+    type: "team.spawned"
+    teamName: {featureId}
+    teamSize: {N}
+    taskCount: {M}
+    dispatchMode: "agent-team"
+
+# Execute side effect
+TeamCreate:
+  team_name: {featureId}
+  description: "SDLC delegation for {featureId}"
+```
+
+Idempotency: before retrying, check if `~/.claude/teams/{featureId}/` already exists.
+
+**Step 2: Create Native Tasks** (COMPENSABLE)
+
+Emit ALL task planning events in a single batched call (1 MCP call instead of N):
+
+```
+# Emit ALL task events in one batch (source of truth)
+exarchos_event batch_append:
+  stream: {featureId}
+  events:
+    - type: "team.task.planned"
+      taskId: "task-001"
+      title: {task.title}
+      modules: {task.files}
+      blockedBy: {task.blockedBy}
+    - type: "team.task.planned"
+      taskId: "task-002"
+      ...
+```
+
+`batch_append` atomicity: acquires the stream lock once, validates all events, writes with sequential sequence numbers in a single append. All-or-nothing -- if any event fails validation, none are written.
+
+Then create native tasks and wire dependencies:
+
+```
+# Execute side effects (one TaskCreate per task)
+TaskCreate:
+  subject: {task.title}
+  description: {task.fullDescription}
+  activeForm: "Implementing {task.title}"
+  # Returns nativeTaskId
+
+# Wire dependencies (after ALL tasks created -- requires sequential creation)
+TaskUpdate:
+  taskId: {nativeTaskId}
+  addBlockedBy: [{blockerNativeTaskIds}]
+```
+
+Idempotency: before retrying, check `TaskList` for existing tasks with matching subjects to avoid duplicates.
+
+After all tasks are created, store the correlation (orchestrator is the **sole writer** of `workflow.tasks[]`):
+
+```
+exarchos_workflow set:
+  featureId: {featureId}
+  updates:
+    tasks: [{...task, nativeTaskId: "returned-id"}]
+```
+
+**Step 3: Spawn Teammates** (PIVOT -- point of no return)
+
+> This is the **pivot transaction**. Once teammates start working, their side effects (file writes, commits, worktree modifications) cannot be cleanly reversed. Steps 1-2 are compensable; Step 3+ are not fully reversible.
+
+For each teammate:
+
+```
+# Emit event (source of truth)
+exarchos_event append:
+  stream: {featureId}
+  event:
+    type: "team.teammate.dispatched"
+    teammateName: {name}
+    worktreePath: {path}
+    assignedTaskIds: [{taskIds}]
+    model: "opus"
+
+# Execute side effect
+# Note: teammates inherit the lead's permission mode (per Claude Code docs).
+# Do NOT set `mode` at spawn -- it is not respected.
+Task:
+  subagent_type: "general-purpose"
+  team_name: {featureId}
+  name: {teammateName}
+  model: "opus"
+  prompt: {spawnPrompt}  # See implementer-prompt.md template
+```
+
+**Step 4: Monitor** (RETRYABLE)
+
+The orchestrator enters delegate mode (Shift+Tab). Hooks operate autonomously:
+- **SubagentStart** -- injects live coordination data only (task status changes, newly unblocked tasks). Historical intelligence and team context are already in the spawn prompt.
+- **TeammateIdle** -- runs quality gates, emits `team.task.completed` or `team.task.failed` events. Does NOT mutate `workflow.tasks[]` (single-writer principle). The orchestrator reads these events and updates state.
+
+**Tiered monitoring strategy** (minimizes token cost):
+
+| Tier | Tool | When | Cost |
+|------|------|------|------|
+| Routine | `exarchos_view workflow_status` | Every 30-60s | ~85 tokens |
+| On task completion | `exarchos_workflow get` (fields: tasks) | When TeammateIdle fires | ~200 tokens |
+| On-demand | `exarchos_view delegation_timeline` | Task stall or all complete | ~120 tokens |
+
+Do NOT triple-read on every cycle. `delegation_timeline` replays the full event stream -- reserve for final summary or anomaly detection.
+
+When the orchestrator detects `team.task.completed` events, it updates `workflow.tasks[]`:
+```
+exarchos_workflow set:
+  featureId: {featureId}
+  updates:
+    tasks: [{...task, status: "complete", completedAt: timestamp}]
+```
+
+**Step 5: Disband** (RETRYABLE)
+
+When all tasks complete:
+
+```
+# Emit event
+exarchos_event append:
+  stream: {featureId}
+  event:
+    type: "team.disbanded"
+    totalDurationMs: {calculated}
+    tasksCompleted: {count}
+    tasksFailed: {count}
+
+# Shutdown remaining teammates
+SendMessage:
+  type: "shutdown_request"
+  recipient: {each remaining teammate}
+
+# Cleanup native team (after all teammates confirm shutdown)
+TeamDelete
+```
+
+**Step 6: Transition** (RETRYABLE)
+
+```
+exarchos_workflow set:
+  featureId: {featureId}
+  phase: "review"
+  # auto-emits workflow.transition event
+```
+
+#### Saga Compensation
+
+When the saga fails at any step, compensate in reverse order:
+
+| Failed At | Compensating Actions | Idempotency Check |
+|-----------|---------------------|-------------------|
+| Step 1 (team create) | `TeamDelete` | Check `~/.claude/teams/{featureId}/` exists before delete |
+| Step 2 (task create) | Delete created tasks via `TaskUpdate(status: "deleted")` x created, then `TeamDelete` | Check `TaskList` for existing tasks before delete |
+| Step 3 (spawn -- PIVOT) | `SendMessage(type: "shutdown_request")` x spawned teammates, delete tasks, `TeamDelete` | Check team config `members` array for active teammates |
+| Step 4+ (monitoring) | `exarchos_workflow cancel` (handles full compensation) | Already idempotent via workflow state check |
+
+Compensation steps themselves must be idempotent: deleting an already-deleted team is a no-op; shutting down an already-terminated teammate is a no-op.
+
+If a compensating action itself fails after 3 retries, mark the workflow with `_compensationFailed: true` and emit `team.compensation.failed`. The SessionStart hook detects this on next session for manual resolution.
+
+#### Claude Code Agent Teams Constraints
+
+| Constraint | Impact |
+|------------|--------|
+| **No session resumption** for teammates | Teammates are ephemeral. On restart, SessionStart detects orphaned teams but cannot restore them. Spawn new teammates if delegation is incomplete. |
+| **One team per session** | Naturally enforces single-orchestrator invariant. No additional locking needed. |
+| **No nested teams** | Teammates cannot spawn sub-teams. Team composition is flat. |
+| **Permissions inherit from lead** | Do NOT set `mode` at spawn -- not respected. All teammates inherit the lead's permission mode. |
+| **Teammates load MCP automatically** | Exarchos MCP tools are available without explicit instruction. The spawn prompt guides WHICH tools to use, not HOW to access them. |
+
+**CRITICAL:** Ensure your session is using the opus model for coding tasks. All teammates inherit the session model -- use Task tool dispatch if you need per-task model selection.
 
 ## Adaptive Orchestration
 
@@ -230,46 +406,69 @@ See `@skills/delegation/references/troubleshooting.md` for detailed troubleshoot
 
 ## Exarchos Integration
 
-Emit events at each delegation milestone using Exarchos MCP tools:
+### Subagent Mode Events
+
+When using subagent mode (`Task` tool), emit events at each delegation milestone:
 
 1. **Delegation start:** `exarchos_event` append `workflow.started` (if not already emitted)
-2. **Task dispatch:** Launch subagents via Claude Code `Task` tool. Inter-agent messaging uses Claude Code's native Agent Teams (not Exarchos)
+2. **Task dispatch:** Launch subagents via Claude Code `Task` tool
 3. **Task assignment:** `exarchos_event` append `task.assigned` with taskId, title, branch, worktree
 4. **Monitor:** `exarchos_view` `workflow_status` or `exarchos_workflow` `get` with `fields: ["tasks"]`
-5. **Task completion:** Record stack positions via `exarchos_view` `stack_place`. Subagents handle Graphite stacking via `gt create`
-6. **All complete:** Auto-emitted by `exarchos_workflow` `set` when phase transitions — emits `workflow.transition` from delegate to next phase
+5. **Task completion:** `exarchos_orchestrate` `task_complete` (auto-emits `task.completed`). Record stack positions via `exarchos_view` `stack_place`
+6. **All complete:** Auto-emitted by `exarchos_workflow` `set` when phase transitions -- emits `workflow.transition`
 
-### Claim Guard
+### Agent Team Mode Events
 
-Use `exarchos_orchestrate` `task_claim` for optimistic concurrency. On `ALREADY_CLAIMED`, skip the task and check status via `exarchos_view` `tasks` before re-dispatching.
+When using agent-team mode, follow the 6-step delegation saga documented in the "Agent Teams (Teammates)" section above. The saga prescribes the exact event sequence. Do NOT mix subagent-mode event patterns with agent-team-mode patterns.
+
+### Claim Guard (Subagent Mode Only)
+
+Use `exarchos_orchestrate` `task_claim` for optimistic concurrency in subagent mode. On `ALREADY_CLAIMED`, skip the task and check status via `exarchos_view` `tasks` before re-dispatching.
+
+> **Note:** Claim guards are not needed in agent-team mode. Native task dependencies and the `addBlockedBy` mechanism handle coordination.
 
 ### State Bridge (TeammateIdle)
 
-When using Agent Teams mode, the `TeammateIdle` hook fires when a teammate completes its work and becomes idle, bridging real-time Agent Teams coordination with persistent Exarchos state:
+When using Agent Teams mode, the `TeammateIdle` hook fires when a teammate completes its work and becomes idle. It bridges real-time Agent Teams coordination with the Exarchos event stream:
 
-- **On quality pass:** Updates the matching task's status to "complete" in the workflow state file
-- **On quality fail:** Returns exit code 2 (sends feedback to teammate, keeps it working)
-- **Graceful degradation:** If no matching workflow/worktree found, gate still passes
+- **On quality pass:** Emits `team.task.completed` event to the event stream. Does NOT mutate `workflow.tasks[]` -- the orchestrator is the sole writer (single-writer principle).
+- **On quality fail:** Returns exit code 2 (sends feedback to teammate, keeps it working). Emits `team.task.failed` event with gate results.
+- **Circuit breaker:** On repeated quality failures, emits `team.task.failed` with circuit open signal.
+- **Graceful degradation:** If no matching workflow/worktree found, gate still passes.
+
+**Single-writer principle:** The orchestrator reads `team.task.completed` events during its monitoring loop and updates `workflow.tasks[]` via `exarchos_workflow set`. This eliminates CAS race conditions between hook and orchestrator writes. The 30-60s latency between event emission and projection update is acceptable -- native task dependency unblocking is automatic (handled by Claude Code) and unaffected by this delay.
 
 This implements a **layered coordination** model:
 - Agent Teams handles real-time dispatch and self-coordination
-- Exarchos handles persistent workflow state and event sourcing
+- Exarchos event stream records all lifecycle events (source of truth)
+- Orchestrator materializes events into `workflow.tasks[]` (working projection)
 
 ### Agent Teams Event Emission
 
-When using Agent Teams mode, events are emitted at each lifecycle boundary:
+When using Agent Teams mode, the delegation saga emits events at each lifecycle boundary:
 
-**Orchestrator-emitted events:**
-- `team.spawned` — When team is created (includes teamSize, teammateNames, taskCount, dispatchMode)
-- `team.task.assigned` — When tasks are assigned to teammates (includes taskId, teammateName, worktreePath, modules)
-- `team.disbanded` — When all tasks complete (includes totalDurationMs, tasksCompleted, tasksFailed)
+**Orchestrator-emitted events (saga steps):**
+- `team.spawned` -- Step 1: team creation (includes teamName, teamSize, taskCount, dispatchMode)
+- `team.task.planned` -- Step 2: task planning via `batch_append` (includes taskId, title, modules, blockedBy)
+- `team.teammate.dispatched` -- Step 3: teammate spawn (includes teammateName, worktreePath, assignedTaskIds, model)
+- `team.disbanded` -- Step 5: team disbandment (includes totalDurationMs, tasksCompleted, tasksFailed)
 
 **Hook-emitted events (automatic via TeammateIdle):**
-- `team.task.completed` — After quality gates pass (includes taskId, teammateName, durationMs, filesChanged, testsPassed)
-- `team.task.failed` — After quality gates fail (includes taskId, teammateName, failureReason, gateResults)
-- `team.context.injected` — From SubagentStart hook (includes phase, toolsAvailable, historicalHints)
+- `team.task.completed` -- After quality gates pass (includes taskId, teammateName, durationMs, filesChanged, testsPassed). Hook emits only; does NOT mutate workflow state.
+- `team.task.failed` -- After quality gates fail (includes taskId, teammateName, failureReason, gateResults). Hook emits only.
+- `team.context.injected` -- From SubagentStart hook (includes phase, toolsAvailable)
 
-> **Note:** TeammateIdle hook now emits rich events with performance data, not just state updates.
+**Superseded events:**
+- `team.task.assigned` -- Superseded by the combination of `team.task.planned` (Step 2) + `team.teammate.dispatched` (Step 3). Existing event streams may still contain `team.task.assigned` events; CQRS views handle both old and new types during the transition period.
+
+**Tool usage by delegation mode:**
+
+| Delegation Mode | Task Completion Signal | State Update |
+|----------------|----------------------|--------------|
+| **Subagent mode** | `exarchos_orchestrate task_complete` (auto-emits `task.completed`) | Orchestrator calls `exarchos_workflow set` |
+| **Agent team mode** | TeammateIdle hook emits `team.task.completed` | Orchestrator reads event, calls `exarchos_workflow set` |
+
+> **Important:** Do NOT use `exarchos_orchestrate task_complete` or `task_fail` during agent team delegation. The TeammateIdle hook handles completion signaling. Using both would produce duplicate events in the stream.
 
 ### Intelligence Views
 

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -78,7 +78,7 @@ The dispatch follows a saga pattern with compensable, pivot, and retryable trans
 
 **Step 1: Create Team** (COMPENSABLE)
 
-```
+```yaml
 # Emit event (source of truth)
 exarchos_event append:
   stream: {featureId}
@@ -101,7 +101,7 @@ Idempotency: before retrying, check if `~/.claude/teams/{featureId}/` already ex
 
 Emit ALL task planning events in a single batched call (1 MCP call instead of N):
 
-```
+```yaml
 # Emit ALL task events in one batch (source of truth)
 exarchos_event batch_append:
   stream: {featureId}
@@ -120,7 +120,7 @@ exarchos_event batch_append:
 
 Then create native tasks and wire dependencies:
 
-```
+```yaml
 # Execute side effects (one TaskCreate per task)
 TaskCreate:
   subject: {task.title}
@@ -138,7 +138,7 @@ Idempotency: before retrying, check `TaskList` for existing tasks with matching 
 
 After all tasks are created, store the correlation (orchestrator is the **sole writer** of `workflow.tasks[]`):
 
-```
+```yaml
 exarchos_workflow set:
   featureId: {featureId}
   updates:
@@ -151,7 +151,7 @@ exarchos_workflow set:
 
 For each teammate:
 
-```
+```yaml
 # Emit event (source of truth)
 exarchos_event append:
   stream: {featureId}
@@ -190,7 +190,7 @@ The orchestrator enters delegate mode (Shift+Tab). Hooks operate autonomously:
 Do NOT triple-read on every cycle. `delegation_timeline` replays the full event stream -- reserve for final summary or anomaly detection.
 
 When the orchestrator detects `team.task.completed` events, it updates `workflow.tasks[]`:
-```
+```yaml
 exarchos_workflow set:
   featureId: {featureId}
   updates:
@@ -201,7 +201,7 @@ exarchos_workflow set:
 
 When all tasks complete:
 
-```
+```yaml
 # Emit event
 exarchos_event append:
   stream: {featureId}
@@ -222,7 +222,7 @@ TeamDelete
 
 **Step 6: Transition** (RETRYABLE)
 
-```
+```yaml
 exarchos_workflow set:
   featureId: {featureId}
   phase: "review"

--- a/skills/delegation/references/implementer-prompt.md
+++ b/skills/delegation/references/implementer-prompt.md
@@ -102,7 +102,7 @@ describe('[ComponentName]', () => {
 - Use `exarchos_view tasks` to see task details across the team
 - Use `exarchos_event append` to report TDD phase transitions:
     stream: "{featureId}"
-    event: { type: "task.progressed", taskId: "{taskId}", tddPhase: "red|green|refactor" }
+    event: { type: "task.progress", taskId: "{taskId}", tddPhase: "red|green|refactor" }
 
 ## Team Context
 <!-- Agent Teams mode only. Populated at spawn time by orchestrator. -->

--- a/skills/delegation/references/implementer-prompt.md
+++ b/skills/delegation/references/implementer-prompt.md
@@ -90,6 +90,32 @@ describe('[ComponentName]', () => {
 - [ ] No extra code beyond requirements
 - [ ] All tests in worktree pass
 
+## Coordination (Native APIs)
+<!-- Agent Teams mode only. Remove this section for subagent mode. -->
+- Use `TaskList` to see available tasks and their statuses
+- Use `TaskUpdate` to mark tasks `in_progress` when you start and `completed` when done
+- Use `SendMessage` to communicate findings to teammates or the lead
+
+## Workflow Intelligence (Exarchos MCP)
+<!-- Agent Teams mode only. Remove this section for subagent mode. -->
+- Use `exarchos_workflow get` to query current workflow state
+- Use `exarchos_view tasks` to see task details across the team
+- Use `exarchos_event append` to report TDD phase transitions:
+    stream: "{featureId}"
+    event: { type: "task.progressed", taskId: "{taskId}", tddPhase: "red|green|refactor" }
+
+## Team Context
+<!-- Agent Teams mode only. Populated at spawn time by orchestrator. -->
+{teamComposition}
+
+> This data is injected at spawn time. The SubagentStart hook provides only live coordination updates (task status changes, newly unblocked tasks).
+
+## Historical Context
+<!-- Agent Teams mode only. Populated at spawn time by orchestrator. -->
+{historicalIntelligence}
+
+> This data is injected at spawn time. The SubagentStart hook provides only live coordination updates.
+
 ## Code Exploration Tools
 
 For navigating and understanding code, prefer Serena MCP tools over grep/glob:
@@ -243,3 +269,18 @@ describe('validateEmail', () => {
 4. **TDD Mandatory** - Always include TDD requirements
 5. **Graphite-First** - Include commit strategy section; always use `gt create` and `gt submit`
 6. **Clear Success Criteria** - Checkboxes for completion
+
+## Agent Teams vs Subagent Mode
+
+The template sections marked "Agent Teams mode only" (Coordination, Workflow Intelligence, Team Context, Historical Context) should be **included only when dispatching via Agent Teams mode** (`Task` with `team_name`). When dispatching via subagent mode (`Task` with `run_in_background`), omit these sections -- the SubagentStart hook handles context injection for subagents.
+
+| Section | Agent Teams Mode | Subagent Mode |
+|---------|-----------------|---------------|
+| Coordination (Native APIs) | Include in spawn prompt | Omit (not applicable) |
+| Workflow Intelligence (Exarchos MCP) | Include in spawn prompt | Omit (hook injects) |
+| Team Context | Include -- populated at spawn time | Omit (hook injects) |
+| Historical Context | Include -- populated at spawn time | Omit (hook injects) |
+
+## MCP Auto-Loading
+
+Teammates automatically load project MCP servers (including Exarchos). The Coordination and Workflow Intelligence sections guide WHICH tools to use, not HOW to access them. Do not include MCP connection instructions or tool registration details in the spawn prompt.


### PR DESCRIPTION
Rewrite Agent Teams dispatch flow in delegation SKILL.md with 6-step
event-first delegation saga (emit event then execute native API side
effect). Add saga compensation table with idempotency checks, pivot
transaction documentation at Step 3, tiered monitoring strategy, and
Claude Code constraints. Update implementer prompt template with native
API coordination, Exarchos workflow intelligence, team context, and
historical context sections for Agent Teams mode.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>