### PR TITLE
feat: extend workflow reconcile with native task status reconciliation

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -2593,216 +2593,216 @@ describe('handleSet_EventFirst', () => {
 
     writeSpy.mockRestore();
   });
+});
 
-  // ─── reconcileTasks ─────────────────────────────────────────────────────────
+// ─── reconcileTasks ─────────────────────────────────────────────────────────
 
-  describe('reconcileTasks_DriftDetected_ReportsMismatch', () => {
-    it('should report drift when native status differs from Exarchos status', async () => {
-      // Arrange: Exarchos task is "pending", native task is "completed"
-      const nativeTaskDir = path.join(tmpDir, 'native-tasks');
-      await fs.mkdir(nativeTaskDir, { recursive: true });
-      await fs.writeFile(
-        path.join(nativeTaskDir, 'native-1.json'),
-        JSON.stringify({ id: 'native-1', subject: 'Implement auth', status: 'completed' }),
-      );
+describe('reconcileTasks_DriftDetected_ReportsMismatch', () => {
+  it('should report drift when native status differs from Exarchos status', async () => {
+    // Arrange: Exarchos task is "pending", native task is "completed"
+    const nativeTaskDir = path.join(tmpDir, 'native-tasks');
+    await fs.mkdir(nativeTaskDir, { recursive: true });
+    await fs.writeFile(
+      path.join(nativeTaskDir, 'native-1.json'),
+      JSON.stringify({ id: 'native-1', subject: 'Implement auth', status: 'completed' }),
+    );
 
-      const exarchosTasks = [
-        { id: 'task-001', title: 'Implement auth', status: 'pending', nativeTaskId: 'native-1' },
-      ];
+    const exarchosTasks = [
+      { id: 'task-001', title: 'Implement auth', status: 'pending', nativeTaskId: 'native-1' },
+    ];
 
-      // Act
-      const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
+    // Act
+    const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
 
-      // Assert
-      expect(report.skipped).toBe(false);
-      expect(report.drift).toHaveLength(1);
-      expect(report.drift[0]).toMatchObject({
-        taskId: 'task-001',
-        exarchosStatus: 'pending',
-        nativeStatus: 'completed',
-      });
-      expect(report.drift[0].recommendation).toBeDefined();
-      expect(report.drift[0].recommendation.length).toBeGreaterThan(0);
+    // Assert
+    expect(report.skipped).toBe(false);
+    expect(report.drift).toHaveLength(1);
+    expect(report.drift[0]).toMatchObject({
+      taskId: 'task-001',
+      exarchosStatus: 'pending',
+      nativeStatus: 'completed',
     });
+    expect(report.drift[0].recommendation).toBeDefined();
+    expect(report.drift[0].recommendation.length).toBeGreaterThan(0);
   });
+});
 
-  describe('reconcileTasks_NativeCompleted_WorkflowPending_RecommendsUpdate', () => {
-    it('should recommend marking Exarchos task complete when native is completed', async () => {
-      // Arrange
-      const nativeTaskDir = path.join(tmpDir, 'native-tasks-2');
-      await fs.mkdir(nativeTaskDir, { recursive: true });
-      await fs.writeFile(
-        path.join(nativeTaskDir, 'native-2.json'),
-        JSON.stringify({ id: 'native-2', subject: 'Add tests', status: 'completed' }),
-      );
+describe('reconcileTasks_NativeCompleted_WorkflowPending_RecommendsUpdate', () => {
+  it('should recommend marking Exarchos task complete when native is completed', async () => {
+    // Arrange
+    const nativeTaskDir = path.join(tmpDir, 'native-tasks-2');
+    await fs.mkdir(nativeTaskDir, { recursive: true });
+    await fs.writeFile(
+      path.join(nativeTaskDir, 'native-2.json'),
+      JSON.stringify({ id: 'native-2', subject: 'Add tests', status: 'completed' }),
+    );
 
-      const exarchosTasks = [
-        { id: 'task-002', title: 'Add tests', status: 'pending', nativeTaskId: 'native-2' },
-      ];
+    const exarchosTasks = [
+      { id: 'task-002', title: 'Add tests', status: 'pending', nativeTaskId: 'native-2' },
+    ];
 
-      // Act
-      const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
+    // Act
+    const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
 
-      // Assert
-      expect(report.drift).toHaveLength(1);
-      expect(report.drift[0].recommendation).toContain('complete');
-    });
+    // Assert
+    expect(report.drift).toHaveLength(1);
+    expect(report.drift[0].recommendation).toContain('complete');
   });
+});
 
-  describe('reconcileTasks_NoNativeTaskList_SkipsReconciliation', () => {
-    it('should return skipped report with note when native dir does not exist', async () => {
-      const nativeTaskDir = path.join(tmpDir, 'nonexistent-dir');
+describe('reconcileTasks_NoNativeTaskList_SkipsReconciliation', () => {
+  it('should return skipped report with note when native dir does not exist', async () => {
+    const nativeTaskDir = path.join(tmpDir, 'nonexistent-dir');
 
-      const exarchosTasks = [
-        { id: 'task-003', title: 'Build UI', status: 'pending', nativeTaskId: 'native-3' },
-      ];
+    const exarchosTasks = [
+      { id: 'task-003', title: 'Build UI', status: 'pending', nativeTaskId: 'native-3' },
+    ];
 
-      // Act
-      const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
+    // Act
+    const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
 
-      // Assert
-      expect(report.skipped).toBe(true);
-      expect(report.skipReason).toBeDefined();
-      expect(report.skipReason!.length).toBeGreaterThan(0);
-      expect(report.drift).toHaveLength(0);
-    });
+    // Assert
+    expect(report.skipped).toBe(true);
+    expect(report.skipReason).toBeDefined();
+    expect(report.skipReason!.length).toBeGreaterThan(0);
+    expect(report.drift).toHaveLength(0);
   });
+});
 
-  describe('reconcileTasks_AllConsistent_ReturnsCleanReport', () => {
-    it('should return empty drift array when statuses match', async () => {
-      // Arrange: both native and Exarchos say "completed"
-      const nativeTaskDir = path.join(tmpDir, 'native-tasks-consistent');
-      await fs.mkdir(nativeTaskDir, { recursive: true });
-      await fs.writeFile(
-        path.join(nativeTaskDir, 'native-4.json'),
-        JSON.stringify({ id: 'native-4', subject: 'Refactor module', status: 'completed' }),
-      );
+describe('reconcileTasks_AllConsistent_ReturnsCleanReport', () => {
+  it('should return empty drift array when statuses match', async () => {
+    // Arrange: both native and Exarchos say "completed"
+    const nativeTaskDir = path.join(tmpDir, 'native-tasks-consistent');
+    await fs.mkdir(nativeTaskDir, { recursive: true });
+    await fs.writeFile(
+      path.join(nativeTaskDir, 'native-4.json'),
+      JSON.stringify({ id: 'native-4', subject: 'Refactor module', status: 'completed' }),
+    );
 
-      const exarchosTasks = [
-        { id: 'task-004', title: 'Refactor module', status: 'complete', nativeTaskId: 'native-4' },
-      ];
+    const exarchosTasks = [
+      { id: 'task-004', title: 'Refactor module', status: 'complete', nativeTaskId: 'native-4' },
+    ];
 
-      // Act
-      const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
+    // Act
+    const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
 
-      // Assert
-      expect(report.skipped).toBe(false);
-      expect(report.drift).toHaveLength(0);
-    });
+    // Assert
+    expect(report.skipped).toBe(false);
+    expect(report.drift).toHaveLength(0);
   });
+});
 
-  describe('reconcileTasks_UnmatchedNativeTask_ReportsUntracked', () => {
-    it('should flag native tasks that have no Exarchos match', async () => {
-      // Arrange: native has a task, Exarchos does not
-      const nativeTaskDir = path.join(tmpDir, 'native-tasks-untracked');
-      await fs.mkdir(nativeTaskDir, { recursive: true });
-      await fs.writeFile(
-        path.join(nativeTaskDir, 'native-5.json'),
-        JSON.stringify({ id: 'native-5', subject: 'Untracked work', status: 'in_progress' }),
-      );
+describe('reconcileTasks_UnmatchedNativeTask_ReportsUntracked', () => {
+  it('should flag native tasks that have no Exarchos match', async () => {
+    // Arrange: native has a task, Exarchos does not
+    const nativeTaskDir = path.join(tmpDir, 'native-tasks-untracked');
+    await fs.mkdir(nativeTaskDir, { recursive: true });
+    await fs.writeFile(
+      path.join(nativeTaskDir, 'native-5.json'),
+      JSON.stringify({ id: 'native-5', subject: 'Untracked work', status: 'in_progress' }),
+    );
 
-      const exarchosTasks: Array<Record<string, unknown>> = [];
+    const exarchosTasks: Array<Record<string, unknown>> = [];
 
-      // Act
-      const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
+    // Act
+    const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
 
-      // Assert
-      expect(report.skipped).toBe(false);
-      expect(report.drift).toHaveLength(1);
-      expect(report.drift[0]).toMatchObject({
-        taskId: 'native-5',
-        exarchosStatus: null,
-        nativeStatus: 'in_progress',
-      });
-      expect(report.drift[0].recommendation).toContain('Untracked');
+    // Assert
+    expect(report.skipped).toBe(false);
+    expect(report.drift).toHaveLength(1);
+    expect(report.drift[0]).toMatchObject({
+      taskId: 'native-5',
+      exarchosStatus: null,
+      nativeStatus: 'in_progress',
     });
+    expect(report.drift[0].recommendation).toContain('Untracked');
   });
+});
 
-  describe('reconcileTasks_MissingNativeTask_ReportsMissing', () => {
-    it('should flag Exarchos tasks with nativeTaskId but no native file', async () => {
-      // Arrange: Exarchos has a task with nativeTaskId, but native dir is empty
-      const nativeTaskDir = path.join(tmpDir, 'native-tasks-missing');
-      await fs.mkdir(nativeTaskDir, { recursive: true });
+describe('reconcileTasks_MissingNativeTask_ReportsMissing', () => {
+  it('should flag Exarchos tasks with nativeTaskId but no native file', async () => {
+    // Arrange: Exarchos has a task with nativeTaskId, but native dir is empty
+    const nativeTaskDir = path.join(tmpDir, 'native-tasks-missing');
+    await fs.mkdir(nativeTaskDir, { recursive: true });
 
-      const exarchosTasks = [
-        { id: 'task-006', title: 'Deploy service', status: 'in_progress', nativeTaskId: 'native-6' },
-      ];
+    const exarchosTasks = [
+      { id: 'task-006', title: 'Deploy service', status: 'in_progress', nativeTaskId: 'native-6' },
+    ];
 
-      // Act
-      const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
+    // Act
+    const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
 
-      // Assert
-      expect(report.skipped).toBe(false);
-      expect(report.drift).toHaveLength(1);
-      expect(report.drift[0]).toMatchObject({
-        taskId: 'task-006',
-        exarchosStatus: 'in_progress',
-        nativeStatus: null,
-      });
-      expect(report.drift[0].recommendation).toContain('missing');
+    // Assert
+    expect(report.skipped).toBe(false);
+    expect(report.drift).toHaveLength(1);
+    expect(report.drift[0]).toMatchObject({
+      taskId: 'task-006',
+      exarchosStatus: 'in_progress',
+      nativeStatus: null,
     });
+    expect(report.drift[0].recommendation).toContain('missing');
   });
+});
 
-  // ─── handleReconcile with task reconciliation ────────────────────────────
+// ─── handleReconcile with task reconciliation ────────────────────────────
 
-  describe('ToolReconcile_WithNativeTaskId_IncludesTaskDrift', () => {
-    it('should include taskDrift in reconcile output when tasks have nativeTaskId', async () => {
-      await handleInit({ featureId: 'reconcile-tasks', workflowType: 'feature' }, tmpDir);
+describe('ToolReconcile_WithNativeTaskId_IncludesTaskDrift', () => {
+  it('should include taskDrift in reconcile output when tasks have nativeTaskId', async () => {
+    await handleInit({ featureId: 'reconcile-tasks', workflowType: 'feature' }, tmpDir);
 
-      // Set up a task with nativeTaskId in the state file
-      const stateFile = path.join(tmpDir, 'reconcile-tasks.state.json');
-      const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
-      raw.tasks = [
-        { id: 'task-001', title: 'Build API', status: 'pending', nativeTaskId: 'nt-1' },
-      ];
-      await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+    // Set up a task with nativeTaskId in the state file
+    const stateFile = path.join(tmpDir, 'reconcile-tasks.state.json');
+    const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+    raw.tasks = [
+      { id: 'task-001', title: 'Build API', status: 'pending', nativeTaskId: 'nt-1' },
+    ];
+    await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
 
-      // Create native task dir with completed task
-      const nativeTaskDir = path.join(tmpDir, 'tasks', 'reconcile-tasks');
-      await fs.mkdir(nativeTaskDir, { recursive: true });
-      await fs.writeFile(
-        path.join(nativeTaskDir, 'nt-1.json'),
-        JSON.stringify({ id: 'nt-1', subject: 'Build API', status: 'completed' }),
-      );
+    // Create native task dir with completed task
+    const nativeTaskDir = path.join(tmpDir, 'tasks', 'reconcile-tasks');
+    await fs.mkdir(nativeTaskDir, { recursive: true });
+    await fs.writeFile(
+      path.join(nativeTaskDir, 'nt-1.json'),
+      JSON.stringify({ id: 'nt-1', subject: 'Build API', status: 'completed' }),
+    );
 
-      const result = await handleReconcile(
-        { featureId: 'reconcile-tasks' },
-        tmpDir,
-        path.join(tmpDir, 'tasks'),
-      );
+    const result = await handleReconcile(
+      { featureId: 'reconcile-tasks' },
+      tmpDir,
+      path.join(tmpDir, 'tasks'),
+    );
 
-      expect(result.success).toBe(true);
-      const data = result.data as Record<string, unknown>;
-      expect(data.taskDrift).toBeDefined();
-      const taskDrift = data.taskDrift as { skipped: boolean; drift: Array<Record<string, unknown>> };
-      expect(taskDrift.skipped).toBe(false);
-      expect(taskDrift.drift).toHaveLength(1);
-      expect(taskDrift.drift[0].exarchosStatus).toBe('pending');
-      expect(taskDrift.drift[0].nativeStatus).toBe('completed');
-    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.taskDrift).toBeDefined();
+    const taskDrift = data.taskDrift as { skipped: boolean; drift: Array<Record<string, unknown>> };
+    expect(taskDrift.skipped).toBe(false);
+    expect(taskDrift.drift).toHaveLength(1);
+    expect(taskDrift.drift[0].exarchosStatus).toBe('pending');
+    expect(taskDrift.drift[0].nativeStatus).toBe('completed');
   });
+});
 
-  describe('ToolReconcile_WithoutNativeTaskId_OmitsTaskDrift', () => {
-    it('should not include taskDrift when no tasks have nativeTaskId', async () => {
-      await handleInit({ featureId: 'reconcile-no-native', workflowType: 'feature' }, tmpDir);
+describe('ToolReconcile_WithoutNativeTaskId_OmitsTaskDrift', () => {
+  it('should not include taskDrift when no tasks have nativeTaskId', async () => {
+    await handleInit({ featureId: 'reconcile-no-native', workflowType: 'feature' }, tmpDir);
 
-      // Set up a task WITHOUT nativeTaskId
-      const stateFile = path.join(tmpDir, 'reconcile-no-native.state.json');
-      const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
-      raw.tasks = [
-        { id: 'task-001', title: 'Build API', status: 'pending' },
-      ];
-      await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+    // Set up a task WITHOUT nativeTaskId
+    const stateFile = path.join(tmpDir, 'reconcile-no-native.state.json');
+    const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+    raw.tasks = [
+      { id: 'task-001', title: 'Build API', status: 'pending' },
+    ];
+    await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
 
-      const result = await handleReconcile(
-        { featureId: 'reconcile-no-native' },
-        tmpDir,
-        path.join(tmpDir, 'tasks'),
-      );
+    const result = await handleReconcile(
+      { featureId: 'reconcile-no-native' },
+      tmpDir,
+      path.join(tmpDir, 'tasks'),
+    );
 
-      expect(result.success).toBe(true);
-      const data = result.data as Record<string, unknown>;
-      expect(data.taskDrift).toBeUndefined();
-    });
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.taskDrift).toBeUndefined();
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -17,7 +17,7 @@ import {
 } from '../../workflow/tools.js';
 import { initStateFile, readStateFile, writeStateFile, VersionConflictError } from '../../workflow/state-store.js';
 import { EventStore } from '../../event-store/store.js';
-import { configureQueryEventStore } from '../../workflow/query.js';
+import { configureQueryEventStore, reconcileTasks } from '../../workflow/query.js';
 import { configureNextActionEventStore } from '../../workflow/next-action.js';
 import type { WorkflowState } from '../../workflow/types.js';
 
@@ -2592,5 +2592,217 @@ describe('handleSet_EventFirst', () => {
     expect(data.eventWarning).toBeUndefined();
 
     writeSpy.mockRestore();
+  });
+
+  // ─── reconcileTasks ─────────────────────────────────────────────────────────
+
+  describe('reconcileTasks_DriftDetected_ReportsMismatch', () => {
+    it('should report drift when native status differs from Exarchos status', async () => {
+      // Arrange: Exarchos task is "pending", native task is "completed"
+      const nativeTaskDir = path.join(tmpDir, 'native-tasks');
+      await fs.mkdir(nativeTaskDir, { recursive: true });
+      await fs.writeFile(
+        path.join(nativeTaskDir, 'native-1.json'),
+        JSON.stringify({ id: 'native-1', subject: 'Implement auth', status: 'completed' }),
+      );
+
+      const exarchosTasks = [
+        { id: 'task-001', title: 'Implement auth', status: 'pending', nativeTaskId: 'native-1' },
+      ];
+
+      // Act
+      const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
+
+      // Assert
+      expect(report.skipped).toBe(false);
+      expect(report.drift).toHaveLength(1);
+      expect(report.drift[0]).toMatchObject({
+        taskId: 'task-001',
+        exarchosStatus: 'pending',
+        nativeStatus: 'completed',
+      });
+      expect(report.drift[0].recommendation).toBeDefined();
+      expect(report.drift[0].recommendation.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('reconcileTasks_NativeCompleted_WorkflowPending_RecommendsUpdate', () => {
+    it('should recommend marking Exarchos task complete when native is completed', async () => {
+      // Arrange
+      const nativeTaskDir = path.join(tmpDir, 'native-tasks-2');
+      await fs.mkdir(nativeTaskDir, { recursive: true });
+      await fs.writeFile(
+        path.join(nativeTaskDir, 'native-2.json'),
+        JSON.stringify({ id: 'native-2', subject: 'Add tests', status: 'completed' }),
+      );
+
+      const exarchosTasks = [
+        { id: 'task-002', title: 'Add tests', status: 'pending', nativeTaskId: 'native-2' },
+      ];
+
+      // Act
+      const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
+
+      // Assert
+      expect(report.drift).toHaveLength(1);
+      expect(report.drift[0].recommendation).toContain('complete');
+    });
+  });
+
+  describe('reconcileTasks_NoNativeTaskList_SkipsReconciliation', () => {
+    it('should return skipped report with note when native dir does not exist', async () => {
+      const nativeTaskDir = path.join(tmpDir, 'nonexistent-dir');
+
+      const exarchosTasks = [
+        { id: 'task-003', title: 'Build UI', status: 'pending', nativeTaskId: 'native-3' },
+      ];
+
+      // Act
+      const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
+
+      // Assert
+      expect(report.skipped).toBe(true);
+      expect(report.skipReason).toBeDefined();
+      expect(report.skipReason!.length).toBeGreaterThan(0);
+      expect(report.drift).toHaveLength(0);
+    });
+  });
+
+  describe('reconcileTasks_AllConsistent_ReturnsCleanReport', () => {
+    it('should return empty drift array when statuses match', async () => {
+      // Arrange: both native and Exarchos say "completed"
+      const nativeTaskDir = path.join(tmpDir, 'native-tasks-consistent');
+      await fs.mkdir(nativeTaskDir, { recursive: true });
+      await fs.writeFile(
+        path.join(nativeTaskDir, 'native-4.json'),
+        JSON.stringify({ id: 'native-4', subject: 'Refactor module', status: 'completed' }),
+      );
+
+      const exarchosTasks = [
+        { id: 'task-004', title: 'Refactor module', status: 'complete', nativeTaskId: 'native-4' },
+      ];
+
+      // Act
+      const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
+
+      // Assert
+      expect(report.skipped).toBe(false);
+      expect(report.drift).toHaveLength(0);
+    });
+  });
+
+  describe('reconcileTasks_UnmatchedNativeTask_ReportsUntracked', () => {
+    it('should flag native tasks that have no Exarchos match', async () => {
+      // Arrange: native has a task, Exarchos does not
+      const nativeTaskDir = path.join(tmpDir, 'native-tasks-untracked');
+      await fs.mkdir(nativeTaskDir, { recursive: true });
+      await fs.writeFile(
+        path.join(nativeTaskDir, 'native-5.json'),
+        JSON.stringify({ id: 'native-5', subject: 'Untracked work', status: 'in_progress' }),
+      );
+
+      const exarchosTasks: Array<Record<string, unknown>> = [];
+
+      // Act
+      const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
+
+      // Assert
+      expect(report.skipped).toBe(false);
+      expect(report.drift).toHaveLength(1);
+      expect(report.drift[0]).toMatchObject({
+        taskId: 'native-5',
+        exarchosStatus: null,
+        nativeStatus: 'in_progress',
+      });
+      expect(report.drift[0].recommendation).toContain('Untracked');
+    });
+  });
+
+  describe('reconcileTasks_MissingNativeTask_ReportsMissing', () => {
+    it('should flag Exarchos tasks with nativeTaskId but no native file', async () => {
+      // Arrange: Exarchos has a task with nativeTaskId, but native dir is empty
+      const nativeTaskDir = path.join(tmpDir, 'native-tasks-missing');
+      await fs.mkdir(nativeTaskDir, { recursive: true });
+
+      const exarchosTasks = [
+        { id: 'task-006', title: 'Deploy service', status: 'in_progress', nativeTaskId: 'native-6' },
+      ];
+
+      // Act
+      const report = await reconcileTasks(exarchosTasks, nativeTaskDir);
+
+      // Assert
+      expect(report.skipped).toBe(false);
+      expect(report.drift).toHaveLength(1);
+      expect(report.drift[0]).toMatchObject({
+        taskId: 'task-006',
+        exarchosStatus: 'in_progress',
+        nativeStatus: null,
+      });
+      expect(report.drift[0].recommendation).toContain('missing');
+    });
+  });
+
+  // ─── handleReconcile with task reconciliation ────────────────────────────
+
+  describe('ToolReconcile_WithNativeTaskId_IncludesTaskDrift', () => {
+    it('should include taskDrift in reconcile output when tasks have nativeTaskId', async () => {
+      await handleInit({ featureId: 'reconcile-tasks', workflowType: 'feature' }, tmpDir);
+
+      // Set up a task with nativeTaskId in the state file
+      const stateFile = path.join(tmpDir, 'reconcile-tasks.state.json');
+      const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+      raw.tasks = [
+        { id: 'task-001', title: 'Build API', status: 'pending', nativeTaskId: 'nt-1' },
+      ];
+      await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+      // Create native task dir with completed task
+      const nativeTaskDir = path.join(tmpDir, 'tasks', 'reconcile-tasks');
+      await fs.mkdir(nativeTaskDir, { recursive: true });
+      await fs.writeFile(
+        path.join(nativeTaskDir, 'nt-1.json'),
+        JSON.stringify({ id: 'nt-1', subject: 'Build API', status: 'completed' }),
+      );
+
+      const result = await handleReconcile(
+        { featureId: 'reconcile-tasks' },
+        tmpDir,
+        path.join(tmpDir, 'tasks'),
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      expect(data.taskDrift).toBeDefined();
+      const taskDrift = data.taskDrift as { skipped: boolean; drift: Array<Record<string, unknown>> };
+      expect(taskDrift.skipped).toBe(false);
+      expect(taskDrift.drift).toHaveLength(1);
+      expect(taskDrift.drift[0].exarchosStatus).toBe('pending');
+      expect(taskDrift.drift[0].nativeStatus).toBe('completed');
+    });
+  });
+
+  describe('ToolReconcile_WithoutNativeTaskId_OmitsTaskDrift', () => {
+    it('should not include taskDrift when no tasks have nativeTaskId', async () => {
+      await handleInit({ featureId: 'reconcile-no-native', workflowType: 'feature' }, tmpDir);
+
+      // Set up a task WITHOUT nativeTaskId
+      const stateFile = path.join(tmpDir, 'reconcile-no-native.state.json');
+      const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+      raw.tasks = [
+        { id: 'task-001', title: 'Build API', status: 'pending' },
+      ];
+      await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+
+      const result = await handleReconcile(
+        { featureId: 'reconcile-no-native' },
+        tmpDir,
+        path.join(tmpDir, 'tasks'),
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      expect(data.taskDrift).toBeUndefined();
+    });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/query.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/query.ts
@@ -119,11 +119,183 @@ export async function handleSummary(
   };
 }
 
+// ─── Task Drift Report Types ─────────────────────────────────────────────────
+
+export interface TaskDriftEntry {
+  readonly taskId: string;
+  readonly exarchosStatus: string | null;
+  readonly nativeStatus: string | null;
+  readonly recommendation: string;
+}
+
+export interface TaskDriftReport {
+  readonly skipped: boolean;
+  readonly skipReason?: string;
+  readonly drift: readonly TaskDriftEntry[];
+}
+
+// ─── Native Task File Reading ────────────────────────────────────────────────
+
+interface NativeTaskFile {
+  readonly id: string;
+  readonly subject?: string;
+  readonly status: string;
+}
+
+/**
+ * Read all native task JSON files from a directory.
+ * Returns a map of task ID to parsed task data.
+ * Returns null if the directory does not exist.
+ */
+async function readNativeTaskFiles(
+  nativeTaskDir: string,
+): Promise<Map<string, NativeTaskFile> | null> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(nativeTaskDir);
+  } catch {
+    return null;
+  }
+
+  const jsonFiles = entries.filter((f) => f.endsWith('.json'));
+  const tasks = new Map<string, NativeTaskFile>();
+
+  for (const file of jsonFiles) {
+    try {
+      const raw = await fs.readFile(path.join(nativeTaskDir, file), 'utf-8');
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+      if (typeof parsed.id !== 'string' || typeof parsed.status !== 'string') {
+        continue;
+      }
+
+      tasks.set(parsed.id, {
+        id: parsed.id,
+        subject: typeof parsed.subject === 'string' ? parsed.subject : undefined,
+        status: parsed.status,
+      });
+    } catch {
+      continue;
+    }
+  }
+
+  return tasks;
+}
+
+// ─── Status Normalization ────────────────────────────────────────────────────
+
+/**
+ * Normalize status strings for comparison.
+ * Exarchos uses "complete", native may use "completed" — treat as equivalent.
+ */
+function normalizeStatus(status: string): string {
+  if (status === 'complete' || status === 'completed') return 'completed';
+  return status;
+}
+
+// ─── reconcileTasks ──────────────────────────────────────────────────────────
+
+/**
+ * Compare native task statuses with Exarchos workflow tasks and produce a drift report.
+ *
+ * Matches tasks by `nativeTaskId` field if present, or by title/subject as fallback.
+ * Reports drift for mismatches, untracked native tasks, and missing native tasks.
+ */
+export async function reconcileTasks(
+  exarchosTasks: ReadonlyArray<Record<string, unknown>>,
+  nativeTaskDir: string,
+): Promise<TaskDriftReport> {
+  const nativeTasks = await readNativeTaskFiles(nativeTaskDir);
+
+  if (nativeTasks === null) {
+    return {
+      skipped: true,
+      skipReason: `Native task directory not found: ${nativeTaskDir}`,
+      drift: [],
+    };
+  }
+
+  const drift: TaskDriftEntry[] = [];
+  const matchedNativeIds = new Set<string>();
+
+  // Check each Exarchos task against native tasks
+  for (const exTask of exarchosTasks) {
+    const taskId = typeof exTask.id === 'string' ? exTask.id : undefined;
+    const nativeTaskId = typeof exTask.nativeTaskId === 'string' ? exTask.nativeTaskId : undefined;
+    const exStatus = typeof exTask.status === 'string' ? exTask.status : 'unknown';
+
+    if (!nativeTaskId) continue;
+
+    // Match by nativeTaskId
+    const nativeTask = nativeTasks.get(nativeTaskId);
+
+    if (!nativeTask) {
+      // Exarchos task has nativeTaskId but no corresponding native file
+      drift.push({
+        taskId: taskId ?? nativeTaskId,
+        exarchosStatus: exStatus,
+        nativeStatus: null,
+        recommendation: `Native task missing (session may have ended) — native task '${nativeTaskId}' not found in task directory`,
+      });
+      continue;
+    }
+
+    matchedNativeIds.add(nativeTaskId);
+
+    // Compare statuses
+    if (normalizeStatus(exStatus) !== normalizeStatus(nativeTask.status)) {
+      const recommendation = nativeTask.status === 'completed'
+        ? `Update Exarchos task to complete — native task '${nativeTaskId}' shows completed`
+        : `Status mismatch: Exarchos='${exStatus}', native='${nativeTask.status}' — investigate and reconcile`;
+
+      drift.push({
+        taskId: taskId ?? nativeTaskId,
+        exarchosStatus: exStatus,
+        nativeStatus: nativeTask.status,
+        recommendation,
+      });
+    }
+  }
+
+  // Check for untracked native tasks (exist in native but not matched by any Exarchos task)
+  for (const [nativeId, nativeTask] of nativeTasks) {
+    if (matchedNativeIds.has(nativeId)) continue;
+
+    // Try title-based matching as fallback
+    const matchedByTitle = exarchosTasks.some((t) => {
+      const title = typeof t.title === 'string' ? t.title : '';
+      return title === nativeTask.subject;
+    });
+
+    if (!matchedByTitle) {
+      drift.push({
+        taskId: nativeId,
+        exarchosStatus: null,
+        nativeStatus: nativeTask.status,
+        recommendation: `Untracked native task '${nativeId}' (subject: '${nativeTask.subject ?? 'unknown'}') — consider adding to workflow state`,
+      });
+    }
+  }
+
+  return {
+    skipped: false,
+    drift,
+  };
+}
+
+// ─── Default Native Task Base Directory ──────────────────────────────────────
+
+function defaultNativeTaskBaseDir(): string {
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
+  return path.join(home, '.claude', 'tasks');
+}
+
 // ─── handleReconcile ────────────────────────────────────────────────────────
 
 export async function handleReconcile(
   input: ReconcileInput,
   stateDir: string,
+  nativeTaskBaseDir?: string,
 ): Promise<ToolResult> {
   const stateFile = path.join(stateDir, `${input.featureId}.state.json`);
 
@@ -177,11 +349,32 @@ export async function handleReconcile(
     worktreeResults.push(result);
   }
 
+  // Task reconciliation: read raw state to access nativeTaskId (stripped by Zod)
+  let taskDrift: TaskDriftReport | undefined;
+  try {
+    const rawJson = await fs.readFile(stateFile, 'utf-8');
+    const rawState = JSON.parse(rawJson) as Record<string, unknown>;
+    const rawTasks = rawState.tasks as Array<Record<string, unknown>> | undefined;
+
+    const hasNativeTasks = rawTasks?.some(
+      (t) => typeof t.nativeTaskId === 'string',
+    );
+
+    if (hasNativeTasks && rawTasks) {
+      const baseDir = nativeTaskBaseDir ?? defaultNativeTaskBaseDir();
+      const nativeTaskDir = path.join(baseDir, input.featureId);
+      taskDrift = await reconcileTasks(rawTasks, nativeTaskDir);
+    }
+  } catch {
+    // If raw read fails, skip task reconciliation gracefully
+  }
+
   return {
     success: true,
     data: {
       featureId: state.featureId,
       worktrees: worktreeResults,
+      ...(taskDrift && { taskDrift }),
     },
     _meta: buildCheckpointMeta(state._checkpoint),
   };

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/query.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/query.ts
@@ -18,6 +18,7 @@ import { checkCircuitBreakerFromStore } from './circuit-breaker.js';
 import type { EventStore } from '../event-store/store.js';
 import { formatResult, stripNullish, type ToolResult } from '../format.js';
 import * as path from 'node:path';
+import * as os from 'node:os';
 import * as fs from 'node:fs/promises';
 
 // ─── Module-Level EventStore Configuration ──────────────────────────────────
@@ -244,7 +245,8 @@ export async function reconcileTasks(
 
     // Compare statuses
     if (normalizeStatus(exStatus) !== normalizeStatus(nativeTask.status)) {
-      const recommendation = nativeTask.status === 'completed'
+      const normalizedNative = normalizeStatus(nativeTask.status);
+      const recommendation = normalizedNative === 'completed'
         ? `Update Exarchos task to complete — native task '${nativeTaskId}' shows completed`
         : `Status mismatch: Exarchos='${exStatus}', native='${nativeTask.status}' — investigate and reconcile`;
 
@@ -286,8 +288,8 @@ export async function reconcileTasks(
 // ─── Default Native Task Base Directory ──────────────────────────────────────
 
 function defaultNativeTaskBaseDir(): string {
-  const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
-  return path.join(home, '.claude', 'tasks');
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
+  return path.resolve(home, '.claude', 'tasks');
 }
 
 // ─── handleReconcile ────────────────────────────────────────────────────────


### PR DESCRIPTION
Add reconcileTasks() to detect drift between native Agent Teams task
list (~/.claude/tasks/{featureId}/) and Exarchos workflow.tasks[].
Wired into handleReconcile — runs only when tasks have nativeTaskId
fields, reports mismatches, untracked native tasks, and missing native
tasks with actionable recommendations.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>