### PR TITLE
refactor: enrich HSM transition errors with guard metadata and document phase graphs

### DIFF
--- a/docs/prompts/optimize.md
+++ b/docs/prompts/optimize.md
@@ -2,174 +2,84 @@
 
 **Context:** This audit covers two layers:
 
-1. **MCP Server** (`plugins/exarchos/servers/exarchos-mcp/src/`) — A TypeScript MCP server with 5 composite tools spanning workflow HSM, event store, CQRS views, task coordination, stack, and sync modules. Local store is append-only JSONL (`{streamId}.events.jsonl`) with in-memory materialized views and JSON snapshots. Remote store (Marten/PostgreSQL) is scaffolded via an outbox (`sync/outbox.ts`) but not yet wired. Note: inter-agent messaging is handled by Claude Code's native Agent Teams, not by Exarchos.
+1. **MCP Server** (`plugins/exarchos/servers/exarchos-mcp/src/`) — TypeScript MCP server with composite tools spanning workflow HSM, event store, CQRS views, task coordination, stack, and sync modules. Local store is append-only JSONL with in-memory materialized views and JSON snapshots.
 
-2. **Content Layer** (`commands/`, `skills/`, `rules/`) — Markdown-based skills with YAML frontmatter, slash commands, and behavioral rules that Claude loads via progressive disclosure. These install to `~/.claude/` via symlinks and govern agent behavior across all SDLC workflows.
+2. **Content Layer** (`commands/`, `skills/`, `rules/`) — Markdown-based skills with YAML frontmatter, slash commands, and behavioral rules. Installed to `~/.claude/` via symlinks. Three-level progressive disclosure: frontmatter → SKILL.md body → `references/`.
 
-**Your Task:** Audit the codebase and identify optimization opportunities across these five categories. For each finding, state what's wrong, where it is, and what the fix should be.
-
----
-
-### 1. Pattern Alignment (MCP Server)
-
-Validate that our implementations are faithful to the canonical definitions of these patterns. Cross-reference against authoritative sources — particularly Microsoft Learn's [CQRS Pattern](https://learn.microsoft.com/en-us/azure/architecture/patterns/cqrs), [Saga Pattern](https://learn.microsoft.com/en-us/azure/architecture/patterns/saga), and [Event Sourcing](https://learn.microsoft.com/en-us/azure/architecture/patterns/event-sourcing).
-
-**CQRS — Read/write separation:**
-- Are all read paths hitting materialized views (`views/materializer.ts`), or do any tool handlers query raw events and aggregate inline? Check `stack/tools.ts` and `workflow/query.ts` specifically. (Note: task claims now use CQRS materializer — verify no regressions.)
-- Does the materializer's projection model match canonical CQRS — event stream as write model, views as read model, views rebuilt from events on demand?
-
-**Event Sourcing — Append-only, events as source of truth:**
-- Is the event store (`event-store/store.ts`) truly append-only? Are events ever mutated or deleted? (The idempotency key cache is in-memory with JSONL persistence — verify this doesn't introduce a mutation path.)
-- Are events self-describing and sufficient to rebuild state, or do any views depend on state file data (`.state.json`) that isn't derivable from events alone? The event-first architecture in `workflow/tools.ts` appends transition events BEFORE writing state files, with idempotency keys preventing duplicates on CAS retry. Verify: is `reconcileFromEvents()` sufficient to rebuild state from events alone, or do state files still carry data not captured in events?
-- Do the event schemas (`event-store/schemas.ts`) carry the metadata the ADR specifies (`correlationId`, `causationId`, `agentId`, `source`)?
-
-**Outbox — Transactional Outbox pattern:**
-- Does `sync/outbox.ts` implement the pattern faithfully? The canonical form writes to the outbox in the same transaction as the local store. Since we use JSONL (no transactions), how is atomicity approximated? The outbox drain now propagates `idempotencyKey` — verify this closes the gap where an event could be appended to JSONL but not enqueued to the outbox.
-
-**Saga — Compensation on cancel:**
-- `workflow/cancel.ts` implements checkpoint-based compensation with reverse-order execution and idempotent skip logic. Verify: Are all compensation actions truly idempotent in practice (e.g., deleting a worktree that's already gone, archiving an already-archived state file)?
-- Does checkpoint file cleanup happen after successful full compensation, or do stale checkpoints accumulate?
-
-**HSM — Hierarchical State Machine:**
-- Does the transition algorithm in `workflow/state-machine.ts` correctly implement HSM semantics (compound states, history, guards)?
-- Are guard definitions in `workflow/guards.ts` pure functions with no side effects?
+**Your Task:** Audit the codebase against the principles below. For each finding, state what violates the principle, where, and what the fix should be.
 
 ---
 
-### 2. Skill & Content Quality (Content Layer)
+### 1. Architectural Alignment
 
-Validate that all skills, commands, and rules follow Anthropic's official skill-building best practices. Use the three-level progressive disclosure model as the primary structural lens.
+Each pattern must be faithful to its canonical definition. Cross-reference against authoritative sources (Microsoft Learn CQRS, Saga, Event Sourcing patterns).
 
-**Frontmatter compliance:**
-- Does every `SKILL.md` have valid YAML frontmatter with `---` delimiters?
-- Does the `name` field use kebab-case, match the folder name, and avoid spaces/capitals/underscores?
-- Does the `description` field follow the `[What it does] + [When to use it] + [Key capabilities]` structure?
-- Are descriptions under 1,024 characters and free of XML angle brackets (`<`, `>`)?
-- Do descriptions include trigger phrases users would actually say?
-- Does `metadata` include `author`, `version`, `mcp-server` (where applicable), `category`, and `phase-affinity`?
+**CQRS:** All read paths must hit materialized views. No tool handler should query raw events and aggregate inline. The materializer must follow canonical projection: event stream as write model, views as read model, views rebuildable from events on demand.
 
-**Progressive disclosure:**
-- **Level 1 (frontmatter):** Is there enough information for Claude to decide when to load the skill without reading the body? Is the description specific enough to avoid overtriggering and detailed enough to avoid undertriggering?
-- **Level 2 (SKILL.md body):** Is the body focused on core instructions, or does it embed reference material that should live in `references/`? Is the SKILL.md under 5,000 words?
-- **Level 3 (references/):** Are detailed guides, templates, API patterns, and examples offloaded to `references/` and clearly linked from the body? Can Claude navigate to them on demand?
+**Event Sourcing:** The event store must be strictly append-only — no mutation, no deletion. Events must be self-describing and sufficient to rebuild all state. Any data in state files (`.state.json`) that isn't derivable from events alone is an integrity violation. Event schemas must carry the metadata the ADR specifies (`correlationId`, `causationId`, `agentId`, `source`).
 
-**Instruction quality:**
-- Are instructions specific and actionable (command-like: "Run X", "Call Y with Z") rather than vague ("validate the data before proceeding")?
-- Are critical instructions placed at the top of the document, using `## Important` or `## Critical` headers?
-- Is error handling documented for common failure modes with cause/solution pairs?
-- Are examples provided for common scenarios showing trigger, steps, and expected result?
-- Are instructions free of ambiguous language? ("Make sure to validate things properly" is bad; "CRITICAL: Before calling X, verify: [checklist]" is good.)
+**Outbox:** The transactional outbox pattern requires the outbox write and the local store write to be atomic. Since JSONL has no transactions, verify that the atomicity approximation (idempotency keys across both stores) closes all gaps where an event could be appended to JSONL but not enqueued to the outbox.
 
-**Command structure:**
-- Does each command in `commands/*.md` have valid frontmatter and reference its skill via `@skills/<name>/SKILL.md`?
-- Do commands include workflow position diagrams showing where they sit in the phase pipeline?
-- Are commands focused on entry-point routing or do they duplicate skill logic inline?
+**Saga:** Compensation actions must be idempotent — every compensating operation must be safe to re-execute (e.g., deleting an already-deleted worktree, archiving an already-archived file). Checkpoint files must be cleaned up after successful completion.
 
-**Use case documentation:**
-- Does each skill document its intended use cases in `Trigger / Steps / Result` format — either in the SKILL.md body or a `references/` file?
-- Are use cases concrete enough to serve as functional test cases? (e.g., "User says 'help me plan this sprint' -> Fetch project status -> Analyze capacity -> Suggest prioritization -> Create tasks -> Result: Fully planned sprint with tasks created")
-- Do skills that serve multiple use cases document each one, or rely on a single generic description?
-
-**Composability:**
-- Do any skills assume they are the only loaded skill? (e.g., monopolizing workflow state, conflicting tool usage patterns, overriding global behavior)
-- When multiple skills are loaded simultaneously (our default), do any have conflicting instructions for the same trigger conditions?
-- Do skills cleanly delegate to other skills where appropriate, or do they duplicate logic that belongs in a different skill?
-
-**Validation scripts:**
-- For skills with critical validation steps (gate checks, review criteria, quality thresholds), are those checks implemented as `scripts/` that run programmatically, or expressed only as prose instructions? (Note: skills should reference their validation scripts — either in SKILL.md body or `references/` subdirectories. Verified as of v2 audit.)
-- Code is deterministic; language interpretation is not. Identify validation steps that would benefit from a bundled script rather than relying on Claude to interpret prose criteria consistently.
-
-**Rule scoping:**
-- Do rules in `rules/*.md` use `paths` frontmatter to scope to specific file patterns where applicable?
-- Are rules behavioral constraints (not implementation instructions)?
-- Do any rules conflict with each other or with skill instructions?
+**HSM:** The transition algorithm must implement full HSM semantics: compound states, history, guards. Guard functions must be pure — no side effects.
 
 ---
 
-### 3. Token Economy (Both Layers)
+### 2. Token Economy
 
-Every byte in a tool response or skill body consumes agent context window. Audit both layers for unnecessary payload.
+Every byte in a tool response or skill body consumes agent context window.
 
-**MCP tool responses (`views/tools.ts`):**
-- Do view handlers return full objects when agents typically only need summary fields? (e.g., full `TaskDetail` vs. `{ taskId, status, assignee }`)
-- Does `handleViewPipeline` embed event arrays that grow unbounded?
-- Could a `compact` vs. `full` parameter let agents choose their detail level?
+**MCP tool responses:** Return the minimum payload agents need. Prefer reference IDs over embedded objects. Offer `compact` vs. `full` detail levels where applicable. Views must not embed unbounded arrays (e.g., growing event lists). Enforce a consistent, minimal `ToolResult` shape across all modules.
 
-**Workflow responses:**
-- Does `handleSummary` (`workflow/query.ts`) return full event payloads when `{ type, timestamp }` references would suffice?
+**Event payloads:** Event types must not carry large freeform strings (`detail`, `diagnostics`, `context`) that inflate view projections downstream. Keep events lean; attach detail to linked artifacts, not to the event itself.
 
-**Event payloads (`event-store/schemas.ts`):**
-- Do any event types carry large freeform strings (`detail`, `diagnostics`, `context`) that inflate view projections downstream?
+**Skill budget:** SKILL.md files should stay under 1,300 words. Move templates, checklists, code blocks, and reference material to `references/` for on-demand access. Commands must reference skills via `@skills/` paths, not embed skill content inline. References should be linked for progressive discovery, not loaded eagerly.
 
-**MCP general patterns:**
-- Are Ref IDs (`taskId`, `streamId`) used instead of embedding full objects, forcing agents to drill down only when needed?
-- Is `format.ts` enforcing a consistent, minimal `ToolResult` shape across all modules?
-
-**Skill token budget:**
-- Which `SKILL.md` files exceed 5,000 words? These degrade Claude's instruction-following and should be split into body + `references/`. (Note: skills are expected to be under 1,300 words. Verified as of v2 audit.)
-- Are any skills loading large inline templates, checklists, or code blocks that could be moved to `references/` for on-demand access?
-- Do commands embed full skill content inline instead of referencing via `@skills/` paths?
-- Are any `references/` files loaded eagerly (mentioned at the top of SKILL.md as required reading) rather than linked for progressive discovery?
-
-**Rule token cost:**
-- Are any rules excessively verbose for the constraint they express?
-- Could related rules be consolidated without losing specificity?
-- Do any rules repeat guidance already present in `CLAUDE.md` or skills?
+**Rule budget:** Rules should be concise behavioral constraints, not verbose implementation guides. Consolidate related rules without losing specificity. Eliminate duplication with `CLAUDE.md` or skills. Scope rules to file patterns via `paths` frontmatter where applicable.
 
 ---
 
-### 4. Operational Performance (MCP Server)
+### 3. Operational Performance
 
-Audit runtime characteristics: latency per tool call, I/O patterns, memory growth, and concurrency safety.
+**I/O efficiency:** Read paths should skip unnecessary parsing (e.g., pre-filtering event lines by sequence before `JSON.parse`). Verify that invariants supporting these optimizations (line-number-equals-sequence) hold under all conditions including compaction and manual edits.
 
-**Implemented safeguards (confirmed working — audit for regressions):**
-- **Pre-parse sequence filtering** — `query()` skips `JSON.parse` for lines below `sinceSequence`. Verify the line-number-equals-sequence invariant holds after compaction or manual edits. Event store now tolerates blank lines.
-- **LRU eviction** — `ViewMaterializer` has configurable `maxCacheEntries` (default 100) with Map-order LRU. Verify eviction doesn't discard views that are immediately re-requested in tight loops.
-- **CAS versioning + idempotency** — `workflow/tools.ts` uses `_version` with retry loop (max 3) and event-first architecture with idempotency keys preventing duplicates on CAS retry. Verify retry exhaustion produces a clear error, not silent data loss.
-- **Optimistic task claims** — `handleTaskClaim` now uses CQRS materializer (not inline event aggregation) with `expectedSequence`. Verify the retry loop handles sequence gaps from concurrent event appends.
-- **Idempotency keys** — `append()` deduplicates via in-memory FIFO cache (100 keys), rebuilt from JSONL on restart. Verify cache rebuild performance at scale (thousands of events per stream).
-- **Saga compensation** — `cancel.ts` persists `CompensationCheckpoint` on partial failure for resumable re-execution. Checkpoint cleanup after successful completion confirmed working.
+**Memory management:** Caches must have bounded size with eviction policies. Verify eviction doesn't thrash in tight request loops. Idempotency key caches rebuilt from disk on restart must perform acceptably at scale.
 
-**Open concerns:**
-- `event-store/store.ts` — In-memory promise-chain locks only protect within a single Node.js process. If multiple MCP instances share a `stateDir`, JSONL corruption is possible. Is the single-instance assumption validated or enforced (e.g., PID lock file)?
-- `event-store/store.ts` — The `.seq` cache race condition: if two processes both call `initializeSequence()` concurrently, both may compute the same sequence number. The cache is best-effort, but what's the blast radius of a stale `.seq` value?
-- `views/tools.ts` — Cold-start materialization replays all events. At what event count does cold start become a latency problem? Is snapshot loading reliable enough to avoid this in practice?
-- Are there hot paths beyond `workflow/tools.ts` fast-path that pay unnecessary Zod validation costs?
+**Concurrency safety:** In-process locks (promise chains) only protect a single Node.js process. If the architecture assumes single-instance, that assumption must be enforced (e.g., PID lock file), not just documented. Sequence number initialization must be safe under concurrent access.
+
+**Cold start:** View materialization that replays all events must have a viable snapshot strategy to avoid latency degradation as event counts grow.
+
+**Validation cost:** Zod validation on hot paths has measurable overhead. Reserve schema validation for system boundaries (external input, API responses), not internal data passing between trusted modules.
+
+**Error clarity:** Retry exhaustion (CAS loops, optimistic concurrency) must produce clear, actionable errors — never silent data loss.
 
 ---
 
-### 5. Workflow Effectiveness (Content Layer)
+### 4. Skill & Content Quality
 
-Validate that skills produce consistent, efficient outcomes when Claude executes them. Use Anthropic's quantitative and qualitative success criteria as the benchmark.
+Validate against Anthropic's skill-building best practices and the three-level progressive disclosure model.
 
-**Triggering accuracy:**
-- For each skill, identify 3-5 phrases that should trigger it and 3-5 that should not. Does the `description` field discriminate correctly?
-- Are there skills with overlapping trigger conditions that could cause ambiguous loading? (e.g., `/ideate` vs. `/plan` — when would Claude load the wrong one?)
-- Do any skills lack negative triggers where scope clarification would prevent misfires?
+**Frontmatter:** Valid YAML with `---` delimiters. `name` in kebab-case matching folder name. `description` follows `[What] + [When] + [Capabilities]`, under 1,024 chars, includes trigger phrases, no XML angle brackets. `metadata` includes `author`, `version`, `category`, `phase-affinity`, and `mcp-server` where applicable.
 
-**Workflow completeness:**
-- Can each skill complete its workflow in X tool calls without user correction? Identify steps where Claude is likely to need redirection.
-- Are dependencies between steps explicit? (e.g., "Wait for: payment method verification" before proceeding)
-- Are rollback or compensation instructions included for steps that can fail?
-- Do multi-MCP workflows (skills that coordinate Exarchos + GitHub + Graphite) have clear phase separation, data passing between phases, and validation before proceeding?
+**Progressive disclosure:** Level 1 (frontmatter) must be sufficient to decide when to load without reading the body — specific enough to avoid overtriggering, detailed enough to avoid undertriggering. Level 2 (body) focused on core instructions only. Level 3 (`references/`) holds all detailed guides, templates, and examples.
 
-**Pattern adherence:**
-- Which Anthropic skill pattern does each skill follow? (Sequential orchestration, Multi-MCP coordination, Iterative refinement, Context-aware tool selection, Domain-specific intelligence)
-- Are skills that should use iterative refinement (e.g., `/review`) structured with explicit quality criteria and termination conditions?
-- Are skills that coordinate multiple MCPs (e.g., `/synthesize` using Exarchos + Graphite + GitHub) structured with clear phase separation?
+**Instruction quality:** Instructions must be specific and actionable ("Run X", "Call Y with Z"), not vague ("validate things properly"). Critical instructions at the top. Error handling documented as cause/solution pairs. Examples in `Trigger / Steps / Result` format concrete enough to serve as functional test cases.
 
-**Consistency across sessions:**
-- Do skills produce structurally consistent output when run 3-5 times with the same input?
-- Are there any skills where the output format varies depending on which MCP responses Claude sees first?
-- Do checkpoint/resume flows (`/checkpoint`, `/resume`) preserve enough context to continue without quality degradation?
+**Composability:** No skill should assume it is the only loaded skill. No conflicting instructions for the same trigger conditions across simultaneously loaded skills. Skills must delegate to other skills where appropriate, not duplicate logic.
 
-**Performance baseline:**
-- For each primary workflow skill (`/ideate`, `/debug`, `/refactor`), estimate the with-skill vs. without-skill cost:
-  - Messages exchanged (back-and-forth requiring user redirection)
-  - Failed MCP tool calls (wrong parameters, missing context)
-  - Total tokens consumed (skill overhead vs. ad-hoc prompting)
-- Identify skills where the overhead of loading the skill (token cost of SKILL.md + references) may exceed the efficiency gains for simple tasks. Should any skills offer a "lite" mode?
+**Deterministic validation:** Validation steps (gate checks, review criteria, quality thresholds) should be implemented as executable scripts, not prose instructions. Code is deterministic; language interpretation is not.
 
-**Model laziness mitigation:**
-- Do any skills lack explicit encouragement to be thorough? (e.g., "Take your time", "Quality is more important than speed", "Do not skip validation steps")
-- Note: Anthropic recommends adding these to user prompts rather than SKILL.md — are any misplaced?
+---
+
+### 5. Workflow Effectiveness
+
+**Triggering accuracy:** For each skill, its `description` must cleanly discriminate between phrases that should and should not trigger it. No two skills should have ambiguous overlap in trigger conditions.
+
+**Workflow completeness:** Each skill should complete its workflow without user correction. Step dependencies must be explicit. Rollback/compensation instructions must be included for steps that can fail. Multi-MCP workflows (Exarchos + GitHub + Graphite) must have clear phase separation, explicit data passing, and validation gates between phases.
+
+**Pattern adherence:** Each skill should follow the appropriate Anthropic skill pattern (sequential orchestration, multi-MCP coordination, iterative refinement, context-aware tool selection, domain-specific intelligence). Iterative skills need explicit quality criteria and termination conditions. Multi-MCP skills need clear phase separation.
+
+**Session consistency:** Skills must produce structurally consistent output across repeated runs with the same input. Output format must not depend on MCP response ordering. Checkpoint/resume flows must preserve sufficient context to continue without quality degradation.
+
+**Overhead justification:** The token cost of loading a skill (SKILL.md + eagerly loaded references) must be justified by the efficiency gain over ad-hoc prompting. Skills where overhead may exceed benefit for simple tasks should offer a streamlined path.

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
@@ -504,6 +504,13 @@ describe('HSM Transition Algorithm', () => {
       expect(result.errorCode).toBe('INVALID_TRANSITION');
       expect(result.validTargets).toBeDefined();
       expect(result.validTargets!.length).toBeGreaterThan(0);
+
+      // Enriched validTargets include guard metadata
+      const planTarget = result.validTargets!.find((t) => t.phase === 'plan');
+      expect(planTarget).toBeDefined();
+      expect(planTarget!.guard).toBeDefined();
+      expect(planTarget!.guard!.id).toBe('design-artifact-exists');
+      expect(planTarget!.guard!.description).toBe('Design artifact must exist');
     });
 
     it('ExecuteTransition_GuardFails_ReturnsGuardFailed', () => {
@@ -685,12 +692,15 @@ describe('HSM Transition Algorithm', () => {
   });
 
   describe('getValidTransitions', () => {
+    /** Extract phase strings from enriched ValidTransitionTarget array */
+    const phases = (targets: readonly { phase: string }[]) => targets.map((t) => t.phase);
+
     it('returns valid target phases from a given phase', () => {
       const hsm = getHSMDefinition('feature');
       const targets = getValidTransitions(hsm, 'ideate');
 
-      expect(targets).toContain('plan');
-      expect(targets).toContain('cancelled');
+      expect(phases(targets)).toContain('plan');
+      expect(phases(targets)).toContain('cancelled');
     });
 
     it('returns empty array for final states', () => {
@@ -705,45 +715,45 @@ describe('HSM Transition Algorithm', () => {
 
       // delegate is inside implementation compound — goes directly to review
       const delegateTargets = getValidTransitions(hsm, 'delegate');
-      expect(delegateTargets).toContain('review');
-      expect(delegateTargets).toContain('cancelled');
-      expect(delegateTargets).not.toContain('integrate');
+      expect(phases(delegateTargets)).toContain('review');
+      expect(phases(delegateTargets)).toContain('cancelled');
+      expect(phases(delegateTargets)).not.toContain('integrate');
 
       // review has two transitions: synthesize (passed) and delegate (fix cycle)
       const reviewTargets = getValidTransitions(hsm, 'review');
-      expect(reviewTargets).toContain('synthesize');
-      expect(reviewTargets).toContain('delegate');
-      expect(reviewTargets).toContain('cancelled');
+      expect(phases(reviewTargets)).toContain('synthesize');
+      expect(phases(reviewTargets)).toContain('delegate');
+      expect(phases(reviewTargets)).toContain('cancelled');
     });
 
     it('returns valid transitions for debug HSM phases', () => {
       const hsm = getHSMDefinition('debug');
 
       const triageTargets = getValidTransitions(hsm, 'triage');
-      expect(triageTargets).toContain('investigate');
-      expect(triageTargets).toContain('cancelled');
+      expect(phases(triageTargets)).toContain('investigate');
+      expect(phases(triageTargets)).toContain('cancelled');
 
       const investigateTargets = getValidTransitions(hsm, 'investigate');
-      expect(investigateTargets).toContain('rca');
-      expect(investigateTargets).toContain('hotfix-implement');
-      expect(investigateTargets).toContain('cancelled');
+      expect(phases(investigateTargets)).toContain('rca');
+      expect(phases(investigateTargets)).toContain('hotfix-implement');
+      expect(phases(investigateTargets)).toContain('cancelled');
 
       const rcaTargets = getValidTransitions(hsm, 'rca');
-      expect(rcaTargets).toContain('design');
-      expect(rcaTargets).toContain('cancelled');
+      expect(phases(rcaTargets)).toContain('design');
+      expect(phases(rcaTargets)).toContain('cancelled');
     });
 
     it('returns valid transitions for refactor HSM phases', () => {
       const hsm = getHSMDefinition('refactor');
 
       const exploreTargets = getValidTransitions(hsm, 'explore');
-      expect(exploreTargets).toContain('brief');
-      expect(exploreTargets).toContain('cancelled');
+      expect(phases(exploreTargets)).toContain('brief');
+      expect(phases(exploreTargets)).toContain('cancelled');
 
       const briefTargets = getValidTransitions(hsm, 'brief');
-      expect(briefTargets).toContain('polish-implement');
-      expect(briefTargets).toContain('overhaul-plan');
-      expect(briefTargets).toContain('cancelled');
+      expect(phases(briefTargets)).toContain('polish-implement');
+      expect(phases(briefTargets)).toContain('overhaul-plan');
+      expect(phases(briefTargets)).toContain('cancelled');
     });
 
     it('returns empty array for cancelled (final) state', () => {
@@ -1650,6 +1660,58 @@ describe('Final state transitions', () => {
 
     expect(result.success).toBe(false);
     expect(result.errorCode).toBe('INVALID_TRANSITION');
+  });
+});
+
+// ─── Task: getValidTransitions enriched output ────────────────────────────────
+
+describe('getValidTransitions guard metadata', () => {
+  it('returns guard id and description for guarded transitions', () => {
+    const hsm = getHSMDefinition('feature');
+    const targets = getValidTransitions(hsm, 'ideate');
+
+    const planTarget = targets.find((t) => t.phase === 'plan');
+    expect(planTarget).toBeDefined();
+    expect(planTarget!.guard).toEqual({
+      id: 'design-artifact-exists',
+      description: 'Design artifact must exist',
+    });
+  });
+
+  it('omits guard for unguarded transitions (cancelled)', () => {
+    const hsm = getHSMDefinition('feature');
+    const targets = getValidTransitions(hsm, 'ideate');
+
+    const cancelTarget = targets.find((t) => t.phase === 'cancelled');
+    expect(cancelTarget).toBeDefined();
+    expect(cancelTarget!.guard).toBeUndefined();
+  });
+
+  it('includes merge-verified guard for universal completed transition', () => {
+    const hsm = getHSMDefinition('feature');
+    const targets = getValidTransitions(hsm, 'ideate');
+
+    const completedTarget = targets.find((t) => t.phase === 'completed');
+    expect(completedTarget).toBeDefined();
+    expect(completedTarget!.guard).toEqual({
+      id: 'merge-verified',
+      description: 'Merge must be verified by the orchestrator before cleanup',
+    });
+  });
+
+  it('returns empty array for final states', () => {
+    const hsm = getHSMDefinition('feature');
+    expect(getValidTransitions(hsm, 'completed')).toEqual([]);
+    expect(getValidTransitions(hsm, 'cancelled')).toEqual([]);
+  });
+
+  it('returns guards for refactor polish track transitions', () => {
+    const hsm = getHSMDefinition('refactor');
+    const targets = getValidTransitions(hsm, 'polish-validate');
+
+    const docsTarget = targets.find((t) => t.phase === 'polish-update-docs');
+    expect(docsTarget).toBeDefined();
+    expect(docsTarget!.guard!.id).toBe('goals-verified');
   });
 });
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -585,7 +585,13 @@ describe('Core Tools', () => {
       expect(result.error).toBeDefined();
       expect(result.error?.code).toBe('INVALID_TRANSITION');
       expect(result.error?.validTargets).toBeDefined();
-      expect(result.error?.validTargets).toContain('plan');
+
+      // Enriched validTargets include guard metadata
+      const targets = result.error?.validTargets as Array<{ phase: string; guard?: { id: string; description: string } }>;
+      const planTarget = targets.find((t) => t.phase === 'plan');
+      expect(planTarget).toBeDefined();
+      expect(planTarget!.guard).toBeDefined();
+      expect(planTarget!.guard!.id).toBe('design-artifact-exists');
     });
   });
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/format.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/format.ts
@@ -1,9 +1,11 @@
 // ─── Shared Tool Result Formatting ──────────────────────────────────────────
 
+import type { ValidTransitionTarget } from './workflow/state-machine.js';
+
 export interface ToolResult {
   readonly success: boolean;
   readonly data?: unknown;
-  readonly error?: { code: string; message: string; validTargets?: readonly string[] };
+  readonly error?: { code: string; message: string; validTargets?: readonly (string | ValidTransitionTarget)[] };
   readonly _meta?: unknown;
 }
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/state-machine.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/state-machine.ts
@@ -43,6 +43,11 @@ export interface TransitionEvent {
   readonly metadata?: Record<string, unknown>;
 }
 
+export interface ValidTransitionTarget {
+  readonly phase: string;
+  readonly guard?: { readonly id: string; readonly description: string };
+}
+
 export interface TransitionResult {
   readonly success: boolean;
   readonly idempotent: boolean;
@@ -53,7 +58,7 @@ export interface TransitionResult {
   readonly errorCode?: string;
   readonly errorMessage?: string;
   readonly guardDescription?: string;
-  readonly validTargets?: readonly string[];
+  readonly validTargets?: readonly ValidTransitionTarget[];
 }
 
 // ─── HSM Registry ───────────────────────────────────────────────────────────
@@ -119,30 +124,40 @@ function countFixCycles(
 
 /**
  * Get all valid target phases for transitions from a given phase,
- * including the universal cancel transition.
+ * including the universal cancel and cleanup transitions.
+ * Returns guard metadata for each target so agents can see prerequisites.
  */
 export function getValidTransitions(
   hsm: HSMDefinition,
   fromPhase: string
-): readonly string[] {
+): readonly ValidTransitionTarget[] {
   const state = hsm.states[fromPhase];
   if (!state || state.type === 'final') return [];
 
-  const targets = hsm.transitions
-    .filter((t) => t.from === fromPhase)
-    .map((t) => t.to);
+  const seen = new Set<string>();
+  const targets: ValidTransitionTarget[] = [];
+
+  for (const t of hsm.transitions) {
+    if (t.from !== fromPhase || seen.has(t.to)) continue;
+    seen.add(t.to);
+    targets.push(
+      t.guard
+        ? { phase: t.to, guard: { id: t.guard.id, description: t.guard.description } }
+        : { phase: t.to },
+    );
+  }
 
   // Add universal cancel if not already present
-  if (!targets.includes('cancelled') && hsm.states['cancelled']) {
-    targets.push('cancelled');
+  if (!seen.has('cancelled') && hsm.states['cancelled']) {
+    targets.push({ phase: 'cancelled' });
   }
 
   // Add universal cleanup (completed) if not already present
-  if (!targets.includes('completed') && hsm.states['completed']) {
-    targets.push('completed');
+  if (!seen.has('completed') && hsm.states['completed']) {
+    targets.push({ phase: 'completed', guard: { id: 'merge-verified', description: 'Merge must be verified by the orchestrator before cleanup' } });
   }
 
-  return [...new Set(targets)];
+  return targets;
 }
 
 /**

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/state-machine.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/state-machine.ts
@@ -154,7 +154,7 @@ export function getValidTransitions(
 
   // Add universal cleanup (completed) if not already present
   if (!seen.has('completed') && hsm.states['completed']) {
-    targets.push({ phase: 'completed', guard: { id: 'merge-verified', description: 'Merge must be verified by the orchestrator before cleanup' } });
+    targets.push({ phase: 'completed', guard: { id: guards.mergeVerified.id, description: guards.mergeVerified.description } });
   }
 
   return targets;

--- a/skills/workflow-state/SKILL.md
+++ b/skills/workflow-state/SKILL.md
@@ -30,6 +30,10 @@ Activate this skill when:
 - Restoring context after summarization (`/resume`)
 - Saving progress for later continuation (`/checkpoint`)
 
+## Phase Transitions
+
+Valid transitions, guards, and prerequisites for all workflow types are documented in `references/phase-transitions.md`. **CRITICAL:** When a transition has a guard, send the prerequisite `updates` and `phase` in a single `set` call — updates apply before guards evaluate.
+
 ## State File Location
 
 ```

--- a/skills/workflow-state/references/mcp-tool-reference.md
+++ b/skills/workflow-state/references/mcp-tool-reference.md
@@ -10,7 +10,7 @@ Unified MCP server for workflow orchestration, event sourcing, CQRS views, and t
 
 | Tool | Actions | When to Use |
 |------|---------|-------------|
-| `mcp__exarchos__exarchos_workflow` | `init`, `get`, `set`, `cancel` | Workflow CRUD: starting workflows, reading/updating state, cancelling abandoned workflows |
+| `mcp__exarchos__exarchos_workflow` | `init`, `get`, `set`, `cancel`, `cleanup` | Workflow CRUD: starting workflows, reading/updating state, cancelling abandoned workflows, resolving merged workflows |
 | `mcp__exarchos__exarchos_event` | `append`, `query` | Event sourcing: recording workflow events, reading event history |
 | `mcp__exarchos__exarchos_orchestrate` | `task_claim`, `task_complete`, `task_fail` | Task coordination and lifecycle |
 | `mcp__exarchos__exarchos_view` | `pipeline`, `tasks`, `workflow_status`, `stack_status`, `stack_place` | CQRS materialized views for read-optimized queries |
@@ -24,6 +24,7 @@ Unified MCP server for workflow orchestration, event sourcing, CQRS views, and t
 | `get` | Restoring context, checking phase, reading task details. Use `query` for dot-path lookup (e.g., `query: "phase"`), or `fields` array for projection (e.g., `fields: ["phase", "tasks"]`) to reduce token cost |
 | `set` | Updating phase (`phase: "delegate"`), recording artifacts, marking tasks complete. Use `updates` for field changes and `phase` for transitions |
 | `cancel` | Cleaning up abandoned workflows. Supports `dryRun: true` to preview cleanup actions |
+| `cleanup` | Resolve a merged workflow to completed. Verifies merge, backfills synthesis metadata, force-resolves reviews, transitions to completed. Requires `mergeVerified: true` — pass after verifying PRs are merged via GitHub API |
 
 **Hooks (automatic, no tool call needed):**
 - **SessionStart hook** — Discovers active workflows, restores context, determines next action, and verifies state on resume (replaces former `workflow_list`, `workflow_summary`, `workflow_next_action`, `workflow_reconcile` tools)

--- a/skills/workflow-state/references/mcp-tool-reference.md
+++ b/skills/workflow-state/references/mcp-tool-reference.md
@@ -28,7 +28,7 @@ Unified MCP server for workflow orchestration, event sourcing, CQRS views, and t
 **Hooks (automatic, no tool call needed):**
 - **SessionStart hook** — Discovers active workflows, restores context, determines next action, and verifies state on resume (replaces former `workflow_list`, `workflow_summary`, `workflow_next_action`, `workflow_reconcile` tools)
 - **PreCompact hook** — Saves checkpoints before context exhaustion (replaces former `workflow_checkpoint` tool)
-- Valid phase transitions are documented statically (replaces former `workflow_transitions` tool)
+- Valid phase transitions are documented in `references/phase-transitions.md` (replaces former `workflow_transitions` tool). `INVALID_TRANSITION` errors include valid targets with guard descriptions.
 
 ### Event Tool Actions
 
@@ -147,6 +147,17 @@ Official Microsoft/Azure documentation via remote HTTP MCP. **Use for any Micros
 | `get-document` | Deep-reading full docs when search excerpts aren't enough |
 
 **Proactive use:** When working with .NET, Azure, or any Microsoft SDK, search docs to verify API usage rather than guessing from training data.
+
+## Workflow Transition Errors
+
+### INVALID_TRANSITION
+No path exists from current phase to target. Check `validTargets` in the error — it lists reachable phases with guard descriptions. You may need to step through intermediate phases.
+
+### GUARD_FAILED
+The transition exists but the guard condition is unmet. Send prerequisite `updates` and `phase` in a **single** `set` call — updates apply before guards evaluate. See `references/phase-transitions.md` for guard prerequisites.
+
+### CIRCUIT_OPEN
+A compound state's fix cycle limit was reached. Escalate to user or cancel the workflow.
 
 ## Anti-Patterns
 

--- a/skills/workflow-state/references/phase-transitions.md
+++ b/skills/workflow-state/references/phase-transitions.md
@@ -1,0 +1,141 @@
+# Phase Transitions Reference
+
+All valid HSM phase transitions for each workflow type. Every transition listed here is the **only** way to move between phases — the HSM rejects unlisted transitions with `INVALID_TRANSITION`.
+
+## Combined Updates + Phase Pattern
+
+**CRITICAL:** When a transition has a guard that requires prerequisite state, send `updates` and `phase` in a single `set` call. Updates are applied BEFORE guards evaluate:
+
+```
+action: "set"
+featureId: "my-feature"
+phase: "delegate"
+updates: { "planReview.approved": true }
+```
+
+This satisfies the `planReviewComplete` guard in one call. Two separate calls (set data, then transition) also work but waste a tool call.
+
+## Universal Transitions
+
+Available from **any non-final** phase in all workflow types:
+
+| To | Guard | How to Trigger |
+|----|-------|----------------|
+| `cancelled` | None | `exarchos_workflow cancel` (not `set`) — runs saga compensation |
+| `completed` | `merge-verified` | `exarchos_workflow cleanup` with `mergeVerified: true` — for post-merge resolution |
+
+## Feature Workflow
+
+```
+ideate → plan → plan-review → delegate ⇄ review → synthesize → completed
+                     ↓
+                    plan (gaps found)
+```
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `ideate` | `plan` | `design-artifact-exists` | Set `artifacts.design` |
+| `plan` | `plan-review` | `plan-artifact-exists` | Set `artifacts.plan` |
+| `plan-review` | `delegate` | `plan-review-complete` | Set `planReview.approved = true` |
+| `plan-review` | `plan` | `plan-review-gaps-found` | Set `planReview.gapsFound = true` |
+| `delegate` | `review` | `all-tasks-complete` | All `tasks[].status = "complete"` |
+| `review` | `synthesize` | `all-reviews-passed` | All `reviews.{name}.status` in `["pass", "passed", "approved"]` |
+| `review` | `delegate` | `any-review-failed` | Any `reviews.{name}.status` in `["fail", "failed", "needs_fixes"]` (fix cycle) |
+| `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+| `blocked` | `delegate` | `human-unblocked` | Set `unblocked = true` |
+
+**Compound state:** `implementation` contains `delegate` and `review`. Max 3 fix cycles before circuit breaker opens.
+
+## Debug Workflow
+
+```
+triage → investigate → [hotfix-track | thorough-track] → synthesize → completed
+```
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `triage` | `investigate` | `triage-complete` | Set `triage.symptom` |
+| `investigate` | `rca` | `thorough-track-selected` | Set `track = "thorough"` |
+| `investigate` | `hotfix-implement` | `hotfix-track-selected` | Set `track = "hotfix"` |
+
+### Thorough Track
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `rca` | `design` | `rca-document-complete` | Set `artifacts.rca` |
+| `design` | `debug-implement` | `fix-design-complete` | Set `artifacts.fixDesign` |
+| `debug-implement` | `debug-validate` | `implementation-complete` | Always passes |
+| `debug-validate` | `debug-review` | `validation-passed` | Set `validation.testsPass = true` |
+| `debug-review` | `synthesize` | `review-passed` | All `reviews.{name}.status` passing |
+
+**Compound state:** `thorough-track` contains `rca` through `debug-review`. Max 2 fix cycles.
+
+### Hotfix Track
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `hotfix-implement` | `hotfix-validate` | `implementation-complete` | Always passes |
+| `hotfix-validate` | `completed` | `validation-passed` | Set `validation.testsPass = true` |
+
+### Shared
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+## Refactor Workflow
+
+```
+explore → brief → [polish-track | overhaul-track] → completed
+```
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `explore` | `brief` | `scope-assessment-complete` | Set `explore.scopeAssessment` |
+| `brief` | `polish-implement` | `polish-track-selected` | Set `track = "polish"` |
+| `brief` | `overhaul-plan` | `overhaul-track-selected` | Set `track = "overhaul"` |
+
+### Polish Track
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `polish-implement` | `polish-validate` | `implementation-complete` | Always passes |
+| `polish-validate` | `polish-update-docs` | `goals-verified` | Set `validation.testsPass = true` |
+| `polish-update-docs` | `completed` | `docs-updated` | Set `validation.docsUpdated = true` |
+
+### Overhaul Track
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `overhaul-plan` | `overhaul-delegate` | `plan-artifact-exists` | Set `artifacts.plan` |
+| `overhaul-delegate` | `overhaul-review` | `all-tasks-complete` | All `tasks[].status = "complete"` |
+| `overhaul-review` | `overhaul-update-docs` | `all-reviews-passed` | All `reviews.{name}.status` passing |
+| `overhaul-review` | `overhaul-delegate` | `any-review-failed` | Any `reviews.{name}.status` failing (fix cycle) |
+| `overhaul-update-docs` | `synthesize` | `docs-updated` | Set `validation.docsUpdated = true` |
+| `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+**Compound state:** `overhaul-track` contains `overhaul-plan` through `overhaul-review`. Max 3 fix cycles.
+
+## Troubleshooting
+
+### INVALID_TRANSITION Error
+
+The HSM rejected the transition because no path exists from the current phase to the target.
+
+1. Check `validTargets` in the error response — it lists all reachable phases with their guards
+2. You may need to step through intermediate phases (no phase skipping)
+
+### GUARD_FAILED Error
+
+The transition exists but the guard condition is not met.
+
+1. Check `guardDescription` in the error response for what's required
+2. Set the prerequisite state via `updates` in the same `set` call as the `phase`
+3. Refer to the "Prerequisite" column in the tables above
+
+### CIRCUIT_OPEN Error
+
+A compound state's fix cycle limit has been reached (e.g., review → delegate looped too many times).
+
+1. The workflow is stuck — escalate to the user
+2. Consider cancelling and restarting with a different approach


### PR DESCRIPTION
## Summary

INVALID_TRANSITION errors now include guard descriptions for each valid target phase, enabling agents to self-correct without consulting external references. Phase transition tables for all 3 workflow types are documented in a new skill reference file. The `optimize.md` audit prompt is rewritten as timeless, principle-based guidelines that don't go stale with code changes.

## Changes

- **`workflow/state-machine.ts`** — `getValidTransitions()` returns `ValidTransitionTarget` objects with `{ phase, guard?: { id, description } }` instead of bare strings. `TransitionResult.validTargets` type updated accordingly.
- **`skills/workflow-state/references/phase-transitions.md`** — New reference documenting all transitions, guards, prerequisites, and the combined updates+phase pattern for feature, debug, and refactor workflows.
- **`skills/workflow-state/SKILL.md`** — Added "Phase Transitions" section linking to the reference.
- **`skills/workflow-state/references/mcp-tool-reference.md`** — Added "Workflow Transition Errors" troubleshooting section (INVALID_TRANSITION, GUARD_FAILED, CIRCUIT_OPEN).
- **`docs/prompts/optimize.md`** — Rewritten from 2,124-word stateful audit to 1,089-word principle-based guidelines.
- **Tests** — Updated 4 existing tests for new return type; added 5 new tests for guard metadata.

## Test Plan

- [x] `npm run test:run` — 1248 passed, 0 failed
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] Manual: call `exarchos_workflow set` with invalid phase, verify enriched `validTargets` in error

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)