### PR TITLE
feat: add telemetry-awareness rule for session-start hint application

### DIFF
--- a/rules/telemetry-awareness.md
+++ b/rules/telemetry-awareness.md
@@ -1,3 +1,7 @@
+---
+title: Telemetry Awareness
+---
+
 # Telemetry Awareness
 
 When `telemetryHints` appear in session-start output, apply the suggested

--- a/rules/telemetry-awareness.md
+++ b/rules/telemetry-awareness.md
@@ -1,0 +1,4 @@
+# Telemetry Awareness
+
+When `telemetryHints` appear in session-start output, apply the suggested
+optimizations to subsequent MCP tool calls for the remainder of the session.


### PR DESCRIPTION
Add a lightweight rule that instructs the agent to apply optimization
hints from telemetryHints in session-start output to subsequent MCP
tool calls during the session.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>