### PR TITLE
feat: add quality.regression event type and CodeQualityView projection interfaces

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -358,8 +358,8 @@ describe('StackEnqueuedData', () => {
 // ─── EventTypes Discriminated Union (A03) ───────────────────────────────────
 
 describe('EventTypes', () => {
-  it('should contain all 32 event types', () => {
-    expect(EventTypes).toHaveLength(32);
+  it('should contain all 33 event types', () => {
+    expect(EventTypes).toHaveLength(33);
   });
 
   it('should include workflow-level types', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -276,6 +276,7 @@ describe('QualityRegressionData', () => {
       consecutiveFailures: 3,
       firstFailureCommit: 'abc',
       lastFailureCommit: 'def',
+      detectedAt: '2026-02-17T00:00:00.000Z',
     });
     expect(result.success).toBe(true);
     if (result.success) {
@@ -284,6 +285,7 @@ describe('QualityRegressionData', () => {
       expect(result.data.consecutiveFailures).toBe(3);
       expect(result.data.firstFailureCommit).toBe('abc');
       expect(result.data.lastFailureCommit).toBe('def');
+      expect(result.data.detectedAt).toBe('2026-02-17T00:00:00.000Z');
     }
   });
 });
@@ -291,5 +293,9 @@ describe('QualityRegressionData', () => {
 describe('EventTypes', () => {
   it('EventTypes_IncludesQualityRegression', () => {
     expect(EventTypes).toContain('quality.regression');
+  });
+
+  it('EventTypes_HasExpectedCount', () => {
+    expect(EventTypes).toHaveLength(33);
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -12,6 +12,7 @@ import {
   TeamContextInjectedData,
   TeamTaskPlannedData,
   TeamTeammateDispatchedData,
+  QualityRegressionData,
 } from './schemas.js';
 
 describe('validateAgentEvent', () => {
@@ -262,5 +263,33 @@ describe('TeamTeammateDispatchedData', () => {
       },
     });
     expect(event.success).toBe(true);
+  });
+});
+
+// ─── T11: quality.regression Event Type ──────────────────────────────────────
+
+describe('QualityRegressionData', () => {
+  it('QualityRegressionData_Valid_Parses', () => {
+    const result = QualityRegressionData.safeParse({
+      skill: 'delegation',
+      gate: 'typecheck',
+      consecutiveFailures: 3,
+      firstFailureCommit: 'abc',
+      lastFailureCommit: 'def',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.skill).toBe('delegation');
+      expect(result.data.gate).toBe('typecheck');
+      expect(result.data.consecutiveFailures).toBe(3);
+      expect(result.data.firstFailureCommit).toBe('abc');
+      expect(result.data.lastFailureCommit).toBe('def');
+    }
+  });
+});
+
+describe('EventTypes', () => {
+  it('EventTypes_IncludesQualityRegression', () => {
+    expect(EventTypes).toContain('quality.regression');
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -293,9 +293,10 @@ export const TeamTeammateDispatchedData = z.object({
 export const QualityRegressionData = z.object({
   skill: z.string(),
   gate: z.string(),
-  consecutiveFailures: z.number(),
+  consecutiveFailures: z.number().int().nonnegative(),
   firstFailureCommit: z.string(),
   lastFailureCommit: z.string(),
+  detectedAt: z.string().datetime(),
 });
 
 // ─── TypeScript Types ───────────────────────────────────────────────────────

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -35,6 +35,7 @@ export const EventTypes = [
   'team.context.injected',
   'team.task.planned',
   'team.teammate.dispatched',
+  'quality.regression',
 ] as const;
 
 export type EventType = typeof EventTypes[number];
@@ -287,6 +288,16 @@ export const TeamTeammateDispatchedData = z.object({
   model: z.string(),
 });
 
+// ─── Quality Regression Event Data ──────────────────────────────────────────
+
+export const QualityRegressionData = z.object({
+  skill: z.string(),
+  gate: z.string(),
+  consecutiveFailures: z.number(),
+  firstFailureCommit: z.string(),
+  lastFailureCommit: z.string(),
+});
+
 // ─── TypeScript Types ───────────────────────────────────────────────────────
 
 export type WorkflowEvent = z.infer<typeof WorkflowEventBase>;
@@ -322,6 +333,7 @@ export type TeamDisbanded = z.infer<typeof TeamDisbandedData>;
 export type TeamContextInjected = z.infer<typeof TeamContextInjectedData>;
 export type TeamTaskPlanned = z.infer<typeof TeamTaskPlannedData>;
 export type TeamTeammateDispatched = z.infer<typeof TeamTeammateDispatchedData>;
+export type QualityRegression = z.infer<typeof QualityRegressionData>;
 
 // ─── Agent Event Validation ──────────────────────────────────────────────────
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/code-quality-view.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/code-quality-view.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import {
+  codeQualityProjection,
+  CODE_QUALITY_VIEW,
+} from './code-quality-view.js';
+import type { CodeQualityViewState } from './code-quality-view.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+
+const makeEvent = (type: string, data: Record<string, unknown>, seq = 1): WorkflowEvent => ({
+  streamId: 'test',
+  sequence: seq,
+  timestamp: new Date().toISOString(),
+  type: type as WorkflowEvent['type'],
+  data,
+  schemaVersion: '1.0',
+});
+
+// ─── T12: Init ────────────────────────────────────────────────────────────────
+
+describe('CodeQualityView', () => {
+  describe('init', () => {
+    it('codeQualityProjection_Init_ReturnsEmptyState', () => {
+      const state = codeQualityProjection.init();
+      expect(state).toEqual({
+        skills: {},
+        gates: {},
+        regressions: [],
+        benchmarks: [],
+      });
+    });
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/code-quality-view.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/code-quality-view.ts
@@ -8,43 +8,43 @@ export const CODE_QUALITY_VIEW = 'code-quality';
 // ─── View State Interfaces ─────────────────────────────────────────────────
 
 export interface SkillQualityMetrics {
-  skill: string;
-  totalExecutions: number;
-  gatePassRate: number;
-  selfCorrectionRate: number;
-  avgRemediationAttempts: number;
-  topFailureCategories: Array<{ category: string; count: number }>;
+  readonly skill: string;
+  readonly totalExecutions: number;
+  readonly gatePassRate: number;
+  readonly selfCorrectionRate: number;
+  readonly avgRemediationAttempts: number;
+  readonly topFailureCategories: ReadonlyArray<{ readonly category: string; readonly count: number }>;
 }
 
 export interface GateMetrics {
-  gate: string;
-  executionCount: number;
-  passRate: number;
-  avgDuration: number;
-  failureReasons: Array<{ reason: string; count: number }>;
+  readonly gate: string;
+  readonly executionCount: number;
+  readonly passRate: number;
+  readonly avgDuration: number;
+  readonly failureReasons: ReadonlyArray<{ readonly reason: string; readonly count: number }>;
 }
 
 export interface BenchmarkTrend {
-  operation: string;
-  metric: string;
-  values: Array<{ value: number; commit: string; timestamp: string }>;
-  trend: 'improving' | 'stable' | 'degrading';
+  readonly operation: string;
+  readonly metric: string;
+  readonly values: ReadonlyArray<{ readonly value: number; readonly commit: string; readonly timestamp: string }>;
+  readonly trend: 'improving' | 'stable' | 'degrading';
 }
 
 export interface QualityRegression {
-  skill: string;
-  gate: string;
-  consecutiveFailures: number;
-  firstFailureCommit: string;
-  lastFailureCommit: string;
-  detectedAt: string;
+  readonly skill: string;
+  readonly gate: string;
+  readonly consecutiveFailures: number;
+  readonly firstFailureCommit: string;
+  readonly lastFailureCommit: string;
+  readonly detectedAt: string;
 }
 
 export interface CodeQualityViewState {
-  skills: Record<string, SkillQualityMetrics>;
-  gates: Record<string, GateMetrics>;
-  regressions: QualityRegression[];
-  benchmarks: BenchmarkTrend[];
+  readonly skills: Record<string, SkillQualityMetrics>;
+  readonly gates: Record<string, GateMetrics>;
+  readonly regressions: ReadonlyArray<QualityRegression>;
+  readonly benchmarks: ReadonlyArray<BenchmarkTrend>;
 }
 
 // ─── Projection ────────────────────────────────────────────────────────────

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/code-quality-view.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/code-quality-view.ts
@@ -1,0 +1,63 @@
+import type { ViewProjection } from './materializer.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+
+// ─── View Name Constant ────────────────────────────────────────────────────
+
+export const CODE_QUALITY_VIEW = 'code-quality';
+
+// ─── View State Interfaces ─────────────────────────────────────────────────
+
+export interface SkillQualityMetrics {
+  skill: string;
+  totalExecutions: number;
+  gatePassRate: number;
+  selfCorrectionRate: number;
+  avgRemediationAttempts: number;
+  topFailureCategories: Array<{ category: string; count: number }>;
+}
+
+export interface GateMetrics {
+  gate: string;
+  executionCount: number;
+  passRate: number;
+  avgDuration: number;
+  failureReasons: Array<{ reason: string; count: number }>;
+}
+
+export interface BenchmarkTrend {
+  operation: string;
+  metric: string;
+  values: Array<{ value: number; commit: string; timestamp: string }>;
+  trend: 'improving' | 'stable' | 'degrading';
+}
+
+export interface QualityRegression {
+  skill: string;
+  gate: string;
+  consecutiveFailures: number;
+  firstFailureCommit: string;
+  lastFailureCommit: string;
+  detectedAt: string;
+}
+
+export interface CodeQualityViewState {
+  skills: Record<string, SkillQualityMetrics>;
+  gates: Record<string, GateMetrics>;
+  regressions: QualityRegression[];
+  benchmarks: BenchmarkTrend[];
+}
+
+// ─── Projection ────────────────────────────────────────────────────────────
+
+export const codeQualityProjection: ViewProjection<CodeQualityViewState> = {
+  init: () => ({
+    skills: {},
+    gates: {},
+    regressions: [],
+    benchmarks: [],
+  }),
+
+  apply: (view, _event) => {
+    return view;
+  },
+};


### PR DESCRIPTION
## Summary

Adds the `quality.regression` event type to the event store schema and defines the CodeQualityView CQRS projection interfaces. This provides the foundational types and empty projection stub for quality trend analysis across workflows.

## Changes

- **event-store/schemas.ts** — Added `quality.regression` to `EventTypes` array, `QualityRegressionData` Zod schema, and `QualityRegression` type export
- **views/code-quality-view.ts** — Created projection file with `SkillQualityMetrics`, `GateMetrics`, `BenchmarkTrend`, `QualityRegression`, and `CodeQualityViewState` interfaces; stub `ViewProjection` with `init()` and passthrough `apply()`
- **event-store/schemas.test.ts** — Tests for schema parsing and EventTypes inclusion
- **views/code-quality-view.test.ts** — Test for projection init returning empty state

## Test Plan

- [x] `QualityRegressionData` parses valid payload
- [x] `EventTypes` contains `quality.regression`
- [x] `codeQualityProjection.init()` returns `{ skills: {}, gates: {}, regressions: [], benchmarks: [] }`