### PR TITLE
feat: CAS diagnostic events, configurable LRU cache, and exponential backoff

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -358,8 +358,8 @@ describe('StackEnqueuedData', () => {
 // ─── EventTypes Discriminated Union (A03) ───────────────────────────────────
 
 describe('EventTypes', () => {
-  it('should contain all 33 event types', () => {
-    expect(EventTypes).toHaveLength(33);
+  it('should contain all 34 event types', () => {
+    expect(EventTypes).toHaveLength(34);
   });
 
   it('should include workflow-level types', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -2951,3 +2951,49 @@ describe('ToolReconcile_WithoutNativeTaskId_OmitsTaskDrift', () => {
     expect(data.taskDrift).toBeUndefined();
   });
 });
+
+// ─── T27: CAS Diagnostic Event on Exhaustion ────────────────────────────────
+
+describe('HandleSet CAS Diagnostic', () => {
+  it('HandleSet_CasExhausted_EmitsWorkflowCasFailed', async () => {
+    const eventStore = new EventStore(tmpDir);
+    configureWorkflowEventStore(eventStore);
+
+    // Arrange: Create workflow and set design artifact
+    await handleInit({ featureId: 'cas-diag', workflowType: 'feature' }, tmpDir);
+    await handleSet(
+      { featureId: 'cas-diag', updates: { 'artifacts.design': 'design.md' } },
+      tmpDir,
+    );
+
+    // Mock writeStateFile to always throw VersionConflictError (exhaust all retries)
+    const stateStoreMod = await import('../../workflow/state-store.js');
+    const writeSpy = vi.spyOn(stateStoreMod, 'writeStateFile').mockImplementation(
+      async (_stateFile, _state, options) => {
+        if (options?.expectedVersion !== undefined) {
+          throw new VersionConflictError(options.expectedVersion, options.expectedVersion + 1);
+        }
+        // Non-CAS writes pass through (shouldn't happen in this test)
+        throw new Error('Unexpected non-CAS write');
+      },
+    );
+
+    // Act: Transition from ideate to plan (should exhaust CAS retries)
+    try {
+      await handleSet({ featureId: 'cas-diag', phase: 'plan' }, tmpDir);
+    } catch {
+      // Expected to throw after CAS exhaustion
+    }
+
+    // Assert: Check that a workflow.cas-failed event was emitted
+    const events = await eventStore.query('cas-diag');
+    const casFailedEvents = events.filter(e => e.type === 'workflow.cas-failed');
+    expect(casFailedEvents).toHaveLength(1);
+    const casFailedData = casFailedEvents[0].data as Record<string, unknown>;
+    expect(casFailedData.featureId).toBe('cas-diag');
+    expect(casFailedData.phase).toBeDefined();
+    expect(casFailedData.retries).toBeDefined();
+
+    writeSpy.mockRestore();
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -13,6 +13,7 @@ import {
   TeamTaskPlannedData,
   TeamTeammateDispatchedData,
   QualityRegressionData,
+  WorkflowCasFailedData,
 } from './schemas.js';
 
 describe('validateAgentEvent', () => {
@@ -290,12 +291,34 @@ describe('QualityRegressionData', () => {
   });
 });
 
+// ─── T26: workflow.cas-failed Event Schema ───────────────────────────────────
+
+describe('WorkflowCasFailedData', () => {
+  it('WorkflowCasFailedData_Valid_Parses', () => {
+    const result = WorkflowCasFailedData.safeParse({
+      featureId: 'test',
+      phase: 'delegate',
+      retries: 3,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.featureId).toBe('test');
+      expect(result.data.phase).toBe('delegate');
+      expect(result.data.retries).toBe(3);
+    }
+  });
+});
+
 describe('EventTypes', () => {
   it('EventTypes_IncludesQualityRegression', () => {
     expect(EventTypes).toContain('quality.regression');
   });
 
+  it('EventTypes_IncludesWorkflowCasFailed', () => {
+    expect(EventTypes).toContain('workflow.cas-failed');
+  });
+
   it('EventTypes_HasExpectedCount', () => {
-    expect(EventTypes).toHaveLength(33);
+    expect(EventTypes).toHaveLength(34);
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -36,6 +36,7 @@ export const EventTypes = [
   'team.task.planned',
   'team.teammate.dispatched',
   'quality.regression',
+  'workflow.cas-failed',
 ] as const;
 
 export type EventType = typeof EventTypes[number];
@@ -196,6 +197,12 @@ export const WorkflowCircuitOpenData = z.object({
   maxFixCycles: z.number().int().optional(),
 });
 
+export const WorkflowCasFailedData = z.object({
+  featureId: z.string(),
+  phase: z.string(),
+  retries: z.number().int(),
+});
+
 // ─── Telemetry Event Data ──────────────────────────────────────────────────
 
 export const ToolInvokedData = z.object({
@@ -322,6 +329,7 @@ export type WorkflowCleanup = z.infer<typeof WorkflowCleanupData>;
 export type WorkflowCancel = z.infer<typeof WorkflowCancelData>;
 export type WorkflowCompensation = z.infer<typeof WorkflowCompensationData>;
 export type WorkflowCircuitOpen = z.infer<typeof WorkflowCircuitOpenData>;
+export type WorkflowCasFailed = z.infer<typeof WorkflowCasFailedData>;
 export type ToolInvoked = z.infer<typeof ToolInvokedData>;
 export type ToolCompleted = z.infer<typeof ToolCompletedData>;
 export type ToolErrored = z.infer<typeof ToolErroredData>;

--- a/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.test.ts
@@ -170,6 +170,17 @@ describe('handleTaskClaim (materialized view)', () => {
 // This lets us verify retry count and delay scheduling without waiting.
 
 describe('handleTaskClaim Exponential Backoff', () => {
+  // Math.random is mocked to 0 so jitter is eliminated and delay values
+  // become fully deterministic. setTimeout is spied to call fn() synchronously,
+  // avoiding real wall-clock waits while still recording requested delays.
+  beforeEach(() => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('HandleTaskClaim_Retries_WithExponentialBackoff', async () => {
     // Arrange: seed the stream before installing the setTimeout spy
     const store = new EventStore(tempDir);
@@ -206,17 +217,14 @@ describe('handleTaskClaim Exponential Backoff', () => {
     // Assert: append was called once per attempt
     expect(appendCallCount).toBe(3);
 
-    // Assert: exponential backoff was requested (3 delays, one per attempt)
-    // attempt 0: delay = 50 * 2^0 + jitter = 50..100ms
-    // attempt 1: delay = 50 * 2^1 + jitter = 100..150ms
-    // attempt 2: delay = 50 * 2^2 + jitter = 200..250ms
+    // Assert: exponential backoff delays are deterministic (Math.random = 0, jitter = 0)
+    // attempt 0: 50 * 2^0 + 0 = 50ms
+    // attempt 1: 50 * 2^1 + 0 = 100ms
+    // attempt 2: 50 * 2^2 + 0 = 200ms
     expect(capturedDelays).toHaveLength(3);
-    expect(capturedDelays[0]).toBeGreaterThanOrEqual(50);
-    expect(capturedDelays[1]).toBeGreaterThanOrEqual(100);
-    expect(capturedDelays[2]).toBeGreaterThanOrEqual(200);
-    // Each successive delay is strictly larger (exponential growth)
-    expect(capturedDelays[1]).toBeGreaterThan(capturedDelays[0]);
-    expect(capturedDelays[2]).toBeGreaterThan(capturedDelays[1]);
+    expect(capturedDelays[0]).toBe(50);
+    expect(capturedDelays[1]).toBe(100);
+    expect(capturedDelays[2]).toBe(200);
   });
 
   it('HandleTaskClaim_StillReturnsClaimFailed_AfterRetries', async () => {
@@ -277,11 +285,10 @@ describe('handleTaskClaim Exponential Backoff', () => {
       tempDir,
     );
 
-    // Assert: total requested virtual delay should be well below a reasonable cap (< 500ms)
-    // With CLAIM_BASE_DELAY_MS=50: delays are 50*1+jitter and 50*2+jitter
-    // Max sum with full jitter: (50+50) + (100+50) = 250ms
+    // Assert: with Math.random mocked to 0, total delay is deterministic:
+    // 50 + 100 + 200 = 350ms, well below any reasonable cap
     const totalRequestedDelay = capturedDelays.reduce((sum, d) => sum + d, 0);
-    expect(totalRequestedDelay).toBeLessThan(500);
+    expect(totalRequestedDelay).toBe(350);
     expect(result.success).toBe(false);
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as path from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { EventStore } from '../event-store/store.js';
+import { EventStore, SequenceConflictError } from '../event-store/store.js';
 import { handleTaskClaim, resetModuleEventStore } from './tools.js';
 import { resetMaterializerCache } from '../views/tools.js';
 
@@ -157,5 +157,114 @@ describe('handleTaskClaim (materialized view)', () => {
 
     // Assert
     expect(result.success).toBe(true);
+  });
+});
+
+// ─── T33-T34: Exponential Backoff in Task Claim Retries ─────────────────────
+
+describe('handleTaskClaim Exponential Backoff', () => {
+  it('HandleTaskClaim_Retries_WithExponentialBackoff', async () => {
+    // Arrange: seed a stream with just a task.assigned event
+    const store = new EventStore(tempDir);
+    await store.append('wf-backoff', {
+      type: 'task.assigned',
+      data: { taskId: 't-bo', title: 'Backoff task', assignee: 'agent-1' },
+    });
+
+    // Mock the store's append to throw SequenceConflictError on first 3 calls
+    // (the claim attempts), then never succeed
+    const storeMod = await import('../event-store/store.js');
+    const originalAppend = EventStore.prototype.append;
+    let appendCallCount = 0;
+    const delays: number[] = [];
+    let lastCallTime = Date.now();
+
+    vi.spyOn(EventStore.prototype, 'append').mockImplementation(async function (this: EventStore, ...args) {
+      appendCallCount++;
+      const now = Date.now();
+      if (appendCallCount > 1) {
+        delays.push(now - lastCallTime);
+      }
+      lastCallTime = now;
+      // Always throw conflict to test backoff timing
+      throw new SequenceConflictError(0, 1);
+    });
+
+    const start = Date.now();
+
+    // Act
+    const result = await handleTaskClaim(
+      { taskId: 't-bo', agentId: 'agent-1', streamId: 'wf-backoff' },
+      tempDir,
+    );
+
+    const totalDuration = Date.now() - start;
+
+    // Assert: Should fail after retries
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('CLAIM_FAILED');
+
+    // Assert: Verify backoff delays occurred (~50ms, ~100ms, ~200ms)
+    // Total should be at least ~150ms (minimum backoff sum: 50 + 100 = 150 for 3 retries)
+    expect(totalDuration).toBeGreaterThan(100);
+
+    vi.restoreAllMocks();
+  });
+
+  it('HandleTaskClaim_StillReturnsClaimFailed_AfterRetries', async () => {
+    // Arrange: seed a stream
+    const store = new EventStore(tempDir);
+    await store.append('wf-retry-fail', {
+      type: 'task.assigned',
+      data: { taskId: 't-rf', title: 'Retry fail task', assignee: 'agent-1' },
+    });
+
+    // Mock append to always throw SequenceConflictError
+    vi.spyOn(EventStore.prototype, 'append').mockImplementation(async function () {
+      throw new SequenceConflictError(0, 1);
+    });
+
+    // Act
+    const result = await handleTaskClaim(
+      { taskId: 't-rf', agentId: 'agent-1', streamId: 'wf-retry-fail' },
+      tempDir,
+    );
+
+    // Assert
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('CLAIM_FAILED');
+    expect(result.error?.message).toContain('retries');
+
+    vi.restoreAllMocks();
+  });
+
+  it('HandleTaskClaim_BackoffCapped_AtReasonableMax', async () => {
+    // Arrange: seed a stream
+    const store = new EventStore(tempDir);
+    await store.append('wf-cap', {
+      type: 'task.assigned',
+      data: { taskId: 't-cap', title: 'Capped task', assignee: 'agent-1' },
+    });
+
+    // Mock append to always throw SequenceConflictError
+    vi.spyOn(EventStore.prototype, 'append').mockImplementation(async function () {
+      throw new SequenceConflictError(0, 1);
+    });
+
+    const start = Date.now();
+
+    // Act
+    const result = await handleTaskClaim(
+      { taskId: 't-cap', agentId: 'agent-1', streamId: 'wf-cap' },
+      tempDir,
+    );
+
+    const totalDuration = Date.now() - start;
+
+    // Assert: total delay should be less than 500ms
+    expect(totalDuration).toBeLessThan(500);
+    expect(result.success).toBe(false);
+
+    vi.restoreAllMocks();
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.test.ts
@@ -18,6 +18,8 @@ afterEach(async () => {
   resetModuleEventStore();
   resetMaterializerCache();
   await rm(tempDir, { recursive: true, force: true });
+  vi.useRealTimers();
+  vi.restoreAllMocks();
 });
 
 describe('handleTaskClaim (materialized view)', () => {
@@ -161,36 +163,35 @@ describe('handleTaskClaim (materialized view)', () => {
 });
 
 // ─── T33-T34: Exponential Backoff in Task Claim Retries ─────────────────────
+//
+// The sleep() helper in tools.ts uses setTimeout. To make backoff tests
+// deterministic (no real wall-clock delay, no flakiness under load), we
+// spy on globalThis.setTimeout and make it invoke the callback synchronously.
+// This lets us verify retry count and delay scheduling without waiting.
 
 describe('handleTaskClaim Exponential Backoff', () => {
   it('HandleTaskClaim_Retries_WithExponentialBackoff', async () => {
-    // Arrange: seed a stream with just a task.assigned event
+    // Arrange: seed the stream before installing the setTimeout spy
     const store = new EventStore(tempDir);
     await store.append('wf-backoff', {
       type: 'task.assigned',
       data: { taskId: 't-bo', title: 'Backoff task', assignee: 'agent-1' },
     });
 
-    // Mock the store's append to throw SequenceConflictError on first 3 calls
-    // (the claim attempts), then never succeed
-    const storeMod = await import('../event-store/store.js');
-    const originalAppend = EventStore.prototype.append;
-    let appendCallCount = 0;
-    const delays: number[] = [];
-    let lastCallTime = Date.now();
-
-    vi.spyOn(EventStore.prototype, 'append').mockImplementation(async function (this: EventStore, ...args) {
-      appendCallCount++;
-      const now = Date.now();
-      if (appendCallCount > 1) {
-        delays.push(now - lastCallTime);
-      }
-      lastCallTime = now;
-      // Always throw conflict to test backoff timing
-      throw new SequenceConflictError(0, 1);
+    // Capture requested sleep delays; resolve immediately for determinism
+    const capturedDelays: number[] = [];
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation((fn: (...args: unknown[]) => void, ms?: number) => {
+      capturedDelays.push(ms ?? 0);
+      fn();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
     });
 
-    const start = Date.now();
+    // Mock append to always throw SequenceConflictError so all retries exhaust
+    let appendCallCount = 0;
+    vi.spyOn(EventStore.prototype, 'append').mockImplementation(async function () {
+      appendCallCount++;
+      throw new SequenceConflictError(0, 1);
+    });
 
     // Act
     const result = await handleTaskClaim(
@@ -198,25 +199,38 @@ describe('handleTaskClaim Exponential Backoff', () => {
       tempDir,
     );
 
-    const totalDuration = Date.now() - start;
-
-    // Assert: Should fail after retries
+    // Assert: Should fail after exhausting retries (MAX_CLAIM_RETRIES = 3)
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('CLAIM_FAILED');
 
-    // Assert: Verify backoff delays occurred (~50ms, ~100ms, ~200ms)
-    // Total should be at least ~150ms (minimum backoff sum: 50 + 100 = 150 for 3 retries)
-    expect(totalDuration).toBeGreaterThan(100);
+    // Assert: append was called once per attempt
+    expect(appendCallCount).toBe(3);
 
-    vi.restoreAllMocks();
+    // Assert: exponential backoff was requested (3 delays, one per attempt)
+    // attempt 0: delay = 50 * 2^0 + jitter = 50..100ms
+    // attempt 1: delay = 50 * 2^1 + jitter = 100..150ms
+    // attempt 2: delay = 50 * 2^2 + jitter = 200..250ms
+    expect(capturedDelays).toHaveLength(3);
+    expect(capturedDelays[0]).toBeGreaterThanOrEqual(50);
+    expect(capturedDelays[1]).toBeGreaterThanOrEqual(100);
+    expect(capturedDelays[2]).toBeGreaterThanOrEqual(200);
+    // Each successive delay is strictly larger (exponential growth)
+    expect(capturedDelays[1]).toBeGreaterThan(capturedDelays[0]);
+    expect(capturedDelays[2]).toBeGreaterThan(capturedDelays[1]);
   });
 
   it('HandleTaskClaim_StillReturnsClaimFailed_AfterRetries', async () => {
-    // Arrange: seed a stream
+    // Arrange: seed the stream before installing the setTimeout spy
     const store = new EventStore(tempDir);
     await store.append('wf-retry-fail', {
       type: 'task.assigned',
       data: { taskId: 't-rf', title: 'Retry fail task', assignee: 'agent-1' },
+    });
+
+    // Make sleep() resolve immediately for determinism
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation((fn: (...args: unknown[]) => void) => {
+      fn();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
     });
 
     // Mock append to always throw SequenceConflictError
@@ -234,16 +248,22 @@ describe('handleTaskClaim Exponential Backoff', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('CLAIM_FAILED');
     expect(result.error?.message).toContain('retries');
-
-    vi.restoreAllMocks();
   });
 
   it('HandleTaskClaim_BackoffCapped_AtReasonableMax', async () => {
-    // Arrange: seed a stream
+    // Arrange: seed the stream before installing the setTimeout spy
     const store = new EventStore(tempDir);
     await store.append('wf-cap', {
       type: 'task.assigned',
       data: { taskId: 't-cap', title: 'Capped task', assignee: 'agent-1' },
+    });
+
+    // Capture requested delays; resolve immediately for determinism
+    const capturedDelays: number[] = [];
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation((fn: (...args: unknown[]) => void, ms?: number) => {
+      capturedDelays.push(ms ?? 0);
+      fn();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
     });
 
     // Mock append to always throw SequenceConflictError
@@ -251,20 +271,17 @@ describe('handleTaskClaim Exponential Backoff', () => {
       throw new SequenceConflictError(0, 1);
     });
 
-    const start = Date.now();
-
     // Act
     const result = await handleTaskClaim(
       { taskId: 't-cap', agentId: 'agent-1', streamId: 'wf-cap' },
       tempDir,
     );
 
-    const totalDuration = Date.now() - start;
-
-    // Assert: total delay should be less than 500ms
-    expect(totalDuration).toBeLessThan(500);
+    // Assert: total requested virtual delay should be well below a reasonable cap (< 500ms)
+    // With CLAIM_BASE_DELAY_MS=50: delays are 50*1+jitter and 50*2+jitter
+    // Max sum with full jitter: (50+50) + (100+50) = 250ms
+    const totalRequestedDelay = capturedDelays.reduce((sum, d) => sum + d, 0);
+    expect(totalRequestedDelay).toBeLessThan(500);
     expect(result.success).toBe(false);
-
-    vi.restoreAllMocks();
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/tasks/tools.ts
@@ -11,6 +11,12 @@ import type { TaskDetailViewState } from '../views/task-detail-view.js';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+const CLAIM_BASE_DELAY_MS = 50;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 function alreadyClaimedResult(taskId: string): ToolResult {
   return {
     success: false,
@@ -68,6 +74,9 @@ export async function handleTaskClaim(
       return await attemptTaskClaim(args, stateDir);
     } catch (err) {
       if (err instanceof SequenceConflictError) {
+        // Exponential backoff: baseDelay * 2^attempt + jitter
+        const delay = CLAIM_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * CLAIM_BASE_DELAY_MS;
+        await sleep(delay);
         continue; // Retry: re-query and re-check
       }
       return {

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/materializer.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/materializer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { ViewMaterializer, type ViewProjection } from './materializer.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
 
@@ -245,29 +245,34 @@ describe('ViewMaterializer LRU Eviction', () => {
 
 describe('ViewMaterializer Configurable Cache', () => {
   const VIEW_NAME = 'counter';
+  const originalEnv = process.env.EXARCHOS_MAX_CACHE_ENTRIES;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.EXARCHOS_MAX_CACHE_ENTRIES;
+    } else {
+      process.env.EXARCHOS_MAX_CACHE_ENTRIES = originalEnv;
+    }
+  });
 
   it('ViewMaterializer_RespectsEnvVar_MaxCacheEntries', () => {
     process.env.EXARCHOS_MAX_CACHE_ENTRIES = '5';
-    try {
-      const materializer = new ViewMaterializer();
-      materializer.register(VIEW_NAME, counterProjection);
+    const materializer = new ViewMaterializer();
+    materializer.register(VIEW_NAME, counterProjection);
 
-      // Materialize 6 streams — cache limit should be 5
-      for (let i = 1; i <= 6; i++) {
-        materializer.materialize(`stream-${i}`, VIEW_NAME, [
-          makeEvent(1, `stream-${i}`),
-        ]);
-      }
-
-      // stream-1 should have been evicted
-      expect(materializer.getState('stream-1', VIEW_NAME)).toBeUndefined();
-
-      // stream-2 through stream-6 should still be present
-      expect(materializer.getState('stream-2', VIEW_NAME)).toBeDefined();
-      expect(materializer.getState('stream-6', VIEW_NAME)).toBeDefined();
-    } finally {
-      delete process.env.EXARCHOS_MAX_CACHE_ENTRIES;
+    // Materialize 6 streams — cache limit should be 5
+    for (let i = 1; i <= 6; i++) {
+      materializer.materialize(`stream-${i}`, VIEW_NAME, [
+        makeEvent(1, `stream-${i}`),
+      ]);
     }
+
+    // stream-1 should have been evicted
+    expect(materializer.getState('stream-1', VIEW_NAME)).toBeUndefined();
+
+    // stream-2 through stream-6 should still be present
+    expect(materializer.getState('stream-2', VIEW_NAME)).toBeDefined();
+    expect(materializer.getState('stream-6', VIEW_NAME)).toBeDefined();
   });
 
   it('ViewMaterializer_DefaultsTo100_WhenNoEnvVar', () => {
@@ -290,43 +295,35 @@ describe('ViewMaterializer Configurable Cache', () => {
 
   it('ViewMaterializer_InvalidEnvVar_FallsBackToDefault', () => {
     process.env.EXARCHOS_MAX_CACHE_ENTRIES = 'abc';
-    try {
-      const materializer = new ViewMaterializer();
-      materializer.register(VIEW_NAME, counterProjection);
+    const materializer = new ViewMaterializer();
+    materializer.register(VIEW_NAME, counterProjection);
 
-      // Materialize 101 streams — should use default 100
-      for (let i = 1; i <= 101; i++) {
-        materializer.materialize(`stream-${i}`, VIEW_NAME, [
-          makeEvent(1, `stream-${i}`),
-        ]);
-      }
-
-      // stream-1 evicted at default 100 limit
-      expect(materializer.getState('stream-1', VIEW_NAME)).toBeUndefined();
-      expect(materializer.getState('stream-2', VIEW_NAME)).toBeDefined();
-    } finally {
-      delete process.env.EXARCHOS_MAX_CACHE_ENTRIES;
+    // Materialize 101 streams — should use default 100
+    for (let i = 1; i <= 101; i++) {
+      materializer.materialize(`stream-${i}`, VIEW_NAME, [
+        makeEvent(1, `stream-${i}`),
+      ]);
     }
+
+    // stream-1 evicted at default 100 limit
+    expect(materializer.getState('stream-1', VIEW_NAME)).toBeUndefined();
+    expect(materializer.getState('stream-2', VIEW_NAME)).toBeDefined();
   });
 
   it('ViewMaterializer_ZeroEnvVar_FallsBackToDefault', () => {
     process.env.EXARCHOS_MAX_CACHE_ENTRIES = '0';
-    try {
-      const materializer = new ViewMaterializer();
-      materializer.register(VIEW_NAME, counterProjection);
+    const materializer = new ViewMaterializer();
+    materializer.register(VIEW_NAME, counterProjection);
 
-      // Materialize 101 streams — should use default 100
-      for (let i = 1; i <= 101; i++) {
-        materializer.materialize(`stream-${i}`, VIEW_NAME, [
-          makeEvent(1, `stream-${i}`),
-        ]);
-      }
-
-      // stream-1 evicted at default 100 limit
-      expect(materializer.getState('stream-1', VIEW_NAME)).toBeUndefined();
-      expect(materializer.getState('stream-2', VIEW_NAME)).toBeDefined();
-    } finally {
-      delete process.env.EXARCHOS_MAX_CACHE_ENTRIES;
+    // Materialize 101 streams — should use default 100
+    for (let i = 1; i <= 101; i++) {
+      materializer.materialize(`stream-${i}`, VIEW_NAME, [
+        makeEvent(1, `stream-${i}`),
+      ]);
     }
+
+    // stream-1 evicted at default 100 limit
+    expect(materializer.getState('stream-1', VIEW_NAME)).toBeUndefined();
+    expect(materializer.getState('stream-2', VIEW_NAME)).toBeDefined();
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/materializer.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/materializer.test.ts
@@ -240,3 +240,93 @@ describe('ViewMaterializer LRU Eviction', () => {
     });
   });
 });
+
+// ─── T29-T30: Configurable LRU Cache via Env Var ────────────────────────────
+
+describe('ViewMaterializer Configurable Cache', () => {
+  const VIEW_NAME = 'counter';
+
+  it('ViewMaterializer_RespectsEnvVar_MaxCacheEntries', () => {
+    process.env.EXARCHOS_MAX_CACHE_ENTRIES = '5';
+    try {
+      const materializer = new ViewMaterializer();
+      materializer.register(VIEW_NAME, counterProjection);
+
+      // Materialize 6 streams — cache limit should be 5
+      for (let i = 1; i <= 6; i++) {
+        materializer.materialize(`stream-${i}`, VIEW_NAME, [
+          makeEvent(1, `stream-${i}`),
+        ]);
+      }
+
+      // stream-1 should have been evicted
+      expect(materializer.getState('stream-1', VIEW_NAME)).toBeUndefined();
+
+      // stream-2 through stream-6 should still be present
+      expect(materializer.getState('stream-2', VIEW_NAME)).toBeDefined();
+      expect(materializer.getState('stream-6', VIEW_NAME)).toBeDefined();
+    } finally {
+      delete process.env.EXARCHOS_MAX_CACHE_ENTRIES;
+    }
+  });
+
+  it('ViewMaterializer_DefaultsTo100_WhenNoEnvVar', () => {
+    delete process.env.EXARCHOS_MAX_CACHE_ENTRIES;
+    const materializer = new ViewMaterializer();
+    materializer.register(VIEW_NAME, counterProjection);
+
+    // Materialize 101 streams — cache limit should be 100 (default)
+    for (let i = 1; i <= 101; i++) {
+      materializer.materialize(`stream-${i}`, VIEW_NAME, [
+        makeEvent(1, `stream-${i}`),
+      ]);
+    }
+
+    // stream-1 should be evicted at 100 limit
+    expect(materializer.getState('stream-1', VIEW_NAME)).toBeUndefined();
+    expect(materializer.getState('stream-2', VIEW_NAME)).toBeDefined();
+    expect(materializer.getState('stream-101', VIEW_NAME)).toBeDefined();
+  });
+
+  it('ViewMaterializer_InvalidEnvVar_FallsBackToDefault', () => {
+    process.env.EXARCHOS_MAX_CACHE_ENTRIES = 'abc';
+    try {
+      const materializer = new ViewMaterializer();
+      materializer.register(VIEW_NAME, counterProjection);
+
+      // Materialize 101 streams — should use default 100
+      for (let i = 1; i <= 101; i++) {
+        materializer.materialize(`stream-${i}`, VIEW_NAME, [
+          makeEvent(1, `stream-${i}`),
+        ]);
+      }
+
+      // stream-1 evicted at default 100 limit
+      expect(materializer.getState('stream-1', VIEW_NAME)).toBeUndefined();
+      expect(materializer.getState('stream-2', VIEW_NAME)).toBeDefined();
+    } finally {
+      delete process.env.EXARCHOS_MAX_CACHE_ENTRIES;
+    }
+  });
+
+  it('ViewMaterializer_ZeroEnvVar_FallsBackToDefault', () => {
+    process.env.EXARCHOS_MAX_CACHE_ENTRIES = '0';
+    try {
+      const materializer = new ViewMaterializer();
+      materializer.register(VIEW_NAME, counterProjection);
+
+      // Materialize 101 streams — should use default 100
+      for (let i = 1; i <= 101; i++) {
+        materializer.materialize(`stream-${i}`, VIEW_NAME, [
+          makeEvent(1, `stream-${i}`),
+        ]);
+      }
+
+      // stream-1 evicted at default 100 limit
+      expect(materializer.getState('stream-1', VIEW_NAME)).toBeUndefined();
+      expect(materializer.getState('stream-2', VIEW_NAME)).toBeDefined();
+    } finally {
+      delete process.env.EXARCHOS_MAX_CACHE_ENTRIES;
+    }
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/materializer.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/materializer.ts
@@ -30,6 +30,15 @@ export interface MaterializerOptions {
 const DEFAULT_SNAPSHOT_INTERVAL = 50;
 const DEFAULT_MAX_CACHE_ENTRIES = 100;
 
+/** Read EXARCHOS_MAX_CACHE_ENTRIES from env, falling back to default on invalid/missing. */
+function parseEnvMaxCacheEntries(): number {
+  const raw = process.env.EXARCHOS_MAX_CACHE_ENTRIES;
+  if (raw === undefined) return DEFAULT_MAX_CACHE_ENTRIES;
+  const parsed = parseInt(raw, 10);
+  if (isNaN(parsed) || parsed <= 0) return DEFAULT_MAX_CACHE_ENTRIES;
+  return parsed;
+}
+
 // ─── View Materializer ─────────────────────────────────────────────────────
 
 export class ViewMaterializer {
@@ -46,7 +55,7 @@ export class ViewMaterializer {
   constructor(options?: MaterializerOptions) {
     this.snapshotStore = options?.snapshotStore;
     this.snapshotInterval = options?.snapshotInterval ?? DEFAULT_SNAPSHOT_INTERVAL;
-    this.maxCacheEntries = options?.maxCacheEntries ?? DEFAULT_MAX_CACHE_ENTRIES;
+    this.maxCacheEntries = options?.maxCacheEntries ?? parseEnvMaxCacheEntries();
   }
 
   /**

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
@@ -483,6 +483,23 @@ export async function handleSet(
         // deduplicated
         continue;
       }
+
+      // CAS exhaustion: emit diagnostic event before throwing
+      if (err instanceof VersionConflictError && moduleEventStore) {
+        try {
+          await moduleEventStore.append(input.featureId, {
+            type: 'workflow.cas-failed' as import('../event-store/schemas.js').EventType,
+            data: {
+              featureId: input.featureId,
+              phase: input.phase ?? (mutableState.phase as string) ?? 'unknown',
+              retries: MAX_CAS_RETRIES,
+            },
+          });
+        } catch {
+          // Best-effort diagnostic emission — don't mask the actual CAS error
+        }
+      }
+
       throw err;
     }
 
@@ -501,7 +518,7 @@ export async function handleSet(
   // Should not be reached, but satisfy TypeScript
   throw new StateStoreError(
     ErrorCode.VERSION_CONFLICT,
-    `Concurrent write conflict: failed to acquire consistent version after ${MAX_CAS_RETRIES} retries for feature: ${input.featureId}`,
+    `Concurrent write conflict: failed to acquire consistent version after ${MAX_CAS_RETRIES} retries for feature: ${input.featureId}, phase: ${input.phase ?? 'field-update'}`,
   );
 }
 


### PR DESCRIPTION
## Summary

Add P1 observability and configuration hardening for the MCP server: workflow.cas-failed diagnostic event emitted on CAS retry exhaustion, configurable LRU view cache size via env var, and exponential backoff with jitter on task claim retries.

## Changes

- **schemas.ts** -- Add `workflow.cas-failed` to `EventTypes` union, add `WorkflowCasFailedData` Zod schema with `featureId`, `phase`, `retries`
- **workflow/tools.ts** -- Emit `workflow.cas-failed` diagnostic event on CAS retry exhaustion before re-throwing, enrich error message with featureId and phase
- **views/materializer.ts** -- Add `parseEnvMaxCacheEntries()` to read `EXARCHOS_MAX_CACHE_ENTRIES` env var, fall back to default 100 on invalid/missing
- **tasks/tools.ts** -- Add exponential backoff (`baseDelay * 2^attempt + jitter`) between task claim retries with 50ms base delay

## Test Plan

- [x] `WorkflowCasFailedData_Valid_Parses` -- schema validates correctly
- [x] `EventTypes_IncludesWorkflowCasFailed` -- type in union
- [x] `HandleSet_CasExhausted_EmitsWorkflowCasFailed` -- diagnostic event emitted
- [x] `ViewMaterializer_RespectsEnvVar_MaxCacheEntries` -- env var honored
- [x] `ViewMaterializer_DefaultsTo100_WhenNoEnvVar` -- default 100
- [x] `ViewMaterializer_InvalidEnvVar_FallsBackToDefault` -- invalid falls back
- [x] `ViewMaterializer_ZeroEnvVar_FallsBackToDefault` -- zero falls back
- [x] `HandleTaskClaim_Retries_WithExponentialBackoff` -- delays > 100ms total
- [x] `HandleTaskClaim_StillReturnsClaimFailed_AfterRetries` -- fails after retries
- [x] `HandleTaskClaim_BackoffCapped_AtReasonableMax` -- total < 500ms

---
1334 tests passing, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)