### PR TITLE
refactor: replace Zod safeParse with type guards in telemetry projection (T12-T13)

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts
@@ -190,6 +190,107 @@ describe('TelemetryProjection', () => {
       expect(state.totalTokens).toBe(2010);
     });
   });
+
+  // ─── T12: Zod removal from tool.completed handler ──────────────────────
+
+  describe('apply - tool.completed guard (T12)', () => {
+    it('Apply_ToolCompleted_ValidData_UpdatesMetrics', () => {
+      let state = telemetryProjection.init();
+      const event = makeEvent('tool.completed', {
+        tool: 'workflow_get',
+        durationMs: 15,
+        responseBytes: 400,
+        tokenEstimate: 100,
+      });
+      state = telemetryProjection.apply(state, event);
+
+      expect(state.tools['workflow_get']).toBeDefined();
+      expect(state.tools['workflow_get'].invocations).toBe(1);
+      expect(state.tools['workflow_get'].totalDurationMs).toBe(15);
+      expect(state.tools['workflow_get'].totalBytes).toBe(400);
+      expect(state.tools['workflow_get'].totalTokens).toBe(100);
+      expect(state.totalInvocations).toBe(1);
+      expect(state.totalTokens).toBe(100);
+    });
+
+    it('Apply_ToolCompleted_MissingFields_ReturnsViewUnchanged', () => {
+      const state = telemetryProjection.init();
+
+      // Missing 'tool' field
+      const noTool = telemetryProjection.apply(state, makeEvent('tool.completed', {
+        durationMs: 15,
+        responseBytes: 400,
+        tokenEstimate: 100,
+      }));
+      expect(noTool).toBe(state);
+
+      // Missing 'durationMs' field
+      const noDuration = telemetryProjection.apply(state, makeEvent('tool.completed', {
+        tool: 'workflow_get',
+        responseBytes: 400,
+        tokenEstimate: 100,
+      }));
+      expect(noDuration).toBe(state);
+
+      // durationMs is not a number
+      const badDuration = telemetryProjection.apply(state, makeEvent('tool.completed', {
+        tool: 'workflow_get',
+        durationMs: 'not-a-number',
+        responseBytes: 400,
+        tokenEstimate: 100,
+      }));
+      expect(badDuration).toBe(state);
+
+      // No data at all
+      const noData = telemetryProjection.apply(state, {
+        streamId: 'telemetry',
+        sequence: 1,
+        timestamp: new Date().toISOString(),
+        type: 'tool.completed',
+        schemaVersion: '1.0',
+      } as WorkflowEvent);
+      expect(noData).toBe(state);
+    });
+  });
+
+  // ─── T13: Zod removal from tool.errored handler ───────────────────────
+
+  describe('apply - tool.errored guard (T13)', () => {
+    it('Apply_ToolErrored_ValidData_UpdatesMetrics', () => {
+      let state = telemetryProjection.init();
+      const event = makeEvent('tool.errored', {
+        tool: 'workflow_set',
+        durationMs: 5,
+        errorMessage: 'TIMEOUT',
+      });
+      state = telemetryProjection.apply(state, event);
+
+      expect(state.tools['workflow_set']).toBeDefined();
+      expect(state.tools['workflow_set'].errors).toBe(1);
+      expect(state.tools['workflow_set'].invocations).toBe(0);
+    });
+
+    it('Apply_ToolErrored_MissingFields_ReturnsViewUnchanged', () => {
+      const state = telemetryProjection.init();
+
+      // Missing 'tool' field
+      const noTool = telemetryProjection.apply(state, makeEvent('tool.errored', {
+        durationMs: 5,
+        errorMessage: 'TIMEOUT',
+      }));
+      expect(noTool).toBe(state);
+
+      // No data at all
+      const noData = telemetryProjection.apply(state, {
+        streamId: 'telemetry',
+        sequence: 1,
+        timestamp: new Date().toISOString(),
+        type: 'tool.errored',
+        schemaVersion: '1.0',
+      } as WorkflowEvent);
+      expect(noData).toBe(state);
+    });
+  });
 });
 
 // Helper to create a minimal WorkflowEvent

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts
@@ -251,6 +251,29 @@ describe('TelemetryProjection', () => {
       } as WorkflowEvent);
       expect(noData).toBe(state);
     });
+
+    it('Apply_ToolCompleted_NonStringTool_ReturnsViewUnchanged', () => {
+      const state = telemetryProjection.init();
+
+      const numericTool = telemetryProjection.apply(state, makeEvent('tool.completed', {
+        tool: 123,
+        durationMs: 15,
+      }));
+      expect(numericTool).toBe(state);
+    });
+
+    it('Apply_ToolCompleted_NonNumericOptionals_DefaultsToZero', () => {
+      let state = telemetryProjection.init();
+      state = telemetryProjection.apply(state, makeEvent('tool.completed', {
+        tool: 'test_tool',
+        durationMs: 10,
+        responseBytes: 'garbage',
+        tokenEstimate: 'garbage',
+      }));
+
+      expect(state.tools['test_tool'].totalBytes).toBe(0);
+      expect(state.tools['test_tool'].totalTokens).toBe(0);
+    });
   });
 
   // ─── T13: Zod removal from tool.errored handler ───────────────────────
@@ -289,6 +312,16 @@ describe('TelemetryProjection', () => {
         schemaVersion: '1.0',
       } as WorkflowEvent);
       expect(noData).toBe(state);
+    });
+
+    it('Apply_ToolErrored_NonStringTool_ReturnsViewUnchanged', () => {
+      const state = telemetryProjection.init();
+
+      const numericTool = telemetryProjection.apply(state, makeEvent('tool.errored', {
+        tool: 42,
+        durationMs: 5,
+      }));
+      expect(numericTool).toBe(state);
     });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.ts
@@ -82,10 +82,13 @@ export const telemetryProjection: ViewProjection<TelemetryViewState> = {
   apply: (view, event) => {
     switch (event.type) {
       case 'tool.completed': {
-        const data = event.data as { tool?: string; durationMs?: number; responseBytes?: number; tokenEstimate?: number } | undefined;
-        if (!data?.tool || typeof data.durationMs !== 'number') return view;
+        const data = event.data as { tool?: unknown; durationMs?: unknown; responseBytes?: unknown; tokenEstimate?: unknown } | undefined;
+        if (!data || typeof data.tool !== 'string' || typeof data.durationMs !== 'number') return view;
 
-        const { tool: toolName, durationMs, responseBytes = 0, tokenEstimate = 0 } = data;
+        const toolName = data.tool;
+        const durationMs = data.durationMs;
+        const responseBytes = typeof data.responseBytes === 'number' ? data.responseBytes : 0;
+        const tokenEstimate = typeof data.tokenEstimate === 'number' ? data.tokenEstimate : 0;
 
         const existing = view.tools[toolName] ?? initToolMetrics();
 
@@ -119,8 +122,8 @@ export const telemetryProjection: ViewProjection<TelemetryViewState> = {
       }
 
       case 'tool.errored': {
-        const errData = event.data as { tool?: string; durationMs?: number; errorMessage?: string } | undefined;
-        if (!errData?.tool) return view;
+        const errData = event.data as { tool?: unknown } | undefined;
+        if (!errData || typeof errData.tool !== 'string') return view;
         const toolName = errData.tool;
 
         const existing = view.tools[toolName] ?? initToolMetrics();

--- a/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/telemetry/telemetry-projection.ts
@@ -1,6 +1,5 @@
 import type { ViewProjection } from '../views/materializer.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
-import { ToolCompletedData, ToolErroredData } from '../event-store/schemas.js';
 import { percentile } from './percentile.js';
 
 // ─── View Name Constant ────────────────────────────────────────────────────
@@ -83,10 +82,10 @@ export const telemetryProjection: ViewProjection<TelemetryViewState> = {
   apply: (view, event) => {
     switch (event.type) {
       case 'tool.completed': {
-        const parsed = ToolCompletedData.safeParse(event.data);
-        if (!parsed.success) return view;
+        const data = event.data as { tool?: string; durationMs?: number; responseBytes?: number; tokenEstimate?: number } | undefined;
+        if (!data?.tool || typeof data.durationMs !== 'number') return view;
 
-        const { tool: toolName, durationMs, responseBytes, tokenEstimate } = parsed.data;
+        const { tool: toolName, durationMs, responseBytes = 0, tokenEstimate = 0 } = data;
 
         const existing = view.tools[toolName] ?? initToolMetrics();
 
@@ -120,9 +119,9 @@ export const telemetryProjection: ViewProjection<TelemetryViewState> = {
       }
 
       case 'tool.errored': {
-        const parsed = ToolErroredData.safeParse(event.data);
-        if (!parsed.success) return view;
-        const toolName = parsed.data.tool;
+        const errData = event.data as { tool?: string; durationMs?: number; errorMessage?: string } | undefined;
+        if (!errData?.tool) return view;
+        const toolName = errData.tool;
 
         const existing = view.tools[toolName] ?? initToolMetrics();
 


### PR DESCRIPTION
## Summary

Removes Zod `safeParse()` from telemetry projection hot path for `tool.completed` and `tool.errored` events. Replaces with type assertions and runtime guards since events are already validated at append time.

## Changes

- **telemetry-projection.ts** — Replace `ToolCompletedData.safeParse()` with type assertion + `typeof` guard for tool/durationMs
- **telemetry-projection.ts** — Replace `ToolErroredData.safeParse()` with type assertion + `?.tool` guard
- **telemetry-projection.ts** — Remove unused Zod schema imports
- **Tests** — 4 new tests: valid data behavior preserved, missing fields return unchanged, no-data graceful handling

## Test Plan

- [x] All 18 telemetry projection tests pass
- [x] Full MCP server test suite (1330 tests)
- [x] Build passes