### PR TITLE
refactor: add skipValidation to writeStateFile, use in handleSet (T16-T17)

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-store.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/state-store.test.ts
@@ -760,6 +760,55 @@ describe('State Store', () => {
     });
   });
 
+  // ─── T16: skipValidation option for writeStateFile ─────────────────────
+
+  describe('writeStateFile_SkipValidation', () => {
+    it('WriteStateFile_SkipValidation_WritesWithoutZodParse', async () => {
+      const { stateFile, state } = await initStateFile(tmpDir, 'skip-val-test', 'feature');
+
+      // Write with skipValidation: true should succeed
+      const updated = { ...state, updatedAt: new Date().toISOString() };
+      await writeStateFile(stateFile, updated, { skipValidation: true });
+
+      // Verify the file was written
+      const raw = await fs.readFile(stateFile, 'utf-8');
+      const parsed = JSON.parse(raw);
+      expect(parsed.updatedAt).toBe(updated.updatedAt);
+      // _version should still be auto-incremented
+      expect(parsed._version).toBe(2);
+    });
+
+    it('WriteStateFile_SkipValidation_StillPerformsCAS', async () => {
+      const { stateFile, state } = await initStateFile(tmpDir, 'skip-val-cas', 'feature');
+
+      // Write once to increment version to 2
+      await writeStateFile(stateFile, state);
+
+      // Read fresh state
+      const freshState = await readStateFile(stateFile);
+
+      // Now try with skipValidation + stale expectedVersion — should still fail CAS
+      await expect(
+        writeStateFile(stateFile, freshState, { expectedVersion: 1, skipValidation: true }),
+      ).rejects.toThrow(VersionConflictError);
+    });
+
+    it('WriteStateFile_WithoutSkipValidation_StillValidates', async () => {
+      const { stateFile, state } = await initStateFile(tmpDir, 'no-skip-val', 'feature');
+      const mutated = structuredClone(state) as Record<string, unknown>;
+      (mutated.worktrees as Record<string, unknown>)['bad-wt'] = {
+        branch: 'feat/bad',
+        status: 'active',
+        // Missing both taskId and tasks — schema violation
+      };
+
+      // Without skipValidation — should reject
+      await expect(
+        writeStateFile(stateFile, mutated as typeof state),
+      ).rejects.toThrow(ErrorCode.INVALID_INPUT);
+    });
+  });
+
   // ─── Reconcile From Events ──────────────────────────────────────────────
 
   describe('reconcileFromEvents', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -2900,6 +2900,34 @@ describe('ToolReconcile_WithNativeTaskId_IncludesTaskDrift', () => {
   });
 });
 
+// ─── T17: handleSet passes skipValidation: true to writeStateFile ────────
+
+describe('HandleSet_WritesWithSkipValidation', () => {
+  it('should pass skipValidation: true to writeStateFile', async () => {
+    await handleInit({ featureId: 'skip-val-set', workflowType: 'feature' }, tmpDir);
+
+    // Spy on writeStateFile to verify options are passed
+    const stateStoreMod = await import('../../workflow/state-store.js');
+    const writeSpy = vi.spyOn(stateStoreMod, 'writeStateFile');
+
+    // Perform a field update
+    const result = await handleSet(
+      { featureId: 'skip-val-set', updates: { 'artifacts.design': 'design.md' } },
+      tmpDir,
+    );
+
+    expect(result.success).toBe(true);
+
+    // Verify writeStateFile was called with skipValidation: true
+    expect(writeSpy).toHaveBeenCalled();
+    const lastCall = writeSpy.mock.calls[writeSpy.mock.calls.length - 1];
+    const options = lastCall[2] as { expectedVersion?: number; skipValidation?: boolean } | undefined;
+    expect(options?.skipValidation).toBe(true);
+
+    writeSpy.mockRestore();
+  });
+});
+
 describe('ToolReconcile_WithoutNativeTaskId_OmitsTaskDrift', () => {
   it('should not include taskDrift when no tasks have nativeTaskId', async () => {
     await handleInit({ featureId: 'reconcile-no-native', workflowType: 'feature' }, tmpDir);

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/state-store.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/state-store.ts
@@ -196,7 +196,7 @@ function getStateVersion(state: WorkflowState): number {
 export async function writeStateFile(
   stateFile: string,
   state: WorkflowState,
-  options?: { expectedVersion?: number },
+  options?: { expectedVersion?: number; skipValidation?: boolean },
 ): Promise<void> {
   // CAS check: if expectedVersion is provided, verify it matches the current file
   if (options?.expectedVersion !== undefined) {
@@ -221,12 +221,15 @@ export async function writeStateFile(
   } as WorkflowState;
 
   // Validate before writing to catch schema violations at write time (not deferred to read)
-  const validation = WorkflowStateSchema.safeParse(stateWithVersion);
-  if (!validation.success) {
-    throw new StateStoreError(
-      ErrorCode.INVALID_INPUT,
-      `Write-time validation failed: ${validation.error.message}`,
-    );
+  // Skip when caller guarantees state is already validated (e.g. handleSet reads then writes)
+  if (!options?.skipValidation) {
+    const validation = WorkflowStateSchema.safeParse(stateWithVersion);
+    if (!validation.success) {
+      throw new StateStoreError(
+        ErrorCode.INVALID_INPUT,
+        `Write-time validation failed: ${validation.error.message}`,
+      );
+    }
   }
 
   const tmpPath = `${stateFile}.tmp.${process.pid}`;

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/tools.ts
@@ -475,7 +475,7 @@ export async function handleSet(
 
     // Write back to disk with CAS protection
     try {
-      await writeStateFile(stateFile, mutableState as WorkflowState, { expectedVersion });
+      await writeStateFile(stateFile, mutableState as WorkflowState, { expectedVersion, skipValidation: true });
     } catch (err) {
       if (err instanceof VersionConflictError && attempt < MAX_CAS_RETRIES) {
         // Re-read and retry on version conflict — events already appended


### PR DESCRIPTION
## Summary

Eliminates double Zod validation in handleSet by adding a `skipValidation` option to `writeStateFile`. State is already validated on read, so re-validating on write is redundant when the caller guarantees schema compliance.

## Changes

- **state-store.ts** — Add `skipValidation?: boolean` to writeStateFile options; skip Zod safeParse when true while preserving CAS check and atomic write
- **tools.ts** — handleSet passes `{ skipValidation: true }` to writeStateFile
- **Tests** — 4 new tests: skipValidation writes without Zod, CAS still enforced, validation still runs by default, handleSet spy verifies option passed

## Test Plan

- [x] All 63 state-store tests pass
- [x] All 114 tools tests pass
- [x] Full MCP server test suite (1330 tests)
- [x] Build passes