### PR TITLE
refactor: cap timeline tasks and stack positions with hasMore indicator (T18-T21)

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/pipeline-view.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/views/pipeline-view.test.ts
@@ -158,6 +158,87 @@ describe('PipelineView', () => {
     });
   });
 
+  // ─── T19: Cap pipeline stackPositions array ──────────────────────────
+
+  describe('StackPositionBounds', () => {
+    it('Apply_StackPositionFilled_ExceedsMax_EvictsOldest', () => {
+      // Fill 110 stack positions (exceeds MAX_STACK_POSITIONS = 100)
+      const events = [
+        makeEvent(1, 'workflow.started', { featureId: 'feat-a', workflowType: 'feature' }),
+      ];
+      for (let i = 0; i < 110; i++) {
+        events.push(
+          makeEvent(i + 2, 'stack.position-filled', {
+            position: i + 1,
+            taskId: `t${i}`,
+            branch: `feat/t${i}`,
+          }),
+        );
+      }
+
+      const view = materializer.materialize<PipelineViewState>(
+        'wf-001',
+        PIPELINE_VIEW,
+        events,
+      );
+
+      // Should be capped at 100
+      expect(view.stackPositions).toHaveLength(100);
+      // Oldest (t0 through t9) should be evicted
+      expect(view.stackPositions[0].taskId).toBe('t10');
+      expect(view.stackPositions[99].taskId).toBe('t109');
+    });
+  });
+
+  // ─── T21: hasMore indicator for pipeline view ─────────────────────
+
+  describe('PipelineHasMore', () => {
+    it('ViewState_HasEvicted_HasMoreIsTrue', () => {
+      // Under the limit
+      const events100 = [
+        makeEvent(1, 'workflow.started', { featureId: 'feat-a', workflowType: 'feature' }),
+      ];
+      for (let i = 0; i < 100; i++) {
+        events100.push(
+          makeEvent(i + 2, 'stack.position-filled', {
+            position: i + 1,
+            taskId: `t${i}`,
+            branch: `feat/t${i}`,
+          }),
+        );
+      }
+
+      const view100 = materializer.materialize<PipelineViewState>(
+        'wf-no-evict',
+        PIPELINE_VIEW,
+        events100,
+      );
+      expect(view100.hasMore).toBe(false);
+
+      // Over the limit
+      const events101 = [
+        makeEvent(1, 'workflow.started', { featureId: 'feat-a', workflowType: 'feature' }),
+      ];
+      for (let i = 0; i < 101; i++) {
+        events101.push(
+          makeEvent(i + 2, 'stack.position-filled', {
+            position: i + 1,
+            taskId: `t${i}`,
+            branch: `feat/t${i}`,
+          }),
+        );
+      }
+
+      const view101 = materializer.materialize<PipelineViewState>(
+        'wf-evict',
+        PIPELINE_VIEW,
+        events101,
+      );
+      expect(view101.hasMore).toBe(true);
+      expect(view101.stackPositions).toHaveLength(100);
+    });
+  });
+
   describe('EmptyPipeline', () => {
     it('should return defaults for empty stream', () => {
       const view = materializer.materialize<PipelineViewState>(
@@ -170,6 +251,7 @@ describe('PipelineView', () => {
       expect(view.phase).toBe('');
       expect(view.taskCount).toBe(0);
       expect(view.stackPositions).toEqual([]);
+      expect(view.hasMore).toBe(false);
     });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/delegation-timeline-view.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/delegation-timeline-view.test.ts
@@ -36,6 +36,7 @@ describe('DelegationTimelineView', () => {
         totalDurationMs: 0,
         tasks: [],
         bottleneck: null,
+        hasMore: false,
       });
     });
   });
@@ -142,6 +143,64 @@ describe('DelegationTimelineView', () => {
 
       expect(state.teamDisbandedAt).toBe(disbandTs);
       expect(state.totalDurationMs).toBe(600000);
+    });
+
+    // ─── T18: Cap delegation timeline tasks array ──────────────────────
+
+    it('Apply_TeamTaskAssigned_ExceedsMaxTasks_EvictsOldest', () => {
+      let state = delegationTimelineProjection.init();
+
+      // Assign 210 tasks (exceeds MAX_TIMELINE_TASKS = 200)
+      for (let i = 0; i < 210; i++) {
+        state = delegationTimelineProjection.apply(
+          state,
+          makeEvent('team.task.assigned', {
+            taskId: `task-${i}`,
+            teammateName: `worker-${i}`,
+            worktreePath: `/tmp/wt-${i}`,
+            modules: ['auth'],
+          }, i + 1),
+        );
+      }
+
+      // Should be capped at 200
+      expect(state.tasks).toHaveLength(200);
+      // Oldest (task-0 through task-9) should be evicted
+      expect(state.tasks[0].taskId).toBe('task-10');
+      expect(state.tasks[199].taskId).toBe('task-209');
+    });
+
+    // ─── T20: hasMore indicator for delegation timeline ──────────────
+
+    it('ViewState_HasEvicted_HasMoreIsTrue', () => {
+      let state = delegationTimelineProjection.init();
+
+      // Under the limit — no eviction
+      for (let i = 0; i < 200; i++) {
+        state = delegationTimelineProjection.apply(
+          state,
+          makeEvent('team.task.assigned', {
+            taskId: `task-${i}`,
+            teammateName: `worker-${i}`,
+            worktreePath: `/tmp/wt-${i}`,
+            modules: ['auth'],
+          }, i + 1),
+        );
+      }
+      expect(state.hasMore).toBe(false);
+
+      // One more pushes over the limit
+      state = delegationTimelineProjection.apply(
+        state,
+        makeEvent('team.task.assigned', {
+          taskId: 'task-200',
+          teammateName: 'worker-200',
+          worktreePath: '/tmp/wt-200',
+          modules: ['auth'],
+        }, 201),
+      );
+      expect(state.hasMore).toBe(true);
+      expect(state.tasks).toHaveLength(200);
     });
 
     it('apply_MultipleCompleted_IdentifiesBottleneck', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/delegation-timeline-view.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/delegation-timeline-view.test.ts
@@ -242,5 +242,56 @@ describe('DelegationTimelineView', () => {
       expect(state.bottleneck!.durationMs).toBe(5000);
       expect(state.bottleneck!.reason).toBe('longest_task');
     });
+
+    it('Apply_TaskEviction_BottleneckEvicted_BottleneckResetToNull', () => {
+      let state = delegationTimelineProjection.init();
+
+      // Assign and complete task-0 so it becomes the bottleneck (long duration)
+      state = delegationTimelineProjection.apply(
+        state,
+        makeEvent('team.task.assigned', {
+          taskId: 'task-0',
+          teammateName: 'worker-0',
+          worktreePath: '/tmp/wt-0',
+          modules: ['auth'],
+        }, 1),
+      );
+      state = delegationTimelineProjection.apply(
+        state,
+        makeEvent('team.task.completed', {
+          taskId: 'task-0',
+          teammateName: 'worker-0',
+          durationMs: 99999,
+          filesChanged: [],
+          testsPassed: true,
+          qualityGateResults: {},
+        }, 2),
+      );
+
+      // task-0 should now be the bottleneck
+      expect(state.bottleneck?.taskId).toBe('task-0');
+
+      // Assign tasks 1 through 209 — once we exceed MAX_TIMELINE_TASKS (200),
+      // task-0 (the current bottleneck) will be evicted from the bounded array
+      for (let i = 1; i <= 209; i++) {
+        state = delegationTimelineProjection.apply(
+          state,
+          makeEvent('team.task.assigned', {
+            taskId: `task-${i}`,
+            teammateName: `worker-${i}`,
+            worktreePath: `/tmp/wt-${i}`,
+            modules: ['auth'],
+          }, i + 2),
+        );
+      }
+
+      // 210 total tasks assigned → capped at 200, task-0 through task-9 evicted
+      expect(state.tasks).toHaveLength(200);
+      expect(state.tasks[0].taskId).toBe('task-10');
+      expect(state.hasMore).toBe(true);
+
+      // bottleneck referenced task-0 which was evicted — must be reset to null
+      expect(state.bottleneck).toBeNull();
+    });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/delegation-timeline-view.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/delegation-timeline-view.ts
@@ -5,6 +5,10 @@ import type { WorkflowEvent } from '../event-store/schemas.js';
 
 export const DELEGATION_TIMELINE_VIEW = 'delegation-timeline';
 
+// ─── Bounds ─────────────────────────────────────────────────────────────────
+
+export const MAX_TIMELINE_TASKS = 200;
+
 // ─── View State ────────────────────────────────────────────────────────────
 
 export interface TimelineTask {
@@ -28,6 +32,7 @@ export interface DelegationTimelineViewState {
   totalDurationMs: number;
   tasks: TimelineTask[];
   bottleneck: Bottleneck | null;
+  hasMore: boolean;
 }
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
@@ -62,6 +67,7 @@ export const delegationTimelineProjection: ViewProjection<DelegationTimelineView
     totalDurationMs: 0,
     tasks: [],
     bottleneck: null,
+    hasMore: false,
   }),
 
   apply: (view, event) => {
@@ -92,9 +98,16 @@ export const delegationTimelineProjection: ViewProjection<DelegationTimelineView
           durationMs: 0,
         };
 
+        const newTasks = [...view.tasks, task];
+        const evicted = newTasks.length > MAX_TIMELINE_TASKS;
+        const boundedTasks = evicted
+          ? newTasks.slice(newTasks.length - MAX_TIMELINE_TASKS)
+          : newTasks;
+
         return {
           ...view,
-          tasks: [...view.tasks, task],
+          tasks: boundedTasks,
+          hasMore: view.hasMore || evicted,
         };
       }
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/delegation-timeline-view.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/delegation-timeline-view.ts
@@ -104,9 +104,15 @@ export const delegationTimelineProjection: ViewProjection<DelegationTimelineView
           ? newTasks.slice(newTasks.length - MAX_TIMELINE_TASKS)
           : newTasks;
 
+        const bottleneckStillPresent =
+          view.bottleneck === null ||
+          boundedTasks.some((t) => t.taskId === view.bottleneck!.taskId);
+        const bottleneck = bottleneckStillPresent ? view.bottleneck : null;
+
         return {
           ...view,
           tasks: boundedTasks,
+          bottleneck,
           hasMore: view.hasMore || evicted,
         };
       }

--- a/plugins/exarchos/servers/exarchos-mcp/src/views/pipeline-view.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/views/pipeline-view.ts
@@ -5,6 +5,10 @@ import type { WorkflowEvent } from '../event-store/schemas.js';
 
 export const PIPELINE_VIEW = 'pipeline';
 
+// ─── Bounds ─────────────────────────────────────────────────────────────────
+
+export const MAX_STACK_POSITIONS = 100;
+
 // ─── Stack Position ────────────────────────────────────────────────────────
 
 export interface StackPosition {
@@ -24,6 +28,7 @@ export interface PipelineViewState {
   completedCount: number;
   failedCount: number;
   stackPositions: StackPosition[];
+  hasMore: boolean;
 }
 
 // ─── Projection ────────────────────────────────────────────────────────────
@@ -37,6 +42,7 @@ export const pipelineProjection: ViewProjection<PipelineViewState> = {
     completedCount: 0,
     failedCount: 0,
     stackPositions: [],
+    hasMore: false,
   }),
 
   apply: (view, event) => {
@@ -91,17 +97,24 @@ export const pipelineProjection: ViewProjection<PipelineViewState> = {
           prUrl?: string;
         } | undefined;
         if (data?.position === undefined || !data?.taskId) return view;
+        const newPositions = [
+          ...view.stackPositions,
+          {
+            position: data.position,
+            taskId: data.taskId,
+            branch: data.branch,
+            prUrl: data.prUrl,
+          },
+        ];
+        const evicted = newPositions.length > MAX_STACK_POSITIONS;
+        const boundedPositions = evicted
+          ? newPositions.slice(newPositions.length - MAX_STACK_POSITIONS)
+          : newPositions;
+
         return {
           ...view,
-          stackPositions: [
-            ...view.stackPositions,
-            {
-              position: data.position,
-              taskId: data.taskId,
-              branch: data.branch,
-              prUrl: data.prUrl,
-            },
-          ],
+          stackPositions: boundedPositions,
+          hasMore: view.hasMore || evicted,
         };
       }
 


### PR DESCRIPTION
## Summary

Adds bounds to unbounded view arrays. `DelegationTimelineViewState.tasks` is capped at 200 entries and `PipelineViewState.stackPositions` at 100. Both views gain a `hasMore: boolean` field that flips true when eviction occurs.

## Changes

- **delegation-timeline-view.ts** — Add `MAX_TIMELINE_TASKS = 200`, `hasMore: boolean` to state, FIFO eviction in `team.task.assigned` handler
- **pipeline-view.ts** — Add `MAX_STACK_POSITIONS = 100`, `hasMore: boolean` to state, FIFO eviction in `stack.position-filled` handler
- **Tests** — 4 new tests: task eviction at 200, hasMore flag on eviction, stack position eviction at 100, pipeline hasMore flag

## Test Plan

- [x] All 10 delegation timeline tests pass
- [x] All 8 pipeline view tests pass
- [x] Full MCP server test suite (1330 tests)
- [x] Build passes