### PR TITLE
refactor: add required JSON output schema to review skills

### DIFF
--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -129,6 +129,32 @@ If HIGH-priority issues found:
 3. Re-review quality after fixes
 4. Only mark APPROVED when all HIGH items resolved and tests pass
 
+## Required Output Format
+
+The subagent MUST return results as structured JSON. The orchestrator parses this JSON to populate state. Any other format is an error.
+
+```json
+{
+  "verdict": "pass | fail | blocked",
+  "summary": "1-2 sentence summary",
+  "issues": [
+    {
+      "severity": "HIGH | MEDIUM | LOW",
+      "category": "security | solid | dry | perf | naming | other",
+      "file": "path/to/file",
+      "line": 123,
+      "description": "Issue description",
+      "required_fix": "What must change"
+    }
+  ],
+  "test_results": {
+    "passed": 0,
+    "failed": 0,
+    "coverage_percent": 0
+  }
+}
+```
+
 ## Anti-Patterns
 
 | Don't | Do Instead |

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -126,6 +126,32 @@ Task({
 })
 ```
 
+## Required Output Format
+
+The subagent MUST return results as structured JSON. The orchestrator parses this JSON to populate state. Any other format is an error.
+
+```json
+{
+  "verdict": "pass | fail | blocked",
+  "summary": "1-2 sentence summary",
+  "issues": [
+    {
+      "severity": "HIGH | MEDIUM | LOW",
+      "category": "spec | tdd | coverage",
+      "file": "path/to/file",
+      "line": 123,
+      "description": "Issue description",
+      "required_fix": "What must change"
+    }
+  ],
+  "test_results": {
+    "passed": 0,
+    "failed": 0,
+    "coverage_percent": 0
+  }
+}
+```
+
 ## Anti-Patterns
 
 | Don't | Do Instead |


### PR DESCRIPTION
## Summary

Add structured JSON output format to both review skills so the orchestrator can reliably parse subagent results into workflow state. Spec-review uses categories: spec, tdd, coverage. Quality-review uses categories: security, solid, dry, perf, naming, other.

## Changes

- **skills/spec-review/SKILL.md** -- Add Required Output Format section with JSON schema
- **skills/quality-review/SKILL.md** -- Add Required Output Format section with extended category enum

## Test Plan

- [ ] Verify JSON schema is valid
- [ ] Verify both skills have matching schema structure

---
Tasks: T29, T30