### PR TITLE
refactor: add auto-chain validation and workflow gates

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -147,6 +147,15 @@ scripts/verify-ideate-artifacts.sh --state-file <state-file> --docs-dir docs/des
 
 After brainstorming completes, **auto-continue to planning** (no user confirmation):
 
+### Pre-Chain Validation (MANDATORY)
+
+Before invoking `/plan`:
+1. Verify `artifacts.design` exists in workflow state
+2. Verify the design file exists on disk: `test -f "$DESIGN_PATH"`
+3. If either fails: "Design artifact not found, cannot auto-chain to /plan"
+
+### Chain Steps
+
 1. Update state with design path and phase using `mcp__exarchos__exarchos_workflow` with `action: "set"`:
    - Set `artifacts.design` to the design path
    - Set `phase` to "plan"
@@ -160,7 +169,7 @@ After brainstorming completes, **auto-continue to planning** (no user confirmati
 
 This is NOT a human checkpoint. The human checkpoint occurs at plan-review (plan approval) and synthesize (merge confirmation).
 
-**Workflow continues:** `/ideate` → `/plan` → plan-review → [HUMAN CHECKPOINT] → `/delegate` → `/review` → `/synthesize` → [HUMAN CHECKPOINT]
+**Workflow continues:** `/ideate` -> `/plan` -> plan-review -> [HUMAN CHECKPOINT] -> `/delegate` -> `/review` -> `/synthesize` -> [HUMAN CHECKPOINT]
 
 ## Exarchos Integration
 

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -169,6 +169,14 @@ For detailed fix mode process, task structure, and transition flow, see `@skills
 
 After all tasks complete, **auto-continue immediately** (no user confirmation):
 
+### Pre-Chain Validation (MANDATORY)
+
+Before invoking `/review`:
+1. Verify all `tasks[].status === 'complete'` in workflow state
+2. If incomplete tasks exist: "Not all tasks complete, cannot proceed to review"
+
+### Chain Steps
+
 1. Update state: `.phase = "review"`, mark all tasks complete
 2. Output: "All [N] tasks complete. Auto-continuing to review..."
 3. Invoke immediately:

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -191,7 +191,7 @@ All transitions happen **immediately** without user confirmation:
 ### Pre-Chain Validation (MANDATORY)
 
 Before invoking quality-review:
-1. Verify spec-review verdict is "pass" in state
+1. Verify `reviews.spec.status === "pass"` in workflow state (all tasks passed)
 2. If not: "Spec review did not pass, cannot proceed to quality review"
 
 ### If PASS:

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -188,6 +188,12 @@ Use mcp__exarchos__exarchos_workflow with action: "set", featureId:
 
 All transitions happen **immediately** without user confirmation:
 
+### Pre-Chain Validation (MANDATORY)
+
+Before invoking quality-review:
+1. Verify spec-review verdict is "pass" in state
+2. If not: "Spec review did not pass, cannot proceed to quality review"
+
 ### If PASS:
 1. Update state with review results
 2. Output: "Spec review passed. Auto-continuing to quality review..."

--- a/skills/synthesis/SKILL.md
+++ b/skills/synthesis/SKILL.md
@@ -40,7 +40,7 @@ Since delegation creates Graphite stack branches and review validates them, synt
 ## Synthesis Process
 
 1. **Verify readiness** -- `scripts/pre-synthesis-check.sh` (includes phase readiness check with transition guidance)
-2. **Verify/reconstruct Graphite stack** -- `scripts/reconstruct-stack.sh`
+2. **REQUIRED: Verify/reconstruct Graphite stack** -- Run `scripts/reconstruct-stack.sh` before PR creation. If exit 1: stop and report error.
 3. **Quick test verification** -- `npm run test:run && npm run typecheck`
 4. **Check CodeRabbit reviews** -- `scripts/check-coderabbit.sh`
 5. **Submit to merge queue** -- `gt submit --no-interactive --publish --merge-when-ready`
@@ -84,7 +84,7 @@ Set `phase` to "completed".
 
 ## Completion Criteria
 
-- [ ] Graphite stack verified
+- [ ] Graphite stack verified via reconstruct-stack.sh
 - [ ] Quick test verification passed
 - [ ] CodeRabbit reviews checked (no CHANGES_REQUESTED blocking)
 - [ ] PRs enqueued via `--merge-when-ready`


### PR DESCRIPTION
## Summary

Add mandatory pre-chain validation guards at every auto-chain transition point: brainstorming verifies design artifact exists before /plan, delegation verifies all tasks complete before /review, spec-review verifies pass verdict before quality-review. Makes reconstruct-stack.sh mandatory in synthesis with exit-code enforcement.

## Changes

- **skills/brainstorming/SKILL.md** -- Add Pre-Chain Validation section to Transition
- **skills/delegation/SKILL.md** -- Add Pre-Chain Validation section to Transition
- **skills/spec-review/SKILL.md** -- Add Pre-Chain Validation section to Transition
- **skills/synthesis/SKILL.md** -- Make reconstruct-stack.sh required; update completion criteria

## Test Plan

- [ ] Verify each skill has validation guard before auto-chain
- [ ] Verify synthesis completion criteria includes stack verification

---
Tasks: T31, T32, T33, T35