### PR TITLE
refactor: return null checkpoint on successful compensation

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/cancel.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/cancel.test.ts
@@ -109,14 +109,7 @@ describe('handleCancel', () => {
             ],
             events: [],
             success: true,
-            checkpoint: {
-              completedActions: [
-                'synthesize:close-pr',
-                'delegate:delete-integration-branch',
-                'delegate:cleanup-worktrees',
-                'delegate:delete-feature-branches',
-              ],
-            },
+            checkpoint: null,
           };
         },
       );
@@ -144,7 +137,7 @@ describe('handleCancel', () => {
       };
       await writeRawState('ckpt-clear', rawState);
 
-      // Mock executeCompensation to return success
+      // Mock executeCompensation to return success (null checkpoint)
       const compensationModule = await import('../../workflow/compensation.js');
       vi.spyOn(compensationModule, 'executeCompensation').mockResolvedValue({
         actions: [
@@ -152,9 +145,7 @@ describe('handleCancel', () => {
         ],
         events: [],
         success: true,
-        checkpoint: {
-          completedActions: ['synthesize:close-pr', 'delegate:cleanup-worktrees'],
-        },
+        checkpoint: null,
       });
 
       // Act
@@ -166,6 +157,42 @@ describe('handleCancel', () => {
       // Assert: state file should NOT contain _compensationCheckpoint
       const stateAfter = await readRawState('ckpt-clear');
       expect(stateAfter._compensationCheckpoint).toBeUndefined();
+    });
+
+    // ─── T5: Clean _compensationCheckpoint from state after cancel (ARCH-5) ──
+
+    it('should set _compensationCheckpoint to null in state on successful compensation', async () => {
+      // Arrange: create a workflow with _compensationCheckpoint from a prior partial failure
+      await handleInit({ featureId: 'ckpt-null', workflowType: 'feature' }, tmpDir);
+
+      const rawState = await readRawState('ckpt-null');
+      rawState.phase = 'delegate';
+      rawState._history = { feature: 'delegate' };
+      rawState._compensationCheckpoint = {
+        completedActions: ['synthesize:close-pr'],
+      };
+      await writeRawState('ckpt-null', rawState);
+
+      // Mock executeCompensation to return success
+      const compensationModule = await import('../../workflow/compensation.js');
+      vi.spyOn(compensationModule, 'executeCompensation').mockResolvedValue({
+        actions: [
+          { actionId: 'delegate:cleanup-worktrees', status: 'executed', message: 'Done' },
+        ],
+        events: [],
+        success: true,
+        checkpoint: null,
+      });
+
+      // Act
+      const result = await handleCancel({ featureId: 'ckpt-null' }, tmpDir);
+
+      // Assert: cancel should succeed
+      expect(result.success).toBe(true);
+
+      // Assert: the raw state on disk should not have _compensationCheckpoint
+      const stateAfter = await readRawState('ckpt-null');
+      expect(stateAfter).not.toHaveProperty('_compensationCheckpoint');
     });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/compensation.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/compensation.test.ts
@@ -1046,27 +1046,50 @@ describe('Compensation', () => {
   });
 
   describe('ExecuteCompensation_ReturnsCheckpoint', () => {
-    it('should return a checkpoint with IDs of all executed and skipped actions', async () => {
+    it('should return null checkpoint when all actions succeed', async () => {
       const state = makeState({ phase: 'delegate' });
       const events = makeEvents(1);
 
       const result = await executeCompensation(state, 'delegate', events, 1, { dryRun: false });
 
-      // Result should include checkpoint
-      expect(result.checkpoint).toBeDefined();
-      expect(Array.isArray(result.checkpoint.completedActions)).toBe(true);
+      // All actions succeed — checkpoint should be null (cleanup signal)
+      expect(result.success).toBe(true);
+      expect(result.checkpoint).toBeNull();
+    });
+
+    it('should return a checkpoint with completed action IDs on partial failure', async () => {
+      const state = makeState({ phase: 'synthesize' });
+      const events = makeEvents(2);
+
+      // Make the close-pr command fail so we get a partial failure
+      mockedExecFile.mockImplementation((cmd: unknown, args: unknown, opts: unknown, cb?: unknown) => {
+        const callback = typeof opts === 'function' ? opts : cb;
+        if (cmd === 'gh' && Array.isArray(args) && args.includes('close')) {
+          (callback as (err: Error) => void)(new Error('gh: command failed'));
+        } else {
+          (callback as (err: null, stdout: string, stderr: string) => void)(null, '', '');
+        }
+        return undefined as never;
+      });
+
+      const result = await executeCompensation(state, 'synthesize', events, 2, { dryRun: false });
+
+      // Partial failure — checkpoint should be returned
+      expect(result.success).toBe(false);
+      expect(result.checkpoint).not.toBeNull();
+      expect(Array.isArray(result.checkpoint!.completedActions)).toBe(true);
 
       // All actions that were executed or skipped should appear in checkpoint
       for (const action of result.actions) {
         if (action.status === 'executed' || action.status === 'skipped') {
-          expect(result.checkpoint.completedActions).toContain(action.actionId);
+          expect(result.checkpoint!.completedActions).toContain(action.actionId);
         }
       }
 
       // Failed actions should NOT appear in checkpoint
       const failedActions = result.actions.filter((a) => a.status === 'failed');
       for (const action of failedActions) {
-        expect(result.checkpoint.completedActions).not.toContain(action.actionId);
+        expect(result.checkpoint!.completedActions).not.toContain(action.actionId);
       }
     });
   });
@@ -1094,9 +1117,8 @@ describe('Compensation', () => {
       // Actions should still execute or be condition-skipped as normal
       expect(result.actions.length).toBeGreaterThan(0);
 
-      // Checkpoint should be returned with all executed/skipped action IDs
-      expect(result.checkpoint).toBeDefined();
-      expect(result.checkpoint.completedActions.length).toBeGreaterThan(0);
+      // All actions succeeded — checkpoint should be null (cleanup signal)
+      expect(result.checkpoint).toBeNull();
     });
   });
 
@@ -1116,9 +1138,28 @@ describe('Compensation', () => {
       // Actions should still execute or be condition-skipped as normal
       expect(result.actions.length).toBeGreaterThan(0);
 
-      // Checkpoint should still be returned in the result
-      expect(result.checkpoint).toBeDefined();
-      expect(Array.isArray(result.checkpoint.completedActions)).toBe(true);
+      // All actions succeeded — checkpoint should be null (cleanup signal)
+      expect(result.checkpoint).toBeNull();
+    });
+  });
+
+  // ─── T4: Compensation checkpoint cleanup (ARCH-5) ──────────────────────────
+
+  describe('ExecuteCompensation_AllActionsSucceed_ReturnsNullCheckpoint', () => {
+    it('should return null checkpoint when all actions succeed', async () => {
+      // State with all resources present so actions actually execute (not just skip)
+      const state = makeState({ phase: 'synthesize' });
+      const events = makeEvents(2);
+
+      const result = await executeCompensation(state, 'synthesize', events, 2, { dryRun: false });
+
+      // All actions should succeed (executed or skipped — no failures)
+      expect(result.success).toBe(true);
+      const failedActions = result.actions.filter((a) => a.status === 'failed');
+      expect(failedActions.length).toBe(0);
+
+      // When all actions succeed, checkpoint should be null (cleanup signal)
+      expect(result.checkpoint).toBeNull();
     });
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/workflow/compensation.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/workflow/compensation.ts
@@ -49,7 +49,7 @@ export interface CompensationResult {
   readonly events: readonly Event[];
   readonly success: boolean;
   readonly errorCode?: string;
-  readonly checkpoint: CompensationCheckpoint;
+  readonly checkpoint: CompensationCheckpoint | null;
 }
 
 // ─── Phase Order (reverse compensation order) ───────────────────────────────
@@ -356,6 +356,6 @@ export async function executeCompensation(
     events: compensationEvents,
     success: !hasFailure,
     ...(hasFailure && { errorCode: ErrorCode.COMPENSATION_PARTIAL }),
-    checkpoint: { completedActions: [...completedSet] },
+    checkpoint: hasFailure ? { completedActions: [...completedSet] } : null,
   };
 }


### PR DESCRIPTION
executeCompensation now returns checkpoint: null when all actions
succeed, signaling that no retry checkpoint needs to be persisted.
This avoids stale compensation checkpoint data lingering in state
files after successful cancel operations.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>