### PR TITLE
refactor: disambiguate skill triggers and add guards

### DIFF
--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-review
-description: "Stage 2 code quality review after spec compliance passes. Use when the user says 'review code', 'check quality', 'code review', or runs /review. Checks SOLID principles, DRY, security, and test quality. Requires spec-review to pass first. Do NOT use for spec review (use spec-review) or brainstorming."
+description: "Stage 2 code quality review after spec compliance passes. Use when the user says 'quality review', 'check code quality', or runs /review (stage 2). Requires spec-review to have passed first (stage 2 of /review). Checks SOLID principles, DRY, security, and test quality. Do NOT use for spec compliance — use spec-review instead. Do NOT use for brainstorming."
 metadata:
   author: exarchos
   version: 1.0.0

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refactor
-description: "Code improvement workflow with two tracks: polish (small, direct changes) and overhaul (large, delegated restructuring). Use when the user says \"refactor\", \"clean up\", \"restructure\", \"reorganize\", \"refactor this code\", or runs /refactor. Handles explore, brief, implement, validate, and documentation phases. Do NOT use for bug fixes (use debug) or new features (use ideate)."
+description: "Code improvement workflow with two tracks: polish (small, direct changes) and overhaul (large, delegated restructuring). Use when the user says \"refactor\", \"clean up\", \"restructure\", \"reorganize\", \"refactor this code\", or runs /refactor. Handles explore, brief, implement, validate, and documentation phases. Do NOT use for bug fixes (use /debug) or new features (use /ideate). Applies to existing code only."
 metadata:
   author: exarchos
   version: 1.0.0

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-review
-description: "Implementation-to-spec compliance verification (code review stage 1). Use during the review phase after delegation completes to compare implemented code against design specification. Checks functional completeness, TDD compliance, and test coverage. Do NOT use for code quality review (use quality-review) or debugging."
+description: "Implementation-to-spec compliance verification (code review stage 1). Use when verifying implementation matches design specification (stage 1 of /review). Checks functional completeness, TDD compliance, and test coverage. Do NOT use for code quality checks — use quality-review instead. Do NOT use for debugging."
 metadata:
   author: exarchos
   version: 1.0.0


### PR DESCRIPTION
## Summary

Update frontmatter descriptions for spec-review, quality-review, and refactor skills to include explicit trigger discrimination. Each skill now states what it should NOT be used for, reducing misrouting by the model.

## Changes

- **skills/spec-review/SKILL.md** -- Clarify stage 1 usage; add "Do NOT use for code quality checks"
- **skills/quality-review/SKILL.md** -- Replace "review code" trigger with "quality review"; require spec-review first
- **skills/refactor/SKILL.md** -- Add exclusion for bug fixes and new features; specify existing code only

## Test Plan

- [ ] Verify each description is under 1,024 characters
- [ ] Verify negative triggers are explicit

---
Tasks: T36, T37, T38