### PR TITLE
refactor: add quality gates, timer, priority rules

### DIFF
--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -70,6 +70,15 @@ Activate this skill when:
 - Include at least one "flexible but complex" option
 - Recommend one option but explain why
 
+### Exploration Quality Gate
+
+Stop Phase 2 when ALL are true:
+- [ ] 2-3 approaches documented
+- [ ] Each answers design questions from Phase 1
+- [ ] Approaches differ in at least 2 of: {data structure, API design, complexity}
+- [ ] Trade-offs are honest and specific
+- [ ] One approach recommended with rationale
+
 ### Phase 3: Design Presentation
 
 **Goal:** Document the chosen approach in detail.

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -96,6 +96,13 @@ Fix production issues ASAP. Speed over ceremony.
 
 **Phases:** Triage -> Investigate (15 min max) -> Implement (no worktree) -> Validate -> Merge
 
+### Investigation Timer
+
+1. On hotfix track selection: record `investigation.startedAt` in state
+2. After each major finding: check elapsed time
+3. At 15 min mark: emit `investigation.timeout` event, pause for user confirmation
+   - Switch to thorough track? (yes/no)
+
 For detailed phase instructions, see `references/hotfix-track.md`.
 
 ## Thorough Track

--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -120,6 +120,14 @@ Use the template from `references/review-report-template.md` to structure the re
 | **MEDIUM** | Should fix, may defer | SOLID violations, complexity |
 | **LOW** | Nice to have | Style preferences, minor refactors |
 
+### Priority Classification Rules
+
+- **HIGH:** security vulnerabilities, data loss risk, API contract breaks, uncaught exception paths
+- **MEDIUM:** SOLID violations (LSP, ISP), cyclomatic complexity >15, test coverage <70%
+- **LOW:** naming, code style, comment clarity, non-impactful performance
+
+If classification is ambiguous, default to MEDIUM and flag for human decision.
+
 ## Fix Loop for HIGH-Priority
 
 If HIGH-priority issues found:


### PR DESCRIPTION
## Summary

Add concrete stop criteria and enforcement mechanisms: brainstorming Phase 2 gets an exploration quality gate with checkboxes, debug hotfix track gets a 15-minute investigation timer with track-switch prompt, and quality-review gets explicit priority classification rules with severity definitions.

## Changes

- **skills/brainstorming/SKILL.md** -- Add Exploration Quality Gate after Phase 2
- **skills/debug/SKILL.md** -- Add Investigation Timer to hotfix track section
- **skills/quality-review/SKILL.md** -- Add Priority Classification Rules with HIGH/MEDIUM/LOW criteria

## Test Plan

- [ ] Verify quality gate has all 5 checklist items
- [ ] Verify timer references state field and event emission
- [ ] Verify priority rules cover all severity levels with examples

---
Tasks: T39, T40, T41