### PR TITLE
feat: enhanced session-start with pre-computed context injection

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.test.ts
@@ -34,6 +34,7 @@ interface CheckpointData {
   readonly artifacts: Record<string, unknown>;
   readonly stateFile: string;
   readonly teamState?: unknown;
+  readonly contextFile?: string;
 }
 
 /** Minimal valid workflow state file for testing. */
@@ -369,6 +370,139 @@ describe('session-start command', () => {
 
       // Assert — the malformed file should NOT be deleted (skipped before unlink)
       await expect(fs.access(filePath)).resolves.toBeUndefined();
+    });
+
+    // ─── Context Document Injection Tests ──────────────────────────────────────
+
+    it('should include contextDocument when checkpoint has contextFile', async () => {
+      // Arrange
+      const contextContent = '## Workflow Context: test-feature\n**Phase:** delegate';
+      const contextPath = path.join(tmpDir, 'test-feature.context.md');
+      await fs.writeFile(contextPath, contextContent);
+
+      const checkpoint = createCheckpointFile({
+        featureId: 'test-feature',
+        contextFile: contextPath,
+      });
+      await fs.writeFile(
+        path.join(tmpDir, 'test-feature.checkpoint.json'),
+        JSON.stringify(checkpoint),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir);
+
+      // Assert
+      expect(result.contextDocument).toBeDefined();
+      expect(result.contextDocument).toContain('Workflow Context');
+    });
+
+    it('should not include contextDocument when checkpoint has no contextFile', async () => {
+      // Arrange — checkpoint without contextFile field
+      const checkpoint = createCheckpointFile({ featureId: 'test-feature' });
+      await fs.writeFile(
+        path.join(tmpDir, 'test-feature.checkpoint.json'),
+        JSON.stringify(checkpoint),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir);
+
+      // Assert
+      expect(result.contextDocument).toBeUndefined();
+      expect(result.workflows).toBeDefined();
+      expect(result.workflows).toHaveLength(1);
+    });
+
+    it('should degrade gracefully when contextFile is referenced but missing', async () => {
+      // Arrange — checkpoint references context.md that doesn't exist
+      const checkpoint = createCheckpointFile({
+        featureId: 'test-feature',
+        contextFile: path.join(tmpDir, 'nonexistent.context.md'),
+      });
+      await fs.writeFile(
+        path.join(tmpDir, 'test-feature.checkpoint.json'),
+        JSON.stringify(checkpoint),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir);
+
+      // Assert
+      expect(result.contextDocument).toBeUndefined();
+      expect(result.workflows).toBeDefined();
+      // Should not crash — workflow info still present
+    });
+
+    it('should delete context.md after reading', async () => {
+      // Arrange
+      const contextPath = path.join(tmpDir, 'test-feature.context.md');
+      await fs.writeFile(contextPath, '## Workflow Context: test-feature');
+
+      const checkpoint = createCheckpointFile({
+        featureId: 'test-feature',
+        contextFile: contextPath,
+      });
+      await fs.writeFile(
+        path.join(tmpDir, 'test-feature.checkpoint.json'),
+        JSON.stringify(checkpoint),
+      );
+
+      // Act
+      await handleSessionStart({}, tmpDir);
+
+      // Assert — context.md should be deleted after reading
+      await expect(fs.access(contextPath)).rejects.toThrow();
+    });
+
+    it('should not include contextDocument when active workflow has no checkpoint', async () => {
+      // Arrange — state file but no checkpoint
+      const stateData = createValidStateFile();
+      await fs.writeFile(
+        path.join(tmpDir, 'test-feature.state.json'),
+        JSON.stringify(stateData, null, 2),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir);
+
+      // Assert
+      expect(result.contextDocument).toBeUndefined();
+      expect(result.workflows).toBeDefined();
+    });
+
+    it('should combine context documents from multiple checkpoints', async () => {
+      // Arrange
+      const contextPath1 = path.join(tmpDir, 'feature-one.context.md');
+      const contextPath2 = path.join(tmpDir, 'feature-two.context.md');
+      await fs.writeFile(contextPath1, '## Workflow Context: feature-one');
+      await fs.writeFile(contextPath2, '## Workflow Context: feature-two');
+
+      const checkpoint1 = createCheckpointFile({
+        featureId: 'feature-one',
+        contextFile: contextPath1,
+      });
+      const checkpoint2 = createCheckpointFile({
+        featureId: 'feature-two',
+        contextFile: contextPath2,
+      });
+      await fs.writeFile(
+        path.join(tmpDir, 'feature-one.checkpoint.json'),
+        JSON.stringify(checkpoint1),
+      );
+      await fs.writeFile(
+        path.join(tmpDir, 'feature-two.checkpoint.json'),
+        JSON.stringify(checkpoint2),
+      );
+
+      // Act
+      const result = await handleSessionStart({}, tmpDir);
+
+      // Assert
+      expect(result.contextDocument).toBeDefined();
+      expect(result.contextDocument).toContain('feature-one');
+      expect(result.contextDocument).toContain('feature-two');
+      expect(result.contextDocument).toContain('---');  // separator between documents
     });
   });
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/session-start.ts
@@ -19,6 +19,7 @@ interface CheckpointData {
   readonly artifacts: Record<string, unknown>;
   readonly stateFile: string;
   readonly teamState?: unknown;
+  readonly contextFile?: string;
 }
 
 /** Recovery info attached when orphaned team state is detected. */
@@ -51,6 +52,7 @@ export interface SessionStartResult extends CommandResult {
   readonly workflows?: ReadonlyArray<WorkflowInfo>;
   readonly orphanedTeams?: ReadonlyArray<string>;
   readonly telemetryHints?: ReadonlyArray<string>;
+  readonly contextDocument?: string;
 }
 
 // ─── Terminal Phases ────────────────────────────────────────────────────────
@@ -117,6 +119,51 @@ async function readAndDeleteCheckpoints(stateDir: string): Promise<CheckpointDat
   }
 
   return results;
+}
+
+// ─── Context File Reader ────────────────────────────────────────────────────
+
+/**
+ * Read and delete a pre-computed context.md file.
+ * Returns the file content on success, or null if the file is missing or unreadable.
+ * Deletes the file before returning to ensure at-most-once delivery.
+ */
+async function readAndDeleteContextFile(contextPath: string): Promise<string | null> {
+  try {
+    const content = await fs.readFile(contextPath, 'utf-8');
+    await fs.unlink(contextPath);
+    return content;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Collect and combine context documents from checkpoints that have a contextFile field.
+ * Multiple context documents are joined with a `\n---\n` separator.
+ * Validates that contextFile paths are contained within stateDir to prevent path traversal.
+ * Returns undefined when no context documents are available.
+ */
+async function collectContextDocuments(
+  checkpoints: ReadonlyArray<CheckpointData>,
+  stateDir: string,
+): Promise<string | undefined> {
+  const contextDocuments: string[] = [];
+  const resolvedStateDir = path.resolve(stateDir);
+
+  for (const cp of checkpoints) {
+    if (!cp.contextFile) continue;
+    const resolvedPath = path.resolve(stateDir, cp.contextFile);
+    if (!resolvedPath.startsWith(resolvedStateDir + path.sep) && resolvedPath !== resolvedStateDir) continue;
+    const content = await readAndDeleteContextFile(resolvedPath);
+    if (content) {
+      contextDocuments.push(content);
+    }
+  }
+
+  return contextDocuments.length > 0
+    ? contextDocuments.join('\n---\n')
+    : undefined;
 }
 
 // ─── Orphaned Team Detection ────────────────────────────────────────────────
@@ -428,6 +475,9 @@ export async function handleSessionStart(
       };
     });
 
+    // Collect pre-computed context documents from checkpoint references
+    const contextDocument = await collectContextDocuments(checkpoints, stateDir);
+
     // Also check for active state files not covered by checkpoints
     try {
       const stateFiles = await listStateFiles(stateDir);
@@ -446,8 +496,16 @@ export async function handleSessionStart(
       // Non-critical: if listing fails, we still have checkpoint data
     }
 
-    if (teamsDir) return enrichWithTelemetryHints(await applyNativeTeamDetection(workflows, teamsDir), stateDir);
-    return enrichWithTelemetryHints({ workflows }, stateDir);
+    const baseResult: SessionStartResult = contextDocument
+      ? { workflows, contextDocument }
+      : { workflows };
+
+    if (teamsDir) {
+      const teamResult = await applyNativeTeamDetection(workflows, teamsDir);
+      const merged = contextDocument ? { ...teamResult, contextDocument } : teamResult;
+      return enrichWithTelemetryHints(merged, stateDir);
+    }
+    return enrichWithTelemetryHints(baseResult, stateDir);
   }
 
   // Step 2: No checkpoints — discover active workflows from state files


### PR DESCRIPTION
## Summary

Enhances the SessionStart hook to read pre-computed context documents from checkpoints and inject them as `contextDocument` in the response. This enables Claude to resume with full workflow awareness after `/clear` without inline context assembly.

## Changes

- **session-start.ts** — Added `readAndDeleteContextFile` and `collectContextDocuments` helpers; `contextDocument` field in `SessionStartResult`
- **At-most-once delivery** — Context files deleted after reading to prevent stale injection
- **hooks.json** — SessionStart matcher expanded to `startup|resume|compact|clear`

## Test Plan

7 new tests covering context injection, graceful degradation (missing files), at-most-once cleanup, and multi-checkpoint document combining.

---

**Results:** Tests 1446 ✓ · Build 0 errors
**Design:** [context-reload.md](docs/designs/2026-02-18-context-reload.md)