### PR TITLE
feat: enhanced pre-compact with context.md generation and trigger awareness

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/pre-compact.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/pre-compact.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { handlePreCompact } from './pre-compact.js';
+import { resetMaterializerCache } from '../views/tools.js';
 
 // ─── Test Helpers ──────────────────────────────────────────────────────────
 
@@ -55,12 +56,32 @@ async function writeMockState(
   return stateFile;
 }
 
+async function writeMockEvents(
+  stateDir: string,
+  streamId: string,
+  events: Array<Record<string, unknown>>,
+): Promise<void> {
+  const lines = events.map((e, i) =>
+    JSON.stringify({
+      ...e,
+      streamId,
+      sequence: i + 1,
+      timestamp: e.timestamp || '2026-01-01T00:00:00Z',
+    }),
+  );
+  await fs.writeFile(
+    path.join(stateDir, `${streamId}.events.jsonl`),
+    lines.join('\n') + '\n',
+  );
+}
+
 // ─── Tests ─────────────────────────────────────────────────────────────────
 
 describe('pre-compact', () => {
   let tmpDir: string;
 
   beforeEach(async () => {
+    resetMaterializerCache();
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pre-compact-test-'));
   });
 
@@ -95,7 +116,7 @@ describe('pre-compact', () => {
 
       // Assert
       expect(result.continue).toBe(false);
-      expect(result.stopReason).toContain('1 workflow(s)');
+      expect(result.stopReason).toContain('/clear');
     });
 
     it('should write checkpoint with phase, tasks, and nextAction fields', async () => {
@@ -160,7 +181,7 @@ describe('pre-compact', () => {
 
       // Assert
       expect(result.continue).toBe(false);
-      expect(result.stopReason).toContain('2 workflow(s)');
+      expect(result.stopReason).toContain('/clear');
 
       const cp1Path = path.join(stateDir, 'feature-one.checkpoint.json');
       const cp2Path = path.join(stateDir, 'feature-two.checkpoint.json');
@@ -191,7 +212,7 @@ describe('pre-compact', () => {
 
       // Assert
       expect(result.continue).toBe(false);
-      expect(result.stopReason).toContain('1 workflow(s)');
+      expect(result.stopReason).toContain('/clear');
 
       const activeCp = path.join(stateDir, 'active-wf.checkpoint.json');
       const doneCp = path.join(stateDir, 'done-wf.checkpoint.json');
@@ -219,7 +240,7 @@ describe('pre-compact', () => {
       expect(result.continue).toBe(true);
     });
 
-    it('should handle manual trigger type the same as auto', async () => {
+    it('should return continue true for manual trigger', async () => {
       // Arrange
       const stateDir = tmpDir;
       await writeMockState(stateDir, 'test-feature');
@@ -228,7 +249,7 @@ describe('pre-compact', () => {
       const result = await handlePreCompact({ event: 'PreCompact', type: 'manual' }, stateDir);
 
       // Assert
-      expect(result.continue).toBe(false);
+      expect(result.continue).toBe(true);
     });
 
     it('should return continue true when state directory does not exist', async () => {
@@ -237,6 +258,129 @@ describe('pre-compact', () => {
 
       // Act
       const result = await handlePreCompact({ event: 'PreCompact', type: 'auto' }, stateDir);
+
+      // Assert
+      expect(result.continue).toBe(true);
+    });
+  });
+
+  describe('context.md generation', () => {
+    it('should write context.md file when active workflow exists', async () => {
+      // Arrange
+      const stateDir = tmpDir;
+      await writeMockState(stateDir, 'test-feature');
+      await writeMockEvents(stateDir, 'test-feature', [
+        { type: 'workflow.started', data: { featureId: 'test-feature', workflowType: 'feature' } },
+      ]);
+
+      // Act
+      await handlePreCompact({ event: 'PreCompact', type: 'auto' }, stateDir);
+
+      // Assert
+      const contextPath = path.join(stateDir, 'test-feature.context.md');
+      const contextContent = await fs.readFile(contextPath, 'utf-8');
+      expect(contextContent).toContain('Workflow Context');
+    });
+
+    it('should include contextFile path in checkpoint', async () => {
+      // Arrange
+      const stateDir = tmpDir;
+      await writeMockState(stateDir, 'test-feature');
+      await writeMockEvents(stateDir, 'test-feature', [
+        { type: 'workflow.started', data: { featureId: 'test-feature', workflowType: 'feature' } },
+      ]);
+
+      // Act
+      await handlePreCompact({ event: 'PreCompact', type: 'auto' }, stateDir);
+
+      // Assert
+      const checkpointPath = path.join(stateDir, 'test-feature.checkpoint.json');
+      const checkpoint = JSON.parse(await fs.readFile(checkpointPath, 'utf-8'));
+      expect(checkpoint.contextFile).toBeDefined();
+      expect(typeof checkpoint.contextFile).toBe('string');
+      expect(checkpoint.contextFile).toContain('context.md');
+    });
+
+    it('should not write context.md when no active workflows exist', async () => {
+      // Arrange — empty state dir
+      const stateDir = tmpDir;
+
+      // Act
+      const result = await handlePreCompact({ event: 'PreCompact', type: 'auto' }, stateDir);
+
+      // Assert
+      expect(result.continue).toBe(true);
+      const files = await fs.readdir(stateDir).catch(() => []);
+      const contextFiles = (files as string[]).filter((f: string) => f.endsWith('.context.md'));
+      expect(contextFiles).toHaveLength(0);
+    });
+
+    it('should still write checkpoint and context.md for manual trigger', async () => {
+      // Arrange
+      const stateDir = tmpDir;
+      await writeMockState(stateDir, 'test-feature');
+      await writeMockEvents(stateDir, 'test-feature', [
+        { type: 'workflow.started', data: { featureId: 'test-feature', workflowType: 'feature' } },
+      ]);
+
+      // Act
+      const result = await handlePreCompact({ event: 'PreCompact', type: 'manual' }, stateDir);
+
+      // Assert
+      expect(result.continue).toBe(true);
+      // Checkpoint should still be written
+      const checkpointPath = path.join(stateDir, 'test-feature.checkpoint.json');
+      const checkpoint = JSON.parse(await fs.readFile(checkpointPath, 'utf-8'));
+      expect(checkpoint.featureId).toBe('test-feature');
+      // Context.md should still be written
+      const contextPath = path.join(stateDir, 'test-feature.context.md');
+      await expect(fs.access(contextPath)).resolves.toBeUndefined();
+    });
+
+    it('should write context.md for each workflow when multiple active', async () => {
+      // Arrange
+      const stateDir = tmpDir;
+      await writeMockState(stateDir, 'feature-one', { phase: 'delegate' });
+      await writeMockState(stateDir, 'feature-two', { phase: 'review' });
+      await writeMockEvents(stateDir, 'feature-one', [
+        { type: 'workflow.started', data: { featureId: 'feature-one', workflowType: 'feature' } },
+      ]);
+      await writeMockEvents(stateDir, 'feature-two', [
+        { type: 'workflow.started', data: { featureId: 'feature-two', workflowType: 'feature' } },
+      ]);
+
+      // Act
+      await handlePreCompact({ event: 'PreCompact', type: 'auto' }, stateDir);
+
+      // Assert
+      const contextOne = path.join(stateDir, 'feature-one.context.md');
+      const contextTwo = path.join(stateDir, 'feature-two.context.md');
+      await expect(fs.access(contextOne)).resolves.toBeUndefined();
+      await expect(fs.access(contextTwo)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('trigger awareness', () => {
+    it('should return continue false for auto trigger', async () => {
+      // Arrange
+      const stateDir = tmpDir;
+      await writeMockState(stateDir, 'test-feature');
+
+      // Act
+      const result = await handlePreCompact({ event: 'PreCompact', type: 'auto' }, stateDir);
+
+      // Assert
+      expect(result.continue).toBe(false);
+      expect(result.stopReason).toContain('/clear');
+    });
+
+    it('should return continue true for manual trigger', async () => {
+      // Arrange
+      const stateDir = tmpDir;
+      await writeMockState(stateDir, 'test-feature');
+
+      // Act
+      const result = await handlePreCompact({ event: 'PreCompact', type: 'manual' }, stateDir);
 
       // Assert
       expect(result.continue).toBe(true);

--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/pre-compact.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/pre-compact.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { listStateFiles } from '../workflow/state-store.js';
 import { PHASE_ACTION_MAP, HUMAN_CHECKPOINT_PHASES } from '../workflow/next-action.js';
+import { handleAssembleContext } from './assemble-context.js';
 import type { CommandResult } from '../cli.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -17,6 +18,7 @@ interface CheckpointData {
   readonly artifacts: Record<string, unknown>;
   readonly stateFile: string;
   readonly teamState?: unknown;
+  readonly contextFile?: string;
 }
 
 /** Result returned from the pre-compact handler. */
@@ -77,9 +79,11 @@ function buildSummary(
  * and return whether compaction should proceed.
  */
 export async function handlePreCompact(
-  _stdinData: Record<string, unknown>,
+  stdinData: Record<string, unknown>,
   stateDir: string,
 ): Promise<PreCompactResult> {
+  const trigger = typeof stdinData.type === 'string' ? stdinData.type : 'auto';
+
   // List all state files (listStateFiles handles missing directory gracefully)
   const allWorkflows = await listStateFiles(stateDir);
 
@@ -125,10 +129,28 @@ export async function handlePreCompact(
 
     const checkpointPath = path.join(stateDir, `${featureId}.checkpoint.json`);
     await fs.writeFile(checkpointPath, JSON.stringify(checkpoint, null, 2), 'utf-8');
+
+    // Generate context.md alongside the checkpoint
+    try {
+      const contextResult = await handleAssembleContext({ featureId }, stateDir);
+      if (contextResult.contextDocument) {
+        const contextPath = path.join(stateDir, `${featureId}.context.md`);
+        await fs.writeFile(contextPath, contextResult.contextDocument, 'utf-8');
+        // Re-write checkpoint with contextFile field
+        const updatedCheckpoint: CheckpointData = { ...checkpoint, contextFile: contextPath };
+        await fs.writeFile(checkpointPath, JSON.stringify(updatedCheckpoint, null, 2), 'utf-8');
+      }
+    } catch {
+      // Graceful degradation — checkpoint works without context.md
+    }
+  }
+
+  if (trigger === 'manual') {
+    return { continue: true };
   }
 
   return {
     continue: false,
-    stopReason: `Checkpoint saved for ${activeWorkflows.length} workflow(s). Run /resume to continue.`,
+    stopReason: `Context checkpoint saved. Type /clear to reload with fresh context.`,
   };
 }


### PR DESCRIPTION
## Summary

Enhances the PreCompact hook to generate pre-computed context documents alongside checkpoints, and adds trigger-aware behavior that distinguishes auto-compaction (stop session) from manual `/compact` (allow continuation).

## Changes

- **pre-compact.ts** — Calls `handleAssembleContext` after checkpoint, writes `{featureId}.context.md`, adds `contextFile` field to checkpoint data
- **Trigger awareness** — Auto trigger returns `continue: false` with `/clear` instruction; manual trigger returns `continue: true`
- **hooks.json** — PreCompact matcher changed from `"auto"` to `""` (fires on all compaction events)

## Test Plan

7 new tests for context.md generation and trigger-aware behavior, plus 4 updated existing tests for new stop reason format.

---

**Results:** Tests 1446 ✓ · Build 0 errors
**Design:** [context-reload.md](docs/designs/2026-02-18-context-reload.md)