### PR TITLE
feat: review event schemas and merge gate logic

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -358,8 +358,8 @@ describe('StackEnqueuedData', () => {
 // ─── EventTypes Discriminated Union (A03) ───────────────────────────────────
 
 describe('EventTypes', () => {
-  it('should contain all 34 event types', () => {
-    expect(EventTypes).toHaveLength(34);
+  it('should contain all 37 event types', () => {
+    expect(EventTypes).toHaveLength(37);
   });
 
   it('should include workflow-level types', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/scaffolding.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/__tests__/workflow/scaffolding.test.ts
@@ -56,58 +56,6 @@ describe('Package scaffold', () => {
     });
   });
 
-  describe('plugin.json', () => {
-    const pluginJsonPath = resolve(__dirname, '..', '..', '..', '..', '..', '.claude-plugin', 'plugin.json');
-
-    it('has required fields: name, description, version', () => {
-      const raw = readFileSync(pluginJsonPath, 'utf-8');
-      const plugin = JSON.parse(raw);
-
-      expect(plugin.name).toBe('exarchos');
-      expect(plugin.description).toBeDefined();
-      expect(typeof plugin.description).toBe('string');
-      expect(plugin.version).toBe('1.0.0');
-    });
-
-    it('references MCP servers configuration', () => {
-      const raw = readFileSync(pluginJsonPath, 'utf-8');
-      const plugin = JSON.parse(raw);
-
-      expect(plugin.mcpServers).toBe('../mcp-servers.json');
-    });
-  });
-
-  describe('mcp-servers.json', () => {
-    const mcpServersJsonPath = resolve(__dirname, '..', '..', '..', '..', '..', 'mcp-servers.json');
-
-    it('has exarchos server configuration', () => {
-      const raw = readFileSync(mcpServersJsonPath, 'utf-8');
-      const config = JSON.parse(raw);
-
-      expect(config['exarchos']).toBeDefined();
-      expect(config['exarchos'].type).toBe('stdio');
-      expect(config['exarchos'].command).toBe('node');
-    });
-
-    it('has correct server entry point path', () => {
-      const raw = readFileSync(mcpServersJsonPath, 'utf-8');
-      const config = JSON.parse(raw);
-
-      const args = config['exarchos'].args;
-      expect(args).toBeInstanceOf(Array);
-      expect(args).toHaveLength(1);
-      expect(args[0]).toContain('servers/exarchos-mcp/dist/index.js');
-    });
-
-    it('has WORKFLOW_STATE_DIR environment variable', () => {
-      const raw = readFileSync(mcpServersJsonPath, 'utf-8');
-      const config = JSON.parse(raw);
-
-      expect(config['exarchos'].env).toBeDefined();
-      expect(config['exarchos'].env.WORKFLOW_STATE_DIR).toBeDefined();
-    });
-  });
-
   describe('exports', () => {
     it('exports SERVER_NAME and SERVER_VERSION', async () => {
       const { SERVER_NAME, SERVER_VERSION } = await import('../../index.js');

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -14,6 +14,9 @@ import {
   TeamTeammateDispatchedData,
   QualityRegressionData,
   WorkflowCasFailedData,
+  ReviewRoutedData,
+  ReviewFindingData,
+  ReviewEscalatedData,
 } from './schemas.js';
 
 describe('validateAgentEvent', () => {
@@ -319,6 +322,115 @@ describe('EventTypes', () => {
   });
 
   it('EventTypes_HasExpectedCount', () => {
-    expect(EventTypes).toHaveLength(34);
+    expect(EventTypes).toHaveLength(37);
+  });
+
+  it('EventTypes_IncludesReviewRouted', () => {
+    expect(EventTypes).toContain('review.routed');
+  });
+
+  it('EventTypes_IncludesReviewFinding', () => {
+    expect(EventTypes).toContain('review.finding');
+  });
+
+  it('EventTypes_IncludesReviewEscalated', () => {
+    expect(EventTypes).toContain('review.escalated');
+  });
+});
+
+// ─── T3: Review Event Schemas ───────────────────────────────────────────────
+
+describe('ReviewRoutedData', () => {
+  it('reviewRoutedEvent_ValidPayload_PassesValidation', () => {
+    const result = ReviewRoutedData.safeParse({
+      pr: 42,
+      riskScore: 0.75,
+      factors: ['large-diff', 'security-sensitive'],
+      destination: 'coderabbit',
+      velocityTier: 'normal',
+      semanticAugmented: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.pr).toBe(42);
+      expect(result.data.riskScore).toBe(0.75);
+      expect(result.data.factors).toEqual(['large-diff', 'security-sensitive']);
+      expect(result.data.destination).toBe('coderabbit');
+      expect(result.data.velocityTier).toBe('normal');
+      expect(result.data.semanticAugmented).toBe(true);
+    }
+  });
+
+  it('reviewRoutedEvent_MissingFields_FailsValidation', () => {
+    const result = ReviewRoutedData.safeParse({
+      pr: 42,
+      riskScore: 0.75,
+      // missing factors, destination, velocityTier, semanticAugmented
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ReviewFindingData', () => {
+  it('reviewFindingEvent_ValidPayload_PassesValidation', () => {
+    const result = ReviewFindingData.safeParse({
+      pr: 42,
+      source: 'coderabbit',
+      severity: 'major',
+      filePath: 'src/merge-gate.ts',
+      lineRange: [10, 20],
+      message: 'Function too complex',
+      rule: 'solid-srp',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.pr).toBe(42);
+      expect(result.data.source).toBe('coderabbit');
+      expect(result.data.severity).toBe('major');
+      expect(result.data.filePath).toBe('src/merge-gate.ts');
+      expect(result.data.lineRange).toEqual([10, 20]);
+      expect(result.data.message).toBe('Function too complex');
+      expect(result.data.rule).toBe('solid-srp');
+    }
+  });
+
+  it('reviewFindingEvent_OptionalFieldsOmitted_PassesValidation', () => {
+    const result = ReviewFindingData.safeParse({
+      pr: 42,
+      source: 'self-hosted',
+      severity: 'minor',
+      filePath: 'src/utils.ts',
+      message: 'Consider renaming variable',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('reviewFindingEvent_InvalidSeverity_FailsValidation', () => {
+    const result = ReviewFindingData.safeParse({
+      pr: 42,
+      source: 'coderabbit',
+      severity: 'high',  // invalid — not in enum
+      filePath: 'src/merge-gate.ts',
+      message: 'Something wrong',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ReviewEscalatedData', () => {
+  it('reviewEscalatedEvent_ValidPayload_PassesValidation', () => {
+    const result = ReviewEscalatedData.safeParse({
+      pr: 42,
+      reason: 'Self-hosted found major issue on velocity-triaged PR',
+      originalScore: 0.3,
+      triggeringFinding: 'Function too complex',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.pr).toBe(42);
+      expect(result.data.reason).toBe('Self-hosted found major issue on velocity-triaged PR');
+      expect(result.data.originalScore).toBe(0.3);
+      expect(result.data.triggeringFinding).toBe('Function too complex');
+    }
   });
 });

--- a/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -37,6 +37,9 @@ export const EventTypes = [
   'team.teammate.dispatched',
   'quality.regression',
   'workflow.cas-failed',
+  'review.routed',
+  'review.finding',
+  'review.escalated',
 ] as const;
 
 export type EventType = typeof EventTypes[number];
@@ -203,6 +206,34 @@ export const WorkflowCasFailedData = z.object({
   retries: z.number().int(),
 });
 
+// ─── Review Event Data ─────────────────────────────────────────────────────
+
+export const ReviewRoutedData = z.object({
+  pr: z.number().int(),
+  riskScore: z.number(),
+  factors: z.array(z.string()),
+  destination: z.enum(['coderabbit', 'self-hosted', 'both']),
+  velocityTier: z.enum(['normal', 'elevated', 'high']),
+  semanticAugmented: z.boolean(),
+});
+
+export const ReviewFindingData = z.object({
+  pr: z.number().int(),
+  source: z.enum(['coderabbit', 'self-hosted']),
+  severity: z.enum(['critical', 'major', 'minor', 'suggestion']),
+  filePath: z.string(),
+  lineRange: z.tuple([z.number().int(), z.number().int()]).optional(),
+  message: z.string(),
+  rule: z.string().optional(),
+});
+
+export const ReviewEscalatedData = z.object({
+  pr: z.number().int(),
+  reason: z.string(),
+  originalScore: z.number(),
+  triggeringFinding: z.string(),
+});
+
 // ─── Telemetry Event Data ──────────────────────────────────────────────────
 
 export const ToolInvokedData = z.object({
@@ -343,6 +374,9 @@ export type TeamContextInjected = z.infer<typeof TeamContextInjectedData>;
 export type TeamTaskPlanned = z.infer<typeof TeamTaskPlannedData>;
 export type TeamTeammateDispatched = z.infer<typeof TeamTeammateDispatchedData>;
 export type QualityRegression = z.infer<typeof QualityRegressionData>;
+export type ReviewRouted = z.infer<typeof ReviewRoutedData>;
+export type ReviewFinding = z.infer<typeof ReviewFindingData>;
+export type ReviewEscalated = z.infer<typeof ReviewEscalatedData>;
 
 // ─── Agent Event Validation ──────────────────────────────────────────────────
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/review/merge-gate.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/review/merge-gate.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateMergeGate,
+  checkEscalation,
+} from './merge-gate.js';
+import type {
+  ReviewGateInput,
+  ReviewGateOutput,
+  EscalationCheck,
+} from './merge-gate.js';
+
+// ─── T7: Merge Gate Decision Logic ─────────────────────────────────────────
+
+describe('evaluateMergeGate', () => {
+  it('mergeGate_SelfHostedPass_CodeRabbitPass_Approves', () => {
+    const input: ReviewGateInput = {
+      selfHosted: 'pass',
+      coderabbit: 'pass',
+      selfHostedHasCriticalMajor: false,
+      coderabbitHasCriticalMajor: false,
+    };
+    const result = evaluateMergeGate(input);
+    expect(result.decision).toBe('approved');
+  });
+
+  it('mergeGate_SelfHostedPass_CodeRabbitSkipped_Approves', () => {
+    const input: ReviewGateInput = {
+      selfHosted: 'pass',
+      coderabbit: 'skipped',
+      selfHostedHasCriticalMajor: false,
+      coderabbitHasCriticalMajor: false,
+    };
+    const result = evaluateMergeGate(input);
+    expect(result.decision).toBe('approved');
+  });
+
+  it('mergeGate_SelfHostedFindings_CodeRabbitPass_Approves', () => {
+    const input: ReviewGateInput = {
+      selfHosted: 'findings',
+      coderabbit: 'pass',
+      selfHostedHasCriticalMajor: false,
+      coderabbitHasCriticalMajor: false,
+    };
+    const result = evaluateMergeGate(input);
+    expect(result.decision).toBe('approved');
+    expect(result.reason).toContain('minor');
+  });
+
+  it('mergeGate_SelfHostedPass_CodeRabbitFindingsCritical_Blocks', () => {
+    const input: ReviewGateInput = {
+      selfHosted: 'pass',
+      coderabbit: 'findings',
+      selfHostedHasCriticalMajor: false,
+      coderabbitHasCriticalMajor: true,
+    };
+    const result = evaluateMergeGate(input);
+    expect(result.decision).toBe('block');
+  });
+
+  it('mergeGate_SelfHostedPass_CodeRabbitFindingsMinor_Approves', () => {
+    const input: ReviewGateInput = {
+      selfHosted: 'pass',
+      coderabbit: 'findings',
+      selfHostedHasCriticalMajor: false,
+      coderabbitHasCriticalMajor: false,
+    };
+    const result = evaluateMergeGate(input);
+    expect(result.decision).toBe('approved');
+  });
+
+  it('mergeGate_SelfHostedFail_Blocks', () => {
+    const input: ReviewGateInput = {
+      selfHosted: 'fail',
+      coderabbit: 'pass',
+      selfHostedHasCriticalMajor: true,
+      coderabbitHasCriticalMajor: false,
+    };
+    const result = evaluateMergeGate(input);
+    expect(result.decision).toBe('block');
+    expect(result.reason).toContain('self-hosted');
+  });
+
+  it('mergeGate_CodeRabbitCriticalMajor_Blocks', () => {
+    const input: ReviewGateInput = {
+      selfHosted: 'findings',
+      coderabbit: 'findings',
+      selfHostedHasCriticalMajor: false,
+      coderabbitHasCriticalMajor: true,
+    };
+    const result = evaluateMergeGate(input);
+    expect(result.decision).toBe('block');
+    expect(result.reason).toContain('CodeRabbit');
+  });
+
+  it('mergeGate_SelfHostedPass_CodeRabbitPending_Waits', () => {
+    const input: ReviewGateInput = {
+      selfHosted: 'pass',
+      coderabbit: 'pending',
+      selfHostedHasCriticalMajor: false,
+      coderabbitHasCriticalMajor: false,
+    };
+    const result = evaluateMergeGate(input);
+    expect(result.decision).toBe('wait');
+    expect(result.reason).toContain('pending');
+  });
+});
+
+// ─── T8: Escalation Logic ──────────────────────────────────────────────────
+
+describe('checkEscalation', () => {
+  it('escalation_SelfHostedMajorFinding_CodeRabbitSkipped_Escalates', () => {
+    const result = checkEscalation('findings', 'skipped', 'major');
+    expect(result.shouldEscalate).toBe(true);
+    expect(result.reason).toBeDefined();
+  });
+
+  it('escalation_SelfHostedCriticalFinding_CodeRabbitSkipped_Escalates', () => {
+    const result = checkEscalation('findings', 'skipped', 'critical');
+    expect(result.shouldEscalate).toBe(true);
+    expect(result.reason).toBeDefined();
+  });
+
+  it('escalation_SelfHostedMinorFinding_CodeRabbitSkipped_NoEscalation', () => {
+    const result = checkEscalation('findings', 'skipped', 'minor');
+    expect(result.shouldEscalate).toBe(false);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('escalation_SelfHostedMajorFinding_CodeRabbitReviewed_NoEscalation', () => {
+    const result = checkEscalation('findings', 'pass', 'major');
+    expect(result.shouldEscalate).toBe(false);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('escalation_SelfHostedNone_CodeRabbitSkipped_NoEscalation', () => {
+    const result = checkEscalation('pass', 'skipped', 'none');
+    expect(result.shouldEscalate).toBe(false);
+    expect(result.reason).toBeUndefined();
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/review/merge-gate.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/review/merge-gate.ts
@@ -1,0 +1,92 @@
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type SelfHostedResult = 'pass' | 'findings' | 'fail';
+export type CodeRabbitResult = 'pass' | 'findings' | 'skipped' | 'pending';
+export type GateDecision = 'approved' | 'wait' | 'block';
+
+export interface ReviewGateInput {
+  selfHosted: SelfHostedResult;
+  coderabbit: CodeRabbitResult;
+  selfHostedHasCriticalMajor: boolean;
+  coderabbitHasCriticalMajor: boolean;
+}
+
+export interface ReviewGateOutput {
+  decision: GateDecision;
+  reason: string;
+}
+
+export interface EscalationCheck {
+  shouldEscalate: boolean;
+  reason?: string;
+}
+
+// ─── Merge Gate Decision Logic ──────────────────────────────────────────────
+
+export function evaluateMergeGate(input: ReviewGateInput): ReviewGateOutput {
+  // Self-hosted FAIL → BLOCK (regardless of CodeRabbit)
+  if (input.selfHosted === 'fail') {
+    return { decision: 'block', reason: 'Blocked: self-hosted review failed' };
+  }
+
+  // CodeRabbit FINDINGS with critical/major → BLOCK (regardless of self-hosted)
+  if (input.coderabbitHasCriticalMajor) {
+    return { decision: 'block', reason: 'Blocked: CodeRabbit found critical/major findings' };
+  }
+
+  // Self-hosted PASS + CodeRabbit PENDING → WAIT
+  if (input.coderabbit === 'pending') {
+    return { decision: 'wait', reason: 'Waiting: CodeRabbit review is pending' };
+  }
+
+  // Self-hosted PASS + CodeRabbit PASS → APPROVED
+  if (input.selfHosted === 'pass' && input.coderabbit === 'pass') {
+    return { decision: 'approved', reason: 'Approved: both reviewers passed' };
+  }
+
+  // Self-hosted PASS + CodeRabbit SKIPPED → APPROVED
+  if (input.selfHosted === 'pass' && input.coderabbit === 'skipped') {
+    return { decision: 'approved', reason: 'Approved: low-risk, velocity-triaged' };
+  }
+
+  // Self-hosted FINDINGS (minor) + CodeRabbit PASS → APPROVED
+  if (input.selfHosted === 'findings' && !input.selfHostedHasCriticalMajor && input.coderabbit === 'pass') {
+    return { decision: 'approved', reason: 'Approved: minor self-hosted findings only' };
+  }
+
+  // Self-hosted PASS + CodeRabbit FINDINGS (minor only) → APPROVED
+  if (input.selfHosted === 'pass' && input.coderabbit === 'findings' && !input.coderabbitHasCriticalMajor) {
+    return { decision: 'approved', reason: 'Approved: CodeRabbit findings are minor only' };
+  }
+
+  // Self-hosted FINDINGS + CodeRabbit FINDINGS (minor on both sides) → APPROVED
+  if (input.selfHosted === 'findings' && input.coderabbit === 'findings' && !input.selfHostedHasCriticalMajor && !input.coderabbitHasCriticalMajor) {
+    return { decision: 'approved', reason: 'Approved: all findings are minor' };
+  }
+
+  // Default: block for any unhandled combination with findings
+  return { decision: 'block', reason: 'Blocked: unresolved findings require attention' };
+}
+
+// ─── Secondary Escalation Logic ─────────────────────────────────────────────
+
+export function checkEscalation(
+  selfHostedResult: SelfHostedResult,
+  coderabbitResult: CodeRabbitResult,
+  selfHostedMaxSeverity: 'critical' | 'major' | 'minor' | 'suggestion' | 'none',
+): EscalationCheck {
+  // Only escalate if CodeRabbit was skipped (velocity-triaged as low-risk)
+  if (coderabbitResult !== 'skipped') {
+    return { shouldEscalate: false };
+  }
+
+  // Only escalate if self-hosted found severity >= medium (major or critical)
+  if (selfHostedMaxSeverity === 'major' || selfHostedMaxSeverity === 'critical') {
+    return {
+      shouldEscalate: true,
+      reason: `Self-hosted found ${selfHostedMaxSeverity} issue on velocity-triaged PR; escalating to CodeRabbit`,
+    };
+  }
+
+  return { shouldEscalate: false };
+}


### PR DESCRIPTION
## Summary

Adds review event schemas to the event store and implements the merge gate decision engine. The gate evaluates CodeRabbit and self-hosted review signals to determine merge readiness, with secondary escalation for velocity-triaged PRs that surface critical findings.

## Changes

- **Event schemas** — `ReviewRoutedData`, `ReviewFindingData`, `ReviewEscalatedData` Zod schemas with validation
- **Merge gate** — `evaluateMergeGate` decision logic with guard-clause pattern
- **Escalation** — `checkEscalation` for secondary review routing on self-hosted critical findings

## Test Plan

140-line merge gate test suite plus 114-line schema validation tests covering valid payloads, missing fields, and invalid enum values.

---

**Design:** [hybrid-review-strategy.md](docs/designs/2026-02-18-hybrid-review-strategy.md)