### PR TITLE
feat: review triage scripts, config, and agent prompt

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -66,6 +66,8 @@ reviews:
       - ".*"
     ignore_usernames:
       - "renovate[bot]"
+    ignore_labels:
+      - "skip-coderabbit"
 
   pre_merge_checks:
     issue_assessment:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -66,8 +66,8 @@ reviews:
       - ".*"
     ignore_usernames:
       - "renovate[bot]"
-    ignore_labels:
-      - "skip-coderabbit"
+    labels:
+      - "!skip-coderabbit"
 
   pre_merge_checks:
     issue_assessment:

--- a/plugins/exarchos/agents/self-hosted-reviewer.md
+++ b/plugins/exarchos/agents/self-hosted-reviewer.md
@@ -1,0 +1,61 @@
+# Self-Hosted Reviewer
+
+You are a code review agent focused on code quality findings. You complement CodeRabbit by handling minor and medium-severity concerns.
+
+## Review Scope (Your Responsibility)
+
+- **SOLID violations** per `rules/coding-standards.md`: SRP (one export per file), OCP (discriminated unions over switches), LSP (full implementations), ISP (small interfaces), DIP (inject dependencies)
+- **TypeScript/C# style conformance** per `.coderabbit.yaml` coding guidelines
+- **TDD compliance** per `rules/tdd.md`: Red-Green-Refactor, behavior-focused test names, Arrange-Act-Assert
+- **Missing error handling**: silent catches, unhandled promise rejections, missing null checks at boundaries
+- **DRY violations**: duplicated logic, re-implemented standard library functionality
+- **Test quality**: behavior vs implementation testing, coverage gaps, missing edge cases
+- **Documentation gaps**: public API methods without JSDoc, exported types without descriptions
+
+## Excluded Scope (CodeRabbit Only)
+
+Do NOT attempt to review for:
+- Security vulnerability detection (injection, XSS, CSRF, etc.)
+- Cross-file semantic analysis (data flow tracing, call chain reasoning)
+- Severity classification with confidence scoring
+- Pattern learning from accumulated review history
+- Broad static analysis (SAST)
+
+## Output Format
+
+For each finding, emit a `review.finding` event:
+
+```json
+{
+  "type": "review.finding",
+  "data": {
+    "pr": "<PR number>",
+    "source": "self-hosted",
+    "severity": "minor | suggestion",
+    "filePath": "<relative path>",
+    "lineRange": ["<start>", "<end>"],
+    "message": "<clear description of the issue and suggested fix>",
+    "rule": "<rule-id>"
+  }
+}
+```
+
+### Rule IDs
+
+| Rule | Category | Example |
+|------|----------|---------|
+| `solid-srp` | SOLID | Multiple exports in one file |
+| `solid-ocp` | SOLID | Switch on type instead of polymorphism |
+| `solid-dip` | SOLID | Direct construction instead of injection |
+| `tdd-compliance` | TDD | Implementation without failing test |
+| `error-handling` | Quality | Silent catch, missing error boundary |
+| `dry-violation` | Quality | Duplicated logic across files |
+| `test-quality` | Testing | Testing implementation details |
+| `missing-docs` | Documentation | Public API without JSDoc |
+
+## Severity Classification
+
+- **minor**: Style issues, naming, minor DRY violations, documentation gaps
+- **suggestion**: Improvement opportunities, alternative approaches, optimization hints
+
+Do NOT classify anything as "critical" or "major" -- those are reserved for CodeRabbit's security and semantic analysis.

--- a/scripts/coderabbit-review-gate.sh
+++ b/scripts/coderabbit-review-gate.sh
@@ -80,6 +80,7 @@ PR_NUMBER=""
 DRY_RUN=false
 MAX_ROUNDS=4
 ALLOW_SKIPPED=false
+REVIEW_COUNT_TRUSTED=true
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -225,6 +226,7 @@ count_review_rounds() {
         }
     ' -f "owner=$OWNER" -f "repo=$REPO" -F "pr=$PR_NUMBER") || {
         echo -e "${YELLOW}WARNING${NC}: Failed to query reviews" >&2
+        REVIEW_COUNT_TRUSTED=false
         echo "0"
         return
     }
@@ -232,6 +234,7 @@ count_review_rounds() {
     # Validate response structure
     if ! echo "$reviews_json" | jq -e '.data.repository.pullRequest' > /dev/null 2>&1; then
         echo -e "${YELLOW}WARNING${NC}: Malformed reviews response" >&2
+        REVIEW_COUNT_TRUSTED=false
         echo "0"
         return
     fi
@@ -452,7 +455,7 @@ has_skip_label() {
 ROUND_COUNT=$(count_review_rounds)
 
 # 1a. Check for --allow-skipped short-circuit
-if [[ "$ALLOW_SKIPPED" == true && "$ROUND_COUNT" -eq 0 ]]; then
+if [[ "$ALLOW_SKIPPED" == true && "$ROUND_COUNT" -eq 0 && "$REVIEW_COUNT_TRUSTED" == true ]]; then
     if has_skip_label; then
         cat <<SUMMARY
 ## CodeRabbit Review Gate

--- a/scripts/coderabbit-review-gate.sh
+++ b/scripts/coderabbit-review-gate.sh
@@ -15,6 +15,7 @@
 #   --pr <number>        PR number to check (required)
 #   --dry-run            Suppress PR comments (show what would happen)
 #   --max-rounds <n>     Max review rounds before escalation (default: 4)
+#   --allow-skipped      Treat PRs with skip-coderabbit label and no CR review as approved
 #   --help               Show this help message
 #
 # Exit codes:
@@ -54,6 +55,7 @@ Options:
   --pr <number>        PR number to check (required)
   --dry-run            Suppress PR comments (show what would happen)
   --max-rounds <n>     Max review rounds before escalation (default: 4)
+  --allow-skipped      Treat PRs with skip-coderabbit label and no CR review as approved
   --help               Show this help message
 
 Exit codes:
@@ -77,6 +79,7 @@ REPO=""
 PR_NUMBER=""
 DRY_RUN=false
 MAX_ROUNDS=4
+ALLOW_SKIPPED=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -106,6 +109,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --dry-run)
             DRY_RUN=true
+            shift
+            ;;
+        --allow-skipped)
+            ALLOW_SKIPPED=true
             shift
             ;;
         --max-rounds)
@@ -424,11 +431,42 @@ COMMENT
 }
 
 # ============================================================
+# SKIP-LABEL CHECK
+# ============================================================
+
+# Check if PR has the skip-coderabbit label
+has_skip_label() {
+    local labels_json
+    labels_json=$(gh api "repos/$OWNER/$REPO/issues/$PR_NUMBER/labels" 2>/dev/null) || {
+        echo -e "${YELLOW}WARNING${NC}: Failed to query PR labels" >&2
+        return 1
+    }
+    echo "$labels_json" | jq -e '[.[] | select(.name == "skip-coderabbit")] | length > 0' > /dev/null 2>&1
+}
+
+# ============================================================
 # MAIN
 # ============================================================
 
 # 1. Count review rounds
 ROUND_COUNT=$(count_review_rounds)
+
+# 1a. Check for --allow-skipped short-circuit
+if [[ "$ALLOW_SKIPPED" == true && "$ROUND_COUNT" -eq 0 ]]; then
+    if has_skip_label; then
+        cat <<SUMMARY
+## CodeRabbit Review Gate
+
+- **PR:** ${OWNER}/${REPO}#${PR_NUMBER}
+- **Round:** 0
+- **Active Threads:** 0
+- **Blocking Findings:** false
+- **Action:** approve
+- **Skipped:** true (skip-coderabbit label, no CodeRabbit review)
+SUMMARY
+        exit 0
+    fi
+fi
 
 # 2. Query all review threads
 ALL_THREADS_JSON=$(query_all_threads)

--- a/scripts/coderabbit-review-gate.test.sh
+++ b/scripts/coderabbit-review-gate.test.sh
@@ -128,7 +128,7 @@ if [[ "$1" == "api" ]]; then
             exit 0
         fi
     else
-        # REST API call (e.g., posting comments)
+        # REST API call (e.g., posting comments, querying labels)
         API_PATH="$1"
         shift
         # Capture request body if present
@@ -150,6 +150,17 @@ if [[ "$1" == "api" ]]; then
             esac
         done
         echo "REST|$API_PATH|$BODY" >> "$CALL_LOG"
+
+        # Check for label query responses
+        if echo "$API_PATH" | grep -q "labels"; then
+            if [[ -f "$RESPONSES_DIR/labels.json" ]]; then
+                cat "$RESPONSES_DIR/labels.json"
+                exit 0
+            fi
+            echo '[]'
+            exit 0
+        fi
+
         echo '{"id":1,"body":"comment"}'
         exit 0
     fi
@@ -189,6 +200,12 @@ write_threads_response() {
 write_mutation_response() {
     local json="$1"
     echo "$json" > "$MOCK_RESPONSES_DIR/mutation.json"
+}
+
+# Helper: write a mock response for label queries
+write_labels_response() {
+    local json="$1"
+    echo "$json" > "$MOCK_RESPONSES_DIR/labels.json"
 }
 
 # Helper: clear all mock responses and call log
@@ -712,6 +729,57 @@ if [[ "$REST_CALLS" -eq 0 ]]; then
     pass "DryRun_Approve_NoComment"
 else
     fail "DryRun_Approve_NoComment — expected 0 REST calls, got $REST_CALLS: $(get_call_log)"
+fi
+
+# ============================================================
+# TASK 10: --allow-skipped FLAG TESTS
+# ============================================================
+echo ""
+echo "=== Task 10: --allow-skipped Flag ==="
+
+# Test: allowSkipped_PRWithSkipLabel_NoReview_Approves
+# With --allow-skipped, PR with skip-coderabbit label and no CR review → approve
+clear_mocks
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}'
+write_threads_response '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
+write_labels_response '[{"name":"skip-coderabbit"},{"name":"enhancement"}]'
+RESULT=$(run_script_full --owner testowner --repo testrepo --pr 100 --allow-skipped --dry-run)
+if echo "$RESULT" | grep -qF '**Action:** approve'; then
+    pass "allowSkipped_PRWithSkipLabel_NoReview_Approves"
+else
+    fail "allowSkipped_PRWithSkipLabel_NoReview_Approves — output: $RESULT"
+fi
+
+# Test: allowSkipped_PRWithSkipLabel_HasReview_NormalFlow
+# With --allow-skipped, PR with label BUT also has CR review → normal flow (don't skip)
+clear_mocks
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"author":{"login":"coderabbitai"},"submittedAt":"2026-01-15T10:00:00Z"}]}}}}}'
+write_threads_response '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[
+  {"id":"T_1","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"body":"Active finding","author":{"login":"coderabbitai"}}]}}
+]}}}}}'
+write_labels_response '[{"name":"skip-coderabbit"},{"name":"enhancement"}]'
+RESULT=$(run_script_full --owner testowner --repo testrepo --pr 100 --allow-skipped --dry-run)
+# Round 1 with 1 active thread → should be wait (normal flow), not approve
+if echo "$RESULT" | grep -qF '**Action:** wait'; then
+    pass "allowSkipped_PRWithSkipLabel_HasReview_NormalFlow"
+else
+    fail "allowSkipped_PRWithSkipLabel_HasReview_NormalFlow — output: $RESULT"
+fi
+
+# Test: noAllowSkipped_PRWithSkipLabel_NoReview_Waits
+# Without --allow-skipped flag, PR with label but no review → default behavior (wait with 0 rounds, 0 threads = approve since round 0 < 1)
+# Actually: round count 0, active threads 0 → doesn't match any approve condition (round_count -eq 1 and active 0 → false since 0 != 1)
+# So this should be "wait"
+clear_mocks
+write_reviews_response '{"data":{"repository":{"pullRequest":{"reviews":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}'
+write_threads_response '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
+write_labels_response '[{"name":"skip-coderabbit"},{"name":"enhancement"}]'
+RESULT=$(run_script_full --owner testowner --repo testrepo --pr 100 --dry-run)
+# Without --allow-skipped: round 0, 0 threads, no blockers → wait (0 rounds doesn't match any approve case)
+if echo "$RESULT" | grep -qF '**Action:** wait'; then
+    pass "noAllowSkipped_PRWithSkipLabel_NoReview_Waits"
+else
+    fail "noAllowSkipped_PRWithSkipLabel_NoReview_Waits — output: $RESULT"
 fi
 
 # ============================================================

--- a/scripts/verify-review-triage.sh
+++ b/scripts/verify-review-triage.sh
@@ -7,7 +7,7 @@
 # Checks:
 #   1. All PRs in state file have a review.routed event in the event stream
 #   2. High-risk PRs (riskScore >= 0.4) were sent to CodeRabbit
-#   3. Self-hosted review ran for all PRs (selfHosted: true)
+#   3. Self-hosted review ran for all PRs (destination is "self-hosted" or "both")
 #   4. No PR is missing review routing
 #
 # Exit codes:
@@ -163,7 +163,7 @@ fi
 # Parse each line that is a review.routed event
 for pr in $PR_NUMBERS; do
     # Check 1: review.routed event exists for this PR
-    ROUTED_EVENT=$(jq -c "select(.type == \"review.routed\" and .data.pr == $pr)" "$EVENT_STREAM" 2>/dev/null | head -1)
+    ROUTED_EVENT=$(jq -c "select(.type == \"review.routed\" and .data.pr == $pr)" "$EVENT_STREAM" 2>/dev/null | tail -1)
 
     if [[ -z "$ROUTED_EVENT" ]]; then
         report_fail "PR #$pr: missing review.routed event"
@@ -177,7 +177,7 @@ for pr in $PR_NUMBERS; do
     IS_HIGH_RISK=$(echo "$RISK_SCORE" | jq -Rr 'tonumber >= 0.4')
 
     if [[ "$IS_HIGH_RISK" == "true" ]]; then
-        HAS_CODERABBIT=$(echo "$ROUTED_EVENT" | jq -r '[.data.destination[] | select(. == "coderabbit")] | length > 0')
+        HAS_CODERABBIT=$(echo "$ROUTED_EVENT" | jq -r '.data.destination == "coderabbit" or .data.destination == "both"')
         if [[ "$HAS_CODERABBIT" == "true" ]]; then
             report_pass "PR #$pr: high-risk (score=$RISK_SCORE) sent to CodeRabbit"
         else
@@ -186,7 +186,7 @@ for pr in $PR_NUMBERS; do
     fi
 
     # Check 3: Self-hosted review ran for all PRs
-    SELF_HOSTED=$(echo "$ROUTED_EVENT" | jq -r '.data.selfHosted // false')
+    SELF_HOSTED=$(echo "$ROUTED_EVENT" | jq -r '.data.destination == "self-hosted" or .data.destination == "both"')
     if [[ "$SELF_HOSTED" == "true" ]]; then
         report_pass "PR #$pr: self-hosted review enabled"
     else

--- a/scripts/verify-review-triage.sh
+++ b/scripts/verify-review-triage.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# verify-review-triage.sh
+# Verifies review triage was applied correctly to a stack of PRs.
+#
+# Usage: verify-review-triage.sh --state-file <path> --event-stream <path>
+#
+# Checks:
+#   1. All PRs in state file have a review.routed event in the event stream
+#   2. High-risk PRs (riskScore >= 0.4) were sent to CodeRabbit
+#   3. Self-hosted review ran for all PRs (selfHosted: true)
+#   4. No PR is missing review routing
+#
+# Exit codes:
+#   0  All checks pass
+#   1  Verification failed (details in output)
+#   2  Usage error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ============================================================
+# USAGE
+# ============================================================
+
+usage() {
+    cat <<'EOF'
+Usage: verify-review-triage.sh --state-file <path> --event-stream <path>
+
+Verifies review triage was applied correctly to a stack of PRs.
+
+Options:
+  --state-file <path>     Path to workflow state JSON file (required)
+  --event-stream <path>   Path to event stream JSONL file (required)
+  --help                  Show this help message
+
+Checks:
+  1. All PRs have a review.routed event
+  2. High-risk PRs (score >= 0.4) sent to CodeRabbit
+  3. Self-hosted review ran for all PRs
+  4. No PR missing review routing
+
+Exit codes:
+  0   All checks pass
+  1   Verification failed (details in output)
+  2   Usage error (missing required arguments)
+EOF
+}
+
+# ============================================================
+# ARGUMENT PARSING
+# ============================================================
+
+STATE_FILE=""
+EVENT_STREAM=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --state-file)
+            if [[ $# -lt 2 ]]; then
+                echo -e "${RED}ERROR${NC}: --state-file requires a value" >&2
+                exit 2
+            fi
+            STATE_FILE="$2"
+            shift 2
+            ;;
+        --event-stream)
+            if [[ $# -lt 2 ]]; then
+                echo -e "${RED}ERROR${NC}: --event-stream requires a value" >&2
+                exit 2
+            fi
+            EVENT_STREAM="$2"
+            shift 2
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        -*)
+            echo -e "${RED}ERROR${NC}: Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            echo -e "${RED}ERROR${NC}: Unexpected argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ============================================================
+# VALIDATION
+# ============================================================
+
+if [[ -z "$STATE_FILE" ]]; then
+    echo -e "${RED}ERROR${NC}: --state-file is required" >&2
+    usage >&2
+    exit 2
+fi
+
+if [[ ! -f "$STATE_FILE" ]]; then
+    echo -e "${RED}ERROR${NC}: State file not found: $STATE_FILE" >&2
+    exit 2
+fi
+
+if [[ -z "$EVENT_STREAM" ]]; then
+    echo -e "${RED}ERROR${NC}: --event-stream is required" >&2
+    usage >&2
+    exit 2
+fi
+
+if [[ ! -f "$EVENT_STREAM" ]]; then
+    echo -e "${RED}ERROR${NC}: Event stream file not found: $EVENT_STREAM" >&2
+    exit 2
+fi
+
+# ============================================================
+# DEPENDENCY CHECKS
+# ============================================================
+
+if ! command -v jq &> /dev/null; then
+    echo -e "${RED}ERROR${NC}: jq is not installed" >&2
+    exit 1
+fi
+
+# ============================================================
+# VERIFICATION LOGIC
+# ============================================================
+
+HAS_FAILURE=false
+CHECKS_PASSED=0
+CHECKS_FAILED=0
+REPORT_LINES=()
+
+report_pass() {
+    local msg="$1"
+    REPORT_LINES+=("| PASS | $msg |")
+    CHECKS_PASSED=$((CHECKS_PASSED + 1))
+}
+
+report_fail() {
+    local msg="$1"
+    REPORT_LINES+=("| FAIL | $msg |")
+    CHECKS_FAILED=$((CHECKS_FAILED + 1))
+    HAS_FAILURE=true
+}
+
+# Extract PR numbers from state file
+PR_NUMBERS=$(jq -r '.prs[].number' "$STATE_FILE" 2>/dev/null)
+if [[ -z "$PR_NUMBERS" ]]; then
+    echo -e "${RED}ERROR${NC}: No PRs found in state file" >&2
+    exit 1
+fi
+
+# Build a lookup of review.routed events from the event stream (one per line JSONL)
+# Parse each line that is a review.routed event
+for pr in $PR_NUMBERS; do
+    # Check 1: review.routed event exists for this PR
+    ROUTED_EVENT=$(jq -c "select(.type == \"review.routed\" and .data.pr == $pr)" "$EVENT_STREAM" 2>/dev/null | head -1)
+
+    if [[ -z "$ROUTED_EVENT" ]]; then
+        report_fail "PR #$pr: missing review.routed event"
+        continue
+    fi
+
+    report_pass "PR #$pr: review.routed event exists"
+
+    # Check 2: High-risk PRs (riskScore >= 0.4) sent to CodeRabbit
+    RISK_SCORE=$(echo "$ROUTED_EVENT" | jq -r '.data.riskScore // 0')
+    IS_HIGH_RISK=$(echo "$RISK_SCORE" | jq -Rr 'tonumber >= 0.4')
+
+    if [[ "$IS_HIGH_RISK" == "true" ]]; then
+        HAS_CODERABBIT=$(echo "$ROUTED_EVENT" | jq -r '[.data.destination[] | select(. == "coderabbit")] | length > 0')
+        if [[ "$HAS_CODERABBIT" == "true" ]]; then
+            report_pass "PR #$pr: high-risk (score=$RISK_SCORE) sent to CodeRabbit"
+        else
+            report_fail "PR #$pr: high-risk (score=$RISK_SCORE) NOT sent to CodeRabbit"
+        fi
+    fi
+
+    # Check 3: Self-hosted review ran for all PRs
+    SELF_HOSTED=$(echo "$ROUTED_EVENT" | jq -r '.data.selfHosted // false')
+    if [[ "$SELF_HOSTED" == "true" ]]; then
+        report_pass "PR #$pr: self-hosted review enabled"
+    else
+        report_fail "PR #$pr: self-hosted review NOT enabled"
+    fi
+done
+
+# ============================================================
+# OUTPUT REPORT
+# ============================================================
+
+echo "## Review Triage Verification"
+echo ""
+echo "| Status | Check |"
+echo "|--------|-------|"
+for line in "${REPORT_LINES[@]}"; do
+    echo "$line"
+done
+echo ""
+echo "**Passed:** $CHECKS_PASSED | **Failed:** $CHECKS_FAILED"
+
+# ============================================================
+# EXIT CODE
+# ============================================================
+
+if [[ "$HAS_FAILURE" == true ]]; then
+    exit 1
+else
+    exit 0
+fi

--- a/scripts/verify-review-triage.test.sh
+++ b/scripts/verify-review-triage.test.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Verify Review Triage — Test Script
+# Tests verify-review-triage.sh with mocked state files and event streams
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/verify-review-triage.sh"
+
+PASS=0
+FAIL=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAIL=$((FAIL + 1))
+}
+
+# ============================================================
+# MOCK SETUP
+# ============================================================
+
+MOCK_DIR="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$MOCK_DIR"
+}
+trap cleanup EXIT
+
+# Helper: create a state file with PRs and review dispatch events
+# Args: state_file_path, json_content
+write_state_file() {
+    local path="$1"
+    local json="$2"
+    echo "$json" > "$path"
+}
+
+# Helper: create an event stream JSONL file
+# Args: stream_file_path, events (each line is a JSON event)
+write_event_stream() {
+    local path="$1"
+    shift
+    : > "$path"
+    for event in "$@"; do
+        echo "$event" >> "$path"
+    done
+}
+
+# Helper: run the script under test
+run_script() {
+    bash "$SCRIPT_UNDER_TEST" "$@" 2>&1
+}
+
+# Helper: get just the exit code
+run_script_exit_code() {
+    set +e
+    bash "$SCRIPT_UNDER_TEST" "$@" > /dev/null 2>&1
+    local ec=$?
+    set -e
+    echo "$ec"
+}
+
+# Helper: run script and capture both output and exit code
+run_script_full() {
+    set +e
+    local output
+    output=$(bash "$SCRIPT_UNDER_TEST" "$@" 2>&1)
+    local ec=$?
+    set -e
+    echo "EXIT_CODE=$ec"
+    echo "$output"
+}
+
+# ============================================================
+# TEST: validState_AllPRsRouted_Passes
+# ============================================================
+echo "=== Verify Review Triage Tests ==="
+
+# Setup: state file with 2 PRs, both routed, high-risk one sent to coderabbit
+STATE_FILE="$MOCK_DIR/valid-state.json"
+EVENT_STREAM="$MOCK_DIR/valid-events.jsonl"
+
+write_state_file "$STATE_FILE" '{
+  "featureId": "test-feature",
+  "stack": "test-stack",
+  "prs": [
+    {"number": 100, "branch": "task-1"},
+    {"number": 101, "branch": "task-2"}
+  ]
+}'
+
+write_event_stream "$EVENT_STREAM" \
+    '{"type":"review.routed","data":{"pr":100,"riskScore":0.5,"destination":["coderabbit","self-hosted"],"selfHosted":true}}' \
+    '{"type":"review.routed","data":{"pr":101,"riskScore":0.2,"destination":["self-hosted"],"selfHosted":true}}'
+
+EXIT_CODE=$(run_script_exit_code --state-file "$STATE_FILE" --event-stream "$EVENT_STREAM")
+if [[ "$EXIT_CODE" -eq 0 ]]; then
+    pass "validState_AllPRsRouted_Passes"
+else
+    OUTPUT=$(run_script --state-file "$STATE_FILE" --event-stream "$EVENT_STREAM")
+    fail "validState_AllPRsRouted_Passes (expected exit 0, got $EXIT_CODE) — output: $OUTPUT"
+fi
+
+# ============================================================
+# TEST: missingRoutedEvent_Fails
+# ============================================================
+
+STATE_FILE_MISSING="$MOCK_DIR/missing-routed-state.json"
+EVENT_STREAM_MISSING="$MOCK_DIR/missing-routed-events.jsonl"
+
+write_state_file "$STATE_FILE_MISSING" '{
+  "featureId": "test-feature",
+  "stack": "test-stack",
+  "prs": [
+    {"number": 200, "branch": "task-1"},
+    {"number": 201, "branch": "task-2"}
+  ]
+}'
+
+# Only PR 200 has a routed event — PR 201 is missing
+write_event_stream "$EVENT_STREAM_MISSING" \
+    '{"type":"review.routed","data":{"pr":200,"riskScore":0.3,"destination":["self-hosted"],"selfHosted":true}}'
+
+EXIT_CODE=$(run_script_exit_code --state-file "$STATE_FILE_MISSING" --event-stream "$EVENT_STREAM_MISSING")
+if [[ "$EXIT_CODE" -eq 1 ]]; then
+    pass "missingRoutedEvent_Fails"
+else
+    OUTPUT=$(run_script --state-file "$STATE_FILE_MISSING" --event-stream "$EVENT_STREAM_MISSING")
+    fail "missingRoutedEvent_Fails (expected exit 1, got $EXIT_CODE) — output: $OUTPUT"
+fi
+
+# ============================================================
+# TEST: highRiskPR_NotSentToCodeRabbit_Fails
+# ============================================================
+
+STATE_FILE_HIGHRISK="$MOCK_DIR/highrisk-state.json"
+EVENT_STREAM_HIGHRISK="$MOCK_DIR/highrisk-events.jsonl"
+
+write_state_file "$STATE_FILE_HIGHRISK" '{
+  "featureId": "test-feature",
+  "stack": "test-stack",
+  "prs": [
+    {"number": 300, "branch": "task-1"},
+    {"number": 301, "branch": "task-2"}
+  ]
+}'
+
+# PR 300 is high-risk (score >= 0.4) but only sent to self-hosted, not coderabbit
+write_event_stream "$EVENT_STREAM_HIGHRISK" \
+    '{"type":"review.routed","data":{"pr":300,"riskScore":0.6,"destination":["self-hosted"],"selfHosted":true}}' \
+    '{"type":"review.routed","data":{"pr":301,"riskScore":0.2,"destination":["self-hosted"],"selfHosted":true}}'
+
+EXIT_CODE=$(run_script_exit_code --state-file "$STATE_FILE_HIGHRISK" --event-stream "$EVENT_STREAM_HIGHRISK")
+if [[ "$EXIT_CODE" -eq 1 ]]; then
+    pass "highRiskPR_NotSentToCodeRabbit_Fails"
+else
+    OUTPUT=$(run_script --state-file "$STATE_FILE_HIGHRISK" --event-stream "$EVENT_STREAM_HIGHRISK")
+    fail "highRiskPR_NotSentToCodeRabbit_Fails (expected exit 1, got $EXIT_CODE) — output: $OUTPUT"
+fi
+
+# ============================================================
+# TEST: missingArgs_ExitsUsageError
+# ============================================================
+
+EXIT_CODE=$(run_script_exit_code)
+if [[ "$EXIT_CODE" -eq 2 ]]; then
+    pass "missingArgs_ExitsUsageError"
+else
+    fail "missingArgs_ExitsUsageError (expected exit 2, got $EXIT_CODE)"
+fi
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "## Test Summary"
+echo -e "Passed: ${GREEN}$PASS${NC}"
+echo -e "Failed: ${RED}$FAIL${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/scripts/verify-review-triage.test.sh
+++ b/scripts/verify-review-triage.test.sh
@@ -100,8 +100,8 @@ write_state_file "$STATE_FILE" '{
 }'
 
 write_event_stream "$EVENT_STREAM" \
-    '{"type":"review.routed","data":{"pr":100,"riskScore":0.5,"destination":["coderabbit","self-hosted"],"selfHosted":true}}' \
-    '{"type":"review.routed","data":{"pr":101,"riskScore":0.2,"destination":["self-hosted"],"selfHosted":true}}'
+    '{"type":"review.routed","data":{"pr":100,"riskScore":0.5,"destination":"both","factors":["large-diff","new-api"],"velocityTier":"normal","semanticAugmented":false}}' \
+    '{"type":"review.routed","data":{"pr":101,"riskScore":0.2,"destination":"self-hosted","factors":[],"velocityTier":"normal","semanticAugmented":false}}'
 
 EXIT_CODE=$(run_script_exit_code --state-file "$STATE_FILE" --event-stream "$EVENT_STREAM")
 if [[ "$EXIT_CODE" -eq 0 ]]; then
@@ -129,7 +129,7 @@ write_state_file "$STATE_FILE_MISSING" '{
 
 # Only PR 200 has a routed event — PR 201 is missing
 write_event_stream "$EVENT_STREAM_MISSING" \
-    '{"type":"review.routed","data":{"pr":200,"riskScore":0.3,"destination":["self-hosted"],"selfHosted":true}}'
+    '{"type":"review.routed","data":{"pr":200,"riskScore":0.3,"destination":"self-hosted","factors":[],"velocityTier":"normal","semanticAugmented":false}}'
 
 EXIT_CODE=$(run_script_exit_code --state-file "$STATE_FILE_MISSING" --event-stream "$EVENT_STREAM_MISSING")
 if [[ "$EXIT_CODE" -eq 1 ]]; then
@@ -157,8 +157,8 @@ write_state_file "$STATE_FILE_HIGHRISK" '{
 
 # PR 300 is high-risk (score >= 0.4) but only sent to self-hosted, not coderabbit
 write_event_stream "$EVENT_STREAM_HIGHRISK" \
-    '{"type":"review.routed","data":{"pr":300,"riskScore":0.6,"destination":["self-hosted"],"selfHosted":true}}' \
-    '{"type":"review.routed","data":{"pr":301,"riskScore":0.2,"destination":["self-hosted"],"selfHosted":true}}'
+    '{"type":"review.routed","data":{"pr":300,"riskScore":0.6,"destination":"self-hosted","factors":["large-diff"],"velocityTier":"normal","semanticAugmented":false}}' \
+    '{"type":"review.routed","data":{"pr":301,"riskScore":0.2,"destination":"self-hosted","factors":[],"velocityTier":"normal","semanticAugmented":false}}'
 
 EXIT_CODE=$(run_script_exit_code --state-file "$STATE_FILE_HIGHRISK" --event-stream "$EVENT_STREAM_HIGHRISK")
 if [[ "$EXIT_CODE" -eq 1 ]]; then


### PR DESCRIPTION
## Summary

Adds the operational layer for hybrid review: self-hosted reviewer agent prompt, CodeRabbit gate script extension, verification script for review triage correctness, and CodeRabbit ignore label configuration.

## Changes

- **Agent prompt** — `self-hosted-reviewer.md` structured review agent instructions
- **Gate script** — `coderabbit-review-gate.sh` extended with `--allow-skipped` flag for velocity-triaged PRs
- **Verification** — `verify-review-triage.sh` validates all PRs have correct routing events
- **Config** — `.coderabbit.yaml` updated with `ignore_labels` for triage-skipped PRs

## Test Plan

37 gate tests (including 3 new --allow-skipped tests) plus 4 verification tests covering valid routing, missing events, and high-risk misrouting.

---

**Design:** [hybrid-review-strategy.md](docs/designs/2026-02-18-hybrid-review-strategy.md)