### PR TITLE
feat: wire review triage into MCP orchestrate tool

### DIFF
--- a/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/cli-commands/subagent-context.test.ts
@@ -90,19 +90,22 @@ describe('subagent-context', () => {
       expect(orchestrate!.actions).toContain('task_fail');
     });
 
-    it('should not have any denied orchestrate actions for delegate phase with teammate role', () => {
-      // Arrange — with team actions removed, only task actions remain (all teammate-accessible)
+    it('should deny review_triage orchestrate action for delegate phase with teammate role', () => {
+      // Arrange — task actions are teammate-accessible in delegate, but review_triage
+      // is lead-only and not in delegate phases
       const phase = 'delegate';
       const role = 'teammate';
 
       // Act
       const result = filterToolsForPhaseAndRole(phase, role);
 
-      // Assert — no orchestrate actions should be denied (all 3 remaining are teammate-accessible)
+      // Assert — review_triage should be denied (lead role + review phase only)
       const deniedOrchestrate = result.denied.find(
         (c) => c.name === 'exarchos_orchestrate',
       );
-      expect(deniedOrchestrate).toBeUndefined();
+      expect(deniedOrchestrate).toBeDefined();
+      expect(deniedOrchestrate!.actions).toContain('review_triage');
+      expect(deniedOrchestrate!.actions).toHaveLength(1);
     });
 
     it('should include event actions for delegate phase with teammate role', () => {
@@ -144,13 +147,13 @@ describe('subagent-context', () => {
       // Act
       const result = filterToolsForPhaseAndRole(phase, role);
 
-      // Assert — all orchestrate actions should be denied (delegate phase only)
+      // Assert — all orchestrate actions should be denied:
+      // task_claim/task_complete/task_fail (delegate phase only) + review_triage (lead role only)
       const deniedOrchestrate = result.denied.find(
         (c) => c.name === 'exarchos_orchestrate',
       );
       expect(deniedOrchestrate).toBeDefined();
-      // All 3 orchestrate actions should be denied in review phase
-      expect(deniedOrchestrate!.actions.length).toBe(3);
+      expect(deniedOrchestrate!.actions.length).toBe(4);
     });
 
     it('should deny workflow init and cancel for teammate role', () => {

--- a/plugins/exarchos/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -13,6 +13,7 @@ import {
   handleTaskComplete,
   handleTaskFail,
 } from '../tasks/tools.js';
+import { handleReviewTriage } from '../review/tools.js';
 
 // ─── Action Router ──────────────────────────────────────────────────────────
 
@@ -22,6 +23,7 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   task_claim: handleTaskClaim as ActionHandler,
   task_complete: handleTaskComplete as ActionHandler,
   task_fail: handleTaskFail as ActionHandler,
+  review_triage: handleReviewTriage as ActionHandler,
 };
 
 // ─── Composite Handler ──────────────────────────────────────────────────────

--- a/plugins/exarchos/servers/exarchos-mcp/src/registry.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/registry.test.ts
@@ -272,10 +272,10 @@ describe('TOOL_REGISTRY', () => {
   });
 
   describe('exarchos_orchestrate', () => {
-    it('should have 3 actions for task management', () => {
+    it('should have 4 actions for task management and review triage', () => {
       const composite = findComposite('exarchos_orchestrate');
       expect(composite).toBeDefined();
-      expect(composite!.actions).toHaveLength(3);
+      expect(composite!.actions).toHaveLength(4);
 
       const actionNames = composite!.actions.map((a) => a.name);
       expect(actionNames).toEqual(
@@ -283,6 +283,7 @@ describe('TOOL_REGISTRY', () => {
           'task_claim',
           'task_complete',
           'task_fail',
+          'review_triage',
         ]),
       );
     });

--- a/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/registry.ts
@@ -217,6 +217,11 @@ const STACK_PHASES: ReadonlySet<string> = new Set([
   'overhaul-delegate',
   'debug-implement',
 ]);
+const REVIEW_PHASES: ReadonlySet<string> = new Set([
+  'review',
+  'overhaul-review',
+  'debug-review',
+]);
 
 // ─── Shared Schema Fragments ────────────────────────────────────────────────
 
@@ -358,6 +363,25 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: DELEGATE_PHASES,
     roles: ROLE_TEAMMATE,
+  },
+  {
+    name: 'review_triage',
+    description: 'Score PRs by risk and dispatch to CodeRabbit or self-hosted review based on velocity',
+    schema: z.object({
+      featureId: z.string().min(1),
+      prs: z.array(z.object({
+        number: z.number().int().positive(),
+        paths: z.array(z.string()),
+        linesChanged: z.number().int().nonnegative(),
+        filesChanged: z.number().int().nonnegative(),
+        newFiles: z.number().int().nonnegative(),
+      })),
+      activeWorkflows: z.array(z.object({ phase: z.string() })).optional(),
+      pendingCodeRabbitReviews: z.number().int().nonnegative().optional(),
+      basileusConnected: z.boolean().optional(),
+    }),
+    phases: REVIEW_PHASES,
+    roles: ROLE_LEAD,
   },
 ];
 

--- a/plugins/exarchos/servers/exarchos-mcp/src/review/tools.test.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/review/tools.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import type { PRDiffMetadata } from './types.js';
+
+// ─── Test Fixtures ──────────────────────────────────────────────────────────
+
+function lowRiskPR(number = 100): PRDiffMetadata {
+  return {
+    number,
+    paths: ['src/utils/format.test.ts'],
+    linesChanged: 10,
+    filesChanged: 1,
+    newFiles: 0,
+  };
+}
+
+function medRiskPR(number = 200): PRDiffMetadata {
+  return {
+    number,
+    paths: ['src/api/handler.ts'],
+    linesChanged: 50,
+    filesChanged: 2,
+    newFiles: 1,
+  };
+}
+
+function highRiskPR(number = 300): PRDiffMetadata {
+  return {
+    number,
+    paths: ['src/auth/login.ts', 'src/api/handler.ts'],
+    linesChanged: 400,
+    filesChanged: 12,
+    newFiles: 2,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('handleReviewTriage', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'review-triage-test-'));
+  });
+
+  async function importHandler() {
+    const { handleReviewTriage } = await import('./tools.js');
+    return handleReviewTriage;
+  }
+
+  it('should return dispatch results for valid input with 3 PRs', async () => {
+    const handleReviewTriage = await importHandler();
+    const args = {
+      featureId: 'test-feature',
+      prs: [lowRiskPR(1), medRiskPR(2), highRiskPR(3)],
+      activeWorkflows: [],
+      pendingCodeRabbitReviews: 0,
+      basileusConnected: false,
+    };
+
+    const result = await handleReviewTriage(args as Record<string, unknown>, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      velocity: string;
+      dispatches: Array<{ pr: number; coderabbit: boolean; selfHosted: boolean }>;
+      summary: { total: number; coderabbit: number; selfHostedOnly: number };
+    };
+    expect(data.velocity).toBe('normal');
+    expect(data.dispatches).toHaveLength(3);
+    expect(data.summary.total).toBe(3);
+    // At normal velocity (threshold 0.0), all PRs get coderabbit
+    expect(data.summary.coderabbit).toBe(3);
+    expect(data.summary.selfHostedOnly).toBe(0);
+  });
+
+  it('should emit review.routed events to the event store', async () => {
+    const handleReviewTriage = await importHandler();
+    const args = {
+      featureId: 'test-events',
+      prs: [lowRiskPR(10), highRiskPR(20)],
+      activeWorkflows: [],
+      pendingCodeRabbitReviews: 0,
+      basileusConnected: false,
+    };
+
+    await handleReviewTriage(args as Record<string, unknown>, tmpDir);
+
+    // Verify events were written to the JSONL file
+    const eventsPath = path.join(tmpDir, 'test-events.events.jsonl');
+    const content = await fs.readFile(eventsPath, 'utf-8');
+    const events = content.trim().split('\n').map(line => JSON.parse(line));
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe('review.routed');
+    expect(events[1].type).toBe('review.routed');
+    expect(events[0].data.pr).toBe(10);
+    expect(events[1].data.pr).toBe(20);
+    expect(events[0].data.velocityTier).toBe('normal');
+    expect(events[0].data.semanticAugmented).toBe(false);
+  });
+
+  it('should filter coderabbit for low-risk PRs at high velocity', async () => {
+    const handleReviewTriage = await importHandler();
+    const args = {
+      featureId: 'test-high-velocity',
+      prs: [lowRiskPR(1), highRiskPR(2)],
+      activeWorkflows: [],
+      pendingCodeRabbitReviews: 8, // >6 triggers 'high' velocity
+      basileusConnected: false,
+    };
+
+    const result = await handleReviewTriage(args as Record<string, unknown>, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      velocity: string;
+      dispatches: Array<{ pr: number; coderabbit: boolean }>;
+      summary: { total: number; coderabbit: number; selfHostedOnly: number };
+    };
+    expect(data.velocity).toBe('high');
+
+    const lowDispatch = data.dispatches.find(d => d.pr === 1);
+    const highDispatch = data.dispatches.find(d => d.pr === 2);
+    // Low-risk PR (score 0.0) should NOT get coderabbit at high velocity (threshold 0.5)
+    expect(lowDispatch?.coderabbit).toBe(false);
+    // High-risk PR should get coderabbit
+    expect(highDispatch?.coderabbit).toBe(true);
+    expect(data.summary.selfHostedOnly).toBeGreaterThan(0);
+  });
+
+  it('should return error when featureId is missing', async () => {
+    const handleReviewTriage = await importHandler();
+    const args = {
+      prs: [lowRiskPR()],
+    };
+
+    const result = await handleReviewTriage(args as Record<string, unknown>, tmpDir);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toContain('featureId');
+  });
+
+  it('should return empty dispatches for empty prs array', async () => {
+    const handleReviewTriage = await importHandler();
+    const args = {
+      featureId: 'test-empty',
+      prs: [],
+      activeWorkflows: [],
+      pendingCodeRabbitReviews: 0,
+    };
+
+    const result = await handleReviewTriage(args as Record<string, unknown>, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      dispatches: unknown[];
+      summary: { total: number; coderabbit: number; selfHostedOnly: number };
+    };
+    expect(data.dispatches).toHaveLength(0);
+    expect(data.summary.total).toBe(0);
+    expect(data.summary.coderabbit).toBe(0);
+    expect(data.summary.selfHostedOnly).toBe(0);
+
+    // Verify no events file was created
+    const eventsPath = path.join(tmpDir, 'test-empty.events.jsonl');
+    await expect(fs.access(eventsPath)).rejects.toThrow();
+  });
+
+  it('should default basileusConnected to false when omitted', async () => {
+    const handleReviewTriage = await importHandler();
+    const args = {
+      featureId: 'test-default-basileus',
+      prs: [lowRiskPR()],
+      activeWorkflows: [],
+      pendingCodeRabbitReviews: 0,
+      // basileusConnected deliberately omitted
+    };
+
+    const result = await handleReviewTriage(args as Record<string, unknown>, tmpDir);
+
+    // Should succeed — basileusConnected defaults to false
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      dispatches: Array<{ pr: number; coderabbit: boolean; selfHosted: boolean }>;
+    };
+    expect(data.dispatches).toHaveLength(1);
+    // The dispatch should work correctly with default basileusConnected=false
+    expect(data.dispatches[0].selfHosted).toBe(true);
+  });
+});
+
+// ─── Orchestrate Composite Integration ──────────────────────────────────────
+
+describe('orchestrate review_triage action', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'orchestrate-review-test-'));
+  });
+
+  it('should route review_triage action to handleReviewTriage', async () => {
+    const { handleOrchestrate } = await import('../orchestrate/composite.js');
+    const args = {
+      action: 'review_triage',
+      featureId: 'test-orchestrate',
+      prs: [lowRiskPR()],
+      activeWorkflows: [],
+      pendingCodeRabbitReviews: 0,
+      basileusConnected: false,
+    };
+
+    const result = await handleOrchestrate(args as Record<string, unknown>, tmpDir);
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      velocity: string;
+      dispatches: Array<{ pr: number }>;
+    };
+    expect(data.velocity).toBe('normal');
+    expect(data.dispatches).toHaveLength(1);
+    expect(data.dispatches[0].pr).toBe(100);
+  });
+});

--- a/plugins/exarchos/servers/exarchos-mcp/src/review/tools.ts
+++ b/plugins/exarchos/servers/exarchos-mcp/src/review/tools.ts
@@ -1,0 +1,124 @@
+// ─── Review Triage Tool Handler ─────────────────────────────────────────────
+//
+// Scores PRs by risk and dispatches to CodeRabbit or self-hosted review
+// based on velocity. Emits review.routed events for each dispatched PR.
+// ────────────────────────────────────────────────────────────────────────────
+
+import type { ToolResult } from '../format.js';
+import { EventStore } from '../event-store/store.js';
+import { detectVelocity } from './velocity.js';
+import { dispatchReviews } from './dispatch.js';
+import type { PRDiffMetadata, ReviewContext, ReviewDispatch } from './types.js';
+
+// ─── Input Validation ──────────────────────────────────────────────────────
+
+interface ReviewTriageInput {
+  featureId: string;
+  prs: PRDiffMetadata[];
+  activeWorkflows?: Array<{ phase: string }>;
+  pendingCodeRabbitReviews?: number;
+  basileusConnected?: boolean;
+}
+
+function parseInput(args: Record<string, unknown>): ReviewTriageInput | ToolResult {
+  const featureId = args.featureId as string | undefined;
+  if (!featureId) {
+    return {
+      success: false,
+      error: { code: 'INVALID_INPUT', message: 'featureId is required' },
+    };
+  }
+
+  const prs = args.prs as PRDiffMetadata[] | undefined;
+  if (!Array.isArray(prs)) {
+    return {
+      success: false,
+      error: { code: 'INVALID_INPUT', message: 'prs must be an array' },
+    };
+  }
+
+  return {
+    featureId,
+    prs,
+    activeWorkflows: (args.activeWorkflows as Array<{ phase: string }>) ?? [],
+    pendingCodeRabbitReviews: (args.pendingCodeRabbitReviews as number) ?? 0,
+    basileusConnected: (args.basileusConnected as boolean) ?? false,
+  };
+}
+
+function isError(result: ReviewTriageInput | ToolResult): result is ToolResult {
+  return 'success' in result && result.success === false;
+}
+
+// ─── Event Emission ────────────────────────────────────────────────────────
+
+async function emitRoutedEvents(
+  eventStore: EventStore,
+  featureId: string,
+  dispatches: ReviewDispatch[],
+): Promise<void> {
+  for (const dispatch of dispatches) {
+    const idempotencyKey = `${featureId}:review.routed:${dispatch.pr}`;
+    await eventStore.append(featureId, {
+      type: 'review.routed',
+      data: {
+        pr: dispatch.pr,
+        riskScore: dispatch.riskScore.score,
+        factors: dispatch.riskScore.factors.filter(f => f.matched).map(f => f.name),
+        destination: dispatch.coderabbit ? 'both' : 'self-hosted',
+        velocityTier: dispatch.velocity,
+        semanticAugmented: false,
+      },
+    }, { idempotencyKey });
+  }
+}
+
+// ─── Summary ───────────────────────────────────────────────────────────────
+
+interface DispatchSummary {
+  total: number;
+  coderabbit: number;
+  selfHostedOnly: number;
+}
+
+function summarizeDispatches(dispatches: ReviewDispatch[]): DispatchSummary {
+  const coderabbitCount = dispatches.filter(d => d.coderabbit).length;
+  return {
+    total: dispatches.length,
+    coderabbit: coderabbitCount,
+    selfHostedOnly: dispatches.length - coderabbitCount,
+  };
+}
+
+// ─── Handler ───────────────────────────────────────────────────────────────
+
+export async function handleReviewTriage(
+  args: Record<string, unknown>,
+  stateDir: string,
+): Promise<ToolResult> {
+  const input = parseInput(args);
+  if (isError(input)) return input;
+
+  const context: ReviewContext = {
+    activeWorkflows: input.activeWorkflows ?? [],
+    pendingCodeRabbitReviews: input.pendingCodeRabbitReviews ?? 0,
+  };
+
+  const velocity = detectVelocity(context);
+  const dispatches = dispatchReviews(input.prs, velocity, input.basileusConnected ?? false);
+
+  // Emit review.routed events (skip if no dispatches)
+  if (dispatches.length > 0) {
+    const eventStore = new EventStore(stateDir);
+    await emitRoutedEvents(eventStore, input.featureId, dispatches);
+  }
+
+  return {
+    success: true,
+    data: {
+      velocity,
+      dispatches,
+      summary: summarizeDispatches(dispatches),
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Integrates all review triage components into the Exarchos MCP server as the `review_triage` action on the `exarchos_orchestrate` composite tool. Accepts PR metadata, runs scoring/velocity/dispatch pipeline, emits `review.routed` events, and returns dispatch results.

## Changes

- **Tool handler** — `tools.ts` with `parseInput`, `executeReviewTriage`, and `emitRoutedEvents`
- **Registry** — `review_triage` action registered with Zod input schema
- **Composite wiring** — Routed through `exarchos_orchestrate` tool

## Test Plan

227-line test suite covering input parsing, triage execution, event emission, and error handling.

---

**Design:** [hybrid-review-strategy.md](docs/designs/2026-02-18-hybrid-review-strategy.md)