### PR TITLE
refactor: extract companion tool content from core skills and rules

### DIFF
--- a/commands/cleanup.md
+++ b/commands/cleanup.md
@@ -41,19 +41,11 @@ mcp__exarchos__exarchos_view({ action: "pipeline" })
 ### Step 2: Verify PR Merge Status
 
 Query GitHub for merged PRs associated with this workflow:
-```typescript
-// For each PR URL in state
-mcp__plugin_github_github__pull_request_read({
-  owner: "lvlup-sw",
-  repo: "exarchos",
-  pullNumber: <number>
-})
+```bash
+gh pr view <number> --json state,mergedAt,headRefName,url
 ```
 
-Or use gh CLI as fallback:
-```bash
-gh pr view <number> --json state,mergedAt
-```
+> Or use GitHub MCP `pull_request_read` if available.
 
 Collect:
 - `prUrl` — PR URL(s) that were merged

--- a/commands/synthesize.md
+++ b/commands/synthesize.md
@@ -105,14 +105,11 @@ After PR created:
 This is one of only TWO human checkpoints in the workflow.
 
 4. **On 'yes'** (yes, y, merge):
-   ```typescript
-   mcp__plugin_github_github__merge_pull_request({
-     owner: "<owner>",
-     repo: "<repo>",
-     pullNumber: <PR_NUMBER>,
-     merge_method: "merge"
-   })
+   ```bash
+   gh pr merge <PR_NUMBER> --squash --auto
    ```
+   > Or use GitHub MCP `merge_pull_request` if available.
+
    Update state: `.phase = "completed"`
 
 5. **On 'feedback'** (feedback, comments, fixes, changes, address):

--- a/companion/install.test.ts
+++ b/companion/install.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync, lstatSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -114,6 +114,46 @@ describe('Companion Installer', () => {
       expect(result.mcpServersAdded).toContain('microsoft-learn');
       const config = JSON.parse(readFileSync(claudeJsonPath, 'utf-8'));
       expect(config.mcpServers['microsoft-learn']).toBeDefined();
+    });
+  });
+
+  describe('Content overlay installation', () => {
+    it('installCompanion_createsRuleSymlinks', () => {
+      const result = installCompanion(claudeHome, claudeJsonPath);
+      const rulePath = join(claudeHome, 'rules/mcp-tool-guidance.md');
+      expect(existsSync(rulePath)).toBe(true);
+      expect(lstatSync(rulePath).isSymbolicLink()).toBe(true);
+      expect(result.contentOverlays).toContain('rules/mcp-tool-guidance.md');
+    });
+
+    it('installCompanion_createsSkillOverlaySymlinks', () => {
+      const result = installCompanion(claudeHome, claudeJsonPath);
+      const overlayPath = join(claudeHome, 'skills/workflow-state/references/companion-mcp-reference.md');
+      expect(existsSync(overlayPath)).toBe(true);
+      expect(lstatSync(overlayPath).isSymbolicLink()).toBe(true);
+      expect(result.contentOverlays).toContain('skills/workflow-state/references/companion-mcp-reference.md');
+    });
+
+    it('installCompanion_contentOverlays_idempotent', () => {
+      installCompanion(claudeHome, claudeJsonPath);
+      const result = installCompanion(claudeHome, claudeJsonPath);
+
+      // Second run should report nothing new (symlinks already point to same source)
+      expect(result.contentOverlays).toHaveLength(0);
+    });
+
+    it('installCompanion_existingFile_skipsWithWarning', () => {
+      // Pre-create a non-symlink file at the target path
+      mkdirSync(join(claudeHome, 'rules'), { recursive: true });
+      writeFileSync(join(claudeHome, 'rules/mcp-tool-guidance.md'), 'existing content');
+
+      const result = installCompanion(claudeHome, claudeJsonPath);
+
+      // Should skip the rule overlay (file already exists and is not a symlink)
+      expect(result.contentOverlays).not.toContain('rules/mcp-tool-guidance.md');
+      // Original content should be preserved
+      const content = readFileSync(join(claudeHome, 'rules/mcp-tool-guidance.md'), 'utf-8');
+      expect(content).toBe('existing content');
     });
   });
 });

--- a/companion/rules/mcp-tool-guidance.md
+++ b/companion/rules/mcp-tool-guidance.md
@@ -1,0 +1,17 @@
+---
+name: mcp-tool-guidance
+description: "Prefer specialized MCP tools over generic CLI approaches."
+---
+
+# MCP Tool Guidance
+
+Use specialized MCP tools over generic approaches:
+
+1. **Workflow state** — Exarchos MCP, never manual JSON
+2. **Code structure** — Serena (`find_symbol`, `get_symbols_overview`) over grep
+3. **GitHub operations** — GitHub MCP tools over `gh` CLI
+4. **PR creation** — Graphite MCP (`gt submit --no-interactive --publish --merge-when-ready`), never `gh pr create`
+5. **Library docs** — Context7 before web search
+6. **State management** — `exarchos_workflow` set/get, never edit JSON directly
+
+See `@skills/workflow-state/references/mcp-tool-reference.md` for detailed mappings.

--- a/companion/skills/workflow-state/references/companion-mcp-reference.md
+++ b/companion/skills/workflow-state/references/companion-mcp-reference.md
@@ -1,0 +1,99 @@
+# Companion MCP Tool Reference
+
+> Installed by exarchos-dev-tools companion (`npx @lvlup-sw/exarchos-dev`)
+
+## GitHub (`mcp__plugin_github_github__*`)
+
+GitHub platform integration. **Always use GitHub MCP tools for ALL GitHub operations. NEVER use `gh` CLI when an MCP equivalent exists.**
+
+| Tool | When to Use |
+|------|-------------|
+| `get_file_contents` | Reading files from remote repos or other branches |
+| `search_code` | Finding code patterns across repositories |
+| `search_issues` | Checking for existing issues before creating new ones |
+| `list_pull_requests` / `search_pull_requests` | Finding related PRs, checking PR status |
+| `pull_request_read` | Reading PR details, diffs, review comments, status checks, files changed |
+| `issue_read` / `issue_write` | Reading/managing issues |
+| `list_commits` / `get_commit` | Examining commit history |
+| `list_branches` / `create_branch` | Branch management |
+| `add_issue_comment` | Commenting on issues |
+| `pull_request_review_write` | Submitting PR reviews |
+| `merge_pull_request` | Merging pull requests |
+| `update_pull_request` | Updating PR title, body, or state |
+
+### Key methods for `pull_request_read`
+
+| Method | Instead of |
+|--------|-----------|
+| `get` | `gh pr view` |
+| `get_diff` | `gh pr diff` |
+| `get_status` | `gh pr checks` |
+| `get_files` | `gh pr view --json files` |
+| `get_review_comments` | `gh api repos/.../pulls/.../comments` |
+| `get_reviews` | `gh pr view --json reviews` |
+| `get_comments` | `gh pr view --json comments` |
+
+**Proactive use:** When the user mentions a PR number, issue, or GitHub URL, use these tools to fetch context rather than asking the user to paste content. When checking PR merge status, review comments, or CI status, always use `pull_request_read` with the appropriate method.
+
+## Serena (`mcp__plugin_serena_serena__*`)
+
+Semantic code analysis with symbol-level understanding. **Prefer over grep/glob for code structure questions.**
+
+| Tool | When to Use |
+|------|-------------|
+| `find_symbol` | Locating classes, functions, methods by name — faster and more precise than grep |
+| `get_symbols_overview` | Understanding file/module structure without reading entire files |
+| `find_referencing_symbols` | Finding all callers/users of a symbol — critical for safe refactoring |
+| `search_for_pattern` | Regex search when symbol name is unknown |
+| `replace_symbol_body` | Replacing entire function/class bodies with structural awareness |
+| `insert_before_symbol` / `insert_after_symbol` | Adding code at precise structural locations |
+| `rename_symbol` | Safe renames that update all references |
+| `replace_content` | Regex-based replacement within files |
+
+**Proactive use:** When exploring unfamiliar code, start with `get_symbols_overview` and `find_symbol` before reading full files. Use `find_referencing_symbols` before modifying any public API.
+
+## Context7 (`mcp__plugin_context7_context7__*`)
+
+Up-to-date library documentation. **Use instead of web search for library/framework questions.**
+
+| Tool | When to Use |
+|------|-------------|
+| `resolve-library-id` | Finding the Context7 ID for a library |
+| `query-docs` | Getting current API docs, examples, and usage patterns |
+
+**Proactive use:** When writing code that uses external libraries, query Context7 for current API docs rather than relying on training data which may be outdated.
+
+## Microsoft Learn (`mcp__microsoft-learn__*`)
+
+Official Microsoft/Azure documentation via remote HTTP MCP. **Use for any Microsoft technology questions.**
+
+| Tool | When to Use |
+|------|-------------|
+| `search` | Quick overview of Azure/.NET/M365 topics |
+| `get-code-samples` | Finding working code examples for Microsoft SDKs |
+| `get-document` | Deep-reading full docs when search excerpts aren't enough |
+
+**Proactive use:** When working with .NET, Azure, or any Microsoft SDK, search docs to verify API usage rather than guessing from training data.
+
+## Companion Tool Anti-Patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Grep for class definitions | Use Serena `find_symbol` |
+| Ask user to paste PR content | Use GitHub `pull_request_read` |
+| Use `gh pr view` | Use GitHub `pull_request_read` with method `get` |
+| Use `gh pr list` | Use GitHub `list_pull_requests` or `search_pull_requests` |
+| Use `gh pr diff` | Use GitHub `pull_request_read` with method `get_diff` |
+| Use `gh pr checks` | Use GitHub `pull_request_read` with method `get_status` |
+| Use `gh pr merge` | Use GitHub `merge_pull_request` |
+| Use `gh api repos/.../pulls/.../comments` | Use GitHub `pull_request_read` with method `get_review_comments` |
+| Use `gh api` for any GitHub data | Use the corresponding GitHub MCP tool |
+| Use `gh issue view` or `gh issue list` | Use GitHub `issue_read` or `list_issues` / `search_issues` |
+| Use `gh pr view --json` for structured data | Use GitHub MCP tools which return structured data natively |
+| Guess library APIs from memory | Use Context7 `query-docs` |
+| Web search for .NET API reference | Use Microsoft Learn `search` |
+| Read entire files to find functions or understand structure | Use Serena `get_symbols_overview` then `find_symbol` with `include_body` |
+| Use grep/rg to search code patterns | Use Serena `search_for_pattern` for regex search |
+| Use sed/awk for code replacement | Use Serena `replace_content` or `replace_symbol_body` |
+| Generate diffs with shell commands | Use GitHub `pull_request_read` or Graphite `gt diff` |
+| Manually parse PR comments | Use GitHub `pull_request_read` for structured review data |

--- a/companion/src/install.ts
+++ b/companion/src/install.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, realpathSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, realpathSync, symlinkSync, lstatSync, readlinkSync } from 'node:fs';
+import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
@@ -32,17 +32,62 @@ const MCP_SERVERS_TO_ADD: Record<string, McpServerEntry> = {
   },
 };
 
+const CONTENT_OVERLAYS = [
+  { source: 'rules/mcp-tool-guidance.md', target: 'rules/mcp-tool-guidance.md' },
+  { source: 'skills/workflow-state/references/companion-mcp-reference.md', target: 'skills/workflow-state/references/companion-mcp-reference.md' },
+];
+
 export function installCompanion(
   claudeHome?: string,
   claudeJsonPath?: string,
-): { pluginsEnabled: string[]; mcpServersAdded: string[] } {
+): { pluginsEnabled: string[]; mcpServersAdded: string[]; contentOverlays: string[] } {
   const home = claudeHome ?? join(homedir(), '.claude');
   const configPath = claudeJsonPath ?? join(homedir(), '.claude.json');
 
   const pluginsEnabled = installPlugins(home);
   const mcpServersAdded = installMcpServers(configPath);
+  const contentOverlays = installContentOverlays(home);
 
-  return { pluginsEnabled, mcpServersAdded };
+  return { pluginsEnabled, mcpServersAdded, contentOverlays };
+}
+
+function installContentOverlays(claudeHome: string): string[] {
+  const companionRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+  const installed: string[] = [];
+
+  for (const overlay of CONTENT_OVERLAYS) {
+    const sourcePath = join(companionRoot, overlay.source);
+    const targetPath = join(claudeHome, overlay.target);
+
+    // Ensure target directory exists
+    mkdirSync(dirname(targetPath), { recursive: true });
+
+    // Skip if already symlinked to the same source
+    try {
+      const existing = lstatSync(targetPath);
+      if (existing.isSymbolicLink()) {
+        try {
+          const resolvedLink = realpathSync(targetPath);
+          const resolvedSource = realpathSync(sourcePath);
+          if (resolvedLink === resolvedSource) continue;
+        } catch {
+          // Resolution failed — treat as different, warn below
+        }
+      }
+      // Different file exists — warn but don't overwrite
+      process.stderr.write(`Warning: ${overlay.target} already exists, skipping.\n`);
+      continue;
+    } catch (err: unknown) {
+      if (!(err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT')) {
+        throw err;
+      }
+    }
+
+    symlinkSync(sourcePath, targetPath);
+    installed.push(overlay.target);
+  }
+
+  return installed;
 }
 
 function parseJsonFile<T extends object>(filePath: string, label: string): T {
@@ -121,4 +166,5 @@ if (isMainModule) {
   console.log('Exarchos Dev Tools installed:');
   result.pluginsEnabled.forEach(p => console.log(`  Plugin enabled: ${p}`));
   result.mcpServersAdded.forEach(s => console.log(`  MCP server added: ${s}`));
+  result.contentOverlays.forEach(o => console.log(`  Content overlay: ${o}`));
 }

--- a/rules/mcp-tool-guidance.md
+++ b/rules/mcp-tool-guidance.md
@@ -8,10 +8,9 @@ description: "Prefer specialized MCP tools over generic CLI approaches."
 Use specialized MCP tools over generic approaches:
 
 1. **Workflow state** — Exarchos MCP, never manual JSON
-2. **Code structure** — Serena (`find_symbol`, `get_symbols_overview`) over grep
-3. **GitHub operations** — GitHub MCP tools over `gh` CLI
-4. **PR creation** — Graphite MCP (`gt submit --no-interactive --publish --merge-when-ready`), never `gh pr create`
-5. **Library docs** — Context7 before web search
-6. **State management** — `exarchos_workflow` set/get, never edit JSON directly
+2. **PR creation** — Graphite MCP (`gt submit --no-interactive --publish --merge-when-ready`), never `gh pr create`
+3. **State management** — `exarchos_workflow` set/get, never edit JSON directly
+
+> Additional tool guidance (Serena, GitHub MCP, Context7) is provided by the exarchos-dev-tools companion. Install: `npx @lvlup-sw/exarchos-dev`
 
 See `@skills/workflow-state/references/mcp-tool-reference.md` for detailed mappings.

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -46,19 +46,12 @@ mcp__exarchos__exarchos_view({ action: "pipeline" })
 
 For each PR associated with the workflow, verify it is merged.
 
-**Primary method** — GitHub MCP:
-```typescript
-mcp__plugin_github_github__pull_request_read({
-  owner: "lvlup-sw",
-  repo: "exarchos",
-  pullNumber: <number>
-})
-```
-
-**Fallback** — gh CLI:
+**Primary method** — gh CLI:
 ```bash
 gh pr view <number> --json state,mergedAt,headRefName
 ```
+
+> Or use GitHub MCP `pull_request_read` if available.
 
 Collect from merged PRs:
 - `prUrl`: The PR URL (or array of URLs for stacked PRs)

--- a/skills/cleanup/references/merge-verification.md
+++ b/skills/cleanup/references/merge-verification.md
@@ -10,24 +10,14 @@ The cleanup action trusts the `mergeVerified` flag — it does not query GitHub 
 
 ## Verification Methods
 
-### GitHub MCP (Preferred)
-
-```typescript
-const pr = await mcp__plugin_github_github__pull_request_read({
-  owner: "lvlup-sw",
-  repo: "exarchos",
-  pullNumber: 123
-});
-
-// Check: pr.state === "MERGED" or pr.merged === true
-```
-
-### gh CLI (Fallback)
+### gh CLI (Primary)
 
 ```bash
 gh pr view 123 --json state,mergedAt,headRefName
 # Check: .state == "MERGED" and .mergedAt is not null
 ```
+
+> Or use GitHub MCP `pull_request_read` if available for structured data.
 
 ### For Stacked PRs
 

--- a/skills/debug/references/thorough-track.md
+++ b/skills/debug/references/thorough-track.md
@@ -132,13 +132,22 @@ mcp__graphite__run_gt_cmd({ args: ["create", "-m", "fix: <issue summary>"], cwd:
 mcp__graphite__run_gt_cmd({ args: ["submit", "--no-interactive", "--publish", "--merge-when-ready"], cwd: "<repo-root>" })
 ```
 
-Then update the PR description using GitHub MCP:
+Then update the PR description:
+```bash
+gh pr edit <number> --body "## Summary
+[Brief description]
+
+## Root Cause Analysis
+See: docs/rca/YYYY-MM-DD-<issue-slug>.md
+
+## Changes
+- [change 1]
+
+## Test Plan
+- [test approach]"
 ```
-mcp__plugin_github_github__update_pull_request({
-  owner, repo, pullNumber,
-  body: "## Summary\n[Brief description]\n\n## Root Cause Analysis\nSee: docs/rca/YYYY-MM-DD-<issue-slug>.md\n\n## Changes\n- [change 1]\n\n## Test Plan\n- [test approach]"
-})
-```
+
+> Or use GitHub MCP `update_pull_request` if available.
 
 **Human checkpoint:** Confirm merge.
 

--- a/skills/delegation/references/implementer-prompt.md
+++ b/skills/delegation/references/implementer-prompt.md
@@ -132,7 +132,12 @@ describe('[ComponentName]', () => {
 
 ## Code Exploration Tools
 
-For navigating and understanding code, prefer Serena MCP tools over grep/glob:
+For navigating and understanding code:
+- `Grep` — Search for patterns across the codebase
+- `Glob` — Find files by name pattern
+- `Read` — Read file contents (prefer targeted reads over full-file reads)
+
+When Serena MCP is available, prefer semantic tools for precision:
 - `mcp__plugin_serena_serena__find_symbol` — Locate classes, functions, methods by name
 - `mcp__plugin_serena_serena__get_symbols_overview` — Understand file structure without reading entire files
 - `mcp__plugin_serena_serena__search_for_pattern` — Regex search across the codebase

--- a/skills/delegation/references/pr-fixes-mode.md
+++ b/skills/delegation/references/pr-fixes-mode.md
@@ -15,21 +15,15 @@ When invoked with `--pr-fixes [PR_URL]`, delegation addresses human review feedb
 
 ### Step 1: Fetch All PR Feedback
 
-```typescript
-// Get full PR details including reviews and comments
-mcp__plugin_github_github__pull_request_read({
-  owner: "<owner>",
-  repo: "<repo>",
-  pullNumber: <number>
-})
+```bash
+# Get full PR details including reviews and comments
+gh pr view <number> --json title,body,state,files,reviewDecision,reviews,comments
 
-// Get issue-level comments (pre-merge check summaries)
-mcp__plugin_github_github__issue_read({
-  owner: "<owner>",
-  repo: "<repo>",
-  issueNumber: <number>
-})
+# Get issue-level comments (pre-merge check summaries)
+gh issue view <number> --json comments
 ```
+
+> Or use GitHub MCP `pull_request_read` and `issue_read` if available.
 
 ### Step 2: Parse CodeRabbit Feedback
 

--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -44,8 +44,9 @@ gt diff main > /tmp/stack-diff.patch
 # Alternative: git diff for integration branch
 git diff main...integration-branch > /tmp/integration-diff.patch
 
-# Alternative: use GitHub MCP to get PR diff
-# mcp__plugin_github_github__pull_request_read({ owner, repo, pullNumber, method: "get_diff" })
+# Alternative: use gh CLI to get PR diff
+# gh pr diff <number>
+# Or use GitHub MCP pull_request_read with method "get_diff" if available
 ```
 
 This reduces context consumption by 80-90% while providing the complete picture.
@@ -244,7 +245,7 @@ This is NOT a human checkpoint - workflow continues autonomously.
 
 When Exarchos MCP tools are available, emit gate events during review:
 
-1. **Read CI status** via `pull_request_read` with `method: "get_status"`
+1. **Read CI status** via `gh pr checks <number>` (or GitHub MCP `pull_request_read` with method `get_status` if available)
 2. **Emit gate events** via `exarchos_event` with `action: "append"`, type `gate.executed` (include `gateName`, `layer`, `passed`, `duration`)
 3. **Read unified status** via `exarchos_view` with `action: "tasks"`, `fields: ["taskId", "status", "title"]`, `limit: 20`
 4. **When all per-PR gates pass**, apply `stack-ready` label to the PR

--- a/skills/refactor/references/overhaul-track.md
+++ b/skills/refactor/references/overhaul-track.md
@@ -138,7 +138,9 @@ Invoke `/synthesize` skill:
 Skill({ skill: "synthesize", args: "<feature-name>" })
 ```
 
-Creates PR via Graphite, updates description via GitHub MCP. **Human checkpoint:** Confirm merge.
+Creates PR via Graphite, updates description via `gh pr edit`. **Human checkpoint:** Confirm merge.
+
+> Or use GitHub MCP `update_pull_request` if available.
 
 ## Auto-Chain
 

--- a/skills/synthesis/references/troubleshooting.md
+++ b/skills/synthesis/references/troubleshooting.md
@@ -21,7 +21,7 @@ If tests fail during synthesis (they passed in review):
 ### Merge Queue Rejection
 
 If the merge queue rejects a PR:
-1. Check CI status via GitHub MCP: `pull_request_read` with method `get_status`
+1. Check CI status via `gh pr checks <number>` (or GitHub MCP `pull_request_read` with method `get_status` if available)
 2. Fix failing checks
 3. Push fixes and re-enqueue
 
@@ -34,10 +34,11 @@ If the user receives PR review comments:
    Skill({ skill: "delegate", args: "--pr-fixes [PR_URL]" })
    ```
 
-2. Delegate reads PR comments via GitHub MCP:
+2. Delegate reads PR comments via gh CLI:
+   ```bash
+   gh pr view <number> --json reviews,comments
    ```
-   mcp__plugin_github_github__pull_request_read({ owner, repo, pullNumber })
-   ```
+   > Or use GitHub MCP `pull_request_read` if available.
 
 3. Creates fix tasks from review comments
 4. After fixes, amend the stack with `mcp__graphite__run_gt_cmd` using `["modify", "-m", "fix: <description>"]` and resubmit with `["submit", "--no-interactive", "--publish", "--merge-when-ready"]`

--- a/skills/workflow-state/references/mcp-tool-reference.md
+++ b/skills/workflow-state/references/mcp-tool-reference.md
@@ -57,65 +57,13 @@ Unified MCP server for workflow orchestration, event sourcing, CQRS views, and t
 | `stack_place` | Record a stack position with `position`, `taskId`, `branch`, optional `prUrl` |
 
 ## GitHub (`mcp__plugin_github_github__*`)
-
-GitHub platform integration. **Always use GitHub MCP tools for ALL GitHub operations. NEVER use `gh` CLI when an MCP equivalent exists.**
-
-| Tool | When to Use |
-|------|-------------|
-| `get_file_contents` | Reading files from remote repos or other branches |
-| `search_code` | Finding code patterns across repositories |
-| `search_issues` | Checking for existing issues before creating new ones |
-| `list_pull_requests` / `search_pull_requests` | Finding related PRs, checking PR status |
-| `pull_request_read` | Reading PR details, diffs, review comments, status checks, files changed |
-| `issue_read` / `issue_write` | Reading/managing issues |
-| `list_commits` / `get_commit` | Examining commit history |
-| `list_branches` / `create_branch` | Branch management |
-| `add_issue_comment` | Commenting on issues |
-| `pull_request_review_write` | Submitting PR reviews |
-| `merge_pull_request` | Merging pull requests |
-| `update_pull_request` | Updating PR title, body, or state |
-
-### Key methods for `pull_request_read`
-
-| Method | Instead of |
-|--------|-----------|
-| `get` | `gh pr view` |
-| `get_diff` | `gh pr diff` |
-| `get_status` | `gh pr checks` |
-| `get_files` | `gh pr view --json files` |
-| `get_review_comments` | `gh api repos/.../pulls/.../comments` |
-| `get_reviews` | `gh pr view --json reviews` |
-| `get_comments` | `gh pr view --json comments` |
-
-**Proactive use:** When the user mentions a PR number, issue, or GitHub URL, use these tools to fetch context rather than asking the user to paste content. When checking PR merge status, review comments, or CI status, always use `pull_request_read` with the appropriate method.
+> Available with exarchos-dev-tools companion. Fallback: use `gh` CLI.
 
 ## Serena (`mcp__plugin_serena_serena__*`)
-
-Semantic code analysis with symbol-level understanding. **Prefer over grep/glob for code structure questions.**
-
-| Tool | When to Use |
-|------|-------------|
-| `find_symbol` | Locating classes, functions, methods by name — faster and more precise than grep |
-| `get_symbols_overview` | Understanding file/module structure without reading entire files |
-| `find_referencing_symbols` | Finding all callers/users of a symbol — critical for safe refactoring |
-| `search_for_pattern` | Regex search when symbol name is unknown |
-| `replace_symbol_body` | Replacing entire function/class bodies with structural awareness |
-| `insert_before_symbol` / `insert_after_symbol` | Adding code at precise structural locations |
-| `rename_symbol` | Safe renames that update all references |
-| `replace_content` | Regex-based replacement within files |
-
-**Proactive use:** When exploring unfamiliar code, start with `get_symbols_overview` and `find_symbol` before reading full files. Use `find_referencing_symbols` before modifying any public API.
+> Available with exarchos-dev-tools companion. Fallback: use Grep/Read/Glob.
 
 ## Context7 (`mcp__plugin_context7_context7__*`)
-
-Up-to-date library documentation. **Use instead of web search for library/framework questions.**
-
-| Tool | When to Use |
-|------|-------------|
-| `resolve-library-id` | Finding the Context7 ID for a library |
-| `query-docs` | Getting current API docs, examples, and usage patterns |
-
-**Proactive use:** When writing code that uses external libraries, query Context7 for current API docs rather than relying on training data which may be outdated.
+> Available with exarchos-dev-tools companion. Fallback: use WebSearch.
 
 ## Graphite (`mcp__graphite__*`)
 
@@ -138,16 +86,7 @@ Stacked PR management and merge queue. **Use for all PR stacking and submission.
 **Proactive use:** When the workflow involves stacked PRs or progressive merging (e.g., `/delegate` with multiple tasks), use `mcp__graphite__run_gt_cmd` for stack management rather than raw git commands or `gh pr create`.
 
 ## Microsoft Learn (`mcp__microsoft-learn__*`)
-
-Official Microsoft/Azure documentation via remote HTTP MCP. **Use for any Microsoft technology questions.**
-
-| Tool | When to Use |
-|------|-------------|
-| `search` | Quick overview of Azure/.NET/M365 topics |
-| `get-code-samples` | Finding working code examples for Microsoft SDKs |
-| `get-document` | Deep-reading full docs when search excerpts aren't enough |
-
-**Proactive use:** When working with .NET, Azure, or any Microsoft SDK, search docs to verify API usage rather than guessing from training data.
+> Available with exarchos-dev-tools companion. Fallback: use WebSearch.
 
 ## Workflow Transition Errors
 
@@ -164,26 +103,9 @@ A compound state's fix cycle limit was reached. Escalate to user or cancel the w
 
 | Don't | Do Instead |
 |-------|------------|
-| Grep for class definitions | Use Serena `find_symbol` |
-| Ask user to paste PR content | Use GitHub `pull_request_read` |
 | Use `gh pr create` or `create_pull_request` | Use Graphite `gt submit --no-interactive --publish --merge-when-ready` for ALL PR creation |
-| Use `gh pr view` | Use GitHub `pull_request_read` with method `get` |
-| Use `gh pr list` | Use GitHub `list_pull_requests` or `search_pull_requests` |
-| Use `gh pr diff` | Use GitHub `pull_request_read` with method `get_diff` |
-| Use `gh pr checks` | Use GitHub `pull_request_read` with method `get_status` |
-| Use `gh pr merge` | Use GitHub `merge_pull_request` |
-| Use `gh api repos/.../pulls/.../comments` | Use GitHub `pull_request_read` with method `get_review_comments` |
-| Use `gh api` for any GitHub data | Use the corresponding GitHub MCP tool |
-| Use `gh issue view` or `gh issue list` | Use GitHub `issue_read` or `list_issues` / `search_issues` |
-| Use `gh pr view --json` for structured data | Use GitHub MCP tools which return structured data natively |
-| Guess library APIs from memory | Use Context7 `query-docs` |
 | Manually edit workflow state JSON | Use `mcp__exarchos__exarchos_workflow` with `action: "set"` |
-| Web search for .NET API reference | Use Microsoft Learn `search` |
-| Read entire files to find a function | Use Serena `get_symbols_overview` then `find_symbol` with `include_body` |
 | Use `git commit` or `git push` | Use `gt create` + `gt submit --no-interactive --publish --merge-when-ready` |
-| Use grep/rg to search code patterns | Use Serena `search_for_pattern` for regex search |
-| Use sed/awk for code replacement | Use Serena `replace_content` or `replace_symbol_body` |
-| Read entire files to understand structure | Use Serena `get_symbols_overview` then `find_symbol` with `include_body` |
-| Generate diffs with shell commands | Use GitHub `pull_request_read` or Graphite `gt diff` |
-| Manually parse PR comments | Use GitHub `pull_request_read` for structured review data |
 | Skip state reconciliation on resume | The SessionStart hook handles reconciliation automatically |
+
+> See companion reference for additional tool anti-patterns (Serena, GitHub MCP, Context7).

--- a/src/companion-content-validation.test.ts
+++ b/src/companion-content-validation.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('Companion content separation', () => {
+  describe('Core rules', () => {
+    it('coreRules_mcpToolGuidance_onlyReferencesCoreMcpTools', () => {
+      const content = readFileSync(join(repoRoot, 'rules/mcp-tool-guidance.md'), 'utf-8');
+      // Core should reference Exarchos and Graphite
+      expect(content).toContain('Exarchos');
+      // Core should NOT reference companion tools
+      expect(content).not.toMatch(/mcp__plugin_github/);
+      expect(content).not.toMatch(/mcp__plugin_serena/);
+      expect(content).not.toMatch(/mcp__plugin_context7/);
+      expect(content).not.toContain('microsoft-learn');
+      // But it CAN mention them by name with "companion" qualifier
+      // Just not as hard tool references
+    });
+  });
+
+  describe('Companion rules', () => {
+    it('companionRules_mcpToolGuidance_containsAllToolReferences', () => {
+      const path = join(repoRoot, 'companion/rules/mcp-tool-guidance.md');
+      expect(existsSync(path), 'companion/rules/mcp-tool-guidance.md must exist').toBe(true);
+      const content = readFileSync(path, 'utf-8');
+      expect(content).toContain('Serena');
+      expect(content).toContain('GitHub');
+      expect(content).toContain('Context7');
+    });
+  });
+
+  describe('Companion MCP reference', () => {
+    it('companionMcpReference_containsAllCompanionSections', () => {
+      const path = join(repoRoot, 'companion/skills/workflow-state/references/companion-mcp-reference.md');
+      expect(existsSync(path), 'companion MCP reference must exist').toBe(true);
+      const content = readFileSync(path, 'utf-8');
+      expect(content).toMatch(/##.*GitHub/);
+      expect(content).toMatch(/##.*Serena/);
+      expect(content).toMatch(/##.*Context7/);
+      expect(content).toMatch(/##.*Microsoft Learn/);
+    });
+  });
+
+  describe('Implementer prompt', () => {
+    it('implementerPrompt_serenaGuidance_present', () => {
+      const content = readFileSync(join(repoRoot, 'skills/delegation/references/implementer-prompt.md'), 'utf-8');
+      // Serena tool names MUST still be present
+      expect(content).toContain('mcp__plugin_serena_serena__find_symbol');
+      expect(content).toContain('mcp__plugin_serena_serena__get_symbols_overview');
+      expect(content).toContain('mcp__plugin_serena_serena__search_for_pattern');
+      expect(content).toContain('mcp__plugin_serena_serena__find_referencing_symbols');
+      // Primary fallback tools must also be present
+      expect(content).toMatch(/Grep/i);
+      expect(content).toMatch(/Read/i);
+      expect(content).toMatch(/Glob/i);
+    });
+  });
+
+  describe('No-degradation', () => {
+    it('companionMcpToolGuidance_coversAllCurrentToolReferences', () => {
+      const content = readFileSync(join(repoRoot, 'companion/rules/mcp-tool-guidance.md'), 'utf-8');
+      // These must be present (they're in today's version)
+      expect(content).toContain('Serena');
+      expect(content).toContain('find_symbol');
+      expect(content).toContain('get_symbols_overview');
+      expect(content).toContain('GitHub');
+      expect(content).toContain('Context7');
+      expect(content).toContain('web search');
+    });
+
+    it('implementerPrompt_serenaToolNames_allPresent', () => {
+      const content = readFileSync(join(repoRoot, 'skills/delegation/references/implementer-prompt.md'), 'utf-8');
+      const requiredTools = [
+        'mcp__plugin_serena_serena__find_symbol',
+        'mcp__plugin_serena_serena__get_symbols_overview',
+        'mcp__plugin_serena_serena__search_for_pattern',
+        'mcp__plugin_serena_serena__find_referencing_symbols',
+      ];
+      for (const tool of requiredTools) {
+        expect(content, `Missing Serena tool: ${tool}`).toContain(tool);
+      }
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'companion/**/*.test.ts'],
     globals: false,
     environment: 'node',
   },


### PR DESCRIPTION
## Summary

Extracts companion-plugin-dependent content (GitHub MCP, Serena, Context7, Microsoft Learn references) from core into the companion plugin. Core retains soft "when available" fallbacks; companion restores full tool-preference guidance via its npm installer. Serena tool names are never removed — only reframed as conditional.

## Changes

- **Core rules** — `rules/mcp-tool-guidance.md` stripped to Exarchos + Graphite only
- **Companion rules** — `companion/rules/mcp-tool-guidance.md` with verbatim copy of original 6-tool guidance
- **Companion reference** — Full GitHub, Serena, Context7, Microsoft Learn MCP reference
- **Implementer prompt** — Primary: Grep/Glob/Read; Secondary: "When Serena MCP available" with all 4 tool names preserved
- **GitHub MCP swaps** — ~12 files updated: `gh` CLI primary + "or use GitHub MCP if available"
- **Companion installer** — Added `installContentOverlays()` for rule/skill symlinks with idempotency

## Test Plan

- [x] 6 companion-content-validation tests (core stripping, companion existence, Serena preservation)
- [x] 4 companion installer tests (overlay symlinks, idempotency, skip-on-existing)
- [x] 259 total tests pass

---
Design: `docs/designs/2026-02-17-distribution-strategy.md`
Plan: `docs/plans/2026-02-19-distribution-strategy-phase1b.md` (Group E, Tasks E1-E6)