### PR TITLE
feat: consolidate rules into CLAUDE.md and fix mcp.json validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,53 @@ cd servers/exarchos-mcp && npm run test:run
 
 Human checkpoints at plan-review and merge only. Auto-continues via SessionStart hook.
 
+## Coding Standards
+
+- **SOLID:** SRP (one component per file), OCP (discriminated unions/strategy pattern), LSP (full interface implementation), ISP (small focused interfaces), DIP (inject dependencies)
+- **Control flow:** Guard clauses first, early returns, no arrow code, extract complex conditions into named predicates
+- **Error handling:** Result types for recoverable errors, custom error classes for programmer errors, never silent catches, explicit error boundaries at API/UI layers
+- **DRY:** Extract duplicated logic, use built-in collection methods (`map`/`filter`/`reduce`, LINQ), leverage standard utility types
+
+## TDD Rules
+
+- **RED:** Write a failing test describing expected behavior — verify it fails for the right reason
+- **GREEN:** Write minimum code to pass — no extra features or optimizations
+- **REFACTOR:** Clean up while tests stay green — extract helpers, improve naming, apply SOLID
+- Test files: `foo.test.ts` co-located alongside `foo.ts`, run: `npm run test:run`
+- Test pattern: Arrange/Act/Assert with descriptive names (`Method_Scenario_Outcome`)
+- Mocking: `vi.mock()` for modules, `vi.fn()` for functions
+
+## Orchestrator Constraints
+
+- **MUST NOT:** Write implementation code, fix review findings directly, run integration tests inline, work in main project root
+- **SHOULD:** Parse/extract plans, dispatch/monitor subagents, manage workflow state, chain phases, handle failures
+- **Exception:** During `polish-implement` phase only, the orchestrator may write code directly (stay within brief scope, follow TDD if changing behavior)
+
+## Primary Workflows
+
+| Task | Command |
+|------|---------|
+| New feature/design | `/ideate` |
+| Bug fix | `/debug` |
+| Code improvement | `/refactor` |
+
+Supporting: `/plan`, `/delegate`, `/review`, `/synthesize`, `/resume`, `/checkpoint` — phase commands within workflows.
+
+## MCP Tool Guidance
+
+- **Workflow state** — Exarchos MCP (`exarchos_workflow` set/get), never manual JSON editing
+- **PR creation** — Graphite MCP (`gt submit --no-interactive --publish --merge-when-ready`), never `gh pr create`
+
+## PR Descriptions
+
+- **Title:** `<type>: <what>` (max 72 chars)
+- **Body:** Summary (2-3 sentences) → Changes (bulleted, `**Component** — description`) → Test Plan → Footer (`---` + results, design doc, related PRs). Aim for 120-200 words.
+
+## Safety
+
+- **NEVER:** `rm -rf /`, `rm -rf ~`, `rm -rf .` in home/root, `rm` with unset variables (`$UNSET_VAR/*`)
+- **ALWAYS:** Use specific paths, `ls` before deleting, avoid `-f` unless needed, verify `-r` targets. When uncertain, preview with `echo rm ...` or ask.
+
 ## Key Conventions
 
 - **ESM** — `"type": "module"`, NodeNext resolution

--- a/scripts/validate-plugin.sh
+++ b/scripts/validate-plugin.sh
@@ -154,8 +154,8 @@ fi
 
 # --- Check 4: .mcp.json is valid JSON with exarchos and graphite entries ---
 if [[ -f "$MCP_FILE" ]] && jq empty "$MCP_FILE" 2>/dev/null; then
-  HAS_EXARCHOS=$(jq -e '.exarchos' "$MCP_FILE" >/dev/null 2>&1 && echo "true" || echo "false")
-  HAS_GRAPHITE=$(jq -e '.graphite' "$MCP_FILE" >/dev/null 2>&1 && echo "true" || echo "false")
+  HAS_EXARCHOS=$(jq -e '.mcpServers.exarchos' "$MCP_FILE" >/dev/null 2>&1 && echo "true" || echo "false")
+  HAS_GRAPHITE=$(jq -e '.mcpServers.graphite' "$MCP_FILE" >/dev/null 2>&1 && echo "true" || echo "false")
   if [[ "$HAS_EXARCHOS" == "true" && "$HAS_GRAPHITE" == "true" ]]; then
     check ".mcp.json contains exarchos and graphite entries" "true"
   else

--- a/scripts/validate-plugin.test.sh
+++ b/scripts/validate-plugin.test.sh
@@ -45,8 +45,10 @@ cat > "$TMPDIR1/.claude-plugin/plugin.json" << 'EOF'
 EOF
 cat > "$TMPDIR1/.mcp.json" << 'EOF'
 {
-  "exarchos": { "type": "stdio", "command": "bun", "args": ["run", "dist/exarchos-mcp.js"] },
-  "graphite": { "type": "stdio", "command": "gt", "args": ["mcp"] }
+  "mcpServers": {
+    "exarchos": { "type": "stdio", "command": "bun", "args": ["run", "dist/exarchos-mcp.js"] },
+    "graphite": { "type": "stdio", "command": "gt", "args": ["mcp"] }
+  }
 }
 EOF
 cat > "$TMPDIR1/hooks/hooks.json" << 'HOOKEOF'
@@ -84,8 +86,10 @@ cat > "$TMPDIR3/.claude-plugin/plugin.json" << 'EOF'
 EOF
 cat > "$TMPDIR3/.mcp.json" << 'EOF'
 {
-  "exarchos": { "type": "stdio" },
-  "graphite": { "type": "stdio" }
+  "mcpServers": {
+    "exarchos": { "type": "stdio" },
+    "graphite": { "type": "stdio" }
+  }
 }
 EOF
 cat > "$TMPDIR3/hooks/hooks.json" << 'HOOKEOF'
@@ -114,8 +118,10 @@ cat > "$TMPDIR4/.claude-plugin/plugin.json" << 'EOF'
 EOF
 cat > "$TMPDIR4/.mcp.json" << 'EOF'
 {
-  "exarchos": { "type": "stdio" },
-  "graphite": { "type": "stdio" }
+  "mcpServers": {
+    "exarchos": { "type": "stdio" },
+    "graphite": { "type": "stdio" }
+  }
 }
 EOF
 cat > "$TMPDIR4/hooks/hooks.json" << 'HOOKEOF'

--- a/src/claudemd-validation.test.ts
+++ b/src/claudemd-validation.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repoRoot = join(import.meta.dirname, '..');
+
+describe('CLAUDE.md rules consolidation', () => {
+  const content = readFileSync(join(repoRoot, 'CLAUDE.md'), 'utf-8');
+
+  it('claudeMd_essentialRuleSections_present', () => {
+    // Check for essential sections (case-insensitive header matching)
+    const requiredPatterns = [
+      /##.*coding\s+standards/i,
+      /##.*tdd/i,
+      /##.*orchestrator/i,
+      /##.*workflow/i,
+      /##.*mcp.*tool/i,
+    ];
+    for (const pattern of requiredPatterns) {
+      expect(content, `Missing section matching ${pattern}`).toMatch(pattern);
+    }
+  });
+
+  it('claudeMd_underLineLimit', () => {
+    const lines = content.split('\n').length;
+    expect(lines, `CLAUDE.md is ${lines} lines, should be under 200`).toBeLessThanOrEqual(200);
+  });
+
+  it('claudeMd_hasExistingSections', () => {
+    // Existing sections that should be preserved
+    expect(content).toContain('## Build & Test');
+    expect(content).toContain('## Key Conventions');
+  });
+});


### PR DESCRIPTION
## Summary

Consolidates essential rules from `rules/` directory into `CLAUDE.md` for marketplace plugin delivery (under 200 lines). Also fixes the `.mcp.json` validation script to handle the `mcpServers` wrapper key format.

## Changes

- **Validation fix** — Updated `scripts/validate-plugin.sh` jq queries from `.exarchos` to `.mcpServers.exarchos`
- **Test fixtures** — Updated 3 mock `.mcp.json` fixtures in `validate-plugin.test.sh`
- **CLAUDE.md** — Expanded with condensed rule sections: Coding Standards, TDD, Orchestrator Constraints, Primary Workflows, MCP Tool Guidance, PR Descriptions, Safety (92 lines total)
- **Validation test** — New `src/claudemd-validation.test.ts` verifying section presence, line limit, existing sections

## Test Plan

- [x] 3 new CLAUDE.md validation tests
- [x] Validation script 8/8 checks pass
- [x] 4/4 script tests pass
- [x] 242 total tests pass

---
Design: `docs/designs/2026-02-17-distribution-strategy.md`
Plan: `docs/plans/2026-02-19-distribution-strategy-phase1b.md` (Group D, Tasks D1-D3)