### PR TITLE
fix: configurable snapshot interval and cleanup on workflow completion

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/views/snapshot-store.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/views/snapshot-store.test.ts
@@ -262,4 +262,95 @@ describe('SnapshotStore', () => {
       expect(result).toBeUndefined();
     });
   });
+
+  // ─── 15. delete_ExistingSnapshot_RemovesFile ──────────────────────────────
+
+  describe('delete_ExistingSnapshot_RemovesFile', () => {
+    it('should remove an existing snapshot file so load returns undefined', async () => {
+      await store.save('del-stream', 'myview', { x: 1 }, 5);
+
+      // Confirm it exists
+      const before = await store.load('del-stream', 'myview');
+      expect(before).toBeDefined();
+
+      // Delete it
+      await store.delete('del-stream', 'myview');
+
+      // Confirm it's gone
+      const after = await store.load('del-stream', 'myview');
+      expect(after).toBeUndefined();
+    });
+  });
+
+  // ─── 16. delete_NonExistentSnapshot_NoError ───────────────────────────────
+
+  describe('delete_NonExistentSnapshot_NoError', () => {
+    it('should not throw when deleting a snapshot that does not exist', async () => {
+      // Should be idempotent — no error
+      await expect(
+        store.delete('nonexistent-stream', 'noview'),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // ─── 17. deleteAllForStream_MultipleSnapshots_RemovesAll ──────────────────
+
+  describe('deleteAllForStream_MultipleSnapshots_RemovesAll', () => {
+    it('should remove all snapshots for a given stream across different views', async () => {
+      await store.save('multi-stream', 'viewa', { a: 1 }, 1);
+      await store.save('multi-stream', 'viewb', { b: 2 }, 2);
+      await store.save('multi-stream', 'viewc', { c: 3 }, 3);
+
+      await store.deleteAllForStream('multi-stream');
+
+      expect(await store.load('multi-stream', 'viewa')).toBeUndefined();
+      expect(await store.load('multi-stream', 'viewb')).toBeUndefined();
+      expect(await store.load('multi-stream', 'viewc')).toBeUndefined();
+    });
+  });
+
+  // ─── 18. deleteAllForStream_DoesNotTouchOtherStreams ───────────────────────
+
+  describe('deleteAllForStream_DoesNotTouchOtherStreams', () => {
+    it('should not delete snapshots belonging to other streams', async () => {
+      await store.save('stream-a', 'myview', { a: 1 }, 1);
+      await store.save('stream-b', 'myview', { b: 2 }, 2);
+
+      await store.deleteAllForStream('stream-a');
+
+      expect(await store.load('stream-a', 'myview')).toBeUndefined();
+      expect(await store.load('stream-b', 'myview')).toBeDefined();
+    });
+  });
+
+  // ─── 19. deleteAllForStream_ReturnsDeletedFileNames ───────────────────────
+
+  describe('deleteAllForStream_ReturnsDeletedFileNames', () => {
+    it('should return the array of deleted file names', async () => {
+      await store.save('ret-stream', 'viewa', { a: 1 }, 1);
+      await store.save('ret-stream', 'viewb', { b: 2 }, 2);
+
+      const deleted = await store.deleteAllForStream('ret-stream');
+
+      expect(deleted).toHaveLength(2);
+      expect(deleted.sort()).toEqual([
+        'ret-stream.viewa.snapshot.json',
+        'ret-stream.viewb.snapshot.json',
+      ]);
+    });
+  });
+
+  // ─── 20. deleteAllForStream_ExactPrefixMatch_NoFalsePositives ─────────────
+
+  describe('deleteAllForStream_ExactPrefixMatch_NoFalsePositives', () => {
+    it('should not delete snapshots for streams with a matching prefix but different id', async () => {
+      await store.save('my-feature', 'myview', { a: 1 }, 1);
+      await store.save('my-feature-2', 'myview', { b: 2 }, 2);
+
+      await store.deleteAllForStream('my-feature');
+
+      expect(await store.load('my-feature', 'myview')).toBeUndefined();
+      expect(await store.load('my-feature-2', 'myview')).toBeDefined();
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
@@ -86,6 +86,7 @@ vi.mock('../../workflow/cancel.js', () => ({
 
 vi.mock('../../workflow/cleanup.js', () => ({
   configureCleanupEventStore: vi.fn(),
+  configureCleanupSnapshotStore: vi.fn(),
 }));
 
 vi.mock('../../workflow/query.js', () => ({
@@ -94,6 +95,10 @@ vi.mock('../../workflow/query.js', () => ({
 
 vi.mock('../../event-store/store.js', () => ({
   EventStore: vi.fn(),
+}));
+
+vi.mock('../../views/snapshot-store.js', () => ({
+  SnapshotStore: vi.fn(),
 }));
 
 // Mock telemetry middleware (pass-through by default)

--- a/servers/exarchos-mcp/src/index.ts
+++ b/servers/exarchos-mcp/src/index.ts
@@ -20,9 +20,10 @@ import { handleSync } from './sync/composite.js';
 import { configureWorkflowEventStore } from './workflow/tools.js';
 import { configureNextActionEventStore } from './workflow/next-action.js';
 import { configureCancelEventStore } from './workflow/cancel.js';
-import { configureCleanupEventStore } from './workflow/cleanup.js';
+import { configureCleanupEventStore, configureCleanupSnapshotStore } from './workflow/cleanup.js';
 import { configureQueryEventStore } from './workflow/query.js';
 import { EventStore } from './event-store/store.js';
+import { SnapshotStore } from './views/snapshot-store.js';
 
 // Telemetry middleware
 import { withTelemetry } from './telemetry/middleware.js';
@@ -58,6 +59,7 @@ export function createServer(stateDir: string): McpServer {
   configureNextActionEventStore(eventStore);
   configureCancelEventStore(eventStore);
   configureCleanupEventStore(eventStore);
+  configureCleanupSnapshotStore(new SnapshotStore(stateDir));
   configureQueryEventStore(eventStore);
 
   // Register composite tools from registry

--- a/servers/exarchos-mcp/src/views/materializer.test.ts
+++ b/servers/exarchos-mcp/src/views/materializer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ViewMaterializer, type ViewProjection } from './materializer.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
 import {
@@ -379,5 +379,111 @@ describe('ViewMaterializer WorkflowStateProjection Registration', () => {
     expect(view.createdAt).toBe('2026-02-19T10:00:00.000Z');
     expect(view.updatedAt).toBe('2026-02-19T10:10:00.000Z');
     expect(view.artifacts.design).toBe('docs/design.md');
+  });
+});
+
+// ─── Configurable Snapshot Interval via Env Var ──────────────────────────────
+
+describe('ViewMaterializer Configurable Snapshot Interval', () => {
+  const VIEW_NAME = 'counter';
+  const originalEnv = process.env.EXARCHOS_SNAPSHOT_INTERVAL;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.EXARCHOS_SNAPSHOT_INTERVAL;
+    } else {
+      process.env.EXARCHOS_SNAPSHOT_INTERVAL = originalEnv;
+    }
+  });
+
+  it('parseEnvSnapshotInterval_ValidEnvVar_ReturnsValue', () => {
+    process.env.EXARCHOS_SNAPSHOT_INTERVAL = '100';
+    const snapshotStore = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    const materializer = new ViewMaterializer({ snapshotStore });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    const events50 = Array.from({ length: 50 }, (_, i) =>
+      makeEvent(i + 1, `stream-1`),
+    );
+    materializer.materialize('stream-1', VIEW_NAME, events50);
+    expect(snapshotStore.save).not.toHaveBeenCalled();
+
+    const events100 = Array.from({ length: 100 }, (_, i) =>
+      makeEvent(i + 1, `stream-1`),
+    );
+    materializer.materialize('stream-1', VIEW_NAME, events100);
+    expect(snapshotStore.save).toHaveBeenCalled();
+  });
+
+  it('parseEnvSnapshotInterval_MissingEnvVar_ReturnsDefault', () => {
+    delete process.env.EXARCHOS_SNAPSHOT_INTERVAL;
+    const snapshotStore = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    const materializer = new ViewMaterializer({ snapshotStore });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    const events50 = Array.from({ length: 50 }, (_, i) =>
+      makeEvent(i + 1, `stream-1`),
+    );
+    materializer.materialize('stream-1', VIEW_NAME, events50);
+    expect(snapshotStore.save).toHaveBeenCalled();
+  });
+
+  it('parseEnvSnapshotInterval_InvalidEnvVar_ReturnsDefault', () => {
+    process.env.EXARCHOS_SNAPSHOT_INTERVAL = 'abc';
+    const snapshotStore = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    const materializer = new ViewMaterializer({ snapshotStore });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    const events50 = Array.from({ length: 50 }, (_, i) =>
+      makeEvent(i + 1, `stream-1`),
+    );
+    materializer.materialize('stream-1', VIEW_NAME, events50);
+    expect(snapshotStore.save).toHaveBeenCalled();
+  });
+
+  it('parseEnvSnapshotInterval_NegativeEnvVar_ReturnsDefault', () => {
+    process.env.EXARCHOS_SNAPSHOT_INTERVAL = '-1';
+    const snapshotStore = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    const materializer = new ViewMaterializer({ snapshotStore });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    const events50 = Array.from({ length: 50 }, (_, i) =>
+      makeEvent(i + 1, `stream-1`),
+    );
+    materializer.materialize('stream-1', VIEW_NAME, events50);
+    expect(snapshotStore.save).toHaveBeenCalled();
+  });
+
+  it('constructor_WithOption_OverridesEnvVar', () => {
+    process.env.EXARCHOS_SNAPSHOT_INTERVAL = '100';
+    const snapshotStore = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    const materializer = new ViewMaterializer({ snapshotStore, snapshotInterval: 30 });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    const events30 = Array.from({ length: 30 }, (_, i) =>
+      makeEvent(i + 1, `stream-1`),
+    );
+    materializer.materialize('stream-1', VIEW_NAME, events30);
+    expect(snapshotStore.save).toHaveBeenCalled();
   });
 });

--- a/servers/exarchos-mcp/src/views/materializer.ts
+++ b/servers/exarchos-mcp/src/views/materializer.ts
@@ -39,6 +39,15 @@ function parseEnvMaxCacheEntries(): number {
   return parsed;
 }
 
+/** Read EXARCHOS_SNAPSHOT_INTERVAL from env, falling back to default on invalid/missing. */
+function parseEnvSnapshotInterval(): number {
+  const raw = process.env.EXARCHOS_SNAPSHOT_INTERVAL;
+  if (raw === undefined) return DEFAULT_SNAPSHOT_INTERVAL;
+  const parsed = parseInt(raw, 10);
+  if (isNaN(parsed) || parsed <= 0) return DEFAULT_SNAPSHOT_INTERVAL;
+  return parsed;
+}
+
 // ─── View Materializer ─────────────────────────────────────────────────────
 
 export class ViewMaterializer {
@@ -54,7 +63,7 @@ export class ViewMaterializer {
 
   constructor(options?: MaterializerOptions) {
     this.snapshotStore = options?.snapshotStore;
-    this.snapshotInterval = options?.snapshotInterval ?? DEFAULT_SNAPSHOT_INTERVAL;
+    this.snapshotInterval = options?.snapshotInterval ?? parseEnvSnapshotInterval();
     this.maxCacheEntries = options?.maxCacheEntries ?? parseEnvMaxCacheEntries();
   }
 

--- a/servers/exarchos-mcp/src/views/snapshot-store.ts
+++ b/servers/exarchos-mcp/src/views/snapshot-store.ts
@@ -21,6 +21,15 @@ function assertSafeId(value: string, label: string): void {
   }
 }
 
+/** Unlink a file, ignoring ENOENT (file-not-found) errors. */
+async function unlinkIfExists(filePath: string): Promise<void> {
+  try {
+    await fs.unlink(filePath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+}
+
 // ─── Snapshot Store ────────────────────────────────────────────────────────
 
 export class SnapshotStore {
@@ -98,5 +107,48 @@ export class SnapshotStore {
     } catch {
       return undefined;
     }
+  }
+
+  /**
+   * Delete a specific snapshot file.
+   * Idempotent: does not throw if the file does not exist.
+   */
+  async delete(streamId: string, viewName: string): Promise<void> {
+    const filePath = this.getSnapshotPath(streamId, viewName);
+    await unlinkIfExists(filePath);
+  }
+
+  /**
+   * Delete ALL snapshots for a given stream.
+   * Uses exact prefix matching (`${streamId}.` with trailing dot) to avoid
+   * false positives (e.g., "my-feature" vs "my-feature-2").
+   * Returns array of deleted file names.
+   */
+  async deleteAllForStream(streamId: string): Promise<string[]> {
+    assertSafeId(streamId, 'streamId');
+
+    const prefix = `${streamId}.`;
+    const suffix = '.snapshot.json';
+    const deleted: string[] = [];
+
+    let files: string[];
+    try {
+      files = await fs.readdir(this.stateDir);
+    } catch {
+      return deleted;
+    }
+
+    const matching = files.filter((f) => f.startsWith(prefix) && f.endsWith(suffix));
+
+    for (const file of matching) {
+      try {
+        await unlinkIfExists(path.join(this.stateDir, file));
+        deleted.push(file);
+      } catch {
+        // Skip files that couldn't be deleted (e.g., permission denied)
+      }
+    }
+
+    return deleted;
   }
 }

--- a/servers/exarchos-mcp/src/workflow/cleanup.ts
+++ b/servers/exarchos-mcp/src/workflow/cleanup.ts
@@ -13,6 +13,7 @@ import { mapInternalToExternalType } from './events.js';
 import { getHSMDefinition, executeTransition } from './state-machine.js';
 import type { EventStore } from '../event-store/store.js';
 import type { EventType } from '../event-store/schemas.js';
+import type { SnapshotStore } from '../views/snapshot-store.js';
 import type { ToolResult } from '../format.js';
 import * as path from 'node:path';
 
@@ -28,10 +29,16 @@ function isEventSourced(state: Record<string, unknown>): boolean {
 // ─── Module-Level EventStore Configuration ──────────────────────────────────
 
 let moduleEventStore: EventStore | null = null;
+let moduleSnapshotStore: SnapshotStore | null = null;
 
 /** Configure the EventStore instance used by cleanup handlers. */
 export function configureCleanupEventStore(store: EventStore | null): void {
   moduleEventStore = store;
+}
+
+/** Configure the SnapshotStore instance used by cleanup handlers. */
+export function configureCleanupSnapshotStore(store: SnapshotStore | null): void {
+  moduleSnapshotStore = store;
 }
 
 // ─── Event-First Emission ───────────────────────────────────────────────────
@@ -374,6 +381,15 @@ export async function handleCleanup(
       input.featureId,
       transitionResult.events,
     );
+  }
+
+  // Clean up derived snapshot files (best-effort — failures do not block cleanup)
+  if (moduleSnapshotStore) {
+    try {
+      await moduleSnapshotStore.deleteAllForStream(input.featureId);
+    } catch {
+      // Snapshot files are derived artifacts; deletion failure is non-critical
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

Adds `EXARCHOS_SNAPSHOT_INTERVAL` env var support for tuning view materialization snapshot frequency, and implements snapshot cleanup on workflow completion to prevent disk bloat from orphaned snapshot files.

## Changes

- **`materializer.ts`** — Add `parseEnvSnapshotInterval()` with precedence: constructor option > env var > default (50)
- **`snapshot-store.ts`** — Add `delete()` (idempotent, catches ENOENT) and `deleteAllForStream()` (exact prefix matching with trailing dot) methods
- **`cleanup.ts`** — Add `configureCleanupSnapshotStore()` wired as best-effort post-completion step
- **`index.ts`** — Register snapshot store with cleanup handler
- **Tests** — 11 new tests covering env var parsing, idempotent delete, prefix matching, and cross-stream isolation

## Test Plan

- [x] Env var: valid, missing, invalid, negative values all handled correctly
- [x] Constructor option overrides env var
- [x] Delete is idempotent (no error on missing file)
- [x] `deleteAllForStream` uses exact prefix (`my-feature.` not matching `my-feature-2.`)
- [x] Cleanup doesn't fail workflow if snapshot deletion errors
- [x] Full suite: 1521 tests pass, 0 failures

---

Addresses #408 P2-1 (configurable interval) and P2-2 (snapshot cleanup).