### PR TITLE
feat: add state.patched event type, _esVersion field, and export deepMerge

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -358,8 +358,8 @@ describe('StackEnqueuedData', () => {
 // ─── EventTypes Discriminated Union (A03) ───────────────────────────────────
 
 describe('EventTypes', () => {
-  it('should contain all 37 event types', () => {
-    expect(EventTypes).toHaveLength(37);
+  it('should contain all 38 event types', () => {
+    expect(EventTypes).toHaveLength(38);
   });
 
   it('should include workflow-level types', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -322,7 +322,23 @@ describe('EventTypes', () => {
   });
 
   it('EventTypes_HasExpectedCount', () => {
-    expect(EventTypes).toHaveLength(37);
+    expect(EventTypes).toHaveLength(38);
+  });
+
+  it('EventTypes_StatePatchedType_IsValidEventType', () => {
+    expect(EventTypes).toContain('state.patched');
+  });
+
+  it('EventTypes_StatePatchedType_ParsesAsBaseEvent', () => {
+    const event = WorkflowEventBase.safeParse({
+      streamId: 'my-workflow',
+      sequence: 1,
+      type: 'state.patched',
+      data: {
+        fields: { 'tasks[0].status': 'complete' },
+      },
+    });
+    expect(event.success).toBe(true);
   });
 
   it('EventTypes_IncludesReviewRouted', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -10,6 +10,7 @@ export const EventTypes = [
   'task.completed',
   'task.failed',
   'gate.executed',
+  'state.patched',
   'stack.position-filled',
   'stack.restacked',
   'stack.enqueued',

--- a/servers/exarchos-mcp/src/workflow/schemas.test.ts
+++ b/servers/exarchos-mcp/src/workflow/schemas.test.ts
@@ -107,6 +107,123 @@ describe('TaskSchema with testingStrategy', () => {
   });
 });
 
+// ─── _esVersion field tests ───────────────────────────────────────────────
+
+describe('WorkflowStateSchema _esVersion field', () => {
+  it('WorkflowStateSchema_EsVersionField_AcceptsVersion2', async () => {
+    const { WorkflowStateSchema } = await import('./schemas.js');
+    const input = {
+      version: '1.1',
+      workflowType: 'feature',
+      featureId: 'test-feature',
+      phase: 'ideate',
+      createdAt: '2026-02-19T00:00:00Z',
+      updatedAt: '2026-02-19T00:00:00Z',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      integration: null,
+      synthesis: {
+        integrationBranch: null,
+        mergeOrder: [],
+        mergedBranches: [],
+        prUrl: null,
+        prFeedback: [],
+      },
+      _esVersion: 2,
+    };
+    const result = WorkflowStateSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data._esVersion).toBe(2);
+    }
+  });
+
+  it('WorkflowStateSchema_EsVersionField_OptionalForLegacy', async () => {
+    const { WorkflowStateSchema } = await import('./schemas.js');
+    const input = {
+      version: '1.1',
+      workflowType: 'feature',
+      featureId: 'test-feature',
+      phase: 'ideate',
+      createdAt: '2026-02-19T00:00:00Z',
+      updatedAt: '2026-02-19T00:00:00Z',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      integration: null,
+      synthesis: {
+        integrationBranch: null,
+        mergeOrder: [],
+        mergedBranches: [],
+        prUrl: null,
+        prFeedback: [],
+      },
+    };
+    const result = WorkflowStateSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data._esVersion).toBeUndefined();
+    }
+  });
+
+  it('WorkflowStateSchema_EsVersionField_RejectsNonInteger', async () => {
+    const { WorkflowStateSchema } = await import('./schemas.js');
+    const input = {
+      version: '1.1',
+      workflowType: 'feature',
+      featureId: 'test-feature',
+      phase: 'ideate',
+      createdAt: '2026-02-19T00:00:00Z',
+      updatedAt: '2026-02-19T00:00:00Z',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      integration: null,
+      synthesis: {
+        integrationBranch: null,
+        mergeOrder: [],
+        mergedBranches: [],
+        prUrl: null,
+        prFeedback: [],
+      },
+      _esVersion: 1.5,
+    };
+    const result = WorkflowStateSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it('WorkflowStateSchema_EsVersionField_RejectsZero', async () => {
+    const { WorkflowStateSchema } = await import('./schemas.js');
+    const input = {
+      version: '1.1',
+      workflowType: 'feature',
+      featureId: 'test-feature',
+      phase: 'ideate',
+      createdAt: '2026-02-19T00:00:00Z',
+      updatedAt: '2026-02-19T00:00:00Z',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      integration: null,
+      synthesis: {
+        integrationBranch: null,
+        mergeOrder: [],
+        mergedBranches: [],
+        prUrl: null,
+        prFeedback: [],
+      },
+      _esVersion: 0,
+    };
+    const result = WorkflowStateSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+});
+
 // T3: WorkflowState integration validation
 describe('WorkflowState integration', () => {
   it('WorkflowState_TasksWithTestingStrategy_Parses', async () => {

--- a/servers/exarchos-mcp/src/workflow/schemas.ts
+++ b/servers/exarchos-mcp/src/workflow/schemas.ts
@@ -207,6 +207,7 @@ const BaseWorkflowStateSchema = z.object({
     passed: z.boolean(),
   }).nullable().default(null),
   synthesis: SynthesisSchema,
+  _esVersion: z.number().int().positive().optional(),
   _version: z.number().int().positive().default(1),
   _history: z.record(z.string(), z.string()).default({}),
   // _events and _eventSequence removed — events now live in external JSONL store

--- a/servers/exarchos-mcp/src/workflow/state-store.test.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { deepMerge, isPlainObject } from './state-store.js';
+
+describe('deepMerge', () => {
+  it('DeepMerge_NestedObjects_MergesRecursively', () => {
+    const target = { a: { b: 1, c: 2 }, d: 3 };
+    const source = { a: { b: 10, e: 5 } };
+
+    const result = deepMerge(target, source);
+
+    expect(result).toEqual({ a: { b: 10, c: 2, e: 5 }, d: 3 });
+  });
+
+  it('DeepMerge_ArrayValues_ReplacesNotMerges', () => {
+    const target = { items: [1, 2, 3] };
+    const source = { items: [4, 5] };
+
+    const result = deepMerge(target, source);
+
+    expect(result).toEqual({ items: [4, 5] });
+  });
+
+  it('DeepMerge_FlatObjects_MergesTopLevel', () => {
+    const target = { a: 1, b: 2 };
+    const source = { b: 3, c: 4 };
+
+    const result = deepMerge(target, source);
+
+    expect(result).toEqual({ a: 1, b: 3, c: 4 });
+  });
+
+  it('DeepMerge_EmptySource_ReturnsTargetCopy', () => {
+    const target = { a: 1, b: { c: 2 } };
+    const source = {};
+
+    const result = deepMerge(target, source);
+
+    expect(result).toEqual({ a: 1, b: { c: 2 } });
+    expect(result).not.toBe(target);
+  });
+
+  it('DeepMerge_DoesNotMutateOriginals', () => {
+    const target = { a: { b: 1 } };
+    const source = { a: { c: 2 } };
+
+    deepMerge(target, source);
+
+    expect(target).toEqual({ a: { b: 1 } });
+    expect(source).toEqual({ a: { c: 2 } });
+  });
+});
+
+describe('isPlainObject', () => {
+  it('IsPlainObject_PlainObject_ReturnsTrue', () => {
+    expect(isPlainObject({ a: 1 })).toBe(true);
+  });
+
+  it('IsPlainObject_EmptyObject_ReturnsTrue', () => {
+    expect(isPlainObject({})).toBe(true);
+  });
+
+  it('IsPlainObject_Array_ReturnsFalse', () => {
+    expect(isPlainObject([1, 2])).toBe(false);
+  });
+
+  it('IsPlainObject_Null_ReturnsFalse', () => {
+    expect(isPlainObject(null)).toBe(false);
+  });
+
+  it('IsPlainObject_String_ReturnsFalse', () => {
+    expect(isPlainObject('hello')).toBe(false);
+  });
+
+  it('IsPlainObject_Number_ReturnsFalse', () => {
+    expect(isPlainObject(42)).toBe(false);
+  });
+
+  it('IsPlainObject_Undefined_ReturnsFalse', () => {
+    expect(isPlainObject(undefined)).toBe(false);
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/state-store.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.ts
@@ -254,7 +254,7 @@ export async function writeStateFile(
 /**
  * Check if a value is a plain object (not null, not array).
  */
-function isPlainObject(value: unknown): value is Record<string, unknown> {
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
@@ -262,7 +262,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * Deep-merge source into target, returning a new merged object.
  * Arrays are replaced, not merged.
  */
-function deepMerge(
+export function deepMerge(
   target: Record<string, unknown>,
   source: Record<string, unknown>,
 ): Record<string, unknown> {


### PR DESCRIPTION
## Summary

Foundation for event-sourcing purity: adds the `state.patched` event type to the EventTypes enum, introduces `_esVersion` as an optional field in the workflow state schema for version discrimination, and exports `deepMerge`/`isPlainObject` from state-store for use by the projection layer.

## Changes

- **EventTypes enum** — Added `state.patched` to valid event types
- **WorkflowStateSchema** — Added `_esVersion` as optional positive integer field
- **state-store exports** — Exported `deepMerge` and `isPlainObject` for reuse by WorkflowStateProjection

## Test Plan

- [x] Unit tests for `state.patched` in EventTypes validation
- [x] Unit tests for `_esVersion` schema acceptance
- [x] Unit tests for `deepMerge` recursive merge and array replacement behavior
- [x] All 266 tests passing

---

Part 1/8 of event-sourcing purity (#475).
Design: `docs/designs/2026-02-19-event-sourcing-purity.md`