### PR TITLE
feat: set _esVersion 2 on new workflows and add isEventSourced helper

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -14,6 +14,8 @@ import {
   handleCancel,
   handleCheckpoint,
   configureWorkflowEventStore,
+  isEventSourced,
+  CURRENT_ES_VERSION,
 } from '../../workflow/tools.js';
 import { initStateFile, readStateFile, writeStateFile, VersionConflictError } from '../../workflow/state-store.js';
 import { EventStore } from '../../event-store/store.js';
@@ -3033,5 +3035,58 @@ describe('HandleSet CAS Diagnostic', () => {
     expect(casFailedData.retries).toBeDefined();
 
     writeSpy.mockRestore();
+  });
+});
+
+// ─── _esVersion on handleInit and isEventSourced helper ──────────────────────
+
+describe('HandleInit_NewWorkflow_SetsEsVersion2', () => {
+  it('should set _esVersion to 2 on newly created workflows', async () => {
+    await handleInit({ featureId: 'esv-test', workflowType: 'feature' }, tmpDir);
+
+    const state = await readStateFile(path.join(tmpDir, 'esv-test.state.json'));
+    const stateRecord = state as unknown as Record<string, unknown>;
+    expect(stateRecord._esVersion).toBe(2);
+  });
+});
+
+describe('HandleInit_NewWorkflow_PreservesExistingFields', () => {
+  it('should preserve all standard init fields alongside _esVersion', async () => {
+    await handleInit({ featureId: 'esv-fields', workflowType: 'debug' }, tmpDir);
+
+    const state = await readStateFile(path.join(tmpDir, 'esv-fields.state.json'));
+    const stateRecord = state as unknown as Record<string, unknown>;
+
+    // Core fields still present
+    expect(state.featureId).toBe('esv-fields');
+    expect(state.workflowType).toBe('debug');
+    expect(state.phase).toBe('triage');
+    expect(state.tasks).toEqual([]);
+    expect(state.createdAt).toBeDefined();
+    expect(state.updatedAt).toBeDefined();
+
+    // _esVersion is also present
+    expect(stateRecord._esVersion).toBe(2);
+  });
+});
+
+describe('IsEventSourced_Version2_ReturnsTrue', () => {
+  it('should return true when state has _esVersion equal to CURRENT_ES_VERSION', () => {
+    const state = { _esVersion: CURRENT_ES_VERSION } as Record<string, unknown>;
+    expect(isEventSourced(state)).toBe(true);
+  });
+});
+
+describe('IsEventSourced_NoVersion_ReturnsFalse', () => {
+  it('should return false when state has no _esVersion field', () => {
+    const state = {} as Record<string, unknown>;
+    expect(isEventSourced(state)).toBe(false);
+  });
+});
+
+describe('IsEventSourced_Version1_ReturnsFalse', () => {
+  it('should return false when state has _esVersion of 1', () => {
+    const state = { _esVersion: 1 } as Record<string, unknown>;
+    expect(isEventSourced(state)).toBe(false);
   });
 });

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -67,6 +67,15 @@ function stripInternalFields(state: Record<string, unknown>): Record<string, unk
   return stripped;
 }
 
+// ─── Event-Sourcing Version Discriminator ───────────────────────────────────
+
+export const CURRENT_ES_VERSION = 2;
+
+/** Check whether a workflow state uses the pure event-sourcing path. */
+export function isEventSourced(state: Record<string, unknown>): boolean {
+  return state._esVersion === CURRENT_ES_VERSION;
+}
+
 // ─── handleInit ─────────────────────────────────────────────────────────────
 
 /**
@@ -133,7 +142,7 @@ export async function handleInit(
       stateDir,
       input.featureId,
       input.workflowType,
-      { _eventSequence: eventSequence },
+      { _eventSequence: eventSequence, _esVersion: CURRENT_ES_VERSION },
     );
 
     return {


### PR DESCRIPTION
## Summary

Sets `_esVersion: 2` on all newly initialized workflows, enabling the version discriminator that controls whether handlers use the event-sourced path or legacy state-file path. Adds the `isEventSourced()` helper used by handleGet, handleSet, and handleCleanup.

## Changes

- **handleInit** — Passes `_esVersion: 2` to `initStateFile()` for new workflows
- **isEventSourced helper** — Checks `_esVersion === CURRENT_ES_VERSION` for path discrimination

## Test Plan

- [x] Unit test: new workflows have `_esVersion: 2`
- [x] Unit test: `isEventSourced()` returns true for v2, false for v1/missing
- [x] All 266 tests passing

---

Part 3/8 of event-sourcing purity (#475).