### PR TITLE
feat: rewrite handleGet with CQRS read path for ES v2 workflows

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -14,11 +14,14 @@ import {
   handleCancel,
   handleCheckpoint,
   configureWorkflowEventStore,
+  configureWorkflowMaterializer,
   isEventSourced,
   CURRENT_ES_VERSION,
 } from '../../workflow/tools.js';
 import { initStateFile, readStateFile, writeStateFile, VersionConflictError } from '../../workflow/state-store.js';
 import { EventStore } from '../../event-store/store.js';
+import { ViewMaterializer } from '../../views/materializer.js';
+import { workflowStateProjection, WORKFLOW_STATE_VIEW } from '../../views/workflow-state-projection.js';
 import { configureQueryEventStore, reconcileTasks } from '../../workflow/query.js';
 import { configureNextActionEventStore } from '../../workflow/next-action.js';
 import type { WorkflowState } from '../../workflow/types.js';
@@ -31,6 +34,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   configureWorkflowEventStore(null);
+  configureWorkflowMaterializer(null);
   configureQueryEventStore(null);
   configureNextActionEventStore(null);
   await fs.rm(tmpDir, { recursive: true, force: true });
@@ -3088,5 +3092,126 @@ describe('IsEventSourced_Version1_ReturnsFalse', () => {
   it('should return false when state has _esVersion of 1', () => {
     const state = { _esVersion: 1 } as Record<string, unknown>;
     expect(isEventSourced(state)).toBe(false);
+  });
+});
+
+// ─── CQRS Read Path: handleGet with Event-Sourced Materialization ────────────
+
+describe('HandleGet_EsVersion2_MaterializesFromEvents', () => {
+  it('should materialize state from events for v2 workflows, not from state file', async () => {
+    // Arrange: Create an event store and materializer, configure both
+    const eventStore = new EventStore(tmpDir);
+    configureWorkflowEventStore(eventStore);
+    const materializer = new ViewMaterializer();
+    materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
+    configureWorkflowMaterializer(materializer);
+
+    // Init creates a v2 workflow (sets _esVersion: 2, emits workflow.started event)
+    await handleInit({ featureId: 'es-get-v2', workflowType: 'feature' }, tmpDir);
+
+    // Now tamper with the state file to set a different phase.
+    // If handleGet reads from events, it should return 'ideate' (from the workflow.started event).
+    // If handleGet reads from the state file, it will return 'plan' (the tampered value).
+    const stateFile = path.join(tmpDir, 'es-get-v2.state.json');
+    const rawState = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+    rawState.phase = 'plan'; // Tamper the phase
+    await fs.writeFile(stateFile, JSON.stringify(rawState));
+
+    // Act: Call handleGet — should materialize from events, not from file
+    const result = await handleGet({ featureId: 'es-get-v2' }, tmpDir);
+
+    // Assert: Phase should be 'ideate' (from event materialization), NOT 'plan' (from tampered file)
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase).toBe('ideate');
+    expect(data.featureId).toBe('es-get-v2');
+    expect(data.workflowType).toBe('feature');
+  });
+});
+
+describe('HandleGet_EsVersion1_ReadsStateFileDirectly', () => {
+  it('should read from state file for legacy v1 workflows without _esVersion', async () => {
+    // Arrange: Create a workflow without event store (no _esVersion set — legacy path)
+    configureWorkflowEventStore(null);
+    await handleInit({ featureId: 'legacy-get', workflowType: 'debug' }, tmpDir);
+
+    // Verify it has no _esVersion (or at least not v2) — since no event store is configured,
+    // handleInit still writes _esVersion:2 but _eventSequence:0. However, when moduleEventStore
+    // is null during init, it still sets _esVersion:2.
+    // Let's manually create a truly legacy state file instead.
+    const stateFile = path.join(tmpDir, 'legacy-v1.state.json');
+    const legacyState = {
+      version: '1.1',
+      featureId: 'legacy-v1',
+      workflowType: 'debug',
+      phase: 'triage',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      integration: null,
+      synthesis: {
+        integrationBranch: null,
+        mergeOrder: [],
+        mergedBranches: [],
+        prUrl: null,
+        prFeedback: [],
+      },
+      _version: 1,
+      _history: {},
+      _checkpoint: {
+        timestamp: new Date().toISOString(),
+        phase: 'triage',
+        summary: '',
+        operationsSince: 0,
+        fixCycleCount: 0,
+        lastActivityTimestamp: new Date().toISOString(),
+        staleAfterMinutes: 120,
+      },
+      // Note: no _esVersion — legacy workflow
+    };
+    await fs.writeFile(stateFile, JSON.stringify(legacyState));
+
+    // Act: Call handleGet on legacy workflow
+    const result = await handleGet({ featureId: 'legacy-v1' }, tmpDir);
+
+    // Assert: Should read directly from state file (legacy path)
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase).toBe('triage');
+    expect(data.featureId).toBe('legacy-v1');
+    expect(data.workflowType).toBe('debug');
+  });
+});
+
+describe('HandleGet_EsVersion2_FieldProjection_Works', () => {
+  it('should project only requested fields when materializing from events', async () => {
+    // Arrange: Create a v2 workflow with event store and materializer
+    const eventStore = new EventStore(tmpDir);
+    configureWorkflowEventStore(eventStore);
+    const materializer = new ViewMaterializer();
+    materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
+    configureWorkflowMaterializer(materializer);
+
+    await handleInit({ featureId: 'es-fields', workflowType: 'feature' }, tmpDir);
+
+    // Act: Call handleGet with field projection
+    const result = await handleGet(
+      { featureId: 'es-fields', fields: ['phase', 'featureId'] },
+      tmpDir,
+    );
+
+    // Assert: Only the requested fields should be returned
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase).toBe('ideate');
+    expect(data.featureId).toBe('es-fields');
+
+    // Should NOT contain other fields
+    expect(data.workflowType).toBeUndefined();
+    expect(data.tasks).toBeUndefined();
+    expect(data.createdAt).toBeUndefined();
   });
 });

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -29,6 +29,8 @@ import { getHSMDefinition, executeTransition } from './state-machine.js';
 import { formatResult, type ToolResult } from '../format.js';
 import * as fs from 'node:fs/promises';
 import type { EventStore } from '../event-store/store.js';
+import type { ViewMaterializer } from '../views/materializer.js';
+import { WORKFLOW_STATE_VIEW, type WorkflowStateView } from '../views/workflow-state-projection.js';
 import * as path from 'node:path';
 
 // ─── Module-Level EventStore Configuration ──────────────────────────────────
@@ -38,6 +40,15 @@ let moduleEventStore: EventStore | null = null;
 /** Configure the EventStore instance used by workflow tool handlers. */
 export function configureWorkflowEventStore(store: EventStore | null): void {
   moduleEventStore = store;
+}
+
+// ─── Module-Level ViewMaterializer Configuration ─────────────────────────────
+
+let moduleViewMaterializer: ViewMaterializer | null = null;
+
+/** Configure the ViewMaterializer instance used by handleGet for ES v2 workflows. */
+export function configureWorkflowMaterializer(materializer: ViewMaterializer | null): void {
+  moduleViewMaterializer = materializer;
 }
 
 // Re-export from dedicated modules for backward compatibility
@@ -198,7 +209,9 @@ export async function handleGet(
 ): Promise<ToolResult> {
   const stateFile = path.join(stateDir, `${input.featureId}.state.json`);
 
-  // Fast path for simple top-level scalar queries — skips Zod validation
+  // Fast path for simple top-level scalar queries — skips Zod validation.
+  // The state file is kept in sync for v2 workflows, so fast path is safe
+  // for both legacy and ES v2 workflows.
   if (input.query && FAST_PATH_FIELDS.has(input.query)) {
     try {
       const { value, checkpoint } = await readFieldFast(stateFile, input.query);
@@ -215,6 +228,7 @@ export async function handleGet(
     }
   }
 
+  // Read state file — needed for version check and as fallback for legacy path
   let state: WorkflowState;
   try {
     state = await readStateFile(stateFile);
@@ -231,14 +245,63 @@ export async function handleGet(
     throw err;
   }
 
-  const meta = buildCheckpointMeta(state._checkpoint);
+  // Version discriminator: ES v2 workflows materialize from events
+  const useEventSource = isEventSourced(state as unknown as Record<string, unknown>)
+    && moduleEventStore !== null
+    && moduleViewMaterializer !== null;
 
-  // Fields projection: return only requested fields (skips internal fields)
+  if (useEventSource) {
+    return handleGetFromEvents(input, state);
+  }
+
+  // Legacy path: read directly from state file
+  return handleGetFromStateFile(input, state);
+}
+
+/**
+ * ES v2 read path: materialize state from events via ViewMaterializer.
+ */
+async function handleGetFromEvents(
+  input: GetInput,
+  fileState: WorkflowState,
+): Promise<ToolResult> {
+  const events = await moduleEventStore!.query(input.featureId);
+  const materialized = moduleViewMaterializer!.materialize<WorkflowStateView>(
+    input.featureId,
+    WORKFLOW_STATE_VIEW,
+    events,
+  );
+
+  const materializedRecord = materialized as unknown as Record<string, unknown>;
+  // Checkpoint meta comes from state file (not materialized) since it's the
+  // authoritative source for checkpoint tracking.
+  const meta = buildCheckpointMeta(fileState._checkpoint);
+  return projectState(input, materializedRecord, meta);
+}
+
+/**
+ * Legacy read path: read directly from state file (v1 workflows or missing dependencies).
+ */
+function handleGetFromStateFile(
+  input: GetInput,
+  state: WorkflowState,
+): ToolResult {
+  const meta = buildCheckpointMeta(state._checkpoint);
+  return projectState(input, state as unknown as Record<string, unknown>, meta);
+}
+
+/**
+ * Shared projection logic: apply field projection, strip internals, or resolve dot-path query.
+ */
+function projectState(
+  input: GetInput,
+  stateObj: Record<string, unknown>,
+  meta: ReturnType<typeof buildCheckpointMeta>,
+): ToolResult {
+  // Fields projection
   if (input.fields && !input.query) {
-    const stateObj = state as unknown as Record<string, unknown>;
     const projected: Record<string, unknown> = {};
     for (const field of input.fields) {
-      // Skip internal fields
       if (field.startsWith('_')) continue;
       const value = resolveDotPath(stateObj, field);
       if (value !== undefined) {
@@ -248,8 +311,9 @@ export async function handleGet(
     return { success: true, data: projected, _meta: meta };
   }
 
+  // Full state (no query, no fields)
   if (!input.query) {
-    const strippedState = stripInternalFields(state as unknown as Record<string, unknown>);
+    const strippedState = stripInternalFields(stateObj);
     return {
       success: true,
       data: strippedState,
@@ -257,8 +321,8 @@ export async function handleGet(
     };
   }
 
-  // Resolve dot-path query against the state object
-  const value = resolveDotPath(state as unknown as Record<string, unknown>, input.query);
+  // Dot-path query
+  const value = resolveDotPath(stateObj, input.query);
   return {
     success: true,
     data: value,


### PR DESCRIPTION
## Summary

Rewrites handleGet() with a version discriminator that routes v2 workflows through event materialization (CQRS read path) while preserving the legacy state-file path for v1 workflows. Addresses ARCH-2 finding.

## Changes

- **handleGet** — Version discriminator routes to `handleGetFromEvents()` (v2) or `handleGetFromStateFile()` (v1)
- **ES read path** — Loads events via EventStore, materializes via ViewMaterializer, strips internal fields, applies field projection
- **Legacy path** — Unchanged behavior for v1 workflows

## Test Plan

- [x] Unit test: v2 workflows materialize from events
- [x] Unit test: v1 workflows read state file directly
- [x] Unit test: field projection works on materialized state
- [x] All 266 tests passing

---

Part 5/8 of event-sourcing purity (#475).