### PR TITLE
test: add event-sourcing purity integration tests

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/integration/event-sourcing-purity.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/integration/event-sourcing-purity.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  handleInit,
+  handleGet,
+  handleSet,
+  configureWorkflowEventStore,
+  configureWorkflowMaterializer,
+} from '../../workflow/tools.js';
+import { handleCleanup, configureCleanupEventStore } from '../../workflow/cleanup.js';
+import { EventStore } from '../../event-store/store.js';
+import { ViewMaterializer } from '../../views/materializer.js';
+import {
+  workflowStateProjection,
+  WORKFLOW_STATE_VIEW,
+} from '../../views/workflow-state-projection.js';
+import type { WorkflowStateView } from '../../views/workflow-state-projection.js';
+
+describe('Event-Sourcing Purity Integration', () => {
+  let stateDir: string;
+  let eventStore: EventStore;
+  let materializer: ViewMaterializer;
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'es-purity-'));
+    eventStore = new EventStore(stateDir);
+    materializer = new ViewMaterializer();
+    materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
+    configureWorkflowEventStore(eventStore);
+    configureCleanupEventStore(eventStore);
+    configureWorkflowMaterializer(materializer);
+  });
+
+  afterEach(async () => {
+    configureWorkflowEventStore(null);
+    configureCleanupEventStore(null);
+    configureWorkflowMaterializer(null);
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  /** Read the raw state JSON from disk, bypassing Zod validation. */
+  async function readRawState(featureId: string): Promise<Record<string, unknown>> {
+    const stateFile = path.join(stateDir, `${featureId}.state.json`);
+    return JSON.parse(await fs.readFile(stateFile, 'utf-8')) as Record<string, unknown>;
+  }
+
+  /** Write raw state JSON to disk, bypassing Zod validation. */
+  async function writeRawState(
+    featureId: string,
+    state: Record<string, unknown>,
+  ): Promise<void> {
+    const stateFile = path.join(stateDir, `${featureId}.state.json`);
+    await fs.writeFile(stateFile, JSON.stringify(state, null, 2), 'utf-8');
+  }
+
+  // ─── 1. FullLifecycle_InitSetTransitionCleanup_StateRebuildsFromEvents ────
+
+  describe('FullLifecycle_InitSetTransitionCleanup_StateRebuildsFromEvents', () => {
+    it('should rebuild complete state from events after state file deletion', async () => {
+      const featureId = 'es-lifecycle';
+
+      // Step 1: Init a v2 workflow
+      const initResult = await handleInit(
+        { featureId, workflowType: 'feature' },
+        stateDir,
+      );
+      expect(initResult.success).toBe(true);
+
+      // Verify it's a v2 workflow
+      const rawAfterInit = await readRawState(featureId);
+      expect(rawAfterInit._esVersion).toBe(2);
+
+      // Step 2: Add tasks array with 3 tasks
+      await handleSet(
+        {
+          featureId,
+          updates: {
+            'tasks[0]': { id: 'task-1', title: 'Task 1', status: 'pending', branch: 'feat/task-1' },
+            'tasks[1]': { id: 'task-2', title: 'Task 2', status: 'pending', branch: 'feat/task-2' },
+            'tasks[2]': { id: 'task-3', title: 'Task 3', status: 'pending', branch: 'feat/task-3' },
+          },
+        },
+        stateDir,
+      );
+
+      // Step 3: Set design artifact + transition to plan
+      await handleSet(
+        { featureId, updates: { 'artifacts.design': 'docs/design.md' } },
+        stateDir,
+      );
+      const toPlan = await handleSet(
+        { featureId, phase: 'plan' },
+        stateDir,
+      );
+      expect(toPlan.success).toBe(true);
+      expect((toPlan.data as Record<string, unknown>).phase).toBe('plan');
+
+      // Set plan artifact + transition to plan-review
+      await handleSet(
+        { featureId, updates: { 'artifacts.plan': 'docs/plan.md' } },
+        stateDir,
+      );
+      const toPlanReview = await handleSet(
+        { featureId, phase: 'plan-review' },
+        stateDir,
+      );
+      expect(toPlanReview.success).toBe(true);
+      expect((toPlanReview.data as Record<string, unknown>).phase).toBe('plan-review');
+
+      // Step 4: Transition plan-review -> delegate (needs planReview.approved = true)
+      await handleSet(
+        { featureId, updates: { planReview: { approved: true } } },
+        stateDir,
+      );
+      const toDelegate = await handleSet(
+        { featureId, phase: 'delegate' },
+        stateDir,
+      );
+      expect(toDelegate.success).toBe(true);
+      expect((toDelegate.data as Record<string, unknown>).phase).toBe('delegate');
+
+      // Step 5: Update task statuses to complete
+      await handleSet(
+        {
+          featureId,
+          updates: {
+            'tasks[0]': { id: 'task-1', title: 'Task 1', status: 'complete', branch: 'feat/task-1' },
+            'tasks[1]': { id: 'task-2', title: 'Task 2', status: 'complete', branch: 'feat/task-2' },
+            'tasks[2]': { id: 'task-3', title: 'Task 3', status: 'complete', branch: 'feat/task-3' },
+          },
+        },
+        stateDir,
+      );
+
+      // Transition delegate -> review (requires all tasks complete)
+      const toReview = await handleSet(
+        { featureId, phase: 'review' },
+        stateDir,
+      );
+      expect(toReview.success).toBe(true);
+      expect((toReview.data as Record<string, unknown>).phase).toBe('review');
+
+      // Set reviews as passing + transition to synthesize
+      await handleSet(
+        {
+          featureId,
+          updates: { 'reviews.quality': { passed: true, reviewer: 'bot' } },
+        },
+        stateDir,
+      );
+      const toSynthesize = await handleSet(
+        { featureId, phase: 'synthesize' },
+        stateDir,
+      );
+      expect(toSynthesize.success).toBe(true);
+      expect((toSynthesize.data as Record<string, unknown>).phase).toBe('synthesize');
+
+      // Step 7: handleCleanup to completed
+      const cleanupResult = await handleCleanup(
+        {
+          featureId,
+          mergeVerified: true,
+          prUrl: 'https://github.com/org/repo/pull/42',
+          mergedBranches: ['feat/task-1', 'feat/task-2', 'feat/task-3'],
+        },
+        stateDir,
+      );
+      expect(cleanupResult.success).toBe(true);
+      expect((cleanupResult.data as Record<string, unknown>).phase).toBe('completed');
+
+      // Step 8: Verify final state is 'completed' via handleGet
+      // Note: handleGet for v2 workflows materializes from events.
+      // The projection handles workflow.transition events which include
+      // the synthesize->completed transition emitted by cleanup.
+      const finalGet = await handleGet({ featureId }, stateDir);
+      expect(finalGet.success).toBe(true);
+      const finalState = finalGet.data as Record<string, unknown>;
+      expect(finalState.phase).toBe('completed');
+
+      // Step 9: DELETE the .state.json file
+      const stateFile = path.join(stateDir, `${featureId}.state.json`);
+      await fs.unlink(stateFile);
+
+      // Confirm file is gone
+      await expect(fs.access(stateFile)).rejects.toThrow();
+
+      // Step 10: Re-materialize from events
+      const allEvents = await eventStore.query(featureId);
+      expect(allEvents.length).toBeGreaterThan(0);
+
+      // Create a fresh materializer (no cached state)
+      const freshMaterializer = new ViewMaterializer();
+      freshMaterializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
+
+      const rebuilt = freshMaterializer.materialize<WorkflowStateView>(
+        featureId,
+        WORKFLOW_STATE_VIEW,
+        allEvents,
+      );
+
+      // Step 11: Verify the re-materialized state
+      expect(rebuilt.featureId).toBe(featureId);
+      expect(rebuilt.workflowType).toBe('feature');
+      expect(rebuilt.phase).toBe('completed');
+
+      // Tasks: should have been set via state.patched events
+      expect(rebuilt.tasks).toHaveLength(3);
+      expect(rebuilt.tasks[0].status).toBe('complete');
+      expect(rebuilt.tasks[1].status).toBe('complete');
+      expect(rebuilt.tasks[2].status).toBe('complete');
+
+      // Synthesis: prUrl and mergedBranches from cleanup's state.patched
+      expect(rebuilt.synthesis.prUrl).toBe('https://github.com/org/repo/pull/42');
+      expect(rebuilt.synthesis.mergedBranches).toEqual([
+        'feat/task-1',
+        'feat/task-2',
+        'feat/task-3',
+      ]);
+
+      // Artifacts: plan should be set from state.patched events
+      expect(rebuilt.artifacts.plan).toBe('docs/plan.md');
+      expect(rebuilt.artifacts.design).toBe('docs/design.md');
+    });
+  });
+
+  // ─── 2. SnapshotRecovery_DeleteSnapshot_FullReplayProducesCorrectState ────
+
+  describe('SnapshotRecovery_DeleteSnapshot_FullReplayProducesCorrectState', () => {
+    it('should produce correct state via full replay after snapshot deletion', async () => {
+      const featureId = 'es-snapshot';
+
+      // Step 1: Init a v2 workflow
+      const initResult = await handleInit(
+        { featureId, workflowType: 'feature' },
+        stateDir,
+      );
+      expect(initResult.success).toBe(true);
+
+      // Step 2: Several handleSet operations (field updates + transitions)
+      await handleSet(
+        { featureId, updates: { 'artifacts.design': 'docs/design.md' } },
+        stateDir,
+      );
+      await handleSet(
+        {
+          featureId,
+          updates: {
+            'tasks[0]': { id: 't-1', title: 'Task A', status: 'pending', branch: 'feat/a' },
+            'tasks[1]': { id: 't-2', title: 'Task B', status: 'pending', branch: 'feat/b' },
+          },
+        },
+        stateDir,
+      );
+      await handleSet(
+        { featureId, phase: 'plan' },
+        stateDir,
+      );
+      await handleSet(
+        { featureId, updates: { 'artifacts.plan': 'docs/plan.md' } },
+        stateDir,
+      );
+
+      // Step 3: Materialize and confirm the snapshot state file
+      const getBeforeDelete = await handleGet({ featureId }, stateDir);
+      expect(getBeforeDelete.success).toBe(true);
+      const stateBeforeDelete = getBeforeDelete.data as Record<string, unknown>;
+
+      // Read the raw state file to confirm it has materialized content
+      const stateFile = path.join(stateDir, `${featureId}.state.json`);
+      const rawSnapshot = await readRawState(featureId);
+      expect(rawSnapshot._esVersion).toBe(2);
+      expect(rawSnapshot.phase).toBe('plan');
+
+      // Step 4: Delete the snapshot file
+      await fs.unlink(stateFile);
+      await expect(fs.access(stateFile)).rejects.toThrow();
+
+      // Step 5: Re-materialize from full event replay
+      const allEvents = await eventStore.query(featureId);
+      expect(allEvents.length).toBeGreaterThan(0);
+
+      const freshMaterializer = new ViewMaterializer();
+      freshMaterializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
+
+      const rebuilt = freshMaterializer.materialize<WorkflowStateView>(
+        featureId,
+        WORKFLOW_STATE_VIEW,
+        allEvents,
+      );
+
+      // Step 6: Verify state matches what it was before deletion
+      expect(rebuilt.featureId).toBe(featureId);
+      expect(rebuilt.workflowType).toBe('feature');
+      expect(rebuilt.phase).toBe('plan');
+
+      // Field projections from state.patched events
+      expect(rebuilt.artifacts.design).toBe('docs/design.md');
+      expect(rebuilt.artifacts.plan).toBe('docs/plan.md');
+      expect(rebuilt.tasks).toHaveLength(2);
+      expect(rebuilt.tasks[0].id).toBe('t-1');
+      expect(rebuilt.tasks[1].id).toBe('t-2');
+
+      // Verify it matches the original data (non-metadata fields)
+      expect(rebuilt.phase).toBe(stateBeforeDelete.phase);
+      expect(rebuilt.featureId).toBe((stateBeforeDelete as Record<string, unknown>).featureId);
+      expect(rebuilt.workflowType).toBe(
+        (stateBeforeDelete as Record<string, unknown>).workflowType,
+      );
+    });
+  });
+
+  // ─── 3. LegacyWorkflow_EsVersion1_UsesLegacyPath ─────────────────────────
+
+  describe('LegacyWorkflow_EsVersion1_UsesLegacyPath', () => {
+    it('should use legacy path for v1 workflows with no event emission', async () => {
+      const featureId = 'es-legacy';
+
+      // Step 1: Create a workflow by manually writing a state file WITHOUT _esVersion
+      const now = new Date().toISOString();
+      const legacyState = {
+        version: '1.1',
+        featureId,
+        workflowType: 'feature',
+        phase: 'ideate',
+        createdAt: now,
+        updatedAt: now,
+        artifacts: { design: null, plan: null, pr: null },
+        tasks: [],
+        worktrees: {},
+        reviews: {},
+        synthesis: {
+          integrationBranch: null,
+          mergeOrder: [],
+          mergedBranches: [],
+          prUrl: null,
+          prFeedback: [],
+        },
+        planReview: { approved: false },
+        _version: 1,
+        _history: {},
+        _checkpoint: {
+          timestamp: now,
+          phase: 'ideate',
+          summary: 'Workflow initialized',
+          operationsSince: 0,
+          fixCycleCount: 0,
+          lastActivityTimestamp: now,
+          staleAfterMinutes: 120,
+        },
+        _eventSequence: 0,
+      };
+
+      await writeRawState(featureId, legacyState);
+
+      // Step 2: Call handleGet -- verify it reads from state file (legacy path)
+      const getResult = await handleGet({ featureId }, stateDir);
+      expect(getResult.success).toBe(true);
+      const stateData = getResult.data as Record<string, unknown>;
+      expect(stateData.phase).toBe('ideate');
+      expect(stateData.featureId).toBe(featureId);
+
+      // Step 3: Call handleSet with field updates
+      const setResult = await handleSet(
+        { featureId, updates: { 'artifacts.design': 'docs/legacy-design.md' } },
+        stateDir,
+      );
+      expect(setResult.success).toBe(true);
+
+      // Step 4: Verify NO state.patched events were emitted
+      const events = await eventStore.query(featureId);
+      const patchedEvents = events.filter((e) => e.type === 'state.patched');
+      expect(patchedEvents).toHaveLength(0);
+
+      // Step 5: Verify the state file was updated directly
+      const rawAfterSet = await readRawState(featureId);
+      const artifacts = rawAfterSet.artifacts as Record<string, unknown>;
+      expect(artifacts.design).toBe('docs/legacy-design.md');
+
+      // Also do a phase transition to verify no transition events for the field update
+      await handleSet(
+        { featureId, phase: 'plan' },
+        stateDir,
+      );
+
+      // For v1 legacy, transitions DO still emit events to the external store
+      // (best-effort after state write), but state.patched should still be 0
+      const allEvents = await eventStore.query(featureId);
+      const statePatchedEvents = allEvents.filter((e) => e.type === 'state.patched');
+      expect(statePatchedEvents).toHaveLength(0);
+
+      // Verify the state file reflects the transition
+      const rawAfterTransition = await readRawState(featureId);
+      expect(rawAfterTransition.phase).toBe('plan');
+
+      // Confirm no _esVersion on this workflow
+      expect(rawAfterTransition._esVersion).toBeUndefined();
+    });
+  });
+});

--- a/servers/exarchos-mcp/src/__tests__/workflow/cleanup.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/cleanup.test.ts
@@ -3,9 +3,10 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { handleCleanup, configureCleanupEventStore } from '../../workflow/cleanup.js';
-import { handleInit } from '../../workflow/tools.js';
+import { handleInit, configureWorkflowEventStore } from '../../workflow/tools.js';
 import { handleWorkflow } from '../../workflow/composite.js';
-import type { EventStore } from '../../event-store/store.js';
+import { EventStore } from '../../event-store/store.js';
+import type { EventStore as EventStoreType } from '../../event-store/store.js';
 
 let tmpDir: string;
 
@@ -202,12 +203,12 @@ describe('handleCleanup', () => {
         append: vi.fn().mockResolvedValue({
           sequence: 1,
           timestamp: new Date().toISOString(),
-          type: 'workflow.transition',
+          type: 'workflow.cleanup',
           streamId: 'cleanup-event-test',
           schemaVersion: '1.0',
         }),
         query: vi.fn().mockResolvedValue([]),
-      } as unknown as EventStore;
+      } as unknown as EventStoreType;
 
       configureCleanupEventStore(mockEventStore);
 
@@ -222,23 +223,28 @@ describe('handleCleanup', () => {
       }, tmpDir);
 
       expect(result.success).toBe(true);
+      // v2 event-first: append is called with idempotency key (3rd arg)
       expect(mockEventStore.append).toHaveBeenCalledWith(
         'cleanup-event-test',
         expect.objectContaining({
+          type: 'workflow.cleanup',
           data: expect.objectContaining({
             featureId: 'cleanup-event-test',
           }),
+        }),
+        expect.objectContaining({
+          idempotencyKey: expect.stringContaining('cleanup-event-test:cleanup:'),
         }),
       );
 
       configureCleanupEventStore(null);
     });
 
-    it('should not break cleanup when event store append fails', async () => {
+    it('should abort cleanup when event store append fails (v2 event-first)', async () => {
       const mockEventStore = {
         append: vi.fn().mockRejectedValue(new Error('store error')),
         query: vi.fn().mockResolvedValue([]),
-      } as unknown as EventStore;
+      } as unknown as EventStoreType;
 
       configureCleanupEventStore(mockEventStore);
 
@@ -252,8 +258,14 @@ describe('handleCleanup', () => {
         mergeVerified: true,
       }, tmpDir);
 
-      expect(result.success).toBe(true);
-      expect((result.data as Record<string, unknown>)?.phase).toBe('completed');
+      // v2 event-first: event failure aborts cleanup
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('EVENT_APPEND_FAILED');
+      expect(result.error?.message).toContain('store error');
+
+      // State should NOT have been written
+      const state = await readRawState('cleanup-store-fail');
+      expect(state.phase).toBe('review');
 
       configureCleanupEventStore(null);
     });
@@ -272,6 +284,219 @@ describe('handleCleanup', () => {
       // Should fail with GUARD_FAILED (not UNKNOWN_ACTION)
       expect(result.success).toBe(false);
       expect(result.error?.code).toBe('GUARD_FAILED');
+    });
+  });
+
+  describe('ES v2 event-first cleanup', () => {
+    let eventStore: EventStore;
+
+    beforeEach(() => {
+      eventStore = new EventStore(tmpDir);
+      configureWorkflowEventStore(eventStore);
+      configureCleanupEventStore(eventStore);
+    });
+
+    afterEach(() => {
+      configureWorkflowEventStore(null);
+      configureCleanupEventStore(null);
+    });
+
+    it('HandleCleanup_EsVersion2_EmitsEventsBeforeStateWrite', async () => {
+      // Arrange — init creates v2 workflow with event store configured
+      await handleInit({ featureId: 'v2-event-order', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('v2-event-order');
+      raw.phase = 'synthesize';
+      await writeRawState('v2-event-order', raw);
+
+      // Act
+      const result = await handleCleanup({
+        featureId: 'v2-event-order',
+        mergeVerified: true,
+        prUrl: 'https://github.com/test/pr/42',
+        mergedBranches: ['feature/task-1'],
+      }, tmpDir);
+
+      // Assert — cleanup succeeded
+      expect(result.success).toBe(true);
+
+      // Query event stream for cleanup-related events
+      // Note: HSM emits 'cleanup' type events which map to 'workflow.cleanup'
+      // So we look for workflow.cleanup (transition + explicit cleanup event)
+      const allEvents = await eventStore.query('v2-event-order');
+      const cleanupEvents = allEvents.filter(e => e.type === 'workflow.cleanup');
+      const patchEvents = allEvents.filter(e => e.type === 'state.patched');
+
+      // Verify cleanup events exist (HSM transition event + explicit cleanup event = 2)
+      expect(cleanupEvents.length).toBeGreaterThanOrEqual(2);
+      expect(patchEvents.length).toBeGreaterThanOrEqual(1);
+
+      // Verify state was written (event-first means events are committed,
+      // then state is written as follow-up materialization)
+      const state = await readRawState('v2-event-order');
+      expect(state.phase).toBe('completed');
+
+      // Verify event timestamps are within a reasonable window of updatedAt
+      // (events are emitted just before state write, timestamps may differ by a few ms)
+      const updatedAt = new Date(state.updatedAt as string).getTime();
+      for (const evt of [...cleanupEvents, ...patchEvents]) {
+        const eventTime = new Date(evt.timestamp).getTime();
+        // Events should be within 100ms of the state write timestamp
+        expect(Math.abs(eventTime - updatedAt)).toBeLessThan(100);
+      }
+    });
+
+    it('HandleCleanup_EsVersion2_IdempotencyKeysPresent', async () => {
+      // Arrange
+      await handleInit({ featureId: 'v2-idemp', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('v2-idemp');
+      raw.phase = 'synthesize';
+      await writeRawState('v2-idemp', raw);
+
+      // Act — call cleanup
+      await handleCleanup({
+        featureId: 'v2-idemp',
+        mergeVerified: true,
+        prUrl: 'https://github.com/test/pr/1',
+      }, tmpDir);
+
+      // Query all events
+      const allEvents = await eventStore.query('v2-idemp');
+      const cleanupRelated = allEvents.filter(e =>
+        e.type === 'state.patched' ||
+        e.type === 'workflow.transition' ||
+        e.type === 'workflow.cleanup'
+      );
+
+      // Assert — all cleanup-related events have idempotency keys
+      expect(cleanupRelated.length).toBeGreaterThanOrEqual(2); // at least transition + cleanup
+      for (const evt of cleanupRelated) {
+        expect(evt.idempotencyKey).toBeDefined();
+        expect(evt.idempotencyKey).toContain('v2-idemp:cleanup:');
+      }
+
+      // Act — call cleanup again (should be idempotent via ALREADY_COMPLETED guard)
+      // But we can verify no duplicate events were added by checking count
+      const eventCountBefore = allEvents.length;
+      const secondResult = await handleCleanup({
+        featureId: 'v2-idemp',
+        mergeVerified: true,
+      }, tmpDir);
+      // Second call should fail with ALREADY_COMPLETED
+      expect(secondResult.success).toBe(false);
+      expect(secondResult.error?.code).toBe('ALREADY_COMPLETED');
+
+      const eventsAfter = await eventStore.query('v2-idemp');
+      expect(eventsAfter.length).toBe(eventCountBefore);
+    });
+
+    it('HandleCleanup_EsVersion2_EventFailure_AbortsStateWrite', async () => {
+      // Arrange — init with real event store for v2 workflow creation
+      await handleInit({ featureId: 'v2-evt-fail', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('v2-evt-fail');
+      raw.phase = 'synthesize';
+      await writeRawState('v2-evt-fail', raw);
+
+      // Mock event store append to fail AFTER init
+      const appendSpy = vi.spyOn(eventStore, 'append').mockRejectedValue(
+        new Error('Disk full'),
+      );
+
+      // Act
+      const result = await handleCleanup({
+        featureId: 'v2-evt-fail',
+        mergeVerified: true,
+        prUrl: 'https://github.com/test/pr/1',
+      }, tmpDir);
+
+      // Assert — should return error
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('EVENT_APPEND_FAILED');
+      expect(result.error?.message).toContain('Disk full');
+
+      // Assert — state file should be unchanged (still synthesize)
+      const state = await readRawState('v2-evt-fail');
+      expect(state.phase).toBe('synthesize');
+
+      appendSpy.mockRestore();
+    });
+
+    it('HandleCleanup_EsVersion2_EmitsStatePatchedForBackfill', async () => {
+      // Arrange — v2 workflow with reviews to force-resolve
+      await handleInit({ featureId: 'v2-patch', workflowType: 'feature' }, tmpDir);
+      const raw = await readRawState('v2-patch');
+      raw.phase = 'review';
+      raw.reviews = {
+        'task-1': { status: 'in-progress' },
+      };
+      await writeRawState('v2-patch', raw);
+
+      // Act
+      const result = await handleCleanup({
+        featureId: 'v2-patch',
+        mergeVerified: true,
+        prUrl: 'https://github.com/test/pr/99',
+        mergedBranches: ['feature/branch-a', 'feature/branch-b'],
+      }, tmpDir);
+
+      expect(result.success).toBe(true);
+
+      // Query for state.patched events
+      const allEvents = await eventStore.query('v2-patch');
+      const patchEvents = allEvents.filter(e => e.type === 'state.patched');
+
+      // Assert — should have a state.patched event with synthesis/review data
+      expect(patchEvents.length).toBeGreaterThanOrEqual(1);
+      const patchData = patchEvents[0].data as Record<string, unknown>;
+      expect(patchData.featureId).toBe('v2-patch');
+      expect(patchData.fields).toBeDefined();
+      const fields = patchData.fields as string[];
+      // Should include synthesis and/or reviews data
+      expect(
+        fields.includes('synthesis') || fields.includes('reviews') || fields.includes('artifacts'),
+      ).toBe(true);
+      // The patch should contain the actual backfilled data
+      const patch = patchData.patch as Record<string, unknown>;
+      expect(patch).toBeDefined();
+      if (patch.synthesis) {
+        const synthPatch = patch.synthesis as Record<string, unknown>;
+        expect(synthPatch.prUrl).toBe('https://github.com/test/pr/99');
+        expect(synthPatch.mergedBranches).toEqual(['feature/branch-a', 'feature/branch-b']);
+      }
+      if (patch.reviews) {
+        const reviewsPatch = patch.reviews as Record<string, Record<string, unknown>>;
+        expect(reviewsPatch['task-1'].status).toBe('approved');
+      }
+    });
+
+    it('HandleCleanup_V1Legacy_StillWorksWithBestEffortEvents', async () => {
+      // Arrange — create a v1 workflow (no _esVersion field)
+      // Disconnect event store from init so workflow is created without _esVersion: 2
+      configureWorkflowEventStore(null);
+      await handleInit({ featureId: 'v1-legacy', workflowType: 'feature' }, tmpDir);
+      configureWorkflowEventStore(eventStore);
+
+      const raw = await readRawState('v1-legacy');
+      // Ensure no _esVersion (v1)
+      delete raw._esVersion;
+      raw.phase = 'review';
+      await writeRawState('v1-legacy', raw);
+
+      // Mock event store to fail
+      const appendSpy = vi.spyOn(eventStore, 'append').mockRejectedValue(
+        new Error('store error'),
+      );
+
+      // Act — v1 should succeed even when event store fails (best-effort)
+      const result = await handleCleanup({
+        featureId: 'v1-legacy',
+        mergeVerified: true,
+      }, tmpDir);
+
+      // Assert — v1 legacy path: state-first, events best-effort
+      expect(result.success).toBe(true);
+      expect((result.data as Record<string, unknown>)?.phase).toBe('completed');
+
+      appendSpy.mockRestore();
     });
   });
 });

--- a/servers/exarchos-mcp/src/__tests__/workflow/integration.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/integration.test.ts
@@ -860,15 +860,15 @@ describe('Integration', () => {
       );
       await handleSet({ featureId: 'consistency-test', phase: 'plan' }, stateDir, eventStore);
       events = await eventStore.query('consistency-test');
-      expect(events.length).toBe(2); // workflow.started + workflow.transition
+      expect(events.length).toBe(3); // workflow.started + state.patched + workflow.transition
 
       raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
-      expect(raw._eventSequence).toBe(2);
+      expect(raw._eventSequence).toBe(3);
 
       // Checkpoint
       await handleCheckpoint({ featureId: 'consistency-test', summary: 'Mid-plan' }, stateDir);
       events = await eventStore.query('consistency-test');
-      expect(events.length).toBe(3); // + workflow.checkpoint
+      expect(events.length).toBe(4); // + workflow.checkpoint
 
       // Another phase transition (plan -> plan-review)
       await handleSet(
@@ -878,10 +878,10 @@ describe('Integration', () => {
       );
       await handleSet({ featureId: 'consistency-test', phase: 'plan-review' }, stateDir, eventStore);
       events = await eventStore.query('consistency-test');
-      expect(events.length).toBe(4); // + another workflow.transition
+      expect(events.length).toBe(6); // + state.patched + workflow.transition
 
       raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
-      expect(raw._eventSequence).toBe(4);
+      expect(raw._eventSequence).toBe(6);
 
       // Reconcile should be idempotent (no changes)
       const result = await reconcileFromEvents(stateDir, 'consistency-test', eventStore);

--- a/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -2603,7 +2603,7 @@ describe('handleSet_EventFirst', () => {
     expect(transitions[0].idempotencyKey).toContain('ef-idem');
   });
 
-  it('should handle field-only updates without event emission', async () => {
+  it('should emit state.patched event for v2 field-only updates', async () => {
     const eventStore = new EventStore(tmpDir);
     configureWorkflowEventStore(eventStore);
 
@@ -2618,12 +2618,14 @@ describe('handleSet_EventFirst', () => {
     expect(result.success).toBe(true);
 
     const eventsAfter = await eventStore.query('ef-fields');
-    // No new events for field-only updates
-    expect(eventsAfter.length).toBe(eventsBefore.length);
+    // v2 workflows emit state.patched for field updates
+    expect(eventsAfter.length).toBe(eventsBefore.length + 1);
+    const patchedEvent = eventsAfter.find(e => e.type === 'state.patched');
+    expect(patchedEvent).toBeDefined();
 
-    // _eventSequence unchanged
+    // _eventSequence updated to include the state.patched event
     const raw = JSON.parse(await fs.readFile(path.join(tmpDir, 'ef-fields.state.json'), 'utf-8'));
-    expect(raw._eventSequence).toBe(1); // only from init
+    expect(raw._eventSequence).toBeGreaterThan(1);
   });
 
   it('should update _eventSequence after successful transition', async () => {
@@ -3213,5 +3215,191 @@ describe('HandleGet_EsVersion2_FieldProjection_Works', () => {
     expect(data.workflowType).toBeUndefined();
     expect(data.tasks).toBeUndefined();
     expect(data.createdAt).toBeUndefined();
+  });
+});
+
+// ─── Tasks 10+11: handleSet emits state.patched events for ES v2 ────────────
+
+describe('HandleSet_EsVersion2_FieldUpdates_EmitsStatePatchedEvent', () => {
+  it('should emit a state.patched event when updating fields on a v2 workflow', async () => {
+    // Arrange: Create a v2 workflow with event store and materializer
+    const eventStore = new EventStore(tmpDir);
+    configureWorkflowEventStore(eventStore);
+    const materializer = new ViewMaterializer();
+    materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
+    configureWorkflowMaterializer(materializer);
+
+    await handleInit({ featureId: 'es-set-patch', workflowType: 'feature' }, tmpDir);
+
+    // Act: Update fields via handleSet
+    const result = await handleSet(
+      {
+        featureId: 'es-set-patch',
+        updates: {
+          tasks: [{ id: 'task-1', title: 'Build API', status: 'pending' }],
+        },
+      },
+      tmpDir,
+    );
+
+    // Assert: Should succeed
+    expect(result.success).toBe(true);
+
+    // Assert: A state.patched event should appear in the event stream
+    const events = await eventStore.query('es-set-patch');
+    const patchedEvents = events.filter(e => e.type === 'state.patched');
+    expect(patchedEvents).toHaveLength(1);
+
+    const patchedData = patchedEvents[0].data as Record<string, unknown>;
+    expect(patchedData.featureId).toBe('es-set-patch');
+    expect(patchedData.fields).toEqual(['tasks']);
+    expect(patchedData.patch).toEqual({
+      tasks: [{ id: 'task-1', title: 'Build API', status: 'pending' }],
+    });
+  });
+});
+
+describe('HandleSet_EsVersion2_PhaseAndFields_EmitsBothEvents', () => {
+  it('should emit both workflow.transition and state.patched events when phase and fields change', async () => {
+    // Arrange: Create a v2 workflow with event store and materializer
+    const eventStore = new EventStore(tmpDir);
+    configureWorkflowEventStore(eventStore);
+    const materializer = new ViewMaterializer();
+    materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
+    configureWorkflowMaterializer(materializer);
+
+    await handleInit({ featureId: 'es-set-both', workflowType: 'feature' }, tmpDir);
+
+    // Act: Set both phase and field updates
+    const result = await handleSet(
+      {
+        featureId: 'es-set-both',
+        phase: 'plan',
+        updates: {
+          'artifacts.design': 'design.md',
+        },
+      },
+      tmpDir,
+    );
+
+    // Assert: Should succeed
+    expect(result.success).toBe(true);
+
+    // Assert: Both event types should appear in the stream
+    const events = await eventStore.query('es-set-both');
+    const transitionEvents = events.filter(e => e.type === 'workflow.transition');
+    const patchedEvents = events.filter(e => e.type === 'state.patched');
+
+    expect(transitionEvents.length).toBeGreaterThanOrEqual(1);
+    expect(patchedEvents).toHaveLength(1);
+
+    // Verify the transition event
+    const lastTransition = transitionEvents[transitionEvents.length - 1];
+    const transitionData = lastTransition.data as Record<string, unknown>;
+    expect(transitionData.to).toBe('plan');
+
+    // Verify the patched event
+    const patchedData = patchedEvents[0].data as Record<string, unknown>;
+    expect(patchedData.fields).toEqual(['artifacts.design']);
+    expect(patchedData.patch).toEqual({ 'artifacts.design': 'design.md' });
+  });
+});
+
+describe('HandleSet_EsVersion2_AfterEmit_StateFileReflectsEvents', () => {
+  it('should write a state file that reflects materialized event state', async () => {
+    // Arrange: Create a v2 workflow with event store and materializer
+    const eventStore = new EventStore(tmpDir);
+    configureWorkflowEventStore(eventStore);
+    const materializer = new ViewMaterializer();
+    materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
+    configureWorkflowMaterializer(materializer);
+
+    await handleInit({ featureId: 'es-set-snap', workflowType: 'feature' }, tmpDir);
+
+    // Act: Update tasks via handleSet
+    await handleSet(
+      {
+        featureId: 'es-set-snap',
+        updates: {
+          tasks: [{ id: 'task-1', title: 'Build API', status: 'pending' }],
+        },
+      },
+      tmpDir,
+    );
+
+    // Assert: Read the state file directly
+    const stateFile = path.join(tmpDir, 'es-set-snap.state.json');
+    const rawState = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+
+    // The state file should reflect the tasks from the state.patched event
+    expect(rawState.tasks).toEqual([{ id: 'task-1', title: 'Build API', status: 'pending' }]);
+
+    // Also verify by materializing independently and comparing key fields
+    const events = await eventStore.query('es-set-snap');
+    const freshMaterializer = new ViewMaterializer();
+    freshMaterializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
+    const materialized = freshMaterializer.materialize<Record<string, unknown>>(
+      'es-set-snap',
+      WORKFLOW_STATE_VIEW,
+      events,
+    );
+
+    expect(rawState.featureId).toBe(materialized.featureId);
+    expect(rawState.phase).toBe(materialized.phase);
+    expect(rawState.tasks).toEqual(materialized.tasks);
+  });
+});
+
+describe('HandleSet_EsVersion2_IdempotencyKey_PreventsDuplicates', () => {
+  it('should not emit duplicate state.patched events with the same idempotency key', async () => {
+    // Arrange: Create a v2 workflow with event store and materializer
+    const eventStore = new EventStore(tmpDir);
+    configureWorkflowEventStore(eventStore);
+    const materializer = new ViewMaterializer();
+    materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
+    configureWorkflowMaterializer(materializer);
+
+    await handleInit({ featureId: 'es-set-idemp', workflowType: 'feature' }, tmpDir);
+
+    // Read the state to determine the expected version used in idempotency key
+    const stateFile = path.join(tmpDir, 'es-set-idemp.state.json');
+    const stateBeforeSet = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+    const expectedVersion = stateBeforeSet._version ?? 1;
+    const fieldsHash = 'tasks';
+
+    // Pre-seed an event with the same idempotency key that handleSet would use
+    const idempotencyKey = `${stateBeforeSet.featureId}:patch:${expectedVersion}:${fieldsHash}`;
+    await eventStore.append('es-set-idemp', {
+      type: 'state.patched',
+      correlationId: 'es-set-idemp',
+      source: 'workflow',
+      data: {
+        featureId: 'es-set-idemp',
+        fields: ['tasks'],
+        patch: { tasks: [{ id: 'pre-seeded', title: 'Pre-seeded', status: 'pending' }] },
+      },
+    }, { idempotencyKey });
+
+    // Act: Call handleSet with the same field — should hit idempotency dedup
+    await handleSet(
+      {
+        featureId: 'es-set-idemp',
+        updates: {
+          tasks: [{ id: 'task-1', title: 'Build API', status: 'pending' }],
+        },
+      },
+      tmpDir,
+    );
+
+    // Assert: Only ONE state.patched event should exist (the pre-seeded one, not a duplicate)
+    const events = await eventStore.query('es-set-idemp');
+    const patchedEvents = events.filter(e => e.type === 'state.patched');
+    expect(patchedEvents).toHaveLength(1);
+
+    // The event should be the pre-seeded one, not the handleSet one
+    const data = patchedEvents[0].data as Record<string, unknown>;
+    expect(data.patch).toEqual({
+      tasks: [{ id: 'pre-seeded', title: 'Pre-seeded', status: 'pending' }],
+    });
   });
 });

--- a/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -17,6 +17,7 @@ import {
   configureWorkflowMaterializer,
   isEventSourced,
   CURRENT_ES_VERSION,
+  expandDotPaths,
 } from '../../workflow/tools.js';
 import { initStateFile, readStateFile, writeStateFile, VersionConflictError } from '../../workflow/state-store.js';
 import { EventStore } from '../../event-store/store.js';
@@ -3301,7 +3302,7 @@ describe('HandleSet_EsVersion2_PhaseAndFields_EmitsBothEvents', () => {
     // Verify the patched event
     const patchedData = patchedEvents[0].data as Record<string, unknown>;
     expect(patchedData.fields).toEqual(['artifacts.design']);
-    expect(patchedData.patch).toEqual({ 'artifacts.design': 'design.md' });
+    expect(patchedData.patch).toEqual({ artifacts: { design: 'design.md' } });
   });
 });
 
@@ -3401,5 +3402,40 @@ describe('HandleSet_EsVersion2_IdempotencyKey_PreventsDuplicates', () => {
     expect(data.patch).toEqual({
       tasks: [{ id: 'pre-seeded', title: 'Pre-seeded', status: 'pending' }],
     });
+  });
+});
+
+// ─── expandDotPaths ──────────────────────────────────────────────────────────
+
+describe('expandDotPaths', () => {
+  it('should expand simple dot-path keys into nested objects', () => {
+    const result = expandDotPaths({ 'artifacts.design': 'docs/design.md' });
+    expect(result).toEqual({ artifacts: { design: 'docs/design.md' } });
+  });
+
+  it('should expand multi-level dot-paths', () => {
+    const result = expandDotPaths({ 'a.b.c': 42 });
+    expect(result).toEqual({ a: { b: { c: 42 } } });
+  });
+
+  it('should expand bracket notation into arrays', () => {
+    const result = expandDotPaths({
+      'tasks[0]': { id: 't1', status: 'complete' },
+    });
+    expect(result.tasks).toBeDefined();
+    expect((result.tasks as unknown[])[0]).toEqual({ id: 't1', status: 'complete' });
+  });
+
+  it('should pass through top-level keys unchanged', () => {
+    const result = expandDotPaths({ planReview: { approved: true } });
+    expect(result).toEqual({ planReview: { approved: true } });
+  });
+
+  it('should merge multiple dot-paths into the same parent', () => {
+    const result = expandDotPaths({
+      'artifacts.design': 'design.md',
+      'artifacts.plan': 'plan.md',
+    });
+    expect(result).toEqual({ artifacts: { design: 'design.md', plan: 'plan.md' } });
   });
 });

--- a/servers/exarchos-mcp/src/views/workflow-state-projection.ts
+++ b/servers/exarchos-mcp/src/views/workflow-state-projection.ts
@@ -279,13 +279,20 @@ export const workflowStateProjection: ViewProjection<WorkflowStateView> = {
       case 'review.escalated':
       case 'workflow.fix-cycle':
       case 'workflow.guard-failed':
+      case 'workflow.cancel':
+      case 'workflow.cleanup': {
+        // Cancel and cleanup events carry {from, to} transition data
+        // that must update the materialized phase.
+        const data = event.data as { to?: string } | undefined;
+        if (!data?.to) return view;
+        return { ...view, phase: data.to, updatedAt: event.timestamp };
+      }
+
       case 'workflow.compound-entry':
       case 'workflow.compound-exit':
       case 'workflow.compensation':
       case 'workflow.circuit-open':
       case 'workflow.cas-failed':
-      case 'workflow.cancel':
-      case 'workflow.cleanup':
       case 'stack.restacked':
       case 'stack.enqueued':
       case 'task.claimed':

--- a/servers/exarchos-mcp/src/workflow/cleanup.ts
+++ b/servers/exarchos-mcp/src/workflow/cleanup.ts
@@ -12,8 +12,18 @@ import {
 import { mapInternalToExternalType } from './events.js';
 import { getHSMDefinition, executeTransition } from './state-machine.js';
 import type { EventStore } from '../event-store/store.js';
+import type { EventType } from '../event-store/schemas.js';
 import type { ToolResult } from '../format.js';
 import * as path from 'node:path';
+
+// ─── Event-Sourcing Version Discriminator ───────────────────────────────────
+
+const CURRENT_ES_VERSION = 2;
+
+/** Check whether a workflow state uses the pure event-sourcing path. */
+function isEventSourced(state: Record<string, unknown>): boolean {
+  return state._esVersion === CURRENT_ES_VERSION;
+}
 
 // ─── Module-Level EventStore Configuration ──────────────────────────────────
 
@@ -24,8 +34,145 @@ export function configureCleanupEventStore(store: EventStore | null): void {
   moduleEventStore = store;
 }
 
+// ─── Event-First Emission ───────────────────────────────────────────────────
+
+interface CleanupEventPayload {
+  featureId: string;
+  currentPhase: string;
+  synthesis: Record<string, unknown>;
+  artifacts: Record<string, unknown>;
+  reviews: Record<string, unknown> | undefined;
+  hasReviewEntries: boolean;
+  hasSynthesisBackfill: boolean;
+  transitionEvents: ReadonlyArray<{
+    type: string;
+    from: string;
+    to: string;
+    trigger: string;
+    metadata?: Record<string, unknown>;
+  }>;
+  prUrl?: string | string[];
+  mergedBranches?: string[];
+}
+
+/**
+ * Emit cleanup events to the event store (v2 event-first contract).
+ *
+ * Events are emitted in order:
+ * 1. `state.patched` — synthesis/review backfill (if applicable)
+ * 2. `workflow.cleanup` — HSM transition events with idempotency keys
+ * 3. `workflow.cleanup` — explicit cleanup completion event
+ *
+ * @throws Error if any event append fails (caller should abort state write)
+ */
+async function emitCleanupEvents(
+  store: EventStore,
+  payload: CleanupEventPayload,
+): Promise<void> {
+  const { featureId, currentPhase } = payload;
+
+  // 1. Emit state.patched for backfilled fields
+  const backfillPatch: Record<string, unknown> = {};
+  if (payload.hasSynthesisBackfill) {
+    backfillPatch.synthesis = payload.synthesis;
+    backfillPatch.artifacts = payload.artifacts;
+  }
+  if (payload.hasReviewEntries) {
+    backfillPatch.reviews = payload.reviews;
+  }
+  if (Object.keys(backfillPatch).length > 0) {
+    await store.append(featureId, {
+      type: 'state.patched' as EventType,
+      correlationId: featureId,
+      source: 'workflow',
+      data: {
+        featureId,
+        fields: Object.keys(backfillPatch),
+        patch: backfillPatch,
+      },
+    }, { idempotencyKey: `${featureId}:cleanup:patch:${currentPhase}` });
+  }
+
+  // 2. Emit transition events with idempotency keys
+  for (const evt of payload.transitionEvents) {
+    await store.append(featureId, {
+      type: mapInternalToExternalType(evt.type) as EventType,
+      correlationId: featureId,
+      source: 'workflow',
+      data: {
+        from: evt.from,
+        to: evt.to,
+        trigger: evt.trigger,
+        featureId,
+        ...(evt.metadata ?? {}),
+      },
+    }, { idempotencyKey: `${featureId}:cleanup:transition:${evt.from}:${evt.to}` });
+  }
+
+  // 3. Emit workflow.cleanup completion event
+  await store.append(featureId, {
+    type: 'workflow.cleanup' as EventType,
+    correlationId: featureId,
+    source: 'workflow',
+    data: {
+      featureId,
+      previousPhase: currentPhase,
+      mergeVerified: true,
+      prUrl: payload.prUrl,
+      mergedBranches: payload.mergedBranches,
+    },
+  }, { idempotencyKey: `${featureId}:cleanup:complete` });
+}
+
+// ─── V1 Legacy Event Emission ───────────────────────────────────────────────
+
+/**
+ * Emit transition events after state write (v1 legacy best-effort).
+ * Failures are silently swallowed — state is already written.
+ */
+async function emitLegacyTransitionEvents(
+  store: EventStore,
+  featureId: string,
+  transitionEvents: ReadonlyArray<{
+    type: string;
+    from: string;
+    to: string;
+    trigger: string;
+    metadata?: Record<string, unknown>;
+  }>,
+): Promise<void> {
+  try {
+    for (const evt of transitionEvents) {
+      await store.append(featureId, {
+        type: mapInternalToExternalType(evt.type) as EventType,
+        data: {
+          from: evt.from,
+          to: evt.to,
+          trigger: evt.trigger,
+          featureId,
+          ...(evt.metadata ?? {}),
+        },
+      });
+    }
+  } catch {
+    // V1 legacy: external store is supplementary; append failure must not break cleanup
+  }
+}
+
 // ─── handleCleanup ──────────────────────────────────────────────────────────
 
+/**
+ * Clean up a workflow by transitioning it to completed.
+ *
+ * **Event-first contract (ES v2):** When the workflow uses event-sourcing v2,
+ * cleanup events (`state.patched`, `workflow.cleanup`) are appended to the
+ * event store BEFORE the state file is written. If event append fails, no
+ * state file is written and an error is returned. All events carry
+ * idempotency keys for safe retry.
+ *
+ * **Legacy path (v1):** State file is written first; events are emitted
+ * after as best-effort (failures are silently swallowed).
+ */
 export async function handleCleanup(
   input: CleanupInput,
   stateDir: string,
@@ -48,7 +195,7 @@ export async function handleCleanup(
     throw err;
   }
 
-  // Check if already completed
+  // Guard: terminal states
   if (state.phase === 'completed') {
     return {
       success: false,
@@ -59,7 +206,6 @@ export async function handleCleanup(
     };
   }
 
-  // Check if cancelled (cannot cleanup a cancelled workflow)
   if (state.phase === 'cancelled') {
     return {
       success: false,
@@ -70,7 +216,7 @@ export async function handleCleanup(
     };
   }
 
-  // Check merge verification
+  // Guard: merge verification
   if (!input.mergeVerified) {
     return {
       success: false,
@@ -81,7 +227,7 @@ export async function handleCleanup(
     };
   }
 
-  // ─── Happy path (Task 5) ──────────────────────────────────────────────
+  // ─── Build mutations ──────────────────────────────────────────────────
 
   const mutableState = structuredClone(state) as Record<string, unknown>;
   const currentPhase = state.phase;
@@ -106,15 +252,14 @@ export async function handleCleanup(
 
   // Force-resolve all blocking review statuses
   const reviews = mutableState.reviews as Record<string, unknown> | undefined;
+  const hasReviewEntries = reviews !== undefined && Object.keys(reviews).length > 0;
   if (reviews) {
     for (const [, value] of Object.entries(reviews)) {
       if (typeof value !== 'object' || value === null) continue;
       const entry = value as Record<string, unknown>;
       if (typeof entry.status === 'string') {
-        // Flat review: { status: "in-progress" } → { status: "approved" }
         entry.status = 'approved';
       } else {
-        // Nested: { specReview: { status: "fail" }, qualityReview: { status: "needs_fixes" } }
         for (const [, subValue] of Object.entries(entry)) {
           if (typeof subValue === 'object' && subValue !== null) {
             const sub = subValue as Record<string, unknown>;
@@ -127,10 +272,11 @@ export async function handleCleanup(
     }
   }
 
-  // Set _cleanup.mergeVerified for the guard
+  // Set _cleanup.mergeVerified for the HSM guard
   mutableState._cleanup = { mergeVerified: true };
 
-  // Execute HSM transition to completed
+  // ─── HSM transition ───────────────────────────────────────────────────
+
   const hsm = getHSMDefinition(state.workflowType);
   const transitionResult = executeTransition(hsm, mutableState, 'completed');
 
@@ -161,10 +307,10 @@ export async function handleCleanup(
     };
   }
 
-  // Mutate state
+  // ─── Apply state mutations ────────────────────────────────────────────
+
   mutableState.phase = 'completed';
 
-  // Apply history updates from transition
   if (transitionResult.historyUpdates) {
     const history = { ...(mutableState._history as Record<string, string>) };
     for (const [key, value] of Object.entries(transitionResult.historyUpdates)) {
@@ -173,42 +319,59 @@ export async function handleCleanup(
     mutableState._history = history;
   }
 
-  // Reset checkpoint counter
   mutableState._checkpoint = resetCounter(
     mutableState._checkpoint as WorkflowState['_checkpoint'],
     'completed',
     'Workflow completed via cleanup',
   );
 
-  // Update timestamps
   mutableState.updatedAt = new Date().toISOString();
   const checkpoint = mutableState._checkpoint as Record<string, unknown>;
   checkpoint.lastActivityTimestamp = new Date().toISOString();
 
-  // Clean up internal cleanup flag
   delete mutableState._cleanup;
 
-  // Write state first — cleanup events are supplementary
+  // ─── Event emission + state write ─────────────────────────────────────
+
+  const stateRecord = state as unknown as Record<string, unknown>;
+  const useEventFirst = isEventSourced(stateRecord) && moduleEventStore !== null;
+
+  if (useEventFirst) {
+    // ES v2: emit events BEFORE writing state
+    try {
+      await emitCleanupEvents(moduleEventStore!, {
+        featureId: input.featureId,
+        currentPhase,
+        synthesis,
+        artifacts,
+        reviews,
+        hasReviewEntries,
+        hasSynthesisBackfill: input.prUrl !== undefined || input.mergedBranches !== undefined,
+        transitionEvents: transitionResult.events,
+        prUrl: input.prUrl,
+        mergedBranches: input.mergedBranches,
+      });
+    } catch (err) {
+      return {
+        success: false,
+        error: {
+          code: ErrorCode.EVENT_APPEND_FAILED,
+          message: `Event append failed during cleanup: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      };
+    }
+  }
+
+  // Write state file (after events for v2, as primary store for v1)
   await writeStateFile(stateFile, mutableState as WorkflowState);
 
-  // Emit transition events after state write (best-effort)
-  if (moduleEventStore) {
-    try {
-      for (const transitionEvent of transitionResult.events) {
-        await moduleEventStore.append(input.featureId, {
-          type: mapInternalToExternalType(transitionEvent.type) as import('../event-store/schemas.js').EventType,
-          data: {
-            from: transitionEvent.from,
-            to: transitionEvent.to,
-            trigger: transitionEvent.trigger,
-            featureId: input.featureId,
-            ...(transitionEvent.metadata ?? {}),
-          },
-        });
-      }
-    } catch {
-      // External store is supplementary; append failure must not break cleanup
-    }
+  // V1 legacy: best-effort event emission AFTER state write
+  if (!useEventFirst && moduleEventStore) {
+    await emitLegacyTransitionEvents(
+      moduleEventStore,
+      input.featureId,
+      transitionResult.events,
+    );
   }
 
   return {

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -386,8 +386,13 @@ const MAX_CAS_RETRIES = 3;
  * modified and an error is returned. Idempotency keys prevent duplicate
  * events on CAS retry: `${featureId}:${from}:${to}:${expectedVersion}`.
  *
- * For field-only updates (no phase change), no events are emitted and
- * `_eventSequence` is not modified.
+ * **ES v2 field updates:** For workflows with `_esVersion === 2`, field
+ * updates emit a `state.patched` event with the patch delta before
+ * writing. After the CAS write succeeds, the state file is overwritten
+ * with a snapshot re-materialized from the full event stream, ensuring
+ * the file is always a derived artifact.
+ *
+ * **Legacy v1 path:** Field-only updates write directly without events.
  */
 export async function handleSet(
   input: SetInput,
@@ -529,7 +534,40 @@ export async function handleSet(
       }
     }
 
-    // Update _eventSequence only when transition events were appended
+    // ─── Event-first: append state.patched event for v2 field updates ──
+    if (
+      isEventSourced(state as unknown as Record<string, unknown>)
+      && moduleEventStore
+      && input.updates
+    ) {
+      try {
+        const fieldsHash = Object.keys(input.updates).sort().join(',');
+        const idempotencyKey = `${input.featureId}:patch:${expectedVersion}:${fieldsHash}`;
+        const event = await moduleEventStore.append(input.featureId, {
+          type: 'state.patched' as import('../event-store/schemas.js').EventType,
+          correlationId: input.featureId,
+          source: 'workflow',
+          data: {
+            featureId: input.featureId,
+            fields: Object.keys(input.updates),
+            patch: input.updates,
+          },
+        }, { idempotencyKey });
+
+        highestEventSequence = Math.max(highestEventSequence ?? 0, event.sequence);
+      } catch (err) {
+        // Event-first: if event append fails, do NOT update state
+        return {
+          success: false,
+          error: {
+            code: ErrorCode.EVENT_APPEND_FAILED,
+            message: `Event append failed: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        };
+      }
+    }
+
+    // Update _eventSequence when any events were appended
     if (highestEventSequence !== undefined) {
       mutableState._eventSequence = highestEventSequence;
     }
@@ -584,6 +622,36 @@ export async function handleSet(
       }
 
       throw err;
+    }
+
+    // ─── Re-materialize state from events for v2 workflows ──────────
+    // After the CAS write succeeds, overwrite the state file with a
+    // snapshot derived from the full event stream. This ensures the
+    // state file is always a derived artifact of the event log.
+    if (
+      isEventSourced(state as unknown as Record<string, unknown>)
+      && moduleEventStore
+      && moduleViewMaterializer
+    ) {
+      const allEvents = await moduleEventStore.query(input.featureId);
+      const materialized = moduleViewMaterializer.materialize<WorkflowStateView>(
+        input.featureId,
+        WORKFLOW_STATE_VIEW,
+        allEvents,
+      );
+
+      // Merge materialized state with checkpoint/version metadata from the
+      // mutable state (checkpoint tracking is not event-sourced)
+      const snapshot = {
+        ...(materialized as unknown as Record<string, unknown>),
+        _version: (mutableState._version as number),
+        _eventSequence: mutableState._eventSequence,
+        _esVersion: CURRENT_ES_VERSION,
+        _checkpoint: mutableState._checkpoint,
+        updatedAt: mutableState.updatedAt,
+      };
+
+      await writeStateFile(stateFile, snapshot as unknown as WorkflowState, { skipValidation: true });
     }
 
     // Event-first: events already appended before CAS write with idempotency keys.

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -78,6 +78,80 @@ function stripInternalFields(state: Record<string, unknown>): Record<string, unk
   return stripped;
 }
 
+// ─── Dot-Path Expansion ─────────────────────────────────────────────────────
+
+/**
+ * Expand flat dot-path keys into a nested object structure suitable for
+ * deep-merging. Handles bracket notation (e.g., "tasks[0]") by creating
+ * arrays with sparse indices.
+ *
+ * Example:
+ *   { 'artifacts.design': 'x', 'tasks[0]': {...} }
+ *   → { artifacts: { design: 'x' }, tasks: [{...}] }
+ */
+export function expandDotPaths(
+  updates: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [dotPath, value] of Object.entries(updates)) {
+    const segments = parseDotPath(dotPath);
+    setNestedValue(result, segments, value);
+  }
+
+  return result;
+}
+
+/** Parse a dot-path into string/number segments. */
+function parseDotPath(dotPath: string): Array<string | number> {
+  const segments: Array<string | number> = [];
+  for (const part of dotPath.split('.')) {
+    const bracketMatch = part.match(/^([^[]+)\[(\d+)\]$/);
+    if (bracketMatch) {
+      segments.push(bracketMatch[1]);
+      segments.push(parseInt(bracketMatch[2], 10));
+    } else {
+      segments.push(part);
+    }
+  }
+  return segments;
+}
+
+/** Set a value at a nested path, creating intermediate objects/arrays as needed. */
+function setNestedValue(
+  obj: Record<string, unknown>,
+  segments: Array<string | number>,
+  value: unknown,
+): void {
+  let current: unknown = obj;
+
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    const nextSeg = segments[i + 1];
+
+    if (typeof seg === 'number') {
+      const arr = current as unknown[];
+      if (arr[seg] === undefined) {
+        arr[seg] = typeof nextSeg === 'number' ? [] : {};
+      }
+      current = arr[seg];
+    } else {
+      const record = current as Record<string, unknown>;
+      if (record[seg] === undefined || record[seg] === null) {
+        record[seg] = typeof nextSeg === 'number' ? [] : {};
+      }
+      current = record[seg];
+    }
+  }
+
+  const lastSeg = segments[segments.length - 1];
+  if (typeof lastSeg === 'number') {
+    (current as unknown[])[lastSeg] = value;
+  } else {
+    (current as Record<string, unknown>)[lastSeg] = value;
+  }
+}
+
 // ─── Event-Sourcing Version Discriminator ───────────────────────────────────
 
 export const CURRENT_ES_VERSION = 2;
@@ -543,6 +617,7 @@ export async function handleSet(
       try {
         const fieldsHash = Object.keys(input.updates).sort().join(',');
         const idempotencyKey = `${input.featureId}:patch:${expectedVersion}:${fieldsHash}`;
+        const expandedPatch = expandDotPaths(input.updates);
         const event = await moduleEventStore.append(input.featureId, {
           type: 'state.patched' as import('../event-store/schemas.js').EventType,
           correlationId: input.featureId,
@@ -550,7 +625,7 @@ export async function handleSet(
           data: {
             featureId: input.featureId,
             fields: Object.keys(input.updates),
-            patch: input.updates,
+            patch: expandedPatch,
           },
         }, { idempotencyKey });
 


### PR DESCRIPTION
## Summary

Integration tests validating the full event-sourcing purity implementation: complete workflow lifecycle with state rebuilt entirely from events, snapshot recovery after state file deletion, and legacy v1 workflow backward compatibility.

## Changes

- **Lifecycle test** — init → set fields → transition phases → cleanup → delete state file → re-materialize from events → verify match
- **Snapshot recovery test** — Delete snapshot, verify full replay produces correct state
- **Legacy compatibility test** — v1 workflows without `_esVersion` use legacy path, no `state.patched` events emitted

## Test Plan

- [x] Full lifecycle: state rebuildable from events alone
- [x] Snapshot recovery: full replay matches original state
- [x] Legacy path: v1 workflows unchanged
- [x] All 266 tests passing

---

Part 8/8 of event-sourcing purity (#475).
Design: `docs/designs/2026-02-19-event-sourcing-purity.md`
Plan: `docs/plans/2026-02-19-event-sourcing-purity.md`