### PR TITLE
docs: add property-based testing section to TDD rules

### DIFF
--- a/rules/tdd.md
+++ b/rules/tdd.md
@@ -137,3 +137,33 @@ mock.GetOrderAsync(Arg.Any<Guid>()).Returns(Result<Order>.Success(order));
 await mock.Received(1).GetOrderAsync(expectedId);
 await mock.DidNotReceive().DeleteAsync(Arg.Any<Guid>());
 ```
+
+---
+
+## Property-Based Testing (fast-check)
+
+### When to Use
+
+- Data transformations (encode/decode, serialize/deserialize) → Roundtrip
+- State machines (transitions, guards) → Invariant
+- Collections/ordering (sort, filter, pagination) → Idempotence
+- Mathematical operations (scoring, budgets) → Bounds/constraints
+- Concurrency (optimistic locking) → Linearizability
+
+### Import
+
+```typescript
+import { fc } from '@fast-check/vitest';
+```
+
+### Basic Usage
+
+```typescript
+it.prop([fc.array(fc.integer())], (arr) => {
+  expect(sort(sort(arr))).toEqual(sort(arr));
+});
+```
+
+See `@skills/delegation/references/pbt-patterns.md` for roundtrip, invariant, idempotence, and commutativity pattern templates.
+
+Property tests are written alongside example tests in the RED phase. They complement, not replace, example tests.


### PR DESCRIPTION
## Summary

Adds a concise `## Property-Based Testing (fast-check)` section to `rules/tdd.md`, after the existing C# TUnit section. The section covers when to apply PBT, the import pattern, a basic `it.prop` usage example, a cross-reference to detailed pattern templates, and an integration note clarifying that property tests complement rather than replace example tests.

## Changes

- **`rules/tdd.md`** — Added 30-line PBT section with when-to-use list, import, basic example, cross-reference, and integration note

## Test Plan

- [ ] Verify `rules/tdd.md` contains the new `## Property-Based Testing (fast-check)` section
- [ ] Confirm no existing content was modified
- [ ] Confirm formatting matches existing TypeScript (Vitest) and C# (TUnit) sections

---

Related: T7 (add PBT section to TDD rules)