### PR TITLE
feat: add per-model attribution, auto-determination, and benchmark labeling

### DIFF
--- a/servers/exarchos-mcp/src/views/code-quality-view.test.ts
+++ b/servers/exarchos-mcp/src/views/code-quality-view.test.ts
@@ -23,6 +23,7 @@ describe('CodeQualityView', () => {
       const state = codeQualityProjection.init();
       expect(state).toEqual({
         skills: {},
+        models: {},
         gates: {},
         regressions: [],
         benchmarks: [],
@@ -215,6 +216,70 @@ describe('CodeQualityView', () => {
       }
 
       expect(state.regressions).toHaveLength(0);
+    });
+  });
+
+  // ─── Per-model attribution ──────────────────────────────────────────────
+
+  describe('apply - per-model attribution', () => {
+    it('Apply_GateExecuted_WithModel_UpdatesModelMetrics', () => {
+      const state = codeQualityProjection.init();
+      const event = makeEvent('gate.executed', {
+        gateName: 'typecheck',
+        layer: 'build',
+        passed: true,
+        duration: 1200,
+        details: { model: 'claude-opus-4-6' },
+      });
+
+      const next = codeQualityProjection.apply(state, event);
+      expect(next.models['claude-opus-4-6']).toBeDefined();
+      expect(next.models['claude-opus-4-6'].totalExecutions).toBe(1);
+      expect(next.models['claude-opus-4-6'].gatePassRate).toBe(1);
+    });
+
+    it('Apply_GateExecuted_WithoutModel_DoesNotCreateModelEntry', () => {
+      const state = codeQualityProjection.init();
+      const event = makeEvent('gate.executed', {
+        gateName: 'typecheck',
+        layer: 'build',
+        passed: true,
+        duration: 1200,
+        details: {},
+      });
+
+      const next = codeQualityProjection.apply(state, event);
+      expect(next.models).toEqual({});
+    });
+
+    it('Apply_GateExecuted_MultipleModels_TracksIndependently', () => {
+      let state = codeQualityProjection.init();
+
+      state = codeQualityProjection.apply(state, makeEvent('gate.executed', {
+        gateName: 'typecheck',
+        layer: 'build',
+        passed: true,
+        duration: 1000,
+        details: { model: 'claude-opus-4-6' },
+      }, 1));
+
+      state = codeQualityProjection.apply(state, makeEvent('gate.executed', {
+        gateName: 'typecheck',
+        layer: 'build',
+        passed: false,
+        duration: 800,
+        details: { model: 'claude-sonnet-4-6', reason: 'TS2345' },
+      }, 2));
+
+      expect(state.models['claude-opus-4-6'].totalExecutions).toBe(1);
+      expect(state.models['claude-opus-4-6'].gatePassRate).toBe(1);
+      expect(state.models['claude-sonnet-4-6'].totalExecutions).toBe(1);
+      expect(state.models['claude-sonnet-4-6'].gatePassRate).toBe(0);
+    });
+
+    it('Init_IncludesEmptyModelsRecord', () => {
+      const state = codeQualityProjection.init();
+      expect(state.models).toEqual({});
     });
   });
 

--- a/servers/exarchos-mcp/src/views/code-quality-view.ts
+++ b/servers/exarchos-mcp/src/views/code-quality-view.ts
@@ -40,8 +40,15 @@ export interface QualityRegression {
   readonly detectedAt: string;
 }
 
+export interface ModelQualityMetrics {
+  readonly model: string;
+  readonly totalExecutions: number;
+  readonly gatePassRate: number;
+}
+
 export interface CodeQualityViewState {
   readonly skills: Record<string, SkillQualityMetrics>;
+  readonly models: Record<string, ModelQualityMetrics>;
   readonly gates: Record<string, GateMetrics>;
   readonly regressions: ReadonlyArray<QualityRegression>;
   readonly benchmarks: ReadonlyArray<BenchmarkTrend>;
@@ -90,6 +97,14 @@ function defaultSkillMetrics(skill: string): SkillQualityMetrics {
     selfCorrectionRate: 0,
     avgRemediationAttempts: 0,
     topFailureCategories: [],
+  };
+}
+
+function defaultModelMetrics(model: string): ModelQualityMetrics {
+  return {
+    model,
+    totalExecutions: 0,
+    gatePassRate: 0,
   };
 }
 
@@ -172,6 +187,7 @@ function handleGateExecuted(state: InternalState, event: WorkflowEvent): CodeQua
   const duration = data.duration ?? 0;
   const details = data.details ?? {};
   const skill = typeof details.skill === 'string' ? details.skill : undefined;
+  const model = typeof details.model === 'string' ? details.model : undefined;
   const commit = typeof details.commit === 'string' ? details.commit : undefined;
   const reason = typeof details.reason === 'string' ? details.reason : undefined;
 
@@ -203,6 +219,23 @@ function handleGateExecuted(state: InternalState, event: WorkflowEvent): CodeQua
         ...prevSkill,
         totalExecutions: newExec,
         gatePassRate: skillPassCount / newExec,
+      },
+    };
+  }
+
+  // Update model metrics if model is present
+  let updatedModels = state.models;
+  if (model) {
+    const prevModel = state.models[model] ?? defaultModelMetrics(model);
+    const newModelExec = prevModel.totalExecutions + 1;
+    const modelPassCount = Math.round(prevModel.gatePassRate * prevModel.totalExecutions) + (passed ? 1 : 0);
+
+    updatedModels = {
+      ...state.models,
+      [model]: {
+        ...prevModel,
+        totalExecutions: newModelExec,
+        gatePassRate: modelPassCount / newModelExec,
       },
     };
   }
@@ -249,6 +282,7 @@ function handleGateExecuted(state: InternalState, event: WorkflowEvent): CodeQua
     ...state,
     gates: { ...state.gates, [gateName]: updatedGate },
     skills: updatedSkills,
+    models: updatedModels,
     regressions: updatedRegressions,
     _failureTrackers: updatedTrackers,
   });
@@ -312,6 +346,7 @@ function handleBenchmarkCompleted(state: InternalState, event: WorkflowEvent): C
 export const codeQualityProjection: ViewProjection<CodeQualityViewState> = {
   init: (): CodeQualityViewState => ({
     skills: {},
+    models: {},
     gates: {},
     regressions: [],
     benchmarks: [],

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -96,15 +96,28 @@ Use `@skills/delegation/references/implementer-prompt.md` as template for Task t
 
 **Conditional PBT section:** When a task has `testingStrategy.propertyTests: true`, include the "Property-Based Testing Patterns" section from `references/pbt-patterns.md` in the implementer prompt. This section provides framework-specific patterns (fast-check for TypeScript, FsCheck for .NET) and integrates with the TDD RED phase. When `propertyTests: false`, omit the section entirely.
 
+## Benchmark Label (Automatic)
+
+After extracting tasks from the plan, check if ANY task has `testingStrategy.benchmarks: true`. If so, apply the `has-benchmarks` label to the PR after synthesis. Record this in workflow state:
+
+```
+action: "set", featureId: "<id>", updates: {
+  "verification.hasBenchmarks": true
+}
+```
+
+The `/synthesize` skill reads `verification.hasBenchmarks` and applies the label via `gh pr edit <number> --add-label has-benchmarks`. This label triggers conditional benchmark CI gates.
+
 ## Delegation Workflow — Subagent Mode
 
 1. Prepare worktrees — `scripts/setup-worktree.sh`
 2. Extract task details from plan
-3. Create TodoWrite entries for tracking
-4. Dispatch parallel subagents via Task tool
-5. Monitor progress via TaskOutput
-6. Collect and verify — `scripts/post-delegation-check.sh`
-7. Schema sync if API files modified
+3. Check for benchmark tasks and set `verification.hasBenchmarks` in state
+4. Create TodoWrite entries for tracking
+5. Dispatch parallel subagents via Task tool
+6. Monitor progress via TaskOutput
+7. Collect and verify — `scripts/post-delegation-check.sh`
+8. Schema sync if API files modified
 
 For detailed step instructions, see `references/workflow-steps.md`.
 

--- a/skills/implementation-planning/SKILL.md
+++ b/skills/implementation-planning/SKILL.md
@@ -99,7 +99,7 @@ Each task follows the TDD format in `references/task-template.md`.
 - One test = one behavior
 - Prefer many small tasks over few large ones
 
-Assign a `testingStrategy` to each task using `references/testing-strategy-guide.md` to control which verification techniques agents apply.
+Assign a `testingStrategy` to each task using `references/testing-strategy-guide.md` to control which verification techniques agents apply. Auto-determine `propertyTests` and `benchmarks` flags by matching each task's description and file paths against the category tables — do not leave these for the implementer to decide.
 
 **Task Ordering:**
 1. Foundation first (types, interfaces, data structures)

--- a/skills/implementation-planning/references/testing-strategy-guide.md
+++ b/skills/implementation-planning/references/testing-strategy-guide.md
@@ -49,6 +49,40 @@ When `propertyTests: true`, provide guidance strings in the `properties` array d
 }
 ```
 
+## Benchmark Requirements
+
+Assign `benchmarks: true` when the task involves any of these categories:
+
+| Category | Example Code | What to Measure |
+|---|---|---|
+| **Event store operations** | Append, query, snapshot | Throughput (ops/sec), p99 latency |
+| **View materialization** | Projection apply, cold-start rebuild | Events/sec, cold-start time |
+| **Serialization hot paths** | JSON parse/stringify, schema validation | Throughput, memory allocation |
+| **Query-heavy reads** | CQRS projections, aggregations | Query latency under load |
+
+Assign `benchmarks: false` when the task is:
+- Pure wiring, configuration, or DI registration
+- Content-only changes (Markdown, documentation)
+- Test infrastructure (test helpers, fixtures)
+- UI components or styling
+
+When `benchmarks: true`, populate `performanceSLAs` with targets:
+
+```json
+{
+  "exampleTests": true,
+  "propertyTests": false,
+  "benchmarks": true,
+  "performanceSLAs": [
+    { "operation": "event-append", "metric": "p99_ms", "threshold": 10 }
+  ]
+}
+```
+
+## Auto-Determination
+
+The planner MUST auto-determine `propertyTests` and `benchmarks` for each task based on the category tables above. Do NOT leave these fields for the implementer to decide. Analyze each task's description and file paths to match against the categories. When uncertain, default to `false`.
+
 ## Reference
 
 See [Autonomous Code Verification design](../../../docs/designs/2026-02-15-autonomous-code-verification.md#when-to-require-property-based-tests) for the full rationale and category taxonomy.

--- a/skills/synthesis/SKILL.md
+++ b/skills/synthesis/SKILL.md
@@ -45,7 +45,8 @@ Since delegation creates Graphite stack branches and review validates them, synt
 4. **Check CodeRabbit reviews** -- `scripts/check-coderabbit.sh`
 5. **Write PR descriptions** -- Follow `references/pr-descriptions.md` for title format and body structure
 6. **Submit to merge queue** -- `gt submit --no-interactive --publish --merge-when-ready`
-7. **Cleanup after merge** -- `gt sync` + remove worktrees
+7. **Apply benchmark label** -- If `verification.hasBenchmarks` is `true` in workflow state, apply label to each PR: `gh pr edit <number> --add-label has-benchmarks`
+8. **Cleanup after merge** -- `gt sync` + remove worktrees
 
 For detailed step instructions, see `references/synthesis-steps.md`.
 


### PR DESCRIPTION
Completes verification flywheel polish items: CodeQualityView now
tracks per-model gate metrics, /plan auto-determines propertyTests
and benchmarks flags per task, and /delegate + /synthesize coordinate
has-benchmarks label for conditional CI gates.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>