### PR TITLE
feat: add eval event schemas, harness emission, and EvalResultsView

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Exarchos is local agent governance for Claude Code. It provides event-sourced SD
 Single server at `servers/exarchos-mcp/` exposing 5 composite tools:
 
 - **exarchos_workflow** — HSM-based workflow lifecycle (init/get/set/cancel)
-- **exarchos_event** — Append-only JSONL event store with 39 event types
+- **exarchos_event** — Append-only JSONL event store with 42 event types
 - **exarchos_orchestrate** — Agent team spawn/message/shutdown + task claim/complete/fail
 - **exarchos_view** — CQRS materialized views (pipeline, tasks, workflow status, team status, stack, telemetry)
 - **exarchos_sync** — Remote sync (stub)

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -358,8 +358,8 @@ describe('StackEnqueuedData', () => {
 // ─── EventTypes Discriminated Union (A03) ───────────────────────────────────
 
 describe('EventTypes', () => {
-  it('should contain all 39 event types', () => {
-    expect(EventTypes).toHaveLength(39);
+  it('should contain all 42 event types', () => {
+    expect(EventTypes).toHaveLength(42);
   });
 
   it('should include workflow-level types', () => {

--- a/servers/exarchos-mcp/src/evals/harness.test.ts
+++ b/servers/exarchos-mcp/src/evals/harness.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -357,5 +357,153 @@ describe('Integration — Real Eval Suites', () => {
     expect(summary.suiteId).toBe('quality-review');
     expect(summary.runId).toBeTruthy();
     expect(summary.passed + summary.failed).toBe(summary.total);
+  });
+});
+
+// ─── T08: Event Emission Tests ───────────────────────────────────────────────
+
+const createMockEventStore = () => ({
+  append: vi.fn().mockResolvedValue(undefined),
+  query: vi.fn().mockResolvedValue([]),
+});
+
+describe('runSuite — event emission', () => {
+  it('runSuite_WithEventStore_EmitsRunStartedEvent', async () => {
+    // Arrange
+    const cases = [makeEvalCase('c-1', { input: { value: 'a' }, expected: { value: 'a' } })];
+    const config = makeValidSuiteConfig();
+    const suiteDir = await createSuite('event-suite', config, { main: cases });
+    const mockStore = createMockEventStore();
+
+    // Act
+    await runSuite(config, tmpDir, suiteDir, registry, {
+      eventStore: mockStore,
+      streamId: 'eval-stream',
+      trigger: 'local',
+    });
+
+    // Assert
+    const startedCalls = mockStore.append.mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).type === 'eval.run.started',
+    );
+    expect(startedCalls).toHaveLength(1);
+    const startedEvent = startedCalls[0][1] as Record<string, unknown>;
+    const data = startedEvent.data as Record<string, unknown>;
+    expect(data.suiteId).toBe('delegation');
+    expect(data.caseCount).toBe(1);
+    expect(data.trigger).toBe('local');
+  });
+
+  it('runSuite_WithEventStore_EmitsCaseCompletedPerCase', async () => {
+    // Arrange
+    const cases = [
+      makeEvalCase('c-1', { input: { value: 'a' }, expected: { value: 'a' } }),
+      makeEvalCase('c-2', { input: { value: 'b' }, expected: { value: 'b' } }),
+      makeEvalCase('c-3', { input: { value: 'c' }, expected: { value: 'c' } }),
+    ];
+    const config = makeValidSuiteConfig();
+    const suiteDir = await createSuite('case-events', config, { main: cases });
+    const mockStore = createMockEventStore();
+
+    // Act
+    await runSuite(config, tmpDir, suiteDir, registry, {
+      eventStore: mockStore,
+      streamId: 'eval-stream',
+    });
+
+    // Assert
+    const caseCalls = mockStore.append.mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).type === 'eval.case.completed',
+    );
+    expect(caseCalls).toHaveLength(3);
+  });
+
+  it('runSuite_WithEventStore_EmitsRunCompletedWithSummary', async () => {
+    // Arrange
+    const cases = [
+      makeEvalCase('c-1', { input: { value: 'a' }, expected: { value: 'a' } }),
+      makeEvalCase('c-2', { input: { value: 'b' }, expected: { value: 'different' } }),
+    ];
+    const config = makeValidSuiteConfig();
+    const suiteDir = await createSuite('completed-events', config, { main: cases });
+    const mockStore = createMockEventStore();
+
+    // Act
+    await runSuite(config, tmpDir, suiteDir, registry, {
+      eventStore: mockStore,
+      streamId: 'eval-stream',
+    });
+
+    // Assert
+    const completedCalls = mockStore.append.mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).type === 'eval.run.completed',
+    );
+    expect(completedCalls).toHaveLength(1);
+    const data = (completedCalls[0][1] as Record<string, unknown>).data as Record<string, unknown>;
+    expect(data.total).toBe(2);
+    expect(data.passed).toBe(1);
+    expect(data.failed).toBe(1);
+  });
+
+  it('runSuite_WithEventStore_EventsInCorrectOrder', async () => {
+    // Arrange
+    const cases = [
+      makeEvalCase('c-1', { input: { value: 'a' }, expected: { value: 'a' } }),
+      makeEvalCase('c-2', { input: { value: 'b' }, expected: { value: 'b' } }),
+    ];
+    const config = makeValidSuiteConfig();
+    const suiteDir = await createSuite('order-events', config, { main: cases });
+    const mockStore = createMockEventStore();
+
+    // Act
+    await runSuite(config, tmpDir, suiteDir, registry, {
+      eventStore: mockStore,
+      streamId: 'eval-stream',
+    });
+
+    // Assert
+    const types = mockStore.append.mock.calls.map(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).type,
+    );
+    expect(types[0]).toBe('eval.run.started');
+    expect(types[types.length - 1]).toBe('eval.run.completed');
+    const middleTypes = types.slice(1, -1);
+    expect(middleTypes.every((t: unknown) => t === 'eval.case.completed')).toBe(true);
+  });
+
+  it('runSuite_WithoutEventStore_NoEventsEmitted', async () => {
+    // Arrange
+    const cases = [makeEvalCase('c-1', { input: { value: 'a' }, expected: { value: 'a' } })];
+    const config = makeValidSuiteConfig();
+    const suiteDir = await createSuite('no-events', config, { main: cases });
+
+    // Act — no eventStore in options
+    const summary = await runSuite(config, tmpDir, suiteDir, registry);
+
+    // Assert — should still work and return a valid summary
+    expect(summary.total).toBe(1);
+    expect(summary.passed).toBe(1);
+  });
+
+  it('runSuite_WithTriggerOption_PassesTriggerInStartedEvent', async () => {
+    // Arrange
+    const cases = [makeEvalCase('c-1', { input: { value: 'a' }, expected: { value: 'a' } })];
+    const config = makeValidSuiteConfig();
+    const suiteDir = await createSuite('trigger-events', config, { main: cases });
+    const mockStore = createMockEventStore();
+
+    // Act
+    await runSuite(config, tmpDir, suiteDir, registry, {
+      eventStore: mockStore,
+      streamId: 'eval-stream',
+      trigger: 'ci',
+    });
+
+    // Assert
+    const startedCalls = mockStore.append.mock.calls.filter(
+      (call: unknown[]) => (call[1] as Record<string, unknown>).type === 'eval.run.started',
+    );
+    const data = (startedCalls[0][1] as Record<string, unknown>).data as Record<string, unknown>;
+    expect(data.trigger).toBe('ci');
   });
 });

--- a/servers/exarchos-mcp/src/evals/harness.ts
+++ b/servers/exarchos-mcp/src/evals/harness.ts
@@ -64,6 +64,23 @@ export async function discoverSuites(
 }
 
 /**
+ * Duck-typed event store interface to avoid circular dependencies.
+ * Only requires the append method needed for event emission.
+ */
+export interface EvalEventStore {
+  append(streamId: string, event: Record<string, unknown>): Promise<void>;
+}
+
+/**
+ * Options for event emission during suite runs.
+ */
+export interface RunSuiteOptions {
+  eventStore?: EvalEventStore;
+  streamId?: string;
+  trigger?: 'ci' | 'local' | 'scheduled';
+}
+
+/**
  * Run all cases in a suite against the registered graders.
  */
 export async function runSuite(
@@ -71,14 +88,41 @@ export async function runSuite(
   _evalsDir: string,
   suiteDir: string,
   graderRegistry: GraderRegistry,
+  options?: RunSuiteOptions,
 ): Promise<RunSummary> {
   const startTime = Date.now();
+  const runId = crypto.randomUUID();
   const allResults: EvalResult[] = [];
+  const eventStore = options?.eventStore;
+  const streamId = options?.streamId ?? 'default';
+  const trigger = options?.trigger ?? 'local';
 
-  for (const [_datasetName, datasetRef] of Object.entries(suite.datasets)) {
+  // Count total cases across all datasets for the started event
+  let totalCaseCount = 0;
+  const datasetEntries = Object.entries(suite.datasets);
+  const loadedDatasets: Array<{ datasetRef: { path: string; description: string }; cases: Awaited<ReturnType<typeof loadDataset>> }> = [];
+
+  for (const [_datasetName, datasetRef] of datasetEntries) {
     const datasetPath = path.resolve(suiteDir, datasetRef.path);
     const cases = await loadDataset(datasetPath);
+    totalCaseCount += cases.length;
+    loadedDatasets.push({ datasetRef, cases });
+  }
 
+  // Emit eval.run.started
+  if (eventStore) {
+    await eventStore.append(streamId, {
+      type: 'eval.run.started',
+      data: {
+        runId,
+        suiteId: suite.metadata.skill,
+        trigger,
+        caseCount: totalCaseCount,
+      },
+    });
+  }
+
+  for (const { cases } of loadedDatasets) {
     for (const evalCase of cases) {
       const caseStart = Date.now();
       const assertionResults: AssertionResult[] = [];
@@ -111,6 +155,7 @@ export async function runSuite(
         scoredAssertions.length > 0
           ? scoredAssertions.reduce((sum, a) => sum + a.score, 0) / scoredAssertions.length
           : 1.0;
+      const caseDuration = Date.now() - caseStart;
 
       allResults.push({
         caseId: evalCase.id,
@@ -118,8 +163,30 @@ export async function runSuite(
         passed: casePassed,
         score: caseScore,
         assertions: assertionResults,
-        duration: Date.now() - caseStart,
+        duration: caseDuration,
       });
+
+      // Emit eval.case.completed
+      if (eventStore) {
+        await eventStore.append(streamId, {
+          type: 'eval.case.completed',
+          data: {
+            runId,
+            caseId: evalCase.id,
+            suiteId: suite.metadata.skill,
+            passed: casePassed,
+            score: caseScore,
+            assertions: assertionResults.map((a) => ({
+              name: a.name,
+              type: a.type,
+              passed: a.passed,
+              score: a.score,
+              reason: a.reason,
+            })),
+            duration: caseDuration,
+          },
+        });
+      }
     }
   }
 
@@ -133,8 +200,8 @@ export async function runSuite(
       ? allResults.reduce((sum, r) => sum + r.score, 0) / allResults.length
       : 0;
 
-  return {
-    runId: crypto.randomUUID(),
+  const summary: RunSummary = {
+    runId,
     suiteId: suite.metadata.skill,
     total: allResults.length,
     passed: totalPassed,
@@ -144,6 +211,25 @@ export async function runSuite(
     duration: Date.now() - startTime,
     results: allResults,
   };
+
+  // Emit eval.run.completed
+  if (eventStore) {
+    await eventStore.append(streamId, {
+      type: 'eval.run.completed',
+      data: {
+        runId,
+        suiteId: suite.metadata.skill,
+        total: summary.total,
+        passed: summary.passed,
+        failed: summary.failed,
+        avgScore: summary.avgScore,
+        duration: summary.duration,
+        regressions: [],
+      },
+    });
+  }
+
+  return summary;
 }
 
 /**
@@ -151,13 +237,13 @@ export async function runSuite(
  */
 export async function runAll(
   evalsDir: string,
-  options?: { skill?: string; dataset?: string },
+  options?: { skill?: string; dataset?: string } & RunSuiteOptions,
 ): Promise<RunSummary[]> {
   const discovered = await discoverSuites(evalsDir, { skill: options?.skill });
   const summaries: RunSummary[] = [];
 
   for (const { config, suiteDir } of discovered) {
-    const summary = await runSuite(config, evalsDir, suiteDir, createDefaultRegistry());
+    const summary = await runSuite(config, evalsDir, suiteDir, createDefaultRegistry(), options);
     summaries.push(summary);
   }
 

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -18,6 +18,9 @@ import {
   ReviewFindingData,
   ReviewEscalatedData,
   QualityHintGeneratedData,
+  EvalRunStartedData,
+  EvalCaseCompletedData,
+  EvalRunCompletedData,
 } from './schemas.js';
 
 describe('validateAgentEvent', () => {
@@ -323,7 +326,7 @@ describe('EventTypes', () => {
   });
 
   it('EventTypes_HasExpectedCount', () => {
-    expect(EventTypes).toHaveLength(39);
+    expect(EventTypes).toHaveLength(42);
   });
 
   it('EventTypes_StatePatchedType_IsValidEventType', () => {
@@ -494,5 +497,182 @@ describe('QualityHintGeneratedData', () => {
 describe('EventTypes', () => {
   it('EventTypes_IncludesQualityHintGenerated', () => {
     expect(EventTypes).toContain('quality.hint.generated');
+  });
+});
+
+// ─── T07: Eval Event Type Schemas ──────────────────────────────────────────
+
+describe('EvalRunStartedData', () => {
+  it('EvalRunStartedData_ValidPayload_Parses', () => {
+    const result = EvalRunStartedData.safeParse({
+      runId: crypto.randomUUID(),
+      suiteId: 'delegation',
+      trigger: 'local',
+      caseCount: 10,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('EvalRunStartedData_MissingRunId_Fails', () => {
+    const result = EvalRunStartedData.safeParse({
+      suiteId: 'delegation',
+      trigger: 'local',
+      caseCount: 10,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('EvalRunStartedData_InvalidTrigger_Fails', () => {
+    const result = EvalRunStartedData.safeParse({
+      runId: crypto.randomUUID(),
+      suiteId: 'delegation',
+      trigger: 'unknown',
+      caseCount: 10,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('EvalRunStartedData_WithOptionalLayer_Parses', () => {
+    const result = EvalRunStartedData.safeParse({
+      runId: crypto.randomUUID(),
+      suiteId: 'delegation',
+      trigger: 'local',
+      caseCount: 10,
+      layer: 'regression',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.layer).toBe('regression');
+    }
+  });
+});
+
+describe('EvalCaseCompletedData', () => {
+  it('EvalCaseCompletedData_ValidPayload_Parses', () => {
+    const result = EvalCaseCompletedData.safeParse({
+      runId: crypto.randomUUID(),
+      caseId: 'case-001',
+      suiteId: 'delegation',
+      passed: true,
+      score: 0.95,
+      assertions: [
+        { name: 'check-output', type: 'exact-match', passed: true, score: 0.95, reason: 'matched' },
+      ],
+      duration: 1200,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('EvalCaseCompletedData_ScoreOutOfRange_Fails', () => {
+    const result = EvalCaseCompletedData.safeParse({
+      runId: crypto.randomUUID(),
+      caseId: 'case-001',
+      suiteId: 'delegation',
+      passed: true,
+      score: 1.5,
+      assertions: [],
+      duration: 1200,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('EvalCaseCompletedData_EmptyAssertions_Parses', () => {
+    const result = EvalCaseCompletedData.safeParse({
+      runId: crypto.randomUUID(),
+      caseId: 'case-001',
+      suiteId: 'delegation',
+      passed: true,
+      score: 1.0,
+      assertions: [],
+      duration: 500,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.assertions).toEqual([]);
+    }
+  });
+});
+
+describe('EvalRunCompletedData', () => {
+  it('EvalRunCompletedData_ValidPayload_Parses', () => {
+    const result = EvalRunCompletedData.safeParse({
+      runId: crypto.randomUUID(),
+      suiteId: 'delegation',
+      total: 10,
+      passed: 8,
+      failed: 2,
+      avgScore: 0.85,
+      duration: 5000,
+      regressions: ['case-003'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('EvalRunCompletedData_NegativeFailed_Fails', () => {
+    const result = EvalRunCompletedData.safeParse({
+      runId: crypto.randomUUID(),
+      suiteId: 'delegation',
+      total: 10,
+      passed: 8,
+      failed: -1,
+      avgScore: 0.85,
+      duration: 5000,
+      regressions: [],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('WorkflowEventBase — eval event types', () => {
+  it('WorkflowEventBase_EvalRunStartedType_Parses', () => {
+    const event = WorkflowEventBase.safeParse({
+      streamId: 'eval-stream',
+      sequence: 1,
+      type: 'eval.run.started',
+      data: {
+        runId: crypto.randomUUID(),
+        suiteId: 'delegation',
+        trigger: 'local',
+        caseCount: 5,
+      },
+    });
+    expect(event.success).toBe(true);
+  });
+
+  it('WorkflowEventBase_EvalCaseCompletedType_Parses', () => {
+    const event = WorkflowEventBase.safeParse({
+      streamId: 'eval-stream',
+      sequence: 2,
+      type: 'eval.case.completed',
+      data: {
+        runId: crypto.randomUUID(),
+        caseId: 'case-001',
+        suiteId: 'delegation',
+        passed: true,
+        score: 1.0,
+        assertions: [],
+        duration: 100,
+      },
+    });
+    expect(event.success).toBe(true);
+  });
+
+  it('WorkflowEventBase_EvalRunCompletedType_Parses', () => {
+    const event = WorkflowEventBase.safeParse({
+      streamId: 'eval-stream',
+      sequence: 3,
+      type: 'eval.run.completed',
+      data: {
+        runId: crypto.randomUUID(),
+        suiteId: 'delegation',
+        total: 5,
+        passed: 5,
+        failed: 0,
+        avgScore: 1.0,
+        duration: 3000,
+        regressions: [],
+      },
+    });
+    expect(event.success).toBe(true);
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -42,6 +42,9 @@ export const EventTypes = [
   'review.finding',
   'review.escalated',
   'quality.hint.generated',
+  'eval.run.started',
+  'eval.case.completed',
+  'eval.run.completed',
 ] as const;
 
 export type EventType = typeof EventTypes[number];
@@ -348,6 +351,43 @@ export const QualityHintGeneratedData = z.object({
   generatedAt: z.string().datetime(),
 });
 
+// ─── Eval Event Data ────────────────────────────────────────────────────────
+
+export const EvalRunStartedData = z.object({
+  runId: z.string().uuid(),
+  suiteId: z.string(),
+  layer: z.enum(['regression', 'capability', 'reliability']).optional(),
+  trigger: z.enum(['ci', 'local', 'scheduled']),
+  caseCount: z.number().int().nonnegative(),
+});
+
+export const EvalCaseCompletedData = z.object({
+  runId: z.string().uuid(),
+  caseId: z.string(),
+  suiteId: z.string(),
+  passed: z.boolean(),
+  score: z.number().min(0).max(1),
+  assertions: z.array(z.object({
+    name: z.string(),
+    type: z.string(),
+    passed: z.boolean(),
+    score: z.number().min(0).max(1),
+    reason: z.string(),
+  })),
+  duration: z.number().int().nonnegative(),
+});
+
+export const EvalRunCompletedData = z.object({
+  runId: z.string().uuid(),
+  suiteId: z.string(),
+  total: z.number().int().nonnegative(),
+  passed: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  avgScore: z.number().min(0).max(1),
+  duration: z.number().int().nonnegative(),
+  regressions: z.array(z.string()),
+});
+
 // ─── TypeScript Types ───────────────────────────────────────────────────────
 
 export type WorkflowEvent = z.infer<typeof WorkflowEventBase>;
@@ -389,6 +429,9 @@ export type ReviewRouted = z.infer<typeof ReviewRoutedData>;
 export type ReviewFinding = z.infer<typeof ReviewFindingData>;
 export type ReviewEscalated = z.infer<typeof ReviewEscalatedData>;
 export type QualityHintGenerated = z.infer<typeof QualityHintGeneratedData>;
+export type EvalRunStarted = z.infer<typeof EvalRunStartedData>;
+export type EvalCaseCompleted = z.infer<typeof EvalCaseCompletedData>;
+export type EvalRunCompleted = z.infer<typeof EvalRunCompletedData>;
 
 // ─── Agent Event Validation ──────────────────────────────────────────────────
 

--- a/servers/exarchos-mcp/src/views/composite.test.ts
+++ b/servers/exarchos-mcp/src/views/composite.test.ts
@@ -9,6 +9,7 @@ vi.mock('./tools.js', () => ({
   handleViewDelegationTimeline: vi.fn(),
   handleViewCodeQuality: vi.fn(),
   handleViewQualityHints: vi.fn(),
+  handleViewEvalResults: vi.fn(),
 }));
 
 // Mock the stack tools module
@@ -31,6 +32,7 @@ import {
   handleViewDelegationTimeline,
   handleViewCodeQuality,
   handleViewQualityHints,
+  handleViewEvalResults,
 } from './tools.js';
 import { handleStackStatus, handleStackPlace } from '../stack/tools.js';
 import { handleViewTelemetry } from '../telemetry/tools.js';
@@ -343,8 +345,31 @@ describe('handleView', () => {
     });
   });
 
+  describe('eval_results', () => {
+    it('handleView_EvalResultsAction_DispatchesToHandler', async () => {
+      // Arrange
+      const expected = {
+        success: true,
+        data: { skills: {}, runs: [], regressions: [] },
+      };
+      vi.mocked(handleViewEvalResults).mockResolvedValue(expected);
+      const args = { action: 'eval_results', workflowId: 'eval-wf', skill: 'delegation', limit: 5 };
+
+      // Act
+      const result = await handleView(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(result.success).toBe(true);
+      expect(handleViewEvalResults).toHaveBeenCalledWith(
+        { workflowId: 'eval-wf', skill: 'delegation', limit: 5 },
+        STATE_DIR,
+      );
+    });
+  });
+
   describe('unknown action', () => {
-    it('HandleView_UnknownAction_IncludesCodeQualityAndQualityHints', async () => {
+    it('HandleView_UnknownAction_IncludesEvalResultsAndCodeQuality', async () => {
       // Arrange
       const args = { action: 'nonexistent' };
 
@@ -357,6 +382,7 @@ describe('handleView', () => {
       const validTargets = (result.error as Record<string, unknown>)?.validTargets as string[];
       expect(validTargets).toContain('code_quality');
       expect(validTargets).toContain('quality_hints');
+      expect(validTargets).toContain('eval_results');
     });
 
     it('should return error for unknown action', async () => {

--- a/servers/exarchos-mcp/src/views/composite.ts
+++ b/servers/exarchos-mcp/src/views/composite.ts
@@ -12,6 +12,7 @@ import {
   handleViewDelegationTimeline,
   handleViewCodeQuality,
   handleViewQualityHints,
+  handleViewEvalResults,
 } from './tools.js';
 import { handleStackStatus, handleStackPlace } from '../stack/tools.js';
 import { handleViewTelemetry } from '../telemetry/tools.js';
@@ -109,6 +110,16 @@ export async function handleView(
         stateDir,
       );
 
+    case 'eval_results':
+      return handleViewEvalResults(
+        rest as {
+          workflowId?: string;
+          skill?: string;
+          limit?: number;
+        },
+        stateDir,
+      );
+
     default:
       return {
         success: false,
@@ -126,6 +137,7 @@ export async function handleView(
             'delegation_timeline',
             'code_quality',
             'quality_hints',
+            'eval_results',
           ] as const,
         },
       };

--- a/servers/exarchos-mcp/src/views/eval-results-view.test.ts
+++ b/servers/exarchos-mcp/src/views/eval-results-view.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evalResultsProjection,
+  EVAL_RESULTS_VIEW,
+} from './eval-results-view.js';
+import type { EvalResultsViewState } from './eval-results-view.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+
+const makeEvent = (type: string, data: Record<string, unknown>, seq = 1): WorkflowEvent => ({
+  streamId: 'test',
+  sequence: seq,
+  timestamp: new Date().toISOString(),
+  type: type as WorkflowEvent['type'],
+  data,
+  schemaVersion: '1.0',
+});
+
+// ─── T09: EvalResultsView Projection Tests ──────────────────────────────────
+
+describe('EvalResultsView', () => {
+  describe('init', () => {
+    it('evalResultsProjection_Init_ReturnsEmptyState', () => {
+      const state = evalResultsProjection.init();
+      expect(state).toEqual({
+        skills: {},
+        runs: [],
+        regressions: [],
+      });
+    });
+  });
+
+  describe('apply — eval.run.completed', () => {
+    it('evalResultsProjection_EvalRunCompleted_AddsRunRecord', () => {
+      const state = evalResultsProjection.init();
+      const event = makeEvent('eval.run.completed', {
+        runId: 'run-001',
+        suiteId: 'delegation',
+        total: 10,
+        passed: 8,
+        failed: 2,
+        avgScore: 0.85,
+        duration: 5000,
+        regressions: [],
+      });
+
+      const next = evalResultsProjection.apply(state, event);
+      expect(next.runs).toHaveLength(1);
+      expect(next.runs[0].runId).toBe('run-001');
+      expect(next.runs[0].suiteId).toBe('delegation');
+      expect(next.runs[0].total).toBe(10);
+      expect(next.runs[0].passed).toBe(8);
+      expect(next.runs[0].failed).toBe(2);
+      expect(next.runs[0].avgScore).toBe(0.85);
+      expect(next.runs[0].duration).toBe(5000);
+    });
+
+    it('evalResultsProjection_EvalRunCompleted_UpdatesSkillMetrics', () => {
+      const state = evalResultsProjection.init();
+      const event = makeEvent('eval.run.completed', {
+        runId: 'run-001',
+        suiteId: 'delegation',
+        total: 10,
+        passed: 8,
+        failed: 2,
+        avgScore: 0.85,
+        duration: 5000,
+        regressions: [],
+      });
+
+      const next = evalResultsProjection.apply(state, event);
+      expect(next.skills['delegation']).toBeDefined();
+      expect(next.skills['delegation'].latestScore).toBe(0.85);
+      expect(next.skills['delegation'].lastRunId).toBe('run-001');
+      expect(next.skills['delegation'].totalRuns).toBe(1);
+    });
+
+    it('evalResultsProjection_MultipleRuns_SameSkill_IncrementsTotalRuns', () => {
+      let state = evalResultsProjection.init();
+
+      state = evalResultsProjection.apply(state, makeEvent('eval.run.completed', {
+        runId: 'run-001',
+        suiteId: 'delegation',
+        total: 10,
+        passed: 8,
+        failed: 2,
+        avgScore: 0.8,
+        duration: 5000,
+        regressions: [],
+      }, 1));
+
+      state = evalResultsProjection.apply(state, makeEvent('eval.run.completed', {
+        runId: 'run-002',
+        suiteId: 'delegation',
+        total: 10,
+        passed: 9,
+        failed: 1,
+        avgScore: 0.9,
+        duration: 4000,
+        regressions: [],
+      }, 2));
+
+      expect(state.skills['delegation'].totalRuns).toBe(2);
+      expect(state.skills['delegation'].latestScore).toBe(0.9);
+      expect(state.skills['delegation'].lastRunId).toBe('run-002');
+      expect(state.runs).toHaveLength(2);
+    });
+
+    it('evalResultsProjection_ThreeImprovingRuns_TrendIsImproving', () => {
+      let state = evalResultsProjection.init();
+
+      const scores = [0.5, 0.7, 0.9];
+      for (let i = 0; i < scores.length; i++) {
+        state = evalResultsProjection.apply(state, makeEvent('eval.run.completed', {
+          runId: `run-00${i + 1}`,
+          suiteId: 'delegation',
+          total: 10,
+          passed: Math.round(scores[i] * 10),
+          failed: 10 - Math.round(scores[i] * 10),
+          avgScore: scores[i],
+          duration: 5000,
+          regressions: [],
+        }, i + 1));
+      }
+
+      expect(state.skills['delegation'].trend).toBe('improving');
+    });
+
+    it('evalResultsProjection_ThreeDegradingRuns_TrendIsDegrading', () => {
+      let state = evalResultsProjection.init();
+
+      const scores = [0.9, 0.7, 0.5];
+      for (let i = 0; i < scores.length; i++) {
+        state = evalResultsProjection.apply(state, makeEvent('eval.run.completed', {
+          runId: `run-00${i + 1}`,
+          suiteId: 'delegation',
+          total: 10,
+          passed: Math.round(scores[i] * 10),
+          failed: 10 - Math.round(scores[i] * 10),
+          avgScore: scores[i],
+          duration: 5000,
+          regressions: [],
+        }, i + 1));
+      }
+
+      expect(state.skills['delegation'].trend).toBe('degrading');
+    });
+
+    it('evalResultsProjection_StableScores_TrendIsStable', () => {
+      let state = evalResultsProjection.init();
+
+      const scores = [0.8, 0.8, 0.8];
+      for (let i = 0; i < scores.length; i++) {
+        state = evalResultsProjection.apply(state, makeEvent('eval.run.completed', {
+          runId: `run-00${i + 1}`,
+          suiteId: 'delegation',
+          total: 10,
+          passed: 8,
+          failed: 2,
+          avgScore: scores[i],
+          duration: 5000,
+          regressions: [],
+        }, i + 1));
+      }
+
+      expect(state.skills['delegation'].trend).toBe('stable');
+    });
+
+    it('evalResultsProjection_LessThanThreeRuns_TrendIsStable', () => {
+      let state = evalResultsProjection.init();
+
+      state = evalResultsProjection.apply(state, makeEvent('eval.run.completed', {
+        runId: 'run-001',
+        suiteId: 'delegation',
+        total: 10,
+        passed: 9,
+        failed: 1,
+        avgScore: 0.9,
+        duration: 5000,
+        regressions: [],
+      }, 1));
+
+      state = evalResultsProjection.apply(state, makeEvent('eval.run.completed', {
+        runId: 'run-002',
+        suiteId: 'delegation',
+        total: 10,
+        passed: 5,
+        failed: 5,
+        avgScore: 0.5,
+        duration: 5000,
+        regressions: [],
+      }, 2));
+
+      expect(state.skills['delegation'].trend).toBe('stable');
+    });
+  });
+
+  describe('apply — eval.case.completed (regression detection)', () => {
+    it('evalResultsProjection_EvalCaseCompleted_TracksPassHistory', () => {
+      let state = evalResultsProjection.init();
+
+      state = evalResultsProjection.apply(state, makeEvent('eval.case.completed', {
+        runId: 'run-001',
+        caseId: 'case-001',
+        suiteId: 'delegation',
+        passed: true,
+        score: 1.0,
+        assertions: [],
+        duration: 100,
+      }, 1));
+
+      // The case was tracked internally (no regression)
+      expect(state.regressions).toHaveLength(0);
+    });
+
+    it('evalResultsProjection_CasePreviouslyPassedNowFails_DetectsRegression', () => {
+      let state = evalResultsProjection.init();
+
+      // First: case passes
+      state = evalResultsProjection.apply(state, makeEvent('eval.case.completed', {
+        runId: 'run-001',
+        caseId: 'case-001',
+        suiteId: 'delegation',
+        passed: true,
+        score: 1.0,
+        assertions: [],
+        duration: 100,
+      }, 1));
+
+      // Second: same case fails
+      state = evalResultsProjection.apply(state, makeEvent('eval.case.completed', {
+        runId: 'run-002',
+        caseId: 'case-001',
+        suiteId: 'delegation',
+        passed: false,
+        score: 0.0,
+        assertions: [],
+        duration: 100,
+      }, 2));
+
+      expect(state.regressions).toHaveLength(1);
+      expect(state.regressions[0].caseId).toBe('case-001');
+      expect(state.regressions[0].suiteId).toBe('delegation');
+      expect(state.regressions[0].firstFailedRunId).toBe('run-002');
+      expect(state.regressions[0].consecutiveFailures).toBe(1);
+    });
+
+    it('evalResultsProjection_CaseFailsThenPasses_ClearsRegression', () => {
+      let state = evalResultsProjection.init();
+
+      // Pass
+      state = evalResultsProjection.apply(state, makeEvent('eval.case.completed', {
+        runId: 'run-001',
+        caseId: 'case-001',
+        suiteId: 'delegation',
+        passed: true,
+        score: 1.0,
+        assertions: [],
+        duration: 100,
+      }, 1));
+
+      // Fail (creates regression)
+      state = evalResultsProjection.apply(state, makeEvent('eval.case.completed', {
+        runId: 'run-002',
+        caseId: 'case-001',
+        suiteId: 'delegation',
+        passed: false,
+        score: 0.0,
+        assertions: [],
+        duration: 100,
+      }, 2));
+
+      expect(state.regressions).toHaveLength(1);
+
+      // Pass again (clears regression)
+      state = evalResultsProjection.apply(state, makeEvent('eval.case.completed', {
+        runId: 'run-003',
+        caseId: 'case-001',
+        suiteId: 'delegation',
+        passed: true,
+        score: 1.0,
+        assertions: [],
+        duration: 100,
+      }, 3));
+
+      expect(state.regressions).toHaveLength(0);
+    });
+
+    it('evalResultsProjection_ConsecutiveFailures_IncrementsRegressionCount', () => {
+      let state = evalResultsProjection.init();
+
+      // Pass first
+      state = evalResultsProjection.apply(state, makeEvent('eval.case.completed', {
+        runId: 'run-001',
+        caseId: 'case-001',
+        suiteId: 'delegation',
+        passed: true,
+        score: 1.0,
+        assertions: [],
+        duration: 100,
+      }, 1));
+
+      // Fail twice
+      state = evalResultsProjection.apply(state, makeEvent('eval.case.completed', {
+        runId: 'run-002',
+        caseId: 'case-001',
+        suiteId: 'delegation',
+        passed: false,
+        score: 0.0,
+        assertions: [],
+        duration: 100,
+      }, 2));
+
+      state = evalResultsProjection.apply(state, makeEvent('eval.case.completed', {
+        runId: 'run-003',
+        caseId: 'case-001',
+        suiteId: 'delegation',
+        passed: false,
+        score: 0.0,
+        assertions: [],
+        duration: 100,
+      }, 3));
+
+      expect(state.regressions).toHaveLength(1);
+      expect(state.regressions[0].consecutiveFailures).toBe(2);
+      expect(state.regressions[0].firstFailedRunId).toBe('run-002');
+    });
+  });
+
+  describe('apply — unknown event', () => {
+    it('evalResultsProjection_UnknownEventType_ReturnsUnchanged', () => {
+      const state = evalResultsProjection.init();
+      const event = makeEvent('task.assigned', {
+        taskId: 'task-1',
+        title: 'Implement auth',
+      });
+
+      const next = evalResultsProjection.apply(state, event);
+      expect(next).toBe(state);
+    });
+  });
+
+  describe('view name constant', () => {
+    it('EVAL_RESULTS_VIEW_HasCorrectValue', () => {
+      expect(EVAL_RESULTS_VIEW).toBe('eval-results');
+    });
+  });
+});

--- a/servers/exarchos-mcp/src/views/eval-results-view.ts
+++ b/servers/exarchos-mcp/src/views/eval-results-view.ts
@@ -1,0 +1,290 @@
+import type { ViewProjection } from './materializer.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+
+// ─── View Name Constant ────────────────────────────────────────────────────
+
+export const EVAL_RESULTS_VIEW = 'eval-results';
+
+// ─── View State Interfaces ─────────────────────────────────────────────────
+
+export interface SkillEvalMetrics {
+  readonly skill: string;
+  readonly latestScore: number;
+  readonly trend: 'improving' | 'stable' | 'degrading';
+  readonly lastRunId: string;
+  readonly lastRunTimestamp: string;
+  readonly totalRuns: number;
+  readonly regressionCount: number;
+  readonly capabilityPassRate: number;
+}
+
+export interface EvalRunRecord {
+  readonly runId: string;
+  readonly suiteId: string;
+  readonly trigger: string;
+  readonly total: number;
+  readonly passed: number;
+  readonly failed: number;
+  readonly avgScore: number;
+  readonly duration: number;
+  readonly timestamp: string;
+}
+
+export interface EvalRegression {
+  readonly caseId: string;
+  readonly suiteId: string;
+  readonly firstFailedRunId: string;
+  readonly consecutiveFailures: number;
+}
+
+export interface EvalResultsViewState {
+  readonly skills: Record<string, SkillEvalMetrics>;
+  readonly runs: ReadonlyArray<EvalRunRecord>;
+  readonly regressions: ReadonlyArray<EvalRegression>;
+}
+
+// ─── Internal Tracking State ───────────────────────────────────────────────
+
+interface CaseHistory {
+  lastPassed: boolean;
+  consecutiveFailures: number;
+  firstFailedRunId: string;
+}
+
+interface ScoreHistory {
+  scores: number[];
+}
+
+interface InternalState extends EvalResultsViewState {
+  readonly _caseHistory: Record<string, CaseHistory>;
+  readonly _scoreHistory: Record<string, ScoreHistory>;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+/** Calculate trend direction from last 3+ scores. */
+function calculateTrend(scores: number[]): 'improving' | 'stable' | 'degrading' {
+  if (scores.length < 3) return 'stable';
+
+  const recent = scores.slice(-3);
+  const diffs: number[] = [];
+  for (let i = 1; i < recent.length; i++) {
+    diffs.push(recent[i] - recent[i - 1]);
+  }
+
+  const avgDiff = diffs.reduce((sum, d) => sum + d, 0) / diffs.length;
+
+  if (avgDiff > 0.001) return 'improving';
+  if (avgDiff < -0.001) return 'degrading';
+  return 'stable';
+}
+
+/** Convert public view state to internal state. */
+function toInternal(view: EvalResultsViewState): InternalState {
+  return {
+    ...view,
+    _caseHistory: (view as Partial<InternalState>)._caseHistory ?? {},
+    _scoreHistory: (view as Partial<InternalState>)._scoreHistory ?? {},
+  };
+}
+
+/** Create a result that hides internal tracking from enumeration. */
+function fromInternal(state: InternalState): EvalResultsViewState {
+  const { _caseHistory, _scoreHistory, ...publicState } = state;
+  const result = { ...publicState } as EvalResultsViewState;
+  // Store internal trackers as non-enumerable so they survive apply() chaining
+  // but don't leak into toEqual/JSON.stringify comparisons
+  Object.defineProperty(result, '_caseHistory', {
+    value: _caseHistory,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  Object.defineProperty(result, '_scoreHistory', {
+    value: _scoreHistory,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  return result;
+}
+
+// ─── Event Handlers ────────────────────────────────────────────────────────
+
+function handleEvalRunCompleted(state: InternalState, event: WorkflowEvent): EvalResultsViewState {
+  const data = event.data as {
+    runId?: string;
+    suiteId?: string;
+    trigger?: string;
+    total?: number;
+    passed?: number;
+    failed?: number;
+    avgScore?: number;
+    duration?: number;
+    regressions?: string[];
+  } | undefined;
+
+  if (!data) return fromInternal(state);
+
+  const runId = data.runId ?? '';
+  const suiteId = data.suiteId ?? '';
+  const trigger = data.trigger ?? 'local';
+  const total = data.total ?? 0;
+  const passed = data.passed ?? 0;
+  const failed = data.failed ?? 0;
+  const avgScore = data.avgScore ?? 0;
+  const duration = data.duration ?? 0;
+
+  // Add run record
+  const newRun: EvalRunRecord = {
+    runId,
+    suiteId,
+    trigger,
+    total,
+    passed,
+    failed,
+    avgScore,
+    duration,
+    timestamp: event.timestamp,
+  };
+
+  // Update score history for trend calculation
+  const prevScoreHistory = state._scoreHistory[suiteId] ?? { scores: [] };
+  const updatedScores = [...prevScoreHistory.scores, avgScore];
+  const trend = calculateTrend(updatedScores);
+
+  // Count regressions for this skill
+  const regressionCount = state.regressions.filter((r) => r.suiteId === suiteId).length;
+
+  // Calculate capability pass rate
+  const skillRuns = [...state.runs.filter((r) => r.suiteId === suiteId), newRun];
+  const totalPassed = skillRuns.reduce((sum, r) => sum + r.passed, 0);
+  const totalCases = skillRuns.reduce((sum, r) => sum + r.total, 0);
+  const capabilityPassRate = totalCases > 0 ? totalPassed / totalCases : 0;
+
+  // Build updated skill metrics
+  const prevSkill = state.skills[suiteId];
+  const updatedSkill: SkillEvalMetrics = {
+    skill: suiteId,
+    latestScore: avgScore,
+    trend,
+    lastRunId: runId,
+    lastRunTimestamp: event.timestamp,
+    totalRuns: (prevSkill?.totalRuns ?? 0) + 1,
+    regressionCount,
+    capabilityPassRate,
+  };
+
+  return fromInternal({
+    ...state,
+    skills: { ...state.skills, [suiteId]: updatedSkill },
+    runs: [...state.runs, newRun],
+    _scoreHistory: { ...state._scoreHistory, [suiteId]: { scores: updatedScores } },
+  });
+}
+
+function handleEvalCaseCompleted(state: InternalState, event: WorkflowEvent): EvalResultsViewState {
+  const data = event.data as {
+    runId?: string;
+    caseId?: string;
+    suiteId?: string;
+    passed?: boolean;
+  } | undefined;
+
+  if (!data) return fromInternal(state);
+
+  const caseId = data.caseId ?? '';
+  const suiteId = data.suiteId ?? '';
+  const passed = data.passed ?? false;
+  const runId = data.runId ?? '';
+  const caseKey = `${suiteId}:${caseId}`;
+
+  const prevHistory = state._caseHistory[caseKey];
+  let updatedRegressions = [...state.regressions];
+
+  if (passed) {
+    // Case passed — remove any existing regression for this case
+    updatedRegressions = updatedRegressions.filter(
+      (r) => !(r.caseId === caseId && r.suiteId === suiteId),
+    );
+
+    return fromInternal({
+      ...state,
+      regressions: updatedRegressions,
+      _caseHistory: {
+        ...state._caseHistory,
+        [caseKey]: {
+          lastPassed: true,
+          consecutiveFailures: 0,
+          firstFailedRunId: '',
+        },
+      },
+    });
+  }
+
+  // Case failed
+  const wasPreviouslyPassing = prevHistory?.lastPassed === true;
+  const prevConsecutiveFailures = prevHistory?.consecutiveFailures ?? 0;
+  const newConsecutiveFailures = prevConsecutiveFailures + 1;
+  const firstFailedRunId = prevHistory?.firstFailedRunId && !wasPreviouslyPassing
+    ? prevHistory.firstFailedRunId
+    : runId;
+
+  if (wasPreviouslyPassing || prevConsecutiveFailures > 0) {
+    // This is a regression (was passing) or ongoing regression (already failing)
+    // Remove existing regression entry for this case
+    updatedRegressions = updatedRegressions.filter(
+      (r) => !(r.caseId === caseId && r.suiteId === suiteId),
+    );
+
+    // Add updated regression entry
+    updatedRegressions.push({
+      caseId,
+      suiteId,
+      firstFailedRunId,
+      consecutiveFailures: newConsecutiveFailures,
+    });
+  }
+
+  return fromInternal({
+    ...state,
+    regressions: updatedRegressions,
+    _caseHistory: {
+      ...state._caseHistory,
+      [caseKey]: {
+        lastPassed: false,
+        consecutiveFailures: newConsecutiveFailures,
+        firstFailedRunId,
+      },
+    },
+  });
+}
+
+// ─── Projection ────────────────────────────────────────────────────────────
+
+export const evalResultsProjection: ViewProjection<EvalResultsViewState> = {
+  init: (): EvalResultsViewState => ({
+    skills: {},
+    runs: [],
+    regressions: [],
+  }),
+
+  apply: (view: EvalResultsViewState, event: WorkflowEvent): EvalResultsViewState => {
+    switch (event.type) {
+      case 'eval.run.completed': {
+        if (!event.data) return view;
+        const state = toInternal(view);
+        return handleEvalRunCompleted(state, event);
+      }
+
+      case 'eval.case.completed': {
+        if (!event.data) return view;
+        const state = toInternal(view);
+        return handleEvalCaseCompleted(state, event);
+      }
+
+      default:
+        return view;
+    }
+  },
+};

--- a/servers/exarchos-mcp/src/views/eval-results-view.ts
+++ b/servers/exarchos-mcp/src/views/eval-results-view.ts
@@ -230,7 +230,11 @@ function handleEvalCaseCompleted(state: InternalState, event: WorkflowEvent): Ev
     ? prevHistory.firstFailedRunId
     : runId;
 
-  if (wasPreviouslyPassing || prevConsecutiveFailures > 0) {
+  const hadRegression = state.regressions.some(
+    (r) => r.caseId === caseId && r.suiteId === suiteId,
+  );
+
+  if (wasPreviouslyPassing || hadRegression) {
     // This is a regression (was passing) or ongoing regression (already failing)
     // Remove existing regression entry for this case
     updatedRegressions = updatedRegressions.filter(

--- a/servers/exarchos-mcp/src/views/tools.test.ts
+++ b/servers/exarchos-mcp/src/views/tools.test.ts
@@ -9,6 +9,7 @@ import {
   handleViewTeamPerformance,
   handleViewDelegationTimeline,
   handleViewCodeQuality,
+  handleViewEvalResults,
 } from './tools.js';
 import { EventStore } from '../event-store/store.js';
 
@@ -356,6 +357,107 @@ describe('View Handlers', () => {
       expect(benchmarks).toHaveLength(1);
       const regressions = data.regressions as unknown[];
       expect(regressions).toHaveLength(1);
+    });
+  });
+
+  // ─── T10: handleViewEvalResults ────────────────────────────────────────────
+
+  describe('handleViewEvalResults', () => {
+    it('handleViewEvalResults_NoEvents_ReturnsEmptyState', async () => {
+      // Act
+      const result = await handleViewEvalResults({}, tmpDir);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      expect(data).toHaveProperty('skills');
+      expect(data).toHaveProperty('runs');
+      expect(data).toHaveProperty('regressions');
+      expect(data.skills).toEqual({});
+      expect(data.runs).toEqual([]);
+      expect(data.regressions).toEqual([]);
+    });
+
+    it('handleViewEvalResults_WithSkillFilter_FiltersResults', async () => {
+      // Arrange: seed eval events for two skills
+      const store = new EventStore(tmpDir);
+      await store.append('eval-stream', {
+        streamId: 'eval-stream',
+        sequence: 1,
+        timestamp: new Date().toISOString(),
+        type: 'eval.run.completed',
+        data: {
+          runId: 'run-001',
+          suiteId: 'delegation',
+          total: 10,
+          passed: 8,
+          failed: 2,
+          avgScore: 0.8,
+          duration: 5000,
+          regressions: [],
+        },
+        schemaVersion: '1.0',
+      });
+      await store.append('eval-stream', {
+        streamId: 'eval-stream',
+        sequence: 2,
+        timestamp: new Date().toISOString(),
+        type: 'eval.run.completed',
+        data: {
+          runId: 'run-002',
+          suiteId: 'quality-review',
+          total: 5,
+          passed: 5,
+          failed: 0,
+          avgScore: 1.0,
+          duration: 3000,
+          regressions: [],
+        },
+        schemaVersion: '1.0',
+      });
+
+      // Act: filter to delegation skill only
+      const result = await handleViewEvalResults({ workflowId: 'eval-stream', skill: 'delegation' }, tmpDir);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      const skills = data.skills as Record<string, unknown>;
+      expect(Object.keys(skills)).toEqual(['delegation']);
+      expect(skills).not.toHaveProperty('quality-review');
+    });
+
+    it('handleViewEvalResults_WithLimit_LimitsRunsAndRegressions', async () => {
+      // Arrange: seed multiple eval runs
+      const store = new EventStore(tmpDir);
+      for (let i = 1; i <= 5; i++) {
+        await store.append('eval-limit', {
+          streamId: 'eval-limit',
+          sequence: i,
+          timestamp: new Date().toISOString(),
+          type: 'eval.run.completed',
+          data: {
+            runId: `run-${String(i).padStart(3, '0')}`,
+            suiteId: 'delegation',
+            total: 10,
+            passed: 10 - i,
+            failed: i,
+            avgScore: (10 - i) / 10,
+            duration: 5000,
+            regressions: [],
+          },
+          schemaVersion: '1.0',
+        });
+      }
+
+      // Act: limit to 2 entries
+      const result = await handleViewEvalResults({ workflowId: 'eval-limit', limit: 2 }, tmpDir);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      const runs = data.runs as unknown[];
+      expect(runs).toHaveLength(2);
     });
   });
 });

--- a/servers/exarchos-mcp/src/views/tools.ts
+++ b/servers/exarchos-mcp/src/views/tools.ts
@@ -45,6 +45,11 @@ import {
 } from './code-quality-view.js';
 import type { CodeQualityViewState } from './code-quality-view.js';
 import {
+  evalResultsProjection,
+  EVAL_RESULTS_VIEW,
+} from './eval-results-view.js';
+import type { EvalResultsViewState } from './eval-results-view.js';
+import {
   workflowStateProjection,
   WORKFLOW_STATE_VIEW,
 } from './workflow-state-projection.js';
@@ -62,6 +67,7 @@ function createMaterializer(stateDir: string): ViewMaterializer {
   materializer.register(TEAM_PERFORMANCE_VIEW, teamPerformanceProjection);
   materializer.register(DELEGATION_TIMELINE_VIEW, delegationTimelineProjection);
   materializer.register(CODE_QUALITY_VIEW, codeQualityProjection);
+  materializer.register(EVAL_RESULTS_VIEW, evalResultsProjection);
   materializer.register(WORKFLOW_STATE_VIEW, workflowStateProjection);
   return materializer;
 }
@@ -390,6 +396,60 @@ export async function handleViewCodeQuality(
       filtered = {
         ...filtered,
         benchmarks: filtered.benchmarks.slice(0, args.limit),
+        regressions: filtered.regressions.slice(0, args.limit),
+      };
+    }
+
+    return { success: true, data: filtered };
+  } catch (err) {
+    return {
+      success: false,
+      error: {
+        code: 'VIEW_ERROR',
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+}
+
+// ─── View Eval Results Handler ──────────────────────────────────────────────
+
+export async function handleViewEvalResults(
+  args: {
+    workflowId?: string;
+    skill?: string;
+    limit?: number;
+  },
+  stateDir: string,
+): Promise<ToolResult> {
+  try {
+    const store = getOrCreateEventStore(stateDir);
+    const materializer = getOrCreateMaterializer(stateDir);
+    const streamId = args.workflowId ?? 'default';
+
+    await materializer.loadFromSnapshot(streamId, EVAL_RESULTS_VIEW);
+    const events = await store.query(streamId);
+    const view = materializer.materialize<EvalResultsViewState>(
+      streamId,
+      EVAL_RESULTS_VIEW,
+      events,
+    );
+
+    // Apply optional filters
+    let filtered: EvalResultsViewState = { ...view };
+
+    if (args.skill) {
+      const matchingSkill = filtered.skills[args.skill];
+      filtered = {
+        ...filtered,
+        skills: matchingSkill ? { [args.skill]: matchingSkill } : {},
+      };
+    }
+
+    if (args.limit !== undefined) {
+      filtered = {
+        ...filtered,
+        runs: filtered.runs.slice(0, args.limit),
         regressions: filtered.regressions.slice(0, args.limit),
       };
     }


### PR DESCRIPTION
## Summary

Add event-sourced eval tracking: 3 new event types (`eval.run.started`, `eval.case.completed`, `eval.run.completed`) with Zod schemas, optional event emission in the harness, and an `EvalResultsView` CQRS projection tracking per-skill scores, trends, and regressions.

## Changes

- **Event schemas** — 3 Zod data schemas with validation (trigger enum, score range, non-negative integers), added to `EventTypes` array (39 → 42)
- **Harness event emission** — `runSuite()` accepts optional `RunSuiteOptions` with `eventStore`, `streamId`, `trigger`; emits start/case/complete events during execution
- **EvalResultsView** — CQRS projection following `CodeQualityView` pattern with `SkillEvalMetrics`, trend calculation (3+ data points), regression detection via case pass history
- **View routing** — `handleViewEvalResults` handler with skill/limit filtering, registered in `createMaterializer()`, routed via `eval_results` action in composite

## Test Plan

- [x] 12 tests for eval event Zod schemas (valid/invalid payloads, edge cases)
- [x] 6 tests for harness event emission (ordering, no-op without store, trigger passthrough)
- [x] 14 tests for EvalResultsView (init, metrics, trends, regressions, unknown events)
- [x] 5 tests for view routing and integration (empty state, filtering, limits)
- [x] Full suite: 1831 tests pass, TypeScript clean

---

Design: `docs/designs/2026-02-20-eval-framework-phase-2.md`
Plan: `docs/plans/2026-02-20-eval-framework-phase-2.plan.md` (Tasks T07-T10)