### PR TITLE
feat: add CI eval gate with GitHub Actions annotations

### DIFF
--- a/.github/workflows/eval-gate.yml
+++ b/.github/workflows/eval-gate.yml
@@ -1,0 +1,43 @@
+name: Eval Gate
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+      - 'commands/**'
+      - 'rules/**'
+      - 'servers/exarchos-mcp/src/**'
+      - 'evals/**'
+
+jobs:
+  eval-regression:
+    name: Eval Regression Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: servers/exarchos-mcp/package-lock.json
+
+      - name: Install Dependencies
+        working-directory: servers/exarchos-mcp
+        run: npm ci
+
+      - name: Build
+        working-directory: servers/exarchos-mcp
+        run: npm run build
+
+      - name: Run Regression Evals
+        working-directory: servers/exarchos-mcp
+        run: |
+          echo '{"ci": true}' | node dist/cli.js eval-run
+        env:
+          # Optional: LLM graders (llm-rubric, llm-similarity) skip gracefully when not set
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          EVALS_DIR: ../../evals

--- a/.github/workflows/eval-gate.yml
+++ b/.github/workflows/eval-gate.yml
@@ -8,12 +8,16 @@ on:
       - 'rules/**'
       - 'servers/exarchos-mcp/src/**'
       - 'evals/**'
+      - '.github/workflows/eval-gate.yml'
 
 jobs:
   eval-regression:
     name: Eval Regression Check
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    concurrency:
+      group: eval-gate-${{ github.head_ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,59 @@
+# Eval Framework
+
+Deterministic and LLM-graded evaluation suites for Exarchos skills.
+
+## Running Evals
+
+```bash
+# Local (rich terminal output)
+cd servers/exarchos-mcp && echo '{}' | node dist/cli.js eval-run
+
+# CI mode (GitHub Actions annotations)
+echo '{"ci": true}' | node dist/cli.js eval-run
+
+# Filter by skill
+echo '{"skill": "delegation"}' | node dist/cli.js eval-run
+```
+
+## API Key Configuration
+
+LLM-based graders (`llm-rubric`, `llm-similarity`) require `ANTHROPIC_API_KEY` to call the Anthropic API via Promptfoo.
+
+**The key is optional.** When not set:
+- LLM assertions are skipped (not failed)
+- Non-LLM graders (`exact-match`, `schema`, `tool-call`, `trace-pattern`) run normally
+- Skipped assertions are reported separately in output
+- CI gate still passes for non-LLM regressions
+
+```bash
+# Enable LLM graders locally
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Enable in CI (add to GitHub repo secrets)
+# Settings → Secrets → ANTHROPIC_API_KEY
+```
+
+**Note:** Claude Code subscriptions use OAuth, not API keys. LLM graders require a separate API key from [console.anthropic.com](https://console.anthropic.com).
+
+## Suite Structure
+
+```text
+evals/
+├── README.md
+├── <skill-name>/
+│   ├── suite.json          # Suite config: assertions + datasets
+│   └── datasets/
+│       ├── regression.jsonl # Known-good traces (must not regress)
+│       └── golden.jsonl     # Capability test scenarios
+```
+
+## Assertion Types
+
+| Type | Requires API Key | Description |
+|------|:---:|---|
+| `exact-match` | No | Field-level equality |
+| `schema` | No | Zod schema validation |
+| `tool-call` | No | Required tool invocations present |
+| `trace-pattern` | No | Ordered/unordered pattern matching |
+| `llm-rubric` | Yes | LLM judges output against a rubric |
+| `llm-similarity` | Yes | LLM-based semantic similarity |

--- a/servers/exarchos-mcp/src/cli-commands/eval-run.test.ts
+++ b/servers/exarchos-mcp/src/cli-commands/eval-run.test.ts
@@ -33,6 +33,7 @@ function makeSummary(overrides: Partial<RunSummary> & { suiteId: string }): RunS
     total: 2,
     passed: 2,
     failed: 0,
+    skipped: 0,
     avgScore: 1.0,
     duration: 100,
     results: [],
@@ -107,7 +108,7 @@ describe('handleEvalRun', () => {
     expect(result.failures).toBe(0);
   });
 
-  it('HandleEvalRun_HasFailures_ReturnsResultWithFailures', async () => {
+  it('HandleEvalRun_HasFailures_ReturnsErrorWithFailures', async () => {
     // Arrange
     const summaries = [
       makeSummary({ suiteId: 'suite-a', total: 5, passed: 3, failed: 2 }),
@@ -121,6 +122,9 @@ describe('handleEvalRun', () => {
     expect(result.passed).toBe(false);
     expect(result.total).toBe(5);
     expect(result.failures).toBe(2);
+    expect(result.error).toBeDefined();
+    expect(result.error?.code).toBe('EVAL_FAILED');
+    expect(result.error?.message).toContain('2/5');
   });
 
   it('HandleEvalRun_RunAllThrows_ReturnsRunFailedError', async () => {
@@ -176,7 +180,7 @@ describe('handleEvalRun CI mode', () => {
     expect(result.passed).toBe(true);
   });
 
-  it('HandleEvalRun_CiFlag_Failures_ReturnsPassedFalse', async () => {
+  it('HandleEvalRun_CiFlag_Failures_ReturnsErrorWithPassedFalse', async () => {
     // Arrange
     const summaries = [makeSummary({ suiteId: 'suite-a', total: 5, passed: 3, failed: 2 })];
     mockRunAll.mockResolvedValue(summaries);
@@ -186,6 +190,8 @@ describe('handleEvalRun CI mode', () => {
 
     // Assert
     expect(result.passed).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error?.code).toBe('EVAL_FAILED');
   });
 
   it('HandleEvalRun_NoCiFlag_UsesCliReporter', async () => {

--- a/servers/exarchos-mcp/src/cli-commands/eval-run.test.ts
+++ b/servers/exarchos-mcp/src/cli-commands/eval-run.test.ts
@@ -12,10 +12,18 @@ vi.mock('../evals/reporters/cli-reporter.js', () => ({
   formatMultiSuiteReport: vi.fn().mockReturnValue('mock report'),
 }));
 
+vi.mock('../evals/reporters/ci-reporter.js', () => ({
+  formatCIReport: vi.fn().mockReturnValue('::notice title=Eval: mock::1/1 passed (100.0%)'),
+}));
+
 import { handleEvalRun, resolveEvalsDir } from './eval-run.js';
 import { runAll } from '../evals/harness.js';
+import { formatMultiSuiteReport } from '../evals/reporters/cli-reporter.js';
+import { formatCIReport } from '../evals/reporters/ci-reporter.js';
 
 const mockRunAll = vi.mocked(runAll);
+const mockFormatMultiSuiteReport = vi.mocked(formatMultiSuiteReport);
+const mockFormatCIReport = vi.mocked(formatCIReport);
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -126,6 +134,71 @@ describe('handleEvalRun', () => {
     expect(result.error).toBeDefined();
     expect(result.error?.code).toBe('RUN_FAILED');
     expect(result.error?.message).toContain('disk full');
+  });
+});
+
+// ─── CI Flag ─────────────────────────────────────────────────────────────────
+
+describe('handleEvalRun CI mode', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it('HandleEvalRun_CiFlag_UsesFormatCIReport', async () => {
+    // Arrange
+    const summaries = [makeSummary({ suiteId: 'delegation' })];
+    mockRunAll.mockResolvedValue(summaries);
+
+    // Act
+    await handleEvalRun({ ci: true }, '/fake/evals');
+
+    // Assert
+    expect(mockFormatCIReport).toHaveBeenCalledWith(summaries);
+    expect(mockFormatMultiSuiteReport).not.toHaveBeenCalled();
+  });
+
+  it('HandleEvalRun_CiFlag_AllPass_ReturnsPassedTrue', async () => {
+    // Arrange
+    const summaries = [makeSummary({ suiteId: 'suite-a', total: 3, passed: 3, failed: 0 })];
+    mockRunAll.mockResolvedValue(summaries);
+
+    // Act
+    const result = await handleEvalRun({ ci: true }, '/fake/evals');
+
+    // Assert
+    expect(result.passed).toBe(true);
+  });
+
+  it('HandleEvalRun_CiFlag_Failures_ReturnsPassedFalse', async () => {
+    // Arrange
+    const summaries = [makeSummary({ suiteId: 'suite-a', total: 5, passed: 3, failed: 2 })];
+    mockRunAll.mockResolvedValue(summaries);
+
+    // Act
+    const result = await handleEvalRun({ ci: true }, '/fake/evals');
+
+    // Assert
+    expect(result.passed).toBe(false);
+  });
+
+  it('HandleEvalRun_NoCiFlag_UsesCliReporter', async () => {
+    // Arrange
+    const summaries = [makeSummary({ suiteId: 'delegation' })];
+    mockRunAll.mockResolvedValue(summaries);
+
+    // Act
+    await handleEvalRun({}, '/fake/evals');
+
+    // Assert
+    expect(mockFormatMultiSuiteReport).toHaveBeenCalledWith(summaries);
+    expect(mockFormatCIReport).not.toHaveBeenCalled();
   });
 });
 

--- a/servers/exarchos-mcp/src/cli-commands/eval-run.ts
+++ b/servers/exarchos-mcp/src/cli-commands/eval-run.ts
@@ -89,6 +89,14 @@ export async function handleEvalRun(
   const allPassed = totalFailures === 0;
 
   return {
+    ...(allPassed
+      ? {}
+      : {
+          error: {
+            code: 'EVAL_FAILED',
+            message: `${totalFailures}/${totalCases} eval cases failed`,
+          },
+        }),
     summaries,
     passed: allPassed,
     total: totalCases,

--- a/servers/exarchos-mcp/src/cli-commands/eval-run.ts
+++ b/servers/exarchos-mcp/src/cli-commands/eval-run.ts
@@ -44,6 +44,7 @@ export async function handleEvalRun(
   evalsDir: string,
 ): Promise<CommandResult> {
   const options: { skill?: string; dataset?: string } = {};
+  const ciMode = stdinData['ci'] === true;
 
   if (typeof stdinData['skill'] === 'string') {
     options.skill = stdinData['skill'];
@@ -70,9 +71,18 @@ export async function handleEvalRun(
     };
   }
 
-  // Write formatted report to stderr so it's visible in terminal
-  const report = formatMultiSuiteReport(summaries);
-  process.stderr.write(report + '\n');
+  if (ciMode) {
+    // CI mode: GitHub Actions annotations to stderr
+    const { formatCIReport } = await import('../evals/reporters/ci-reporter.js');
+    const ciOutput = formatCIReport(summaries);
+    if (ciOutput) {
+      process.stderr.write(ciOutput + '\n');
+    }
+  } else {
+    // Local mode: rich terminal output to stderr
+    const report = formatMultiSuiteReport(summaries);
+    process.stderr.write(report + '\n');
+  }
 
   const totalCases = summaries.reduce((sum, s) => sum + s.total, 0);
   const totalFailures = summaries.reduce((sum, s) => sum + s.failed, 0);

--- a/servers/exarchos-mcp/src/evals/reporters/ci-reporter.test.ts
+++ b/servers/exarchos-mcp/src/evals/reporters/ci-reporter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatCIReport, formatFailedAssertions } from './ci-reporter.js';
+import { formatCIReport, formatFailedAssertions, escapeCommandValue, escapeCommandProperty } from './ci-reporter.js';
 import type { RunSummary, EvalResult } from '../types.js';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -112,7 +112,7 @@ describe('formatCIReport', () => {
     expect(output).toContain('delegate-task-routing');
     const errorLine = output.split('\n').find((l) => l.startsWith('::error'));
     expect(errorLine).toBeDefined();
-    expect(errorLine).toContain('title=Eval Regression: delegate-task-routing');
+    expect(errorLine).toContain('title=Eval Regression%3A delegate-task-routing');
   });
 
   it('formatCIReport_ErrorAnnotation_IncludesFailedAssertionReasons', () => {
@@ -220,6 +220,22 @@ describe('formatCIReport', () => {
 // ─── formatFailedAssertions ─────────────────────────────────────────────────
 
 describe('formatFailedAssertions', () => {
+  it('formatFailedAssertions_NoFailures_ReturnsDefaultMessage', () => {
+    // Arrange
+    const result = makeResult({
+      caseId: 'c-1',
+      passed: false,
+      score: 0.0,
+      assertions: [],
+    });
+
+    // Act
+    const output = formatFailedAssertions(result);
+
+    // Assert
+    expect(output).toBe('No assertion details');
+  });
+
   it('formatFailedAssertions_SingleFailure_FormatsReason', () => {
     // Arrange
     const result = makeResult({
@@ -257,5 +273,64 @@ describe('formatFailedAssertions', () => {
     // Assert
     expect(output).toBe('exact-match: Field mismatch; schema: Invalid structure');
     expect(output).not.toContain('passing-one');
+  });
+});
+
+// ─── escapeCommandValue ─────────────────────────────────────────────────────
+
+describe('escapeCommandValue', () => {
+  it('escapeCommandValue_SpecialChars_EscapesPercentsAndNewlines', () => {
+    expect(escapeCommandValue('50% done\nline2\rend')).toBe('50%25 done%0Aline2%0Dend');
+  });
+
+  it('escapeCommandValue_PlainText_ReturnsUnchanged', () => {
+    expect(escapeCommandValue('hello world')).toBe('hello world');
+  });
+});
+
+// ─── escapeCommandProperty ──────────────────────────────────────────────────
+
+describe('escapeCommandProperty', () => {
+  it('escapeCommandProperty_ColonsAndCommas_EscapesPropertyChars', () => {
+    expect(escapeCommandProperty('key:value,item')).toBe('key%3Avalue%2Citem');
+  });
+
+  it('escapeCommandProperty_AllSpecialChars_EscapesEverything', () => {
+    expect(escapeCommandProperty('a:b,c%d\ne')).toBe('a%3Ab%2Cc%25d%0Ae');
+  });
+});
+
+// ─── formatCIReport escaping ────────────────────────────────────────────────
+
+describe('formatCIReport escaping', () => {
+  it('formatCIReport_SpecialCharsInCaseId_EscapesAnnotationTitle', () => {
+    // Arrange
+    const summaries = [
+      makeSummary({
+        suiteId: 'test:suite',
+        avgScore: 0.0,
+        results: [
+          makeResult({
+            caseId: 'case:with,special%chars',
+            passed: false,
+            score: 0.0,
+            assertions: [
+              { name: 'check', type: 'exact-match', passed: false, score: 0.0, reason: 'fail\nreason', threshold: 1.0 },
+            ],
+          }),
+        ],
+      }),
+    ];
+
+    // Act
+    const output = formatCIReport(summaries);
+
+    // Assert
+    const errorLine = output.split('\n').find((l) => l.startsWith('::error'));
+    expect(errorLine).toBeDefined();
+    expect(errorLine).toContain('case%3Awith%2Cspecial%25chars');
+    expect(errorLine).toContain('fail%0Areason');
+    const noticeLine = output.split('\n').find((l) => l.startsWith('::notice'));
+    expect(noticeLine).toContain('test%3Asuite');
   });
 });

--- a/servers/exarchos-mcp/src/evals/reporters/ci-reporter.test.ts
+++ b/servers/exarchos-mcp/src/evals/reporters/ci-reporter.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from 'vitest';
+import { formatCIReport, formatFailedAssertions } from './ci-reporter.js';
+import type { RunSummary, EvalResult } from '../types.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeResult(overrides: Partial<EvalResult> & { caseId: string }): EvalResult {
+  return {
+    suiteId: 'test-suite',
+    passed: true,
+    score: 1.0,
+    assertions: [],
+    duration: 50,
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<RunSummary> & { suiteId: string }): RunSummary {
+  const results = overrides.results ?? [];
+  const total = overrides.total ?? results.length;
+  const passed = overrides.passed ?? results.filter((r) => r.passed).length;
+  const failed = overrides.failed ?? results.filter((r) => !r.passed).length;
+  return {
+    runId: 'run-001',
+    total,
+    passed,
+    failed,
+    avgScore: overrides.avgScore ?? (results.length > 0
+      ? results.reduce((sum, r) => sum + r.score, 0) / results.length
+      : 0),
+    duration: overrides.duration ?? 100,
+    results,
+    ...overrides,
+  };
+}
+
+// ─── formatCIReport ─────────────────────────────────────────────────────────
+
+describe('formatCIReport', () => {
+  it('formatCIReport_AllPassing_ReturnsNoticeAnnotations', () => {
+    // Arrange
+    const summaries = [
+      makeSummary({
+        suiteId: 'delegation',
+        avgScore: 1.0,
+        results: [
+          makeResult({ caseId: 'c-1', passed: true, score: 1.0 }),
+          makeResult({ caseId: 'c-2', passed: true, score: 1.0 }),
+        ],
+      }),
+    ];
+
+    // Act
+    const output = formatCIReport(summaries);
+
+    // Assert
+    expect(output).toContain('::notice');
+    expect(output).not.toContain('::error');
+  });
+
+  it('formatCIReport_WithFailures_ReturnsErrorAnnotations', () => {
+    // Arrange
+    const summaries = [
+      makeSummary({
+        suiteId: 'delegation',
+        avgScore: 0.5,
+        results: [
+          makeResult({ caseId: 'c-1', passed: true, score: 1.0 }),
+          makeResult({
+            caseId: 'c-2',
+            passed: false,
+            score: 0.0,
+            assertions: [
+              { name: 'check-1', type: 'exact-match', passed: false, score: 0.0, reason: 'mismatch', threshold: 1.0 },
+            ],
+          }),
+        ],
+      }),
+    ];
+
+    // Act
+    const output = formatCIReport(summaries);
+
+    // Assert
+    expect(output).toContain('::error');
+    expect(output).toContain('::notice');
+  });
+
+  it('formatCIReport_ErrorAnnotation_IncludesCaseId', () => {
+    // Arrange
+    const summaries = [
+      makeSummary({
+        suiteId: 'delegation',
+        avgScore: 0.0,
+        results: [
+          makeResult({
+            caseId: 'delegate-task-routing',
+            passed: false,
+            score: 0.0,
+            assertions: [
+              { name: 'check-1', type: 'exact-match', passed: false, score: 0.0, reason: 'wrong', threshold: 1.0 },
+            ],
+          }),
+        ],
+      }),
+    ];
+
+    // Act
+    const output = formatCIReport(summaries);
+
+    // Assert
+    expect(output).toContain('delegate-task-routing');
+    const errorLine = output.split('\n').find((l) => l.startsWith('::error'));
+    expect(errorLine).toBeDefined();
+    expect(errorLine).toContain('title=Eval Regression: delegate-task-routing');
+  });
+
+  it('formatCIReport_ErrorAnnotation_IncludesFailedAssertionReasons', () => {
+    // Arrange
+    const summaries = [
+      makeSummary({
+        suiteId: 'delegation',
+        avgScore: 0.0,
+        results: [
+          makeResult({
+            caseId: 'c-1',
+            passed: false,
+            score: 0.0,
+            assertions: [
+              { name: 'tool-call', type: 'tool-call', passed: false, score: 0.0, reason: 'Expected exarchos_orchestrate', threshold: 1.0 },
+            ],
+          }),
+        ],
+      }),
+    ];
+
+    // Act
+    const output = formatCIReport(summaries);
+
+    // Assert
+    const errorLine = output.split('\n').find((l) => l.startsWith('::error'));
+    expect(errorLine).toContain('Expected exarchos_orchestrate');
+  });
+
+  it('formatCIReport_NoticeAnnotation_IncludesPassCount', () => {
+    // Arrange
+    const summaries = [
+      makeSummary({
+        suiteId: 'delegation',
+        total: 5,
+        passed: 3,
+        failed: 2,
+        avgScore: 0.6,
+        results: [],
+      }),
+    ];
+
+    // Act
+    const output = formatCIReport(summaries);
+
+    // Assert
+    const noticeLine = output.split('\n').find((l) => l.startsWith('::notice'));
+    expect(noticeLine).toBeDefined();
+    expect(noticeLine).toContain('3/5 passed');
+  });
+
+  it('formatCIReport_NoticeAnnotation_IncludesScorePercentage', () => {
+    // Arrange
+    const summaries = [
+      makeSummary({
+        suiteId: 'delegation',
+        avgScore: 0.857,
+        results: [],
+      }),
+    ];
+
+    // Act
+    const output = formatCIReport(summaries);
+
+    // Assert
+    const noticeLine = output.split('\n').find((l) => l.startsWith('::notice'));
+    expect(noticeLine).toBeDefined();
+    expect(noticeLine).toContain('85.7%');
+  });
+
+  it('formatCIReport_MultipleSuites_ReportsEachSuite', () => {
+    // Arrange
+    const summaries = [
+      makeSummary({
+        suiteId: 'delegation',
+        avgScore: 1.0,
+        results: [makeResult({ caseId: 'c-1', passed: true })],
+      }),
+      makeSummary({
+        suiteId: 'quality-review',
+        avgScore: 0.8,
+        results: [makeResult({ caseId: 'c-2', passed: true })],
+      }),
+    ];
+
+    // Act
+    const output = formatCIReport(summaries);
+
+    // Assert
+    const noticeLines = output.split('\n').filter((l) => l.startsWith('::notice'));
+    expect(noticeLines).toHaveLength(2);
+    expect(noticeLines[0]).toContain('delegation');
+    expect(noticeLines[1]).toContain('quality-review');
+  });
+
+  it('formatCIReport_EmptySummaries_ReturnsEmptyString', () => {
+    // Arrange & Act
+    const output = formatCIReport([]);
+
+    // Assert
+    expect(output).toBe('');
+  });
+});
+
+// ─── formatFailedAssertions ─────────────────────────────────────────────────
+
+describe('formatFailedAssertions', () => {
+  it('formatFailedAssertions_SingleFailure_FormatsReason', () => {
+    // Arrange
+    const result = makeResult({
+      caseId: 'c-1',
+      passed: false,
+      score: 0.0,
+      assertions: [
+        { name: 'tool-call', type: 'tool-call', passed: false, score: 0.0, reason: 'Missing tool invocation', threshold: 1.0 },
+      ],
+    });
+
+    // Act
+    const output = formatFailedAssertions(result);
+
+    // Assert
+    expect(output).toBe('tool-call: Missing tool invocation');
+  });
+
+  it('formatFailedAssertions_MultipleFailures_JoinsReasons', () => {
+    // Arrange
+    const result = makeResult({
+      caseId: 'c-1',
+      passed: false,
+      score: 0.0,
+      assertions: [
+        { name: 'exact-match', type: 'exact-match', passed: false, score: 0.0, reason: 'Field mismatch', threshold: 1.0 },
+        { name: 'schema', type: 'schema', passed: false, score: 0.0, reason: 'Invalid structure', threshold: 1.0 },
+        { name: 'passing-one', type: 'exact-match', passed: true, score: 1.0, reason: 'OK', threshold: 1.0 },
+      ],
+    });
+
+    // Act
+    const output = formatFailedAssertions(result);
+
+    // Assert
+    expect(output).toBe('exact-match: Field mismatch; schema: Invalid structure');
+    expect(output).not.toContain('passing-one');
+  });
+});

--- a/servers/exarchos-mcp/src/evals/reporters/ci-reporter.ts
+++ b/servers/exarchos-mcp/src/evals/reporters/ci-reporter.ts
@@ -1,6 +1,22 @@
 import type { RunSummary, EvalResult } from '../types.js';
 
 /**
+ * Escape a string for use in a GitHub Actions annotation message body.
+ * See: https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts
+ */
+export function escapeCommandValue(value: string): string {
+  return value.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+
+/**
+ * Escape a string for use in a GitHub Actions annotation property (title, file, etc.).
+ * Properties additionally need `:` and `,` escaped.
+ */
+export function escapeCommandProperty(value: string): string {
+  return escapeCommandValue(value).replace(/:/g, '%3A').replace(/,/g, '%2C');
+}
+
+/**
  * Format failed assertion reasons into a single line for annotations.
  */
 export function formatFailedAssertions(result: EvalResult): string {
@@ -24,18 +40,20 @@ export function formatCIReport(summaries: RunSummary[]): string {
     // Error annotations for each failed case
     for (const result of summary.results) {
       if (!result.passed) {
-        lines.push(
-          `::error title=Eval Regression: ${result.caseId}::${formatFailedAssertions(result)}`,
-        );
+        const title = escapeCommandProperty(`Eval Regression: ${result.caseId}`);
+        const message = escapeCommandValue(formatFailedAssertions(result));
+        lines.push(`::error title=${title}::${message}`);
       }
     }
 
     // Notice annotation for suite summary
     const scorePct = (summary.avgScore * 100).toFixed(1);
     const skippedSuffix = summary.skipped > 0 ? `, ${summary.skipped} LLM skipped` : '';
-    lines.push(
-      `::notice title=Eval: ${summary.suiteId}::${summary.passed}/${summary.total} passed (${scorePct}%)${skippedSuffix}`,
+    const noticeTitle = escapeCommandProperty(`Eval: ${summary.suiteId}`);
+    const noticeMsg = escapeCommandValue(
+      `${summary.passed}/${summary.total} passed (${scorePct}%)${skippedSuffix}`,
     );
+    lines.push(`::notice title=${noticeTitle}::${noticeMsg}`);
   }
 
   return lines.join('\n');

--- a/servers/exarchos-mcp/src/evals/reporters/ci-reporter.ts
+++ b/servers/exarchos-mcp/src/evals/reporters/ci-reporter.ts
@@ -1,0 +1,41 @@
+import type { RunSummary, EvalResult } from '../types.js';
+
+/**
+ * Format failed assertion reasons into a single line for annotations.
+ */
+export function formatFailedAssertions(result: EvalResult): string {
+  const failed = result.assertions.filter((a) => !a.passed);
+  if (failed.length === 0) return 'No assertion details';
+  return failed.map((a) => `${a.name}: ${a.reason}`).join('; ');
+}
+
+/**
+ * Format eval summaries as GitHub Actions annotations.
+ *
+ * Uses `::error` for failed cases and `::notice` for suite summaries.
+ * See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+ */
+export function formatCIReport(summaries: RunSummary[]): string {
+  if (summaries.length === 0) return '';
+
+  const lines: string[] = [];
+
+  for (const summary of summaries) {
+    // Error annotations for each failed case
+    for (const result of summary.results) {
+      if (!result.passed) {
+        lines.push(
+          `::error title=Eval Regression: ${result.caseId}::${formatFailedAssertions(result)}`,
+        );
+      }
+    }
+
+    // Notice annotation for suite summary
+    const scorePct = (summary.avgScore * 100).toFixed(1);
+    lines.push(
+      `::notice title=Eval: ${summary.suiteId}::${summary.passed}/${summary.total} passed (${scorePct}%)`,
+    );
+  }
+
+  return lines.join('\n');
+}

--- a/servers/exarchos-mcp/src/evals/reporters/ci-reporter.ts
+++ b/servers/exarchos-mcp/src/evals/reporters/ci-reporter.ts
@@ -32,8 +32,9 @@ export function formatCIReport(summaries: RunSummary[]): string {
 
     // Notice annotation for suite summary
     const scorePct = (summary.avgScore * 100).toFixed(1);
+    const skippedSuffix = summary.skipped > 0 ? `, ${summary.skipped} LLM skipped` : '';
     lines.push(
-      `::notice title=Eval: ${summary.suiteId}::${summary.passed}/${summary.total} passed (${scorePct}%)`,
+      `::notice title=Eval: ${summary.suiteId}::${summary.passed}/${summary.total} passed (${scorePct}%)${skippedSuffix}`,
     );
   }
 

--- a/servers/exarchos-mcp/src/evals/reporters/cli-reporter.ts
+++ b/servers/exarchos-mcp/src/evals/reporters/cli-reporter.ts
@@ -38,7 +38,8 @@ export function formatRunSummary(summary: RunSummary): string {
   const caseLines = summary.results.map(formatCaseResult);
 
   const avgPct = (summary.avgScore * 100).toFixed(0);
-  const footer = `${summary.total} cases: ${summary.passed} passed, ${summary.failed} failed | avg score: ${avgPct}% | ${summary.duration}ms`;
+  const skippedSuffix = summary.skipped > 0 ? ` (${summary.skipped} LLM assertions skipped)` : '';
+  const footer = `${summary.total} cases: ${summary.passed} passed, ${summary.failed} failed | avg score: ${avgPct}% | ${summary.duration}ms${skippedSuffix}`;
 
   const sections = [headerLine];
   if (caseLines.length > 0) {


### PR DESCRIPTION
## Summary

Add CI regression detection: a `formatCIReport` function producing GitHub Actions `::error`/`::notice` annotations, a `--ci` flag on the `eval-run` CLI command, and an `eval-gate.yml` GitHub Actions workflow that runs evals on PRs touching skills, commands, rules, or MCP server source.

## Changes

- **CI reporter** — `formatCIReport(summaries)` produces `::error title=Eval Regression: <caseId>::<reasons>` for failures and `::notice title=Eval: <suiteId>::X/Y passed (Z%)` for suite summaries
- **CLI --ci flag** — `handleEvalRun` detects `ci: true` in stdin, switches to CI reporter output, suppresses rich CLI report
- **eval-gate.yml** — GitHub Actions workflow triggered on PRs modifying `skills/**`, `commands/**`, `rules/**`, `servers/exarchos-mcp/src/**`, or `evals/**`; runs Node 22, builds MCP server, pipes `{"ci": true}` to eval-run

## Test Plan

- [x] 10 tests for formatCIReport (annotations, case IDs, assertion reasons, multi-suite)
- [x] 4 tests for --ci flag (reporter selection, pass/fail return values)
- [x] Full suite: 1809 tests pass, TypeScript clean

---

Design: `docs/designs/2026-02-20-eval-framework-phase-2.md`
Plan: `docs/plans/2026-02-20-eval-framework-phase-2.plan.md` (Tasks T11-T13)