### PR TITLE
fix: resolve plan doc merge conflict and harden script

### DIFF
--- a/docs/plans/2026-02-20-eval-framework-phase-3.plan.md
+++ b/docs/plans/2026-02-20-eval-framework-phase-3.plan.md
@@ -128,11 +128,7 @@ Four focused improvements identified during Phase 2 review: connect the event pi
 
 All 4 streams are independent:
 
-<<<<<<< Updated upstream
 ```text
-=======
-```
->>>>>>> Stashed changes
 Stream A (EventStore wiring)  ─── T:A1 → T:A2
 Stream B (LLM helper DRY)     ─── T:B1
 Stream C (CI exit code)        ─── T:C1

--- a/scripts/verify-plan-coverage.sh
+++ b/scripts/verify-plan-coverage.sh
@@ -138,6 +138,12 @@ while IFS= read -r line; do
     fi
 done < "$PLAN_FILE"
 
+# Validate we found tasks
+if [[ ${#PLAN_TASKS[@]} -eq 0 ]]; then
+    echo "ERROR: No '### Task' headers found in plan file: $PLAN_FILE" >&2
+    exit 1
+fi
+
 # Also read the full plan content for free-text matching
 PLAN_CONTENT="$(cat "$PLAN_FILE")"
 
@@ -154,7 +160,7 @@ for section in "${DESIGN_SECTIONS[@]}"; do
     # Check if any task title or plan content references this design section
     MATCHED_TASKS=()
 
-    for task in "${PLAN_TASKS[@]}"; do
+    for task in "${PLAN_TASKS[@]+${PLAN_TASKS[@]}}"; do
         # Case-insensitive substring match
         if echo "$task" | grep -qiF "$section"; then
             MATCHED_TASKS+=("$task")

--- a/scripts/verify-plan-coverage.sh
+++ b/scripts/verify-plan-coverage.sh
@@ -6,7 +6,7 @@
 #
 # Exit codes:
 #   0 = complete coverage (every Technical Design subsection maps to >= 1 task)
-#   1 = gaps found (unmapped sections)
+#   1 = gaps found (unmapped sections) or no '### Task' headers found in plan
 #   2 = usage error (missing required args, empty design, missing files)
 
 set -euo pipefail

--- a/scripts/verify-plan-coverage.test.sh
+++ b/scripts/verify-plan-coverage.test.sh
@@ -277,6 +277,61 @@ else
 fi
 teardown
 
+# --------------------------------------------------
+# Test 8: NoTasks_EmptyPlan_ExitsOne
+# --------------------------------------------------
+setup
+cat > "$TMPDIR_ROOT/design.md" << 'EOF'
+# Feature Design
+
+## Problem Statement
+
+We need a full system.
+
+## Technical Design
+
+### Widget Component
+
+Renders the main UI.
+
+### API Client
+
+Handles data fetching.
+
+## Testing Strategy
+
+Unit tests needed.
+EOF
+
+cat > "$TMPDIR_ROOT/plan.md" << 'EOF'
+# Implementation Plan
+
+## Overview
+
+This plan covers the widget system build-out.
+
+## Schedule
+
+Week 1: Design review
+Week 2: Implementation
+EOF
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "$TMPDIR_ROOT/design.md" --plan-file "$TMPDIR_ROOT/plan.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "NoTasks_EmptyPlan_ExitsOne"
+else
+    fail "NoTasks_EmptyPlan_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+# Verify error message mentions no tasks found
+if echo "$OUTPUT" | grep -qi "No.*Task.*headers"; then
+    pass "NoTasks_ErrorMessageMentionsTasks"
+else
+    fail "NoTasks_ErrorMessageMentionsTasks (expected 'No Task headers' in output)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
 # ============================================================
 # SUMMARY
 # ============================================================


### PR DESCRIPTION
Remove merge conflict markers from Phase 3 plan doc. Add defensive
empty-array guard to verify-plan-coverage.sh for Bash portability.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>