### PR TITLE
feat: add Zod schema validation to sync config loading

### DIFF
--- a/servers/exarchos-mcp/src/sync/config.test.ts
+++ b/servers/exarchos-mcp/src/sync/config.test.ts
@@ -1,0 +1,96 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, afterEach } from 'vitest';
+import { loadSyncConfig } from './config.js';
+
+describe('SyncConfigSchema', () => {
+  it('SyncConfigSchema_ValidFullConfig_Parses', async () => {
+    const { SyncConfigSchema } = await import('./types.js');
+    const input = {
+      mode: 'dual',
+      syncIntervalMs: 60000,
+      batchSize: 100,
+      maxRetries: 5,
+      remote: {
+        apiToken: 'token-123',
+        apiBaseUrl: 'https://api.example.com',
+        exarchosId: 'ex-1',
+        timeoutMs: 10000,
+      },
+    };
+    const result = SyncConfigSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.mode).toBe('dual');
+      expect(result.data.remote?.apiToken).toBe('token-123');
+    }
+  });
+
+  it('SyncConfigSchema_InvalidMode_Rejects', async () => {
+    const { SyncConfigSchema } = await import('./types.js');
+    const result = SyncConfigSchema.safeParse({ mode: 'invalid' });
+    expect(result.success).toBe(false);
+  });
+
+  it('SyncConfigSchema_EmptyObject_AppliesDefaults', async () => {
+    const { SyncConfigSchema } = await import('./types.js');
+    const result = SyncConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.mode).toBe('local');
+      expect(result.data.syncIntervalMs).toBe(30000);
+      expect(result.data.batchSize).toBe(50);
+      expect(result.data.maxRetries).toBe(10);
+    }
+  });
+
+  it('SyncConfigSchema_NegativeBatchSize_Rejects', async () => {
+    const { SyncConfigSchema } = await import('./types.js');
+    const result = SyncConfigSchema.safeParse({ batchSize: -1 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('loadSyncConfig', () => {
+  const tempDirs: string[] = [];
+
+  function createTempConfigDir(config: Record<string, unknown>): string {
+    const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sync-config-'));
+    const subDir = path.join(parentDir, 'state');
+    fs.mkdirSync(subDir);
+    fs.writeFileSync(
+      path.join(parentDir, 'bridge-config.json'),
+      JSON.stringify(config),
+    );
+    tempDirs.push(parentDir);
+    return subDir;
+  }
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+    // Clean up env vars
+    delete process.env.EXARCHOS_API_TOKEN;
+    delete process.env.BASILEUS_API_URL;
+  });
+
+  it('LoadSyncConfig_InvalidJsonTypes_FallsBackToDefaults', () => {
+    // Arrange: write a config file with invalid types
+    const stateDir = createTempConfigDir({
+      mode: 123,
+      batchSize: 'not-a-number',
+    });
+
+    // Act
+    const config = loadSyncConfig(stateDir);
+
+    // Assert: returns default config because Zod rejects invalid types
+    expect(config.mode).toBe('local');
+    expect(config.batchSize).toBe(50);
+    expect(config.syncIntervalMs).toBe(30000);
+    expect(config.maxRetries).toBe(10);
+  });
+});

--- a/servers/exarchos-mcp/src/sync/config.ts
+++ b/servers/exarchos-mcp/src/sync/config.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { SyncConfig } from './types.js';
+import { SyncConfigSchema } from './types.js';
 
 // ─── Default Config ──────────────────────────────────────────────────────────
 
@@ -16,43 +17,32 @@ export function getDefaultConfig(): SyncConfig {
 // ─── Load Sync Config ────────────────────────────────────────────────────────
 
 export function loadSyncConfig(stateDir: string): SyncConfig {
-  const defaults = getDefaultConfig();
-
   // Try loading from bridge-config.json in parent directory
   const configPath = path.join(stateDir, '..', 'bridge-config.json');
-  let fileConfig: Partial<SyncConfig> = {};
+  let parsedConfig: SyncConfig | undefined;
 
   try {
     const content = fs.readFileSync(configPath, 'utf-8');
-    fileConfig = JSON.parse(content) as Partial<SyncConfig>;
+    const rawJson: unknown = JSON.parse(content);
+
+    // Validate with Zod — applies defaults for missing fields
+    const parseResult = SyncConfigSchema.safeParse(rawJson);
+    if (parseResult.success) {
+      parsedConfig = parseResult.data;
+    } else {
+      console.warn(
+        `Invalid config in ${configPath}:`,
+        parseResult.error.issues,
+      );
+    }
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
       console.warn(`Failed to load config from ${configPath}:`, err);
     }
   }
 
-  // Default remote config values
-  const remoteDefaults = {
-    apiBaseUrl: 'http://localhost:5000',
-    exarchosId: 'default',
-    timeoutMs: 5000,
-  };
-
-  // Merge file config over defaults, normalizing remote with defaults
-  const config: SyncConfig = {
-    mode: fileConfig.mode ?? defaults.mode,
-    syncIntervalMs: fileConfig.syncIntervalMs ?? defaults.syncIntervalMs,
-    batchSize: fileConfig.batchSize ?? defaults.batchSize,
-    maxRetries: fileConfig.maxRetries ?? defaults.maxRetries,
-    remote: fileConfig.remote?.apiToken
-      ? {
-          apiToken: fileConfig.remote.apiToken,
-          apiBaseUrl: fileConfig.remote.apiBaseUrl ?? remoteDefaults.apiBaseUrl,
-          exarchosId: fileConfig.remote.exarchosId ?? remoteDefaults.exarchosId,
-          timeoutMs: fileConfig.remote.timeoutMs ?? remoteDefaults.timeoutMs,
-        }
-      : undefined,
-  };
+  // Fall back to defaults if file was missing or invalid
+  const config: SyncConfig = parsedConfig ?? getDefaultConfig();
 
   // Fall back to environment variables for remote config if not in file
   if (!config.remote) {

--- a/servers/exarchos-mcp/src/sync/types.ts
+++ b/servers/exarchos-mcp/src/sync/types.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { WorkflowEvent } from '../event-store/schemas.js';
 
 // ─── Remote Configuration ────────────────────────────────────────────────────
@@ -9,6 +10,13 @@ export interface RemoteConfig {
   timeoutMs: number;
 }
 
+export const RemoteConfigSchema = z.object({
+  apiToken: z.string().min(1),
+  apiBaseUrl: z.string().default('http://localhost:5000'),
+  exarchosId: z.string().default('default'),
+  timeoutMs: z.number().int().positive().default(5000),
+});
+
 // ─── Sync Configuration ─────────────────────────────────────────────────────
 
 export interface SyncConfig {
@@ -18,6 +26,14 @@ export interface SyncConfig {
   maxRetries: number;
   remote?: RemoteConfig;
 }
+
+export const SyncConfigSchema = z.object({
+  mode: z.enum(['local', 'remote', 'dual']).default('local'),
+  syncIntervalMs: z.number().int().positive().default(30000),
+  batchSize: z.number().int().positive().default(50),
+  maxRetries: z.number().int().nonnegative().default(10),
+  remote: RemoteConfigSchema.optional(),
+});
 
 // ─── Sync State ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Define SyncConfigSchema and RemoteConfigSchema with Zod. Wire
.safeParse() into loadSyncConfig() — invalid configs fall back to
defaults with a warning instead of crashing.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>