### PR TITLE
refactor: extract shared LLM grader helper

### DIFF
--- a/servers/exarchos-mcp/src/evals/graders/llm-helper.test.ts
+++ b/servers/exarchos-mcp/src/evals/graders/llm-helper.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { GradeResult } from '../types.js';
+
+// We'll need to mock process.env and promptfoo
+const originalEnv = process.env;
+
+describe('callLlmAssertion', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('CallLlmAssertion_NoApiKey_ReturnsSkipped', async () => {
+    delete process.env['ANTHROPIC_API_KEY'];
+    const { callLlmAssertion } = await import('./llm-helper.js');
+    const fn = vi.fn();
+    const result = await callLlmAssertion(fn, [], {});
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(0);
+    expect(result.details).toHaveProperty('skipped', true);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('CallLlmAssertion_ApiKeyError_ReturnsSkipped', async () => {
+    process.env['ANTHROPIC_API_KEY'] = 'test-key';
+    const { callLlmAssertion } = await import('./llm-helper.js');
+    const fn = vi.fn().mockRejectedValue(new Error('Invalid API key'));
+    const result = await callLlmAssertion(fn, ['arg1'], { model: 'test' });
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(0);
+    expect(result.details).toHaveProperty('skipped', true);
+  });
+
+  it('CallLlmAssertion_GenericError_ReturnsFailure', async () => {
+    process.env['ANTHROPIC_API_KEY'] = 'test-key';
+    const { callLlmAssertion } = await import('./llm-helper.js');
+    const fn = vi.fn().mockRejectedValue(new Error('network timeout'));
+    const result = await callLlmAssertion(fn, [], { model: 'test' });
+    expect(result.passed).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.reason).toContain('network timeout');
+  });
+
+  it('CallLlmAssertion_Success_ReturnsNormalizedResult', async () => {
+    process.env['ANTHROPIC_API_KEY'] = 'test-key';
+    const { callLlmAssertion } = await import('./llm-helper.js');
+    const fn = vi.fn().mockResolvedValue({ pass: true, score: 0.85, reason: 'Good match' });
+    const result = await callLlmAssertion(fn, ['a', 'b'], { model: 'claude' });
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(0.85);
+    expect(result.reason).toBe('Good match');
+  });
+});

--- a/servers/exarchos-mcp/src/evals/graders/llm-helper.ts
+++ b/servers/exarchos-mcp/src/evals/graders/llm-helper.ts
@@ -1,0 +1,59 @@
+import type { GradeResult } from '../types.js';
+
+interface LlmAssertionOptions {
+  /** Default reason when assertion passes with no reason string */
+  passReason?: string;
+  /** Default reason when assertion fails with no reason string */
+  failReason?: string;
+}
+
+/**
+ * Shared helper for LLM-based grader assertions.
+ * Handles: API key check, error classification, score normalization.
+ */
+export async function callLlmAssertion(
+  fn: (...args: unknown[]) => Promise<{ pass: boolean; score?: number; reason?: string }>,
+  args: unknown[],
+  details: Record<string, unknown>,
+  options?: LlmAssertionOptions,
+): Promise<GradeResult> {
+  const passReason = options?.passReason ?? 'Passed';
+  const failReason = options?.failReason ?? 'Failed';
+
+  // Skip if no API key
+  if (!process.env['ANTHROPIC_API_KEY']) {
+    return {
+      passed: true,
+      score: 0,
+      reason: 'Skipped: ANTHROPIC_API_KEY not set',
+      details: { skipped: true },
+    };
+  }
+
+  try {
+    const result = await fn(...args);
+    return {
+      passed: result.pass,
+      score: result.score ?? (result.pass ? 1.0 : 0.0),
+      reason: result.reason ?? (result.pass ? passReason : failReason),
+      details,
+    };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    const isApiKeyError = message.includes('API key') || message.includes('apiKey');
+    if (isApiKeyError) {
+      return {
+        passed: true,
+        score: 0,
+        reason: `Skipped: ${message}`,
+        details: { ...details, error: message, skipped: true },
+      };
+    }
+    return {
+      passed: false,
+      score: 0,
+      reason: `LLM grader error: ${message}`,
+      details: { ...details, error: message },
+    };
+  }
+}

--- a/servers/exarchos-mcp/src/evals/graders/llm-rubric.ts
+++ b/servers/exarchos-mcp/src/evals/graders/llm-rubric.ts
@@ -1,5 +1,6 @@
 import type { GradeResult, IGrader } from '../types.js';
 import { extractOutputText } from './output-extractor.js';
+import { callLlmAssertion } from './llm-helper.js';
 
 /**
  * LLM-based rubric grader that wraps Promptfoo's matchesLlmRubric assertion.
@@ -26,51 +27,22 @@ export class LlmRubricGrader implements IGrader {
       };
     }
 
-    // Skip if no API key available
-    if (!process.env['ANTHROPIC_API_KEY']) {
-      return {
-        passed: true,
-        score: 0,
-        reason: 'Skipped: ANTHROPIC_API_KEY not set',
-        details: { skipped: true },
-      };
-    }
-
     const model = config?.model as string | undefined;
     const outputText = extractOutputText(output, config?.outputPath as string | undefined);
+    const options = { provider: model ? `anthropic:messages:${model}` : undefined };
 
-    // Dynamic import to avoid loading promptfoo when not needed
-    const { assertions } = await import('promptfoo');
-
-    let result: { pass: boolean; score?: number; reason?: string };
-    try {
-      result = await assertions.matchesLlmRubric(rubric, outputText, {
-        provider: model ? `anthropic:messages:${model}` : undefined,
-      });
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      const isApiKeyError = message.includes('API key') || message.includes('apiKey');
-      if (isApiKeyError) {
-        return {
-          passed: true,
-          score: 0,
-          reason: `Skipped: ${message}`,
-          details: { model, rubric, error: message, skipped: true },
-        };
-      }
-      return {
-        passed: false,
-        score: 0,
-        reason: `LLM grader error: ${message}`,
-        details: { model, rubric, error: message },
-      };
-    }
-
-    return {
-      passed: result.pass,
-      score: result.score ?? (result.pass ? 1.0 : 0.0),
-      reason: result.reason ?? (result.pass ? 'Passed rubric' : 'Failed rubric'),
-      details: { model, rubric },
-    };
+    return callLlmAssertion(
+      async (r: unknown, o: unknown, opts: unknown) => {
+        const { assertions } = await import('promptfoo');
+        return assertions.matchesLlmRubric(
+          r as string,
+          o as string,
+          opts as Record<string, unknown>,
+        );
+      },
+      [rubric, outputText, options],
+      { model, rubric },
+      { passReason: 'Passed rubric', failReason: 'Failed rubric' },
+    );
   }
 }

--- a/servers/exarchos-mcp/src/evals/graders/llm-similarity.ts
+++ b/servers/exarchos-mcp/src/evals/graders/llm-similarity.ts
@@ -1,5 +1,6 @@
 import type { GradeResult, IGrader } from '../types.js';
 import { extractOutputText } from './output-extractor.js';
+import { callLlmAssertion } from './llm-helper.js';
 
 const DEFAULT_THRESHOLD = 0.8;
 
@@ -29,52 +30,22 @@ export class LlmSimilarityGrader implements IGrader {
       expectedText = extractOutputText(expected, config?.expectedPath as string | undefined);
     }
 
-    // Skip if no API key available
-    if (!process.env['ANTHROPIC_API_KEY']) {
-      return {
-        passed: true,
-        score: 0,
-        reason: 'Skipped: ANTHROPIC_API_KEY not set',
-        details: { skipped: true },
-      };
-    }
+    const options = { provider: model ? `anthropic:messages:${model}` : undefined };
 
-    // Dynamic import to avoid loading promptfoo when not needed
-    const { assertions } = await import('promptfoo');
-
-    let result: { pass: boolean; score?: number; reason?: string };
-    try {
-      result = await assertions.matchesSimilarity(
-        expectedText,
-        outputText,
-        threshold,
-        false,
-        { provider: model ? `anthropic:messages:${model}` : undefined },
-      );
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      const isApiKeyError = message.includes('API key') || message.includes('apiKey');
-      if (isApiKeyError) {
-        return {
-          passed: true,
-          score: 0,
-          reason: `Skipped: ${message}`,
-          details: { model, threshold, expectedText, error: message, skipped: true },
-        };
-      }
-      return {
-        passed: false,
-        score: 0,
-        reason: `LLM grader error: ${message}`,
-        details: { model, threshold, expectedText, error: message },
-      };
-    }
-
-    return {
-      passed: result.pass,
-      score: result.score ?? (result.pass ? 1.0 : 0.0),
-      reason: result.reason ?? (result.pass ? 'Passed similarity' : 'Failed similarity'),
-      details: { model, threshold, expectedText },
-    };
+    return callLlmAssertion(
+      async (exp: unknown, out: unknown, thr: unknown, inv: unknown, opts: unknown) => {
+        const { assertions } = await import('promptfoo');
+        return assertions.matchesSimilarity(
+          exp as string,
+          out as string,
+          thr as number,
+          inv as boolean,
+          opts as Record<string, unknown>,
+        );
+      },
+      [expectedText, outputText, threshold, false, options],
+      { model, threshold, expectedText },
+      { passReason: 'Passed similarity', failReason: 'Failed similarity' },
+    );
   }
 }


### PR DESCRIPTION
DRY the duplicated error handling between llm-rubric and
llm-similarity into callLlmAssertion() helper. Each grader
reduced ~36% (API key check, try-catch, score normalization
now centralized).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>