### PR TITLE
fix: guard empty arrays in validation scripts for bash 4.x compat (#639)

### DIFF
--- a/scripts/assess-refactor-scope.sh
+++ b/scripts/assess-refactor-scope.sh
@@ -192,7 +192,7 @@ for f in "${FILE_LIST[@]}"; do
 done
 
 # For scope assessment purposes, having test counterparts is informational
-if [[ ${#MISSING_TESTS[@]} -eq 0 ]]; then
+if [[ -z "${MISSING_TESTS+x}" ]] || [[ ${#MISSING_TESTS[@]} -eq 0 ]]; then
     check_pass "Test coverage assessment (all source files have known patterns)"
 else
     # This is informational, not a hard fail for track decision

--- a/scripts/check-coderabbit.sh
+++ b/scripts/check-coderabbit.sh
@@ -136,7 +136,7 @@ if [[ -z "$REPO" ]]; then
 fi
 validate_github_name "$REPO" "repo"
 
-if [[ ${#PR_NUMBERS[@]} -eq 0 ]]; then
+if [[ -z "${PR_NUMBERS+x}" ]] || [[ ${#PR_NUMBERS[@]} -eq 0 ]]; then
     echo -e "${RED}ERROR${NC}: At least one PR number is required" >&2
     usage >&2
     exit 2

--- a/scripts/check-polish-scope.sh
+++ b/scripts/check-polish-scope.sh
@@ -182,7 +182,7 @@ for f in "${MODIFIED_FILES[@]}"; do
     fi
 done
 
-if [[ ${#MISSING_TESTS[@]} -eq 0 ]]; then
+if [[ -z "${MISSING_TESTS+x}" ]] || [[ ${#MISSING_TESTS[@]} -eq 0 ]]; then
     check_pass "Test coverage OK (all impl files have test counterparts)"
 else
     check_fail "New test files needed" "${#MISSING_TESTS[@]} impl files without tests: ${MISSING_TESTS[*]}"
@@ -231,7 +231,7 @@ echo ""
 echo "---"
 echo ""
 
-if [[ ${#TRIGGERS_FIRED[@]} -eq 0 ]]; then
+if [[ -z "${TRIGGERS_FIRED+x}" ]] || [[ ${#TRIGGERS_FIRED[@]} -eq 0 ]]; then
     echo "**Result: SCOPE OK** — All within polish limits"
     exit 0
 else

--- a/scripts/check-property-tests.sh
+++ b/scripts/check-property-tests.sh
@@ -87,7 +87,7 @@ for task in plan.get('tasks', []):
 " "$PLAN_FILE" 2>/dev/null
 )
 
-if [[ ${#PBT_TASK_IDS[@]} -eq 0 ]]; then
+if [[ -z "${PBT_TASK_IDS+x}" ]] || [[ ${#PBT_TASK_IDS[@]} -eq 0 ]]; then
     echo "## PBT Check: PASS"
     echo "No tasks require property-based tests."
     exit 0
@@ -126,7 +126,7 @@ done < <(
 # ─── Cross-Reference ───────────────────────────────────────────────────────
 
 HAS_PBT=false
-if [[ ${#PBT_FILES[@]} -gt 0 ]]; then
+if [[ -n "${PBT_FILES+x}" ]] && [[ ${#PBT_FILES[@]} -gt 0 ]]; then
     HAS_PBT=true
     echo "Found PBT patterns in:"
     for f in "${PBT_FILES[@]}"; do
@@ -150,7 +150,7 @@ fi
 
 # ─── Result ─────────────────────────────────────────────────────────────────
 
-if [[ ${#UNCOVERED_TASKS[@]} -gt 0 ]]; then
+if [[ -n "${UNCOVERED_TASKS+x}" ]] && [[ ${#UNCOVERED_TASKS[@]} -gt 0 ]]; then
     echo "## PBT Check: FAIL"
     echo ""
     echo "The following tasks require property-based tests but none were found:"

--- a/scripts/check-tdd-compliance.sh
+++ b/scripts/check-tdd-compliance.sh
@@ -140,7 +140,7 @@ while IFS= read -r commit_hash; do
     [[ -n "$commit_hash" ]] && COMMITS+=("$commit_hash")
 done < <(git log --reverse --format="%H" "${BASE_BRANCH}..${BRANCH}" 2>/dev/null)
 
-if [[ ${#COMMITS[@]} -eq 0 ]]; then
+if [[ -z "${COMMITS+x}" ]] || [[ ${#COMMITS[@]} -eq 0 ]]; then
     echo "## TDD Compliance Report"
     echo ""
     echo "**Branch:** $BRANCH"
@@ -243,7 +243,7 @@ for result in "${RESULTS[@]}"; do
 done
 echo ""
 
-if [[ ${#VIOLATIONS[@]} -gt 0 ]]; then
+if [[ -n "${VIOLATIONS+x}" ]] && [[ ${#VIOLATIONS[@]} -gt 0 ]]; then
     echo "### Violations"
     echo ""
     for v in "${VIOLATIONS[@]}"; do

--- a/scripts/generate-traceability.sh
+++ b/scripts/generate-traceability.sh
@@ -117,7 +117,7 @@ while IFS= read -r line; do
     fi
 done < "$DESIGN_FILE"
 
-if [[ ${#DESIGN_SECTIONS[@]} -eq 0 ]]; then
+if [[ -z "${DESIGN_SECTIONS+x}" ]] || [[ ${#DESIGN_SECTIONS[@]} -eq 0 ]]; then
     echo "Error: No ## or ### headers found in design document" >&2
     exit 1
 fi
@@ -173,14 +173,14 @@ generate_table() {
         done
 
         # Also check plan body
-        if [[ ${#matched_ids[@]} -eq 0 ]]; then
+        if [[ -z "${matched_ids+x}" ]] || [[ ${#matched_ids[@]} -eq 0 ]]; then
             if echo "$PLAN_CONTENT" | grep -qiF "$section"; then
                 matched_ids+=("?")
             fi
         fi
 
         # Format output
-        if [[ ${#matched_ids[@]} -gt 0 ]]; then
+        if [[ -n "${matched_ids+x}" ]] && [[ ${#matched_ids[@]} -gt 0 ]]; then
             ids="$(printf '%s, ' "${matched_ids[@]}")"
             ids="${ids%, }"
             echo "| $section | (to be filled) | $ids | Covered |"

--- a/scripts/needs-schema-sync.sh
+++ b/scripts/needs-schema-sync.sh
@@ -157,7 +157,7 @@ done <<< "$CHANGED_FILES"
 # OUTPUT
 # ============================================================
 
-if [[ ${#API_FILES[@]} -eq 0 ]]; then
+if [[ -z "${API_FILES+x}" ]] || [[ ${#API_FILES[@]} -eq 0 ]]; then
     echo "## Schema Sync Check"
     echo ""
     echo "**Result: No sync needed** — No API files modified"

--- a/scripts/pre-synthesis-check.sh
+++ b/scripts/pre-synthesis-check.sh
@@ -213,7 +213,7 @@ check_phase_readiness() {
             ;;
     esac
 
-    if [[ ${#missing[@]} -gt 0 ]]; then
+    if [[ -n "${missing+x}" ]] && [[ ${#missing[@]} -gt 0 ]]; then
         local detail
         detail="Phase is '$phase', need ${#missing[@]} transition(s):"
         for m in "${missing[@]}"; do

--- a/scripts/reconcile-state.sh
+++ b/scripts/reconcile-state.sh
@@ -215,7 +215,7 @@ check_task_branches() {
         fi
     done <<< "$task_branches"
 
-    if [[ ${#missing_branches[@]} -eq 0 ]]; then
+    if [[ -z "${missing_branches+x}" ]] || [[ ${#missing_branches[@]} -eq 0 ]]; then
         check_pass "Task branches exist ($branches_checked branches verified)"
         return 0
     else
@@ -261,7 +261,7 @@ check_worktrees_exist() {
         fi
     done <<< "$worktree_paths"
 
-    if [[ ${#missing_worktrees[@]} -eq 0 ]]; then
+    if [[ -z "${missing_worktrees+x}" ]] || [[ ${#missing_worktrees[@]} -eq 0 ]]; then
         check_pass "Worktrees exist ($worktrees_checked worktrees verified)"
         return 0
     else
@@ -296,7 +296,7 @@ check_task_status_consistency() {
         inconsistencies+=("Task $task_id is in-progress but has no branch")
     done <<< "$in_progress_no_branch"
 
-    if [[ ${#inconsistencies[@]} -eq 0 ]]; then
+    if [[ -z "${inconsistencies+x}" ]] || [[ ${#inconsistencies[@]} -eq 0 ]]; then
         check_pass "Task status consistency ($task_count tasks checked)"
         return 0
     else

--- a/scripts/reconstruct-stack.sh
+++ b/scripts/reconstruct-stack.sh
@@ -237,7 +237,7 @@ reconstruct_stack() {
         expected_branches+=("$branch")
     done < <(get_expected_branches)
 
-    if [[ ${#expected_branches[@]} -eq 0 ]]; then
+    if [[ -z "${expected_branches+x}" ]] || [[ ${#expected_branches[@]} -eq 0 ]]; then
         echo -e "${YELLOW}No task branches to reconstruct${NC}"
         return 0
     fi
@@ -373,7 +373,7 @@ main() {
     DETECTED_MISSING=()
     detect_problems "$gt_log_output"
 
-    if [[ ${#DETECTED_PROBLEMS[@]} -eq 0 ]]; then
+    if [[ -z "${DETECTED_PROBLEMS+x}" ]] || [[ ${#DETECTED_PROBLEMS[@]} -eq 0 ]]; then
         echo -e "${GREEN}Stack is healthy${NC} — all ${task_count} task branches tracked and clean"
         exit 0
     fi
@@ -384,13 +384,13 @@ main() {
     done
     echo ""
 
-    if [[ ${#DETECTED_DIVERGED[@]} -gt 0 ]]; then
+    if [[ -n "${DETECTED_DIVERGED+x}" ]] && [[ ${#DETECTED_DIVERGED[@]} -gt 0 ]]; then
         echo "Diverged branches: ${DETECTED_DIVERGED[*]}"
     fi
-    if [[ ${#DETECTED_RESTACK[@]} -gt 0 ]]; then
+    if [[ -n "${DETECTED_RESTACK+x}" ]] && [[ ${#DETECTED_RESTACK[@]} -gt 0 ]]; then
         echo "Needs restack: ${DETECTED_RESTACK[*]}"
     fi
-    if [[ ${#DETECTED_MISSING[@]} -gt 0 ]]; then
+    if [[ -n "${DETECTED_MISSING+x}" ]] && [[ ${#DETECTED_MISSING[@]} -gt 0 ]]; then
         echo "Missing from stack: ${DETECTED_MISSING[*]}"
     fi
     echo ""
@@ -415,7 +415,7 @@ main() {
     VALIDATION_ISSUES=()
     validate_stack "$post_gt_log"
 
-    if [[ ${#VALIDATION_ISSUES[@]} -eq 0 ]]; then
+    if [[ -z "${VALIDATION_ISSUES+x}" ]] || [[ ${#VALIDATION_ISSUES[@]} -eq 0 ]]; then
         echo -e "${GREEN}Validation passed${NC} — stack is clean after reconstruction"
         exit 0
     fi

--- a/scripts/spec-coverage-check.sh
+++ b/scripts/spec-coverage-check.sh
@@ -143,7 +143,7 @@ done < "$PLAN_FILE"
 # CHECK: Test files referenced in plan
 # ============================================================
 
-if [[ ${#TEST_FILES[@]} -eq 0 ]]; then
+if [[ -z "${TEST_FILES+x}" ]] || [[ ${#TEST_FILES[@]} -eq 0 ]]; then
     check_fail "Test files in plan" "No test files referenced in plan document"
 fi
 
@@ -201,7 +201,7 @@ echo "- Found on disk: $FOUND"
 echo "- Missing: $MISSING"
 echo ""
 
-if [[ ${#MISSING_LIST[@]} -gt 0 ]]; then
+if [[ -n "${MISSING_LIST+x}" ]] && [[ ${#MISSING_LIST[@]} -gt 0 ]]; then
     echo "### Missing Test Files"
     echo ""
     for f in "${MISSING_LIST[@]}"; do

--- a/scripts/validate-dotnet-standards.sh
+++ b/scripts/validate-dotnet-standards.sh
@@ -218,7 +218,7 @@ check_no_inline_versions() {
         fi
     done < <(find "$src_dir" -name '*.csproj' -type f 2>/dev/null)
 
-    if [[ ${#violations[@]} -eq 0 ]]; then
+    if [[ -z "${violations+x}" ]] || [[ ${#violations[@]} -eq 0 ]]; then
         check_pass "No inline package versions in .csproj files"
         return 0
     else

--- a/scripts/validate-installation.sh
+++ b/scripts/validate-installation.sh
@@ -89,7 +89,7 @@ fi
 
 echo "=== Installation Validation: ${PASS_COUNT}/${TOTAL} skills passed ==="
 
-if [[ ${#ERRORS[@]} -gt 0 ]]; then
+if [[ -n "${ERRORS+x}" ]] && [[ ${#ERRORS[@]} -gt 0 ]]; then
   echo ""
   echo "Errors:"
   for err in "${ERRORS[@]}"; do

--- a/scripts/validate-rm.sh
+++ b/scripts/validate-rm.sh
@@ -84,7 +84,7 @@ while IFS= read -r target; do
   fi
 done <<< "$TARGETS"
 
-if [[ ${#BLOCKED_PATHS[@]} -gt 0 ]]; then
+if [[ -n "${BLOCKED_PATHS+x}" ]] && [[ ${#BLOCKED_PATHS[@]} -gt 0 ]]; then
   echo "BLOCKED: rm targets paths outside current directory ($CWD):" >&2
   printf "  - %s\n" "${BLOCKED_PATHS[@]}" >&2
   exit 2

--- a/scripts/verify-delegation-saga.sh
+++ b/scripts/verify-delegation-saga.sh
@@ -198,10 +198,10 @@ done <<< "$TEAM_EVENTS"
 # RULE 3: All dispatched task IDs must have been planned
 # ============================================================
 
-if [[ ${#DISPATCHED_TASK_IDS[@]} -gt 0 ]]; then
+if [[ -n "${DISPATCHED_TASK_IDS+x}" ]] && [[ ${#DISPATCHED_TASK_IDS[@]} -gt 0 ]]; then
     for dispatched_id in "${DISPATCHED_TASK_IDS[@]}"; do
         found=false
-        if [[ ${#PLANNED_TASK_IDS[@]} -gt 0 ]]; then
+        if [[ -n "${PLANNED_TASK_IDS+x}" ]] && [[ ${#PLANNED_TASK_IDS[@]} -gt 0 ]]; then
             for planned_id in "${PLANNED_TASK_IDS[@]}"; do
                 if [[ "$dispatched_id" == "$planned_id" ]]; then
                     found=true
@@ -219,7 +219,7 @@ fi
 # OUTPUT AND EXIT
 # ============================================================
 
-if [[ ${#VIOLATIONS[@]} -gt 0 ]]; then
+if [[ -n "${VIOLATIONS+x}" ]] && [[ ${#VIOLATIONS[@]} -gt 0 ]]; then
     echo "## Delegation Saga Validation"
     echo ""
     echo "**Status:** FAILED for feature \`$FEATURE_ID\`"

--- a/scripts/verify-ideate-artifacts.sh
+++ b/scripts/verify-ideate-artifacts.sh
@@ -196,7 +196,7 @@ check_required_sections() {
         fi
     done
 
-    if [[ ${#missing[@]} -eq 0 ]]; then
+    if [[ -z "${missing+x}" ]] || [[ ${#missing[@]} -eq 0 ]]; then
         check_pass "Required sections present (${#REQUIRED_SECTIONS[@]}/${#REQUIRED_SECTIONS[@]})"
         return 0
     else

--- a/scripts/verify-plan-coverage.sh
+++ b/scripts/verify-plan-coverage.sh
@@ -114,7 +114,7 @@ while IFS= read -r line; do
 done < "$DESIGN_FILE"
 
 # Validate we found sections
-if [[ ${#DESIGN_SECTIONS[@]} -eq 0 ]]; then
+if [[ -z "${DESIGN_SECTIONS+x}" ]] || [[ ${#DESIGN_SECTIONS[@]} -eq 0 ]]; then
     echo "Error: No Technical Design subsections found in design document" >&2
     echo "Expected ### headers under '## Technical Design'" >&2
     exit 2
@@ -139,7 +139,7 @@ while IFS= read -r line; do
 done < "$PLAN_FILE"
 
 # Validate we found tasks
-if [[ ${#PLAN_TASKS[@]} -eq 0 ]]; then
+if [[ -z "${PLAN_TASKS+x}" ]] || [[ ${#PLAN_TASKS[@]} -eq 0 ]]; then
     echo "ERROR: No '### Task' headers found in plan file: $PLAN_FILE" >&2
     exit 1
 fi
@@ -168,13 +168,13 @@ for section in "${DESIGN_SECTIONS[@]}"; do
     done
 
     # If no task title matches, check the full plan content for the section name
-    if [[ ${#MATCHED_TASKS[@]} -eq 0 ]]; then
+    if [[ -z "${MATCHED_TASKS+x}" ]] || [[ ${#MATCHED_TASKS[@]} -eq 0 ]]; then
         if echo "$PLAN_CONTENT" | grep -qiF "$section"; then
             MATCHED_TASKS+=("(referenced in plan body)")
         fi
     fi
 
-    if [[ ${#MATCHED_TASKS[@]} -gt 0 ]]; then
+    if [[ -n "${MATCHED_TASKS+x}" ]] && [[ ${#MATCHED_TASKS[@]} -gt 0 ]]; then
         task_list="$(printf '%s, ' "${MATCHED_TASKS[@]}")"
         task_list="${task_list%, }"
         MATRIX_ROWS+=("| $section | $task_list | Covered |")
@@ -213,7 +213,7 @@ echo "- Covered: $CHECK_PASS"
 echo "- Gaps: $CHECK_FAIL"
 echo ""
 
-if [[ ${#GAPS[@]} -gt 0 ]]; then
+if [[ -n "${GAPS+x}" ]] && [[ ${#GAPS[@]} -gt 0 ]]; then
     echo "### Unmapped Sections"
     echo ""
     for gap in "${GAPS[@]}"; do


### PR DESCRIPTION
Add ${VAR+x} guards before ${#VAR[@]} references in all validation
scripts using set -euo pipefail. Older bash versions (4.x) treat empty
array length checks as unbound variable errors under nounset. The
primary fix is in verify-plan-coverage.sh (line 142) but the same
pattern was applied across 16 other scripts for consistency.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>