### PR TITLE
feat: applyDotPath sparse array bounds guard

### DIFF
--- a/servers/exarchos-mcp/package-lock.json
+++ b/servers/exarchos-mcp/package-lock.json
@@ -1718,26 +1718,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@azure/core-client": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
-      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.10.0",
-        "@azure/core-rest-pipeline": "^1.22.0",
-        "@azure/core-tracing": "^1.3.0",
-        "@azure/core-util": "^1.13.0",
-        "@azure/logger": "^1.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@azure/core-http-compat": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.3.2.tgz",
@@ -1785,26 +1765,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
-      "integrity": "sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@azure/abort-controller": "^2.1.2",
-        "@azure/core-auth": "^1.10.0",
-        "@azure/core-tracing": "^1.3.0",
-        "@azure/core-util": "^1.13.0",
-        "@azure/logger": "^1.3.0",
-        "@typespec/ts-http-runtime": "^0.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-sse": {
@@ -2271,6 +2231,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -2311,6 +2272,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -4171,6 +4133,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4493,22 +4456,6 @@
       "optional": true,
       "peerDependencies": {
         "@redis/client": "^1.0.0"
-      }
-    },
-    "node_modules/@redis/client": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
-      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "cluster-key-slot": "1.1.2",
-        "generic-pool": "3.9.0",
-        "yallist": "4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@redis/graph": {
@@ -6149,6 +6096,7 @@
       "integrity": "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6771,6 +6719,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -8840,6 +8789,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9795,6 +9745,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11453,7 +11404,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -11468,28 +11418,11 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
         "is-stream": "^2.0.0",
         "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongoose/node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^5.0.0",
-        "json-bigint": "^1.0.0"
       },
       "engines": {
         "node": ">=12"
@@ -11502,7 +11435,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -12550,35 +12482,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/pg": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
-      "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pg-connection-string": "^2.11.0",
-        "pg-pool": "^3.11.0",
-        "pg-protocol": "^1.11.0",
-        "pg-types": "2.2.0",
-        "pgpass": "1.0.5"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
-      },
-      "peerDependencies": {
-        "pg-native": ">=3.0.1"
-      },
-      "peerDependenciesMeta": {
-        "pg-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/pg-cloudflare": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
@@ -12667,6 +12570,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12723,32 +12627,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/playwright-extra": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/playwright-extra/-/playwright-extra-4.3.6.tgz",
-      "integrity": "sha512-q2rVtcE8V8K3vPVF1zny4pvwZveHLH8KBuVU2MoE3Jw4OKVoBWsHI9CH9zPydovHHOCDxjGN2Vg+2m644q3ijA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "playwright": "*",
-        "playwright-core": "*"
-      },
-      "peerDependenciesMeta": {
-        "playwright": {
-          "optional": true
-        },
-        "playwright-core": {
-          "optional": true
-        }
       }
     },
     "node_modules/playwright/node_modules/fsevents": {
@@ -13291,6 +13169,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -13689,6 +13568,7 @@
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15589,6 +15469,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -15687,6 +15568,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -16225,6 +16107,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/servers/exarchos-mcp/src/__tests__/workflow/state-store.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/state-store.test.ts
@@ -1165,4 +1165,119 @@ describe('State Store', () => {
       expect(state.phase).toBe('plan');
     });
   });
+
+  // ─── Task 5: applyDotPath Sparse Array Bounds Guard ─────────────────────
+
+  describe('applyDotPath_SparseArrayBounds', () => {
+    it('ApplyDotPath_SparseArrayIndex_ThrowsInvalidInput', () => {
+      const obj: Record<string, unknown> = { tasks: [] };
+      expect(() => applyDotPath(obj, 'tasks[50].name', 'x')).toThrow(ErrorCode.INVALID_INPUT);
+    });
+
+    it('ApplyDotPath_AppendIndex_Succeeds', () => {
+      const obj: Record<string, unknown> = { tasks: ['a', 'b'] };
+      applyDotPath(obj, 'tasks[2]', 'c');
+      expect((obj.tasks as string[])[2]).toBe('c');
+    });
+
+    it('ApplyDotPath_NextGapIndex_Succeeds', () => {
+      const obj: Record<string, unknown> = { tasks: ['a'] };
+      // index 2 when length is 1 → gap of 1 → allowed
+      applyDotPath(obj, 'tasks[2]', 'c');
+      expect((obj.tasks as unknown[])[2]).toBe('c');
+    });
+
+    it('ApplyDotPath_IntermediateSparseArray_ThrowsInvalidInput', () => {
+      const obj: Record<string, unknown> = {};
+      // 'items' doesn't exist → auto-created as empty array → index 100 >> length 0
+      expect(() => applyDotPath(obj, 'items[100].name', 'x')).toThrow(ErrorCode.INVALID_INPUT);
+    });
+
+    it('ApplyDotPath_FinalSparseIndex_ThrowsInvalidInput', () => {
+      const obj: Record<string, unknown> = { items: [1, 2] };
+      expect(() => applyDotPath(obj, 'items[50]', 99)).toThrow(ErrorCode.INVALID_INPUT);
+    });
+  });
+
+  // ─── Task 6: writeStateFile CAS Corrupt File Handling ───────────────────
+
+  describe('writeStateFile_CASCorruptHandling', () => {
+    it('WriteStateFile_CorruptExistingFile_ThrowsStateCorrupt', async () => {
+      const stateFile = path.join(tmpDir, 'corrupt.state.json');
+      await fs.writeFile(stateFile, 'invalid json{{{', 'utf-8');
+
+      const { state } = await initStateFile(tmpDir, 'test-feature', 'feature');
+
+      await expect(
+        writeStateFile(stateFile, state, { expectedVersion: 1 }),
+      ).rejects.toThrow(ErrorCode.STATE_CORRUPT);
+    });
+
+    it('WriteStateFile_MissingFile_CASDefaultsToVersion1', async () => {
+      const stateFile = path.join(tmpDir, 'nonexistent.state.json');
+      const { state } = await initStateFile(tmpDir, 'test-feature', 'feature');
+
+      // Should not throw — ENOENT defaults to version 1, expectedVersion=1 matches
+      await expect(
+        writeStateFile(stateFile, state, { expectedVersion: 1 }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('WriteStateFile_ValidFile_CASSucceeds', async () => {
+      const { stateFile, state } = await initStateFile(tmpDir, 'test-feature', 'feature');
+      // initStateFile writes with _version: 1
+
+      await expect(
+        writeStateFile(stateFile, state, { expectedVersion: 1 }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('WriteStateFile_ValidFile_CASConflict_ThrowsVersionConflict', async () => {
+      const { stateFile, state } = await initStateFile(tmpDir, 'test-feature', 'feature');
+      // State is at version 1, but we claim version 5
+
+      await expect(
+        writeStateFile(stateFile, state, { expectedVersion: 5 }),
+      ).rejects.toThrow('VERSION_CONFLICT');
+    });
+  });
+
+  // ─── Task 7: initStateFile Crash Safety (temp+link) ─────────────────────
+
+  describe('initStateFile_CrashSafety', () => {
+    it('InitStateFile_Success_NoTempFileRemains', async () => {
+      await initStateFile(tmpDir, 'test-feature', 'feature');
+
+      // Verify no .init.PID temp files remain
+      const entries = await fs.readdir(tmpDir);
+      const initTmpFiles = entries.filter((f) => f.includes('.init.'));
+      expect(initTmpFiles).toHaveLength(0);
+    });
+
+    it('InitStateFile_ExistingFile_ThrowsAlreadyExists', async () => {
+      await initStateFile(tmpDir, 'test-feature', 'feature');
+
+      // Second init should fail with STATE_ALREADY_EXISTS
+      await expect(
+        initStateFile(tmpDir, 'test-feature', 'feature'),
+      ).rejects.toThrow(ErrorCode.STATE_ALREADY_EXISTS);
+    });
+
+    it('InitStateFile_ConcurrentInit_OneSucceedsOneFailsEEXIST', async () => {
+      // Launch two inits concurrently
+      const results = await Promise.allSettled([
+        initStateFile(tmpDir, 'race-feature', 'feature'),
+        initStateFile(tmpDir, 'race-feature', 'feature'),
+      ]);
+
+      const successes = results.filter((r) => r.status === 'fulfilled');
+      const failures = results.filter((r) => r.status === 'rejected');
+
+      expect(successes).toHaveLength(1);
+      expect(failures).toHaveLength(1);
+
+      const failureReason = (failures[0] as PromiseRejectedResult).reason;
+      expect(failureReason.message).toContain(ErrorCode.STATE_ALREADY_EXISTS);
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/workflow/state-store.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.ts
@@ -7,6 +7,9 @@ import * as fs from 'node:fs/promises';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 
+/** Maximum gap between array length and new index. Allows append (gap 0) and one-past-end (gap 1). */
+export const MAX_ARRAY_GAP = 1;
+
 // ─── Initial Phase by Workflow Type ────────────────────────────────────────
 
 const INITIAL_PHASE: Record<WorkflowType, string> = {
@@ -92,13 +95,20 @@ export async function initStateFile(
   // Ensure directory exists
   await fs.mkdir(stateDir, { recursive: true });
 
-  // Write atomically with exclusive flag (fails if file exists)
-  // This avoids TOCTOU race condition — no separate existence check needed
+  // Write via temp file + atomic link for crash safety.
+  // link() fails with EEXIST if target exists, preserving exclusive-create semantics.
+  // On crash before link(), only the temp file remains — no corrupt state file.
+  const tmpPath = `${stateFile}.init.${process.pid}`;
   try {
-    await fs.writeFile(stateFile, JSON.stringify(state, null, 2), {
-      encoding: 'utf-8',
-      flag: 'wx', // exclusive create - fails with EEXIST if file exists
-    });
+    await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf-8');
+  } catch (err) {
+    throw new StateStoreError(
+      ErrorCode.FILE_IO_ERROR,
+      `Failed to write temp state file: ${stateFile} — ${(err as Error).message}`,
+    );
+  }
+  try {
+    await fs.link(tmpPath, stateFile);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
       throw new StateStoreError(
@@ -108,8 +118,11 @@ export async function initStateFile(
     }
     throw new StateStoreError(
       ErrorCode.FILE_IO_ERROR,
-      `Failed to write state file: ${stateFile} — ${(err as Error).message}`,
+      `Failed to create state file: ${stateFile} — ${(err as Error).message}`,
     );
+  } finally {
+    // Always clean up temp file (link created a second hard link to same inode)
+    await fs.unlink(tmpPath).catch(() => {});
   }
 
   return { stateFile, state };
@@ -203,10 +216,27 @@ export async function writeStateFile(
     let currentVersion = 1;
     try {
       const raw = await fs.readFile(stateFile, 'utf-8');
-      const parsed = JSON.parse(raw) as Record<string, unknown>;
-      currentVersion = typeof parsed._version === 'number' ? parsed._version : 1;
-    } catch {
-      // If file doesn't exist or is unreadable, default to version 1
+      try {
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        currentVersion = typeof parsed._version === 'number' ? parsed._version : 1;
+      } catch {
+        // File exists but has invalid JSON — surface corruption instead of masking it
+        throw new StateStoreError(
+          ErrorCode.STATE_CORRUPT,
+          `Cannot perform CAS check — state file has invalid JSON: ${stateFile}`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof StateStoreError) throw err; // re-throw STATE_CORRUPT
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        // File doesn't exist — version 1 is correct for first write
+        currentVersion = 1;
+      } else {
+        throw new StateStoreError(
+          ErrorCode.FILE_IO_ERROR,
+          `Cannot read state file for CAS check: ${stateFile}`,
+        );
+      }
     }
 
     if (options.expectedVersion !== currentVersion) {
@@ -308,6 +338,23 @@ function parsePath(dotPath: string): Array<string | number> {
   return segments;
 }
 
+/**
+ * Guard against sparse array creation. Throws if the index exceeds the
+ * array length by more than MAX_ARRAY_GAP.
+ */
+function assertArrayBounds(
+  arr: unknown[],
+  index: number,
+  dotPath: string,
+): void {
+  if (index > arr.length + MAX_ARRAY_GAP) {
+    throw new StateStoreError(
+      ErrorCode.INVALID_INPUT,
+      `Array index ${index} exceeds length ${arr.length} by more than ${MAX_ARRAY_GAP} in path ${dotPath}`,
+    );
+  }
+}
+
 export function applyDotPath(
   obj: Record<string, unknown>,
   dotPath: string,
@@ -338,6 +385,7 @@ export function applyDotPath(
           `Expected array at index ${segment} in path ${dotPath}`,
         );
       }
+      assertArrayBounds(current, segment, dotPath);
       if (current[segment] === undefined) {
         // Create intermediate object or array based on next segment
         current[segment] = typeof nextSegment === 'number' ? [] : {};
@@ -363,6 +411,7 @@ export function applyDotPath(
         `Expected array for final index ${lastSegment} in path ${dotPath}`,
       );
     }
+    assertArrayBounds(current, lastSegment, dotPath);
     current[lastSegment] = value;
   } else {
     const record = current as Record<string, unknown>;


### PR DESCRIPTION
Add MAX_ARRAY_GAP constant and assertArrayBounds helper to prevent
sparse array creation in dot-path updates. Reject indices that exceed
array length by more than 1 (append + one-past-end allowed).

Also fix writeStateFile CAS to throw STATE_CORRUPT on invalid JSON
instead of masking corruption, and replace initStateFile wx flag
with temp+link for crash safety.