### PR TITLE
feat: listStateFiles corrupt reporting + orphaned temp cleanup (#io-hardening)

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/utils/process.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/utils/process.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { isPidAlive } from '../../utils/process.js';
+
+describe('isPidAlive', () => {
+  it('IsPidAlive_CurrentProcess_ReturnsTrue', () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+
+  it('IsPidAlive_DeadPid_ReturnsFalse', () => {
+    // PID 999999 is extremely unlikely to be alive
+    expect(isPidAlive(999999)).toBe(false);
+  });
+
+  it('IsPidAlive_InvalidPid_ReturnsFalse', () => {
+    expect(isPidAlive(-1)).toBe(false);
+  });
+});

--- a/servers/exarchos-mcp/src/__tests__/workflow/state-store.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/state-store.test.ts
@@ -203,21 +203,23 @@ describe('State Store', () => {
 
       const results = await listStateFiles(tmpDir);
 
-      expect(results).toHaveLength(3);
-      const featureIds = results.map((r) => r.featureId).sort();
+      expect(results.valid).toHaveLength(3);
+      const featureIds = results.valid.map((r) => r.featureId).sort();
       expect(featureIds).toEqual(['feature-a', 'feature-b', 'feature-c']);
 
       // Each entry should have stateFile and state
-      for (const entry of results) {
+      for (const entry of results.valid) {
         expect(entry.stateFile).toContain('.state.json');
         expect(entry.state).toBeDefined();
         expect(entry.state.featureId).toBe(entry.featureId);
       }
+      expect(results.corrupt).toHaveLength(0);
     });
 
     it('should return empty array for empty directory', async () => {
       const results = await listStateFiles(tmpDir);
-      expect(results).toEqual([]);
+      expect(results.valid).toEqual([]);
+      expect(results.corrupt).toEqual([]);
     });
 
     it('should ignore non-state files', async () => {
@@ -226,8 +228,8 @@ describe('State Store', () => {
       await fs.writeFile(path.join(tmpDir, 'readme.md'), '# Notes', 'utf-8');
 
       const results = await listStateFiles(tmpDir);
-      expect(results).toHaveLength(1);
-      expect(results[0].featureId).toBe('real-state');
+      expect(results.valid).toHaveLength(1);
+      expect(results.valid[0].featureId).toBe('real-state');
     });
   });
 
@@ -353,11 +355,13 @@ describe('State Store', () => {
       );
 
       const results = await listStateFiles(tmpDir);
-      expect(results).toHaveLength(1);
-      expect(results[0].featureId).toBe('valid-feature');
+      expect(results.valid).toHaveLength(1);
+      expect(results.valid[0].featureId).toBe('valid-feature');
+      expect(results.corrupt).toHaveLength(1);
+      expect(results.corrupt[0].featureId).toBe('corrupt');
     });
 
-    it('should return empty array when all state files are corrupt', async () => {
+    it('should return empty valid array when all state files are corrupt', async () => {
       await fs.writeFile(
         path.join(tmpDir, 'bad1.state.json'),
         '{not valid}}}',
@@ -370,16 +374,18 @@ describe('State Store', () => {
       );
 
       const results = await listStateFiles(tmpDir);
-      expect(results).toHaveLength(0);
+      expect(results.valid).toHaveLength(0);
+      expect(results.corrupt).toHaveLength(2);
     });
   });
 
   describe('listStateFiles_ENOENT_ReturnsEmptyArray', () => {
-    it('should return empty array when directory does not exist', async () => {
+    it('should return empty arrays when directory does not exist', async () => {
       const nonExistentDir = path.join(tmpDir, 'does-not-exist');
 
       const results = await listStateFiles(nonExistentDir);
-      expect(results).toEqual([]);
+      expect(results.valid).toEqual([]);
+      expect(results.corrupt).toEqual([]);
     });
   });
 
@@ -397,6 +403,89 @@ describe('State Store', () => {
         expect(err).toBeInstanceOf(StateStoreError);
         expect((err as StateStoreError).code).toBe(ErrorCode.FILE_IO_ERROR);
       }
+    });
+  });
+
+  describe('listStateFiles_CorruptFileReporting', () => {
+    it('ListStateFiles_CorruptFile_ReportsInCorruptArray', async () => {
+      await initStateFile(tmpDir, 'valid-feature', 'feature');
+      await fs.writeFile(
+        path.join(tmpDir, 'corrupt.state.json'),
+        'invalid json{{{',
+        'utf-8',
+      );
+
+      const result = await listStateFiles(tmpDir);
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].featureId).toBe('valid-feature');
+      expect(result.corrupt).toHaveLength(1);
+      expect(result.corrupt[0].featureId).toBe('corrupt');
+      expect(result.corrupt[0].stateFile).toContain('corrupt.state.json');
+      expect(result.corrupt[0].error).toBeTruthy();
+    });
+
+    it('ListStateFiles_MixedFiles_SeparatesValidAndCorrupt', async () => {
+      await initStateFile(tmpDir, 'good-one', 'feature');
+      await initStateFile(tmpDir, 'good-two', 'debug');
+      await fs.writeFile(
+        path.join(tmpDir, 'bad.state.json'),
+        '{not valid}}}',
+        'utf-8',
+      );
+
+      const result = await listStateFiles(tmpDir);
+      expect(result.valid).toHaveLength(2);
+      expect(result.corrupt).toHaveLength(1);
+      expect(result.corrupt[0].featureId).toBe('bad');
+    });
+
+    it('ListStateFiles_AllCorrupt_ReturnsEmptyValidNonEmptyCorrupt', async () => {
+      await fs.writeFile(path.join(tmpDir, 'bad1.state.json'), '{{{', 'utf-8');
+      await fs.writeFile(path.join(tmpDir, 'bad2.state.json'), '', 'utf-8');
+
+      const result = await listStateFiles(tmpDir);
+      expect(result.valid).toHaveLength(0);
+      expect(result.corrupt).toHaveLength(2);
+    });
+  });
+
+  describe('listStateFiles_OrphanedTempCleanup', () => {
+    it('ListStateFiles_OrphanedTmpFromDeadPid_CleansUp', async () => {
+      // Create an orphaned temp file with a dead PID
+      const tmpFile = path.join(tmpDir, 'test.state.json.tmp.999999');
+      await fs.writeFile(tmpFile, '{}', 'utf-8');
+
+      await listStateFiles(tmpDir);
+
+      // Verify temp file was cleaned up
+      await expect(fs.access(tmpFile)).rejects.toThrow();
+    });
+
+    it('ListStateFiles_TmpFromLivePid_Preserved', async () => {
+      // Create a temp file with our own PID (alive)
+      const tmpFile = path.join(tmpDir, `test.state.json.tmp.${process.pid}`);
+      await fs.writeFile(tmpFile, '{}', 'utf-8');
+
+      await listStateFiles(tmpDir);
+
+      // Verify temp file was NOT cleaned up
+      await expect(fs.access(tmpFile)).resolves.toBeUndefined();
+    });
+
+    it('ListStateFiles_InitTmpFromDeadPid_CleansUp', async () => {
+      const tmpFile = path.join(tmpDir, 'test.state.json.init.999999');
+      await fs.writeFile(tmpFile, '{}', 'utf-8');
+
+      await listStateFiles(tmpDir);
+
+      await expect(fs.access(tmpFile)).rejects.toThrow();
+    });
+
+    it('ListStateFiles_NoTmpFiles_NoError', async () => {
+      await initStateFile(tmpDir, 'valid-feature', 'feature');
+
+      const result = await listStateFiles(tmpDir);
+      expect(result.valid).toHaveLength(1);
     });
   });
 

--- a/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -206,6 +206,39 @@ describe('Core Tools', () => {
     });
   });
 
+  describe('HandleList_CorruptFiles_IncludesWarnings', () => {
+    it('should include warnings for corrupt state files', async () => {
+      // Create a valid workflow
+      await handleInit({ featureId: 'good-wf', workflowType: 'feature' }, tmpDir);
+
+      // Create a corrupt state file
+      const corruptFile = path.join(tmpDir, 'corrupt-wf.state.json');
+      await fs.writeFile(corruptFile, 'invalid json{{{', 'utf-8');
+
+      const result = await handleList({}, tmpDir);
+
+      expect(result.success).toBe(true);
+      const data = result.data as Array<Record<string, unknown>>;
+      expect(data).toHaveLength(1);
+      expect(data[0].featureId).toBe('good-wf');
+
+      // Verify warnings are included
+      const warnings = result.warnings as string[];
+      expect(warnings).toBeDefined();
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('corrupt-wf');
+    });
+
+    it('should not include warnings when no corrupt files', async () => {
+      await handleInit({ featureId: 'clean-wf', workflowType: 'feature' }, tmpDir);
+
+      const result = await handleList({}, tmpDir);
+
+      expect(result.success).toBe(true);
+      expect(result.warnings).toBeUndefined();
+    });
+  });
+
   // ─── ToolGet ────────────────────────────────────────────────────────────────
 
   describe('ToolGet_DotPathQuery_ReturnsValue', () => {

--- a/servers/exarchos-mcp/src/cli-commands/guard.ts
+++ b/servers/exarchos-mcp/src/cli-commands/guard.ts
@@ -102,7 +102,7 @@ async function findActiveWorkflowPhase(
 ): Promise<string | null> {
   let stateFiles;
   try {
-    stateFiles = await listStateFiles(stateDir);
+    stateFiles = (await listStateFiles(stateDir)).valid;
   } catch {
     // State directory doesn't exist or is unreadable
     return null;

--- a/servers/exarchos-mcp/src/cli-commands/pre-compact.ts
+++ b/servers/exarchos-mcp/src/cli-commands/pre-compact.ts
@@ -85,7 +85,7 @@ export async function handlePreCompact(
   const trigger = typeof stdinData.type === 'string' ? stdinData.type : 'auto';
 
   // List all state files (listStateFiles handles missing directory gracefully)
-  const allWorkflows = await listStateFiles(stateDir);
+  const allWorkflows = (await listStateFiles(stateDir)).valid;
 
   // Filter to active (non-terminal) workflows
   const activeWorkflows = allWorkflows.filter(

--- a/servers/exarchos-mcp/src/cli-commands/session-start.ts
+++ b/servers/exarchos-mcp/src/cli-commands/session-start.ts
@@ -529,7 +529,7 @@ export async function handleSessionStart(
 
     // Also check for active state files not covered by checkpoints
     try {
-      const stateFiles = await listStateFiles(stateDir);
+      const stateFiles = (await listStateFiles(stateDir)).valid;
       for (const entry of stateFiles) {
         if (checkpointFeatureIds.has(entry.featureId)) continue;
         if (TERMINAL_PHASES.has(entry.state.phase)) continue;
@@ -559,7 +559,7 @@ export async function handleSessionStart(
 
   // Step 2: No checkpoints — discover active workflows from state files
   try {
-    const stateFiles = await listStateFiles(stateDir);
+    const stateFiles = (await listStateFiles(stateDir)).valid;
     const activeWorkflows = stateFiles.filter(
       (entry) => !TERMINAL_PHASES.has(entry.state.phase),
     );

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -7,6 +7,7 @@ import type { WorkflowEvent } from './schemas.js';
 import type { Outbox } from '../sync/outbox.js';
 import { migrateEvent } from './event-migration.js';
 import { storeLogger } from '../logger.js';
+import { isPidAlive } from '../utils/process.js';
 
 // ─── Sequence Conflict Error ────────────────────────────────────────────────
 
@@ -32,18 +33,6 @@ export class PidLockError extends Error {
       `Event store is locked by live process PID ${existingPid}`,
     );
     this.name = 'PidLockError';
-  }
-}
-
-// ─── PID Helpers ─────────────────────────────────────────────────────────────
-
-/** Check if a process with the given PID is alive. */
-function isPidAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
   }
 }
 

--- a/servers/exarchos-mcp/src/format.ts
+++ b/servers/exarchos-mcp/src/format.ts
@@ -6,6 +6,7 @@ export interface ToolResult {
   readonly success: boolean;
   readonly data?: unknown;
   readonly error?: { code: string; message: string; validTargets?: readonly (string | ValidTransitionTarget)[] };
+  readonly warnings?: readonly string[];
   readonly _meta?: unknown;
 }
 

--- a/servers/exarchos-mcp/src/utils/process.ts
+++ b/servers/exarchos-mcp/src/utils/process.ts
@@ -1,0 +1,10 @@
+/** Check if a process with the given PID is alive. */
+export function isPidAlive(pid: number): boolean {
+  if (pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/servers/exarchos-mcp/src/workflow/state-store.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.ts
@@ -3,6 +3,7 @@ import { migrateState, CURRENT_VERSION, backupStateFile } from './migration.js';
 import type { WorkflowState, WorkflowType } from './types.js';
 import type { EventStore } from '../event-store/store.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
+import { isPidAlive } from '../utils/process.js';
 import * as fs from 'node:fs/promises';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
@@ -386,15 +387,20 @@ export function applyDotPath(
 
 // ─── List State Files ──────────────────────────────────────────────────────
 
+export interface ListStateFilesResult {
+  valid: Array<{ featureId: string; stateFile: string; state: WorkflowState }>;
+  corrupt: Array<{ featureId: string; stateFile: string; error: string }>;
+}
+
 export async function listStateFiles(
   stateDir: string,
-): Promise<Array<{ featureId: string; stateFile: string; state: WorkflowState }>> {
+): Promise<ListStateFilesResult> {
   let entries: string[];
   try {
     entries = await fs.readdir(stateDir);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      return [];
+      return { valid: [], corrupt: [] };
     }
     throw new StateStoreError(
       ErrorCode.FILE_IO_ERROR,
@@ -403,21 +409,39 @@ export async function listStateFiles(
   }
 
   const stateFiles = entries.filter((f) => f.endsWith('.state.json'));
-  const results: Array<{ featureId: string; stateFile: string; state: WorkflowState }> = [];
+
+  // Clean up orphaned temp files from crashed writes
+  const tmpPattern = /\.(tmp|init)\.(\d+)$/;
+  const tmpFiles = entries.filter((f) => tmpPattern.test(f));
+  for (const tmpFile of tmpFiles) {
+    const match = tmpFile.match(tmpPattern);
+    if (match) {
+      const pid = parseInt(match[2], 10);
+      if (!isNaN(pid) && !isPidAlive(pid)) {
+        await fs.unlink(path.join(stateDir, tmpFile)).catch(() => {});
+      }
+    }
+  }
+
+  const valid: ListStateFilesResult['valid'] = [];
+  const corrupt: ListStateFilesResult['corrupt'] = [];
 
   for (const file of stateFiles) {
     const stateFile = path.join(stateDir, file);
     const featureId = file.replace('.state.json', '');
     try {
       const state = await readStateFile(stateFile);
-      results.push({ featureId, stateFile, state });
-    } catch {
-      // Skip corrupt or unreadable state files
-      continue;
+      valid.push({ featureId, stateFile, state });
+    } catch (err) {
+      corrupt.push({
+        featureId,
+        stateFile,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 
-  return results;
+  return { valid, corrupt };
 }
 
 // ─── Apply Event to State (pure helper) ─────────────────────────────────────

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -185,7 +185,7 @@ export async function handleList(
   _input: ListInput,
   stateDir: string,
 ): Promise<ToolResult> {
-  const entries = await listStateFiles(stateDir);
+  const { valid: entries, corrupt } = await listStateFiles(stateDir);
 
   const data = entries.map((entry) => ({
     featureId: entry.featureId,
@@ -198,6 +198,9 @@ export async function handleList(
   return {
     success: true,
     data,
+    ...(corrupt.length > 0 && {
+      warnings: corrupt.map((c) => `Corrupt state file: ${c.featureId} — ${c.error}`),
+    }),
   };
 }
 


### PR DESCRIPTION
Extract isPidAlive to shared utils, change listStateFiles return type to
{valid, corrupt}, add orphaned temp file cleanup, update all callers,
surface warnings in handleList.