### PR TITLE
fix: batch outbox drain and atomic snapshot writes

### DIFF
--- a/servers/exarchos-mcp/src/sync/outbox.test.ts
+++ b/servers/exarchos-mcp/src/sync/outbox.test.ts
@@ -78,3 +78,61 @@ describe('Outbox drain idempotencyKey propagation', () => {
     expect(sentEvents[0][0].idempotencyKey).toBeUndefined();
   });
 });
+
+// ─── Outbox drain batch I/O tests ───────────────────────────────────────────
+
+describe('Outbox drain batch I/O', () => {
+  let tempDir: string;
+  let outbox: Outbox;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'outbox-batch-test-'));
+    outbox = new Outbox(tempDir);
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('drain_BatchOfN_LoadsEntriesOnce', async () => {
+    // Arrange: add 3 pending entries
+    for (let i = 1; i <= 3; i++) {
+      await outbox.addEntry('test-stream', makeEvent({ sequence: i }));
+    }
+
+    const mockClient: EventSender = {
+      appendEvents: vi.fn().mockResolvedValue({ accepted: 1, streamVersion: 1 }),
+    };
+
+    // Spy on loadEntries to count calls during drain
+    const loadSpy = vi.spyOn(outbox, 'loadEntries');
+
+    // Act
+    await outbox.drain(mockClient, 'test-stream');
+
+    // Assert: loadEntries should be called exactly once (batch load at start)
+    // The current O(n²) implementation calls it once at start + once per entry via _updateEntry
+    expect(loadSpy.mock.calls.length).toBe(1);
+  });
+
+  it('drain_BatchOfN_SavesEntriesOnce', async () => {
+    // Arrange: add 3 pending entries
+    for (let i = 1; i <= 3; i++) {
+      await outbox.addEntry('test-stream', makeEvent({ sequence: i }));
+    }
+
+    const mockClient: EventSender = {
+      appendEvents: vi.fn().mockResolvedValue({ accepted: 1, streamVersion: 1 }),
+    };
+
+    // Spy on saveEntries (private method, accessed via prototype)
+    const saveSpy = vi.spyOn(outbox as never, 'saveEntries' as never);
+
+    // Act
+    await outbox.drain(mockClient, 'test-stream');
+
+    // Assert: saveEntries should be called exactly once (batch save at end)
+    // The current O(n²) implementation calls it once per entry via _updateEntry
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/servers/exarchos-mcp/src/sync/outbox.ts
+++ b/servers/exarchos-mcp/src/sync/outbox.ts
@@ -144,6 +144,7 @@ export class Outbox {
       let failed = 0;
 
       for (const entry of pending) {
+        const index = entries.findIndex((e) => e.id === entry.id);
         try {
           await client.appendEvents(streamId, [
             {
@@ -162,32 +163,43 @@ export class Outbox {
             },
           ]);
 
-          await this._updateEntry(streamId, entry.id, {
-            status: 'confirmed',
-            attempts: entry.attempts + 1,
-            lastAttemptAt: new Date().toISOString(),
-          });
+          if (index >= 0) {
+            entries[index] = {
+              ...entries[index],
+              status: 'confirmed',
+              attempts: entry.attempts + 1,
+              lastAttemptAt: new Date().toISOString(),
+            };
+          }
           sent++;
         } catch (err) {
           const attempts = entry.attempts + 1;
           const maxRetries = 10;
 
-          if (attempts >= maxRetries) {
-            await this._updateEntry(streamId, entry.id, {
-              status: 'dead-letter',
-              error: err instanceof Error ? err.message : String(err),
-              lastAttemptAt: new Date().toISOString(),
-            });
-          } else {
-            await this._updateEntry(streamId, entry.id, {
-              attempts,
-              lastAttemptAt: new Date().toISOString(),
-              nextRetryAt: this.calculateNextRetry(attempts),
-              error: err instanceof Error ? err.message : String(err),
-            });
+          if (index >= 0) {
+            if (attempts >= maxRetries) {
+              entries[index] = {
+                ...entries[index],
+                status: 'dead-letter',
+                error: err instanceof Error ? err.message : String(err),
+                lastAttemptAt: new Date().toISOString(),
+              };
+            } else {
+              entries[index] = {
+                ...entries[index],
+                attempts,
+                lastAttemptAt: new Date().toISOString(),
+                nextRetryAt: this.calculateNextRetry(attempts),
+                error: err instanceof Error ? err.message : String(err),
+              };
+            }
           }
           failed++;
         }
+      }
+
+      if (pending.length > 0) {
+        await this.saveEntries(streamId, entries);
       }
 
       return { sent, failed };

--- a/servers/exarchos-mcp/src/views/snapshot-store.test.ts
+++ b/servers/exarchos-mcp/src/views/snapshot-store.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as path from 'node:path';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+// Track writeFile and rename calls from inside snapshot-store
+const writeFileCalls: { path: string; data: string }[] = [];
+let renameFailOnce = false;
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+  return {
+    ...actual,
+    writeFile: vi.fn(async (filePath: string, data: string, encoding?: string) => {
+      writeFileCalls.push({ path: filePath, data: typeof data === 'string' ? data : '' });
+      return actual.writeFile(filePath, data, encoding as BufferEncoding);
+    }),
+    rename: vi.fn(async (oldPath: string, newPath: string) => {
+      if (renameFailOnce) {
+        renameFailOnce = false;
+        throw new Error('Simulated crash during rename');
+      }
+      return actual.rename(oldPath, newPath);
+    }),
+  };
+});
+
+// Import AFTER mock setup
+const { SnapshotStore } = await import('./snapshot-store.js');
+
+// ─── Atomic Snapshot Write Tests ──────────────────────────────────────────────
+
+describe('SnapshotStore atomic writes', () => {
+  let tempDir: string;
+  let store: SnapshotStore;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'snapshot-atomic-test-'));
+    store = new SnapshotStore(tempDir);
+    writeFileCalls.length = 0;
+    renameFailOnce = false;
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('snapshotSave_CrashDuringWrite_DoesNotCorruptExistingSnapshot', async () => {
+    // Arrange: save a valid snapshot first
+    const originalData = { status: 'good', count: 42 };
+    await store.save('test-stream', 'myview', originalData, 5);
+
+    // Verify the original file exists and is valid
+    const filePath = path.join(tempDir, 'test-stream.myview.snapshot.json');
+    const originalContent = await readFile(filePath, 'utf-8');
+    const originalParsed = JSON.parse(originalContent);
+    expect(originalParsed.view).toEqual(originalData);
+
+    // Clear tracked calls to focus on the second save
+    writeFileCalls.length = 0;
+
+    // Act: make rename fail to simulate crash after write but before rename
+    renameFailOnce = true;
+
+    try {
+      await store.save('test-stream', 'myview', { status: 'corrupted' }, 10);
+    } catch {
+      // Expected to throw if using atomic pattern
+    }
+
+    // Assert: the original file must NOT be corrupted.
+    // If save() writes directly to the target file (current buggy behavior),
+    // the original content is already overwritten.
+    // If save() uses tmp+rename (desired atomic behavior), the original is preserved.
+    const afterContent = await readFile(filePath, 'utf-8');
+    const afterParsed = JSON.parse(afterContent);
+    expect(afterParsed.view).toEqual(originalData);
+    expect(afterParsed.highWaterMark).toBe(5);
+
+    // Verify the write went to a tmp file, not the target directly
+    expect(writeFileCalls.length).toBeGreaterThan(0);
+    const lastWrite = writeFileCalls[writeFileCalls.length - 1];
+    expect(lastWrite.path).not.toBe(filePath);
+    expect(lastWrite.path).toContain('.tmp');
+  });
+});

--- a/servers/exarchos-mcp/src/views/snapshot-store.ts
+++ b/servers/exarchos-mcp/src/views/snapshot-store.ts
@@ -62,7 +62,9 @@ export class SnapshotStore {
   }
 
   /**
-   * Save a view snapshot to disk.
+   * Save a view snapshot to disk atomically using tmp+rename.
+   * Writes to a temporary file first, then renames to the target path.
+   * This ensures the target file is never left in a partially-written state.
    */
   async save<T>(
     streamId: string,
@@ -71,6 +73,7 @@ export class SnapshotStore {
     highWaterMark: number,
   ): Promise<void> {
     const filePath = this.getSnapshotPath(streamId, viewName);
+    const tmpPath = `${filePath}.tmp.${Date.now()}`;
     await fs.mkdir(path.dirname(filePath), { recursive: true });
 
     const data: SnapshotData<T> = {
@@ -80,7 +83,8 @@ export class SnapshotStore {
       schemaVersion: EVENT_SCHEMA_VERSION,
     };
 
-    await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+    await fs.writeFile(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+    await fs.rename(tmpPath, filePath);
   }
 
   /**


### PR DESCRIPTION
Refactor Outbox.drain() from O(n²) to O(n) by loading entries once at
batch start, processing all pending entries in-memory, and saving once
at batch end. Add atomic tmp+rename pattern to SnapshotStore.save() to
prevent snapshot corruption on crash.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>