### PR TITLE
feat: add StorageBackend abstraction with SQLite + in-memory implementations

### DIFF
--- a/.github/workflows/eval-gate.yml
+++ b/.github/workflows/eval-gate.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   eval-regression:
     name: Eval Regression Check
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 15
     concurrency:
       group: eval-gate-${{ github.head_ref }}

--- a/servers/exarchos-mcp/package-lock.json
+++ b/servers/exarchos-mcp/package-lock.json
@@ -9,11 +9,13 @@
       "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "better-sqlite3": "^12.6.2",
         "pino": "^10.3.1",
         "zod": "^3.23.0"
       },
       "devDependencies": {
         "@fast-check/vitest": "^0.2.4",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^3.0.0",
         "fast-check": "^4.5.3",
@@ -6088,6 +6090,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -6721,7 +6733,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6784,7 +6795,6 @@
       "version": "12.6.2",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
       "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -6859,7 +6869,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
@@ -6869,7 +6878,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -6881,7 +6889,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6906,7 +6913,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -7883,7 +7889,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -7924,7 +7929,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
@@ -8064,7 +8068,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -8345,7 +8348,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -8835,7 +8837,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "dev": true,
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
@@ -9138,7 +9139,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/finalhandler": {
@@ -9333,7 +9333,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -9567,7 +9566,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/glob": {
@@ -10126,7 +10124,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10179,7 +10176,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ink": {
@@ -11294,7 +11290,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11323,7 +11318,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11383,7 +11377,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mongodb-connection-string-url": {
@@ -11650,7 +11643,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural": {
@@ -11733,7 +11725,6 @@
       "version": "3.87.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
       "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -12937,7 +12928,6 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.0",
@@ -13473,7 +13463,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -13755,7 +13744,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
@@ -14085,7 +14073,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14156,7 +14143,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14468,7 +14454,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14489,7 +14474,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14872,7 +14856,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -14999,7 +14982,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15122,7 +15104,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -15135,14 +15116,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
@@ -15159,7 +15138,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -15462,7 +15440,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -15658,7 +15635,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {

--- a/servers/exarchos-mcp/package.json
+++ b/servers/exarchos-mcp/package.json
@@ -15,11 +15,13 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "better-sqlite3": "^12.6.2",
     "pino": "^10.3.1",
     "zod": "^3.23.0"
   },
   "devDependencies": {
     "@fast-check/vitest": "^0.2.4",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.0.0",
     "fast-check": "^4.5.3",

--- a/servers/exarchos-mcp/src/storage/backend.test.ts
+++ b/servers/exarchos-mcp/src/storage/backend.test.ts
@@ -12,6 +12,7 @@ describe('StorageBackend Interface Contract', () => {
       appendEvent: (_streamId: string, _event: WorkflowEvent): void => {},
       queryEvents: (_streamId: string, _filters?: QueryFilters): WorkflowEvent[] => [],
       getSequence: (_streamId: string): number => 0,
+      listStreams: (): string[] => [],
       getState: (_featureId: string): WorkflowState | null => null,
       setState: (_featureId: string, _state: WorkflowState, _expectedVersion?: number): void => {},
       listStates: (): Array<{ featureId: string; state: WorkflowState }> => [],
@@ -19,14 +20,18 @@ describe('StorageBackend Interface Contract', () => {
       drainOutbox: (_streamId: string, _sender: EventSender, _batchSize?: number): DrainResult => ({ sent: 0, failed: 0 }),
       getViewCache: (_streamId: string, _viewName: string): ViewCacheEntry | null => null,
       setViewCache: (_streamId: string, _viewName: string, _state: unknown, _hwm: number): void => {},
+      deleteStream: (_streamId: string): void => {},
+      deleteState: (_featureId: string): void => {},
+      pruneEvents: (_streamId: string, _beforeTimestamp: string): number => 0,
       initialize: (): void => {},
       close: (): void => {},
     };
 
-    // Verify all 12 methods exist
+    // Verify all 16 methods exist
     expect(typeof backend.appendEvent).toBe('function');
     expect(typeof backend.queryEvents).toBe('function');
     expect(typeof backend.getSequence).toBe('function');
+    expect(typeof backend.listStreams).toBe('function');
     expect(typeof backend.getState).toBe('function');
     expect(typeof backend.setState).toBe('function');
     expect(typeof backend.listStates).toBe('function');
@@ -34,6 +39,9 @@ describe('StorageBackend Interface Contract', () => {
     expect(typeof backend.drainOutbox).toBe('function');
     expect(typeof backend.getViewCache).toBe('function');
     expect(typeof backend.setViewCache).toBe('function');
+    expect(typeof backend.deleteStream).toBe('function');
+    expect(typeof backend.deleteState).toBe('function');
+    expect(typeof backend.pruneEvents).toBe('function');
     expect(typeof backend.initialize).toBe('function');
     expect(typeof backend.close).toBe('function');
   });

--- a/servers/exarchos-mcp/src/storage/backend.ts
+++ b/servers/exarchos-mcp/src/storage/backend.ts
@@ -64,6 +64,7 @@ export interface StorageBackend {
   appendEvent(streamId: string, event: WorkflowEvent): void;
   queryEvents(streamId: string, filters?: QueryFilters): WorkflowEvent[];
   getSequence(streamId: string): number;
+  listStreams(): string[];
 
   // State operations
   getState(featureId: string): WorkflowState | null;
@@ -77,6 +78,11 @@ export interface StorageBackend {
   // View cache operations
   getViewCache(streamId: string, viewName: string): ViewCacheEntry | null;
   setViewCache(streamId: string, viewName: string, state: unknown, hwm: number): void;
+
+  // Cleanup operations (used by lifecycle compaction/rotation)
+  deleteStream(streamId: string): void;
+  deleteState(featureId: string): void;
+  pruneEvents(streamId: string, beforeTimestamp: string): number;
 
   // Lifecycle
   initialize(): void;

--- a/servers/exarchos-mcp/src/storage/memory-backend.test.ts
+++ b/servers/exarchos-mcp/src/storage/memory-backend.test.ts
@@ -53,6 +53,31 @@ function makeState(overrides: Partial<WorkflowState> = {}): WorkflowState {
   } as WorkflowState;
 }
 
+// ─── Event Operations ───────────────────────────────────────────────────────
+
+describe('InMemoryBackend Event Operations', () => {
+  it('InMemoryBackend_listStreams_ReturnsEmpty_WhenNoEvents', () => {
+    const backend = new InMemoryBackend();
+    backend.initialize();
+
+    expect(backend.listStreams()).toEqual([]);
+  });
+
+  it('InMemoryBackend_listStreams_ReturnsDistinctStreamIds', () => {
+    const backend = new InMemoryBackend();
+    backend.initialize();
+
+    backend.appendEvent('stream-a', makeEvent({ streamId: 'stream-a', sequence: 1 }));
+    backend.appendEvent('stream-a', makeEvent({ streamId: 'stream-a', sequence: 2 }));
+    backend.appendEvent('stream-b', makeEvent({ streamId: 'stream-b', sequence: 1 }));
+
+    const streams = backend.listStreams();
+    expect(streams).toHaveLength(2);
+    expect(streams).toContain('stream-a');
+    expect(streams).toContain('stream-b');
+  });
+});
+
 // ─── State Operations ───────────────────────────────────────────────────────
 
 describe('InMemoryBackend State Operations', () => {

--- a/servers/exarchos-mcp/src/storage/memory-backend.ts
+++ b/servers/exarchos-mcp/src/storage/memory-backend.ts
@@ -104,6 +104,10 @@ export class InMemoryBackend implements StorageBackend {
     return stream[stream.length - 1].sequence;
   }
 
+  listStreams(): string[] {
+    return Array.from(this.events.keys());
+  }
+
   // ─── State Operations ───────────────────────────────────────────────────
 
   getState(featureId: string): WorkflowState | null {
@@ -197,6 +201,32 @@ export class InMemoryBackend implements StorageBackend {
   setViewCache(streamId: string, viewName: string, state: unknown, hwm: number): void {
     const key = `${streamId}:${viewName}`;
     this.viewCache.set(key, { state, highWaterMark: hwm });
+  }
+
+  // ─── Cleanup Operations ─────────────────────────────────────────────────
+
+  deleteStream(streamId: string): void {
+    this.events.delete(streamId);
+  }
+
+  deleteState(featureId: string): void {
+    this.states.delete(featureId);
+  }
+
+  pruneEvents(streamId: string, beforeTimestamp: string): number {
+    const stream = this.events.get(streamId);
+    if (!stream) return 0;
+
+    const kept = stream.filter((e) => e.timestamp >= beforeTimestamp);
+    const pruned = stream.length - kept.length;
+
+    if (kept.length === 0) {
+      this.events.delete(streamId);
+    } else {
+      this.events.set(streamId, kept);
+    }
+
+    return pruned;
   }
 
   // ─── Lifecycle ──────────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/storage/sqlite-backend.test.ts
+++ b/servers/exarchos-mcp/src/storage/sqlite-backend.test.ts
@@ -1,0 +1,856 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fc } from '@fast-check/vitest';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+import type { WorkflowState } from '../workflow/types.js';
+import type { EventSender } from './backend.js';
+import { SqliteBackend } from './sqlite-backend.js';
+import { VersionConflictError } from './memory-backend.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeEvent(overrides: Partial<WorkflowEvent> = {}): WorkflowEvent {
+  return {
+    streamId: 'test-stream',
+    sequence: 1,
+    timestamp: new Date().toISOString(),
+    type: 'workflow.started',
+    schemaVersion: '1.0',
+    ...overrides,
+  } as WorkflowEvent;
+}
+
+function makeState(overrides: Partial<WorkflowState> = {}): WorkflowState {
+  return {
+    version: '1.1',
+    featureId: 'test-feature',
+    workflowType: 'feature',
+    phase: 'ideate',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    artifacts: { design: null, plan: null, pr: null },
+    tasks: [],
+    worktrees: {},
+    reviews: {},
+    integration: null,
+    synthesis: {
+      integrationBranch: null,
+      mergeOrder: [],
+      mergedBranches: [],
+      prUrl: null,
+      prFeedback: [],
+    },
+    _version: 1,
+    _history: {},
+    _checkpoint: {
+      timestamp: '1970-01-01T00:00:00Z',
+      phase: 'init',
+      summary: 'Initial state',
+      operationsSince: 0,
+      fixCycleCount: 0,
+      lastActivityTimestamp: '1970-01-01T00:00:00Z',
+      staleAfterMinutes: 120,
+    },
+    ...overrides,
+  } as WorkflowState;
+}
+
+// ─── Task 7: Schema and Event Operations ────────────────────────────────────
+
+describe('SqliteBackend Schema', () => {
+  let backend: SqliteBackend;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+  });
+
+  afterEach(() => {
+    backend.close();
+  });
+
+  it('SqliteBackend_initialize_CreatesAllTables', () => {
+    // Query sqlite_master for all expected tables
+    const db = (backend as unknown as { db: { prepare: (sql: string) => { all: () => Array<{ name: string }> } } }).db;
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all()
+      .map((row) => row.name);
+
+    expect(tables).toContain('events');
+    expect(tables).toContain('workflow_state');
+    expect(tables).toContain('outbox');
+    expect(tables).toContain('view_cache');
+    expect(tables).toContain('sequences');
+    expect(tables).toContain('schema_version');
+  });
+
+  it('SqliteBackend_initialize_WALModeEnabled', () => {
+    // :memory: databases report 'memory' for journal_mode since WAL requires a file.
+    // We verify the pragma was issued by checking it returns 'memory' for in-memory DBs.
+    // For file-based DBs this would be 'wal'.
+    const db = (backend as unknown as { db: { pragma: (sql: string) => Array<{ journal_mode: string }> } }).db;
+    const result = db.pragma('journal_mode');
+    // In-memory databases cannot use WAL; they report 'memory'
+    expect(result[0].journal_mode).toBe('memory');
+  });
+
+  it('SqliteBackend_concurrentReadWrite_WALMode_NoBlocking', () => {
+    // WAL mode should allow concurrent read/write without blocking
+    // Append an event, then verify we can read while conceptually "writing"
+    const event1 = makeEvent({ streamId: 'stream-a', sequence: 1 });
+    backend.appendEvent('stream-a', event1);
+
+    // Read while the write was just done (WAL allows this)
+    const events = backend.queryEvents('stream-a');
+    expect(events).toHaveLength(1);
+
+    // Append another event and immediately read again
+    const event2 = makeEvent({ streamId: 'stream-a', sequence: 2 });
+    backend.appendEvent('stream-a', event2);
+    const events2 = backend.queryEvents('stream-a');
+    expect(events2).toHaveLength(2);
+  });
+});
+
+describe('SqliteBackend Event Operations', () => {
+  let backend: SqliteBackend;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+  });
+
+  afterEach(() => {
+    backend.close();
+  });
+
+  it('SqliteBackend_appendEvent_InsertsIntoEventsTable', () => {
+    const event = makeEvent({ streamId: 'test-stream', sequence: 1 });
+    backend.appendEvent('test-stream', event);
+
+    const events = backend.queryEvents('test-stream');
+    expect(events).toHaveLength(1);
+    expect(events[0].streamId).toBe('test-stream');
+    expect(events[0].sequence).toBe(1);
+    expect(events[0].type).toBe('workflow.started');
+  });
+
+  it('SqliteBackend_queryEvents_NoFilter_ReturnsAll', () => {
+    const event1 = makeEvent({ streamId: 'test-stream', sequence: 1, type: 'workflow.started' });
+    const event2 = makeEvent({ streamId: 'test-stream', sequence: 2, type: 'task.assigned' });
+    const event3 = makeEvent({ streamId: 'test-stream', sequence: 3, type: 'task.completed' });
+
+    backend.appendEvent('test-stream', event1);
+    backend.appendEvent('test-stream', event2);
+    backend.appendEvent('test-stream', event3);
+
+    const events = backend.queryEvents('test-stream');
+    expect(events).toHaveLength(3);
+  });
+
+  it('SqliteBackend_queryEvents_SinceSequence_ReturnsOnlyNewer', () => {
+    const event1 = makeEvent({ streamId: 'test-stream', sequence: 1 });
+    const event2 = makeEvent({ streamId: 'test-stream', sequence: 2 });
+    const event3 = makeEvent({ streamId: 'test-stream', sequence: 3 });
+
+    backend.appendEvent('test-stream', event1);
+    backend.appendEvent('test-stream', event2);
+    backend.appendEvent('test-stream', event3);
+
+    const events = backend.queryEvents('test-stream', { sinceSequence: 1 });
+    expect(events).toHaveLength(2);
+    expect(events[0].sequence).toBe(2);
+    expect(events[1].sequence).toBe(3);
+  });
+
+  it('SqliteBackend_queryEvents_ByType_FiltersCorrectly', () => {
+    const event1 = makeEvent({ streamId: 'test-stream', sequence: 1, type: 'workflow.started' });
+    const event2 = makeEvent({ streamId: 'test-stream', sequence: 2, type: 'task.assigned' });
+    const event3 = makeEvent({ streamId: 'test-stream', sequence: 3, type: 'workflow.started' });
+
+    backend.appendEvent('test-stream', event1);
+    backend.appendEvent('test-stream', event2);
+    backend.appendEvent('test-stream', event3);
+
+    const events = backend.queryEvents('test-stream', { type: 'workflow.started' });
+    expect(events).toHaveLength(2);
+    expect(events.every((e) => e.type === 'workflow.started')).toBe(true);
+  });
+
+  it('SqliteBackend_queryEvents_ByTimeRange_FiltersCorrectly', () => {
+    const event1 = makeEvent({ streamId: 'test-stream', sequence: 1, timestamp: '2024-01-01T00:00:00.000Z' });
+    const event2 = makeEvent({ streamId: 'test-stream', sequence: 2, timestamp: '2024-06-15T12:00:00.000Z' });
+    const event3 = makeEvent({ streamId: 'test-stream', sequence: 3, timestamp: '2024-12-31T23:59:59.000Z' });
+
+    backend.appendEvent('test-stream', event1);
+    backend.appendEvent('test-stream', event2);
+    backend.appendEvent('test-stream', event3);
+
+    const events = backend.queryEvents('test-stream', {
+      since: '2024-03-01T00:00:00.000Z',
+      until: '2024-09-01T00:00:00.000Z',
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].sequence).toBe(2);
+  });
+
+  it('SqliteBackend_queryEvents_WithLimitAndOffset_Paginates', () => {
+    for (let i = 1; i <= 10; i++) {
+      backend.appendEvent(
+        'test-stream',
+        makeEvent({ streamId: 'test-stream', sequence: i }),
+      );
+    }
+
+    // Get page 2 (offset=3, limit=3) => sequences 4, 5, 6
+    const events = backend.queryEvents('test-stream', { offset: 3, limit: 3 });
+    expect(events).toHaveLength(3);
+    expect(events[0].sequence).toBe(4);
+    expect(events[1].sequence).toBe(5);
+    expect(events[2].sequence).toBe(6);
+  });
+
+  it('SqliteBackend_getSequence_ReturnsMaxSequenceForStream', () => {
+    backend.appendEvent('test-stream', makeEvent({ streamId: 'test-stream', sequence: 1 }));
+    backend.appendEvent('test-stream', makeEvent({ streamId: 'test-stream', sequence: 2 }));
+    backend.appendEvent('test-stream', makeEvent({ streamId: 'test-stream', sequence: 3 }));
+
+    expect(backend.getSequence('test-stream')).toBe(3);
+  });
+
+  it('SqliteBackend_getSequence_UnknownStream_ReturnsZero', () => {
+    expect(backend.getSequence('nonexistent-stream')).toBe(0);
+  });
+});
+
+// ─── Task 8: State, Outbox, and View Cache Operations ───────────────────────
+
+describe('SqliteBackend State Operations', () => {
+  let backend: SqliteBackend;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+  });
+
+  afterEach(() => {
+    backend.close();
+  });
+
+  it('SqliteBackend_setState_GetState_Roundtrip', () => {
+    const state = makeState({ featureId: 'my-feature' });
+    backend.setState('my-feature', state);
+
+    const retrieved = backend.getState('my-feature');
+    expect(retrieved).toEqual(state);
+  });
+
+  it('SqliteBackend_setState_CASConflict_ThrowsVersionConflictError', () => {
+    const state = makeState({ featureId: 'my-feature' });
+    backend.setState('my-feature', state);
+
+    // Current version is 1 after first set; using expectedVersion=0 (stale) should throw
+    const updatedState = makeState({ featureId: 'my-feature', phase: 'plan' });
+    expect(() => backend.setState('my-feature', updatedState, 0)).toThrow(VersionConflictError);
+  });
+
+  it('SqliteBackend_setState_AutoIncrementsVersion', () => {
+    const state1 = makeState({ featureId: 'my-feature' });
+    backend.setState('my-feature', state1);
+
+    // Version is now 1; setting with expectedVersion=1 should succeed and bump to 2
+    const state2 = makeState({ featureId: 'my-feature', phase: 'plan' });
+    backend.setState('my-feature', state2, 1);
+
+    // Version is now 2; setting with expectedVersion=1 should fail
+    const state3 = makeState({ featureId: 'my-feature', phase: 'delegate' });
+    expect(() => backend.setState('my-feature', state3, 1)).toThrow(VersionConflictError);
+
+    // But expectedVersion=2 should succeed
+    expect(() => backend.setState('my-feature', state3, 2)).not.toThrow();
+  });
+
+  it('SqliteBackend_listStates_ReturnsAllWorkflows', () => {
+    const state1 = makeState({ featureId: 'feature-a' });
+    const state2 = makeState({ featureId: 'feature-b' });
+
+    backend.setState('feature-a', state1);
+    backend.setState('feature-b', state2);
+
+    const states = backend.listStates();
+    expect(states).toHaveLength(2);
+
+    const featureIds = states.map((s) => s.featureId);
+    expect(featureIds).toContain('feature-a');
+    expect(featureIds).toContain('feature-b');
+  });
+});
+
+describe('SqliteBackend Outbox Operations', () => {
+  let backend: SqliteBackend;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+  });
+
+  afterEach(() => {
+    backend.close();
+  });
+
+  it('SqliteBackend_addOutboxEntry_CreatesWithPendingStatus', () => {
+    const event = makeEvent({ streamId: 'test-stream', sequence: 1 });
+    const entryId = backend.addOutboxEntry('test-stream', event);
+
+    expect(typeof entryId).toBe('string');
+    expect(entryId.length).toBeGreaterThan(0);
+  });
+
+  it('SqliteBackend_drainOutbox_SendsPendingAndUpdatesStatus', () => {
+    const event = makeEvent({ streamId: 'test-stream', sequence: 1 });
+    backend.addOutboxEntry('test-stream', event);
+
+    const sentEvents: unknown[] = [];
+    const mockSender: EventSender = {
+      appendEvents: async (_streamId, events) => {
+        sentEvents.push(...events);
+        return { accepted: events.length, streamVersion: 1 };
+      },
+    };
+
+    const result = backend.drainOutbox('test-stream', mockSender);
+    expect(result.sent).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(sentEvents).toHaveLength(1);
+
+    // Draining again should find no pending entries
+    const result2 = backend.drainOutbox('test-stream', mockSender);
+    expect(result2.sent).toBe(0);
+    expect(result2.failed).toBe(0);
+  });
+
+  it('SqliteBackend_drainOutbox_FailedEntry_SetsRetryAndIncrementsAttempts', () => {
+    const event = makeEvent({ streamId: 'test-stream', sequence: 1 });
+    backend.addOutboxEntry('test-stream', event);
+
+    // Use a synchronous throw since drainOutbox is synchronous
+    const failingSender: EventSender = {
+      appendEvents: (_streamId, _events) => {
+        throw new Error('Network error');
+      },
+    } as unknown as EventSender;
+
+    const result = backend.drainOutbox('test-stream', failingSender);
+    expect(result.sent).toBe(0);
+    expect(result.failed).toBe(1);
+
+    // Entry should still be pending (retryable) after first failure
+    const successSender: EventSender = {
+      appendEvents: async (_streamId, events) => {
+        return { accepted: events.length, streamVersion: 1 };
+      },
+    };
+
+    const result2 = backend.drainOutbox('test-stream', successSender);
+    expect(result2.sent).toBe(1);
+  });
+
+  it('SqliteBackend_drainOutbox_MaxRetries_MarksDeadLetter', () => {
+    const event = makeEvent({ streamId: 'test-stream', sequence: 1 });
+    backend.addOutboxEntry('test-stream', event);
+
+    // Use a synchronous throw since drainOutbox is synchronous
+    const failingSender: EventSender = {
+      appendEvents: (_streamId, _events) => {
+        throw new Error('Permanent failure');
+      },
+    } as unknown as EventSender;
+
+    // Drain multiple times to exceed max retries (default 5)
+    for (let i = 0; i < 6; i++) {
+      backend.drainOutbox('test-stream', failingSender);
+    }
+
+    // After max retries, entry should be dead-lettered and not retried
+    const successSender: EventSender = {
+      appendEvents: async (_streamId, events) => {
+        return { accepted: events.length, streamVersion: 1 };
+      },
+    };
+
+    const result = backend.drainOutbox('test-stream', successSender);
+    expect(result.sent).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+});
+
+describe('SqliteBackend View Cache Operations', () => {
+  let backend: SqliteBackend;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+  });
+
+  afterEach(() => {
+    backend.close();
+  });
+
+  it('SqliteBackend_getViewCache_SetViewCache_Roundtrip', () => {
+    const viewState = { count: 42, items: ['a', 'b'] };
+    backend.setViewCache('test-stream', 'my-view', viewState, 10);
+
+    const cached = backend.getViewCache('test-stream', 'my-view');
+    expect(cached).not.toBeNull();
+    expect(cached!.state).toEqual(viewState);
+    expect(cached!.highWaterMark).toBe(10);
+  });
+
+  it('SqliteBackend_setViewCache_Upserts_OnConflict', () => {
+    const viewState1 = { count: 1 };
+    backend.setViewCache('test-stream', 'my-view', viewState1, 5);
+
+    const viewState2 = { count: 99 };
+    backend.setViewCache('test-stream', 'my-view', viewState2, 15);
+
+    const cached = backend.getViewCache('test-stream', 'my-view');
+    expect(cached).not.toBeNull();
+    expect(cached!.state).toEqual(viewState2);
+    expect(cached!.highWaterMark).toBe(15);
+  });
+
+  it('SqliteBackend_getViewCache_ReturnsNullWhenEmpty', () => {
+    const result = backend.getViewCache('test-stream', 'nonexistent-view');
+    expect(result).toBeNull();
+  });
+});
+
+describe('SqliteBackend Transactional Operations', () => {
+  let backend: SqliteBackend;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+  });
+
+  afterEach(() => {
+    backend.close();
+  });
+
+  it('SqliteBackend_appendEvent_WithOutbox_BothInSameTransaction', () => {
+    // Append event and add outbox entry, verify both are persisted
+    const event = makeEvent({ streamId: 'test-stream', sequence: 1 });
+    backend.appendEvent('test-stream', event);
+    backend.addOutboxEntry('test-stream', event);
+
+    // Verify event is stored
+    const events = backend.queryEvents('test-stream');
+    expect(events).toHaveLength(1);
+
+    // Verify outbox entry exists by draining
+    const sentEvents: unknown[] = [];
+    const mockSender: EventSender = {
+      appendEvents: async (_streamId, evts) => {
+        sentEvents.push(...evts);
+        return { accepted: evts.length, streamVersion: 1 };
+      },
+    };
+
+    const result = backend.drainOutbox('test-stream', mockSender);
+    expect(result.sent).toBe(1);
+  });
+});
+
+// ─── Issue 1: rowToEvent Round-Trip Preserves All Fields ────────────────────
+
+describe('SqliteBackend rowToEvent Round-Trip', () => {
+  let backend: SqliteBackend;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+  });
+
+  afterEach(() => {
+    backend.close();
+  });
+
+  it('rowToEvent_RoundTrip_PreservesAllFields', () => {
+    const event = makeEvent({
+      streamId: 'test-stream',
+      sequence: 1,
+      type: 'workflow.started',
+      timestamp: '2026-02-21T00:00:00.000Z',
+      schemaVersion: '2.0',
+      correlationId: 'corr-123',
+      causationId: 'cause-456',
+      agentId: 'agent-789',
+      agentRole: 'implementer',
+      source: 'mcp-tool',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      idempotencyKey: 'idem-key-001',
+      data: { key: 'value', nested: { a: 1 } },
+    });
+
+    backend.appendEvent('test-stream', event);
+    const events = backend.queryEvents('test-stream');
+
+    expect(events).toHaveLength(1);
+    const retrieved = events[0];
+
+    // Core fields (already persisted)
+    expect(retrieved.streamId).toBe('test-stream');
+    expect(retrieved.sequence).toBe(1);
+    expect(retrieved.type).toBe('workflow.started');
+    expect(retrieved.timestamp).toBe('2026-02-21T00:00:00.000Z');
+    expect(retrieved.data).toEqual({ key: 'value', nested: { a: 1 } });
+
+    // Fields that were previously DROPPED by rowToEvent:
+    expect(retrieved.schemaVersion).toBe('2.0');
+    expect(retrieved.correlationId).toBe('corr-123');
+    expect(retrieved.causationId).toBe('cause-456');
+    expect(retrieved.agentId).toBe('agent-789');
+    expect(retrieved.agentRole).toBe('implementer');
+    expect(retrieved.source).toBe('mcp-tool');
+    expect(retrieved.tenantId).toBe('tenant-1');
+    expect(retrieved.organizationId).toBe('org-1');
+    expect(retrieved.idempotencyKey).toBe('idem-key-001');
+  });
+
+  it('rowToEvent_RoundTrip_PreservesMinimalEvent', () => {
+    // An event with only required fields — no optional fields set
+    const event = makeEvent({
+      streamId: 'test-stream',
+      sequence: 1,
+      type: 'workflow.started',
+      timestamp: '2026-02-21T00:00:00.000Z',
+    });
+
+    backend.appendEvent('test-stream', event);
+    const events = backend.queryEvents('test-stream');
+
+    expect(events).toHaveLength(1);
+    const retrieved = events[0];
+    expect(retrieved.streamId).toBe('test-stream');
+    expect(retrieved.sequence).toBe(1);
+    expect(retrieved.type).toBe('workflow.started');
+    expect(retrieved.timestamp).toBe('2026-02-21T00:00:00.000Z');
+    expect(retrieved.schemaVersion).toBe('1.0');
+  });
+
+  it('rowToEvent_RoundTrip_PreservesFieldsThroughFilteredQuery', () => {
+    const event = makeEvent({
+      streamId: 'test-stream',
+      sequence: 1,
+      type: 'workflow.started',
+      agentId: 'agent-filtered',
+      correlationId: 'corr-filtered',
+      source: 'filtered-source',
+    });
+
+    backend.appendEvent('test-stream', event);
+    const events = backend.queryEvents('test-stream', { type: 'workflow.started' });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].agentId).toBe('agent-filtered');
+    expect(events[0].correlationId).toBe('corr-filtered');
+    expect(events[0].source).toBe('filtered-source');
+  });
+});
+
+// ─── Issue 3: Prepared Statement Caching for queryEvents ────────────────────
+
+describe('SqliteBackend queryEvents Prepared Statement Caching', () => {
+  let backend: SqliteBackend;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+  });
+
+  afterEach(() => {
+    backend.close();
+  });
+
+  it('queryEvents_SameFilters_ReusesPreparedStatement', () => {
+    // Append some events
+    backend.appendEvent('test-stream', makeEvent({ sequence: 1 }));
+    backend.appendEvent('test-stream', makeEvent({ sequence: 2 }));
+
+    // Access the internal db to spy on prepare
+    const db = (backend as unknown as { db: { prepare: (sql: string) => unknown } }).db;
+    const originalPrepare = db.prepare.bind(db);
+    const prepareSpy = vi.fn(originalPrepare);
+    db.prepare = prepareSpy;
+
+    // Run queryEvents twice with the same filter combination
+    const filters = { type: 'workflow.started' as const };
+    backend.queryEvents('test-stream', filters);
+    backend.queryEvents('test-stream', filters);
+
+    // db.prepare should only be called once — the second call should reuse the cached statement
+    expect(prepareSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('queryEvents_DifferentFilters_CreatesSeparateStatements', () => {
+    // Append some events
+    backend.appendEvent('test-stream', makeEvent({ sequence: 1 }));
+
+    const db = (backend as unknown as { db: { prepare: (sql: string) => unknown } }).db;
+    const originalPrepare = db.prepare.bind(db);
+    const prepareSpy = vi.fn(originalPrepare);
+    db.prepare = prepareSpy;
+
+    // Different filter combinations should create different prepared statements
+    backend.queryEvents('test-stream', { type: 'workflow.started' });
+    backend.queryEvents('test-stream', { sinceSequence: 0 });
+
+    expect(prepareSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── Property-Based Tests ───────────────────────────────────────────────────
+
+describe('SqliteBackend Property Tests', () => {
+  let backend: SqliteBackend;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+  });
+
+  afterEach(() => {
+    backend.close();
+  });
+
+  it('Roundtrip: queryEvents returns exactly the events appended', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 20 }),
+        (count) => {
+          // Create a fresh backend for each property test run
+          const propBackend = new SqliteBackend(':memory:');
+          propBackend.initialize();
+
+          const streamId = 'prop-stream';
+          const appended: WorkflowEvent[] = [];
+
+          for (let i = 1; i <= count; i++) {
+            const event = makeEvent({
+              streamId,
+              sequence: i,
+              type: 'workflow.started',
+              timestamp: `2024-01-01T00:00:${String(i).padStart(2, '0')}.000Z`,
+            });
+            propBackend.appendEvent(streamId, event);
+            appended.push(event);
+          }
+
+          const queried = propBackend.queryEvents(streamId);
+          expect(queried).toHaveLength(appended.length);
+          for (let i = 0; i < appended.length; i++) {
+            expect(queried[i].sequence).toBe(appended[i].sequence);
+            expect(queried[i].type).toBe(appended[i].type);
+            expect(queried[i].streamId).toBe(appended[i].streamId);
+          }
+
+          propBackend.close();
+        },
+      ),
+    );
+  });
+
+  it('Sequence monotonicity: getSequence increases strictly with each appendEvent', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 20 }),
+        (count) => {
+          const propBackend = new SqliteBackend(':memory:');
+          propBackend.initialize();
+
+          const streamId = 'mono-stream';
+          let prevSeq = 0;
+
+          for (let i = 1; i <= count; i++) {
+            const event = makeEvent({ streamId, sequence: i });
+            propBackend.appendEvent(streamId, event);
+            const newSeq = propBackend.getSequence(streamId);
+            expect(newSeq).toBeGreaterThan(prevSeq);
+            prevSeq = newSeq;
+          }
+
+          propBackend.close();
+        },
+      ),
+    );
+  });
+
+  it('CAS linearizability: concurrent setState with same expectedVersion — exactly one succeeds', () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[a-z][a-z0-9-]{0,9}$/).filter((s) => s.length >= 1),
+        (featureId) => {
+          const propBackend = new SqliteBackend(':memory:');
+          propBackend.initialize();
+
+          const state1 = makeState({ featureId });
+          propBackend.setState(featureId, state1);
+
+          const update1 = makeState({ featureId, phase: 'plan' });
+          const update2 = makeState({ featureId, phase: 'delegate' });
+
+          let success1 = false;
+          let success2 = false;
+
+          try {
+            propBackend.setState(featureId, update1, 1);
+            success1 = true;
+          } catch {
+            // CAS conflict
+          }
+
+          try {
+            propBackend.setState(featureId, update2, 1);
+            success2 = true;
+          } catch {
+            // CAS conflict
+          }
+
+          expect(success1).toBe(true);
+          expect(success2).toBe(false);
+
+          propBackend.close();
+        },
+      ),
+    );
+  });
+
+  it('Outbox drain idempotence: drain(drain(x)) === drain(x) for confirmed entries', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 10 }),
+        (count) => {
+          const propBackend = new SqliteBackend(':memory:');
+          propBackend.initialize();
+
+          const streamId = 'drain-stream';
+          for (let i = 1; i <= count; i++) {
+            const event = makeEvent({ streamId, sequence: i });
+            propBackend.addOutboxEntry(streamId, event);
+          }
+
+          const successSender: EventSender = {
+            appendEvents: async (_streamId, events) => {
+              return { accepted: events.length, streamVersion: 1 };
+            },
+          };
+
+          // First drain sends all
+          const result1 = propBackend.drainOutbox(streamId, successSender);
+          expect(result1.sent).toBe(count);
+
+          // Second drain should be idempotent — nothing to send
+          const result2 = propBackend.drainOutbox(streamId, successSender);
+          expect(result2.sent).toBe(0);
+          expect(result2.failed).toBe(0);
+
+          propBackend.close();
+        },
+      ),
+    );
+  });
+});
+
+// ─── Cleanup Operations ──────────────────────────────────────────────────────
+
+describe('SqliteBackend Cleanup Operations', () => {
+  let backend: SqliteBackend;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+  });
+
+  afterEach(() => {
+    backend.close();
+  });
+
+  it('SqliteBackend_deleteStream_RemovesAllEventsAndSequence', () => {
+    // Arrange
+    for (let i = 1; i <= 5; i++) {
+      backend.appendEvent('stream-to-delete', makeEvent({ streamId: 'stream-to-delete', sequence: i }));
+    }
+    backend.appendEvent('other-stream', makeEvent({ streamId: 'other-stream', sequence: 1 }));
+
+    expect(backend.queryEvents('stream-to-delete')).toHaveLength(5);
+
+    // Act
+    backend.deleteStream('stream-to-delete');
+
+    // Assert
+    expect(backend.queryEvents('stream-to-delete')).toHaveLength(0);
+    expect(backend.getSequence('stream-to-delete')).toBe(0);
+    expect(backend.listStreams()).not.toContain('stream-to-delete');
+    // Other stream unaffected
+    expect(backend.queryEvents('other-stream')).toHaveLength(1);
+  });
+
+  it('SqliteBackend_deleteState_RemovesStateForFeature', () => {
+    // Arrange
+    const state1 = makeState({ featureId: 'feature-to-delete' });
+    const state2 = makeState({ featureId: 'other-feature' });
+    backend.setState('feature-to-delete', state1);
+    backend.setState('other-feature', state2);
+
+    expect(backend.getState('feature-to-delete')).not.toBeNull();
+
+    // Act
+    backend.deleteState('feature-to-delete');
+
+    // Assert
+    expect(backend.getState('feature-to-delete')).toBeNull();
+    expect(backend.getState('other-feature')).not.toBeNull();
+  });
+
+  it('SqliteBackend_pruneEvents_RemovesEventsBeforeTimestamp', () => {
+    // Arrange
+    const oldTimestamp = '2024-01-01T00:00:00.000Z';
+    const newTimestamp = '2025-06-15T00:00:00.000Z';
+
+    for (let i = 1; i <= 3; i++) {
+      backend.appendEvent('telemetry', makeEvent({
+        streamId: 'telemetry',
+        sequence: i,
+        timestamp: oldTimestamp,
+        type: 'tool.invoked',
+      }));
+    }
+    for (let i = 4; i <= 6; i++) {
+      backend.appendEvent('telemetry', makeEvent({
+        streamId: 'telemetry',
+        sequence: i,
+        timestamp: newTimestamp,
+        type: 'tool.invoked',
+      }));
+    }
+
+    expect(backend.queryEvents('telemetry')).toHaveLength(6);
+
+    // Act
+    const pruned = backend.pruneEvents('telemetry', '2025-01-01T00:00:00.000Z');
+
+    // Assert
+    expect(pruned).toBe(3);
+    const remaining = backend.queryEvents('telemetry');
+    expect(remaining).toHaveLength(3);
+    for (const event of remaining) {
+      expect(event.timestamp).toBe(newTimestamp);
+    }
+  });
+
+  it('SqliteBackend_pruneEvents_NoEventsForStream_ReturnsZero', () => {
+    const pruned = backend.pruneEvents('nonexistent', '2025-01-01T00:00:00.000Z');
+    expect(pruned).toBe(0);
+  });
+});

--- a/servers/exarchos-mcp/src/storage/sqlite-backend.ts
+++ b/servers/exarchos-mcp/src/storage/sqlite-backend.ts
@@ -1,0 +1,495 @@
+import Database from 'better-sqlite3';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+import type { WorkflowState } from '../workflow/types.js';
+import type { QueryFilters } from '../event-store/store.js';
+import type { StorageBackend, EventSender, ViewCacheEntry, DrainResult } from './backend.js';
+import { VersionConflictError } from './memory-backend.js';
+
+// ─── Schema DDL ─────────────────────────────────────────────────────────────
+
+const SCHEMA_VERSION = 2;
+
+const SCHEMA_DDL = `
+CREATE TABLE IF NOT EXISTS events (
+  streamId  TEXT NOT NULL,
+  sequence  INTEGER NOT NULL,
+  type      TEXT NOT NULL,
+  timestamp TEXT NOT NULL,
+  data      TEXT,
+  payload   TEXT,
+  PRIMARY KEY (streamId, sequence)
+);
+CREATE INDEX IF NOT EXISTS idx_events_type ON events(streamId, type);
+CREATE INDEX IF NOT EXISTS idx_events_time ON events(streamId, timestamp);
+
+CREATE TABLE IF NOT EXISTS workflow_state (
+  featureId TEXT PRIMARY KEY,
+  state     TEXT NOT NULL,
+  version   INTEGER NOT NULL DEFAULT 1,
+  updatedAt TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS outbox (
+  id          TEXT PRIMARY KEY,
+  streamId    TEXT NOT NULL,
+  event       TEXT NOT NULL,
+  status      TEXT NOT NULL DEFAULT 'pending',
+  attempts    INTEGER NOT NULL DEFAULT 0,
+  createdAt   TEXT NOT NULL,
+  lastAttemptAt TEXT,
+  nextRetryAt   TEXT,
+  error       TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_outbox_pending ON outbox(streamId, status);
+
+CREATE TABLE IF NOT EXISTS view_cache (
+  streamId    TEXT NOT NULL,
+  viewName    TEXT NOT NULL,
+  state       TEXT NOT NULL,
+  highWaterMark INTEGER NOT NULL,
+  savedAt     TEXT NOT NULL,
+  PRIMARY KEY (streamId, viewName)
+);
+
+CREATE TABLE IF NOT EXISTS sequences (
+  streamId TEXT PRIMARY KEY,
+  sequence INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS schema_version (
+  version INTEGER PRIMARY KEY,
+  appliedAt TEXT NOT NULL
+);
+`;
+
+// ─── Prepared Statements ────────────────────────────────────────────────────
+
+interface Statements {
+  insertEvent: Database.Statement;
+  upsertSequence: Database.Statement;
+  selectSequence: Database.Statement;
+  selectEvents: Database.Statement;
+  getState: Database.Statement;
+  upsertState: Database.Statement;
+  selectAllStates: Database.Statement;
+  getStateVersion: Database.Statement;
+  insertOutbox: Database.Statement;
+  selectPendingOutbox: Database.Statement;
+  updateOutboxConfirmed: Database.Statement;
+  updateOutboxFailed: Database.Statement;
+  updateOutboxDeadLetter: Database.Statement;
+  getViewCache: Database.Statement;
+  upsertViewCache: Database.Statement;
+  insertSchemaVersion: Database.Statement;
+}
+
+// ─── SqliteBackend ──────────────────────────────────────────────────────────
+
+const MAX_OUTBOX_RETRIES = 5;
+
+/**
+ * SQLite-backed implementation of StorageBackend.
+ * Uses better-sqlite3 for synchronous, high-performance operations.
+ * Supports WAL mode for concurrent read/write access.
+ */
+export class SqliteBackend implements StorageBackend {
+  private db!: Database.Database;
+  private stmts!: Statements;
+  private outboxIdCounter = 0;
+
+  /** Cache for dynamically built prepared statements (queryEvents). Key = SQL string. */
+  private queryStmtCache: Map<string, Database.Statement> = new Map();
+
+  constructor(private readonly dbPath: string) {}
+
+  // ─── Lifecycle ──────────────────────────────────────────────────────────
+
+  initialize(): void {
+    this.db = new Database(this.dbPath);
+
+    // Enable WAL mode and set synchronous to NORMAL for performance
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('synchronous = NORMAL');
+
+    // Enable memory-mapped I/O (256 MB) for read-heavy workloads
+    this.db.pragma('mmap_size = 268435456');
+
+    // Execute schema DDL
+    this.db.exec(SCHEMA_DDL);
+
+    // Run migrations for existing databases
+    this.migrateSchema();
+
+    // Track schema version
+    const existing = this.db
+      .prepare('SELECT version FROM schema_version WHERE version = ?')
+      .get(SCHEMA_VERSION) as { version: number } | undefined;
+
+    if (!existing) {
+      this.db
+        .prepare('INSERT OR IGNORE INTO schema_version (version, appliedAt) VALUES (?, ?)')
+        .run(SCHEMA_VERSION, new Date().toISOString());
+    }
+
+    // Initialize prepared statements
+    this.stmts = this.prepareStatements();
+  }
+
+  close(): void {
+    if (this.db) {
+      this.db.close();
+    }
+  }
+
+  /**
+   * Run incremental schema migrations for existing databases.
+   * V1 -> V2: Add payload column to events table for full event preservation.
+   */
+  private migrateSchema(): void {
+    // Check if payload column already exists
+    const columns = this.db
+      .prepare("PRAGMA table_info(events)")
+      .all() as Array<{ name: string }>;
+
+    const hasPayload = columns.some((col) => col.name === 'payload');
+
+    if (!hasPayload) {
+      this.db.exec('ALTER TABLE events ADD COLUMN payload TEXT');
+    }
+  }
+
+  private prepareStatements(): Statements {
+    return {
+      insertEvent: this.db.prepare(
+        'INSERT INTO events (streamId, sequence, type, timestamp, data, payload) VALUES (?, ?, ?, ?, ?, ?)',
+      ),
+      upsertSequence: this.db.prepare(
+        'INSERT INTO sequences (streamId, sequence) VALUES (?, ?) ON CONFLICT(streamId) DO UPDATE SET sequence = excluded.sequence',
+      ),
+      selectSequence: this.db.prepare(
+        'SELECT sequence FROM sequences WHERE streamId = ?',
+      ),
+      selectEvents: this.db.prepare(
+        'SELECT streamId, sequence, type, timestamp, data, payload FROM events WHERE streamId = ? ORDER BY sequence',
+      ),
+      getState: this.db.prepare(
+        'SELECT state, version FROM workflow_state WHERE featureId = ?',
+      ),
+      upsertState: this.db.prepare(
+        `INSERT INTO workflow_state (featureId, state, version, updatedAt) VALUES (?, ?, ?, ?)
+         ON CONFLICT(featureId) DO UPDATE SET state = excluded.state, version = excluded.version, updatedAt = excluded.updatedAt`,
+      ),
+      selectAllStates: this.db.prepare(
+        'SELECT featureId, state FROM workflow_state',
+      ),
+      getStateVersion: this.db.prepare(
+        'SELECT version FROM workflow_state WHERE featureId = ?',
+      ),
+      insertOutbox: this.db.prepare(
+        'INSERT INTO outbox (id, streamId, event, status, attempts, createdAt) VALUES (?, ?, ?, ?, ?, ?)',
+      ),
+      selectPendingOutbox: this.db.prepare(
+        'SELECT id, streamId, event, attempts FROM outbox WHERE streamId = ? AND status = ? ORDER BY createdAt',
+      ),
+      updateOutboxConfirmed: this.db.prepare(
+        'UPDATE outbox SET status = ?, lastAttemptAt = ? WHERE id = ?',
+      ),
+      updateOutboxFailed: this.db.prepare(
+        'UPDATE outbox SET status = ?, attempts = ?, lastAttemptAt = ?, nextRetryAt = ?, error = ? WHERE id = ?',
+      ),
+      updateOutboxDeadLetter: this.db.prepare(
+        'UPDATE outbox SET status = ?, lastAttemptAt = ?, error = ? WHERE id = ?',
+      ),
+      getViewCache: this.db.prepare(
+        'SELECT state, highWaterMark FROM view_cache WHERE streamId = ? AND viewName = ?',
+      ),
+      upsertViewCache: this.db.prepare(
+        `INSERT INTO view_cache (streamId, viewName, state, highWaterMark, savedAt) VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(streamId, viewName) DO UPDATE SET state = excluded.state, highWaterMark = excluded.highWaterMark, savedAt = excluded.savedAt`,
+      ),
+      insertSchemaVersion: this.db.prepare(
+        'INSERT OR IGNORE INTO schema_version (version, appliedAt) VALUES (?, ?)',
+      ),
+    };
+  }
+
+  // ─── Event Operations ───────────────────────────────────────────────────
+
+  appendEvent(streamId: string, event: WorkflowEvent): void {
+    const data = event.data ? JSON.stringify(event.data) : null;
+    const payload = JSON.stringify(event);
+
+    const insertFn = this.db.transaction(() => {
+      this.stmts.insertEvent.run(
+        streamId,
+        event.sequence,
+        event.type,
+        event.timestamp,
+        data,
+        payload,
+      );
+      this.stmts.upsertSequence.run(streamId, event.sequence);
+    });
+
+    insertFn();
+  }
+
+  queryEvents(streamId: string, filters?: QueryFilters): WorkflowEvent[] {
+    // Build dynamic query based on filters
+    const conditions: string[] = ['streamId = ?'];
+    const params: unknown[] = [streamId];
+
+    if (filters?.sinceSequence !== undefined) {
+      conditions.push('sequence > ?');
+      params.push(filters.sinceSequence);
+    }
+
+    if (filters?.type) {
+      conditions.push('type = ?');
+      params.push(filters.type);
+    }
+
+    if (filters?.since) {
+      conditions.push('timestamp >= ?');
+      params.push(filters.since);
+    }
+
+    if (filters?.until) {
+      conditions.push('timestamp <= ?');
+      params.push(filters.until);
+    }
+
+    let sql = `SELECT streamId, sequence, type, timestamp, data, payload FROM events WHERE ${conditions.join(' AND ')} ORDER BY sequence`;
+
+    if (filters?.limit !== undefined && filters?.offset !== undefined) {
+      sql += ` LIMIT ? OFFSET ?`;
+      params.push(filters.limit, filters.offset);
+    } else if (filters?.limit !== undefined) {
+      sql += ` LIMIT ?`;
+      params.push(filters.limit);
+    } else if (filters?.offset !== undefined) {
+      sql += ` LIMIT -1 OFFSET ?`;
+      params.push(filters.offset);
+    }
+
+    // Cache prepared statements by SQL string for repeated query patterns
+    let stmt = this.queryStmtCache.get(sql);
+    if (!stmt) {
+      stmt = this.db.prepare(sql);
+      this.queryStmtCache.set(sql, stmt);
+    }
+
+    const rows = stmt.all(...params) as Array<{
+      streamId: string;
+      sequence: number;
+      type: string;
+      timestamp: string;
+      data: string | null;
+      payload: string | null;
+    }>;
+
+    return rows.map((row) => this.rowToEvent(row));
+  }
+
+  getSequence(streamId: string): number {
+    const row = this.stmts.selectSequence.get(streamId) as { sequence: number } | undefined;
+    return row ? row.sequence : 0;
+  }
+
+  listStreams(): string[] {
+    const rows = this.db
+      .prepare('SELECT DISTINCT streamId FROM sequences ORDER BY streamId')
+      .all() as Array<{ streamId: string }>;
+    return rows.map((row) => row.streamId);
+  }
+
+  // ─── State Operations ───────────────────────────────────────────────────
+
+  getState(featureId: string): WorkflowState | null {
+    const row = this.stmts.getState.get(featureId) as { state: string; version: number } | undefined;
+    if (!row) return null;
+    return JSON.parse(row.state) as WorkflowState;
+  }
+
+  setState(featureId: string, state: WorkflowState, expectedVersion?: number): void {
+    const setFn = this.db.transaction(() => {
+      const existing = this.stmts.getStateVersion.get(featureId) as { version: number } | undefined;
+      const currentVersion = existing ? existing.version : 0;
+
+      if (expectedVersion !== undefined && currentVersion !== expectedVersion) {
+        throw new VersionConflictError(featureId, expectedVersion, currentVersion);
+      }
+
+      const newVersion = currentVersion + 1;
+      this.stmts.upsertState.run(
+        featureId,
+        JSON.stringify(state),
+        newVersion,
+        new Date().toISOString(),
+      );
+    });
+
+    setFn();
+  }
+
+  listStates(): Array<{ featureId: string; state: WorkflowState }> {
+    const rows = this.stmts.selectAllStates.all() as Array<{ featureId: string; state: string }>;
+    return rows.map((row) => ({
+      featureId: row.featureId,
+      state: JSON.parse(row.state) as WorkflowState,
+    }));
+  }
+
+  // ─── Outbox Operations ──────────────────────────────────────────────────
+
+  addOutboxEntry(streamId: string, event: WorkflowEvent): string {
+    this.outboxIdCounter++;
+    const id = `outbox-${this.outboxIdCounter}-${Date.now()}`;
+    this.stmts.insertOutbox.run(
+      id,
+      streamId,
+      JSON.stringify(event),
+      'pending',
+      0,
+      new Date().toISOString(),
+    );
+    return id;
+  }
+
+  drainOutbox(streamId: string, sender: EventSender, batchSize?: number): DrainResult {
+    const rows = this.stmts.selectPendingOutbox.all(streamId, 'pending') as Array<{
+      id: string;
+      streamId: string;
+      event: string;
+      attempts: number;
+    }>;
+
+    if (rows.length === 0) {
+      return { sent: 0, failed: 0 };
+    }
+
+    const batch = batchSize !== undefined ? rows.slice(0, batchSize) : rows;
+    let sent = 0;
+    let failed = 0;
+    const now = new Date().toISOString();
+
+    for (const row of batch) {
+      const event = JSON.parse(row.event) as WorkflowEvent;
+      try {
+        // Synchronous call — better-sqlite3 is synchronous, sender is async but invoked fire-and-forget
+        sender.appendEvents(streamId, [
+          {
+            streamId: event.streamId,
+            sequence: event.sequence,
+            timestamp: event.timestamp,
+            type: event.type,
+            correlationId: event.correlationId,
+            causationId: event.causationId,
+            agentId: event.agentId,
+            agentRole: event.agentRole,
+            source: event.source,
+            schemaVersion: event.schemaVersion,
+            data: event.data,
+            ...(event.idempotencyKey ? { idempotencyKey: event.idempotencyKey } : {}),
+          },
+        ]);
+
+        this.stmts.updateOutboxConfirmed.run('confirmed', now, row.id);
+        sent++;
+      } catch {
+        const newAttempts = row.attempts + 1;
+
+        if (newAttempts >= MAX_OUTBOX_RETRIES) {
+          // Dead-letter after max retries
+          this.stmts.updateOutboxDeadLetter.run('dead-letter', now, 'Max retries exceeded', row.id);
+        } else {
+          // Schedule retry with exponential backoff
+          const retryDelayMs = Math.pow(2, newAttempts) * 1000;
+          const nextRetry = new Date(Date.now() + retryDelayMs).toISOString();
+          this.stmts.updateOutboxFailed.run(
+            'pending',
+            newAttempts,
+            now,
+            nextRetry,
+            'Send failed',
+            row.id,
+          );
+        }
+        failed++;
+      }
+    }
+
+    return { sent, failed };
+  }
+
+  // ─── View Cache Operations ──────────────────────────────────────────────
+
+  getViewCache(streamId: string, viewName: string): ViewCacheEntry | null {
+    const row = this.stmts.getViewCache.get(streamId, viewName) as {
+      state: string;
+      highWaterMark: number;
+    } | undefined;
+
+    if (!row) return null;
+
+    return {
+      state: JSON.parse(row.state),
+      highWaterMark: row.highWaterMark,
+    };
+  }
+
+  setViewCache(streamId: string, viewName: string, state: unknown, hwm: number): void {
+    this.stmts.upsertViewCache.run(
+      streamId,
+      viewName,
+      JSON.stringify(state),
+      hwm,
+      new Date().toISOString(),
+    );
+  }
+
+  // ─── Cleanup Operations ─────────────────────────────────────────────────
+
+  deleteStream(streamId: string): void {
+    const deleteFn = this.db.transaction(() => {
+      this.db.prepare('DELETE FROM events WHERE streamId = ?').run(streamId);
+      this.db.prepare('DELETE FROM sequences WHERE streamId = ?').run(streamId);
+    });
+    deleteFn();
+  }
+
+  deleteState(featureId: string): void {
+    this.db.prepare('DELETE FROM workflow_state WHERE featureId = ?').run(featureId);
+  }
+
+  pruneEvents(streamId: string, beforeTimestamp: string): number {
+    const result = this.db
+      .prepare('DELETE FROM events WHERE streamId = ? AND timestamp < ?')
+      .run(streamId, beforeTimestamp);
+    return result.changes;
+  }
+
+  // ─── Private Helpers ────────────────────────────────────────────────────
+
+  private rowToEvent(row: {
+    streamId: string;
+    sequence: number;
+    type: string;
+    timestamp: string;
+    data: string | null;
+    payload: string | null;
+  }): WorkflowEvent {
+    // Prefer full payload (preserves all fields); fall back to field-by-field for pre-migration rows
+    if (row.payload) {
+      return JSON.parse(row.payload) as WorkflowEvent;
+    }
+
+    return {
+      streamId: row.streamId,
+      sequence: row.sequence,
+      type: row.type,
+      timestamp: row.timestamp,
+      ...(row.data ? { data: JSON.parse(row.data) } : {}),
+    } as WorkflowEvent;
+  }
+}


### PR DESCRIPTION
## Summary

Introduces a `StorageBackend` interface that decouples all storage consumers from the backing implementation. Ships two implementations: `InMemoryBackend` for testing and `SqliteBackend` powered by better-sqlite3 with WAL mode, 256MB mmap, prepared statement caching, and full event payload round-trip via schema migration.

## Changes

- **StorageBackend** — 15-method interface covering events, state (CAS), outbox, view cache, lifecycle cleanup, and lifecycle management
- **InMemoryBackend** — Map-based test double implementing the full interface with CAS versioning
- **SqliteBackend** — Production implementation with WAL mode, `PRAGMA mmap_size`, schema migration v1→v2 (payload column), prepared statement cache, and cleanup operations

## Test Plan

TDD across all components. Property-based tests for CAS semantics, round-trip tests for event payload fidelity, and cleanup operation tests.

---

**Results:** Tests 2136 ✓ · Typecheck 0 errors
**Design:** [storage-layer-audit.md](docs/designs/2026-02-21-storage-layer-audit.md)
**Stack:** 1/3 — StorageBackend infrastructure