### PR TITLE
feat: refactor event store modules to delegate to StorageBackend

### DIFF
--- a/.github/workflows/eval-gate.yml
+++ b/.github/workflows/eval-gate.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   eval-regression:
     name: Eval Regression Check
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 15
     concurrency:
       group: eval-gate-${{ github.head_ref }}

--- a/servers/exarchos-mcp/src/event-store/store.test.ts
+++ b/servers/exarchos-mcp/src/event-store/store.test.ts
@@ -5,6 +5,8 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { EventStore, SequenceConflictError, PidLockError } from './store.js';
 import { Outbox } from '../sync/outbox.js';
+import { InMemoryBackend } from '../storage/memory-backend.js';
+import type { StorageBackend } from '../storage/backend.js';
 
 let tempDir: string;
 
@@ -1364,5 +1366,133 @@ describe('EventStore Query with Event Migration', () => {
     expect(events[0].type).toBe('task.assigned');
     // Event should pass through migrateEvent identity path
     expect(events[0].streamId).toBe('migration-transform');
+  });
+});
+
+// ─── Task 9: EventStore StorageBackend Integration ────────────────────────────
+
+describe('EventStore StorageBackend Integration', () => {
+  it('EventStore_query_DelegatesToBackend', async () => {
+    const backend = new InMemoryBackend();
+    const store = new EventStore(tempDir, { backend });
+
+    // Append an event through the store (writes to JSONL and backend)
+    await store.append('my-workflow', { type: 'workflow.started', data: { featureId: 'test' } });
+
+    // Query should delegate to the backend
+    const querySpy = vi.spyOn(backend, 'queryEvents');
+    const events = await store.query('my-workflow');
+
+    expect(querySpy).toHaveBeenCalledWith('my-workflow', undefined);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('workflow.started');
+  });
+
+  it('EventStore_query_WithBackend_DoesNotReadJSONL', async () => {
+    const backend = new InMemoryBackend();
+    const store = new EventStore(tempDir, { backend });
+
+    await store.append('my-workflow', { type: 'workflow.started', data: { featureId: 'test' } });
+
+    // Delete the JSONL file — if query tried to read it, it would return empty
+    const filePath = path.join(tempDir, 'my-workflow.events.jsonl');
+    await rm(filePath);
+
+    // Query should still succeed via backend (not JSONL)
+    const events = await store.query('my-workflow');
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('workflow.started');
+  });
+
+  it('EventStore_query_WithoutBackend_FallsBackToJSONL', async () => {
+    // No backend — existing behavior
+    const store = new EventStore(tempDir);
+
+    await store.append('my-workflow', { type: 'workflow.started', data: { featureId: 'test' } });
+
+    const events = await store.query('my-workflow');
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('workflow.started');
+
+    // Verify JSONL file was created (proof of file-based storage)
+    const filePath = path.join(tempDir, 'my-workflow.events.jsonl');
+    const content = await fs.readFile(filePath, 'utf-8');
+    expect(content.trim().split('\n')).toHaveLength(1);
+  });
+
+  it('EventStore_append_WritesToJSONLAndBackend', async () => {
+    const backend = new InMemoryBackend();
+    const appendSpy = vi.spyOn(backend, 'appendEvent');
+    const store = new EventStore(tempDir, { backend });
+
+    const event = await store.append('my-workflow', { type: 'workflow.started', data: { featureId: 'test' } });
+
+    // Backend should have received the event
+    expect(appendSpy).toHaveBeenCalledWith('my-workflow', event);
+
+    // JSONL file should also have the event
+    const filePath = path.join(tempDir, 'my-workflow.events.jsonl');
+    const content = await fs.readFile(filePath, 'utf-8');
+    expect(content.trim().split('\n')).toHaveLength(1);
+  });
+
+  it('EventStore_getSequence_DelegatesToBackend', async () => {
+    const backend = new InMemoryBackend();
+    const store = new EventStore(tempDir, { backend });
+
+    await store.append('my-workflow', { type: 'workflow.started' });
+    await store.append('my-workflow', { type: 'task.assigned' });
+    await store.append('my-workflow', { type: 'workflow.transition' });
+
+    const seqSpy = vi.spyOn(backend, 'getSequence');
+
+    // Create a new store with the same backend (simulating restart)
+    const store2 = new EventStore(tempDir, { backend });
+    const event = await store2.append('my-workflow', { type: 'task.claimed' });
+
+    // Backend's getSequence should have been used for initialization
+    expect(seqSpy).toHaveBeenCalledWith('my-workflow');
+    expect(event.sequence).toBe(4);
+  });
+
+  it('append_BackendWriteFails_StillSucceedsWithWarning', async () => {
+    const backend = new InMemoryBackend();
+    // Make appendEvent throw an error (simulating disk full, constraint violation, etc.)
+    vi.spyOn(backend, 'appendEvent').mockImplementation(() => {
+      throw new Error('SQLite disk full');
+    });
+
+    const store = new EventStore(tempDir, { backend });
+
+    // The append should still succeed (JSONL is source of truth)
+    const event = await store.append('my-workflow', {
+      type: 'workflow.started',
+      data: { featureId: 'test' },
+    });
+
+    expect(event.sequence).toBe(1);
+    expect(event.type).toBe('workflow.started');
+
+    // Verify JSONL file was written (source of truth)
+    const filePath = path.join(tempDir, 'my-workflow.events.jsonl');
+    const content = await fs.readFile(filePath, 'utf-8');
+    expect(content.trim().split('\n')).toHaveLength(1);
+  });
+
+  it('EventStore_query_WithBackend_PassesFilters', async () => {
+    const backend = new InMemoryBackend();
+    const store = new EventStore(tempDir, { backend });
+
+    await store.append('my-workflow', { type: 'workflow.started' });
+    await store.append('my-workflow', { type: 'task.assigned' });
+    await store.append('my-workflow', { type: 'workflow.transition' });
+
+    const querySpy = vi.spyOn(backend, 'queryEvents');
+    const filters = { type: 'task.assigned' };
+    const events = await store.query('my-workflow', filters);
+
+    expect(querySpy).toHaveBeenCalledWith('my-workflow', filters);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('task.assigned');
   });
 });

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { WorkflowEventBase } from './schemas.js';
 import type { WorkflowEvent } from './schemas.js';
 import type { Outbox } from '../sync/outbox.js';
+import type { StorageBackend } from '../storage/backend.js';
 import { migrateEvent } from './event-migration.js';
 import { storeLogger } from '../logger.js';
 import { isPidAlive } from '../utils/process.js';
@@ -79,10 +80,19 @@ function parseEnvInt(envVar: string, defaultValue: number): number {
   return parsed;
 }
 
+// ─── Event Store Options ────────────────────────────────────────────────────
+
+export interface EventStoreOptions {
+  backend?: StorageBackend;
+}
+
 // ─── Event Store ────────────────────────────────────────────────────────────
 
 /**
  * Append-only event store backed by JSONL files with .seq sequence caches.
+ *
+ * When an optional `StorageBackend` is provided, reads (query, getSequence)
+ * delegate to the backend while writes still go to JSONL first (dual-write).
  *
  * Uses in-memory promise-chain locks that only protect within a single Node.js process.
  * Multiple EventStore instances sharing the same stateDir will corrupt data.
@@ -114,9 +124,13 @@ export class EventStore {
   /** Optional outbox for supplementary event replication */
   private outbox?: Outbox;
 
-  constructor(private readonly stateDir: string) {
+  /** Optional storage backend for delegating reads */
+  private readonly backend?: StorageBackend;
+
+  constructor(private readonly stateDir: string, options?: EventStoreOptions) {
     this.lockFilePath = path.join(stateDir, '.event-store.lock');
     this.maxIdempotencyKeys = parseEnvInt('EXARCHOS_MAX_IDEMPOTENCY_KEYS', 200);
+    this.backend = options?.backend;
   }
 
   /** Configure an optional outbox for event replication. */
@@ -259,6 +273,19 @@ export class EventStore {
       await this.writeEvents(streamId, [fullEvent]);
       this.cacheIdempotencyKey(streamId, fullEvent);
 
+      // Backend dual-write: replicate to backend if available
+      // JSONL is the source of truth; backend write failure is logged but does not fail the append
+      if (this.backend) {
+        try {
+          this.backend.appendEvent(streamId, fullEvent);
+        } catch (err) {
+          storeLogger.warn(
+            { err: err instanceof Error ? err.message : String(err), streamId, sequence: fullEvent.sequence },
+            'Backend dual-write failed — stores may diverge',
+          );
+        }
+      }
+
       // Outbox integration: write supplementary entry under the same lock
       if (this.outbox) {
         try {
@@ -380,6 +407,11 @@ export class EventStore {
   }
 
   async query(streamId: string, filters?: QueryFilters): Promise<WorkflowEvent[]> {
+    // Delegate to backend if available
+    if (this.backend) {
+      return this.backend.queryEvents(streamId, filters);
+    }
+
     const filePath = this.getEventFilePath(streamId);
 
     // Check if file exists
@@ -450,6 +482,18 @@ export class EventStore {
     return events;
   }
 
+  /**
+   * List all known stream IDs.
+   * Delegates to backend when available; returns null otherwise
+   * (caller should fall back to directory scanning).
+   */
+  listStreams(): string[] | null {
+    if (this.backend) {
+      return this.backend.listStreams();
+    }
+    return null;
+  }
+
   async refreshSequence(streamId: string): Promise<void> {
     await this.initializeSequence(streamId);
   }
@@ -494,6 +538,13 @@ export class EventStore {
   }
 
   private async initializeSequence(streamId: string): Promise<void> {
+    // Delegate to backend if available
+    if (this.backend) {
+      const seq = this.backend.getSequence(streamId);
+      this.sequenceCounters.set(streamId, seq);
+      return;
+    }
+
     // Try .seq file first (O(1))
     const seqPath = this.getSeqFilePath(streamId);
     // Clean up orphaned .seq.tmp files left by crashed atomic writes

--- a/servers/exarchos-mcp/src/sync/outbox.test.ts
+++ b/servers/exarchos-mcp/src/sync/outbox.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { Outbox } from './outbox.js';
 import type { EventSender, ExarchosEventDto } from './types.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
+import { InMemoryBackend } from '../storage/memory-backend.js';
 
 function makeEvent(overrides?: Partial<WorkflowEvent>): WorkflowEvent {
   return {
@@ -111,7 +112,6 @@ describe('Outbox drain batch I/O', () => {
     await outbox.drain(mockClient, 'test-stream');
 
     // Assert: loadEntries should be called exactly once (batch load at start)
-    // The current O(n²) implementation calls it once at start + once per entry via _updateEntry
     expect(loadSpy.mock.calls.length).toBe(1);
   });
 
@@ -132,7 +132,79 @@ describe('Outbox drain batch I/O', () => {
     await outbox.drain(mockClient, 'test-stream');
 
     // Assert: saveEntries should be called exactly once (batch save at end)
-    // The current O(n²) implementation calls it once per entry via _updateEntry
     expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── Task 10: Outbox StorageBackend Integration ──────────────────────────────
+
+describe('Outbox StorageBackend Integration', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'outbox-backend-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('Outbox_addEntry_WithBackend_DelegatesToBackend', async () => {
+    const backend = new InMemoryBackend();
+    const addSpy = vi.spyOn(backend, 'addOutboxEntry');
+    const outbox = new Outbox(tempDir, { backend });
+
+    const event = makeEvent();
+    await outbox.addEntry('test-stream', event);
+
+    expect(addSpy).toHaveBeenCalledWith('test-stream', event);
+  });
+
+  it('Outbox_drain_WithBackend_DelegatesToBackend', async () => {
+    const backend = new InMemoryBackend();
+    const drainSpy = vi.spyOn(backend, 'drainOutbox');
+    const outbox = new Outbox(tempDir, { backend });
+
+    const event = makeEvent();
+    await outbox.addEntry('test-stream', event);
+
+    const mockSender: EventSender = {
+      appendEvents: vi.fn().mockResolvedValue({ accepted: 1, streamVersion: 1 }),
+    };
+
+    const result = await outbox.drain(mockSender, 'test-stream');
+
+    expect(drainSpy).toHaveBeenCalledWith('test-stream', mockSender, 50);
+    expect(result.sent).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+
+  it('Outbox_addEntry_WithoutBackend_UsesJSONFile', async () => {
+    // No backend — existing behavior
+    const outbox = new Outbox(tempDir);
+
+    const event = makeEvent();
+    const entry = await outbox.addEntry('test-stream', event);
+
+    expect(entry.id).toBeDefined();
+    expect(entry.status).toBe('pending');
+
+    // Verify JSON file was created
+    const entries = await outbox.loadEntries('test-stream');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].event.type).toBe('task.completed');
+  });
+
+  it('Outbox_addEntry_WithBackend_ReturnsEntryWithId', async () => {
+    const backend = new InMemoryBackend();
+    const outbox = new Outbox(tempDir, { backend });
+
+    const event = makeEvent();
+    const entry = await outbox.addEntry('test-stream', event);
+
+    // Should return a properly structured entry even with backend
+    expect(entry.id).toBeDefined();
+    expect(entry.status).toBe('pending');
+    expect(entry.streamId).toBe('test-stream');
   });
 });

--- a/servers/exarchos-mcp/src/sync/outbox.ts
+++ b/servers/exarchos-mcp/src/sync/outbox.ts
@@ -3,17 +3,27 @@ import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import type { WorkflowEvent } from '../event-store/schemas.js';
 import type { OutboxEntry, EventSender } from './types.js';
+import type { StorageBackend } from '../storage/backend.js';
 
 // ─── Stream ID Validation ────────────────────────────────────────────────────
 
 const SAFE_STREAM_ID = /^[A-Za-z0-9._-]+$/;
 
+// ─── Outbox Options ─────────────────────────────────────────────────────────
+
+export interface OutboxOptions {
+  backend?: StorageBackend;
+}
+
 // ─── Outbox ──────────────────────────────────────────────────────────────────
 
 export class Outbox {
   private readonly locks = new Map<string, Promise<void>>();
+  private readonly backend?: StorageBackend;
 
-  constructor(private readonly stateDir: string) {}
+  constructor(private readonly stateDir: string, options?: OutboxOptions) {
+    this.backend = options?.backend;
+  }
 
   // ─── Per-Stream Locking ─────────────────────────────────────────────────
 
@@ -54,22 +64,43 @@ export class Outbox {
       );
     }
 
-    return this.withLock(streamId, async () => {
-      const entry: OutboxEntry = {
-        id: crypto.randomUUID(),
+    // Delegate to backend if available
+    if (this.backend) {
+      const id = this.backend.addOutboxEntry(streamId, event);
+      return {
+        id,
         streamId,
         event,
         status: 'pending',
         attempts: 0,
         createdAt: new Date().toISOString(),
       };
+    }
 
-      const entries = await this.loadEntries(streamId);
-      entries.push(entry);
-      await this.saveEntries(streamId, entries);
-
-      return entry;
+    return this.withLock(streamId, async () => {
+      return this.addEntryToJsonFile(streamId, event);
     });
+  }
+
+  /** Add entry to JSON file (fallback when no backend). */
+  private async addEntryToJsonFile(
+    streamId: string,
+    event: WorkflowEvent,
+  ): Promise<OutboxEntry> {
+    const entry: OutboxEntry = {
+      id: crypto.randomUUID(),
+      streamId,
+      event,
+      status: 'pending',
+      attempts: 0,
+      createdAt: new Date().toISOString(),
+    };
+
+    const entries = await this.loadEntries(streamId);
+    entries.push(entry);
+    await this.saveEntries(streamId, entries);
+
+    return entry;
   }
 
   // ─── Load Entries ───────────────────────────────────────────────────────
@@ -130,6 +161,12 @@ export class Outbox {
     streamId: string,
     batchSize: number = 50,
   ): Promise<{ sent: number; failed: number }> {
+    // Delegate to backend if available
+    if (this.backend) {
+      const result = this.backend.drainOutbox(streamId, client, batchSize);
+      return { sent: result.sent, failed: result.failed };
+    }
+
     return this.withLock(streamId, async () => {
       const entries = await this.loadEntries(streamId);
       const pending = entries

--- a/servers/exarchos-mcp/src/views/materializer.test.ts
+++ b/servers/exarchos-mcp/src/views/materializer.test.ts
@@ -6,6 +6,7 @@ import {
   WORKFLOW_STATE_VIEW,
 } from './workflow-state-projection.js';
 import type { WorkflowStateView } from './workflow-state-projection.js';
+import { InMemoryBackend } from '../storage/memory-backend.js';
 
 // ─── Test Helpers ──────────────────────────────────────────────────────────
 
@@ -485,5 +486,98 @@ describe('ViewMaterializer Configurable Snapshot Interval', () => {
     );
     materializer.materialize('stream-1', VIEW_NAME, events30);
     expect(snapshotStore.save).toHaveBeenCalled();
+  });
+});
+
+// ─── Task 11: ViewMaterializer StorageBackend Integration ────────────────────
+
+describe('ViewMaterializer StorageBackend Integration', () => {
+  const VIEW_NAME = 'counter';
+
+  it('ViewMaterializer_loadFromSnapshot_WithBackend_ReadsFromViewCache', async () => {
+    const backend = new InMemoryBackend();
+    // Pre-populate the backend view cache
+    backend.setViewCache('stream-1', VIEW_NAME, 42, 10);
+
+    const materializer = new ViewMaterializer({ backend });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    const getCacheSpy = vi.spyOn(backend, 'getViewCache');
+    const loaded = await materializer.loadFromSnapshot('stream-1', VIEW_NAME);
+
+    expect(loaded).toBe(true);
+    expect(getCacheSpy).toHaveBeenCalledWith('stream-1', VIEW_NAME);
+
+    const state = materializer.getState<number>('stream-1', VIEW_NAME);
+    expect(state?.view).toBe(42);
+    expect(state?.highWaterMark).toBe(10);
+  });
+
+  it('ViewMaterializer_materialize_WithBackend_SavesViewCacheOnInterval', () => {
+    const backend = new InMemoryBackend();
+    const setCacheSpy = vi.spyOn(backend, 'setViewCache');
+
+    // Set snapshot interval to 5 so we hit it quickly
+    const materializer = new ViewMaterializer({ backend, snapshotInterval: 5 });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    // Materialize 5 events — should trigger cache save at interval=5
+    const events = Array.from({ length: 5 }, (_, i) =>
+      makeEvent(i + 1, 'stream-1'),
+    );
+    materializer.materialize('stream-1', VIEW_NAME, events);
+
+    expect(setCacheSpy).toHaveBeenCalledWith('stream-1', VIEW_NAME, 5, 5);
+  });
+
+  it('ViewMaterializer_materialize_WithBackend_SkipsSnapshotStore', () => {
+    const backend = new InMemoryBackend();
+    const snapshotStore = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // Both backend and snapshotStore provided — backend should be preferred
+    const materializer = new ViewMaterializer({
+      backend,
+      snapshotStore,
+      snapshotInterval: 5,
+    });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    const events = Array.from({ length: 5 }, (_, i) =>
+      makeEvent(i + 1, 'stream-1'),
+    );
+    materializer.materialize('stream-1', VIEW_NAME, events);
+
+    // SnapshotStore.save should NOT be called when backend is available
+    expect(snapshotStore.save).not.toHaveBeenCalled();
+  });
+
+  it('ViewMaterializer_loadFromSnapshot_WithBackend_ReturnsFalseWhenNoCache', async () => {
+    const backend = new InMemoryBackend();
+    const materializer = new ViewMaterializer({ backend });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    // No cache exists for this stream
+    const loaded = await materializer.loadFromSnapshot('nonexistent', VIEW_NAME);
+    expect(loaded).toBe(false);
+  });
+
+  it('ViewMaterializer_loadFromSnapshot_WithoutBackend_FallsBackToSnapshotStore', async () => {
+    const snapshotStore = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn().mockResolvedValue({ view: 99, highWaterMark: 20, savedAt: '2026-01-01T00:00:00Z', schemaVersion: '1.0' }),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // No backend — should use snapshotStore
+    const materializer = new ViewMaterializer({ snapshotStore });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    const loaded = await materializer.loadFromSnapshot('stream-1', VIEW_NAME);
+    expect(loaded).toBe(true);
+    expect(snapshotStore.load).toHaveBeenCalledWith('stream-1', VIEW_NAME);
   });
 });

--- a/servers/exarchos-mcp/src/views/materializer.ts
+++ b/servers/exarchos-mcp/src/views/materializer.ts
@@ -1,5 +1,6 @@
 import type { WorkflowEvent } from '../event-store/schemas.js';
 import type { SnapshotStore } from './snapshot-store.js';
+import type { StorageBackend } from '../storage/backend.js';
 import { viewLogger } from '../logger.js';
 
 // ─── View Projection Interface ─────────────────────────────────────────────
@@ -24,6 +25,7 @@ export interface MaterializerOptions {
   readonly snapshotStore?: SnapshotStore;
   readonly snapshotInterval?: number;
   readonly maxCacheEntries?: number;
+  readonly backend?: StorageBackend;
 }
 
 // ─── Default Snapshot Interval ─────────────────────────────────────────────
@@ -61,11 +63,13 @@ export class ViewMaterializer {
   private readonly snapshotStore?: SnapshotStore;
   private readonly snapshotInterval: number;
   private readonly maxCacheEntries: number;
+  private readonly backend?: StorageBackend;
 
   constructor(options?: MaterializerOptions) {
     this.snapshotStore = options?.snapshotStore;
     this.snapshotInterval = options?.snapshotInterval ?? parseEnvSnapshotInterval();
     this.maxCacheEntries = options?.maxCacheEntries ?? parseEnvMaxCacheEntries();
+    this.backend = options?.backend;
   }
 
   /**
@@ -122,15 +126,21 @@ export class ViewMaterializer {
     // Evict least recently used if over limit
     this.evictIfNeeded();
 
-    // Trigger snapshot if interval crossed
-    if (this.snapshotStore && newEvents.length > 0) {
+    // Trigger cache/snapshot save if interval crossed
+    if (newEvents.length > 0) {
       const lastSnapHwm = this.lastSnapshotHwm.get(stateKey) ?? 0;
       if (maxSequence - lastSnapHwm >= this.snapshotInterval) {
         this.lastSnapshotHwm.set(stateKey, maxSequence);
-        // Fire and forget - snapshot is async but we don't block materialization
-        this.snapshotStore.save(streamId, viewName, currentView, maxSequence).catch((err) => {
-          viewLogger.error({ err: err instanceof Error ? err.message : String(err) }, 'Snapshot save failed');
-        });
+
+        if (this.backend) {
+          // Synchronous backend cache save
+          this.backend.setViewCache(streamId, viewName, currentView, maxSequence);
+        } else if (this.snapshotStore) {
+          // Fire and forget - snapshot is async but we don't block materialization
+          this.snapshotStore.save(streamId, viewName, currentView, maxSequence).catch((err) => {
+            viewLogger.error({ err: err instanceof Error ? err.message : String(err) }, 'Snapshot save failed');
+          });
+        }
       }
     }
 
@@ -142,6 +152,21 @@ export class ViewMaterializer {
    * Falls back to default init state if snapshot is missing or corrupt.
    */
   async loadFromSnapshot(streamId: string, viewName: string): Promise<boolean> {
+    // Prefer backend view cache when available
+    if (this.backend) {
+      const cached = this.backend.getViewCache(streamId, viewName);
+      if (!cached) return false;
+
+      const stateKey = `${viewName}:${streamId}`;
+      this.states.set(stateKey, {
+        view: cached.state,
+        highWaterMark: cached.highWaterMark,
+      });
+      this.lastSnapshotHwm.set(stateKey, cached.highWaterMark);
+      this.evictIfNeeded();
+      return true;
+    }
+
     if (!this.snapshotStore) return false;
 
     const snapshot = await this.snapshotStore.load(streamId, viewName);

--- a/servers/exarchos-mcp/src/views/tools.test.ts
+++ b/servers/exarchos-mcp/src/views/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -6,12 +6,16 @@ import {
   getOrCreateMaterializer,
   getOrCreateEventStore,
   resetMaterializerCache,
+  handleViewWorkflowStatus,
+  handleViewTasks,
+  handleViewPipeline,
   handleViewTeamPerformance,
   handleViewDelegationTimeline,
   handleViewCodeQuality,
   handleViewEvalResults,
 } from './tools.js';
 import { EventStore } from '../event-store/store.js';
+import { InMemoryBackend } from '../storage/memory-backend.js';
 
 describe('Singleton Cache', () => {
   beforeEach(() => {
@@ -459,5 +463,367 @@ describe('View Handlers', () => {
       const runs = data.runs as unknown[];
       expect(runs).toHaveLength(2);
     });
+  });
+});
+
+// ─── Task 1: sinceSequence Delta Queries ─────────────────────────────────────
+
+describe('Delta Query (sinceSequence)', () => {
+  let tmpDir: string;
+  let store: EventStore;
+
+  beforeEach(async () => {
+    resetMaterializerCache();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'exarchos-delta-test-'));
+    store = new EventStore(tmpDir);
+  });
+
+  afterEach(async () => {
+    resetMaterializerCache();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('handleViewWorkflowStatus_WarmCall_QueriesOnlyDeltaEvents', async () => {
+    // Arrange: seed events and do a first (cold) call
+    await store.append('wf-delta', {
+      type: 'workflow.started',
+      data: { featureId: 'delta-feature', workflowType: 'feature' },
+    });
+    await store.append('wf-delta', {
+      type: 'workflow.transition',
+      data: { from: 'started', to: 'delegating', trigger: 'auto', featureId: 'delta-feature' },
+    });
+
+    // Cold call to populate materializer state
+    const coldResult = await handleViewWorkflowStatus({ workflowId: 'wf-delta' }, tmpDir);
+    expect(coldResult.success).toBe(true);
+
+    // Add more events
+    await store.append('wf-delta', {
+      type: 'task.assigned',
+      data: { taskId: 't1', title: 'Build login', branch: 'feat/login' },
+    });
+
+    // Spy on the cached store
+    const cachedStore = getOrCreateEventStore(tmpDir);
+    const storeQuerySpy = vi.spyOn(cachedStore, 'query');
+
+    // Act: warm call
+    const warmResult = await handleViewWorkflowStatus({ workflowId: 'wf-delta' }, tmpDir);
+    expect(warmResult.success).toBe(true);
+
+    // Assert: store.query was called with sinceSequence filter
+    expect(storeQuerySpy).toHaveBeenCalledWith(
+      'wf-delta',
+      expect.objectContaining({ sinceSequence: expect.any(Number) }),
+    );
+    const callArgs = storeQuerySpy.mock.calls[0];
+    expect(callArgs[1]).toHaveProperty('sinceSequence');
+    expect((callArgs[1] as { sinceSequence: number }).sinceSequence).toBeGreaterThan(0);
+
+    storeQuerySpy.mockRestore();
+  });
+
+  it('handleViewTasks_WarmCall_QueriesOnlyDeltaEvents', async () => {
+    // Arrange: seed events and do a first (cold) call
+    await store.append('wf-delta-tasks', {
+      type: 'task.assigned',
+      data: { taskId: 't1', title: 'Task 1', branch: 'feat/t1' },
+    });
+
+    // Cold call
+    await handleViewTasks({ workflowId: 'wf-delta-tasks' }, tmpDir);
+
+    // Add more events
+    await store.append('wf-delta-tasks', {
+      type: 'task.assigned',
+      data: { taskId: 't2', title: 'Task 2', branch: 'feat/t2' },
+    });
+
+    // Spy on the cached store
+    const cachedStore = getOrCreateEventStore(tmpDir);
+    const storeQuerySpy = vi.spyOn(cachedStore, 'query');
+
+    // Act: warm call
+    const warmResult = await handleViewTasks({ workflowId: 'wf-delta-tasks' }, tmpDir);
+    expect(warmResult.success).toBe(true);
+
+    // Assert: store.query was called with sinceSequence filter
+    expect(storeQuerySpy).toHaveBeenCalledWith(
+      'wf-delta-tasks',
+      expect.objectContaining({ sinceSequence: expect.any(Number) }),
+    );
+
+    storeQuerySpy.mockRestore();
+  });
+
+  it('handleViewPipeline_WarmCall_QueriesOnlyDeltaEvents', async () => {
+    // Arrange: seed events and do a first (cold) call
+    await store.append('wf-delta-pipe', {
+      type: 'workflow.started',
+      data: { featureId: 'pipe-feature', workflowType: 'feature' },
+    });
+
+    // Cold call
+    await handleViewPipeline({}, tmpDir);
+
+    // Add more events
+    await store.append('wf-delta-pipe', {
+      type: 'task.assigned',
+      data: { taskId: 't1', title: 'Task 1', branch: 'feat/t1' },
+    });
+
+    // Spy on the cached store
+    const cachedStore = getOrCreateEventStore(tmpDir);
+    const storeQuerySpy = vi.spyOn(cachedStore, 'query');
+
+    // Act: warm call
+    const warmResult = await handleViewPipeline({}, tmpDir);
+    expect(warmResult.success).toBe(true);
+
+    // Assert: store.query was called with sinceSequence filter for the stream
+    expect(storeQuerySpy).toHaveBeenCalledWith(
+      'wf-delta-pipe',
+      expect.objectContaining({ sinceSequence: expect.any(Number) }),
+    );
+
+    storeQuerySpy.mockRestore();
+  });
+
+  it('handleViewTeamPerformance_WarmCall_QueriesOnlyDeltaEvents', async () => {
+    // Arrange: seed events and do a first (cold) call
+    await store.append('wf-delta-team', {
+      type: 'team.task.completed',
+      data: {
+        taskId: 'task-1',
+        teammateName: 'worker-1',
+        durationMs: 5000,
+        filesChanged: ['src/auth/login.ts'],
+        testsPassed: true,
+        qualityGateResults: {},
+      },
+    });
+
+    // Cold call
+    await handleViewTeamPerformance({ workflowId: 'wf-delta-team' }, tmpDir);
+
+    // Add more events
+    await store.append('wf-delta-team', {
+      type: 'team.task.completed',
+      data: {
+        taskId: 'task-2',
+        teammateName: 'worker-2',
+        durationMs: 3000,
+        filesChanged: ['src/auth/signup.ts'],
+        testsPassed: true,
+        qualityGateResults: {},
+      },
+    });
+
+    // Spy on the cached store
+    const cachedStore = getOrCreateEventStore(tmpDir);
+    const storeQuerySpy = vi.spyOn(cachedStore, 'query');
+
+    // Act: warm call
+    const warmResult = await handleViewTeamPerformance({ workflowId: 'wf-delta-team' }, tmpDir);
+    expect(warmResult.success).toBe(true);
+
+    // Assert: store.query was called with sinceSequence filter
+    expect(storeQuerySpy).toHaveBeenCalledWith(
+      'wf-delta-team',
+      expect.objectContaining({ sinceSequence: expect.any(Number) }),
+    );
+
+    storeQuerySpy.mockRestore();
+  });
+});
+
+// ─── Task 2: Skip loadFromSnapshot on Warm Calls ────────────────────────────
+
+describe('Skip loadFromSnapshot on warm calls', () => {
+  let tmpDir: string;
+  let store: EventStore;
+
+  beforeEach(async () => {
+    resetMaterializerCache();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'exarchos-snap-test-'));
+    store = new EventStore(tmpDir);
+  });
+
+  afterEach(async () => {
+    resetMaterializerCache();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('handleViewWorkflowStatus_WarmCall_SkipsSnapshotLoad', async () => {
+    // Arrange: seed events and do a first (cold) call
+    await store.append('wf-snap', {
+      type: 'workflow.started',
+      data: { featureId: 'snap-feature', workflowType: 'feature' },
+    });
+
+    // Cold call to populate materializer state
+    await handleViewWorkflowStatus({ workflowId: 'wf-snap' }, tmpDir);
+
+    // Spy on materializer.loadFromSnapshot for warm call
+    const materializer = getOrCreateMaterializer(tmpDir);
+    const loadSpy = vi.spyOn(materializer, 'loadFromSnapshot');
+
+    // Act: warm call (materializer already has state)
+    const warmResult = await handleViewWorkflowStatus({ workflowId: 'wf-snap' }, tmpDir);
+    expect(warmResult.success).toBe(true);
+
+    // Assert: loadFromSnapshot should NOT have been called
+    expect(loadSpy).not.toHaveBeenCalled();
+
+    loadSpy.mockRestore();
+  });
+
+  it('handleViewWorkflowStatus_ColdCall_LoadsSnapshot', async () => {
+    // Arrange: seed events
+    await store.append('wf-cold', {
+      type: 'workflow.started',
+      data: { featureId: 'cold-feature', workflowType: 'feature' },
+    });
+
+    // Spy on materializer.loadFromSnapshot BEFORE the cold call
+    const materializer = getOrCreateMaterializer(tmpDir);
+    const loadSpy = vi.spyOn(materializer, 'loadFromSnapshot');
+
+    // Act: cold call (no cached state)
+    const coldResult = await handleViewWorkflowStatus({ workflowId: 'wf-cold' }, tmpDir);
+    expect(coldResult.success).toBe(true);
+
+    // Assert: loadFromSnapshot SHOULD have been called (cold = no cached state)
+    expect(loadSpy).toHaveBeenCalledWith('wf-cold', expect.any(String));
+
+    loadSpy.mockRestore();
+  });
+});
+
+// ─── Task 12: Backend Integration Tests ──────────────────────────────────────
+
+describe('Backend Integration (Task 12)', () => {
+  let tmpDir: string;
+  let backend: InMemoryBackend;
+  let store: EventStore;
+
+  beforeEach(async () => {
+    resetMaterializerCache();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'exarchos-backend-test-'));
+    backend = new InMemoryBackend();
+    store = new EventStore(tmpDir, { backend });
+  });
+
+  afterEach(async () => {
+    resetMaterializerCache();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('handleViewWorkflowStatus_WithBackend_QueriesSQLite', async () => {
+    // Arrange: seed events through the store (dual-writes to backend)
+    await store.append('wf-backend', {
+      type: 'workflow.started',
+      data: { featureId: 'backend-feature', workflowType: 'feature' },
+    });
+    await store.append('wf-backend', {
+      type: 'workflow.transition',
+      data: { from: 'started', to: 'delegating', trigger: 'auto', featureId: 'backend-feature' },
+    });
+
+    // Spy on backend.queryEvents to verify delegation
+    const querySpy = vi.spyOn(backend, 'queryEvents');
+
+    // Inject our backend-aware store into the module
+    resetMaterializerCache();
+    // Use registerViewTools-style injection by setting module store
+    // We need handleViewWorkflowStatus to use our backend-aware store
+    // Set up the module-level event store by calling getOrCreateEventStore
+    // after injecting via the exported setter
+    const { registerViewTools } = await import('./tools.js');
+    const mockServer = { tool: vi.fn() } as unknown as Parameters<typeof registerViewTools>[0];
+    registerViewTools(mockServer, tmpDir, store);
+
+    // Act
+    const result = await handleViewWorkflowStatus({ workflowId: 'wf-backend' }, tmpDir);
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(querySpy).toHaveBeenCalled();
+    const queryCallStreamId = querySpy.mock.calls[0][0];
+    expect(queryCallStreamId).toBe('wf-backend');
+
+    querySpy.mockRestore();
+  });
+
+  it('handleViewPipeline_WithBackend_DiscoverStreamsFromBackend', async () => {
+    // Arrange: seed events for two streams via the store (dual-writes to backend)
+    await store.append('wf-one', {
+      type: 'workflow.started',
+      data: { featureId: 'feature-one', workflowType: 'feature' },
+    });
+    await store.append('wf-two', {
+      type: 'workflow.started',
+      data: { featureId: 'feature-two', workflowType: 'feature' },
+    });
+
+    // Spy on backend.listStreams to verify it's used for discovery
+    const listStreamsSpy = vi.spyOn(backend, 'listStreams');
+
+    // Inject our backend-aware store
+    resetMaterializerCache();
+    const { registerViewTools } = await import('./tools.js');
+    const mockServer = { tool: vi.fn() } as unknown as Parameters<typeof registerViewTools>[0];
+    registerViewTools(mockServer, tmpDir, store);
+
+    // Act
+    const result = await handleViewPipeline({}, tmpDir);
+
+    // Assert
+    expect(result.success).toBe(true);
+    // discoverStreams should use backend.listStreams() instead of fs.readdir
+    expect(listStreamsSpy).toHaveBeenCalled();
+
+    // Verify both workflows are discovered
+    const data = result.data as { workflows: unknown[]; total: number };
+    expect(data.total).toBe(2);
+
+    listStreamsSpy.mockRestore();
+  });
+
+  it('handleViewTasks_WithBackend_QueriesSQLite', async () => {
+    // Arrange: seed task events through the store (dual-writes to backend)
+    await store.append('wf-tasks-backend', {
+      type: 'task.assigned',
+      data: { taskId: 't1', title: 'Build auth', branch: 'feat/auth' },
+    });
+    await store.append('wf-tasks-backend', {
+      type: 'task.assigned',
+      data: { taskId: 't2', title: 'Build UI', branch: 'feat/ui' },
+    });
+
+    // Spy on backend.queryEvents
+    const querySpy = vi.spyOn(backend, 'queryEvents');
+
+    // Inject our backend-aware store
+    resetMaterializerCache();
+    const { registerViewTools } = await import('./tools.js');
+    const mockServer = { tool: vi.fn() } as unknown as Parameters<typeof registerViewTools>[0];
+    registerViewTools(mockServer, tmpDir, store);
+
+    // Act
+    const result = await handleViewTasks({ workflowId: 'wf-tasks-backend' }, tmpDir);
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(querySpy).toHaveBeenCalled();
+    const queryCallStreamId = querySpy.mock.calls[0][0];
+    expect(queryCallStreamId).toBe('wf-tasks-backend');
+
+    // Verify tasks are returned from the backend-delegated query
+    const data = result.data as Array<Record<string, unknown>>;
+    expect(data).toHaveLength(2);
+
+    querySpy.mockRestore();
   });
 });

--- a/servers/exarchos-mcp/src/views/tools.ts
+++ b/servers/exarchos-mcp/src/views/tools.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { EventStore } from '../event-store/store.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
 import { formatResult, pickFields, type ToolResult } from '../format.js';
 import { ViewMaterializer } from './materializer.js';
 import { SnapshotStore } from './snapshot-store.js';
@@ -129,9 +130,40 @@ export function resetMaterializerCache(): void {
   moduleEventStore = null;
 }
 
+// ─── Helper: query delta events using materializer high-water mark ──────────
+
+async function queryDeltaEvents(
+  store: EventStore,
+  materializer: ViewMaterializer,
+  streamId: string,
+  viewName: string,
+): Promise<WorkflowEvent[]> {
+  const cachedState = materializer.getState(streamId, viewName);
+  if (cachedState) {
+    // Warm call: only fetch events past the high-water mark
+    const hwm = cachedState.highWaterMark;
+    return hwm > 0
+      ? store.query(streamId, { sinceSequence: hwm })
+      : store.query(streamId);
+  }
+  // Cold call: load snapshot then query all events
+  await materializer.loadFromSnapshot(streamId, viewName);
+  return store.query(streamId);
+}
+
 // ─── Helper: discover all event stream files ───────────────────────────────
 
-async function discoverStreams(stateDir: string): Promise<string[]> {
+async function discoverStreams(stateDir: string, store?: EventStore): Promise<string[]> {
+  // When a storage backend is available, use it for stream discovery
+  // (equivalent to SELECT DISTINCT streamId FROM events)
+  if (store) {
+    const backendStreams = store.listStreams();
+    if (backendStreams !== null) {
+      return backendStreams;
+    }
+  }
+
+  // Fallback: scan directory for .events.jsonl files
   try {
     const files = await fs.readdir(stateDir);
     return files
@@ -153,8 +185,7 @@ export async function handleViewWorkflowStatus(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    await materializer.loadFromSnapshot(streamId, WORKFLOW_STATUS_VIEW);
-    const events = await store.query(streamId);
+    const events = await queryDeltaEvents(store, materializer, streamId, WORKFLOW_STATUS_VIEW);
     const view = materializer.materialize<WorkflowStatusViewState>(
       streamId,
       WORKFLOW_STATUS_VIEW,
@@ -190,8 +221,7 @@ export async function handleViewTasks(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    await materializer.loadFromSnapshot(streamId, TASK_DETAIL_VIEW);
-    const events = await store.query(streamId);
+    const events = await queryDeltaEvents(store, materializer, streamId, TASK_DETAIL_VIEW);
     const view = materializer.materialize<TaskDetailViewState>(
       streamId,
       TASK_DETAIL_VIEW,
@@ -253,7 +283,7 @@ export async function handleViewPipeline(
     const materializer = getOrCreateMaterializer(stateDir);
 
     // Discover all streams and paginate IDs before materialization
-    const streamIds = await discoverStreams(stateDir);
+    const streamIds = await discoverStreams(stateDir, store);
     const total = streamIds.length;
     const start = args.offset ?? 0;
     const end = args.limit !== undefined ? start + args.limit : undefined;
@@ -263,8 +293,7 @@ export async function handleViewPipeline(
     const workflows: PipelineViewState[] = [];
 
     for (const streamId of paginatedIds) {
-      await materializer.loadFromSnapshot(streamId, PIPELINE_VIEW);
-      const events = await store.query(streamId);
+      const events = await queryDeltaEvents(store, materializer, streamId, PIPELINE_VIEW);
       const view = materializer.materialize<PipelineViewState>(
         streamId,
         PIPELINE_VIEW,
@@ -296,8 +325,7 @@ export async function handleViewTeamPerformance(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    await materializer.loadFromSnapshot(streamId, TEAM_PERFORMANCE_VIEW);
-    const events = await store.query(streamId);
+    const events = await queryDeltaEvents(store, materializer, streamId, TEAM_PERFORMANCE_VIEW);
     const view = materializer.materialize<TeamPerformanceViewState>(
       streamId,
       TEAM_PERFORMANCE_VIEW,
@@ -327,8 +355,7 @@ export async function handleViewDelegationTimeline(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    await materializer.loadFromSnapshot(streamId, DELEGATION_TIMELINE_VIEW);
-    const events = await store.query(streamId);
+    const events = await queryDeltaEvents(store, materializer, streamId, DELEGATION_TIMELINE_VIEW);
     const view = materializer.materialize<DelegationTimelineViewState>(
       streamId,
       DELEGATION_TIMELINE_VIEW,
@@ -363,8 +390,7 @@ export async function handleViewCodeQuality(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    await materializer.loadFromSnapshot(streamId, CODE_QUALITY_VIEW);
-    const events = await store.query(streamId);
+    const events = await queryDeltaEvents(store, materializer, streamId, CODE_QUALITY_VIEW);
     const view = materializer.materialize<CodeQualityViewState>(
       streamId,
       CODE_QUALITY_VIEW,
@@ -427,8 +453,7 @@ export async function handleViewEvalResults(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    await materializer.loadFromSnapshot(streamId, EVAL_RESULTS_VIEW);
-    const events = await store.query(streamId);
+    const events = await queryDeltaEvents(store, materializer, streamId, EVAL_RESULTS_VIEW);
     const view = materializer.materialize<EvalResultsViewState>(
       streamId,
       EVAL_RESULTS_VIEW,
@@ -477,8 +502,7 @@ export async function handleViewQualityHints(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    await materializer.loadFromSnapshot(streamId, CODE_QUALITY_VIEW);
-    const events = await store.query(streamId);
+    const events = await queryDeltaEvents(store, materializer, streamId, CODE_QUALITY_VIEW);
     const view = materializer.materialize<CodeQualityViewState>(
       streamId,
       CODE_QUALITY_VIEW,

--- a/servers/exarchos-mcp/src/workflow/state-store.test.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.test.ts
@@ -1,9 +1,24 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import * as os from 'node:os';
+import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { deepMerge, isPlainObject, initStateFile, reconcileFromEvents } from './state-store.js';
+import {
+  deepMerge,
+  isPlainObject,
+  readStateFile,
+  writeStateFile,
+  initStateFile,
+  listStateFiles,
+  configureStateStoreBackend,
+  reconcileFromEvents,
+  VersionConflictError,
+  StateStoreError,
+} from './state-store.js';
 import { EventStore } from '../event-store/store.js';
+import { InMemoryBackend, VersionConflictError as BackendVersionConflictError } from '../storage/memory-backend.js';
+import type { WorkflowState } from './types.js';
 
 describe('deepMerge', () => {
   it('DeepMerge_NestedObjects_MergesRecursively', () => {
@@ -84,6 +99,127 @@ describe('isPlainObject', () => {
   });
 });
 
+// ─── Issue 4: extractFeatureIdFromPath Validation ─────────────────────────
+
+describe('extractFeatureIdFromPath validation', () => {
+  afterEach(() => {
+    configureStateStoreBackend(undefined as unknown as InMemoryBackend);
+  });
+
+  it('extractFeatureIdFromPath_MaliciousPath_Throws', async () => {
+    const backend = new InMemoryBackend();
+    configureStateStoreBackend(backend);
+
+    // basename of this is "$(rm -rf).state.json" -> featureId "$(rm -rf)"
+    // The extracted featureId contains shell metacharacters and should be rejected
+    // with INVALID_INPUT, not STATE_NOT_FOUND
+    const maliciousPath = '/some/dir/$(rm -rf).state.json';
+
+    await expect(readStateFile(maliciousPath)).rejects.toThrow(/invalid featureId/i);
+  });
+
+  it('extractFeatureIdFromPath_ValidPath_Succeeds', async () => {
+    const backend = new InMemoryBackend();
+    configureStateStoreBackend(backend);
+
+    // Normal feature ID with allowed characters
+    const state = {
+      version: '1.1',
+      featureId: 'my-feature',
+      workflowType: 'feature',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      phase: 'ideate',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      synthesis: {
+        integrationBranch: null,
+        mergeOrder: [],
+        mergedBranches: [],
+        prUrl: null,
+        prFeedback: [],
+      },
+      _version: 1,
+      _history: {},
+      _checkpoint: {
+        timestamp: new Date().toISOString(),
+        phase: 'ideate',
+        summary: 'Test',
+        operationsSince: 0,
+        fixCycleCount: 0,
+        lastActivityTimestamp: new Date().toISOString(),
+        staleAfterMinutes: 120,
+      },
+    } as WorkflowState;
+    backend.setState('my-feature', state);
+
+    const validPath = '/some/dir/my-feature.state.json';
+    const result = await readStateFile(validPath);
+    expect(result.featureId).toBe('my-feature');
+  });
+
+  it('extractFeatureIdFromPath_PathWithSpaces_Throws', async () => {
+    const backend = new InMemoryBackend();
+    configureStateStoreBackend(backend);
+
+    const spacePath = '/some/dir/my feature.state.json';
+    await expect(readStateFile(spacePath)).rejects.toThrow(/invalid featureId/i);
+  });
+
+  it('extractFeatureIdFromPath_PathWithShellChars_Throws', async () => {
+    const backend = new InMemoryBackend();
+    configureStateStoreBackend(backend);
+
+    // basename of "feat;echo pwned.state.json" produces featureId "feat;echo pwned"
+    // which contains shell metacharacters
+    const shellPath = '/some/dir/feat;echo pwned.state.json';
+    await expect(readStateFile(shellPath)).rejects.toThrow(/invalid featureId/i);
+  });
+
+  it('extractFeatureIdFromPath_FeatureIdWithDotsAndUnderscores_Succeeds', async () => {
+    const backend = new InMemoryBackend();
+    configureStateStoreBackend(backend);
+
+    const state = {
+      version: '1.1',
+      featureId: 'my_feature.v2',
+      workflowType: 'feature',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      phase: 'ideate',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      synthesis: {
+        integrationBranch: null,
+        mergeOrder: [],
+        mergedBranches: [],
+        prUrl: null,
+        prFeedback: [],
+      },
+      _version: 1,
+      _history: {},
+      _checkpoint: {
+        timestamp: new Date().toISOString(),
+        phase: 'ideate',
+        summary: 'Test',
+        operationsSince: 0,
+        fixCycleCount: 0,
+        lastActivityTimestamp: new Date().toISOString(),
+        staleAfterMinutes: 120,
+      },
+    } as WorkflowState;
+    backend.setState('my_feature.v2', state);
+
+    const validPath = '/some/dir/my_feature.v2.state.json';
+    const result = await readStateFile(validPath);
+    expect(result.featureId).toBe('my_feature.v2');
+  });
+});
+
 // ─── reconcileFromEvents Query Efficiency ─────────────────────────────────
 
 describe('reconcileFromEvents query efficiency', () => {
@@ -131,7 +267,6 @@ describe('reconcileFromEvents query efficiency', () => {
     expect(result.eventsApplied).toBe(1);
 
     // Assert: eventStore.query should be called at most once for the delta path
-    // (the code currently calls it twice: once for delta, once for phase reconciliation)
     expect(querySpy).toHaveBeenCalledTimes(1);
     expect(querySpy).toHaveBeenCalledWith('query-test', { sinceSequence: 2 });
 
@@ -180,5 +315,230 @@ describe('reconcileFromEvents query efficiency', () => {
     expect(querySpy).toHaveBeenCalledTimes(1);
 
     querySpy.mockRestore();
+  });
+});
+
+// ─── Task 16: State Store StorageBackend Integration ─────────────────────────
+
+describe('State Store StorageBackend Integration', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'state-store-backend-test-'));
+  });
+
+  afterEach(async () => {
+    // Reset module-level backend to null after each test
+    configureStateStoreBackend(undefined as unknown as InMemoryBackend);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // Helper to create a minimal valid WorkflowState for testing
+  function makeState(overrides?: Record<string, unknown>): WorkflowState {
+    const now = new Date().toISOString();
+    return {
+      version: '1.1',
+      featureId: 'test-feature',
+      workflowType: 'feature',
+      createdAt: now,
+      updatedAt: now,
+      phase: 'ideate',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      synthesis: {
+        integrationBranch: null,
+        mergeOrder: [],
+        mergedBranches: [],
+        prUrl: null,
+        prFeedback: [],
+      },
+      _version: 1,
+      _history: {},
+      _checkpoint: {
+        timestamp: now,
+        phase: 'ideate',
+        summary: 'Test state',
+        operationsSince: 0,
+        fixCycleCount: 0,
+        lastActivityTimestamp: now,
+        staleAfterMinutes: 120,
+      },
+      ...overrides,
+    } as WorkflowState;
+  }
+
+  it('readStateFile_WithBackend_ReadsFromBackend', async () => {
+    const backend = new InMemoryBackend();
+    const state = makeState({ featureId: 'my-feature' });
+    backend.setState('my-feature', state);
+
+    configureStateStoreBackend(backend);
+
+    const stateFile = path.join(tempDir, 'my-feature.state.json');
+    const result = await readStateFile(stateFile);
+
+    expect(result.featureId).toBe('my-feature');
+    expect(result.phase).toBe('ideate');
+  });
+
+  it('writeStateFile_WithBackend_WritesToBackend', async () => {
+    const backend = new InMemoryBackend();
+    configureStateStoreBackend(backend);
+
+    const state = makeState({ featureId: 'my-feature' });
+    const stateFile = path.join(tempDir, 'my-feature.state.json');
+
+    await writeStateFile(stateFile, state);
+
+    // Verify state was written to backend
+    const stored = backend.getState('my-feature');
+    expect(stored).not.toBeNull();
+    expect(stored!.featureId).toBe('my-feature');
+  });
+
+  it('writeStateFile_WithBackend_CASConflict_Throws', async () => {
+    const backend = new InMemoryBackend();
+    configureStateStoreBackend(backend);
+
+    const state = makeState({ featureId: 'my-feature' });
+
+    // Write initial state (creates version 1 in backend)
+    backend.setState('my-feature', state);
+
+    const stateFile = path.join(tempDir, 'my-feature.state.json');
+
+    // Write with wrong expectedVersion — should throw
+    await expect(
+      writeStateFile(stateFile, state, { expectedVersion: 99 }),
+    ).rejects.toThrow(VersionConflictError);
+  });
+
+  it('initStateFile_WithBackend_InsertsIntoBackend', async () => {
+    const backend = new InMemoryBackend();
+    configureStateStoreBackend(backend);
+
+    const { state } = await initStateFile(tempDir, 'new-feature', 'feature');
+
+    // Verify the state was saved into the backend
+    const stored = backend.getState('new-feature');
+    expect(stored).not.toBeNull();
+    expect(stored!.featureId).toBe('new-feature');
+    expect(stored!.phase).toBe('ideate');
+  });
+
+  it('listStateFiles_WithBackend_QueriesBackend', async () => {
+    const backend = new InMemoryBackend();
+    configureStateStoreBackend(backend);
+
+    // Add two states to the backend
+    backend.setState('feature-a', makeState({ featureId: 'feature-a' }));
+    backend.setState('feature-b', makeState({ featureId: 'feature-b' }));
+
+    const result = await listStateFiles(tempDir);
+
+    expect(result.valid).toHaveLength(2);
+    expect(result.corrupt).toHaveLength(0);
+    expect(result.valid.map(v => v.featureId).sort()).toEqual(['feature-a', 'feature-b']);
+  });
+
+  it('readStateFile_WithoutBackend_FallsBackToJSONFile', async () => {
+    // No backend configured — use file path
+    const { state, stateFile } = await initStateFile(tempDir, 'file-feature', 'feature');
+
+    const result = await readStateFile(stateFile);
+    expect(result.featureId).toBe('file-feature');
+    expect(result.phase).toBe('ideate');
+  });
+
+  it('readStateFile_WithBackend_StateNotFound_Throws', async () => {
+    const backend = new InMemoryBackend();
+    configureStateStoreBackend(backend);
+
+    const stateFile = path.join(tempDir, 'nonexistent.state.json');
+
+    await expect(readStateFile(stateFile)).rejects.toThrow(StateStoreError);
+  });
+});
+
+// ─── Task 16: Property Tests for CAS ─────────────────────────────────────────
+
+describe('State Store CAS Property Test', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'state-cas-property-test-'));
+  });
+
+  afterEach(async () => {
+    configureStateStoreBackend(undefined as unknown as InMemoryBackend);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  function makeState(overrides?: Record<string, unknown>): WorkflowState {
+    const now = new Date().toISOString();
+    return {
+      version: '1.1',
+      featureId: 'cas-test',
+      workflowType: 'feature',
+      createdAt: now,
+      updatedAt: now,
+      phase: 'ideate',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      synthesis: {
+        integrationBranch: null,
+        mergeOrder: [],
+        mergedBranches: [],
+        prUrl: null,
+        prFeedback: [],
+      },
+      _version: 1,
+      _history: {},
+      _checkpoint: {
+        timestamp: now,
+        phase: 'ideate',
+        summary: 'CAS test',
+        operationsSince: 0,
+        fixCycleCount: 0,
+        lastActivityTimestamp: now,
+        staleAfterMinutes: 120,
+      },
+      ...overrides,
+    } as WorkflowState;
+  }
+
+  it('CAS_ConcurrentWrites_ExactlyOneSucceeds', async () => {
+    const backend = new InMemoryBackend();
+    configureStateStoreBackend(backend);
+
+    // Seed the backend with initial state (version 1)
+    const state = makeState({ featureId: 'cas-test' });
+    backend.setState('cas-test', state);
+
+    const stateFile = path.join(tempDir, 'cas-test.state.json');
+
+    // Both writers read version 1 and try to write with expectedVersion=1
+    const stateA = makeState({ featureId: 'cas-test', phase: 'plan' });
+    const stateB = makeState({ featureId: 'cas-test', phase: 'delegate' });
+
+    const results = await Promise.allSettled([
+      writeStateFile(stateFile, stateA, { expectedVersion: 1 }),
+      writeStateFile(stateFile, stateB, { expectedVersion: 1 }),
+    ]);
+
+    const successes = results.filter(r => r.status === 'fulfilled');
+    const failures = results.filter(r => r.status === 'rejected');
+
+    // Exactly one should succeed and one should fail
+    expect(successes).toHaveLength(1);
+    expect(failures).toHaveLength(1);
+
+    // The failure should be a VersionConflictError
+    const failedResult = failures[0] as PromiseRejectedResult;
+    expect(failedResult.reason).toBeInstanceOf(VersionConflictError);
   });
 });

--- a/servers/exarchos-mcp/src/workflow/state-store.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.ts
@@ -3,10 +3,42 @@ import { migrateState, CURRENT_VERSION, backupStateFile } from './migration.js';
 import type { WorkflowState, WorkflowType } from './types.js';
 import type { EventStore } from '../event-store/store.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
+import type { StorageBackend } from '../storage/backend.js';
 import { isPidAlive } from '../utils/process.js';
 import * as fs from 'node:fs/promises';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
+
+// ─── Module-Level StorageBackend ──────────────────────────────────────────────
+
+/** Module-level storage backend. When set, state operations delegate here. */
+let _stateStoreBackend: StorageBackend | undefined;
+
+/**
+ * Configure the module-level storage backend for state operations.
+ * Pass `undefined` to reset to file-based mode.
+ */
+export function configureStateStoreBackend(backend: StorageBackend | undefined): void {
+  _stateStoreBackend = backend;
+}
+
+/** Safe pattern for feature IDs: alphanumeric, dots, underscores, and hyphens. */
+const SAFE_FEATURE_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+/** Extract featureId from a state file path (e.g., "/dir/my-feature.state.json" -> "my-feature"). */
+function extractFeatureIdFromPath(stateFile: string): string {
+  const basename = path.basename(stateFile);
+  const featureId = basename.replace('.state.json', '');
+
+  if (!SAFE_FEATURE_ID_PATTERN.test(featureId)) {
+    throw new StateStoreError(
+      ErrorCode.INVALID_INPUT,
+      `Invalid featureId "${featureId}" extracted from path: must match ${SAFE_FEATURE_ID_PATTERN}`,
+    );
+  }
+
+  return featureId;
+}
 
 /** Maximum gap between array length and new index. Allows append (gap 0) and one-past-end (gap 1). */
 export const MAX_ARRAY_GAP = 1;
@@ -93,6 +125,24 @@ export async function initStateFile(
 
   const state = parseResult.data;
 
+  // Delegate to backend if available
+  if (_stateStoreBackend) {
+    // Use version 0 as expectedVersion for exclusive-create semantics:
+    // setState with expectedVersion=0 only succeeds if no state exists yet
+    try {
+      _stateStoreBackend.setState(featureId, state, 0);
+    } catch (err) {
+      if (err instanceof Error && err.name === 'VersionConflictError') {
+        throw new StateStoreError(
+          ErrorCode.STATE_ALREADY_EXISTS,
+          `State already exists in backend for featureId: ${featureId}`,
+        );
+      }
+      throw err;
+    }
+    return { stateFile, state };
+  }
+
   // Ensure directory exists
   await fs.mkdir(stateDir, { recursive: true });
 
@@ -132,6 +182,19 @@ export async function initStateFile(
 // ─── Read and Validate a State File (with Migration) ───────────────────────
 
 export async function readStateFile(stateFile: string): Promise<WorkflowState> {
+  // Delegate to backend if available
+  if (_stateStoreBackend) {
+    const featureId = extractFeatureIdFromPath(stateFile);
+    const state = _stateStoreBackend.getState(featureId);
+    if (!state) {
+      throw new StateStoreError(
+        ErrorCode.STATE_NOT_FOUND,
+        `State not found in backend for featureId: ${featureId}`,
+      );
+    }
+    return state;
+  }
+
   let raw: string;
 
   try {
@@ -218,6 +281,48 @@ export async function writeStateFile(
   state: WorkflowState,
   options?: { expectedVersion?: number; skipValidation?: boolean },
 ): Promise<void> {
+  // Delegate to backend if available
+  if (_stateStoreBackend) {
+    const featureId = extractFeatureIdFromPath(stateFile);
+
+    // Auto-increment _version before writing
+    const stateWithVersion = {
+      ...state,
+      _version: getStateVersion(state) + 1,
+    } as WorkflowState;
+
+    // Validate before writing
+    if (!options?.skipValidation) {
+      const validation = WorkflowStateSchema.safeParse(stateWithVersion);
+      if (!validation.success) {
+        throw new StateStoreError(
+          ErrorCode.INVALID_INPUT,
+          `Write-time validation failed: ${validation.error.message}`,
+        );
+      }
+    }
+
+    try {
+      _stateStoreBackend.setState(featureId, stateWithVersion, options?.expectedVersion);
+    } catch (err) {
+      // Re-throw backend version conflicts as state-store VersionConflictErrors
+      if (err instanceof Error && err.name === 'VersionConflictError') {
+        const message = err.message;
+        // Parse expected and actual from the error message
+        const match = message.match(/expected (\d+), actual (\d+)/);
+        if (match) {
+          throw new VersionConflictError(parseInt(match[1], 10), parseInt(match[2], 10));
+        }
+        throw new VersionConflictError(
+          options?.expectedVersion ?? 0,
+          0,
+        );
+      }
+      throw err;
+    }
+    return;
+  }
+
   // CAS check: if expectedVersion is provided, verify it matches the current file
   if (options?.expectedVersion !== undefined) {
     let currentVersion = 1;
@@ -444,6 +549,19 @@ export interface ListStateFilesResult {
 export async function listStateFiles(
   stateDir: string,
 ): Promise<ListStateFilesResult> {
+  // Delegate to backend if available
+  if (_stateStoreBackend) {
+    const states = _stateStoreBackend.listStates();
+    return {
+      valid: states.map(({ featureId, state }) => ({
+        featureId,
+        stateFile: path.join(stateDir, `${featureId}.state.json`),
+        state,
+      })),
+      corrupt: [],
+    };
+  }
+
   let entries: string[];
   try {
     entries = await fs.readdir(stateDir);


### PR DESCRIPTION
## Summary

Refactors EventStore, Outbox, ViewMaterializer, StateStore, and view handlers to delegate reads/writes through the StorageBackend interface. Adds defensive measures including backend dual-write error resilience, featureId path traversal validation, and delta query optimization for view handlers.

## Changes

- **EventStore** — Delegates event append/query to backend with try/catch resilience (JSONL remains source of truth)
- **Outbox** — Routes drain operations through StorageBackend outbox methods
- **ViewMaterializer** — Uses backend view cache for materialized view snapshots
- **StateStore** — CAS-versioned state operations via backend with `configureStateStoreBackend()` injection
- **View Handlers** — `sinceSequence` pass-through and warm-call snapshot skip optimization
- **Security** — `SAFE_FEATURE_ID_PATTERN` regex validation against path traversal

## Test Plan

TDD with integration tests verifying backend delegation, CAS conflict handling, dual-write failure resilience, and delta query efficiency.

---

**Results:** Tests 2136 ✓ · Typecheck 0 errors
**Design:** [storage-layer-audit.md](docs/designs/2026-02-21-storage-layer-audit.md)
**Stack:** 2/3 — Module refactoring