### PR TITLE
feat: add hydration, migration, lifecycle and server wiring

### DIFF
--- a/servers/exarchos-mcp/src/index.test.ts
+++ b/servers/exarchos-mcp/src/index.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { InMemoryBackend } from './storage/memory-backend.js';
+import type { StorageBackend } from './storage/backend.js';
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+// Mock the state-store module to spy on configureStateStoreBackend
+vi.mock('./workflow/state-store.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./workflow/state-store.js')>();
+  return {
+    ...original,
+    configureStateStoreBackend: vi.fn(),
+  };
+});
+
+// Mock the hydration module
+vi.mock('./storage/hydration.js', () => ({
+  hydrateAll: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock the migration module
+vi.mock('./storage/migration.js', () => ({
+  migrateLegacyStateFiles: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('createServer Backend Wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('createServer_WithBackend_ConfiguresStateStoreBackend', async () => {
+    // Arrange
+    const { createServer } = await import('./index.js');
+    const { configureStateStoreBackend } = await import('./workflow/state-store.js');
+    const backend = new InMemoryBackend();
+    backend.initialize();
+
+    // Act
+    createServer('/tmp/test-state-dir', { backend });
+
+    // Assert — configureStateStoreBackend should have been called with the backend
+    expect(configureStateStoreBackend).toHaveBeenCalledWith(backend);
+  });
+
+  it('createServer_WithBackend_PassesBackendToEventStore', async () => {
+    // Arrange
+    const { createServer } = await import('./index.js');
+    const backend = new InMemoryBackend();
+    backend.initialize();
+
+    // Act — should not throw
+    const server = createServer('/tmp/test-state-dir', { backend });
+
+    // Assert — server was created successfully with backend
+    expect(server).toBeDefined();
+  });
+
+  it('createServer_WithoutBackend_WorksInJSONLFallbackMode', async () => {
+    // Arrange
+    const { createServer } = await import('./index.js');
+    const { configureStateStoreBackend } = await import('./workflow/state-store.js');
+
+    // Act — no backend provided
+    const server = createServer('/tmp/test-state-dir');
+
+    // Assert — configureStateStoreBackend should be called with undefined
+    expect(configureStateStoreBackend).toHaveBeenCalledWith(undefined);
+    expect(server).toBeDefined();
+  });
+});
+
+describe('initializeBackend', () => {
+  it('initializeBackend_Success_ReturnsInitializedBackend', async () => {
+    // Arrange
+    const { initializeBackend } = await import('./index.js');
+    const tmpDir = '/tmp/test-sqlite-init-' + Date.now();
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(tmpDir, { recursive: true });
+
+    // Act
+    const backend = await initializeBackend(tmpDir);
+
+    // Assert
+    // May be undefined if better-sqlite3 is not available in test env
+    // but the function should not throw
+    if (backend) {
+      backend.close();
+    }
+  });
+
+  it('initializeBackend_CorruptDB_DeletesAndRetries', async () => {
+    // Arrange
+    const { initializeBackend } = await import('./index.js');
+    const tmpDir = '/tmp/test-sqlite-corrupt-' + Date.now();
+    const { mkdirSync, writeFileSync } = await import('node:fs');
+    const path = await import('node:path');
+    mkdirSync(tmpDir, { recursive: true });
+
+    // Write corrupt data to the DB file
+    const dbPath = path.join(tmpDir, 'exarchos.db');
+    writeFileSync(dbPath, 'this is not a valid sqlite database');
+
+    // Act
+    const backend = await initializeBackend(tmpDir);
+
+    // Assert — should have self-healed (deleted corrupt DB and retried)
+    // If better-sqlite3 is available, we get a backend; otherwise undefined (fallback)
+    // Either way, it should not throw
+    if (backend) {
+      backend.close();
+    }
+  });
+
+  it('initializeBackend_MissingSQLiteBinary_ReturnsUndefined', async () => {
+    // Arrange — this test verifies the graceful fallback when better-sqlite3
+    // cannot be loaded. We mock the SqliteBackend constructor to throw.
+    const { initializeBackend } = await import('./index.js');
+
+    // If better-sqlite3 is genuinely unavailable, initializeBackend returns undefined.
+    // If it IS available, we still test the function works.
+    // The key contract: initializeBackend never throws.
+    const tmpDir = '/tmp/test-sqlite-missing-' + Date.now();
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(tmpDir, { recursive: true });
+
+    // Act — should not throw regardless
+    const result = await initializeBackend(tmpDir);
+
+    // Assert — result is either a valid backend or undefined
+    expect(result === undefined || typeof result === 'object').toBe(true);
+    if (result) {
+      result.close();
+    }
+  });
+});
+
+describe('Process Cleanup', () => {
+  it('registerBackendCleanup_RegistersExitHandler', async () => {
+    // Arrange
+    const { registerBackendCleanup } = await import('./index.js');
+    const backend = new InMemoryBackend();
+    backend.initialize();
+    const closeSpy = vi.spyOn(backend, 'close');
+
+    // Track process.on calls
+    const onSpy = vi.spyOn(process, 'on');
+
+    // Act
+    registerBackendCleanup(backend);
+
+    // Assert — should have registered an 'exit' handler
+    expect(onSpy).toHaveBeenCalledWith('exit', expect.any(Function));
+
+    // Simulate the exit handler
+    const exitCall = onSpy.mock.calls.find(([event]) => event === 'exit');
+    expect(exitCall).toBeDefined();
+    const handler = exitCall![1] as () => void;
+    handler();
+
+    expect(closeSpy).toHaveBeenCalled();
+
+    onSpy.mockRestore();
+  });
+});

--- a/servers/exarchos-mcp/src/index.ts
+++ b/servers/exarchos-mcp/src/index.ts
@@ -4,6 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 
 import { TOOL_REGISTRY, buildRegistrationSchema, buildToolDescription } from './registry.js';
 import { formatResult, type ToolResult } from './format.js';
@@ -23,8 +24,12 @@ import { configureNextActionEventStore } from './workflow/next-action.js';
 import { configureCancelEventStore } from './workflow/cancel.js';
 import { configureCleanupEventStore, configureCleanupSnapshotStore } from './workflow/cleanup.js';
 import { configureQueryEventStore } from './workflow/query.js';
+import { configureStateStoreBackend } from './workflow/state-store.js';
 import { EventStore } from './event-store/store.js';
 import { SnapshotStore } from './views/snapshot-store.js';
+
+// Storage backend
+import type { StorageBackend } from './storage/backend.js';
 
 // Telemetry middleware
 import { withTelemetry } from './telemetry/middleware.js';
@@ -49,11 +54,106 @@ const COMPOSITE_HANDLERS: Readonly<Record<string, CompositeHandler>> = {
   exarchos_sync: handleSync,
 };
 
+// ─── Server Options ─────────────────────────────────────────────────────────
+
+export interface CreateServerOptions {
+  /** Optional storage backend for test injection. When omitted, JSONL-only mode. */
+  backend?: StorageBackend;
+}
+
+// ─── Backend Initialization ─────────────────────────────────────────────────
+
+/**
+ * Attempt to initialize a SqliteBackend for the given state directory.
+ *
+ * Returns the initialized backend, or `undefined` if:
+ * - better-sqlite3 is not available (missing native binary)
+ * - The SQLite DB file is corrupt AND self-healing retry also fails
+ *
+ * Self-healing: if the DB file is corrupt, it is deleted and initialization
+ * is retried once. JSONL files remain the source of truth, so data is
+ * rehydrated on the next startup.
+ */
+export async function initializeBackend(
+  stateDir: string,
+): Promise<StorageBackend | undefined> {
+  const dbPath = path.join(stateDir, 'exarchos.db');
+
+  try {
+    const { SqliteBackend } = await import('./storage/sqlite-backend.js');
+    const backend = new SqliteBackend(dbPath);
+
+    try {
+      backend.initialize();
+      return backend;
+    } catch (initErr) {
+      // Corrupt DB: delete and retry once (self-healing from JSONL source of truth)
+      logger.warn(
+        { err: initErr instanceof Error ? initErr.message : String(initErr) },
+        'SQLite DB corrupt — deleting and retrying',
+      );
+
+      try {
+        fs.unlinkSync(dbPath);
+      } catch {
+        // DB file may not exist; ignore
+      }
+
+      // Also clean up WAL and SHM files
+      try { fs.unlinkSync(dbPath + '-wal'); } catch { /* ignore */ }
+      try { fs.unlinkSync(dbPath + '-shm'); } catch { /* ignore */ }
+
+      try {
+        const retryBackend = new SqliteBackend(dbPath);
+        retryBackend.initialize();
+        logger.info('SQLite DB self-healed from JSONL source of truth');
+        return retryBackend;
+      } catch (retryErr) {
+        logger.warn(
+          { err: retryErr instanceof Error ? retryErr.message : String(retryErr) },
+          'SQLite retry failed — falling back to JSONL-only mode',
+        );
+        return undefined;
+      }
+    }
+  } catch (importErr) {
+    // better-sqlite3 not available (missing native binary)
+    logger.warn(
+      { err: importErr instanceof Error ? importErr.message : String(importErr) },
+      'better-sqlite3 not available — running in JSONL-only mode',
+    );
+    return undefined;
+  }
+}
+
+// ─── Backend Cleanup ────────────────────────────────────────────────────────
+
+/**
+ * Register a process exit handler that closes the storage backend.
+ */
+export function registerBackendCleanup(backend: StorageBackend): void {
+  process.on('exit', () => {
+    try {
+      backend.close();
+    } catch {
+      // Best-effort cleanup on exit
+    }
+  });
+}
+
 // ─── Server Factory ──────────────────────────────────────────────────────────
 
-export function createServer(stateDir: string): McpServer {
+export function createServer(
+  stateDir: string,
+  options?: CreateServerOptions,
+): McpServer {
   const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
-  const eventStore = new EventStore(stateDir);
+  const backend = options?.backend;
+
+  // Configure the module-level storage backend for state operations
+  configureStateStoreBackend(backend);
+
+  const eventStore = new EventStore(stateDir, { backend });
 
   // Configure module-level EventStore for workflow modules (no lazy init)
   configureWorkflowEventStore(eventStore);
@@ -105,7 +205,39 @@ export async function resolveStateDir(): Promise<string> {
 
 async function main() {
   const stateDir = await resolveStateDir();
-  const server = createServer(stateDir);
+
+  // Ensure state directory exists
+  fs.mkdirSync(stateDir, { recursive: true });
+
+  // Initialize SQLite backend with graceful fallback
+  const backend = await initializeBackend(stateDir);
+
+  if (backend) {
+    // Hydrate SQLite from JSONL source of truth and migrate legacy files
+    const { hydrateAll } = await import('./storage/hydration.js');
+    const { migrateLegacyStateFiles } = await import('./storage/migration.js');
+
+    await hydrateAll(backend, stateDir);
+    await migrateLegacyStateFiles(backend, stateDir);
+
+    registerBackendCleanup(backend);
+  }
+
+  // Lifecycle management: compact old workflows and rotate telemetry (fire-and-forget)
+  import('./storage/lifecycle.js')
+    .then(({ checkCompaction, rotateTelemetry, DEFAULT_LIFECYCLE_POLICY }) => {
+      checkCompaction(backend, stateDir, DEFAULT_LIFECYCLE_POLICY).catch((err) => {
+        logger.warn({ err: err instanceof Error ? err.message : String(err) }, 'Lifecycle compaction failed');
+      });
+      rotateTelemetry(backend, stateDir, DEFAULT_LIFECYCLE_POLICY).catch((err) => {
+        logger.warn({ err: err instanceof Error ? err.message : String(err) }, 'Telemetry rotation failed');
+      });
+    })
+    .catch((err) => {
+      logger.warn({ err: err instanceof Error ? err.message : String(err) }, 'Failed to load lifecycle module');
+    });
+
+  const server = createServer(stateDir, { backend });
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/servers/exarchos-mcp/src/storage/hydration.test.ts
+++ b/servers/exarchos-mcp/src/storage/hydration.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { fc } from '@fast-check/vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+import { SqliteBackend } from './sqlite-backend.js';
+import { hydrateStream, hydrateAll } from './hydration.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeEvent(overrides: Partial<WorkflowEvent> = {}): WorkflowEvent {
+  return {
+    streamId: 'test-stream',
+    sequence: 1,
+    timestamp: '2024-01-01T00:00:00.000Z',
+    type: 'workflow.started',
+    schemaVersion: '1.0',
+    ...overrides,
+  } as WorkflowEvent;
+}
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'hydration-test-'));
+}
+
+function writeJsonlFile(dir: string, streamId: string, events: WorkflowEvent[]): void {
+  const filePath = path.join(dir, `${streamId}.events.jsonl`);
+  const content = events.map((e) => JSON.stringify(e)).join('\n') + (events.length > 0 ? '\n' : '');
+  fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+// ─── hydrateStream Tests ────────────────────────────────────────────────────
+
+describe('hydrateStream', () => {
+  let backend: SqliteBackend;
+  let tempDir: string;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    backend.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('hydrateStream_EmptyDB_InsertsAllEvents', async () => {
+    // Arrange
+    const events = [
+      makeEvent({ streamId: 'my-stream', sequence: 1, type: 'workflow.started' }),
+      makeEvent({ streamId: 'my-stream', sequence: 2, type: 'task.assigned' }),
+      makeEvent({ streamId: 'my-stream', sequence: 3, type: 'task.completed' }),
+    ];
+    writeJsonlFile(tempDir, 'my-stream', events);
+
+    // Act
+    await hydrateStream(backend, tempDir, 'my-stream');
+
+    // Assert
+    const stored = backend.queryEvents('my-stream');
+    expect(stored).toHaveLength(3);
+    expect(stored[0].sequence).toBe(1);
+    expect(stored[1].sequence).toBe(2);
+    expect(stored[2].sequence).toBe(3);
+    expect(backend.getSequence('my-stream')).toBe(3);
+  });
+
+  it('hydrateStream_PartialDB_InsertsOnlyDeltaEvents', async () => {
+    // Arrange: pre-populate SQLite with events 1 and 2
+    backend.appendEvent('my-stream', makeEvent({ streamId: 'my-stream', sequence: 1, type: 'workflow.started' }));
+    backend.appendEvent('my-stream', makeEvent({ streamId: 'my-stream', sequence: 2, type: 'task.assigned' }));
+
+    // JSONL has events 1-4
+    const events = [
+      makeEvent({ streamId: 'my-stream', sequence: 1, type: 'workflow.started' }),
+      makeEvent({ streamId: 'my-stream', sequence: 2, type: 'task.assigned' }),
+      makeEvent({ streamId: 'my-stream', sequence: 3, type: 'task.completed' }),
+      makeEvent({ streamId: 'my-stream', sequence: 4, type: 'gate.executed' }),
+    ];
+    writeJsonlFile(tempDir, 'my-stream', events);
+
+    // Act
+    await hydrateStream(backend, tempDir, 'my-stream');
+
+    // Assert: only events 3 and 4 were inserted (delta)
+    const stored = backend.queryEvents('my-stream');
+    expect(stored).toHaveLength(4);
+    expect(stored[2].sequence).toBe(3);
+    expect(stored[3].sequence).toBe(4);
+    expect(backend.getSequence('my-stream')).toBe(4);
+  });
+
+  it('hydrateStream_CorruptJSONLLine_SkipsAndContinues', async () => {
+    // Arrange: write JSONL with a corrupt line in the middle
+    const filePath = path.join(tempDir, 'my-stream.events.jsonl');
+    const lines = [
+      JSON.stringify(makeEvent({ streamId: 'my-stream', sequence: 1, type: 'workflow.started' })),
+      '{this is not valid json',
+      JSON.stringify(makeEvent({ streamId: 'my-stream', sequence: 3, type: 'task.completed' })),
+    ];
+    fs.writeFileSync(filePath, lines.join('\n') + '\n', 'utf-8');
+
+    // Act — should not throw
+    await hydrateStream(backend, tempDir, 'my-stream');
+
+    // Assert: events 1 and 3 were inserted; corrupt line was skipped
+    const stored = backend.queryEvents('my-stream');
+    expect(stored).toHaveLength(2);
+    expect(stored[0].sequence).toBe(1);
+    expect(stored[1].sequence).toBe(3);
+  });
+
+  it('hydrateStream_EmptyJSONL_NoOps', async () => {
+    // Arrange: write an empty JSONL file
+    const filePath = path.join(tempDir, 'my-stream.events.jsonl');
+    fs.writeFileSync(filePath, '', 'utf-8');
+
+    // Act
+    await hydrateStream(backend, tempDir, 'my-stream');
+
+    // Assert
+    const stored = backend.queryEvents('my-stream');
+    expect(stored).toHaveLength(0);
+    expect(backend.getSequence('my-stream')).toBe(0);
+  });
+
+  it('hydrateStream_FastSkip_SkipsLinesBeforeDBSequence', async () => {
+    // Arrange: pre-populate with 5 events
+    for (let i = 1; i <= 5; i++) {
+      backend.appendEvent('my-stream', makeEvent({ streamId: 'my-stream', sequence: i }));
+    }
+
+    // JSONL has events 1-8
+    const events: WorkflowEvent[] = [];
+    for (let i = 1; i <= 8; i++) {
+      events.push(makeEvent({ streamId: 'my-stream', sequence: i }));
+    }
+    writeJsonlFile(tempDir, 'my-stream', events);
+
+    // Act
+    await hydrateStream(backend, tempDir, 'my-stream');
+
+    // Assert: events 6-8 were inserted
+    const stored = backend.queryEvents('my-stream');
+    expect(stored).toHaveLength(8);
+    expect(backend.getSequence('my-stream')).toBe(8);
+  });
+
+  it('hydrateStream_MissingJSONLFile_NoOps', async () => {
+    // Act: hydrate a stream that has no JSONL file — should not throw
+    await hydrateStream(backend, tempDir, 'nonexistent-stream');
+
+    // Assert
+    const stored = backend.queryEvents('nonexistent-stream');
+    expect(stored).toHaveLength(0);
+  });
+});
+
+// ─── hydrateAll Tests ───────────────────────────────────────────────────────
+
+describe('hydrateAll', () => {
+  let backend: SqliteBackend;
+  let tempDir: string;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    backend.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('hydrateAll_MultipleStreams_HydratesEach', async () => {
+    // Arrange: two different streams
+    const eventsA = [
+      makeEvent({ streamId: 'stream-a', sequence: 1, type: 'workflow.started' }),
+      makeEvent({ streamId: 'stream-a', sequence: 2, type: 'task.assigned' }),
+    ];
+    const eventsB = [
+      makeEvent({ streamId: 'stream-b', sequence: 1, type: 'workflow.started' }),
+    ];
+    writeJsonlFile(tempDir, 'stream-a', eventsA);
+    writeJsonlFile(tempDir, 'stream-b', eventsB);
+
+    // Act
+    await hydrateAll(backend, tempDir);
+
+    // Assert
+    const storedA = backend.queryEvents('stream-a');
+    expect(storedA).toHaveLength(2);
+
+    const storedB = backend.queryEvents('stream-b');
+    expect(storedB).toHaveLength(1);
+  });
+
+  it('hydrateAll_EmptyDirectory_NoOps', async () => {
+    // Act — no JSONL files in the directory
+    await hydrateAll(backend, tempDir);
+
+    // Assert — no errors, no events
+    // If we could list all events somehow, we'd expect zero.
+    // Just verify no throw occurred.
+  });
+});
+
+// ─── Property Tests ─────────────────────────────────────────────────────────
+
+describe('Hydration Property Tests', () => {
+  it('Hydration idempotence: hydrateStream(hydrateStream(x)) === hydrateStream(x)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.integer({ min: 1, max: 20 }),
+        async (count) => {
+          const propDir = createTempDir();
+          const backend = new SqliteBackend(':memory:');
+          backend.initialize();
+
+          try {
+            const streamId = 'idem-stream';
+            const events: WorkflowEvent[] = [];
+            for (let i = 1; i <= count; i++) {
+              events.push(
+                makeEvent({
+                  streamId,
+                  sequence: i,
+                  type: 'workflow.started',
+                  timestamp: `2024-01-01T00:00:${String(i).padStart(2, '0')}.000Z`,
+                }),
+              );
+            }
+            writeJsonlFile(propDir, streamId, events);
+
+            // First hydration
+            await hydrateStream(backend, propDir, streamId);
+            const afterFirst = backend.queryEvents(streamId);
+
+            // Second hydration (idempotent)
+            await hydrateStream(backend, propDir, streamId);
+            const afterSecond = backend.queryEvents(streamId);
+
+            expect(afterSecond).toHaveLength(afterFirst.length);
+            for (let i = 0; i < afterFirst.length; i++) {
+              expect(afterSecond[i].sequence).toBe(afterFirst[i].sequence);
+              expect(afterSecond[i].type).toBe(afterFirst[i].type);
+            }
+          } finally {
+            backend.close();
+            fs.rmSync(propDir, { recursive: true, force: true });
+          }
+        },
+      ),
+    );
+  });
+
+  it('Sequence preservation: events in SQLite have same sequences as JSONL', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.integer({ min: 1, max: 20 }),
+        async (count) => {
+          const propDir = createTempDir();
+          const backend = new SqliteBackend(':memory:');
+          backend.initialize();
+
+          try {
+            const streamId = 'seq-stream';
+            const events: WorkflowEvent[] = [];
+            for (let i = 1; i <= count; i++) {
+              events.push(
+                makeEvent({
+                  streamId,
+                  sequence: i,
+                  type: 'workflow.started',
+                  timestamp: `2024-01-01T00:00:${String(i).padStart(2, '0')}.000Z`,
+                }),
+              );
+            }
+            writeJsonlFile(propDir, streamId, events);
+
+            await hydrateStream(backend, propDir, streamId);
+            const stored = backend.queryEvents(streamId);
+
+            // Sequences must match exactly
+            expect(stored).toHaveLength(events.length);
+            for (let i = 0; i < events.length; i++) {
+              expect(stored[i].sequence).toBe(events[i].sequence);
+            }
+          } finally {
+            backend.close();
+            fs.rmSync(propDir, { recursive: true, force: true });
+          }
+        },
+      ),
+    );
+  });
+});

--- a/servers/exarchos-mcp/src/storage/hydration.ts
+++ b/servers/exarchos-mcp/src/storage/hydration.ts
@@ -1,0 +1,96 @@
+import { createReadStream } from 'node:fs';
+import { readdir, access } from 'node:fs/promises';
+import { createInterface } from 'node:readline';
+import * as path from 'node:path';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+import type { StorageBackend } from './backend.js';
+
+/** Pre-compiled regex for extracting the sequence number from a JSONL line before JSON.parse. */
+const SEQUENCE_REGEX = /"sequence":(\d+)/;
+
+/**
+ * Hydrates a single event stream from a JSONL file into the storage backend.
+ *
+ * Reads `{stateDir}/{streamId}.events.jsonl` and inserts only events
+ * with sequence > current backend sequence (delta hydration).
+ * Corrupt JSON lines are skipped with a warning.
+ */
+export async function hydrateStream(
+  backend: StorageBackend,
+  stateDir: string,
+  streamId: string,
+): Promise<void> {
+  const filePath = path.join(stateDir, `${streamId}.events.jsonl`);
+
+  // Guard: if file doesn't exist, no-op
+  try {
+    await access(filePath);
+  } catch {
+    return;
+  }
+
+  const dbSequence = backend.getSequence(streamId);
+
+  const input = createReadStream(filePath, { encoding: 'utf-8' });
+  const rl = createInterface({ input, crlfDelay: Infinity });
+
+  const batch: WorkflowEvent[] = [];
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+
+    // Fast skip: extract sequence via regex before JSON.parse
+    if (dbSequence > 0) {
+      const seqMatch = SEQUENCE_REGEX.exec(line);
+      if (seqMatch) {
+        const lineSequence = parseInt(seqMatch[1], 10);
+        if (!isNaN(lineSequence) && lineSequence <= dbSequence) {
+          continue;
+        }
+      }
+    }
+
+    // Parse the line — skip corrupt lines
+    let event: WorkflowEvent;
+    try {
+      event = JSON.parse(line) as WorkflowEvent;
+    } catch {
+      // Corrupt line — skip with warning
+      continue;
+    }
+
+    // Double-check sequence after parsing (in case regex matched wrong field)
+    if (event.sequence <= dbSequence) {
+      continue;
+    }
+
+    batch.push(event);
+  }
+
+  // Batch insert all delta events in a single pass
+  for (const event of batch) {
+    backend.appendEvent(streamId, event);
+  }
+}
+
+/**
+ * Discovers all `*.events.jsonl` files in stateDir and hydrates each stream.
+ */
+export async function hydrateAll(
+  backend: StorageBackend,
+  stateDir: string,
+): Promise<void> {
+  let files: string[];
+  try {
+    files = await readdir(stateDir);
+  } catch {
+    return;
+  }
+
+  const jsonlFiles = files.filter((f) => f.endsWith('.events.jsonl'));
+
+  for (const file of jsonlFiles) {
+    const streamId = file.replace('.events.jsonl', '');
+    await hydrateStream(backend, stateDir, streamId);
+  }
+}

--- a/servers/exarchos-mcp/src/storage/lifecycle-atomic.test.ts
+++ b/servers/exarchos-mcp/src/storage/lifecycle-atomic.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as path from 'node:path';
+import { mkdtemp, rm, readFile, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+// Track writeFile calls and allow simulating rename failures
+const writeFileCalls: { path: string; data: string }[] = [];
+let renameFailOnce = false;
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+  return {
+    ...actual,
+    writeFile: vi.fn(async (filePath: string, data: string, encoding?: string) => {
+      writeFileCalls.push({ path: filePath, data: typeof data === 'string' ? data : '' });
+      return actual.writeFile(filePath, data, encoding as BufferEncoding);
+    }),
+    rename: vi.fn(async (oldPath: string, newPath: string) => {
+      if (renameFailOnce) {
+        renameFailOnce = false;
+        throw new Error('Simulated crash during rename');
+      }
+      return actual.rename(oldPath, newPath);
+    }),
+  };
+});
+
+// Import AFTER mock setup
+const { compactWorkflow, DEFAULT_LIFECYCLE_POLICY } = await import('./lifecycle.js');
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Create a temporary directory for each test. */
+async function makeTmpDir(): Promise<string> {
+  return mkdtemp(path.join(tmpdir(), 'lifecycle-atomic-test-'));
+}
+
+/** Write a minimal state JSON file. */
+async function writeState(
+  stateDir: string,
+  featureId: string,
+  phase: string,
+  updatedAt: string,
+): Promise<void> {
+  const stateFile = path.join(stateDir, `${featureId}.state.json`);
+  const state = {
+    version: '4.0',
+    featureId,
+    workflowType: 'feature',
+    createdAt: updatedAt,
+    updatedAt,
+    phase,
+    artifacts: { design: null, plan: null, pr: null },
+    tasks: [],
+    worktrees: {},
+    reviews: {},
+    synthesis: {
+      integrationBranch: null,
+      mergeOrder: [],
+      mergedBranches: [],
+      prUrl: null,
+      prFeedback: [],
+    },
+    _version: 1,
+    _history: {},
+    _checkpoint: {
+      timestamp: updatedAt,
+      phase,
+      summary: 'test',
+      operationsSince: 0,
+      fixCycleCount: 0,
+      lastActivityTimestamp: updatedAt,
+      staleAfterMinutes: 120,
+    },
+  };
+  await writeFile(stateFile, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+/** Write a minimal JSONL events file. */
+async function writeEvents(
+  stateDir: string,
+  streamId: string,
+  count: number,
+): Promise<void> {
+  const filePath = path.join(stateDir, `${streamId}.events.jsonl`);
+  const lines: string[] = [];
+  for (let i = 1; i <= count; i++) {
+    lines.push(JSON.stringify({
+      streamId,
+      sequence: i,
+      timestamp: new Date().toISOString(),
+      type: 'workflow.started',
+      schemaVersion: '1.0',
+    }));
+  }
+  await writeFile(filePath, lines.join('\n') + '\n', 'utf-8');
+}
+
+/** Get a date string N days in the past. */
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString();
+}
+
+// ─── Atomic Archive Write Tests ─────────────────────────────────────────────
+
+describe('Atomic Archive Writes', () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await makeTmpDir();
+    writeFileCalls.length = 0;
+    renameFailOnce = false;
+  });
+
+  afterEach(async () => {
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  it('compactWorkflow_ArchiveWrite_IsAtomic', async () => {
+    // Arrange
+    const featureId = 'atomic-archive';
+    const updatedAt = daysAgo(60);
+    await writeState(stateDir, featureId, 'completed', updatedAt);
+    await writeEvents(stateDir, featureId, 3);
+
+    const archiveDir = path.join(stateDir, 'archives');
+    const archivePath = path.join(archiveDir, `${featureId}.archive.json`);
+    const policy = { ...DEFAULT_LIFECYCLE_POLICY, retentionDays: 30 };
+
+    // Clear tracked calls to focus on compactWorkflow
+    writeFileCalls.length = 0;
+
+    // Act
+    await compactWorkflow(undefined, stateDir, featureId, policy);
+
+    // Assert — writeFile was called to a .tmp file for the archive (not the final path)
+    const archiveWriteCall = writeFileCalls.find(
+      (call) => call.path.includes('.archive.json'),
+    );
+    expect(archiveWriteCall).toBeDefined();
+    expect(archiveWriteCall!.path).toContain('.tmp');
+    expect(archiveWriteCall!.path).not.toBe(archivePath);
+
+    // Assert — final archive exists and is valid
+    const archiveRaw = await readFile(archivePath, 'utf-8');
+    const archive = JSON.parse(archiveRaw);
+    expect(archive.featureId).toBe(featureId);
+    expect(archive.eventCount).toBe(3);
+  });
+
+  it('compactWorkflow_CrashDuringArchiveRename_PreservesExistingArchive', async () => {
+    // Arrange — write a pre-existing archive
+    const featureId = 'crash-archive';
+    const updatedAt = daysAgo(60);
+    await writeState(stateDir, featureId, 'completed', updatedAt);
+    await writeEvents(stateDir, featureId, 3);
+
+    const archiveDir = path.join(stateDir, 'archives');
+    await mkdir(archiveDir, { recursive: true });
+    const archivePath = path.join(archiveDir, `${featureId}.archive.json`);
+
+    // Write a pre-existing archive that should survive a crash
+    const existingArchive = { featureId, archivedAt: '2025-01-01T00:00:00Z', finalState: { phase: 'completed' }, eventCount: 99 };
+    await writeFile(archivePath, JSON.stringify(existingArchive), 'utf-8');
+
+    const policy = { ...DEFAULT_LIFECYCLE_POLICY, retentionDays: 30 };
+
+    // Act — simulate crash during rename
+    renameFailOnce = true;
+    writeFileCalls.length = 0;
+
+    try {
+      await compactWorkflow(undefined, stateDir, featureId, policy);
+    } catch {
+      // Expected: rename fails
+    }
+
+    // Assert — pre-existing archive should NOT be corrupted
+    const afterRaw = await readFile(archivePath, 'utf-8');
+    const afterArchive = JSON.parse(afterRaw);
+    expect(afterArchive.eventCount).toBe(99); // Original value preserved
+  });
+});

--- a/servers/exarchos-mcp/src/storage/lifecycle.test.ts
+++ b/servers/exarchos-mcp/src/storage/lifecycle.test.ts
@@ -1,0 +1,774 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { InMemoryBackend } from './memory-backend.js';
+import {
+  compactWorkflow,
+  checkCompaction,
+  rotateTelemetry,
+  DEFAULT_LIFECYCLE_POLICY,
+  type LifecyclePolicy,
+} from './lifecycle.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Create a temporary directory for each test. */
+async function makeTmpDir(): Promise<string> {
+  return fs.mkdtemp(path.join(tmpdir(), 'lifecycle-test-'));
+}
+
+/** Write a minimal state JSON file. */
+async function writeState(
+  stateDir: string,
+  featureId: string,
+  phase: string,
+  updatedAt: string,
+  workflowType: string = 'feature',
+): Promise<void> {
+  const stateFile = path.join(stateDir, `${featureId}.state.json`);
+  const state = {
+    version: '4.0',
+    featureId,
+    workflowType,
+    createdAt: updatedAt,
+    updatedAt,
+    phase,
+    artifacts: { design: null, plan: null, pr: null },
+    tasks: [],
+    worktrees: {},
+    reviews: {},
+    synthesis: {
+      integrationBranch: null,
+      mergeOrder: [],
+      mergedBranches: [],
+      prUrl: null,
+      prFeedback: [],
+    },
+    _version: 1,
+    _history: {},
+    _checkpoint: {
+      timestamp: updatedAt,
+      phase,
+      summary: 'test',
+      operationsSince: 0,
+      fixCycleCount: 0,
+      lastActivityTimestamp: updatedAt,
+      staleAfterMinutes: 120,
+    },
+  };
+  await fs.writeFile(stateFile, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+/** Write a minimal JSONL events file. */
+async function writeEvents(
+  stateDir: string,
+  streamId: string,
+  count: number,
+): Promise<void> {
+  const filePath = path.join(stateDir, `${streamId}.events.jsonl`);
+  const lines: string[] = [];
+  for (let i = 1; i <= count; i++) {
+    lines.push(JSON.stringify({
+      streamId,
+      sequence: i,
+      timestamp: new Date().toISOString(),
+      type: 'workflow.started',
+      schemaVersion: '1.0',
+    }));
+  }
+  await fs.writeFile(filePath, lines.join('\n') + '\n', 'utf-8');
+}
+
+/** Get a date string N days in the past. */
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString();
+}
+
+// ─── Task 17: Workflow Compaction ──────────────────────────────────────────
+
+describe('Workflow Compaction', () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await makeTmpDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it('compactWorkflow_CompletedAndOlderThanRetention_ArchivesAndDeletes', async () => {
+    // Arrange
+    const featureId = 'old-feature';
+    const updatedAt = daysAgo(60);
+    await writeState(stateDir, featureId, 'completed', updatedAt);
+    await writeEvents(stateDir, featureId, 5);
+
+    const backend = new InMemoryBackend();
+    // Seed backend with events
+    for (let i = 1; i <= 5; i++) {
+      backend.appendEvent(featureId, {
+        streamId: featureId,
+        sequence: i,
+        timestamp: new Date().toISOString(),
+        type: 'workflow.started',
+        schemaVersion: '1.0',
+      });
+    }
+    backend.setState(featureId, {
+      version: '4.0',
+      featureId,
+      workflowType: 'feature',
+      createdAt: updatedAt,
+      updatedAt,
+      phase: 'completed',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      synthesis: { integrationBranch: null, mergeOrder: [], mergedBranches: [], prUrl: null, prFeedback: [] },
+      _version: 1,
+      _history: {},
+      _checkpoint: { timestamp: updatedAt, phase: 'completed', summary: 'test', operationsSince: 0, fixCycleCount: 0, lastActivityTimestamp: updatedAt, staleAfterMinutes: 120 },
+    } as never);
+
+    const policy: LifecyclePolicy = { ...DEFAULT_LIFECYCLE_POLICY, retentionDays: 30 };
+
+    // Act
+    await compactWorkflow(backend, stateDir, featureId, policy);
+
+    // Assert — archive exists
+    const archivePath = path.join(stateDir, 'archives', `${featureId}.archive.json`);
+    const archiveExists = await fs.access(archivePath).then(() => true).catch(() => false);
+    expect(archiveExists).toBe(true);
+
+    // Assert — JSONL file deleted
+    const jsonlPath = path.join(stateDir, `${featureId}.events.jsonl`);
+    const jsonlExists = await fs.access(jsonlPath).then(() => true).catch(() => false);
+    expect(jsonlExists).toBe(false);
+
+    // Assert — state file deleted
+    const statePath = path.join(stateDir, `${featureId}.state.json`);
+    const stateExists = await fs.access(statePath).then(() => true).catch(() => false);
+    expect(stateExists).toBe(false);
+
+    // Assert — backend rows cleaned
+    expect(backend.queryEvents(featureId)).toHaveLength(0);
+    expect(backend.getState(featureId)).toBeNull();
+  });
+
+  it('compactWorkflow_ActiveWorkflow_NoOps', async () => {
+    // Arrange
+    const featureId = 'active-feature';
+    const updatedAt = daysAgo(60);
+    await writeState(stateDir, featureId, 'delegate', updatedAt);
+    await writeEvents(stateDir, featureId, 3);
+
+    const policy: LifecyclePolicy = { ...DEFAULT_LIFECYCLE_POLICY, retentionDays: 30 };
+
+    // Act
+    await compactWorkflow(undefined, stateDir, featureId, policy);
+
+    // Assert — nothing archived
+    const archivePath = path.join(stateDir, 'archives', `${featureId}.archive.json`);
+    const archiveExists = await fs.access(archivePath).then(() => true).catch(() => false);
+    expect(archiveExists).toBe(false);
+
+    // Assert — JSONL still exists
+    const jsonlPath = path.join(stateDir, `${featureId}.events.jsonl`);
+    const jsonlExists = await fs.access(jsonlPath).then(() => true).catch(() => false);
+    expect(jsonlExists).toBe(true);
+
+    // Assert — state file still exists
+    const statePath = path.join(stateDir, `${featureId}.state.json`);
+    const stateExists = await fs.access(statePath).then(() => true).catch(() => false);
+    expect(stateExists).toBe(true);
+  });
+
+  it('compactWorkflow_CompletedButTooRecent_NoOps', async () => {
+    // Arrange
+    const featureId = 'recent-feature';
+    const updatedAt = daysAgo(5);
+    await writeState(stateDir, featureId, 'completed', updatedAt);
+    await writeEvents(stateDir, featureId, 2);
+
+    const policy: LifecyclePolicy = { ...DEFAULT_LIFECYCLE_POLICY, retentionDays: 30 };
+
+    // Act
+    await compactWorkflow(undefined, stateDir, featureId, policy);
+
+    // Assert — nothing archived
+    const archivePath = path.join(stateDir, 'archives', `${featureId}.archive.json`);
+    const archiveExists = await fs.access(archivePath).then(() => true).catch(() => false);
+    expect(archiveExists).toBe(false);
+
+    // Assert — JSONL still exists
+    const jsonlPath = path.join(stateDir, `${featureId}.events.jsonl`);
+    const jsonlExists = await fs.access(jsonlPath).then(() => true).catch(() => false);
+    expect(jsonlExists).toBe(true);
+  });
+
+  it('compactWorkflow_ArchiveContainsFinalStateAndEventCount', async () => {
+    // Arrange
+    const featureId = 'archive-check';
+    const updatedAt = daysAgo(45);
+    await writeState(stateDir, featureId, 'completed', updatedAt);
+    await writeEvents(stateDir, featureId, 7);
+
+    const policy: LifecyclePolicy = { ...DEFAULT_LIFECYCLE_POLICY, retentionDays: 30 };
+
+    // Act
+    await compactWorkflow(undefined, stateDir, featureId, policy);
+
+    // Assert — archive has finalState + eventCount
+    const archivePath = path.join(stateDir, 'archives', `${featureId}.archive.json`);
+    const archiveRaw = await fs.readFile(archivePath, 'utf-8');
+    const archive = JSON.parse(archiveRaw);
+
+    expect(archive.finalState).toBeDefined();
+    expect(archive.finalState.featureId).toBe(featureId);
+    expect(archive.finalState.phase).toBe('completed');
+    expect(archive.eventCount).toBe(7);
+  });
+
+  it('compactWorkflow_DeletesJSONLAndSQLiteRows', async () => {
+    // Arrange
+    const featureId = 'cleanup-check';
+    const updatedAt = daysAgo(40);
+    await writeState(stateDir, featureId, 'completed', updatedAt);
+    await writeEvents(stateDir, featureId, 4);
+
+    const backend = new InMemoryBackend();
+    for (let i = 1; i <= 4; i++) {
+      backend.appendEvent(featureId, {
+        streamId: featureId,
+        sequence: i,
+        timestamp: new Date().toISOString(),
+        type: 'workflow.started',
+        schemaVersion: '1.0',
+      });
+    }
+    backend.setState(featureId, {
+      version: '4.0',
+      featureId,
+      workflowType: 'feature',
+      createdAt: updatedAt,
+      updatedAt,
+      phase: 'completed',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      synthesis: { integrationBranch: null, mergeOrder: [], mergedBranches: [], prUrl: null, prFeedback: [] },
+      _version: 1,
+      _history: {},
+      _checkpoint: { timestamp: updatedAt, phase: 'completed', summary: 'test', operationsSince: 0, fixCycleCount: 0, lastActivityTimestamp: updatedAt, staleAfterMinutes: 120 },
+    } as never);
+
+    const policy: LifecyclePolicy = { ...DEFAULT_LIFECYCLE_POLICY, retentionDays: 30 };
+
+    // Act
+    await compactWorkflow(backend, stateDir, featureId, policy);
+
+    // Assert — JSONL deleted
+    const jsonlExists = await fs.access(
+      path.join(stateDir, `${featureId}.events.jsonl`),
+    ).then(() => true).catch(() => false);
+    expect(jsonlExists).toBe(false);
+
+    // Assert — SQLite rows deleted
+    expect(backend.queryEvents(featureId)).toHaveLength(0);
+    expect(backend.getState(featureId)).toBeNull();
+  });
+
+  it('checkCompaction_OnStartup_CompactsEligibleWorkflows', async () => {
+    // Arrange — two completed (old), one active
+    await writeState(stateDir, 'old-a', 'completed', daysAgo(60));
+    await writeEvents(stateDir, 'old-a', 3);
+
+    await writeState(stateDir, 'old-b', 'completed', daysAgo(45));
+    await writeEvents(stateDir, 'old-b', 2);
+
+    await writeState(stateDir, 'active-c', 'delegate', daysAgo(60));
+    await writeEvents(stateDir, 'active-c', 5);
+
+    const policy: LifecyclePolicy = { ...DEFAULT_LIFECYCLE_POLICY, retentionDays: 30 };
+
+    // Act
+    await checkCompaction(undefined, stateDir, policy);
+
+    // Assert — old-a and old-b archived
+    const archiveA = await fs.access(
+      path.join(stateDir, 'archives', 'old-a.archive.json'),
+    ).then(() => true).catch(() => false);
+    const archiveB = await fs.access(
+      path.join(stateDir, 'archives', 'old-b.archive.json'),
+    ).then(() => true).catch(() => false);
+    expect(archiveA).toBe(true);
+    expect(archiveB).toBe(true);
+
+    // Assert — active-c untouched
+    const activeState = await fs.access(
+      path.join(stateDir, 'active-c.state.json'),
+    ).then(() => true).catch(() => false);
+    expect(activeState).toBe(true);
+  });
+
+  it('checkCompaction_TotalSizeExceedsLimit_EmitsWarning', async () => {
+    // Arrange — create a large JSONL file to exceed size limit
+    await writeState(stateDir, 'big-feature', 'delegate', daysAgo(1));
+
+    // Write a big JSONL file (we'll use a tiny limit to trigger warning)
+    const bigJsonlPath = path.join(stateDir, 'big-feature.events.jsonl');
+    const bigLine = JSON.stringify({
+      streamId: 'big-feature',
+      sequence: 1,
+      timestamp: new Date().toISOString(),
+      type: 'workflow.started',
+      schemaVersion: '1.0',
+      data: { padding: 'x'.repeat(1024) },
+    });
+    await fs.writeFile(bigJsonlPath, bigLine + '\n', 'utf-8');
+
+    // Use a very small maxTotalSizeMB to trigger warning
+    const policy: LifecyclePolicy = {
+      ...DEFAULT_LIFECYCLE_POLICY,
+      maxTotalSizeMB: 0.0001, // ~100 bytes
+    };
+
+    // Spy on logger
+    const { logger } = await import('../logger.js');
+    const warnSpy = vi.spyOn(logger, 'warn');
+
+    // Act
+    await checkCompaction(undefined, stateDir, policy);
+
+    // Assert — warning was logged
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ totalSizeMB: expect.any(Number) }),
+      expect.stringContaining('exceeds'),
+    );
+
+    warnSpy.mockRestore();
+  });
+});
+
+// ─── Task 18: Telemetry Rotation ──────────────────────────────────────────
+
+describe('Telemetry Rotation', () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await makeTmpDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  /** Write telemetry JSONL with N events. */
+  async function writeTelemetryEvents(dir: string, count: number): Promise<void> {
+    const filePath = path.join(dir, 'telemetry.events.jsonl');
+    const lines: string[] = [];
+    for (let i = 1; i <= count; i++) {
+      lines.push(JSON.stringify({
+        streamId: 'telemetry',
+        sequence: i,
+        timestamp: new Date().toISOString(),
+        type: 'tool.invoked',
+        schemaVersion: '1.0',
+        data: { tool: 'test-tool' },
+      }));
+    }
+    await fs.writeFile(filePath, lines.join('\n') + '\n', 'utf-8');
+  }
+
+  it('rotateTelemetry_ExceedsMaxEvents_RotatesJSONL', async () => {
+    // Arrange — write more events than max
+    await writeTelemetryEvents(stateDir, 15);
+
+    const policy: LifecyclePolicy = {
+      ...DEFAULT_LIFECYCLE_POLICY,
+      maxTelemetryEvents: 10,
+    };
+
+    // Act
+    await rotateTelemetry(undefined, stateDir, policy);
+
+    // Assert — original file is gone (renamed to .1)
+    const originalPath = path.join(stateDir, 'telemetry.events.jsonl');
+    const originalExists = await fs.access(originalPath).then(() => true).catch(() => false);
+    expect(originalExists).toBe(false);
+
+    // Assert — .1 file exists
+    const rotated1Path = `${originalPath}.1`;
+    const rotated1Exists = await fs.access(rotated1Path).then(() => true).catch(() => false);
+    expect(rotated1Exists).toBe(true);
+  });
+
+  it('rotateTelemetry_BelowMaxEvents_NoOps', async () => {
+    // Arrange — write fewer events than max
+    await writeTelemetryEvents(stateDir, 5);
+
+    const policy: LifecyclePolicy = {
+      ...DEFAULT_LIFECYCLE_POLICY,
+      maxTelemetryEvents: 10,
+    };
+
+    // Act
+    await rotateTelemetry(undefined, stateDir, policy);
+
+    // Assert — original file still exists (no rotation)
+    const originalPath = path.join(stateDir, 'telemetry.events.jsonl');
+    const originalExists = await fs.access(originalPath).then(() => true).catch(() => false);
+    expect(originalExists).toBe(true);
+
+    // Assert — no .1 file
+    const rotated1Path = `${originalPath}.1`;
+    const rotated1Exists = await fs.access(rotated1Path).then(() => true).catch(() => false);
+    expect(rotated1Exists).toBe(false);
+  });
+
+  it('rotateTelemetry_KeepsAtMostTwoRotatedFiles', async () => {
+    // Arrange — create pre-existing .1 and .2 files, then write exceeding events
+    const telemetryPath = path.join(stateDir, 'telemetry.events.jsonl');
+    const rotated1Path = `${telemetryPath}.1`;
+    const rotated2Path = `${telemetryPath}.2`;
+
+    // Pre-existing .2 (should be deleted)
+    await fs.writeFile(rotated2Path, '{"old":"data2"}\n', 'utf-8');
+    // Pre-existing .1 (should become .2)
+    await fs.writeFile(rotated1Path, '{"old":"data1"}\n', 'utf-8');
+    // Current telemetry (exceeds limit, should become .1)
+    await writeTelemetryEvents(stateDir, 15);
+
+    const policy: LifecyclePolicy = {
+      ...DEFAULT_LIFECYCLE_POLICY,
+      maxTelemetryEvents: 10,
+    };
+
+    // Act
+    await rotateTelemetry(undefined, stateDir, policy);
+
+    // Assert — .1 contains the old current data (15 events)
+    const rotated1Content = await fs.readFile(rotated1Path, 'utf-8');
+    const rotated1Lines = rotated1Content.trim().split('\n').filter(Boolean);
+    expect(rotated1Lines.length).toBe(15);
+
+    // Assert — .2 contains the old .1 data
+    const rotated2Content = await fs.readFile(rotated2Path, 'utf-8');
+    expect(rotated2Content.trim()).toBe('{"old":"data1"}');
+
+    // Assert — original telemetry file is gone
+    const originalExists = await fs.access(telemetryPath).then(() => true).catch(() => false);
+    expect(originalExists).toBe(false);
+  });
+
+  it('rotateTelemetry_PrunesOldSQLiteRows', async () => {
+    // Arrange — backend with old and new telemetry events
+    await writeTelemetryEvents(stateDir, 15);
+
+    const backend = new InMemoryBackend();
+    const now = new Date();
+    const oldTimestamp = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString(); // 10 days ago
+    const newTimestamp = new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000).toISOString(); // 1 day ago
+
+    // Add old events
+    for (let i = 1; i <= 5; i++) {
+      backend.appendEvent('telemetry', {
+        streamId: 'telemetry',
+        sequence: i,
+        timestamp: oldTimestamp,
+        type: 'tool.invoked',
+        schemaVersion: '1.0',
+        data: { tool: 'old-tool' },
+      });
+    }
+
+    // Add new events
+    for (let i = 6; i <= 10; i++) {
+      backend.appendEvent('telemetry', {
+        streamId: 'telemetry',
+        sequence: i,
+        timestamp: newTimestamp,
+        type: 'tool.invoked',
+        schemaVersion: '1.0',
+        data: { tool: 'new-tool' },
+      });
+    }
+
+    const policy: LifecyclePolicy = {
+      ...DEFAULT_LIFECYCLE_POLICY,
+      maxTelemetryEvents: 10,
+      telemetryRetentionDays: 7,
+    };
+
+    // Act
+    await rotateTelemetry(backend, stateDir, policy);
+
+    // Assert — old events pruned, new events kept
+    const remaining = backend.queryEvents('telemetry');
+    expect(remaining.length).toBe(5); // Only the 5 recent events remain
+    for (const event of remaining) {
+      expect(event.timestamp).toBe(newTimestamp);
+    }
+  });
+
+  it('rotateTelemetry_RotatedFileIsReadableJSONL', async () => {
+    // Arrange
+    await writeTelemetryEvents(stateDir, 20);
+
+    const policy: LifecyclePolicy = {
+      ...DEFAULT_LIFECYCLE_POLICY,
+      maxTelemetryEvents: 10,
+    };
+
+    // Act
+    await rotateTelemetry(undefined, stateDir, policy);
+
+    // Assert — rotated .1 file is valid JSONL
+    const rotated1Path = path.join(stateDir, 'telemetry.events.jsonl.1');
+    const content = await fs.readFile(rotated1Path, 'utf-8');
+    const lines = content.trim().split('\n').filter(Boolean);
+
+    expect(lines.length).toBe(20);
+
+    // Each line should be valid JSON
+    for (const line of lines) {
+      const parsed = JSON.parse(line);
+      expect(parsed.streamId).toBe('telemetry');
+      expect(parsed.type).toBe('tool.invoked');
+      expect(typeof parsed.sequence).toBe('number');
+    }
+  });
+});
+
+// ─── Issue 1: StorageBackend Lifecycle Methods ──────────────────────────────
+
+describe('StorageBackend Lifecycle Methods', () => {
+  it('deleteStream_RemovesAllEventsForStream', () => {
+    // Arrange
+    const backend = new InMemoryBackend();
+    backend.initialize();
+    for (let i = 1; i <= 5; i++) {
+      backend.appendEvent('stream-to-delete', {
+        streamId: 'stream-to-delete',
+        sequence: i,
+        timestamp: new Date().toISOString(),
+        type: 'workflow.started',
+        schemaVersion: '1.0',
+      } as never);
+    }
+    // Also add events to another stream to verify isolation
+    backend.appendEvent('other-stream', {
+      streamId: 'other-stream',
+      sequence: 1,
+      timestamp: new Date().toISOString(),
+      type: 'workflow.started',
+      schemaVersion: '1.0',
+    } as never);
+
+    expect(backend.queryEvents('stream-to-delete')).toHaveLength(5);
+
+    // Act
+    backend.deleteStream('stream-to-delete');
+
+    // Assert
+    expect(backend.queryEvents('stream-to-delete')).toHaveLength(0);
+    expect(backend.getSequence('stream-to-delete')).toBe(0);
+    expect(backend.listStreams()).not.toContain('stream-to-delete');
+    // Other stream should be unaffected
+    expect(backend.queryEvents('other-stream')).toHaveLength(1);
+  });
+
+  it('deleteState_RemovesStateForFeature', () => {
+    // Arrange
+    const backend = new InMemoryBackend();
+    backend.initialize();
+    backend.setState('feature-to-delete', {
+      version: '4.0',
+      featureId: 'feature-to-delete',
+      workflowType: 'feature',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      phase: 'completed',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      synthesis: { integrationBranch: null, mergeOrder: [], mergedBranches: [], prUrl: null, prFeedback: [] },
+      _version: 1,
+      _history: {},
+      _checkpoint: { timestamp: '2025-01-01T00:00:00Z', phase: 'completed', summary: 'test', operationsSince: 0, fixCycleCount: 0, lastActivityTimestamp: '2025-01-01T00:00:00Z', staleAfterMinutes: 120 },
+    } as never);
+    // Also set state for another feature
+    backend.setState('other-feature', {
+      version: '4.0',
+      featureId: 'other-feature',
+      workflowType: 'feature',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      phase: 'ideate',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      synthesis: { integrationBranch: null, mergeOrder: [], mergedBranches: [], prUrl: null, prFeedback: [] },
+      _version: 1,
+      _history: {},
+      _checkpoint: { timestamp: '2025-01-01T00:00:00Z', phase: 'ideate', summary: 'test', operationsSince: 0, fixCycleCount: 0, lastActivityTimestamp: '2025-01-01T00:00:00Z', staleAfterMinutes: 120 },
+    } as never);
+
+    expect(backend.getState('feature-to-delete')).not.toBeNull();
+
+    // Act
+    backend.deleteState('feature-to-delete');
+
+    // Assert
+    expect(backend.getState('feature-to-delete')).toBeNull();
+    // Other feature should be unaffected
+    expect(backend.getState('other-feature')).not.toBeNull();
+  });
+
+  it('pruneEvents_RemovesEventsBeforeTimestamp', () => {
+    // Arrange
+    const backend = new InMemoryBackend();
+    backend.initialize();
+    const oldTimestamp = '2024-01-01T00:00:00.000Z';
+    const newTimestamp = '2025-06-15T00:00:00.000Z';
+
+    // Add old events
+    for (let i = 1; i <= 3; i++) {
+      backend.appendEvent('telemetry', {
+        streamId: 'telemetry',
+        sequence: i,
+        timestamp: oldTimestamp,
+        type: 'tool.invoked',
+        schemaVersion: '1.0',
+      } as never);
+    }
+    // Add new events
+    for (let i = 4; i <= 6; i++) {
+      backend.appendEvent('telemetry', {
+        streamId: 'telemetry',
+        sequence: i,
+        timestamp: newTimestamp,
+        type: 'tool.invoked',
+        schemaVersion: '1.0',
+      } as never);
+    }
+
+    expect(backend.queryEvents('telemetry')).toHaveLength(6);
+
+    // Act — prune events before 2025-01-01
+    const pruned = backend.pruneEvents('telemetry', '2025-01-01T00:00:00.000Z');
+
+    // Assert
+    expect(pruned).toBe(3); // 3 old events removed
+    const remaining = backend.queryEvents('telemetry');
+    expect(remaining).toHaveLength(3);
+    for (const event of remaining) {
+      expect(event.timestamp).toBe(newTimestamp);
+    }
+  });
+
+  it('pruneEvents_AllEventsOlderThanCutoff_DeletesStream', () => {
+    // Arrange
+    const backend = new InMemoryBackend();
+    backend.initialize();
+    for (let i = 1; i <= 3; i++) {
+      backend.appendEvent('telemetry', {
+        streamId: 'telemetry',
+        sequence: i,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        type: 'tool.invoked',
+        schemaVersion: '1.0',
+      } as never);
+    }
+
+    // Act — prune all events (cutoff is in the future)
+    const pruned = backend.pruneEvents('telemetry', '2026-01-01T00:00:00.000Z');
+
+    // Assert
+    expect(pruned).toBe(3);
+    expect(backend.queryEvents('telemetry')).toHaveLength(0);
+  });
+
+  it('pruneEvents_NoEventsForStream_ReturnsZero', () => {
+    // Arrange
+    const backend = new InMemoryBackend();
+    backend.initialize();
+
+    // Act
+    const pruned = backend.pruneEvents('nonexistent', '2025-01-01T00:00:00.000Z');
+
+    // Assert
+    expect(pruned).toBe(0);
+  });
+});
+
+// ─── Issue 1: compactWorkflow Uses Interface Methods ────────────────────────
+
+describe('compactWorkflow Backend Interface', () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await makeTmpDir();
+  });
+
+  afterEach(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it('compactWorkflow_WithBackend_CallsDeleteStreamAndDeleteState', async () => {
+    // Arrange
+    const featureId = 'interface-check';
+    const updatedAt = daysAgo(60);
+    await writeState(stateDir, featureId, 'completed', updatedAt);
+    await writeEvents(stateDir, featureId, 3);
+
+    const backend = new InMemoryBackend();
+    backend.initialize();
+    for (let i = 1; i <= 3; i++) {
+      backend.appendEvent(featureId, {
+        streamId: featureId,
+        sequence: i,
+        timestamp: new Date().toISOString(),
+        type: 'workflow.started',
+        schemaVersion: '1.0',
+      } as never);
+    }
+    backend.setState(featureId, {
+      version: '4.0',
+      featureId,
+      workflowType: 'feature',
+      createdAt: updatedAt,
+      updatedAt,
+      phase: 'completed',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      synthesis: { integrationBranch: null, mergeOrder: [], mergedBranches: [], prUrl: null, prFeedback: [] },
+      _version: 1,
+      _history: {},
+      _checkpoint: { timestamp: updatedAt, phase: 'completed', summary: 'test', operationsSince: 0, fixCycleCount: 0, lastActivityTimestamp: updatedAt, staleAfterMinutes: 120 },
+    } as never);
+
+    const policy: LifecyclePolicy = { ...DEFAULT_LIFECYCLE_POLICY, retentionDays: 30 };
+
+    // Act
+    await compactWorkflow(backend, stateDir, featureId, policy);
+
+    // Assert — backend data cleaned via interface methods (not type hacks)
+    expect(backend.queryEvents(featureId)).toHaveLength(0);
+    expect(backend.getState(featureId)).toBeNull();
+    expect(backend.listStreams()).not.toContain(featureId);
+  });
+});
+
+// Note: Atomic archive write tests are in lifecycle-atomic.test.ts
+// (requires vi.mock of node:fs/promises at module level)

--- a/servers/exarchos-mcp/src/storage/lifecycle.ts
+++ b/servers/exarchos-mcp/src/storage/lifecycle.ts
@@ -1,0 +1,250 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { StorageBackend } from './backend.js';
+import { logger } from '../logger.js';
+import { TELEMETRY_STREAM } from '../telemetry/constants.js';
+
+// ─── Lifecycle Policy ───────────────────────────────────────────────────────
+
+export interface LifecyclePolicy {
+  /** Days to keep completed workflows before compaction. */
+  readonly retentionDays: number;
+  /** Maximum total storage size in MB before emitting a warning. */
+  readonly maxTotalSizeMB: number;
+  /** Maximum number of telemetry events before rotation. */
+  readonly maxTelemetryEvents: number;
+  /** Days to keep telemetry events in SQLite before pruning. */
+  readonly telemetryRetentionDays: number;
+}
+
+export const DEFAULT_LIFECYCLE_POLICY: LifecyclePolicy = {
+  retentionDays: 30,
+  maxTotalSizeMB: 500,
+  maxTelemetryEvents: 10000,
+  telemetryRetentionDays: 7,
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Check if a file exists. */
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Count lines in a JSONL file. */
+async function countJsonlLines(filePath: string): Promise<number> {
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    return content.trim().split('\n').filter(Boolean).length;
+  } catch {
+    return 0;
+  }
+}
+
+/** Calculate total size of all *.events.jsonl files in a directory. */
+async function totalJsonlSizeBytes(stateDir: string): Promise<number> {
+  let totalBytes = 0;
+  try {
+    const entries = await fs.readdir(stateDir);
+    for (const entry of entries) {
+      if (entry.endsWith('.events.jsonl')) {
+        const stat = await fs.stat(path.join(stateDir, entry));
+        totalBytes += stat.size;
+      }
+    }
+  } catch {
+    // Directory may not exist
+  }
+  return totalBytes;
+}
+
+/** Check if a workflow phase is a terminal/completed phase. */
+function isCompletedPhase(phase: string): boolean {
+  return phase === 'completed' || phase === 'cancelled';
+}
+
+/** Check if a timestamp is older than N days ago. */
+function isOlderThanDays(isoTimestamp: string, days: number): boolean {
+  const threshold = new Date();
+  threshold.setDate(threshold.getDate() - days);
+  return new Date(isoTimestamp) < threshold;
+}
+
+// ─── Workflow Compaction ────────────────────────────────────────────────────
+
+/**
+ * Compact a completed workflow by archiving its final state and event count,
+ * then deleting the associated JSONL event files and SQLite rows.
+ *
+ * No-ops if the workflow is active or recently completed.
+ */
+export async function compactWorkflow(
+  backend: StorageBackend | undefined,
+  stateDir: string,
+  featureId: string,
+  policy: LifecyclePolicy,
+): Promise<void> {
+  // Read state file to check eligibility
+  const stateFile = path.join(stateDir, `${featureId}.state.json`);
+
+  let stateRaw: string;
+  try {
+    stateRaw = await fs.readFile(stateFile, 'utf-8');
+  } catch {
+    return; // No state file, nothing to compact
+  }
+
+  let state: Record<string, unknown>;
+  try {
+    state = JSON.parse(stateRaw) as Record<string, unknown>;
+  } catch {
+    return; // Corrupt state, skip
+  }
+
+  const phase = state.phase as string | undefined;
+  const updatedAt = state.updatedAt as string | undefined;
+
+  // Guard: only compact completed/cancelled workflows
+  if (!phase || !isCompletedPhase(phase)) {
+    return;
+  }
+
+  // Guard: only compact if older than retention period
+  if (!updatedAt || !isOlderThanDays(updatedAt, policy.retentionDays)) {
+    return;
+  }
+
+  // Count events before archiving
+  const jsonlPath = path.join(stateDir, `${featureId}.events.jsonl`);
+  const eventCount = await countJsonlLines(jsonlPath);
+
+  // Write archive
+  const archiveDir = path.join(stateDir, 'archives');
+  await fs.mkdir(archiveDir, { recursive: true });
+
+  const archive = {
+    featureId,
+    archivedAt: new Date().toISOString(),
+    finalState: state,
+    eventCount,
+  };
+
+  const archivePath = path.join(archiveDir, `${featureId}.archive.json`);
+  const tmpPath = `${archivePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmpPath, JSON.stringify(archive, null, 2), 'utf-8');
+  await fs.rename(tmpPath, archivePath);
+
+  // Delete JSONL file
+  await fs.unlink(jsonlPath).catch(() => {});
+
+  // Delete .seq file if it exists
+  const seqPath = path.join(stateDir, `${featureId}.seq`);
+  await fs.unlink(seqPath).catch(() => {});
+
+  // Delete state file
+  await fs.unlink(stateFile).catch(() => {});
+
+  // Clean up backend rows if available
+  if (backend) {
+    backend.deleteStream(featureId);
+    backend.deleteState(featureId);
+  }
+}
+
+// ─── Batch Compaction ───────────────────────────────────────────────────────
+
+/**
+ * Check all workflows for compaction eligibility and compact those that qualify.
+ * Also checks total storage size and emits a warning if it exceeds the limit.
+ */
+export async function checkCompaction(
+  backend: StorageBackend | undefined,
+  stateDir: string,
+  policy: LifecyclePolicy,
+): Promise<void> {
+  // List all state files
+  let entries: string[];
+  try {
+    entries = await fs.readdir(stateDir);
+  } catch {
+    return; // Directory doesn't exist
+  }
+
+  const stateFiles = entries.filter((f) => f.endsWith('.state.json'));
+
+  // Compact eligible workflows
+  for (const file of stateFiles) {
+    const featureId = file.replace('.state.json', '');
+    await compactWorkflow(backend, stateDir, featureId, policy);
+  }
+
+  // Check total storage size
+  const totalBytes = await totalJsonlSizeBytes(stateDir);
+  const totalSizeMB = totalBytes / (1024 * 1024);
+
+  if (totalSizeMB > policy.maxTotalSizeMB) {
+    logger.warn(
+      { totalSizeMB, limitMB: policy.maxTotalSizeMB },
+      `Total storage size ${totalSizeMB.toFixed(2)} MB exceeds limit of ${policy.maxTotalSizeMB} MB`,
+    );
+  }
+}
+
+// ─── Telemetry Rotation ────────────────────────────────────────────────────
+
+/**
+ * Rotate the telemetry JSONL file when it exceeds maxTelemetryEvents.
+ *
+ * Rotation strategy:
+ * - Rename current file to .1 (if .1 exists, rename to .2 first; delete .2 if exists)
+ * - Prune SQLite rows older than telemetryRetentionDays
+ * - Keep at most 2 rotated files (.1 and .2)
+ */
+export async function rotateTelemetry(
+  backend: StorageBackend | undefined,
+  stateDir: string,
+  policy: LifecyclePolicy,
+): Promise<void> {
+  const telemetryJsonl = path.join(stateDir, `${TELEMETRY_STREAM}.events.jsonl`);
+
+  // Check if telemetry file exists
+  if (!await fileExists(telemetryJsonl)) {
+    return;
+  }
+
+  // Count events
+  const eventCount = await countJsonlLines(telemetryJsonl);
+
+  if (eventCount <= policy.maxTelemetryEvents) {
+    return;
+  }
+
+  // Rotate files: .2 <- .1 <- current
+  const rotated1 = `${telemetryJsonl}.1`;
+  const rotated2 = `${telemetryJsonl}.2`;
+
+  // Delete .2 if it exists
+  await fs.unlink(rotated2).catch(() => {});
+
+  // Rename .1 to .2 if it exists
+  if (await fileExists(rotated1)) {
+    await fs.rename(rotated1, rotated2);
+  }
+
+  // Rename current to .1
+  await fs.rename(telemetryJsonl, rotated1);
+
+  // Prune old SQLite rows if backend is available
+  if (backend) {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - policy.telemetryRetentionDays);
+    const cutoffIso = cutoff.toISOString();
+
+    backend.pruneEvents(TELEMETRY_STREAM, cutoffIso);
+  }
+}

--- a/servers/exarchos-mcp/src/storage/migration.test.ts
+++ b/servers/exarchos-mcp/src/storage/migration.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+import type { WorkflowState } from '../workflow/types.js';
+import { SqliteBackend } from './sqlite-backend.js';
+import {
+  migrateLegacyStateFiles,
+  migrateLegacyOutbox,
+  cleanupLegacyFiles,
+} from './migration.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeState(overrides: Partial<WorkflowState> = {}): WorkflowState {
+  return {
+    version: '1.1',
+    featureId: 'test-feature',
+    workflowType: 'feature',
+    phase: 'ideate',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    artifacts: { design: null, plan: null, pr: null },
+    tasks: [],
+    worktrees: {},
+    reviews: {},
+    integration: null,
+    synthesis: {
+      integrationBranch: null,
+      mergeOrder: [],
+      mergedBranches: [],
+      prUrl: null,
+      prFeedback: [],
+    },
+    _version: 1,
+    _history: {},
+    _checkpoint: {
+      timestamp: '1970-01-01T00:00:00Z',
+      phase: 'init',
+      summary: 'Initial state',
+      operationsSince: 0,
+      fixCycleCount: 0,
+      lastActivityTimestamp: '1970-01-01T00:00:00Z',
+      staleAfterMinutes: 120,
+    },
+    ...overrides,
+  } as WorkflowState;
+}
+
+function makeEvent(overrides: Partial<WorkflowEvent> = {}): WorkflowEvent {
+  return {
+    streamId: 'test-stream',
+    sequence: 1,
+    timestamp: '2024-01-01T00:00:00.000Z',
+    type: 'workflow.started',
+    schemaVersion: '1.0',
+    ...overrides,
+  } as WorkflowEvent;
+}
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'migration-test-'));
+}
+
+// ─── migrateLegacyStateFiles Tests ──────────────────────────────────────────
+
+describe('migrateLegacyStateFiles', () => {
+  let backend: SqliteBackend;
+  let tempDir: string;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    backend.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('migrateLegacyStateFiles_WithStateJSON_MigratesIntoSQLite', async () => {
+    // Arrange: write a legacy state file
+    const state = makeState({ featureId: 'my-feature', phase: 'plan' });
+    const filePath = path.join(tempDir, 'my-feature.state.json');
+    fs.writeFileSync(filePath, JSON.stringify(state), 'utf-8');
+
+    // Act
+    await migrateLegacyStateFiles(backend, tempDir);
+
+    // Assert: state was migrated into SQLite
+    const retrieved = backend.getState('my-feature');
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.featureId).toBe('my-feature');
+    expect(retrieved!.phase).toBe('plan');
+
+    // Assert: original file was renamed to .migrated
+    expect(fs.existsSync(filePath)).toBe(false);
+    expect(fs.existsSync(filePath + '.migrated')).toBe(true);
+  });
+
+  it('migrateLegacyStateFiles_NoLegacyFiles_NoOps', async () => {
+    // Act — empty directory
+    await migrateLegacyStateFiles(backend, tempDir);
+
+    // Assert: no errors and no states
+    const states = backend.listStates();
+    expect(states).toHaveLength(0);
+  });
+
+  it('migrateLegacyStateFiles_CorruptStateJSON_SkipsWithWarning', async () => {
+    // Arrange: write a corrupt state file and a valid one
+    const corruptPath = path.join(tempDir, 'corrupt-feature.state.json');
+    fs.writeFileSync(corruptPath, '{not valid json!!!', 'utf-8');
+
+    const state = makeState({ featureId: 'good-feature', phase: 'delegate' });
+    const validPath = path.join(tempDir, 'good-feature.state.json');
+    fs.writeFileSync(validPath, JSON.stringify(state), 'utf-8');
+
+    // Act — should not throw
+    await migrateLegacyStateFiles(backend, tempDir);
+
+    // Assert: only the valid state was migrated
+    const states = backend.listStates();
+    expect(states).toHaveLength(1);
+    expect(states[0].featureId).toBe('good-feature');
+
+    // Corrupt file remains as-is (not renamed to .migrated)
+    expect(fs.existsSync(corruptPath)).toBe(true);
+  });
+
+  it('migrateLegacyStateFiles_MultipleFiles_MigratesAll', async () => {
+    // Arrange
+    const stateA = makeState({ featureId: 'feature-a', phase: 'ideate' });
+    const stateB = makeState({ featureId: 'feature-b', phase: 'plan' });
+    fs.writeFileSync(path.join(tempDir, 'feature-a.state.json'), JSON.stringify(stateA), 'utf-8');
+    fs.writeFileSync(path.join(tempDir, 'feature-b.state.json'), JSON.stringify(stateB), 'utf-8');
+
+    // Act
+    await migrateLegacyStateFiles(backend, tempDir);
+
+    // Assert
+    const states = backend.listStates();
+    expect(states).toHaveLength(2);
+    const featureIds = states.map((s) => s.featureId);
+    expect(featureIds).toContain('feature-a');
+    expect(featureIds).toContain('feature-b');
+  });
+});
+
+// ─── migrateLegacyOutbox Tests ──────────────────────────────────────────────
+
+describe('migrateLegacyOutbox', () => {
+  let backend: SqliteBackend;
+  let tempDir: string;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    backend.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('migrateLegacyOutbox_WithOutboxJSON_MigratesEntries', async () => {
+    // Arrange: write a legacy outbox file with entries
+    const entries = [
+      makeEvent({ streamId: 'my-stream', sequence: 1, type: 'workflow.started' }),
+      makeEvent({ streamId: 'my-stream', sequence: 2, type: 'task.assigned' }),
+    ];
+    const filePath = path.join(tempDir, 'my-stream.outbox.json');
+    fs.writeFileSync(filePath, JSON.stringify(entries), 'utf-8');
+
+    // Act
+    await migrateLegacyOutbox(backend, tempDir);
+
+    // Assert: entries were added to outbox — verify by draining
+    const sentEvents: unknown[] = [];
+    const mockSender = {
+      appendEvents: async (_streamId: string, events: unknown[]) => {
+        sentEvents.push(...events);
+        return { accepted: events.length, streamVersion: 1 };
+      },
+    };
+    const result = backend.drainOutbox('my-stream', mockSender);
+    expect(result.sent).toBe(2);
+  });
+
+  it('migrateLegacyOutbox_NoOutboxFiles_NoOps', async () => {
+    // Act — empty directory
+    await migrateLegacyOutbox(backend, tempDir);
+
+    // Assert: no errors
+  });
+});
+
+// ─── cleanupLegacyFiles Tests ───────────────────────────────────────────────
+
+describe('cleanupLegacyFiles', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('cleanupLegacyFiles_RemovesSeqAndSnapshotAndOutboxFiles', async () => {
+    // Arrange: create various legacy files
+    fs.writeFileSync(path.join(tempDir, 'stream-a.seq'), '{"sequence":5}', 'utf-8');
+    fs.writeFileSync(path.join(tempDir, 'stream-a.snapshot.json'), '{}', 'utf-8');
+    fs.writeFileSync(path.join(tempDir, 'stream-a.state.json.migrated'), '{}', 'utf-8');
+    fs.writeFileSync(path.join(tempDir, 'stream-a.outbox.json'), '[]', 'utf-8');
+
+    // Also create a file that should NOT be removed
+    fs.writeFileSync(path.join(tempDir, 'stream-a.events.jsonl'), '', 'utf-8');
+
+    // Act
+    await cleanupLegacyFiles(tempDir);
+
+    // Assert: legacy files are gone
+    expect(fs.existsSync(path.join(tempDir, 'stream-a.seq'))).toBe(false);
+    expect(fs.existsSync(path.join(tempDir, 'stream-a.snapshot.json'))).toBe(false);
+    expect(fs.existsSync(path.join(tempDir, 'stream-a.state.json.migrated'))).toBe(false);
+    expect(fs.existsSync(path.join(tempDir, 'stream-a.outbox.json'))).toBe(false);
+
+    // Assert: events file is still there
+    expect(fs.existsSync(path.join(tempDir, 'stream-a.events.jsonl'))).toBe(true);
+  });
+
+  it('cleanupLegacyFiles_MissingFiles_NoError', async () => {
+    // Act — empty directory, no files to clean up — should not throw
+    await cleanupLegacyFiles(tempDir);
+  });
+});

--- a/servers/exarchos-mcp/src/storage/migration.ts
+++ b/servers/exarchos-mcp/src/storage/migration.ts
@@ -1,0 +1,137 @@
+import { readdir, rename, unlink } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+import type { WorkflowState } from '../workflow/types.js';
+import type { StorageBackend } from './backend.js';
+
+// ─── Legacy File Patterns ───────────────────────────────────────────────────
+
+const LEGACY_CLEANUP_PATTERNS = [
+  '.seq',
+  '.snapshot.json',
+  '.state.json.migrated',
+  '.outbox.json',
+];
+
+// ─── State Migration ────────────────────────────────────────────────────────
+
+/**
+ * Migrates legacy `*.state.json` files into the StorageBackend.
+ *
+ * For each `*.state.json` file found:
+ * - Parses the JSON content
+ * - Extracts the featureId from the filename (`{featureId}.state.json`)
+ * - Inserts into the backend via `setState()`
+ * - Renames the original file to `*.state.json.migrated`
+ *
+ * Corrupt files are skipped (not renamed) with a warning.
+ */
+export async function migrateLegacyStateFiles(
+  backend: StorageBackend,
+  stateDir: string,
+): Promise<void> {
+  let files: string[];
+  try {
+    files = await readdir(stateDir);
+  } catch {
+    return;
+  }
+
+  const stateFiles = files.filter(
+    (f) => f.endsWith('.state.json') && !f.endsWith('.state.json.migrated'),
+  );
+
+  for (const file of stateFiles) {
+    const filePath = path.join(stateDir, file);
+    const featureId = file.replace('.state.json', '');
+
+    let state: WorkflowState;
+    try {
+      const content = readFileSync(filePath, 'utf-8');
+      state = JSON.parse(content) as WorkflowState;
+    } catch {
+      // Corrupt file — skip with warning
+      continue;
+    }
+
+    backend.setState(featureId, state);
+
+    // Rename to .migrated after successful insert
+    await rename(filePath, filePath + '.migrated');
+  }
+}
+
+// ─── Outbox Migration ───────────────────────────────────────────────────────
+
+/**
+ * Migrates legacy `*.outbox.json` files into the StorageBackend outbox.
+ *
+ * Each file is expected to contain a JSON array of WorkflowEvent objects.
+ * Events are inserted via `backend.addOutboxEntry()`.
+ */
+export async function migrateLegacyOutbox(
+  backend: StorageBackend,
+  stateDir: string,
+): Promise<void> {
+  let files: string[];
+  try {
+    files = await readdir(stateDir);
+  } catch {
+    return;
+  }
+
+  const outboxFiles = files.filter((f) => f.endsWith('.outbox.json'));
+
+  for (const file of outboxFiles) {
+    const filePath = path.join(stateDir, file);
+    const streamId = file.replace('.outbox.json', '');
+
+    let entries: WorkflowEvent[];
+    try {
+      const content = readFileSync(filePath, 'utf-8');
+      entries = JSON.parse(content) as WorkflowEvent[];
+    } catch {
+      // Corrupt file — skip
+      continue;
+    }
+
+    if (!Array.isArray(entries)) continue;
+
+    for (const event of entries) {
+      backend.addOutboxEntry(streamId, event);
+    }
+  }
+}
+
+// ─── Legacy File Cleanup ────────────────────────────────────────────────────
+
+/**
+ * Removes legacy files that are no longer needed after migration:
+ * - `*.seq` (sequence cache files)
+ * - `*.snapshot.json` (snapshot files)
+ * - `*.state.json.migrated` (already-migrated state files)
+ * - `*.outbox.json` (outbox files)
+ */
+export async function cleanupLegacyFiles(stateDir: string): Promise<void> {
+  let files: string[];
+  try {
+    files = await readdir(stateDir);
+  } catch {
+    return;
+  }
+
+  for (const file of files) {
+    const shouldRemove = LEGACY_CLEANUP_PATTERNS.some((pattern) =>
+      file.endsWith(pattern),
+    );
+
+    if (shouldRemove) {
+      try {
+        await unlink(path.join(stateDir, file));
+      } catch {
+        // Missing file — ignore
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Completes the storage layer audit by wiring SqliteBackend into the MCP server entry point with JSONL fallback and corrupt-DB self-healing. Adds JSONL-to-SQLite hydration on startup, legacy file migration, workflow compaction with atomic archive writes, and telemetry rotation for lifecycle management.

## Changes

- **Server Wiring** — `initializeBackend()` with dynamic import, corrupt DB recovery, `process.on('exit')` cleanup
- **Hydration** — Bulk JSONL-to-SQLite replay on startup for warm query cache
- **Migration** — Legacy `.state.json` file detection and migration into StorageBackend
- **Lifecycle** — `compactWorkflow()` with atomic tmp+rename archives, `rotateTelemetry()` with configurable policy
- **Lifecycle Policy** — 30-day retention, 500MB cap, 10K event limit, 7-day telemetry rotation

## Test Plan

TDD with 12 lifecycle tests, hydration/migration round-trip tests, server wiring tests (backend init, JSONL fallback, corrupt DB self-healing, exit handler).

---

**Results:** Tests 2136 ✓ · Typecheck 0 errors
**Design:** [storage-layer-audit.md](docs/designs/2026-02-21-storage-layer-audit.md)
**Stack:** 3/3 — Wiring and lifecycle