### PR TITLE
feat: expose reconcileFromEvents as workflow reconcile action (#738)

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/workflow/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/schemas.test.ts
@@ -935,3 +935,22 @@ describe('cleanup action registration', () => {
     expect(cleanupAction!.schema).toBeDefined();
   });
 });
+
+// ─── reconcile action registration (#738) ────────────────────────────────
+
+describe('reconcile action registration', () => {
+  it('should include reconcile in exarchos_workflow actions', () => {
+    const workflowTool = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow');
+    expect(workflowTool).toBeDefined();
+    const reconcileAction = workflowTool!.actions.find(a => a.name === 'reconcile');
+    expect(reconcileAction).toBeDefined();
+    expect(reconcileAction!.schema).toBeDefined();
+  });
+
+  it('should require featureId parameter', () => {
+    const workflowTool = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow');
+    const reconcileAction = workflowTool!.actions.find(a => a.name === 'reconcile');
+    const shape = reconcileAction!.schema.shape;
+    expect(shape.featureId).toBeDefined();
+  });
+});

--- a/servers/exarchos-mcp/src/errors.ts
+++ b/servers/exarchos-mcp/src/errors.ts
@@ -29,6 +29,7 @@ const categoryMap: Record<string, ErrorCategory> = {
   FILE_IO_ERROR: 'io',
   EVENT_APPEND_FAILED: 'io',
   EVENT_MIGRATION_FAILED: 'state-lifecycle',
+  EVENT_STORE_NOT_CONFIGURED: 'io',
 };
 
 // ─── Recovery Strategies ────────────────────────────────────────────────────
@@ -50,6 +51,7 @@ const recoveryMap: Record<string, string> = {
   EVENT_APPEND_FAILED: 'Check event store integrity and retry the operation',
   VERSION_CONFLICT: 'Re-read current state and retry the operation with updated version',
   EVENT_MIGRATION_FAILED: 'Check event schemaVersion and ensure event migration path exists. Backup events available in .bak files.',
+  EVENT_STORE_NOT_CONFIGURED: 'Ensure the MCP server is started with an event store configured. Reconcile requires event sourcing',
 };
 
 // ─── Retryable Codes ────────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -263,11 +263,11 @@ describe('TOOL_REGISTRY', () => {
   });
 
   describe('exarchos_workflow', () => {
-    it('should have 5 actions: init, get, set, cancel, cleanup', () => {
+    it('should have 6 actions: init, get, set, cancel, cleanup, reconcile', () => {
       const composite = findComposite('exarchos_workflow');
       expect(composite).toBeDefined();
       const actionNames = composite!.actions.map((a) => a.name);
-      expect(actionNames).toEqual(['init', 'get', 'set', 'cancel', 'cleanup']);
+      expect(actionNames).toEqual(['init', 'get', 'set', 'cancel', 'cleanup', 'reconcile']);
     });
   });
 

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -285,6 +285,15 @@ const workflowActions: readonly ToolAction[] = [
     phases: ALL_PHASES,
     roles: ROLE_LEAD,
   },
+  {
+    name: 'reconcile',
+    description: 'Rebuild workflow state from event store. Applies events newer than state _eventSequence. Idempotent — no new events returns {reconciled: false, eventsApplied: 0}. Use after compaction or crash recovery',
+    schema: z.object({
+      featureId: featureIdSchema,
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_LEAD,
+  },
 ];
 
 // ─── Composite Tool: exarchos_event ─────────────────────────────────────────
@@ -505,7 +514,7 @@ const syncActions: readonly ToolAction[] = [
 export const TOOL_REGISTRY: readonly CompositeTool[] = [
   {
     name: 'exarchos_workflow',
-    description: 'Workflow lifecycle management — init, read, update, cancel, and cleanup workflows',
+    description: 'Workflow lifecycle management — init, read, update, cancel, cleanup, and reconcile workflows',
     actions: workflowActions,
   },
   {

--- a/servers/exarchos-mcp/src/workflow/composite.test.ts
+++ b/servers/exarchos-mcp/src/workflow/composite.test.ts
@@ -4,6 +4,7 @@ vi.mock('./tools.js', () => ({
   handleInit: vi.fn().mockResolvedValue({ success: true, data: { phase: 'init-result' } }),
   handleGet: vi.fn().mockResolvedValue({ success: true, data: { phase: 'get-result' } }),
   handleSet: vi.fn().mockResolvedValue({ success: true, data: { phase: 'set-result' } }),
+  handleReconcileState: vi.fn().mockResolvedValue({ success: true, data: { reconciled: true, eventsApplied: 3 } }),
 }));
 
 vi.mock('./cancel.js', () => ({
@@ -11,7 +12,7 @@ vi.mock('./cancel.js', () => ({
 }));
 
 import { handleWorkflow } from './composite.js';
-import { handleInit, handleGet, handleSet } from './tools.js';
+import { handleInit, handleGet, handleSet, handleReconcileState } from './tools.js';
 import { handleCancel } from './cancel.js';
 
 describe('handleWorkflow', () => {
@@ -74,6 +75,20 @@ describe('handleWorkflow', () => {
         stateDir,
       );
       expect(result).toEqual({ success: true, data: { phase: 'cancel-result' } });
+    });
+  });
+
+  describe('reconcile action', () => {
+    it('should delegate to handleReconcileState with correct args', async () => {
+      const args = { action: 'reconcile', featureId: 'test' };
+
+      const result = await handleWorkflow(args, stateDir);
+
+      expect(handleReconcileState).toHaveBeenCalledWith(
+        { featureId: 'test' },
+        stateDir,
+      );
+      expect(result).toEqual({ success: true, data: { reconciled: true, eventsApplied: 3 } });
     });
   });
 

--- a/servers/exarchos-mcp/src/workflow/composite.ts
+++ b/servers/exarchos-mcp/src/workflow/composite.ts
@@ -1,4 +1,4 @@
-import { handleInit, handleGet, handleSet } from './tools.js';
+import { handleInit, handleGet, handleSet, handleReconcileState } from './tools.js';
 import { handleCancel } from './cancel.js';
 import { handleCleanup } from './cleanup.js';
 import type { ToolResult } from '../format.js';
@@ -24,12 +24,14 @@ export async function handleWorkflow(
       return handleCancel(rest as Parameters<typeof handleCancel>[0], stateDir);
     case 'cleanup':
       return handleCleanup(rest as Parameters<typeof handleCleanup>[0], stateDir);
+    case 'reconcile':
+      return handleReconcileState(rest as Parameters<typeof handleReconcileState>[0], stateDir);
     default:
       return {
         success: false,
         error: {
           code: 'UNKNOWN_ACTION',
-          message: `Unknown action: ${String(action)}. Valid actions: init, get, set, cancel, cleanup`,
+          message: `Unknown action: ${String(action)}. Valid actions: init, get, set, cancel, cleanup, reconcile`,
         },
       };
   }

--- a/servers/exarchos-mcp/src/workflow/reconcile-state.test.ts
+++ b/servers/exarchos-mcp/src/workflow/reconcile-state.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  handleReconcileState,
+  configureWorkflowEventStore,
+} from './tools.js';
+import { initStateFile } from './state-store.js';
+import { EventStore } from '../event-store/store.js';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'wf-reconcile-state-'));
+});
+
+afterEach(async () => {
+  configureWorkflowEventStore(null);
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('handleReconcileState', () => {
+  describe('Reconcile_WithStaleTaskState_PatchesFromEvents', () => {
+    it('should reconcile stale state from events showing phase transition', async () => {
+      // Arrange: Create state at 'ideate' phase, then append events that
+      // show a transition to 'plan' without updating the state file
+      const eventStore = new EventStore(tmpDir);
+      configureWorkflowEventStore(eventStore);
+
+      await initStateFile(tmpDir, 'stale-test', 'feature');
+
+      // Append events: workflow.started + workflow.transition
+      await eventStore.append('stale-test', {
+        type: 'workflow.started',
+        data: { featureId: 'stale-test', workflowType: 'feature' },
+      });
+      await eventStore.append('stale-test', {
+        type: 'workflow.transition',
+        data: {
+          from: 'ideate',
+          to: 'plan',
+          trigger: 'execute-transition',
+          featureId: 'stale-test',
+        },
+      });
+
+      // Act
+      const result = await handleReconcileState(
+        { featureId: 'stale-test' },
+        tmpDir,
+      );
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        reconciled: true,
+        eventsApplied: 2,
+      });
+
+      // Verify state file was actually updated
+      const stateFile = path.join(tmpDir, 'stale-test.state.json');
+      const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+      expect(raw.phase).toBe('plan');
+    });
+  });
+
+  describe('Reconcile_WithEmptyEventStream_ReturnsNoChanges', () => {
+    it('should return reconciled:false when no events exist', async () => {
+      // Arrange: Create state but append no events
+      const eventStore = new EventStore(tmpDir);
+      configureWorkflowEventStore(eventStore);
+
+      await initStateFile(tmpDir, 'empty-test', 'feature');
+
+      // Act
+      const result = await handleReconcileState(
+        { featureId: 'empty-test' },
+        tmpDir,
+      );
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        reconciled: false,
+        eventsApplied: 0,
+      });
+    });
+  });
+
+  describe('Reconcile_MissingFeatureId_ReturnsError', () => {
+    it('should return error when featureId is not provided', async () => {
+      const eventStore = new EventStore(tmpDir);
+      configureWorkflowEventStore(eventStore);
+
+      // Act: call without featureId
+      const result = await handleReconcileState(
+        {} as { featureId: string },
+        tmpDir,
+      );
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('INVALID_INPUT');
+    });
+  });
+
+  describe('Reconcile_NoEventStore_ReturnsError', () => {
+    it('should return error when no event store is configured', async () => {
+      // Arrange: ensure no event store
+      configureWorkflowEventStore(null);
+
+      await initStateFile(tmpDir, 'no-store-test', 'feature');
+
+      // Act
+      const result = await handleReconcileState(
+        { featureId: 'no-store-test' },
+        tmpDir,
+      );
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('EVENT_STORE_NOT_CONFIGURED');
+    });
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/schemas.ts
+++ b/servers/exarchos-mcp/src/workflow/schemas.ts
@@ -342,6 +342,7 @@ export const ErrorCode = {
   EVENT_APPEND_FAILED: 'EVENT_APPEND_FAILED',
   VERSION_CONFLICT: 'VERSION_CONFLICT',
   EVENT_MIGRATION_FAILED: 'EVENT_MIGRATION_FAILED',
+  EVENT_STORE_NOT_CONFIGURED: 'EVENT_STORE_NOT_CONFIGURED',
 } as const;
 
 // ─── Reserved Field Validation ──────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -15,6 +15,7 @@ import {
   writeStateFile,
   applyDotPath,
   listStateFiles,
+  reconcileFromEvents,
   StateStoreError,
   VersionConflictError,
 } from './state-store.js';
@@ -769,6 +770,64 @@ export async function handleCheckpoint(
     },
     _meta: buildCheckpointMeta(mutableState._checkpoint as WorkflowState['_checkpoint']),
   };
+}
+
+// ─── handleReconcileState ───────────────────────────────────────────────
+
+/**
+ * Reconcile workflow state from events in the JSONL event store.
+ *
+ * Delegates to `reconcileFromEvents` which rebuilds state from events,
+ * applying any that are newer than the state's `_eventSequence`.
+ * Idempotent — running with no new events returns `{ reconciled: false, eventsApplied: 0 }`.
+ */
+export async function handleReconcileState(
+  input: { featureId: string },
+  stateDir: string,
+): Promise<ToolResult> {
+  // Validate featureId
+  if (!input.featureId) {
+    return {
+      success: false,
+      error: {
+        code: ErrorCode.INVALID_INPUT,
+        message: 'featureId is required for reconcile action',
+      },
+    };
+  }
+
+  // Guard: event store must be configured
+  if (!moduleEventStore) {
+    return {
+      success: false,
+      error: {
+        code: ErrorCode.EVENT_STORE_NOT_CONFIGURED,
+        message: 'Event store is not configured — reconcile requires an event store',
+      },
+    };
+  }
+
+  try {
+    const result = await reconcileFromEvents(stateDir, input.featureId, moduleEventStore);
+    return {
+      success: true,
+      data: {
+        reconciled: result.reconciled,
+        eventsApplied: result.eventsApplied,
+      },
+    };
+  } catch (err) {
+    if (err instanceof StateStoreError) {
+      return {
+        success: false,
+        error: {
+          code: err.code,
+          message: err.message,
+        },
+      };
+    }
+    throw err;
+  }
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Add a 'reconcile' action to the exarchos_workflow composite tool that
calls the existing reconcileFromEvents function from state-store.ts.
This enables compaction recovery by rebuilding workflow state from the
event store. The action is idempotent and returns {reconciled, eventsApplied}.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>