### PR TITLE
ci: switch eval-gate to blacksmith runner (#io-hardening)

### DIFF
--- a/.github/workflows/eval-gate.yml
+++ b/.github/workflows/eval-gate.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   eval-regression:
     name: Eval Regression Check
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 15
     concurrency:
       group: eval-gate-${{ github.head_ref }}


### PR DESCRIPTION
## Summary

Switch the eval-gate GitHub Actions workflow from `ubuntu-latest` to `blacksmith-4vcpu-ubuntu-2204` to avoid GitHub Actions billing issues that were blocking CI on the storage-layer-audit stack.

## Changes

- **`.github/workflows/eval-gate.yml`** — Changed `runs-on` from `ubuntu-latest` to `blacksmith-4vcpu-ubuntu-2204`

## Test Plan

- [ ] Eval-gate workflow triggers successfully on Blacksmith runner
- [ ] No billing-related failures in CI checks

---

Part 1/3 of the storage-layer-audit stack.