### PR TITLE
fix: initialize explore field in state to prevent guard rejection (#775)

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/guards.test.ts
@@ -371,6 +371,69 @@ describe('Phase-Specific Guard Expected Shapes', () => {
   });
 });
 
+// ─── #775: scopeAssessmentComplete guard with explore field variations ───────
+
+describe('ScopeAssessmentComplete Guard (#775)', () => {
+  describe('scopeAssessmentComplete_WithExploreSet_ReturnsTrue', () => {
+    it('should return true when explore.scopeAssessment is set', () => {
+      const state = { explore: { scopeAssessment: 'Assessment complete' } } as Record<string, unknown>;
+
+      const result = guards.scopeAssessmentComplete.evaluate(state);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('scopeAssessmentComplete_WithoutExplore_ReturnsFailure', () => {
+    it('should return { passed: false } when explore is missing entirely', () => {
+      const state = {} as Record<string, unknown>;
+
+      const result = guards.scopeAssessmentComplete.evaluate(state);
+
+      expect(result).not.toBe(true);
+      const obj = result as GuardFailure;
+      expect(obj).toEqual(expect.objectContaining({ passed: false }));
+      expect(obj.expectedShape).toEqual({ explore: { scopeAssessment: '<assessment>' } });
+    });
+  });
+
+  describe('scopeAssessmentComplete_WithEmptyExplore_ReturnsFailure', () => {
+    it('should return { passed: false } when explore exists but scopeAssessment is missing', () => {
+      const state = { explore: {} } as Record<string, unknown>;
+
+      const result = guards.scopeAssessmentComplete.evaluate(state);
+
+      expect(result).not.toBe(true);
+      const obj = result as GuardFailure;
+      expect(obj).toEqual(expect.objectContaining({ passed: false }));
+    });
+  });
+
+  describe('scopeAssessmentComplete_WithNullExplore_ReturnsFailure', () => {
+    it('should return { passed: false } when explore is null', () => {
+      const state = { explore: null } as Record<string, unknown>;
+
+      const result = guards.scopeAssessmentComplete.evaluate(state);
+
+      expect(result).not.toBe(true);
+      const obj = result as GuardFailure;
+      expect(obj).toEqual(expect.objectContaining({ passed: false }));
+    });
+  });
+
+  describe('scopeAssessmentComplete_WithNullScopeAssessment_ReturnsFailure', () => {
+    it('should return { passed: false } when explore.scopeAssessment is null', () => {
+      const state = { explore: { scopeAssessment: null } } as Record<string, unknown>;
+
+      const result = guards.scopeAssessmentComplete.evaluate(state);
+
+      expect(result).not.toBe(true);
+      const obj = result as GuardFailure;
+      expect(obj).toEqual(expect.objectContaining({ passed: false }));
+    });
+  });
+});
+
 // ─── T6: Guard null safety edge cases (ARCH-6) ──────────────────────────────
 
 describe('Guard Null Safety', () => {

--- a/servers/exarchos-mcp/src/__tests__/workflow/state-store.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/state-store.test.ts
@@ -102,6 +102,55 @@ describe('State Store', () => {
     });
   });
 
+  // ─── #775: explore field initialization ──────────────────────────────────
+
+  describe('InitStateFile_RefactorWorkflow_IncludesExploreField', () => {
+    it('should include explore: {} in refactor workflow initial state', async () => {
+      const { state } = await initStateFile(tmpDir, 'refactor-explore', 'refactor');
+
+      const stateRecord = state as unknown as Record<string, unknown>;
+      expect(stateRecord.explore).toBeDefined();
+      expect(stateRecord.explore).toEqual({});
+    });
+
+    it('should include explore: {} in feature workflow initial state', async () => {
+      const { state } = await initStateFile(tmpDir, 'feature-explore', 'feature');
+
+      const stateRecord = state as unknown as Record<string, unknown>;
+      expect(stateRecord.explore).toBeDefined();
+      expect(stateRecord.explore).toEqual({});
+    });
+
+    it('should include explore: {} in debug workflow initial state', async () => {
+      const { state } = await initStateFile(tmpDir, 'debug-explore', 'debug');
+
+      const stateRecord = state as unknown as Record<string, unknown>;
+      expect(stateRecord.explore).toBeDefined();
+      expect(stateRecord.explore).toEqual({});
+    });
+  });
+
+  describe('HandleSet_ExploreScope_ThenTransitionToBrief_Succeeds', () => {
+    it('should allow setting explore.scopeAssessment on initialized refactor state', async () => {
+      const { stateFile, state } = await initStateFile(tmpDir, 'refactor-scope', 'refactor');
+
+      // Set explore.scopeAssessment via applyDotPath (simulating exarchos_workflow set)
+      const stateRecord = state as unknown as Record<string, unknown>;
+      applyDotPath(stateRecord, 'explore.scopeAssessment', 'Files assessed: 5 modules');
+
+      // Verify the value was set
+      const explore = stateRecord.explore as Record<string, unknown>;
+      expect(explore.scopeAssessment).toBe('Files assessed: 5 modules');
+
+      // Write back and re-read to verify persistence
+      await writeStateFile(stateFile, state);
+      const reloaded = await readStateFile(stateFile);
+      const reloadedRecord = reloaded as unknown as Record<string, unknown>;
+      const reloadedExplore = reloadedRecord.explore as Record<string, unknown>;
+      expect(reloadedExplore.scopeAssessment).toBe('Files assessed: 5 modules');
+    });
+  });
+
   describe('ReadStateFile_ValidJSON_ParsesAndValidates', () => {
     it('should read and validate a state file from disk', async () => {
       const { stateFile } = await initStateFile(tmpDir, 'read-test', 'feature');

--- a/servers/exarchos-mcp/src/workflow/state-store.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.ts
@@ -94,6 +94,7 @@ export async function initStateFile(
     tasks: [],
     worktrees: {},
     reviews: {},
+    explore: {},
     synthesis: {
       integrationBranch: null,
       mergeOrder: [],


### PR DESCRIPTION
Add explore: {} to initStateFile() rawState so the scope-assessment-complete
guard does not reject valid refactor workflow state. Add tests for guard
behavior with set, empty, null, and missing explore state, plus
initialization tests for all workflow types.