### PR TITLE
refactor: use typed TeamTaskAssignedData schema in CQRS view

### DIFF
--- a/servers/exarchos-mcp/src/views/delegation-timeline-view.test.ts
+++ b/servers/exarchos-mcp/src/views/delegation-timeline-view.test.ts
@@ -243,6 +243,38 @@ describe('DelegationTimelineView', () => {
       expect(state.bottleneck!.reason).toBe('longest_task');
     });
 
+    it('Apply_TeamTaskAssigned_InvalidSchema_ReturnsViewUnchanged', () => {
+      const state = delegationTimelineProjection.init();
+      // Missing worktreePath and modules — should fail schema validation
+      const event = makeEvent('team.task.assigned', {
+        taskId: 'task-1',
+        teammateName: 'worker-1',
+      }, 1);
+
+      const next = delegationTimelineProjection.apply(state, event);
+      // With safeParse, incomplete data should be rejected
+      expect(next.tasks).toHaveLength(0);
+      expect(next).toEqual(state);
+    });
+
+    it('Apply_TeamTaskAssigned_FullSchema_CreatesTask', () => {
+      const state = delegationTimelineProjection.init();
+      const ts = '2026-02-22T10:00:00.000Z';
+      const event = makeEvent('team.task.assigned', {
+        taskId: 'task-1',
+        teammateName: 'worker-1',
+        worktreePath: '/path/to/.worktrees/wt-1',
+        modules: ['src/foo.ts'],
+      }, 1, ts);
+
+      const next = delegationTimelineProjection.apply(state, event);
+      expect(next.tasks).toHaveLength(1);
+      expect(next.tasks[0].taskId).toBe('task-1');
+      expect(next.tasks[0].teammateName).toBe('worker-1');
+      expect(next.tasks[0].status).toBe('assigned');
+      expect(next.tasks[0].assignedAt).toBe(ts);
+    });
+
     it('Apply_TaskEviction_BottleneckEvicted_BottleneckResetToNull', () => {
       let state = delegationTimelineProjection.init();
 

--- a/servers/exarchos-mcp/src/views/delegation-timeline-view.ts
+++ b/servers/exarchos-mcp/src/views/delegation-timeline-view.ts
@@ -1,5 +1,5 @@
 import type { ViewProjection } from './materializer.js';
-import type { WorkflowEvent } from '../event-store/schemas.js';
+import { TeamTaskAssignedData, type WorkflowEvent } from '../event-store/schemas.js';
 
 // ─── View Name Constant ────────────────────────────────────────────────────
 
@@ -80,14 +80,10 @@ export const delegationTimelineProjection: ViewProjection<DelegationTimelineView
       }
 
       case 'team.task.assigned': {
-        const data = event.data as {
-          taskId?: string;
-          teammateName?: string;
-        } | undefined;
+        const parsed = TeamTaskAssignedData.safeParse(event.data);
+        if (!parsed.success) return view;
 
-        const taskId = data?.taskId;
-        const teammateName = data?.teammateName;
-        if (!taskId || !teammateName) return view;
+        const { taskId, teammateName } = parsed.data;
 
         const task: TimelineTask = {
           taskId,


### PR DESCRIPTION
Replace inline type assertion with TeamTaskAssignedData.safeParse() in the
delegation-timeline-view handler. This enforces the full Zod schema at
runtime, rejecting incomplete payloads that the previous `as` cast would
have silently accepted.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>