### PR TITLE
ci: downgrade setup-node@v6 and github-script@v8 for self-hosted runners

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -12,10 +12,7 @@ jobs:
   update-prs:
     runs-on: self-hosted
     steps:
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@v7
         with:
           script: |
             const pulls = await github.rest.pulls.list({

--- a/.github/workflows/benchmark-gate.yml
+++ b/.github/workflows/benchmark-gate.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: npm
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: npm

--- a/.github/workflows/coderabbit-review-gate.yml
+++ b/.github/workflows/coderabbit-review-gate.yml
@@ -17,6 +17,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install gh CLI
+        run: |
+          if ! command -v gh &> /dev/null; then
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt-get update && sudo apt-get install -y gh
+          fi
+
       - name: Run review gate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/eval-gate.yml
+++ b/.github/workflows/eval-gate.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm install js-yaml
 
       - name: Sync labels
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
@@ -113,7 +113,7 @@ jobs:
       issues: write
     steps:
       - name: Auto-label based on title/body
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const issue = context.payload.issue;
@@ -191,7 +191,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Initialize project fields
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
@@ -371,7 +371,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Update project status
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary

Fixes CI failures on self-hosted runners caused by GitHub Actions using `node24` runtime which runner v2.322 doesn't support. Also installs `gh` CLI in the review gate workflow for runners that lack it.

## Changes

- **ci.yml** — `actions/setup-node@v6` → `@v4` (2 instances)
- **eval-gate.yml** — `actions/setup-node@v6` → `@v4`
- **benchmark-gate.yml** — `actions/setup-node@v6` → `@v4`
- **auto-update-prs.yml** — Removed unnecessary `setup-node` step, downgraded `github-script@v8` → `@v7`
- **project-automation.yml** — `actions/github-script@v8` → `@v7` (4 instances)
- **coderabbit-review-gate.yml** — Added `gh` CLI installation step for self-hosted runners

## Test Plan

- [x] CI workflows will self-validate on this PR
- [x] All affected workflows use `node20`-compatible action runtimes