### PR TITLE
feat: add event store and hydration benchmarks

### DIFF
--- a/servers/exarchos-mcp/src/telemetry/benchmarks/baselines.json
+++ b/servers/exarchos-mcp/src/telemetry/benchmarks/baselines.json
@@ -1,11 +1,20 @@
 {
   "version": "1.0.0",
-  "generated": "2026-02-15",
+  "generated": "2026-02-23",
   "baselines": {
     "telemetry_view_compact_5_tools_max_tokens": 400,
     "telemetry_view_single_tool_max_tokens": 150,
     "perf_field_overhead_max_tokens": 15,
     "telemetry_wrapper_overhead_max_ms": 10,
-    "telemetry_view_100_events_max_ms": 100
+    "telemetry_view_100_events_max_ms": 100,
+    "event_store_single_append_max_ms": 50,
+    "event_store_batch_50_max_ms": 200,
+    "event_store_concurrent_10_max_ms": 500,
+    "event_store_query_100_no_filter_max_ms": 100,
+    "event_store_query_100_type_filter_max_ms": 100,
+    "event_store_init_sequence_100_max_ms": 100,
+    "hydration_single_100_max_ms": 500,
+    "hydration_delta_50_max_ms": 300,
+    "hydration_multi_10x20_max_ms": 1000
   }
 }

--- a/servers/exarchos-mcp/src/telemetry/benchmarks/event-store.test.ts
+++ b/servers/exarchos-mcp/src/telemetry/benchmarks/event-store.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import { writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { EventStore } from '../../event-store/store.js';
+import { generateWorkflowEvents } from './cold-start.js';
+
+const RUN_BENCHMARKS = process.env.RUN_BENCHMARKS === 'true';
+
+// ─── Benchmark Suite ──────────────────────────────────────────────────────
+
+describe('Event Store Benchmarks', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'event-store-bench-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // ─── 1. Single Event Append ───────────────────────────────────────────────
+
+  it.skipIf(!RUN_BENCHMARKS)(
+    'append_SingleEvent_CompletesWithinThreshold',
+    async () => {
+      // Arrange
+      const store = new EventStore(tmpDir);
+      await store.initialize();
+
+      // Act
+      const start = performance.now();
+      await store.append('bench-single', { type: 'workflow.started', data: { featureId: 'bench-single', workflowType: 'feature' } });
+      const elapsed = performance.now() - start;
+
+      // Assert
+      console.log(`[event-store] single-append: ${elapsed.toFixed(3)}ms`);
+      expect(elapsed).toBeLessThan(50);
+    },
+  );
+
+  // ─── 2. Batch Append (50 Events) ─────────────────────────────────────────
+
+  it.skipIf(!RUN_BENCHMARKS)(
+    'batchAppend_50Events_CompletesWithinThreshold',
+    async () => {
+      // Arrange
+      const store = new EventStore(tmpDir);
+      await store.initialize();
+
+      const events = Array.from({ length: 50 }, (_, i) => ({
+        type: 'task.assigned' as const,
+        data: { taskId: `task-${i}`, title: `Task ${i}`, branch: `feat/bench-${i}` },
+      }));
+
+      // Act
+      const start = performance.now();
+      await store.batchAppend('bench-batch', events);
+      const elapsed = performance.now() - start;
+
+      // Assert
+      console.log(`[event-store] batch-append 50 events: ${elapsed.toFixed(3)}ms`);
+      expect(elapsed).toBeLessThan(200);
+    },
+  );
+
+  // ─── 3. Concurrent Append (10 Parallel Streams) ──────────────────────────
+
+  it.skipIf(!RUN_BENCHMARKS)(
+    'append_Concurrent10Streams_CompletesWithinThreshold',
+    async () => {
+      // Arrange
+      const store = new EventStore(tmpDir);
+      await store.initialize();
+
+      // Act — 10 parallel appends to 10 different streams
+      const start = performance.now();
+      await Promise.all(
+        Array.from({ length: 10 }, (_, i) =>
+          store.append(`bench-concurrent-${i}`, {
+            type: 'workflow.started',
+            data: { featureId: `bench-concurrent-${i}`, workflowType: 'feature' },
+          }),
+        ),
+      );
+      const elapsed = performance.now() - start;
+
+      // Assert
+      console.log(`[event-store] concurrent 10 streams: ${elapsed.toFixed(3)}ms`);
+      expect(elapsed).toBeLessThan(500);
+    },
+  );
+
+  // ─── 4. Query 100 Events (No Filter) ─────────────────────────────────────
+
+  it.skipIf(!RUN_BENCHMARKS)(
+    'query_100EventsNoFilter_CompletesWithinThreshold',
+    async () => {
+      // Arrange
+      const store = new EventStore(tmpDir);
+      await store.initialize();
+
+      // Seed 100 events
+      const streamId = 'bench-query-no-filter';
+      const batchEvents = Array.from({ length: 100 }, (_, i) => ({
+        type: (i === 0 ? 'workflow.started' : 'task.assigned') as 'workflow.started' | 'task.assigned',
+        data: i === 0
+          ? { featureId: streamId, workflowType: 'feature' }
+          : { taskId: `task-${i}`, title: `Task ${i}`, branch: `feat/bench-${i}` },
+      }));
+      await store.batchAppend(streamId, batchEvents);
+
+      // Act
+      const start = performance.now();
+      const events = await store.query(streamId);
+      const elapsed = performance.now() - start;
+
+      // Assert
+      expect(events).toHaveLength(100);
+      console.log(`[event-store] query 100 events (no filter): ${elapsed.toFixed(3)}ms`);
+      expect(elapsed).toBeLessThan(100);
+    },
+  );
+
+  // ─── 5. Query 100 Events (Type Filter) ───────────────────────────────────
+
+  it.skipIf(!RUN_BENCHMARKS)(
+    'query_100EventsTypeFilter_CompletesWithinThreshold',
+    async () => {
+      // Arrange
+      const store = new EventStore(tmpDir);
+      await store.initialize();
+
+      // Seed 100 events with mixed types
+      const streamId = 'bench-query-type-filter';
+      const batchEvents = Array.from({ length: 100 }, (_, i) => ({
+        type: (i === 0 ? 'workflow.started' : i % 2 === 0 ? 'task.assigned' : 'task.completed') as 'workflow.started' | 'task.assigned' | 'task.completed',
+        data: i === 0
+          ? { featureId: streamId, workflowType: 'feature' }
+          : i % 2 === 0
+            ? { taskId: `task-${i}`, title: `Task ${i}`, branch: `feat/bench-${i}` }
+            : { taskId: `task-${i}`, artifacts: ['file.ts'], duration: 5000 },
+      }));
+      await store.batchAppend(streamId, batchEvents);
+
+      // Act
+      const start = performance.now();
+      const events = await store.query(streamId, { type: 'task.assigned' });
+      const elapsed = performance.now() - start;
+
+      // Assert
+      expect(events.length).toBeGreaterThan(0);
+      console.log(`[event-store] query 100 events (type filter): ${elapsed.toFixed(3)}ms`);
+      expect(elapsed).toBeLessThan(100);
+    },
+  );
+
+  // ─── 6. Initialize Sequence (from JSONL, 100 Events, No .seq Cache) ─────
+
+  it.skipIf(!RUN_BENCHMARKS)(
+    'initSequence_100EventsNoSeqCache_CompletesWithinThreshold',
+    async () => {
+      // Arrange — write JSONL file directly (bypassing EventStore to avoid .seq cache)
+      const streamId = 'bench-init-seq';
+      const events = generateWorkflowEvents(streamId, 100);
+      const filePath = path.join(tmpDir, `${streamId}.events.jsonl`);
+      const content = events.map(e => JSON.stringify(e)).join('\n') + '\n';
+      writeFileSync(filePath, content, 'utf-8');
+
+      // Ensure no .seq file exists
+      const seqPath = path.join(tmpDir, `${streamId}.seq`);
+      try {
+        await fs.unlink(seqPath);
+      } catch {
+        // Expected: no .seq file to delete
+      }
+
+      // Act — create fresh store and append (which triggers initializeSequence)
+      const start = performance.now();
+      const store = new EventStore(tmpDir);
+      await store.initialize();
+      await store.append(streamId, { type: 'task.completed', data: { taskId: 'task-final', artifacts: [], duration: 100 } });
+      const elapsed = performance.now() - start;
+
+      // Assert — the append succeeded, meaning sequence was initialized correctly
+      const allEvents = await store.query(streamId);
+      expect(allEvents).toHaveLength(101);
+      console.log(`[event-store] init-sequence from JSONL (100 events): ${elapsed.toFixed(3)}ms`);
+      expect(elapsed).toBeLessThan(100);
+    },
+  );
+});

--- a/servers/exarchos-mcp/src/telemetry/benchmarks/hydration.test.ts
+++ b/servers/exarchos-mcp/src/telemetry/benchmarks/hydration.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import { writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { hydrateStream, hydrateAll } from '../../storage/hydration.js';
+import { SqliteBackend } from '../../storage/sqlite-backend.js';
+import { generateWorkflowEvents } from './cold-start.js';
+
+const RUN_BENCHMARKS = process.env.RUN_BENCHMARKS === 'true';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function writeJsonlFile(dir: string, streamId: string, events: unknown[]): void {
+  const filePath = path.join(dir, `${streamId}.events.jsonl`);
+  const content = events.map(e => JSON.stringify(e)).join('\n') + '\n';
+  writeFileSync(filePath, content, 'utf-8');
+}
+
+// ─── Benchmark Suite ────────────────────────────────────────────────────────
+
+describe('Hydration Benchmarks', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'hydration-bench-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // ─── 1. Single Stream Hydration (100 Events) ─────────────────────────────
+
+  it.skipIf(!RUN_BENCHMARKS)(
+    'hydrateStream_100Events_CompletesWithinThreshold',
+    async () => {
+      // Arrange
+      const streamId = 'bench-hydrate';
+      const events = generateWorkflowEvents(streamId, 100);
+      writeJsonlFile(tmpDir, streamId, events);
+
+      const backend = new SqliteBackend(':memory:');
+      backend.initialize();
+
+      // Act
+      const start = performance.now();
+      await hydrateStream(backend, tmpDir, streamId);
+      const elapsed = performance.now() - start;
+
+      // Assert — all events were hydrated
+      const hydrated = backend.queryEvents(streamId);
+      expect(hydrated).toHaveLength(100);
+
+      console.log(`[hydration] single-stream 100 events: ${elapsed.toFixed(3)}ms`);
+      expect(elapsed).toBeLessThan(500);
+
+      backend.close();
+    },
+  );
+
+  // ─── 2. Delta Hydration (100 Events, 50 Already in DB) ───────────────────
+
+  it.skipIf(!RUN_BENCHMARKS)(
+    'hydrateStream_DeltaHydration50New_CompletesWithinThreshold',
+    async () => {
+      // Arrange — pre-populate backend with first 50 events
+      const streamId = 'bench-delta';
+      const allEvents = generateWorkflowEvents(streamId, 100);
+      writeJsonlFile(tmpDir, streamId, allEvents);
+
+      const backend = new SqliteBackend(':memory:');
+      backend.initialize();
+
+      // Insert first 50 events directly into backend
+      for (const event of allEvents.slice(0, 50)) {
+        backend.appendEvent(streamId, event);
+      }
+
+      // Verify pre-population
+      const prePop = backend.queryEvents(streamId);
+      expect(prePop).toHaveLength(50);
+
+      // Act — hydrate should only process events 51-100
+      const start = performance.now();
+      await hydrateStream(backend, tmpDir, streamId);
+      const elapsed = performance.now() - start;
+
+      // Assert — all 100 events now in backend
+      const hydrated = backend.queryEvents(streamId);
+      expect(hydrated).toHaveLength(100);
+
+      console.log(`[hydration] delta 50 new events: ${elapsed.toFixed(3)}ms`);
+      expect(elapsed).toBeLessThan(300);
+
+      backend.close();
+    },
+  );
+
+  // ─── 3. Multi-Stream Hydration (10 Streams x 20 Events) ──────────────────
+
+  it.skipIf(!RUN_BENCHMARKS)(
+    'hydrateAll_10Streams20Events_CompletesWithinThreshold',
+    async () => {
+      // Arrange — write 10 JSONL files, each with 20 events
+      for (let i = 0; i < 10; i++) {
+        const streamId = `bench-multi-${i}`;
+        const events = generateWorkflowEvents(streamId, 20);
+        writeJsonlFile(tmpDir, streamId, events);
+      }
+
+      const backend = new SqliteBackend(':memory:');
+      backend.initialize();
+
+      // Act
+      const start = performance.now();
+      await hydrateAll(backend, tmpDir);
+      const elapsed = performance.now() - start;
+
+      // Assert — all 10 streams hydrated with 20 events each
+      const streams = backend.listStreams();
+      expect(streams).toHaveLength(10);
+      for (const streamId of streams) {
+        const events = backend.queryEvents(streamId);
+        expect(events).toHaveLength(20);
+      }
+
+      console.log(`[hydration] multi-stream 10x20 events: ${elapsed.toFixed(3)}ms`);
+      expect(elapsed).toBeLessThan(1000);
+
+      backend.close();
+    },
+  );
+});


### PR DESCRIPTION
Add benchmark suites for EventStore operations (single/batch/concurrent append,
query with/without filters, sequence initialization) and hydration operations
(single-stream, delta, multi-stream). Update baselines.json with 9 new entries.