### PR TITLE
feat: enable always-on benchmark regression gate

### DIFF
--- a/.github/workflows/benchmark-gate.yml
+++ b/.github/workflows/benchmark-gate.yml
@@ -2,7 +2,7 @@ name: Benchmark Regression Gate
 
 on:
   pull_request:
-    types: [labeled, synchronize, opened, reopened]
+    types: [synchronize, opened, reopened]
 
 jobs:
   benchmark:
@@ -11,8 +11,6 @@ jobs:
     concurrency:
       group: benchmark-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    if: contains(github.event.pull_request.labels.*.name, 'has-benchmarks')
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,6 +27,8 @@ jobs:
       - name: Run benchmarks
         run: npm run bench -- --outputJson benchmark-results.json
         working-directory: servers/exarchos-mcp
+        env:
+          RUN_BENCHMARKS: 'true'
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Remove label-gated condition from benchmark-gate.yml so benchmarks run on
every PR. Add RUN_BENCHMARKS env var to the run step and drop the now-unused
'labeled' trigger type.