### PR TITLE
refactor: harden event store idempotency and sequence invariants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,7 @@ jobs:
             exit 1
           fi
           if [[ "${{ needs.test-mcp.result }}" =~ ^(failure|cancelled)$ ]]; then
-            echo "::error::MCP server tests: ${{ needs.test-mcp.result }}"
-            exit 1
+            echo "::warning::MCP server tests: ${{ needs.test-mcp.result }} (non-blocking — server not live yet)"
           fi
 
           echo "All checks passed (skipped jobs are OK)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,8 @@ jobs:
             exit 1
           fi
           if [[ "${{ needs.test-mcp.result }}" =~ ^(failure|cancelled)$ ]]; then
-            echo "::warning::MCP server tests: ${{ needs.test-mcp.result }} (non-blocking — server not live yet)"
+            echo "::error::MCP server tests: ${{ needs.test-mcp.result }}"
+            exit 1
           fi
 
           echo "All checks passed (skipped jobs are OK)"

--- a/servers/exarchos-mcp/src/event-store/store.test.ts
+++ b/servers/exarchos-mcp/src/event-store/store.test.ts
@@ -887,7 +887,7 @@ describe('EventStore Query Sequence Pre-filter', () => {
     expect(events.every(e => e.type === 'task.completed')).toBe(true);
     expect(events.every(e => e.sequence > 1000)).toBe(true);
     expect(events).toHaveLength(16);
-  });
+  }, 30_000);
 
   it('Query_SequenceRegex_MalformedLine_FallsBackToFullParse', async () => {
     // Arrange: write a JSONL file where the second line has "sequence":"NaN" (a string value).
@@ -1181,6 +1181,78 @@ describe('EventStore Sequence Invariant', () => {
   });
 });
 
+// ─── Sequence Invariant Under Compaction ──────────────────────────────────────
+
+describe('EventStore Sequence Invariant Under Compaction', () => {
+  it('initializeSequence_CompactedFile_ThrowsSequenceInvariantError', async () => {
+    // Arrange: create a JSONL file simulating compaction where middle events
+    // were removed. 3 lines but last event has sequence 5 (gap).
+    const filePath = path.join(tempDir, 'compacted.events.jsonl');
+    const events = [
+      { streamId: 'compacted', sequence: 1, type: 'workflow.started', timestamp: '2025-01-01T00:00:00.000Z', schemaVersion: '1.0' },
+      { streamId: 'compacted', sequence: 3, type: 'task.assigned', timestamp: '2025-01-01T00:00:01.000Z', schemaVersion: '1.0' },
+      { streamId: 'compacted', sequence: 5, type: 'workflow.transition', timestamp: '2025-01-01T00:00:02.000Z', schemaVersion: '1.0' },
+    ];
+    await fs.writeFile(filePath, events.map(e => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+
+    // Delete .seq file to force fallback to JSONL line counting with invariant check
+    const seqPath = path.join(tempDir, 'compacted.seq');
+    await fs.rm(seqPath, { force: true });
+
+    const store = new EventStore(tempDir);
+
+    // Act & Assert: should throw because last event (seq 5) != line count (3)
+    await expect(
+      store.append('compacted', { type: 'task.claimed' }),
+    ).rejects.toThrow(/sequence invariant/i);
+  });
+
+  it('initializeSequence_ValidFile_SetsCorrectSequence', async () => {
+    // Arrange: create a valid JSONL file where seq matches line number
+    const filePath = path.join(tempDir, 'valid-compact.events.jsonl');
+    const events = [
+      { streamId: 'valid-compact', sequence: 1, type: 'workflow.started', timestamp: '2025-01-01T00:00:00.000Z', schemaVersion: '1.0' },
+      { streamId: 'valid-compact', sequence: 2, type: 'task.assigned', timestamp: '2025-01-01T00:00:01.000Z', schemaVersion: '1.0' },
+      { streamId: 'valid-compact', sequence: 3, type: 'workflow.transition', timestamp: '2025-01-01T00:00:02.000Z', schemaVersion: '1.0' },
+    ];
+    await fs.writeFile(filePath, events.map(e => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+
+    // Delete .seq file to force fallback
+    const seqPath = path.join(tempDir, 'valid-compact.seq');
+    await fs.rm(seqPath, { force: true });
+
+    const store = new EventStore(tempDir);
+
+    // Act: should succeed — sequence counter set to 3
+    const event = await store.append('valid-compact', { type: 'task.claimed' });
+
+    // Assert: next event should be sequence 4
+    expect(event.sequence).toBe(4);
+  });
+
+  it('initializeSequence_FirstEventNotOne_ThrowsSequenceInvariantError', async () => {
+    // Arrange: create a JSONL file where first event starts at sequence 2
+    const filePath = path.join(tempDir, 'offset-seq.events.jsonl');
+    const events = [
+      { streamId: 'offset-seq', sequence: 2, type: 'workflow.started', timestamp: '2025-01-01T00:00:00.000Z', schemaVersion: '1.0' },
+      { streamId: 'offset-seq', sequence: 3, type: 'task.assigned', timestamp: '2025-01-01T00:00:01.000Z', schemaVersion: '1.0' },
+      { streamId: 'offset-seq', sequence: 4, type: 'workflow.transition', timestamp: '2025-01-01T00:00:02.000Z', schemaVersion: '1.0' },
+    ];
+    await fs.writeFile(filePath, events.map(e => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+
+    // Delete .seq file to force fallback
+    const seqPath = path.join(tempDir, 'offset-seq.seq');
+    await fs.rm(seqPath, { force: true });
+
+    const store = new EventStore(tempDir);
+
+    // Act & Assert: should throw because first event seq is 2, expected 1
+    await expect(
+      store.append('offset-seq', { type: 'task.claimed' }),
+    ).rejects.toThrow(/sequence invariant/i);
+  });
+});
+
 // ─── T31-T32: Configurable Idempotency Cache ────────────────────────────────
 
 describe('EventStore Configurable Idempotency Cache', () => {
@@ -1366,6 +1438,106 @@ describe('EventStore Query with Event Migration', () => {
     expect(events[0].type).toBe('task.assigned');
     // Event should pass through migrateEvent identity path
     expect(events[0].streamId).toBe('migration-transform');
+  });
+});
+
+// ─── Idempotency Cache Rebuild Race Condition ────────────────────────────────
+
+describe('EventStore Idempotency Cache Race Condition', () => {
+  it('rebuildIdempotencyCache_ConcurrentAccess_DoesNotReturnStaleCache', async () => {
+    // Arrange: write events with idempotency keys via store1
+    const store1 = new EventStore(tempDir);
+    await store1.append(
+      'my-workflow',
+      { type: 'task.assigned' },
+      { idempotencyKey: 'key-a' },
+    );
+    await store1.append(
+      'my-workflow',
+      { type: 'task.claimed' },
+      { idempotencyKey: 'key-b' },
+    );
+
+    // Create a new store instance (simulating restart) — cache is empty
+    const store2 = new EventStore(tempDir);
+
+    // Act: fire two appends with the same idempotency key via Promise.all.
+    // withLock serializes them per-stream: the first acquires the lock, rebuilds
+    // the cache, deduplicates, and releases; the second then acquires the lock,
+    // finds the cache already initialized, and also deduplicates.
+    // This confirms end-to-end deduplication correctness under concurrent callers.
+    const [resultA, resultB] = await Promise.all([
+      store2.append('my-workflow', { type: 'task.assigned' }, { idempotencyKey: 'key-a' }),
+      store2.append('my-workflow', { type: 'task.assigned' }, { idempotencyKey: 'key-a' }),
+    ]);
+
+    // Assert: both should return the SAME event (deduplication)
+    // The original event was sequence 1 with key-a
+    expect(resultA.sequence).toBe(1);
+    expect(resultB.sequence).toBe(1);
+
+    // No duplicates should have been appended
+    const events = await store2.query('my-workflow');
+    expect(events).toHaveLength(2); // only the original 2 events
+  });
+
+  it('rebuildIdempotencyCache_PartialFailure_DoesNotPermanentlyMarkInitialized', async () => {
+    // Arrange: write events with idempotency keys via store1
+    const store1 = new EventStore(tempDir);
+    await store1.append(
+      'my-workflow',
+      { type: 'task.assigned' },
+      { idempotencyKey: 'key-a' },
+    );
+    await store1.append(
+      'my-workflow',
+      { type: 'task.claimed' },
+      { idempotencyKey: 'key-b' },
+    );
+
+    // Create a new store (simulating restart)
+    const store2 = new EventStore(tempDir);
+
+    // Corrupt the JSONL file AFTER the first valid line — force a JSON.parse error
+    // during rebuild. With the bug, the stream gets marked as "initialized" BEFORE
+    // the file is read, so even after the error, subsequent calls skip the rebuild
+    // and use an empty/stale cache.
+    const filePath = path.join(tempDir, 'my-workflow.events.jsonl');
+    const original = await fs.readFile(filePath, 'utf-8');
+    const lines = original.trim().split('\n');
+    // Replace second line with an idempotencyKey-containing but invalid JSON
+    const corrupted = lines[0] + '\n' + '{"idempotencyKey":"key-b", INVALID_JSON}\n';
+    await fs.writeFile(filePath, corrupted, 'utf-8');
+
+    // First attempt: append with idempotency key — triggers rebuildIdempotencyCache
+    // The rebuild will encounter a JSON parse error on the corrupted line.
+    // With the bug, the stream is marked "initialized" before reading, so the error
+    // means the cache stays empty but the flag says it's done.
+    try {
+      await store2.append(
+        'my-workflow',
+        { type: 'task.assigned' },
+        { idempotencyKey: 'key-a' },
+      );
+    } catch {
+      // Expected: the corrupt JSON may cause an error
+    }
+
+    // Fix the file — restore the original valid content
+    await fs.writeFile(filePath, original, 'utf-8');
+
+    // Second attempt: with the bug, the cache is marked "initialized" but empty,
+    // so key-a won't be found and a DUPLICATE event gets appended.
+    // After the fix (marking initialized AFTER populating), the cache won't be
+    // marked initialized if the first attempt failed, so rebuild will be retried.
+    const result = await store2.append(
+      'my-workflow',
+      { type: 'task.assigned' },
+      { idempotencyKey: 'key-a' },
+    );
+
+    // Assert: should deduplicate to original event (sequence 1), NOT create a new event
+    expect(result.sequence).toBe(1);
   });
 });
 

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -514,13 +514,14 @@ export class EventStore {
 
   private async rebuildIdempotencyCache(streamId: string): Promise<void> {
     if (this.idempotencyCacheInitialized.has(streamId)) return;
-    this.idempotencyCacheInitialized.add(streamId);
+    // Do NOT mark as initialized yet — wait until cache is fully populated
 
     const filePath = this.getEventFilePath(streamId);
     try {
       await fs.access(filePath);
     } catch {
-      return; // No events file yet
+      this.idempotencyCacheInitialized.add(streamId); // Mark even if no file
+      return;
     }
 
     const input = createReadStream(filePath, { encoding: 'utf-8' });
@@ -549,6 +550,8 @@ export class EventStore {
       }
       this.idempotencyCache.set(streamId, streamCache);
     }
+
+    this.idempotencyCacheInitialized.add(streamId); // Mark AFTER fully populated
   }
 
   private async initializeSequence(streamId: string): Promise<void> {

--- a/servers/exarchos-mcp/src/quality/quality-correlation.ts
+++ b/servers/exarchos-mcp/src/quality/quality-correlation.ts
@@ -33,8 +33,8 @@ export function correlateQualityAndEvals(
 
   for (const skillName of Object.keys(codeQuality.skills)) {
     const qualityMetrics = codeQuality.skills[skillName];
+    if (!Object.hasOwn(evalResults.skills, skillName)) continue;
     const evalMetrics = evalResults.skills[skillName];
-    if (!evalMetrics) continue; // only include skills present in BOTH views
 
     skills[skillName] = {
       skill: skillName,


### PR DESCRIPTION
Fix race condition in idempotency cache rebuild (mark initialized AFTER
population, not before). Add sequence invariant validation tests for
compacted files, valid sequences, and first-event-not-one scenarios.