### PR TITLE
refactor: add HSM transitions for escalation, revision limits, and hotfix

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
@@ -2403,3 +2403,178 @@ describe('universal cleanup transition', () => {
     expect(result.idempotent).toBe(true);
   });
 });
+
+// ─── Task 3: Debug Escalation HSM Transition ────────────────────────────────
+
+describe('Debug HSM Escalation Transition', () => {
+  it('debugHSM_InvestigateToCancel_EscalationTransitionExists', () => {
+    const hsm = getHSMDefinition('debug');
+    const transition = hsm.transitions.find(
+      (t) => t.from === 'investigate' && t.to === 'cancelled',
+    );
+    expect(transition).toBeDefined();
+    expect(transition!.guard).toBeDefined();
+    expect(transition!.guard!.id).toBe('escalation-required');
+  });
+
+  it('debugHSM_InvestigateToCancelled_SucceedsWhenEscalationRequired', () => {
+    const hsm = getHSMDefinition('debug');
+    const state: Record<string, unknown> = {
+      phase: 'investigate',
+      investigation: { escalate: true, rootCause: 'architectural issue' },
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'cancelled');
+
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('cancelled');
+  });
+
+  it('debugHSM_InvestigateToCancelled_FailsWhenNoEscalation', () => {
+    const hsm = getHSMDefinition('debug');
+    const state: Record<string, unknown> = {
+      phase: 'investigate',
+      investigation: { rootCause: 'simple bug' },
+      _events: [],
+      _history: {},
+    };
+
+    // Note: cancel is a universal transition, so investigate → cancelled
+    // via the escalation guard will fail, but universal cancel will succeed.
+    // The guard-gated transition is distinct from universal cancel.
+    // Let's verify the guard-gated transition is in the definition.
+    const transition = hsm.transitions.find(
+      (t) => t.from === 'investigate' && t.to === 'cancelled',
+    );
+    expect(transition).toBeDefined();
+    expect(transition!.guard).toBeDefined();
+
+    // Verify the guard fails for non-escalation state
+    const guardResult = transition!.guard!.evaluate(state);
+    expect(guardResult).not.toBe(true);
+  });
+});
+
+// ─── Task 4: Plan Revision Termination HSM Transition ───────────────────────
+
+describe('Feature HSM Plan Revision Termination', () => {
+  it('featureHSM_PlanReviewToBlocked_RevisionsExhaustedTransitionExists', () => {
+    const hsm = getHSMDefinition('feature');
+    const transition = hsm.transitions.find(
+      (t) => t.from === 'plan-review' && t.to === 'blocked',
+    );
+    expect(transition).toBeDefined();
+    expect(transition!.guard).toBeDefined();
+    expect(transition!.guard!.id).toBe('revisions-exhausted');
+  });
+
+  it('featureHSM_PlanReviewToBlocked_SucceedsWhenRevisionsExhausted', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'plan-review',
+      planReview: { revisionCount: 3 },
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'blocked');
+
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('blocked');
+  });
+
+  it('featureHSM_PlanReviewToBlocked_FailsWhenRevisionsBelowMax', () => {
+    const hsm = getHSMDefinition('feature');
+    const state: Record<string, unknown> = {
+      phase: 'plan-review',
+      planReview: { revisionCount: 1 },
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'blocked');
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('GUARD_FAILED');
+  });
+});
+
+// ─── Task 8: Hotfix-Validate to Synthesize HSM Transition ───────────────────
+
+describe('Debug HSM Hotfix-Validate to Synthesize', () => {
+  it('debugHSM_HotfixValidateToSynthesize_TransitionExists', () => {
+    const hsm = getHSMDefinition('debug');
+    const transition = hsm.transitions.find(
+      (t) => t.from === 'hotfix-validate' && t.to === 'synthesize',
+    );
+    expect(transition).toBeDefined();
+    expect(transition!.guard).toBeDefined();
+    expect(transition!.guard!.id).toBe('validation+pr-requested');
+  });
+
+  it('debugHSM_HotfixValidateToSynthesize_SucceedsWhenValidAndPrRequested', () => {
+    const hsm = getHSMDefinition('debug');
+    const state: Record<string, unknown> = {
+      phase: 'hotfix-validate',
+      validation: { testsPass: true },
+      synthesis: { requested: true },
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'synthesize');
+
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('synthesize');
+  });
+
+  it('debugHSM_HotfixValidateToSynthesize_FailsWhenNoPrRequested', () => {
+    const hsm = getHSMDefinition('debug');
+    const state: Record<string, unknown> = {
+      phase: 'hotfix-validate',
+      validation: { testsPass: true },
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'synthesize');
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('GUARD_FAILED');
+  });
+
+  it('debugHSM_HotfixValidateToCompleted_StillWorksWithoutPr', () => {
+    const hsm = getHSMDefinition('debug');
+    const state: Record<string, unknown> = {
+      phase: 'hotfix-validate',
+      validation: { testsPass: true },
+      _events: [],
+      _history: {},
+    };
+
+    const result = executeTransition(hsm, state, 'completed');
+
+    expect(result.success).toBe(true);
+    expect(result.newPhase).toBe('completed');
+  });
+
+  it('debugHSM_HotfixValidateToSynthesize_BeforeCompletedInTransitionOrder', () => {
+    const hsm = getHSMDefinition('debug');
+    const transitions = hsm.transitions;
+
+    // Find indices of both transitions from hotfix-validate
+    const synthIdx = transitions.findIndex(
+      (t) => t.from === 'hotfix-validate' && t.to === 'synthesize',
+    );
+    const completedIdx = transitions.findIndex(
+      (t) => t.from === 'hotfix-validate' && t.to === 'completed',
+    );
+
+    // synthesize transition must come before completed transition
+    expect(synthIdx).toBeGreaterThanOrEqual(0);
+    expect(completedIdx).toBeGreaterThanOrEqual(0);
+    expect(synthIdx).toBeLessThan(completedIdx);
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.test.ts
@@ -122,3 +122,166 @@ describe('teamDisbandedEmitted', () => {
     expect(failure.reason).toContain('team-disbanded-emitted');
   });
 });
+
+// ─── Task 3: escalationRequired Guard Tests ─────────────────────────────────
+
+describe('escalationRequired', () => {
+  it('escalationRequired_EscalateTrue_ReturnsTrue', () => {
+    const state: Record<string, unknown> = {
+      investigation: { escalate: true, rootCause: 'architectural issue' },
+    };
+
+    const result = guards.escalationRequired.evaluate(state);
+
+    expect(result).toBe(true);
+  });
+
+  it('escalationRequired_EscalateMissing_ReturnsFailure', () => {
+    const state: Record<string, unknown> = {
+      investigation: { rootCause: 'simple bug' },
+    };
+
+    const result = guards.escalationRequired.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('escalation-required');
+    expect(failure.expectedShape).toEqual({ investigation: { escalate: true } });
+  });
+
+  it('escalationRequired_NoInvestigation_ReturnsFailure', () => {
+    const state: Record<string, unknown> = {};
+
+    const result = guards.escalationRequired.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('escalation-required');
+  });
+
+  it('escalationRequired_EscalateFalse_ReturnsFailure', () => {
+    const state: Record<string, unknown> = {
+      investigation: { escalate: false },
+    };
+
+    const result = guards.escalationRequired.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+  });
+});
+
+// ─── Task 4: revisionsExhausted Guard Tests ─────────────────────────────────
+
+describe('revisionsExhausted', () => {
+  it('revisionsExhausted_CountAtMax_ReturnsTrue', () => {
+    const state: Record<string, unknown> = {
+      planReview: { revisionCount: 3 },
+    };
+
+    const result = guards.revisionsExhausted.evaluate(state);
+
+    expect(result).toBe(true);
+  });
+
+  it('revisionsExhausted_CountAboveMax_ReturnsTrue', () => {
+    const state: Record<string, unknown> = {
+      planReview: { revisionCount: 5 },
+    };
+
+    const result = guards.revisionsExhausted.evaluate(state);
+
+    expect(result).toBe(true);
+  });
+
+  it('revisionsExhausted_CountBelowMax_ReturnsFailure', () => {
+    const state: Record<string, unknown> = {
+      planReview: { revisionCount: 1 },
+    };
+
+    const result = guards.revisionsExhausted.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('revisions-exhausted');
+    expect(failure.reason).toContain('1/3');
+  });
+
+  it('revisionsExhausted_NoRevisionCount_ReturnsFailure', () => {
+    const state: Record<string, unknown> = {};
+
+    const result = guards.revisionsExhausted.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('revisions-exhausted');
+    expect(failure.reason).toContain('0/3');
+  });
+
+  it('revisionsExhausted_ZeroRevisions_ReturnsFailure', () => {
+    const state: Record<string, unknown> = {
+      planReview: { revisionCount: 0 },
+    };
+
+    const result = guards.revisionsExhausted.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+  });
+});
+
+// ─── Task 8: prRequested Guard Tests ────────────────────────────────────────
+
+describe('prRequested', () => {
+  it('prRequested_SynthesisRequestedTrue_ReturnsTrue', () => {
+    const state: Record<string, unknown> = {
+      synthesis: { requested: true },
+    };
+
+    const result = guards.prRequested.evaluate(state);
+
+    expect(result).toBe(true);
+  });
+
+  it('prRequested_SynthesisMissing_ReturnsFailure', () => {
+    const state: Record<string, unknown> = {};
+
+    const result = guards.prRequested.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('pr-requested');
+    expect(failure.expectedShape).toEqual({ synthesis: { requested: true } });
+  });
+
+  it('prRequested_SynthesisRequestedFalse_ReturnsFailure', () => {
+    const state: Record<string, unknown> = {
+      synthesis: { requested: false },
+    };
+
+    const result = guards.prRequested.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+  });
+
+  it('prRequested_SynthesisNoRequestedField_ReturnsFailure', () => {
+    const state: Record<string, unknown> = {
+      synthesis: { prUrl: 'https://example.com' },
+    };
+
+    const result = guards.prRequested.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.ts
@@ -143,6 +143,10 @@ function buildFailedReviewsExpectedShape(
   return { reviews: reviewEntries };
 }
 
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+export const MAX_PLAN_REVISIONS = 3;
+
 // ─── Guards ─────────────────────────────────────────────────────────────────
 
 export const guards = {
@@ -514,6 +518,49 @@ export const guards = {
             },
           },
         },
+      };
+    },
+  },
+
+  escalationRequired: {
+    id: 'escalation-required',
+    description: 'Investigation determined fix requires architectural redesign',
+    evaluate: (state: Record<string, unknown>): GuardResult => {
+      const investigation = state.investigation as Record<string, unknown> | undefined;
+      if (investigation?.escalate === true) return true;
+      return {
+        passed: false,
+        reason: 'escalation-required not satisfied',
+        expectedShape: { investigation: { escalate: true } },
+      };
+    },
+  },
+
+  revisionsExhausted: {
+    id: 'revisions-exhausted',
+    description: 'Plan revision count has reached the maximum allowed',
+    evaluate: (state: Record<string, unknown>): GuardResult => {
+      const planReview = state.planReview as Record<string, unknown> | undefined;
+      const rawCount = planReview?.revisionCount;
+      const count = typeof rawCount === 'number' && Number.isFinite(rawCount) ? rawCount : 0;
+      if (count >= MAX_PLAN_REVISIONS) return true;
+      return {
+        passed: false,
+        reason: `revisions-exhausted not satisfied: ${count}/${MAX_PLAN_REVISIONS} revisions`,
+      };
+    },
+  },
+
+  prRequested: {
+    id: 'pr-requested',
+    description: 'PR creation has been requested',
+    evaluate: (state: Record<string, unknown>): GuardResult => {
+      const synthesis = state.synthesis as Record<string, unknown> | undefined;
+      if (synthesis?.requested === true) return true;
+      return {
+        passed: false,
+        reason: 'pr-requested not satisfied',
+        expectedShape: { synthesis: { requested: true } },
       };
     },
   },

--- a/servers/exarchos-mcp/src/workflow/hsm-definitions.ts
+++ b/servers/exarchos-mcp/src/workflow/hsm-definitions.ts
@@ -34,6 +34,7 @@ export function createFeatureHSM(): HSMDefinition {
       guard: guards.planReviewGapsFound,
       effects: ['log'],
     },
+    { from: 'plan-review', to: 'blocked', guard: guards.revisionsExhausted },
     { from: 'delegate', to: 'review', guard: composeGuards(
       'all-tasks-complete+team-disbanded',
       'All tasks must be complete and team must be disbanded',
@@ -124,6 +125,7 @@ export function createDebugHSM(): HSMDefinition {
       to: 'hotfix-implement',
       guard: guards.hotfixTrackSelected,
     },
+    { from: 'investigate', to: 'cancelled', guard: guards.escalationRequired },
 
     // Thorough track flow
     { from: 'rca', to: 'design', guard: guards.rcaDocumentComplete },
@@ -142,6 +144,12 @@ export function createDebugHSM(): HSMDefinition {
       to: 'hotfix-validate',
       guard: guards.implementationComplete,
     },
+    { from: 'hotfix-validate', to: 'synthesize', guard: composeGuards(
+      'validation+pr-requested',
+      'Validation must pass and PR must be requested',
+      guards.validationPassed,
+      guards.prRequested,
+    ) },
     { from: 'hotfix-validate', to: 'completed', guard: guards.validationPassed },
 
     // Synthesize -> completed


### PR DESCRIPTION
Add escalationRequired, revisionsExhausted, and prRequested guards.
Wire debug escalate-to-ideate, plan revision termination, and
hotfix-validate-to-synthesize transitions. 24 new tests.