### PR TITLE
refactor: add schema safety constraints and synthesize retry

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
@@ -2152,6 +2152,170 @@ describe('Diagnostic Event Emission', () => {
   });
 });
 
+// ─── Task: Synthesize retry transitions ───────────────────────────────────────
+
+describe('Synthesize retry transitions', () => {
+  describe('Feature HSM', () => {
+    it('SynthesizeRetry_WhenRetryable_TransitionsToDelegate', () => {
+      const hsm = getHSMDefinition('feature');
+      const state: Record<string, unknown> = {
+        phase: 'synthesize',
+        synthesis: { lastError: 'merge conflict', retryCount: 1 },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'delegate');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('delegate');
+      expect(result.idempotent).toBe(false);
+    });
+
+    it('SynthesizeRetry_WhenRetriesExhausted_FailsGuard', () => {
+      const hsm = getHSMDefinition('feature');
+      const state: Record<string, unknown> = {
+        phase: 'synthesize',
+        synthesis: { lastError: 'merge conflict', retryCount: 3 },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'delegate');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+
+    it('SynthesizeRetry_WhenNoError_FailsGuard', () => {
+      const hsm = getHSMDefinition('feature');
+      const state: Record<string, unknown> = {
+        phase: 'synthesize',
+        synthesis: {},
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'delegate');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+
+    it('SynthesizeRetry_ValidTransitions_IncludesDelegateTarget', () => {
+      const hsm = getHSMDefinition('feature');
+      const targets = getValidTransitions(hsm, 'synthesize');
+      const delegateTarget = targets.find((t) => t.phase === 'delegate');
+      expect(delegateTarget).toBeDefined();
+      expect(delegateTarget!.guard!.id).toBe('synthesize-retryable');
+    });
+  });
+
+  describe('Debug HSM', () => {
+    it('SynthesizeRetry_WhenRetryable_ThoroughTrack_TransitionsToDebugImplement', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'synthesize',
+        track: 'thorough',
+        synthesis: { lastError: 'merge conflict', retryCount: 0 },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'debug-implement');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('debug-implement');
+      expect(result.idempotent).toBe(false);
+    });
+
+    it('SynthesizeRetry_WhenRetryable_HotfixTrack_TransitionsToHotfixImplement', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'synthesize',
+        track: 'hotfix',
+        synthesis: { lastError: 'merge conflict', retryCount: 0 },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'hotfix-implement');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('hotfix-implement');
+      expect(result.idempotent).toBe(false);
+    });
+
+    it('SynthesizeRetry_WhenRetriesExhausted_FailsGuard', () => {
+      const hsm = getHSMDefinition('debug');
+      const state: Record<string, unknown> = {
+        phase: 'synthesize',
+        track: 'thorough',
+        synthesis: { lastError: 'merge conflict', retryCount: 3 },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'debug-implement');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+
+    it('SynthesizeRetry_ValidTransitions_IncludesTrackAwareTargets', () => {
+      const hsm = getHSMDefinition('debug');
+      const targets = getValidTransitions(hsm, 'synthesize');
+      const debugImplTarget = targets.find((t) => t.phase === 'debug-implement');
+      expect(debugImplTarget).toBeDefined();
+      expect(debugImplTarget!.guard!.id).toBe('synthesize-retryable+thorough-track');
+      const hotfixImplTarget = targets.find((t) => t.phase === 'hotfix-implement');
+      expect(hotfixImplTarget).toBeDefined();
+      expect(hotfixImplTarget!.guard!.id).toBe('synthesize-retryable+hotfix-track');
+    });
+  });
+
+  describe('Refactor HSM', () => {
+    it('SynthesizeRetry_WhenRetryable_TransitionsToOverhaulDelegate', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'synthesize',
+        synthesis: { lastError: 'CI failed', retryCount: 2 },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'overhaul-delegate');
+
+      expect(result.success).toBe(true);
+      expect(result.newPhase).toBe('overhaul-delegate');
+      expect(result.idempotent).toBe(false);
+    });
+
+    it('SynthesizeRetry_WhenRetriesExhausted_FailsGuard', () => {
+      const hsm = getHSMDefinition('refactor');
+      const state: Record<string, unknown> = {
+        phase: 'synthesize',
+        synthesis: { lastError: 'CI failed', retryCount: 3 },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'overhaul-delegate');
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('GUARD_FAILED');
+    });
+
+    it('SynthesizeRetry_ValidTransitions_IncludesOverhaulDelegateTarget', () => {
+      const hsm = getHSMDefinition('refactor');
+      const targets = getValidTransitions(hsm, 'synthesize');
+      const overhaulDelegateTarget = targets.find((t) => t.phase === 'overhaul-delegate');
+      expect(overhaulDelegateTarget).toBeDefined();
+      expect(overhaulDelegateTarget!.guard!.id).toBe('synthesize-retryable');
+    });
+  });
+});
+
 describe('Missing _events and _history defaults', () => {
   it('handles missing _events gracefully (defaults to empty array)', () => {
     const hsm = getHSMDefinition('feature');

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -1032,6 +1032,22 @@ describe('WorkflowEventBase max-length constraints', () => {
     expect(result.success).toBe(true);
   });
 
+  it('WorkflowEventBase_EmptyAgentId_FailsValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      agentId: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('WorkflowEventBase_EmptyIdempotencyKey_FailsValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      idempotencyKey: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
   it('WorkflowEventBase_EmptySchemaVersion_FailsValidation', () => {
     const result = WorkflowEventBase.safeParse({
       ...validBase,

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -895,3 +895,148 @@ describe('EventType_ShepherdTypes_ExistInUnion', () => {
     }
   });
 });
+
+// ─── Task 5: WorkflowEventBase max-length constraints ──────────────────────
+
+describe('WorkflowEventBase max-length constraints', () => {
+  const validBase = {
+    streamId: 'test-stream',
+    sequence: 1,
+    type: 'workflow.started' as const,
+  };
+
+  it('WorkflowEventBase_OversizedStreamId_FailsValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      streamId: 'a'.repeat(101),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('WorkflowEventBase_MaxLengthStreamId_PassesValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      streamId: 'a'.repeat(100),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('WorkflowEventBase_OversizedAgentId_FailsValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      agentId: 'a'.repeat(201),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('WorkflowEventBase_OversizedCorrelationId_FailsValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      correlationId: 'a'.repeat(201),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('WorkflowEventBase_ValidEvent_StillPasses', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      correlationId: 'corr-123',
+      causationId: 'cause-456',
+      agentId: 'agent-789',
+      agentRole: 'implementer',
+      source: 'test-runner',
+      schemaVersion: '1.0',
+      idempotencyKey: 'key-abc',
+      data: { key: 'value' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('WorkflowEventBase_OversizedCausationId_FailsValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      causationId: 'a'.repeat(201),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('WorkflowEventBase_OversizedAgentRole_FailsValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      agentRole: 'a'.repeat(51),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('WorkflowEventBase_OversizedSource_FailsValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      source: 'a'.repeat(101),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('WorkflowEventBase_OversizedSchemaVersion_FailsValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      schemaVersion: 'a'.repeat(21),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('WorkflowEventBase_OversizedIdempotencyKey_FailsValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      idempotencyKey: 'a'.repeat(201),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('WorkflowEventBase_MaxLengthAgentRole_PassesValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      agentRole: 'a'.repeat(50),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('WorkflowEventBase_OversizedTenantId_FailsValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      tenantId: 'a'.repeat(101),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('WorkflowEventBase_MaxLengthTenantId_PassesValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      tenantId: 'a'.repeat(100),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('WorkflowEventBase_OversizedOrganizationId_FailsValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      organizationId: 'a'.repeat(101),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('WorkflowEventBase_MaxLengthOrganizationId_PassesValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      organizationId: 'a'.repeat(100),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('WorkflowEventBase_EmptySchemaVersion_FailsValidation', () => {
+    const result = WorkflowEventBase.safeParse({
+      ...validBase,
+      schemaVersion: '',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -56,20 +56,20 @@ export type EventType = typeof EventTypes[number];
 // ─── Base Event Schema ──────────────────────────────────────────────────────
 
 export const WorkflowEventBase = z.object({
-  streamId: z.string().min(1),
+  streamId: z.string().min(1).max(100),
   sequence: z.number().int().positive(),
   timestamp: z.string().datetime().default(() => new Date().toISOString()),
   type: z.enum(EventTypes),
-  correlationId: z.string().optional(),
-  causationId: z.string().optional(),
-  agentId: z.string().optional(),
-  agentRole: z.string().optional(),
-  tenantId: z.string().min(1).optional(),
-  organizationId: z.string().min(1).optional(),
-  source: z.string().optional(),
-  schemaVersion: z.string().default('1.0'),
+  correlationId: z.string().max(200).optional(),
+  causationId: z.string().max(200).optional(),
+  agentId: z.string().max(200).optional(),
+  agentRole: z.string().max(50).optional(),
+  tenantId: z.string().min(1).max(100).optional(),
+  organizationId: z.string().min(1).max(100).optional(),
+  source: z.string().max(100).optional(),
+  schemaVersion: z.string().min(1).max(20).default('1.0'),
   data: z.record(z.string(), z.unknown()).optional(),
-  idempotencyKey: z.string().optional(),
+  idempotencyKey: z.string().max(200).optional(),
 });
 
 // ─── Workflow-Level Event Data ──────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -62,14 +62,14 @@ export const WorkflowEventBase = z.object({
   type: z.enum(EventTypes),
   correlationId: z.string().max(200).optional(),
   causationId: z.string().max(200).optional(),
-  agentId: z.string().max(200).optional(),
+  agentId: z.string().min(1).max(200).optional(),
   agentRole: z.string().max(50).optional(),
   tenantId: z.string().min(1).max(100).optional(),
   organizationId: z.string().min(1).max(100).optional(),
   source: z.string().max(100).optional(),
   schemaVersion: z.string().min(1).max(20).default('1.0'),
   data: z.record(z.string(), z.unknown()).optional(),
-  idempotencyKey: z.string().max(200).optional(),
+  idempotencyKey: z.string().min(1).max(200).optional(),
 });
 
 // ─── Workflow-Level Event Data ──────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.test.ts
@@ -298,6 +298,19 @@ describe('synthesizeRetryable', () => {
     expect(result).toBe(true);
   });
 
+  it('synthesizeRetryable_EmptyStringError_ReturnsTrue', () => {
+    const state: Record<string, unknown> = {
+      synthesis: {
+        lastError: '',
+        retryCount: 0,
+      },
+    };
+
+    const result = guards.synthesizeRetryable.evaluate(state);
+
+    expect(result).toBe(true);
+  });
+
   it('synthesizeRetryable_NoError_ReturnsFailure', () => {
     const state: Record<string, unknown> = {
       synthesis: {

--- a/servers/exarchos-mcp/src/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.test.ts
@@ -67,7 +67,6 @@ describe('teamDisbandedEmitted', () => {
   // ─── #786: Subagent-mode tests (no team spawned) ────────────────────────
 
   it('teamDisbandedEmitted_NoTeamSpawned_ReturnsTrue', () => {
-    // Subagent mode — no team.spawned event means no team was used
     const state: Record<string, unknown> = {
       featureId: 'test-feature',
       _events: [
@@ -82,7 +81,6 @@ describe('teamDisbandedEmitted', () => {
   });
 
   it('teamDisbandedEmitted_EmptyEvents_ReturnsTrue', () => {
-    // No events at all — subagent mode
     const state: Record<string, unknown> = {
       featureId: 'test-feature',
       _events: [],
@@ -94,7 +92,6 @@ describe('teamDisbandedEmitted', () => {
   });
 
   it('teamDisbandedEmitted_UndefinedEvents_ReturnsTrue', () => {
-    // _events not present at all — subagent mode
     const state: Record<string, unknown> = {
       featureId: 'test-feature',
     };
@@ -105,7 +102,6 @@ describe('teamDisbandedEmitted', () => {
   });
 
   it('teamDisbandedEmitted_TeamSpawnedButNotDisbanded_ReturnsFailure', () => {
-    // Team was spawned but not yet disbanded — guard must block
     const state: Record<string, unknown> = {
       featureId: 'test-feature',
       _events: [
@@ -283,5 +279,106 @@ describe('prRequested', () => {
     expect(result).not.toBe(true);
     const failure = result as GuardFailure;
     expect(failure.passed).toBe(false);
+  });
+});
+
+// ─── synthesizeRetryable Guard Tests ─────────────────────────────────────────
+
+describe('synthesizeRetryable', () => {
+  it('synthesizeRetryable_HasErrorAndRetriesRemaining_ReturnsTrue', () => {
+    const state: Record<string, unknown> = {
+      synthesis: {
+        lastError: 'network error',
+        retryCount: 1,
+      },
+    };
+
+    const result = guards.synthesizeRetryable.evaluate(state);
+
+    expect(result).toBe(true);
+  });
+
+  it('synthesizeRetryable_NoError_ReturnsFailure', () => {
+    const state: Record<string, unknown> = {
+      synthesis: {
+        retryCount: 0,
+      },
+    };
+
+    const result = guards.synthesizeRetryable.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('synthesize-retryable');
+    expect(failure.reason).toContain('no lastError');
+  });
+
+  it('synthesizeRetryable_RetriesExhausted_ReturnsFailure', () => {
+    const state: Record<string, unknown> = {
+      synthesis: {
+        lastError: 'gt submit failed',
+        retryCount: 3,
+      },
+    };
+
+    const result = guards.synthesizeRetryable.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('synthesize-retryable');
+    expect(failure.reason).toContain('retries exhausted');
+  });
+
+  it('synthesizeRetryable_NoSynthesisState_ReturnsFailure', () => {
+    const state: Record<string, unknown> = {};
+
+    const result = guards.synthesizeRetryable.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('no lastError');
+  });
+
+  it('synthesizeRetryable_RetryCountAtMax_ReturnsFailure', () => {
+    const state: Record<string, unknown> = {
+      synthesis: {
+        lastError: 'stack conflict',
+        retryCount: 5,
+      },
+    };
+
+    const result = guards.synthesizeRetryable.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+  });
+
+  it('synthesizeRetryable_ZeroRetryCount_ReturnsTrue', () => {
+    const state: Record<string, unknown> = {
+      synthesis: {
+        lastError: 'first failure',
+        retryCount: 0,
+      },
+    };
+
+    const result = guards.synthesizeRetryable.evaluate(state);
+
+    expect(result).toBe(true);
+  });
+
+  it('synthesizeRetryable_MissingRetryCount_DefaultsToZero_ReturnsTrue', () => {
+    const state: Record<string, unknown> = {
+      synthesis: {
+        lastError: 'network timeout',
+      },
+    };
+
+    const result = guards.synthesizeRetryable.evaluate(state);
+
+    expect(result).toBe(true);
   });
 });

--- a/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.ts
@@ -146,6 +146,7 @@ function buildFailedReviewsExpectedShape(
 // ─── Constants ──────────────────────────────────────────────────────────────
 
 export const MAX_PLAN_REVISIONS = 3;
+const MAX_SYNTHESIZE_RETRIES = 3;
 
 // ─── Guards ─────────────────────────────────────────────────────────────────
 
@@ -562,6 +563,29 @@ export const guards = {
         reason: 'pr-requested not satisfied',
         expectedShape: { synthesis: { requested: true } },
       };
+    },
+  },
+
+  synthesizeRetryable: {
+    id: 'synthesize-retryable',
+    description: 'Synthesis can be retried (has error and retries remaining)',
+    evaluate: (state: Record<string, unknown>): GuardResult => {
+      const synthesis = state.synthesis as Record<string, unknown> | undefined;
+      if (!synthesis?.lastError) {
+        return {
+          passed: false,
+          reason: 'synthesize-retryable not satisfied: no lastError recorded',
+        };
+      }
+      const rawRetry = synthesis.retryCount;
+      const retryCount = typeof rawRetry === 'number' && Number.isFinite(rawRetry) ? rawRetry : 0;
+      if (retryCount >= MAX_SYNTHESIZE_RETRIES) {
+        return {
+          passed: false,
+          reason: `synthesize-retryable not satisfied: ${retryCount}/${MAX_SYNTHESIZE_RETRIES} retries exhausted`,
+        };
+      }
+      return true;
     },
   },
 

--- a/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.ts
@@ -571,7 +571,7 @@ export const guards = {
     description: 'Synthesis can be retried (has error and retries remaining)',
     evaluate: (state: Record<string, unknown>): GuardResult => {
       const synthesis = state.synthesis as Record<string, unknown> | undefined;
-      if (!synthesis?.lastError) {
+      if (synthesis?.lastError == null) {
         return {
           passed: false,
           reason: 'synthesize-retryable not satisfied: no lastError recorded',

--- a/servers/exarchos-mcp/src/workflow/hsm-definitions.ts
+++ b/servers/exarchos-mcp/src/workflow/hsm-definitions.ts
@@ -49,6 +49,7 @@ export function createFeatureHSM(): HSMDefinition {
       isFixCycle: true,
       effects: ['increment-fix-cycle'],
     },
+    { from: 'synthesize', to: 'delegate', guard: guards.synthesizeRetryable },
     { from: 'synthesize', to: 'completed', guard: guards.prUrlExists },
     { from: 'blocked', to: 'delegate', guard: guards.humanUnblocked },
   ];
@@ -152,7 +153,19 @@ export function createDebugHSM(): HSMDefinition {
     ) },
     { from: 'hotfix-validate', to: 'completed', guard: guards.validationPassed },
 
-    // Synthesize -> completed
+    // Synthesize -> retry (track-aware) or completed
+    { from: 'synthesize', to: 'debug-implement', guard: composeGuards(
+      'synthesize-retryable+thorough-track',
+      'Synthesis retryable on thorough track',
+      guards.synthesizeRetryable,
+      guards.thoroughTrackSelected,
+    ) },
+    { from: 'synthesize', to: 'hotfix-implement', guard: composeGuards(
+      'synthesize-retryable+hotfix-track',
+      'Synthesis retryable on hotfix track',
+      guards.synthesizeRetryable,
+      guards.hotfixTrackSelected,
+    ) },
     { from: 'synthesize', to: 'completed', guard: guards.prUrlExists },
   ];
 
@@ -275,7 +288,8 @@ export function createRefactorHSM(): HSMDefinition {
     },
     { from: 'overhaul-update-docs', to: 'synthesize', guard: guards.docsUpdated },
 
-    // Synthesize -> completed
+    // Synthesize -> retry or completed
+    { from: 'synthesize', to: 'overhaul-delegate', guard: guards.synthesizeRetryable },
     { from: 'synthesize', to: 'completed', guard: guards.prUrlExists },
   ];
 


### PR DESCRIPTION
Add max-length constraints to all WorkflowEventBase string fields.
Add synthesizeRetryable guard with HSM transitions for automatic
recovery from merge failures across feature, debug, and refactor
workflows.

Tasks: 5, 7 of foundation audit hardening