### PR TITLE
refactor: clean up content layer documentation and scripts

### DIFF
--- a/scripts/check-pr-comments.sh
+++ b/scripts/check-pr-comments.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Check PR Comments — validates all inline review comments have replies
+#
+# Usage: check-pr-comments.sh --pr <number> [--repo owner/repo]
+#
+# Fetches all review comments on a PR via `gh api` and checks whether
+# each top-level comment thread has at least one reply.
+#
+# Exit codes:
+#   0 = all comments addressed (or no comments)
+#   1 = unaddressed comments found
+#   2 = usage error
+#
+# Dependencies: gh (authenticated), jq
+
+set -euo pipefail
+
+PR_NUMBER=""
+REPO=""
+
+# ============================================================
+# USAGE
+# ============================================================
+
+usage() {
+    cat << 'USAGE'
+Usage: check-pr-comments.sh --pr <number> [--repo owner/repo]
+
+Required:
+  --pr <number>        PR number to check
+
+Optional:
+  --repo <owner/repo>  Repository (default: auto-detect from git remote)
+  --help               Show this help message
+
+Exit codes:
+  0  All inline comments have replies (or no comments)
+  1  Unaddressed comments found
+  2  Usage error
+USAGE
+}
+
+# ============================================================
+# ARGUMENT PARSING
+# ============================================================
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr)
+            [[ -z "${2:-}" ]] && { echo "Error: --pr requires a number" >&2; exit 2; }
+            PR_NUMBER="$2"; shift 2 ;;
+        --repo)
+            [[ -z "${2:-}" ]] && { echo "Error: --repo requires owner/repo" >&2; exit 2; }
+            REPO="$2"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "Error: Unknown argument '$1'" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+[[ -z "$PR_NUMBER" ]] && { echo "Error: --pr is required" >&2; usage >&2; exit 2; }
+
+# ============================================================
+# REPO DETECTION
+# ============================================================
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+    [[ -z "$REPO" ]] && { echo "Error: Could not detect repository. Use --repo" >&2; exit 2; }
+fi
+
+# ============================================================
+# FETCH COMMENTS
+# ============================================================
+
+if ! COMMENTS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate); then
+    echo "Error: Failed to fetch PR comments via gh api" >&2
+    exit 2
+fi
+
+# ============================================================
+# ANALYZE COMMENT THREADS
+# ============================================================
+
+# Count top-level comments (no in_reply_to_id)
+TOP_LEVEL=$(echo "$COMMENTS" | jq '[.[] | select(.in_reply_to_id == null)] | length')
+
+# Count unique top-level IDs that have at least one reply
+REPLIED_TO=$(echo "$COMMENTS" | jq '[.[] | select(.in_reply_to_id != null) | .in_reply_to_id] | unique | length')
+
+UNADDRESSED=$((TOP_LEVEL - REPLIED_TO))
+[[ $UNADDRESSED -lt 0 ]] && UNADDRESSED=0
+
+# ============================================================
+# REPORT
+# ============================================================
+
+echo "## PR #$PR_NUMBER Comment Status"
+echo ""
+echo "Top-level comments: $TOP_LEVEL"
+echo "With replies: $REPLIED_TO"
+echo "Unaddressed: $UNADDRESSED"
+
+if [[ $UNADDRESSED -eq 0 ]]; then
+    echo ""
+    echo "**Result: PASS** — all comments addressed"
+    exit 0
+else
+    echo ""
+    # List unaddressed comments
+    REPLIED_IDS=$(echo "$COMMENTS" | jq '[.[] | select(.in_reply_to_id != null) | .in_reply_to_id] | unique')
+    echo "### Unaddressed Comments"
+    echo "$COMMENTS" | jq -r --argjson replied "$REPLIED_IDS" '
+        .[] | select(.in_reply_to_id == null) |
+        select(.id as $id | ($replied | index($id)) == null) |
+        "- [\(.user.login)] \(.path):\(.line // .original_line // "?"): \(.body | split("\n")[0] | .[0:100])"
+    '
+    echo ""
+    echo "**Result: FAIL** — $UNADDRESSED unaddressed comment(s)"
+    exit 1
+fi

--- a/scripts/check-pr-comments.sh
+++ b/scripts/check-pr-comments.sh
@@ -15,6 +15,13 @@
 
 set -euo pipefail
 
+for dep in gh jq; do
+    command -v "$dep" >/dev/null 2>&1 || {
+        echo "Error: Missing dependency: $dep" >&2
+        exit 2
+    }
+done
+
 PR_NUMBER=""
 REPO=""
 

--- a/scripts/check-pr-comments.test.sh
+++ b/scripts/check-pr-comments.test.sh
@@ -163,8 +163,8 @@ fi
 MOCK
 chmod +x "$MOCK_GH"
 
-output=$(PATH="$MOCK_DIR:$PATH" bash "$SCRIPT" --pr 999 --repo owner/repo 2>&1)
-exit_code=$?
+exit_code=0
+output=$(PATH="$MOCK_DIR:$PATH" bash "$SCRIPT" --pr 999 --repo owner/repo 2>&1) || exit_code=$?
 if [[ $exit_code -eq 2 ]]; then
     pass "gh_api_failure_exit_2"
 else

--- a/scripts/check-pr-comments.test.sh
+++ b/scripts/check-pr-comments.test.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Check PR Comments — Test Script
+# Tests check-pr-comments.sh argument parsing and help output
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-pr-comments.sh"
+PASS=0
+FAIL=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAIL=$((FAIL + 1))
+}
+
+run_test() {
+    local name="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        pass "$name"
+    else
+        fail "$name"
+    fi
+}
+
+run_test_expect_exit() {
+    local name="$1"; local expected_exit="$2"; shift 2
+    local actual_exit=0
+    "$@" >/dev/null 2>&1 || actual_exit=$?
+    if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+        pass "$name"
+    else
+        fail "$name (expected exit $expected_exit, got $actual_exit)"
+    fi
+}
+
+# ============================================================
+# ARGUMENT PARSING TESTS
+# ============================================================
+
+# Test: No arguments → exit 2
+run_test_expect_exit "no_args_exit_2" 2 bash "$SCRIPT"
+
+# Test: Missing --pr value → exit 2
+run_test_expect_exit "missing_pr_value_exit_2" 2 bash "$SCRIPT" --pr
+
+# Test: Unknown argument → exit 2
+run_test_expect_exit "unknown_arg_exit_2" 2 bash "$SCRIPT" --bogus
+
+# Test: --help → exit 0
+run_test "help_exit_0" bash "$SCRIPT" --help
+
+# Test: --help output contains usage info
+if bash "$SCRIPT" --help 2>&1 | grep -q "Usage:"; then
+    pass "help_contains_usage"
+else
+    fail "help_contains_usage"
+fi
+
+# Test: --help output mentions exit codes
+if bash "$SCRIPT" --help 2>&1 | grep -q "Exit codes"; then
+    pass "help_contains_exit_codes"
+else
+    fail "help_contains_exit_codes"
+fi
+
+# ============================================================
+# MOCK-BASED TESTS
+# ============================================================
+
+# Create temporary directory for mock gh CLI
+MOCK_DIR="$(mktemp -d)"
+MOCK_GH="$MOCK_DIR/gh"
+
+cleanup() {
+    rm -rf "$MOCK_DIR"
+}
+trap cleanup EXIT
+
+# Test: All comments addressed (each top-level has reply) → exit 0
+cat > "$MOCK_GH" << 'MOCK'
+#!/usr/bin/env bash
+# Mock gh that returns comments with all threads replied to
+if [[ "$*" == *"pulls"*"comments"* ]]; then
+    echo '[
+        {"id": 100, "in_reply_to_id": null, "user": {"login": "sentry[bot]"}, "path": "src/foo.ts", "line": 10, "body": "Potential bug here"},
+        {"id": 101, "in_reply_to_id": 100, "user": {"login": "developer"}, "path": "src/foo.ts", "line": 10, "body": "Fixed in next commit"}
+    ]'
+elif [[ "$*" == *"nameWithOwner"* ]]; then
+    echo "owner/repo"
+fi
+MOCK
+chmod +x "$MOCK_GH"
+
+if PATH="$MOCK_DIR:$PATH" bash "$SCRIPT" --pr 123 --repo owner/repo 2>&1 | grep -q "PASS"; then
+    pass "all_addressed_exit_0"
+else
+    fail "all_addressed_exit_0"
+fi
+
+# Test: Unaddressed comment → exit 1
+cat > "$MOCK_GH" << 'MOCK'
+#!/usr/bin/env bash
+if [[ "$*" == *"pulls"*"comments"* ]]; then
+    echo '[
+        {"id": 200, "in_reply_to_id": null, "user": {"login": "graphite-app[bot]"}, "path": "src/bar.ts", "line": 5, "body": "Consider DI here"},
+        {"id": 201, "in_reply_to_id": null, "user": {"login": "sentry[bot]"}, "path": "src/baz.ts", "line": 20, "body": "Potential null deref"}
+    ]'
+elif [[ "$*" == *"nameWithOwner"* ]]; then
+    echo "owner/repo"
+fi
+MOCK
+chmod +x "$MOCK_GH"
+
+run_test_expect_exit "unaddressed_comments_exit_1" 1 env PATH="$MOCK_DIR:$PATH" bash "$SCRIPT" --pr 456 --repo owner/repo
+
+UNADDR_OUTPUT=$(PATH="$MOCK_DIR:$PATH" bash "$SCRIPT" --pr 456 --repo owner/repo 2>&1 || true)
+if echo "$UNADDR_OUTPUT" | grep -q "Unaddressed: 2"; then
+    pass "reports_unaddressed_count"
+else
+    fail "reports_unaddressed_count"
+fi
+
+# Test: No comments at all → exit 0 (nothing to address)
+cat > "$MOCK_GH" << 'MOCK'
+#!/usr/bin/env bash
+if [[ "$*" == *"pulls"*"comments"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"nameWithOwner"* ]]; then
+    echo "owner/repo"
+fi
+MOCK
+chmod +x "$MOCK_GH"
+
+if PATH="$MOCK_DIR:$PATH" bash "$SCRIPT" --pr 789 --repo owner/repo 2>&1 | grep -q "PASS"; then
+    pass "no_comments_exit_0"
+else
+    fail "no_comments_exit_0"
+fi
+
+# ────────────────────────────────────────────────────────────
+# Test: gh api failure → exit 2
+# ────────────────────────────────────────────────────────────
+
+cat > "$MOCK_GH" << 'MOCK'
+#!/usr/bin/env bash
+if [[ "$*" == *"pulls"*"comments"* ]]; then
+    echo "Error: API request failed" >&2
+    exit 1
+elif [[ "$*" == *"nameWithOwner"* ]]; then
+    echo "owner/repo"
+fi
+MOCK
+chmod +x "$MOCK_GH"
+
+output=$(PATH="$MOCK_DIR:$PATH" bash "$SCRIPT" --pr 999 --repo owner/repo 2>&1)
+exit_code=$?
+if [[ $exit_code -eq 2 ]]; then
+    pass "gh_api_failure_exit_2"
+else
+    fail "gh_api_failure_exit_2 (expected exit 2, got $exit_code)"
+fi
+
+# ============================================================
+# RESULTS
+# ============================================================
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -62,6 +62,8 @@ Use `@skills/delegation/references/implementer-prompt.md` as template for Task t
 
 **Conditional PBT:** When a task has `testingStrategy.propertyTests: true`, include the PBT section from `references/pbt-patterns.md`. When `false`, omit entirely.
 
+**Testing patterns:** For Arrange/Act/Assert examples, test naming conventions, mocking, and co-location rules, see `references/testing-patterns.md`.
+
 ## Delegation Workflow — Subagent Mode
 
 1. Prepare worktrees — `scripts/setup-worktree.sh`

--- a/skills/delegation/references/testing-patterns.md
+++ b/skills/delegation/references/testing-patterns.md
@@ -2,6 +2,23 @@
 
 Code patterns for TDD implementation. Referenced from `rules/tdd.md`.
 
+## Test File Co-location
+
+Test files live alongside their source files, not in a separate `tests/` directory.
+
+| Language | Source | Test |
+|----------|--------|------|
+| TypeScript | `src/foo.ts` | `src/foo.test.ts` |
+| C# | `Services/OrderService.cs` | `Services/OrderService.Tests.cs` |
+| Bash | `scripts/check-pr-comments.sh` | `scripts/check-pr-comments.test.sh` |
+
+## Naming Convention
+
+Tests use `Method_Scenario_Outcome` format:
+- TypeScript: `it('GetOrder_InvalidId_ReturnsNotFound', ...)`
+- C#: `public async Task GetOrder_InvalidId_ReturnsNotFound()`
+- Bash: function name `test_no_args_exit_2`
+
 ## TypeScript (Vitest)
 
 ```typescript

--- a/skills/git-worktrees/SKILL.md
+++ b/skills/git-worktrees/SKILL.md
@@ -63,35 +63,7 @@ git worktree list
 
 ### 2. Setup Environment
 
-**Auto-detect project type and run setup:**
-
-| Indicator | Setup Command |
-|-----------|---------------|
-| `package.json` | `npm install` or `pnpm install` |
-| `Cargo.toml` | `cargo build` |
-| `requirements.txt` | `pip install -r requirements.txt` |
-| `*.csproj` | `dotnet restore` |
-| `go.mod` | `go mod download` |
-
-**Setup Script:**
-```bash
-cd .worktrees/task-name
-
-# Node.js
-if [ -f "package.json" ]; then
-  npm install
-fi
-
-# .NET
-if ls *.csproj 1> /dev/null 2>&1; then
-  dotnet restore
-fi
-
-# Rust
-if [ -f "Cargo.toml" ]; then
-  cargo build
-fi
-```
+See `references/commands-reference.md` for the full environment setup table and scripts per project type.
 
 ### 3. Baseline Verification
 
@@ -134,48 +106,7 @@ git worktree prune
 
 ## Parallel Worktree Management
 
-### Creating Multiple Worktrees
-
-For parallel task groups from implementation plan:
-
-```bash
-# Group 1 tasks
-git worktree add .worktrees/001-types feature/001-types
-git worktree add .worktrees/002-tests feature/002-tests
-
-# Group 2 tasks (parallel to Group 1)
-git worktree add .worktrees/003-api feature/003-api
-git worktree add .worktrees/004-handlers feature/004-handlers
-```
-
-### Tracking Active Worktrees
-
-Maintain awareness of active worktrees:
-```bash
-git worktree list
-```
-
-Report format:
-```markdown
-## Active Worktrees
-
-| Task | Branch | Status |
-|------|--------|--------|
-| 001-types | feature/001-types | In Progress |
-| 002-tests | feature/002-tests | Complete |
-| 003-api | feature/003-api | In Progress |
-```
-
-## Worktree Commands Reference
-
-| Action | Command |
-|--------|---------|
-| List worktrees | `git worktree list` |
-| Add worktree | `git worktree add <path> <branch>` |
-| Remove worktree | `git worktree remove <path>` |
-| Prune stale refs | `git worktree prune` |
-| Lock (prevent removal) | `git worktree lock <path>` |
-| Unlock | `git worktree unlock <path>` |
+See `references/commands-reference.md` for parallel worktree creation examples, tracking format, and the full commands reference table.
 
 ## Worktree Validation
 

--- a/skills/git-worktrees/references/commands-reference.md
+++ b/skills/git-worktrees/references/commands-reference.md
@@ -1,0 +1,78 @@
+# Worktree Commands Reference
+
+## Core Commands
+
+| Action | Command |
+|--------|---------|
+| List worktrees | `git worktree list` |
+| Add worktree | `git worktree add <path> <branch>` |
+| Remove worktree | `git worktree remove <path>` |
+| Prune stale refs | `git worktree prune` |
+| Lock (prevent removal) | `git worktree lock <path>` |
+| Unlock | `git worktree unlock <path>` |
+
+## Environment Setup
+
+Auto-detect project type and install dependencies in each worktree:
+
+| Indicator | Setup Command |
+|-----------|---------------|
+| `package.json` | `npm install` or `pnpm install` |
+| `Cargo.toml` | `cargo build` |
+| `requirements.txt` | `pip install -r requirements.txt` |
+| `*.csproj` | `dotnet restore` |
+| `go.mod` | `go mod download` |
+
+**Setup Script:**
+```bash
+cd .worktrees/task-name
+
+# Node.js
+if [ -f "package.json" ]; then
+  npm install
+fi
+
+# .NET
+if compgen -G "*.csproj" > /dev/null 2>&1; then
+  dotnet restore
+fi
+
+# Rust
+if [ -f "Cargo.toml" ]; then
+  cargo build
+fi
+```
+
+## Parallel Worktree Management
+
+### Creating Multiple Worktrees
+
+For parallel task groups from implementation plan:
+
+```bash
+# Group 1 tasks
+git worktree add .worktrees/001-types feature/001-types
+git worktree add .worktrees/002-tests feature/002-tests
+
+# Group 2 tasks (parallel to Group 1)
+git worktree add .worktrees/003-api feature/003-api
+git worktree add .worktrees/004-handlers feature/004-handlers
+```
+
+### Tracking Active Worktrees
+
+Maintain awareness of active worktrees:
+```bash
+git worktree list
+```
+
+Report format:
+```markdown
+## Active Worktrees
+
+| Task | Branch | Status |
+|------|--------|--------|
+| 001-types | feature/001-types | In Progress |
+| 002-tests | feature/002-tests | Complete |
+| 003-api | feature/003-api | In Progress |
+```

--- a/skills/shared/SKILL.md
+++ b/skills/shared/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: shared
+description: "Shared prompt templates and resources used by other skills. Contains reusable prompt fragments for context reading, report formatting, and TDD requirements. Not directly invocable as a skill. Use when building or referencing cross-cutting prompt content that multiple skills depend on. Do NOT invoke directly — other skills reference these templates via relative paths."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: utility
+---
+
+# Shared Resources
+
+## Overview
+
+Contains shared prompt templates and reusable resources that other skills reference. This is not a directly invocable skill — it serves as a library of common prompt fragments.
+
+## Contents
+
+- `prompts/context-reading.md` — Shared context reading instructions
+- `prompts/report-format.md` — Standard report formatting template
+- `prompts/tdd-requirements.md` — TDD requirements prompt fragment
+
+## Usage
+
+Other skills reference these templates via relative paths in their own SKILL.md or reference files. Do not invoke this skill directly.

--- a/skills/test-fixtures/SKILL.md
+++ b/skills/test-fixtures/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: test-fixtures
+description: "Fixture skill directories for validating the frontmatter validation script (validate-frontmatter.sh). Contains deliberately broken skills with various issues — missing name, no frontmatter, body too long, name mismatch, etc. Not directly invocable as a skill. Use as test inputs for validation script development. Do NOT modify fixture contents without updating corresponding test expectations."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: utility
+---
+
+# Test Fixtures
+
+## Overview
+
+Contains fixture skill directories used to test the frontmatter validation script (`validate-frontmatter.sh`). Each subdirectory is a mock skill with specific issues designed to exercise validation edge cases.
+
+## Fixture Directories
+
+- `valid-skill/` — Correctly structured skill (passes validation)
+- `missing-name/` — Missing required `name` field
+- `missing-description/` — Missing required `description` field
+- `no-frontmatter/` — No YAML frontmatter block
+- `name-mismatch/` — `name` field does not match directory name
+- `body-too-long/` — Description exceeds 1,024 character limit
+- `broken-reference/` — References a non-existent file
+- `orphan-reference/` — Has unreferenced files in references directory
+- `no-negative-trigger/` — Missing negative trigger pattern
+- `xml-tags/` — Contains XML tags in content
+
+## Usage
+
+Run `bash skills/validate-frontmatter.sh skills/test-fixtures/<fixture>/SKILL.md` to test individual fixtures against the validator. See `validate-frontmatter.test.sh` for the full test suite.

--- a/skills/trigger-tests/SKILL.md
+++ b/skills/trigger-tests/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: trigger-tests
+description: "Test runner and fixtures for skill trigger matching validation. Contains a JSONL fixture file with trigger patterns and expected match results, plus a bash runner script. Not directly invocable as a skill. Use when developing or verifying changes to the skill trigger matching logic. Do NOT use for production trigger resolution."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: utility
+---
+
+# Trigger Tests
+
+## Overview
+
+Validates that skill trigger matching works correctly by running a suite of test cases defined in a JSONL fixture file against the trigger resolution logic.
+
+## Contents
+
+- `fixtures.jsonl` — Test cases with trigger patterns and expected match results
+- `run-trigger-tests.sh` — Bash test runner that executes fixtures and reports results
+
+## Usage
+
+```bash
+bash skills/trigger-tests/run-trigger-tests.sh
+```
+
+This runs all trigger matching test cases and reports pass/fail results. Use after modifying skill trigger patterns or the trigger matching algorithm.

--- a/skills/workflow-state/references/phase-transitions.md
+++ b/skills/workflow-state/references/phase-transitions.md
@@ -114,7 +114,47 @@ explore → brief → [polish-track | overhaul-track] → completed
 | `overhaul-update-docs` | `synthesize` | `docs-updated` | Set `validation.docsUpdated = true` |
 | `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
 
-**Compound state:** `overhaul-track` contains `overhaul-plan` through `overhaul-review`. Max 3 fix cycles.
+**Compound state:** `overhaul-track` contains `overhaul-plan`, `overhaul-delegate`, `overhaul-review`, and `overhaul-update-docs`. Max 3 fix cycles.
+
+## Circuit Breaker
+
+Compound states enforce a maximum number of fix cycles to prevent infinite review-fix loops. When the limit is exceeded, the HSM rejects the transition with a `CIRCUIT_OPEN` error and emits a `workflow.circuit-open` event.
+
+### What Triggers It
+
+A fix cycle occurs when a review phase transitions back to a delegate/implement phase (a `isFixCycle: true` transition). Each such transition increments the fix cycle counter for the enclosing compound state. The circuit breaker opens when the count reaches `maxFixCycles`.
+
+For example, in the feature workflow: `review` -> `delegate` is a fix cycle within the `implementation` compound state. After 3 such cycles, the fourth attempt is blocked.
+
+### Max Fix Cycles Per Workflow
+
+| Workflow | Compound State | Contains | Max Fix Cycles |
+|----------|---------------|----------|----------------|
+| Feature | `implementation` | `delegate`, `review` | 3 |
+| Debug | `thorough-track` | `rca`, `design`, `debug-implement`, `debug-validate`, `debug-review` | 2 |
+| Refactor | `overhaul-track` | `overhaul-plan`, `overhaul-delegate`, `overhaul-review`, `overhaul-update-docs` | 3 |
+
+Note: `polish-track` (refactor) and `hotfix-track` (debug) have no fix cycle transitions, so no circuit breaker applies.
+
+### What Happens When It Opens
+
+1. The HSM emits a `circuit-open` event with metadata:
+   - `compoundStateId` — the compound state that exceeded its limit
+   - `fixCycleCount` — current count
+   - `maxFixCycles` — the configured limit
+2. The transition is **rejected** — the workflow stays in the current phase
+3. The error response contains `errorCode: "CIRCUIT_OPEN"` with a descriptive message
+4. The workflow effectively enters a stuck state requiring human intervention
+
+### How to Recover
+
+When a circuit breaker opens, the agent should:
+
+1. **Report to the user** with the iteration history and persistent failures
+2. **Set `unblocked = true`** after the user provides guidance — this allows the `blocked` → implementing phase transition (e.g., `delegate` for Feature, `debug-implement` for Debug thorough-track, `overhaul-delegate` for Refactor overhaul-track)
+3. Alternatively, **cancel the workflow** via `exarchos_workflow cancel` and restart with a different approach
+
+The circuit breaker count is tracked via `fix-cycle` events in the workflow's `_events` array. These events persist across sessions, so the count survives context compaction and session restarts.
 
 ## Troubleshooting
 
@@ -135,7 +175,7 @@ The transition exists but the guard condition is not met.
 
 ### CIRCUIT_OPEN Error
 
-A compound state's fix cycle limit has been reached (e.g., review → delegate looped too many times).
+A compound state's fix cycle limit has been reached (e.g., review -> delegate looped too many times). See the **Circuit Breaker** section above for full details on limits per workflow, what happens, and recovery steps.
 
-1. The workflow is stuck — escalate to the user
-2. Consider cancelling and restarting with a different approach
+1. Report persistent failures to the user with iteration history
+2. After user guidance, set `unblocked = true` to proceed, or cancel and restart


### PR DESCRIPTION
Add shepherd PR comment validation script with co-located tests.
Create SKILL.md for utility skill directories (shared, test-fixtures,
trigger-tests). Extract git-worktrees inline content to references.
Fix orphaned testing-patterns reference. Document circuit breaker
behavior in phase-transitions.

Tasks: 6, 9-12 of foundation audit hardening