### PR TITLE
feat: add session-end CLI command and hook registration

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -48,6 +48,14 @@
         "command": "node \"${CLAUDE_PLUGIN_ROOT}/dist/exarchos-cli.js\" subagent-context",
         "timeout": 5
       }]
+    }],
+    "SessionEnd": [{
+      "matcher": "auto",
+      "hooks": [{
+        "type": "command",
+        "command": "node \"${CLAUDE_PLUGIN_ROOT}/dist/exarchos-cli.js\" session-end",
+        "timeout": 30
+      }]
     }]
   }
 }

--- a/servers/exarchos-mcp/src/cli-commands/session-end.test.ts
+++ b/servers/exarchos-mcp/src/cli-commands/session-end.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { handleSessionEnd } from './session-end.js';
+import { routeCommand } from '../cli.js';
+
+// ─── Test Suite ─────────────────────────────────────────────────────────────
+
+describe('session-end command', () => {
+  describe('handleSessionEnd', () => {
+    it('handleSessionEnd_ValidStdin_ReturnsSuccess', async () => {
+      // Arrange
+      const stdinData = {
+        session_id: 'abc',
+        transcript_path: '/tmp/test.jsonl',
+      };
+
+      // Act
+      const result = await handleSessionEnd(stdinData, '/tmp/state');
+
+      // Assert
+      expect(result).toEqual({ continue: true });
+    });
+
+    it('handleSessionEnd_MissingSessionId_ReturnsError', async () => {
+      // Arrange
+      const stdinData = {
+        transcript_path: '/tmp/test.jsonl',
+      };
+
+      // Act
+      const result = await handleSessionEnd(stdinData, '/tmp/state');
+
+      // Assert
+      expect(result).toEqual({
+        error: {
+          code: 'MISSING_SESSION_ID',
+          message: 'session_id is required',
+        },
+      });
+    });
+
+    it('handleSessionEnd_MissingTranscriptPath_ReturnsError', async () => {
+      // Arrange
+      const stdinData = {
+        session_id: 'abc',
+      };
+
+      // Act
+      const result = await handleSessionEnd(stdinData, '/tmp/state');
+
+      // Assert
+      expect(result).toEqual({
+        error: {
+          code: 'MISSING_TRANSCRIPT_PATH',
+          message: 'transcript_path is required',
+        },
+      });
+    });
+
+    it('handleSessionEnd_EmptyStdin_ReturnsError', async () => {
+      // Arrange
+      const stdinData = {};
+
+      // Act
+      const result = await handleSessionEnd(stdinData, '/tmp/state');
+
+      // Assert
+      expect(result).toHaveProperty('error');
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('MISSING_SESSION_ID');
+    });
+
+    it('handleSessionEnd_NonStringSessionId_ReturnsError', async () => {
+      // Arrange
+      const stdinData = {
+        session_id: 123,
+        transcript_path: '/tmp/test.jsonl',
+      };
+
+      // Act
+      const result = await handleSessionEnd(stdinData, '/tmp/state');
+
+      // Assert
+      expect(result).toEqual({
+        error: {
+          code: 'MISSING_SESSION_ID',
+          message: 'session_id is required',
+        },
+      });
+    });
+
+    it('handleSessionEnd_NonStringTranscriptPath_ReturnsError', async () => {
+      // Arrange
+      const stdinData = {
+        session_id: 'abc',
+        transcript_path: 42,
+      };
+
+      // Act
+      const result = await handleSessionEnd(stdinData, '/tmp/state');
+
+      // Assert
+      expect(result).toEqual({
+        error: {
+          code: 'MISSING_TRANSCRIPT_PATH',
+          message: 'transcript_path is required',
+        },
+      });
+    });
+  });
+
+  describe('routeCommand integration', () => {
+    it('routeCommand_SessionEnd_CallsSessionEndHandler', async () => {
+      // Arrange
+      const stdinData = {
+        session_id: 'test-session',
+        transcript_path: '/tmp/transcript.jsonl',
+      };
+
+      // Act
+      const result = await routeCommand('session-end', stdinData);
+
+      // Assert
+      expect(result).toEqual({ continue: true });
+    });
+
+    it('routeCommand_SessionEnd_WithMissingData_ReturnsError', async () => {
+      // Act
+      const result = await routeCommand('session-end', {});
+
+      // Assert
+      expect(result).toHaveProperty('error');
+      expect(result.error?.code).toBe('MISSING_SESSION_ID');
+    });
+  });
+});

--- a/servers/exarchos-mcp/src/cli-commands/session-end.ts
+++ b/servers/exarchos-mcp/src/cli-commands/session-end.ts
@@ -1,0 +1,28 @@
+import type { CommandResult } from '../cli.js';
+
+/**
+ * Handle the `session-end` CLI command.
+ *
+ * Validates that `session_id` and `transcript_path` are present in stdin data.
+ * Returns success when both are provided. The actual transcript extraction
+ * logic will be wired in a later task — this is the infrastructure stub.
+ */
+export async function handleSessionEnd(
+  stdinData: Record<string, unknown>,
+  _stateDir: string,
+): Promise<CommandResult> {
+  const sessionId = stdinData.session_id;
+  const transcriptPath = stdinData.transcript_path;
+
+  if (!sessionId || typeof sessionId !== 'string') {
+    return { error: { code: 'MISSING_SESSION_ID', message: 'session_id is required' } };
+  }
+
+  if (!transcriptPath || typeof transcriptPath !== 'string') {
+    return { error: { code: 'MISSING_TRANSCRIPT_PATH', message: 'transcript_path is required' } };
+  }
+
+  // Stub: extraction will be wired in Task 010
+  // For now, just validate inputs and return success
+  return { continue: true };
+}

--- a/servers/exarchos-mcp/src/cli.ts
+++ b/servers/exarchos-mcp/src/cli.ts
@@ -9,6 +9,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { handlePreCompact } from './cli-commands/pre-compact.js';
 import { handleSessionStart } from './cli-commands/session-start.js';
+import { handleSessionEnd } from './cli-commands/session-end.js';
 import { handleGuard } from './cli-commands/guard.js';
 import { handleTaskGate, handleTeammateGate } from './cli-commands/gates.js';
 import { handleSubagentContext } from './cli-commands/subagent-context.js';
@@ -44,6 +45,7 @@ const KNOWN_COMMANDS = [
   'eval-capture',
   'eval-compare',
   'quality-check',
+  'session-end',
 ] as const;
 
 type KnownCommand = (typeof KNOWN_COMMANDS)[number];
@@ -66,6 +68,7 @@ const commandHandlers: Record<KnownCommand, CommandHandler> = {
   'eval-capture': async (stdinData) => handleEvalCapture(stdinData, resolveStateDir()),
   'eval-compare': async (stdinData) => handleEvalCompare(stdinData, resolveStateDir()),
   'quality-check': async (stdinData) => handleQualityCheck(stdinData, resolveStateDir()),
+  'session-end': async (stdinData) => handleSessionEnd(stdinData, resolveStateDir()),
 };
 
 // ─── Stdin Parsing ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds the session-end CLI command infrastructure: handler stub with input
validation for session_id and transcript_path, command registration in
cli.ts, and SessionEnd hook in hooks.json with 30s timeout. Transcript
extraction logic will be wired in Task 010.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>