### PR TITLE
fix: add idempotency keys to checkpoint and task events

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -2221,6 +2221,41 @@ describe('Guaranteed Event Append', () => {
 
     appendSpy.mockRestore();
   });
+
+  it('handleCheckpoint_EventAppend_HasIdempotencyKey', async () => {
+    // Arrange: init with real event store
+    const eventStore = new EventStore(tmpDir);
+    configureWorkflowEventStore(eventStore);
+
+    await handleInit({ featureId: 'ckpt-idem-key', workflowType: 'feature' }, tmpDir);
+
+    // Spy on append to capture idempotency keys
+    const appendCalls: Array<{ type: string; idempotencyKey?: string }> = [];
+    const originalAppend = eventStore.append.bind(eventStore);
+    vi.spyOn(eventStore, 'append').mockImplementation(async (streamId, event, options) => {
+      appendCalls.push({ type: event.type, idempotencyKey: options?.idempotencyKey });
+      return originalAppend(streamId, event, options);
+    });
+
+    // Act
+    await handleCheckpoint(
+      { featureId: 'ckpt-idem-key', summary: 'test checkpoint' },
+      tmpDir,
+    );
+
+    // Assert: the checkpoint event should have an idempotency key
+    const checkpointCalls = appendCalls.filter((c) => c.type === 'workflow.checkpoint');
+    expect(checkpointCalls.length).toBe(1);
+    expect(checkpointCalls[0].idempotencyKey).toBeDefined();
+    // Key pattern: ${featureId}:checkpoint:${phase}:${version}
+    // The version used in the key is the state's version at read time (before checkpoint writes).
+    // handleInit writes with version increment, so the on-disk version after init is 2,
+    // but handleCheckpoint reads the state and uses _version from that read.
+    // Verify the key matches the expected pattern (phase=ideate, version from state read)
+    expect(checkpointCalls[0].idempotencyKey).toMatch(
+      /^ckpt-idem-key:checkpoint:ideate:\d+$/,
+    );
+  });
 });
 
 // ─── CAS Retry: No Duplicate Events (updated for event-first T3) ───────────

--- a/servers/exarchos-mcp/src/tasks/tools.test.ts
+++ b/servers/exarchos-mcp/src/tasks/tools.test.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { EventStore, SequenceConflictError } from '../event-store/store.js';
-import { handleTaskClaim, resetModuleEventStore } from './tools.js';
+import { handleTaskClaim, handleTaskComplete, handleTaskFail, resetModuleEventStore } from './tools.js';
 import { resetMaterializerCache } from '../views/tools.js';
 
 let tempDir: string;
@@ -290,5 +290,77 @@ describe('handleTaskClaim Exponential Backoff', () => {
     const totalRequestedDelay = capturedDelays.reduce((sum, d) => sum + d, 0);
     expect(totalRequestedDelay).toBe(350);
     expect(result.success).toBe(false);
+  });
+});
+
+// ─── F-TASK-1 / F-TASK-2: Idempotency keys on task events ──────────────────
+
+describe('Task event idempotency keys', () => {
+  it('handleTaskComplete_EventAppend_HasIdempotencyKey', async () => {
+    // Arrange: create an event store and seed with a task assignment
+    const store = new EventStore(tempDir);
+    await store.append('wf-idem-comp', {
+      type: 'task.assigned',
+      data: { taskId: 't-idem-1', title: 'Idem test', assignee: 'agent-1' },
+    });
+
+    // Spy on append to capture idempotency keys
+    const appendCalls: Array<{ type: string; idempotencyKey?: string }> = [];
+    const originalAppend = store.append.bind(store);
+    vi.spyOn(EventStore.prototype, 'append').mockImplementation(async function (
+      this: EventStore,
+      streamId: string,
+      event: Parameters<EventStore['append']>[1],
+      options?: Parameters<EventStore['append']>[2],
+    ) {
+      appendCalls.push({ type: event.type, idempotencyKey: options?.idempotencyKey });
+      return originalAppend(streamId, event, options);
+    });
+
+    // Act
+    const result = await handleTaskComplete(
+      { taskId: 't-idem-1', streamId: 'wf-idem-comp' },
+      tempDir,
+    );
+
+    // Assert: task.completed event should have an idempotency key
+    expect(result.success).toBe(true);
+    const completedCalls = appendCalls.filter((c) => c.type === 'task.completed');
+    expect(completedCalls.length).toBe(1);
+    expect(completedCalls[0].idempotencyKey).toBe('wf-idem-comp:task.completed:t-idem-1');
+  });
+
+  it('handleTaskFail_EventAppend_HasIdempotencyKey', async () => {
+    // Arrange: create an event store and seed with a task assignment
+    const store = new EventStore(tempDir);
+    await store.append('wf-idem-fail', {
+      type: 'task.assigned',
+      data: { taskId: 't-idem-2', title: 'Idem fail test', assignee: 'agent-1' },
+    });
+
+    // Spy on append to capture idempotency keys
+    const appendCalls: Array<{ type: string; idempotencyKey?: string }> = [];
+    const originalAppend = store.append.bind(store);
+    vi.spyOn(EventStore.prototype, 'append').mockImplementation(async function (
+      this: EventStore,
+      streamId: string,
+      event: Parameters<EventStore['append']>[1],
+      options?: Parameters<EventStore['append']>[2],
+    ) {
+      appendCalls.push({ type: event.type, idempotencyKey: options?.idempotencyKey });
+      return originalAppend(streamId, event, options);
+    });
+
+    // Act
+    const result = await handleTaskFail(
+      { taskId: 't-idem-2', error: 'Something broke', streamId: 'wf-idem-fail' },
+      tempDir,
+    );
+
+    // Assert: task.failed event should have an idempotency key
+    expect(result.success).toBe(true);
+    const failedCalls = appendCalls.filter((c) => c.type === 'task.failed');
+    expect(failedCalls.length).toBe(1);
+    expect(failedCalls[0].idempotencyKey).toBe('wf-idem-fail:task.failed:t-idem-2');
   });
 });

--- a/servers/exarchos-mcp/src/tasks/tools.ts
+++ b/servers/exarchos-mcp/src/tasks/tools.ts
@@ -200,7 +200,7 @@ export async function handleTaskComplete(
     const event = await store.append(args.streamId, {
       type: 'task.completed',
       data,
-    });
+    }, { idempotencyKey: `${args.streamId}:task.completed:${args.taskId}` });
 
     return { success: true, data: toEventAck(event) };
   } catch (err) {
@@ -261,7 +261,7 @@ export async function handleTaskFail(
     const event = await store.append(args.streamId, {
       type: 'task.failed',
       data,
-    });
+    }, { idempotencyKey: `${args.streamId}:task.failed:${args.taskId}` });
 
     return { success: true, data: toEventAck(event) };
   } catch (err) {

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -793,7 +793,7 @@ export async function handleCheckpoint(
           phase: state.phase,
           featureId: input.featureId,
         },
-      });
+      }, { idempotencyKey: `${input.featureId}:checkpoint:${state.phase}:${state._version}` });
     } catch (err) {
       return {
         success: false,


### PR DESCRIPTION
workflow.checkpoint, task.completed, and task.failed events were
emitted without idempotency keys, risking duplicate events on retry.
Add keys following the established pattern:
- checkpoint: ${featureId}:checkpoint:${phase}:${version}
- task.completed: ${streamId}:task.completed:${taskId}
- task.failed: ${streamId}:task.failed:${taskId}