### PR TITLE
feat: add session lifecycle manager for pruning stale session files

### DIFF
--- a/servers/exarchos-mcp/src/session/lifecycle.test.ts
+++ b/servers/exarchos-mcp/src/session/lifecycle.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+describe('Session Lifecycle', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lifecycle-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  /**
+   * Helper: create a session events file with controlled mtime and size.
+   */
+  async function createSessionFile(
+    sessionsDir: string,
+    filename: string,
+    options: { ageInDays: number; sizeBytes?: number },
+  ): Promise<void> {
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const filePath = path.join(sessionsDir, filename);
+    const content = options.sizeBytes
+      ? 'x'.repeat(options.sizeBytes)
+      : '{"t":"tool","ts":"2026-01-01T00:00:00Z"}\n';
+    await fs.writeFile(filePath, content, 'utf-8');
+
+    const now = Date.now();
+    const mtime = new Date(now - options.ageInDays * 24 * 60 * 60 * 1000);
+    await fs.utimes(filePath, mtime, mtime);
+  }
+
+  it('pruneSessionFiles_OlderThanRetention_Deletes', async () => {
+    const { pruneSessionFiles } = await import('./lifecycle.js');
+    const sessionsDir = path.join(tmpDir, 'sessions');
+
+    // Create files: one 10 days old (should be deleted), one 3 days old (should be kept)
+    await createSessionFile(sessionsDir, 'old-session.events.jsonl', { ageInDays: 10, sizeBytes: 100 });
+    await createSessionFile(sessionsDir, 'recent-session.events.jsonl', { ageInDays: 3, sizeBytes: 100 });
+
+    const result = await pruneSessionFiles(tmpDir, { retentionDays: 7 });
+
+    expect(result.deleted).toBe(1);
+    expect(result.freedBytes).toBe(100);
+
+    // Old file should be gone
+    await expect(fs.access(path.join(sessionsDir, 'old-session.events.jsonl'))).rejects.toThrow();
+    // Recent file should still exist
+    const stat = await fs.stat(path.join(sessionsDir, 'recent-session.events.jsonl'));
+    expect(stat.isFile()).toBe(true);
+  });
+
+  it('pruneSessionFiles_WithinRetention_Keeps', async () => {
+    const { pruneSessionFiles } = await import('./lifecycle.js');
+    const sessionsDir = path.join(tmpDir, 'sessions');
+
+    await createSessionFile(sessionsDir, 'session-1.events.jsonl', { ageInDays: 1, sizeBytes: 200 });
+    await createSessionFile(sessionsDir, 'session-2.events.jsonl', { ageInDays: 5, sizeBytes: 300 });
+
+    const result = await pruneSessionFiles(tmpDir, { retentionDays: 7 });
+
+    expect(result.deleted).toBe(0);
+    expect(result.freedBytes).toBe(0);
+
+    // Both files should still exist
+    const stat1 = await fs.stat(path.join(sessionsDir, 'session-1.events.jsonl'));
+    expect(stat1.isFile()).toBe(true);
+    const stat2 = await fs.stat(path.join(sessionsDir, 'session-2.events.jsonl'));
+    expect(stat2.isFile()).toBe(true);
+  });
+
+  it('pruneSessionFiles_ExceedsSizeCap_DeletesOldestFirst', async () => {
+    const { pruneSessionFiles } = await import('./lifecycle.js');
+    const sessionsDir = path.join(tmpDir, 'sessions');
+
+    // Create three files within retention but exceeding 1MB total cap
+    // Using a tiny cap (1MB) for testing. Files: 500KB each = 1.5MB total
+    const halfMB = 500 * 1024;
+    await createSessionFile(sessionsDir, 'oldest.events.jsonl', { ageInDays: 5, sizeBytes: halfMB });
+    await createSessionFile(sessionsDir, 'middle.events.jsonl', { ageInDays: 3, sizeBytes: halfMB });
+    await createSessionFile(sessionsDir, 'newest.events.jsonl', { ageInDays: 1, sizeBytes: halfMB });
+
+    // Cap at 1MB -- oldest should be deleted to bring total under cap
+    const result = await pruneSessionFiles(tmpDir, { retentionDays: 7, maxSizeMB: 1 });
+
+    expect(result.deleted).toBe(1);
+    expect(result.freedBytes).toBe(halfMB);
+
+    // Oldest should be gone
+    await expect(fs.access(path.join(sessionsDir, 'oldest.events.jsonl'))).rejects.toThrow();
+    // Middle and newest should remain
+    const stat1 = await fs.stat(path.join(sessionsDir, 'middle.events.jsonl'));
+    expect(stat1.isFile()).toBe(true);
+    const stat2 = await fs.stat(path.join(sessionsDir, 'newest.events.jsonl'));
+    expect(stat2.isFile()).toBe(true);
+  });
+
+  it('pruneSessionFiles_EmptyDir_Noop', async () => {
+    const { pruneSessionFiles } = await import('./lifecycle.js');
+
+    // sessions dir does not exist at all
+    const result = await pruneSessionFiles(tmpDir);
+
+    expect(result.deleted).toBe(0);
+    expect(result.freedBytes).toBe(0);
+  });
+
+  it('pruneSessionFiles_ManifestFile_NeverDeleted', async () => {
+    const { pruneSessionFiles } = await import('./lifecycle.js');
+    const sessionsDir = path.join(tmpDir, 'sessions');
+
+    // Create a .manifest.jsonl that is very old -- should never be deleted
+    await createSessionFile(sessionsDir, '.manifest.jsonl', { ageInDays: 30, sizeBytes: 1000 });
+    // Create an old events file that should be deleted
+    await createSessionFile(sessionsDir, 'old-session.events.jsonl', { ageInDays: 10, sizeBytes: 200 });
+
+    const result = await pruneSessionFiles(tmpDir, { retentionDays: 7 });
+
+    expect(result.deleted).toBe(1);
+    expect(result.freedBytes).toBe(200);
+
+    // .manifest.jsonl must still exist
+    const stat = await fs.stat(path.join(sessionsDir, '.manifest.jsonl'));
+    expect(stat.isFile()).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/session/lifecycle.ts
+++ b/servers/exarchos-mcp/src/session/lifecycle.ts
@@ -1,0 +1,152 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+const SESSIONS_DIR = 'sessions';
+const EVENTS_PATTERN = /\.events\.jsonl$/;
+const DEFAULT_RETENTION_DAYS = 7;
+const DEFAULT_MAX_SIZE_MB = 50;
+const BYTES_PER_MB = 1024 * 1024;
+
+/** Result of a session file pruning operation. */
+export interface PruneResult {
+  readonly deleted: number;
+  readonly freedBytes: number;
+}
+
+/** Options for controlling pruning behavior. */
+export interface PruneOptions {
+  /** Maximum age in days before files are deleted. Default: 7 */
+  readonly retentionDays?: number;
+  /** Maximum total size in MB for session files. Default: 50 */
+  readonly maxSizeMB?: number;
+}
+
+interface SessionFileInfo {
+  readonly filePath: string;
+  readonly mtimeMs: number;
+  readonly size: number;
+}
+
+/**
+ * Prune stale session event files from the sessions directory.
+ *
+ * Pass 1: Deletes files older than the retention period.
+ * Pass 2: If remaining files exceed the size cap, deletes oldest first until under cap.
+ *
+ * The `.manifest.jsonl` file is never deleted. Only `*.events.jsonl` files are candidates.
+ *
+ * @param stateDir - Root state directory containing `sessions/` subdirectory
+ * @param options - Optional retention and size cap configuration
+ * @returns Count of deleted files and total freed bytes
+ */
+export async function pruneSessionFiles(
+  stateDir: string,
+  options?: PruneOptions,
+): Promise<PruneResult> {
+  const retentionDays = options?.retentionDays ?? DEFAULT_RETENTION_DAYS;
+  const maxSizeBytes = (options?.maxSizeMB ?? DEFAULT_MAX_SIZE_MB) * BYTES_PER_MB;
+  const sessionsDir = path.join(stateDir, SESSIONS_DIR);
+
+  const entries = await readSessionsDir(sessionsDir);
+  if (entries.length === 0) {
+    return { deleted: 0, freedBytes: 0 };
+  }
+
+  const fileInfos = await collectFileInfos(sessionsDir, entries);
+  if (fileInfos.length === 0) {
+    return { deleted: 0, freedBytes: 0 };
+  }
+
+  // Sort by mtime ascending (oldest first)
+  const sorted = [...fileInfos].sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+  const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+
+  // Pass 1: Delete files older than retention period
+  let deleted = 0;
+  let freedBytes = 0;
+  const remaining: SessionFileInfo[] = [];
+
+  for (const info of sorted) {
+    if (info.mtimeMs < cutoffMs) {
+      const removed = await safeUnlink(info.filePath);
+      if (removed) {
+        deleted += 1;
+        freedBytes += info.size;
+      }
+    } else {
+      remaining.push(info);
+    }
+  }
+
+  // Pass 2: Enforce size cap on remaining files (still sorted oldest first)
+  let totalSize = remaining.reduce((sum, f) => sum + f.size, 0);
+
+  for (const info of remaining) {
+    if (totalSize <= maxSizeBytes) {
+      break;
+    }
+    const removed = await safeUnlink(info.filePath);
+    if (removed) {
+      deleted += 1;
+      freedBytes += info.size;
+      totalSize -= info.size;
+    }
+  }
+
+  return { deleted, freedBytes };
+}
+
+/** Read the sessions directory, returning an empty array if it doesn't exist. */
+async function readSessionsDir(sessionsDir: string): Promise<string[]> {
+  try {
+    return await fs.readdir(sessionsDir);
+  } catch {
+    return [];
+  }
+}
+
+/** Collect stat info for all `*.events.jsonl` files. */
+async function collectFileInfos(
+  sessionsDir: string,
+  entries: readonly string[],
+): Promise<SessionFileInfo[]> {
+  const results: SessionFileInfo[] = [];
+
+  for (const entry of entries) {
+    if (!EVENTS_PATTERN.test(entry)) {
+      continue;
+    }
+
+    const filePath = path.join(sessionsDir, entry);
+    try {
+      const stat = await fs.stat(filePath);
+      results.push({
+        filePath,
+        mtimeMs: stat.mtimeMs,
+        size: stat.size,
+      });
+    } catch {
+      // File may have been deleted between readdir and stat; skip it
+    }
+  }
+
+  return results;
+}
+
+/** Delete a file, returning true if successful. Handles ENOENT gracefully. */
+async function safeUnlink(filePath: string): Promise<boolean> {
+  try {
+    await fs.unlink(filePath);
+    return true;
+  } catch (err: unknown) {
+    if (isNodeError(err) && err.code === 'ENOENT') {
+      return false;
+    }
+    throw err;
+  }
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && 'code' in err;
+}


### PR DESCRIPTION
Implements pruneSessionFiles() that enforces a 7-day retention period
and 50MB total size cap on session event files. Two-pass algorithm:
first deletes files older than retention, then enforces size cap by
removing oldest first. Never deletes .manifest.jsonl. Handles ENOENT
gracefully for concurrent access safety.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>