### PR TITLE
feat: integrate session manifest and retry into SessionStart hook

### DIFF
--- a/servers/exarchos-mcp/src/cli-commands/session-start.test.ts
+++ b/servers/exarchos-mcp/src/cli-commands/session-start.test.ts
@@ -1,8 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { handleSessionStart, detectNativeTeam, queryTelemetryHints, detectGraphite } from './session-start.js';
+
+vi.mock('../session/manifest.js', () => ({
+  writeManifestEntry: vi.fn().mockResolvedValue(undefined),
+  findUnextractedSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../session/transcript-parser.js', () => ({
+  parseTranscript: vi.fn().mockResolvedValue([]),
+}));
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -1221,6 +1230,231 @@ describe('session-start command', () => {
 
       // Assert
       expect(result).toBe(false);
+    });
+  });
+
+  // ─── Session Manifest Integration (Task 008) ───────────────────────────────
+
+  describe('session manifest integration', () => {
+    let manifestMocks: typeof import('../session/manifest.js');
+
+    beforeEach(async () => {
+      manifestMocks = await import('../session/manifest.js');
+      vi.mocked(manifestMocks.writeManifestEntry).mockReset().mockResolvedValue(undefined);
+      vi.mocked(manifestMocks.findUnextractedSessions).mockReset().mockResolvedValue([]);
+    });
+
+    it('handleSessionStart_WritesManifestEntry_WithSessionMetadata', async () => {
+      // Arrange
+      const stdinData = {
+        session_id: 'sess-abc-123',
+        transcript_path: '/home/user/.claude/projects/transcript.jsonl',
+        cwd: '/home/user/project',
+      };
+
+      // Act
+      await handleSessionStart(stdinData, tmpDir);
+
+      // Assert
+      expect(manifestMocks.writeManifestEntry).toHaveBeenCalledOnce();
+      const callArgs = vi.mocked(manifestMocks.writeManifestEntry).mock.calls[0];
+      expect(callArgs[0]).toBe(tmpDir);
+      const entry = callArgs[1];
+      expect(entry.sessionId).toBe('sess-abc-123');
+      expect(entry.transcriptPath).toBe('/home/user/.claude/projects/transcript.jsonl');
+      expect(entry.cwd).toBe('/home/user/project');
+      expect(entry.startedAt).toBeDefined();
+      // startedAt should be a valid ISO date
+      expect(new Date(entry.startedAt).toISOString()).toBe(entry.startedAt);
+    });
+
+    it('handleSessionStart_ResolvesWorkflowId_FromActiveWorkflows', async () => {
+      // Arrange — active workflow state file
+      const stdinData = {
+        session_id: 'sess-with-workflow',
+        transcript_path: '/tmp/transcript.jsonl',
+        cwd: '/home/user/project',
+      };
+      const stateData = createValidStateFile({
+        featureId: 'active-feature',
+        phase: 'delegate',
+      });
+      await fs.writeFile(
+        path.join(tmpDir, 'active-feature.state.json'),
+        JSON.stringify(stateData, null, 2),
+      );
+
+      // Act
+      await handleSessionStart(stdinData, tmpDir);
+
+      // Assert
+      expect(manifestMocks.writeManifestEntry).toHaveBeenCalledOnce();
+      const entry = vi.mocked(manifestMocks.writeManifestEntry).mock.calls[0][1];
+      expect(entry.workflowId).toBe('active-feature');
+    });
+
+    it('handleSessionStart_NoActiveWorkflow_ManifestEntryHasUndefinedWorkflowId', async () => {
+      // Arrange — no state files, no checkpoints
+      const stdinData = {
+        session_id: 'sess-no-workflow',
+        transcript_path: '/tmp/transcript.jsonl',
+        cwd: '/home/user/project',
+      };
+
+      // Act
+      await handleSessionStart(stdinData, tmpDir);
+
+      // Assert
+      expect(manifestMocks.writeManifestEntry).toHaveBeenCalledOnce();
+      const entry = vi.mocked(manifestMocks.writeManifestEntry).mock.calls[0][1];
+      expect(entry.workflowId).toBeUndefined();
+    });
+
+    it('handleSessionStart_ManifestWriteFailure_DoesNotBreakExistingBehavior', async () => {
+      // Arrange — writeManifestEntry throws
+      vi.mocked(manifestMocks.writeManifestEntry).mockRejectedValue(new Error('disk full'));
+      const stdinData = {
+        session_id: 'sess-fail-write',
+        transcript_path: '/tmp/transcript.jsonl',
+        cwd: '/home/user/project',
+      };
+      const stateData = createValidStateFile({
+        featureId: 'resilient-feature',
+        phase: 'review',
+      });
+      await fs.writeFile(
+        path.join(tmpDir, 'resilient-feature.state.json'),
+        JSON.stringify(stateData, null, 2),
+      );
+
+      // Act
+      const result = await handleSessionStart(stdinData, tmpDir);
+
+      // Assert — session-start still returns workflow info
+      expect(result.workflows).toBeDefined();
+      expect(result.workflows).toHaveLength(1);
+      expect(result.workflows![0].featureId).toBe('resilient-feature');
+      expect(result.error).toBeUndefined();
+    });
+  });
+
+  // ─── Session Retry Mechanism (Task 011) ────────────────────────────────────
+
+  describe('session retry mechanism', () => {
+    let manifestMocks: typeof import('../session/manifest.js');
+    let parserMocks: typeof import('../session/transcript-parser.js');
+
+    beforeEach(async () => {
+      manifestMocks = await import('../session/manifest.js');
+      parserMocks = await import('../session/transcript-parser.js');
+      vi.mocked(manifestMocks.writeManifestEntry).mockReset().mockResolvedValue(undefined);
+      vi.mocked(manifestMocks.findUnextractedSessions).mockReset().mockResolvedValue([]);
+      vi.mocked(parserMocks.parseTranscript).mockReset().mockResolvedValue([]);
+    });
+
+    it('handleSessionStart_UnextractedSession_RetriesExtraction', async () => {
+      // Arrange — one unextracted session with existing transcript
+      const transcriptPath = path.join(tmpDir, 'old-transcript.jsonl');
+      await fs.writeFile(transcriptPath, '{"type":"assistant"}\n');
+
+      vi.mocked(manifestMocks.findUnextractedSessions).mockResolvedValue([
+        { sessionId: 'old-sess-1', transcriptPath, cwd: '/tmp', startedAt: '2025-01-01T00:00:00Z', workflowId: 'feat-1' },
+      ]);
+
+      const mockEvents = [
+        { t: 'tool' as const, ts: '2025-01-01T00:00:01Z', tool: 'Read', cat: 'native' as const, inB: 10, outB: 20, sid: 'old-sess-1', wid: 'feat-1' },
+      ];
+      vi.mocked(parserMocks.parseTranscript).mockResolvedValue(mockEvents);
+
+      const stdinData = { session_id: 'current-sess', transcript_path: '/tmp/current.jsonl', cwd: '/tmp' };
+
+      // Act
+      await handleSessionStart(stdinData, tmpDir);
+
+      // Assert — parseTranscript called for the unextracted session
+      expect(parserMocks.parseTranscript).toHaveBeenCalledWith(transcriptPath, { sessionId: 'old-sess-1', workflowId: 'feat-1' });
+
+      // Assert — events written to sessions/{sessionId}.events.jsonl
+      const eventsPath = path.join(tmpDir, 'sessions', 'old-sess-1.events.jsonl');
+      const eventsContent = await fs.readFile(eventsPath, 'utf-8');
+      expect(eventsContent.trim().split('\n')).toHaveLength(1);
+      const parsed = JSON.parse(eventsContent.trim().split('\n')[0]);
+      expect(parsed.t).toBe('tool');
+    });
+
+    it('handleSessionStart_TranscriptGone_MarksSessionAsOrphan', async () => {
+      // Arrange — unextracted session whose transcript file no longer exists
+      vi.mocked(manifestMocks.findUnextractedSessions).mockResolvedValue([
+        { sessionId: 'orphan-sess', transcriptPath: '/nonexistent/transcript.jsonl', cwd: '/tmp', startedAt: '2025-01-01T00:00:00Z' },
+      ]);
+
+      const stdinData = { session_id: 'current-sess', transcript_path: '/tmp/current.jsonl', cwd: '/tmp' };
+
+      // Act
+      await handleSessionStart(stdinData, tmpDir);
+
+      // Assert — parseTranscript should NOT be called
+      expect(parserMocks.parseTranscript).not.toHaveBeenCalled();
+
+      // Assert — orphan marker appended to manifest
+      const manifestPath = path.join(tmpDir, 'sessions', '.manifest.jsonl');
+      const content = await fs.readFile(manifestPath, 'utf-8');
+      const lines = content.trim().split('\n');
+      const orphanLine = lines.find((l) => l.includes('orphan-sess'));
+      expect(orphanLine).toBeDefined();
+      const orphanEntry = JSON.parse(orphanLine!);
+      expect(orphanEntry.sessionId).toBe('orphan-sess');
+      expect(orphanEntry.reason).toBe('transcript_not_found');
+      expect(orphanEntry.orphanedAt).toBeDefined();
+    });
+
+    it('handleSessionStart_MultipleUnextracted_ProcessesAll', async () => {
+      // Arrange — two unextracted sessions
+      const transcriptPath1 = path.join(tmpDir, 'transcript-1.jsonl');
+      const transcriptPath2 = path.join(tmpDir, 'transcript-2.jsonl');
+      await fs.writeFile(transcriptPath1, '{"type":"assistant"}\n');
+      await fs.writeFile(transcriptPath2, '{"type":"assistant"}\n');
+
+      vi.mocked(manifestMocks.findUnextractedSessions).mockResolvedValue([
+        { sessionId: 'multi-sess-1', transcriptPath: transcriptPath1, cwd: '/tmp', startedAt: '2025-01-01T00:00:00Z' },
+        { sessionId: 'multi-sess-2', transcriptPath: transcriptPath2, cwd: '/tmp', startedAt: '2025-01-01T00:01:00Z' },
+      ]);
+
+      vi.mocked(parserMocks.parseTranscript).mockResolvedValue([]);
+
+      const stdinData = { session_id: 'current-sess', transcript_path: '/tmp/current.jsonl', cwd: '/tmp' };
+
+      // Act
+      await handleSessionStart(stdinData, tmpDir);
+
+      // Assert — parseTranscript called for both
+      expect(parserMocks.parseTranscript).toHaveBeenCalledTimes(2);
+      expect(parserMocks.parseTranscript).toHaveBeenCalledWith(transcriptPath1, { sessionId: 'multi-sess-1', workflowId: undefined });
+      expect(parserMocks.parseTranscript).toHaveBeenCalledWith(transcriptPath2, { sessionId: 'multi-sess-2', workflowId: undefined });
+    });
+
+    it('handleSessionStart_RetryFailure_DoesNotBreakStartup', async () => {
+      // Arrange — findUnextractedSessions throws
+      vi.mocked(manifestMocks.findUnextractedSessions).mockRejectedValue(new Error('corrupt manifest'));
+
+      const stdinData = { session_id: 'current-sess', transcript_path: '/tmp/current.jsonl', cwd: '/tmp' };
+      const stateData = createValidStateFile({
+        featureId: 'resilient-feature-2',
+        phase: 'plan',
+      });
+      await fs.writeFile(
+        path.join(tmpDir, 'resilient-feature-2.state.json'),
+        JSON.stringify(stateData, null, 2),
+      );
+
+      // Act
+      const result = await handleSessionStart(stdinData, tmpDir);
+
+      // Assert — session-start still returns workflow info normally
+      expect(result.workflows).toBeDefined();
+      expect(result.workflows).toHaveLength(1);
+      expect(result.workflows![0].featureId).toBe('resilient-feature-2');
+      expect(result.error).toBeUndefined();
     });
   });
 });

--- a/servers/exarchos-mcp/src/cli-commands/session-start.ts
+++ b/servers/exarchos-mcp/src/cli-commands/session-start.ts
@@ -6,6 +6,9 @@ import { listStateFiles } from '../workflow/state-store.js';
 import { telemetryProjection } from '../telemetry/telemetry-projection.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
 import { generateHints } from '../telemetry/hints.js';
+import { writeManifestEntry, findUnextractedSessions } from '../session/manifest.js';
+import { parseTranscript } from '../session/transcript-parser.js';
+import type { SessionManifestEntry } from '../session/types.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -373,6 +376,49 @@ export async function queryTelemetryHints(stateDir: string): Promise<string[]> {
   return hints.map((h) => `${h.tool}: ${h.hint}`);
 }
 
+// ─── Session Retry ──────────────────────────────────────────────────────────
+
+/**
+ * Retry extraction for sessions that were started but never had their
+ * SessionEnd hook fire successfully. Scans the manifest for entries
+ * without a corresponding `.events.jsonl` file.
+ *
+ * For each unextracted session:
+ * - If the transcript file still exists, parse it and write events
+ * - If the transcript is gone, append an orphan marker to the manifest
+ *
+ * Failures are silently caught — retries must never break session startup.
+ */
+async function retryUnextractedSessions(stateDir: string): Promise<void> {
+  const unextracted = await findUnextractedSessions(stateDir);
+  if (unextracted.length === 0) return;
+
+  const sessionsDir = path.join(stateDir, 'sessions');
+  await fs.mkdir(sessionsDir, { recursive: true });
+
+  for (const entry of unextracted) {
+    const transcriptExists = await fs.access(entry.transcriptPath).then(() => true, () => false);
+
+    if (transcriptExists) {
+      const events = await parseTranscript(entry.transcriptPath, {
+        sessionId: entry.sessionId,
+        workflowId: entry.workflowId,
+      });
+      const eventsPath = path.join(sessionsDir, `${entry.sessionId}.events.jsonl`);
+      const eventsContent = events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+      await fs.writeFile(eventsPath, eventsContent, 'utf-8');
+    } else {
+      const manifestPath = path.join(sessionsDir, '.manifest.jsonl');
+      const orphanMarker = {
+        sessionId: entry.sessionId,
+        orphanedAt: new Date().toISOString(),
+        reason: 'transcript_not_found',
+      };
+      await fs.appendFile(manifestPath, JSON.stringify(orphanMarker) + '\n', 'utf-8');
+    }
+  }
+}
+
 // ─── Handler ────────────────────────────────────────────────────────────────
 
 /**
@@ -498,7 +544,7 @@ async function enrichResult(
  * that exceed optimization thresholds.
  */
 export async function handleSessionStart(
-  _stdinData: Record<string, unknown>,
+  stdinData: Record<string, unknown>,
   stateDir: string,
   teamsDir?: string,
 ): Promise<SessionStartResult> {
@@ -507,6 +553,11 @@ export async function handleSessionStart(
 
   // Step 1: Check for checkpoint files (highest priority)
   const checkpoints = await readAndDeleteCheckpoints(stateDir);
+
+  // Collect discovered workflows for manifest workflowId resolution
+  const discoveredWorkflows: WorkflowInfo[] = [];
+
+  let result: SessionStartResult;
 
   if (checkpoints.length > 0) {
     // Collect featureIds from checkpoints to exclude from state file discovery
@@ -545,6 +596,8 @@ export async function handleSessionStart(
       // Non-critical: if listing fails, we still have checkpoint data
     }
 
+    discoveredWorkflows.push(...workflows);
+
     const baseResult: SessionStartResult = contextDocument
       ? { workflows, contextDocument }
       : { workflows };
@@ -552,33 +605,79 @@ export async function handleSessionStart(
     if (teamsDir) {
       const teamResult = await applyNativeTeamDetection(workflows, teamsDir);
       const merged = contextDocument ? { ...teamResult, contextDocument } : teamResult;
-      return enrichResult(merged, stateDir, graphiteAvailable);
+      result = await enrichResult(merged, stateDir, graphiteAvailable);
+    } else {
+      result = await enrichResult(baseResult, stateDir, graphiteAvailable);
     }
-    return enrichResult(baseResult, stateDir, graphiteAvailable);
+  } else {
+    // Step 2: No checkpoints — discover active workflows from state files
+    try {
+      const stateFiles = (await listStateFiles(stateDir)).valid;
+      const activeWorkflows = stateFiles.filter(
+        (entry) => !TERMINAL_PHASES.has(entry.state.phase),
+      );
+
+      const workflows: WorkflowInfo[] = activeWorkflows.map((entry) => ({
+        featureId: entry.featureId,
+        phase: entry.state.phase,
+        summary: `Active workflow discovered (${entry.state.workflowType})`,
+        nextAction: `WAIT:in-progress:${entry.state.phase}`,
+      }));
+
+      discoveredWorkflows.push(...workflows);
+
+      if (activeWorkflows.length === 0 && !teamsDir) {
+        result = await enrichResult({}, stateDir, graphiteAvailable);
+      } else if (teamsDir) {
+        result = await enrichResult(await applyNativeTeamDetection(workflows, teamsDir), stateDir, graphiteAvailable);
+      } else if (workflows.length === 0) {
+        result = await enrichResult({}, stateDir, graphiteAvailable);
+      } else {
+        result = await enrichResult({ workflows }, stateDir, graphiteAvailable);
+      }
+    } catch {
+      // If state dir doesn't exist or is unreadable, still check for orphaned teams
+      if (teamsDir) {
+        result = await enrichResult(await applyNativeTeamDetection([], teamsDir), stateDir, graphiteAvailable);
+      } else {
+        result = await enrichResult({}, stateDir, graphiteAvailable);
+      }
+    }
   }
 
-  // Step 2: No checkpoints — discover active workflows from state files
+  // Step 3: Write session manifest entry (non-critical — failures must not break startup)
   try {
-    const stateFiles = (await listStateFiles(stateDir)).valid;
-    const activeWorkflows = stateFiles.filter(
-      (entry) => !TERMINAL_PHASES.has(entry.state.phase),
-    );
+    const sessionId = typeof stdinData.session_id === 'string' ? stdinData.session_id : undefined;
+    const transcriptPath = typeof stdinData.transcript_path === 'string' ? stdinData.transcript_path : undefined;
+    const cwd = typeof stdinData.cwd === 'string' ? stdinData.cwd : undefined;
+    const branch = typeof stdinData.branch === 'string' ? stdinData.branch : undefined;
 
-    if (activeWorkflows.length === 0 && !teamsDir) return enrichResult({}, stateDir, graphiteAvailable);
+    if (sessionId && transcriptPath && cwd) {
+      const workflowId = discoveredWorkflows.length > 0
+        ? discoveredWorkflows[0].featureId
+        : undefined;
 
-    const workflows: WorkflowInfo[] = activeWorkflows.map((entry) => ({
-      featureId: entry.featureId,
-      phase: entry.state.phase,
-      summary: `Active workflow discovered (${entry.state.workflowType})`,
-      nextAction: `WAIT:in-progress:${entry.state.phase}`,
-    }));
+      const manifestEntry: SessionManifestEntry = {
+        sessionId,
+        transcriptPath,
+        cwd,
+        startedAt: new Date().toISOString(),
+        ...(workflowId !== undefined && { workflowId }),
+        ...(branch !== undefined && { branch }),
+      };
 
-    if (teamsDir) return enrichResult(await applyNativeTeamDetection(workflows, teamsDir), stateDir, graphiteAvailable);
-    if (workflows.length === 0) return enrichResult({}, stateDir, graphiteAvailable);
-    return enrichResult({ workflows }, stateDir, graphiteAvailable);
+      await writeManifestEntry(stateDir, manifestEntry);
+    }
   } catch {
-    // If state dir doesn't exist or is unreadable, still check for orphaned teams
-    if (teamsDir) return enrichResult(await applyNativeTeamDetection([], teamsDir), stateDir, graphiteAvailable);
-    return enrichResult({}, stateDir, graphiteAvailable);
+    // Manifest write failure must not break session startup
   }
+
+  // Step 4: Retry extraction for unextracted sessions (non-critical)
+  try {
+    await retryUnextractedSessions(stateDir);
+  } catch {
+    // Retry failure must not break session startup
+  }
+
+  return result;
 }


### PR DESCRIPTION
Wire writeManifestEntry into handleSessionStart to record session_id,
transcript_path, cwd, and resolved workflowId on each startup. Add
retry logic via retryUnextractedSessions to re-extract sessions whose
SessionEnd hook failed. Both features are wrapped in try/catch to
ensure session startup is never disrupted.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>