### PR TITLE
feat: add session_provenance CQRS view with lazy materialization

### DIFF
--- a/servers/exarchos-mcp/src/session/session-provenance-projection.test.ts
+++ b/servers/exarchos-mcp/src/session/session-provenance-projection.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type {
+  SessionToolEvent,
+  SessionTurnEvent,
+  SessionSummaryEvent,
+} from './types.js';
+
+describe('Session Provenance Projection', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'provenance-test-'));
+    await fs.mkdir(path.join(tmpDir, 'sessions'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  /** Write events to a session JSONL file */
+  async function writeEventsFile(
+    sessionId: string,
+    events: Array<SessionToolEvent | SessionTurnEvent | SessionSummaryEvent>,
+  ): Promise<void> {
+    const eventsPath = path.join(tmpDir, 'sessions', `${sessionId}.events.jsonl`);
+    const content = events.map((e) => JSON.stringify(e)).join('\n') + '\n';
+    await fs.writeFile(eventsPath, content, 'utf-8');
+  }
+
+  /** Write a manifest JSONL with entries */
+  async function writeManifest(
+    entries: Array<{ sessionId: string; workflowId?: string; transcriptPath: string; startedAt: string; cwd: string }>,
+  ): Promise<void> {
+    const manifestPath = path.join(tmpDir, 'sessions', '.manifest.jsonl');
+    const content = entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
+    await fs.writeFile(manifestPath, content, 'utf-8');
+  }
+
+  describe('materializeSession — Tool Events', () => {
+    it('materializeSession_ToolEvents_ReturnsToolBreakdownByCategory', async () => {
+      // Arrange
+      const events: SessionToolEvent[] = [
+        { t: 'tool', ts: '2026-01-01T00:00:00Z', tool: 'Read', cat: 'native', inB: 100, outB: 200, sid: 'sess-1' },
+        { t: 'tool', ts: '2026-01-01T00:01:00Z', tool: 'Write', cat: 'native', inB: 150, outB: 250, sid: 'sess-1' },
+        { t: 'tool', ts: '2026-01-01T00:02:00Z', tool: 'exarchos_workflow', cat: 'mcp_exarchos', inB: 50, outB: 300, sid: 'sess-1' },
+        { t: 'tool', ts: '2026-01-01T00:03:00Z', tool: 'github_search', cat: 'mcp_other', inB: 80, outB: 120, sid: 'sess-1' },
+        { t: 'tool', ts: '2026-01-01T00:04:00Z', tool: 'github_issues', cat: 'mcp_other', inB: 90, outB: 110, sid: 'sess-1' },
+      ];
+      await writeEventsFile('sess-1', events);
+
+      // Act
+      const { materializeSessionProvenance } = await import('./session-provenance-projection.js');
+      const result = await materializeSessionProvenance(tmpDir, { sessionId: 'sess-1' });
+
+      // Assert
+      expect(result.toolsByCategory).toEqual({
+        native: 2,
+        mcp_exarchos: 1,
+        mcp_other: 2,
+      });
+      expect(result.tools).toEqual({
+        Read: 1,
+        Write: 1,
+        exarchos_workflow: 1,
+        github_search: 1,
+        github_issues: 1,
+      });
+    });
+  });
+
+  describe('materializeSession — Turn Events', () => {
+    it('materializeSession_TurnEvents_ReturnsTokenTotals', async () => {
+      // Arrange
+      const events: SessionTurnEvent[] = [
+        { t: 'turn', ts: '2026-01-01T00:00:00Z', model: 'opus-4', tokIn: 1000, tokOut: 500, tokCacheR: 200, tokCacheW: 100, sid: 'sess-2' },
+        { t: 'turn', ts: '2026-01-01T00:01:00Z', model: 'opus-4', tokIn: 800, tokOut: 300, tokCacheR: 150, tokCacheW: 80, sid: 'sess-2' },
+        { t: 'turn', ts: '2026-01-01T00:02:00Z', model: 'opus-4', tokIn: 1200, tokOut: 600, tokCacheR: 250, tokCacheW: 120, sid: 'sess-2' },
+      ];
+      await writeEventsFile('sess-2', events);
+
+      // Act
+      const { materializeSessionProvenance } = await import('./session-provenance-projection.js');
+      const result = await materializeSessionProvenance(tmpDir, { sessionId: 'sess-2' });
+
+      // Assert
+      expect(result.tokens).toEqual({
+        in: 3000,
+        out: 1400,
+        cacheR: 600,
+        cacheW: 300,
+      });
+    });
+  });
+
+  describe('materializeSession — Summary Event', () => {
+    it('materializeSession_SummaryEvent_ReturnsSessionOverview', async () => {
+      // Arrange
+      const events: SessionSummaryEvent[] = [
+        {
+          t: 'summary',
+          ts: '2026-01-01T01:00:00Z',
+          sid: 'sess-3',
+          tools: { Read: 5, Write: 3, exarchos_workflow: 2 },
+          tokTotal: { in: 5000, out: 2000, cacheR: 1000, cacheW: 500 },
+          files: ['src/auth.ts', 'src/login.ts'],
+          dur: 3600,
+          turns: 15,
+        },
+      ];
+      await writeEventsFile('sess-3', events);
+
+      // Act
+      const { materializeSessionProvenance } = await import('./session-provenance-projection.js');
+      const result = await materializeSessionProvenance(tmpDir, { sessionId: 'sess-3' });
+
+      // Assert
+      expect(result.duration).toBe(3600);
+      expect(result.turns).toBe(15);
+      expect(result.files).toEqual(['src/auth.ts', 'src/login.ts']);
+      expect(result.tools).toEqual({ Read: 5, Write: 3, exarchos_workflow: 2 });
+    });
+  });
+
+  describe('materializeWorkflow — Multiple Sessions', () => {
+    it('materializeWorkflow_MultipleSessions_AggregatesAcrossSessions', async () => {
+      // Arrange: two sessions linked to the same workflow
+      await writeManifest([
+        { sessionId: 'wf-sess-1', workflowId: 'wf-abc', transcriptPath: '/tmp/t1', startedAt: '2026-01-01T00:00:00Z', cwd: '/tmp' },
+        { sessionId: 'wf-sess-2', workflowId: 'wf-abc', transcriptPath: '/tmp/t2', startedAt: '2026-01-01T01:00:00Z', cwd: '/tmp' },
+        { sessionId: 'other-sess', workflowId: 'wf-other', transcriptPath: '/tmp/t3', startedAt: '2026-01-01T02:00:00Z', cwd: '/tmp' },
+      ]);
+
+      const sess1Events: Array<SessionToolEvent | SessionSummaryEvent> = [
+        { t: 'tool', ts: '2026-01-01T00:00:00Z', tool: 'Read', cat: 'native', inB: 100, outB: 200, sid: 'wf-sess-1', wid: 'wf-abc' },
+        {
+          t: 'summary', ts: '2026-01-01T00:30:00Z', sid: 'wf-sess-1', wid: 'wf-abc',
+          tools: { Read: 3 }, tokTotal: { in: 2000, out: 1000, cacheR: 500, cacheW: 200 },
+          files: ['src/a.ts'], dur: 1800, turns: 5,
+        },
+      ];
+      const sess2Events: Array<SessionToolEvent | SessionSummaryEvent> = [
+        { t: 'tool', ts: '2026-01-01T01:00:00Z', tool: 'Write', cat: 'native', inB: 50, outB: 100, sid: 'wf-sess-2', wid: 'wf-abc' },
+        {
+          t: 'summary', ts: '2026-01-01T01:30:00Z', sid: 'wf-sess-2', wid: 'wf-abc',
+          tools: { Write: 2 }, tokTotal: { in: 1500, out: 800, cacheR: 300, cacheW: 100 },
+          files: ['src/b.ts'], dur: 1200, turns: 3,
+        },
+      ];
+
+      await writeEventsFile('wf-sess-1', sess1Events);
+      await writeEventsFile('wf-sess-2', sess2Events);
+
+      // Act
+      const { materializeSessionProvenance } = await import('./session-provenance-projection.js');
+      const result = await materializeSessionProvenance(tmpDir, { workflowId: 'wf-abc' });
+
+      // Assert
+      expect(result.workflowId).toBe('wf-abc');
+      expect(result.sessions).toBe(2);
+      expect(result.tokens).toEqual({
+        in: 3500,
+        out: 1800,
+        cacheR: 800,
+        cacheW: 300,
+      });
+      expect(result.duration).toBe(3000); // 1800 + 1200
+      expect(result.turns).toBe(8); // 5 + 3
+      expect(result.files).toEqual(expect.arrayContaining(['src/a.ts', 'src/b.ts']));
+      expect(result.tools).toEqual({ Read: 3, Write: 2 });
+    });
+  });
+
+  describe('materializeMetric — Cost', () => {
+    it('materializeMetric_Cost_ReturnsTokenTotalsBySession', async () => {
+      // Arrange
+      await writeManifest([
+        { sessionId: 'cost-sess-1', workflowId: 'wf-cost', transcriptPath: '/tmp/t1', startedAt: '2026-01-01T00:00:00Z', cwd: '/tmp' },
+        { sessionId: 'cost-sess-2', workflowId: 'wf-cost', transcriptPath: '/tmp/t2', startedAt: '2026-01-01T01:00:00Z', cwd: '/tmp' },
+      ]);
+
+      await writeEventsFile('cost-sess-1', [
+        { t: 'turn', ts: '2026-01-01T00:00:00Z', model: 'opus-4', tokIn: 1000, tokOut: 500, tokCacheR: 200, tokCacheW: 100, sid: 'cost-sess-1', wid: 'wf-cost' },
+        { t: 'turn', ts: '2026-01-01T00:01:00Z', model: 'opus-4', tokIn: 800, tokOut: 300, tokCacheR: 100, tokCacheW: 50, sid: 'cost-sess-1', wid: 'wf-cost' },
+      ]);
+
+      await writeEventsFile('cost-sess-2', [
+        { t: 'turn', ts: '2026-01-01T01:00:00Z', model: 'opus-4', tokIn: 2000, tokOut: 1000, tokCacheR: 500, tokCacheW: 250, sid: 'cost-sess-2', wid: 'wf-cost' },
+      ]);
+
+      // Act
+      const { materializeSessionProvenance } = await import('./session-provenance-projection.js');
+      const result = await materializeSessionProvenance(tmpDir, { workflowId: 'wf-cost', metric: 'cost' });
+
+      // Assert
+      expect(result.costBySession).toHaveLength(2);
+      const sess1 = result.costBySession!.find((s) => s.sid === 'cost-sess-1');
+      expect(sess1).toBeDefined();
+      expect(sess1!.tokens).toEqual({ in: 1800, out: 800 });
+      const sess2 = result.costBySession!.find((s) => s.sid === 'cost-sess-2');
+      expect(sess2).toBeDefined();
+      expect(sess2!.tokens).toEqual({ in: 2000, out: 1000 });
+    });
+  });
+
+  describe('materializeMetric — Attribution', () => {
+    it('materializeMetric_Attribution_ReturnsFileToToolMapping', async () => {
+      // Arrange
+      const events: SessionToolEvent[] = [
+        { t: 'tool', ts: '2026-01-01T00:00:00Z', tool: 'Read', cat: 'native', inB: 100, outB: 200, files: ['src/auth.ts', 'src/login.ts'], sid: 'attr-sess' },
+        { t: 'tool', ts: '2026-01-01T00:01:00Z', tool: 'Write', cat: 'native', inB: 50, outB: 150, files: ['src/auth.ts'], sid: 'attr-sess' },
+        { t: 'tool', ts: '2026-01-01T00:02:00Z', tool: 'Edit', cat: 'native', inB: 80, outB: 120, files: ['src/login.ts', 'src/config.ts'], sid: 'attr-sess' },
+        { t: 'tool', ts: '2026-01-01T00:03:00Z', tool: 'Bash', cat: 'native', inB: 30, outB: 40, sid: 'attr-sess' }, // no files
+      ];
+      await writeEventsFile('attr-sess', events);
+
+      // Act
+      const { materializeSessionProvenance } = await import('./session-provenance-projection.js');
+      const result = await materializeSessionProvenance(tmpDir, { sessionId: 'attr-sess', metric: 'attribution' });
+
+      // Assert
+      expect(result.fileAttribution).toBeDefined();
+      const authEntry = result.fileAttribution!.find((f) => f.file === 'src/auth.ts');
+      expect(authEntry).toBeDefined();
+      expect(authEntry!.tools).toEqual(expect.arrayContaining(['Read', 'Write']));
+      expect(authEntry!.tools).toHaveLength(2);
+
+      const loginEntry = result.fileAttribution!.find((f) => f.file === 'src/login.ts');
+      expect(loginEntry).toBeDefined();
+      expect(loginEntry!.tools).toEqual(expect.arrayContaining(['Read', 'Edit']));
+
+      const configEntry = result.fileAttribution!.find((f) => f.file === 'src/config.ts');
+      expect(configEntry).toBeDefined();
+      expect(configEntry!.tools).toEqual(['Edit']);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('materializeSession_EmptyEventsFile_ReturnsEmptyResult', async () => {
+      // Arrange: empty events file
+      const eventsPath = path.join(tmpDir, 'sessions', 'empty-sess.events.jsonl');
+      await fs.writeFile(eventsPath, '', 'utf-8');
+
+      // Act
+      const { materializeSessionProvenance } = await import('./session-provenance-projection.js');
+      const result = await materializeSessionProvenance(tmpDir, { sessionId: 'empty-sess' });
+
+      // Assert
+      expect(result.sessionId).toBe('empty-sess');
+      expect(result.tools).toEqual({});
+      expect(result.toolsByCategory).toEqual({ native: 0, mcp_exarchos: 0, mcp_other: 0 });
+      expect(result.tokens).toEqual({ in: 0, out: 0, cacheR: 0, cacheW: 0 });
+    });
+
+    it('materializeSession_MissingEventsFile_ReturnsEmptyResult', async () => {
+      // Act: no events file exists
+      const { materializeSessionProvenance } = await import('./session-provenance-projection.js');
+      const result = await materializeSessionProvenance(tmpDir, { sessionId: 'nonexistent' });
+
+      // Assert
+      expect(result.sessionId).toBe('nonexistent');
+      expect(result.tools).toEqual({});
+    });
+  });
+});

--- a/servers/exarchos-mcp/src/session/session-provenance-projection.ts
+++ b/servers/exarchos-mcp/src/session/session-provenance-projection.ts
@@ -1,0 +1,286 @@
+// ─── Session Provenance Projection ──────────────────────────────────────────
+//
+// CQRS view projection that materializes session events into queryable
+// aggregates. Completely lazy — never hydrated at startup, reads session
+// JSONL files on-demand with a bounded LRU cache.
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type {
+  SessionEvent,
+  SessionToolEvent,
+  SessionTurnEvent,
+  SessionSummaryEvent,
+} from './types.js';
+import { readManifestEntries } from './manifest.js';
+
+// ─── Public Types ───────────────────────────────────────────────────────────
+
+export interface SessionProvenanceQuery {
+  sessionId?: string;
+  workflowId?: string;
+  metric?: 'cost' | 'attribution';
+}
+
+export interface SessionProvenanceResult {
+  sessionId?: string;
+  workflowId?: string;
+  sessions?: number;
+  tools?: Record<string, number>;
+  toolsByCategory?: { native: number; mcp_exarchos: number; mcp_other: number };
+  tokens?: { in: number; out: number; cacheR: number; cacheW: number };
+  files?: string[];
+  duration?: number;
+  turns?: number;
+  costBySession?: Array<{ sid: string; tokens: { in: number; out: number } }>;
+  fileAttribution?: Array<{ file: string; tools: string[] }>;
+}
+
+// ─── LRU Cache ──────────────────────────────────────────────────────────────
+
+const MAX_CACHE_SIZE = 20;
+const sessionCache = new Map<string, SessionEvent[]>();
+
+function getCachedEvents(key: string): SessionEvent[] | undefined {
+  const value = sessionCache.get(key);
+  if (value !== undefined) {
+    // Move to end (most recently used)
+    sessionCache.delete(key);
+    sessionCache.set(key, value);
+  }
+  return value;
+}
+
+function setCachedEvents(key: string, events: SessionEvent[]): void {
+  if (sessionCache.size >= MAX_CACHE_SIZE) {
+    // Evict oldest (first key)
+    const oldest = sessionCache.keys().next().value;
+    if (oldest !== undefined) {
+      sessionCache.delete(oldest);
+    }
+  }
+  sessionCache.set(key, events);
+}
+
+// ─── Event File Reading ─────────────────────────────────────────────────────
+
+async function readSessionEvents(
+  stateDir: string,
+  sessionId: string,
+): Promise<SessionEvent[]> {
+  const cacheKey = `${stateDir}:${sessionId}`;
+  const cached = getCachedEvents(cacheKey);
+  if (cached) return cached;
+
+  const eventsPath = path.join(stateDir, 'sessions', `${sessionId}.events.jsonl`);
+  let content: string;
+  try {
+    content = await fs.readFile(eventsPath, 'utf-8');
+  } catch {
+    return [];
+  }
+
+  const trimmed = content.trim();
+  if (trimmed.length === 0) return [];
+
+  const events = trimmed
+    .split('\n')
+    .map((line) => JSON.parse(line) as SessionEvent);
+
+  setCachedEvents(cacheKey, events);
+  return events;
+}
+
+// ─── Single-Session Aggregation ─────────────────────────────────────────────
+
+function aggregateSession(events: SessionEvent[]): {
+  tools: Record<string, number>;
+  toolsByCategory: { native: number; mcp_exarchos: number; mcp_other: number };
+  tokens: { in: number; out: number; cacheR: number; cacheW: number };
+  files: string[];
+  duration: number;
+  turns: number;
+} {
+  const tools: Record<string, number> = {};
+  const toolsByCategory = { native: 0, mcp_exarchos: 0, mcp_other: 0 };
+  const tokens = { in: 0, out: 0, cacheR: 0, cacheW: 0 };
+  const filesSet = new Set<string>();
+  let duration = 0;
+  let turns = 0;
+
+  // Summary events are authoritative — if present, use them for tools/tokens/turns/duration.
+  // Individual tool/turn events are only used for aggregation when no summary exists.
+  const summaryEvents = events.filter((e): e is SessionSummaryEvent => e.t === 'summary');
+  const hasSummary = summaryEvents.length > 0;
+
+  if (hasSummary) {
+    for (const su of summaryEvents) {
+      for (const [name, count] of Object.entries(su.tools)) {
+        tools[name] = (tools[name] ?? 0) + count;
+      }
+      tokens.in += su.tokTotal.in;
+      tokens.out += su.tokTotal.out;
+      tokens.cacheR += su.tokTotal.cacheR;
+      tokens.cacheW += su.tokTotal.cacheW;
+      for (const f of su.files) filesSet.add(f);
+      duration += su.dur;
+      turns += su.turns;
+    }
+    // Still process tool events for category breakdown and file tracking
+    for (const event of events) {
+      if (event.t === 'tool') {
+        const te = event as SessionToolEvent;
+        toolsByCategory[te.cat] += 1;
+        if (te.files) {
+          for (const f of te.files) filesSet.add(f);
+        }
+      }
+    }
+  } else {
+    // No summary — aggregate from individual events
+    for (const event of events) {
+      switch (event.t) {
+        case 'tool': {
+          const te = event as SessionToolEvent;
+          tools[te.tool] = (tools[te.tool] ?? 0) + 1;
+          toolsByCategory[te.cat] += 1;
+          if (te.files) {
+            for (const f of te.files) filesSet.add(f);
+          }
+          break;
+        }
+        case 'turn': {
+          const tu = event as SessionTurnEvent;
+          tokens.in += tu.tokIn;
+          tokens.out += tu.tokOut;
+          tokens.cacheR += tu.tokCacheR;
+          tokens.cacheW += tu.tokCacheW;
+          turns += 1;
+          break;
+        }
+      }
+    }
+  }
+
+  return {
+    tools,
+    toolsByCategory,
+    tokens,
+    files: [...filesSet],
+    duration,
+    turns,
+  };
+}
+
+// ─── Attribution (file → tool mapping) ──────────────────────────────────────
+
+function buildFileAttribution(
+  events: SessionEvent[],
+): Array<{ file: string; tools: string[] }> {
+  const fileToTools = new Map<string, Set<string>>();
+
+  for (const event of events) {
+    if (event.t !== 'tool') continue;
+    const te = event as SessionToolEvent;
+    if (!te.files) continue;
+    for (const f of te.files) {
+      const existing = fileToTools.get(f);
+      if (existing) {
+        existing.add(te.tool);
+      } else {
+        fileToTools.set(f, new Set([te.tool]));
+      }
+    }
+  }
+
+  return [...fileToTools.entries()].map(([file, toolSet]) => ({
+    file,
+    tools: [...toolSet],
+  }));
+}
+
+// ─── Cost breakdown by session ──────────────────────────────────────────────
+
+function buildCostBySession(
+  sessionsEvents: Array<{ sid: string; events: SessionEvent[] }>,
+): Array<{ sid: string; tokens: { in: number; out: number } }> {
+  return sessionsEvents.map(({ sid, events }) => {
+    let tokIn = 0;
+    let tokOut = 0;
+    for (const event of events) {
+      if (event.t === 'turn') {
+        const tu = event as SessionTurnEvent;
+        tokIn += tu.tokIn;
+        tokOut += tu.tokOut;
+      } else if (event.t === 'summary') {
+        const su = event as SessionSummaryEvent;
+        tokIn += su.tokTotal.in;
+        tokOut += su.tokTotal.out;
+      }
+    }
+    return { sid, tokens: { in: tokIn, out: tokOut } };
+  });
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+export async function materializeSessionProvenance(
+  stateDir: string,
+  query: SessionProvenanceQuery,
+): Promise<SessionProvenanceResult> {
+  // Single session query
+  if (query.sessionId && !query.workflowId) {
+    const events = await readSessionEvents(stateDir, query.sessionId);
+    const agg = aggregateSession(events);
+
+    const result: SessionProvenanceResult = {
+      sessionId: query.sessionId,
+      ...agg,
+    };
+
+    if (query.metric === 'attribution') {
+      result.fileAttribution = buildFileAttribution(events);
+    }
+
+    return result;
+  }
+
+  // Workflow query — find all sessions with matching workflowId
+  if (query.workflowId) {
+    const entries = await readManifestEntries(stateDir);
+    const matchingEntries = entries.filter((e) => e.workflowId === query.workflowId);
+
+    const sessionsEvents: Array<{ sid: string; events: SessionEvent[] }> = [];
+    for (const entry of matchingEntries) {
+      const events = await readSessionEvents(stateDir, entry.sessionId);
+      sessionsEvents.push({ sid: entry.sessionId, events });
+    }
+
+    // Aggregate across all sessions
+    const allEvents = sessionsEvents.flatMap((s) => s.events);
+    const agg = aggregateSession(allEvents);
+
+    const result: SessionProvenanceResult = {
+      workflowId: query.workflowId,
+      sessions: matchingEntries.length,
+      ...agg,
+    };
+
+    if (query.metric === 'cost') {
+      result.costBySession = buildCostBySession(sessionsEvents);
+    }
+
+    if (query.metric === 'attribution') {
+      result.fileAttribution = buildFileAttribution(allEvents);
+    }
+
+    return result;
+  }
+
+  // Neither sessionId nor workflowId — return empty
+  return {
+    tools: {},
+    toolsByCategory: { native: 0, mcp_exarchos: 0, mcp_other: 0 },
+    tokens: { in: 0, out: 0, cacheR: 0, cacheW: 0 },
+  };
+}

--- a/servers/exarchos-mcp/src/views/composite.test.ts
+++ b/servers/exarchos-mcp/src/views/composite.test.ts
@@ -11,6 +11,7 @@ vi.mock('./tools.js', () => ({
   handleViewQualityHints: vi.fn(),
   handleViewEvalResults: vi.fn(),
   handleViewQualityCorrelation: vi.fn(),
+  handleViewSessionProvenance: vi.fn(),
 }));
 
 // Mock the stack tools module
@@ -35,6 +36,7 @@ import {
   handleViewQualityHints,
   handleViewEvalResults,
   handleViewQualityCorrelation,
+  handleViewSessionProvenance,
 } from './tools.js';
 import { handleStackStatus, handleStackPlace } from '../stack/tools.js';
 import { handleViewTelemetry } from '../telemetry/tools.js';
@@ -413,6 +415,73 @@ describe('handleView', () => {
     });
   });
 
+  describe('session_provenance', () => {
+    it('exarchosView_SessionProvenance_BySession_ReturnsSessionData', async () => {
+      // Arrange
+      const expected = {
+        success: true,
+        sessionId: 'sess-1',
+        tools: { Read: 5 },
+        toolsByCategory: { native: 5, mcp_exarchos: 0, mcp_other: 0 },
+        tokens: { in: 1000, out: 500, cacheR: 200, cacheW: 100 },
+      };
+      vi.mocked(handleViewSessionProvenance).mockResolvedValue(expected);
+      const args = { action: 'session_provenance', sessionId: 'sess-1' };
+
+      // Act
+      const result = await handleView(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleViewSessionProvenance).toHaveBeenCalledWith(
+        { sessionId: 'sess-1' },
+        STATE_DIR,
+      );
+    });
+
+    it('exarchosView_SessionProvenance_ByWorkflow_ReturnsAggregatedData', async () => {
+      // Arrange
+      const expected = {
+        success: true,
+        workflowId: 'wf-1',
+        sessions: 3,
+        tokens: { in: 5000, out: 2500, cacheR: 1000, cacheW: 500 },
+      };
+      vi.mocked(handleViewSessionProvenance).mockResolvedValue(expected);
+      const args = { action: 'session_provenance', workflowId: 'wf-1' };
+
+      // Act
+      const result = await handleView(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleViewSessionProvenance).toHaveBeenCalledWith(
+        { workflowId: 'wf-1' },
+        STATE_DIR,
+      );
+    });
+
+    it('exarchosView_SessionProvenance_InvalidQuery_ReturnsError', async () => {
+      // Arrange
+      const expected = {
+        success: false,
+        error: { code: 'INVALID_QUERY', message: 'Either sessionId or workflowId is required' },
+      };
+      vi.mocked(handleViewSessionProvenance).mockResolvedValue(expected);
+      const args = { action: 'session_provenance' };
+
+      // Act
+      const result = await handleView(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleViewSessionProvenance).toHaveBeenCalledWith(
+        {},
+        STATE_DIR,
+      );
+    });
+  });
+
   describe('unknown action', () => {
     it('HandleView_UnknownAction_IncludesEvalResultsAndCodeQuality', async () => {
       // Arrange
@@ -429,6 +498,7 @@ describe('handleView', () => {
       expect(validTargets).toContain('quality_hints');
       expect(validTargets).toContain('eval_results');
       expect(validTargets).toContain('quality_correlation');
+      expect(validTargets).toContain('session_provenance');
     });
 
     it('should return error for unknown action', async () => {

--- a/servers/exarchos-mcp/src/views/composite.ts
+++ b/servers/exarchos-mcp/src/views/composite.ts
@@ -14,6 +14,7 @@ import {
   handleViewQualityHints,
   handleViewEvalResults,
   handleViewQualityCorrelation,
+  handleViewSessionProvenance,
 } from './tools.js';
 import { handleStackStatus, handleStackPlace } from '../stack/tools.js';
 import { handleViewTelemetry } from '../telemetry/tools.js';
@@ -127,6 +128,12 @@ export async function handleView(
         stateDir,
       );
 
+    case 'session_provenance':
+      return handleViewSessionProvenance(
+        rest as { sessionId?: string; workflowId?: string; metric?: string },
+        stateDir,
+      );
+
     default:
       return {
         success: false,
@@ -146,6 +153,7 @@ export async function handleView(
             'quality_hints',
             'eval_results',
             'quality_correlation',
+            'session_provenance',
           ] as const,
         },
       };

--- a/servers/exarchos-mcp/src/views/tools.ts
+++ b/servers/exarchos-mcp/src/views/tools.ts
@@ -591,6 +591,43 @@ export async function handleViewQualityCorrelation(
   }
 }
 
+// ─── View Session Provenance Handler ─────────────────────────────────────────
+
+export async function handleViewSessionProvenance(
+  args: { sessionId?: string; workflowId?: string; metric?: string },
+  stateDir: string,
+): Promise<ToolResult> {
+  if (!args.sessionId && !args.workflowId) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_QUERY',
+        message: 'Either sessionId or workflowId is required',
+      },
+    };
+  }
+
+  try {
+    const { materializeSessionProvenance } = await import(
+      '../session/session-provenance-projection.js'
+    );
+    const result = await materializeSessionProvenance(stateDir, {
+      sessionId: args.sessionId,
+      workflowId: args.workflowId,
+      metric: args.metric as 'cost' | 'attribution' | undefined,
+    });
+    return { success: true, ...result };
+  } catch (err) {
+    return {
+      success: false,
+      error: {
+        code: 'VIEW_ERROR',
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+}
+
 // ─── Registration Function ──────────────────────────────────────────────────
 
 export function registerViewTools(server: McpServer, stateDir: string, eventStore: EventStore): void {

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -1120,7 +1120,8 @@ describe('hooks.json', () => {
     expect(eventTypes).toContain('TaskCompleted');
     expect(eventTypes).toContain('TeammateIdle');
     expect(eventTypes).toContain('SubagentStart');
-    expect(eventTypes).toHaveLength(6);
+    expect(eventTypes).toContain('SessionEnd');
+    expect(eventTypes).toHaveLength(7);
   });
 
   it('hooksJson_AllCommandsReferencePluginRoot', () => {


### PR DESCRIPTION
## Summary

Adds the `session_provenance` action to `exarchos_view`, completing the query layer for session provenance data. Uses lazy on-demand materialization from session JSONL files with a bounded LRU cache (20 entries). Zero cold start impact — session data never hydrated into main SQLite.

## Changes

- **`session/session-provenance-projection.ts`** — CQRS projection with LRU cache. Query by sessionId, workflowId, or metric (cost/attribution). Summary events authoritative to prevent double-counting.
- **`views/tools.ts`** — `handleViewSessionProvenance` handler function
- **`views/composite.ts`** — Registered `session_provenance` in action router and valid targets
- **`src/install.test.ts`** — Updated hook count assertion for new SessionEnd hook

## Test Plan

- [x] Session materialization tests (tool breakdown, token totals, summary overview)
- [x] Workflow aggregation across multiple sessions
- [x] Cost and attribution metric queries
- [x] View integration tests (composite handler dispatch)
- [x] 2,776 total tests passing, zero regressions

---

Design: `docs/designs/2026-02-24-session-provenance-capture.md` (Phase C)
Plan: `docs/plans/2026-02-24-session-provenance-capture.md` (Tasks 013-014)