### PR TITLE
fix: add write-through .state.json backup and preserve files during migration (#806)

### DIFF
--- a/docs/rca/2026-02-25-persistence-hydration-806.md
+++ b/docs/rca/2026-02-25-persistence-hydration-806.md
@@ -1,0 +1,110 @@
+# RCA: Workflow State Not Persisted — SQLite Hydration Broken (#806)
+
+**Date:** 2026-02-25
+**Severity:** P1 — Silent data loss on MCP server restart
+**Status:** Investigation complete, fix in progress
+
+## Symptom
+
+Workflow state created at runtime disappears after MCP server restart. Events appended via `exarchos_event` are lost. The `session-provenance-capture` workflow had 18 events and full lifecycle state at runtime but zero artifacts on disk after restart.
+
+## Root Cause Chain
+
+### RC1: State File Write-Through Missing (Critical)
+
+When SQLite backend is configured, `writeStateFile()` delegates entirely to `backend.setState()` and **returns without writing `.state.json`** (state-store.ts:293-331). Similarly, `initStateFile()` writes only to the backend (state-store.ts:130-144).
+
+Meanwhile, `migrateLegacyStateFiles()` renames existing `.state.json` files to `.migrated`, and `cleanupLegacyFiles()` deletes them. This creates a one-way door:
+
+```
+Startup:
+  .state.json → migrated to SQLite → .state.json deleted
+
+Runtime:
+  handleInit/handleSet → backend.setState() → SQLite only
+  (no .state.json written)
+
+Next Startup (if SQLite lost/corrupt):
+  hydrateAll → events from JSONL ✓
+  migrateLegacyStateFiles → no .state.json files to migrate ✗
+  → STATE LOST
+```
+
+### RC2: JSONL Event Files Not Written for Some Workflows
+
+The `EventStore.append()` calls `writeEvents()` which uses `fs.appendFile()` to write JSONL. However, the event store instance used by `exarchos_event` composite handler shares the same `stateDir`. We confirmed `session-provenance-capture.events.jsonl` does NOT exist on disk, meaning either:
+
+- The write silently failed (permissions, path issue)
+- The event store's write-through to JSONL was bypassed
+- Events went to an in-memory-only path when the backend handles all storage
+
+The backend dual-write path (store.ts:273-287) catches and **silently logs** backend errors. But the primary JSONL write should always succeed — its absence indicates a deeper issue in the write path.
+
+### RC3: Platform-Specific Native Binary (Major)
+
+`better-sqlite3` requires a C++ compiled `.node` binary. The build script (`scripts/build-mcp.ts`) copies the binary from the dev machine's `node_modules` to `dist/node_modules/better-sqlite3/build/Release/`. This binary is:
+
+- ELF 64-bit x86-64 Linux only
+- Incompatible with macOS (Intel or ARM), Windows, or Linux ARM64
+- Causes `initializeBackend()` to silently fall back to JSONL-only mode on non-matching platforms
+
+### RC4: Versionless State File Rejection (Minor)
+
+`migrateState()` throws `MIGRATION_FAILED: missing version field` for state files that lack the `version` field. These files were created by older skills/hooks that bypassed the MCP state-store module.
+
+## Impact
+
+1. **Data loss on restart:** Workflows created after SQLite migration have no `.state.json` backup. If SQLite DB is lost, the workflow state is unrecoverable.
+2. **Silent degradation:** Non-Linux users run in JSONL-only mode without knowing it. Performance is acceptable but the data path is different.
+3. **Orphaned workflows:** State files from older versions fail migration and become invisible.
+
+## Fix Design
+
+### Fix 1: Always Write `.state.json` as Write-Through Backup
+
+Modify `writeStateFile()` and `initStateFile()` to **always write `.state.json` to disk**, even when the backend is configured. SQLite remains the primary read/write path; the file is a crash-recovery backup.
+
+```
+writeStateFile(stateFile, state, options):
+  1. backend.setState(featureId, state, expectedVersion)  // Primary: SQLite
+  2. fs.writeFile(stateFile, JSON.stringify(state))        // Backup: .state.json
+  // File write failure is logged but does not fail the operation
+```
+
+Stop deleting `.state.json` files after migration — remove the `.migrated` rename from `migrateLegacyStateFiles()` and remove `*.state.json.migrated` from cleanup patterns.
+
+### Fix 2: Verify JSONL Write-Through
+
+Audit the `EventStore.append()` path to ensure `writeEvents()` always executes. Add integration test that verifies `.events.jsonl` exists on disk after `append()`.
+
+### Fix 3: Replace better-sqlite3 with sql.js
+
+Replace `better-sqlite3` (native C++ bindings) with `sql.js` (pure JavaScript/WebAssembly). This eliminates the platform-specific binary entirely while maintaining SQLite semantics.
+
+Trade-off: ~2-3x slower than better-sqlite3 for heavy queries, but exarchos event counts are small (< 1000 per workflow) so the performance difference is negligible.
+
+Alternative: Keep better-sqlite3 but add multi-platform CI builds. Deferred to separate issue if sql.js proves insufficient.
+
+### Fix 4: Handle Versionless State Files
+
+In `migrateState()`, treat missing `version` field as v1.0 instead of throwing. Apply the standard migration path to bring it current.
+
+## Files Involved
+
+| File | Change |
+|------|--------|
+| `servers/exarchos-mcp/src/workflow/state-store.ts` | Add file write-through after backend.setState |
+| `servers/exarchos-mcp/src/storage/migration.ts` | Stop deleting .state.json; handle versionless files |
+| `servers/exarchos-mcp/src/workflow/migration.ts` | Treat missing version as v1.0 |
+| `servers/exarchos-mcp/package.json` | Replace better-sqlite3 with sql.js |
+| `servers/exarchos-mcp/src/storage/sqlite-backend.ts` | Adapt to sql.js API |
+| `scripts/build-mcp.ts` | Remove native binary copy; sql.js needs no special handling |
+| `servers/exarchos-mcp/src/event-store/store.ts` | Audit JSONL write path |
+
+## Verification
+
+1. After fix: `handleInit` → verify both SQLite row AND `.state.json` exist
+2. After fix: `handleSet` → verify `.state.json` updated alongside SQLite
+3. After fix: Delete `exarchos.db` → restart → verify state recovered from `.state.json`
+4. After fix: Run on macOS → verify SQLite works (sql.js is cross-platform)
+5. After fix: Versionless `.state.json` migrates successfully

--- a/servers/exarchos-mcp/src/storage/migration.test.ts
+++ b/servers/exarchos-mcp/src/storage/migration.test.ts
@@ -95,9 +95,29 @@ describe('migrateLegacyStateFiles', () => {
     expect(retrieved!.featureId).toBe('my-feature');
     expect(retrieved!.phase).toBe('plan');
 
-    // Assert: original file was renamed to .migrated
-    expect(fs.existsSync(filePath)).toBe(false);
-    expect(fs.existsSync(filePath + '.migrated')).toBe(true);
+    // Assert: original file preserved as crash-recovery backup
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it('migrateLegacyStateFiles_AlreadyInBackend_SkipsIdempotently', async () => {
+    // Arrange: state already exists in backend
+    const state = makeState({ featureId: 'existing', phase: 'plan' });
+    backend.setState('existing', state);
+
+    // Write a .state.json that would conflict
+    const filePath = path.join(tempDir, 'existing.state.json');
+    const olderState = makeState({ featureId: 'existing', phase: 'ideate' });
+    fs.writeFileSync(filePath, JSON.stringify(olderState), 'utf-8');
+
+    // Act
+    await migrateLegacyStateFiles(backend, tempDir);
+
+    // Assert: backend still has the original state (not overwritten)
+    const retrieved = backend.getState('existing');
+    expect(retrieved!.phase).toBe('plan');
+
+    // Assert: file remains untouched
+    expect(fs.existsSync(filePath)).toBe(true);
   });
 
   it('migrateLegacyStateFiles_NoLegacyFiles_NoOps', async () => {
@@ -163,7 +183,8 @@ describe('migrateLegacyStateFiles', () => {
     expect(retrieved!.version).toBe('1.1');
     expect(retrieved!._history).toBeDefined();
     expect(retrieved!._checkpoint).toBeDefined();
-    expect(fs.existsSync(filePath + '.migrated')).toBe(true);
+    // File preserved as backup
+    expect(fs.existsSync(filePath)).toBe(true);
   });
 
   it('migrateLegacyStateFiles_VersionlessState_MigratesAsV1_0', async () => {
@@ -197,7 +218,8 @@ describe('migrateLegacyStateFiles', () => {
     expect(retrieved).not.toBeNull();
     expect(retrieved!.version).toBe('1.1');
     expect(retrieved!._checkpoint).toBeDefined();
-    expect(fs.existsSync(filePath + '.migrated')).toBe(true);
+    // File preserved as backup
+    expect(fs.existsSync(filePath)).toBe(true);
   });
 
   it('migrateLegacyStateFiles_MultipleFiles_MigratesAll', async () => {

--- a/servers/exarchos-mcp/src/storage/migration.ts
+++ b/servers/exarchos-mcp/src/storage/migration.ts
@@ -21,16 +21,17 @@ const LEGACY_CLEANUP_PATTERNS = [
 // ─── State Migration ────────────────────────────────────────────────────────
 
 /**
- * Migrates legacy `*.state.json` files into the StorageBackend.
+ * Imports `*.state.json` files into the StorageBackend.
  *
  * For each `*.state.json` file found:
+ * - Skips if the featureId already exists in the backend (idempotent)
  * - Parses the JSON content
  * - Validates against WorkflowStateSchema
  * - Extracts the featureId from the filename (`{featureId}.state.json`)
  * - Inserts into the backend via `setState()`
- * - Renames the original file to `*.state.json.migrated`
  *
- * Corrupt or invalid files are skipped (not renamed).
+ * The `.state.json` file is kept on disk as a crash-recovery backup.
+ * Corrupt or invalid files are skipped.
  */
 export async function migrateLegacyStateFiles(
   backend: StorageBackend,
@@ -51,6 +52,9 @@ export async function migrateLegacyStateFiles(
   for (const file of stateFiles) {
     const filePath = path.join(stateDir, file);
     const featureId = file.replace('.state.json', '');
+
+    // Idempotent: skip if backend already has this state
+    if (backend.getState(featureId) != null) continue;
 
     let raw: unknown;
     try {
@@ -77,9 +81,6 @@ export async function migrateLegacyStateFiles(
     const state: WorkflowState = parsed.data;
 
     backend.setState(featureId, state);
-
-    // Rename to .migrated after successful insert
-    await rename(filePath, filePath + '.migrated');
   }
 }
 

--- a/servers/exarchos-mcp/src/workflow/state-store.test.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.test.ts
@@ -542,3 +542,97 @@ describe('State Store CAS Property Test', () => {
     expect(failedResult.reason).toBeInstanceOf(VersionConflictError);
   });
 });
+
+// ─── Write-Through .state.json Backup ────────────────────────────────────────
+
+describe('writeStateFile_WithBackend_WritesJsonBackup', () => {
+  let tempDir: string;
+  let backend: InMemoryBackend;
+
+  function makeState(overrides?: Record<string, unknown>): WorkflowState {
+    const now = new Date().toISOString();
+    return {
+      version: '1.1',
+      featureId: 'test',
+      workflowType: 'feature',
+      createdAt: now,
+      updatedAt: now,
+      phase: 'ideate',
+      artifacts: { design: null, plan: null, pr: null },
+      tasks: [],
+      worktrees: {},
+      reviews: {},
+      synthesis: { integrationBranch: null, mergeOrder: [], mergedBranches: [], prUrl: null, prFeedback: [] },
+      _version: 1,
+      _history: {},
+      _checkpoint: { timestamp: now, phase: 'ideate', summary: '', operationsSince: 0, fixCycleCount: 0, lastActivityTimestamp: now, staleAfterMinutes: 120 },
+      ...overrides,
+    } as WorkflowState;
+  }
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'state-write-through-'));
+    backend = new InMemoryBackend();
+    configureStateStoreBackend(backend);
+  });
+
+  afterEach(async () => {
+    configureStateStoreBackend(undefined as unknown as InMemoryBackend);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('writeStateFile_WithBackend_AlsoWritesJsonFile', async () => {
+    const state = makeState({ featureId: 'wt-test', phase: 'ideate' });
+    backend.setState('wt-test', state);
+
+    const stateFile = path.join(tempDir, 'wt-test.state.json');
+    const updated = makeState({ featureId: 'wt-test', phase: 'plan' });
+
+    await writeStateFile(stateFile, updated, { expectedVersion: 1 });
+
+    // Backend should have the state
+    const backendState = backend.getState('wt-test');
+    expect(backendState).toBeDefined();
+    expect(backendState!.phase).toBe('plan');
+
+    // JSON file should ALSO exist as backup
+    const fileContent = await fs.readFile(stateFile, 'utf-8');
+    const fileState = JSON.parse(fileContent);
+    expect(fileState.phase).toBe('plan');
+    expect(fileState.featureId).toBe('wt-test');
+  });
+
+  it('initStateFile_WithBackend_AlsoWritesJsonFile', async () => {
+    const { stateFile, state } = await initStateFile(tempDir, 'init-wt', 'feature');
+
+    // Backend should have the state
+    const backendState = backend.getState('init-wt');
+    expect(backendState).toBeDefined();
+    expect(backendState!.phase).toBe('ideate');
+
+    // JSON file should ALSO exist as backup
+    const fileContent = await fs.readFile(stateFile, 'utf-8');
+    const fileState = JSON.parse(fileContent);
+    expect(fileState.phase).toBe('ideate');
+    expect(fileState.featureId).toBe('init-wt');
+  });
+
+  it('writeStateFile_BackendSucceeds_FileWriteFailure_DoesNotThrow', async () => {
+    const state = makeState({ featureId: 'wt-fail', phase: 'ideate' });
+    backend.setState('wt-fail', state);
+
+    // Create a regular file where mkdir expects a directory — this forces
+    // the write-through path to fail (ENOTDIR) deterministically
+    const blocker = path.join(tempDir, 'blocker');
+    await fs.writeFile(blocker, 'not-a-dir', 'utf-8');
+    const stateFile = path.join(blocker, 'nested', 'wt-fail.state.json');
+    const updated = makeState({ featureId: 'wt-fail', phase: 'plan' });
+
+    // Should NOT throw — backend write succeeds, file write failure is logged
+    await expect(writeStateFile(stateFile, updated, { expectedVersion: 1 })).resolves.toBeUndefined();
+
+    // Backend should still have the updated state
+    const backendState = backend.getState('wt-fail');
+    expect(backendState!.phase).toBe('plan');
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/state-store.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.ts
@@ -5,6 +5,7 @@ import type { EventStore } from '../event-store/store.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
 import type { StorageBackend } from '../storage/backend.js';
 import { isPidAlive } from '../utils/process.js';
+import { logger } from '../logger.js';
 import * as fs from 'node:fs/promises';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
@@ -140,6 +141,19 @@ export async function initStateFile(
         );
       }
       throw err;
+    }
+
+    // Write-through: also write .state.json as crash-recovery backup.
+    try {
+      await fs.mkdir(stateDir, { recursive: true });
+      const tmpPath = `${stateFile}.init.${process.pid}`;
+      await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf-8');
+      await fs.rename(tmpPath, stateFile);
+    } catch (err) {
+      logger.warn(
+        { stateFile, err: err instanceof Error ? err.message : String(err) },
+        'Failed to write .state.json backup; backend write succeeded',
+      );
     }
     return { stateFile, state };
   }
@@ -327,6 +341,21 @@ export async function writeStateFile(
         );
       }
       throw err;
+    }
+
+    // Write-through: also write .state.json as crash-recovery backup.
+    // Backend is the primary store; file write failure is non-fatal.
+    try {
+      const dir = path.dirname(stateFile);
+      await fs.mkdir(dir, { recursive: true });
+      const tmpPath = `${stateFile}.tmp.${process.pid}`;
+      await fs.writeFile(tmpPath, JSON.stringify(stateWithVersion, null, 2), 'utf-8');
+      await fs.rename(tmpPath, stateFile);
+    } catch (err) {
+      logger.warn(
+        { stateFile, err: err instanceof Error ? err.message : String(err) },
+        'Failed to write .state.json backup; backend write succeeded',
+      );
     }
     return;
   }


### PR DESCRIPTION
Workflow state created at runtime disappeared after MCP server restart because
writeStateFile() with SQLite backend skipped .state.json writes, and migration
deleted existing files. Now both writeStateFile() and initStateFile() always
write .state.json as a crash-recovery backup alongside the SQLite primary store.
migrateLegacyStateFiles() preserves .state.json files instead of renaming them.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>