### PR TITLE
feat: enforce PR description template with CI validation and configurable overrides (#907)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- 2-3 sentences: What changed, why it matters, what problem it solves -->
+
+## Changes
+
+<!-- Scannable list. Use **Bold** for component names and — (em-dash) as separator -->
+- **Component** — Brief description of what changed
+
+## Test Plan
+
+<!-- 1-2 sentences: Testing approach and coverage summary -->
+
+---
+
+**Results:** Tests X ✓ · Build 0 errors
+**Design:** <!-- link to design doc if applicable -->
+**Related:** <!-- #issue, Continues #PR -->

--- a/.github/workflows/pr-body-check.yml
+++ b/.github/workflows/pr-body-check.yml
@@ -1,0 +1,42 @@
+name: PR Body Check
+
+on:
+  pull_request:
+    types: [opened, edited, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-pr-body:
+    if: |
+      github.event.pull_request.user.login != 'renovate[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      !startsWith(github.event.pull_request.title, '[Graphite MQ]')
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup GitHub CLI
+        env:
+          GH_VERSION: '2.65.0'
+        run: |
+          if ! command -v gh &>/dev/null; then
+            curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+              | tar xz -C /tmp
+            echo "/tmp/gh_${GH_VERSION}_linux_amd64/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Validate PR body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          args=(
+            --pr "${{ github.event.pull_request.number }}"
+            --author "${{ github.event.pull_request.user.login }}"
+          )
+          if [[ -f ".exarchos/pr-template.md" ]]; then
+            args+=(--template ".exarchos/pr-template.md")
+          fi
+          bash scripts/validate-pr-body.sh "${args[@]}"

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -158,21 +158,25 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Setup GitHub CLI
-        env:
-          GH_VERSION: '2.65.0'
-        run: |
-          if ! command -v gh &>/dev/null; then
-            curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
-              | tar xz -C /tmp
-            echo "/tmp/gh_${GH_VERSION}_linux_amd64/bin" >> "$GITHUB_PATH"
-          fi
       - name: Assign PR author
-        run: gh pr edit "$PR_URL" --add-assignee "$AUTHOR"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          AUTHOR: ${{ github.event.pull_request.user.login }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                assignees: [context.payload.pull_request.user.login]
+              });
+              console.log(`Assigned ${context.payload.pull_request.user.login} to PR #${context.payload.pull_request.number}`);
+            } catch (error) {
+              if (error.status === 403 || error.status === 422) {
+                console.log(`Skipping assignment for ${context.payload.pull_request.user.login}: ${error.message}`);
+                return;
+              }
+              throw error;
+            }
 
   # ============================================================
   # PROJECT SYNC: Add issues/PRs to project board

--- a/rules/pr-descriptions.md
+++ b/rules/pr-descriptions.md
@@ -10,3 +10,7 @@ description: "PR title and body format guidelines for Graphite stacked PRs."
 **Body:** Summary (2-3 sentences) → Changes (bulleted, `**Component** — description`) → Test Plan → Footer (`---` + results, design doc, related PRs). Aim for 120-200 words.
 
 See `skills/synthesis/references/pr-descriptions.md` for template and examples.
+
+**Enforcement:** CI runs `scripts/validate-pr-body.sh` on human-authored PRs (skips Renovate/Dependabot and Graphite merge queue). Bodies missing `## Summary`, `## Changes`, or `## Test Plan` will fail the check. After `gt submit`, update each PR body via `gh pr edit <number> --body "..."`.
+
+**Custom templates:** Projects can override the default required sections by placing a `.exarchos/pr-template.md` file in the repo root. Any `## Section` headers in the template define the required sections for validation.

--- a/scripts/validate-pr-body.sh
+++ b/scripts/validate-pr-body.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Validates PR body against required section headers.
+# Exit 0 = valid, Exit 1 = missing sections, Exit 2 = usage error
+#
+# Usage:
+#   echo "$PR_BODY" | validate-pr-body.sh
+#   validate-pr-body.sh --pr 906 [--repo owner/repo]
+#   validate-pr-body.sh --template path/to/template.md < body.md
+#   validate-pr-body.sh --dry-run --pr 906
+#
+# Default required sections: ## Summary, ## Changes, ## Test Plan
+# Custom templates: any line matching `^## <section>` defines a required section.
+# Skip conditions: Graphite merge queue PRs, bot authors (renovate, dependabot).
+
+set -euo pipefail
+
+# ─── Defaults ─────────────────────────────────────────────────────────────────
+
+DEFAULT_SECTIONS=("Summary" "Changes" "Test Plan")
+SKIP_AUTHORS=("renovate[bot]" "dependabot[bot]")
+
+PR_NUMBER=""
+REPO=""
+AUTHOR=""
+TEMPLATE=""
+DRY_RUN=false
+
+# ─── Parse Arguments ──────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      [[ $# -ge 2 ]] || { echo "Missing value for --pr" >&2; exit 2; }
+      PR_NUMBER="$2"
+      shift 2
+      ;;
+    --repo)
+      [[ $# -ge 2 ]] || { echo "Missing value for --repo" >&2; exit 2; }
+      REPO="$2"
+      shift 2
+      ;;
+    --author)
+      [[ $# -ge 2 ]] || { echo "Missing value for --author" >&2; exit 2; }
+      AUTHOR="$2"
+      shift 2
+      ;;
+    --template)
+      [[ $# -ge 2 ]] || { echo "Missing value for --template" >&2; exit 2; }
+      TEMPLATE="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ─── Dry Run ──────────────────────────────────────────────────────────────────
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  exit 0
+fi
+
+# ─── Fetch PR Body ───────────────────────────────────────────────────────────
+
+BODY=""
+if [[ -n "$PR_NUMBER" ]]; then
+  # Fetch from GitHub API
+  REPO_FLAG=""
+  if [[ -n "$REPO" ]]; then
+    REPO_FLAG="--repo $REPO"
+  fi
+  # shellcheck disable=SC2086
+  PR_DATA=$(gh pr view "$PR_NUMBER" $REPO_FLAG --json body,author --jq '{body: .body, author: .author.login}')
+  BODY=$(echo "$PR_DATA" | jq -r '.body // ""')
+  if [[ -z "$AUTHOR" ]]; then
+    AUTHOR=$(echo "$PR_DATA" | jq -r '.author // ""')
+  fi
+else
+  # Read from stdin
+  BODY=$(cat)
+fi
+
+# ─── Skip Conditions ─────────────────────────────────────────────────────────
+
+# Skip bot authors
+for skip_author in "${SKIP_AUTHORS[@]}"; do
+  if [[ "$AUTHOR" == "$skip_author" ]]; then
+    exit 0
+  fi
+done
+
+# Skip Graphite merge queue PRs (defense-in-depth; CI also skips via job condition)
+if echo "$BODY" | grep -qi "graphite merge queue"; then
+  exit 0
+fi
+
+# ─── Determine Required Sections ──────────────────────────────────────────────
+
+REQUIRED_SECTIONS=()
+if [[ -n "$TEMPLATE" ]]; then
+  if [[ ! -f "$TEMPLATE" ]]; then
+    echo "Template file not found: $TEMPLATE" >&2
+    exit 2
+  fi
+  # Extract section headers from custom template
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^##[[:space:]]+(.+)$ ]]; then
+      REQUIRED_SECTIONS+=("${BASH_REMATCH[1]}")
+    fi
+  done < "$TEMPLATE"
+else
+  REQUIRED_SECTIONS=("${DEFAULT_SECTIONS[@]}")
+fi
+
+if [[ ${#REQUIRED_SECTIONS[@]} -eq 0 ]]; then
+  echo "No required sections found in template" >&2
+  exit 2
+fi
+
+# ─── Validate ─────────────────────────────────────────────────────────────────
+
+MISSING=()
+for section in "${REQUIRED_SECTIONS[@]}"; do
+  # Escape regex metacharacters in section name for safe ERE matching
+  escaped_section=$(printf '%s' "$section" | sed 's/[.*+?^${}()|[\]/\\&/g')
+  # Case-insensitive match for ## Section Header
+  if ! echo "$BODY" | grep -qiE "^##[[:space:]]+${escaped_section}[[:space:]]*$"; then
+    MISSING+=("$section")
+  fi
+done
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  echo "PR body validation failed." >&2
+  for section in "${MISSING[@]}"; do
+    echo "  Missing: ## $section" >&2
+  done
+  echo "" >&2
+  echo "Required sections: ${REQUIRED_SECTIONS[*]}" >&2
+  echo "See skills/synthesis/references/pr-descriptions.md for template." >&2
+  exit 1
+fi
+
+exit 0

--- a/scripts/validate-pr-body.test.sh
+++ b/scripts/validate-pr-body.test.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+# validate-pr-body.test.sh — Tests for validate-pr-body.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_UNDER_TEST="$SCRIPT_DIR/validate-pr-body.sh"
+PASS=0
+FAIL=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+    echo -e "${GREEN}PASS${NC}: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAIL=$((FAIL + 1))
+}
+
+# ============================================================
+# TEST CASES
+# ============================================================
+
+echo "=== Validate PR Body Tests ==="
+echo ""
+
+# --------------------------------------------------
+# Test 1: ValidBody_AllSections_ExitsZero
+# --------------------------------------------------
+BODY=$(cat <<'EOF'
+## Summary
+
+This PR adds write-through backup for workflow state files.
+
+## Changes
+
+- **state-store** — Write .state.json alongside SQLite
+- **migration** — Preserve files instead of deleting
+
+## Test Plan
+
+Added 3 unit tests covering write-through and failure paths.
+
+---
+
+**Results:** Tests 2701 ✓ · Build 0 errors
+EOF
+)
+OUTPUT="$(echo "$BODY" | bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "ValidBody_AllSections_ExitsZero"
+else
+    fail "ValidBody_AllSections_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+
+# --------------------------------------------------
+# Test 2: MissingSummary_ExitsOne
+# --------------------------------------------------
+BODY=$(cat <<'EOF'
+## Changes
+
+- **state-store** — Write .state.json alongside SQLite
+
+## Test Plan
+
+Added tests.
+EOF
+)
+OUTPUT="$(echo "$BODY" | bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "MissingSummary_ExitsOne"
+else
+    fail "MissingSummary_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+if echo "$OUTPUT" | grep -qi "summary"; then
+    pass "MissingSummary_OutputMentionsSection"
+else
+    fail "MissingSummary_OutputMentionsSection"
+    echo "  Output: $OUTPUT"
+fi
+
+# --------------------------------------------------
+# Test 3: MissingChanges_ExitsOne
+# --------------------------------------------------
+BODY=$(cat <<'EOF'
+## Summary
+
+This PR does things.
+
+## Test Plan
+
+Added tests.
+EOF
+)
+OUTPUT="$(echo "$BODY" | bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "MissingChanges_ExitsOne"
+else
+    fail "MissingChanges_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+
+# --------------------------------------------------
+# Test 4: MissingTestPlan_ExitsOne
+# --------------------------------------------------
+BODY=$(cat <<'EOF'
+## Summary
+
+This PR does things.
+
+## Changes
+
+- **Component** — Changed something
+EOF
+)
+OUTPUT="$(echo "$BODY" | bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "MissingTestPlan_ExitsOne"
+else
+    fail "MissingTestPlan_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+
+# --------------------------------------------------
+# Test 5: EmptyBody_ExitsOne
+# --------------------------------------------------
+OUTPUT="$(echo "" | bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "EmptyBody_ExitsOne"
+else
+    fail "EmptyBody_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+
+# --------------------------------------------------
+# Test 6: CommitMessageOnly_ExitsOne
+# --------------------------------------------------
+BODY=$(cat <<'EOF'
+fix: add write-through backup
+
+Workflow state disappeared after restart because writeStateFile()
+with SQLite backend skipped .state.json writes.
+EOF
+)
+OUTPUT="$(echo "$BODY" | bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "CommitMessageOnly_ExitsOne"
+else
+    fail "CommitMessageOnly_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+
+# --------------------------------------------------
+# Test 7: GraphiteMergeQueue_Skipped_ExitsZero
+# --------------------------------------------------
+BODY=$(cat <<'EOF'
+This draft PR was created by the Graphite merge queue.
+EOF
+)
+OUTPUT="$(echo "$BODY" | bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "GraphiteMergeQueue_Skipped_ExitsZero"
+else
+    fail "GraphiteMergeQueue_Skipped_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+
+# --------------------------------------------------
+# Test 8: RenovateBot_Skipped_ExitsZero
+# --------------------------------------------------
+BODY=$(cat <<'EOF'
+This PR contains the following updates:
+
+| Package | Type | Update | Change |
+EOF
+)
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --author "renovate[bot]" <<< "$BODY" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "RenovateBot_Skipped_ExitsZero"
+else
+    fail "RenovateBot_Skipped_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+
+# --------------------------------------------------
+# Test 9: CaseInsensitive_SummaryHeader_ExitsZero
+# --------------------------------------------------
+BODY=$(cat <<'EOF'
+## summary
+
+This PR does things.
+
+## changes
+
+- **Component** — Changed something
+
+## test plan
+
+Added tests.
+EOF
+)
+OUTPUT="$(echo "$BODY" | bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "CaseInsensitive_SummaryHeader_ExitsZero"
+else
+    fail "CaseInsensitive_SummaryHeader_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+
+# --------------------------------------------------
+# Test 10: AllMissing_ReportsAllSections
+# --------------------------------------------------
+BODY="Just some text without any sections"
+OUTPUT="$(echo "$BODY" | bash "$SCRIPT_UNDER_TEST" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "AllMissing_ExitsOne"
+else
+    fail "AllMissing_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+MISSING_COUNT=$(echo "$OUTPUT" | grep -c "Missing:" || true)
+if [[ $MISSING_COUNT -ge 3 ]]; then
+    pass "AllMissing_ReportsAllThreeSections"
+else
+    fail "AllMissing_ReportsAllThreeSections (found $MISSING_COUNT, expected >= 3)"
+    echo "  Output: $OUTPUT"
+fi
+
+# --------------------------------------------------
+# Test 11: CustomTemplate_OverridesDefault_ExitsZero
+# --------------------------------------------------
+TMPDIR_ROOT="$(mktemp -d)"
+TEMPLATE_FILE="$TMPDIR_ROOT/pr-template.md"
+cat > "$TEMPLATE_FILE" <<'EOF'
+## Description
+## Impact
+EOF
+BODY=$(cat <<'EOF'
+## Description
+
+This does things.
+
+## Impact
+
+No breaking changes.
+EOF
+)
+OUTPUT="$(echo "$BODY" | bash "$SCRIPT_UNDER_TEST" --template "$TEMPLATE_FILE" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "CustomTemplate_OverridesDefault_ExitsZero"
+else
+    fail "CustomTemplate_OverridesDefault_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+rm -rf "$TMPDIR_ROOT"
+
+# --------------------------------------------------
+# Test 12: CustomTemplate_MissingSection_ExitsOne
+# --------------------------------------------------
+TMPDIR_ROOT="$(mktemp -d)"
+TEMPLATE_FILE="$TMPDIR_ROOT/pr-template.md"
+cat > "$TEMPLATE_FILE" <<'EOF'
+## Description
+## Impact
+EOF
+BODY=$(cat <<'EOF'
+## Description
+
+This does things.
+EOF
+)
+OUTPUT="$(echo "$BODY" | bash "$SCRIPT_UNDER_TEST" --template "$TEMPLATE_FILE" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "CustomTemplate_MissingSection_ExitsOne"
+else
+    fail "CustomTemplate_MissingSection_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+rm -rf "$TMPDIR_ROOT"
+
+# --------------------------------------------------
+# Test 13: MissingTemplateFile_ExitsTwo
+# --------------------------------------------------
+OUTPUT="$(echo "body" | bash "$SCRIPT_UNDER_TEST" --template "/nonexistent/template.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "MissingTemplateFile_ExitsTwo"
+else
+    fail "MissingTemplateFile_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+if echo "$OUTPUT" | grep -q "not found"; then
+    pass "MissingTemplateFile_OutputContainsNotFound"
+else
+    fail "MissingTemplateFile_OutputContainsNotFound"
+    echo "  Output: $OUTPUT"
+fi
+
+# --------------------------------------------------
+# Test 14: MissingFlagValue_ExitsTwo
+# --------------------------------------------------
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --pr 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 2 ]]; then
+    pass "MissingFlagValue_ExitsTwo"
+else
+    fail "MissingFlagValue_ExitsTwo (exit=$EXIT_CODE, expected 2)"
+    echo "  Output: $OUTPUT"
+fi
+
+# --------------------------------------------------
+# Test 15: PrNumberFlag_FetchesBody (mock)
+# --------------------------------------------------
+# This test verifies --pr flag parsing, not actual GH API
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --pr 999 --dry-run 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "PrNumberFlag_DryRun_ExitsZero"
+else
+    fail "PrNumberFlag_DryRun_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "=== Test Summary ==="
+echo -e "Passed: ${GREEN}$PASS${NC}"
+echo -e "Failed: ${RED}$FAIL${NC}"
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo -e "${RED}Tests failed!${NC}"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi

--- a/skills/synthesis/SKILL.md
+++ b/skills/synthesis/SKILL.md
@@ -109,7 +109,7 @@ mcp__plugin_exarchos_exarchos__exarchos_event({
 })
 ```
 
-5. **Write PR descriptions** -- Follow `references/pr-descriptions.md` for title format and body structure
+5. **Write PR descriptions** -- Follow `references/pr-descriptions.md` for title format and body structure. After `gt submit`, update each PR body via `gh pr edit`. Validate with `scripts/validate-pr-body.sh --pr <number>`. Consumers can override the template via `.exarchos/pr-template.md`.
 6. **Submit to merge queue** -- `gt submit --no-interactive --publish --merge-when-ready`
 7. **Apply benchmark label** -- If `verification.hasBenchmarks` is `true` in workflow state, apply label to each PR: `gh pr edit <number> --add-label has-benchmarks`
 8. **Cleanup after merge** -- `gt sync` + remove worktrees

--- a/skills/synthesis/references/synthesis-steps.md
+++ b/skills/synthesis/references/synthesis-steps.md
@@ -76,7 +76,42 @@ Skill({ skill: "exarchos:delegate", args: "--pr-fixes [PR_URL]" })
 ```
 After fixes are applied, return to Step 4 to re-check.
 
-## Step 5: Submit Stack to Merge Queue
+## Step 5: Write PR Descriptions
+
+For each PR in the stack, write a structured description following `references/pr-descriptions.md`:
+
+1. **Title:** `<type>: <what>` (max 72 chars)
+2. **Body:** Summary → Changes → Test Plan → Footer
+
+After `gt submit` creates/updates PRs, update each PR body via GitHub MCP or CLI:
+```bash
+gh pr edit <number> --body "$(cat <<'EOF'
+## Summary
+[2-3 sentences]
+
+## Changes
+- **Component** — Description
+
+## Test Plan
+[1-2 sentences]
+
+---
+**Results:** Tests X ✓ · Build 0 errors
+**Design:** [doc](path)
+**Related:** #issue
+EOF
+)"
+```
+
+**Validation:** Run `scripts/validate-pr-body.sh --pr <number>` to verify the body passes.
+CI enforces this via the `PR Body Check` workflow — PRs missing required sections will fail.
+
+**Custom templates:** If the project has a `.exarchos/pr-template.md`, pass it via `--template`:
+```bash
+scripts/validate-pr-body.sh --pr <number> --template .exarchos/pr-template.md
+```
+
+## Step 6: Submit Stack to Merge Queue
 
 Enqueue the stack for merging (PRs already exist from delegation):
 
@@ -90,7 +125,7 @@ mcp__graphite__run_gt_cmd({
 
 After submission, use `mcp__graphite__run_gt_cmd` with `["log", "--short"]` to get the PR URLs for each stack entry.
 
-## Step 6: Cleanup After Merge
+## Step 7: Cleanup After Merge
 
 After PRs are merged, use Graphite to clean up:
 ```


### PR DESCRIPTION
## Summary

PR descriptions were inconsistently following the template — PRs created outside the `/synthesize` flow (debug workflows, quick fixes) used raw commit messages instead of the structured format. This adds enforcement at the CI level, makes templates configurable for consumers, and fixes the broken `auto-assign-author` workflow.

## Changes

- **`scripts/validate-pr-body.sh`** — Validation script checking PR bodies for required `## Section` headers. Supports `--pr` (GitHub fetch), `--template` (custom sections), `--author` (bot skip). Exit 0/1/2
- **`scripts/validate-pr-body.test.sh`** — 15 test cases covering valid bodies, missing sections, bot skips, custom templates, case insensitivity
- **`.github/workflows/pr-body-check.yml`** — CI workflow triggered on PR open/edit, skips Graphite merge queue and bot PRs
- **`.github/PULL_REQUEST_TEMPLATE.md`** — GitHub-native template pre-populating Summary, Changes, Test Plan sections
- **`skills/synthesis/references/synthesis-steps.md`** — Added missing Step 5 (Write PR Descriptions) with validation and custom template instructions
- **`rules/pr-descriptions.md`** — Added enforcement and configurability documentation
- **`.github/workflows/project-automation.yml`** — Fixed `auto-assign-author` job: replaced `gh pr edit --add-assignee` (deprecated `projectCards` GraphQL) with REST API via `actions/github-script`

## Test Plan

15 bash test cases covering all validation paths: valid/invalid bodies, missing sections, bot authors, Graphite MQ skip, custom template override, case-insensitive headers, dry-run mode. Root test suite (267 tests) unaffected.

---

**Results:** Script tests 15 ✓ · Root tests 267 ✓
**Related:** Closes #907