### PR TITLE
fix: harden PR validation script and CI workflow (#907 follow-up)

### DIFF
--- a/.github/workflows/pr-body-check.yml
+++ b/.github/workflows/pr-body-check.yml
@@ -32,11 +32,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TEMPLATE_FLAG=""
+          args=(
+            --pr "${{ github.event.pull_request.number }}"
+            --author "${{ github.event.pull_request.user.login }}"
+          )
           if [[ -f ".exarchos/pr-template.md" ]]; then
-            TEMPLATE_FLAG="--template .exarchos/pr-template.md"
+            args+=(--template ".exarchos/pr-template.md")
           fi
-          bash scripts/validate-pr-body.sh \
-            --pr "${{ github.event.pull_request.number }}" \
-            --author "${{ github.event.pull_request.user.login }}" \
-            $TEMPLATE_FLAG
+          bash scripts/validate-pr-body.sh "${args[@]}"

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -162,13 +162,21 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            await github.rest.issues.addAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              assignees: [context.payload.pull_request.user.login]
-            });
-            console.log(`Assigned ${context.payload.pull_request.user.login} to PR #${context.payload.pull_request.number}`);
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                assignees: [context.payload.pull_request.user.login]
+              });
+              console.log(`Assigned ${context.payload.pull_request.user.login} to PR #${context.payload.pull_request.number}`);
+            } catch (error) {
+              if (error.status === 403 || error.status === 422) {
+                console.log(`Skipping assignment for ${context.payload.pull_request.user.login}: ${error.message}`);
+                return;
+              }
+              throw error;
+            }
 
   # ============================================================
   # PROJECT SYNC: Add issues/PRs to project board

--- a/rules/pr-descriptions.md
+++ b/rules/pr-descriptions.md
@@ -11,6 +11,6 @@ description: "PR title and body format guidelines for Graphite stacked PRs."
 
 See `skills/synthesis/references/pr-descriptions.md` for template and examples.
 
-**Enforcement:** CI runs `scripts/validate-pr-body.sh` on every PR. Bodies missing `## Summary`, `## Changes`, or `## Test Plan` will fail the check. After `gt submit`, update each PR body via `gh pr edit <number> --body "..."`.
+**Enforcement:** CI runs `scripts/validate-pr-body.sh` on human-authored PRs (skips Renovate/Dependabot and Graphite merge queue). Bodies missing `## Summary`, `## Changes`, or `## Test Plan` will fail the check. After `gt submit`, update each PR body via `gh pr edit <number> --body "..."`.
 
 **Custom templates:** Projects can override the default required sections by placing a `.exarchos/pr-template.md` file in the repo root. Any `## Section` headers in the template define the required sections for validation.

--- a/scripts/validate-pr-body.sh
+++ b/scripts/validate-pr-body.sh
@@ -95,7 +95,7 @@ for skip_author in "${SKIP_AUTHORS[@]}"; do
   fi
 done
 
-# Skip Graphite merge queue PRs
+# Skip Graphite merge queue PRs (defense-in-depth; CI also skips via job condition)
 if echo "$BODY" | grep -qi "graphite merge queue"; then
   exit 0
 fi
@@ -128,7 +128,7 @@ fi
 MISSING=()
 for section in "${REQUIRED_SECTIONS[@]}"; do
   # Escape regex metacharacters in section name for safe ERE matching
-  escaped_section=$(printf '%s' "$section" | sed 's/[.*+?^${}()|[\]/\\&/g')
+  escaped_section=$(printf '%s' "$section" | sed 's/\\/\\\\/g; s/[].*+?^${}()|[]/\\&/g')
   # Case-insensitive match for ## Section Header
   if ! echo "$BODY" | grep -qiE "^##[[:space:]]+${escaped_section}[[:space:]]*$"; then
     MISSING+=("$section")

--- a/skills/synthesis/references/synthesis-steps.md
+++ b/skills/synthesis/references/synthesis-steps.md
@@ -83,7 +83,7 @@ For each PR in the stack, write a structured description following `references/p
 1. **Title:** `<type>: <what>` (max 72 chars)
 2. **Body:** Summary → Changes → Test Plan → Footer
 
-After `gt submit` creates/updates PRs, update each PR body via GitHub MCP or CLI:
+Update each PR body via GitHub MCP or CLI (run this before or after `gt submit` in Step 6):
 ```bash
 gh pr edit <number> --body "$(cat <<'EOF'
 ## Summary


### PR DESCRIPTION
## Summary

Follow-up hardening for the PR validation script and CI workflow from #909. Addresses review feedback from CodeRabbit rounds 2-3 that landed after the merge queue picked up the original PR.

## Changes

- **`scripts/validate-pr-body.sh`** — Fix POSIX sed bracket expression for regex escaping (`[.` collating element bug), add defense-in-depth comment on Graphite MQ skip
- **`.github/workflows/pr-body-check.yml`** — Replace unquoted `$TEMPLATE_FLAG` string with bash array expansion (`${args[@]}`) to satisfy SC2086
- **`.github/workflows/project-automation.yml`** — Wrap `addAssignees` in try-catch for 403/422 errors (fork PRs, non-assignable authors)
- **`rules/pr-descriptions.md`** — Clarify "every PR" → "human-authored PRs" to reflect bot/MQ skip conditions
- **`skills/synthesis/references/synthesis-steps.md`** — Fix Step 5/6 ordering reference

## Test Plan

All 18 existing bash tests pass. No new tests needed — fixes are hardening of existing behavior.

---

**Results:** Script tests 18 ✓
**Related:** Follow-up to #909, closes remaining review items from #907