### PR TITLE
chore: bump to v2.1.0 — session provenance, /rehydrate, PR validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,10 +14,10 @@
       "source": {
         "source": "npm",
         "package": "@lvlup-sw/exarchos",
-        "version": "2.0.8"
+        "version": "2.1.0"
       },
       "description": "SDLC workflows with agent team coordination, quality gates, and Graphite stacked PRs",
-      "version": "2.0.8",
+      "version": "2.1.0",
       "author": {
         "name": "Levelup Software"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "exarchos",
   "description": "SDLC workflows for Claude Code with agent team coordination, quality gates, and Graphite stacked PRs.",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "author": {
     "name": "Levelup Software"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.8",
+  "version": "2.1.0",
   "components": {
     "core": [
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvlup-sw/exarchos",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "Governed SDLC workflows for Claude Code — agent orchestration, quality gates, and Graphite stacked PRs",
   "type": "module",
   "bin": {

--- a/servers/exarchos-mcp/package.json
+++ b/servers/exarchos-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lvlup-sw/exarchos-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
@@ -342,7 +342,7 @@ describe('MCP Server Entry Point', () => {
 
     it('should export SERVER_VERSION', async () => {
       const { SERVER_VERSION } = await import('../../index.js');
-      expect(SERVER_VERSION).toBe('1.0.0');
+      expect(SERVER_VERSION).toBe('1.1.0');
     });
   });
 });

--- a/servers/exarchos-mcp/src/__tests__/workflow/scaffolding.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/scaffolding.test.ts
@@ -13,7 +13,7 @@ describe('Package scaffold', () => {
       const pkg = JSON.parse(raw);
 
       expect(pkg.name).toBe('@lvlup-sw/exarchos-mcp');
-      expect(pkg.version).toBe('1.0.0');
+      expect(pkg.version).toBe('1.1.0');
       expect(pkg.type).toBe('module');
       expect(pkg.main).toBe('dist/index.js');
     });
@@ -61,7 +61,7 @@ describe('Package scaffold', () => {
       const { SERVER_NAME, SERVER_VERSION } = await import('../../index.js');
 
       expect(SERVER_NAME).toBe('exarchos-mcp');
-      expect(SERVER_VERSION).toBe('1.0.0');
+      expect(SERVER_VERSION).toBe('1.1.0');
     });
   });
 });

--- a/servers/exarchos-mcp/src/index.ts
+++ b/servers/exarchos-mcp/src/index.ts
@@ -38,7 +38,7 @@ import { withTelemetry } from './telemetry/middleware.js';
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 export const SERVER_NAME = 'exarchos-mcp';
-export const SERVER_VERSION = '1.0.0';
+export const SERVER_VERSION = '1.1.0';
 
 // ─── Composite Handler Map ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Bump version to 2.1.0 for the session provenance, `/rehydrate` command, and PR validation features that shipped in recent PRs.

## Changes

- **`package.json`** — Root package 2.0.8 → 2.1.0
- **`servers/exarchos-mcp/package.json`** — MCP server 1.0.0 → 1.1.0
- **`manifest.json`** — Installer manifest version sync
- **`.claude-plugin/plugin.json`** — Plugin manifest version sync
- **`.claude-plugin/marketplace.json`** — Marketplace listing version sync

## Test Plan

All 267 root tests pass. Build succeeds (MCP + CLI bundles).

---

**Results:** Tests 267 ✓ · Build 0 errors
**Related:** Rolls up #861, #896, #903, #906, #909, #911