### PR TITLE
fix: add max-length constraints to unbounded event payload fields

### DIFF
--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -25,6 +25,8 @@ import {
   ShepherdIterationData,
   ShepherdApprovalRequestedData,
   ShepherdCompletedData,
+  TaskProgressedData,
+  TaskFailedData,
 } from './schemas.js';
 
 describe('validateAgentEvent', () => {
@@ -1054,5 +1056,57 @@ describe('WorkflowEventBase max-length constraints', () => {
       schemaVersion: '',
     });
     expect(result.success).toBe(false);
+  });
+});
+
+// ─── Task 1: Max-length constraints on unbounded event payload fields ────────
+
+describe('TaskProgressedData max-length constraints', () => {
+  it('TaskProgressedData_MaxDetail_PassesValidation', () => {
+    const data = { taskId: 'task-1', tddPhase: 'red', detail: 'a'.repeat(500) };
+    expect(() => TaskProgressedData.parse(data)).not.toThrow();
+  });
+
+  it('TaskProgressedData_OversizedDetail_FailsValidation', () => {
+    const data = { taskId: 'task-1', tddPhase: 'red', detail: 'a'.repeat(501) };
+    expect(() => TaskProgressedData.parse(data)).toThrow();
+  });
+});
+
+describe('TaskFailedData max-length constraints', () => {
+  it('TaskFailedData_MaxError_PassesValidation', () => {
+    const data = { taskId: 'task-1', error: 'a'.repeat(500) };
+    expect(() => TaskFailedData.parse(data)).not.toThrow();
+  });
+
+  it('TaskFailedData_OversizedError_FailsValidation', () => {
+    const data = { taskId: 'task-1', error: 'a'.repeat(501) };
+    expect(() => TaskFailedData.parse(data)).toThrow();
+  });
+});
+
+describe('EvalCaseCompletedData max-length constraints', () => {
+  it('EvalCaseCompletedData_MaxAssertions_PassesValidation', () => {
+    const assertions = Array.from({ length: 50 }, (_, i) => ({
+      name: `assertion-${i}`, type: 'equality', passed: true, score: 1, reason: 'ok'
+    }));
+    const data = {
+      runId: '00000000-0000-0000-0000-000000000001',
+      caseId: 'case-1', suiteId: 'suite-1',
+      passed: true, score: 1, assertions, duration: 100
+    };
+    expect(() => EvalCaseCompletedData.parse(data)).not.toThrow();
+  });
+
+  it('EvalCaseCompletedData_OversizedAssertions_FailsValidation', () => {
+    const assertions = Array.from({ length: 51 }, (_, i) => ({
+      name: `assertion-${i}`, type: 'equality', passed: true, score: 1, reason: 'ok'
+    }));
+    const data = {
+      runId: '00000000-0000-0000-0000-000000000001',
+      caseId: 'case-1', suiteId: 'suite-1',
+      passed: true, score: 1, assertions, duration: 100
+    };
+    expect(() => EvalCaseCompletedData.parse(data)).toThrow();
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -103,7 +103,7 @@ export const TaskClaimedData = z.object({
 export const TaskProgressedData = z.object({
   taskId: z.string(),
   tddPhase: z.enum(['red', 'green', 'refactor']),
-  detail: z.string().optional(),
+  detail: z.string().max(500).optional(),
 });
 
 export const TaskCompletedData = z.object({
@@ -114,7 +114,7 @@ export const TaskCompletedData = z.object({
 
 export const TaskFailedData = z.object({
   taskId: z.string(),
-  error: z.string(),
+  error: z.string().max(500),
   diagnostics: z.record(z.string(), z.unknown()).optional(),
 });
 
@@ -448,7 +448,7 @@ export const EvalCaseCompletedData = z.object({
     passed: z.boolean(),
     score: z.number().min(0).max(1),
     reason: z.string(),
-  })),
+  })).max(50),
   duration: z.number().int().nonnegative(),
 });
 


### PR DESCRIPTION
## Summary

Add max-length constraints to three unbounded event payload fields to prevent token inflation in event streams. Part of optimization audit remediation.

## Changes

- **schemas.ts** — Add `.max(500)` to `TaskProgressedData.detail` and `TaskFailedData.error`; add `.max(50)` to `EvalCaseCompletedData.assertions`
- **schemas.test.ts** — Add 6 boundary tests (3 reject oversized, 3 accept at-limit)

## Test Plan

- [x] `npm run test:run` — 2,930 tests pass
- [x] `npm run typecheck` — clean

---
Results: 6 new tests, 0 failures
Audit: [optimize.md] Token Economy — unbounded event payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)