### PR TITLE
feat: add cache hit/miss tracking and thrashing detection to ViewMaterializer

### DIFF
--- a/servers/exarchos-mcp/src/views/materializer.test.ts
+++ b/servers/exarchos-mcp/src/views/materializer.test.ts
@@ -7,6 +7,7 @@ import {
 } from './workflow-state-projection.js';
 import type { WorkflowStateView } from './workflow-state-projection.js';
 import { InMemoryBackend } from '../storage/memory-backend.js';
+import { viewLogger } from '../logger.js';
 
 // ─── Test Helpers ──────────────────────────────────────────────────────────
 
@@ -579,5 +580,114 @@ describe('ViewMaterializer StorageBackend Integration', () => {
     const loaded = await materializer.loadFromSnapshot('stream-1', VIEW_NAME);
     expect(loaded).toBe(true);
     expect(snapshotStore.load).toHaveBeenCalledWith('stream-1', VIEW_NAME);
+  });
+});
+
+// ─── Cache Stats Tracking ────────────────────────────────────────────────────
+
+describe('ViewMaterializer Cache Stats', () => {
+  const VIEW_NAME = 'counter';
+
+  it('getCacheStats_NewMaterializer_ReturnsZeros', () => {
+    const materializer = new ViewMaterializer();
+
+    const stats = materializer.getCacheStats();
+
+    expect(stats).toEqual({ hits: 0, misses: 0, size: 0, missRate: 0 });
+  });
+
+  it('getCacheStats_AfterHitsAndMisses_TracksCorrectly', () => {
+    const materializer = new ViewMaterializer({ maxCacheEntries: 10 });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    // Miss: first time materializing stream-a
+    materializer.materialize('stream-a', VIEW_NAME, [makeEvent(1, 'stream-a')]);
+    // Hit: stream-a is already cached
+    materializer.materialize('stream-a', VIEW_NAME, [makeEvent(1, 'stream-a')]);
+    // Miss: first time materializing stream-b
+    materializer.materialize('stream-b', VIEW_NAME, [makeEvent(1, 'stream-b')]);
+
+    const stats = materializer.getCacheStats();
+
+    expect(stats.hits).toBe(1);
+    expect(stats.misses).toBe(2);
+    expect(stats.size).toBe(2);
+    expect(stats.missRate).toBeCloseTo(2 / 3);
+  });
+
+  it('materialize_HighMissRate_LogsWarning', () => {
+    const warnSpy = vi.spyOn(viewLogger, 'warn').mockImplementation(() => undefined as never);
+
+    // Use thrashingWindowSize of 10 so we only need 10 calls to trigger the check
+    const materializer = new ViewMaterializer({
+      maxCacheEntries: 1,
+      thrashingWindowSize: 10,
+    });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    // With maxCacheEntries=1, each new stream evicts the previous one.
+    // Every call to a different stream is a miss. We need 10 calls (the window size)
+    // with >50% miss rate to trigger the warning.
+    for (let i = 1; i <= 10; i++) {
+      materializer.materialize(`stream-${i}`, VIEW_NAME, [
+        makeEvent(1, `stream-${i}`),
+      ]);
+    }
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ cacheSize: 1, maxCacheEntries: 1 }),
+      expect.stringContaining('View cache thrashing detected'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('materialize_LowMissRate_DoesNotLogWarning', () => {
+    const warnSpy = vi.spyOn(viewLogger, 'warn').mockImplementation(() => undefined as never);
+
+    const materializer = new ViewMaterializer({
+      maxCacheEntries: 100,
+      thrashingWindowSize: 10,
+    });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    // Materialize one stream, then re-materialize it 9 more times (all hits after first)
+    // Miss rate = 1/10 = 10% — below 50% threshold
+    materializer.materialize('stream-a', VIEW_NAME, [makeEvent(1, 'stream-a')]);
+    for (let i = 2; i <= 10; i++) {
+      materializer.materialize('stream-a', VIEW_NAME, [makeEvent(1, 'stream-a')]);
+    }
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('materialize_ThrashingWindowResets_AfterWarning', () => {
+    const warnSpy = vi.spyOn(viewLogger, 'warn').mockImplementation(() => undefined as never);
+
+    const materializer = new ViewMaterializer({
+      maxCacheEntries: 1,
+      thrashingWindowSize: 10,
+    });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    // First window: 10 misses → triggers warning
+    for (let i = 1; i <= 10; i++) {
+      materializer.materialize(`stream-${i}`, VIEW_NAME, [
+        makeEvent(1, `stream-${i}`),
+      ]);
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    // Second window: 10 more misses → triggers warning again
+    for (let i = 11; i <= 20; i++) {
+      materializer.materialize(`stream-${i}`, VIEW_NAME, [
+        makeEvent(1, `stream-${i}`),
+      ]);
+    }
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+
+    warnSpy.mockRestore();
   });
 });

--- a/servers/exarchos-mcp/src/views/materializer.ts
+++ b/servers/exarchos-mcp/src/views/materializer.ts
@@ -119,7 +119,7 @@ export class ViewMaterializer {
       if (this.recentMisses / this.recentTotal > 0.5) {
         viewLogger.warn(
           { missRate: (this.recentMisses / this.recentTotal).toFixed(2), cacheSize: this.states.size, maxCacheEntries: this.maxCacheEntries },
-          'View cache thrashing detected — miss rate exceeds 50%% over last window. Consider increasing EXARCHOS_MAX_CACHE_ENTRIES',
+          'View cache thrashing detected — miss rate exceeds 50% over last window. Consider increasing EXARCHOS_MAX_CACHE_ENTRIES',
         );
       }
       this.recentMisses = 0;

--- a/servers/exarchos-mcp/src/views/materializer.ts
+++ b/servers/exarchos-mcp/src/views/materializer.ts
@@ -26,12 +26,15 @@ export interface MaterializerOptions {
   readonly snapshotInterval?: number;
   readonly maxCacheEntries?: number;
   readonly backend?: StorageBackend;
+  /** Size of the sliding window for thrashing detection (default: 100). */
+  readonly thrashingWindowSize?: number;
 }
 
 // ─── Default Snapshot Interval ─────────────────────────────────────────────
 
 const DEFAULT_SNAPSHOT_INTERVAL = 50;
 const DEFAULT_MAX_CACHE_ENTRIES = 100;
+const DEFAULT_THRASHING_WINDOW_SIZE = 100;
 
 /** Read EXARCHOS_MAX_CACHE_ENTRIES from env, falling back to default on invalid/missing. */
 function parseEnvMaxCacheEntries(): number {
@@ -65,11 +68,21 @@ export class ViewMaterializer {
   private readonly maxCacheEntries: number;
   private readonly backend?: StorageBackend;
 
+  // Cache hit/miss counters
+  private cacheHits = 0;
+  private cacheMisses = 0;
+
+  // Thrashing detection sliding window
+  private readonly thrashingWindowSize: number;
+  private recentMisses = 0;
+  private recentTotal = 0;
+
   constructor(options?: MaterializerOptions) {
     this.snapshotStore = options?.snapshotStore;
     this.snapshotInterval = options?.snapshotInterval ?? parseEnvSnapshotInterval();
     this.maxCacheEntries = options?.maxCacheEntries ?? parseEnvMaxCacheEntries();
     this.backend = options?.backend;
+    this.thrashingWindowSize = options?.thrashingWindowSize ?? DEFAULT_THRASHING_WINDOW_SIZE;
   }
 
   /**
@@ -91,6 +104,27 @@ export class ViewMaterializer {
 
     const stateKey = `${viewName}:${streamId}`;
     let state = this.states.get(stateKey) as ViewState<T> | undefined;
+
+    // Track cache hit/miss
+    if (state) {
+      this.cacheHits++;
+    } else {
+      this.cacheMisses++;
+      this.recentMisses++;
+    }
+    this.recentTotal++;
+
+    // Check for thrashing at window boundary
+    if (this.recentTotal >= this.thrashingWindowSize) {
+      if (this.recentMisses / this.recentTotal > 0.5) {
+        viewLogger.warn(
+          { missRate: (this.recentMisses / this.recentTotal).toFixed(2), cacheSize: this.states.size, maxCacheEntries: this.maxCacheEntries },
+          'View cache thrashing detected — miss rate exceeds 50%% over last window. Consider increasing EXARCHOS_MAX_CACHE_ENTRIES',
+        );
+      }
+      this.recentMisses = 0;
+      this.recentTotal = 0;
+    }
 
     if (!state) {
       state = {
@@ -198,6 +232,19 @@ export class ViewMaterializer {
       this.states.set(stateKey, state);
     }
     return state as ViewState<T> | undefined;
+  }
+
+  /**
+   * Return cumulative cache statistics for monitoring and diagnostics.
+   */
+  getCacheStats(): { hits: number; misses: number; size: number; missRate: number } {
+    const total = this.cacheHits + this.cacheMisses;
+    return {
+      hits: this.cacheHits,
+      misses: this.cacheMisses,
+      size: this.states.size,
+      missRate: total > 0 ? this.cacheMisses / total : 0,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Add cache hit/miss counters and thrashing detection to ViewMaterializer for operational observability. Warns when miss rate exceeds 50% over a sliding window, indicating LRU cache is undersized.

## Changes

- **materializer.ts** — Add `cacheHits`/`cacheMisses` private counters, sliding window thrashing detection with configurable window size (default 100), `getCacheStats()` public method, `viewLogger.warn()` on high miss rate
- **materializer.test.ts** — Add 5 tests covering stats tracking, thrashing warning, low miss rate, and window reset

## Test Plan

- [x] `npm run test:run` — 2,930 tests pass
- [x] `npm run typecheck` — clean

---
Results: 5 new tests, 0 failures
Audit: [optimize.md] Operational Performance — cache observability gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)