### PR TITLE
fix: recognize deferred sections in plan coverage verification (#913)

### DIFF
--- a/scripts/verify-plan-coverage.sh
+++ b/scripts/verify-plan-coverage.sh
@@ -248,20 +248,76 @@ keyword_match() {
 }
 
 # ============================================================
+# EXTRACT DEFERRED SECTIONS FROM TRACEABILITY TABLE
+# ============================================================
+
+# Parse deferred section names from the plan's traceability table.
+# Rows containing "Deferred" (case-insensitive) in any column are treated as
+# explicitly deferred — the first column's text (with leading number prefixes
+# like "1.4 " stripped) is the design section name.
+DEFERRED_SECTIONS=()
+while IFS= read -r line; do
+    # Match table rows containing "Deferred" (case-insensitive) with pipe delimiters
+    if echo "$line" | grep -qi "deferred" && [[ "$line" == *"|"* ]]; then
+        # Skip table header/separator rows
+        if echo "$line" | grep -qE '^\|[[:space:]]*[-]+'; then
+            continue
+        fi
+        if echo "$line" | grep -qiE '^\|[[:space:]]*(Design Section|Section)'; then
+            continue
+        fi
+        # Extract first column (design section name), strip leading number prefix like "1.4 "
+        section_name="$(echo "$line" | sed 's/^[[:space:]]*|[[:space:]]*//' | sed 's/[[:space:]]*|.*//' | sed 's/^[0-9.]*[[:space:]]*//' | sed 's/[[:space:]]*$//')"
+        if [[ -n "$section_name" ]]; then
+            DEFERRED_SECTIONS+=("$section_name")
+        fi
+    fi
+done < "$PLAN_FILE"
+
+# ============================================================
 # CROSS-REFERENCE: Design sections to plan tasks
 # ============================================================
 
 CHECK_PASS=0
 CHECK_FAIL=0
+CHECK_DEFERRED=0
 GAPS=()
 MATRIX_ROWS=()
 
 for section in "${DESIGN_SECTIONS[@]}"; do
-    # Check if any task title or plan content references this design section
-    MATCHED_TASKS=()
-
     # Extract keywords from the section name for keyword-based matching
     SECTION_KEYWORDS="$(extract_keywords "$section")"
+
+    # Check if section is explicitly deferred in the traceability table FIRST.
+    # Deferred sections take priority — they represent intentional exclusions
+    # documented with rationale, not gaps.
+    is_deferred=false
+    for deferred in "${DEFERRED_SECTIONS[@]+${DEFERRED_SECTIONS[@]}}"; do
+        # Try exact case-insensitive substring match (both directions)
+        if echo "$deferred" | grep -qiF "$section"; then
+            is_deferred=true
+            break
+        fi
+        if echo "$section" | grep -qiF "$deferred"; then
+            is_deferred=true
+            break
+        fi
+        # Try keyword match
+        deferred_keywords="$(extract_keywords "$deferred")"
+        if keyword_match "$deferred_keywords" "$section" || keyword_match "$SECTION_KEYWORDS" "$deferred"; then
+            is_deferred=true
+            break
+        fi
+    done
+
+    if [[ "$is_deferred" == true ]]; then
+        MATRIX_ROWS+=("| $section | (Deferred in traceability) | Deferred |")
+        CHECK_DEFERRED=$((CHECK_DEFERRED + 1))
+        continue
+    fi
+
+    # Check if any task title or plan content references this design section
+    MATCHED_TASKS=()
 
     for task in "${PLAN_TASKS[@]+${PLAN_TASKS[@]}}"; do
         # First try exact case-insensitive substring match
@@ -317,11 +373,12 @@ for row in "${MATRIX_ROWS[@]}"; do
 done
 echo ""
 
-TOTAL=$((CHECK_PASS + CHECK_FAIL))
+TOTAL=$((CHECK_PASS + CHECK_FAIL + CHECK_DEFERRED))
 echo "### Summary"
 echo ""
 echo "- Design sections: $TOTAL"
 echo "- Covered: $CHECK_PASS"
+echo "- Deferred: $CHECK_DEFERRED"
 echo "- Gaps: $CHECK_FAIL"
 echo ""
 
@@ -338,7 +395,11 @@ echo "---"
 echo ""
 
 if [[ $CHECK_FAIL -eq 0 ]]; then
-    echo "**Result: PASS** (${CHECK_PASS}/${TOTAL} sections covered)"
+    if [[ $CHECK_DEFERRED -gt 0 ]]; then
+        echo "**Result: PASS** (${CHECK_PASS}/${TOTAL} sections covered, ${CHECK_DEFERRED} deferred)"
+    else
+        echo "**Result: PASS** (${CHECK_PASS}/${TOTAL} sections covered)"
+    fi
     exit 0
 else
     echo "**Result: FAIL** (${CHECK_FAIL}/${TOTAL} sections have gaps)"

--- a/scripts/verify-plan-coverage.test.sh
+++ b/scripts/verify-plan-coverage.test.sh
@@ -515,6 +515,226 @@ else
 fi
 teardown
 
+# --------------------------------------------------
+# Test 12: DeferredSection_InTraceability_ExitsZero
+# --------------------------------------------------
+setup
+cat > "$TMPDIR_ROOT/design.md" << 'EOF'
+# Feature Design
+
+## Technical Design
+
+### Component A
+
+Build the A component.
+
+### Component B
+
+Build the B component.
+
+## Testing Strategy
+
+Tests needed.
+EOF
+
+cat > "$TMPDIR_ROOT/plan.md" << 'EOF'
+# Implementation Plan
+
+## Spec Traceability
+
+### Traceability Matrix
+
+| Design Section | Task ID(s) | Status |
+|----------------|-----------|--------|
+| Component A | T001 | Covered |
+| Component B | Deferred | Operational process, not code. |
+
+## Tasks
+
+### Task 001: Build component A
+
+Implement the A component.
+EOF
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "$TMPDIR_ROOT/design.md" --plan-file "$TMPDIR_ROOT/plan.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "DeferredSection_InTraceability_ExitsZero"
+else
+    fail "DeferredSection_InTraceability_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 13: DeferredSection_ShownAsDeferredInMatrix
+# --------------------------------------------------
+setup
+cat > "$TMPDIR_ROOT/design.md" << 'EOF'
+# Feature Design
+
+## Technical Design
+
+### Component A
+
+Build the A component.
+
+### Component B
+
+Build the B component.
+
+## Testing Strategy
+
+Tests needed.
+EOF
+
+cat > "$TMPDIR_ROOT/plan.md" << 'EOF'
+# Implementation Plan
+
+## Spec Traceability
+
+### Traceability Matrix
+
+| Design Section | Task ID(s) | Status |
+|----------------|-----------|--------|
+| Component A | T001 | Covered |
+| Component B | Deferred | Operational process. |
+
+## Tasks
+
+### Task 001: Build component A
+
+Implement the A component.
+EOF
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "$TMPDIR_ROOT/design.md" --plan-file "$TMPDIR_ROOT/plan.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if echo "$OUTPUT" | grep -qi "Component B.*Deferred"; then
+    pass "DeferredSection_ShownAsDeferredInMatrix"
+else
+    fail "DeferredSection_ShownAsDeferredInMatrix (expected 'Component B' with 'Deferred' status)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 14: MixedDeferredAndCovered_ExitsZero
+# --------------------------------------------------
+setup
+cat > "$TMPDIR_ROOT/design.md" << 'EOF'
+# Feature Design
+
+## Technical Design
+
+### Auth Module
+
+Build auth.
+
+### Cache Layer
+
+Build cache.
+
+### Monitoring
+
+Add monitoring.
+
+## Testing Strategy
+
+Tests needed.
+EOF
+
+cat > "$TMPDIR_ROOT/plan.md" << 'EOF'
+# Implementation Plan
+
+## Spec Traceability
+
+### Traceability Matrix
+
+| Design Section | Task ID(s) | Status |
+|----------------|-----------|--------|
+| Auth Module | T001 | Covered |
+| Cache Layer | T002 | Covered |
+| Monitoring | Deferred | Will add in Phase 2. |
+
+## Tasks
+
+### Task 001: Implement auth module
+
+Build authentication.
+
+### Task 002: Implement cache layer
+
+Build caching.
+EOF
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "$TMPDIR_ROOT/design.md" --plan-file "$TMPDIR_ROOT/plan.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 0 ]]; then
+    pass "MixedDeferredAndCovered_ExitsZero"
+else
+    fail "MixedDeferredAndCovered_ExitsZero (exit=$EXIT_CODE, expected 0)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
+# --------------------------------------------------
+# Test 15: DeferredAndGap_ExitsOne
+# --------------------------------------------------
+setup
+cat > "$TMPDIR_ROOT/design.md" << 'EOF'
+# Feature Design
+
+## Technical Design
+
+### Auth Module
+
+Build auth.
+
+### Cache Layer
+
+Build cache.
+
+### Rate Limiting
+
+Add rate limits.
+
+## Testing Strategy
+
+Tests needed.
+EOF
+
+cat > "$TMPDIR_ROOT/plan.md" << 'EOF'
+# Implementation Plan
+
+## Spec Traceability
+
+### Traceability Matrix
+
+| Design Section | Task ID(s) | Status |
+|----------------|-----------|--------|
+| Auth Module | T001 | Covered |
+| Cache Layer | Deferred | Phase 2 work. |
+
+## Tasks
+
+### Task 001: Implement auth module
+
+Build authentication.
+EOF
+
+OUTPUT="$(bash "$SCRIPT_UNDER_TEST" --design-file "$TMPDIR_ROOT/design.md" --plan-file "$TMPDIR_ROOT/plan.md" 2>&1)" && EXIT_CODE=$? || EXIT_CODE=$?
+if [[ $EXIT_CODE -eq 1 ]]; then
+    pass "DeferredAndGap_ExitsOne"
+else
+    fail "DeferredAndGap_ExitsOne (exit=$EXIT_CODE, expected 1)"
+    echo "  Output: $OUTPUT"
+fi
+# Verify Rate Limiting is identified as the gap (not Cache Layer)
+if echo "$OUTPUT" | grep -qi "Rate Limiting"; then
+    pass "DeferredAndGap_IdentifiesCorrectGap"
+else
+    fail "DeferredAndGap_IdentifiesCorrectGap (expected 'Rate Limiting' in gaps)"
+    echo "  Output: $OUTPUT"
+fi
+teardown
+
 # ============================================================
 # SUMMARY
 # ============================================================


### PR DESCRIPTION
## Summary

Fixes `scripts/verify-plan-coverage.sh` to recognize design sections explicitly marked as "Deferred" in a plan file's traceability table. Previously, sections with documented deferral rationale were still reported as coverage gaps. Now deferred sections are parsed from the traceability table, treated as intentionally excluded (not gaps), and shown with "Deferred" status in the coverage matrix.

Closes #913.

## Changes

- **`scripts/verify-plan-coverage.sh`** — Added deferred section extraction from traceability table rows containing "Deferred" (case-insensitive). Deferred check runs before task matching so explicitly deferred sections take priority. Summary output includes a new "Deferred" count line.
- **`scripts/verify-plan-coverage.test.sh`** — Added 4 new test cases (Tests 12-15): deferred section exits 0, deferred shown in matrix, mixed deferred/covered exits 0, deferred with genuine gap exits 1.

## Test Plan

- [x] All 21 tests pass (16 existing + 5 assertions across 4 new tests)
- [x] RED phase verified: Test 13 failed before implementation
- [x] Deferred sections do not count as gaps
- [x] Edge cases handled: table headers, numeric prefixes, case-insensitive matching

---

Test results: 21/21 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)