### PR TITLE
fix: sequence corruption auto-repair, guard diagnostics, shepherd DX

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -645,6 +645,31 @@ describe('Core Tools', () => {
       expect(result.error?.code).toBe('GUARD_FAILED');
     });
 
+    it('should include expectedShape and suggestedFix in guard failure response', async () => {
+      await handleInit({ featureId: 'guard-diag-test', workflowType: 'feature' }, tmpDir);
+
+      // Try to transition ideate -> plan without setting design artifact
+      const result = await handleSet(
+        { featureId: 'guard-diag-test', phase: 'plan' },
+        tmpDir,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('GUARD_FAILED');
+
+      // expectedShape should indicate what artifact is needed
+      const error = result.error as Record<string, unknown>;
+      expect(error.expectedShape).toBeDefined();
+      expect(error.expectedShape).toEqual({ artifacts: { design: '<path-or-content>' } });
+
+      // suggestedFix should provide actionable remediation
+      expect(error.suggestedFix).toBeDefined();
+      const fix = error.suggestedFix as { tool: string; params: Record<string, unknown> };
+      expect(fix.tool).toBe('exarchos_workflow');
+      expect(fix.params.action).toBe('set');
+      expect(fix.params.featureId).toBe('guard-diag-test');
+    });
+
     it('should return INVALID_TRANSITION for invalid target phase', async () => {
       await handleInit({ featureId: 'invalid-test', workflowType: 'feature' }, tmpDir);
 

--- a/servers/exarchos-mcp/src/event-store/store.test.ts
+++ b/servers/exarchos-mcp/src/event-store/store.test.ts
@@ -1140,7 +1140,7 @@ describe('EventStore Sequence Invariant', () => {
     expect(event.sequence).toBe(4);
   });
 
-  it('InitializeSequence_BrokenInvariant_Throws', async () => {
+  it('InitializeSequence_BrokenInvariant_AutoRepairs', async () => {
     // Create a JSONL file where first line has wrong sequence
     const filePath = path.join(tempDir, 'broken-seq.events.jsonl');
     const events = [
@@ -1154,7 +1154,17 @@ describe('EventStore Sequence Invariant', () => {
     await fs.rm(seqPath, { force: true });
 
     const store = new EventStore(tempDir);
-    await expect(store.append('broken-seq', { type: 'task.claimed' })).rejects.toThrow(/sequence invariant/i);
+    // Auto-repair: re-sequences to 1,2 then appends as 3
+    const event = await store.append('broken-seq', { type: 'task.claimed' });
+    expect(event.sequence).toBe(3);
+
+    // Verify repaired file
+    const content = await fs.readFile(filePath, 'utf-8');
+    const lines = content.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(3);
+    for (let i = 0; i < lines.length; i++) {
+      expect(JSON.parse(lines[i]).sequence).toBe(i + 1);
+    }
   });
 
   // T25: Blank-line tolerance
@@ -1184,7 +1194,7 @@ describe('EventStore Sequence Invariant', () => {
 // ─── Sequence Invariant Under Compaction ──────────────────────────────────────
 
 describe('EventStore Sequence Invariant Under Compaction', () => {
-  it('initializeSequence_CompactedFile_ThrowsSequenceInvariantError', async () => {
+  it('initializeSequence_CompactedFile_AutoRepairsSequences', async () => {
     // Arrange: create a JSONL file simulating compaction where middle events
     // were removed. 3 lines but last event has sequence 5 (gap).
     const filePath = path.join(tempDir, 'compacted.events.jsonl');
@@ -1201,10 +1211,17 @@ describe('EventStore Sequence Invariant Under Compaction', () => {
 
     const store = new EventStore(tempDir);
 
-    // Act & Assert: should throw because last event (seq 5) != line count (3)
-    await expect(
-      store.append('compacted', { type: 'task.claimed' }),
-    ).rejects.toThrow(/sequence invariant/i);
+    // Act: auto-repair re-sequences the 3 events to 1,2,3 then appends as 4
+    const event = await store.append('compacted', { type: 'task.claimed' });
+    expect(event.sequence).toBe(4);
+
+    // Verify repaired file
+    const content = await fs.readFile(filePath, 'utf-8');
+    const lines = content.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(4);
+    for (let i = 0; i < lines.length; i++) {
+      expect(JSON.parse(lines[i]).sequence).toBe(i + 1);
+    }
   });
 
   it('initializeSequence_ValidFile_SetsCorrectSequence', async () => {
@@ -1230,7 +1247,7 @@ describe('EventStore Sequence Invariant Under Compaction', () => {
     expect(event.sequence).toBe(4);
   });
 
-  it('initializeSequence_FirstEventNotOne_ThrowsSequenceInvariantError', async () => {
+  it('initializeSequence_FirstEventNotOne_AutoRepairsSequences', async () => {
     // Arrange: create a JSONL file where first event starts at sequence 2
     const filePath = path.join(tempDir, 'offset-seq.events.jsonl');
     const events = [
@@ -1246,10 +1263,17 @@ describe('EventStore Sequence Invariant Under Compaction', () => {
 
     const store = new EventStore(tempDir);
 
-    // Act & Assert: should throw because first event seq is 2, expected 1
-    await expect(
-      store.append('offset-seq', { type: 'task.claimed' }),
-    ).rejects.toThrow(/sequence invariant/i);
+    // Act: auto-repair re-sequences to 1,2,3 then appends as 4
+    const event = await store.append('offset-seq', { type: 'task.claimed' });
+    expect(event.sequence).toBe(4);
+
+    // Verify repaired file
+    const content = await fs.readFile(filePath, 'utf-8');
+    const lines = content.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(4);
+    for (let i = 0; i < lines.length; i++) {
+      expect(JSON.parse(lines[i]).sequence).toBe(i + 1);
+    }
   });
 });
 
@@ -1805,5 +1829,91 @@ describe('EventStore appendValidated', () => {
     const event = await store.appendValidated('my-workflow', prebuilt, {});
 
     expect(addEntrySpy).toHaveBeenCalledWith('my-workflow', event);
+  });
+});
+
+// ─── Sequence Corruption Detection and Repair (#943) ────────────────────────
+
+describe('EventStore Sequence Corruption Repair', () => {
+  it('initializeSequence_DuplicateSequences_RepairsAutomatically', async () => {
+    // Arrange: manually write a JSONL file with duplicate sequence numbers
+    const filePath = path.join(tempDir, 'corrupt-stream.events.jsonl');
+    const corruptEvents = [
+      JSON.stringify({ streamId: 'corrupt-stream', sequence: 1, type: 'workflow.started', timestamp: '2026-01-01T00:00:00Z', schemaVersion: '1.0' }),
+      JSON.stringify({ streamId: 'corrupt-stream', sequence: 2, type: 'task.assigned', timestamp: '2026-01-01T00:00:01Z', schemaVersion: '1.0' }),
+      JSON.stringify({ streamId: 'corrupt-stream', sequence: 3, type: 'ci.status', timestamp: '2026-01-01T00:00:02Z', schemaVersion: '1.0' }),
+      JSON.stringify({ streamId: 'corrupt-stream', sequence: 3, type: 'gate.executed', timestamp: '2026-01-01T00:00:02Z', schemaVersion: '1.0' }),
+    ];
+    await fs.writeFile(filePath, corruptEvents.join('\n') + '\n', 'utf-8');
+
+    // Act: create a new EventStore and append (triggers initializeSequence)
+    const store = new EventStore(tempDir);
+    const event = await store.append('corrupt-stream', { type: 'task.completed' });
+
+    // Assert: the new event gets sequence 5 (4 existing + 1 new)
+    expect(event.sequence).toBe(5);
+
+    // Verify the repaired file has monotonic sequences
+    const content = await fs.readFile(filePath, 'utf-8');
+    const lines = content.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(5); // 4 repaired + 1 new
+    for (let i = 0; i < lines.length; i++) {
+      const parsed = JSON.parse(lines[i]);
+      expect(parsed.sequence).toBe(i + 1);
+    }
+  });
+
+  it('initializeSequence_GapInSequences_RepairsAutomatically', async () => {
+    // Arrange: JSONL with a gap (1, 2, 4 — missing 3)
+    const filePath = path.join(tempDir, 'gap-stream.events.jsonl');
+    const gapEvents = [
+      JSON.stringify({ streamId: 'gap-stream', sequence: 1, type: 'workflow.started', timestamp: '2026-01-01T00:00:00Z', schemaVersion: '1.0' }),
+      JSON.stringify({ streamId: 'gap-stream', sequence: 2, type: 'task.assigned', timestamp: '2026-01-01T00:00:01Z', schemaVersion: '1.0' }),
+      JSON.stringify({ streamId: 'gap-stream', sequence: 4, type: 'task.completed', timestamp: '2026-01-01T00:00:02Z', schemaVersion: '1.0' }),
+    ];
+    await fs.writeFile(filePath, gapEvents.join('\n') + '\n', 'utf-8');
+
+    // Act: create store and append
+    const store = new EventStore(tempDir);
+    const event = await store.append('gap-stream', { type: 'workflow.transition' });
+
+    // Assert: new event gets sequence 4 (3 existing lines + 1)
+    expect(event.sequence).toBe(4);
+
+    // Verify repaired sequences
+    const content = await fs.readFile(filePath, 'utf-8');
+    const lines = content.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(4);
+    for (let i = 0; i < lines.length; i++) {
+      const parsed = JSON.parse(lines[i]);
+      expect(parsed.sequence).toBe(i + 1);
+    }
+  });
+
+  it('initializeSequence_HealthyStream_NoRepairNeeded', async () => {
+    // Arrange: write a healthy JSONL file
+    const filePath = path.join(tempDir, 'healthy-stream.events.jsonl');
+    const healthyEvents = [
+      JSON.stringify({ streamId: 'healthy-stream', sequence: 1, type: 'workflow.started', timestamp: '2026-01-01T00:00:00Z', schemaVersion: '1.0' }),
+      JSON.stringify({ streamId: 'healthy-stream', sequence: 2, type: 'task.assigned', timestamp: '2026-01-01T00:00:01Z', schemaVersion: '1.0' }),
+      JSON.stringify({ streamId: 'healthy-stream', sequence: 3, type: 'task.completed', timestamp: '2026-01-01T00:00:02Z', schemaVersion: '1.0' }),
+    ];
+    await fs.writeFile(filePath, healthyEvents.join('\n') + '\n', 'utf-8');
+
+    // Act: create store and append
+    const store = new EventStore(tempDir);
+    const event = await store.append('healthy-stream', { type: 'workflow.transition' });
+
+    // Assert: new event gets sequence 4 (3 existing + 1)
+    expect(event.sequence).toBe(4);
+
+    // Verify no unnecessary rewrite (original sequences preserved)
+    const content = await fs.readFile(filePath, 'utf-8');
+    const lines = content.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(4);
+    for (let i = 0; i < lines.length; i++) {
+      const parsed = JSON.parse(lines[i]);
+      expect(parsed.sequence).toBe(i + 1);
+    }
   });
 });

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -661,35 +661,51 @@ export class EventStore {
       // Fall through to line counting
     }
 
-    // Fallback: count lines in JSONL file (O(n)) with sequence invariant validation
+    // Fallback: count lines in JSONL file (O(n)) with full monotonicity validation
     const filePath = this.getEventFilePath(streamId);
     try {
       const content = await fs.readFile(filePath, 'utf-8');
       const lines = content.trim().split('\n').filter(Boolean);
 
-      // Sequence invariant validation: sample first and last line
       if (lines.length > 0) {
-        const firstEvent = JSON.parse(lines[0]) as WorkflowEvent;
-        if (firstEvent.sequence !== 1) {
-          throw new Error(
-            `Sequence invariant violated for stream '${streamId}': first event has sequence ${firstEvent.sequence}, expected 1`,
-          );
+        // Full monotonicity check: every event must have sequence === lineIndex + 1
+        let needsRepair = false;
+        for (let i = 0; i < lines.length; i++) {
+          const match = SEQUENCE_REGEX.exec(lines[i]);
+          const seq = match ? parseInt(match[1], 10) : NaN;
+          if (seq !== i + 1) {
+            needsRepair = true;
+            break;
+          }
         }
 
-        const lastEvent = JSON.parse(lines[lines.length - 1]) as WorkflowEvent;
-        if (lastEvent.sequence !== lines.length) {
-          throw new Error(
-            `Sequence invariant violated for stream '${streamId}': last event has sequence ${lastEvent.sequence}, expected ${lines.length}`,
+        if (needsRepair) {
+          storeLogger.warn(
+            { streamId, lineCount: lines.length },
+            'Sequence corruption detected — repairing stream with monotonic re-sequencing',
           );
+          // Re-sequence all events with correct monotonic sequence numbers
+          const repaired: string[] = [];
+          for (let i = 0; i < lines.length; i++) {
+            const event = JSON.parse(lines[i]) as WorkflowEvent;
+            const fixed = { ...event, sequence: i + 1 };
+            repaired.push(JSON.stringify(fixed));
+          }
+          await fs.writeFile(filePath, repaired.join('\n') + '\n', 'utf-8');
+          // Update .seq cache to match repaired state
+          const seqPath = this.getSeqFilePath(streamId);
+          const tmpPath = `${seqPath}.tmp`;
+          try {
+            await fs.writeFile(tmpPath, JSON.stringify({ sequence: lines.length }), 'utf-8');
+            await fs.rename(tmpPath, seqPath);
+          } catch {
+            await fs.rm(tmpPath, { force: true }).catch(() => {});
+          }
         }
       }
 
       this.sequenceCounters.set(streamId, lines.length);
     } catch (err) {
-      // Re-throw sequence invariant errors
-      if (err instanceof Error && err.message.includes('Sequence invariant')) {
-        throw err;
-      }
       this.sequenceCounters.set(streamId, 0);
     }
   }

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -691,7 +691,9 @@ export class EventStore {
             const fixed = { ...event, sequence: i + 1 };
             repaired.push(JSON.stringify(fixed));
           }
-          await fs.writeFile(filePath, repaired.join('\n') + '\n', 'utf-8');
+          const tmpJsonl = `${filePath}.repair.tmp`;
+          await fs.writeFile(tmpJsonl, repaired.join('\n') + '\n', 'utf-8');
+          await fs.rename(tmpJsonl, filePath);
           // Update .seq cache to match repaired state
           const seqPath = this.getSeqFilePath(streamId);
           const tmpPath = `${seqPath}.tmp`;
@@ -706,6 +708,10 @@ export class EventStore {
 
       this.sequenceCounters.set(streamId, lines.length);
     } catch (err) {
+      storeLogger.warn(
+        { streamId, err: err instanceof Error ? err.message : String(err) },
+        'Failed to initialize sequence from JSONL — defaulting to 0',
+      );
       this.sequenceCounters.set(streamId, 0);
     }
   }

--- a/servers/exarchos-mcp/src/format.ts
+++ b/servers/exarchos-mcp/src/format.ts
@@ -5,7 +5,13 @@ import type { ValidTransitionTarget } from './workflow/state-machine.js';
 export interface ToolResult {
   readonly success: boolean;
   readonly data?: unknown;
-  readonly error?: { code: string; message: string; validTargets?: readonly (string | ValidTransitionTarget)[] };
+  readonly error?: {
+    code: string;
+    message: string;
+    validTargets?: readonly (string | ValidTransitionTarget)[];
+    expectedShape?: Record<string, unknown>;
+    suggestedFix?: { tool: string; params: Record<string, unknown> };
+  };
   readonly warnings?: readonly string[];
   readonly _meta?: unknown;
 }

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
@@ -1,9 +1,10 @@
 // ─── Assess Stack Composite Action ──────────────────────────────────────────
 //
-// Orchestrates PR stack health assessment for the shepherd workflow.
-// Queries CI status, reviews, and comments per PR via `gh` CLI, then emits
-// dual events: `ci.status` for ShepherdStatusView and `gate.executed` for
-// CodeQualityView/flywheel pass rate tracking.
+// Orchestrates PR stack health assessment for the shepherd iteration loop.
+// Shepherd is NOT a separate HSM phase — it operates within the `synthesize`
+// phase. This action queries CI status, reviews, and comments per PR via
+// `gh` CLI, then emits dual events: `ci.status` for ShepherdStatusView and
+// `gate.executed` for CodeQualityView/flywheel pass rate tracking.
 // ────────────────────────────────────────────────────────────────────────────
 
 import { execSync } from 'node:child_process';

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -429,7 +429,7 @@ const orchestrateActions: readonly ToolAction[] = [
   },
   {
     name: 'assess_stack',
-    description: 'Assess PR stack health: CI status, reviews, comments. Emits events for shepherd view and eval flywheel.',
+    description: 'Assess PR stack health during synthesize: CI status, reviews, comments. Emits events for the shepherd iteration loop (within synthesize phase) and eval flywheel.',
     schema: z.object({
       featureId: z.string().min(1),
       prNumbers: z.array(z.number().int().positive()),

--- a/servers/exarchos-mcp/src/views/shepherd-status-view.ts
+++ b/servers/exarchos-mcp/src/views/shepherd-status-view.ts
@@ -2,6 +2,9 @@ import type { ViewProjection } from './materializer.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
 
 // ─── View Name Constant ────────────────────────────────────────────────────
+// Shepherd is NOT a separate HSM phase — it operates as an iteration loop
+// within the `synthesize` phase. This view tracks loop progress (iteration
+// counts, PR health) without requiring a phase transition.
 
 export const SHEPHERD_STATUS_VIEW = 'shepherd-status';
 

--- a/servers/exarchos-mcp/src/workflow/state-machine.ts
+++ b/servers/exarchos-mcp/src/workflow/state-machine.ts
@@ -59,6 +59,11 @@ export interface TransitionResult {
   readonly errorMessage?: string;
   readonly guardDescription?: string;
   readonly validTargets?: readonly ValidTransitionTarget[];
+  readonly guardExpectedShape?: Record<string, unknown>;
+  readonly guardSuggestedFix?: {
+    readonly tool: string;
+    readonly params: Record<string, unknown>;
+  };
 }
 
 // ─── HSM Registry ───────────────────────────────────────────────────────────
@@ -337,6 +342,14 @@ export function executeTransition(
     const guardPassed = typeof rawResult === 'boolean' ? rawResult : rawResult.passed;
     const guardReason =
       typeof rawResult === 'object' && 'reason' in rawResult ? rawResult.reason : undefined;
+    const guardExpectedShape =
+      typeof rawResult === 'object' && 'expectedShape' in rawResult
+        ? (rawResult as unknown as Record<string, unknown>).expectedShape as Record<string, unknown> | undefined
+        : undefined;
+    const guardSuggestedFix =
+      typeof rawResult === 'object' && 'suggestedFix' in rawResult
+        ? (rawResult as unknown as Record<string, unknown>).suggestedFix as { tool: string; params: Record<string, unknown> } | undefined
+        : undefined;
     if (!guardPassed) {
       return {
         success: false,
@@ -354,6 +367,8 @@ export function executeTransition(
           ? `Guard '${transition.guard.id}' failed: ${guardReason}`
           : `Guard '${transition.guard.id}' failed: ${transition.guard.description}`,
         guardDescription: transition.guard.description,
+        ...(guardExpectedShape ? { guardExpectedShape } : {}),
+        ...(guardSuggestedFix ? { guardSuggestedFix } : {}),
       };
     }
   }

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -530,6 +530,8 @@ export async function handleSet(
             code: errorCode,
             message: result.errorMessage ?? `Transition failed to '${input.phase}'`,
             ...(result.validTargets?.length ? { validTargets: result.validTargets } : {}),
+            ...(result.guardExpectedShape ? { expectedShape: result.guardExpectedShape } : {}),
+            ...(result.guardSuggestedFix ? { suggestedFix: result.guardSuggestedFix } : {}),
           },
         };
       }

--- a/skills/shepherd/SKILL.md
+++ b/skills/shepherd/SKILL.md
@@ -16,7 +16,7 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
 > **Note:** Shepherd is not a separate HSM phase. It operates as a loop within the `synthesize` phase. The workflow phase remains `synthesize` throughout the shepherd iteration cycle. Events (`shepherd.iteration`, `ci.status`) and the `shepherd_status` view track loop progress without requiring a phase transition.
 
 **Position in workflow:**
-```
+```text
 /synthesize → /shepherd (assess → fix → resubmit → loop) → /cleanup
               ^^^^^^^^^ runs within synthesize phase
 ```

--- a/skills/shepherd/SKILL.md
+++ b/skills/shepherd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shepherd
-description: "Shepherd PRs through CI and reviews to merge readiness using the assess_stack composite action. Use after /synthesize to iterate on failures, address review feedback, and request approval. Triggers: 'shepherd', 'tend PRs', 'check CI', or /shepherd."
+description: "Shepherd PRs through CI and reviews to merge readiness. Operates as an iteration loop within the synthesize phase (not a separate HSM phase). Uses assess_stack to check PR health, fix failures, and request approval. Triggers: 'shepherd', 'tend PRs', 'check CI', or /shepherd."
 metadata:
   author: exarchos
   version: 2.0.0
@@ -13,9 +13,12 @@ metadata:
 
 Iterative loop that shepherds published PRs through CI checks and code reviews to merge readiness. Uses the `assess_stack` composite action for all PR health checks, fixing failures and addressing feedback until the stack is green.
 
+> **Note:** Shepherd is not a separate HSM phase. It operates as a loop within the `synthesize` phase. The workflow phase remains `synthesize` throughout the shepherd iteration cycle. Events (`shepherd.iteration`, `ci.status`) and the `shepherd_status` view track loop progress without requiring a phase transition.
+
 **Position in workflow:**
 ```
 /synthesize → /shepherd (assess → fix → resubmit → loop) → /cleanup
+              ^^^^^^^^^ runs within synthesize phase
 ```
 
 ## Triggers


### PR DESCRIPTION
## Summary

Fixes 3 open bugs (#943, #944, #945) and closes #942 (already resolved).

## Changes

- **#943 — Event store sequence corruption auto-repair** — `initializeSequence` now validates full monotonicity (every sequence == lineIndex + 1) instead of only checking first/last. When corruption is detected (duplicates, gaps, wrong start sequence), the stream is automatically re-sequenced and the .seq cache updated. Previously threw a fatal error that wedged the stream permanently.

- **#944 — Guard failure diagnostic propagation** — `expectedShape` and `suggestedFix` fields from guard failures now flow through `TransitionResult` → `ToolResult` → MCP response. Agents can see exactly what state shape a guard expects and get actionable remediation. Previously these rich diagnostics were computed by guards but discarded at the state machine layer.

- **#945 — Shepherd DX clarification** — Updated skill description, `assess_stack` registry entry, view comments, and assess-stack module header to clarify that shepherd operates as an iteration loop within the `synthesize` phase, not as a separate HSM state.

## Test Plan

- [x] 3 new tests for sequence corruption repair (duplicates, gaps, healthy stream)
- [x] 1 new test for guard failure `expectedShape`/`suggestedFix` propagation
- [x] 3 existing sequence invariant tests updated to match auto-repair behavior
- [x] Full suite: 3287 passed (4 new), 2 pre-existing failures unchanged
- [x] TypeScript: clean `tsc --noEmit`
- [x] Build: clean `npm run build`

Closes #943, closes #944, closes #945

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)