### PR TITLE
fix: remove stale @planned annotation from team.disbanded

### DIFF
--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -152,6 +152,15 @@ describe('Team Event Data Schemas', () => {
       });
       expect(result.success).toBe(true);
     });
+
+    it('TeamDisbandedData_ValidData_ParsesSuccessfully', () => {
+      const result = TeamDisbandedData.safeParse({
+        totalDurationMs: 5000,
+        tasksCompleted: 3,
+        tasksFailed: 0,
+      });
+      expect(result.success).toBe(true);
+    });
   });
 
   describe('TeamContextInjectedData', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -347,7 +347,6 @@ export const TeamTaskFailedData = z.object({
   gateResults: z.record(z.string(), z.unknown()),
 });
 
-/** @planned — not yet emitted in production */
 export const TeamDisbandedData = z.object({
   totalDurationMs: z.number(),
   tasksCompleted: z.number().int(),


### PR DESCRIPTION
## Summary

Removes the `/** @planned — not yet emitted in production */` JSDoc annotation from `TeamDisbandedData`. This event is actively used for `delegate → review` phase guard transitions and is not actually planned/unimplemented.

## Changes

- **`schemas.ts`** — Removed stale `@planned` annotation from `TeamDisbandedData` schema
- **`schemas.test.ts`** — Added `TeamDisbandedData_ValidData_ParsesSuccessfully` regression test

## Test Plan

- [x] `TeamDisbandedData` schema parses valid data
- [x] All 3309 existing MCP server tests pass
- [x] Typecheck clean

---

Part of model-emitted event reliability refactor. Related: #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)