### PR TITLE
feat(mcp): lazy schema + runbook protocol

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,6 +18,7 @@
     "audit-trail",
     "code-review"
   ],
+  "agents": "./agents/",
   "commands": "./commands/",
   "skills": "./skills/",
   "mcpServers": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ cd servers/exarchos-mcp && npm run test:run
 
 - **Installer** (`src/install.ts`) — Symlinks commands/skills/rules to `~/.claude/`, registers MCP servers in `~/.claude.json`
 - **Content layers** — Commands (`commands/*.md`), Skills (`skills/*/SKILL.md` with `references/`), Rules (`rules/*.md` — safety only; domain rules in `skills/*/references/`). Structured Markdown, not executable code.
-- **MCP server** (`servers/exarchos-mcp/`) — 5 composite tools (`exarchos_workflow`, `exarchos_event`, `exarchos_orchestrate`, `exarchos_view`, `exarchos_sync`). Uses `@modelcontextprotocol/sdk` + `zod` over stdio.
+- **MCP server** (`servers/exarchos-mcp/`) — 4 visible composite tools (`exarchos_workflow`, `exarchos_event`, `exarchos_orchestrate`, `exarchos_view`) + 1 hidden sync tool (`exarchos_sync`). Uses `@modelcontextprotocol/sdk` + `zod` over stdio.
 - **Script resolution** — Scripts resolve from `EXARCHOS_PLUGIN_ROOT/scripts/` (plugin install) with fallback to `~/.claude/scripts/` (companion installer). Skills invoke scripts via `exarchos_orchestrate({ action: "run_script" })`, not direct bash paths.
 - **Validation scripts** (`scripts/`) — Deterministic bash replacing prose checklists. Pattern: `set -euo pipefail`, exit codes 0/1/2, co-located `.test.sh`.
 

--- a/docs/designs/2026-03-08-native-subagent-integration.md
+++ b/docs/designs/2026-03-08-native-subagent-integration.md
@@ -1,0 +1,1027 @@
+# Design: Native Subagent Integration
+
+## Problem Statement
+
+Exarchos delegates implementation tasks to Claude Code subagents via the `Task()` tool, but treats them as generic black boxes: every dispatch builds a ~2,000-token inline prompt, uses `subagent_type: "general-purpose"`, manages worktrees manually via `prepare_delegation`, and dispatches fresh fixer agents with zero context when tasks fail. Meanwhile, Claude Code now offers rich native primitives — custom agent definitions, native worktree isolation, agent resume, persistent memory, per-agent hooks, and skill preloading — that Exarchos doesn't use.
+
+At the same time, Exarchos is a standalone CLI that publishes MCP as a subcommand. Any investment in Claude Code-specific features must not break compatibility with other MCP clients (Copilot CLI, Cursor, etc.). The in-flight [Lazy Schema + Runbook Protocol](./2026-03-08-lazy-schema-runbook-protocol.md) design already addresses this tension for schemas and orchestration sequences. This design extends the same pattern to **agent specifications**: registry-sourced, MCP-served, with Claude Code native files as a compiled optimization.
+
+**Three problems, one design:**
+
+1. **Agent identity** — Subagents are generic; they should be typed, version-controlled, and enriched with skills, hooks, and memory
+2. **Agent continuity** — Failed tasks lose all context; fixers should resume with full history
+3. **Agent lifecycle** — State updates are manual orchestrator work; hooks should automate them
+
+**Related:**
+- [#966](https://github.com/lvlup-sw/exarchos/issues/966) — Self-describing MCP for non-Claude-Code clients
+- [Lazy Schema + Runbook Protocol](./2026-03-08-lazy-schema-runbook-protocol.md) — In-flight companion design
+
+## Design Constraints
+
+- **Registry remains the single source of truth** — Agent specs, like schemas and runbooks, are defined in the registry and resolved at serve-time
+- **MCP server stays platform-agnostic** — `agent_spec` is an MCP action; Claude Code `agents/*.md` files are a compiled output
+- **Backward compatible** — Existing `prepare_delegation` and inline prompt dispatch continue to work; native features are additive
+- **Composes with runbook protocol** — `native:Task` runbook steps reference agent types; `agent_spec()` resolves them for non-Claude-Code clients
+- **Zero-drift by construction** — Agent spec drift tests follow the proven bidirectional sync pattern
+- **No new MCP tools** — `agent_spec` is an action on `exarchos_orchestrate`, not a new tool registration
+
+## Prior Art
+
+### Claude Code Custom Subagents
+
+Claude Code supports custom agent definitions as Markdown files with YAML frontmatter:
+
+```markdown
+---
+name: code-reviewer
+description: Reviews code for quality
+tools: Read, Grep, Glob
+model: sonnet
+isolation: worktree
+memory: project
+skills:
+  - review-patterns
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate.sh"
+---
+System prompt here.
+```
+
+Key capabilities: model selection, tool restrictions, native worktree isolation, skill preloading, persistent memory, per-agent hooks, and resume via `agentId`. See [Claude Code sub-agents documentation](https://code.claude.com/docs/en/sub-agents).
+
+### Exarchos Current Approach
+
+Delegation uses `Task()` with inline prompts:
+
+```typescript
+Task({
+  subagent_type: "general-purpose",
+  model: "opus",
+  run_in_background: true,
+  description: "Implement task-001: ...",
+  prompt: `[~2,000 token implementer prompt built from template]`
+})
+```
+
+Worktrees are created manually via `prepare_delegation`. Fixers are dispatched as fresh agents with adversarial prompts. State updates are manual orchestrator calls.
+
+## Chosen Approach: Agent Spec Registry + Native Integration
+
+### Architecture Overview
+
+Agent specifications join schemas and runbooks as a third registry-served specification. Claude Code gets the premium experience (native agent files, resume, hooks, memory), but the same agent intelligence is available to any MCP client via `agent_spec()`.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                   Exarchos Registry                       │
+│           (source of truth for ALL specs)                 │
+│                                                           │
+│  ┌───────────┐  ┌───────────┐  ┌───────────────────────┐ │
+│  │  Actions   │  │ Runbooks  │  │    Agent Specs        │ │
+│  │ + Schemas  │  │ + Gates   │  │ + Prompts + Skills    │ │
+│  └─────┬─────┘  └─────┬─────┘  └──────────┬────────────┘ │
+└────────┼──────────────┼────────────────────┼──────────────┘
+         │              │                    │
+    ┌────┴────┐    ┌────┴────┐    ┌──────────┴──────────┐
+    │describe │    │runbook  │    │    agent_spec        │
+    │ action  │    │ action  │    │     action           │
+    │(any MCP)│    │(any MCP)│    │    (any MCP)         │
+    └─────────┘    └─────────┘    └──────────┬──────────┘
+                                             │
+                              ┌──────────────┼──────────────┐
+                              │              │              │
+                       ┌──────┴──────┐ ┌─────┴─────┐ ┌─────┴─────┐
+                       │  Claude Code│ │ Copilot   │ │ Cursor    │
+                       │  agents/*.md│ │ CLI       │ │           │
+                       │  (native)   │ │ (via MCP) │ │ (via MCP) │
+                       └─────────────┘ └───────────┘ └───────────┘
+```
+
+### Three Tiers of Integration
+
+| Tier | Platform | Agent Specs | Isolation | Resume | Hooks | Memory |
+|------|----------|------------|-----------|--------|-------|--------|
+| **1** | Claude Code | Native `agents/*.md` (build-time) | `isolation: "worktree"` | `resume: agentId` | `SubagentStop` hooks | `memory: project` |
+| **2** | Copilot CLI, Cursor | `agent_spec()` MCP action | Manual worktree or inline | Fresh dispatch + event context | Manual state updates | N/A |
+| **3** | Standalone CLI | `agent_spec()` MCP action | `prepare_delegation` | Fresh dispatch | Manual state updates | N/A |
+
+---
+
+## Technical Design
+
+### 1. Agent Spec Registry
+
+#### 1.1 Agent Spec Type
+
+```typescript
+// src/agents/types.ts
+
+export interface AgentSkill {
+  /** Skill name (resolved from skills/ directory at build time) */
+  readonly name: string;
+  /** Skill content (inlined at serve-time for non-CC clients) */
+  readonly content: string;
+}
+
+export interface AgentValidationRule {
+  /** When the rule fires: 'pre-write', 'pre-edit', 'post-test' */
+  readonly trigger: string;
+  /** Human-readable rule description */
+  readonly rule: string;
+  /** Optional shell command for hook-based enforcement */
+  readonly command?: string;
+}
+
+export interface AgentSpec {
+  /** Unique identifier (e.g., 'implementer', 'fixer', 'reviewer') */
+  readonly id: string;
+  /** Human-readable description — used as CC agent description field */
+  readonly description: string;
+  /** System prompt template (supports {{templateVar}} interpolation) */
+  readonly systemPrompt: string;
+  /** Allowed tools (CC tools format: 'Read', 'Write', 'Bash', etc.) */
+  readonly tools: readonly string[];
+  /** Tools to deny */
+  readonly disallowedTools?: readonly string[];
+  /** Model preference */
+  readonly model: 'opus' | 'sonnet' | 'haiku' | 'inherit';
+  /** Isolation mode */
+  readonly isolation?: 'worktree';
+  /** Skills to preload (content resolved from registry at serve-time) */
+  readonly skills: readonly AgentSkill[];
+  /** Validation rules (mapped to CC hooks or served as advisory for other platforms) */
+  readonly validationRules: readonly AgentValidationRule[];
+  /** Whether the agent supports resume on failure */
+  readonly resumable: boolean;
+  /** Memory scope for persistent learning */
+  readonly memoryScope?: 'user' | 'project' | 'local';
+  /** Maximum agentic turns */
+  readonly maxTurns?: number;
+}
+```
+
+#### 1.2 Agent Spec Definitions
+
+```typescript
+// src/agents/definitions.ts
+
+import type { AgentSpec } from './types.js';
+
+export const IMPLEMENTER: AgentSpec = {
+  id: 'implementer',
+  description: 'TDD implementer for Exarchos-orchestrated tasks. Enforces Red-Green-Refactor discipline in isolated worktrees.',
+  systemPrompt: `You are a TDD implementer working in an isolated git worktree.
+
+## CRITICAL: Worktree Verification (MANDATORY)
+
+Before making ANY file changes:
+1. Run: \`pwd\`
+2. Verify the path contains \`.worktrees/\` or is a git worktree
+3. If NOT in worktree: STOP and report error
+
+## Task
+
+{{taskDescription}}
+
+## Requirements
+
+{{requirements}}
+
+## Files
+
+{{filePaths}}
+
+## TDD Protocol
+
+Follow strict Red-Green-Refactor:
+1. **RED** — Write a failing test that captures the requirement
+2. **GREEN** — Write the minimum implementation to pass the test
+3. **REFACTOR** — Clean up while keeping tests green
+
+Never write implementation code before a failing test exists.
+
+## Completion
+
+When done, output a structured completion report:
+\`\`\`json
+{
+  "status": "complete",
+  "implements": ["<design requirement IDs>"],
+  "tests": [{"name": "testName", "file": "path/to/test.ts"}],
+  "files": ["path/to/impl.ts"]
+}
+\`\`\``,
+  tools: ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob'],
+  disallowedTools: ['Agent'],
+  model: 'opus',
+  isolation: 'worktree',
+  skills: [
+    { name: 'tdd-patterns', content: '' },      // Resolved at serve-time
+    { name: 'testing-patterns', content: '' },   // Resolved at serve-time
+  ],
+  validationRules: [
+    {
+      trigger: 'pre-write',
+      rule: 'Test file must exist before implementation file can be created',
+      command: 'exarchos validate tdd-order',
+    },
+    {
+      trigger: 'post-test',
+      rule: 'All tests must pass before marking complete',
+      command: 'exarchos validate test-pass',
+    },
+  ],
+  resumable: true,
+  memoryScope: 'project',
+  maxTurns: 100,
+};
+
+export const FIXER: AgentSpec = {
+  id: 'fixer',
+  description: 'Resumes failed implementer context to diagnose and fix task failures. Adversarial verification posture.',
+  systemPrompt: `Your previous implementation attempt failed. You have full context of what you tried.
+
+## Failure Context
+
+{{failureContext}}
+
+## Adversarial Verification Protocol
+
+1. Do NOT trust your previous self-assessment
+2. Re-read the actual test output — what EXACTLY failed?
+3. Identify root cause, not symptoms
+4. Implement a minimal, targeted fix
+5. Run ALL tests, not just the failing one
+6. Check for silent failures (tests that pass but don't assert correctly)
+
+## Completion
+
+Same structured output as before. Include what was wrong and how you fixed it.`,
+  tools: ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob'],
+  disallowedTools: ['Agent'],
+  model: 'opus',
+  isolation: 'worktree',
+  skills: [
+    { name: 'tdd-patterns', content: '' },
+  ],
+  validationRules: [
+    {
+      trigger: 'post-test',
+      rule: 'All tests must pass before marking complete',
+      command: 'exarchos validate test-pass',
+    },
+  ],
+  resumable: false,  // Fixer is already a resumed/fresh-dispatched agent
+  memoryScope: 'project',
+};
+
+export const REVIEWER: AgentSpec = {
+  id: 'reviewer',
+  description: 'Code quality reviewer for spec compliance and quality gates. Read-only analysis.',
+  systemPrompt: `You are a code reviewer evaluating implementation quality.
+
+## Review Scope
+
+{{reviewScope}}
+
+## Design Requirements
+
+{{designRequirements}}
+
+## Review Protocol
+
+1. Verify each design requirement has corresponding test coverage
+2. Check TDD compliance (tests committed before implementation)
+3. Evaluate code quality: SOLID, DRY, security, error handling
+4. Flag any test quality issues (.only, .skip, missing assertions)
+
+## Output
+
+Structured findings:
+\`\`\`json
+{
+  "verdict": "pass" | "fail",
+  "findings": [
+    { "severity": "critical" | "warning" | "info", "rule": "RULE-ID", "message": "...", "file": "...", "line": 0 }
+  ]
+}
+\`\`\``,
+  tools: ['Read', 'Grep', 'Glob', 'Bash'],
+  disallowedTools: ['Write', 'Edit', 'Agent'],
+  model: 'opus',
+  skills: [
+    { name: 'review-patterns', content: '' },
+  ],
+  validationRules: [],
+  resumable: false,
+  memoryScope: 'project',
+};
+
+export const ALL_AGENT_SPECS: readonly AgentSpec[] = [
+  IMPLEMENTER,
+  FIXER,
+  REVIEWER,
+];
+```
+
+### 2. `agent_spec` Action
+
+New action on `exarchos_orchestrate` — serves agent specifications to any MCP client.
+
+#### 2.1 Schema
+
+```typescript
+const agentSpecSchema = z.object({
+  agent: z.enum(['implementer', 'fixer', 'reviewer'])
+    .describe('Agent type to retrieve specification for.'),
+  context: z.record(z.string()).optional()
+    .describe('Template variables to interpolate into the system prompt (e.g., taskDescription, requirements).'),
+  format: z.enum(['full', 'prompt-only']).default('full')
+    .describe('full: complete spec with tools, skills, rules. prompt-only: just the interpolated system prompt.'),
+});
+```
+
+#### 2.2 Handler
+
+```typescript
+async function handleAgentSpec(
+  args: { agent: string; context?: Record<string, string>; format?: string },
+  ctx: DispatchContext,
+): Promise<ToolResult> {
+  const spec = ALL_AGENT_SPECS.find(s => s.id === args.agent);
+  if (!spec) {
+    return {
+      success: false,
+      error: {
+        code: 'UNKNOWN_AGENT',
+        message: `Unknown agent: ${args.agent}`,
+        validAgents: ALL_AGENT_SPECS.map(s => s.id),
+      },
+    };
+  }
+
+  // Interpolate template variables into system prompt
+  let prompt = spec.systemPrompt;
+  if (args.context) {
+    for (const [key, value] of Object.entries(args.context)) {
+      prompt = prompt.replaceAll(`{{${key}}}`, value);
+    }
+  }
+
+  // Warn about unresolved template variables
+  const unresolved = [...prompt.matchAll(/\{\{(\w+)\}\}/g)].map(m => m[1]);
+
+  if (args.format === 'prompt-only') {
+    return {
+      success: true,
+      data: { agent: spec.id, systemPrompt: prompt, unresolvedVars: unresolved },
+    };
+  }
+
+  // Full spec with resolved skill content
+  const skills = spec.skills.map(skill => ({
+    name: skill.name,
+    content: resolveSkillContent(skill.name),  // Load from skills/ directory
+  }));
+
+  return {
+    success: true,
+    data: {
+      agent: spec.id,
+      description: spec.description,
+      systemPrompt: prompt,
+      tools: spec.tools,
+      disallowedTools: spec.disallowedTools ?? [],
+      model: spec.model,
+      isolation: spec.isolation ?? null,
+      skills,
+      validationRules: spec.validationRules,
+      resumable: spec.resumable,
+      memoryScope: spec.memoryScope ?? null,
+      maxTurns: spec.maxTurns ?? null,
+      unresolvedVars: unresolved,
+    },
+  };
+}
+```
+
+#### 2.3 Response Example
+
+```json
+{
+  "success": true,
+  "data": {
+    "agent": "implementer",
+    "description": "TDD implementer for Exarchos-orchestrated tasks...",
+    "systemPrompt": "You are a TDD implementer working in an isolated git worktree.\n\n## Task\n\nImplement user authentication...",
+    "tools": ["Read", "Write", "Edit", "Bash", "Grep", "Glob"],
+    "disallowedTools": ["Agent"],
+    "model": "opus",
+    "isolation": "worktree",
+    "skills": [
+      { "name": "tdd-patterns", "content": "## TDD Red-Green-Refactor\n\n..." },
+      { "name": "testing-patterns", "content": "## Testing Patterns\n\n..." }
+    ],
+    "validationRules": [
+      { "trigger": "pre-write", "rule": "Test file must exist before implementation file", "command": "exarchos validate tdd-order" }
+    ],
+    "resumable": true,
+    "memoryScope": "project",
+    "maxTurns": 100,
+    "unresolvedVars": []
+  }
+}
+```
+
+### 3. Claude Code Agent File Generation
+
+At plugin build time, generate `agents/*.md` files from the registry.
+
+#### 3.1 Build Script
+
+```typescript
+// src/agents/generate-cc-agents.ts
+
+import { ALL_AGENT_SPECS } from './definitions.js';
+import type { AgentSpec } from './types.js';
+
+function generateAgentMarkdown(spec: AgentSpec): string {
+  const frontmatter: Record<string, unknown> = {
+    name: `exarchos-${spec.id}`,
+    description: spec.description,
+    tools: spec.tools.join(', '),
+    model: spec.model,
+  };
+
+  if (spec.disallowedTools?.length) {
+    frontmatter.disallowedTools = spec.disallowedTools.join(', ');
+  }
+  if (spec.isolation) {
+    frontmatter.isolation = spec.isolation;
+  }
+  if (spec.memoryScope) {
+    frontmatter.memory = spec.memoryScope;
+  }
+  if (spec.maxTurns) {
+    frontmatter.maxTurns = spec.maxTurns;
+  }
+  if (spec.skills.length > 0) {
+    frontmatter.skills = spec.skills.map(s => s.name);
+  }
+  if (spec.validationRules.length > 0) {
+    frontmatter.hooks = buildHooksFromRules(spec.validationRules);
+  }
+
+  const yaml = serializeYaml(frontmatter);
+  return `---\n${yaml}---\n\n${spec.systemPrompt}\n`;
+}
+
+function buildHooksFromRules(
+  rules: readonly AgentValidationRule[],
+): Record<string, unknown> {
+  const hooks: Record<string, unknown[]> = {};
+
+  for (const rule of rules) {
+    if (!rule.command) continue;
+
+    const matcher = rule.trigger === 'pre-write' ? 'Write|Edit'
+      : rule.trigger === 'pre-edit' ? 'Edit'
+      : rule.trigger === 'post-test' ? 'Bash'
+      : '*';
+
+    const event = rule.trigger.startsWith('pre-') ? 'PreToolUse' : 'PostToolUse';
+
+    if (!hooks[event]) hooks[event] = [];
+    hooks[event].push({
+      matcher,
+      hooks: [{ type: 'command', command: rule.command }],
+    });
+  }
+
+  return hooks;
+}
+
+// Build entry point
+export function generateAllAgentFiles(outDir: string): void {
+  for (const spec of ALL_AGENT_SPECS) {
+    const content = generateAgentMarkdown(spec);
+    const filePath = path.join(outDir, `exarchos-${spec.id}.md`);
+    fs.writeFileSync(filePath, content, 'utf-8');
+  }
+}
+```
+
+#### 3.2 Generated Output Example (`agents/exarchos-implementer.md`)
+
+```markdown
+---
+name: exarchos-implementer
+description: TDD implementer for Exarchos-orchestrated tasks. Enforces Red-Green-Refactor discipline in isolated worktrees.
+tools: Read, Write, Edit, Bash, Grep, Glob
+disallowedTools: Agent
+model: opus
+isolation: worktree
+memory: project
+maxTurns: 100
+skills:
+  - tdd-patterns
+  - testing-patterns
+hooks:
+  PreToolUse:
+    - matcher: "Write|Edit"
+      hooks:
+        - type: command
+          command: "exarchos validate tdd-order"
+  PostToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "exarchos validate test-pass"
+---
+
+You are a TDD implementer working in an isolated git worktree.
+
+## CRITICAL: Worktree Verification (MANDATORY)
+
+Before making ANY file changes:
+1. Run: `pwd`
+2. Verify the path contains `.worktrees/` or is a git worktree
+3. If NOT in worktree: STOP and report error
+
+...
+```
+
+#### 3.3 Plugin Directory Structure
+
+```
+exarchos/
+├── agents/                          # NEW: Generated CC agent definitions
+│   ├── exarchos-implementer.md
+│   ├── exarchos-fixer.md
+│   └── exarchos-reviewer.md
+├── skills/                          # Existing: workflow skills
+│   ├── delegation/
+│   ├── synthesis/
+│   └── ...
+├── commands/                        # Existing: slash commands
+├── servers/exarchos-mcp/            # Existing: MCP server
+│   └── src/
+│       └── agents/                  # NEW: Agent spec registry
+│           ├── types.ts
+│           ├── definitions.ts
+│           └── generate-cc-agents.ts
+└── .claude-plugin/
+    └── plugin.json                  # Updated: includes agents/ directory
+```
+
+### 4. Resume-Aware Fixer Flow
+
+#### 4.1 Workflow State Extension
+
+Add `agentId` tracking to task entries in workflow state:
+
+```typescript
+// In workflow state task schema
+interface WorkflowTask {
+  id: string;
+  status: 'pending' | 'in_progress' | 'complete' | 'failed';
+  // NEW:
+  agentId?: string;       // Claude Code agent ID for resume capability
+  agentResumed?: boolean;  // Whether the fixer used resume vs. fresh dispatch
+}
+```
+
+#### 4.2 Agent ID Capture
+
+When the orchestrator receives `Task()` completion, it extracts the `agentId` from the result:
+
+```typescript
+// In delegation skill — after TaskOutput returns
+const result = await TaskOutput({ task_id: taskId, block: true });
+
+// Update workflow state with agentId for potential resume
+exarchos_workflow({
+  action: 'set',
+  featureId,
+  updates: {
+    [`tasks.${taskId}.agentId`]: result.agentId,
+  },
+});
+```
+
+#### 4.3 Resume vs. Fresh Dispatch Decision
+
+```
+Task fails
+    │
+    ├── agentId available AND platform supports resume?
+    │       │
+    │       YES → Resume with adversarial context injection
+    │       │     Task({ resume: agentId, prompt: "Your implementation failed. ..." })
+    │       │
+    │       NO  → Fresh dispatch with fixer agent spec
+    │             Task({ subagent_type: "exarchos-fixer", prompt: "..." })
+    │
+    └── Either way → Run gate chain (task-completion runbook)
+```
+
+#### 4.4 TASK_FIX Runbook
+
+New runbook definition (extends the in-flight runbook protocol):
+
+```typescript
+export const TASK_FIX: RunbookDefinition = {
+  id: 'task-fix',
+  phase: 'delegate',
+  description: 'Fix a failed task. Platforms with resume use agent context continuity; others dispatch fixer agent with failure context from event store.',
+  steps: [
+    { tool: 'native:Task', action: 'resume_or_spawn', onFail: 'stop',
+      params: {
+        resumeAgent: 'agentId',           // Template var — resolved from workflow state
+        fallbackAgent: 'fixer',            // Agent spec to use if resume unavailable
+      },
+      note: 'CC: resume agentId with full context. Others: agent_spec("fixer") + fresh dispatch.' },
+    { tool: 'exarchos_orchestrate', action: 'check_tdd_compliance', onFail: 'stop' },
+    { tool: 'exarchos_orchestrate', action: 'check_static_analysis', onFail: 'stop' },
+    { tool: 'exarchos_orchestrate', action: 'task_complete', onFail: 'stop' },
+  ],
+  templateVars: ['taskId', 'featureId', 'streamId', 'agentId', 'failureContext'],
+  autoEmits: ['gate.executed', 'task.completed'],
+};
+```
+
+### 5. SubagentStop Hooks for Automatic State Management
+
+#### 5.1 Plugin Hook Definition
+
+In the Exarchos plugin's hook configuration:
+
+```json
+{
+  "hooks": {
+    "SubagentStop": [
+      {
+        "matcher": "exarchos-implementer|exarchos-fixer",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "exarchos hook subagent-stop"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### 5.2 Hook Handler
+
+New CLI subcommand: `exarchos hook subagent-stop`
+
+The hook receives JSON via stdin with the subagent's completion status, agent ID, and result summary. It calls MCP actions to update workflow state:
+
+```typescript
+// src/hooks/subagent-stop.ts
+
+interface SubagentStopInput {
+  agent_type: string;       // 'exarchos-implementer' | 'exarchos-fixer'
+  agent_id: string;         // For resume tracking
+  exit_reason: string;      // 'complete' | 'error' | 'max_turns'
+  // Result is in the agent's transcript, not directly available to hooks
+}
+
+async function handleSubagentStop(input: SubagentStopInput): Promise<void> {
+  // Extract featureId + taskId from agent name or environment
+  const { featureId, taskId } = parseAgentContext();
+
+  // Update workflow state with agentId
+  await callMcp('exarchos_workflow', {
+    action: 'set',
+    featureId,
+    updates: {
+      [`tasks.${taskId}.agentId`]: input.agent_id,
+      [`tasks.${taskId}.lastExitReason`]: input.exit_reason,
+    },
+  });
+
+  // Emit event for observability
+  await callMcp('exarchos_event', {
+    action: 'append',
+    streamId: featureId,
+    type: 'agent.stopped',
+    data: {
+      agent: input.agent_type,
+      agentId: input.agent_id,
+      taskId,
+      exitReason: input.exit_reason,
+    },
+  });
+}
+```
+
+#### 5.3 What Hooks Replace vs. What They Don't
+
+| Orchestrator Responsibility | Replaced by Hook? | Notes |
+|---|---|---|
+| Track agentId for resume | Yes | Hook captures agentId on stop |
+| Update task status | Partially | Hook records exit reason; orchestrator still decides pass/fail based on gate results |
+| Run quality gates | No | Gates require sequential execution with stop-on-fail semantics — runbooks handle this |
+| Mark task complete | No | Requires provenance data that only the orchestrator has |
+| Emit events | Yes | Hook emits `agent.stopped` event automatically |
+
+Hooks handle **bookkeeping**. Orchestration logic stays in runbooks and the delegation skill.
+
+### 6. Impact on `prepare_delegation`
+
+#### 6.1 Current Responsibilities
+
+`prepare_delegation` currently does:
+1. Validate workflow is in `delegate` phase
+2. Create worktrees (`git worktree add`)
+3. Install dependencies (`npm install` in each worktree)
+4. Track worktree state in workflow
+5. Run quality pre-checks
+6. Return readiness verdict
+
+#### 6.2 With Native Worktree Isolation
+
+When agents use `isolation: "worktree"`, Claude Code handles worktree creation and cleanup natively. `prepare_delegation` narrows:
+
+1. Validate workflow is in `delegate` phase
+2. ~~Create worktrees~~ → Handled by `isolation: "worktree"` on agent definition
+3. ~~Install dependencies~~ → Handled by agent post-setup (or hook)
+4. Track worktree state in workflow → Updated by `SubagentStop` hook with worktree path
+5. Run quality pre-checks → Unchanged
+6. Return readiness verdict → Unchanged
+
+**For non-Claude-Code clients:** `prepare_delegation` retains full functionality. The worktree creation code stays but is bypassed when the client signals native isolation support.
+
+#### 6.3 Platform Capability Signal
+
+```typescript
+const prepareDelegationSchema = z.object({
+  featureId: z.string(),
+  tasks: z.array(taskSchema),
+  // NEW:
+  nativeIsolation: z.boolean().default(false)
+    .describe('Set true if the client handles worktree isolation natively (e.g., Claude Code isolation: "worktree"). Skips manual worktree creation.'),
+});
+```
+
+### 7. Delegation Skill Updates
+
+The delegation skill (`skills/delegation/SKILL.md`) simplifies significantly:
+
+#### 7.1 Before (Current)
+
+```markdown
+### Step 2: Dispatch
+
+For each task, build a Task() call with the full implementer prompt:
+
+Task({
+  subagent_type: "general-purpose",
+  model: "opus",
+  run_in_background: true,
+  description: "Implement task-001: ...",
+  prompt: `[2,000 tokens of inline prompt from implementer-prompt.md template]`
+})
+```
+
+#### 7.2 After (With Native Agents)
+
+```markdown
+### Step 2: Dispatch
+
+For each task, dispatch using the `exarchos-implementer` agent type:
+
+Task({
+  subagent_type: "exarchos-implementer",
+  run_in_background: true,
+  description: "Implement task-001: [title]",
+  prompt: "[Task-specific context only: requirements, file paths, acceptance criteria]"
+})
+
+The agent's system prompt, model, isolation, skills, hooks, and memory are defined
+by the agent specification. The dispatch prompt provides ONLY task-specific context.
+
+### Step 3: Fix Failed Tasks
+
+If a task fails and agentId is available:
+
+Task({
+  resume: "[agentId from workflow state]",
+  prompt: "Your implementation failed. [failure context]. Apply adversarial verification."
+})
+
+If agentId unavailable (non-CC platform or agent not resumable):
+
+Task({
+  subagent_type: "exarchos-fixer",
+  run_in_background: true,
+  prompt: "[Failure context + original task context]"
+})
+```
+
+### 8. Runbook Protocol Integration
+
+#### 8.1 Updated AGENT_TEAMS_SAGA
+
+The in-flight AGENT_TEAMS_SAGA runbook references `native:Task`. With agent specs, the step gains type information:
+
+```typescript
+// Before (in-flight design):
+{ tool: 'native:Task', action: 'spawn', onFail: 'stop',
+  note: 'Spawn N teammates in worktrees' },
+
+// After (with agent specs):
+{ tool: 'native:Task', action: 'spawn', onFail: 'stop',
+  params: { agent: 'implementer' },
+  note: 'Spawn N teammates using exarchos-implementer agent spec. CC: native agent file. Others: agent_spec() for configuration.' },
+```
+
+#### 8.2 New TASK_FIX Runbook
+
+See section 4.4 above. Added to `ALL_RUNBOOKS`.
+
+#### 8.3 Runbook Step Resolution for `native:Task`
+
+When a non-Claude-Code client encounters a `native:Task` step with `params.agent`, it calls `agent_spec()` to resolve the agent configuration, then uses its platform's mechanism to spawn an agent with that spec.
+
+The runbook handler can include a hint:
+
+```typescript
+// In resolved runbook step for native:Task
+{
+  seq: 7,
+  tool: 'native:Task',
+  action: 'spawn',
+  params: { agent: 'implementer' },
+  note: 'Spawn using exarchos-implementer agent spec.',
+  platformHint: {
+    claudeCode: 'Uses native agent definition with isolation: "worktree"',
+    generic: 'Call agent_spec("implementer") to get system prompt and tool restrictions',
+  },
+}
+```
+
+---
+
+## Anti-Drift Architecture
+
+### Agent Spec Drift Tests
+
+Following the proven bidirectional sync pattern:
+
+```typescript
+// src/agents/agents.test.ts
+
+describe('Agent spec drift prevention', () => {
+  it('every agent referenced in runbooks has a registry spec', () => {
+    const agentRefs = ALL_RUNBOOKS
+      .flatMap(r => r.steps)
+      .filter(s => s.params?.agent)
+      .map(s => s.params.agent as string);
+    for (const agent of new Set(agentRefs)) {
+      expect(ALL_AGENT_SPECS.find(s => s.id === agent)).toBeDefined(
+        `Runbook references unknown agent: ${agent}`
+      );
+    }
+  });
+
+  it('every agent spec references valid skills', () => {
+    const availableSkills = getAvailableSkillNames();
+    for (const spec of ALL_AGENT_SPECS) {
+      for (const skill of spec.skills) {
+        expect(availableSkills).toContain(skill.name,
+          `Agent "${spec.id}" references unknown skill: ${skill.name}`
+        );
+      }
+    }
+  });
+
+  it('every agent spec references valid tools', () => {
+    const validTools = getValidToolNames();
+    for (const spec of ALL_AGENT_SPECS) {
+      for (const tool of spec.tools) {
+        expect(validTools).toContain(tool,
+          `Agent "${spec.id}" references unknown tool: ${tool}`
+        );
+      }
+    }
+  });
+
+  it('agent IDs are unique', () => {
+    const ids = ALL_AGENT_SPECS.map(s => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('template vars in system prompts are documented', () => {
+    for (const spec of ALL_AGENT_SPECS) {
+      const vars = [...spec.systemPrompt.matchAll(/\{\{(\w+)\}\}/g)].map(m => m[1]);
+      // All template vars should be documented (future: formal registry)
+      expect(vars.length).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+```
+
+### Generated File Drift Tests
+
+```typescript
+describe('Generated CC agent files match registry', () => {
+  it('agents/*.md files are in sync with registry specs', () => {
+    for (const spec of ALL_AGENT_SPECS) {
+      const filePath = path.join(AGENTS_DIR, `exarchos-${spec.id}.md`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const parsed = parseFrontmatter(content);
+
+      expect(parsed.name).toBe(`exarchos-${spec.id}`);
+      expect(parsed.model).toBe(spec.model);
+      expect(parsed.description).toBe(spec.description);
+
+      if (spec.isolation) {
+        expect(parsed.isolation).toBe(spec.isolation);
+      }
+      if (spec.memoryScope) {
+        expect(parsed.memory).toBe(spec.memoryScope);
+      }
+    }
+  });
+});
+```
+
+---
+
+## Token Budget Impact
+
+| Scenario | Before | After |
+|---|---|---|
+| Implementer dispatch prompt | ~2,000 tokens (full inline) | ~200-400 tokens (task context only) |
+| Fixer dispatch prompt | ~1,500 tokens (full inline) | ~0 tokens (resume) or ~300 tokens (context only) |
+| Agent spec registration (CC) | 0 (inline) | 0 (native agent files, no MCP cost) |
+| Agent spec fetch (non-CC) | N/A | ~500-800 tokens (one-time per session) |
+
+**Combined with lazy schema savings:** A full delegation session drops from ~3,045 (MCP registration) + ~6,000 (3 implementer prompts) = ~9,045 tokens to ~700 (slim registration) + ~1,200 (3 task contexts) = ~1,900 tokens. **~79% reduction.**
+
+---
+
+## Implementation Plan
+
+### Phase 1: Agent Spec Registry (Foundation)
+
+1. Define `AgentSpec` types in `src/agents/types.ts`
+2. Write initial agent spec definitions (implementer, fixer, reviewer)
+3. Implement `agent_spec` action on `exarchos_orchestrate`
+4. Write anti-drift tests for agent specs
+
+**Dependency:** None. Can proceed in parallel with runbook protocol Phase 1-2.
+
+### Phase 2: Claude Code Agent Generation (Native Integration)
+
+5. Implement `generate-cc-agents.ts` build script
+6. Add `agents/` directory to plugin manifest (`plugin.json`)
+7. Wire into build pipeline (`npm run build` generates agent files)
+8. Write generated-file drift tests
+9. Update delegation skill to reference `exarchos-implementer` instead of inline prompts
+
+**Dependency:** Phase 1 complete. Runbook protocol Phase 2 (for TASK_FIX runbook).
+
+### Phase 3: Resume + Hooks (Agent Continuity)
+
+10. Add `agentId` field to workflow task state schema
+11. Implement `exarchos hook subagent-stop` CLI subcommand
+12. Add `SubagentStop` hook to plugin hook configuration
+13. Write TASK_FIX runbook definition
+14. Update delegation skill with resume-aware fixer flow
+
+**Dependency:** Phase 2 complete. Runbook protocol Phase 2 (runbook definitions exist).
+
+### Phase 4: Platform Capability + Polish
+
+15. Add `nativeIsolation` parameter to `prepare_delegation`
+16. Add `platformHint` to runbook step resolution for `native:Task` steps
+17. Measure token savings and fix success rates (resume vs. fresh dispatch)
+18. Update skill reference docs (`references/implementer-prompt.md` → agent spec registry)
+
+**Dependency:** Phase 3 complete. End-to-end testing.
+
+---
+
+## Appendix: Comparison with Lazy Schema + Runbook Protocol
+
+| Concern | Lazy Schema Design | This Design |
+|---|---|---|
+| What it makes lazy | Schema loading (action params) | Agent configuration (system prompts, tools, skills) |
+| What it codifies | Step sequences (gate ordering) | Agent identity (who does the work) |
+| MCP action | `describe()`, `runbook()` | `agent_spec()` |
+| Anti-drift pattern | Same bidirectional sync | Same bidirectional sync |
+| Token savings source | Registration payload | Inline prompt elimination |
+| Cross-platform story | Runbooks are self-describing | Agent specs are self-describing |
+| Claude Code optimization | Slim descriptions (less text) | Native agent files (no MCP call) |
+
+The two designs are complementary halves of the same philosophy: **the MCP server is self-describing, Claude Code native features are an optimization layer, and the registry is the single source of truth.**

--- a/docs/designs/2026-03-08-native-subagent-integration.md
+++ b/docs/designs/2026-03-08-native-subagent-integration.md
@@ -698,17 +698,7 @@ async function handleSubagentStop(input: SubagentStopInput): Promise<void> {
   // Extract featureId + taskId from agent name or environment
   const { featureId, taskId } = parseAgentContext();
 
-  // Update workflow state with agentId
-  await callMcp('exarchos_workflow', {
-    action: 'set',
-    featureId,
-    updates: {
-      [`tasks.${taskId}.agentId`]: input.agent_id,
-      [`tasks.${taskId}.lastExitReason`]: input.exit_reason,
-    },
-  });
-
-  // Emit event for observability
+  // Event-sourced: append event FIRST (the event store is the commit point)
   await callMcp('exarchos_event', {
     action: 'append',
     streamId: featureId,
@@ -718,6 +708,16 @@ async function handleSubagentStop(input: SubagentStopInput): Promise<void> {
       agentId: input.agent_id,
       taskId,
       exitReason: input.exit_reason,
+    },
+  });
+
+  // Then project workflow state from the committed event
+  await callMcp('exarchos_workflow', {
+    action: 'set',
+    featureId,
+    updates: {
+      [`tasks.${taskId}.agentId`]: input.agent_id,
+      [`tasks.${taskId}.lastExitReason`]: input.exit_reason,
     },
   });
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -49,6 +49,14 @@
         "timeout": 5
       }]
     }],
+    "SubagentStop": [{
+      "matcher": "exarchos-implementer|exarchos-fixer",
+      "hooks": [{
+        "type": "command",
+        "command": "node \"${CLAUDE_PLUGIN_ROOT}/dist/exarchos.js\" subagent-stop",
+        "timeout": 10
+      }]
+    }],
     "SessionEnd": [{
       "matcher": "auto",
       "hooks": [{

--- a/servers/exarchos-mcp/package.json
+++ b/servers/exarchos-mcp/package.json
@@ -11,7 +11,8 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "bench": "vitest bench",
-    "generate:docs": "tsx scripts/generate-docs.ts"
+    "generate:docs": "tsx scripts/generate-docs.ts",
+    "generate:agents": "tsx src/agents/generate-cc-agents.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
@@ -119,7 +119,7 @@ describe('MCP Server Entry Point', () => {
   });
 
   describe('createServer', () => {
-    it('should register exactly 5 composite tools', () => {
+    it('should register only non-hidden composite tools', () => {
       createServer('/tmp/test-state-dir');
 
       const expectedTools = [
@@ -127,21 +127,27 @@ describe('MCP Server Entry Point', () => {
         'exarchos_event',
         'exarchos_orchestrate',
         'exarchos_view',
-        'exarchos_sync',
       ];
 
-      expect(toolRegistrations.size).toBe(5);
+      expect(toolRegistrations.size).toBe(4);
 
       for (const toolName of expectedTools) {
         expect(toolRegistrations.has(toolName)).toBe(true);
       }
+
+      // Hidden tools should NOT be registered
+      expect(toolRegistrations.has('exarchos_sync')).toBe(false);
     });
 
-    it('should register one tool per registry entry', () => {
+    it('should register one tool per non-hidden registry entry', () => {
       createServer('/tmp/test-state-dir');
 
       for (const tool of TOOL_REGISTRY) {
-        expect(toolRegistrations.has(tool.name)).toBe(true);
+        if (tool.hidden) {
+          expect(toolRegistrations.has(tool.name)).toBe(false);
+        } else {
+          expect(toolRegistrations.has(tool.name)).toBe(true);
+        }
       }
     });
 
@@ -275,17 +281,9 @@ describe('MCP Server Entry Point', () => {
   });
 
   describe('sync tools', () => {
-    it('should return success for exarchos_sync now action', async () => {
+    it('should not register exarchos_sync (hidden tool)', () => {
       createServer('/tmp/test-state-dir');
-      const result = await toolRegistrations.get('exarchos_sync')!.handler({
-        action: 'now',
-      });
-
-      const typedResult = result as { content: Array<{ type: string; text: string }>; isError: boolean };
-      expect(typedResult.isError).toBe(false);
-      const parsed = JSON.parse(typedResult.content[0].text);
-      expect(parsed.success).toBe(true);
-      expect(parsed.data.message).toContain('no remote configured');
+      expect(toolRegistrations.has('exarchos_sync')).toBe(false);
     });
   });
 

--- a/servers/exarchos-mcp/src/adapters/mcp.test.ts
+++ b/servers/exarchos-mcp/src/adapters/mcp.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { EventStore } from '../event-store/store.js';
-import { TOOL_REGISTRY } from '../registry.js';
+import { TOOL_REGISTRY, buildToolDescription } from '../registry.js';
 import type { DispatchContext } from '../core/dispatch.js';
 
 // Mock the state-store module
@@ -54,5 +54,26 @@ describe('createMcpServer', () => {
     expect(server).toBeDefined();
     // Verify the expected number of tools are in the registry
     expect(TOOL_REGISTRY.length).toBe(5);
+  });
+
+  it('CreateMcpServer_SlimRegistration_UsesSlimDescriptions', async () => {
+    // Arrange: create context with slimRegistration enabled
+    const slimCtx: DispatchContext = { ...ctx, slimRegistration: true };
+    const { createMcpServer } = await import('./mcp.js');
+
+    // Act: buildToolDescription with slim=true should return slim descriptions
+    const visibleTools = TOOL_REGISTRY.filter(t => !t.hidden);
+    for (const tool of visibleTools) {
+      const slimDesc = buildToolDescription(tool, true);
+      const fullDesc = buildToolDescription(tool, false);
+
+      // Assert: slim description should be different (shorter) than full description
+      expect(slimDesc).toBe(tool.slimDescription);
+      expect(slimDesc.length).toBeLessThan(fullDesc.length);
+    }
+
+    // Assert: server creates successfully with slim context
+    const server = createMcpServer(slimCtx);
+    expect(server).toBeDefined();
   });
 });

--- a/servers/exarchos-mcp/src/adapters/mcp.ts
+++ b/servers/exarchos-mcp/src/adapters/mcp.ts
@@ -23,7 +23,7 @@ export function createMcpServer(ctx: DispatchContext): McpServer {
   for (const tool of getFullRegistry()) {
     if (tool.hidden) continue;
     const inputSchema = buildRegistrationSchema(tool.actions);
-    const description = buildToolDescription(tool);
+    const description = buildToolDescription(tool, ctx.slimRegistration ?? false);
 
     const toolName = tool.name;
 

--- a/servers/exarchos-mcp/src/agents/agents.test.ts
+++ b/servers/exarchos-mcp/src/agents/agents.test.ts
@@ -1,0 +1,140 @@
+// ─── Agent Spec Types & Definitions Tests ──────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import type { AgentSpec, AgentSkill, AgentValidationRule, AgentSpecId } from './types.js';
+import { IMPLEMENTER, FIXER, REVIEWER, ALL_AGENT_SPECS } from './definitions.js';
+
+// ─── Task 1: AgentSpec Types ────────────────────────────────────────────────
+
+describe('AgentSpec Types', () => {
+  it('AgentSpecTypes_ValidateShape_AcceptsCompleteSpec', () => {
+    // Arrange: create a complete spec using the type interfaces
+    const skill: AgentSkill = { name: 'test-skill', content: 'skill content' };
+    const rule: AgentValidationRule = { trigger: 'pre-write', rule: 'test must exist', command: 'test' };
+    const ruleNoCommand: AgentValidationRule = { trigger: 'post-test', rule: 'must pass' };
+
+    const spec: AgentSpec = {
+      id: 'implementer' as AgentSpecId,
+      description: 'TDD implementer',
+      systemPrompt: 'You are an implementer',
+      tools: ['Read', 'Write', 'Edit'],
+      disallowedTools: ['Agent'],
+      model: 'opus',
+      isolation: 'worktree',
+      skills: [skill],
+      validationRules: [rule, ruleNoCommand],
+      resumable: true,
+      memoryScope: 'project',
+      maxTurns: 50,
+    };
+
+    // Assert: all fields are accessible and correctly typed
+    expect(spec.id).toBe('implementer');
+    expect(spec.description).toBe('TDD implementer');
+    expect(spec.systemPrompt).toBe('You are an implementer');
+    expect(spec.tools).toEqual(['Read', 'Write', 'Edit']);
+    expect(spec.disallowedTools).toEqual(['Agent']);
+    expect(spec.model).toBe('opus');
+    expect(spec.isolation).toBe('worktree');
+    expect(spec.skills).toHaveLength(1);
+    expect(spec.skills[0].name).toBe('test-skill');
+    expect(spec.validationRules).toHaveLength(2);
+    expect(spec.validationRules[0].command).toBe('test');
+    expect(spec.validationRules[1].command).toBeUndefined();
+    expect(spec.resumable).toBe(true);
+    expect(spec.memoryScope).toBe('project');
+    expect(spec.maxTurns).toBe(50);
+
+    // Assert: optional fields can be omitted
+    const minimalSpec: AgentSpec = {
+      id: 'reviewer' as AgentSpecId,
+      description: 'Code reviewer',
+      systemPrompt: 'You review code',
+      tools: ['Read'],
+      model: 'sonnet',
+      skills: [],
+      validationRules: [],
+      resumable: false,
+    };
+    expect(minimalSpec.disallowedTools).toBeUndefined();
+    expect(minimalSpec.isolation).toBeUndefined();
+    expect(minimalSpec.memoryScope).toBeUndefined();
+    expect(minimalSpec.maxTurns).toBeUndefined();
+  });
+});
+
+// ─── Task 2: Agent Spec Definitions ─────────────────────────────────────────
+
+describe('Agent Spec Definitions', () => {
+  it('ImplementerSpec_HasRequiredFields_Complete', () => {
+    expect(IMPLEMENTER.id).toBe('implementer');
+    expect(IMPLEMENTER.model).toBe('opus');
+    expect(IMPLEMENTER.isolation).toBe('worktree');
+    expect(IMPLEMENTER.resumable).toBe(true);
+    expect(IMPLEMENTER.memoryScope).toBe('project');
+    expect(IMPLEMENTER.tools).toContain('Read');
+    expect(IMPLEMENTER.tools).toContain('Write');
+    expect(IMPLEMENTER.tools).toContain('Edit');
+    expect(IMPLEMENTER.tools).toContain('Bash');
+    expect(IMPLEMENTER.tools).toContain('Grep');
+    expect(IMPLEMENTER.tools).toContain('Glob');
+    expect(IMPLEMENTER.disallowedTools).toContain('Agent');
+    expect(IMPLEMENTER.skills.length).toBeGreaterThanOrEqual(2);
+    const skillNames = IMPLEMENTER.skills.map(s => s.name);
+    expect(skillNames).toContain('tdd-patterns');
+    expect(skillNames).toContain('testing-patterns');
+    expect(IMPLEMENTER.validationRules.length).toBeGreaterThanOrEqual(2);
+    expect(IMPLEMENTER.systemPrompt).toContain('{{taskDescription}}');
+    expect(IMPLEMENTER.systemPrompt).toContain('{{requirements}}');
+    expect(IMPLEMENTER.systemPrompt).toContain('{{filePaths}}');
+    expect(IMPLEMENTER.description).toBeTruthy();
+  });
+
+  it('FixerSpec_IsNotResumable_ReturnsTrue', () => {
+    expect(FIXER.id).toBe('fixer');
+    expect(FIXER.resumable).toBe(false);
+    expect(FIXER.model).toBe('opus');
+    expect(FIXER.systemPrompt).toContain('{{failureContext}}');
+    expect(FIXER.tools).toContain('Read');
+    expect(FIXER.tools).toContain('Write');
+    expect(FIXER.tools).toContain('Edit');
+    expect(FIXER.tools).toContain('Bash');
+  });
+
+  it('ReviewerSpec_HasReadOnlyTools_NoWriteEdit', () => {
+    expect(REVIEWER.id).toBe('reviewer');
+    expect(REVIEWER.model).toBe('opus');
+    expect(REVIEWER.resumable).toBe(false);
+    expect(REVIEWER.tools).toContain('Read');
+    expect(REVIEWER.tools).toContain('Grep');
+    expect(REVIEWER.tools).toContain('Glob');
+    expect(REVIEWER.tools).toContain('Bash');
+    expect(REVIEWER.tools).not.toContain('Write');
+    expect(REVIEWER.tools).not.toContain('Edit');
+    expect(REVIEWER.disallowedTools).toContain('Write');
+    expect(REVIEWER.disallowedTools).toContain('Edit');
+    expect(REVIEWER.disallowedTools).toContain('Agent');
+    expect(REVIEWER.systemPrompt).toContain('{{reviewScope}}');
+    expect(REVIEWER.systemPrompt).toContain('{{designRequirements}}');
+  });
+
+  it('AllSpecs_HaveUniqueIds_NoDuplicates', () => {
+    const ids = ALL_AGENT_SPECS.map(s => s.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it('AllSpecs_ToolsAreValid_KnownToolNames', () => {
+    const KNOWN_TOOLS = new Set(['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob', 'Agent', 'WebFetch', 'WebSearch']);
+    for (const spec of ALL_AGENT_SPECS) {
+      for (const tool of spec.tools) {
+        expect(KNOWN_TOOLS.has(tool), `${spec.id}: unknown tool '${tool}'`).toBe(true);
+      }
+      if (spec.disallowedTools) {
+        for (const tool of spec.disallowedTools) {
+          expect(KNOWN_TOOLS.has(tool), `${spec.id}: unknown disallowed tool '${tool}'`).toBe(true);
+        }
+      }
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/agents/definitions.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.ts
@@ -170,7 +170,7 @@ Code review request triggers the reviewer agent for read-only analysis.
 
 Rules:
 - You have READ-ONLY access — do not modify any files
-- Use Bash only for running read-only commands (git diff, test runners in dry-run)
+- Bash is restricted to read-only commands only (e.g., git diff, git log, test runners in dry-run mode). NEVER use Bash to create, edit, or delete files.
 - Be specific in findings — include file paths and line references
 - Categorize findings: critical, warning, suggestion
 

--- a/servers/exarchos-mcp/src/agents/definitions.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.ts
@@ -1,0 +1,201 @@
+// ─── Agent Spec Definitions ────────────────────────────────────────────────
+//
+// Concrete agent specifications for subagent dispatch. Each spec defines
+// the tools, system prompt template, validation rules, and behavioral
+// parameters for a specific agent role.
+// ────────────────────────────────────────────────────────────────────────────
+
+import type { AgentSpec } from './types.js';
+
+// ─── Implementer ────────────────────────────────────────────────────────────
+
+export const IMPLEMENTER: AgentSpec = {
+  id: 'implementer',
+  description: `Use this agent when dispatching TDD implementation tasks to a subagent in an isolated worktree.
+
+<example>
+Context: Orchestrator is dispatching a task from an implementation plan
+user: "Implement the agent spec handler (task-003)"
+assistant: "I'll dispatch the exarchos-implementer agent to implement this task using TDD in an isolated worktree."
+<commentary>
+Implementation task requiring test-first development triggers the implementer agent.
+</commentary>
+</example>`,
+  color: 'blue',
+  systemPrompt: `You are a TDD implementer agent working in an isolated worktree.
+
+## Worktree Verification
+Before making ANY file changes:
+1. Run: \`pwd\`
+2. Verify the path contains \`.worktrees/\`
+3. If NOT in worktree: STOP and report error
+
+## Task
+{{taskDescription}}
+
+## Requirements
+{{requirements}}
+
+## Files
+{{filePaths}}
+
+## TDD Protocol (Red-Green-Refactor)
+1. **RED**: Write a failing test that defines the expected behavior
+2. **GREEN**: Write the minimum code to make the test pass
+3. **REFACTOR**: Clean up while keeping tests green
+
+Rules:
+- NEVER write implementation before its test
+- Each test must fail before writing implementation
+- Run tests after each change to verify state
+- Keep commits atomic: one logical change per commit
+
+## Completion Report
+When done, output a JSON completion report:
+\`\`\`json
+{
+  "status": "complete",
+  "implements": ["<design requirement IDs>"],
+  "tests": [{"name": "<test name>", "file": "<path>"}],
+  "files": ["<created/modified files>"]
+}
+\`\`\``,
+  tools: ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob'],
+  disallowedTools: ['Agent'],
+  model: 'opus',
+  isolation: 'worktree',
+  skills: [
+    { name: 'tdd-patterns', content: '' },
+    { name: 'testing-patterns', content: '' },
+  ],
+  validationRules: [
+    { trigger: 'pre-write', rule: 'Test file must exist before implementation file is written' },
+    { trigger: 'post-test', rule: 'All tests must pass', command: 'npm run test:run' },
+  ],
+  resumable: true,
+  memoryScope: 'project',
+};
+
+// ─── Fixer ──────────────────────────────────────────────────────────────────
+
+export const FIXER: AgentSpec = {
+  id: 'fixer',
+  description: `Use this agent when a task has failed and needs diagnosis and repair with adversarial verification.
+
+<example>
+Context: A delegated task failed its quality gates or tests
+user: "Task-005 failed TDD compliance — fix it"
+assistant: "I'll dispatch the exarchos-fixer agent to diagnose and repair the failure."
+<commentary>
+Failed task requiring root cause analysis and targeted fix triggers the fixer agent.
+</commentary>
+</example>`,
+  color: 'red',
+  systemPrompt: `You are a fixer agent. Your job is to diagnose and repair failures.
+
+## Failure Context
+{{failureContext}}
+
+## Task
+{{taskDescription}}
+
+## Files
+{{filePaths}}
+
+## Adversarial Verification Protocol
+1. Reproduce the failure first — confirm you can see it fail
+2. Identify root cause — do not guess, trace the actual error
+3. Apply minimal fix — change only what is necessary
+4. Verify fix — run the failing test and confirm it passes
+5. Run full test suite — ensure no regressions
+6. If fix introduces new failures, revert and try again
+
+Rules:
+- NEVER apply a fix without first reproducing the failure
+- NEVER suppress or skip failing tests
+- Prefer targeted fixes over broad changes
+- Document what caused the failure and why the fix works
+
+## Completion Report
+When done, output a JSON completion report:
+\`\`\`json
+{
+  "status": "complete",
+  "implements": ["<design requirement IDs>"],
+  "tests": [{"name": "<test name>", "file": "<path>"}],
+  "files": ["<created/modified files>"]
+}
+\`\`\``,
+  tools: ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob'],
+  disallowedTools: ['Agent'],
+  model: 'opus',
+  skills: [
+    { name: 'tdd-patterns', content: '' },
+  ],
+  validationRules: [
+    { trigger: 'post-test', rule: 'All tests must pass after fix', command: 'npm run test:run' },
+  ],
+  resumable: false,
+};
+
+// ─── Reviewer ───────────────────────────────────────────────────────────────
+
+export const REVIEWER: AgentSpec = {
+  id: 'reviewer',
+  description: `Use this agent when performing read-only code review for quality, design compliance, and test coverage.
+
+<example>
+Context: Feature implementation is complete and needs review
+user: "Review the agent spec handler for code quality"
+assistant: "I'll dispatch the exarchos-reviewer agent to analyze code quality and design compliance."
+<commentary>
+Code review request triggers the reviewer agent for read-only analysis.
+</commentary>
+</example>`,
+  color: 'green',
+  systemPrompt: `You are a code reviewer agent. You analyze code for quality, correctness, and design compliance.
+
+## Review Scope
+{{reviewScope}}
+
+## Design Requirements
+{{designRequirements}}
+
+## Review Protocol
+1. Read all changed files in scope
+2. Check design requirement compliance
+3. Verify test coverage for new code
+4. Check for common anti-patterns
+5. Produce structured review verdict
+
+Rules:
+- You have READ-ONLY access — do not modify any files
+- Use Bash only for running read-only commands (git diff, test runners in dry-run)
+- Be specific in findings — include file paths and line references
+- Categorize findings: critical, warning, suggestion
+
+## Completion Report
+When done, output a JSON completion report:
+\`\`\`json
+{
+  "status": "complete",
+  "implements": ["<design requirement IDs>"],
+  "tests": [{"name": "<test name>", "file": "<path>"}],
+  "files": ["<reviewed files>"]
+}
+\`\`\``,
+  tools: ['Read', 'Grep', 'Glob', 'Bash'],
+  disallowedTools: ['Write', 'Edit', 'Agent'],
+  model: 'opus',
+  skills: [],
+  validationRules: [],
+  resumable: false,
+};
+
+// ─── All Specs ──────────────────────────────────────────────────────────────
+
+export const ALL_AGENT_SPECS: readonly AgentSpec[] = [
+  IMPLEMENTER,
+  FIXER,
+  REVIEWER,
+];

--- a/servers/exarchos-mcp/src/agents/drift.test.ts
+++ b/servers/exarchos-mcp/src/agents/drift.test.ts
@@ -1,0 +1,79 @@
+// ─── Agent Spec Anti-Drift Tests ───────────────────────────────────────────
+//
+// Bidirectional sync tests that prevent agent spec definitions from drifting
+// out of valid constraints. These tests catch issues at commit time rather
+// than at runtime.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { ALL_AGENT_SPECS } from './definitions.js';
+
+// ─── Known Tool Names ──────────────────────────────────────────────────────
+
+const KNOWN_TOOLS: ReadonlySet<string> = new Set([
+  'Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob', 'Agent', 'WebFetch', 'WebSearch',
+]);
+
+// ─── Template Var Pattern ──────────────────────────────────────────────────
+
+const TEMPLATE_VAR_PATTERN = /\{\{(\w+)\}\}/g;
+const VALID_IDENTIFIER = /^[a-zA-Z_]\w*$/;
+
+// ─── Drift Tests ───────────────────────────────────────────────────────────
+
+describe('Agent Spec Drift Prevention', () => {
+  it('AllAgentSpecs_ReferenceValidTools_KnownToolNames', () => {
+    for (const spec of ALL_AGENT_SPECS) {
+      for (const tool of spec.tools) {
+        expect(
+          KNOWN_TOOLS.has(tool),
+          `${spec.id}: tool '${tool}' is not in the known tool set: ${[...KNOWN_TOOLS].join(', ')}`,
+        ).toBe(true);
+      }
+      if (spec.disallowedTools) {
+        for (const tool of spec.disallowedTools) {
+          expect(
+            KNOWN_TOOLS.has(tool),
+            `${spec.id}: disallowed tool '${tool}' is not in the known tool set: ${[...KNOWN_TOOLS].join(', ')}`,
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('AllAgentSpecs_UniqueIds_NoDuplicates', () => {
+    const ids = ALL_AGENT_SPECS.map(s => s.id);
+    const uniqueIds = new Set(ids);
+    expect(
+      uniqueIds.size,
+      `Duplicate agent spec IDs found: ${ids.filter((id, i) => ids.indexOf(id) !== i).join(', ')}`,
+    ).toBe(ids.length);
+  });
+
+  it('AllAgentSpecs_TemplateVarsInPrompts_UseCorrectSyntax', () => {
+    for (const spec of ALL_AGENT_SPECS) {
+      let match: RegExpExecArray | null;
+      const regex = new RegExp(TEMPLATE_VAR_PATTERN.source, 'g');
+      while ((match = regex.exec(spec.systemPrompt)) !== null) {
+        const varName = match[1];
+        expect(
+          VALID_IDENTIFIER.test(varName),
+          `${spec.id}: template var '{{${varName}}}' uses invalid identifier characters`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('AllAgentSpecs_DisallowedToolsNotInTools_NoOverlap', () => {
+    for (const spec of ALL_AGENT_SPECS) {
+      if (!spec.disallowedTools) continue;
+      const toolSet = new Set(spec.tools);
+      for (const disallowed of spec.disallowedTools) {
+        expect(
+          toolSet.has(disallowed),
+          `${spec.id}: disallowed tool '${disallowed}' also appears in tools array`,
+        ).toBe(false);
+      }
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/agents/drift.test.ts
+++ b/servers/exarchos-mcp/src/agents/drift.test.ts
@@ -16,7 +16,8 @@ const KNOWN_TOOLS: ReadonlySet<string> = new Set([
 
 // ─── Template Var Pattern ──────────────────────────────────────────────────
 
-const TEMPLATE_VAR_PATTERN = /\{\{(\w+)\}\}/g;
+/** Matches any content between {{ and }} — captures the raw token for validation. */
+const TEMPLATE_VAR_PATTERN = /\{\{(.+?)\}\}/g;
 const VALID_IDENTIFIER = /^[a-zA-Z_]\w*$/;
 
 // ─── Drift Tests ───────────────────────────────────────────────────────────
@@ -55,10 +56,11 @@ describe('Agent Spec Drift Prevention', () => {
       let match: RegExpExecArray | null;
       const regex = new RegExp(TEMPLATE_VAR_PATTERN.source, 'g');
       while ((match = regex.exec(spec.systemPrompt)) !== null) {
-        const varName = match[1];
+        const rawToken = match[1];
+        const trimmed = rawToken.trim();
         expect(
-          VALID_IDENTIFIER.test(varName),
-          `${spec.id}: template var '{{${varName}}}' uses invalid identifier characters`,
+          VALID_IDENTIFIER.test(trimmed),
+          `${spec.id}: template var '{{${rawToken}}}' is malformed — token must be a valid identifier (got '${trimmed}')`,
         ).toBe(true);
       }
     }

--- a/servers/exarchos-mcp/src/agents/generate-cc-agents.test.ts
+++ b/servers/exarchos-mcp/src/agents/generate-cc-agents.test.ts
@@ -1,0 +1,207 @@
+// ─── CC Agent File Generator Tests ──────────────────────────────────────────
+//
+// Tests for generating Claude Code agent definition (.md) files from the
+// agent spec registry. Verifies frontmatter structure, hook mapping,
+// optional field handling, and bulk file generation.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { generateAgentMarkdown, buildHooksFromRules, generateAllAgentFiles } from './generate-cc-agents.js';
+import { IMPLEMENTER, FIXER, REVIEWER, ALL_AGENT_SPECS } from './definitions.js';
+
+// ─── Helper: Parse Frontmatter ────────────────────────────────────────────
+
+function parseFrontmatter(md: string): Record<string, string> {
+  const parts = md.split('---');
+  if (parts.length < 3) return {};
+  const yaml = parts[1].trim();
+  const result: Record<string, string> = {};
+  for (const line of yaml.split('\n')) {
+    // Skip indented lines (part of multi-line block scalar values)
+    if (line.startsWith('  ')) continue;
+    const match = line.match(/^(\w+):\s*(.+)$/);
+    if (match) {
+      result[match[1]] = match[2].replace(/^"(.*)"$/, '$1');
+    }
+  }
+  return result;
+}
+
+function getBody(md: string): string {
+  const parts = md.split('---');
+  if (parts.length < 3) return '';
+  return parts.slice(2).join('---').trim();
+}
+
+// ─── Task 6: Generate CC Agent Files ──────────────────────────────────────
+
+describe('GenerateAgentMarkdown', () => {
+  it('GenerateAgentMarkdown_Implementer_HasCorrectFrontmatter', () => {
+    // Act
+    const md = generateAgentMarkdown(IMPLEMENTER);
+    const fm = parseFrontmatter(md);
+
+    // Assert: required frontmatter fields
+    expect(fm.name).toBe('exarchos-implementer');
+    expect(fm.tools).toBe('["Read", "Write", "Edit", "Bash", "Grep", "Glob"]');
+    expect(fm.model).toBe('opus');
+    expect(fm.color).toBe('blue');
+    expect(fm.isolation).toBe('worktree');
+    expect(fm.memory).toBe('project');
+
+    // Description uses block scalar for multi-line content with examples
+    expect(md).toContain('description: |');
+    expect(md).toContain('<example>');
+
+    // maxTurns should be absent since IMPLEMENTER doesn't define it
+    // but the field should appear if the spec defines it
+
+    // Body should be the system prompt
+    const body = getBody(md);
+    expect(body).toContain('You are a TDD implementer agent');
+  });
+
+  it('GenerateAgentMarkdown_Implementer_HasHooksFromRules', () => {
+    // Act
+    const md = generateAgentMarkdown(IMPLEMENTER);
+
+    // Assert: hooks section present in frontmatter
+    // IMPLEMENTER has pre-write (no command, skipped) and post-test (has command) rules
+    expect(md).toContain('hooks:');
+    expect(md).toContain('PostToolUse:');
+    expect(md).toContain('matcher: "Bash"');
+    expect(md).toContain('command: "npm run test:run"');
+  });
+
+  it('GenerateAgentMarkdown_Reviewer_OmitsOptionalFields', () => {
+    // Act
+    const md = generateAgentMarkdown(REVIEWER);
+    const fm = parseFrontmatter(md);
+
+    // Assert: no isolation (REVIEWER doesn't define it)
+    expect(fm.isolation).toBeUndefined();
+    // Assert: no maxTurns
+    expect(fm.maxTurns).toBeUndefined();
+    // Assert: no memory (REVIEWER doesn't define memoryScope)
+    expect(fm.memory).toBeUndefined();
+    // Assert: no hooks section since REVIEWER has no validation rules with commands
+    expect(md).not.toContain('hooks:');
+    // Assert: no skills section (empty array)
+    expect(md).not.toMatch(/^skills:/m);
+  });
+
+  it('GenerateAgentMarkdown_Fixer_DisallowedToolsPresent', () => {
+    // Act
+    const md = generateAgentMarkdown(FIXER);
+    const fm = parseFrontmatter(md);
+
+    // Assert: disallowedTools present in JSON array format
+    expect(fm.disallowedTools).toBe('["Agent"]');
+  });
+});
+
+describe('BuildHooksFromRules', () => {
+  it('BuildHooksFromRules_PreWrite_MapsToWriteEditMatcher', () => {
+    // Arrange
+    const rules = [
+      { trigger: 'pre-write', rule: 'Test must exist', command: 'exarchos validate tdd-order' },
+    ] as const;
+
+    // Act
+    const hooks = buildHooksFromRules(rules);
+
+    // Assert
+    expect(hooks).toHaveProperty('PreToolUse');
+    const preToolUse = (hooks as Record<string, unknown[]>).PreToolUse;
+    expect(preToolUse).toHaveLength(1);
+    expect(preToolUse[0]).toEqual({
+      matcher: 'Write|Edit',
+      hooks: [{ type: 'command', command: 'exarchos validate tdd-order' }],
+    });
+  });
+
+  it('BuildHooksFromRules_PostTest_MapsToBashMatcher', () => {
+    // Arrange
+    const rules = [
+      { trigger: 'post-test', rule: 'All tests must pass', command: 'npm run test:run' },
+    ] as const;
+
+    // Act
+    const hooks = buildHooksFromRules(rules);
+
+    // Assert
+    expect(hooks).toHaveProperty('PostToolUse');
+    const postToolUse = (hooks as Record<string, unknown[]>).PostToolUse;
+    expect(postToolUse).toHaveLength(1);
+    expect(postToolUse[0]).toEqual({
+      matcher: 'Bash',
+      hooks: [{ type: 'command', command: 'npm run test:run' }],
+    });
+  });
+
+  it('BuildHooksFromRules_RuleWithoutCommand_Skipped', () => {
+    // Arrange
+    const rules = [
+      { trigger: 'pre-write', rule: 'Test must exist' },
+    ] as const;
+
+    // Act
+    const hooks = buildHooksFromRules(rules);
+
+    // Assert: empty object since the only rule has no command
+    expect(Object.keys(hooks)).toHaveLength(0);
+  });
+
+  it('BuildHooksFromRules_PreEdit_MapsToEditMatcher', () => {
+    // Arrange
+    const rules = [
+      { trigger: 'pre-edit', rule: 'Must validate', command: 'validate-edit' },
+    ] as const;
+
+    // Act
+    const hooks = buildHooksFromRules(rules);
+
+    // Assert
+    expect(hooks).toHaveProperty('PreToolUse');
+    const preToolUse = (hooks as Record<string, unknown[]>).PreToolUse;
+    expect(preToolUse[0]).toEqual({
+      matcher: 'Edit',
+      hooks: [{ type: 'command', command: 'validate-edit' }],
+    });
+  });
+});
+
+describe('GenerateAllAgentFiles', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-agents-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('GenerateAllAgentFiles_CreatesAllFiles_MatchesSpecCount', () => {
+    // Act
+    generateAllAgentFiles(tmpDir);
+
+    // Assert: correct number of files
+    const files = fs.readdirSync(tmpDir).filter(f => f.endsWith('.md'));
+    expect(files).toHaveLength(ALL_AGENT_SPECS.length);
+
+    // Assert: each spec has a corresponding file
+    for (const spec of ALL_AGENT_SPECS) {
+      const expectedFile = `${spec.id}.md`;
+      expect(files).toContain(expectedFile);
+
+      // Verify file content starts with frontmatter
+      const content = fs.readFileSync(path.join(tmpDir, expectedFile), 'utf-8');
+      expect(content).toMatch(/^---\n/);
+      expect(content).toContain(`name: exarchos-${spec.id}`);
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/agents/generate-cc-agents.ts
+++ b/servers/exarchos-mcp/src/agents/generate-cc-agents.ts
@@ -1,0 +1,182 @@
+// ─── CC Agent File Generator ────────────────────────────────────────────────
+//
+// Build-time tool that generates Claude Code agent definition (.md) files
+// from the agent spec registry. Each generated file contains YAML frontmatter
+// and a system prompt body.
+// ────────────────────────────────────────────────────────────────────────────
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { AgentSpec, AgentValidationRule } from './types.js';
+import { ALL_AGENT_SPECS } from './definitions.js';
+
+// ─── Trigger-to-Matcher Mapping ─────────────────────────────────────────────
+
+const TRIGGER_MAP: Record<string, { hookType: string; matcher: string }> = {
+  'pre-write': { hookType: 'PreToolUse', matcher: 'Write|Edit' },
+  'pre-edit': { hookType: 'PreToolUse', matcher: 'Edit' },
+  'post-test': { hookType: 'PostToolUse', matcher: 'Bash' },
+};
+
+// ─── Build Hooks from Rules ─────────────────────────────────────────────────
+
+/**
+ * Maps validation rules to CC hook format.
+ * Rules without a `command` property are skipped.
+ */
+export function buildHooksFromRules(
+  rules: readonly AgentValidationRule[],
+): Record<string, unknown> {
+  const hooks: Record<string, Array<{ matcher: string; hooks: Array<{ type: string; command: string }> }>> = {};
+
+  for (const rule of rules) {
+    if (!rule.command) continue;
+
+    const mapping = TRIGGER_MAP[rule.trigger];
+    if (!mapping) continue;
+
+    const { hookType, matcher } = mapping;
+
+    if (!hooks[hookType]) {
+      hooks[hookType] = [];
+    }
+
+    hooks[hookType].push({
+      matcher,
+      hooks: [{ type: 'command', command: rule.command }],
+    });
+  }
+
+  return hooks;
+}
+
+// ─── YAML Serialization Helpers ─────────────────────────────────────────────
+
+function escapeYamlString(value: string): string {
+  // Wrap in quotes if it contains special characters
+  if (value.includes(':') || value.includes('#') || value.includes('"') || value.includes("'")) {
+    return `"${value.replace(/"/g, '\\"')}"`;
+  }
+  return value;
+}
+
+function serializeHooksYaml(hooks: Record<string, unknown>, indent: number): string {
+  const pad = ' '.repeat(indent);
+  const entries = Object.entries(hooks) as [string, Array<{ matcher: string; hooks: Array<{ type: string; command: string }> }>][];
+  let yaml = '';
+
+  for (const [hookType, hookList] of entries) {
+    yaml += `${pad}${hookType}:\n`;
+    for (const hookEntry of hookList) {
+      yaml += `${pad}  - matcher: "${hookEntry.matcher}"\n`;
+      yaml += `${pad}    hooks:\n`;
+      for (const h of hookEntry.hooks) {
+        yaml += `${pad}      - type: ${h.type}\n`;
+        yaml += `${pad}        command: "${h.command}"\n`;
+      }
+    }
+  }
+
+  return yaml;
+}
+
+// ─── Generate Agent Markdown ────────────────────────────────────────────────
+
+/**
+ * Generates a markdown file with YAML frontmatter + system prompt body
+ * from an AgentSpec.
+ */
+export function generateAgentMarkdown(spec: AgentSpec): string {
+  let frontmatter = '---\n';
+
+  // Required fields
+  frontmatter += `name: exarchos-${spec.id}\n`;
+
+  // Description: multi-line uses YAML block scalar, single-line uses quoted string
+  if (spec.description.includes('\n')) {
+    frontmatter += 'description: |\n';
+    for (const line of spec.description.split('\n')) {
+      frontmatter += `  ${line}\n`;
+    }
+  } else {
+    frontmatter += `description: "${spec.description}"\n`;
+  }
+
+  frontmatter += `tools: [${spec.tools.map(t => `"${t}"`).join(', ')}]\n`;
+  frontmatter += `model: ${spec.model}\n`;
+
+  // Optional: color
+  if (spec.color) {
+    frontmatter += `color: ${spec.color}\n`;
+  }
+
+  // Optional: disallowedTools
+  if (spec.disallowedTools && spec.disallowedTools.length > 0) {
+    frontmatter += `disallowedTools: [${spec.disallowedTools.map(t => `"${t}"`).join(', ')}]\n`;
+  }
+
+  // Optional: isolation
+  if (spec.isolation) {
+    frontmatter += `isolation: ${spec.isolation}\n`;
+  }
+
+  // Optional: memory (mapped from memoryScope)
+  if (spec.memoryScope) {
+    frontmatter += `memory: ${spec.memoryScope}\n`;
+  }
+
+  // Optional: maxTurns
+  if (spec.maxTurns !== undefined) {
+    frontmatter += `maxTurns: ${spec.maxTurns}\n`;
+  }
+
+  // Optional: skills (array format)
+  if (spec.skills.length > 0) {
+    frontmatter += 'skills:\n';
+    for (const skill of spec.skills) {
+      frontmatter += `  - ${skill.name}\n`;
+    }
+  }
+
+  // Optional: hooks (from validation rules)
+  const hooks = buildHooksFromRules(spec.validationRules);
+  if (Object.keys(hooks).length > 0) {
+    frontmatter += 'hooks:\n';
+    frontmatter += serializeHooksYaml(hooks, 2);
+  }
+
+  frontmatter += '---\n';
+
+  return `${frontmatter}\n${spec.systemPrompt}\n`;
+}
+
+// ─── Generate All Agent Files ───────────────────────────────────────────────
+
+/**
+ * Writes all agent spec files as markdown to the output directory.
+ */
+export function generateAllAgentFiles(outDir: string): void {
+  // Ensure output directory exists
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir, { recursive: true });
+  }
+
+  for (const spec of ALL_AGENT_SPECS) {
+    const markdown = generateAgentMarkdown(spec);
+    const filePath = path.join(outDir, `${spec.id}.md`);
+    fs.writeFileSync(filePath, markdown, 'utf-8');
+  }
+}
+
+// ─── CLI Entry Point ────────────────────────────────────────────────────────
+
+const isMainModule = process.argv[1] && (
+  process.argv[1].endsWith('generate-cc-agents.ts') ||
+  process.argv[1].endsWith('generate-cc-agents.js')
+);
+
+if (isMainModule) {
+  const outDir = process.argv[2] || path.resolve(import.meta.dirname, '../../../../agents');
+  generateAllAgentFiles(outDir);
+  process.stderr.write(`Generated ${ALL_AGENT_SPECS.length} agent files to ${outDir}\n`);
+}

--- a/servers/exarchos-mcp/src/agents/generate-cc-agents.ts
+++ b/servers/exarchos-mcp/src/agents/generate-cc-agents.ts
@@ -161,6 +161,17 @@ export function generateAllAgentFiles(outDir: string): void {
     fs.mkdirSync(outDir, { recursive: true });
   }
 
+  // Compute the set of expected file names from current specs
+  const expectedFiles = new Set(ALL_AGENT_SPECS.map(spec => `${spec.id}.md`));
+
+  // Remove stale .md files from previous runs that no longer correspond to a spec
+  const existingFiles = fs.readdirSync(outDir).filter(f => f.endsWith('.md'));
+  for (const file of existingFiles) {
+    if (!expectedFiles.has(file)) {
+      fs.unlinkSync(path.join(outDir, file));
+    }
+  }
+
   for (const spec of ALL_AGENT_SPECS) {
     const markdown = generateAgentMarkdown(spec);
     const filePath = path.join(outDir, `${spec.id}.md`);

--- a/servers/exarchos-mcp/src/agents/generated-drift.test.ts
+++ b/servers/exarchos-mcp/src/agents/generated-drift.test.ts
@@ -1,0 +1,182 @@
+// ─── Generated Agent File Drift Tests ───────────────────────────────────────
+//
+// Verifies that generated agent files stay in sync with the agent spec
+// registry. Generates files to a temp directory, parses frontmatter, and
+// compares against ALL_AGENT_SPECS.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { generateAllAgentFiles } from './generate-cc-agents.js';
+import { ALL_AGENT_SPECS } from './definitions.js';
+
+// ─── Helper: Parse YAML Frontmatter ─────────────────────────────────────────
+
+function parseFrontmatter(content: string): Record<string, string> {
+  const parts = content.split('---');
+  if (parts.length < 3) return {};
+  const yaml = parts[1].trim();
+  const result: Record<string, string> = {};
+  for (const line of yaml.split('\n')) {
+    // Only match top-level key: value pairs (no leading whitespace)
+    const match = line.match(/^(\w+):\s*(.+)$/);
+    if (match) {
+      result[match[1]] = match[2].replace(/^"(.*)"$/, '$1');
+    }
+  }
+  return result;
+}
+
+// ─── Shared Setup ───────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let generatedFiles: string[];
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'drift-test-'));
+  generateAllAgentFiles(tmpDir);
+  generatedFiles = fs.readdirSync(tmpDir).filter(f => f.endsWith('.md'));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── Task 8: Generated File Drift Tests ─────────────────────────────────────
+
+describe('Generated Agent File Drift', () => {
+  it('GeneratedAgentFiles_MatchRegistrySpecs_NameCorrect', () => {
+    for (const spec of ALL_AGENT_SPECS) {
+      const filePath = path.join(tmpDir, `${spec.id}.md`);
+      expect(fs.existsSync(filePath), `Missing file for spec '${spec.id}'`).toBe(true);
+
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const fm = parseFrontmatter(content);
+
+      expect(
+        fm.name,
+        `Frontmatter name mismatch for spec '${spec.id}'`,
+      ).toBe(`exarchos-${spec.id}`);
+    }
+  });
+
+  it('GeneratedAgentFiles_MatchRegistrySpecs_ModelCorrect', () => {
+    for (const spec of ALL_AGENT_SPECS) {
+      const filePath = path.join(tmpDir, `${spec.id}.md`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const fm = parseFrontmatter(content);
+
+      expect(
+        fm.model,
+        `Frontmatter model mismatch for spec '${spec.id}': expected '${spec.model}', got '${fm.model}'`,
+      ).toBe(spec.model);
+    }
+  });
+
+  it('GeneratedAgentFiles_AllSpecsHaveFiles_NoneSkipped', () => {
+    // Every spec should have a corresponding .md file
+    expect(generatedFiles).toHaveLength(ALL_AGENT_SPECS.length);
+
+    for (const spec of ALL_AGENT_SPECS) {
+      const expectedFile = `${spec.id}.md`;
+      expect(
+        generatedFiles,
+        `Missing generated file for spec '${spec.id}'`,
+      ).toContain(expectedFile);
+    }
+
+    // No extra files beyond what specs define
+    const expectedFileNames = ALL_AGENT_SPECS.map(s => `${s.id}.md`);
+    for (const file of generatedFiles) {
+      expect(
+        expectedFileNames,
+        `Unexpected generated file '${file}' not in registry`,
+      ).toContain(file);
+    }
+  });
+
+  it('GeneratedAgentFiles_MatchRegistrySpecs_ToolsCorrect', () => {
+    for (const spec of ALL_AGENT_SPECS) {
+      const filePath = path.join(tmpDir, `${spec.id}.md`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const fm = parseFrontmatter(content);
+
+      const expectedTools = `[${spec.tools.map(t => `"${t}"`).join(', ')}]`;
+      expect(
+        fm.tools,
+        `Frontmatter tools mismatch for spec '${spec.id}'`,
+      ).toBe(expectedTools);
+    }
+  });
+
+  it('GeneratedAgentFiles_MatchRegistrySpecs_DescriptionPresent', () => {
+    for (const spec of ALL_AGENT_SPECS) {
+      const filePath = path.join(tmpDir, `${spec.id}.md`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+
+      if (spec.description.includes('\n')) {
+        // Multi-line descriptions use block scalar — verify content is present
+        expect(
+          content,
+          `Description content missing for spec '${spec.id}'`,
+        ).toContain('description: |');
+        // First line of description should appear indented in frontmatter
+        const firstLine = spec.description.split('\n')[0];
+        expect(
+          content,
+          `Description first line missing for spec '${spec.id}'`,
+        ).toContain(`  ${firstLine}`);
+      } else {
+        const fm = parseFrontmatter(content);
+        expect(
+          fm.description,
+          `Frontmatter description missing for spec '${spec.id}'`,
+        ).toBeTruthy();
+        expect(
+          fm.description,
+          `Frontmatter description mismatch for spec '${spec.id}'`,
+        ).toBe(spec.description);
+      }
+    }
+  });
+
+  it('GeneratedAgentFiles_MatchRegistrySpecs_ColorCorrect', () => {
+    for (const spec of ALL_AGENT_SPECS) {
+      const filePath = path.join(tmpDir, `${spec.id}.md`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const fm = parseFrontmatter(content);
+
+      if (spec.color) {
+        expect(
+          fm.color,
+          `Frontmatter color mismatch for spec '${spec.id}'`,
+        ).toBe(spec.color);
+      } else {
+        expect(
+          fm.color,
+          `Unexpected color in frontmatter for spec '${spec.id}'`,
+        ).toBeUndefined();
+      }
+    }
+  });
+
+  it('GeneratedAgentFiles_BodyContainsSystemPrompt', () => {
+    for (const spec of ALL_AGENT_SPECS) {
+      const filePath = path.join(tmpDir, `${spec.id}.md`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+
+      // Body is everything after the second ---
+      const parts = content.split('---');
+      const body = parts.slice(2).join('---').trim();
+
+      // The body should contain the beginning of the system prompt
+      const promptStart = spec.systemPrompt.substring(0, 50);
+      expect(
+        body,
+        `Body for spec '${spec.id}' does not contain system prompt`,
+      ).toContain(promptStart);
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/agents/handler.test.ts
+++ b/servers/exarchos-mcp/src/agents/handler.test.ts
@@ -35,7 +35,7 @@ describe('handleAgentSpec', () => {
 
   it('AgentSpec_UnknownAgent_ReturnsError', async () => {
     // Arrange
-    const args = { agent: 'unknown-agent' as any };
+    const args = { agent: 'unknown-agent' } as unknown as Parameters<typeof handleAgentSpec>[0];
 
     // Act
     const result = await handleAgentSpec(args);
@@ -44,13 +44,12 @@ describe('handleAgentSpec', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('UNKNOWN_AGENT');
     expect(result.error?.message).toContain('unknown-agent');
-    // Should include validAgents in the error data
-    const data = result.data as Record<string, unknown>;
-    expect(data.validAgents).toBeDefined();
-    const validAgents = data.validAgents as string[];
-    expect(validAgents).toContain('implementer');
-    expect(validAgents).toContain('fixer');
-    expect(validAgents).toContain('reviewer');
+    // Should include validTargets in the error (matching codebase error pattern)
+    expect(result.error?.validTargets).toBeDefined();
+    const validTargets = result.error!.validTargets as string[];
+    expect(validTargets).toContain('implementer');
+    expect(validTargets).toContain('fixer');
+    expect(validTargets).toContain('reviewer');
   });
 
   it('AgentSpec_WithContext_InterpolatesTemplateVars', async () => {

--- a/servers/exarchos-mcp/src/agents/handler.test.ts
+++ b/servers/exarchos-mcp/src/agents/handler.test.ts
@@ -1,0 +1,173 @@
+// ─── Agent Spec Handler Tests ──────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { handleAgentSpec, agentSpecSchema } from './handler.js';
+
+describe('handleAgentSpec', () => {
+  it('AgentSpec_ValidAgent_ReturnsFullSpec', async () => {
+    // Arrange
+    const args = { agent: 'implementer' as const, format: 'full' as const };
+
+    // Act
+    const result = await handleAgentSpec(args);
+
+    // Assert
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.agent).toBe('implementer');
+    expect(data.systemPrompt).toBeDefined();
+    expect(data.tools).toContain('Read');
+    expect(data.tools).toContain('Write');
+    expect(data.model).toBe('opus');
+    expect(data.isolation).toBe('worktree');
+    expect(data.resumable).toBe(true);
+    expect(data.memoryScope).toBe('project');
+    expect(data.validationRules).toBeDefined();
+    expect(data.skills).toBeDefined();
+    // Skills should have name but empty content (deferred to runtime)
+    const skills = data.skills as Array<{ name: string; content: string }>;
+    expect(skills.length).toBeGreaterThan(0);
+    for (const skill of skills) {
+      expect(skill.name).toBeTruthy();
+      expect(skill.content).toBe('');
+    }
+  });
+
+  it('AgentSpec_UnknownAgent_ReturnsError', async () => {
+    // Arrange
+    const args = { agent: 'unknown-agent' as any };
+
+    // Act
+    const result = await handleAgentSpec(args);
+
+    // Assert
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('UNKNOWN_AGENT');
+    expect(result.error?.message).toContain('unknown-agent');
+    // Should include validAgents in the error data
+    const data = result.data as Record<string, unknown>;
+    expect(data.validAgents).toBeDefined();
+    const validAgents = data.validAgents as string[];
+    expect(validAgents).toContain('implementer');
+    expect(validAgents).toContain('fixer');
+    expect(validAgents).toContain('reviewer');
+  });
+
+  it('AgentSpec_WithContext_InterpolatesTemplateVars', async () => {
+    // Arrange
+    const args = {
+      agent: 'implementer' as const,
+      context: {
+        taskDescription: 'Build the login page',
+        requirements: 'Must validate email format',
+        filePaths: 'src/login.ts, src/login.test.ts',
+      },
+      format: 'full' as const,
+    };
+
+    // Act
+    const result = await handleAgentSpec(args);
+
+    // Assert
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const prompt = data.systemPrompt as string;
+    expect(prompt).toContain('Build the login page');
+    expect(prompt).toContain('Must validate email format');
+    expect(prompt).toContain('src/login.ts, src/login.test.ts');
+    expect(prompt).not.toContain('{{taskDescription}}');
+    expect(prompt).not.toContain('{{requirements}}');
+    expect(prompt).not.toContain('{{filePaths}}');
+  });
+
+  it('AgentSpec_UnresolvedVars_ReportsUnresolved', async () => {
+    // Arrange: only provide one of three template vars
+    const args = {
+      agent: 'implementer' as const,
+      context: {
+        taskDescription: 'Build it',
+      },
+      format: 'full' as const,
+    };
+
+    // Act
+    const result = await handleAgentSpec(args);
+
+    // Assert
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const unresolvedVars = data.unresolvedVars as string[];
+    expect(unresolvedVars).toBeDefined();
+    expect(unresolvedVars.length).toBeGreaterThan(0);
+    expect(unresolvedVars).toContain('requirements');
+    expect(unresolvedVars).toContain('filePaths');
+    expect(unresolvedVars).not.toContain('taskDescription');
+  });
+
+  it('AgentSpec_PromptOnlyFormat_ReturnsJustPrompt', async () => {
+    // Arrange
+    const args = {
+      agent: 'reviewer' as const,
+      context: {
+        reviewScope: 'PR #42',
+        designRequirements: 'DR-1: Must have tests',
+      },
+      format: 'prompt-only' as const,
+    };
+
+    // Act
+    const result = await handleAgentSpec(args);
+
+    // Assert
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.agent).toBe('reviewer');
+    expect(data.systemPrompt).toBeDefined();
+    expect(data.systemPrompt).toContain('PR #42');
+    // prompt-only format should NOT include tools, model, etc.
+    expect(data.tools).toBeUndefined();
+    expect(data.model).toBeUndefined();
+    expect(data.isolation).toBeUndefined();
+    expect(data.validationRules).toBeUndefined();
+    expect(data.skills).toBeUndefined();
+    expect(data.resumable).toBeUndefined();
+    // unresolvedVars should still be reported
+    expect(data.unresolvedVars).toBeDefined();
+  });
+});
+
+describe('agentSpecSchema', () => {
+  it('should accept valid full format', () => {
+    const result = agentSpecSchema.safeParse({
+      agent: 'implementer',
+      format: 'full',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept valid prompt-only format', () => {
+    const result = agentSpecSchema.safeParse({
+      agent: 'reviewer',
+      format: 'prompt-only',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should default format to full', () => {
+    const result = agentSpecSchema.safeParse({
+      agent: 'fixer',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.format).toBe('full');
+    }
+  });
+
+  it('should accept optional context', () => {
+    const result = agentSpecSchema.safeParse({
+      agent: 'implementer',
+      context: { taskDescription: 'Build it' },
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/agents/handler.ts
+++ b/servers/exarchos-mcp/src/agents/handler.ts
@@ -1,0 +1,106 @@
+// ─── Agent Spec Action Handler ─────────────────────────────────────────────
+//
+// Handles the `agent_spec` action: looks up an agent specification by ID,
+// interpolates template variables, and returns the spec in the requested format.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { z } from 'zod';
+import type { ToolResult } from '../format.js';
+import { ALL_AGENT_SPECS } from './definitions.js';
+import type { AgentSpec } from './types.js';
+
+// ─── Schema ─────────────────────────────────────────────────────────────────
+
+const AGENT_IDS = ALL_AGENT_SPECS.map(s => s.id) as [string, ...string[]];
+
+export const agentSpecSchema = z.object({
+  agent: z.enum(AGENT_IDS),
+  context: z.record(z.string(), z.string()).optional(),
+  format: z.enum(['full', 'prompt-only']).default('full'),
+});
+
+type AgentSpecArgs = z.infer<typeof agentSpecSchema>;
+
+// ─── Template Interpolation ─────────────────────────────────────────────────
+
+const TEMPLATE_VAR_PATTERN = /\{\{(\w+)\}\}/g;
+
+function interpolatePrompt(
+  prompt: string,
+  context: Record<string, string>,
+): { systemPrompt: string; unresolvedVars: string[] } {
+  let systemPrompt = prompt;
+
+  // Replace all provided context vars
+  for (const [key, value] of Object.entries(context)) {
+    systemPrompt = systemPrompt.replaceAll(`{{${key}}}`, value);
+  }
+
+  // Detect unresolved vars
+  const unresolvedVars: string[] = [];
+  let match: RegExpExecArray | null;
+  const regex = new RegExp(TEMPLATE_VAR_PATTERN.source, 'g');
+  while ((match = regex.exec(systemPrompt)) !== null) {
+    if (!unresolvedVars.includes(match[1])) {
+      unresolvedVars.push(match[1]);
+    }
+  }
+
+  return { systemPrompt, unresolvedVars };
+}
+
+// ─── Handler ────────────────────────────────────────────────────────────────
+
+export async function handleAgentSpec(args: AgentSpecArgs): Promise<ToolResult> {
+  const { agent, context = {}, format = 'full' } = args;
+
+  // Find spec by agent ID
+  const spec: AgentSpec | undefined = ALL_AGENT_SPECS.find(s => s.id === agent);
+
+  if (!spec) {
+    return {
+      success: false,
+      error: {
+        code: 'UNKNOWN_AGENT',
+        message: `Unknown agent '${agent}'. Valid agents: ${AGENT_IDS.join(', ')}`,
+      },
+      data: {
+        validAgents: AGENT_IDS,
+      },
+    };
+  }
+
+  // Interpolate template vars
+  const { systemPrompt, unresolvedVars } = interpolatePrompt(spec.systemPrompt, context);
+
+  // Format: prompt-only
+  if (format === 'prompt-only') {
+    return {
+      success: true,
+      data: {
+        agent: spec.id,
+        systemPrompt,
+        unresolvedVars,
+      },
+    };
+  }
+
+  // Format: full
+  return {
+    success: true,
+    data: {
+      agent: spec.id,
+      systemPrompt,
+      tools: [...spec.tools],
+      disallowedTools: spec.disallowedTools ? [...spec.disallowedTools] : undefined,
+      model: spec.model,
+      isolation: spec.isolation,
+      validationRules: [...spec.validationRules],
+      resumable: spec.resumable,
+      memoryScope: spec.memoryScope,
+      maxTurns: spec.maxTurns,
+      skills: spec.skills.map(s => ({ name: s.name, content: '' })),
+      unresolvedVars,
+    },
+  };
+}

--- a/servers/exarchos-mcp/src/agents/handler.ts
+++ b/servers/exarchos-mcp/src/agents/handler.ts
@@ -63,9 +63,7 @@ export async function handleAgentSpec(args: AgentSpecArgs): Promise<ToolResult> 
       error: {
         code: 'UNKNOWN_AGENT',
         message: `Unknown agent '${agent}'. Valid agents: ${AGENT_IDS.join(', ')}`,
-      },
-      data: {
-        validAgents: AGENT_IDS,
+        validTargets: AGENT_IDS,
       },
     };
   }

--- a/servers/exarchos-mcp/src/agents/plugin.test.ts
+++ b/servers/exarchos-mcp/src/agents/plugin.test.ts
@@ -1,0 +1,50 @@
+// ─── Plugin Manifest Tests ──────────────────────────────────────────────────
+//
+// Verifies the plugin.json manifest includes the agents directory reference,
+// and that the generate:agents script is configured.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ─── Resolve plugin root relative to this file ────────────────────────────
+
+// This file is at servers/exarchos-mcp/src/agents/plugin.test.ts
+// Plugin root is at ../../.claude-plugin/ (relative to repo root)
+const REPO_ROOT = path.resolve(import.meta.dirname, '../../../../');
+const PLUGIN_JSON_PATH = path.join(REPO_ROOT, '.claude-plugin', 'plugin.json');
+const AGENTS_DIR = path.join(REPO_ROOT, 'agents');
+
+// ─── Task 7: Plugin Manifest ─────────────────────────────────────────────
+
+describe('Plugin Manifest', () => {
+  it('PluginManifest_IncludesAgentsDirectory_InComponents', () => {
+    // Arrange: read plugin.json
+    const raw = fs.readFileSync(PLUGIN_JSON_PATH, 'utf-8');
+    const manifest = JSON.parse(raw);
+
+    // Assert: agents field present and points to agents/
+    expect(manifest).toHaveProperty('agents');
+    expect(manifest.agents).toBe('./agents/');
+  });
+
+  it('PluginManifest_AgentsDirectoryExists_HasGitkeep', () => {
+    // Assert: agents/ directory exists
+    expect(fs.existsSync(AGENTS_DIR)).toBe(true);
+    expect(fs.statSync(AGENTS_DIR).isDirectory()).toBe(true);
+
+    // Assert: .gitkeep exists
+    expect(fs.existsSync(path.join(AGENTS_DIR, '.gitkeep'))).toBe(true);
+  });
+
+  it('PluginManifest_GenerateAgentsScript_Exists', () => {
+    // Arrange: read servers/exarchos-mcp/package.json
+    const pkgPath = path.resolve(import.meta.dirname, '../../package.json');
+    const raw = fs.readFileSync(pkgPath, 'utf-8');
+    const pkg = JSON.parse(raw);
+
+    // Assert: generate:agents script exists
+    expect(pkg.scripts).toHaveProperty('generate:agents');
+  });
+});

--- a/servers/exarchos-mcp/src/agents/types.ts
+++ b/servers/exarchos-mcp/src/agents/types.ts
@@ -1,0 +1,38 @@
+// ─── Agent Spec Types ──────────────────────────────────────────────────────
+//
+// Defines the shape of agent specifications for subagent dispatch.
+// These types are consumed by the agent_spec handler and definitions.
+// ────────────────────────────────────────────────────────────────────────────
+
+/** A skill that can be loaded into an agent's context. */
+export interface AgentSkill {
+  readonly name: string;
+  readonly content: string;
+}
+
+/** A validation rule applied during agent execution. */
+export interface AgentValidationRule {
+  readonly trigger: string;
+  readonly rule: string;
+  readonly command?: string;
+}
+
+/** Canonical agent spec IDs. */
+export type AgentSpecId = 'implementer' | 'fixer' | 'reviewer';
+
+/** Complete specification for a subagent. */
+export interface AgentSpec {
+  readonly id: AgentSpecId;
+  readonly description: string;
+  readonly systemPrompt: string;
+  readonly tools: readonly string[];
+  readonly disallowedTools?: readonly string[];
+  readonly model: 'opus' | 'sonnet' | 'haiku' | 'inherit';
+  readonly color?: string;
+  readonly isolation?: 'worktree';
+  readonly skills: readonly AgentSkill[];
+  readonly validationRules: readonly AgentValidationRule[];
+  readonly resumable: boolean;
+  readonly memoryScope?: 'user' | 'project' | 'local';
+  readonly maxTurns?: number;
+}

--- a/servers/exarchos-mcp/src/cli-commands/subagent-stop.test.ts
+++ b/servers/exarchos-mcp/src/cli-commands/subagent-stop.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { handleSubagentStop } from './subagent-stop.js';
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('subagent-stop', () => {
+  let originalFeatureId: string | undefined;
+  let originalTaskId: string | undefined;
+
+  beforeEach(() => {
+    originalFeatureId = process.env.EXARCHOS_FEATURE_ID;
+    originalTaskId = process.env.EXARCHOS_TASK_ID;
+  });
+
+  afterEach(() => {
+    if (originalFeatureId !== undefined) {
+      process.env.EXARCHOS_FEATURE_ID = originalFeatureId;
+    } else {
+      delete process.env.EXARCHOS_FEATURE_ID;
+    }
+    if (originalTaskId !== undefined) {
+      process.env.EXARCHOS_TASK_ID = originalTaskId;
+    } else {
+      delete process.env.EXARCHOS_TASK_ID;
+    }
+  });
+
+  it('HandleSubagentStop_ValidInput_ReturnsAgentContext', async () => {
+    // Arrange
+    process.env.EXARCHOS_FEATURE_ID = 'my-feature';
+    process.env.EXARCHOS_TASK_ID = 'task-001';
+
+    const stdinData = {
+      agent_type: 'exarchos-implementer',
+      agent_id: 'agent-abc-123',
+      exit_reason: 'complete',
+    };
+
+    // Act
+    const result = await handleSubagentStop(stdinData);
+
+    // Assert
+    expect(result).toHaveProperty('agentId', 'agent-abc-123');
+    expect(result).toHaveProperty('exitReason', 'complete');
+    expect(result).toHaveProperty('featureId', 'my-feature');
+    expect(result).toHaveProperty('taskId', 'task-001');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('HandleSubagentStop_NonExarchosAgent_ReturnsNoOp', async () => {
+    // Arrange
+    const stdinData = {
+      agent_type: 'some-other-agent',
+      agent_id: 'agent-xyz-789',
+      exit_reason: 'complete',
+    };
+
+    // Act
+    const result = await handleSubagentStop(stdinData);
+
+    // Assert — should return a no-op result (continue: true, no agentId/exitReason)
+    expect(result).toHaveProperty('continue', true);
+    expect(result).not.toHaveProperty('agentId');
+    expect(result).not.toHaveProperty('exitReason');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('HandleSubagentStop_MissingAgentId_ReturnsError', async () => {
+    // Arrange
+    const stdinData = {
+      agent_type: 'exarchos-implementer',
+      // agent_id is missing
+      exit_reason: 'complete',
+    };
+
+    // Act
+    const result = await handleSubagentStop(stdinData);
+
+    // Assert
+    expect(result).toHaveProperty('error');
+    expect(result.error).toHaveProperty('code', 'MISSING_AGENT_ID');
+    expect(result.error).toHaveProperty('message');
+  });
+
+  it('HandleSubagentStop_MissingExitReason_ReturnsError', async () => {
+    // Arrange
+    const stdinData = {
+      agent_type: 'exarchos-fixer',
+      agent_id: 'agent-abc-123',
+      // exit_reason is missing
+    };
+
+    // Act
+    const result = await handleSubagentStop(stdinData);
+
+    // Assert
+    expect(result).toHaveProperty('error');
+    expect(result.error).toHaveProperty('code', 'MISSING_EXIT_REASON');
+    expect(result.error).toHaveProperty('message');
+  });
+
+  it('HandleSubagentStop_NoContext_ReturnsAgentInfoOnly', async () => {
+    // Arrange — no env vars set for feature/task context
+    delete process.env.EXARCHOS_FEATURE_ID;
+    delete process.env.EXARCHOS_TASK_ID;
+
+    const stdinData = {
+      agent_type: 'exarchos-implementer',
+      agent_id: 'agent-abc-123',
+      exit_reason: 'error',
+    };
+
+    // Act
+    const result = await handleSubagentStop(stdinData);
+
+    // Assert — should still return agentId and exitReason, but no featureId/taskId
+    expect(result).toHaveProperty('agentId', 'agent-abc-123');
+    expect(result).toHaveProperty('exitReason', 'error');
+    expect(result).not.toHaveProperty('featureId');
+    expect(result).not.toHaveProperty('taskId');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('HandleSubagentStop_ExarchosFixerAgent_ReturnsAgentContext', async () => {
+    // Arrange — verify prefix matching works for different exarchos agent types
+    process.env.EXARCHOS_FEATURE_ID = 'fix-feature';
+    process.env.EXARCHOS_TASK_ID = 'task-fix-001';
+
+    const stdinData = {
+      agent_type: 'exarchos-fixer',
+      agent_id: 'agent-fixer-456',
+      exit_reason: 'max_turns',
+    };
+
+    // Act
+    const result = await handleSubagentStop(stdinData);
+
+    // Assert
+    expect(result).toHaveProperty('agentId', 'agent-fixer-456');
+    expect(result).toHaveProperty('exitReason', 'max_turns');
+    expect(result).toHaveProperty('featureId', 'fix-feature');
+    expect(result).toHaveProperty('taskId', 'task-fix-001');
+  });
+});

--- a/servers/exarchos-mcp/src/cli-commands/subagent-stop.ts
+++ b/servers/exarchos-mcp/src/cli-commands/subagent-stop.ts
@@ -1,0 +1,74 @@
+import type { CommandResult } from '../cli.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** Expected shape of the SubagentStop stdin JSON. */
+interface SubagentStopInput {
+  agent_type: string;      // e.g., 'exarchos-implementer'
+  agent_id: string;        // Claude Code agent ID
+  exit_reason: string;     // 'complete' | 'error' | 'max_turns'
+}
+
+// ─── Handler ────────────────────────────────────────────────────────────────
+
+/**
+ * Handle the `subagent-stop` CLI command.
+ *
+ * When a Claude Code subagent (exarchos-implementer or exarchos-fixer) stops,
+ * this handler receives the stop event via stdin JSON and returns structured
+ * output with the agent's ID and exit reason for the orchestrator to use
+ * when updating workflow state.
+ *
+ * Non-exarchos agents are ignored gracefully (returns a no-op result).
+ * Context (featureId, taskId) is extracted from environment variables.
+ */
+export async function handleSubagentStop(
+  stdinData: Record<string, unknown>,
+): Promise<CommandResult> {
+  const agentType = stdinData.agent_type;
+
+  // Non-exarchos agents are a no-op — return early
+  if (typeof agentType !== 'string' || !agentType.startsWith('exarchos-')) {
+    return { continue: true };
+  }
+
+  // Validate required fields
+  const agentId = stdinData.agent_id;
+  if (!agentId || typeof agentId !== 'string') {
+    return {
+      error: {
+        code: 'MISSING_AGENT_ID',
+        message: 'agent_id is required for exarchos subagent stop events',
+      },
+    };
+  }
+
+  const exitReason = stdinData.exit_reason;
+  if (!exitReason || typeof exitReason !== 'string') {
+    return {
+      error: {
+        code: 'MISSING_EXIT_REASON',
+        message: 'exit_reason is required for exarchos subagent stop events',
+      },
+    };
+  }
+
+  // Extract context from environment variables
+  const featureId = process.env.EXARCHOS_FEATURE_ID;
+  const taskId = process.env.EXARCHOS_TASK_ID;
+
+  const result: Record<string, unknown> = {
+    agentId,
+    exitReason,
+  };
+
+  if (featureId) {
+    result.featureId = featureId;
+  }
+
+  if (taskId) {
+    result.taskId = taskId;
+  }
+
+  return result;
+}

--- a/servers/exarchos-mcp/src/cli.ts
+++ b/servers/exarchos-mcp/src/cli.ts
@@ -13,6 +13,7 @@ import { handleSessionEnd } from './cli-commands/session-end.js';
 import { handleGuard } from './cli-commands/guard.js';
 import { handleTaskGate, handleTeammateGate } from './cli-commands/gates.js';
 import { handleSubagentContext } from './cli-commands/subagent-context.js';
+import { handleSubagentStop } from './cli-commands/subagent-stop.js';
 import { handleAssembleContext } from './cli-commands/assemble-context.js';
 import { handleEvalRun, resolveEvalsDir } from './cli-commands/eval-run.js';
 import { handleEvalCapture } from './cli-commands/eval-capture.js';
@@ -49,6 +50,7 @@ const KNOWN_COMMANDS = [
   'quality-check',
   'eval-calibrate',
   'session-end',
+  'subagent-stop',
 ] as const;
 
 type KnownCommand = (typeof KNOWN_COMMANDS)[number];
@@ -85,6 +87,7 @@ const commandHandlers: Record<KnownCommand, CommandHandler> = {
     return handleCalibrate(parsed.data, resolveEvalsDir());
   },
   'session-end': async (stdinData) => handleSessionEnd(stdinData, resolveStateDir()),
+  'subagent-stop': handleSubagentStop,
 };
 
 // ─── Stdin Parsing ──────────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/core/dispatch.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.ts
@@ -23,6 +23,7 @@ export interface DispatchContext {
   readonly eventStore: EventStore;
   readonly enableTelemetry: boolean;
   readonly config?: ExarchosConfig;
+  readonly slimRegistration?: boolean;
 }
 
 // ─── Composite Handler Map ──────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/describe/handler.test.ts
+++ b/servers/exarchos-mcp/src/describe/handler.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { handleDescribe } from './handler.js';
+import { TOOL_REGISTRY } from '../registry.js';
+
+const workflowTool = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow')!;
+
+describe('handleDescribe', () => {
+  it('HandleDescribe_ValidAction_ReturnsSchemaAndMetadata', async () => {
+    const result = await handleDescribe({ actions: ['init'] }, workflowTool.actions);
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveProperty('init');
+    const desc = (result.data as Record<string, unknown>)['init'] as Record<string, unknown>;
+    expect(desc).toHaveProperty('description');
+    expect(desc).toHaveProperty('schema');
+    expect(desc).toHaveProperty('phases');
+    expect(desc).toHaveProperty('roles');
+  });
+
+  it('HandleDescribe_MultipleActions_ReturnsAll', async () => {
+    const result = await handleDescribe({ actions: ['init', 'get'] }, workflowTool.actions);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(Object.keys(data)).toHaveLength(2);
+    expect(data).toHaveProperty('init');
+    expect(data).toHaveProperty('get');
+  });
+
+  it('HandleDescribe_UnknownAction_ReturnsErrorWithValidTargets', async () => {
+    const result = await handleDescribe({ actions: ['nonexistent'] }, workflowTool.actions);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('UNKNOWN_ACTION');
+    expect(result.error?.validTargets).toBeDefined();
+    expect(result.error?.validTargets?.length).toBeGreaterThan(0);
+  });
+
+  it('HandleDescribe_GateMetadata_IncludedWhenPresent', async () => {
+    // Use orchestrate tool which has gate metadata on check_* actions
+    // Note: gate metadata may not exist yet (T1 adds it). If action.gate is undefined, expect null.
+    const orchTool = TOOL_REGISTRY.find(t => t.name === 'exarchos_orchestrate')!;
+    const result = await handleDescribe({ actions: ['check_tdd_compliance'] }, orchTool.actions);
+    expect(result.success).toBe(true);
+    const desc = (result.data as Record<string, unknown>)['check_tdd_compliance'] as Record<string, unknown>;
+    // gate field should be present (null if no gate metadata, object if present)
+    expect('gate' in desc).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/describe/handler.ts
+++ b/servers/exarchos-mcp/src/describe/handler.ts
@@ -1,0 +1,39 @@
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import type { ToolAction } from '../registry.js';
+import type { ToolResult } from '../format.js';
+
+/**
+ * Handles the `describe` action for composite tools.
+ * Returns full schemas, descriptions, gate metadata, and phase/role info
+ * for the requested action names.
+ */
+export async function handleDescribe(
+  args: { actions: string[] },
+  toolActions: readonly ToolAction[],
+): Promise<ToolResult> {
+  const results: Record<string, unknown> = {};
+
+  for (const actionName of args.actions) {
+    const action = toolActions.find(a => a.name === actionName);
+    if (!action) {
+      return {
+        success: false,
+        error: {
+          code: 'UNKNOWN_ACTION',
+          message: `Unknown action: ${actionName}`,
+          validTargets: toolActions.map(a => a.name),
+        },
+      };
+    }
+
+    results[actionName] = {
+      description: action.description,
+      schema: zodToJsonSchema(action.schema),
+      gate: (action as ToolAction & { gate?: unknown }).gate ?? null,
+      phases: [...action.phases],
+      roles: [...action.roles],
+    };
+  }
+
+  return { success: true, data: results };
+}

--- a/servers/exarchos-mcp/src/describe/handler.ts
+++ b/servers/exarchos-mcp/src/describe/handler.ts
@@ -11,6 +11,17 @@ export async function handleDescribe(
   args: { actions: string[] },
   toolActions: readonly ToolAction[],
 ): Promise<ToolResult> {
+  if (!Array.isArray(args.actions) || !args.actions.every((a: unknown) => typeof a === 'string')) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'describe requires actions: string[]',
+        expectedShape: { actions: ['action_name_1', 'action_name_2'] },
+      },
+    };
+  }
+
   const results: Record<string, unknown> = {};
 
   for (const actionName of args.actions) {

--- a/servers/exarchos-mcp/src/event-store/composite.test.ts
+++ b/servers/exarchos-mcp/src/event-store/composite.test.ts
@@ -99,7 +99,7 @@ describe('handleEvent', () => {
         success: false,
         error: {
           code: 'UNKNOWN_ACTION',
-          message: 'Unknown action: delete. Valid actions: append, query, batch_append',
+          message: 'Unknown action: delete. Valid actions: append, query, batch_append, describe',
         },
       });
       expect(handleEventAppend).not.toHaveBeenCalled();

--- a/servers/exarchos-mcp/src/event-store/composite.ts
+++ b/servers/exarchos-mcp/src/event-store/composite.ts
@@ -1,8 +1,12 @@
 import type { ToolResult } from '../format.js';
 import { handleEventAppend, handleEventQuery, handleBatchAppend } from './tools.js';
+import { handleDescribe } from '../describe/handler.js';
+import { TOOL_REGISTRY } from '../registry.js';
 
-const VALID_ACTIONS = ['append', 'query', 'batch_append'] as const;
+const VALID_ACTIONS = ['append', 'query', 'batch_append', 'describe'] as const;
 type EventAction = (typeof VALID_ACTIONS)[number];
+
+const eventActions = TOOL_REGISTRY.find(t => t.name === 'exarchos_event')!.actions;
 
 /** Composite handler that routes `action` to the appropriate event-store handler. */
 export async function handleEvent(
@@ -32,6 +36,10 @@ export async function handleEvent(
         rest as Parameters<typeof handleBatchAppend>[0],
         stateDir,
       );
+    }
+    case 'describe': {
+      const { action: _, ...rest } = args;
+      return handleDescribe(rest as { actions: string[] }, eventActions);
     }
     default:
       return {

--- a/servers/exarchos-mcp/src/orchestrate/composite.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.test.ts
@@ -43,6 +43,14 @@ vi.mock('./post-merge.js', () => ({
   handlePostMerge: vi.fn(),
 }));
 
+vi.mock('../agents/handler.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    handleAgentSpec: vi.fn(),
+  };
+});
+
 import { handleTaskClaim, handleTaskComplete, handleTaskFail } from '../tasks/tools.js';
 import { handleReviewTriage } from '../review/tools.js';
 import { handlePrepareDelegation } from './prepare-delegation.js';
@@ -52,6 +60,7 @@ import { handleDesignCompleteness } from './design-completeness.js';
 import { handlePlanCoverage } from './plan-coverage.js';
 import { handleTddCompliance } from './tdd-compliance.js';
 import { handlePostMerge } from './post-merge.js';
+import { handleAgentSpec } from '../agents/handler.js';
 import { handleOrchestrate } from './composite.js';
 
 const STATE_DIR = '/tmp/test-state';
@@ -318,6 +327,35 @@ describe('handleOrchestrate', () => {
       const desc = data['task_claim'] as Record<string, unknown>;
       expect(desc).toHaveProperty('description');
       expect(desc).toHaveProperty('schema');
+    });
+  });
+
+  // ─── Agent Spec Routing ──────────────────────────────────────────────────
+
+  describe('agent spec routing', () => {
+    it('OrchestrateComposite_AgentSpecAction_RoutesToHandler', async () => {
+      // Arrange
+      const expected = successResult({
+        agent: 'implementer',
+        systemPrompt: 'You are a TDD implementer',
+        tools: ['Read', 'Write'],
+      });
+      vi.mocked(handleAgentSpec).mockResolvedValue(expected);
+      const args = {
+        action: 'agent_spec',
+        agent: 'implementer',
+        format: 'full',
+      };
+
+      // Act
+      const result = await handleOrchestrate(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleAgentSpec).toHaveBeenCalledWith(
+        { agent: 'implementer', format: 'full' },
+        STATE_DIR,
+      );
     });
   });
 

--- a/servers/exarchos-mcp/src/orchestrate/composite.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.test.ts
@@ -51,6 +51,10 @@ vi.mock('../agents/handler.js', async (importOriginal) => {
   };
 });
 
+vi.mock('../runbooks/handler.js', () => ({
+  handleRunbook: vi.fn(),
+}));
+
 import { handleTaskClaim, handleTaskComplete, handleTaskFail } from '../tasks/tools.js';
 import { handleReviewTriage } from '../review/tools.js';
 import { handlePrepareDelegation } from './prepare-delegation.js';
@@ -61,6 +65,7 @@ import { handlePlanCoverage } from './plan-coverage.js';
 import { handleTddCompliance } from './tdd-compliance.js';
 import { handlePostMerge } from './post-merge.js';
 import { handleAgentSpec } from '../agents/handler.js';
+import { handleRunbook } from '../runbooks/handler.js';
 import { handleOrchestrate } from './composite.js';
 
 const STATE_DIR = '/tmp/test-state';
@@ -356,6 +361,38 @@ describe('handleOrchestrate', () => {
         { agent: 'implementer', format: 'full' },
         STATE_DIR,
       );
+    });
+  });
+
+  // ─── Runbook Routing ──────────────────────────────────────────────────
+
+  describe('runbook routing', () => {
+    it('HandleOrchestrate_RunbookList_RoutesToHandleRunbook', async () => {
+      // Arrange
+      const expected = successResult([{ id: 'task-completion', phase: 'delegate', description: 'Complete a task', stepCount: 3 }]);
+      vi.mocked(handleRunbook).mockResolvedValue(expected);
+      const args = { action: 'runbook', phase: 'delegate' };
+
+      // Act
+      const result = await handleOrchestrate(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleRunbook).toHaveBeenCalledWith({ phase: 'delegate' });
+    });
+
+    it('HandleOrchestrate_RunbookDetail_RoutesToHandleRunbook', async () => {
+      // Arrange
+      const expected = successResult({ id: 'task-completion', steps: [] });
+      vi.mocked(handleRunbook).mockResolvedValue(expected);
+      const args = { action: 'runbook', id: 'task-completion' };
+
+      // Act
+      const result = await handleOrchestrate(args, STATE_DIR);
+
+      // Assert
+      expect(result).toBe(expected);
+      expect(handleRunbook).toHaveBeenCalledWith({ id: 'task-completion' });
     });
   });
 

--- a/servers/exarchos-mcp/src/orchestrate/composite.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.test.ts
@@ -301,6 +301,26 @@ describe('handleOrchestrate', () => {
     });
   });
 
+  // ─── Describe Routing ────────────────────────────────────────────────
+
+  describe('describe routing', () => {
+    it('HandleOrchestrate_Describe_RoutesToDescribeHandler', async () => {
+      // Arrange — describe is not mocked; it resolves schemas from the live registry
+      const args = { action: 'describe', actions: ['task_claim'] };
+
+      // Act
+      const result = await handleOrchestrate(args, STATE_DIR);
+
+      // Assert — verify describe returns schema metadata for the requested action
+      expect(result.success).toBe(true);
+      const data = result.data as Record<string, unknown>;
+      expect(data).toHaveProperty('task_claim');
+      const desc = data['task_claim'] as Record<string, unknown>;
+      expect(desc).toHaveProperty('description');
+      expect(desc).toHaveProperty('schema');
+    });
+  });
+
   // ─── Error Handling ─────────────────────────────────────────────────────
 
   describe('error handling', () => {

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -37,6 +37,7 @@ import { handleProvenanceChain } from './provenance-chain.js';
 import { handleTaskDecomposition } from './task-decomposition.js';
 import { handleCheckEventEmissions } from './check-event-emissions.js';
 import { handleRunScript } from './run-script.js';
+import { handleAgentSpec } from '../agents/handler.js';
 
 // ─── Action Router ──────────────────────────────────────────────────────────
 
@@ -70,6 +71,7 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   check_task_decomposition: adapt(handleTaskDecomposition),
   check_event_emissions: adapt(handleCheckEventEmissions),
   run_script: adapt(handleRunScript),
+  agent_spec: adapt(handleAgentSpec),
 };
 
 /** Exported for sync test — ensures registry.ts stays in sync with handler keys. */

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -6,6 +6,7 @@
 
 import type { ToolResult } from '../format.js';
 import { handleDescribe } from '../describe/handler.js';
+import { handleRunbook } from '../runbooks/handler.js';
 import { TOOL_REGISTRY } from '../registry.js';
 
 const orchestrateActions = TOOL_REGISTRY.find(t => t.name === 'exarchos_orchestrate')!.actions;
@@ -91,6 +92,11 @@ export async function handleOrchestrate(
   // Handle describe specially — it needs the action list, not stateDir
   if (action === 'describe') {
     return handleDescribe(rest as { actions: string[] }, orchestrateActions);
+  }
+
+  // Handle runbook specially — it doesn't need stateDir
+  if (action === 'runbook') {
+    return handleRunbook(rest as { phase?: string; id?: string });
   }
 
   const handler = typeof action === 'string' ? ACTION_HANDLERS[action] : undefined;

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -105,7 +105,7 @@ export async function handleOrchestrate(
       success: false,
       error: {
         code: 'UNKNOWN_ACTION',
-        message: `Unknown orchestrate action '${String(action)}'. Valid actions: ${Object.keys(ACTION_HANDLERS).join(', ')}, describe`,
+        message: `Unknown orchestrate action '${String(action)}'. Valid actions: ${Object.keys(ACTION_HANDLERS).join(', ')}, describe, runbook`,
       },
     };
   }

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -5,6 +5,10 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import type { ToolResult } from '../format.js';
+import { handleDescribe } from '../describe/handler.js';
+import { TOOL_REGISTRY } from '../registry.js';
+
+const orchestrateActions = TOOL_REGISTRY.find(t => t.name === 'exarchos_orchestrate')!.actions;
 
 // ─── Task Handlers ──────────────────────────────────────────────────────────
 
@@ -82,21 +86,23 @@ export async function handleOrchestrate(
   args: Record<string, unknown>,
   stateDir: string,
 ): Promise<ToolResult> {
-  const action = args.action as string | undefined;
+  const { action, ...rest } = args;
 
-  const handler = action ? ACTION_HANDLERS[action] : undefined;
+  // Handle describe specially — it needs the action list, not stateDir
+  if (action === 'describe') {
+    return handleDescribe(rest as { actions: string[] }, orchestrateActions);
+  }
+
+  const handler = typeof action === 'string' ? ACTION_HANDLERS[action] : undefined;
   if (!handler) {
     return {
       success: false,
       error: {
         code: 'UNKNOWN_ACTION',
-        message: `Unknown orchestrate action '${String(action)}'. Valid actions: ${Object.keys(ACTION_HANDLERS).join(', ')}`,
+        message: `Unknown orchestrate action '${String(action)}'. Valid actions: ${Object.keys(ACTION_HANDLERS).join(', ')}, describe`,
       },
     };
   }
 
-  // Strip the `action` field before forwarding to the underlying handler
-  const { action: _action, ...handlerArgs } = args;
-
-  return handler(handlerArgs as Record<string, unknown>, stateDir);
+  return handler(rest as Record<string, unknown>, stateDir);
 }

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -93,11 +93,39 @@ export async function handleOrchestrate(
 
   // Handle describe specially — it needs the action list, not stateDir
   if (action === 'describe') {
+    if (!Array.isArray(rest.actions) || !rest.actions.every(a => typeof a === 'string')) {
+      return {
+        success: false,
+        error: {
+          code: 'INVALID_INPUT',
+          message: 'describe requires actions: string[]',
+          expectedShape: { actions: ['action_name_1', 'action_name_2'] },
+        },
+      };
+    }
     return handleDescribe(rest as { actions: string[] }, orchestrateActions);
   }
 
   // Handle runbook specially — it doesn't need stateDir
   if (action === 'runbook') {
+    if (rest.phase !== undefined && typeof rest.phase !== 'string') {
+      return {
+        success: false,
+        error: {
+          code: 'INVALID_INPUT',
+          message: 'runbook phase must be a string if provided',
+        },
+      };
+    }
+    if (rest.id !== undefined && typeof rest.id !== 'string') {
+      return {
+        success: false,
+        error: {
+          code: 'INVALID_INPUT',
+          message: 'runbook id must be a string if provided',
+        },
+      };
+    }
     return handleRunbook(rest as { phase?: string; id?: string });
   }
 

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -403,6 +403,107 @@ describe('handlePrepareDelegation', () => {
     expect(data.blockers).toContain('Plan artifact is missing');
   });
 
+  // ─── T-15: nativeIsolation parameter ──────────────────────────────────────
+
+  it('PrepareDelegation_NativeIsolationTrue_SkipsWorktreeBlockers', async () => {
+    // Arrange: worktrees not ready, but nativeIsolation skips those blockers
+    const state = readyWorkflowState();
+    const drState: DelegationReadinessState = {
+      ready: false,
+      blockers: ['no worktrees expected'],
+      plan: { approved: true, taskCount: 2 },
+      quality: { queried: true, gatePassRate: null, regressions: [] },
+      worktrees: { expected: 0, ready: 0, failed: [] },
+    };
+    setupMaterializer(state, undefined, drState);
+    vi.mocked(generateQualityHints).mockReturnValue([]);
+    const args = { featureId: 'test-feature', nativeIsolation: true };
+
+    // Act
+    const result = await handlePrepareDelegation(args, STATE_DIR);
+
+    // Assert — should be ready despite worktree blockers
+    expect(result.success).toBe(true);
+    const data = result.data as { ready: boolean; isolation: string; blockers?: string[] };
+    expect(data.ready).toBe(true);
+    expect(data.isolation).toBe('native');
+  });
+
+  it('PrepareDelegation_NativeIsolationFalse_PreservesWorktreeBlockers', async () => {
+    // Arrange: worktrees not ready, nativeIsolation false (default)
+    const state = readyWorkflowState();
+    const drState: DelegationReadinessState = {
+      ready: false,
+      blockers: ['no worktrees expected'],
+      plan: { approved: true, taskCount: 2 },
+      quality: { queried: true, gatePassRate: null, regressions: [] },
+      worktrees: { expected: 0, ready: 0, failed: [] },
+    };
+    setupMaterializer(state, undefined, drState);
+    const args = { featureId: 'test-feature' };
+
+    // Act
+    const result = await handlePrepareDelegation(args, STATE_DIR);
+
+    // Assert — should NOT be ready because of worktree blockers
+    expect(result.success).toBe(true);
+    const data = result.data as { ready: boolean; blockers?: string[]; isolation?: string };
+    expect(data.ready).toBe(false);
+    expect(data.blockers).toContain('no worktrees expected');
+    expect(data.isolation).toBeUndefined();
+  });
+
+  it('PrepareDelegation_NativeIsolationTrue_StillTracksState', async () => {
+    // Arrange: nativeIsolation but plan not approved — non-worktree blockers still apply
+    const state = notReadyWorkflowState();
+    const drState: DelegationReadinessState = {
+      ready: false,
+      blockers: ['plan not approved', 'no worktrees expected'],
+      plan: { approved: false, taskCount: 0 },
+      quality: { queried: true, gatePassRate: null, regressions: [] },
+      worktrees: { expected: 0, ready: 0, failed: [] },
+    };
+    setupMaterializer(state, undefined, drState);
+    const args = { featureId: 'test-feature', nativeIsolation: true };
+
+    // Act
+    const result = await handlePrepareDelegation(args, STATE_DIR);
+
+    // Assert — still not ready because plan not approved (non-worktree blocker persists)
+    expect(result.success).toBe(true);
+    const data = result.data as { ready: boolean; blockers?: string[]; readiness: DelegationReadinessState };
+    expect(data.ready).toBe(false);
+    expect(data.blockers).toContain('plan not approved');
+    expect(data.readiness).toBeDefined();
+  });
+
+  it('PrepareDelegation_NativeIsolationTrue_StillRunsPreChecks', async () => {
+    // Arrange: nativeIsolation with ready state — quality hints still assembled
+    const state = readyWorkflowState();
+    const drState = readyDelegationReadiness();
+    setupMaterializer(state, undefined, drState);
+    const hints = mockQualityHints();
+    vi.mocked(generateQualityHints).mockReturnValue(
+      hints as ReturnType<typeof generateQualityHints>,
+    );
+    const args = { featureId: 'test-feature', nativeIsolation: true };
+
+    // Act
+    const result = await handlePrepareDelegation(args, STATE_DIR);
+
+    // Assert — quality hints still present
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      ready: boolean;
+      isolation: string;
+      qualityHints: Array<{ category: string; severity: string; hint: string }>;
+    };
+    expect(data.ready).toBe(true);
+    expect(data.isolation).toBe('native');
+    expect(data.qualityHints).toHaveLength(2);
+    expect(generateQualityHints).toHaveBeenCalled();
+  });
+
   it('HandlePrepareDelegation_ReadinessIncludesWorktreeData', async () => {
     // Arrange: ready state with worktree data
     const state = readyWorkflowState();

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -140,6 +140,7 @@ export async function handlePrepareDelegation(
         ready: false,
         readiness: effectiveReadiness,
         blockers: effectiveBlockers,
+        ...(args.nativeIsolation ? { isolation: 'native' as const } : {}),
       };
       return { success: true, data: result };
     }

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -39,6 +39,19 @@ export interface PrepareDelegationResult {
   readonly readiness: DelegationReadinessState;
   readonly blockers?: string[];
   readonly qualityHints?: Array<{ category: string; severity: string; hint: string }>;
+  readonly isolation?: 'native';
+}
+
+// ─── Worktree Blocker Patterns ──────────────────────────────────────────────
+
+const WORKTREE_BLOCKER_PATTERNS = [
+  'worktrees pending',
+  'worktrees failed',
+  'no worktrees expected',
+];
+
+function isWorktreeBlocker(blocker: string): boolean {
+  return WORKTREE_BLOCKER_PATTERNS.some(p => blocker.includes(p));
 }
 
 // ─── Quality Hint Assembly ──────────────────────────────────────────────────
@@ -65,7 +78,7 @@ function assembleQualityHints(
 // ─── Handler ────────────────────────────────────────────────────────────────
 
 export async function handlePrepareDelegation(
-  args: { featureId: string; tasks?: Array<{ id: string; title: string }> },
+  args: { featureId: string; tasks?: Array<{ id: string; title: string }>; nativeIsolation?: boolean },
   stateDir: string,
 ): Promise<ToolResult> {
   // Validate input
@@ -105,8 +118,15 @@ export async function handlePrepareDelegation(
     }
 
     // Merge readiness from view with supplementary checks
-    const effectiveReady = readiness.ready && additionalBlockers.length === 0;
-    const effectiveBlockers = [...readiness.blockers, ...additionalBlockers];
+    const allBlockers = [...readiness.blockers, ...additionalBlockers];
+
+    // When nativeIsolation is true, filter out worktree-related blockers
+    // (Claude Code handles worktree isolation natively via `isolation: "worktree"`)
+    const effectiveBlockers = args.nativeIsolation
+      ? allBlockers.filter(b => !isWorktreeBlocker(b))
+      : allBlockers;
+
+    const effectiveReady = effectiveBlockers.length === 0;
 
     const effectiveReadiness: DelegationReadinessState = {
       ...readiness,
@@ -160,6 +180,7 @@ export async function handlePrepareDelegation(
       ready: true,
       readiness: effectiveReadiness,
       qualityHints,
+      ...(args.nativeIsolation ? { isolation: 'native' as const } : {}),
     };
     return { success: true, data: result };
   } catch (err) {

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import {
   buildCompositeSchema,
   buildRegistrationSchema,
+  buildToolDescription,
   coercedRecord,
   coercedPositiveInt,
   coercedNonnegativeInt,
@@ -829,5 +830,64 @@ describe('Dynamic Tool Registration', () => {
     expect(
       () => registerCustomTool(customTool),
     ).toThrow(/already registered/i);
+  });
+});
+
+// ─── Gate Metadata Tests ──────────────────────────────────────────────────────
+
+describe('Gate Metadata', () => {
+  it('GateMetadata_CheckActions_HaveGateField', () => {
+    const checkActions = [
+      'check_tdd_compliance', 'check_static_analysis', 'check_security_scan',
+      'check_context_economy', 'check_operational_resilience', 'check_workflow_determinism',
+      'check_review_verdict', 'check_convergence', 'check_provenance_chain',
+      'check_design_completeness', 'check_plan_coverage', 'check_task_decomposition',
+      'check_post_merge',
+    ];
+    for (const composite of TOOL_REGISTRY) {
+      for (const action of composite.actions) {
+        if (checkActions.includes(action.name)) {
+          expect(action.gate, `${action.name} should have gate metadata`).toBeDefined();
+          expect(typeof action.gate!.blocking).toBe('boolean');
+        }
+      }
+    }
+  });
+});
+
+// ─── Slim Description Tests ───────────────────────────────────────────────────
+
+describe('Slim Description', () => {
+  it('SlimDescription_AllVisibleTools_HaveSlimDescription', () => {
+    for (const tool of TOOL_REGISTRY) {
+      if (tool.hidden) continue;
+      expect(tool.slimDescription, `${tool.name} should have slimDescription`).toBeDefined();
+      expect(tool.slimDescription!.length).toBeGreaterThan(0);
+      expect(tool.slimDescription!).toContain('describe');  // Must mention describe action
+    }
+  });
+});
+
+// ─── Dual Mode buildToolDescription Tests ─────────────────────────────────────
+
+describe('buildToolDescription dual mode', () => {
+  it('BuildToolDescription_SlimMode_ReturnsSlimDescription', () => {
+    const tool = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow')!;
+    const desc = buildToolDescription(tool, true);
+    expect(desc).toBe(tool.slimDescription);
+  });
+
+  it('BuildToolDescription_FullMode_ReturnsFullDescription', () => {
+    const tool = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow')!;
+    const full = buildToolDescription(tool, false);
+    expect(full).toContain('Actions:');
+    expect(full).toContain('- init(');
+  });
+
+  it('BuildToolDescription_DefaultMode_ReturnsFullDescription', () => {
+    const tool = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow')!;
+    const desc = buildToolDescription(tool);
+    expect(desc).toContain('Actions:');
+    expect(desc).toContain('- init(');
   });
 });

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -278,10 +278,10 @@ describe('TOOL_REGISTRY', () => {
   });
 
   describe('exarchos_orchestrate', () => {
-    it('should have 23 actions for task management, review triage, gate checks, script execution, and composite actions', () => {
+    it('should have 24 actions for task management, review triage, gate checks, script execution, runbooks, and composite actions', () => {
       const composite = findComposite('exarchos_orchestrate');
       expect(composite).toBeDefined();
-      expect(composite!.actions).toHaveLength(23);
+      expect(composite!.actions).toHaveLength(24);
 
       const actionNames = composite!.actions.map((a) => a.name);
       expect(actionNames).toEqual(
@@ -321,7 +321,7 @@ describe('TOOL_REGISTRY', () => {
     const { ACTION_HANDLER_KEYS } = await import('./orchestrate/composite.js');
 
     // Actions that are handled specially in the composite router (not via ACTION_HANDLERS)
-    const SPECIAL_ACTIONS = new Set(['describe']);
+    const SPECIAL_ACTIONS = new Set(['describe', 'runbook']);
 
     for (const handlerKey of ACTION_HANDLER_KEYS) {
       expect(
@@ -912,6 +912,22 @@ describe('findActionInRegistry', () => {
 
   it('FindActionInRegistry_InvalidTool_ReturnsUndefined', () => {
     expect(findActionInRegistry('nonexistent_tool', 'init')).toBeUndefined();
+  });
+});
+
+// ─── Runbook Action Registry Tests ──────────────────────────────────────────
+
+describe('Runbook action in registry', () => {
+  it('RunbookAction_ExistsInOrchestrateRegistry', () => {
+    const orchTool = findComposite('exarchos_orchestrate');
+    expect(orchTool).toBeDefined();
+    const runbookAction = orchTool!.actions.find(a => a.name === 'runbook');
+    expect(runbookAction, 'exarchos_orchestrate should have a runbook action').toBeDefined();
+    expect(runbookAction!.description).toBeTruthy();
+    // Should accept both empty and parameterized input
+    expect(runbookAction!.schema.safeParse({}).success).toBe(true);
+    expect(runbookAction!.schema.safeParse({ phase: 'delegate' }).success).toBe(true);
+    expect(runbookAction!.schema.safeParse({ id: 'task-completion' }).success).toBe(true);
   });
 });
 

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -278,10 +278,10 @@ describe('TOOL_REGISTRY', () => {
   });
 
   describe('exarchos_orchestrate', () => {
-    it('should have 24 actions for task management, review triage, gate checks, script execution, runbooks, and composite actions', () => {
+    it('should have 25 actions for task management, review triage, gate checks, script execution, runbooks, agent spec, and composite actions', () => {
       const composite = findComposite('exarchos_orchestrate');
       expect(composite).toBeDefined();
-      expect(composite!.actions).toHaveLength(24);
+      expect(composite!.actions).toHaveLength(25);
 
       const actionNames = composite!.actions.map((a) => a.name);
       expect(actionNames).toEqual(

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -12,6 +12,7 @@ import {
   unregisterCustomTool,
   getFullRegistry,
   clearCustomTools,
+  findActionInRegistry,
 } from './registry.js';
 import type { ToolAction, CompositeTool } from './registry.js';
 
@@ -268,19 +269,19 @@ describe('TOOL_REGISTRY', () => {
   });
 
   describe('exarchos_workflow', () => {
-    it('should have 6 actions: init, get, set, cancel, cleanup, reconcile', () => {
+    it('should have 7 actions: init, get, set, cancel, cleanup, reconcile, describe', () => {
       const composite = findComposite('exarchos_workflow');
       expect(composite).toBeDefined();
       const actionNames = composite!.actions.map((a) => a.name);
-      expect(actionNames).toEqual(['init', 'get', 'set', 'cancel', 'cleanup', 'reconcile']);
+      expect(actionNames).toEqual(['init', 'get', 'set', 'cancel', 'cleanup', 'reconcile', 'describe']);
     });
   });
 
   describe('exarchos_orchestrate', () => {
-    it('should have 22 actions for task management, review triage, gate checks, script execution, and composite actions', () => {
+    it('should have 23 actions for task management, review triage, gate checks, script execution, and composite actions', () => {
       const composite = findComposite('exarchos_orchestrate');
       expect(composite).toBeDefined();
-      expect(composite!.actions).toHaveLength(22);
+      expect(composite!.actions).toHaveLength(23);
 
       const actionNames = composite!.actions.map((a) => a.name);
       expect(actionNames).toEqual(
@@ -319,6 +320,9 @@ describe('TOOL_REGISTRY', () => {
 
     const { ACTION_HANDLER_KEYS } = await import('./orchestrate/composite.js');
 
+    // Actions that are handled specially in the composite router (not via ACTION_HANDLERS)
+    const SPECIAL_ACTIONS = new Set(['describe']);
+
     for (const handlerKey of ACTION_HANDLER_KEYS) {
       expect(
         registryNames.has(handlerKey),
@@ -326,6 +330,7 @@ describe('TOOL_REGISTRY', () => {
       ).toBe(true);
     }
     for (const registryName of registryNames) {
+      if (SPECIAL_ACTIONS.has(registryName)) continue;
       expect(
         ACTION_HANDLER_KEYS.includes(registryName),
         `Registry action '${registryName}' has no handler in composite.ts`,
@@ -889,5 +894,35 @@ describe('buildToolDescription dual mode', () => {
     const desc = buildToolDescription(tool);
     expect(desc).toContain('Actions:');
     expect(desc).toContain('- init(');
+  });
+});
+
+// ─── findActionInRegistry Tests ──────────────────────────────────────────────
+
+describe('findActionInRegistry', () => {
+  it('FindActionInRegistry_ValidAction_ReturnsAction', () => {
+    const action = findActionInRegistry('exarchos_workflow', 'init');
+    expect(action).toBeDefined();
+    expect(action!.name).toBe('init');
+  });
+
+  it('FindActionInRegistry_InvalidAction_ReturnsUndefined', () => {
+    expect(findActionInRegistry('exarchos_workflow', 'nonexistent')).toBeUndefined();
+  });
+
+  it('FindActionInRegistry_InvalidTool_ReturnsUndefined', () => {
+    expect(findActionInRegistry('nonexistent_tool', 'init')).toBeUndefined();
+  });
+});
+
+// ─── Describe Action Registry Tests ──────────────────────────────────────────
+
+describe('Describe action in registry', () => {
+  it('DescribeAction_AllVisibleTools_HaveDescribeAction', () => {
+    for (const tool of TOOL_REGISTRY) {
+      if (tool.hidden) continue;
+      const describeAction = tool.actions.find(a => a.name === 'describe');
+      expect(describeAction, `${tool.name} should have a describe action`).toBeDefined();
+    }
   });
 });

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -842,20 +842,33 @@ describe('Dynamic Tool Registration', () => {
 
 describe('Gate Metadata', () => {
   it('GateMetadata_CheckActions_HaveGateField', () => {
-    const checkActions = [
+    // check_event_emissions is intentionally excluded — it's an advisory hint action
+    // that returns missing event suggestions, not a gate with blocking/dimension metadata.
+    const expectedCheckActions = new Set([
       'check_tdd_compliance', 'check_static_analysis', 'check_security_scan',
       'check_context_economy', 'check_operational_resilience', 'check_workflow_determinism',
       'check_review_verdict', 'check_convergence', 'check_provenance_chain',
       'check_design_completeness', 'check_plan_coverage', 'check_task_decomposition',
       'check_post_merge',
-    ];
+    ]);
+    const visited = new Set<string>();
+
     for (const composite of TOOL_REGISTRY) {
       for (const action of composite.actions) {
-        if (checkActions.includes(action.name)) {
+        if (expectedCheckActions.has(action.name)) {
+          visited.add(action.name);
           expect(action.gate, `${action.name} should have gate metadata`).toBeDefined();
           expect(typeof action.gate!.blocking).toBe('boolean');
         }
       }
+    }
+
+    // Ensure every expected check action was actually found in the registry
+    for (const expected of expectedCheckActions) {
+      expect(
+        visited.has(expected),
+        `Expected check action '${expected}' was not found in TOOL_REGISTRY`,
+      ).toBe(true);
     }
   });
 });

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -687,6 +687,16 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: ALL_PHASES,
     roles: ROLE_ANY,
   },
+  {
+    name: 'runbook',
+    description: 'List available runbooks or get a resolved runbook with schemas',
+    schema: z.object({
+      phase: z.string().optional(),
+      id: z.string().optional(),
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_ANY,
+  },
   makeDescribeAction(),
 ];
 
@@ -873,7 +883,7 @@ export const TOOL_REGISTRY: readonly CompositeTool[] = [
     description: 'Task coordination — claim, complete, and fail tasks',
     actions: orchestrateActions,
     cli: { alias: 'orch' },
-    slimDescription: 'Task coordination, quality gates, and script execution. Use describe(actions) for schemas.\n\nActions: task_claim, task_complete, task_fail, review_triage, prepare_delegation, prepare_synthesis, assess_stack, check_static_analysis, check_security_scan, check_context_economy, check_operational_resilience, check_workflow_determinism, check_review_verdict, check_convergence, check_provenance_chain, check_design_completeness, check_plan_coverage, check_tdd_compliance, check_post_merge, check_task_decomposition, check_event_emissions, run_script',
+    slimDescription: 'Task coordination, quality gates, and script execution. Use describe(actions) for schemas.\n\nActions: task_claim, task_complete, task_fail, review_triage, prepare_delegation, prepare_synthesis, assess_stack, check_static_analysis, check_security_scan, check_context_economy, check_operational_resilience, check_workflow_determinism, check_review_verdict, check_convergence, check_provenance_chain, check_design_completeness, check_plan_coverage, check_tdd_compliance, check_post_merge, check_task_decomposition, check_event_emissions, run_script, runbook',
   },
   {
     name: 'exarchos_view',

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -63,6 +63,11 @@ export interface CliToolHints {
   readonly group?: string;
 }
 
+export interface GateMetadata {
+  readonly blocking: boolean;
+  readonly dimension?: string;
+}
+
 export interface ToolAction {
   readonly name: string;
   readonly description: string;
@@ -70,6 +75,7 @@ export interface ToolAction {
   readonly phases: ReadonlySet<string>;
   readonly roles: ReadonlySet<string>;
   readonly cli?: CliActionHints;
+  readonly gate?: GateMetadata;
 }
 
 export interface CompositeTool {
@@ -79,6 +85,8 @@ export interface CompositeTool {
   readonly cli?: CliToolHints;
   /** When true, the tool is excluded from MCP registration (not exposed to agents). CLI access is preserved. */
   readonly hidden?: boolean;
+  /** One-line summary for slim MCP registration. Used when slimRegistration is enabled. */
+  readonly slimDescription?: string;
 }
 
 // ─── Schema Generation ──────────────────────────────────────────────────────
@@ -177,7 +185,10 @@ export function buildRegistrationSchema(
  * Builds a tool description that includes action signatures.
  * Appends action names and their parameters to the base description.
  */
-export function buildToolDescription(tool: CompositeTool): string {
+export function buildToolDescription(tool: CompositeTool, slim = false): string {
+  if (slim && tool.slimDescription) {
+    return tool.slimDescription;
+  }
   const actionSigs = tool.actions.map((action) => {
     const fields = Object.entries(action.schema.shape);
     const params = fields.map(([key, zodType]) => {
@@ -485,6 +496,7 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,
+    gate: { blocking: true, dimension: 'D2' },
   },
   {
     name: 'check_security_scan',
@@ -496,6 +508,7 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,
+    gate: { blocking: false, dimension: 'D1' },
   },
   {
     name: 'check_context_economy',
@@ -507,6 +520,7 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,
+    gate: { blocking: false, dimension: 'D3' },
   },
   {
     name: 'check_operational_resilience',
@@ -518,6 +532,7 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,
+    gate: { blocking: false, dimension: 'D4' },
   },
   {
     name: 'check_workflow_determinism',
@@ -529,6 +544,7 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,
+    gate: { blocking: false, dimension: 'D5' },
   },
   {
     name: 'check_review_verdict',
@@ -546,6 +562,7 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,
+    gate: { blocking: true },
   },
   {
     name: 'check_convergence',
@@ -556,6 +573,7 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,
+    gate: { blocking: false },
   },
   {
     name: 'check_provenance_chain',
@@ -567,6 +585,7 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: PLAN_PHASES,
     roles: ROLE_LEAD,
+    gate: { blocking: true, dimension: 'D1' },
   },
   {
     name: 'check_design_completeness',
@@ -578,6 +597,7 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: new Set<string>(['ideate', 'plan']),
     roles: ROLE_LEAD,
+    gate: { blocking: false, dimension: 'D1' },
   },
   {
     name: 'check_plan_coverage',
@@ -589,6 +609,7 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: PLAN_PHASES,
     roles: ROLE_LEAD,
+    gate: { blocking: true, dimension: 'D1' },
   },
   {
     name: 'check_tdd_compliance',
@@ -601,6 +622,7 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: DELEGATE_PHASES,
     roles: ROLE_LEAD,
+    gate: { blocking: true, dimension: 'D1' },
   },
   {
     name: 'check_post_merge',
@@ -612,6 +634,7 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: new Set<string>(['synthesize']),
     roles: ROLE_LEAD,
+    gate: { blocking: false, dimension: 'D4' },
   },
   {
     name: 'check_task_decomposition',
@@ -622,6 +645,7 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: PLAN_PHASES,
     roles: ROLE_LEAD,
+    gate: { blocking: false, dimension: 'D5' },
   },
   {
     name: 'check_event_emissions',
@@ -813,24 +837,28 @@ export const TOOL_REGISTRY: readonly CompositeTool[] = [
     description: 'Workflow lifecycle management — init, read, update, cancel, cleanup, and reconcile workflows',
     actions: workflowActions,
     cli: { alias: 'wf' },
+    slimDescription: 'Workflow lifecycle management. Use describe(actions) for schemas.\n\nActions: init, get, set, cancel, cleanup, reconcile',
   },
   {
     name: 'exarchos_event',
     description: 'Event sourcing — append and query events in streams',
     actions: eventActions,
     cli: { alias: 'ev' },
+    slimDescription: 'Event sourcing — append and query events. Use describe(actions) for schemas.\n\nActions: append, query, batch_append',
   },
   {
     name: 'exarchos_orchestrate',
     description: 'Task coordination — claim, complete, and fail tasks',
     actions: orchestrateActions,
     cli: { alias: 'orch' },
+    slimDescription: 'Task coordination, quality gates, and script execution. Use describe(actions) for schemas.\n\nActions: task_claim, task_complete, task_fail, review_triage, prepare_delegation, prepare_synthesis, assess_stack, check_static_analysis, check_security_scan, check_context_economy, check_operational_resilience, check_workflow_determinism, check_review_verdict, check_convergence, check_provenance_chain, check_design_completeness, check_plan_coverage, check_tdd_compliance, check_post_merge, check_task_decomposition, check_event_emissions, run_script',
   },
   {
     name: 'exarchos_view',
     description: 'CQRS materialized views — pipeline, tasks, workflow status, stack, and telemetry',
     actions: viewActions,
     cli: { alias: 'vw' },
+    slimDescription: 'CQRS materialized views for pipeline, tasks, and telemetry. Use describe(actions) for schemas.\n\nActions: pipeline, tasks, workflow_status, stack_status, stack_place, telemetry, team_performance, delegation_timeline, code_quality, delegation_readiness, synthesis_readiness, shepherd_status, convergence',
   },
   {
     name: 'exarchos_sync',
@@ -838,6 +866,7 @@ export const TOOL_REGISTRY: readonly CompositeTool[] = [
     actions: syncActions,
     cli: { alias: 'sy' },
     hidden: true,
+    slimDescription: 'Remote synchronization. Use describe(actions) for schemas.\n\nActions: now',
   },
 ];
 

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { WorkflowTypeSchema } from './workflow/schemas.js';
+import { agentSpecSchema as agentSpecSchemaForRegistry } from './agents/handler.js';
 
 // ─── Type Coercion Helpers ──────────────────────────────────────────────────
 // LLM tool callers sometimes pass objects as JSON strings and numbers as
@@ -482,6 +483,7 @@ const orchestrateActions: readonly ToolAction[] = [
     schema: z.object({
       featureId: z.string().min(1),
       tasks: z.array(z.object({ id: z.string(), title: z.string() })).optional(),
+      nativeIsolation: z.boolean().default(false).describe('When true, skip worktree-related blockers (Claude Code handles isolation natively via isolation: "worktree")'),
     }),
     phases: DELEGATE_PHASES,
     roles: ROLE_LEAD,
@@ -697,6 +699,13 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: ALL_PHASES,
     roles: ROLE_ANY,
   },
+  {
+    name: 'agent_spec',
+    description: 'Retrieve agent specification for subagent dispatch',
+    schema: agentSpecSchemaForRegistry,
+    phases: ALL_PHASES,
+    roles: ROLE_ANY,
+  },
   makeDescribeAction(),
 ];
 
@@ -883,7 +892,7 @@ export const TOOL_REGISTRY: readonly CompositeTool[] = [
     description: 'Task coordination — claim, complete, and fail tasks',
     actions: orchestrateActions,
     cli: { alias: 'orch' },
-    slimDescription: 'Task coordination, quality gates, and script execution. Use describe(actions) for schemas.\n\nActions: task_claim, task_complete, task_fail, review_triage, prepare_delegation, prepare_synthesis, assess_stack, check_static_analysis, check_security_scan, check_context_economy, check_operational_resilience, check_workflow_determinism, check_review_verdict, check_convergence, check_provenance_chain, check_design_completeness, check_plan_coverage, check_tdd_compliance, check_post_merge, check_task_decomposition, check_event_emissions, run_script, runbook',
+    slimDescription: 'Task coordination, quality gates, and script execution. Use describe(actions) for schemas.\n\nActions: task_claim, task_complete, task_fail, review_triage, prepare_delegation, prepare_synthesis, assess_stack, check_static_analysis, check_security_scan, check_context_economy, check_operational_resilience, check_workflow_determinism, check_review_verdict, check_convergence, check_provenance_chain, check_design_completeness, check_plan_coverage, check_tdd_compliance, check_post_merge, check_task_decomposition, check_event_emissions, run_script, runbook, agent_spec',
   },
   {
     name: 'exarchos_view',

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -270,6 +270,24 @@ const PLAN_PHASES: ReadonlySet<string> = new Set([
 
 const featureIdSchema = z.string().min(1).regex(/^[a-z0-9-]+$/);
 
+// ─── Describe Action ────────────────────────────────────────────────────────
+
+const describeSchema = z.object({
+  actions: z.array(z.string()).min(1).max(10)
+    .describe('Action names to describe. Returns full schema + description for each.'),
+});
+
+/** Creates a shared describe action definition for composite tools. */
+function makeDescribeAction(): ToolAction {
+  return {
+    name: 'describe',
+    description: 'Return full schemas, descriptions, gate metadata, and phase/role info for specific actions',
+    schema: describeSchema,
+    phases: ALL_PHASES,
+    roles: ROLE_ANY,
+  };
+}
+
 // ─── Composite Tool: exarchos_workflow ───────────────────────────────────────
 
 const workflowActions: readonly ToolAction[] = [
@@ -350,6 +368,7 @@ const workflowActions: readonly ToolAction[] = [
     phases: ALL_PHASES,
     roles: ROLE_LEAD,
   },
+  makeDescribeAction(),
 ];
 
 // ─── Composite Tool: exarchos_event ─────────────────────────────────────────
@@ -393,6 +412,7 @@ const eventActions: readonly ToolAction[] = [
     phases: DELEGATE_PHASES,
     roles: ROLE_LEAD,
   },
+  makeDescribeAction(),
 ];
 
 // ─── Composite Tool: exarchos_orchestrate ───────────────────────────────────
@@ -667,6 +687,7 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: ALL_PHASES,
     roles: ROLE_ANY,
   },
+  makeDescribeAction(),
 ];
 
 // ─── Composite Tool: exarchos_view ──────────────────────────────────────────
@@ -815,6 +836,7 @@ const viewActions: readonly ToolAction[] = [
     phases: ALL_PHASES,
     roles: ROLE_ANY,
   },
+  makeDescribeAction(),
 ];
 
 // ─── Composite Tool: exarchos_sync ──────────────────────────────────────────
@@ -973,4 +995,13 @@ export function getFullRegistry(): readonly CompositeTool[] {
 export function clearCustomTools(): void {
   customTools.length = 0;
   customToolHandlers.clear();
+}
+
+/**
+ * Find a specific action within a tool in the full registry (built-in + custom).
+ * Returns undefined if the tool or action is not found.
+ */
+export function findActionInRegistry(toolName: string, actionName: string): ToolAction | undefined {
+  const tool = getFullRegistry().find(t => t.name === toolName);
+  return tool?.actions.find(a => a.name === actionName);
 }

--- a/servers/exarchos-mcp/src/runbooks/definitions.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/definitions.test.ts
@@ -5,6 +5,7 @@ import {
   AGENT_TEAMS_SAGA,
   SYNTHESIS_FLOW,
   SHEPHERD_ITERATION,
+  TASK_FIX,
   ALL_RUNBOOKS,
 } from './definitions.js';
 
@@ -73,7 +74,29 @@ describe('Runbook definitions', () => {
     expect(SHEPHERD_ITERATION.phase).toBe('synthesize');
   });
 
+  it('TaskFixRunbook_HasCorrectPhase_Delegate', () => {
+    expect(TASK_FIX.phase).toBe('delegate');
+  });
+
+  it('TaskFixRunbook_FirstStepIsResumeOrSpawn_NativeTask', () => {
+    expect(TASK_FIX.steps[0].tool).toBe('native:Task');
+    expect(TASK_FIX.steps[0].action).toBe('resume_or_spawn');
+  });
+
+  it('TaskFixRunbook_IncludesGateChain_TddThenStatic', () => {
+    const actions = TASK_FIX.steps.map(s => s.action);
+    const tddIndex = actions.indexOf('check_tdd_compliance');
+    const staticIndex = actions.indexOf('check_static_analysis');
+    expect(tddIndex).toBeGreaterThan(-1);
+    expect(staticIndex).toBeGreaterThan(-1);
+    expect(tddIndex).toBeLessThan(staticIndex);
+  });
+
+  it('TaskFixRunbook_TemplateVarsIncludeAgentId_ForResume', () => {
+    expect(TASK_FIX.templateVars).toContain('agentId');
+  });
+
   it('AllRunbooks_Count', () => {
-    expect(ALL_RUNBOOKS).toHaveLength(5);
+    expect(ALL_RUNBOOKS).toHaveLength(6);
   });
 });

--- a/servers/exarchos-mcp/src/runbooks/definitions.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/definitions.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TASK_COMPLETION,
+  QUALITY_EVALUATION,
+  AGENT_TEAMS_SAGA,
+  SYNTHESIS_FLOW,
+  SHEPHERD_ITERATION,
+  ALL_RUNBOOKS,
+} from './definitions.js';
+
+describe('Runbook definitions', () => {
+  it('AllRunbooks_HaveUniqueIds', () => {
+    const ids = ALL_RUNBOOKS.map(r => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('AllRunbooks_HaveAtLeastOneStep', () => {
+    for (const rb of ALL_RUNBOOKS) {
+      expect(rb.steps.length, `${rb.id} should have steps`).toBeGreaterThan(0);
+    }
+  });
+
+  it('AllRunbooks_HaveNonEmptyTemplateVars', () => {
+    for (const rb of ALL_RUNBOOKS) {
+      expect(rb.templateVars.length, `${rb.id} should have templateVars`).toBeGreaterThan(0);
+    }
+  });
+
+  it('AllRunbooks_StepsHaveValidOnFail', () => {
+    const validValues = new Set(['stop', 'continue', 'retry']);
+    for (const rb of ALL_RUNBOOKS) {
+      for (const step of rb.steps) {
+        expect(validValues.has(step.onFail), `${rb.id} step ${step.action} has invalid onFail: ${step.onFail}`).toBe(true);
+      }
+    }
+  });
+
+  it('TaskCompletion_HasThreeSteps_InCorrectOrder', () => {
+    expect(TASK_COMPLETION.steps).toHaveLength(3);
+    expect(TASK_COMPLETION.steps[0].action).toBe('check_tdd_compliance');
+    expect(TASK_COMPLETION.steps[1].action).toBe('check_static_analysis');
+    expect(TASK_COMPLETION.steps[2].action).toBe('task_complete');
+    expect(TASK_COMPLETION.phase).toBe('delegate');
+  });
+
+  it('QualityEvaluation_HasFourSteps', () => {
+    expect(QUALITY_EVALUATION.steps).toHaveLength(4);
+    expect(QUALITY_EVALUATION.steps[0].action).toBe('check_static_analysis');
+    expect(QUALITY_EVALUATION.steps[3].action).toBe('check_review_verdict');
+    expect(QUALITY_EVALUATION.phase).toBe('review');
+  });
+
+  it('AgentTeamsSaga_HasElevenSteps', () => {
+    expect(AGENT_TEAMS_SAGA.steps).toHaveLength(11);
+    expect(AGENT_TEAMS_SAGA.phase).toBe('delegate');
+    // First step should be event-first: team.spawned
+    expect(AGENT_TEAMS_SAGA.steps[0].tool).toBe('exarchos_event');
+    expect(AGENT_TEAMS_SAGA.steps[0].params?.type).toBe('team.spawned');
+    // Last step should be workflow transition
+    expect(AGENT_TEAMS_SAGA.steps[10].tool).toBe('exarchos_workflow');
+    expect(AGENT_TEAMS_SAGA.steps[10].action).toBe('set');
+  });
+
+  it('SynthesisFlow_HasFourSteps', () => {
+    expect(SYNTHESIS_FLOW.steps).toHaveLength(4);
+    expect(SYNTHESIS_FLOW.steps[0].action).toBe('prepare_synthesis');
+    expect(SYNTHESIS_FLOW.phase).toBe('synthesize');
+  });
+
+  it('ShepherdIteration_HasSixSteps', () => {
+    expect(SHEPHERD_ITERATION.steps).toHaveLength(6);
+    expect(SHEPHERD_ITERATION.steps[0].action).toBe('assess_stack');
+    expect(SHEPHERD_ITERATION.phase).toBe('synthesize');
+  });
+
+  it('AllRunbooks_Count', () => {
+    expect(ALL_RUNBOOKS).toHaveLength(5);
+  });
+});

--- a/servers/exarchos-mcp/src/runbooks/definitions.ts
+++ b/servers/exarchos-mcp/src/runbooks/definitions.ts
@@ -1,0 +1,114 @@
+import type { RunbookDefinition } from './types.js';
+
+export const TASK_COMPLETION: RunbookDefinition = {
+  id: 'task-completion',
+  phase: 'delegate',
+  description: 'Complete a task after execution: run blocking gates, then mark complete.',
+  steps: [
+    { tool: 'exarchos_orchestrate', action: 'check_tdd_compliance', onFail: 'stop' },
+    { tool: 'exarchos_orchestrate', action: 'check_static_analysis', onFail: 'stop' },
+    { tool: 'exarchos_orchestrate', action: 'task_complete', onFail: 'stop' },
+  ],
+  templateVars: ['taskId', 'featureId', 'streamId'],
+  autoEmits: ['gate.executed', 'task.completed'],
+};
+
+export const QUALITY_EVALUATION: RunbookDefinition = {
+  id: 'quality-evaluation',
+  phase: 'review',
+  description: 'Run quality gates and compute review verdict.',
+  steps: [
+    { tool: 'exarchos_orchestrate', action: 'check_static_analysis', onFail: 'stop' },
+    { tool: 'exarchos_orchestrate', action: 'check_security_scan', onFail: 'continue' },
+    { tool: 'exarchos_orchestrate', action: 'check_convergence', onFail: 'continue' },
+    { tool: 'exarchos_orchestrate', action: 'check_review_verdict', onFail: 'stop' },
+  ],
+  templateVars: ['featureId'],
+  autoEmits: ['gate.executed'],
+};
+
+export const AGENT_TEAMS_SAGA: RunbookDefinition = {
+  id: 'agent-teams-saga',
+  phase: 'delegate',
+  description: 'Full delegation saga: create team, plan tasks, dispatch teammates, monitor, disband.',
+  steps: [
+    { tool: 'exarchos_event', action: 'append', onFail: 'stop',
+      params: { type: 'team.spawned' },
+      note: 'Event-first: emit before TeamCreate' },
+    { tool: 'native:TeamCreate', action: 'create', onFail: 'stop' },
+    { tool: 'exarchos_event', action: 'batch_append', onFail: 'stop',
+      params: { type: 'team.task.planned' },
+      note: 'Atomic batch: ALL task events in one call' },
+    { tool: 'native:TaskCreate', action: 'create', onFail: 'stop',
+      note: 'Create N tasks, then wire dependencies' },
+    { tool: 'exarchos_workflow', action: 'set', onFail: 'stop',
+      note: 'Store task correlation — orchestrator is sole writer of workflow.tasks[]' },
+    { tool: 'exarchos_event', action: 'append', onFail: 'stop',
+      params: { type: 'team.teammate.dispatched' },
+      note: 'Emit per teammate. PIVOT POINT: past here, compensation is partial' },
+    { tool: 'native:Task', action: 'spawn', onFail: 'stop',
+      note: 'Spawn N teammates in worktrees' },
+    { tool: 'exarchos_view', action: 'workflow_status', onFail: 'continue',
+      note: 'Monitor: poll every 30-60s (~85 tokens)' },
+    { tool: 'exarchos_event', action: 'append', onFail: 'stop',
+      params: { type: 'team.disbanded' },
+      note: 'Event-first: emit before SendMessage shutdown' },
+    { tool: 'native:SendMessage', action: 'shutdown', onFail: 'continue',
+      note: 'Shutdown N teammates, then TeamDelete' },
+    { tool: 'exarchos_workflow', action: 'set', onFail: 'stop',
+      params: { phase: 'review' },
+      note: 'Auto-emits workflow.transition' },
+  ],
+  templateVars: ['featureId', 'streamId', 'teamId'],
+  autoEmits: ['workflow.transition'],
+};
+
+export const SYNTHESIS_FLOW: RunbookDefinition = {
+  id: 'synthesis-flow',
+  phase: 'synthesize',
+  description: 'Verify readiness, create PR, submit for merge.',
+  steps: [
+    { tool: 'exarchos_orchestrate', action: 'prepare_synthesis', onFail: 'stop' },
+    { tool: 'exarchos_orchestrate', action: 'run_script', onFail: 'stop',
+      params: { script: 'validate-pr-body.sh' } },
+    { tool: 'native:bash', action: 'gh_pr_create', onFail: 'stop',
+      note: 'Create PR via gh CLI' },
+    { tool: 'exarchos_workflow', action: 'set', onFail: 'stop',
+      note: 'Record PR URL in artifacts.prUrl' },
+  ],
+  templateVars: ['featureId'],
+  autoEmits: ['gate.executed'],
+};
+
+export const SHEPHERD_ITERATION: RunbookDefinition = {
+  id: 'shepherd-iteration',
+  phase: 'synthesize',
+  description: 'Assess PR stack health, fix issues, re-push.',
+  steps: [
+    { tool: 'exarchos_orchestrate', action: 'assess_stack', onFail: 'stop',
+      note: 'Returns actionItems[] and recommendation' },
+    { tool: 'exarchos_event', action: 'append', onFail: 'continue',
+      params: { type: 'shepherd.iteration' },
+      note: 'Record iteration for convergence tracking' },
+    { tool: 'exarchos_event', action: 'append', onFail: 'continue',
+      params: { type: 'remediation.attempted' },
+      note: 'Per action item: emit before fix attempt' },
+    { tool: 'native:bash', action: 'fix', onFail: 'continue',
+      note: 'Apply fixes for each action item' },
+    { tool: 'exarchos_event', action: 'append', onFail: 'continue',
+      params: { type: 'remediation.succeeded' },
+      note: 'Per action item: emit after successful fix' },
+    { tool: 'native:bash', action: 'push', onFail: 'stop',
+      note: 'git push to trigger CI re-run' },
+  ],
+  templateVars: ['featureId', 'streamId'],
+  autoEmits: ['ci.status', 'shepherd.started', 'shepherd.approval_requested', 'shepherd.completed'],
+};
+
+export const ALL_RUNBOOKS: readonly RunbookDefinition[] = [
+  TASK_COMPLETION,
+  QUALITY_EVALUATION,
+  AGENT_TEAMS_SAGA,
+  SYNTHESIS_FLOW,
+  SHEPHERD_ITERATION,
+];

--- a/servers/exarchos-mcp/src/runbooks/definitions.ts
+++ b/servers/exarchos-mcp/src/runbooks/definitions.ts
@@ -9,7 +9,7 @@ export const TASK_COMPLETION: RunbookDefinition = {
     { tool: 'exarchos_orchestrate', action: 'check_static_analysis', onFail: 'stop' },
     { tool: 'exarchos_orchestrate', action: 'task_complete', onFail: 'stop' },
   ],
-  templateVars: ['taskId', 'featureId', 'streamId'],
+  templateVars: ['taskId', 'featureId', 'streamId', 'branch'],
   autoEmits: ['gate.executed', 'task.completed'],
 };
 
@@ -23,7 +23,7 @@ export const QUALITY_EVALUATION: RunbookDefinition = {
     { tool: 'exarchos_orchestrate', action: 'check_convergence', onFail: 'continue' },
     { tool: 'exarchos_orchestrate', action: 'check_review_verdict', onFail: 'stop' },
   ],
-  templateVars: ['featureId'],
+  templateVars: ['featureId', 'high', 'medium', 'low'],
   autoEmits: ['gate.executed'],
 };
 
@@ -59,7 +59,7 @@ export const AGENT_TEAMS_SAGA: RunbookDefinition = {
       params: { phase: 'review' },
       note: 'Auto-emits workflow.transition' },
   ],
-  templateVars: ['featureId', 'streamId', 'teamId'],
+  templateVars: ['featureId', 'streamId', 'stream', 'event', 'events', 'teamId'],
   autoEmits: ['workflow.transition'],
 };
 
@@ -101,8 +101,8 @@ export const SHEPHERD_ITERATION: RunbookDefinition = {
     { tool: 'native:bash', action: 'push', onFail: 'stop',
       note: 'git push to trigger CI re-run' },
   ],
-  templateVars: ['featureId', 'streamId'],
-  autoEmits: ['ci.status', 'shepherd.started', 'shepherd.approval_requested', 'shepherd.completed'],
+  templateVars: ['featureId', 'streamId', 'stream', 'event', 'prNumbers'],
+  autoEmits: ['shepherd.started', 'shepherd.approval_requested', 'shepherd.completed'],
 };
 
 export const ALL_RUNBOOKS: readonly RunbookDefinition[] = [

--- a/servers/exarchos-mcp/src/runbooks/definitions.ts
+++ b/servers/exarchos-mcp/src/runbooks/definitions.ts
@@ -47,6 +47,7 @@ export const AGENT_TEAMS_SAGA: RunbookDefinition = {
       params: { type: 'team.teammate.dispatched' },
       note: 'Emit per teammate. PIVOT POINT: past here, compensation is partial' },
     { tool: 'native:Task', action: 'spawn', onFail: 'stop',
+      params: { agent: 'teammate' },
       note: 'Spawn N teammates in worktrees' },
     { tool: 'exarchos_view', action: 'workflow_status', onFail: 'continue',
       note: 'Monitor: poll every 30-60s (~85 tokens)' },
@@ -105,10 +106,30 @@ export const SHEPHERD_ITERATION: RunbookDefinition = {
   autoEmits: ['shepherd.started', 'shepherd.approval_requested', 'shepherd.completed'],
 };
 
+export const TASK_FIX: RunbookDefinition = {
+  id: 'task-fix',
+  phase: 'delegate',
+  description: 'Fix a failed task. Platforms with resume use agent context continuity; others dispatch fixer agent with failure context from event store.',
+  steps: [
+    { tool: 'native:Task', action: 'resume_or_spawn', onFail: 'stop',
+      params: {
+        resumeAgent: 'agentId',
+        fallbackAgent: 'fixer',
+      },
+      note: 'CC: resume agentId with full context. Others: agent_spec("fixer") + fresh dispatch.' },
+    { tool: 'exarchos_orchestrate', action: 'check_tdd_compliance', onFail: 'stop' },
+    { tool: 'exarchos_orchestrate', action: 'check_static_analysis', onFail: 'stop' },
+    { tool: 'exarchos_orchestrate', action: 'task_complete', onFail: 'stop' },
+  ],
+  templateVars: ['taskId', 'featureId', 'streamId', 'branch', 'agentId', 'failureContext'],
+  autoEmits: ['gate.executed', 'task.completed'],
+};
+
 export const ALL_RUNBOOKS: readonly RunbookDefinition[] = [
   TASK_COMPLETION,
   QUALITY_EVALUATION,
   AGENT_TEAMS_SAGA,
   SYNTHESIS_FLOW,
   SHEPHERD_ITERATION,
+  TASK_FIX,
 ];

--- a/servers/exarchos-mcp/src/runbooks/drift.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/drift.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 import { ALL_RUNBOOKS } from './definitions.js';
 import { findActionInRegistry, getFullRegistry } from '../registry.js';
 import { EVENT_EMISSION_REGISTRY } from '../event-store/schemas.js';
@@ -21,10 +22,31 @@ describe('Runbook drift detection', () => {
 
   it('RunbookDrift_TemplateVarsCoverRequiredParams', () => {
     for (const runbook of ALL_RUNBOOKS) {
-      expect(
-        runbook.templateVars.length,
-        `Runbook '${runbook.id}' should have a non-empty templateVars array`,
-      ).toBeGreaterThan(0);
+      for (const step of runbook.steps) {
+        if (step.tool.startsWith('native:')) continue;
+
+        const action = findActionInRegistry(step.tool, step.action);
+        if (!action) continue; // covered by EveryStepReferencesValidRegistryAction
+
+        const jsonSchema = zodToJsonSchema(action.schema) as {
+          required?: string[];
+        };
+        const required = jsonSchema.required ?? [];
+
+        for (const field of required) {
+          // The 'action' field is the discriminator — auto-filled by the composite router
+          if (field === 'action') continue;
+
+          const covered =
+            runbook.templateVars.includes(field) ||
+            (step.params != null && field in step.params);
+          expect(
+            covered,
+            `Runbook '${runbook.id}' missing coverage for required field '${field}' ` +
+            `in ${step.tool}.${step.action} — add to templateVars or step.params`,
+          ).toBe(true);
+        }
+      }
     }
   });
 
@@ -76,6 +98,12 @@ describe('Runbook drift detection', () => {
           validEventNames.has(eventName),
           `Runbook '${runbook.id}' autoEmits '${eventName}' which is not in the EVENT_EMISSION_REGISTRY`,
         ).toBe(true);
+
+        const source = EVENT_EMISSION_REGISTRY[eventName as keyof typeof EVENT_EMISSION_REGISTRY];
+        expect(
+          source,
+          `Runbook '${runbook.id}' autoEmits '${eventName}' but its source is '${source}', expected 'auto'`,
+        ).toBe('auto');
       }
     }
   });

--- a/servers/exarchos-mcp/src/runbooks/drift.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/drift.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { ALL_RUNBOOKS } from './definitions.js';
+import { findActionInRegistry, getFullRegistry } from '../registry.js';
+import { EVENT_EMISSION_REGISTRY } from '../event-store/schemas.js';
+
+describe('Runbook drift detection', () => {
+  it('RunbookDrift_EveryStepReferencesValidRegistryAction', () => {
+    for (const runbook of ALL_RUNBOOKS) {
+      for (const step of runbook.steps) {
+        // Skip native tools — they are Claude Code native tools, not MCP tools
+        if (step.tool.startsWith('native:')) continue;
+
+        const action = findActionInRegistry(step.tool, step.action);
+        expect(
+          action,
+          `Runbook '${runbook.id}' step references ${step.tool}.${step.action} which is not in the registry`,
+        ).toBeDefined();
+      }
+    }
+  });
+
+  it('RunbookDrift_TemplateVarsCoverRequiredParams', () => {
+    for (const runbook of ALL_RUNBOOKS) {
+      expect(
+        runbook.templateVars.length,
+        `Runbook '${runbook.id}' should have a non-empty templateVars array`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('RunbookDrift_EveryBlockingGateAppearsInRunbook', () => {
+    // Plan-phase blocking gates that don't yet have runbooks.
+    // When a plan-phase runbook is added, remove entries from this set to enforce coverage.
+    const KNOWN_UNRUNBOOKED_GATES = new Set([
+      'exarchos_orchestrate.check_provenance_chain',
+      'exarchos_orchestrate.check_plan_coverage',
+    ]);
+
+    // Collect all blocking gate actions from the registry
+    const blockingGateActions: Array<{ tool: string; action: string }> = [];
+    for (const tool of getFullRegistry()) {
+      for (const action of tool.actions) {
+        if (action.gate?.blocking === true) {
+          blockingGateActions.push({ tool: tool.name, action: action.name });
+        }
+      }
+    }
+
+    expect(blockingGateActions.length).toBeGreaterThan(0);
+
+    // Collect all (tool, action) pairs referenced in runbooks
+    const runbookStepPairs = new Set<string>();
+    for (const runbook of ALL_RUNBOOKS) {
+      for (const step of runbook.steps) {
+        runbookStepPairs.add(`${step.tool}.${step.action}`);
+      }
+    }
+
+    for (const gateAction of blockingGateActions) {
+      const key = `${gateAction.tool}.${gateAction.action}`;
+      if (KNOWN_UNRUNBOOKED_GATES.has(key)) continue;
+      expect(
+        runbookStepPairs.has(key),
+        `Blocking gate action '${key}' should appear in at least one runbook`,
+      ).toBe(true);
+    }
+  });
+
+  it('RunbookDrift_AutoEmitsMatchEventEmissionRegistry', () => {
+    // Get all valid event names from the emission registry
+    const validEventNames = new Set(Object.keys(EVENT_EMISSION_REGISTRY));
+
+    for (const runbook of ALL_RUNBOOKS) {
+      for (const eventName of runbook.autoEmits) {
+        expect(
+          validEventNames.has(eventName),
+          `Runbook '${runbook.id}' autoEmits '${eventName}' which is not in the EVENT_EMISSION_REGISTRY`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('RunbookDrift_RunbookIdsAreUnique', () => {
+    const ids = ALL_RUNBOOKS.map(r => r.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+});

--- a/servers/exarchos-mcp/src/runbooks/handler.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/handler.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { handleRunbook } from './handler.js';
+import { ALL_RUNBOOKS } from './definitions.js';
+
+describe('handleRunbook', () => {
+  // ─── List Mode ────────────────────────────────────────────────────────
+
+  it('HandleRunbook_ListMode_NoParams_ReturnsAllRunbooks', async () => {
+    const result = await handleRunbook({});
+    expect(result.success).toBe(true);
+    const data = result.data as Array<{ id: string; phase: string; description: string; stepCount: number }>;
+    expect(data).toHaveLength(ALL_RUNBOOKS.length);
+    for (const entry of data) {
+      expect(entry).toHaveProperty('id');
+      expect(entry).toHaveProperty('phase');
+      expect(entry).toHaveProperty('description');
+      expect(entry).toHaveProperty('stepCount');
+    }
+  });
+
+  it('HandleRunbook_ListMode_WithPhase_FiltersRunbooks', async () => {
+    const result = await handleRunbook({ phase: 'delegate' });
+    expect(result.success).toBe(true);
+    const data = result.data as Array<{ id: string; phase: string }>;
+    expect(data.length).toBeGreaterThan(0);
+    for (const entry of data) {
+      expect(entry.phase).toBe('delegate');
+    }
+    // Should match only delegate-phase runbooks
+    const expected = ALL_RUNBOOKS.filter(r => r.phase === 'delegate');
+    expect(data).toHaveLength(expected.length);
+  });
+
+  it('HandleRunbook_ListMode_UnknownPhase_ReturnsEmptyArray', async () => {
+    const result = await handleRunbook({ phase: 'nonexistent-phase' });
+    expect(result.success).toBe(true);
+    const data = result.data as Array<unknown>;
+    expect(data).toHaveLength(0);
+  });
+
+  // ─── Detail Mode ──────────────────────────────────────────────────────
+
+  it('HandleRunbook_DetailMode_ValidId_ReturnsResolvedSteps', async () => {
+    const result = await handleRunbook({ id: 'task-completion' });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      id: string;
+      phase: string;
+      description: string;
+      steps: Array<{ seq: number; tool: string; action: string }>;
+    };
+    expect(data.id).toBe('task-completion');
+    expect(data.phase).toBe('delegate');
+    expect(data.steps.length).toBeGreaterThan(0);
+    // Verify seq numbers are 1-based
+    for (let i = 0; i < data.steps.length; i++) {
+      expect(data.steps[i].seq).toBe(i + 1);
+    }
+  });
+
+  it('HandleRunbook_DetailMode_ResolvesSchemaFromRegistry', async () => {
+    const result = await handleRunbook({ id: 'task-completion' });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      steps: Array<{ seq: number; tool: string; action: string; schema: unknown }>;
+    };
+    // task-completion uses exarchos_orchestrate actions — schema should be resolved
+    const orchSteps = data.steps.filter(s => s.tool === 'exarchos_orchestrate');
+    expect(orchSteps.length).toBeGreaterThan(0);
+    for (const step of orchSteps) {
+      expect(step.schema).not.toBeNull();
+      expect(typeof step.schema).toBe('object');
+    }
+  });
+
+  it('HandleRunbook_DetailMode_ResolvesGateFromRegistry', async () => {
+    // task-completion has check_tdd_compliance which has gate: { blocking: true, dimension: 'D1' }
+    const result = await handleRunbook({ id: 'task-completion' });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      steps: Array<{ action: string; gate: { blocking: boolean; dimension?: string } | null }>;
+    };
+    const tddStep = data.steps.find(s => s.action === 'check_tdd_compliance');
+    expect(tddStep).toBeDefined();
+    expect(tddStep!.gate).not.toBeNull();
+    expect(tddStep!.gate!.blocking).toBe(true);
+    expect(tddStep!.gate!.dimension).toBe('D1');
+  });
+
+  it('HandleRunbook_DetailMode_SkipsSchemaForNativeTools', async () => {
+    // agent-teams-saga has native: tools
+    const result = await handleRunbook({ id: 'agent-teams-saga' });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      steps: Array<{ tool: string; schema: unknown }>;
+    };
+    const nativeSteps = data.steps.filter(s => s.tool.startsWith('native:'));
+    expect(nativeSteps.length).toBeGreaterThan(0);
+    for (const step of nativeSteps) {
+      expect(step.schema).toBeNull();
+    }
+  });
+
+  it('HandleRunbook_DetailMode_UnknownId_ReturnsErrorWithValidTargets', async () => {
+    const result = await handleRunbook({ id: 'nonexistent-runbook' });
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('UNKNOWN_RUNBOOK');
+    expect(result.error?.validTargets).toBeDefined();
+    const targets = result.error!.validTargets as string[];
+    expect(targets.length).toBe(ALL_RUNBOOKS.length);
+    for (const rb of ALL_RUNBOOKS) {
+      expect(targets).toContain(rb.id);
+    }
+  });
+
+  it('HandleRunbook_DetailMode_IncludesTemplateVarsAndAutoEmits', async () => {
+    const result = await handleRunbook({ id: 'task-completion' });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      templateVars: readonly string[];
+      autoEmits: readonly string[];
+    };
+    expect(Array.isArray(data.templateVars)).toBe(true);
+    expect(data.templateVars.length).toBeGreaterThan(0);
+    expect(Array.isArray(data.autoEmits)).toBe(true);
+    expect(data.autoEmits.length).toBeGreaterThan(0);
+  });
+});

--- a/servers/exarchos-mcp/src/runbooks/handler.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/handler.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { handleRunbook } from './handler.js';
 import { ALL_RUNBOOKS } from './definitions.js';
+import type { ResolvedRunbookStep } from './types.js';
 
 describe('handleRunbook', () => {
   // ─── List Mode ────────────────────────────────────────────────────────
@@ -124,5 +125,58 @@ describe('handleRunbook', () => {
     expect(data.templateVars.length).toBeGreaterThan(0);
     expect(Array.isArray(data.autoEmits)).toBe(true);
     expect(data.autoEmits.length).toBeGreaterThan(0);
+  });
+
+  // ─── Platform Hint ────────────────────────────────────────────────────
+
+  it('RunbookResolve_NativeTaskWithAgent_IncludesPlatformHint', async () => {
+    // agent-teams-saga has a native:Task step with params.agent = 'teammate'
+    const result = await handleRunbook({ id: 'agent-teams-saga' });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      steps: Array<ResolvedRunbookStep & {
+        platformHint?: { claudeCode: string; generic: string };
+      }>;
+    };
+    const nativeTaskWithAgent = data.steps.find(
+      s => s.tool === 'native:Task' && (s.params as Record<string, unknown>)?.agent,
+    );
+    expect(nativeTaskWithAgent).toBeDefined();
+    expect(nativeTaskWithAgent!.platformHint).toBeDefined();
+    expect(nativeTaskWithAgent!.platformHint!.claudeCode).toBe(
+      'Uses native agent definition exarchos-teammate',
+    );
+    expect(nativeTaskWithAgent!.platformHint!.generic).toBe(
+      'Call agent_spec("teammate") to get system prompt and tool restrictions',
+    );
+  });
+
+  it('RunbookResolve_NativeTaskWithoutAgent_NoPlatformHint', async () => {
+    // task-fix has a native:Task step without params.agent (has resumeAgent/fallbackAgent instead)
+    const result = await handleRunbook({ id: 'task-fix' });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      steps: Array<ResolvedRunbookStep & {
+        platformHint?: { claudeCode: string; generic: string };
+      }>;
+    };
+    const nativeTaskStep = data.steps.find(s => s.tool === 'native:Task');
+    expect(nativeTaskStep).toBeDefined();
+    expect(nativeTaskStep!.platformHint).toBeUndefined();
+  });
+
+  it('RunbookResolve_McpStep_NoPlatformHint', async () => {
+    // task-completion has only exarchos_orchestrate steps (non-native MCP steps)
+    const result = await handleRunbook({ id: 'task-completion' });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      steps: Array<ResolvedRunbookStep & {
+        platformHint?: { claudeCode: string; generic: string };
+      }>;
+    };
+    for (const step of data.steps) {
+      expect(step.tool.startsWith('native:')).toBe(false);
+      expect(step.platformHint).toBeUndefined();
+    }
   });
 });

--- a/servers/exarchos-mcp/src/runbooks/handler.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/handler.test.ts
@@ -152,7 +152,9 @@ describe('handleRunbook', () => {
   });
 
   it('RunbookResolve_NativeTaskWithoutAgent_NoPlatformHint', async () => {
-    // task-fix has a native:Task step without params.agent (has resumeAgent/fallbackAgent instead)
+    // task-fix uses resumeAgent/fallbackAgent (not params.agent) because
+    // platformHint only applies when a single agent spec is referenced.
+    // Resume/fallback is a runtime decision — the platform picks which agent to use.
     const result = await handleRunbook({ id: 'task-fix' });
     expect(result.success).toBe(true);
     const data = result.data as {

--- a/servers/exarchos-mcp/src/runbooks/handler.ts
+++ b/servers/exarchos-mcp/src/runbooks/handler.ts
@@ -71,6 +71,10 @@ export async function handleRunbook(args: RunbookArgs): Promise<ToolResult> {
       }
     }
 
+    const agentName = isNative
+      ? (step.params as Record<string, unknown> | undefined)?.agent
+      : undefined;
+
     return {
       seq: index + 1,
       tool: step.tool,
@@ -81,6 +85,14 @@ export async function handleRunbook(args: RunbookArgs): Promise<ToolResult> {
       schema,
       description,
       gate,
+      ...(typeof agentName === 'string'
+        ? {
+            platformHint: {
+              claudeCode: `Uses native agent definition exarchos-${agentName}`,
+              generic: `Call agent_spec("${agentName}") to get system prompt and tool restrictions`,
+            },
+          }
+        : {}),
     };
   });
 

--- a/servers/exarchos-mcp/src/runbooks/handler.ts
+++ b/servers/exarchos-mcp/src/runbooks/handler.ts
@@ -55,7 +55,9 @@ export async function handleRunbook(args: RunbookArgs): Promise<ToolResult> {
     };
   }
 
-  const resolvedSteps: ResolvedRunbookStep[] = runbook.steps.map((step, index) => {
+  const resolvedSteps: ResolvedRunbookStep[] = [];
+  for (let index = 0; index < runbook.steps.length; index++) {
+    const step = runbook.steps[index];
     const isNative = step.tool.startsWith('native:');
 
     let schema: unknown = null;
@@ -68,6 +70,14 @@ export async function handleRunbook(args: RunbookArgs): Promise<ToolResult> {
         schema = zodToJsonSchema(action.schema);
         description = action.description;
         gate = action.gate ?? null;
+      } else {
+        return {
+          success: false,
+          error: {
+            code: 'UNRESOLVED_STEP',
+            message: `Step ${index + 1} references unregistered action '${step.action}' on tool '${step.tool}' in runbook '${runbook.id}'`,
+          },
+        };
       }
     }
 
@@ -75,7 +85,7 @@ export async function handleRunbook(args: RunbookArgs): Promise<ToolResult> {
       ? (step.params as Record<string, unknown> | undefined)?.agent
       : undefined;
 
-    return {
+    resolvedSteps.push({
       seq: index + 1,
       tool: step.tool,
       action: step.action,
@@ -93,8 +103,8 @@ export async function handleRunbook(args: RunbookArgs): Promise<ToolResult> {
             },
           }
         : {}),
-    };
-  });
+    });
+  }
 
   return {
     success: true,

--- a/servers/exarchos-mcp/src/runbooks/handler.ts
+++ b/servers/exarchos-mcp/src/runbooks/handler.ts
@@ -1,0 +1,98 @@
+// ─── Runbook Handler ─────────────────────────────────────────────────────────
+//
+// Two modes:
+// - List mode (no `id`): returns summary of all runbooks, optionally filtered by phase.
+// - Detail mode (`id` provided): returns the full resolved runbook with schemas
+//   resolved from the registry at serve-time.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import type { ToolResult } from '../format.js';
+import { findActionInRegistry } from '../registry.js';
+import { ALL_RUNBOOKS } from './definitions.js';
+import type { ResolvedRunbookStep } from './types.js';
+
+interface RunbookArgs {
+  readonly phase?: string;
+  readonly id?: string;
+}
+
+/**
+ * Handles the `runbook` action on exarchos_orchestrate.
+ *
+ * List mode: returns `{ id, phase, description, stepCount }` for each runbook.
+ * Detail mode: returns a fully resolved runbook with schemas from the registry.
+ */
+export async function handleRunbook(args: RunbookArgs): Promise<ToolResult> {
+  // ─── List mode ────────────────────────────────────────────────────────
+  if (!args.id) {
+    let runbooks = ALL_RUNBOOKS;
+    if (args.phase) {
+      runbooks = runbooks.filter(r => r.phase === args.phase);
+    }
+
+    return {
+      success: true,
+      data: runbooks.map(r => ({
+        id: r.id,
+        phase: r.phase,
+        description: r.description,
+        stepCount: r.steps.length,
+      })),
+    };
+  }
+
+  // ─── Detail mode ──────────────────────────────────────────────────────
+  const runbook = ALL_RUNBOOKS.find(r => r.id === args.id);
+  if (!runbook) {
+    return {
+      success: false,
+      error: {
+        code: 'UNKNOWN_RUNBOOK',
+        message: `Unknown runbook id: '${args.id}'`,
+        validTargets: ALL_RUNBOOKS.map(r => r.id),
+      },
+    };
+  }
+
+  const resolvedSteps: ResolvedRunbookStep[] = runbook.steps.map((step, index) => {
+    const isNative = step.tool.startsWith('native:');
+
+    let schema: unknown = null;
+    let description: string | undefined;
+    let gate: { readonly blocking: boolean; readonly dimension?: string } | null = null;
+
+    if (!isNative) {
+      const action = findActionInRegistry(step.tool, step.action);
+      if (action) {
+        schema = zodToJsonSchema(action.schema);
+        description = action.description;
+        gate = action.gate ?? null;
+      }
+    }
+
+    return {
+      seq: index + 1,
+      tool: step.tool,
+      action: step.action,
+      onFail: step.onFail,
+      ...(step.params !== undefined ? { params: step.params } : {}),
+      ...(step.note !== undefined ? { note: step.note } : {}),
+      schema,
+      description,
+      gate,
+    };
+  });
+
+  return {
+    success: true,
+    data: {
+      id: runbook.id,
+      phase: runbook.phase,
+      description: runbook.description,
+      templateVars: runbook.templateVars,
+      autoEmits: runbook.autoEmits,
+      steps: resolvedSteps,
+    },
+  };
+}

--- a/servers/exarchos-mcp/src/runbooks/skill-coverage.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/skill-coverage.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const skillsDir = resolve(__dirname, '../../../../skills');
+
+function readSkillFile(relativePath: string): string {
+  const fullPath = resolve(skillsDir, relativePath);
+  return readFileSync(fullPath, 'utf-8');
+}
+
+function assertRunbookReference(content: string, runbookId: string): void {
+  // Check that the content references the runbook ID in a context that
+  // makes it clear it's a runbook reference (action: "runbook" with the id,
+  // or similar patterns)
+  const hasRunbookAction = content.includes('action: "runbook"') && content.includes(`"${runbookId}"`);
+  const hasRunbookIdField = content.includes(`id: "${runbookId}"`);
+  expect(
+    hasRunbookAction || hasRunbookIdField,
+    `Expected reference to runbook "${runbookId}" (e.g., action: "runbook", id: "${runbookId}")`,
+  ).toBe(true);
+}
+
+describe('Skill coverage — runbook references', () => {
+  it('SkillCoverage_DelegationSkill_ReferencesTaskCompletionRunbook', () => {
+    const content = readSkillFile('delegation/SKILL.md');
+    assertRunbookReference(content, 'task-completion');
+  });
+
+  it('SkillCoverage_DelegationSkill_ReferencesAgentTeamsSagaRunbook', () => {
+    const content = readSkillFile('delegation/references/agent-teams-saga.md');
+    assertRunbookReference(content, 'agent-teams-saga');
+  });
+
+  it('SkillCoverage_QualityReviewSkill_ReferencesQualityEvaluationRunbook', () => {
+    const content = readSkillFile('quality-review/SKILL.md');
+    assertRunbookReference(content, 'quality-evaluation');
+  });
+
+  it('SkillCoverage_SynthesisSkill_ReferencesSynthesisFlowRunbook', () => {
+    const content = readSkillFile('synthesis/SKILL.md');
+    assertRunbookReference(content, 'synthesis-flow');
+  });
+
+  it('SkillCoverage_ShepherdSkill_ReferencesShepherdIterationRunbook', () => {
+    const content = readSkillFile('shepherd/SKILL.md');
+    assertRunbookReference(content, 'shepherd-iteration');
+  });
+});

--- a/servers/exarchos-mcp/src/runbooks/types.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/types.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import type { RunbookStep, RunbookDefinition, ResolvedRunbookStep } from './types.js';
+
+describe('Runbook types', () => {
+  it('RunbookStep_ValidStep_Compiles', () => {
+    const step: RunbookStep = {
+      tool: 'exarchos_orchestrate',
+      action: 'check_tdd_compliance',
+      onFail: 'stop',
+    };
+    expect(step.tool).toBe('exarchos_orchestrate');
+    expect(step.onFail).toBe('stop');
+  });
+
+  it('RunbookStep_WithOptionalFields_Compiles', () => {
+    const step: RunbookStep = {
+      tool: 'exarchos_event',
+      action: 'append',
+      onFail: 'continue',
+      params: { type: 'team.spawned' },
+      note: 'Event-first: emit before TeamCreate',
+    };
+    expect(step.params).toEqual({ type: 'team.spawned' });
+    expect(step.note).toBeDefined();
+  });
+
+  it('RunbookDefinition_ValidDefinition_Compiles', () => {
+    const def: RunbookDefinition = {
+      id: 'test-runbook',
+      phase: 'delegate',
+      description: 'A test runbook',
+      steps: [
+        { tool: 'exarchos_orchestrate', action: 'task_complete', onFail: 'stop' },
+      ],
+      templateVars: ['taskId'],
+      autoEmits: ['task.completed'],
+    };
+    expect(def.id).toBe('test-runbook');
+    expect(def.steps).toHaveLength(1);
+  });
+
+  it('ResolvedRunbookStep_HasSeqAndSchema', () => {
+    const resolved: ResolvedRunbookStep = {
+      seq: 1,
+      tool: 'exarchos_orchestrate',
+      action: 'check_tdd_compliance',
+      onFail: 'stop',
+      schema: { type: 'object', properties: {} },
+      description: 'TDD compliance check',
+      gate: { blocking: true, dimension: 'D1' },
+    };
+    expect(resolved.seq).toBe(1);
+    expect(resolved.gate?.blocking).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/runbooks/types.ts
+++ b/servers/exarchos-mcp/src/runbooks/types.ts
@@ -1,0 +1,57 @@
+/**
+ * A single step in a runbook sequence.
+ * Tools prefixed with 'native:' (e.g., 'native:Task') represent Claude Code
+ * native tools — their schemas are not resolved from the MCP registry.
+ */
+export interface RunbookStep {
+  /** Tool name (e.g., 'exarchos_orchestrate') or 'native:Task' for native tools */
+  readonly tool: string;
+  /** Action name within the tool */
+  readonly action: string;
+  /** Behavior on failure: 'stop' halts the sequence, 'continue' proceeds, 'retry' retries once */
+  readonly onFail: 'stop' | 'continue' | 'retry';
+  /** Static params to pre-fill (agent fills the rest from templateVars) */
+  readonly params?: Readonly<Record<string, unknown>>;
+  /** Human-readable note for this step */
+  readonly note?: string;
+}
+
+/**
+ * A runbook defines an ordered sequence of tool calls for a workflow operation.
+ * Runbooks reference actions by name — schemas are resolved from the registry
+ * at serve-time, preventing schema drift.
+ */
+export interface RunbookDefinition {
+  /** Unique identifier (e.g., 'task-completion') */
+  readonly id: string;
+  /** Workflow phase this runbook applies to */
+  readonly phase: string;
+  /** Human-readable description */
+  readonly description: string;
+  /** Ordered steps */
+  readonly steps: readonly RunbookStep[];
+  /** Variables the agent must supply (resolved from context) */
+  readonly templateVars: readonly string[];
+  /** Events auto-emitted by the steps (agent should NOT manually emit these) */
+  readonly autoEmits: readonly string[];
+}
+
+/**
+ * A runbook step with resolved schema and metadata from the registry.
+ * This is what the agent receives when requesting a runbook in detail mode.
+ */
+export interface ResolvedRunbookStep {
+  /** Step sequence number (1-based) */
+  readonly seq: number;
+  readonly tool: string;
+  readonly action: string;
+  readonly onFail: 'stop' | 'continue' | 'retry';
+  readonly params?: Readonly<Record<string, unknown>>;
+  readonly note?: string;
+  /** JSON Schema resolved from registry (null for native: tools) */
+  readonly schema?: unknown;
+  /** Action description from registry */
+  readonly description?: string;
+  /** Gate metadata from registry (null if not a gate action) */
+  readonly gate?: { readonly blocking: boolean; readonly dimension?: string } | null;
+}

--- a/servers/exarchos-mcp/src/runbooks/types.ts
+++ b/servers/exarchos-mcp/src/runbooks/types.ts
@@ -54,4 +54,6 @@ export interface ResolvedRunbookStep {
   readonly description?: string;
   /** Gate metadata from registry (null if not a gate action) */
   readonly gate?: { readonly blocking: boolean; readonly dimension?: string } | null;
+  /** Platform-specific hints for native steps that reference agent specs */
+  readonly platformHint?: { readonly claudeCode: string; readonly generic: string };
 }

--- a/servers/exarchos-mcp/src/views/composite.ts
+++ b/servers/exarchos-mcp/src/views/composite.ts
@@ -4,6 +4,8 @@
 // individual MCP tools with a single `exarchos_view` entry point.
 
 import type { ToolResult } from '../format.js';
+import { handleDescribe } from '../describe/handler.js';
+import { TOOL_REGISTRY } from '../registry.js';
 import {
   handleViewPipeline,
   handleViewTasks,
@@ -25,6 +27,8 @@ import {
 } from './tools.js';
 import { handleStackStatus, handleStackPlace } from '../stack/tools.js';
 import { handleViewTelemetry } from '../telemetry/tools.js';
+
+const viewActions = TOOL_REGISTRY.find(t => t.name === 'exarchos_view')!.actions;
 
 /**
  * Composite handler that dispatches to existing view/stack handlers
@@ -187,6 +191,9 @@ export async function handleView(
         rest as { workflowId?: string },
         stateDir,
       );
+
+    case 'describe':
+      return handleDescribe(rest as { actions: string[] }, viewActions);
 
     default:
       return {

--- a/servers/exarchos-mcp/src/views/composite.ts
+++ b/servers/exarchos-mcp/src/views/composite.ts
@@ -222,6 +222,7 @@ export async function handleView(
             'provenance',
             'ideate_readiness',
             'convergence',
+            'describe',
           ] as const,
         },
       };

--- a/servers/exarchos-mcp/src/workflow/composite.ts
+++ b/servers/exarchos-mcp/src/workflow/composite.ts
@@ -1,7 +1,11 @@
 import { handleInit, handleGet, handleSet, handleReconcileState } from './tools.js';
 import { handleCancel } from './cancel.js';
 import { handleCleanup } from './cleanup.js';
+import { handleDescribe } from '../describe/handler.js';
+import { TOOL_REGISTRY } from '../registry.js';
 import type { ToolResult } from '../format.js';
+
+const workflowActions = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow')!.actions;
 
 /**
  * Composite handler that routes `action` to the appropriate workflow handler.
@@ -26,12 +30,14 @@ export async function handleWorkflow(
       return handleCleanup(rest as Parameters<typeof handleCleanup>[0], stateDir);
     case 'reconcile':
       return handleReconcileState(rest as Parameters<typeof handleReconcileState>[0], stateDir);
+    case 'describe':
+      return handleDescribe(rest as { actions: string[] }, workflowActions);
     default:
       return {
         success: false,
         error: {
           code: 'UNKNOWN_ACTION',
-          message: `Unknown action: ${String(action)}. Valid actions: init, get, set, cancel, cleanup, reconcile`,
+          message: `Unknown action: ${String(action)}. Valid actions: init, get, set, cancel, cleanup, reconcile, describe`,
         },
       };
   }

--- a/servers/exarchos-mcp/src/workflow/schemas.test.ts
+++ b/servers/exarchos-mcp/src/workflow/schemas.test.ts
@@ -300,6 +300,71 @@ describe('WorkflowStateSchema _esVersion field', () => {
   });
 });
 
+// ─── TaskSchema Agent Tracking Fields ─────────────────────────────────────
+
+describe('TaskSchema agent tracking fields', () => {
+  it('TaskSchema_AgentId_AcceptsOptionalString', async () => {
+    const { TaskSchema } = await import('./schemas.js');
+    const input = {
+      id: 'task-010',
+      title: 'Extend state schema',
+      status: 'in_progress',
+      agentId: 'agent-abc-123',
+    };
+    const result = TaskSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.agentId).toBe('agent-abc-123');
+    }
+  });
+
+  it('TaskSchema_AgentResumed_AcceptsOptionalBoolean', async () => {
+    const { TaskSchema } = await import('./schemas.js');
+    const input = {
+      id: 'task-010',
+      title: 'Extend state schema',
+      status: 'in_progress',
+      agentResumed: true,
+    };
+    const result = TaskSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.agentResumed).toBe(true);
+    }
+  });
+
+  it('TaskSchema_LastExitReason_AcceptsOptionalString', async () => {
+    const { TaskSchema } = await import('./schemas.js');
+    const input = {
+      id: 'task-010',
+      title: 'Extend state schema',
+      status: 'complete',
+      lastExitReason: 'subtask_completed',
+    };
+    const result = TaskSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.lastExitReason).toBe('subtask_completed');
+    }
+  });
+
+  it('TaskSchema_BackwardCompatible_AcceptsWithoutNewFields', async () => {
+    const { TaskSchema } = await import('./schemas.js');
+    const input = {
+      id: 'task-010',
+      title: 'Extend state schema',
+      status: 'pending',
+    };
+    const result = TaskSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.agentId).toBeUndefined();
+      expect(result.data.agentResumed).toBeUndefined();
+      expect(result.data.lastExitReason).toBeUndefined();
+    }
+  });
+});
+
 // T3: WorkflowState integration validation
 describe('WorkflowState integration', () => {
   it('WorkflowState_TasksWithTestingStrategy_Parses', async () => {

--- a/servers/exarchos-mcp/src/workflow/schemas.ts
+++ b/servers/exarchos-mcp/src/workflow/schemas.ts
@@ -149,6 +149,12 @@ export const TaskSchema = z.object({
   blockedBy: z.array(z.string()).default([]),
   worktreePath: z.string().optional(),
   testingStrategy: TestingStrategySchema.optional(),
+  /** Claude Code agent ID for resume capability */
+  agentId: z.string().optional(),
+  /** Whether the fixer used resume vs fresh dispatch */
+  agentResumed: z.boolean().optional(),
+  /** Completion status from SubagentStop hook */
+  lastExitReason: z.string().optional(),
 });
 
 // ─── Worktree Schema ────────────────────────────────────────────────────────

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -41,7 +41,7 @@ Rationalization patterns that violate this principle are catalogued in `referenc
 
 **Auto-detection:** tmux + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` present means `agent-team`. Otherwise `subagent`. Override with `/exarchos:delegate --mode subagent|agent-team`.
 
-**CRITICAL:** Always specify `model: "opus"` for coding tasks.
+**CRITICAL:** Always specify `model: "opus"` for coding tasks (when not using native agent definitions).
 
 ---
 
@@ -87,6 +87,17 @@ Build subagent prompts using `references/implementer-prompt.md` as the template.
 
 ### Prompt Construction
 
+**When using native agent definitions (preferred):**
+
+The `exarchos-implementer` agent spec already includes the system prompt, model, isolation, skills, hooks, and memory. The dispatch prompt should contain ONLY task-specific context:
+1. Full task description (requirements, acceptance criteria)
+2. Working directory (worktree path from Step 1)
+3. File paths to create/modify and test file paths
+4. Quality hints (if any)
+5. PBT flag when `propertyTests: true`
+
+**When using legacy prompt template (fallback):**
+
 For each task:
 1. Fill the implementer prompt template with task-specific details
 2. Set the `Working Directory` to the worktree path from Step 1
@@ -96,7 +107,22 @@ For each task:
 
 ### Parallel Dispatch
 
-Dispatch all independent tasks in a **single message** with multiple `Task` calls:
+Dispatch all independent tasks in a **single message** with multiple `Task` calls.
+
+**Native Agent Dispatch (preferred):**
+
+```typescript
+Task({
+  subagent_type: "exarchos-implementer",
+  run_in_background: true,
+  description: "Implement task-001: [title]",
+  prompt: `Task-specific context only: requirements, file paths, acceptance criteria`
+})
+```
+
+> **Note:** The agent's system prompt, model, isolation, skills, hooks, and memory are defined by the agent specification in `servers/exarchos-mcp/src/agents/definitions.ts`. The dispatch prompt provides ONLY task-specific context.
+
+**Legacy Dispatch (fallback for non-native platforms):**
 
 ```typescript
 Task({
@@ -213,10 +239,34 @@ This is advisory — findings are recorded for the convergence view but do not b
 When a task fails:
 1. Read the failure output from `TaskOutput`
 2. Diagnose root cause — do NOT trust the implementer's self-assessment (see R3 adversarial posture)
-3. Re-dispatch with a fixer prompt (`references/fixer-prompt.md`) in the **same worktree**
-4. The fixer agent gets fresh context with the failure details embedded
+3. Fix the task using the resume-aware fixer flow below
+4. Run the `task-fix` runbook gate chain after the fix completes
 
 For the full recovery flow with a concrete example, see `references/worked-example.md`.
+
+### Fix Failed Tasks
+
+If a task fails and `agentId` is available in workflow state:
+
+**Resume (preferred — preserves full implementer context):**
+```
+Task({
+  resume: "[agentId from workflow state]",
+  prompt: "Your implementation failed. [failure context from test output]. Apply adversarial verification: do NOT trust your previous self-assessment, re-read actual test output, identify root cause not symptoms."
+})
+```
+
+**Fresh dispatch (fallback — when agentId unavailable or platform doesn't support resume):**
+```
+Task({
+  subagent_type: "exarchos-fixer",
+  run_in_background: true,
+  prompt: "[Full failure context + original task context]"
+})
+```
+
+After fix completes, run the `task-fix` runbook gate chain:
+`exarchos_orchestrate({ action: "runbook", id: "task-fix" })`
 
 ---
 

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -164,36 +164,7 @@ After each subagent reports completion:
 
 2. **Verify worktree state** — confirm each worktree has clean `git status` and passing tests
 
-3. **TDD compliance gate (MANDATORY)** — MUST invoke the compliance check BEFORE marking the task as complete:
-
-```typescript
-exarchos_orchestrate({
-  action: "check_tdd_compliance",
-  featureId: "<featureId>",
-  taskId: "<taskId>",
-  branch: "<task-branch>"
-})
-```
-
-Gate on the result:
-- If `result.success !== true`: Treat as gate-execution failure. Keep task in-progress, surface the tool error, and do NOT mark the task as complete.
-- If `result.data.passed === true`: Task passes TDD compliance. Proceed to static analysis check.
-- If `result.data.passed === false`: Keep task in-progress. Report TDD compliance findings to the user and include violations in the task failure diagnostics. Do NOT mark the task as complete.
-
-4. **Static analysis gate (D2, blocking)** — after TDD compliance passes, run a D2 check on the task branch:
-
-```typescript
-exarchos_orchestrate({
-  action: "check_static_analysis",
-  featureId: "<featureId>",
-  taskId: "<taskId>",
-  repoRoot: "<worktree-path>"
-})
-```
-
-This check is **blocking** — `handleTaskComplete` enforces that a passing `static-analysis` gate event exists for the task (same pattern as TDD compliance). If `passed: false`, keep task in-progress and report findings.
-
-All handlers auto-emit `gate.executed` events, so manual `exarchos_event` calls are not needed.
+3. **Run blocking gates** — the `task-completion` runbook (referenced above) defines the exact gate sequence (TDD compliance, static analysis, then task_complete). On any gate failure, keep the task in-progress and report findings. All gate handlers auto-emit `gate.executed` events, so manual `exarchos_event` calls are not needed.
 
 5. **Pass provenance in task completion** — when marking a task complete, pass the extracted provenance fields in the `result` parameter so they flow into the `task.completed` event:
 
@@ -249,7 +220,7 @@ For the full recovery flow with a concrete example, see `references/worked-examp
 If a task fails and `agentId` is available in workflow state:
 
 **Resume (preferred — preserves full implementer context):**
-```
+```typescript
 Task({
   resume: "[agentId from workflow state]",
   prompt: "Your implementation failed. [failure context from test output]. Apply adversarial verification: do NOT trust your previous self-assessment, re-read actual test output, identify root cause not symptoms."
@@ -257,7 +228,7 @@ Task({
 ```
 
 **Fresh dispatch (fallback — when agentId unavailable or platform doesn't support resume):**
-```
+```typescript
 Task({
   subagent_type: "exarchos-fixer",
   run_in_background: true,

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -130,6 +130,10 @@ TaskOutput({ task_id: "<id>", block: true })
 
 After each subagent reports completion:
 
+> **Runbook:** For each completed task, execute the task-completion runbook:
+> `exarchos_orchestrate({ action: "runbook", id: "task-completion" })`
+> Execute the returned steps in order. Stop on gate failure.
+
 1. **Extract provenance from subagent report** — parse the subagent's completion output and extract structured provenance fields (`implements`, `tests`, `files`). These fields are reported by the subagent following the Provenance Reporting section of the implementer prompt.
 
 2. **Verify worktree state** — confirm each worktree has clean `git status` and passing tests

--- a/skills/delegation/references/agent-teams-saga.md
+++ b/skills/delegation/references/agent-teams-saga.md
@@ -1,5 +1,8 @@
 # Agent Teams Delegation Saga
 
+> **Machine-readable version:** `exarchos_orchestrate({ action: "runbook", id: "agent-teams-saga" })`
+> The runbook below is the authoritative sequence. The prose description provides human-readable context.
+
 Event-first delegation saga for Agent Teams mode. Every coordination action is preceded by an Exarchos event emission. The event stream is the authoritative record; native API calls are side effects.
 
 **Architectural principle:** Events record intent. Native API calls execute effects.

--- a/skills/delegation/references/fix-mode.md
+++ b/skills/delegation/references/fix-mode.md
@@ -37,11 +37,21 @@ Or auto-invoked after review failures.
    - Include full issue context
    - Specify target worktree
 
-4. **Dispatch fixers** (same as implementers, different prompt):
+4. **Dispatch fixers** — prefer resume when `agentId` is available, otherwise fresh dispatch:
+
+   **Resume (preferred):**
    ```typescript
    Task({
-     subagent_type: "general-purpose",
-     model: "opus",
+     resume: "[agentId from workflow state]",
+     prompt: "Your implementation failed. [failure context]. Apply adversarial verification."
+   })
+   ```
+
+   **Fresh dispatch (fallback):**
+   ```typescript
+   Task({
+     subagent_type: "exarchos-fixer",
+     run_in_background: true,
      description: "Fix: [issue summary]",
      prompt: "[fixer-prompt template with issue details]"
    })
@@ -52,6 +62,35 @@ Or auto-invoked after review failures.
    ```typescript
    Skill({ skill: "exarchos:review", args: "<state-file>" })
    ```
+
+## Resume-First Strategy
+
+When fixing failed tasks, prefer resuming the original agent over dispatching a fresh fixer. Resume preserves the implementer's full context (file reads, reasoning, partial progress), making fixes faster and more accurate.
+
+### agentId Tracking
+
+The `agentId` is captured from the `Task()` completion output and stored in workflow task state. The `SubagentStop` hook (`hooks/hooks.json`) automatically captures `agentId` when `exarchos-implementer` or `exarchos-fixer` agents complete.
+
+Check workflow state for `agentId`:
+```
+exarchos_workflow get with fields: ["tasks"]
+→ tasks[id=<taskId>].agentId
+```
+
+### Decision Flow
+
+1. **agentId available?** → Resume with failure context (preferred)
+2. **agentId unavailable?** → Fresh dispatch with `exarchos-fixer` agent type
+3. **Resume fails or platform doesn't support it?** → Fall back to fresh dispatch
+
+### Gate Chain After Fix
+
+After any fix (resume or fresh dispatch), run the `task-fix` runbook:
+```
+exarchos_orchestrate({ action: "runbook", id: "task-fix" })
+```
+
+This executes the gate chain: re-run tests → TDD compliance check → static analysis → mark task complete if all pass.
 
 ## Fix Task Structure
 

--- a/skills/delegation/references/fix-mode.md
+++ b/skills/delegation/references/fix-mode.md
@@ -72,7 +72,7 @@ When fixing failed tasks, prefer resuming the original agent over dispatching a 
 The `agentId` is captured from the `Task()` completion output and stored in workflow task state. The `SubagentStop` hook (`hooks/hooks.json`) automatically captures `agentId` when `exarchos-implementer` or `exarchos-fixer` agents complete.
 
 Check workflow state for `agentId`:
-```
+```text
 exarchos_workflow get with fields: ["tasks"]
 → tasks[id=<taskId>].agentId
 ```
@@ -86,7 +86,7 @@ exarchos_workflow get with fields: ["tasks"]
 ### Gate Chain After Fix
 
 After any fix (resume or fresh dispatch), run the `task-fix` runbook:
-```
+```typescript
 exarchos_orchestrate({ action: "runbook", id: "task-fix" })
 ```
 

--- a/skills/delegation/references/implementer-prompt.md
+++ b/skills/delegation/references/implementer-prompt.md
@@ -1,5 +1,7 @@
 # Implementer Prompt Template
 
+**Note:** When using Claude Code with native agent definitions, this template is compiled into `servers/exarchos-mcp/src/agents/definitions.ts` (IMPLEMENTER spec). The native agent file `agents/exarchos-implementer.md` is generated from the registry at build time. This reference document is maintained for non-Claude-Code platforms and as the canonical prompt evolution record.
+
 Use this template when dispatching tasks via the Task tool.
 
 ## Quality Hints Integration

--- a/skills/delegation/references/state-management.md
+++ b/skills/delegation/references/state-management.md
@@ -49,3 +49,36 @@ action: "set", featureId: "<id>", updates: {
 ```
 
 The `/exarchos:synthesize` skill reads `verification.hasBenchmarks` and applies the `has-benchmarks` label via `gh pr edit <number> --add-label has-benchmarks`.
+
+## Agent ID Tracking
+
+Workflow task state includes additional fields for resume-aware fixer flow:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agentId` | string | Claude Code agent ID for resume. Captured from `Task()` completion output. |
+| `agentResumed` | boolean | Whether this agent was resumed (vs. fresh dispatch). |
+| `lastExitReason` | string | Completion status (e.g., `"success"`, `"failure"`, `"timeout"`). |
+
+The `SubagentStop` hook (`hooks/hooks.json`) automatically captures `agentId` when `exarchos-implementer` or `exarchos-fixer` agents complete. This enables the resume-first strategy in the fixer flow: when a task fails, the orchestrator can resume the original agent with failure context rather than dispatching a fresh fixer.
+
+**State update on agent completion:**
+```
+action: "set", featureId: "<id>", updates: {
+  "tasks[id=<taskId>]": {
+    "agentId": "<claude-code-agent-id>",
+    "agentResumed": false,
+    "lastExitReason": "success|failure"
+  }
+}
+```
+
+**State update on resume:**
+```
+action: "set", featureId: "<id>", updates: {
+  "tasks[id=<taskId>]": {
+    "agentResumed": true,
+    "status": "in_progress"
+  }
+}
+```

--- a/skills/delegation/references/state-management.md
+++ b/skills/delegation/references/state-management.md
@@ -56,19 +56,19 @@ Workflow task state includes additional fields for resume-aware fixer flow:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `agentId` | string | Claude Code agent ID for resume. Captured from `Task()` completion output. |
+| `agentId` | string | Claude Code agent ID for resume. Canonical source: `SubagentStop` hook payload. |
 | `agentResumed` | boolean | Whether this agent was resumed (vs. fresh dispatch). |
-| `lastExitReason` | string | Completion status (e.g., `"success"`, `"failure"`, `"timeout"`). |
+| `lastExitReason` | string | Completion status (e.g., `"success"`, `"failure"`, `"timeout"`). Canonical source: `SubagentStop` hook payload. |
 
-The `SubagentStop` hook (`hooks/hooks.json`) automatically captures `agentId` when `exarchos-implementer` or `exarchos-fixer` agents complete. This enables the resume-first strategy in the fixer flow: when a task fails, the orchestrator can resume the original agent with failure context rather than dispatching a fresh fixer.
+The `SubagentStop` hook (`hooks/hooks.json`) is the **canonical source** for `agentId` and `lastExitReason`. When the hook fires for `exarchos-implementer` or `exarchos-fixer` agents, the orchestrator persists the hook payload fields into `tasks[id=taskId]`. This enables the resume-first strategy in the fixer flow: when a task fails, the orchestrator can resume the original agent with failure context rather than dispatching a fresh fixer.
 
-**State update on agent completion:**
-```
+**State update on SubagentStop hook:**
+```text
 action: "set", featureId: "<id>", updates: {
   "tasks[id=<taskId>]": {
-    "agentId": "<claude-code-agent-id>",
+    "agentId": "<from SubagentStop hook payload: agent_id>",
     "agentResumed": false,
-    "lastExitReason": "success|failure"
+    "lastExitReason": "<from SubagentStop hook payload: exit_reason>"
   }
 }
 ```

--- a/skills/delegation/references/state-management.md
+++ b/skills/delegation/references/state-management.md
@@ -74,7 +74,7 @@ action: "set", featureId: "<id>", updates: {
 ```
 
 **State update on resume:**
-```
+```text
 action: "set", featureId: "<id>", updates: {
   "tasks[id=<taskId>]": {
     "agentResumed": true,

--- a/skills/delegation/references/worktree-enforcement.md
+++ b/skills/delegation/references/worktree-enforcement.md
@@ -53,6 +53,15 @@ Include in ALL implementer prompts:
 2. **Worktree verification block** (from implementer-prompt.md template)
 3. **Abort instructions** if not in worktree
 
+## Native Worktree Isolation
+
+When the `exarchos-implementer` agent definition includes `isolation: worktree` in its frontmatter, Claude Code handles worktree creation natively. The `prepare_delegation` action accepts `nativeIsolation: true` to skip manual worktree creation while preserving quality pre-checks. The worktree verification in the agent system prompt remains as defense-in-depth.
+
+When using native isolation:
+- Claude Code creates and manages the worktree lifecycle
+- The `prepare_delegation` action skips `setup-worktree.sh` but still validates state, checks quality signals, and detects benchmarks
+- The worktree verification block in the implementer prompt acts as a safety net — if native isolation fails silently, the agent self-aborts rather than modifying the main project root
+
 ## Anti-Patterns
 
 | Don't | Do Instead |

--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -136,6 +136,9 @@ exarchos_orchestrate({
 
 ### Step 1: Static Analysis + Security + Extended Gates
 
+> **Runbook:** Run quality evaluation gates via runbook:
+> `exarchos_orchestrate({ action: "runbook", id: "quality-evaluation" })`
+
 Run automated gates via orchestrate actions. See `references/gate-execution.md` for orchestrate action signatures and response handling.
 
 1. `check_static_analysis` — lint, typecheck, quality-check (D2). **Must pass** before continuing.

--- a/skills/shepherd/SKILL.md
+++ b/skills/shepherd/SKILL.md
@@ -36,6 +36,9 @@ Activate when:
 
 ## Process
 
+> **Runbook:** Each shepherd iteration follows the shepherd-iteration runbook:
+> `exarchos_orchestrate({ action: "runbook", id: "shepherd-iteration" })`
+
 The shepherd loop repeats until all PRs are healthy or escalation criteria are met. Default: 5 iterations.
 
 ### Step 0 — Surface Quality Signals

--- a/skills/synthesis/SKILL.md
+++ b/skills/synthesis/SKILL.md
@@ -31,6 +31,9 @@ Activate this skill when:
 
 ## Process
 
+> **Runbook:** Follow the synthesis-flow runbook:
+> `exarchos_orchestrate({ action: "runbook", id: "synthesis-flow" })`
+
 ### Step 1: Verify Readiness
 
 Call the `prepare_synthesis` composite action to validate all preconditions in a single operation:

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -1114,7 +1114,8 @@ describe('hooks.json', () => {
     expect(eventTypes).toContain('TaskCompleted');
     expect(eventTypes).toContain('TeammateIdle');
     expect(eventTypes).toContain('SubagentStart');
-    expect(eventTypes).toHaveLength(7);
+    expect(eventTypes).toContain('SubagentStop');
+    expect(eventTypes).toHaveLength(8);
   });
 
   it('hooksJson_AllCommandsReferencePluginRoot', () => {

--- a/src/operations/hooks-config.test.ts
+++ b/src/operations/hooks-config.test.ts
@@ -25,6 +25,19 @@ describe('hooks.json configuration', () => {
     expect(sessionStart.matcher).toContain('resume');
   });
 
+  it('hooksJson_SubagentStop_DefinedForExarchosAgents', () => {
+    const hooks = (hooksConfig as { hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ type: string; command: string }> }>> }).hooks;
+    expect(hooks.SubagentStop).toBeDefined();
+    expect(hooks.SubagentStop).toHaveLength(1);
+
+    const entry = hooks.SubagentStop[0];
+    expect(entry.matcher).toContain('exarchos-implementer');
+    expect(entry.matcher).toContain('exarchos-fixer');
+    expect(entry.hooks).toHaveLength(1);
+    expect(entry.hooks[0].type).toBe('command');
+    expect(entry.hooks[0].command).toContain('subagent-stop');
+  });
+
   it('reloadCommand_Exists_InCommandsDirectory', async () => {
     const reloadPath = path.resolve(__dirname, '../../commands/reload.md');
     const content = await fs.readFile(reloadPath, 'utf-8');


### PR DESCRIPTION
## Summary

- Add slim registration mode reducing MCP tool description payload from ~3,045 to ~500 tokens
- Add `describe` action on all 4 visible composite tools for on-demand schema loading
- Add gate metadata (blocking/advisory + dimension) to all 13 check_* actions
- Implement runbook protocol: 5 machine-readable orchestration sequences replacing prose skill instructions
- Add `runbook` action on `exarchos_orchestrate` with list/detail modes and runtime schema resolution
- Add 5 anti-drift bidirectional sync tests ensuring runbooks stay in sync with registry
- Update delegation, quality-review, synthesis, and shepherd skills with runbook references

## Design

`docs/designs/2026-03-08-lazy-schema-runbook-protocol.md`

## Test plan

- [x] 3,612 tests pass (`npm run test:run`)
- [x] TypeScript typecheck clean (`npm run typecheck`)
- [x] Anti-drift tests validate runbook-registry sync
- [x] Skill-coverage tests verify runbook references in all orchestration skills
- [x] Stage 1 spec review: PASS
- [x] Stage 2 quality review: PASS

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)