### PR TITLE
feat(mcp): extend describe for event schemas, add mcpServers scoping, fix model inheritance

### DIFF
--- a/.exarchos/pr-template.md
+++ b/.exarchos/pr-template.md
@@ -10,3 +10,9 @@
 ## Test Plan
 
 <!-- 1-2 sentences: Testing approach and coverage summary -->
+
+---
+
+**Results:** Tests X ✓ · Build 0 errors
+**Design:** <!-- link to design doc if applicable -->
+**Related:** <!-- #issue, Continues #PR -->

--- a/servers/exarchos-mcp/src/agents/agents.test.ts
+++ b/servers/exarchos-mcp/src/agents/agents.test.ts
@@ -87,6 +87,7 @@ describe('Agent Spec Definitions', () => {
     expect(IMPLEMENTER.systemPrompt).toContain('{{taskDescription}}');
     expect(IMPLEMENTER.systemPrompt).toContain('{{requirements}}');
     expect(IMPLEMENTER.systemPrompt).toContain('{{filePaths}}');
+    expect(IMPLEMENTER.mcpServers).toEqual(['exarchos']);
     expect(IMPLEMENTER.description).toBeTruthy();
   });
 
@@ -99,6 +100,7 @@ describe('Agent Spec Definitions', () => {
     expect(FIXER.tools).toContain('Write');
     expect(FIXER.tools).toContain('Edit');
     expect(FIXER.tools).toContain('Bash');
+    expect(FIXER.mcpServers).toEqual(['exarchos']);
   });
 
   it('ReviewerSpec_HasReadOnlyTools_NoWriteEdit', () => {
@@ -116,6 +118,7 @@ describe('Agent Spec Definitions', () => {
     expect(REVIEWER.disallowedTools).toContain('Agent');
     expect(REVIEWER.systemPrompt).toContain('{{reviewScope}}');
     expect(REVIEWER.systemPrompt).toContain('{{designRequirements}}');
+    expect(REVIEWER.mcpServers).toEqual(['exarchos']);
   });
 
   it('AllSpecs_HaveUniqueIds_NoDuplicates', () => {

--- a/servers/exarchos-mcp/src/agents/agents.test.ts
+++ b/servers/exarchos-mcp/src/agents/agents.test.ts
@@ -19,7 +19,7 @@ describe('AgentSpec Types', () => {
       systemPrompt: 'You are an implementer',
       tools: ['Read', 'Write', 'Edit'],
       disallowedTools: ['Agent'],
-      model: 'opus',
+      model: 'inherit',
       isolation: 'worktree',
       skills: [skill],
       validationRules: [rule, ruleNoCommand],
@@ -34,7 +34,7 @@ describe('AgentSpec Types', () => {
     expect(spec.systemPrompt).toBe('You are an implementer');
     expect(spec.tools).toEqual(['Read', 'Write', 'Edit']);
     expect(spec.disallowedTools).toEqual(['Agent']);
-    expect(spec.model).toBe('opus');
+    expect(spec.model).toBe('inherit');
     expect(spec.isolation).toBe('worktree');
     expect(spec.skills).toHaveLength(1);
     expect(spec.skills[0].name).toBe('test-skill');
@@ -68,7 +68,7 @@ describe('AgentSpec Types', () => {
 describe('Agent Spec Definitions', () => {
   it('ImplementerSpec_HasRequiredFields_Complete', () => {
     expect(IMPLEMENTER.id).toBe('implementer');
-    expect(IMPLEMENTER.model).toBe('opus');
+    expect(IMPLEMENTER.model).toBe('inherit');
     expect(IMPLEMENTER.isolation).toBe('worktree');
     expect(IMPLEMENTER.resumable).toBe(true);
     expect(IMPLEMENTER.memoryScope).toBe('project');
@@ -93,7 +93,7 @@ describe('Agent Spec Definitions', () => {
   it('FixerSpec_IsNotResumable_ReturnsTrue', () => {
     expect(FIXER.id).toBe('fixer');
     expect(FIXER.resumable).toBe(false);
-    expect(FIXER.model).toBe('opus');
+    expect(FIXER.model).toBe('inherit');
     expect(FIXER.systemPrompt).toContain('{{failureContext}}');
     expect(FIXER.tools).toContain('Read');
     expect(FIXER.tools).toContain('Write');
@@ -103,7 +103,7 @@ describe('Agent Spec Definitions', () => {
 
   it('ReviewerSpec_HasReadOnlyTools_NoWriteEdit', () => {
     expect(REVIEWER.id).toBe('reviewer');
-    expect(REVIEWER.model).toBe('opus');
+    expect(REVIEWER.model).toBe('inherit');
     expect(REVIEWER.resumable).toBe(false);
     expect(REVIEWER.tools).toContain('Read');
     expect(REVIEWER.tools).toContain('Grep');

--- a/servers/exarchos-mcp/src/agents/definitions.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.ts
@@ -62,7 +62,7 @@ When done, output a JSON completion report:
 \`\`\``,
   tools: ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob'],
   disallowedTools: ['Agent'],
-  model: 'opus',
+  model: 'inherit',
   isolation: 'worktree',
   skills: [
     { name: 'tdd-patterns', content: '' },
@@ -74,6 +74,7 @@ When done, output a JSON completion report:
   ],
   resumable: true,
   memoryScope: 'project',
+  mcpServers: ['exarchos'],
 };
 
 // ─── Fixer ──────────────────────────────────────────────────────────────────
@@ -128,7 +129,7 @@ When done, output a JSON completion report:
 \`\`\``,
   tools: ['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob'],
   disallowedTools: ['Agent'],
-  model: 'opus',
+  model: 'inherit',
   skills: [
     { name: 'tdd-patterns', content: '' },
   ],
@@ -136,6 +137,7 @@ When done, output a JSON completion report:
     { trigger: 'post-test', rule: 'All tests must pass after fix', command: 'npm run test:run' },
   ],
   resumable: false,
+  mcpServers: ['exarchos'],
 };
 
 // ─── Reviewer ───────────────────────────────────────────────────────────────
@@ -186,10 +188,11 @@ When done, output a JSON completion report:
 \`\`\``,
   tools: ['Read', 'Grep', 'Glob', 'Bash'],
   disallowedTools: ['Write', 'Edit', 'Agent'],
-  model: 'opus',
+  model: 'inherit',
   skills: [],
   validationRules: [],
   resumable: false,
+  mcpServers: ['exarchos'],
 };
 
 // ─── All Specs ──────────────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/agents/generate-cc-agents.test.ts
+++ b/servers/exarchos-mcp/src/agents/generate-cc-agents.test.ts
@@ -47,7 +47,7 @@ describe('GenerateAgentMarkdown', () => {
     // Assert: required frontmatter fields
     expect(fm.name).toBe('exarchos-implementer');
     expect(fm.tools).toBe('["Read", "Write", "Edit", "Bash", "Grep", "Glob"]');
-    expect(fm.model).toBe('opus');
+    expect(fm.model).toBe('inherit');
     expect(fm.color).toBe('blue');
     expect(fm.isolation).toBe('worktree');
     expect(fm.memory).toBe('project');
@@ -56,8 +56,10 @@ describe('GenerateAgentMarkdown', () => {
     expect(md).toContain('description: |');
     expect(md).toContain('<example>');
 
+    // mcpServers should appear in frontmatter
+    expect(md).toContain('mcpServers: ["exarchos"]');
+
     // maxTurns should be absent since IMPLEMENTER doesn't define it
-    // but the field should appear if the spec defines it
 
     // Body should be the system prompt
     const body = getBody(md);

--- a/servers/exarchos-mcp/src/agents/generate-cc-agents.ts
+++ b/servers/exarchos-mcp/src/agents/generate-cc-agents.ts
@@ -131,8 +131,13 @@ export function generateAgentMarkdown(spec: AgentSpec): string {
   }
 
   // Optional: mcpServers (allowlist of MCP server names)
-  if (spec.mcpServers && spec.mcpServers.length > 0) {
-    frontmatter += `mcpServers: [${spec.mcpServers.map(s => `"${s}"`).join(', ')}]\n`;
+  // Distinguish undefined (inherit all) from empty array (deny all)
+  if (spec.mcpServers !== undefined) {
+    if (spec.mcpServers.length > 0) {
+      frontmatter += `mcpServers: [${spec.mcpServers.map(s => `"${s}"`).join(', ')}]\n`;
+    } else {
+      frontmatter += `mcpServers: []\n`;
+    }
   }
 
   // Optional: skills (array format)

--- a/servers/exarchos-mcp/src/agents/generate-cc-agents.ts
+++ b/servers/exarchos-mcp/src/agents/generate-cc-agents.ts
@@ -130,6 +130,11 @@ export function generateAgentMarkdown(spec: AgentSpec): string {
     frontmatter += `maxTurns: ${spec.maxTurns}\n`;
   }
 
+  // Optional: mcpServers (allowlist of MCP server names)
+  if (spec.mcpServers && spec.mcpServers.length > 0) {
+    frontmatter += `mcpServers: [${spec.mcpServers.map(s => `"${s}"`).join(', ')}]\n`;
+  }
+
   // Optional: skills (array format)
   if (spec.skills.length > 0) {
     frontmatter += 'skills:\n';

--- a/servers/exarchos-mcp/src/agents/handler.test.ts
+++ b/servers/exarchos-mcp/src/agents/handler.test.ts
@@ -18,7 +18,8 @@ describe('handleAgentSpec', () => {
     expect(data.systemPrompt).toBeDefined();
     expect(data.tools).toContain('Read');
     expect(data.tools).toContain('Write');
-    expect(data.model).toBe('opus');
+    expect(data.model).toBe('inherit');
+    expect(data.mcpServers).toEqual(['exarchos']);
     expect(data.isolation).toBe('worktree');
     expect(data.resumable).toBe(true);
     expect(data.memoryScope).toBe('project');

--- a/servers/exarchos-mcp/src/agents/handler.ts
+++ b/servers/exarchos-mcp/src/agents/handler.ts
@@ -97,6 +97,7 @@ export async function handleAgentSpec(args: AgentSpecArgs): Promise<ToolResult> 
       resumable: spec.resumable,
       memoryScope: spec.memoryScope,
       maxTurns: spec.maxTurns,
+      mcpServers: spec.mcpServers ? [...spec.mcpServers] : undefined,
       skills: spec.skills.map(s => ({ name: s.name, content: '' })),
       unresolvedVars,
     },

--- a/servers/exarchos-mcp/src/agents/types.ts
+++ b/servers/exarchos-mcp/src/agents/types.ts
@@ -35,4 +35,5 @@ export interface AgentSpec {
   readonly resumable: boolean;
   readonly memoryScope?: 'user' | 'project' | 'local';
   readonly maxTurns?: number;
+  readonly mcpServers?: readonly string[];
 }

--- a/servers/exarchos-mcp/src/describe/handler.test.ts
+++ b/servers/exarchos-mcp/src/describe/handler.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { handleDescribe } from './handler.js';
+import { handleDescribe, handleEventTypeDescribe, handleEventDescribe } from './handler.js';
 import { TOOL_REGISTRY } from '../registry.js';
 
 const workflowTool = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow')!;
+const eventTool = TOOL_REGISTRY.find(t => t.name === 'exarchos_event')!;
 
 describe('handleDescribe', () => {
   it('HandleDescribe_ValidAction_ReturnsSchemaAndMetadata', async () => {
@@ -42,5 +43,93 @@ describe('handleDescribe', () => {
     const desc = (result.data as Record<string, unknown>)['check_tdd_compliance'] as Record<string, unknown>;
     // gate field should be present (null if no gate metadata, object if present)
     expect('gate' in desc).toBe(true);
+  });
+});
+
+describe('handleEventTypeDescribe', () => {
+  it('EventTypeDescribe_ValidType_ReturnsSchemaSourceAndBuiltIn', async () => {
+    const result = await handleEventTypeDescribe(['shepherd.iteration']);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, Record<string, unknown>>;
+    expect(data).toHaveProperty('shepherd.iteration');
+    const desc = data['shepherd.iteration'];
+    expect(desc.schema).not.toBeNull();
+    expect(desc.source).toBe('model');
+    expect(desc.isBuiltIn).toBe(true);
+  });
+
+  it('EventTypeDescribe_MultipleTypes_ReturnsAll', async () => {
+    const result = await handleEventTypeDescribe(['team.spawned', 'workflow.started']);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(Object.keys(data)).toHaveLength(2);
+    expect(data).toHaveProperty('team.spawned');
+    expect(data).toHaveProperty('workflow.started');
+  });
+
+  it('EventTypeDescribe_UnknownType_ReturnsErrorWithValidTargets', async () => {
+    const result = await handleEventTypeDescribe(['nonexistent.event']);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('UNKNOWN_EVENT_TYPE');
+    expect(result.error?.validTargets).toBeDefined();
+    expect(result.error?.validTargets?.length).toBeGreaterThan(0);
+  });
+
+  it('EventTypeDescribe_AutoSource_ReturnsCorrectSource', async () => {
+    const result = await handleEventTypeDescribe(['workflow.started']);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, Record<string, unknown>>;
+    expect(data['workflow.started'].source).toBe('auto');
+  });
+
+  it('EventTypeDescribe_SchemaContainsProperties_HasJsonSchema', async () => {
+    const result = await handleEventTypeDescribe(['task.completed']);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, Record<string, unknown>>;
+    const schema = data['task.completed'].schema as Record<string, unknown>;
+    // JSON Schema should have type and properties
+    expect(schema.type).toBe('object');
+    expect(schema).toHaveProperty('properties');
+  });
+});
+
+describe('handleEventDescribe', () => {
+  it('EventDescribe_ActionsOnly_ReturnsActionSchemas', async () => {
+    const result = await handleEventDescribe({ actions: ['append'] }, eventTool.actions);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('actions');
+    expect(data).not.toHaveProperty('eventTypes');
+  });
+
+  it('EventDescribe_EventTypesOnly_ReturnsEventSchemas', async () => {
+    const result = await handleEventDescribe({ eventTypes: ['shepherd.iteration'] }, eventTool.actions);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('eventTypes');
+    expect(data).not.toHaveProperty('actions');
+  });
+
+  it('EventDescribe_BothActionsAndEventTypes_ReturnsBoth', async () => {
+    const result = await handleEventDescribe(
+      { actions: ['append'], eventTypes: ['team.spawned'] },
+      eventTool.actions,
+    );
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('actions');
+    expect(data).toHaveProperty('eventTypes');
+  });
+
+  it('EventDescribe_InvalidAction_ReturnsError', async () => {
+    const result = await handleEventDescribe({ actions: ['nonexistent'] }, eventTool.actions);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('UNKNOWN_ACTION');
+  });
+
+  it('EventDescribe_InvalidEventType_ReturnsError', async () => {
+    const result = await handleEventDescribe({ eventTypes: ['nonexistent.type'] }, eventTool.actions);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('UNKNOWN_EVENT_TYPE');
   });
 });

--- a/servers/exarchos-mcp/src/describe/handler.ts
+++ b/servers/exarchos-mcp/src/describe/handler.ts
@@ -1,6 +1,12 @@
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import type { ToolAction } from '../registry.js';
 import type { ToolResult } from '../format.js';
+import {
+  EVENT_DATA_SCHEMAS,
+  EVENT_EMISSION_REGISTRY,
+  getValidEventTypes,
+  isBuiltInEventType,
+} from '../event-store/schemas.js';
 
 /**
  * Handles the `describe` action for composite tools.
@@ -44,6 +50,85 @@ export async function handleDescribe(
       phases: [...action.phases],
       roles: [...action.roles],
     };
+  }
+
+  return { success: true, data: results };
+}
+
+/**
+ * Handles event type schema discovery for the event tool's `describe` action.
+ * Returns data schema, emission source, and built-in status for each event type.
+ */
+export async function handleEventTypeDescribe(
+  eventTypes: string[],
+): Promise<ToolResult> {
+  const validTypes = getValidEventTypes();
+  const results: Record<string, unknown> = {};
+
+  for (const eventType of eventTypes) {
+    if (!validTypes.includes(eventType)) {
+      return {
+        success: false,
+        error: {
+          code: 'UNKNOWN_EVENT_TYPE',
+          message: `Unknown event type: ${eventType}`,
+          validTargets: validTypes,
+        },
+      };
+    }
+
+    const schema = (EVENT_DATA_SCHEMAS as Record<string, unknown>)[eventType];
+    const source = (EVENT_EMISSION_REGISTRY as Record<string, string>)[eventType];
+
+    results[eventType] = {
+      schema: schema ? zodToJsonSchema(schema as Parameters<typeof zodToJsonSchema>[0]) : null,
+      source: source ?? null,
+      isBuiltIn: isBuiltInEventType(eventType),
+    };
+  }
+
+  return { success: true, data: results };
+}
+
+/**
+ * Combined describe handler for the event tool.
+ * Supports both `actions` (tool action schemas) and `eventTypes` (event data schemas).
+ */
+export async function handleEventDescribe(
+  args: { actions?: string[]; eventTypes?: string[] },
+  toolActions: readonly ToolAction[],
+): Promise<ToolResult> {
+  const hasActions = args.actions && args.actions.length > 0;
+  const hasEventTypes = args.eventTypes && args.eventTypes.length > 0;
+
+  if (!hasActions && !hasEventTypes) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'At least one of actions or eventTypes must be provided',
+        expectedShape: {
+          actions: ['append', 'query'],
+          eventTypes: ['shepherd.iteration', 'team.spawned'],
+        },
+      },
+    };
+  }
+
+  const results: Record<string, unknown> = {};
+
+  // Resolve action schemas if requested
+  if (args.actions && args.actions.length > 0) {
+    const actionResult = await handleDescribe({ actions: args.actions }, toolActions);
+    if (!actionResult.success) return actionResult;
+    Object.assign(results, { actions: actionResult.data });
+  }
+
+  // Resolve event type schemas if requested
+  if (args.eventTypes && args.eventTypes.length > 0) {
+    const eventResult = await handleEventTypeDescribe(args.eventTypes);
+    if (!eventResult.success) return eventResult;
+    Object.assign(results, { eventTypes: eventResult.data });
   }
 
   return { success: true, data: results };

--- a/servers/exarchos-mcp/src/event-store/composite.ts
+++ b/servers/exarchos-mcp/src/event-store/composite.ts
@@ -1,6 +1,6 @@
 import type { ToolResult } from '../format.js';
 import { handleEventAppend, handleEventQuery, handleBatchAppend } from './tools.js';
-import { handleDescribe } from '../describe/handler.js';
+import { handleEventDescribe } from '../describe/handler.js';
 import { TOOL_REGISTRY } from '../registry.js';
 
 const VALID_ACTIONS = ['append', 'query', 'batch_append', 'describe'] as const;
@@ -39,7 +39,10 @@ export async function handleEvent(
     }
     case 'describe': {
       const { action: _, ...rest } = args;
-      return handleDescribe(rest as { actions: string[] }, eventActions);
+      return handleEventDescribe(
+        rest as { actions?: string[]; eventTypes?: string[] },
+        eventActions,
+      );
     }
     default:
       return {

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -289,6 +289,26 @@ function makeDescribeAction(): ToolAction {
   };
 }
 
+const eventDescribeSchema = z.object({
+  actions: z.array(z.string()).min(1).max(10)
+    .describe('Action names to describe. Returns full schema + description for each.')
+    .optional(),
+  eventTypes: z.array(z.string()).min(1).max(20)
+    .describe('Event type names to describe. Returns data schema, emission source, and built-in status for each.')
+    .optional(),
+});
+
+/** Creates a describe action for the event tool that supports both actions and eventTypes. */
+function makeEventDescribeAction(): ToolAction {
+  return {
+    name: 'describe',
+    description: 'Return schemas for actions and/or event types. At least one of actions or eventTypes must be provided.',
+    schema: eventDescribeSchema,
+    phases: ALL_PHASES,
+    roles: ROLE_ANY,
+  };
+}
+
 // ─── Composite Tool: exarchos_workflow ───────────────────────────────────────
 
 const workflowActions: readonly ToolAction[] = [
@@ -413,7 +433,7 @@ const eventActions: readonly ToolAction[] = [
     phases: DELEGATE_PHASES,
     roles: ROLE_LEAD,
   },
-  makeDescribeAction(),
+  makeEventDescribeAction(),
 ];
 
 // ─── Composite Tool: exarchos_orchestrate ───────────────────────────────────
@@ -885,7 +905,7 @@ export const TOOL_REGISTRY: readonly CompositeTool[] = [
     description: 'Event sourcing — append and query events in streams',
     actions: eventActions,
     cli: { alias: 'ev' },
-    slimDescription: 'Event sourcing — append and query events. Use describe(actions) for schemas.\n\nActions: append, query, batch_append',
+    slimDescription: 'Event sourcing — append and query events. Use describe(actions) for action schemas, describe(eventTypes) for event data schemas.\n\nActions: append, query, batch_append',
   },
   {
     name: 'exarchos_orchestrate',

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -97,6 +97,38 @@ This creates a state file tracked by the MCP server.
 action: "set", featureId: "<id>", updates: { "artifacts": { "design": "<path>" } }, phase: "plan"
 ```
 
+### Phase Transitions and Guards
+
+This skill is the entry point for the **feature workflow** (`workflowType: "feature"`). The full lifecycle is:
+
+```
+ideate → plan → plan-review → delegate ⇄ review → synthesize → completed
+```
+
+For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
+
+**Feature workflow guard table:**
+
+| Transition | Guard | Prerequisite (send in `updates` with `phase`) |
+|------------|-------|-----------------------------------------------|
+| `ideate` → `plan` | `design-artifact-exists` | Set `artifacts.design` |
+| `plan` → `plan-review` | `plan-artifact-exists` | Set `artifacts.plan` |
+| `plan-review` → `delegate` | `plan-review-complete` | Set `planReview.approved = true` |
+| `plan-review` → `plan` | `plan-review-gaps-found` | Set `planReview.gapsFound = true` |
+| `delegate` → `review` | `all-tasks-complete` | All `tasks[].status = "complete"` |
+| `review` → `synthesize` | `all-reviews-passed` | All `reviews.{name}.status` passing |
+| `review` → `delegate` | `any-review-failed` | Any `reviews.{name}.status` failing (fix cycle) |
+| `synthesize` → `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+### Schema Discovery
+
+Use `describe` to discover action parameter schemas or event data schemas when needed:
+
+```
+exarchos_workflow({ action: "describe", actions: ["set", "init"] })
+exarchos_event({ action: "describe", eventTypes: ["workflow.transition"] })
+```
+
 ## Completion Verification
 
 Run the ideation artifact verification:

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -155,7 +155,7 @@ See `@skills/debug/references/state-schema.md` for full schema.
 
 Every phase transition has a guard that must be satisfied. Before transitioning, consult `@skills/workflow-state/references/phase-transitions.md` for the exact prerequisite for each guard.
 
-**Quick reference — guards that require state updates:**
+**Quick reference — transition guards:**
 
 | Transition | Guard | Prerequisite (send in `updates` with `phase`) |
 |------------|-------|-----------------------------------------------|

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -151,6 +151,35 @@ action: "init", featureId: "debug-<issue-slug>", workflowType: "debug"
 
 See `@skills/debug/references/state-schema.md` for full schema.
 
+### Phase Transitions and Guards
+
+Every phase transition has a guard that must be satisfied. Before transitioning, consult `@skills/workflow-state/references/phase-transitions.md` for the exact prerequisite for each guard.
+
+**Quick reference — guards that require state updates:**
+
+| Transition | Guard | Prerequisite (send in `updates` with `phase`) |
+|------------|-------|-----------------------------------------------|
+| `triage` → `investigate` | `triage-complete` | Set `triage.symptom` |
+| `investigate` → `rca` | `thorough-track-selected` | Set `track = "thorough"` |
+| `investigate` → `hotfix-implement` | `hotfix-track-selected` | Set `track = "hotfix"` |
+| `rca` → `design` | `rca-document-complete` | Set `artifacts.rca` |
+| `design` → `debug-implement` | `fix-design-complete` | Set `artifacts.fixDesign` |
+| `debug-implement` → `debug-validate` | `implementation-complete` | Always passes |
+| `debug-validate` → `debug-review` | `validation-passed` | Set `validation.testsPass = true` |
+| `debug-review` → `synthesize` | `review-passed` | All `reviews.{name}.status` passing |
+| `hotfix-implement` → `hotfix-validate` | `implementation-complete` | Always passes |
+| `hotfix-validate` → `completed` | `validation-passed` | Set `validation.testsPass = true` |
+| `synthesize` → `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+### Schema Discovery
+
+Use `describe` to discover action parameter schemas or event data schemas when needed:
+
+```
+exarchos_workflow({ action: "describe", actions: ["set", "init"] })
+exarchos_event({ action: "describe", eventTypes: ["shepherd.iteration", "team.spawned"] })
+```
+
 ## Integration Points
 
 ### With /exarchos:rehydrate

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -175,7 +175,7 @@ Every phase transition has a guard that must be satisfied. Before transitioning,
 
 Use `describe` to discover action parameter schemas or event data schemas when needed:
 
-```
+```typescript
 exarchos_workflow({ action: "describe", actions: ["set", "init"] })
 exarchos_event({ action: "describe", eventTypes: ["shepherd.iteration", "team.spawned"] })
 ```

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -264,6 +264,18 @@ If context compaction occurs during delegation:
 
 ---
 
+## Phase Transitions and Guards
+
+For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
+
+**Quick reference:** The `delegate` → `review` transition requires guard `all-tasks-complete` — all `tasks[].status` must be `"complete"` in workflow state.
+
+Use `describe` to discover action or event schemas when needed:
+```
+exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })
+exarchos_event({ action: "describe", eventTypes: ["team.spawned", "team.task.completed"] })
+```
+
 ## Transition
 
 After all tasks complete, **auto-continue immediately** (no user confirmation):

--- a/skills/implementation-planning/SKILL.md
+++ b/skills/implementation-planning/SKILL.md
@@ -224,6 +224,17 @@ action: "set", featureId: "<id>", phase: "<plan-review-phase>", updates: {
 }
 ```
 
+### Phase Transitions and Guards
+
+For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
+
+**Quick reference:** The `plan` → `plan-review` transition requires guard `plan-artifact-exists` — set `artifacts.plan` in the same `set` call as `phase`.
+
+Use `describe` to discover action schemas when needed:
+```
+exarchos_orchestrate({ action: "describe", actions: ["check_plan_coverage", "check_provenance_chain"] })
+```
+
 ## Completion Criteria
 
 - [ ] Design document read and understood

--- a/skills/implementation-planning/SKILL.md
+++ b/skills/implementation-planning/SKILL.md
@@ -231,7 +231,7 @@ For the full transition table, consult `@skills/workflow-state/references/phase-
 **Quick reference:** The `plan` → `plan-review` transition requires guard `plan-artifact-exists` — set `artifacts.plan` in the same `set` call as `phase`.
 
 Use `describe` to discover action schemas when needed:
-```
+```typescript
 exarchos_orchestrate({ action: "describe", actions: ["check_plan_coverage", "check_provenance_chain"] })
 ```
 

--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -256,6 +256,19 @@ action: "set", featureId: "<id>", updates: {
 action: "set", featureId: "<id>", phase: "synthesize"
 ```
 
+### Phase Transitions and Guards
+
+For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
+
+**Quick reference:**
+- `review` → `synthesize` requires guard `all-reviews-passed` — all `reviews.{name}.status` must be passing
+- `review` → `delegate` requires guard `any-review-failed` — triggers fix cycle when any review fails
+
+Use `describe` to discover action schemas when needed:
+```
+exarchos_orchestrate({ action: "describe", actions: ["check_static_analysis", "check_security_scan", "check_review_verdict"] })
+```
+
 ## Completion Criteria
 
 - [ ] Static analysis passes

--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -265,7 +265,7 @@ For the full transition table, consult `@skills/workflow-state/references/phase-
 - `review` → `delegate` requires guard `any-review-failed` — triggers fix cycle when any review fails
 
 Use `describe` to discover action schemas when needed:
-```
+```typescript
 exarchos_orchestrate({ action: "describe", actions: ["check_static_analysis", "check_security_scan", "check_review_verdict"] })
 ```
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -154,6 +154,36 @@ Full state schema:
 }
 ```
 
+### Phase Transitions and Guards
+
+Every phase transition has a guard that must be satisfied. Before transitioning, consult `@skills/workflow-state/references/phase-transitions.md` for the exact prerequisite for each guard.
+
+**Quick reference — guards that require state updates:**
+
+| Transition | Guard | Prerequisite (send in `updates` with `phase`) |
+|------------|-------|-----------------------------------------------|
+| `explore` → `brief` | `scope-assessment-complete` | Set `explore.scopeAssessment` |
+| `brief` → `polish-implement` | `polish-track-selected` | Set `track = "polish"` |
+| `brief` → `overhaul-plan` | `overhaul-track-selected` | Set `track = "overhaul"` |
+| `polish-implement` → `polish-validate` | `implementation-complete` | Always passes |
+| `polish-validate` → `polish-update-docs` | `goals-verified` | Set `validation.testsPass = true` |
+| `polish-update-docs` → `completed` | `docs-updated` | Set `validation.docsUpdated = true` |
+| `overhaul-plan` → `overhaul-delegate` | `plan-artifact-exists` | Set `artifacts.plan` |
+| `overhaul-delegate` → `overhaul-review` | `all-tasks-complete` | All `tasks[].status = "complete"` |
+| `overhaul-review` → `overhaul-update-docs` | `all-reviews-passed` | All `reviews.{name}.status` passing |
+| `overhaul-review` → `overhaul-delegate` | `any-review-failed` | Any `reviews.{name}.status` failing |
+| `overhaul-update-docs` → `synthesize` | `docs-updated` | Set `validation.docsUpdated = true` |
+| `synthesize` → `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+### Schema Discovery
+
+Use `describe` to discover action parameter schemas or event data schemas when needed:
+
+```
+exarchos_workflow({ action: "describe", actions: ["set", "init"] })
+exarchos_event({ action: "describe", eventTypes: ["team.spawned"] })
+```
+
 ## Track Switching
 
 If scope expands beyond polish limits during explore or brief phase, use `mcp__plugin_exarchos_exarchos__exarchos_workflow` with `action: "set"` to set `track` to "overhaul" and update `explore.scopeAssessment.recommendedTrack`.

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -179,7 +179,7 @@ Every phase transition has a guard that must be satisfied. Before transitioning,
 
 Use `describe` to discover action parameter schemas or event data schemas when needed:
 
-```
+```typescript
 exarchos_workflow({ action: "describe", actions: ["set", "init"] })
 exarchos_event({ action: "describe", eventTypes: ["team.spawned"] })
 ```

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -158,7 +158,7 @@ Full state schema:
 
 Every phase transition has a guard that must be satisfied. Before transitioning, consult `@skills/workflow-state/references/phase-transitions.md` for the exact prerequisite for each guard.
 
-**Quick reference — guards that require state updates:**
+**Quick reference — transition guards:**
 
 | Transition | Guard | Prerequisite (send in `updates` with `phase`) |
 |------------|-------|-----------------------------------------------|

--- a/skills/shepherd/SKILL.md
+++ b/skills/shepherd/SKILL.md
@@ -192,7 +192,7 @@ mcp__plugin_exarchos_exarchos__exarchos_workflow({
 For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
 
 The shepherd skill operates within the `synthesize` phase and does not drive phase transitions directly. Use `describe` to discover event data schemas before emitting events:
-```
+```typescript
 exarchos_event({ action: "describe", eventTypes: ["shepherd.iteration", "shepherd.completed", "ci.status", "remediation.attempted"] })
 ```
 

--- a/skills/shepherd/SKILL.md
+++ b/skills/shepherd/SKILL.md
@@ -187,6 +187,15 @@ mcp__plugin_exarchos_exarchos__exarchos_workflow({
 
 **After each iteration:** Update `currentIteration`, record assessment summary and actions taken. On approval: set `approvalRequested: true` with timestamp and approver list.
 
+### Phase Transitions and Guards
+
+For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
+
+The shepherd skill operates within the `synthesize` phase and does not drive phase transitions directly. Use `describe` to discover event data schemas before emitting events:
+```
+exarchos_event({ action: "describe", eventTypes: ["shepherd.iteration", "shepherd.completed", "ci.status", "remediation.attempted"] })
+```
+
 ## Event Emission
 
 Before emitting any shepherd events, consult `references/shepherd-event-schemas.md` for full Zod schemas, type constraints, and example payloads. The table below is a summary — the reference has the exact shapes that MCP validation enforces.

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -215,6 +215,19 @@ action: "set", featureId: "<id>", updates: {
 }
 ```
 
+### Phase Transitions and Guards
+
+For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
+
+**Quick reference:**
+- `review` → `synthesize` requires guard `all-reviews-passed` — all `reviews.{name}.status` must be passing
+- `review` → `delegate` requires guard `any-review-failed` — triggers fix cycle when any review fails
+
+Use `describe` to discover action schemas when needed:
+```
+exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "check_static_analysis"] })
+```
+
 ## Transition
 
 All transitions happen **immediately** without user confirmation:

--- a/skills/synthesis/SKILL.md
+++ b/skills/synthesis/SKILL.md
@@ -155,6 +155,17 @@ Then sync: `git fetch --prune` and remove worktrees.
 
 See `references/troubleshooting.md` for test failures, PR check failures, merge queue rejections, and MCP tool errors.
 
+## Phase Transitions and Guards
+
+For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
+
+**Quick reference:** The `synthesize` → `completed` transition requires guard `pr-url-exists` — set `synthesis.prUrl` or `artifacts.pr` in the same `set` call as `phase`.
+
+Use `describe` to discover action schemas when needed:
+```
+exarchos_orchestrate({ action: "describe", actions: ["prepare_synthesis"] })
+```
+
 ## Completion Criteria
 
 - [ ] `prepare_synthesis` readiness check passed

--- a/skills/workflow-state/SKILL.md
+++ b/skills/workflow-state/SKILL.md
@@ -37,7 +37,7 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 ### Schema Discovery
 
 Use `describe` to discover action parameter schemas or event data schemas at runtime:
-```
+```typescript
 exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })
 exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })
 ```

--- a/skills/workflow-state/SKILL.md
+++ b/skills/workflow-state/SKILL.md
@@ -34,6 +34,14 @@ Activate this skill when:
 
 Valid transitions, guards, and prerequisites for all workflow types are documented in `references/phase-transitions.md`. **CRITICAL:** When a transition has a guard, send the prerequisite `updates` and `phase` in a single `set` call — updates apply before guards evaluate.
 
+### Schema Discovery
+
+Use `describe` to discover action parameter schemas or event data schemas at runtime:
+```
+exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })
+exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })
+```
+
 ## State Location
 
 Workflow state lives in the **MCP event store**, not the filesystem. Use `exarchos_workflow get` to read state and `exarchos_view pipeline` to discover active workflows. Do **not** scan `~/.claude/workflow-state/*.state.json` — that path is legacy and may be stale or empty.


### PR DESCRIPTION
## Summary

Closes #975. Three gaps identified through dogfooding and gap analysis:

- **Event type schema discovery** — Extend `exarchos_event` describe action with optional `eventTypes` param to surface `EVENT_DATA_SCHEMAS` via MCP. Eliminates trial-and-error schema discovery (3 validation failures in dogfood session).
- **MCP server scoping** — Add `mcpServers` allowlist to `AgentSpec`, restricting subagents to only the MCP servers they need. All agents scoped to `exarchos` only.
- **Model inheritance** — Change `model: 'opus'` → `model: 'inherit'` on all agent specs. Subagents now follow the session's configured model instead of hardcoding Opus.

Additionally standardizes all 10 workflow skills with guard table references and `describe` usage patterns (found via dogfood analysis of 5 failed tool calls in this session).

### MCP Server Changes (11 files)

| Change | Key Files |
|--------|-----------|
| Event describe with `eventTypes` | `registry.ts`, `describe/handler.ts` (+3 functions, +10 tests), `event-store/composite.ts` |
| `mcpServers` on AgentSpec | `types.ts`, `definitions.ts`, `generate-cc-agents.ts`, `handler.ts` |
| `model: 'inherit'` | `definitions.ts` (3 agents) |
| Tool description | `registry.ts` slimDescription mentions `describe(eventTypes)` |

### Skill Consistency (10 files)

Every workflow skill now has:
1. Guard prerequisite table referencing `@skills/workflow-state/references/phase-transitions.md`
2. `describe` usage examples for action and/or event type schemas
3. Entry-point skills (brainstorming, debug, refactor) have full workflow guard tables

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run test:run` — 3687 passed, 0 failed
- [x] `npm run build` — succeeds
- [x] New tests: 10 tests for `handleEventTypeDescribe` and `handleEventDescribe`
- [x] Updated tests: `mcpServers` assertions in handler + generator tests
- [x] Updated tests: `model: 'inherit'` assertions across 3 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)