### PR TITLE
fix: restore missing overhaul-plan-review transition in docs

### DIFF
--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -168,7 +168,9 @@ Every phase transition has a guard that must be satisfied. Before transitioning,
 | `polish-implement` → `polish-validate` | `implementation-complete` | Always passes |
 | `polish-validate` → `polish-update-docs` | `goals-verified` | Set `validation.testsPass = true` |
 | `polish-update-docs` → `completed` | `docs-updated` | Set `validation.docsUpdated = true` |
-| `overhaul-plan` → `overhaul-delegate` | `plan-artifact-exists` | Set `artifacts.plan` |
+| `overhaul-plan` → `overhaul-plan-review` | `plan-artifact-exists` | Set `artifacts.plan` |
+| `overhaul-plan-review` → `overhaul-delegate` | `plan-review-complete` | Plan approved |
+| `overhaul-plan-review` → `overhaul-plan` | `plan-review-gaps-found` | Revise plan |
 | `overhaul-delegate` → `overhaul-review` | `all-tasks-complete` | All `tasks[].status = "complete"` |
 | `overhaul-review` → `overhaul-update-docs` | `all-reviews-passed` | All `reviews.{name}.status` passing |
 | `overhaul-review` → `overhaul-delegate` | `any-review-failed` | Any `reviews.{name}.status` failing |

--- a/skills/workflow-state/references/phase-transitions.md
+++ b/skills/workflow-state/references/phase-transitions.md
@@ -107,14 +107,16 @@ explore → brief → [polish-track | overhaul-track] → completed
 
 | From | To | Guard | Prerequisite |
 |------|----|-------|-------------|
-| `overhaul-plan` | `overhaul-delegate` | `plan-artifact-exists` | Set `artifacts.plan` |
+| `overhaul-plan` | `overhaul-plan-review` | `plan-artifact-exists` | Set `artifacts.plan` |
+| `overhaul-plan-review` | `overhaul-delegate` | `plan-review-complete` | Plan approved |
+| `overhaul-plan-review` | `overhaul-plan` | `plan-review-gaps-found` | Revise plan |
 | `overhaul-delegate` | `overhaul-review` | `all-tasks-complete` | All `tasks[].status = "complete"` |
 | `overhaul-review` | `overhaul-update-docs` | `all-reviews-passed` | All `reviews.{name}.status` passing |
 | `overhaul-review` | `overhaul-delegate` | `any-review-failed` | Any `reviews.{name}.status` failing (fix cycle) |
 | `overhaul-update-docs` | `synthesize` | `docs-updated` | Set `validation.docsUpdated = true` |
 | `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
 
-**Compound state:** `overhaul-track` contains `overhaul-plan`, `overhaul-delegate`, `overhaul-review`, and `overhaul-update-docs`. Max 3 fix cycles.
+**Compound state:** `overhaul-track` contains `overhaul-plan`, `overhaul-plan-review`, `overhaul-delegate`, `overhaul-review`, and `overhaul-update-docs`. Max 3 fix cycles.
 
 ## Circuit Breaker
 


### PR DESCRIPTION
## Summary

The HSM code defines `overhaul-plan → overhaul-plan-review → overhaul-delegate` but both the refactor SKILL.md quick-reference table and the canonical phase-transitions.md were missing `overhaul-plan-review`, jumping directly from `overhaul-plan` to `overhaul-delegate`. Found during CodeRabbit review of #976.

## Changes

- **skills/refactor/SKILL.md** — Split `overhaul-plan → overhaul-delegate` into two transitions with `overhaul-plan-review` intermediate step, plus reverse transition for revision
- **skills/workflow-state/references/phase-transitions.md** — Same fix in canonical transition table, added `overhaul-plan-review` to compound state list

## Test Plan

Doc-only change — transitions now match HSM code in `hsm-definitions.ts:274-289`.

---

**Results:** Tests 270 ✓ · Build 0 errors
**Related:** Follows up #976