### PR TITLE
feat(introspection): add HSM topology and event emission catalog to describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Exarchos are documented in this file. Organized by semver release.
 
+## [Unreleased]
+
+### Features
+- HSM topology introspection via `exarchos_workflow describe` with `topology` parameter (#979)
+- Event emission catalog via `exarchos_event describe` with `emissionGuide` parameter (#979)
+- CLI `topology [type]` and `emissions` commands for plugin-free introspection (#979)
+
 ## [2.5.0] - 2026-03-09
 
 **First public release.** Lazy schema loading, runbook protocol, typed agent specs, and a documentation site — reducing tool registration overhead by 83% while making workflows self-describing.

--- a/documentation/reference/tools/event.md
+++ b/documentation/reference/tools/event.md
@@ -92,7 +92,7 @@ Phases: delegate, overhaul-delegate, debug-implement. Role: `lead`.
 
 ### describe
 
-Get full schemas for specific actions.
+Get full schemas for specific actions, event type data schemas, and/or the event emission catalog.
 
 ```json
 {
@@ -101,10 +101,27 @@ Get full schemas for specific actions.
 }
 ```
 
+```json
+{
+  "action": "describe",
+  "emissionGuide": true
+}
+```
+
 | Parameter | Required | Type | Description |
 |-----------|----------|------|-------------|
-| `actions` | yes | string[] (1-10) | Action names to describe |
+| `actions` | no | string[] (1-10) | Action names to describe |
+| `eventTypes` | no | string[] (1-20) | Event type names to describe. Returns data schema, emission source, and built-in status |
+| `emissionGuide` | no | boolean | When true, returns the full event emission catalog grouped by source |
 
-Returns: Full Zod schemas, descriptions, and phase/role constraints for each requested action.
+At least one of `actions`, `eventTypes`, or `emissionGuide` must be provided.
+
+**Actions response:** Full Zod schemas, descriptions, and phase/role constraints for each requested action.
+
+**Event types response:** Data schema (JSON Schema), emission source (`auto`/`model`/`hook`/`planned`), and built-in status for each event type.
+
+**Emission guide response:** Complete catalog of all registered event types grouped by emission source, with per-type metadata (source, built-in flag, schema availability) and a total count.
+
+All parameters can be used together in a single call.
 
 Phases: all. Role: `any`.

--- a/documentation/reference/tools/workflow.md
+++ b/documentation/reference/tools/workflow.md
@@ -149,7 +149,7 @@ Phases: all. Role: `lead`.
 
 ### describe
 
-Get full schemas for specific actions.
+Get full schemas for specific actions and/or HSM topology for workflow types.
 
 ```json
 {
@@ -158,10 +158,24 @@ Get full schemas for specific actions.
 }
 ```
 
+```json
+{
+  "action": "describe",
+  "topology": "feature"
+}
+```
+
 | Parameter | Required | Type | Description |
 |-----------|----------|------|-------------|
-| `actions` | yes | string[] (1-10) | Action names to describe |
+| `actions` | no | string[] (1-10) | Action names to describe |
+| `topology` | no | string | Workflow type to return HSM topology for. Use `"all"` to list all types |
 
-Returns: Full Zod schemas, descriptions, gate metadata, and phase/role constraints for each requested action.
+At least one of `actions` or `topology` must be provided.
+
+**Actions response:** Full Zod schemas, descriptions, gate metadata, and phase/role constraints for each requested action.
+
+**Topology response:** When a specific type is given (e.g. `"feature"`), returns the serialized HSM definition including states (with type, parent, initial), transitions (with guard id/description), and tracks (compound state children). When `"all"` is given, returns a listing of all registered workflow types with phase count and track count.
+
+Both parameters can be used together in a single call.
 
 Phases: all. Role: `any`.

--- a/servers/exarchos-mcp/package-lock.json
+++ b/servers/exarchos-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lvlup-sw/exarchos-mcp",
-  "version": "2.5.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lvlup-sw/exarchos-mcp",
-      "version": "2.5.0",
+      "version": "1.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "better-sqlite3": "^12.6.2",
@@ -11454,6 +11454,71 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/mongoose/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {

--- a/servers/exarchos-mcp/package-lock.json
+++ b/servers/exarchos-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lvlup-sw/exarchos-mcp",
-  "version": "1.1.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lvlup-sw/exarchos-mcp",
-      "version": "1.1.0",
+      "version": "2.5.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "better-sqlite3": "^12.6.2",
@@ -11454,71 +11454,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
-      }
-    },
-    "node_modules/mongoose/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/mongoose/node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongoose/node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^5.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongoose/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {

--- a/servers/exarchos-mcp/src/adapters/cli.ts
+++ b/servers/exarchos-mcp/src/adapters/cli.ts
@@ -6,7 +6,7 @@ import { dispatch } from '../core/dispatch.js';
 import type { DispatchContext } from '../core/dispatch.js';
 import { addFlagsFromSchema, coerceFlags, validateRequiredBooleans, toKebab } from './schema-to-flags.js';
 import { prettyPrint, printError } from './cli-format.js';
-import { listSchemas, resolveSchemaRef } from './schema-introspection.js';
+import { listSchemas, resolveSchemaRef, resolveTopologyRef, resolveEmissionCatalog } from './schema-introspection.js';
 import { createMcpServer } from './mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
@@ -92,6 +92,34 @@ export function buildCli(ctx: DispatchContext): Command {
           process.exitCode = 1;
         }
       }
+    });
+
+  // ─── Topology introspection command ──────────────────────────────────────────
+
+  program
+    .command('topology [type]')
+    .description('Show HSM topology. Without type, lists all workflow types.')
+    .action(async (type?: string) => {
+      try {
+        const result = resolveTopologyRef(type || undefined);
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+      } catch (err) {
+        printError({
+          code: 'INVALID_TOPOLOGY_REF',
+          message: err instanceof Error ? err.message : String(err),
+        });
+        process.exitCode = 1;
+      }
+    });
+
+  // ─── Emissions catalog command ──────────────────────────────────────────────
+
+  program
+    .command('emissions')
+    .description('Show event emission catalog grouped by source.')
+    .action(async () => {
+      const result = resolveEmissionCatalog();
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n');
     });
 
   // ─── MCP server mode command ───────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/adapters/schema-introspection.test.ts
+++ b/servers/exarchos-mcp/src/adapters/schema-introspection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveSchemaRef, listSchemas } from './schema-introspection.js';
+import { resolveSchemaRef, listSchemas, resolveTopologyRef, resolveEmissionCatalog } from './schema-introspection.js';
 
 describe('resolveSchemaRef', () => {
   it('ResolveSchemaRef_ValidRef_ReturnsJsonSchema', () => {
@@ -75,5 +75,42 @@ describe('listSchemas', () => {
         expect(action.description).toBeTruthy();
       }
     }
+  });
+});
+
+describe('resolveTopologyRef', () => {
+  it('ResolveTopologyRef_ValidType_ReturnsTopology', () => {
+    const result = resolveTopologyRef('feature');
+    expect(result).toHaveProperty('workflowType', 'feature');
+    expect(result).toHaveProperty('states');
+    expect(result).toHaveProperty('transitions');
+    expect(result).toHaveProperty('tracks');
+    expect(result.initialPhase).toBe('ideate');
+  });
+
+  it('ResolveTopologyRef_NoType_ReturnsAllTypes', () => {
+    const result = resolveTopologyRef();
+    expect(result).toHaveProperty('workflowTypes');
+    expect(result.workflowTypes.length).toBeGreaterThanOrEqual(3);
+    const names = result.workflowTypes.map((t: { name: string }) => t.name);
+    expect(names).toContain('feature');
+    expect(names).toContain('debug');
+    expect(names).toContain('refactor');
+  });
+
+  it('ResolveTopologyRef_InvalidType_ThrowsError', () => {
+    expect(() => resolveTopologyRef('nonexistent')).toThrow(/Unknown workflow type/);
+  });
+});
+
+describe('resolveEmissionCatalog', () => {
+  it('ResolveEmissionCatalog_ReturnsCatalog', () => {
+    const result = resolveEmissionCatalog();
+    expect(result).toHaveProperty('types');
+    expect(result).toHaveProperty('bySource');
+    expect(result).toHaveProperty('totalCount');
+    expect(result.totalCount).toBeGreaterThan(0);
+    expect(result.bySource.auto.length).toBeGreaterThan(0);
+    expect(result.bySource.model.length).toBeGreaterThan(0);
   });
 });

--- a/servers/exarchos-mcp/src/adapters/schema-introspection.ts
+++ b/servers/exarchos-mcp/src/adapters/schema-introspection.ts
@@ -1,9 +1,12 @@
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { getFullRegistry } from '../registry.js';
-import { getHSMDefinition, getInitialPhase } from '../workflow/state-machine.js';
-import type { State, Transition } from '../workflow/state-machine.js';
-import { EventTypes, EVENT_EMISSION_REGISTRY } from '../event-store/schemas.js';
-import type { EventEmissionSource } from '../event-store/schemas.js';
+import {
+  serializeTopology,
+  listWorkflowTypes,
+} from '../workflow/state-machine.js';
+import type { SerializedTopology, WorkflowTypeSummary } from '../workflow/state-machine.js';
+import { serializeEventCatalog } from '../event-store/schemas.js';
+import type { EventCatalog } from '../event-store/schemas.js';
 
 /**
  * Resolves a schema reference (e.g., "workflow.init") to its JSON Schema representation.
@@ -59,146 +62,28 @@ export function listSchemas(): Array<{
   }));
 }
 
-// ─── Topology Types ───────────────────────────────────────────────────────
-
-export interface SerializedState {
-  readonly id: string;
-  readonly type: 'atomic' | 'compound' | 'final';
-  readonly parent?: string;
-  readonly initial?: string;
-  readonly maxFixCycles?: number;
-}
-
-export interface SerializedTransition {
-  readonly from: string;
-  readonly to: string;
-  readonly guard?: string;
-  readonly isFixCycle?: boolean;
-}
-
-export interface SerializedTopology {
-  readonly workflowType: string;
-  readonly initialPhase: string;
-  readonly states: readonly SerializedState[];
-  readonly transitions: readonly SerializedTransition[];
-  readonly tracks: readonly string[];
-}
-
-export interface WorkflowTypeSummary {
-  readonly name: string;
-  readonly initialPhase: string;
-  readonly stateCount: number;
-  readonly trackCount: number;
-}
-
-export interface WorkflowTypeListing {
-  readonly workflowTypes: readonly WorkflowTypeSummary[];
-}
-
-// ─── Event Catalog Types ──────────────────────────────────────────────────
-
-export interface EventCatalog {
-  readonly types: readonly string[];
-  readonly bySource: Record<string, readonly string[]>;
-  readonly totalCount: number;
-}
-
-// ─── Built-in workflow type names ─────────────────────────────────────────
-
-const BUILT_IN_WORKFLOW_TYPES = ['feature', 'debug', 'refactor'] as const;
-
-// ─── Topology Introspection ──────────────────────────────────────────────
-
-function serializeHSMState(state: State): SerializedState {
-  const serialized: SerializedState = {
-    id: state.id,
-    type: state.type,
-    ...(state.parent ? { parent: state.parent } : {}),
-    ...(state.initial ? { initial: state.initial } : {}),
-    ...(state.maxFixCycles != null ? { maxFixCycles: state.maxFixCycles } : {}),
-  };
-  return serialized;
-}
-
-function serializeHSMTransition(transition: Transition): SerializedTransition {
-  const serialized: SerializedTransition = {
-    from: transition.from,
-    to: transition.to,
-    ...(transition.guard ? { guard: transition.guard.id } : {}),
-    ...(transition.isFixCycle ? { isFixCycle: transition.isFixCycle } : {}),
-  };
-  return serialized;
-}
-
-function getTopologyForType(workflowType: string): SerializedTopology {
-  const hsm = getHSMDefinition(workflowType);
-  const initialPhase = getInitialPhase(workflowType);
-
-  const states = Object.values(hsm.states).map(serializeHSMState);
-  const transitions = hsm.transitions.map(serializeHSMTransition);
-  const tracks = Object.values(hsm.states)
-    .filter((s) => s.type === 'compound')
-    .map((s) => s.id);
-
-  return {
-    workflowType,
-    initialPhase,
-    states,
-    transitions,
-    tracks,
-  };
-}
-
 /**
  * Resolves HSM topology for a specific workflow type or lists all workflow types.
  *
+ * Delegates to canonical serialization functions in state-machine.ts.
  * When called with a workflow type, returns the full serialized HSM topology.
  * When called without arguments, returns a listing of all available workflow types
- * with summary metadata (state count, track count).
+ * with summary metadata.
  *
  * @throws Error if the workflow type is not found.
  */
-export function resolveTopologyRef(workflowType?: string): SerializedTopology | WorkflowTypeListing {
+export function resolveTopologyRef(workflowType?: string): SerializedTopology | WorkflowTypeSummary {
   if (workflowType) {
-    return getTopologyForType(workflowType);
+    return serializeTopology(workflowType);
   }
-
-  const workflowTypes: WorkflowTypeSummary[] = BUILT_IN_WORKFLOW_TYPES.map((name) => {
-    const hsm = getHSMDefinition(name);
-    const initialPhase = getInitialPhase(name);
-    const trackCount = Object.values(hsm.states).filter((s) => s.type === 'compound').length;
-
-    return {
-      name,
-      initialPhase,
-      stateCount: Object.keys(hsm.states).length,
-      trackCount,
-    };
-  });
-
-  return { workflowTypes };
+  return listWorkflowTypes();
 }
 
 /**
  * Returns the event emission catalog grouped by source (auto, model, hook, planned).
  *
- * Provides a complete listing of all event types, grouped by their emission source,
- * along with a total count.
+ * Delegates to canonical serializeEventCatalog() in schemas.ts.
  */
 export function resolveEmissionCatalog(): EventCatalog {
-  const types = [...EventTypes];
-  const bySource: Record<string, string[]> = {};
-
-  for (const [eventType, source] of Object.entries(EVENT_EMISSION_REGISTRY) as [string, EventEmissionSource][]) {
-    if (!bySource[source]) {
-      bySource[source] = [];
-    }
-    bySource[source].push(eventType);
-  }
-
-  return {
-    types,
-    bySource,
-    totalCount: types.length,
-  };
+  return serializeEventCatalog();
 }

--- a/servers/exarchos-mcp/src/adapters/schema-introspection.ts
+++ b/servers/exarchos-mcp/src/adapters/schema-introspection.ts
@@ -1,5 +1,9 @@
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { getFullRegistry } from '../registry.js';
+import { getHSMDefinition, getInitialPhase } from '../workflow/state-machine.js';
+import type { State, Transition } from '../workflow/state-machine.js';
+import { EventTypes, EVENT_EMISSION_REGISTRY } from '../event-store/schemas.js';
+import type { EventEmissionSource } from '../event-store/schemas.js';
 
 /**
  * Resolves a schema reference (e.g., "workflow.init") to its JSON Schema representation.
@@ -53,4 +57,148 @@ export function listSchemas(): Array<{
       description: action.description,
     })),
   }));
+}
+
+// ─── Topology Types ───────────────────────────────────────────────────────
+
+export interface SerializedState {
+  readonly id: string;
+  readonly type: 'atomic' | 'compound' | 'final';
+  readonly parent?: string;
+  readonly initial?: string;
+  readonly maxFixCycles?: number;
+}
+
+export interface SerializedTransition {
+  readonly from: string;
+  readonly to: string;
+  readonly guard?: string;
+  readonly isFixCycle?: boolean;
+}
+
+export interface SerializedTopology {
+  readonly workflowType: string;
+  readonly initialPhase: string;
+  readonly states: readonly SerializedState[];
+  readonly transitions: readonly SerializedTransition[];
+  readonly tracks: readonly string[];
+}
+
+export interface WorkflowTypeSummary {
+  readonly name: string;
+  readonly initialPhase: string;
+  readonly stateCount: number;
+  readonly trackCount: number;
+}
+
+export interface WorkflowTypeListing {
+  readonly workflowTypes: readonly WorkflowTypeSummary[];
+}
+
+// ─── Event Catalog Types ──────────────────────────────────────────────────
+
+export interface EventCatalog {
+  readonly types: readonly string[];
+  readonly bySource: Record<string, readonly string[]>;
+  readonly totalCount: number;
+}
+
+// ─── Built-in workflow type names ─────────────────────────────────────────
+
+const BUILT_IN_WORKFLOW_TYPES = ['feature', 'debug', 'refactor'] as const;
+
+// ─── Topology Introspection ──────────────────────────────────────────────
+
+function serializeHSMState(state: State): SerializedState {
+  const serialized: SerializedState = {
+    id: state.id,
+    type: state.type,
+    ...(state.parent ? { parent: state.parent } : {}),
+    ...(state.initial ? { initial: state.initial } : {}),
+    ...(state.maxFixCycles != null ? { maxFixCycles: state.maxFixCycles } : {}),
+  };
+  return serialized;
+}
+
+function serializeHSMTransition(transition: Transition): SerializedTransition {
+  const serialized: SerializedTransition = {
+    from: transition.from,
+    to: transition.to,
+    ...(transition.guard ? { guard: transition.guard.id } : {}),
+    ...(transition.isFixCycle ? { isFixCycle: transition.isFixCycle } : {}),
+  };
+  return serialized;
+}
+
+function getTopologyForType(workflowType: string): SerializedTopology {
+  const hsm = getHSMDefinition(workflowType);
+  const initialPhase = getInitialPhase(workflowType);
+
+  const states = Object.values(hsm.states).map(serializeHSMState);
+  const transitions = hsm.transitions.map(serializeHSMTransition);
+  const tracks = Object.values(hsm.states)
+    .filter((s) => s.type === 'compound')
+    .map((s) => s.id);
+
+  return {
+    workflowType,
+    initialPhase,
+    states,
+    transitions,
+    tracks,
+  };
+}
+
+/**
+ * Resolves HSM topology for a specific workflow type or lists all workflow types.
+ *
+ * When called with a workflow type, returns the full serialized HSM topology.
+ * When called without arguments, returns a listing of all available workflow types
+ * with summary metadata (state count, track count).
+ *
+ * @throws Error if the workflow type is not found.
+ */
+export function resolveTopologyRef(workflowType?: string): SerializedTopology | WorkflowTypeListing {
+  if (workflowType) {
+    return getTopologyForType(workflowType);
+  }
+
+  const workflowTypes: WorkflowTypeSummary[] = BUILT_IN_WORKFLOW_TYPES.map((name) => {
+    const hsm = getHSMDefinition(name);
+    const initialPhase = getInitialPhase(name);
+    const trackCount = Object.values(hsm.states).filter((s) => s.type === 'compound').length;
+
+    return {
+      name,
+      initialPhase,
+      stateCount: Object.keys(hsm.states).length,
+      trackCount,
+    };
+  });
+
+  return { workflowTypes };
+}
+
+/**
+ * Returns the event emission catalog grouped by source (auto, model, hook, planned).
+ *
+ * Provides a complete listing of all event types, grouped by their emission source,
+ * along with a total count.
+ */
+export function resolveEmissionCatalog(): EventCatalog {
+  const types = [...EventTypes];
+  const bySource: Record<string, string[]> = {};
+
+  for (const [eventType, source] of Object.entries(EVENT_EMISSION_REGISTRY) as [string, EventEmissionSource][]) {
+    if (!bySource[source]) {
+      bySource[source] = [];
+    }
+    bySource[source].push(eventType);
+  }
+
+  return {
+    types,
+    bySource,
+    totalCount: types.length,
+  };
 }

--- a/servers/exarchos-mcp/src/describe/handler.test.ts
+++ b/servers/exarchos-mcp/src/describe/handler.test.ts
@@ -156,10 +156,11 @@ describe('handleDescribe topology', () => {
     expect(data).toHaveProperty('topology');
     const topology = data.topology as Record<string, unknown>;
     expect(topology).toHaveProperty('workflowTypes');
-    const types = topology.workflowTypes as string[];
-    expect(types).toContain('feature');
-    expect(types).toContain('debug');
-    expect(types).toContain('refactor');
+    const types = topology.workflowTypes as Array<{ name: string }>;
+    const names = types.map(t => t.name);
+    expect(names).toContain('feature');
+    expect(names).toContain('debug');
+    expect(names).toContain('refactor');
   });
 
   it('HandleDescribe_TopologyInvalidType_ReturnsError', async () => {

--- a/servers/exarchos-mcp/src/describe/handler.test.ts
+++ b/servers/exarchos-mcp/src/describe/handler.test.ts
@@ -4,6 +4,7 @@ import { TOOL_REGISTRY } from '../registry.js';
 
 const workflowTool = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow')!;
 const eventTool = TOOL_REGISTRY.find(t => t.name === 'exarchos_event')!;
+const workflowActions = workflowTool.actions;
 
 describe('handleDescribe', () => {
   it('HandleDescribe_ValidAction_ReturnsSchemaAndMetadata', async () => {
@@ -131,5 +132,63 @@ describe('handleEventDescribe', () => {
     const result = await handleEventDescribe({ eventTypes: ['nonexistent.type'] }, eventTool.actions);
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('UNKNOWN_EVENT_TYPE');
+  });
+});
+
+describe('handleDescribe topology', () => {
+  it('HandleDescribe_TopologyParam_ReturnsHSMForWorkflowType', async () => {
+    const result = await handleDescribe({ topology: 'feature' }, workflowActions);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('topology');
+    const topology = data.topology as Record<string, unknown>;
+    expect(topology).toHaveProperty('workflowType');
+    expect(topology.workflowType).toBe('feature');
+    expect(topology).toHaveProperty('states');
+    expect(topology).toHaveProperty('transitions');
+    expect(topology).toHaveProperty('tracks');
+  });
+
+  it('HandleDescribe_TopologyAll_ReturnsAllWorkflowTypes', async () => {
+    const result = await handleDescribe({ topology: 'all' }, workflowActions);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('topology');
+    const topology = data.topology as Record<string, unknown>;
+    expect(topology).toHaveProperty('workflowTypes');
+    const types = topology.workflowTypes as string[];
+    expect(types).toContain('feature');
+    expect(types).toContain('debug');
+    expect(types).toContain('refactor');
+  });
+
+  it('HandleDescribe_TopologyInvalidType_ReturnsError', async () => {
+    const result = await handleDescribe({ topology: 'nonexistent' }, workflowActions);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('UNKNOWN_WORKFLOW_TYPE');
+  });
+
+  it('HandleDescribe_TopologyAndActions_ReturnsBoth', async () => {
+    const result = await handleDescribe(
+      { actions: ['init'], topology: 'feature' },
+      workflowActions,
+    );
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('init');
+    expect(data).toHaveProperty('topology');
+    const initDesc = data.init as Record<string, unknown>;
+    expect(initDesc).toHaveProperty('description');
+    expect(initDesc).toHaveProperty('schema');
+    const topology = data.topology as Record<string, unknown>;
+    expect(topology).toHaveProperty('workflowType');
+  });
+
+  it('HandleDescribe_ActionsOnly_BackwardCompatible', async () => {
+    const result = await handleDescribe({ actions: ['init'] }, workflowActions);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('init');
+    expect(data).not.toHaveProperty('topology');
   });
 });

--- a/servers/exarchos-mcp/src/describe/handler.test.ts
+++ b/servers/exarchos-mcp/src/describe/handler.test.ts
@@ -135,6 +135,49 @@ describe('handleEventDescribe', () => {
   });
 });
 
+describe('handleEventDescribe emissionGuide', () => {
+  it('HandleEventDescribe_EmissionGuide_ReturnsFullCatalog', async () => {
+    const result = await handleEventDescribe({ emissionGuide: true }, eventTool.actions);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('emissionGuide');
+    const guide = data.emissionGuide as Record<string, unknown>;
+    expect(guide).toHaveProperty('types');
+    expect(guide).toHaveProperty('bySource');
+    expect(guide).toHaveProperty('totalCount');
+  });
+
+  it('HandleEventDescribe_EmissionGuideAndEventTypes_ReturnsBoth', async () => {
+    const result = await handleEventDescribe(
+      { emissionGuide: true, eventTypes: ['workflow.transition'] },
+      eventTool.actions,
+    );
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('emissionGuide');
+    expect(data).toHaveProperty('eventTypes');
+  });
+
+  it('HandleEventDescribe_EmissionGuideAndActions_ReturnsBoth', async () => {
+    const result = await handleEventDescribe(
+      { emissionGuide: true, actions: ['append'] },
+      eventTool.actions,
+    );
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('emissionGuide');
+    expect(data).toHaveProperty('actions');
+  });
+
+  it('HandleEventDescribe_ActionsOnly_BackwardCompatible', async () => {
+    const result = await handleEventDescribe({ actions: ['append'] }, eventTool.actions);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('actions');
+    expect(data).not.toHaveProperty('emissionGuide');
+  });
+});
+
 describe('handleDescribe topology', () => {
   it('HandleDescribe_TopologyParam_ReturnsHSMForWorkflowType', async () => {
     const result = await handleDescribe({ topology: 'feature' }, workflowActions);

--- a/servers/exarchos-mcp/src/describe/handler.ts
+++ b/servers/exarchos-mcp/src/describe/handler.ts
@@ -6,6 +6,7 @@ import {
   EVENT_EMISSION_REGISTRY,
   getValidEventTypes,
   isBuiltInEventType,
+  serializeEventCatalog,
 } from '../event-store/schemas.js';
 import { serializeTopology, listWorkflowTypes } from '../workflow/state-machine.js';
 
@@ -149,24 +150,27 @@ export async function handleEventTypeDescribe(
 
 /**
  * Combined describe handler for the event tool.
- * Supports both `actions` (tool action schemas) and `eventTypes` (event data schemas).
+ * Supports `actions` (tool action schemas), `eventTypes` (event data schemas),
+ * and `emissionGuide` (full event emission catalog grouped by source).
  */
 export async function handleEventDescribe(
-  args: { actions?: string[]; eventTypes?: string[] },
+  args: { actions?: string[]; eventTypes?: string[]; emissionGuide?: boolean },
   toolActions: readonly ToolAction[],
 ): Promise<ToolResult> {
   const hasActions = args.actions && args.actions.length > 0;
   const hasEventTypes = args.eventTypes && args.eventTypes.length > 0;
+  const hasEmissionGuide = args.emissionGuide === true;
 
-  if (!hasActions && !hasEventTypes) {
+  if (!hasActions && !hasEventTypes && !hasEmissionGuide) {
     return {
       success: false,
       error: {
         code: 'INVALID_INPUT',
-        message: 'At least one of actions or eventTypes must be provided',
+        message: 'At least one of actions, eventTypes, or emissionGuide must be provided',
         expectedShape: {
           actions: ['append', 'query'],
           eventTypes: ['shepherd.iteration', 'team.spawned'],
+          emissionGuide: true,
         },
       },
     };
@@ -186,6 +190,11 @@ export async function handleEventDescribe(
     const eventResult = await handleEventTypeDescribe(args.eventTypes);
     if (!eventResult.success) return eventResult;
     Object.assign(results, { eventTypes: eventResult.data });
+  }
+
+  // Resolve emission guide if requested
+  if (hasEmissionGuide) {
+    results.emissionGuide = serializeEventCatalog();
   }
 
   return { success: true, data: results };

--- a/servers/exarchos-mcp/src/describe/handler.ts
+++ b/servers/exarchos-mcp/src/describe/handler.ts
@@ -7,17 +7,36 @@ import {
   getValidEventTypes,
   isBuiltInEventType,
 } from '../event-store/schemas.js';
+import { serializeTopology, listWorkflowTypes } from '../workflow/state-machine.js';
 
 /**
  * Handles the `describe` action for composite tools.
  * Returns full schemas, descriptions, gate metadata, and phase/role info
- * for the requested action names.
+ * for the requested action names. Optionally includes HSM topology when
+ * the `topology` parameter is provided.
  */
 export async function handleDescribe(
-  args: { actions: string[] },
+  args: { actions?: string[]; topology?: string },
   toolActions: readonly ToolAction[],
 ): Promise<ToolResult> {
-  if (!Array.isArray(args.actions) || !args.actions.every((a: unknown) => typeof a === 'string')) {
+  const hasActions = args.actions && args.actions.length > 0;
+  const hasTopology = typeof args.topology === 'string' && args.topology.length > 0;
+
+  if (!hasActions && !hasTopology) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'describe requires at least one of actions or topology',
+        expectedShape: {
+          actions: ['action_name_1', 'action_name_2'],
+          topology: 'feature | debug | refactor | all',
+        },
+      },
+    };
+  }
+
+  if (hasActions && (!Array.isArray(args.actions) || !args.actions.every((a: unknown) => typeof a === 'string'))) {
     return {
       success: false,
       error: {
@@ -30,29 +49,67 @@ export async function handleDescribe(
 
   const results: Record<string, unknown> = {};
 
-  for (const actionName of args.actions) {
-    const action = toolActions.find(a => a.name === actionName);
-    if (!action) {
-      return {
-        success: false,
-        error: {
-          code: 'UNKNOWN_ACTION',
-          message: `Unknown action: ${actionName}`,
-          validTargets: toolActions.map(a => a.name),
-        },
+  // Resolve action schemas if requested
+  if (args.actions && args.actions.length > 0) {
+    for (const actionName of args.actions) {
+      const action = toolActions.find(a => a.name === actionName);
+      if (!action) {
+        return {
+          success: false,
+          error: {
+            code: 'UNKNOWN_ACTION',
+            message: `Unknown action: ${actionName}`,
+            validTargets: toolActions.map(a => a.name),
+          },
+        };
+      }
+
+      results[actionName] = {
+        description: action.description,
+        schema: zodToJsonSchema(action.schema),
+        gate: (action as ToolAction & { gate?: unknown }).gate ?? null,
+        phases: [...action.phases],
+        roles: [...action.roles],
       };
     }
+  }
 
-    results[actionName] = {
-      description: action.description,
-      schema: zodToJsonSchema(action.schema),
-      gate: (action as ToolAction & { gate?: unknown }).gate ?? null,
-      phases: [...action.phases],
-      roles: [...action.roles],
-    };
+  // Resolve topology if requested
+  if (hasTopology) {
+    const topologyResult = handleTopologyDescribe(args.topology as string);
+    if (!topologyResult.success) return topologyResult;
+    results.topology = topologyResult.data;
   }
 
   return { success: true, data: results };
+}
+
+/**
+ * Handles topology introspection for the workflow describe action.
+ * When topology is "all", returns a listing of all workflow types.
+ * Otherwise, returns the serialized HSM topology for the specified type.
+ */
+function handleTopologyDescribe(topology: string): ToolResult {
+  if (topology === 'all') {
+    return {
+      success: true,
+      data: { workflowTypes: listWorkflowTypes() },
+    };
+  }
+
+  try {
+    const serialized = serializeTopology(topology);
+    return { success: true, data: serialized };
+  } catch {
+    return {
+      success: false,
+      error: {
+        code: 'UNKNOWN_WORKFLOW_TYPE',
+        message: `Unknown workflow type: ${topology}`,
+        validTargets: listWorkflowTypes(),
+      },
+    };
+  }
 }
 
 /**

--- a/servers/exarchos-mcp/src/describe/handler.ts
+++ b/servers/exarchos-mcp/src/describe/handler.ts
@@ -93,7 +93,7 @@ function handleTopologyDescribe(topology: string): ToolResult {
   if (topology === 'all') {
     return {
       success: true,
-      data: { workflowTypes: listWorkflowTypes() },
+      data: listWorkflowTypes(),
     };
   }
 
@@ -106,7 +106,7 @@ function handleTopologyDescribe(topology: string): ToolResult {
       error: {
         code: 'UNKNOWN_WORKFLOW_TYPE',
         message: `Unknown workflow type: ${topology}`,
-        validTargets: listWorkflowTypes(),
+        validTargets: listWorkflowTypes().workflowTypes.map(wt => wt.name),
       },
     };
   }

--- a/servers/exarchos-mcp/src/event-store/composite.ts
+++ b/servers/exarchos-mcp/src/event-store/composite.ts
@@ -40,7 +40,7 @@ export async function handleEvent(
     case 'describe': {
       const { action: _, ...rest } = args;
       return handleEventDescribe(
-        rest as { actions?: string[]; eventTypes?: string[] },
+        rest as { actions?: string[]; eventTypes?: string[]; emissionGuide?: boolean },
         eventActions,
       );
     }

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -44,6 +44,7 @@ import {
   unregisterEventType,
   getValidEventTypes,
   isBuiltInEventType,
+  serializeEventCatalog,
 } from './schemas.js';
 
 // ─── T1: EventEmissionSource + EVENT_EMISSION_REGISTRY ──────────────────────
@@ -1794,5 +1795,48 @@ describe('isBuiltInEventType', () => {
 
   it('IsBuiltInEventType_CustomType_ReturnsFalse', () => {
     expect(isBuiltInEventType('deploy.started')).toBe(false);
+  });
+});
+
+// ─── serializeEventCatalog ──────────────────────────────────────────────────
+
+describe('serializeEventCatalog', () => {
+  it('SerializeEventCatalog_ReturnsAllBuiltInEventTypes', () => {
+    const catalog = serializeEventCatalog();
+    for (const eventType of EventTypes) {
+      expect(catalog.types).toHaveProperty(eventType);
+    }
+  });
+
+  it('SerializeEventCatalog_IncludesEmissionSource', () => {
+    const catalog = serializeEventCatalog();
+    expect(catalog.types['workflow.started'].source).toBe('auto');
+    expect(catalog.types['team.spawned'].source).toBe('model');
+  });
+
+  it('SerializeEventCatalog_GroupsBySource', () => {
+    const catalog = serializeEventCatalog();
+    expect(catalog.bySource.auto).toContain('workflow.started');
+    expect(catalog.bySource.model).toContain('team.spawned');
+  });
+
+  it('SerializeEventCatalog_IncludesBuiltInFlag', () => {
+    const catalog = serializeEventCatalog();
+    expect(catalog.types['workflow.started'].isBuiltIn).toBe(true);
+    expect(catalog.types['task.completed'].isBuiltIn).toBe(true);
+    expect(catalog.types['team.spawned'].isBuiltIn).toBe(true);
+  });
+
+  it('SerializeEventCatalog_IncludesHasSchemaFlag', () => {
+    const catalog = serializeEventCatalog();
+    // task.completed has a schema in EVENT_DATA_SCHEMAS
+    expect(catalog.types['task.completed'].hasSchema).toBe(true);
+    // state.patched does NOT have a schema in EVENT_DATA_SCHEMAS
+    expect(catalog.types['state.patched'].hasSchema).toBe(false);
+  });
+
+  it('SerializeEventCatalog_TotalCount_MatchesTypeCount', () => {
+    const catalog = serializeEventCatalog();
+    expect(catalog.totalCount).toBe(Object.keys(catalog.types).length);
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -929,6 +929,58 @@ export type EventDataMap = {
   'comment.resolved': CommentResolved;
 };
 
+// ─── Event Catalog Serialization ────────────────────────────────────────────
+
+export interface EventCatalog {
+  types: Record<string, {
+    source: string;
+    isBuiltIn: boolean;
+    hasSchema: boolean;
+  }>;
+  bySource: {
+    auto: string[];
+    model: string[];
+    hook: string[];
+    planned: string[];
+  };
+  totalCount: number;
+}
+
+/**
+ * Returns a comprehensive catalog of all registered event types (built-in + custom)
+ * with their emission source, built-in status, and whether they have a data schema.
+ *
+ * Pure function with no side effects.
+ */
+export function serializeEventCatalog(): EventCatalog {
+  const allTypes = getValidEventTypes();
+  const registry = EVENT_EMISSION_REGISTRY as Record<string, EventEmissionSource>;
+  const schemas = EVENT_DATA_SCHEMAS as Partial<Record<string, z.ZodSchema>>;
+
+  const types: EventCatalog['types'] = {};
+  const bySource: EventCatalog['bySource'] = {
+    auto: [],
+    model: [],
+    hook: [],
+    planned: [],
+  };
+
+  for (const eventType of allTypes) {
+    const source = registry[eventType] ?? 'model';
+    const isBuiltIn = isBuiltInEventType(eventType);
+    const hasSchema = eventType in schemas && schemas[eventType] !== undefined;
+
+    types[eventType] = { source, isBuiltIn, hasSchema };
+    bySource[source as keyof EventCatalog['bySource']].push(eventType);
+  }
+
+  return {
+    types,
+    bySource,
+    totalCount: allTypes.length,
+  };
+}
+
 // ─── Agent Event Validation ──────────────────────────────────────────────────
 
 /** Event types that require agentId and source metadata. */

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -247,6 +247,27 @@ function makeDescribeAction(): ToolAction {
   };
 }
 
+/** Workflow-specific describe schema: supports both actions and topology. */
+const workflowDescribeSchema = z.object({
+  actions: z.array(z.string()).min(1).max(10)
+    .describe('Action names to describe. Returns full schema + description for each.')
+    .optional(),
+  topology: z.string()
+    .describe('Workflow type to return HSM topology for. Use "all" to list all types.')
+    .optional(),
+});
+
+/** Creates a workflow-specific describe action with topology support. */
+function makeWorkflowDescribeAction(): ToolAction {
+  return {
+    name: 'describe',
+    description: 'Return full schemas, descriptions, gate metadata, and phase/role info for specific actions. Optionally return HSM topology for a workflow type.',
+    schema: workflowDescribeSchema,
+    phases: ALL_PHASES,
+    roles: ROLE_ANY,
+  };
+}
+
 const eventDescribeSchema = z.object({
   actions: z.array(z.string()).min(1).max(10)
     .describe('Action names to describe. Returns full schema + description for each.')
@@ -347,7 +368,7 @@ const workflowActions: readonly ToolAction[] = [
     phases: ALL_PHASES,
     roles: ROLE_LEAD,
   },
-  makeDescribeAction(),
+  makeWorkflowDescribeAction(),
 ];
 
 // ─── Composite Tool: exarchos_event ─────────────────────────────────────────

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -275,13 +275,15 @@ const eventDescribeSchema = z.object({
   eventTypes: z.array(z.string()).min(1).max(20)
     .describe('Event type names to describe. Returns data schema, emission source, and built-in status for each.')
     .optional(),
+  emissionGuide: z.boolean().optional()
+    .describe('When true, returns the full event emission catalog grouped by source'),
 });
 
-/** Creates a describe action for the event tool that supports both actions and eventTypes. */
+/** Creates a describe action for the event tool that supports both actions, eventTypes, and emissionGuide. */
 function makeEventDescribeAction(): ToolAction {
   return {
     name: 'describe',
-    description: 'Return schemas for actions and/or event types. At least one of actions or eventTypes must be provided.',
+    description: 'Return schemas for actions and/or event types, or the emission guide. At least one of actions, eventTypes, or emissionGuide must be provided.',
     schema: eventDescribeSchema,
     phases: ALL_PHASES,
     roles: ROLE_ANY,

--- a/servers/exarchos-mcp/src/workflow/composite.ts
+++ b/servers/exarchos-mcp/src/workflow/composite.ts
@@ -31,7 +31,7 @@ export async function handleWorkflow(
     case 'reconcile':
       return handleReconcileState(rest as Parameters<typeof handleReconcileState>[0], stateDir);
     case 'describe':
-      return handleDescribe(rest as { actions: string[] }, workflowActions);
+      return handleDescribe(rest as { actions?: string[]; topology?: string }, workflowActions);
     default:
       return {
         success: false,

--- a/servers/exarchos-mcp/src/workflow/state-machine.test.ts
+++ b/servers/exarchos-mcp/src/workflow/state-machine.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { serializeTopology, listWorkflowTypes } from './state-machine.js';
+import type { SerializedTopology, WorkflowTypeSummary } from './state-machine.js';
+
+describe('serializeTopology', () => {
+  it('SerializeTopology_FeatureWorkflow_ReturnsStatesAndTransitions', () => {
+    const result: SerializedTopology = serializeTopology('feature');
+
+    expect(result.workflowType).toBe('feature');
+    expect(result.initialPhase).toBe('ideate');
+
+    // States should have id and type
+    expect(result.states['ideate']).toBeDefined();
+    expect(result.states['ideate'].id).toBe('ideate');
+    expect(result.states['ideate'].type).toBe('atomic');
+
+    expect(result.states['completed']).toBeDefined();
+    expect(result.states['completed'].type).toBe('final');
+
+    expect(result.states['implementation']).toBeDefined();
+    expect(result.states['implementation'].type).toBe('compound');
+
+    // Transitions should have from and to
+    expect(result.transitions.length).toBeGreaterThan(0);
+    const ideaToPlan = result.transitions.find(
+      (t) => t.from === 'ideate' && t.to === 'plan',
+    );
+    expect(ideaToPlan).toBeDefined();
+    expect(ideaToPlan!.from).toBe('ideate');
+    expect(ideaToPlan!.to).toBe('plan');
+  });
+
+  it('SerializeTopology_RefactorWorkflow_IncludesTracks', () => {
+    const result: SerializedTopology = serializeTopology('refactor');
+
+    // Tracks should be derived from compound states
+    expect(result.tracks).toBeDefined();
+    expect(Object.keys(result.tracks).length).toBeGreaterThan(0);
+
+    // Polish track should contain its child states
+    expect(result.tracks['polish-track']).toBeDefined();
+    expect(result.tracks['polish-track']).toContain('polish-implement');
+    expect(result.tracks['polish-track']).toContain('polish-validate');
+    expect(result.tracks['polish-track']).toContain('polish-update-docs');
+
+    // Overhaul track should contain its child states
+    expect(result.tracks['overhaul-track']).toBeDefined();
+    expect(result.tracks['overhaul-track']).toContain('overhaul-plan');
+    expect(result.tracks['overhaul-track']).toContain('overhaul-delegate');
+    expect(result.tracks['overhaul-track']).toContain('overhaul-review');
+    expect(result.tracks['overhaul-track']).toContain('overhaul-update-docs');
+  });
+
+  it('SerializeTopology_TransitionGuards_IncludeIdAndDescription', () => {
+    const result: SerializedTopology = serializeTopology('feature');
+
+    // Find a guarded transition (ideate -> plan has designArtifactExists guard)
+    const ideaToPlan = result.transitions.find(
+      (t) => t.from === 'ideate' && t.to === 'plan',
+    );
+    expect(ideaToPlan).toBeDefined();
+    expect(ideaToPlan!.guard).toBeDefined();
+    expect(ideaToPlan!.guard!.id).toBe('design-artifact-exists');
+    expect(ideaToPlan!.guard!.description).toBe('Design artifact must exist');
+
+    // Guard should NOT have an evaluate function (JSON-serializable)
+    expect((ideaToPlan!.guard as Record<string, unknown>)['evaluate']).toBeUndefined();
+  });
+
+  it('SerializeTopology_CompoundStates_IncludeParentAndInitial', () => {
+    const result: SerializedTopology = serializeTopology('feature');
+
+    // The compound state should have initial and maxFixCycles
+    const implementation = result.states['implementation'];
+    expect(implementation).toBeDefined();
+    expect(implementation.type).toBe('compound');
+    expect(implementation.initial).toBe('delegate');
+    expect(implementation.maxFixCycles).toBe(3);
+
+    // Child states should have parent
+    const delegate = result.states['delegate'];
+    expect(delegate).toBeDefined();
+    expect(delegate.parent).toBe('implementation');
+
+    const review = result.states['review'];
+    expect(review).toBeDefined();
+    expect(review.parent).toBe('implementation');
+
+    // Compound state should include onEntry and onExit
+    expect(implementation.onEntry).toEqual(['log']);
+    expect(implementation.onExit).toEqual(['log']);
+  });
+
+  it('SerializeTopology_UnknownWorkflowType_Throws', () => {
+    expect(() => serializeTopology('nonexistent')).toThrow(
+      'Unknown workflow type: nonexistent',
+    );
+  });
+
+  it('SerializeTopology_TransitionsIncludeFixCycleAndEffects', () => {
+    const result: SerializedTopology = serializeTopology('feature');
+
+    // review -> delegate is a fix cycle
+    const reviewToDelegate = result.transitions.find(
+      (t) => t.from === 'review' && t.to === 'delegate',
+    );
+    expect(reviewToDelegate).toBeDefined();
+    expect(reviewToDelegate!.isFixCycle).toBe(true);
+    expect(reviewToDelegate!.effects).toEqual(['increment-fix-cycle']);
+  });
+});
+
+describe('listWorkflowTypes', () => {
+  it('ListWorkflowTypes_ReturnsAllRegisteredTypes', () => {
+    const result: WorkflowTypeSummary = listWorkflowTypes();
+
+    expect(result.workflowTypes).toBeDefined();
+    expect(result.workflowTypes.length).toBeGreaterThanOrEqual(3);
+
+    // Should include feature, debug, and refactor
+    const names = result.workflowTypes.map((wt) => wt.name);
+    expect(names).toContain('feature');
+    expect(names).toContain('debug');
+    expect(names).toContain('refactor');
+
+    // Each entry should have initialPhase, phaseCount, trackCount
+    const feature = result.workflowTypes.find((wt) => wt.name === 'feature');
+    expect(feature).toBeDefined();
+    expect(feature!.initialPhase).toBe('ideate');
+    expect(feature!.phaseCount).toBeGreaterThan(0);
+    expect(feature!.trackCount).toBeGreaterThanOrEqual(0);
+
+    // Debug has two tracks (thorough-track, hotfix-track)
+    const debug = result.workflowTypes.find((wt) => wt.name === 'debug');
+    expect(debug).toBeDefined();
+    expect(debug!.trackCount).toBe(2);
+
+    // Refactor has two tracks (polish-track, overhaul-track)
+    const refactor = result.workflowTypes.find((wt) => wt.name === 'refactor');
+    expect(refactor).toBeDefined();
+    expect(refactor!.trackCount).toBe(2);
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/state-machine.ts
+++ b/servers/exarchos-mcp/src/workflow/state-machine.ts
@@ -67,6 +67,39 @@ export interface TransitionResult {
   };
 }
 
+// ─── Serialization Types ────────────────────────────────────────────────────
+
+export interface SerializedTopology {
+  workflowType: string;
+  initialPhase: string;
+  states: Record<string, {
+    id: string;
+    type: 'atomic' | 'compound' | 'final';
+    parent?: string;
+    initial?: string;
+    maxFixCycles?: number;
+    onEntry?: readonly string[];
+    onExit?: readonly string[];
+  }>;
+  transitions: Array<{
+    from: string;
+    to: string;
+    guard?: { id: string; description: string };
+    isFixCycle?: boolean;
+    effects?: readonly string[];
+  }>;
+  tracks: Record<string, string[]>;
+}
+
+export interface WorkflowTypeSummary {
+  workflowTypes: Array<{
+    name: string;
+    initialPhase: string;
+    phaseCount: number;
+    trackCount: number;
+  }>;
+}
+
 // ─── HSM Registry ───────────────────────────────────────────────────────────
 
 const BUILT_IN_TYPES = new Set(['feature', 'debug', 'refactor']);
@@ -101,6 +134,97 @@ export function getInitialPhase(workflowType: string): string {
     throw new Error(`Unknown workflow type: ${workflowType}`);
   }
   return phase;
+}
+
+// ─── Topology Serialization ─────────────────────────────────────────────────
+
+/**
+ * Derive tracks from compound states: for each compound state, collect
+ * its children (states where parent === compoundState.id).
+ */
+function deriveTracks(hsm: HSMDefinition): Record<string, string[]> {
+  const tracks: Record<string, string[]> = {};
+  for (const state of Object.values(hsm.states)) {
+    if (state.type === 'compound') {
+      tracks[state.id] = [];
+    }
+  }
+  for (const state of Object.values(hsm.states)) {
+    if (state.parent && tracks[state.parent] !== undefined) {
+      tracks[state.parent].push(state.id);
+    }
+  }
+  return tracks;
+}
+
+/**
+ * Serialize an HSM definition into a plain JSON-serializable object.
+ * Strips evaluate functions from guards, derives tracks from compound states.
+ */
+export function serializeTopology(workflowType: string): SerializedTopology {
+  const hsm = getHSMDefinition(workflowType);
+  const initialPhase = getInitialPhase(workflowType);
+
+  const states: SerializedTopology['states'] = {};
+  for (const [id, state] of Object.entries(hsm.states)) {
+    const entry: SerializedTopology['states'][string] = {
+      id: state.id,
+      type: state.type,
+    };
+    if (state.parent !== undefined) entry.parent = state.parent;
+    if (state.initial !== undefined) entry.initial = state.initial;
+    if (state.maxFixCycles !== undefined) entry.maxFixCycles = state.maxFixCycles;
+    if (state.onEntry !== undefined) entry.onEntry = state.onEntry;
+    if (state.onExit !== undefined) entry.onExit = state.onExit;
+    states[id] = entry;
+  }
+
+  const transitions: SerializedTopology['transitions'] = hsm.transitions.map((t) => {
+    const entry: SerializedTopology['transitions'][number] = {
+      from: t.from,
+      to: t.to,
+    };
+    if (t.guard) {
+      entry.guard = { id: t.guard.id, description: t.guard.description };
+    }
+    if (t.isFixCycle !== undefined) entry.isFixCycle = t.isFixCycle;
+    if (t.effects !== undefined) entry.effects = t.effects;
+    return entry;
+  });
+
+  const tracks = deriveTracks(hsm);
+
+  return {
+    workflowType,
+    initialPhase,
+    states,
+    transitions,
+    tracks,
+  };
+}
+
+/**
+ * List all registered workflow types with summary information.
+ */
+export function listWorkflowTypes(): WorkflowTypeSummary {
+  const workflowTypes: WorkflowTypeSummary['workflowTypes'] = [];
+
+  for (const name of Object.keys(hsmRegistry)) {
+    const hsm = hsmRegistry[name];
+    const initialPhase = initialPhaseRegistry[name];
+    const phaseCount = Object.keys(hsm.states).length;
+    const tracks = deriveTracks(hsm);
+    const trackCount = Object.keys(tracks).length;
+
+    workflowTypes.push({
+      name,
+      initialPhase,
+      phaseCount,
+      trackCount,
+    });
+  }
+
+  return { workflowTypes };
 }
 
 // ─── Workflow Definition → HSM Conversion ────────────────────────────────────

--- a/servers/exarchos-mcp/src/workflow/state-machine.ts
+++ b/servers/exarchos-mcp/src/workflow/state-machine.ts
@@ -103,6 +103,76 @@ export function getInitialPhase(workflowType: string): string {
   return phase;
 }
 
+// ─── Topology Introspection ─────────────────────────────────────────────────
+
+export interface SerializedTopology {
+  readonly workflowType: string;
+  readonly states: Record<string, {
+    readonly type: string;
+    readonly parent?: string;
+    readonly initial?: string;
+    readonly maxFixCycles?: number;
+  }>;
+  readonly transitions: readonly {
+    readonly from: string;
+    readonly to: string;
+    readonly guard?: { readonly id: string; readonly description: string };
+    readonly isFixCycle?: boolean;
+  }[];
+  readonly tracks: Record<string, readonly string[]>;
+}
+
+/**
+ * Serialize the HSM topology for a workflow type into a JSON-safe structure.
+ * Strips runtime guard functions, preserving only id + description metadata.
+ * Throws if the workflow type is unknown.
+ */
+export function serializeTopology(workflowType: string): SerializedTopology {
+  const hsm = getHSMDefinition(workflowType);
+
+  // Serialize states (strip onEntry/onExit effects — they are runtime details)
+  const states: SerializedTopology['states'] = {};
+  for (const [id, state] of Object.entries(hsm.states)) {
+    const entry: Record<string, unknown> = { type: state.type };
+    if (state.parent) entry.parent = state.parent;
+    if (state.initial) entry.initial = state.initial;
+    if (state.maxFixCycles != null) entry.maxFixCycles = state.maxFixCycles;
+    states[id] = entry as SerializedTopology['states'][string];
+  }
+
+  // Serialize transitions (replace guard functions with metadata)
+  const transitions = hsm.transitions.map((t) => {
+    const entry: Record<string, unknown> = { from: t.from, to: t.to };
+    if (t.guard) {
+      entry.guard = { id: t.guard.id, description: t.guard.description };
+    }
+    if (t.isFixCycle) entry.isFixCycle = true;
+    return entry as SerializedTopology['transitions'][number];
+  });
+
+  // Derive tracks: compound states and their children
+  const tracks: Record<string, string[]> = {};
+  for (const [id, state] of Object.entries(hsm.states)) {
+    if (state.type === 'compound') {
+      tracks[id] = [];
+    }
+  }
+  for (const [id, state] of Object.entries(hsm.states)) {
+    if (state.parent && tracks[state.parent]) {
+      tracks[state.parent].push(id);
+    }
+  }
+
+  return { workflowType, states, transitions, tracks };
+}
+
+/**
+ * List all registered workflow type names.
+ */
+export function listWorkflowTypes(): string[] {
+  return Object.keys(hsmRegistry);
+}
+
 // ─── Workflow Definition → HSM Conversion ────────────────────────────────────
 
 import type { WorkflowDefinition, GuardDefinition } from '../config/define.js';

--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -247,7 +247,7 @@ If an issue spans multiple tasks:
 **On review complete:**
 ```text
 action: "set", featureId: "<id>", updates: {
-  "reviews": { "quality": { "status": "pass", "summary": "...", "issues": [...] } }
+  "reviews": { "quality-review": { "status": "pass", "summary": "...", "issues": [...] } }
 }
 ```
 
@@ -288,6 +288,32 @@ Summary: `check_convergence` returns per-dimension D1-D5 status. `check_review_v
 
 All transitions are automatic — no user confirmation. See `references/auto-transition.md` for per-verdict transition details, Skill invocations, and integration notes.
 
-- **APPROVED** → set phase `synthesize`, invoke `/exarchos:synthesize`
-- **NEEDS_FIXES** → invoke `/exarchos:delegate --fixes`
-- **BLOCKED** → set phase `blocked`, invoke `/exarchos:ideate --redesign`
+### Recording Results
+
+Before transitioning, record the review verdict. The reviews value MUST be an object with a `status` field, not a flat string:
+
+**APPROVED:**
+```
+exarchos_workflow({ action: "set", featureId: "<id>", updates: {
+  reviews: { "quality-review": { status: "pass", summary: "...", issues: [] } }
+}, phase: "synthesize" })
+```
+Then invoke `/exarchos:synthesize`.
+
+**NEEDS_FIXES:**
+```
+exarchos_workflow({ action: "set", featureId: "<id>", updates: {
+  reviews: { "quality-review": { status: "fail", summary: "...", issues: [{ severity: "HIGH", file: "...", description: "..." }] } }
+}})
+```
+Then invoke `/exarchos:delegate --fixes`.
+
+**BLOCKED:**
+```
+exarchos_workflow({ action: "set", featureId: "<id>", phase: "blocked" })
+```
+Then invoke `/exarchos:ideate --redesign`.
+
+> **Gate events:** Do NOT manually emit `gate.executed` events via `exarchos_event`. Gate events are automatically emitted by the `check_review_verdict` orchestrate handler. Manual emission causes duplicates.
+
+> **Guard shape:** The `all-reviews-passed` guard requires `reviews.{name}.status` to be a passing value (`pass`, `passed`, `approved`, `fixes-applied`). Flat strings like `reviews: { "quality-review": "pass" }` are silently ignored and will block the `review → synthesize` transition.

--- a/skills/quality-review/references/auto-transition.md
+++ b/skills/quality-review/references/auto-transition.md
@@ -13,7 +13,7 @@ All transitions happen **immediately** without user confirmation:
    ```
 
 ### If NEEDS_FIXES:
-1. Update state: `action: "set", featureId: "<id>", updates: { "reviews": { "quality": { "status": "fail", "issues": [...] } } }`
+1. Update state: `action: "set", featureId: "<id>", updates: { "reviews": { "quality-review": { "status": "fail", "issues": [...] } } }`
 2. Output: "Quality review found [N] HIGH-priority issues. Auto-continuing to fixes..."
 3. Auto-invoke delegate with fix tasks:
    ```typescript

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -156,6 +156,8 @@ Full state schema:
 
 ### Phase Transitions and Guards
 
+> **Sequential traversal required.** Every phase MUST be traversed in order — you cannot skip phases. For example, from `brief` you must go to `polish-implement`, not directly to `completed`. Each transition requires its guard to be satisfied via `updates` sent alongside the `phase` parameter in a single `set` call. See `@skills/refactor/references/polish-track.md` or `@skills/refactor/references/overhaul-track.md` for the exact tool call at each step.
+
 Every phase transition has a guard that must be satisfied. Before transitioning, consult `@skills/workflow-state/references/phase-transitions.md` for the exact prerequisite for each guard.
 
 **Quick reference — transition guards:**
@@ -176,6 +178,15 @@ Every phase transition has a guard that must be satisfied. Before transitioning,
 | `overhaul-review` → `overhaul-delegate` | `any-review-failed` | Any `reviews.{name}.status` failing |
 | `overhaul-update-docs` → `synthesize` | `docs-updated` | Set `validation.docsUpdated = true` |
 | `synthesize` → `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+**Example — advancing from polish-validate to polish-update-docs:**
+```
+exarchos_workflow({ action: "set", featureId: "refactor-<slug>", updates: {
+  validation: { testsPass: true, goalsVerified: ["<verified goals>"] }
+}, phase: "polish-update-docs" })
+```
+
+The pattern is the same for every transition: send the guard prerequisite in `updates` and the target in `phase` in a single `set` call.
 
 ### Schema Discovery
 

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -204,16 +204,18 @@ If an issue spans multiple tasks:
 **Pass:**
 ```
 action: "set", featureId: "<id>", updates: {
-  "reviews": { "spec": { "status": "pass", "summary": "...", "issues": [] } }
+  "reviews": { "spec-review": { "status": "pass", "summary": "...", "issues": [] } }
 }
 ```
 
 **Fail:**
 ```
 action: "set", featureId: "<id>", updates: {
-  "reviews": { "spec": { "status": "fail", "summary": "...", "issues": [{ "severity": "...", "file": "...", "description": "..." }] } }
+  "reviews": { "spec-review": { "status": "fail", "summary": "...", "issues": [{ "severity": "...", "file": "...", "description": "..." }] } }
 }
 ```
+
+> **Important:** The review value MUST be an object with a `status` field (e.g., `{ "status": "pass" }`), not a flat string (e.g., `"pass"`). The `all-reviews-passed` guard silently ignores non-object entries. Accepted statuses: `pass`, `passed`, `approved`, `fixes-applied`.
 
 ### Phase Transitions and Guards
 
@@ -235,16 +237,28 @@ All transitions happen **immediately** without user confirmation:
 ### Pre-Chain Validation (MANDATORY)
 
 Before invoking quality-review:
-1. Verify `reviews.spec.status === "pass"` in workflow state (all tasks passed)
+1. Verify `reviews["spec-review"].status === "pass"` in workflow state (all tasks passed)
 2. If not: "Spec review did not pass, cannot proceed to quality review"
 
 ### If PASS:
-1. Update state with review results
+1. Record results — the reviews value MUST be an object with a `status` field, not a flat string:
+   ```
+   exarchos_workflow({ action: "set", featureId: "<id>", updates: {
+     reviews: { "spec-review": { status: "pass", summary: "...", issues: [] } }
+   }})
+   ```
 2. Output: "Spec review passed. Auto-continuing to quality review..."
 3. Orchestrator dispatches quality-review subagent immediately
 
+> **Gate events:** Do NOT manually emit `gate.executed` events via `exarchos_event`. Gate events are automatically emitted by the `check_review_verdict` orchestrate handler. Manual emission causes duplicates.
+
 ### If FAIL:
-1. Update state with failed issues
+1. Record results with failing status and issue details:
+   ```
+   exarchos_workflow({ action: "set", featureId: "<id>", updates: {
+     reviews: { "spec-review": { status: "fail", summary: "...", issues: [{ severity: "HIGH", file: "...", description: "..." }] } }
+   }})
+   ```
 2. Output: "Spec review found [N] issues. Auto-continuing to fixes..."
 3. Auto-invoke delegate with fix tasks:
    ```typescript

--- a/skills/spec-review/references/worked-example.md
+++ b/skills/spec-review/references/worked-example.md
@@ -69,4 +69,4 @@ Subagent initially flags "Missing rate-limit guard" as a spec gap. On re-reading
 }
 ```
 
-State updated with `reviews.spec.status = "fail"`. Orchestrator dispatches fix task automatically.
+State updated with `reviews["spec-review"].status = "fail"`. Orchestrator dispatches fix task automatically.


### PR DESCRIPTION
## Summary

Expand tool introspection (Phase 1 of #979) so plugin-free agents and CLI users can discover HSM topology, phase transitions, guards, tracks, and event emission patterns without content layers.

## Changes

- **HSM topology serialization** — `serializeTopology()` and `listWorkflowTypes()` expose states, transitions, guards, compound states, and tracks as JSON-serializable objects
- **Event emission catalog** — `serializeEventCatalog()` returns all event types grouped by emission source (auto/model/hook/planned) with schema availability
- **Workflow describe** — new optional `topology` parameter on `exarchos_workflow describe` returns HSM topology for any workflow type or lists all types
- **Event describe** — new optional `emissionGuide` parameter on `exarchos_event describe` returns the full emission catalog
- **CLI commands** — `exarchos topology [type]` and `exarchos emissions` for plugin-free introspection
- **DRY refactor** — CLI adapter now delegates to canonical serialization functions instead of reimplementing
- All changes are additive — existing describe behavior unchanged when new params aren't used

## Test plan

- [x] 26 new tests across 4 test files (3724 total, all passing)
- [x] TypeScript strict mode — zero errors
- [x] Backward compatibility — explicit regression tests verify existing responses unchanged
- [x] Two-stage review: spec compliance PASS, code quality PASS
- [x] Feature audit: all 5 convergence dimensions APPROVED

Closes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)