### PR TITLE
feat(introspection): tool introspection phases 2-4 — autoEmits, playbooks, skill refactoring

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/views/materializer.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/views/materializer.test.ts
@@ -372,8 +372,8 @@ describe('ViewMaterializer with Snapshots', () => {
 
       materializer.materialize<CounterView>('test-stream', 'counter', events);
 
-      // Allow async snapshot write to complete
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      // Await pending snapshot writes
+      await materializer.flush();
 
       const snapshot = await snapshotStore.load<CounterView>('test-stream', 'counter');
       expect(snapshot).toBeDefined();

--- a/servers/exarchos-mcp/src/adapters/schema-introspection.test.ts
+++ b/servers/exarchos-mcp/src/adapters/schema-introspection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveSchemaRef, listSchemas, resolveTopologyRef, resolveEmissionCatalog } from './schema-introspection.js';
+import { resolveSchemaRef, listSchemas, resolveTopologyRef, resolveEmissionCatalog, resolvePlaybookRef } from './schema-introspection.js';
 
 describe('resolveSchemaRef', () => {
   it('ResolveSchemaRef_ValidRef_ReturnsJsonSchema', () => {
@@ -100,6 +100,25 @@ describe('resolveTopologyRef', () => {
 
   it('ResolveTopologyRef_InvalidType_ThrowsError', () => {
     expect(() => resolveTopologyRef('nonexistent')).toThrow(/Unknown workflow type/);
+  });
+});
+
+describe('resolvePlaybookRef', () => {
+  it('ResolvePlaybookRef_Feature_ReturnsSerializedPlaybooks', () => {
+    const result = resolvePlaybookRef('feature');
+    expect(result).toHaveProperty('workflowType', 'feature');
+    expect(result).toHaveProperty('phases');
+    expect(result).toHaveProperty('phaseCount');
+    expect((result as { phaseCount: number }).phaseCount).toBeGreaterThan(0);
+  });
+
+  it('ResolvePlaybookRef_NoArg_ReturnsWorkflowTypeList', () => {
+    const result = resolvePlaybookRef();
+    expect(Array.isArray(result)).toBe(true);
+    const types = result as string[];
+    expect(types).toContain('feature');
+    expect(types).toContain('debug');
+    expect(types).toContain('refactor');
   });
 });
 

--- a/servers/exarchos-mcp/src/adapters/schema-introspection.ts
+++ b/servers/exarchos-mcp/src/adapters/schema-introspection.ts
@@ -7,6 +7,11 @@ import {
 import type { SerializedTopology, WorkflowTypeSummary } from '../workflow/state-machine.js';
 import { serializeEventCatalog } from '../event-store/schemas.js';
 import type { EventCatalog } from '../event-store/schemas.js';
+import {
+  serializePlaybooks,
+  listPlaybookWorkflowTypes,
+} from '../workflow/playbooks.js';
+import type { SerializedPlaybooks } from '../workflow/playbooks.js';
 
 /**
  * Resolves a schema reference (e.g., "workflow.init") to its JSON Schema representation.
@@ -77,6 +82,24 @@ export function resolveTopologyRef(workflowType?: string): SerializedTopology | 
     return serializeTopology(workflowType);
   }
   return listWorkflowTypes();
+}
+
+/**
+ * Resolves playbook data for a specific workflow type or lists all workflow types.
+ *
+ * Delegates to canonical serialization functions in playbooks.ts.
+ * When called with a workflow type, returns all serialized phase playbooks.
+ * When called without arguments, returns a listing of all available workflow types.
+ *
+ * @throws Error if the workflow type is not found.
+ */
+export function resolvePlaybookRef(
+  workflowType?: string,
+): SerializedPlaybooks | string[] {
+  if (workflowType) {
+    return serializePlaybooks(workflowType);
+  }
+  return listPlaybookWorkflowTypes();
 }
 
 /**

--- a/servers/exarchos-mcp/src/describe/handler.test.ts
+++ b/servers/exarchos-mcp/src/describe/handler.test.ts
@@ -196,6 +196,70 @@ describe('handleEventDescribe emissionGuide', () => {
   });
 });
 
+describe('handleDescribe playbook', () => {
+  it('HandleDescribe_PlaybookFeature_ReturnsSerializedPlaybooks', async () => {
+    const result = await handleDescribe({ playbook: 'feature' }, workflowActions);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('playbook');
+    const playbook = data.playbook as Record<string, unknown>;
+    expect(playbook).toHaveProperty('workflowType');
+    expect(playbook.workflowType).toBe('feature');
+    expect(playbook).toHaveProperty('phases');
+    const phases = playbook.phases as Record<string, unknown>;
+    expect(phases).toHaveProperty('ideate');
+    expect(phases).toHaveProperty('plan');
+    expect(phases).toHaveProperty('delegate');
+  });
+
+  it('HandleDescribe_PlaybookAll_ReturnsWorkflowTypeList', async () => {
+    const result = await handleDescribe({ playbook: 'all' }, workflowActions);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('playbook');
+    const types = data.playbook as string[];
+    expect(types).toContain('feature');
+    expect(types).toContain('debug');
+    expect(types).toContain('refactor');
+  });
+
+  it('HandleDescribe_PlaybookUnknown_ReturnsErrorWithValidTargets', async () => {
+    const result = await handleDescribe({ playbook: 'nonexistent' }, workflowActions);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('UNKNOWN_WORKFLOW_TYPE');
+    expect(result.error?.validTargets).toBeDefined();
+    expect(result.error?.validTargets?.length).toBeGreaterThan(0);
+  });
+
+  it('HandleDescribe_NoParams_ErrorIncludesPlaybookInExpectedShape', async () => {
+    const result = await handleDescribe({} as { actions?: string[]; topology?: string; playbook?: string }, workflowActions);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.expectedShape).toBeDefined();
+    expect(result.error?.expectedShape).toHaveProperty('playbook');
+  });
+
+  it('HandleDescribe_PlaybookAndActions_ReturnsBoth', async () => {
+    const result = await handleDescribe(
+      { actions: ['init'], playbook: 'feature' },
+      workflowActions,
+    );
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('init');
+    expect(data).toHaveProperty('playbook');
+  });
+
+  it('HandleDescribe_PlaybookOnly_ActionsNotInResult', async () => {
+    const result = await handleDescribe({ playbook: 'feature' }, workflowActions);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('playbook');
+    expect(data).not.toHaveProperty('init');
+    expect(data).not.toHaveProperty('get');
+  });
+});
+
 describe('handleDescribe topology', () => {
   it('HandleDescribe_TopologyParam_ReturnsHSMForWorkflowType', async () => {
     const result = await handleDescribe({ topology: 'feature' }, workflowActions);

--- a/servers/exarchos-mcp/src/describe/handler.test.ts
+++ b/servers/exarchos-mcp/src/describe/handler.test.ts
@@ -250,6 +250,23 @@ describe('handleDescribe playbook', () => {
     expect(data).toHaveProperty('playbook');
   });
 
+  it('HandleDescribe_PlaybookMalformed_ReturnsInvalidInput', async () => {
+    const result = await handleDescribe(
+      { playbook: 123 as unknown as string },
+      workflowActions,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toContain('non-empty string');
+  });
+
+  it('HandleDescribe_PlaybookEmptyString_ReturnsInvalidInput', async () => {
+    const result = await handleDescribe({ playbook: '' }, workflowActions);
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toContain('non-empty string');
+  });
+
   it('HandleDescribe_PlaybookOnly_ActionsNotInResult', async () => {
     const result = await handleDescribe({ playbook: 'feature' }, workflowActions);
     expect(result.success).toBe(true);

--- a/servers/exarchos-mcp/src/describe/handler.test.ts
+++ b/servers/exarchos-mcp/src/describe/handler.test.ts
@@ -35,6 +35,24 @@ describe('handleDescribe', () => {
     expect(result.error?.validTargets?.length).toBeGreaterThan(0);
   });
 
+  it('HandleDescribe_ActionWithAutoEmits_ReturnsEmissionMetadata', async () => {
+    const result = await handleDescribe({ actions: ['init'] }, workflowTool.actions);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, Record<string, unknown>>;
+    expect(data.init.autoEmits).toEqual([
+      { event: 'workflow.started', condition: 'always' },
+    ]);
+  });
+
+  it('HandleDescribe_ActionWithoutAutoEmits_OmitsField', async () => {
+    const result = await handleDescribe({ actions: ['get'] }, workflowTool.actions);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, Record<string, unknown>>;
+    // autoEmits should be omitted entirely (not null, not empty array)
+    expect(data.get.autoEmits).toBeUndefined();
+    expect('autoEmits' in data.get).toBe(false);
+  });
+
   it('HandleDescribe_GateMetadata_IncludedWhenPresent', async () => {
     // Use orchestrate tool which has gate metadata on check_* actions
     // Note: gate metadata may not exist yet (T1 adds it). If action.gate is undefined, expect null.

--- a/servers/exarchos-mcp/src/describe/handler.test.ts
+++ b/servers/exarchos-mcp/src/describe/handler.test.ts
@@ -250,6 +250,16 @@ describe('handleDescribe playbook', () => {
     expect(data).toHaveProperty('playbook');
   });
 
+  it('HandleDescribe_ActionsMalformed_ReturnsInvalidInput', async () => {
+    const result = await handleDescribe(
+      { actions: 123 as unknown as string[], playbook: 'feature' },
+      workflowActions,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toContain('string[]');
+  });
+
   it('HandleDescribe_PlaybookMalformed_ReturnsInvalidInput', async () => {
     const result = await handleDescribe(
       { playbook: 123 as unknown as string },

--- a/servers/exarchos-mcp/src/describe/handler.ts
+++ b/servers/exarchos-mcp/src/describe/handler.ts
@@ -22,12 +22,18 @@ export async function handleDescribe(
   args: { actions?: string[]; topology?: string; playbook?: string },
   toolActions: readonly ToolAction[],
 ): Promise<ToolResult> {
-  const hasActions = args.actions && args.actions.length > 0;
-  const hasTopology = typeof args.topology === 'string' && args.topology.length > 0;
-  const hasPlaybook = typeof args.playbook === 'string' && args.playbook.length > 0;
-
-  // Reject malformed playbook/topology values (present but not a non-empty string)
-  if (args.playbook !== undefined && !hasPlaybook) {
+  // Guard clauses: reject malformed values before computing flags
+  if (args.actions !== undefined && (!Array.isArray(args.actions) || !args.actions.every((a: unknown) => typeof a === 'string'))) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'actions must be a non-empty string[]',
+        expectedShape: { actions: ['action_name_1', 'action_name_2'] },
+      },
+    };
+  }
+  if (args.playbook !== undefined && (typeof args.playbook !== 'string' || args.playbook.length === 0)) {
     return {
       success: false,
       error: {
@@ -37,7 +43,7 @@ export async function handleDescribe(
       },
     };
   }
-  if (args.topology !== undefined && !hasTopology) {
+  if (args.topology !== undefined && (typeof args.topology !== 'string' || args.topology.length === 0)) {
     return {
       success: false,
       error: {
@@ -47,6 +53,10 @@ export async function handleDescribe(
       },
     };
   }
+
+  const hasActions = Array.isArray(args.actions) && args.actions.length > 0;
+  const hasTopology = typeof args.topology === 'string' && args.topology.length > 0;
+  const hasPlaybook = typeof args.playbook === 'string' && args.playbook.length > 0;
 
   if (!hasActions && !hasTopology && !hasPlaybook) {
     return {
@@ -59,17 +69,6 @@ export async function handleDescribe(
           topology: 'feature | debug | refactor | all',
           playbook: 'feature | debug | refactor | all',
         },
-      },
-    };
-  }
-
-  if (hasActions && (!Array.isArray(args.actions) || !args.actions.every((a: unknown) => typeof a === 'string'))) {
-    return {
-      success: false,
-      error: {
-        code: 'INVALID_INPUT',
-        message: 'describe requires actions: string[]',
-        expectedShape: { actions: ['action_name_1', 'action_name_2'] },
       },
     };
   }

--- a/servers/exarchos-mcp/src/describe/handler.ts
+++ b/servers/exarchos-mcp/src/describe/handler.ts
@@ -71,6 +71,7 @@ export async function handleDescribe(
         gate: (action as ToolAction & { gate?: unknown }).gate ?? null,
         phases: [...action.phases],
         roles: [...action.roles],
+        ...(action.autoEmits ? { autoEmits: [...action.autoEmits] } : {}),
       };
     }
   }

--- a/servers/exarchos-mcp/src/describe/handler.ts
+++ b/servers/exarchos-mcp/src/describe/handler.ts
@@ -9,29 +9,33 @@ import {
   serializeEventCatalog,
 } from '../event-store/schemas.js';
 import { serializeTopology, listWorkflowTypes } from '../workflow/state-machine.js';
+import { serializePlaybooks, listPlaybookWorkflowTypes } from '../workflow/playbooks.js';
 
 /**
  * Handles the `describe` action for composite tools.
  * Returns full schemas, descriptions, gate metadata, and phase/role info
  * for the requested action names. Optionally includes HSM topology when
- * the `topology` parameter is provided.
+ * the `topology` parameter is provided, or phase playbooks when the
+ * `playbook` parameter is provided.
  */
 export async function handleDescribe(
-  args: { actions?: string[]; topology?: string },
+  args: { actions?: string[]; topology?: string; playbook?: string },
   toolActions: readonly ToolAction[],
 ): Promise<ToolResult> {
   const hasActions = args.actions && args.actions.length > 0;
   const hasTopology = typeof args.topology === 'string' && args.topology.length > 0;
+  const hasPlaybook = typeof args.playbook === 'string' && args.playbook.length > 0;
 
-  if (!hasActions && !hasTopology) {
+  if (!hasActions && !hasTopology && !hasPlaybook) {
     return {
       success: false,
       error: {
         code: 'INVALID_INPUT',
-        message: 'describe requires at least one of actions or topology',
+        message: 'describe requires at least one of actions, topology, or playbook',
         expectedShape: {
           actions: ['action_name_1', 'action_name_2'],
           topology: 'feature | debug | refactor | all',
+          playbook: 'feature | debug | refactor | all',
         },
       },
     };
@@ -83,6 +87,13 @@ export async function handleDescribe(
     results.topology = topologyResult.data;
   }
 
+  // Resolve playbook if requested
+  if (hasPlaybook) {
+    const playbookResult = handlePlaybookDescribe(args.playbook as string);
+    if (!playbookResult.success) return playbookResult;
+    results.playbook = playbookResult.data;
+  }
+
   return { success: true, data: results };
 }
 
@@ -109,6 +120,34 @@ function handleTopologyDescribe(topology: string): ToolResult {
         code: 'UNKNOWN_WORKFLOW_TYPE',
         message: `Unknown workflow type: ${topology}`,
         validTargets: listWorkflowTypes().workflowTypes.map(wt => wt.name),
+      },
+    };
+  }
+}
+
+/**
+ * Handles playbook introspection for the workflow describe action.
+ * When playbook is "all", returns a listing of all workflow types with playbooks.
+ * Otherwise, returns the serialized phase playbooks for the specified type.
+ */
+function handlePlaybookDescribe(playbook: string): ToolResult {
+  if (playbook === 'all') {
+    return {
+      success: true,
+      data: listPlaybookWorkflowTypes(),
+    };
+  }
+
+  try {
+    const serialized = serializePlaybooks(playbook);
+    return { success: true, data: serialized };
+  } catch {
+    return {
+      success: false,
+      error: {
+        code: 'UNKNOWN_WORKFLOW_TYPE',
+        message: `Unknown workflow type: ${playbook}`,
+        validTargets: listPlaybookWorkflowTypes(),
       },
     };
   }

--- a/servers/exarchos-mcp/src/describe/handler.ts
+++ b/servers/exarchos-mcp/src/describe/handler.ts
@@ -26,6 +26,28 @@ export async function handleDescribe(
   const hasTopology = typeof args.topology === 'string' && args.topology.length > 0;
   const hasPlaybook = typeof args.playbook === 'string' && args.playbook.length > 0;
 
+  // Reject malformed playbook/topology values (present but not a non-empty string)
+  if (args.playbook !== undefined && !hasPlaybook) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'playbook must be a non-empty string',
+        expectedShape: { playbook: 'feature | debug | refactor | all' },
+      },
+    };
+  }
+  if (args.topology !== undefined && !hasTopology) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'topology must be a non-empty string',
+        expectedShape: { topology: 'feature | debug | refactor | all' },
+      },
+    };
+  }
+
   if (!hasActions && !hasTopology && !hasPlaybook) {
     return {
       success: false,

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -15,7 +15,7 @@ import {
   clearCustomTools,
   findActionInRegistry,
 } from './registry.js';
-import type { ToolAction, CompositeTool } from './registry.js';
+import type { ToolAction, CompositeTool, AutoEmission } from './registry.js';
 
 describe('buildCompositeSchema', () => {
   it('should create a discriminated union from two actions', () => {
@@ -992,5 +992,71 @@ describe('Describe action in registry', () => {
       const describeAction = tool.actions.find(a => a.name === 'describe');
       expect(describeAction, `${tool.name} should have a describe action`).toBeDefined();
     }
+  });
+});
+
+// ─── AutoEmission Interface Tests ────────────────────────────────────────────
+
+describe('AutoEmission', () => {
+  it('AutoEmission_Interface_ExistsAndExported', () => {
+    // Assert: AutoEmission type can be used to type a value with the expected shape
+    const emission: AutoEmission = {
+      event: 'workflow.started',
+      condition: 'always',
+    };
+    expect(emission.event).toBe('workflow.started');
+    expect(emission.condition).toBe('always');
+
+    // Assert: description is optional
+    const emissionWithDesc: AutoEmission = {
+      event: 'workflow.transition',
+      condition: 'conditional',
+      description: 'Emitted when phase is provided',
+    };
+    expect(emissionWithDesc.description).toBe('Emitted when phase is provided');
+  });
+
+  it('ToolAction_AutoEmits_AcceptsEmissionArray', () => {
+    // Register a custom tool with an action that has autoEmits
+    const toolWithEmissions: CompositeTool = {
+      name: 'exarchos_test_emissions',
+      description: 'Test tool for auto-emissions',
+      actions: [
+        {
+          name: 'emit_test',
+          description: 'Action that auto-emits',
+          schema: z.object({ featureId: z.string() }),
+          phases: new Set(['ideate']),
+          roles: new Set(['lead']),
+          autoEmits: [
+            { event: 'workflow.started', condition: 'always' as const },
+          ],
+        },
+        {
+          name: 'no_emit_test',
+          description: 'Action without auto-emissions',
+          schema: z.object({ id: z.string() }),
+          phases: new Set(['ideate']),
+          roles: new Set(['any']),
+        },
+      ],
+    };
+
+    registerCustomTool(toolWithEmissions);
+
+    // Verify the action with autoEmits is findable
+    const actionWithEmits = findActionInRegistry('exarchos_test_emissions', 'emit_test');
+    expect(actionWithEmits).toBeDefined();
+    expect(actionWithEmits!.autoEmits).toBeDefined();
+    expect(actionWithEmits!.autoEmits).toHaveLength(1);
+    expect(actionWithEmits!.autoEmits![0].event).toBe('workflow.started');
+    expect(actionWithEmits!.autoEmits![0].condition).toBe('always');
+
+    // Verify the action without autoEmits works (field is optional)
+    const actionWithoutEmits = findActionInRegistry('exarchos_test_emissions', 'no_emit_test');
+    expect(actionWithoutEmits).toBeDefined();
+    expect(actionWithoutEmits!.autoEmits).toBeUndefined();
+
+    clearCustomTools();
   });
 });

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -15,7 +15,7 @@ import {
   clearCustomTools,
   findActionInRegistry,
 } from './registry.js';
-import type { ToolAction, CompositeTool, AutoEmission } from './registry.js';
+import type { ToolAction, CompositeTool } from './registry.js';
 
 describe('buildCompositeSchema', () => {
   it('should create a discriminated union from two actions', () => {
@@ -995,68 +995,57 @@ describe('Describe action in registry', () => {
   });
 });
 
-// ─── AutoEmission Interface Tests ────────────────────────────────────────────
+// ─── AutoEmits Drift Tests ──────────────────────────────────────────────────
 
-describe('AutoEmission', () => {
-  it('AutoEmission_Interface_ExistsAndExported', () => {
-    // Assert: AutoEmission type can be used to type a value with the expected shape
-    const emission: AutoEmission = {
-      event: 'workflow.started',
-      condition: 'always',
-    };
-    expect(emission.event).toBe('workflow.started');
-    expect(emission.condition).toBe('always');
+describe('AutoEmits Drift Tests', () => {
+  it('RegistryDrift_AutoEmitsMatchEventEmissionRegistry', async () => {
+    const { EVENT_EMISSION_REGISTRY } = await import('./event-store/schemas.js');
 
-    // Assert: description is optional
-    const emissionWithDesc: AutoEmission = {
-      event: 'workflow.transition',
-      condition: 'conditional',
-      description: 'Emitted when phase is provided',
-    };
-    expect(emissionWithDesc.description).toBe('Emitted when phase is provided');
+    // At least one action must have autoEmits populated
+    let anyPopulated = false;
+    const violations: string[] = [];
+
+    for (const tool of TOOL_REGISTRY) {
+      for (const action of tool.actions) {
+        if (!action.autoEmits || action.autoEmits.length === 0) continue;
+        anyPopulated = true;
+
+        for (const emission of action.autoEmits) {
+          const source = (EVENT_EMISSION_REGISTRY as Record<string, string>)[emission.event];
+          if (!source) {
+            violations.push(
+              `${tool.name}.${action.name}: autoEmits '${emission.event}' not found in EVENT_EMISSION_REGISTRY`,
+            );
+          } else if (source !== 'auto') {
+            violations.push(
+              `${tool.name}.${action.name}: autoEmits '${emission.event}' has source '${source}', expected 'auto'`,
+            );
+          }
+        }
+      }
+    }
+
+    expect(anyPopulated, 'At least one action must have autoEmits populated').toBe(true);
+    expect(violations, `AutoEmits drift:\n${violations.join('\n')}`).toEqual([]);
   });
 
-  it('ToolAction_AutoEmits_AcceptsEmissionArray', () => {
-    // Register a custom tool with an action that has autoEmits
-    const toolWithEmissions: CompositeTool = {
-      name: 'exarchos_test_emissions',
-      description: 'Test tool for auto-emissions',
-      actions: [
-        {
-          name: 'emit_test',
-          description: 'Action that auto-emits',
-          schema: z.object({ featureId: z.string() }),
-          phases: new Set(['ideate']),
-          roles: new Set(['lead']),
-          autoEmits: [
-            { event: 'workflow.started', condition: 'always' as const },
-          ],
-        },
-        {
-          name: 'no_emit_test',
-          description: 'Action without auto-emissions',
-          schema: z.object({ id: z.string() }),
-          phases: new Set(['ideate']),
-          roles: new Set(['any']),
-        },
-      ],
-    };
+  it('RegistryDrift_DescriptionEmitsImpliesAutoEmitsField', () => {
+    const emitsPatterns = [/Auto-emits/i, /Emits gate\.executed/i, /Emits task\./i];
+    const violations: string[] = [];
 
-    registerCustomTool(toolWithEmissions);
+    for (const tool of TOOL_REGISTRY) {
+      for (const action of tool.actions) {
+        const matchesPattern = emitsPatterns.some((p) => p.test(action.description));
+        if (matchesPattern) {
+          if (!action.autoEmits || action.autoEmits.length === 0) {
+            violations.push(
+              `${tool.name}.${action.name}: description mentions emissions but autoEmits is empty/undefined. Description: "${action.description}"`,
+            );
+          }
+        }
+      }
+    }
 
-    // Verify the action with autoEmits is findable
-    const actionWithEmits = findActionInRegistry('exarchos_test_emissions', 'emit_test');
-    expect(actionWithEmits).toBeDefined();
-    expect(actionWithEmits!.autoEmits).toBeDefined();
-    expect(actionWithEmits!.autoEmits).toHaveLength(1);
-    expect(actionWithEmits!.autoEmits![0].event).toBe('workflow.started');
-    expect(actionWithEmits!.autoEmits![0].condition).toBe('always');
-
-    // Verify the action without autoEmits works (field is optional)
-    const actionWithoutEmits = findActionInRegistry('exarchos_test_emissions', 'no_emit_test');
-    expect(actionWithoutEmits).toBeDefined();
-    expect(actionWithoutEmits!.autoEmits).toBeUndefined();
-
-    clearCustomTools();
+    expect(violations, `Description/autoEmits drift:\n${violations.join('\n')}`).toEqual([]);
   });
 });

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -313,6 +313,9 @@ const workflowActions: readonly ToolAction[] = [
       flags: { featureId: { alias: 'f' }, workflowType: { alias: 't' } },
       examples: ['exarchos wf init -f my-feature -t feature'],
     },
+    autoEmits: [
+      { event: 'workflow.started', condition: 'always' },
+    ],
   },
   {
     name: 'get',
@@ -344,6 +347,10 @@ const workflowActions: readonly ToolAction[] = [
       flags: { featureId: { alias: 'f' } },
       examples: ['exarchos wf set -f my-feature --phase plan'],
     },
+    autoEmits: [
+      { event: 'workflow.transition', condition: 'conditional', description: 'When phase is provided' },
+      { event: 'state.patched', condition: 'always' },
+    ],
   },
   {
     name: 'cancel',
@@ -354,6 +361,10 @@ const workflowActions: readonly ToolAction[] = [
     }),
     phases: ALL_PHASES,
     roles: ROLE_LEAD,
+    autoEmits: [
+      { event: 'workflow.cancel', condition: 'always' },
+      { event: 'workflow.compensation', condition: 'conditional', description: 'Per compensation action' },
+    ],
   },
   {
     name: 'cleanup',
@@ -367,6 +378,9 @@ const workflowActions: readonly ToolAction[] = [
     }),
     phases: ALL_PHASES,
     roles: ROLE_LEAD,
+    autoEmits: [
+      { event: 'workflow.cleanup', condition: 'always' },
+    ],
   },
   {
     name: 'reconcile',
@@ -437,6 +451,9 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: DELEGATE_PHASES,
     roles: ROLE_TEAMMATE,
+    autoEmits: [
+      { event: 'task.claimed', condition: 'always' },
+    ],
   },
   {
     name: 'task_complete',
@@ -453,6 +470,9 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: DELEGATE_PHASES,
     roles: ROLE_TEAMMATE,
+    autoEmits: [
+      { event: 'task.completed', condition: 'always' },
+    ],
   },
   {
     name: 'task_fail',
@@ -465,6 +485,9 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: DELEGATE_PHASES,
     roles: ROLE_TEAMMATE,
+    autoEmits: [
+      { event: 'task.failed', condition: 'always' },
+    ],
   },
   {
     name: 'review_triage',
@@ -495,6 +518,9 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: DELEGATE_PHASES,
     roles: ROLE_LEAD,
+    autoEmits: [
+      { event: 'quality.hint.generated', condition: 'conditional', description: 'When hints exist' },
+    ],
   },
   {
     name: 'prepare_synthesis',
@@ -504,6 +530,9 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: SYNTHESIS_REVIEW_PHASES,
     roles: ROLE_LEAD,
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'assess_stack',
@@ -514,6 +543,12 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: SYNTHESIS_REVIEW_PHASES,
     roles: ROLE_LEAD,
+    autoEmits: [
+      { event: 'shepherd.started', condition: 'conditional', description: 'First invocation (idempotent)' },
+      { event: 'shepherd.approval_requested', condition: 'conditional', description: 'When approval needed' },
+      { event: 'shepherd.completed', condition: 'conditional', description: 'When PR merged' },
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'check_static_analysis',
@@ -527,6 +562,9 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,
     gate: { blocking: true, dimension: 'D2' },
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'check_security_scan',
@@ -539,6 +577,9 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,
     gate: { blocking: false, dimension: 'D1' },
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'check_context_economy',
@@ -551,6 +592,9 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,
     gate: { blocking: false, dimension: 'D3' },
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'check_operational_resilience',
@@ -563,6 +607,9 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,
     gate: { blocking: false, dimension: 'D4' },
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'check_workflow_determinism',
@@ -575,6 +622,9 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,
     gate: { blocking: false, dimension: 'D5' },
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'check_review_verdict',
@@ -593,6 +643,9 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,
     gate: { blocking: true },
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'check_convergence',
@@ -616,6 +669,9 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: PLAN_PHASES,
     roles: ROLE_LEAD,
     gate: { blocking: true, dimension: 'D1' },
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'check_design_completeness',
@@ -628,6 +684,9 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: new Set<string>(['ideate', 'plan']),
     roles: ROLE_LEAD,
     gate: { blocking: false, dimension: 'D1' },
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'check_plan_coverage',
@@ -640,6 +699,9 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: PLAN_PHASES,
     roles: ROLE_LEAD,
     gate: { blocking: true, dimension: 'D1' },
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'check_tdd_compliance',
@@ -653,6 +715,9 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: DELEGATE_PHASES,
     roles: ROLE_LEAD,
     gate: { blocking: true, dimension: 'D1' },
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'check_post_merge',
@@ -665,6 +730,9 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: new Set<string>(['synthesize']),
     roles: ROLE_LEAD,
     gate: { blocking: false, dimension: 'D4' },
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'check_task_decomposition',
@@ -676,6 +744,9 @@ const orchestrateActions: readonly ToolAction[] = [
     phases: PLAN_PHASES,
     roles: ROLE_LEAD,
     gate: { blocking: false, dimension: 'D5' },
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'check_event_emissions',
@@ -686,6 +757,9 @@ const orchestrateActions: readonly ToolAction[] = [
     }),
     phases: ALL_PHASES,
     roles: ROLE_ANY,
+    autoEmits: [
+      { event: 'gate.executed', condition: 'always' },
+    ],
   },
   {
     name: 'run_script',

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -254,7 +254,7 @@ function makeDescribeAction(): ToolAction {
   };
 }
 
-/** Workflow-specific describe schema: supports both actions and topology. */
+/** Workflow-specific describe schema: supports actions, topology, and playbooks. */
 const workflowDescribeSchema = z.object({
   actions: z.array(z.string()).min(1).max(10)
     .describe('Action names to describe. Returns full schema + description for each.')
@@ -262,13 +262,16 @@ const workflowDescribeSchema = z.object({
   topology: z.string()
     .describe('Workflow type to return HSM topology for. Use "all" to list all types.')
     .optional(),
+  playbook: z.string()
+    .describe('Workflow type for phase playbooks. "all" lists types.')
+    .optional(),
 });
 
-/** Creates a workflow-specific describe action with topology support. */
+/** Creates a workflow-specific describe action with topology and playbook support. */
 function makeWorkflowDescribeAction(): ToolAction {
   return {
     name: 'describe',
-    description: 'Return full schemas, descriptions, gate metadata, and phase/role info for specific actions. Optionally return HSM topology for a workflow type.',
+    description: 'Return full schemas, descriptions, gate metadata, and phase/role info for specific actions. Optionally return HSM topology or phase playbooks for a workflow type.',
     schema: workflowDescribeSchema,
     phases: ALL_PHASES,
     roles: ROLE_ANY,

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -27,6 +27,12 @@ export interface GateMetadata {
   readonly dimension?: string;
 }
 
+export interface AutoEmission {
+  readonly event: string;
+  readonly condition: 'always' | 'conditional';
+  readonly description?: string;
+}
+
 export interface ToolAction {
   readonly name: string;
   readonly description: string;
@@ -35,6 +41,7 @@ export interface ToolAction {
   readonly roles: ReadonlySet<string>;
   readonly cli?: CliActionHints;
   readonly gate?: GateMetadata;
+  readonly autoEmits?: readonly AutoEmission[];
 }
 
 export interface CompositeTool {

--- a/servers/exarchos-mcp/src/runbooks/compute.ts
+++ b/servers/exarchos-mcp/src/runbooks/compute.ts
@@ -1,0 +1,23 @@
+import { findActionInRegistry } from '../registry.js';
+import type { RunbookDefinition } from './types.js';
+
+/**
+ * Computes the deduplicated, sorted union of autoEmits event names
+ * across all non-native steps in a runbook.
+ *
+ * Native steps (tool starts with 'native:') are skipped because they
+ * are Claude Code native tools, not MCP tool calls.
+ */
+export function computeRunbookAutoEmits(runbook: RunbookDefinition): readonly string[] {
+  const events = new Set<string>();
+  for (const step of runbook.steps) {
+    if (step.tool.startsWith('native:')) continue;
+    const action = findActionInRegistry(step.tool, step.action);
+    if (action?.autoEmits) {
+      for (const emission of action.autoEmits) {
+        events.add(emission.event);
+      }
+    }
+  }
+  return [...events].sort();
+}

--- a/servers/exarchos-mcp/src/runbooks/definitions.ts
+++ b/servers/exarchos-mcp/src/runbooks/definitions.ts
@@ -61,7 +61,7 @@ export const AGENT_TEAMS_SAGA: RunbookDefinition = {
       note: 'Auto-emits workflow.transition' },
   ],
   templateVars: ['featureId', 'streamId', 'stream', 'event', 'events', 'teamId'],
-  autoEmits: ['workflow.transition'],
+  autoEmits: ['state.patched', 'workflow.transition'],
 };
 
 export const SYNTHESIS_FLOW: RunbookDefinition = {
@@ -78,7 +78,7 @@ export const SYNTHESIS_FLOW: RunbookDefinition = {
       note: 'Record PR URL in artifacts.prUrl' },
   ],
   templateVars: ['featureId'],
-  autoEmits: ['gate.executed'],
+  autoEmits: ['gate.executed', 'state.patched', 'workflow.transition'],
 };
 
 export const SHEPHERD_ITERATION: RunbookDefinition = {
@@ -103,7 +103,7 @@ export const SHEPHERD_ITERATION: RunbookDefinition = {
       note: 'git push to trigger CI re-run' },
   ],
   templateVars: ['featureId', 'streamId', 'stream', 'event', 'prNumbers'],
-  autoEmits: ['shepherd.started', 'shepherd.approval_requested', 'shepherd.completed'],
+  autoEmits: ['gate.executed', 'shepherd.approval_requested', 'shepherd.completed', 'shepherd.started'],
 };
 
 export const TASK_FIX: RunbookDefinition = {

--- a/servers/exarchos-mcp/src/runbooks/drift.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/drift.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { zodToJsonSchema } from 'zod-to-json-schema';
-import { ALL_RUNBOOKS } from './definitions.js';
+import { ALL_RUNBOOKS, TASK_COMPLETION } from './definitions.js';
 import { findActionInRegistry, getFullRegistry } from '../registry.js';
 import { EVENT_EMISSION_REGISTRY } from '../event-store/schemas.js';
+import { computeRunbookAutoEmits } from './compute.js';
 
 describe('Runbook drift detection', () => {
   it('RunbookDrift_EveryStepReferencesValidRegistryAction', () => {
@@ -112,5 +113,23 @@ describe('Runbook drift detection', () => {
     const ids = ALL_RUNBOOKS.map(r => r.id);
     const uniqueIds = new Set(ids);
     expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it('ComputeRunbookAutoEmits_TaskCompletion_MatchesDeclared', () => {
+    const computed = computeRunbookAutoEmits(TASK_COMPLETION);
+    const declared = [...TASK_COMPLETION.autoEmits].sort();
+    expect(computed).toEqual(declared);
+  });
+
+  it('RunbookDrift_AutoEmitsMatchComputedFromToolActions', () => {
+    for (const runbook of ALL_RUNBOOKS) {
+      const computed = computeRunbookAutoEmits(runbook);
+      const declared = [...runbook.autoEmits].sort();
+      expect(
+        computed,
+        `Runbook '${runbook.id}' declared autoEmits ${JSON.stringify(declared)} ` +
+        `does not match computed ${JSON.stringify(computed)} from ToolAction.autoEmits`,
+      ).toEqual(declared);
+    }
   });
 });

--- a/servers/exarchos-mcp/src/views/materializer.ts
+++ b/servers/exarchos-mcp/src/views/materializer.ts
@@ -68,6 +68,9 @@ export class ViewMaterializer {
   private readonly maxCacheEntries: number;
   private readonly backend?: StorageBackend;
 
+  // Pending snapshot writes (fire-and-forget, but flushable for tests/shutdown)
+  private pendingSnapshots: Promise<void>[] = [];
+
   // Cache hit/miss counters
   private cacheHits = 0;
   private cacheMisses = 0;
@@ -188,15 +191,25 @@ export class ViewMaterializer {
             viewLogger.error({ err: err instanceof Error ? err.message : String(err) }, 'Backend view cache save failed');
           }
         } else if (this.snapshotStore) {
-          // Fire and forget - snapshot is async but we don't block materialization
-          this.snapshotStore.save(streamId, viewName, currentView, maxSequence).catch((err) => {
+          // Fire and forget - snapshot is async but we don't block materialization.
+          // Track the promise so flush() can await completion for tests/shutdown.
+          const savePromise = this.snapshotStore.save(streamId, viewName, currentView, maxSequence).catch((err) => {
             viewLogger.error({ err: err instanceof Error ? err.message : String(err) }, 'Snapshot save failed');
           });
+          this.pendingSnapshots.push(savePromise);
         }
       }
     }
 
     return currentView;
+  }
+
+  /**
+   * Await all pending snapshot writes. Useful for tests and graceful shutdown.
+   */
+  async flush(): Promise<void> {
+    await Promise.all(this.pendingSnapshots);
+    this.pendingSnapshots = [];
   }
 
   /**

--- a/servers/exarchos-mcp/src/workflow/playbooks.test.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { getPlaybook, renderPlaybook } from './playbooks.js';
+import { getPlaybook, renderPlaybook, serializePlaybooks, listPlaybookWorkflowTypes } from './playbooks.js';
+import type { SerializedPlaybooks, SerializedPhasePlaybook } from './playbooks.js';
 
 // ─── Task 1: Core getPlaybook / renderPlaybook ──────────────────────────────
 
@@ -235,5 +236,47 @@ describe('Synthesize phase guidance references GitHub CLI', () => {
     const playbook = getPlaybook('refactor', 'synthesize')!;
     expect(playbook.compactGuidance).not.toContain('Graphite');
     expect(playbook.compactGuidance).toContain('GitHub CLI');
+  });
+});
+
+// ─── Task 5: Playbook Serialization ──────────────────────────────────────────
+
+describe('serializePlaybooks', () => {
+  it('SerializePlaybooks_Feature_ReturnsAllPhases', () => {
+    const result: SerializedPlaybooks = serializePlaybooks('feature');
+
+    expect(result.workflowType).toBe('feature');
+
+    const expectedPhases = [
+      'ideate', 'plan', 'plan-review', 'delegate',
+      'review', 'synthesize', 'completed', 'cancelled', 'blocked',
+    ];
+    for (const phase of expectedPhases) {
+      expect(result.phases).toHaveProperty(phase);
+    }
+    expect(result.phaseCount).toBe(expectedPhases.length);
+
+    // Verify structure of a representative phase
+    const ideate: SerializedPhasePlaybook = result.phases['ideate'];
+    expect(ideate.skill).toBe('brainstorming');
+    expect(ideate.skillRef).toBe('@skills/brainstorming/SKILL.md');
+    expect(ideate.tools.length).toBeGreaterThanOrEqual(1);
+    expect(ideate.transitionCriteria).toBeTruthy();
+    expect(ideate.humanCheckpoint).toBe(false);
+    expect(typeof ideate.compactGuidance).toBe('string');
+  });
+
+  it('SerializePlaybooks_Unknown_Throws', () => {
+    expect(() => serializePlaybooks('nonexistent')).toThrow();
+  });
+});
+
+describe('listPlaybookWorkflowTypes', () => {
+  it('ListPlaybookWorkflowTypes_ReturnsKnownTypes', () => {
+    const types = listPlaybookWorkflowTypes();
+    expect(types).toContain('feature');
+    expect(types).toContain('debug');
+    expect(types).toContain('refactor');
+    expect(types.length).toBeGreaterThanOrEqual(3);
   });
 });

--- a/servers/exarchos-mcp/src/workflow/playbooks.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.ts
@@ -944,21 +944,21 @@ register({
 // ─── Serialization Types ─────────────────────────────────────────────────────
 
 export interface SerializedPlaybooks {
-  workflowType: string;
-  phases: Record<string, SerializedPhasePlaybook>;
-  phaseCount: number;
+  readonly workflowType: string;
+  readonly phases: Record<string, SerializedPhasePlaybook>;
+  readonly phaseCount: number;
 }
 
 export interface SerializedPhasePlaybook {
-  skill: string;
-  skillRef: string;
-  tools: readonly ToolInstruction[];
-  events: readonly EventInstruction[];
-  transitionCriteria: string;
-  guardPrerequisites: string;
-  validationScripts: readonly string[];
-  humanCheckpoint: boolean;
-  compactGuidance: string;
+  readonly skill: string;
+  readonly skillRef: string;
+  readonly tools: readonly ToolInstruction[];
+  readonly events: readonly EventInstruction[];
+  readonly transitionCriteria: string;
+  readonly guardPrerequisites: string;
+  readonly validationScripts: readonly string[];
+  readonly humanCheckpoint: boolean;
+  readonly compactGuidance: string;
 }
 
 // ─── Serialization Functions ─────────────────────────────────────────────────
@@ -978,11 +978,11 @@ export function serializePlaybooks(workflowType: string): SerializedPlaybooks {
     phases[playbook.phase] = {
       skill: playbook.skill,
       skillRef: playbook.skillRef,
-      tools: playbook.tools,
-      events: playbook.events,
+      tools: [...playbook.tools],
+      events: [...playbook.events],
       transitionCriteria: playbook.transitionCriteria,
       guardPrerequisites: playbook.guardPrerequisites,
-      validationScripts: playbook.validationScripts,
+      validationScripts: [...playbook.validationScripts],
       humanCheckpoint: playbook.humanCheckpoint,
       compactGuidance: playbook.compactGuidance,
     };

--- a/servers/exarchos-mcp/src/workflow/playbooks.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.ts
@@ -940,3 +940,75 @@ register({
   compactGuidance:
     'Workflow is blocked waiting for human intervention. Wait for user to provide unblock decision. Use exarchos_workflow set to record the decision.',
 });
+
+// ─── Serialization Types ─────────────────────────────────────────────────────
+
+export interface SerializedPlaybooks {
+  workflowType: string;
+  phases: Record<string, SerializedPhasePlaybook>;
+  phaseCount: number;
+}
+
+export interface SerializedPhasePlaybook {
+  skill: string;
+  skillRef: string;
+  tools: readonly ToolInstruction[];
+  events: readonly EventInstruction[];
+  transitionCriteria: string;
+  guardPrerequisites: string;
+  validationScripts: readonly string[];
+  humanCheckpoint: boolean;
+  compactGuidance: string;
+}
+
+// ─── Serialization Functions ─────────────────────────────────────────────────
+
+/**
+ * Serialize all playbooks for a given workflow type into a plain
+ * JSON-serializable object keyed by phase name.
+ *
+ * Pure function with no side effects. Throws for unknown workflow types.
+ */
+export function serializePlaybooks(workflowType: string): SerializedPlaybooks {
+  const phases: Record<string, SerializedPhasePlaybook> = {};
+
+  for (const [, playbook] of registry) {
+    if (playbook.workflowType !== workflowType) continue;
+
+    phases[playbook.phase] = {
+      skill: playbook.skill,
+      skillRef: playbook.skillRef,
+      tools: playbook.tools,
+      events: playbook.events,
+      transitionCriteria: playbook.transitionCriteria,
+      guardPrerequisites: playbook.guardPrerequisites,
+      validationScripts: playbook.validationScripts,
+      humanCheckpoint: playbook.humanCheckpoint,
+      compactGuidance: playbook.compactGuidance,
+    };
+  }
+
+  const phaseCount = Object.keys(phases).length;
+  if (phaseCount === 0) {
+    throw new Error(`Unknown workflow type: ${workflowType}`);
+  }
+
+  return {
+    workflowType,
+    phases,
+    phaseCount,
+  };
+}
+
+/**
+ * List distinct workflow types that have playbooks registered.
+ *
+ * Pure function with no side effects.
+ */
+export function listPlaybookWorkflowTypes(): string[] {
+  const types = new Set<string>();
+  for (const playbook of registry.values()) {
+    types.add(playbook.workflowType);
+  }
+  return [...types];
+}

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -107,27 +107,11 @@ ideate → plan → plan-review → delegate ⇄ review → synthesize → compl
 
 For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
 
-**Feature workflow guard table:**
-
-| Transition | Guard | Prerequisite (send in `updates` with `phase`) |
-|------------|-------|-----------------------------------------------|
-| `ideate` → `plan` | `design-artifact-exists` | Set `artifacts.design` |
-| `plan` → `plan-review` | `plan-artifact-exists` | Set `artifacts.plan` |
-| `plan-review` → `delegate` | `plan-review-complete` | Set `planReview.approved = true` |
-| `plan-review` → `plan` | `plan-review-gaps-found` | Set `planReview.gapsFound = true` |
-| `delegate` → `review` | `all-tasks-complete` | All `tasks[].status = "complete"` |
-| `review` → `synthesize` | `all-reviews-passed` | All `reviews.{name}.status` passing |
-| `review` → `delegate` | `any-review-failed` | Any `reviews.{name}.status` failing (fix cycle) |
-| `synthesize` → `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
-
 ### Schema Discovery
 
-Use `describe` to discover action parameter schemas or event data schemas when needed:
-
-```
-exarchos_workflow({ action: "describe", actions: ["set", "init"] })
-exarchos_event({ action: "describe", eventTypes: ["workflow.transition"] })
-```
+Use `exarchos_workflow({ action: "describe", actions: ["set", "init"] })` for
+parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
+for phase transitions, guards, and playbook guidance.
 
 ## Completion Verification
 

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -155,30 +155,11 @@ See `@skills/debug/references/state-schema.md` for full schema.
 
 Every phase transition has a guard that must be satisfied. Before transitioning, consult `@skills/workflow-state/references/phase-transitions.md` for the exact prerequisite for each guard.
 
-**Quick reference — transition guards:**
-
-| Transition | Guard | Prerequisite (send in `updates` with `phase`) |
-|------------|-------|-----------------------------------------------|
-| `triage` → `investigate` | `triage-complete` | Set `triage.symptom` |
-| `investigate` → `rca` | `thorough-track-selected` | Set `track = "thorough"` |
-| `investigate` → `hotfix-implement` | `hotfix-track-selected` | Set `track = "hotfix"` |
-| `rca` → `design` | `rca-document-complete` | Set `artifacts.rca` |
-| `design` → `debug-implement` | `fix-design-complete` | Set `artifacts.fixDesign` |
-| `debug-implement` → `debug-validate` | `implementation-complete` | Always passes |
-| `debug-validate` → `debug-review` | `validation-passed` | Set `validation.testsPass = true` |
-| `debug-review` → `synthesize` | `review-passed` | All `reviews.{name}.status` passing |
-| `hotfix-implement` → `hotfix-validate` | `implementation-complete` | Always passes |
-| `hotfix-validate` → `completed` | `validation-passed` | Set `validation.testsPass = true` |
-| `synthesize` → `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
-
 ### Schema Discovery
 
-Use `describe` to discover action parameter schemas or event data schemas when needed:
-
-```typescript
-exarchos_workflow({ action: "describe", actions: ["set", "init"] })
-exarchos_event({ action: "describe", eventTypes: ["shepherd.iteration", "team.spawned"] })
-```
+Use `exarchos_workflow({ action: "describe", actions: ["set", "init"] })` for
+parameter schemas and `exarchos_workflow({ action: "describe", playbook: "debug" })`
+for phase transitions, guards, and playbook guidance.
 
 ## Integration Points
 

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -270,11 +270,13 @@ For the full transition table, consult `@skills/workflow-state/references/phase-
 
 **Quick reference:** The `delegate` → `review` transition requires guard `all-tasks-complete` — all `tasks[].status` must be `"complete"` in workflow state.
 
-Use `describe` to discover action or event schemas when needed:
-```
-exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })
-exarchos_event({ action: "describe", eventTypes: ["team.spawned", "team.task.completed"] })
-```
+### Schema Discovery
+
+Use `exarchos_workflow({ action: "describe", actions: ["set", "init"] })` for
+parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
+for phase transitions, guards, and playbook guidance. Use
+`exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })`
+for orchestrate action schemas.
 
 ## Transition
 

--- a/skills/implementation-planning/SKILL.md
+++ b/skills/implementation-planning/SKILL.md
@@ -234,8 +234,8 @@ For the full transition table, consult `@skills/workflow-state/references/phase-
 
 Use `exarchos_workflow({ action: "describe", actions: ["set", "init"] })` for
 parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
-for phase transitions, guards, and playbook guidance. Use
-`exarchos_orchestrate({ action: "describe", actions: ["check_plan_coverage", "check_provenance_chain"] })`
+(or `"debug"`, `"refactor"`) for phase transitions, guards, and playbook guidance.
+Use `exarchos_orchestrate({ action: "describe", actions: ["check_plan_coverage", "check_provenance_chain"] })`
 for orchestrate action schemas.
 
 ## Completion Criteria

--- a/skills/implementation-planning/SKILL.md
+++ b/skills/implementation-planning/SKILL.md
@@ -230,10 +230,13 @@ For the full transition table, consult `@skills/workflow-state/references/phase-
 
 **Quick reference:** The `plan` → `plan-review` transition requires guard `plan-artifact-exists` — set `artifacts.plan` in the same `set` call as `phase`.
 
-Use `describe` to discover action schemas when needed:
-```typescript
-exarchos_orchestrate({ action: "describe", actions: ["check_plan_coverage", "check_provenance_chain"] })
-```
+### Schema Discovery
+
+Use `exarchos_workflow({ action: "describe", actions: ["set", "init"] })` for
+parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
+for phase transitions, guards, and playbook guidance. Use
+`exarchos_orchestrate({ action: "describe", actions: ["check_plan_coverage", "check_provenance_chain"] })`
+for orchestrate action schemas.
 
 ## Completion Criteria
 

--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -264,10 +264,13 @@ For the full transition table, consult `@skills/workflow-state/references/phase-
 - `review` → `synthesize` requires guard `all-reviews-passed` — all `reviews.{name}.status` must be passing
 - `review` → `delegate` requires guard `any-review-failed` — triggers fix cycle when any review fails
 
-Use `describe` to discover action schemas when needed:
-```typescript
-exarchos_orchestrate({ action: "describe", actions: ["check_static_analysis", "check_security_scan", "check_review_verdict"] })
-```
+### Schema Discovery
+
+Use `exarchos_workflow({ action: "describe", actions: ["set", "init"] })` for
+parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
+for phase transitions, guards, and playbook guidance. Use
+`exarchos_orchestrate({ action: "describe", actions: ["check_static_analysis", "check_security_scan", "check_review_verdict"] })`
+for orchestrate action schemas.
 
 ## Completion Criteria
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -114,45 +114,7 @@ Initialize refactor workflow:
 action: "init", featureId: "refactor-<slug>", workflowType: "refactor"
 ```
 
-Full state schema:
-```json
-{
-  "version": "1.1",
-  "featureId": "refactor-<slug>",
-  "workflowType": "refactor",
-  "track": "polish | overhaul",
-  "phase": "explore | brief | polish-implement | polish-validate | polish-update-docs | overhaul-plan | overhaul-plan-review | overhaul-delegate | overhaul-review | overhaul-update-docs | synthesize | completed | cancelled | blocked",
-  "explore": {
-    "startedAt": "ISO8601",
-    "completedAt": "ISO8601 | null",
-    "scopeAssessment": {
-      "filesAffected": ["string"],
-      "modulesAffected": ["string"],
-      "testCoverage": "good | gaps | none",
-      "recommendedTrack": "polish | overhaul"
-    }
-  },
-  "brief": {  // See references/brief-template.md for field descriptions
-    "problem": "string",
-    "goals": ["string"],
-    "approach": "string",
-    "affectedAreas": ["string"],
-    "outOfScope": ["string"],
-    "successCriteria": ["string"],
-    "docsToUpdate": ["string"]
-  },
-  "artifacts": {
-    "plan": "string | null",
-    "pr": "string | null",
-    "updatedDocs": ["string"]
-  },
-  "validation": {
-    "testsPass": "boolean",
-    "goalsVerified": ["string"],
-    "docsUpdated": "boolean"
-  }
-}
-```
+Use `describe` to discover the full state schema at runtime: `exarchos_workflow({ action: "describe", actions: ["init"] })`.
 
 ### Phase Transitions and Guards
 
@@ -160,42 +122,13 @@ Full state schema:
 
 Every phase transition has a guard that must be satisfied. Before transitioning, consult `@skills/workflow-state/references/phase-transitions.md` for the exact prerequisite for each guard.
 
-**Quick reference — transition guards:**
-
-| Transition | Guard | Prerequisite (send in `updates` with `phase`) |
-|------------|-------|-----------------------------------------------|
-| `explore` → `brief` | `scope-assessment-complete` | Set `explore.scopeAssessment` |
-| `brief` → `polish-implement` | `polish-track-selected` | Set `track = "polish"` |
-| `brief` → `overhaul-plan` | `overhaul-track-selected` | Set `track = "overhaul"` |
-| `polish-implement` → `polish-validate` | `implementation-complete` | Always passes |
-| `polish-validate` → `polish-update-docs` | `goals-verified` | Set `validation.testsPass = true` |
-| `polish-update-docs` → `completed` | `docs-updated` | Set `validation.docsUpdated = true` |
-| `overhaul-plan` → `overhaul-plan-review` | `plan-artifact-exists` | Set `artifacts.plan` |
-| `overhaul-plan-review` → `overhaul-delegate` | `plan-review-complete` | Plan approved |
-| `overhaul-plan-review` → `overhaul-plan` | `plan-review-gaps-found` | Revise plan |
-| `overhaul-delegate` → `overhaul-review` | `all-tasks-complete` | All `tasks[].status = "complete"` |
-| `overhaul-review` → `overhaul-update-docs` | `all-reviews-passed` | All `reviews.{name}.status` passing |
-| `overhaul-review` → `overhaul-delegate` | `any-review-failed` | Any `reviews.{name}.status` failing |
-| `overhaul-update-docs` → `synthesize` | `docs-updated` | Set `validation.docsUpdated = true` |
-| `synthesize` → `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
-
-**Example — advancing from polish-validate to polish-update-docs:**
-```
-exarchos_workflow({ action: "set", featureId: "refactor-<slug>", updates: {
-  validation: { testsPass: true, goalsVerified: ["<verified goals>"] }
-}, phase: "polish-update-docs" })
-```
-
-The pattern is the same for every transition: send the guard prerequisite in `updates` and the target in `phase` in a single `set` call.
+The pattern for every transition: send the guard prerequisite in `updates` and the target in `phase` in a single `set` call.
 
 ### Schema Discovery
 
-Use `describe` to discover action parameter schemas or event data schemas when needed:
-
-```typescript
-exarchos_workflow({ action: "describe", actions: ["set", "init"] })
-exarchos_event({ action: "describe", eventTypes: ["team.spawned"] })
-```
+Use `exarchos_workflow({ action: "describe", actions: ["set", "init"] })` for
+parameter schemas and `exarchos_workflow({ action: "describe", playbook: "refactor" })`
+for phase transitions, guards, and playbook guidance.
 
 ## Track Switching
 

--- a/skills/shepherd/SKILL.md
+++ b/skills/shepherd/SKILL.md
@@ -191,25 +191,30 @@ mcp__plugin_exarchos_exarchos__exarchos_workflow({
 
 For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
 
-The shepherd skill operates within the `synthesize` phase and does not drive phase transitions directly. Use `describe` to discover event data schemas before emitting events:
-```typescript
-exarchos_event({ action: "describe", eventTypes: ["shepherd.iteration", "shepherd.completed", "ci.status", "remediation.attempted"] })
-```
+The shepherd skill operates within the `synthesize` phase and does not drive phase transitions directly.
+
+### Schema Discovery
+
+Use `exarchos_workflow({ action: "describe", actions: ["set", "init"] })` for
+parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
+for phase transitions, guards, and playbook guidance. Use
+`exarchos_event({ action: "describe", eventTypes: ["shepherd.iteration", "ci.status", "remediation.attempted"] })`
+for event data schemas before emitting events.
 
 ## Event Emission
 
-Before emitting any shepherd events, consult `references/shepherd-event-schemas.md` for full Zod schemas, type constraints, and example payloads. The table below is a summary — the reference has the exact shapes that MCP validation enforces.
+Before emitting any shepherd events, consult `references/shepherd-event-schemas.md` for full Zod schemas, type constraints, and example payloads. Use `exarchos_event({ action: "describe", eventTypes: ["shepherd.iteration", "ci.status"] })` to discover required fields at runtime.
 
-| Event | Required Fields (`data`) | When | Purpose |
-|-------|--------------------------|------|---------|
-| `shepherd.started` | `featureId` (string) | On skill start (emitted by `assess_stack`) | Audit trail |
-| `shepherd.iteration` | `iteration` (number), `prsAssessed` (number), `fixesApplied` (number), `status` (string) | After each assess cycle | Track progress |
-| `gate.executed` | `gateName`, `layer`, `passed`, `details` | Per CI check (emitted by `assess_stack`) | CodeQualityView — gate pass rates |
-| `ci.status` | `pr` (number), `status` (string) | Per CI check result | ShepherdStatusView — PR health tracking |
-| `remediation.attempted` | `taskId` (string), `skill` (string), `gateName` (string), `attemptNumber` (number), `strategy` (string) | Before applying a fix | selfCorrectionRate metric |
-| `remediation.succeeded` | `taskId` (string), `skill` (string), `gateName` (string), `totalAttempts` (number), `finalStrategy` (string) | After fix confirmed | avgRemediationAttempts metric |
-| `shepherd.approval_requested` | `prUrl` (string) | On requesting review | Audit trail |
-| `shepherd.completed` | `prUrl` (string), `outcome` (string) | On merge detected (emitted by `assess_stack`) | Audit trail |
+| Event | When | Purpose |
+|-------|------|---------|
+| `shepherd.started` | On skill start (emitted by `assess_stack`) | Audit trail |
+| `shepherd.iteration` | After each assess cycle | Track progress |
+| `gate.executed` | Per CI check (emitted by `assess_stack`) | CodeQualityView -- gate pass rates |
+| `ci.status` | Per CI check result | ShepherdStatusView -- PR health tracking |
+| `remediation.attempted` | Before applying a fix | selfCorrectionRate metric |
+| `remediation.succeeded` | After fix confirmed | avgRemediationAttempts metric |
+| `shepherd.approval_requested` | On requesting review | Audit trail |
+| `shepherd.completed` | On merge detected (emitted by `assess_stack`) | Audit trail |
 
 ## Domain Knowledge
 

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -225,10 +225,13 @@ For the full transition table, consult `@skills/workflow-state/references/phase-
 - `review` → `synthesize` requires guard `all-reviews-passed` — all `reviews.{name}.status` must be passing
 - `review` → `delegate` requires guard `any-review-failed` — triggers fix cycle when any review fails
 
-Use `describe` to discover action schemas when needed:
-```
-exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "check_static_analysis"] })
-```
+### Schema Discovery
+
+Use `exarchos_workflow({ action: "describe", actions: ["set", "init"] })` for
+parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
+for phase transitions, guards, and playbook guidance. Use
+`exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "check_static_analysis"] })`
+for orchestrate action schemas.
 
 ## Transition
 

--- a/skills/synthesis/SKILL.md
+++ b/skills/synthesis/SKILL.md
@@ -161,10 +161,13 @@ For the full transition table, consult `@skills/workflow-state/references/phase-
 
 **Quick reference:** The `synthesize` → `completed` transition requires guard `pr-url-exists` — set `synthesis.prUrl` or `artifacts.pr` in the same `set` call as `phase`.
 
-Use `describe` to discover action schemas when needed:
-```
-exarchos_orchestrate({ action: "describe", actions: ["prepare_synthesis"] })
-```
+### Schema Discovery
+
+Use `exarchos_workflow({ action: "describe", actions: ["set", "init"] })` for
+parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
+for phase transitions, guards, and playbook guidance. Use
+`exarchos_orchestrate({ action: "describe", actions: ["prepare_synthesis"] })`
+for orchestrate action schemas.
 
 ## Completion Criteria
 

--- a/skills/workflow-state/SKILL.md
+++ b/skills/workflow-state/SKILL.md
@@ -36,11 +36,11 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 ### Schema Discovery
 
-Use `describe` to discover action parameter schemas or event data schemas at runtime:
-```typescript
-exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })
-exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })
-```
+Use `exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })` for
+parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
+for phase transitions, guards, and playbook guidance. Use
+`exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })`
+for event data schemas.
 
 ## State Location
 


### PR DESCRIPTION
## Summary

Completes tool introspection phases 2-4: adds `autoEmits` metadata to all ToolActions for compile-time emission tracking, introduces playbook serialization and describe support for runtime phase guidance, and refactors 10 skill documents to reference `describe` instead of duplicating schema/guard tables.

## Changes

- **AutoEmission interface** -- New `AutoEmission` type on `ToolAction.autoEmits` with `event`, `condition` ('always'|'conditional'), and optional `description` fields
- **autoEmits population** -- All 20+ tool actions annotated with their auto-emitted events; drift tests enforce consistency with `EVENT_EMISSION_REGISTRY`
- **Describe handler** -- `autoEmits` surfaced in describe output when present; `playbook` parameter added for phase-level guidance queries
- **Runbook derivation** -- `computeRunbookAutoEmits()` derives runbook emissions from constituent ToolAction autoEmits; drift test validates
- **Playbook serialization** -- `serializePlaybooks(workflowType)` and `listPlaybookWorkflowTypes()` export phase playbooks as structured data
- **Schema introspection adapter** -- `resolvePlaybookRef()` bridges CLI/adapter layer to playbook serialization
- **Skill refactoring** -- 10 skills updated: guard tables, state schemas, and event emission tables replaced with `describe` references in new "Schema Discovery" sections

## Test Plan

- 17 new tests across 4 test files covering all new functionality
- Drift tests enforce autoEmits consistency with registry and runbook definitions
- All 270 root tests and 3741 MCP server tests pass
- TypeScript strict mode compiles clean

---
**Results:** 270 root tests pass, 3741 MCP tests pass, build 0 errors
**Design:** [docs/designs/2026-03-09-tool-introspection.md](docs/designs/2026-03-09-tool-introspection.md)
**Plan:** [docs/plans/2026-03-09-tool-introspection.md](docs/plans/2026-03-09-tool-introspection.md)
