### PR TITLE
feat: platform-agnostic guidance layer with decision runbooks

### DIFF
--- a/docs/designs/2026-03-09-platform-agnosticity.md
+++ b/docs/designs/2026-03-09-platform-agnosticity.md
@@ -1,0 +1,222 @@
+# Design: Closing the Platform Agnosticity Gap
+
+**Date:** 2026-03-09
+**Feature ID:** `platform-agnosticity`
+**Spike:** `docs/designs/2026-03-09-platform-agnosticity-spike.md`
+**Depends on:** PRs #982, #986, #988 (tool introspection phases 1-4)
+
+## Problem
+
+Plugin-free MCP clients (Cursor, Copilot, etc.) can navigate Exarchos workflows mechanically via the describe API but make poor judgment calls: when to escalate, when to switch tracks, how to frame subagent prompts, how to detect rationalization. 60-75% of skill content is strategic/decisional, not mechanical.
+
+**Design constraint:** We will NOT ship content layers for other tools. We want the minimum platform-layer enhancements that let plugin-free clients make reasonable decisions without replicating the full methodology.
+
+## Approach
+
+Three complementary levers shipped in priority order. Each lever is independently valuable — no lever depends on another.
+
+## Lever 1: Enriched compactGuidance
+
+### Current State
+
+24 playbook phases each have a `compactGuidance` string averaging 3.6 sentences (55-281 chars). Content is purely mechanical: "Use X to do Y. Transition to Z when done."
+
+### Design
+
+Expand `compactGuidance` from recipe to compact methodology. Each guidance string includes four sections:
+
+1. **What you're doing** (1-2 sentences) — current content, keep as-is
+2. **Key decisions** (1-2 sentences) — the most impactful decision criteria for this phase
+3. **Critical anti-pattern** (1 sentence) — top mistake to avoid
+4. **Escalation trigger** (1 sentence) — when to stop and involve the human
+
+**Length budget (D3-aligned):** ~500 char soft cap per phase. Complex phases (delegate, review, synthesize) may stretch to ~750 chars. Total playbook response grows from ~2KB to ~4KB — a 2x increase, acceptable for a describe response that bootstraps an entire workflow.
+
+### Targets
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| Avg chars | ~150 | ~450 |
+| Escalation criteria mentioned | 1/24 (4%) | ~18/24 (75%) |
+| Anti-patterns mentioned | 2/24 (8%) | ~18/24 (75%) |
+| Decision criteria (X vs Y) | 8/24 (33%) | ~20/24 (83%) |
+
+### Requirements
+
+**DR-1: Enrich all feature workflow compactGuidance strings**
+Expand 9 feature workflow playbook phases (ideate, plan, plan-review, delegate, review, synthesize, completed, cancelled, blocked) with the four-section format.
+**Acceptance criteria:**
+- Each non-terminal phase includes all 4 sections (what/decisions/anti-pattern/escalation)
+- No guidance string exceeds 750 chars
+- Terminal phases (completed, cancelled) remain unchanged
+- Existing playbook tests pass without modification to assertions about structure
+
+**DR-2: Enrich all debug workflow compactGuidance strings**
+Expand 10 debug workflow playbook phases with the four-section format.
+**Acceptance criteria:**
+- Each non-terminal phase includes all 4 sections
+- Track-selection phases (investigate, hotfix-validate) include explicit track decision criteria
+- No guidance string exceeds 750 chars
+
+**DR-3: Enrich all refactor workflow compactGuidance strings**
+Expand 11 refactor workflow playbook phases with the four-section format.
+**Acceptance criteria:**
+- Each non-terminal phase includes all 4 sections
+- Track-selection phase (brief) includes polish vs overhaul decision criteria
+- No guidance string exceeds 750 chars
+
+**DR-4: compactGuidance drift test**
+Add a test that validates structural properties of all compactGuidance strings.
+**Acceptance criteria:**
+- Test verifies no guidance string exceeds 750 chars
+- Test verifies non-terminal, non-blocked phases mention at least one tool or action
+- Test covers all registered playbooks (not a hardcoded list — iterates registry)
+- Test fails if a new playbook is added without compactGuidance
+
+## Lever 2: Decision Runbooks
+
+### Current State
+
+6 runbooks covering 3 phases (delegate, review, synthesize). All are linear step sequences with `onFail: stop | continue`. No conditional branching, no decision encoding.
+
+### Design
+
+Add a new runbook category — decision runbooks — that encode phase-entry decision trees as queryable advisory metadata. Advisory-only: the agent reads the decision tree and follows the guidance. The platform does not execute branches (D5-aligned: structured enough for determinism, no execution coupling).
+
+Extend `RunbookStep` with an optional `decide` field:
+
+```typescript
+interface DecisionBranch {
+  readonly label: string;
+  readonly guidance: string;
+  readonly nextStep?: string;
+  readonly escalate?: boolean;
+}
+
+interface DecisionField {
+  readonly question: string;
+  readonly source: 'state-field' | 'gate-result' | 'event-count' | 'human';
+  readonly field?: string;
+  readonly branches: Record<string, DecisionBranch>;
+}
+
+interface DecisionRunbookStep extends RunbookStep {
+  readonly decide?: DecisionField;
+}
+```
+
+Decision runbooks are authoritative for decision logic. Skills reference them instead of encoding their own decision trees (D2-aligned, same pattern as PR #986's skill refactoring for schemas).
+
+### Coverage
+
+| Phase | Decision Runbook | Key Decision |
+|-------|-----------------|--------------|
+| triage (debug) | `triage-decision` | Hotfix vs thorough track |
+| investigate (debug) | `investigation-decision` | When to escalate to RCA |
+| explore (refactor) | `scope-decision` | Polish vs overhaul track |
+| delegate (feature/refactor) | `dispatch-decision` | Parallel vs sequential, team size |
+| review (all) | `review-escalation` | Fix cycle vs block vs pass |
+| synthesize (all) | `shepherd-escalation` | Keep iterating vs escalate to user |
+
+### Requirements
+
+**DR-5: Extend RunbookStep type with optional decide field**
+Add `DecisionField` and `DecisionBranch` interfaces to the runbook types. Extend `RunbookStep` (or create `DecisionRunbookStep` that extends it) with an optional `decide` field.
+**Acceptance criteria:**
+- New types compile under strict TypeScript
+- Existing runbook definitions remain valid without modification
+- `decide` field is optional — linear runbooks are unaffected
+
+**DR-6: Implement 6 decision runbook definitions**
+Create the 6 decision runbooks listed in the coverage table above.
+**Acceptance criteria:**
+- Each runbook has at least 2 decision steps with branches
+- Each runbook includes at least one `escalate: true` branch
+- Branch guidance strings are actionable (not generic)
+- All runbooks are registered in `ALL_RUNBOOKS` (or equivalent registry)
+
+**DR-7: Serve decision runbooks via existing runbook action**
+Decision runbooks are queryable via `exarchos_orchestrate({ action: "runbook", id: "<id>" })` — same as existing linear runbooks. No new tool actions.
+**Acceptance criteria:**
+- `runbook` action returns decision runbooks with `decide` fields intact
+- Response includes `steps[].decide.question`, `steps[].decide.branches`
+- Existing linear runbook responses are unchanged (backward compatible)
+
+**DR-8: Skill refactoring — replace inline decision logic with runbook references**
+Update skills that currently encode decision trees inline (debug, refactor, delegation, quality-review) to reference decision runbooks instead.
+**Acceptance criteria:**
+- At least 4 skills updated with "Decision Runbook" reference sections
+- Inline decision trees in skill prose are replaced with runbook references
+- Skills that had track-selection logic now reference the corresponding decision runbook
+
+## Lever 3: Schema Field Descriptions
+
+### Current State
+
+`exarchos_event describe(eventTypes: ['team.spawned'])` returns full JSON Schema via `zodToJsonSchema`. Field types and constraints are present, but no human-readable descriptions. Zero `.describe()` calls in `schemas.ts`.
+
+### Design
+
+Add `.describe()` annotations to Zod schema fields for model-emitted event types. `zodToJsonSchema` automatically propagates `.describe()` into the JSON Schema `description` field — no handler changes needed.
+
+Scope: 25 model-emitted event types only (D3-aligned: these are the events agents must construct manually). System-emitted events have auto-populated payloads and are lower priority.
+
+### Requirements
+
+**DR-9: Annotate all model-emitted event schema fields with .describe()**
+Add `.describe()` to every field in the ~25 model-emitted event type Zod schemas.
+**Acceptance criteria:**
+- Every field in model-emitted event schemas has a `.describe()` annotation
+- Descriptions are 5-20 words — concise, not verbose
+- `zodToJsonSchema` output includes `description` for every annotated field
+- No handler code changes — schema file changes only
+
+**DR-10: Schema description drift test**
+Add a test that verifies model-emitted event schemas have descriptions on all fields.
+**Acceptance criteria:**
+- Test iterates all model-emitted event schemas (based on emission catalog from PR #982)
+- Test verifies each field in the JSON Schema output has a `description` property
+- Test fails if a new model-emitted event type is added without field descriptions
+
+## Error Handling & Edge Cases
+
+**DR-11: Graceful degradation for decision runbook queries**
+When a decision runbook references a state field or gate result that doesn't exist yet, the response should still be useful.
+**Acceptance criteria:**
+- Decision runbook responses include the full tree regardless of current state
+- `source: 'state-field'` branches include the field path so agents can query it
+- No runtime errors when querying a decision runbook before any state exists
+
+## Architecture Notes
+
+### What We Explicitly Do NOT Build
+- Full skill serving via MCP (would replicate the content layer)
+- Prompt template serving (implementer/fixer prompts stay in skills)
+- Rationalization-refutation catalogs via MCP (too Claude-Code-specific)
+- Automatic decision execution in runbooks (agents decide, platform advises)
+
+### D1-D5 Alignment Summary
+- **D1 (Spec Fidelity):** Every DR has testable acceptance criteria
+- **D2 (Pattern Compliance):** Decision runbooks follow the same describe-reference pattern established by PR #986. Skills reference platform metadata, not the reverse
+- **D3 (Context Economy):** ~500 char cap on compactGuidance, model-emitted events only for Lever 3, advisory-only runbooks (no extra round-trips)
+- **D4 (Operational Resilience):** All changes are additive — no breaking changes to existing describe responses. Drift tests catch maintenance regressions
+- **D5 (Workflow Determinism):** Structured decision branches replace prose-based decision logic. Advisory model preserves agent autonomy while increasing determinism
+
+## Success Criteria
+
+A plugin-free client (Cursor/Copilot with MCP) should be able to:
+
+1. **Bootstrap:** `describe(playbook: "feature")` → read enriched compactGuidance → know what to do, what to avoid, and when to escalate for every phase
+2. **Emit events:** `_eventHints` with `requiredFields` + `describe(eventTypes)` with field descriptions → construct correct payloads without trial-and-error
+3. **Make decisions:** `runbook({ id: "triage-decision" })` → structured decision tree → choose correct track with documented rationale
+4. **Recover:** `describe(topology)` + guard descriptions → understand why a transition failed and what's needed to satisfy it
+
+**Measurable target:** Plugin-free client completes a feature workflow end-to-end with <= 2x the tool call count of a Claude Code client with full content layer.
+
+## Shipping Order
+
+| Priority | Lever | DRs | Effort | Impact |
+|----------|-------|-----|--------|--------|
+| P0 | Lever 1: Enriched compactGuidance | DR-1 through DR-4 | Low | High |
+| P1 | Lever 3: Schema field descriptions | DR-9, DR-10 | Low | Medium |
+| P2 | Lever 2: Decision runbooks | DR-5 through DR-8, DR-11 | Medium | High |

--- a/docs/designs/2026-03-09-platform-agnosticity.md
+++ b/docs/designs/2026-03-09-platform-agnosticity.md
@@ -44,11 +44,11 @@ Expand `compactGuidance` from recipe to compact methodology. Each guidance strin
 ### Requirements
 
 **DR-1: Enrich all feature workflow compactGuidance strings**
-Expand 9 feature workflow playbook phases (ideate, plan, plan-review, delegate, review, synthesize, completed, cancelled, blocked) with the four-section format.
+Expand 7 non-terminal feature workflow playbook phases (ideate, plan, plan-review, delegate, review, synthesize, blocked) with the four-section format.
 **Acceptance criteria:**
 - Each non-terminal phase includes all 4 sections (what/decisions/anti-pattern/escalation)
 - No guidance string exceeds 750 chars
-- Terminal phases (completed, cancelled) remain unchanged
+- Terminal phases (completed, cancelled) remain unchanged — no expansion needed
 - Existing playbook tests pass without modification to assertions about structure
 
 **DR-2: Enrich all debug workflow compactGuidance strings**

--- a/docs/plans/2026-03-09-platform-agnosticity.md
+++ b/docs/plans/2026-03-09-platform-agnosticity.md
@@ -17,7 +17,7 @@ Link: `docs/designs/2026-03-09-platform-agnosticity.md`
 
 | Design Section | DR | Task(s) | Key Requirements |
 |---|---|---|---|
-| Lever 1: Enriched compactGuidance | DR-1 | 002 | Feature workflow 9 phases, 4-section format, <=750 chars |
+| Lever 1: Enriched compactGuidance | DR-1 | 002 | Feature workflow 7 non-terminal phases (6 enriched + blocked minimal), 4-section format, <=750 chars |
 | Lever 1: Enriched compactGuidance | DR-2 | 003 | Debug workflow 10 phases, track-selection criteria |
 | Lever 1: Enriched compactGuidance | DR-3 | 004 | Refactor workflow 11 phases, polish vs overhaul criteria |
 | Lever 1: Enriched compactGuidance | DR-4 | 001 | Drift test validates all playbooks, iterates registry |

--- a/docs/plans/2026-03-09-platform-agnosticity.md
+++ b/docs/plans/2026-03-09-platform-agnosticity.md
@@ -78,7 +78,7 @@ Link: `docs/designs/2026-03-09-platform-agnosticity.md`
 **Implements:** DR-2
 **Phase:** GREEN → REFACTOR
 
-1. [GREEN] Update 8 non-terminal, non-blocked debug playbook `compactGuidance` strings in `playbooks.ts`:
+1. [GREEN] Update 10 non-terminal, non-blocked debug playbook `compactGuidance` strings in `playbooks.ts`:
    - `triage` — add decision criteria (severity assessment: P0 vs P1), anti-pattern (skipping reproduction), escalation (not reproducible after 15 min)
    - `investigate` — add track-selection criteria (reproducible + <=3 files → hotfix; intermittent or cross-module → thorough), anti-pattern (premature hotfix on complex bugs), escalation (15 min without root cause)
    - `rca` — add decision criteria (depth: immediate cause vs systemic), anti-pattern (stopping at symptoms), escalation (root cause spans multiple subsystems)
@@ -104,7 +104,7 @@ Link: `docs/designs/2026-03-09-platform-agnosticity.md`
 **Implements:** DR-3
 **Phase:** GREEN → REFACTOR
 
-1. [GREEN] Update 9 non-terminal, non-blocked refactor playbook `compactGuidance` strings in `playbooks.ts`:
+1. [GREEN] Update 11 non-terminal, non-blocked refactor playbook `compactGuidance` strings in `playbooks.ts`:
    - `explore` — add decision criteria (scope assessment: files, complexity, risk), anti-pattern (exploring without boundary), escalation (scope exceeds single PR)
    - `brief` — add track-selection criteria (polish: <=5 files, cosmetic/DRY; overhaul: >5 files, structural), anti-pattern (choosing polish for structural changes), escalation (scope unclear after exploration)
    - `polish-implement` — add decision criteria (stay within brief scope), anti-pattern (scope creep), escalation (changes cascade beyond brief)

--- a/docs/plans/2026-03-09-platform-agnosticity.md
+++ b/docs/plans/2026-03-09-platform-agnosticity.md
@@ -1,0 +1,304 @@
+# Implementation Plan: Platform Agnosticity Gap
+
+## Source Design
+Link: `docs/designs/2026-03-09-platform-agnosticity.md`
+
+## Scope
+**Target:** Full design — all 3 levers (11 DRs)
+**Excluded:** None
+
+## Summary
+- Total tasks: 10
+- Parallel groups: 3 (one per lever, all run simultaneously)
+- Estimated test count: ~25
+- Design coverage: 11/11 DRs covered
+
+## Spec Traceability
+
+| Design Section | DR | Task(s) | Key Requirements |
+|---|---|---|---|
+| Lever 1: Enriched compactGuidance | DR-1 | 002 | Feature workflow 9 phases, 4-section format, <=750 chars |
+| Lever 1: Enriched compactGuidance | DR-2 | 003 | Debug workflow 10 phases, track-selection criteria |
+| Lever 1: Enriched compactGuidance | DR-3 | 004 | Refactor workflow 11 phases, polish vs overhaul criteria |
+| Lever 1: Enriched compactGuidance | DR-4 | 001 | Drift test validates all playbooks, iterates registry |
+| Lever 2: Decision Runbooks | DR-5 | 007 | Extend RunbookStep + ResolvedRunbookStep types |
+| Lever 2: Decision Runbooks | DR-6 | 008 | 6 decision runbooks, >=2 decide steps, >=1 escalate |
+| Lever 2: Decision Runbooks | DR-7 | 009 | Serve via existing runbook action, backward-compatible |
+| Lever 2: Decision Runbooks | DR-8 | 010 | 4+ skills updated with decision runbook references |
+| Lever 2: Decision Runbooks | DR-11 | 009 | Graceful degradation, full tree regardless of state |
+| Lever 3: Schema Field Descriptions | DR-9 | 006 | .describe() on all model-emitted event fields |
+| Lever 3: Schema Field Descriptions | DR-10 | 005 | Drift test iterates model-emitted schemas |
+
+## Task Breakdown
+
+### Task 001: compactGuidance drift test (DR-4)
+**Implements:** DR-4
+**Phase:** RED → GREEN (test written first, passes after Tasks 002-004)
+
+1. [RED] Write drift tests in `playbooks.test.ts`:
+   - `compactGuidance_AllNonTerminalPhases_Under750Chars` — iterate all registered playbooks, verify `compactGuidance.length <= 750` for non-terminal phases
+   - `compactGuidance_AllNonTerminalNonBlockedPhases_MentionsToolOrAction` — verify each guidance mentions at least one tool name or action
+   - `compactGuidance_AllRegisteredPlaybooks_HaveGuidance` — verify `compactGuidance.length > 0`
+   - `compactGuidance_NonTerminalNonBlockedPhases_ExceedsMinLength` — verify `compactGuidance.length >= 200` for non-terminal, non-blocked phases (FAILS on current ~150 char averages)
+   - File: `servers/exarchos-mcp/src/workflow/playbooks.test.ts`
+   - Expected failure: min-length test fails because current guidance averages ~150 chars
+
+2. [GREEN] Tests pass once Tasks 002-004 complete
+
+**Dependencies:** None
+**Parallelizable:** Yes (Group A lead, parallel with Groups B/C)
+**testingStrategy:** `{ exampleTests: true, propertyTests: false, benchmarks: false }`
+
+---
+
+### Task 002: Enrich feature workflow compactGuidance (DR-1)
+**Implements:** DR-1
+**Phase:** GREEN → REFACTOR
+
+1. [GREEN] Update 6 non-terminal, non-blocked feature playbook `compactGuidance` strings in `playbooks.ts`:
+   - `ideate` — add decision criteria (problem-first vs solution-first), anti-pattern (jumping to implementation), escalation (design scope unclear after 2 iterations)
+   - `plan` — add decision criteria (task granularity, parallel vs sequential), anti-pattern (monolith tasks), escalation (design has ambiguous requirements)
+   - `plan-review` — add decision criteria (approve vs revise), anti-pattern (rubber-stamping plans without checking coverage), escalation (3+ revision cycles)
+   - `delegate` — use enriched guidance from spike example (subagent prompts self-contained, independent tasks parallel, verify test output independently, escalate on 3 failures)
+   - `review` — add decision criteria (fix vs block vs pass), anti-pattern (trusting passing tests as completeness proof), escalation (same finding appears in 2+ cycles)
+   - `synthesize` — add decision criteria (single PR vs stacked), anti-pattern (merging without CI green), escalation (CI fails 3+ times on same issue)
+   - File: `servers/exarchos-mcp/src/workflow/playbooks.ts`
+   - Preserve existing content that tests assert on (e.g., "GitHub CLI" in synthesize)
+   - Each string: 4 sections (what/decisions/anti-pattern/escalation), <=750 chars
+
+2. [REFACTOR] Verify existing playbook tests still pass (especially `ReferencesGhCli` assertions)
+
+**Dependencies:** Task 001
+**Parallelizable:** No (sequential within Group A, modifies playbooks.ts)
+**testingStrategy:** `{ exampleTests: true, propertyTests: false, benchmarks: false }`
+
+---
+
+### Task 003: Enrich debug workflow compactGuidance (DR-2)
+**Implements:** DR-2
+**Phase:** GREEN → REFACTOR
+
+1. [GREEN] Update 8 non-terminal, non-blocked debug playbook `compactGuidance` strings in `playbooks.ts`:
+   - `triage` — add decision criteria (severity assessment: P0 vs P1), anti-pattern (skipping reproduction), escalation (not reproducible after 15 min)
+   - `investigate` — add track-selection criteria (reproducible + <=3 files → hotfix; intermittent or cross-module → thorough), anti-pattern (premature hotfix on complex bugs), escalation (15 min without root cause)
+   - `rca` — add decision criteria (depth: immediate cause vs systemic), anti-pattern (stopping at symptoms), escalation (root cause spans multiple subsystems)
+   - `design` — add decision criteria (minimal fix vs defensive fix), anti-pattern (scope creep beyond bug fix), escalation (fix requires architectural change)
+   - `debug-implement` — add decision criteria (test-first verification), anti-pattern (fixing without failing test), escalation (implementation touches >5 files)
+   - `debug-validate` — add decision criteria (regression scope), anti-pattern (only testing the fix, not adjacent behavior), escalation (new test failures appear)
+   - `debug-review` — add decision criteria (review depth), anti-pattern (skipping review for "simple" fixes), escalation (fix changes public API)
+   - `hotfix-implement` — add 15-min time limit, anti-pattern (hotfix growing into full fix), escalation (time limit exceeded)
+   - `hotfix-validate` — add decision criteria (PR vs direct commit), anti-pattern (merging without validation)
+   - `synthesize` — include "GitHub CLI" reference, add anti-pattern and escalation
+   - File: `servers/exarchos-mcp/src/workflow/playbooks.ts`
+   - Each string: 4 sections, <=750 chars
+
+2. [REFACTOR] Verify existing debug playbook tests still pass
+
+**Dependencies:** Task 002 (sequential file access)
+**Parallelizable:** No (sequential within Group A)
+**testingStrategy:** `{ exampleTests: true, propertyTests: false, benchmarks: false }`
+
+---
+
+### Task 004: Enrich refactor workflow compactGuidance (DR-3)
+**Implements:** DR-3
+**Phase:** GREEN → REFACTOR
+
+1. [GREEN] Update 9 non-terminal, non-blocked refactor playbook `compactGuidance` strings in `playbooks.ts`:
+   - `explore` — add decision criteria (scope assessment: files, complexity, risk), anti-pattern (exploring without boundary), escalation (scope exceeds single PR)
+   - `brief` — add track-selection criteria (polish: <=5 files, cosmetic/DRY; overhaul: >5 files, structural), anti-pattern (choosing polish for structural changes), escalation (scope unclear after exploration)
+   - `polish-implement` — add decision criteria (stay within brief scope), anti-pattern (scope creep), escalation (changes cascade beyond brief)
+   - `polish-validate` — add decision criteria (verify goals met), anti-pattern (accepting partial completion), escalation (goals not achievable without overhaul)
+   - `polish-update-docs` — add decision criteria (what docs need update), anti-pattern (skipping docs for "obvious" changes)
+   - `overhaul-plan` — add decision criteria (task granularity for large refactor), anti-pattern (monolith tasks), escalation (plan exceeds 20 tasks)
+   - `overhaul-plan-review` — add decision criteria (approve vs revise), anti-pattern (rubber-stamping), escalation (3+ revisions)
+   - `overhaul-delegate` — add delegation strategy, anti-pattern (shared worktrees), escalation (3 task failures)
+   - `overhaul-review` — add review criteria, anti-pattern (trusting self-assessment), escalation (regression findings)
+   - `overhaul-update-docs` — add doc update criteria
+   - `synthesize` — include "GitHub CLI" reference, add anti-pattern and escalation
+   - File: `servers/exarchos-mcp/src/workflow/playbooks.ts`
+   - Each string: 4 sections, <=750 chars
+
+2. [REFACTOR] Verify all playbook tests pass. All drift tests from Task 001 should now be GREEN.
+
+**Dependencies:** Task 003 (sequential file access)
+**Parallelizable:** No (sequential within Group A)
+**testingStrategy:** `{ exampleTests: true, propertyTests: false, benchmarks: false }`
+
+---
+
+### Task 005: Schema description drift test (DR-10)
+**Implements:** DR-10
+**Phase:** RED
+
+1. [RED] Write drift test in `schemas.test.ts`:
+   - `modelEmittedEventSchemas_AllFields_HaveDescriptions` — for each model-emitted event type in `EVENT_EMISSION_REGISTRY`, get its schema from `EVENT_DATA_SCHEMAS`, convert via `zodToJsonSchema`, and verify every field in `properties` has a `description` property
+   - `modelEmittedEventSchemas_Descriptions_AreReasonableLength` — verify each description is 5-80 chars (not empty, not verbose)
+   - File: `servers/exarchos-mcp/src/event-store/schemas.test.ts`
+   - Expected failure: no model-emitted event fields have `.describe()` annotations (0/~100 fields)
+
+2. [GREEN] Tests pass once Task 006 completes
+
+**Dependencies:** None
+**Parallelizable:** Yes (Group B lead, parallel with Groups A/C)
+**testingStrategy:** `{ exampleTests: true, propertyTests: false, benchmarks: false }`
+
+---
+
+### Task 006: Annotate model-emitted event schemas (DR-9)
+**Implements:** DR-9
+**Phase:** GREEN → REFACTOR
+
+1. [GREEN] Add `.describe()` to every field in the 25 model-emitted event Zod schemas in `schemas.ts`:
+   - **Task events** (2 schemas): `TaskAssignedData`, `TaskProgressedData`
+   - **Team events** (7 schemas): `TeamSpawnedData`, `TeamTaskAssignedData`, `TeamTaskCompletedData`, `TeamTaskFailedData`, `TeamDisbandedData`, `TeamTaskPlannedData`, `TeamTeammateDispatchedData`
+   - **Review events** (3 schemas): `ReviewRoutedData`, `ReviewFindingData`, `ReviewEscalatedData`
+   - **Remediation events** (2 schemas): `RemediationAttemptedDataSchema`, `RemediationSucceededDataSchema`
+   - **Session events** (1 schema): `SessionTaggedData`
+   - **Readiness events** (6 schemas): `WorktreeCreatedData`, `WorktreeBaselineData`, `TestResultData`, `TypecheckResultData`, `StackSubmittedData`, `CiStatusData`
+   - **Comment events** (2 schemas): `CommentPostedData`, `CommentResolvedData`
+   - **Shepherd events** (1 schema): `ShepherdIterationData`
+   - **Quality events** (1 schema): `QualityRegressionData`
+   - File: `servers/exarchos-mcp/src/event-store/schemas.ts`
+   - Each description: 5-20 words, concise and actionable
+   - ~100 fields total across 25 schemas
+
+2. [REFACTOR] Verify drift test from Task 005 now passes. Verify existing schema tests unchanged.
+
+**Dependencies:** Task 005
+**Parallelizable:** No (sequential within Group B)
+**testingStrategy:** `{ exampleTests: true, propertyTests: false, benchmarks: false }`
+
+---
+
+### Task 007: Extend RunbookStep types for decision fields (DR-5)
+**Implements:** DR-5
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write type-level tests in a new test section in `runbooks/handler.test.ts` (or `runbooks/types.test.ts`):
+   - `DecisionField_ValidBranches_TypeChecks` — create a decision step object that compiles
+   - `RunbookStep_WithoutDecide_StillValid` — verify existing steps compile without `decide`
+   - `ResolvedRunbookStep_WithDecide_IncludesDecisionFields` — verify resolved step includes `decide`
+   - File: `servers/exarchos-mcp/src/runbooks/types.test.ts` (new)
+   - Expected failure: `decide` property doesn't exist on `RunbookStep`
+
+2. [GREEN] Add types to `types.ts`:
+   - `DecisionBranch` interface: `{ label, guidance, nextStep?, escalate? }`
+   - `DecisionField` interface: `{ question, source, field?, branches }`
+   - Add optional `decide?: DecisionField` to `RunbookStep`
+   - Add optional `decide?: DecisionField` to `ResolvedRunbookStep`
+   - File: `servers/exarchos-mcp/src/runbooks/types.ts`
+
+3. [REFACTOR] Verify existing runbook tests still pass (backward-compatible)
+
+**Dependencies:** None
+**Parallelizable:** Yes (Group C lead, parallel with Groups A/B)
+**testingStrategy:** `{ exampleTests: true, propertyTests: false, benchmarks: false }`
+
+---
+
+### Task 008: Implement 6 decision runbook definitions (DR-6)
+**Implements:** DR-6
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write tests in `runbooks/definitions.test.ts` (new or extend existing drift test):
+   - `decisionRunbooks_EachHasAtLeast2DecideSteps` — iterate decision runbooks, verify `steps.filter(s => s.decide).length >= 2`
+   - `decisionRunbooks_EachHasAtLeast1EscalateBranch` — verify at least one branch has `escalate: true`
+   - `decisionRunbooks_BranchGuidance_IsActionable` — verify branch guidance strings are >= 20 chars (not empty stubs)
+   - `decisionRunbooks_AllRegisteredInAllRunbooks` — verify all 6 are in `ALL_RUNBOOKS`
+   - File: `servers/exarchos-mcp/src/runbooks/definitions.test.ts` (new)
+   - Expected failure: no decision runbooks exist yet
+
+2. [GREEN] Add 6 decision runbooks to `definitions.ts`:
+   - `triage-decision` (debug/triage): Hotfix vs thorough track. Steps: check-reproducibility, check-scope, check-urgency
+   - `investigation-decision` (debug/investigate): When to escalate to RCA. Steps: check-time-spent, check-hypothesis-count, check-cross-module
+   - `scope-decision` (refactor/explore): Polish vs overhaul track. Steps: check-file-count, check-structural-change, check-risk
+   - `dispatch-decision` (feature+refactor/delegate): Parallel vs sequential, team sizing. Steps: check-task-independence, check-file-overlap, check-team-size
+   - `review-escalation` (all/review): Fix cycle vs block vs pass. Steps: check-finding-severity, check-fix-cycle-count, check-design-alignment
+   - `shepherd-escalation` (all/synthesize): Keep iterating vs escalate. Steps: check-iteration-count, check-ci-stability, check-review-status
+   - Add all 6 to `ALL_RUNBOOKS` array
+   - File: `servers/exarchos-mcp/src/runbooks/definitions.ts`
+   - Each uses `tool: 'none', action: 'decide'` for decision steps
+
+3. [REFACTOR] Verify existing drift tests still pass (new runbooks shouldn't break `computeRunbookAutoEmits` since `tool: 'none'` steps are skipped like `native:` steps)
+
+**Dependencies:** Task 007 (needs DecisionField type)
+**Parallelizable:** No (sequential within Group C)
+**testingStrategy:** `{ exampleTests: true, propertyTests: false, benchmarks: false }`
+
+---
+
+### Task 009: Serve decision runbooks via handler (DR-7, DR-11)
+**Implements:** DR-7, DR-11
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write tests in `runbooks/handler.test.ts`:
+   - `handleRunbook_DecisionRunbook_ReturnsDecideFields` — request a decision runbook by id, verify response includes `steps[].decide.question` and `steps[].decide.branches`
+   - `handleRunbook_DecisionRunbook_NoSchemaResolutionForNoneSteps` — verify `tool: 'none'` steps don't fail schema resolution
+   - `handleRunbook_LinearRunbook_UnchangedResponse` — verify existing linear runbook response format is identical (backward-compatible)
+   - `handleRunbook_ListMode_IncludesDecisionRunbooks` — verify list mode includes decision runbook entries
+   - File: `servers/exarchos-mcp/src/runbooks/handler.test.ts`
+   - Expected failure: handler returns error for `tool: 'none'` steps (not in registry, not `native:`)
+
+2. [GREEN] Update handler to support decision steps:
+   - In `handleRunbook`, add condition: if `step.tool === 'none'`, skip schema resolution (same pattern as `native:` check)
+   - Pass through `decide` field in resolved step when present
+   - File: `servers/exarchos-mcp/src/runbooks/handler.ts`
+
+3. [REFACTOR] Verify all runbook handler tests pass, including new and existing
+
+**Dependencies:** Task 008 (needs decision runbook definitions to test against)
+**Parallelizable:** No (sequential within Group C)
+**testingStrategy:** `{ exampleTests: true, propertyTests: false, benchmarks: false }`
+
+---
+
+### Task 010: Skill refactoring — reference decision runbooks (DR-8)
+**Implements:** DR-8
+**Phase:** GREEN → REFACTOR
+
+1. [GREEN] Update 4+ skill SKILL.md files to reference decision runbooks:
+   - `skills/debug/SKILL.md` — replace inline hotfix-vs-thorough decision logic with reference to `triage-decision` and `investigation-decision` runbooks
+   - `skills/refactor/SKILL.md` — replace inline polish-vs-overhaul decision logic with reference to `scope-decision` runbook
+   - `skills/delegation/SKILL.md` — replace inline dispatch strategy with reference to `dispatch-decision` runbook
+   - `skills/quality-review/SKILL.md` — replace inline verdict routing logic with reference to `review-escalation` runbook
+   - Pattern: "For track-selection decision criteria, query: `exarchos_orchestrate({ action: 'runbook', id: '<id>' })`"
+   - Same refactoring pattern as PR #986 (schemas → describe references)
+
+2. [REFACTOR] Verify skill Markdown is well-formed and runbook references are correct IDs
+
+**Dependencies:** Task 008 (needs runbook IDs to reference)
+**Parallelizable:** No (sequential within Group C, but no file overlap with Groups A/B)
+**testingStrategy:** `{ exampleTests: true, propertyTests: false, benchmarks: false }`
+
+## Parallelization Strategy
+
+Three independent tracks running in parallel worktrees:
+
+```
+Group A (Lever 1):  001 → 002 → 003 → 004     [playbooks.ts]
+Group B (Lever 3):  005 → 006                   [schemas.ts]
+Group C (Lever 2):  007 → 008 → 009 → 010      [types.ts, definitions.ts, handler.ts, skills/*.md]
+```
+
+**File ownership (no conflicts):**
+- Group A owns: `playbooks.ts`, `playbooks.test.ts`
+- Group B owns: `schemas.ts`, `schemas.test.ts`
+- Group C owns: `runbooks/types.ts`, `runbooks/types.test.ts`, `runbooks/definitions.ts`, `runbooks/definitions.test.ts`, `runbooks/handler.ts`, `runbooks/handler.test.ts`, `skills/**/*.md`
+
+**No cross-group file overlap** — all three groups can merge independently.
+
+## Deferred Items
+
+None. All 11 DRs are covered.
+
+## Completion Checklist
+- [ ] All tests written before implementation
+- [ ] All tests pass
+- [ ] Existing tests unbroken (especially playbook content assertions)
+- [ ] Code coverage meets standards
+- [ ] compactGuidance drift test validates all playbooks
+- [ ] Schema description drift test validates all model-emitted events
+- [ ] Decision runbooks serve correctly via existing runbook action
+- [ ] Skills reference decision runbooks (not inline logic)
+- [ ] Ready for review

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { describe, it, expect, afterEach } from 'vitest';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 import {
   validateAgentEvent,
   AGENT_EVENT_TYPES,
@@ -1838,5 +1839,57 @@ describe('serializeEventCatalog', () => {
   it('SerializeEventCatalog_TotalCount_MatchesTypeCount', () => {
     const catalog = serializeEventCatalog();
     expect(catalog.totalCount).toBe(Object.keys(catalog.types).length);
+  });
+});
+
+// ─── Task 005/006: Model-emitted event schema description drift tests ────────
+
+describe('Model-emitted event schema descriptions', () => {
+  // Get all model-emitted event types
+  const modelEmittedTypes = Object.entries(EVENT_EMISSION_REGISTRY)
+    .filter(([, source]) => source === 'model')
+    .map(([type]) => type);
+
+  it('modelEmittedEventSchemas_AllFields_HaveDescriptions', () => {
+    const missing: string[] = [];
+
+    for (const eventType of modelEmittedTypes) {
+      const schema = (EVENT_DATA_SCHEMAS as Record<string, unknown>)[eventType];
+      if (!schema) continue; // skip types without schemas
+
+      const jsonSchema = zodToJsonSchema(schema as any) as any;
+      const props = jsonSchema.properties;
+      if (!props) continue;
+
+      for (const [field, fieldSchema] of Object.entries(props)) {
+        if (!(fieldSchema as any).description) {
+          missing.push(`${eventType}.${field}`);
+        }
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+
+  it('modelEmittedEventSchemas_Descriptions_AreReasonableLength', () => {
+    const issues: string[] = [];
+
+    for (const eventType of modelEmittedTypes) {
+      const schema = (EVENT_DATA_SCHEMAS as Record<string, unknown>)[eventType];
+      if (!schema) continue;
+
+      const jsonSchema = zodToJsonSchema(schema as any) as any;
+      const props = jsonSchema.properties;
+      if (!props) continue;
+
+      for (const [field, fieldSchema] of Object.entries(props)) {
+        const desc = (fieldSchema as any).description;
+        if (desc && (desc.length < 5 || desc.length > 80)) {
+          issues.push(`${eventType}.${field}: ${desc.length} chars`);
+        }
+      }
+    }
+
+    expect(issues).toEqual([]);
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -1850,6 +1850,22 @@ describe('Model-emitted event schema descriptions', () => {
     .filter(([, source]) => source === 'model')
     .map(([type]) => type);
 
+  /** Narrowing helper for JSON Schema property objects. */
+  interface JsonSchemaProperty {
+    properties?: Record<string, { description?: string }>;
+  }
+
+  function isJsonSchemaWithProperties(
+    value: unknown,
+  ): value is Required<JsonSchemaProperty> {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      'properties' in value &&
+      typeof (value as JsonSchemaProperty).properties === 'object'
+    );
+  }
+
   it('modelEmittedEventSchemas_AllFields_HaveDescriptions', () => {
     const missing: string[] = [];
 
@@ -1857,12 +1873,11 @@ describe('Model-emitted event schema descriptions', () => {
       const schema = (EVENT_DATA_SCHEMAS as Record<string, unknown>)[eventType];
       if (!schema) continue; // skip types without schemas
 
-      const jsonSchema = zodToJsonSchema(schema as any) as any;
-      const props = jsonSchema.properties;
-      if (!props) continue;
+      const jsonSchema: unknown = zodToJsonSchema(schema as z.ZodSchema);
+      if (!isJsonSchemaWithProperties(jsonSchema)) continue;
 
-      for (const [field, fieldSchema] of Object.entries(props)) {
-        if (!(fieldSchema as any).description) {
+      for (const [field, fieldSchema] of Object.entries(jsonSchema.properties)) {
+        if (!fieldSchema.description) {
           missing.push(`${eventType}.${field}`);
         }
       }
@@ -1878,12 +1893,11 @@ describe('Model-emitted event schema descriptions', () => {
       const schema = (EVENT_DATA_SCHEMAS as Record<string, unknown>)[eventType];
       if (!schema) continue;
 
-      const jsonSchema = zodToJsonSchema(schema as any) as any;
-      const props = jsonSchema.properties;
-      if (!props) continue;
+      const jsonSchema: unknown = zodToJsonSchema(schema as z.ZodSchema);
+      if (!isJsonSchemaWithProperties(jsonSchema)) continue;
 
-      for (const [field, fieldSchema] of Object.entries(props)) {
-        const desc = (fieldSchema as any).description;
+      for (const [field, fieldSchema] of Object.entries(jsonSchema.properties)) {
+        const desc = fieldSchema.description;
         if (desc && (desc.length < 5 || desc.length > 80)) {
           issues.push(`${eventType}.${field}: ${desc.length} chars`);
         }

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -249,11 +249,11 @@ export const WorkflowStartedData = z.object({
 });
 
 export const TaskAssignedData = z.object({
-  taskId: z.string(),
-  title: z.string(),
-  branch: z.string().optional(),
-  worktree: z.string().optional(),
-  assignee: z.string().optional(),
+  taskId: z.string().describe('Unique identifier for the task'),
+  title: z.string().describe('Human-readable task title'),
+  branch: z.string().optional().describe('Git branch for this task'),
+  worktree: z.string().optional().describe('Path to the git worktree for isolation'),
+  assignee: z.string().optional().describe('Agent or user assigned to this task'),
 });
 
 // ─── Task-Level Event Data ──────────────────────────────────────────────────
@@ -265,9 +265,9 @@ export const TaskClaimedData = z.object({
 });
 
 export const TaskProgressedData = z.object({
-  taskId: z.string(),
-  tddPhase: z.enum(['red', 'green', 'refactor']),
-  detail: z.string().max(500).optional(),
+  taskId: z.string().describe('Task being progressed'),
+  tddPhase: z.enum(['red', 'green', 'refactor']).describe('Current TDD phase: red, green, or refactor'),
+  detail: z.string().max(500).optional().describe('Optional detail about the progress step'),
 });
 
 export const TaskCompletedData = z.object({
@@ -411,29 +411,29 @@ export const WorkflowCasFailedData = z.object({
 // ─── Review Event Data ─────────────────────────────────────────────────────
 
 export const ReviewRoutedData = z.object({
-  pr: z.number().int(),
-  riskScore: z.number(),
-  factors: z.array(z.string()),
-  destination: z.enum(['coderabbit', 'self-hosted', 'both']),
-  velocityTier: z.enum(['normal', 'elevated', 'high']),
-  semanticAugmented: z.boolean(),
+  pr: z.number().int().describe('Pull request number'),
+  riskScore: z.number().describe('Computed risk score (0-1) for review routing'),
+  factors: z.array(z.string()).describe('Risk factors that contributed to the score'),
+  destination: z.enum(['coderabbit', 'self-hosted', 'both']).describe('Where the review was routed'),
+  velocityTier: z.enum(['normal', 'elevated', 'high']).describe('Current review velocity tier'),
+  semanticAugmented: z.boolean().describe('Whether semantic analysis augmented the routing'),
 });
 
 export const ReviewFindingData = z.object({
-  pr: z.number().int(),
-  source: z.enum(['coderabbit', 'self-hosted']),
-  severity: z.enum(['critical', 'major', 'minor', 'suggestion']),
-  filePath: z.string(),
-  lineRange: z.tuple([z.number().int(), z.number().int()]).optional(),
-  message: z.string(),
-  rule: z.string().optional(),
+  pr: z.number().int().describe('Pull request where finding was detected'),
+  source: z.enum(['coderabbit', 'self-hosted']).describe('Review tool that produced the finding'),
+  severity: z.enum(['critical', 'major', 'minor', 'suggestion']).describe('Finding severity level'),
+  filePath: z.string().describe('File path where the finding was detected'),
+  lineRange: z.tuple([z.number().int(), z.number().int()]).optional().describe('Start and end line numbers of the finding'),
+  message: z.string().describe('Description of the review finding'),
+  rule: z.string().optional().describe('Lint or analysis rule that triggered the finding'),
 });
 
 export const ReviewEscalatedData = z.object({
-  pr: z.number().int(),
-  reason: z.string(),
-  originalScore: z.number(),
-  triggeringFinding: z.string(),
+  pr: z.number().int().describe('Pull request being escalated'),
+  reason: z.string().describe('Why the review was escalated'),
+  originalScore: z.number().describe('Risk score before escalation'),
+  triggeringFinding: z.string().describe('The finding that triggered escalation'),
 });
 
 // ─── Telemetry Event Data ──────────────────────────────────────────────────
@@ -473,64 +473,64 @@ export const BenchmarkCompletedData = z.object({
 // ─── Team Event Data ────────────────────────────────────────────────────────
 
 export const TeamSpawnedData = z.object({
-  teamSize: z.number().int(),
-  teammateNames: z.array(z.string()),
-  taskCount: z.number().int(),
-  dispatchMode: z.string(),
+  teamSize: z.number().int().describe('Number of agents spawned in this team'),
+  teammateNames: z.array(z.string()).describe('Names assigned to each teammate agent'),
+  taskCount: z.number().int().describe('Number of tasks to distribute across the team'),
+  dispatchMode: z.string().describe('Dispatch mechanism: subagent or agent-team'),
 });
 
 export const TeamTaskAssignedData = z.object({
-  taskId: z.string(),
-  teammateName: z.string(),
-  worktreePath: z.string(),
-  modules: z.array(z.string()),
+  taskId: z.string().describe('Task assigned to this teammate'),
+  teammateName: z.string().describe('Name of the teammate receiving the task'),
+  worktreePath: z.string().describe('Absolute path to the teammate worktree'),
+  modules: z.array(z.string()).describe('Module paths this task is scoped to'),
 });
 
 export const TeamTaskCompletedData = z.object({
-  taskId: z.string(),
-  teammateName: z.string(),
-  durationMs: z.number(),
-  filesChanged: z.array(z.string()),
-  testsPassed: z.boolean(),
-  qualityGateResults: z.record(z.string(), z.unknown()),
+  taskId: z.string().describe('Task that was completed'),
+  teammateName: z.string().describe('Teammate who completed the task'),
+  durationMs: z.number().describe('Wall-clock time in milliseconds'),
+  filesChanged: z.array(z.string()).describe('Paths of files modified by this task'),
+  testsPassed: z.boolean().describe('Whether all tests passed after implementation'),
+  qualityGateResults: z.record(z.string(), z.unknown()).describe('Per-gate pass/fail results from quality checks'),
 });
 
 export const TeamTaskFailedData = z.object({
-  taskId: z.string(),
-  teammateName: z.string(),
-  failureReason: z.string(),
-  gateResults: z.record(z.string(), z.unknown()),
+  taskId: z.string().describe('Task that failed'),
+  teammateName: z.string().describe('Teammate whose task failed'),
+  failureReason: z.string().describe('Root cause or error message for the failure'),
+  gateResults: z.record(z.string(), z.unknown()).describe('Gate results at time of failure'),
 });
 
 export const TeamDisbandedData = z.object({
-  totalDurationMs: z.number(),
-  tasksCompleted: z.number().int(),
-  tasksFailed: z.number().int(),
+  totalDurationMs: z.number().describe('Total wall-clock time for the team'),
+  tasksCompleted: z.number().int().describe('Number of tasks successfully completed'),
+  tasksFailed: z.number().int().describe('Number of tasks that failed'),
 });
 
 export const TeamTaskPlannedData = z.object({
-  taskId: z.string(),
-  title: z.string(),
-  modules: z.array(z.string()),
-  blockedBy: z.array(z.string()),
+  taskId: z.string().describe('Planned task identifier'),
+  title: z.string().describe('Human-readable task title'),
+  modules: z.array(z.string()).describe('Module paths this task will modify'),
+  blockedBy: z.array(z.string()).describe('Task IDs that must complete before this task'),
 });
 
 export const TeamTeammateDispatchedData = z.object({
-  teammateName: z.string(),
-  worktreePath: z.string(),
-  assignedTaskIds: z.array(z.string()),
-  model: z.string(),
+  teammateName: z.string().describe('Name of the dispatched teammate'),
+  worktreePath: z.string().describe('Absolute path to the teammate worktree'),
+  assignedTaskIds: z.array(z.string()).describe('Task IDs assigned to this teammate'),
+  model: z.string().describe('LLM model used for this teammate'),
 });
 
 // ─── Quality Regression Event Data ──────────────────────────────────────────
 
 export const QualityRegressionData = z.object({
-  skill: z.string(),
-  gate: z.string(),
-  consecutiveFailures: z.number().int().nonnegative(),
-  firstFailureCommit: z.string(),
-  lastFailureCommit: z.string(),
-  detectedAt: z.string().datetime(),
+  skill: z.string().describe('Skill where regression was detected'),
+  gate: z.string().describe('Gate that started failing'),
+  consecutiveFailures: z.number().int().nonnegative().describe('Number of consecutive gate failures'),
+  firstFailureCommit: z.string().describe('Git commit SHA of the first failure'),
+  lastFailureCommit: z.string().describe('Git commit SHA of the most recent failure'),
+  detectedAt: z.string().datetime().describe('ISO timestamp when the regression was detected'),
 });
 
 // ─── Quality Hint Event Data ─────────────────────────────────────────────
@@ -569,10 +569,10 @@ export const ShepherdStartedData = z.object({
 });
 
 export const ShepherdIterationData = z.object({
-  iteration: z.number().int().nonnegative(),
-  prsAssessed: z.number().int().nonnegative(),
-  fixesApplied: z.number().int().nonnegative(),
-  status: z.string(),
+  iteration: z.number().int().nonnegative().describe('Iteration number in the shepherd loop'),
+  prsAssessed: z.number().int().nonnegative().describe('Number of PRs assessed in this iteration'),
+  fixesApplied: z.number().int().nonnegative().describe('Number of fixes applied during this iteration'),
+  status: z.string().describe('Current shepherd status summary'),
 });
 
 export const ShepherdApprovalRequestedData = z.object({
@@ -640,79 +640,79 @@ export const JudgeCalibratedDataSchema = z.object({
 // ─── Remediation Event Data ─────────────────────────────────────────────────
 
 export const RemediationAttemptedDataSchema = z.object({
-  taskId: z.string().min(1),
-  skill: z.string().min(1),
-  gateName: z.string().min(1),
-  attemptNumber: z.number().int().min(1),
-  strategy: z.string(),
+  taskId: z.string().min(1).describe('Task being remediated'),
+  skill: z.string().min(1).describe('Skill context for the remediation'),
+  gateName: z.string().min(1).describe('Gate that failed and triggered remediation'),
+  attemptNumber: z.number().int().min(1).describe('Sequential attempt number (1-based)'),
+  strategy: z.string().describe('Remediation strategy being applied'),
 });
 
 export const RemediationSucceededDataSchema = z.object({
-  taskId: z.string().min(1),
-  skill: z.string().min(1),
-  gateName: z.string().min(1),
-  totalAttempts: z.number().int().min(1),
-  finalStrategy: z.string(),
+  taskId: z.string().min(1).describe('Task that was successfully remediated'),
+  skill: z.string().min(1).describe('Skill context for the remediation'),
+  gateName: z.string().min(1).describe('Gate that now passes after remediation'),
+  totalAttempts: z.number().int().min(1).describe('Total attempts before success'),
+  finalStrategy: z.string().describe('Strategy that ultimately succeeded'),
 });
 
 export const SessionTaggedData = z.object({
-  tag: z.string().min(1).max(100),
-  sessionId: z.string().min(1),
-  description: z.string().max(500).optional(),
-  branch: z.string().optional(),
+  tag: z.string().min(1).max(100).describe('Tag label for the session (e.g., feature name)'),
+  sessionId: z.string().min(1).describe('Claude Code session identifier'),
+  description: z.string().max(500).optional().describe('Optional description of what the session covers'),
+  branch: z.string().optional().describe('Git branch associated with this session'),
 });
 
 // ─── Readiness Event Data ───────────────────────────────────────────────────
 
 export const WorktreeCreatedData = z.object({
-  taskId: z.string(),
-  path: z.string(),
-  branch: z.string(),
+  taskId: z.string().describe('Task this worktree was created for'),
+  path: z.string().describe('Absolute filesystem path to the worktree'),
+  branch: z.string().describe('Git branch checked out in the worktree'),
 });
 
 export const WorktreeBaselineData = z.object({
-  taskId: z.string(),
-  path: z.string(),
-  status: z.enum(['passed', 'failed', 'skipped']),
-  output: z.string().optional(),
+  taskId: z.string().describe('Task whose worktree was baselined'),
+  path: z.string().describe('Absolute filesystem path to the worktree'),
+  status: z.enum(['passed', 'failed', 'skipped']).describe('Baseline test result: passed, failed, or skipped'),
+  output: z.string().optional().describe('Test runner output from the baseline run'),
 });
 
 export const TestResultData = z.object({
-  passed: z.boolean(),
-  passCount: z.number().int().nonnegative(),
-  failCount: z.number().int().nonnegative(),
-  coveragePercent: z.number().optional(),
-  output: z.string().optional(),
+  passed: z.boolean().describe('Whether the overall test suite passed'),
+  passCount: z.number().int().nonnegative().describe('Number of passing tests'),
+  failCount: z.number().int().nonnegative().describe('Number of failing tests'),
+  coveragePercent: z.number().optional().describe('Code coverage percentage (0-100)'),
+  output: z.string().optional().describe('Raw test runner output'),
 });
 
 export const TypecheckResultData = z.object({
-  passed: z.boolean(),
-  errorCount: z.number().int().nonnegative(),
-  errors: z.array(z.string()).optional(),
+  passed: z.boolean().describe('Whether TypeScript compilation succeeded'),
+  errorCount: z.number().int().nonnegative().describe('Number of type errors found'),
+  errors: z.array(z.string()).optional().describe('Individual type error messages'),
 });
 
 export const StackSubmittedData = z.object({
-  branches: z.array(z.string()),
-  prNumbers: z.array(z.number().int()),
+  branches: z.array(z.string()).describe('Branch names in the submitted stack'),
+  prNumbers: z.array(z.number().int()).describe('PR numbers created for the stack'),
 });
 
 export const CiStatusData = z.object({
-  pr: z.number().int(),
-  status: z.enum(['passing', 'failing', 'pending']),
-  jobUrl: z.string().optional(),
+  pr: z.number().int().describe('Pull request number'),
+  status: z.enum(['passing', 'failing', 'pending']).describe('Current CI pipeline status'),
+  jobUrl: z.string().optional().describe('URL to the CI job for inspection'),
 });
 
 export const CommentPostedData = z.object({
-  pr: z.number().int(),
-  commentId: z.string(),
-  body: z.string(),
-  inReplyTo: z.string().optional(),
+  pr: z.number().int().describe('Pull request where comment was posted'),
+  commentId: z.string().describe('GitHub comment identifier'),
+  body: z.string().describe('Comment body text'),
+  inReplyTo: z.string().optional().describe('Parent comment ID if this is a reply'),
 });
 
 export const CommentResolvedData = z.object({
-  pr: z.number().int(),
-  threadId: z.string(),
-  resolvedBy: z.enum(['author', 'outdated', 'manual']),
+  pr: z.number().int().describe('Pull request where thread was resolved'),
+  threadId: z.string().describe('GitHub review thread identifier'),
+  resolvedBy: z.enum(['author', 'outdated', 'manual']).describe('How the thread was resolved'),
 });
 
 // ─── Event Data Schemas Map ─────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -412,7 +412,7 @@ export const WorkflowCasFailedData = z.object({
 
 export const ReviewRoutedData = z.object({
   pr: z.number().int().describe('Pull request number'),
-  riskScore: z.number().describe('Computed risk score (0-1) for review routing'),
+  riskScore: z.number().min(0).max(1).describe('Computed risk score (0-1) for review routing'),
   factors: z.array(z.string()).describe('Risk factors that contributed to the score'),
   destination: z.enum(['coderabbit', 'self-hosted', 'both']).describe('Where the review was routed'),
   velocityTier: z.enum(['normal', 'elevated', 'high']).describe('Current review velocity tier'),
@@ -432,7 +432,7 @@ export const ReviewFindingData = z.object({
 export const ReviewEscalatedData = z.object({
   pr: z.number().int().describe('Pull request being escalated'),
   reason: z.string().describe('Why the review was escalated'),
-  originalScore: z.number().describe('Risk score before escalation'),
+  originalScore: z.number().min(0).max(1).describe('Risk score before escalation'),
   triggeringFinding: z.string().describe('The finding that triggered escalation'),
 });
 
@@ -473,9 +473,9 @@ export const BenchmarkCompletedData = z.object({
 // ─── Team Event Data ────────────────────────────────────────────────────────
 
 export const TeamSpawnedData = z.object({
-  teamSize: z.number().int().describe('Number of agents spawned in this team'),
+  teamSize: z.number().int().nonnegative().describe('Number of agents spawned in this team'),
   teammateNames: z.array(z.string()).describe('Names assigned to each teammate agent'),
-  taskCount: z.number().int().describe('Number of tasks to distribute across the team'),
+  taskCount: z.number().int().nonnegative().describe('Number of tasks to distribute across the team'),
   dispatchMode: z.string().describe('Dispatch mechanism: subagent or agent-team'),
 });
 
@@ -489,7 +489,7 @@ export const TeamTaskAssignedData = z.object({
 export const TeamTaskCompletedData = z.object({
   taskId: z.string().describe('Task that was completed'),
   teammateName: z.string().describe('Teammate who completed the task'),
-  durationMs: z.number().describe('Wall-clock time in milliseconds'),
+  durationMs: z.number().nonnegative().describe('Wall-clock time in milliseconds'),
   filesChanged: z.array(z.string()).describe('Paths of files modified by this task'),
   testsPassed: z.boolean().describe('Whether all tests passed after implementation'),
   qualityGateResults: z.record(z.string(), z.unknown()).describe('Per-gate pass/fail results from quality checks'),
@@ -503,9 +503,9 @@ export const TeamTaskFailedData = z.object({
 });
 
 export const TeamDisbandedData = z.object({
-  totalDurationMs: z.number().describe('Total wall-clock time for the team'),
-  tasksCompleted: z.number().int().describe('Number of tasks successfully completed'),
-  tasksFailed: z.number().int().describe('Number of tasks that failed'),
+  totalDurationMs: z.number().nonnegative().describe('Total wall-clock time for the team'),
+  tasksCompleted: z.number().int().nonnegative().describe('Number of tasks successfully completed'),
+  tasksFailed: z.number().int().nonnegative().describe('Number of tasks that failed'),
 });
 
 export const TeamTaskPlannedData = z.object({
@@ -681,7 +681,7 @@ export const TestResultData = z.object({
   passed: z.boolean().describe('Whether the overall test suite passed'),
   passCount: z.number().int().nonnegative().describe('Number of passing tests'),
   failCount: z.number().int().nonnegative().describe('Number of failing tests'),
-  coveragePercent: z.number().optional().describe('Code coverage percentage (0-100)'),
+  coveragePercent: z.number().min(0).max(100).optional().describe('Code coverage percentage (0-100)'),
   output: z.string().optional().describe('Raw test runner output'),
 });
 

--- a/servers/exarchos-mcp/src/runbooks/compute.ts
+++ b/servers/exarchos-mcp/src/runbooks/compute.ts
@@ -11,7 +11,7 @@ import type { RunbookDefinition } from './types.js';
 export function computeRunbookAutoEmits(runbook: RunbookDefinition): readonly string[] {
   const events = new Set<string>();
   for (const step of runbook.steps) {
-    if (step.tool.startsWith('native:')) continue;
+    if (step.tool.startsWith('native:') || step.tool === 'none') continue;
     const action = findActionInRegistry(step.tool, step.action);
     if (action?.autoEmits) {
       for (const emission of action.autoEmits) {

--- a/servers/exarchos-mcp/src/runbooks/decision-runbooks.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/decision-runbooks.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { ALL_RUNBOOKS } from './definitions.js';
+import type { RunbookStep } from './types.js';
+
+const DECISION_RUNBOOK_IDS = [
+  'triage-decision',
+  'investigation-decision',
+  'scope-decision',
+  'dispatch-decision',
+  'review-escalation',
+  'shepherd-escalation',
+];
+
+describe('Decision runbooks', () => {
+  it('decisionRunbooks_AllRegistered', () => {
+    const registeredIds = ALL_RUNBOOKS.map(r => r.id);
+    for (const id of DECISION_RUNBOOK_IDS) {
+      expect(registeredIds).toContain(id);
+    }
+  });
+
+  for (const id of DECISION_RUNBOOK_IDS) {
+    describe(id, () => {
+      it(`${id}_HasAtLeast2DecideSteps`, () => {
+        const runbook = ALL_RUNBOOKS.find(r => r.id === id)!;
+        const decideSteps = runbook.steps.filter((s: RunbookStep) => s.decide);
+        expect(decideSteps.length).toBeGreaterThanOrEqual(2);
+      });
+
+      it(`${id}_HasAtLeast1EscalateBranch`, () => {
+        const runbook = ALL_RUNBOOKS.find(r => r.id === id)!;
+        const hasEscalate = runbook.steps.some((s: RunbookStep) =>
+          s.decide && Object.values(s.decide.branches).some(b => b.escalate === true)
+        );
+        expect(hasEscalate).toBe(true);
+      });
+
+      it(`${id}_BranchGuidanceIsActionable`, () => {
+        const runbook = ALL_RUNBOOKS.find(r => r.id === id)!;
+        for (const step of runbook.steps) {
+          if (!step.decide) continue;
+          for (const [key, branch] of Object.entries(step.decide.branches)) {
+            expect(branch.guidance.length, `${id} step branch "${key}" guidance too short`).toBeGreaterThanOrEqual(20);
+          }
+        }
+      });
+
+      it(`${id}_StepsUseToolNone`, () => {
+        const runbook = ALL_RUNBOOKS.find(r => r.id === id)!;
+        for (const step of runbook.steps) {
+          if (step.decide) {
+            expect(step.tool).toBe('none');
+            expect(step.action).toBe('decide');
+          }
+        }
+      });
+    });
+  }
+});

--- a/servers/exarchos-mcp/src/runbooks/definitions.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/definitions.test.ts
@@ -97,6 +97,6 @@ describe('Runbook definitions', () => {
   });
 
   it('AllRunbooks_Count', () => {
-    expect(ALL_RUNBOOKS).toHaveLength(6);
+    expect(ALL_RUNBOOKS).toHaveLength(12);
   });
 });

--- a/servers/exarchos-mcp/src/runbooks/definitions.ts
+++ b/servers/exarchos-mcp/src/runbooks/definitions.ts
@@ -125,6 +125,270 @@ export const TASK_FIX: RunbookDefinition = {
   autoEmits: ['gate.executed', 'task.completed'],
 };
 
+export const TRIAGE_DECISION: RunbookDefinition = {
+  id: 'triage-decision',
+  phase: 'triage',
+  description: 'Decide between hotfix and thorough investigation tracks based on reproducibility and scope.',
+  steps: [
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      decide: {
+        question: 'Is the bug reproducible with a specific test case?',
+        source: 'human',
+        branches: {
+          'yes': { label: 'Reproducible', guidance: 'Write the failing test first, then proceed to scope check. A reproducible bug with a test is the ideal starting point for hotfix.', nextStep: 'check-scope' },
+          'no': { label: 'Not reproducible', guidance: 'Add logging and check error patterns. Intermittent bugs require thorough investigation — do not attempt hotfix.', nextStep: 'thorough-track' },
+        },
+      },
+    },
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      note: 'check-scope',
+      decide: {
+        question: 'Does the fix touch more than 3 files or cross module boundaries?',
+        source: 'human',
+        branches: {
+          'yes': { label: 'Large scope', guidance: 'Switch to thorough track — cross-module fixes need RCA to avoid incomplete patches.' },
+          'no': { label: 'Small scope', guidance: 'Proceed with hotfix track. Apply minimal targeted fix within 15-minute time limit.' },
+        },
+      },
+    },
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      note: 'thorough-track',
+      decide: {
+        question: 'Has 15 minutes elapsed without identifying the root cause?',
+        source: 'human',
+        branches: {
+          'yes': { label: 'Time exceeded', guidance: 'Escalate to user — the bug may require domain expertise or access to systems you cannot inspect.', escalate: true },
+          'no': { label: 'Still investigating', guidance: 'Continue investigation. Document hypotheses tested and their results for the RCA document.' },
+        },
+      },
+    },
+  ],
+  templateVars: ['featureId'],
+  autoEmits: [],
+};
+
+export const INVESTIGATION_DECISION: RunbookDefinition = {
+  id: 'investigation-decision',
+  phase: 'investigate',
+  description: 'Decide when to escalate investigation to full RCA based on complexity signals.',
+  steps: [
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      decide: {
+        question: 'How many hypotheses have been tested without finding root cause?',
+        source: 'event-count',
+        field: 'investigation.hypothesesTested',
+        branches: {
+          '< 3': { label: 'Few hypotheses', guidance: 'Continue investigating. Systematically eliminate possibilities — check logs, add breakpoints, trace data flow.' },
+          '>= 3': { label: 'Many hypotheses', guidance: 'Pattern suggests deeper issue. Transition to formal RCA with structured 5-whys analysis.', nextStep: 'check-cross-module' },
+        },
+      },
+    },
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      note: 'check-cross-module',
+      decide: {
+        question: 'Does the bug involve interactions between multiple subsystems?',
+        source: 'human',
+        branches: {
+          'yes': { label: 'Cross-module', guidance: 'Escalate to user — cross-module bugs often require architectural context the agent lacks.', escalate: true },
+          'no': { label: 'Single module', guidance: 'Proceed with RCA within the module. Focus the 5-whys on the module boundary.' },
+        },
+      },
+    },
+  ],
+  templateVars: ['featureId'],
+  autoEmits: [],
+};
+
+export const SCOPE_DECISION: RunbookDefinition = {
+  id: 'scope-decision',
+  phase: 'explore',
+  description: 'Decide between polish and overhaul refactoring tracks based on scope assessment.',
+  steps: [
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      decide: {
+        question: 'How many files does the refactoring touch?',
+        source: 'state-field',
+        field: 'exploration.fileCount',
+        branches: {
+          '<= 5': { label: 'Small scope', guidance: 'Polish track is appropriate. Focus on DRY, naming, and small structural improvements within the affected files.', nextStep: 'check-structural' },
+          '> 5': { label: 'Large scope', guidance: 'Overhaul track recommended. Create a formal plan with parallelizable tasks and dependency analysis.' },
+        },
+      },
+    },
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      note: 'check-structural',
+      decide: {
+        question: 'Does the change alter module boundaries, public APIs, or data flow?',
+        source: 'human',
+        branches: {
+          'yes': { label: 'Structural change', guidance: 'Override to overhaul track — structural changes need planning even if file count is low.' },
+          'no': { label: 'Cosmetic change', guidance: 'Confirm polish track. Implement changes directly without formal planning phase.' },
+        },
+      },
+    },
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      decide: {
+        question: 'Does the refactoring scope exceed what can ship in a single PR?',
+        source: 'human',
+        branches: {
+          'yes': { label: 'Multi-PR scope', guidance: 'Escalate to user — discuss phasing the refactor across multiple PRs with clear milestones.', escalate: true },
+          'no': { label: 'Single PR scope', guidance: 'Proceed with selected track. The entire refactor ships as one PR.' },
+        },
+      },
+    },
+  ],
+  templateVars: ['featureId'],
+  autoEmits: [],
+};
+
+export const DISPATCH_DECISION: RunbookDefinition = {
+  id: 'dispatch-decision',
+  phase: 'delegate',
+  description: 'Decide dispatch strategy: parallel vs sequential, team sizing, and isolation mode.',
+  steps: [
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      decide: {
+        question: 'Do any tasks modify the same files or share module boundaries?',
+        source: 'state-field',
+        field: 'tasks[].modules',
+        branches: {
+          'yes': { label: 'File overlap', guidance: 'Sequence overlapping tasks. Only parallelize tasks with zero file overlap to avoid merge conflicts in worktrees.' },
+          'no': { label: 'Independent tasks', guidance: 'Full parallel dispatch is safe. Create one worktree per task for maximum throughput.' },
+        },
+      },
+    },
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      decide: {
+        question: 'How many independent tasks are there?',
+        source: 'state-field',
+        field: 'tasks.length',
+        branches: {
+          '<= 3': { label: 'Small team', guidance: 'Use subagent dispatch with run_in_background. Simple orchestration, no team coordination overhead.' },
+          '> 3': { label: 'Large team', guidance: 'Consider agent-team mode if tmux is available. Otherwise batch subagents in groups of 3-4 to manage context.' },
+        },
+      },
+    },
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      decide: {
+        question: 'Has the same task failed 3 or more times?',
+        source: 'event-count',
+        field: 'task.failed',
+        branches: {
+          'yes': { label: 'Repeated failure', guidance: 'Escalate to user — repeated failures suggest a design issue, missing dependency, or environment problem that the agent cannot resolve alone.', escalate: true },
+          'no': { label: 'Normal progress', guidance: 'Continue dispatch. For failed tasks, use the fixer agent with adversarial verification posture.' },
+        },
+      },
+    },
+  ],
+  templateVars: ['featureId'],
+  autoEmits: [],
+};
+
+export const REVIEW_ESCALATION: RunbookDefinition = {
+  id: 'review-escalation',
+  phase: 'review',
+  description: 'Decide review outcome: pass to synthesis, route to fix cycle, or block for redesign.',
+  steps: [
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      decide: {
+        question: 'Are there any HIGH severity findings?',
+        source: 'gate-result',
+        field: 'review.highFindings',
+        branches: {
+          'yes': { label: 'High findings', guidance: 'Check if findings indicate design-level issues. If so, route to BLOCKED for redesign. If implementation-only, route to fix cycle.', nextStep: 'check-design-alignment' },
+          'no': { label: 'No high findings', guidance: 'Check medium findings and fix cycle count to determine pass vs minor fixes.', nextStep: 'check-fix-cycles' },
+        },
+      },
+    },
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      note: 'check-design-alignment',
+      decide: {
+        question: 'Do the findings indicate a gap in the design specification?',
+        source: 'human',
+        branches: {
+          'yes': { label: 'Design gap', guidance: 'Verdict: BLOCKED. The implementation cannot converge without design changes. Route back to ideate phase.', escalate: true },
+          'no': { label: 'Implementation issue', guidance: 'Verdict: NEEDS_FIXES. Route to delegation with --fixes flag. Include specific findings in the fix task descriptions.' },
+        },
+      },
+    },
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      note: 'check-fix-cycles',
+      decide: {
+        question: 'How many fix cycles have already been attempted?',
+        source: 'event-count',
+        field: 'workflow.fix-cycle',
+        branches: {
+          '0': { label: 'First review', guidance: 'If medium findings exist, route to fix cycle. If only low findings, consider APPROVED with advisory notes.' },
+          '1-2': { label: 'Fix cycles attempted', guidance: 'Findings should be decreasing. If the same finding reappears, escalate — the fix approach may be wrong.' },
+          '>= 3': { label: 'Many fix cycles', guidance: 'Escalate to user — the review-fix loop is not converging. May need design revision or manual intervention.', escalate: true },
+        },
+      },
+    },
+  ],
+  templateVars: ['featureId'],
+  autoEmits: [],
+};
+
+export const SHEPHERD_ESCALATION: RunbookDefinition = {
+  id: 'shepherd-escalation',
+  phase: 'synthesize',
+  description: 'Decide whether to continue shepherd iterations or escalate to user.',
+  steps: [
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      decide: {
+        question: 'How many shepherd iterations have been completed?',
+        source: 'event-count',
+        field: 'shepherd.iteration',
+        branches: {
+          '<= 3': { label: 'Early iterations', guidance: 'Continue iterating. Fix CI failures, address review comments, and re-push. Most PRs converge within 3 iterations.' },
+          '> 3': { label: 'Many iterations', guidance: 'Check if CI failures are stable or flaky. If the same failure repeats, escalate rather than retry.', nextStep: 'check-ci-stability' },
+        },
+      },
+    },
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      note: 'check-ci-stability',
+      decide: {
+        question: 'Is the CI failure the same as in the previous iteration?',
+        source: 'human',
+        branches: {
+          'yes': { label: 'Same failure', guidance: 'Escalate to user — repeated identical CI failure suggests an environment issue, flaky test, or infrastructure problem the agent cannot fix.', escalate: true },
+          'no': { label: 'Different failure', guidance: 'New failure type — one more iteration is warranted. If this also fails, escalate regardless.' },
+        },
+      },
+    },
+    {
+      tool: 'none', action: 'decide', onFail: 'stop',
+      decide: {
+        question: 'Are all review comments addressed and CI passing?',
+        source: 'gate-result',
+        field: 'shepherd.allGreen',
+        branches: {
+          'yes': { label: 'All green', guidance: 'PR is ready. Request approval or enable auto-merge. No further shepherd iterations needed.' },
+          'no': { label: 'Outstanding items', guidance: 'Continue iterating on remaining items. Prioritize CI fixes over review comments — a red CI blocks everything.' },
+        },
+      },
+    },
+  ],
+  templateVars: ['featureId'],
+  autoEmits: [],
+};
+
 export const ALL_RUNBOOKS: readonly RunbookDefinition[] = [
   TASK_COMPLETION,
   QUALITY_EVALUATION,
@@ -132,4 +396,10 @@ export const ALL_RUNBOOKS: readonly RunbookDefinition[] = [
   SYNTHESIS_FLOW,
   SHEPHERD_ITERATION,
   TASK_FIX,
+  TRIAGE_DECISION,
+  INVESTIGATION_DECISION,
+  SCOPE_DECISION,
+  DISPATCH_DECISION,
+  REVIEW_ESCALATION,
+  SHEPHERD_ESCALATION,
 ];

--- a/servers/exarchos-mcp/src/runbooks/drift.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/drift.test.ts
@@ -11,6 +11,8 @@ describe('Runbook drift detection', () => {
       for (const step of runbook.steps) {
         // Skip native tools — they are Claude Code native tools, not MCP tools
         if (step.tool.startsWith('native:')) continue;
+        // Skip decision steps — they are advisory-only, not MCP tool calls
+        if (step.tool === 'none') continue;
 
         const action = findActionInRegistry(step.tool, step.action);
         expect(
@@ -25,6 +27,7 @@ describe('Runbook drift detection', () => {
     for (const runbook of ALL_RUNBOOKS) {
       for (const step of runbook.steps) {
         if (step.tool.startsWith('native:')) continue;
+        if (step.tool === 'none') continue;
 
         const action = findActionInRegistry(step.tool, step.action);
         if (!action) continue; // covered by EveryStepReferencesValidRegistryAction

--- a/servers/exarchos-mcp/src/runbooks/handler.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/handler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { handleRunbook } from './handler.js';
 import { ALL_RUNBOOKS } from './definitions.js';
 import type { ResolvedRunbookStep } from './types.js';

--- a/servers/exarchos-mcp/src/runbooks/handler.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/handler.test.ts
@@ -192,8 +192,10 @@ describe('handleRunbook', () => {
     };
     const decideSteps = data.steps.filter((s) => s.decide);
     expect(decideSteps.length).toBeGreaterThanOrEqual(2);
-    expect(decideSteps[0].decide!.question).toBeTruthy();
-    expect(decideSteps[0].decide!.branches).toBeTruthy();
+    for (const step of decideSteps) {
+      expect(step.decide!.question).toBeTruthy();
+      expect(step.decide!.branches).toBeTruthy();
+    }
   });
 
   it('handleRunbook_DecisionRunbook_NoSchemaForNoneSteps', async () => {
@@ -202,10 +204,10 @@ describe('handleRunbook', () => {
     const data = result.data as {
       steps: Array<{ tool: string; schema: unknown }>;
     };
-    for (const step of data.steps) {
-      if (step.tool === 'none') {
-        expect(step.schema).toBeNull();
-      }
+    const noneSteps = data.steps.filter((step) => step.tool === 'none');
+    expect(noneSteps.length).toBeGreaterThan(0);
+    for (const step of noneSteps) {
+      expect(step.schema).toBeNull();
     }
   });
 

--- a/servers/exarchos-mcp/src/runbooks/handler.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/handler.test.ts
@@ -181,4 +181,51 @@ describe('handleRunbook', () => {
       expect(step.platformHint).toBeUndefined();
     }
   });
+
+  // ─── Decision Runbook Serving ──────────────────────────────────────────
+
+  it('handleRunbook_DecisionRunbook_ReturnsDecideFields', async () => {
+    const result = await handleRunbook({ id: 'triage-decision' });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      steps: Array<{ decide?: { question: string; branches: Record<string, unknown> } }>;
+    };
+    const decideSteps = data.steps.filter((s) => s.decide);
+    expect(decideSteps.length).toBeGreaterThanOrEqual(2);
+    expect(decideSteps[0].decide!.question).toBeTruthy();
+    expect(decideSteps[0].decide!.branches).toBeTruthy();
+  });
+
+  it('handleRunbook_DecisionRunbook_NoSchemaForNoneSteps', async () => {
+    const result = await handleRunbook({ id: 'triage-decision' });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      steps: Array<{ tool: string; schema: unknown }>;
+    };
+    for (const step of data.steps) {
+      if (step.tool === 'none') {
+        expect(step.schema).toBeNull();
+      }
+    }
+  });
+
+  it('handleRunbook_LinearRunbook_UnchangedResponse', async () => {
+    const result = await handleRunbook({ id: 'task-completion' });
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      steps: Array<{ decide?: unknown }>;
+    };
+    // Linear runbooks should have NO decide fields
+    for (const step of data.steps) {
+      expect(step.decide).toBeUndefined();
+    }
+  });
+
+  it('handleRunbook_ListMode_IncludesDecisionRunbooks', async () => {
+    const result = await handleRunbook({});
+    expect(result.success).toBe(true);
+    const ids = (result.data as Array<{ id: string }>).map((r) => r.id);
+    expect(ids).toContain('triage-decision');
+    expect(ids).toContain('review-escalation');
+  });
 });

--- a/servers/exarchos-mcp/src/runbooks/handler.ts
+++ b/servers/exarchos-mcp/src/runbooks/handler.ts
@@ -59,12 +59,13 @@ export async function handleRunbook(args: RunbookArgs): Promise<ToolResult> {
   for (let index = 0; index < runbook.steps.length; index++) {
     const step = runbook.steps[index];
     const isNative = step.tool.startsWith('native:');
+    const isDecision = step.tool === 'none';
 
     let schema: unknown = null;
     let description: string | undefined;
     let gate: { readonly blocking: boolean; readonly dimension?: string } | null = null;
 
-    if (!isNative) {
+    if (!isNative && !isDecision) {
       const action = findActionInRegistry(step.tool, step.action);
       if (action) {
         schema = zodToJsonSchema(action.schema);
@@ -79,6 +80,10 @@ export async function handleRunbook(args: RunbookArgs): Promise<ToolResult> {
           },
         };
       }
+    }
+
+    if (isDecision) {
+      description = step.decide?.question;
     }
 
     const agentName = isNative
@@ -103,6 +108,7 @@ export async function handleRunbook(args: RunbookArgs): Promise<ToolResult> {
             },
           }
         : {}),
+      ...(step.decide !== undefined ? { decide: step.decide } : {}),
     });
   }
 

--- a/servers/exarchos-mcp/src/runbooks/skill-coverage.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/skill-coverage.test.ts
@@ -48,4 +48,31 @@ describe('Skill coverage — runbook references', () => {
     const content = readSkillFile('shepherd/SKILL.md');
     assertRunbookReference(content, 'shepherd-iteration');
   });
+
+  // ─── Decision Runbook References ─────────────────────────────────────
+
+  it('SkillCoverage_DebugSkill_ReferencesTriageDecisionRunbook', () => {
+    const content = readSkillFile('debug/SKILL.md');
+    assertRunbookReference(content, 'triage-decision');
+  });
+
+  it('SkillCoverage_DebugSkill_ReferencesInvestigationDecisionRunbook', () => {
+    const content = readSkillFile('debug/SKILL.md');
+    assertRunbookReference(content, 'investigation-decision');
+  });
+
+  it('SkillCoverage_RefactorSkill_ReferencesScopeDecisionRunbook', () => {
+    const content = readSkillFile('refactor/SKILL.md');
+    assertRunbookReference(content, 'scope-decision');
+  });
+
+  it('SkillCoverage_DelegationSkill_ReferencesDispatchDecisionRunbook', () => {
+    const content = readSkillFile('delegation/SKILL.md');
+    assertRunbookReference(content, 'dispatch-decision');
+  });
+
+  it('SkillCoverage_QualityReviewSkill_ReferencesReviewEscalationRunbook', () => {
+    const content = readSkillFile('quality-review/SKILL.md');
+    assertRunbookReference(content, 'review-escalation');
+  });
 });

--- a/servers/exarchos-mcp/src/runbooks/types.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/types.test.ts
@@ -52,4 +52,79 @@ describe('Runbook types', () => {
     expect(resolved.seq).toBe(1);
     expect(resolved.gate?.blocking).toBe(true);
   });
+
+  // ─── Decision Runbook Types ──────────────────────────────────────────
+
+  it('DecisionField_ValidBranches_TypeChecks', () => {
+    // Create a decision step that compiles correctly
+    const step: RunbookStep = {
+      tool: 'none',
+      action: 'decide',
+      onFail: 'stop' as const,
+      decide: {
+        question: 'Is the bug reproducible?',
+        source: 'human' as const,
+        branches: {
+          'yes': { label: 'Reproducible', guidance: 'Write failing test first.', nextStep: 'check-scope' },
+          'no': { label: 'Not reproducible', guidance: 'Investigate further.', escalate: true },
+        },
+      },
+    };
+    expect(step.decide?.question).toBe('Is the bug reproducible?');
+    expect(step.decide?.branches['yes'].nextStep).toBe('check-scope');
+    expect(step.decide?.branches['no'].escalate).toBe(true);
+  });
+
+  it('RunbookStep_WithoutDecide_StillValid', () => {
+    // Existing steps without decide should still compile
+    const step: RunbookStep = {
+      tool: 'exarchos_orchestrate',
+      action: 'check_tdd_compliance',
+      onFail: 'stop' as const,
+    };
+    expect(step.decide).toBeUndefined();
+  });
+
+  it('ResolvedRunbookStep_WithDecide_IncludesDecisionFields', () => {
+    const resolved: ResolvedRunbookStep = {
+      seq: 1,
+      tool: 'none',
+      action: 'decide',
+      onFail: 'stop' as const,
+      decide: {
+        question: 'Test question?',
+        source: 'human' as const,
+        branches: {
+          'yes': { label: 'Yes', guidance: 'Do this.' },
+        },
+      },
+    };
+    expect(resolved.decide?.question).toBe('Test question?');
+  });
+
+  it('RunbookDefinition_WithDecisionSteps_IsValid', () => {
+    const definition: RunbookDefinition = {
+      id: 'test-decision',
+      phase: 'test',
+      description: 'Test decision runbook',
+      steps: [
+        {
+          tool: 'none',
+          action: 'decide',
+          onFail: 'stop' as const,
+          decide: {
+            question: 'Choose a path?',
+            source: 'human' as const,
+            branches: {
+              'a': { label: 'Path A', guidance: 'Go here.' },
+              'b': { label: 'Path B', guidance: 'Go there.', escalate: true },
+            },
+          },
+        },
+      ],
+      templateVars: [],
+      autoEmits: [],
+    };
+    expect(definition.steps[0].decide?.branches['b'].escalate).toBe(true);
+  });
 });

--- a/servers/exarchos-mcp/src/runbooks/types.ts
+++ b/servers/exarchos-mcp/src/runbooks/types.ts
@@ -1,4 +1,33 @@
 /**
+ * A branch in a decision tree. Advisory — the agent reads and decides.
+ */
+export interface DecisionBranch {
+  /** Human-readable label for this branch (e.g., "yes", "no", ">= 3") */
+  readonly label: string;
+  /** What to do if this branch is chosen */
+  readonly guidance: string;
+  /** Optional: jump to a specific step by id */
+  readonly nextStep?: string;
+  /** Optional: escalate to human if this branch is chosen */
+  readonly escalate?: boolean;
+}
+
+/**
+ * A decision point in a decision runbook. Advisory-only — the platform
+ * provides structure, the agent makes the decision.
+ */
+export interface DecisionField {
+  /** The question to answer at this decision point */
+  readonly question: string;
+  /** Where to get the answer: state field, gate result, event count, or human */
+  readonly source: 'state-field' | 'gate-result' | 'event-count' | 'human';
+  /** State field path or gate name (when source is 'state-field' or 'gate-result') */
+  readonly field?: string;
+  /** Decision branches keyed by answer value */
+  readonly branches: Record<string, DecisionBranch>;
+}
+
+/**
  * A single step in a runbook sequence.
  * Tools prefixed with 'native:' (e.g., 'native:Task') represent Claude Code
  * native tools — their schemas are not resolved from the MCP registry.
@@ -14,6 +43,8 @@ export interface RunbookStep {
   readonly params?: Readonly<Record<string, unknown>>;
   /** Human-readable note for this step */
   readonly note?: string;
+  /** Decision point — advisory structure for the agent to follow */
+  readonly decide?: DecisionField;
 }
 
 /**
@@ -56,4 +87,6 @@ export interface ResolvedRunbookStep {
   readonly gate?: { readonly blocking: boolean; readonly dimension?: string } | null;
   /** Platform-specific hints for native steps that reference agent specs */
   readonly platformHint?: { readonly claudeCode: string; readonly generic: string };
+  /** Decision point — advisory structure for the agent to follow */
+  readonly decide?: DecisionField;
 }

--- a/servers/exarchos-mcp/src/workflow/playbooks.test.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.test.ts
@@ -287,13 +287,13 @@ describe('compactGuidance drift tests', () => {
   const terminalPhases = ['completed', 'cancelled'];
   const blockedPhases = ['blocked'];
 
-  function getAllPlaybooks(): Array<{ workflowType: string; phase: string; guidance: string }> {
-    const result: Array<{ workflowType: string; phase: string; guidance: string }> = [];
+  function getAllPlaybooks(): Array<{ workflowType: string; phase: string; guidance: string; skillRef: string }> {
+    const result: Array<{ workflowType: string; phase: string; guidance: string; skillRef: string }> = [];
     const types = listPlaybookWorkflowTypes();
     for (const wt of types) {
       const serialized = serializePlaybooks(wt);
       for (const [phase, pb] of Object.entries(serialized.phases)) {
-        result.push({ workflowType: wt, phase, guidance: pb.compactGuidance });
+        result.push({ workflowType: wt, phase, guidance: pb.compactGuidance, skillRef: pb.skillRef });
       }
     }
     return result;
@@ -329,6 +329,8 @@ describe('compactGuidance drift tests', () => {
     );
     expect(active.length).toBeGreaterThan(0);
     for (const p of active) {
+      // Skill-ref playbooks delegate guidance to the referenced skill — skip min-length check
+      if (p.skillRef) continue;
       expect(
         p.guidance.length,
         `${p.workflowType}:${p.phase} compactGuidance is ${p.guidance.length} chars, below 200 minimum`,
@@ -345,6 +347,8 @@ describe('compactGuidance drift tests', () => {
       /exarchos_workflow|exarchos_event|exarchos_orchestrate|exarchos_view|transition|emit|record|dispatch/i;
     expect(active.length).toBeGreaterThan(0);
     for (const p of active) {
+      // Skill-ref playbooks delegate guidance to the referenced skill — skip tool/action check
+      if (p.skillRef) continue;
       expect(
         toolOrActionPattern.test(p.guidance),
         `${p.workflowType}:${p.phase} compactGuidance does not mention any tool or action keyword`,

--- a/servers/exarchos-mcp/src/workflow/playbooks.test.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.test.ts
@@ -280,3 +280,75 @@ describe('listPlaybookWorkflowTypes', () => {
     expect(types.length).toBeGreaterThanOrEqual(3);
   });
 });
+
+// ─── DR-4: compactGuidance drift tests ──────────────────────────────────────
+
+describe('compactGuidance drift tests', () => {
+  const terminalPhases = ['completed', 'cancelled'];
+  const blockedPhases = ['blocked'];
+
+  function getAllPlaybooks(): Array<{ workflowType: string; phase: string; guidance: string }> {
+    const result: Array<{ workflowType: string; phase: string; guidance: string }> = [];
+    const types = listPlaybookWorkflowTypes();
+    for (const wt of types) {
+      const serialized = serializePlaybooks(wt);
+      for (const [phase, pb] of Object.entries(serialized.phases)) {
+        result.push({ workflowType: wt, phase, guidance: pb.compactGuidance });
+      }
+    }
+    return result;
+  }
+
+  it('compactGuidance_AllNonTerminalPhases_Under750Chars', () => {
+    const playbooks = getAllPlaybooks();
+    const nonTerminal = playbooks.filter((p) => !terminalPhases.includes(p.phase));
+    expect(nonTerminal.length).toBeGreaterThan(0);
+    for (const p of nonTerminal) {
+      expect(
+        p.guidance.length,
+        `${p.workflowType}:${p.phase} compactGuidance is ${p.guidance.length} chars, exceeds 750`,
+      ).toBeLessThanOrEqual(750);
+    }
+  });
+
+  it('compactGuidance_AllRegisteredPlaybooks_HaveGuidance', () => {
+    const playbooks = getAllPlaybooks();
+    expect(playbooks.length).toBeGreaterThan(0);
+    for (const p of playbooks) {
+      expect(
+        p.guidance.length,
+        `${p.workflowType}:${p.phase} has empty compactGuidance`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('compactGuidance_NonTerminalNonBlockedPhases_ExceedsMinLength', () => {
+    const playbooks = getAllPlaybooks();
+    const active = playbooks.filter(
+      (p) => !terminalPhases.includes(p.phase) && !blockedPhases.includes(p.phase),
+    );
+    expect(active.length).toBeGreaterThan(0);
+    for (const p of active) {
+      expect(
+        p.guidance.length,
+        `${p.workflowType}:${p.phase} compactGuidance is ${p.guidance.length} chars, below 200 minimum`,
+      ).toBeGreaterThanOrEqual(200);
+    }
+  });
+
+  it('compactGuidance_AllNonTerminalNonBlockedPhases_MentionsToolOrAction', () => {
+    const playbooks = getAllPlaybooks();
+    const active = playbooks.filter(
+      (p) => !terminalPhases.includes(p.phase) && !blockedPhases.includes(p.phase),
+    );
+    const toolOrActionPattern =
+      /exarchos_workflow|exarchos_event|exarchos_orchestrate|exarchos_view|transition|emit|record|dispatch/i;
+    expect(active.length).toBeGreaterThan(0);
+    for (const p of active) {
+      expect(
+        toolOrActionPattern.test(p.guidance),
+        `${p.workflowType}:${p.phase} compactGuidance does not mention any tool or action keyword`,
+      ).toBe(true);
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/playbooks.test.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.test.ts
@@ -344,7 +344,7 @@ describe('compactGuidance drift tests', () => {
       (p) => !terminalPhases.includes(p.phase) && !blockedPhases.includes(p.phase),
     );
     const toolOrActionPattern =
-      /exarchos_workflow|exarchos_event|exarchos_orchestrate|exarchos_view|transition|emit|record|dispatch/i;
+      /exarchos_workflow|exarchos_event|exarchos_orchestrate|exarchos_view|exarchos_sync|transition|emit|record|dispatch/i;
     expect(active.length).toBeGreaterThan(0);
     for (const p of active) {
       // Skill-ref playbooks delegate guidance to the referenced skill — skip tool/action check

--- a/servers/exarchos-mcp/src/workflow/playbooks.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.ts
@@ -130,7 +130,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are brainstorming a feature design. Use exarchos_workflow set to record design decisions. Create design doc at docs/designs/. Transition to plan when design artifact is set in state.',
+    'You are brainstorming a feature design. Use exarchos_workflow set to record design decisions. Create design doc at docs/designs/. Transition to plan when design artifact is set in state. Key decision: problem-first exploration vs solution-first — exhaust constraints before converging on an approach. Anti-pattern: jumping to implementation details without understanding the problem space and constraints. Escalate: design scope remains unclear after 2 brainstorming iterations.',
 });
 
 register({
@@ -151,7 +151,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are creating an implementation plan from the design doc. Use exarchos_workflow set to record the plan artifact path. Break work into parallelizable TDD tasks. Transition to plan-review when plan is complete.',
+    'You are creating an implementation plan from the design doc. Use exarchos_workflow set to record the plan artifact path. Break work into parallelizable TDD tasks. Transition to plan-review when plan is complete. Key decision: task granularity (target 2-5 min each) and parallel vs sequential grouping. Anti-pattern: monolith tasks that cannot be parallelized across agents. Escalate: design has ambiguous requirements that block decomposition into concrete tasks.',
 });
 
 register({
@@ -172,7 +172,7 @@ register({
   validationScripts: [],
   humanCheckpoint: true,
   compactGuidance:
-    'You are at a human checkpoint reviewing the implementation plan. Wait for user approval or revision feedback. Record approval with exarchos_workflow set using updates: { planReview: { approved: true } }. Transition to delegate on approval or back to plan if gaps found.',
+    'You are at a human checkpoint reviewing the implementation plan. Wait for user approval or revision feedback. Record approval with exarchos_workflow set using updates: { planReview: { approved: true } }. Transition to delegate on approval or back to plan if gaps found. Key decision: approve plan as-is vs request revision with specific feedback. Anti-pattern: rubber-stamping without checking that every DR-N requirement has a corresponding task. Escalate: 3+ revision cycles without convergence on a viable plan.',
 });
 
 register({
@@ -229,7 +229,7 @@ register({
   validationScripts: ['scripts/post-delegation-check.sh'],
   humanCheckpoint: false,
   compactGuidance:
-    'You are dispatching implementation tasks. Use exarchos_event to emit task.assigned for each dispatch. Use exarchos_workflow set to mark tasks complete. Run post-delegation-check.sh when all tasks finish. Transition to review phase when all tasks complete.',
+    'You are dispatching implementation tasks. Use exarchos_event to emit task.assigned for each dispatch. Use exarchos_workflow set to mark tasks complete. Run post-delegation-check.sh when all tasks finish. Transition to review when all tasks complete. Key decision: parallel vs sequential dispatch; each subagent prompt must be self-contained. Anti-pattern: referencing "the plan" in subagent prompts instead of pasting full context. Verify test output independently — do not trust subagent self-assessment. Escalate: same task fails 3 times or task requires changes outside its declared module scope.',
 });
 
 register({
@@ -267,7 +267,7 @@ register({
   ],
   humanCheckpoint: false,
   compactGuidance:
-    'You are running two-stage code review (spec + quality). Use exarchos_event to emit gate.executed for each review gate. Use exarchos_workflow set to record review results. Transition to synthesize when all reviews pass, or back to delegate if fixes needed.',
+    'You are running two-stage code review (spec + quality). Use exarchos_event to emit gate.executed for each review gate. Use exarchos_workflow set to record review results. Transition to synthesize when all reviews pass, or back to delegate if fixes needed. Key decision: pass vs fix-cycle vs block — assess severity of each finding. Anti-pattern: trusting passing tests as proof of completeness — check what the tests actually verify and look for missing coverage. Escalate: same finding appears in 2+ review cycles.',
 });
 
 register({
@@ -309,7 +309,7 @@ register({
   ],
   humanCheckpoint: true,
   compactGuidance:
-    'You are creating PRs via GitHub CLI. Run pre-synthesis-check.sh first. Use exarchos_event to emit gate.executed results. Wait for user confirmation to merge. This is a human checkpoint — pause and confirm before proceeding.',
+    'You are creating PRs via GitHub CLI. Run pre-synthesis-check.sh first. Use exarchos_event to emit gate.executed results. Wait for user confirmation to merge. This is a human checkpoint — pause and confirm before proceeding. Key decision: single PR vs stacked PRs based on change scope. Anti-pattern: merging without CI green on all checks. Escalate: CI fails 3+ times on the same issue.',
 });
 
 register(
@@ -371,7 +371,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are triaging a bug report. Use exarchos_workflow set to record triage findings, severity, and reproduction steps. Transition to investigate when triage is complete.',
+    'You are triaging a bug report. Use exarchos_workflow set to record triage findings, severity, and reproduction steps. Transition to investigate when triage is complete. Key decision: severity assessment — P0 immediate (production impact) vs P1 planned (next sprint). Anti-pattern: skipping reproduction steps and jumping straight to investigation. Escalate: bug is not reproducible after 15 minutes of attempting reproduction.',
 });
 
 register({
@@ -394,7 +394,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are investigating the bug root cause. Use exarchos_workflow set to record investigation findings. Select thorough track (rca) for complex bugs or hotfix track for simple fixes. Transition based on track selection.',
+    'You are investigating the bug root cause. Use exarchos_workflow set to record investigation findings. Select thorough track (rca) for complex bugs or hotfix track for simple fixes. Transition based on track selection. Key decision: hotfix track (reproducible, <=3 files changed) vs thorough track (intermittent or cross-module). Anti-pattern: premature hotfix on complex bugs that need deeper root cause analysis. Escalate: 15 minutes without root cause identification.',
 });
 
 register({
@@ -415,7 +415,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are performing root cause analysis. Use exarchos_workflow set to record the rca document path and findings. Transition to design when the rca document is complete.',
+    'You are performing root cause analysis. Use exarchos_workflow set to record the rca document path and findings. Transition to design when the rca document is complete. Key decision: immediate cause vs systemic root cause — trace the full causal chain. Anti-pattern: stopping at symptoms without tracing to the underlying root cause in the code. Escalate: root cause spans multiple subsystems requiring coordinated fixes.',
 });
 
 register({
@@ -436,7 +436,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are designing the fix based on the RCA. Use exarchos_workflow set to record the fix design. Transition to debug-implement when the design is complete.',
+    'You are designing the fix based on the RCA. Use exarchos_workflow set to record the fix design. Transition to debug-implement when the design is complete. Key decision: minimal targeted fix vs defensive fix with additional guards and validation. Anti-pattern: scope creep beyond the bug fix — resist adding unrelated improvements. Escalate: fix requires architectural change that cannot be contained to a targeted patch.',
 });
 
 register({
@@ -457,7 +457,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are implementing the fix based on the design. Use exarchos_workflow set to record implementation progress. Follow TDD — write failing test first, then implement fix. Transition to debug-validate when implementation is complete.',
+    'You are implementing the fix based on the design. Use exarchos_workflow set to record implementation progress. Follow TDD — write failing test first, then implement fix. Transition to debug-validate when implementation is complete. Key decision: test-first verification — the failing test must reproduce the exact bug before writing the fix. Anti-pattern: fixing without a failing test that reproduces the bug. Escalate: implementation touches >5 files, consider splitting.',
 });
 
 register({
@@ -478,7 +478,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are validating the fix. Use exarchos_workflow set to record validation results. Run tests, verify the bug is fixed, and check for regressions. Transition to debug-review when validation passes.',
+    'You are validating the fix. Use exarchos_workflow set to record validation results. Run tests, verify the bug is fixed, and check for regressions. Transition to debug-review when validation passes. Key decision: regression testing scope — run full suite, not just the new test. Anti-pattern: only testing the fix without checking adjacent behavior for regressions. Escalate: new test failures appear during validation that are unrelated to the fix.',
 });
 
 register({
@@ -499,7 +499,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are reviewing the fix for code quality and correctness. Use exarchos_workflow set to record review results. Transition to synthesize when the review passes.',
+    'You are reviewing the fix for code quality and correctness. Use exarchos_workflow set to record review results. Transition to synthesize when the review passes. Key decision: review depth proportional to fix scope — larger fixes need deeper review. Anti-pattern: skipping review for "simple" fixes that may have non-obvious side effects. Escalate: fix changes public API surface, requiring broader impact assessment.',
 });
 
 register({
@@ -520,7 +520,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are implementing a hotfix. Use exarchos_workflow set to record implementation progress. This is the fast-track — apply minimal targeted fix. Transition to hotfix-validate when implementation is complete.',
+    'You are implementing a hotfix. Use exarchos_workflow set to record implementation progress. This is the fast-track — apply minimal targeted fix within a 15-minute time budget. Transition to hotfix-validate when implementation is complete. Key decision: stay minimal and targeted within the time budget. Anti-pattern: hotfix growing into a full fix — if scope expands, switch to thorough track via rca. Escalate: time limit exceeded without a working fix.',
 });
 
 register({
@@ -542,7 +542,7 @@ register({
   validationScripts: [],
   humanCheckpoint: true,
   compactGuidance:
-    'You are validating the hotfix. Use exarchos_workflow set to record validation results. Run tests and verify the fix. HUMAN CHECKPOINT: present results and await user decision. If PR is requested, transition to synthesize; otherwise transition to completed.',
+    'You are validating the hotfix. Use exarchos_workflow set to record validation results. Run tests and verify the fix. HUMAN CHECKPOINT: present results and await user decision. If PR is requested, transition to synthesize; otherwise transition to completed. Key decision: PR-based merge vs direct to main based on risk assessment. Anti-pattern: merging without running the full test suite. Escalate: validation reveals the fix is incomplete and needs thorough track.',
 });
 
 register({
@@ -578,7 +578,7 @@ register({
   validationScripts: [],
   humanCheckpoint: true,
   compactGuidance:
-    'You are creating a PR for the debug fix via GitHub CLI. Use exarchos_workflow set to record PR URLs. Wait for user confirmation before merging. This is a human checkpoint — pause and confirm before proceeding.',
+    'You are creating a PR for the debug fix via GitHub CLI. Use exarchos_workflow set to record PR URLs. Wait for user confirmation before merging. This is a human checkpoint — pause and confirm before proceeding. Key decision: single PR for targeted fixes, stacked PRs for multi-part fixes. Anti-pattern: merging without CI green on all checks. Escalate: CI fails 3+ times on the same issue.',
 });
 
 register(
@@ -640,7 +640,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are exploring the codebase to assess refactoring scope. Use exarchos_workflow set to record exploration findings and scope assessment. Transition to brief when scope assessment is complete.',
+    'You are exploring the codebase to assess refactoring scope. Use exarchos_workflow set to record exploration findings and scope assessment. Transition to brief when scope assessment is complete. Key decision: scope assessment — count affected files, assess complexity and risk level. Anti-pattern: exploring without setting a clear boundary on what is in and out of scope. Escalate: scope exceeds what can be delivered in a single PR.',
 });
 
 register({
@@ -662,7 +662,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are writing the refactoring brief. Use exarchos_workflow set to record the brief and select polish (small) or overhaul (large) track. Transition based on track selection.',
+    'You are writing the refactoring brief. Use exarchos_workflow set to record the brief and select polish (small) or overhaul (large) track. Transition based on track selection. Key decision: polish track (<=5 files, cosmetic/DRY) vs overhaul track (>5 files, structural changes). Anti-pattern: choosing polish for structural changes that actually need the overhaul track. Escalate: scope is unclear after exploration, revisit explore phase.',
 });
 
 register({
@@ -683,7 +683,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are implementing polish-track refactoring changes directly. Use exarchos_workflow set to record progress. Follow TDD if changing behavior. Stay within brief scope. Transition to polish-validate when implementation is complete.',
+    'You are implementing polish-track refactoring changes directly. Use exarchos_workflow set to record progress. Follow TDD if changing behavior. Stay within brief scope. Transition to polish-validate when implementation is complete. Key decision: stay strictly within the brief scope for each change. Anti-pattern: scope creep beyond the brief — resist adding improvements not in the brief. Escalate: changes cascade beyond the declared scope, consider switching to overhaul track.',
 });
 
 register({
@@ -704,7 +704,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are validating the polish refactoring meets goals. Use exarchos_workflow set to record validation results. Run tests and verify refactoring goals are met. Transition to polish-update-docs when goals are verified.',
+    'You are validating the polish refactoring meets goals. Use exarchos_workflow set to record validation results. Run tests and verify refactoring goals are met. Transition to polish-update-docs when goals are verified. Key decision: verify all brief goals are met, not just a subset. Anti-pattern: accepting partial completion when some goals remain unmet. Escalate: goals are not achievable without switching to the overhaul track.',
 });
 
 register({
@@ -725,7 +725,7 @@ register({
   validationScripts: [],
   humanCheckpoint: true,
   compactGuidance:
-    'You are updating documentation for the polish refactoring. Use exarchos_workflow set to record docs update completion. HUMAN CHECKPOINT: present updated docs summary and await user confirmation before transitioning to completed.',
+    'You are updating documentation for the polish refactoring. Use exarchos_workflow set to record docs update completion. HUMAN CHECKPOINT: present updated docs summary and await user confirmation before transitioning to completed. Key decision: which docs need updates based on the changes made. Anti-pattern: skipping documentation updates for "obvious" changes that still affect developer understanding.',
 });
 
 register({
@@ -746,7 +746,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are creating an implementation plan for the overhaul refactoring. Use exarchos_workflow set to record the plan artifact path. Break work into parallelizable TDD tasks. Transition to overhaul-plan-review when plan artifact exists.',
+    'You are creating an implementation plan for the overhaul refactoring. Use exarchos_workflow set to record the plan artifact path. Break work into parallelizable TDD tasks. Transition to overhaul-plan-review when plan artifact exists. Key decision: task granularity for the large refactor — target 2-5 min per task. Anti-pattern: monolith tasks that cannot be distributed across agents. Escalate: plan exceeds 20 tasks, split into sequential phases.',
 });
 
 register({
@@ -767,7 +767,7 @@ register({
   validationScripts: [],
   humanCheckpoint: true,
   compactGuidance:
-    'You are at a human checkpoint reviewing the overhaul refactoring plan. Wait for user approval or revision feedback. Record approval with exarchos_workflow set using updates: { planReview: { approved: true } }. Transition to overhaul-delegate on approval, back to overhaul-plan if gaps found, or to blocked when revisions are exhausted.',
+    'You are at a human checkpoint reviewing the overhaul refactoring plan. Wait for user approval or revision feedback. Record approval with exarchos_workflow set using updates: { planReview: { approved: true } }. Transition to overhaul-delegate on approval, back to overhaul-plan if gaps found, or to blocked when revisions are exhausted. Key decision: approve vs revise with specific actionable feedback. Anti-pattern: rubber-stamping without checking task coverage of all brief goals. Escalate: 3+ revision cycles without convergence.',
 });
 
 register({
@@ -807,7 +807,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are dispatching overhaul implementation tasks. Use exarchos_event to emit task.assigned for each dispatch. Use exarchos_workflow set to mark tasks complete. Transition to overhaul-review when all tasks complete.',
+    'You are dispatching overhaul implementation tasks. Use exarchos_event to emit task.assigned for each dispatch. Use exarchos_workflow set to mark tasks complete. Transition to overhaul-review when all tasks complete. Key decision: parallel dispatch strategy — each agent gets its own worktree and self-contained prompt. Anti-pattern: sharing worktrees between agents or referencing shared state without explicit context. Escalate: 3 task failures on the same task.',
 });
 
 register({
@@ -841,7 +841,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are reviewing the overhaul refactoring. Use exarchos_event to emit gate.executed for review gates. Use exarchos_workflow set to record review results. Transition to overhaul-update-docs when all reviews pass, or back to overhaul-delegate if fixes needed.',
+    'You are reviewing the overhaul refactoring. Use exarchos_event to emit gate.executed for review gates. Use exarchos_workflow set to record review results. Transition to overhaul-update-docs when all reviews pass, or back to overhaul-delegate if fixes needed. Key decision: review depth proportional to change scope. Anti-pattern: trusting subagent self-assessment — independently verify test output and coverage. Escalate: regression findings appear in modules unrelated to the refactoring.',
 });
 
 register({
@@ -862,7 +862,7 @@ register({
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:
-    'You are updating documentation for the overhaul refactoring. Use exarchos_workflow set to record docs update completion. Transition to synthesize when docs are updated.',
+    'You are updating documentation for the overhaul refactoring. Use exarchos_workflow set to record docs update completion. Transition to synthesize when docs are updated. Key decision: documentation scope — update all docs affected by the structural changes. Anti-pattern: skipping documentation updates for refactoring that changes module boundaries or APIs.',
 });
 
 register({
@@ -901,7 +901,7 @@ register({
   ],
   humanCheckpoint: true,
   compactGuidance:
-    'You are creating PRs via GitHub CLI for the overhaul refactoring. Use exarchos_workflow set to record PR URLs. Wait for user confirmation before merging. This is a human checkpoint — pause and confirm before proceeding.',
+    'You are creating PRs via GitHub CLI for the overhaul refactoring. Use exarchos_workflow set to record PR URLs. Wait for user confirmation before merging. This is a human checkpoint — pause and confirm before proceeding. Key decision: single PR vs stacked PRs based on change scope. Anti-pattern: merging without CI green on all checks. Escalate: CI fails 3+ times on the same issue.',
 });
 
 register(

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -94,6 +94,16 @@ Activate this skill when:
 | Review | Smoke test only | Spec review |
 | Human Checkpoints | 1 (merge) | 1 (merge) |
 
+### Decision Runbooks
+
+For track-selection criteria at the triage phase, query the decision runbook:
+`exarchos_orchestrate({ action: "runbook", id: "triage-decision" })`
+
+For investigation escalation criteria, query:
+`exarchos_orchestrate({ action: "runbook", id: "investigation-decision" })`
+
+These runbooks encode the structured decision trees for track selection. The agent reads the decision tree and follows the guidance — the platform does not execute branches.
+
 ## Hotfix Track
 
 Fix production issues ASAP. Speed over ceremony.

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -105,6 +105,13 @@ For each task:
 4. Include PBT section from `references/pbt-patterns.md` when `propertyTests: true`
 5. Include testing patterns from `references/testing-patterns.md`
 
+### Decision Runbooks
+
+For dispatch strategy decisions, query the decision runbook:
+`exarchos_orchestrate({ action: "runbook", id: "dispatch-decision" })`
+
+This runbook provides structured criteria for parallel vs sequential dispatch, team sizing, and failure escalation.
+
 ### Parallel Dispatch
 
 Dispatch all independent tasks in a **single message** with multiple `Task` calls.

--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -286,7 +286,7 @@ for orchestrate action schemas.
 For review verdict routing, query the decision runbook:
 `exarchos_orchestrate({ action: "runbook", id: "review-escalation" })`
 
-This runbook provides structured criteria for routing between APPROVED, NEEDS_FIXES, and BLOCKED verdicts based on finding severity and fix cycle count.
+This runbook provides structured criteria for routing between APPROVED and NEEDS_FIXES verdicts based on finding severity and fix cycle count. APPROVED transitions to synthesize; NEEDS_FIXES transitions back to delegate for a fix cycle. (BLOCKED routing is only relevant in plan-review, not here.)
 
 ## Convergence & Verdict
 

--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -281,6 +281,13 @@ for orchestrate action schemas.
 - [ ] Code is maintainable
 - [ ] State file updated with review results
 
+### Decision Runbooks
+
+For review verdict routing, query the decision runbook:
+`exarchos_orchestrate({ action: "runbook", id: "review-escalation" })`
+
+This runbook provides structured criteria for routing between APPROVED, NEEDS_FIXES, and BLOCKED verdicts based on finding severity and fix cycle count.
+
 ## Convergence & Verdict
 
 Query convergence status and compute verdict via orchestrate. See `references/convergence-and-verdict.md` for full orchestrate calls, response fields, and verdict routing logic.

--- a/skills/quality-review/SKILL.md
+++ b/skills/quality-review/SKILL.md
@@ -292,7 +292,7 @@ This runbook provides structured criteria for routing between APPROVED and NEEDS
 
 Query convergence status and compute verdict via orchestrate. See `references/convergence-and-verdict.md` for full orchestrate calls, response fields, and verdict routing logic.
 
-Summary: `check_convergence` returns per-dimension D1-D5 status. `check_review_verdict` takes finding counts and dimension results, emits gate events, and returns APPROVED/NEEDS_FIXES/BLOCKED.
+Summary: `check_convergence` returns per-dimension D1-D5 status. `check_review_verdict` takes finding counts and dimension results, emits gate events, and returns APPROVED or NEEDS_FIXES.
 
 ## Auto-Transition
 
@@ -317,12 +317,6 @@ exarchos_workflow({ action: "set", featureId: "<id>", updates: {
 }})
 ```
 Then invoke `/exarchos:delegate --fixes`.
-
-**BLOCKED:**
-```
-exarchos_workflow({ action: "set", featureId: "<id>", phase: "blocked" })
-```
-Then invoke `/exarchos:ideate --redesign`.
 
 > **Gate events:** Do NOT manually emit `gate.executed` events via `exarchos_event`. Gate events are automatically emitted by the `check_review_verdict` orchestrate handler. Manual emission causes duplicates.
 

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -130,6 +130,13 @@ Use `exarchos_workflow({ action: "describe", actions: ["set", "init"] })` for
 parameter schemas and `exarchos_workflow({ action: "describe", playbook: "refactor" })`
 for phase transitions, guards, and playbook guidance.
 
+### Decision Runbooks
+
+For track-selection criteria at the explore phase, query the decision runbook:
+`exarchos_orchestrate({ action: "runbook", id: "scope-decision" })`
+
+This runbook provides structured criteria for choosing between polish and overhaul tracks based on file count, structural impact, and PR scope.
+
 ## Track Switching
 
 If scope expands beyond polish limits during explore or brief phase, use `mcp__plugin_exarchos_exarchos__exarchos_workflow` with `action: "set"` to set `track` to "overhaul" and update `explore.scopeAssessment.recommendedTrack`.


### PR DESCRIPTION
## Summary

Adds a methodology layer to the workflow engine so that compactGuidance, event schemas, and decision logic are encoded in code rather than prose. This makes the platform self-describing — agents receive structured decision trees and enriched guidance strings instead of relying on skill document interpretation.

## Changes

- **Playbooks** — Enriched compactGuidance for all non-terminal phases across feature, debug, and refactor workflows with what/decisions/anti-pattern/escalation sections
- **Event Schemas** — Added `.describe()` annotations to all 25 model-emitted event schemas with drift tests
- **Decision Runbooks** — New `DecisionBranch`/`DecisionField` types, 6 decision runbook definitions (triage, investigation, scope, dispatch, review-escalation, shepherd-escalation), and handler support for `tool: 'none'` advisory steps
- **Skills** — 4 skills updated to reference decision runbooks instead of inline decision logic

## Test Plan

Added drift tests for compactGuidance bounds and schema descriptions, structural invariant tests for all 6 decision runbooks, handler integration tests, and skill-coverage tests. All tests data-driven against registries to catch future regressions.

---

**Results:** Tests 4060 ✓ · Build 0 errors
**Design:** [platform-agnosticity.md](docs/designs/2026-03-09-platform-agnosticity.md)
**Related:** #992