### PR TITLE
feat: add per-project configuration via .exarchos.yml

### DIFF
--- a/.github/workflows/benchmark-gate.yml
+++ b/.github/workflows/benchmark-gate.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install root dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
 
       - uses: oven-sh/setup-bun@v2
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: servers/exarchos-mcp/package-lock.json
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         working-directory: documentation

--- a/.github/workflows/eval-gate.yml
+++ b/.github/workflows/eval-gate.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: servers/exarchos-mcp/package-lock.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           registry-url: 'https://registry.npmjs.org'
 

--- a/docs/designs/2026-03-13-project-config.md
+++ b/docs/designs/2026-03-13-project-config.md
@@ -1,0 +1,736 @@
+# Design: Per-Project Configuration via `.exarchos.yml`
+
+**Date:** 2026-03-13
+**Feature ID:** `extension-points`
+**Related:** Issue #1024 (VCS provider abstraction), `2026-03-05-ga-extensibility.md` (config-driven custom workflows)
+
+## Problem Statement
+
+Exarchos ships opinionated defaults for review criteria, workflow behavior, VCS operations, and tool settings. These defaults work well for the common case but are not customizable without modifying core code. Users cannot:
+
+- Adjust which quality gates are blocking vs advisory
+- Change risk scoring thresholds for review routing
+- Skip or reorder workflow phases for their team's process
+- Select a VCS provider other than GitHub
+- Configure commit conventions, auto-merge, or PR templates
+- Hook into workflow events for external notifications
+
+The GA extensibility design (`2026-03-05`) introduced `exarchos.config.ts` for programmatic custom workflow definitions. This design adds a complementary **declarative YAML layer** for end-user configuration of built-in behavior — no TypeScript required.
+
+## Design Constraints
+
+- **Per-project** — config lives in the repo, version-controlled, no per-user state
+- **YAML** — declarative, supports comments, low barrier to entry
+- **Sparse overlay** — unspecified fields use built-in defaults; empty/missing file = today's behavior
+- **No presets** — presets can be added later as a non-breaking enhancement
+- **No breaking changes** — the `exarchos.config.ts` path continues to work for programmatic extensions; `.exarchos.yml` handles declarative overrides
+
+## Relationship to `exarchos.config.ts`
+
+Two config surfaces, complementary scopes:
+
+| Surface | Format | Scope | Users |
+|---------|--------|-------|-------|
+| `.exarchos.yml` | YAML | Override built-in defaults (review, VCS, workflow behavior, tools, hooks) | End users tweaking behavior |
+| `exarchos.config.ts` | TypeScript | Define new workflow types, custom events, custom views, custom tools | Power users extending the system |
+
+Both are loaded at MCP server startup. `.exarchos.yml` overrides are applied to the base defaults before `exarchos.config.ts` extensions are registered. This means custom workflows defined in TypeScript inherit the project's YAML overrides (e.g., a custom workflow gets the project's VCS provider and review settings).
+
+```
+Built-in defaults
+       │
+       ▼
+.exarchos.yml overrides (deep merge)
+       │
+       ▼
+Effective base config
+       │
+       ▼
+exarchos.config.ts extensions (additive registration)
+       │
+       ▼
+Runtime config
+```
+
+## Config Schema
+
+### Full Example
+
+```yaml
+# .exarchos.yml
+# All sections are optional. Unspecified = built-in defaults.
+
+# --- Priority 1: Review Criteria ---
+review:
+  # Dimension-level defaults (D1-D5)
+  # Values: "blocking" (default), "warning", "disabled"
+  dimensions:
+    D1: blocking        # Security & compliance — keep strict
+    D2: blocking        # Static quality
+    D3: warning         # Context economy — downgrade to advisory
+    D4: blocking        # Operational resilience
+    D5: disabled        # Workflow determinism — skip entirely
+
+  # Gate-level overrides (take precedence over dimension severity)
+  gates:
+    security-scan:
+      enabled: true
+      blocking: true     # Always block on security
+    tdd-compliance:
+      blocking: false    # Advisory only
+      params:
+        coverage-threshold: 80
+    complexity-threshold:
+      params:
+        max-cyclomatic: 15   # Default is 10
+    error-handling-audit:
+      enabled: false     # Skip for this project
+
+  # Review routing
+  routing:
+    # Risk score threshold for CodeRabbit routing (0.0-1.0, default 0.4)
+    coderabbit-threshold: 0.6
+    # Risk factor weights (must sum to 1.0)
+    risk-weights:
+      security-path: 0.30
+      api-surface: 0.20
+      diff-complexity: 0.15
+      new-files: 0.10
+      infra-config: 0.15
+      cross-module: 0.10
+
+# --- Priority 2: VCS Provider ---
+vcs:
+  # github (default) | gitlab | azure-devops
+  provider: github
+  # Provider-specific settings
+  settings:
+    # GitHub
+    auto-merge-strategy: squash   # squash | merge | rebase
+    # GitLab: merge-method: merge-commit | squash | fast-forward
+    # Azure DevOps: completion-type: squash | merge | rebase
+
+# --- Priority 3: Workflow Behavior ---
+workflow:
+  # Phases to skip (applied to all built-in workflow types)
+  skip-phases: []
+  # Example: skip-phases: [plan-review]
+
+  # Max fix cycles before circuit breaker (default: 3)
+  max-fix-cycles: 3
+
+  # Phase-specific overrides
+  phases:
+    plan-review:
+      # Require human checkpoint (default: true)
+      human-checkpoint: true
+    synthesize:
+      human-checkpoint: true
+
+# --- Priority 4: Tool Behavior ---
+tools:
+  # Default branch for PRs (default: auto-detect from git)
+  default-branch: main
+
+  # Commit message style
+  # conventional: "feat: ...", "fix: ...", etc.
+  # freeform: no enforced format
+  commit-style: conventional
+
+  # PR template path (relative to repo root)
+  pr-template: .github/pull_request_template.md
+
+  # Auto-merge after CI passes (default: true)
+  auto-merge: true
+
+  # Stacked PR strategy
+  # github-native: use --base targeting (default)
+  # single: no stacking, one PR per feature
+  pr-strategy: github-native
+
+# --- Priority 5: Event Hooks ---
+hooks:
+  # Hook format: event-name → list of shell commands
+  # Commands receive event data as JSON via stdin
+  # Environment variables: $EXARCHOS_FEATURE_ID, $EXARCHOS_PHASE,
+  #   $EXARCHOS_EVENT_TYPE, $EXARCHOS_WORKFLOW_TYPE
+  on:
+    workflow.transition:
+      - command: 'echo "Phase changed to $EXARCHOS_PHASE" | slack-notify'
+        timeout: 10000   # ms, default 30000
+    gate.executed:
+      - command: './scripts/report-gate-result.sh'
+    synthesis.complete:
+      - command: 'curl -X POST "$JIRA_WEBHOOK" -d @-'
+```
+
+### Section Schemas
+
+#### `review`
+
+```yaml
+review:
+  dimensions:
+    # Key: D1 | D2 | D3 | D4 | D5
+    # Value: "blocking" | "warning" | "disabled"
+    #   OR object: { severity: blocking|warning, enabled: true|false }
+    D1: blocking                          # shorthand
+    D3: { severity: warning }             # longform (equivalent to "warning")
+
+  gates:
+    # Key: gate action name (from exarchos_orchestrate registry)
+    # Value: object with optional fields
+    <gate-name>:
+      enabled: true          # default: true
+      blocking: true         # default: inherits from dimension
+      params:                # gate-specific parameters
+        <key>: <value>
+
+  routing:
+    coderabbit-threshold: 0.4    # 0.0-1.0
+    risk-weights:                # all 6 must sum to 1.0
+      security-path: 0.30
+      api-surface: 0.20
+      diff-complexity: 0.15
+      new-files: 0.10
+      infra-config: 0.15
+      cross-module: 0.10
+```
+
+#### `vcs`
+
+```yaml
+vcs:
+  provider: github    # github | gitlab | azure-devops
+  settings:
+    # Provider-specific, validated per provider
+    auto-merge-strategy: squash   # GitHub: squash | merge | rebase
+    merge-method: squash          # GitLab: merge-commit | squash | fast-forward
+    completion-type: squash       # Azure DevOps: squash | merge | rebase
+```
+
+#### `workflow`
+
+```yaml
+workflow:
+  skip-phases:           # string[], phase names to skip
+    - plan-review
+  max-fix-cycles: 3      # 1-10, integer
+  phases:
+    <phase-name>:
+      human-checkpoint: true|false
+```
+
+#### `tools`
+
+```yaml
+tools:
+  default-branch: main
+  commit-style: conventional | freeform
+  pr-template: <relative-path>
+  auto-merge: true|false
+  pr-strategy: github-native | single
+```
+
+#### `hooks.on`
+
+```yaml
+hooks:
+  on:
+    <event-type>:           # any valid event type from event store
+      - command: <string>   # shell command, receives event JSON on stdin
+        timeout: 30000      # ms, optional
+```
+
+## Technical Design
+
+### 1. Config Loading
+
+The MCP server loads `.exarchos.yml` from the project root at startup, before processing `exarchos.config.ts`.
+
+```typescript
+// config/yaml-loader.ts
+import { parse as parseYaml } from 'yaml';  // or built-in YAML parser
+import { readFileSync, existsSync } from 'fs';
+
+export interface ProjectConfig {
+  readonly review?: ReviewConfig;
+  readonly vcs?: VcsConfig;
+  readonly workflow?: WorkflowConfig;
+  readonly tools?: ToolsConfig;
+  readonly hooks?: HooksConfig;
+}
+
+export function loadProjectConfig(projectRoot: string): ProjectConfig {
+  const configPath = resolve(projectRoot, '.exarchos.yml');
+  if (!existsSync(configPath)) return {};
+
+  const raw = readFileSync(configPath, 'utf-8');
+  const parsed = parseYaml(raw);
+  return validateProjectConfig(parsed);
+}
+```
+
+### 2. Validation
+
+Zod schemas validate the parsed YAML. Invalid config fails fast with clear error messages.
+
+```typescript
+// config/yaml-schema.ts
+import { z } from 'zod';
+
+const DimensionSeverity = z.enum(['blocking', 'warning', 'disabled']);
+
+const DimensionConfig = z.union([
+  DimensionSeverity,  // shorthand: "blocking"
+  z.object({          // longform: { severity: "warning", enabled: true }
+    severity: DimensionSeverity.optional(),
+    enabled: z.boolean().optional(),
+  }),
+]);
+
+const GateConfig = z.object({
+  enabled: z.boolean().optional(),
+  blocking: z.boolean().optional(),
+  params: z.record(z.unknown()).optional(),
+}).strict();
+
+const RiskWeights = z.object({
+  'security-path': z.number().min(0).max(1),
+  'api-surface': z.number().min(0).max(1),
+  'diff-complexity': z.number().min(0).max(1),
+  'new-files': z.number().min(0).max(1),
+  'infra-config': z.number().min(0).max(1),
+  'cross-module': z.number().min(0).max(1),
+}).refine(
+  (w) => Math.abs(Object.values(w).reduce((a, b) => a + b, 0) - 1.0) < 0.01,
+  { message: 'risk-weights must sum to 1.0' },
+).optional();
+
+const ReviewConfig = z.object({
+  dimensions: z.record(
+    z.enum(['D1', 'D2', 'D3', 'D4', 'D5']),
+    DimensionConfig,
+  ).optional(),
+  gates: z.record(z.string(), GateConfig).optional(),
+  routing: z.object({
+    'coderabbit-threshold': z.number().min(0).max(1).optional(),
+    'risk-weights': RiskWeights,
+  }).optional(),
+}).optional();
+
+const VcsProvider = z.enum(['github', 'gitlab', 'azure-devops']);
+
+const VcsConfig = z.object({
+  provider: VcsProvider.optional(),
+  settings: z.record(z.string(), z.unknown()).optional(),
+}).optional();
+
+const PhaseOverride = z.object({
+  'human-checkpoint': z.boolean().optional(),
+});
+
+const WorkflowConfig = z.object({
+  'skip-phases': z.array(z.string()).optional(),
+  'max-fix-cycles': z.number().int().min(1).max(10).optional(),
+  phases: z.record(z.string(), PhaseOverride).optional(),
+}).optional();
+
+const ToolsConfig = z.object({
+  'default-branch': z.string().optional(),
+  'commit-style': z.enum(['conventional', 'freeform']).optional(),
+  'pr-template': z.string().optional(),
+  'auto-merge': z.boolean().optional(),
+  'pr-strategy': z.enum(['github-native', 'single']).optional(),
+}).optional();
+
+const HookAction = z.object({
+  command: z.string(),
+  timeout: z.number().int().min(1000).max(300000).optional(),
+});
+
+const HooksConfig = z.object({
+  on: z.record(z.string(), z.array(HookAction)).optional(),
+}).optional();
+
+export const ProjectConfigSchema = z.object({
+  review: ReviewConfig,
+  vcs: VcsConfig,
+  workflow: WorkflowConfig,
+  tools: ToolsConfig,
+  hooks: HooksConfig,
+}).strict();
+```
+
+### 3. Config Resolution
+
+The config resolver deep-merges `.exarchos.yml` overrides onto built-in defaults to produce an effective config. This resolved config is then passed through the dispatch context.
+
+```typescript
+// config/resolve.ts
+
+const DEFAULTS: ResolvedConfig = {
+  review: {
+    dimensions: {
+      D1: 'blocking', D2: 'blocking', D3: 'blocking',
+      D4: 'blocking', D5: 'blocking',
+    },
+    gates: {},  // no overrides — all gates use dimension defaults
+    routing: {
+      coderabbitThreshold: 0.4,
+      riskWeights: {
+        securityPath: 0.30, apiSurface: 0.20, diffComplexity: 0.15,
+        newFiles: 0.10, infraConfig: 0.15, crossModule: 0.10,
+      },
+    },
+  },
+  vcs: { provider: 'github', settings: {} },
+  workflow: {
+    skipPhases: [],
+    maxFixCycles: 3,
+    phases: {},
+  },
+  tools: {
+    defaultBranch: undefined,  // auto-detect
+    commitStyle: 'conventional',
+    prTemplate: undefined,
+    autoMerge: true,
+    prStrategy: 'github-native',
+  },
+  hooks: { on: {} },
+};
+
+export function resolveConfig(project: ProjectConfig): ResolvedConfig {
+  return deepMerge(DEFAULTS, normalize(project));
+}
+```
+
+### 4. Integration with Dispatch Context
+
+The resolved config is added to `DispatchContext` and flows through to all handlers:
+
+```typescript
+// core/dispatch.ts
+export interface DispatchContext {
+  readonly stateDir: string;
+  readonly eventStore: EventStore;
+  readonly enableTelemetry: boolean;
+  readonly config?: ExarchosConfig;       // existing: programmatic extensions
+  readonly projectConfig?: ResolvedConfig; // new: YAML overrides
+}
+```
+
+### 5. Gate Severity Resolution
+
+When a gate executes, it checks the resolved config to determine if it should block:
+
+```typescript
+// orchestrate/gate-severity.ts
+export function resolveGateSeverity(
+  gateName: string,
+  dimension: string,
+  config: ResolvedConfig,
+): 'blocking' | 'warning' | 'disabled' {
+  // Gate-level override takes precedence
+  const gateOverride = config.review.gates[gateName];
+  if (gateOverride) {
+    if (gateOverride.enabled === false) return 'disabled';
+    if (gateOverride.blocking === true) return 'blocking';
+    if (gateOverride.blocking === false) return 'warning';
+  }
+
+  // Fall back to dimension-level setting
+  const dimConfig = config.review.dimensions[dimension as DimensionKey];
+  if (dimConfig === 'disabled') return 'disabled';
+  if (dimConfig === 'warning') return 'warning';
+  return 'blocking';
+}
+```
+
+Gate handlers use this resolution to determine their behavior:
+
+```typescript
+// In a gate handler (e.g., orchestrate/check-tdd-compliance.ts)
+const severity = resolveGateSeverity('tdd-compliance', 'D5', ctx.projectConfig);
+
+if (severity === 'disabled') {
+  return { success: true, data: { skipped: true, reason: 'disabled by project config' } };
+}
+
+// ... run the actual check ...
+
+const result = { passed, findings, severity };
+
+// If severity is 'warning', the gate emits the event but doesn't block phase transition
+return {
+  success: true,
+  data: result,
+  warnings: severity === 'warning' && !passed
+    ? [`Gate ${gateName} failed but is configured as warning-only`]
+    : undefined,
+};
+```
+
+### 6. VCS Provider Abstraction
+
+The VCS provider config feeds into a provider interface used by synthesis, shepherd, and PR-fixes:
+
+```typescript
+// vcs/provider.ts
+export interface VcsProvider {
+  readonly name: 'github' | 'gitlab' | 'azure-devops';
+  createPr(opts: CreatePrOpts): Promise<PrResult>;
+  checkCi(prId: string): Promise<CiStatus>;
+  mergePr(prId: string, strategy: string): Promise<MergeResult>;
+  addComment(prId: string, body: string): Promise<void>;
+  getReviewStatus(prId: string): Promise<ReviewStatus>;
+}
+
+// vcs/github.ts — wraps `gh` CLI
+// vcs/gitlab.ts — wraps `glab` CLI
+// vcs/azure-devops.ts — wraps `az repos` CLI
+
+export function createVcsProvider(config: ResolvedConfig): VcsProvider {
+  switch (config.vcs.provider) {
+    case 'github': return new GitHubProvider(config.vcs.settings);
+    case 'gitlab': return new GitLabProvider(config.vcs.settings);
+    case 'azure-devops': return new AzureDevOpsProvider(config.vcs.settings);
+  }
+}
+```
+
+### 7. Workflow Phase Skipping
+
+Skip-phases modifies the HSM at initialization time by marking transitions that bypass skipped phases:
+
+```typescript
+// workflow/phase-skip.ts
+export function applyPhaseSkips(
+  hsm: HSMDefinition,
+  skipPhases: readonly string[],
+): HSMDefinition {
+  if (skipPhases.length === 0) return hsm;
+
+  // For each skipped phase, reroute incoming transitions to the
+  // skipped phase's outgoing target
+  const modified = { ...hsm, transitions: [...hsm.transitions] };
+
+  for (const skip of skipPhases) {
+    const outgoing = modified.transitions.find(t => t.from === skip);
+    if (!outgoing) continue;
+
+    // Reroute all transitions targeting the skipped phase
+    modified.transitions = modified.transitions.map(t =>
+      t.to === skip ? { ...t, to: outgoing.to } : t,
+    ).filter(t => t.from !== skip);
+  }
+
+  return modified;
+}
+```
+
+### 8. Event Hooks
+
+When events are appended to the store, the hook system checks for matching config hooks and executes them:
+
+```typescript
+// hooks/config-hooks.ts
+export function createConfigHookRunner(
+  config: ResolvedConfig,
+): (event: WorkflowEvent) => Promise<void> {
+  return async (event) => {
+    const handlers = config.hooks.on[event.type];
+    if (!handlers?.length) return;
+
+    const env = {
+      EXARCHOS_FEATURE_ID: event.featureId,
+      EXARCHOS_PHASE: event.data?.phase ?? '',
+      EXARCHOS_EVENT_TYPE: event.type,
+      EXARCHOS_WORKFLOW_TYPE: event.data?.workflowType ?? '',
+    };
+
+    for (const handler of handlers) {
+      const proc = spawn('sh', ['-c', handler.command], {
+        env: { ...process.env, ...env },
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: handler.timeout ?? 30000,
+      });
+
+      // Pipe event data as JSON to stdin
+      proc.stdin.write(JSON.stringify(event));
+      proc.stdin.end();
+
+      // Fire-and-forget — hooks don't block the event pipeline
+      proc.on('error', (err) => {
+        console.error(`Config hook failed for ${event.type}: ${err.message}`);
+      });
+    }
+  };
+}
+```
+
+### 9. Discoverability: `exarchos_workflow describe` Extension
+
+Users can inspect the effective config (defaults + overrides) via the describe action:
+
+```typescript
+// New describe option: config
+// exarchos_workflow describe with config: true
+// Returns the resolved project config with annotations showing
+// which values are defaults vs overrides
+
+{
+  "action": "describe",
+  "config": true
+}
+
+// Response:
+{
+  "review": {
+    "dimensions": {
+      "D1": { "value": "blocking", "source": "default" },
+      "D3": { "value": "warning", "source": ".exarchos.yml" }
+    },
+    "gates": {
+      "tdd-compliance": {
+        "blocking": { "value": false, "source": ".exarchos.yml" },
+        "params": {
+          "coverage-threshold": { "value": 80, "source": ".exarchos.yml" }
+        }
+      }
+    }
+  },
+  "vcs": {
+    "provider": { "value": "github", "source": "default" }
+  }
+  // ...
+}
+```
+
+## Project Root Discovery
+
+The MCP server needs to find the project root to locate `.exarchos.yml`. Strategy:
+
+1. Check `$EXARCHOS_PROJECT_ROOT` environment variable (explicit override)
+2. Walk up from the current working directory looking for `.exarchos.yml`
+3. Fall back to git root (`git rev-parse --show-toplevel`)
+4. If none found, use CWD and assume no project config
+
+This aligns with how other tools (ESLint, Prettier, TypeScript) discover their config files.
+
+## Validation Error Reporting
+
+Config validation errors are reported clearly with path and suggestion:
+
+```
+Error loading .exarchos.yml:
+
+  review.dimensions.D6: Invalid dimension key
+    Valid keys: D1, D2, D3, D4, D5
+
+  review.routing.risk-weights: Values must sum to 1.0
+    Current sum: 0.85
+
+  hooks.on.invalid-event: Unknown event type
+    Did you mean: workflow.transition?
+```
+
+The MCP server logs these errors and falls back to defaults for invalid sections (partial failure, not total failure).
+
+## Implementation Requirements
+
+### R1: YAML Config Loader
+Load and validate `.exarchos.yml` from project root. Zod schema validation with clear error messages. Partial failure: invalid sections fall back to defaults.
+**Acceptance criteria:**
+- Missing file returns empty config (today's behavior preserved)
+- Valid file parses all 5 sections
+- Invalid sections produce actionable error messages
+- Unknown keys are rejected (`strict()` mode)
+
+### R2: Config Resolution
+Deep-merge YAML overrides onto built-in defaults. Produce `ResolvedConfig` available via `DispatchContext`.
+**Acceptance criteria:**
+- Unspecified fields use built-in defaults
+- Gate-level overrides take precedence over dimension-level
+- Dimension shorthand (`D3: warning`) normalizes to full object
+- Resolved config is immutable (frozen)
+
+### R3: Gate Severity Resolution
+Orchestrate gate handlers check resolved config for severity (blocking/warning/disabled).
+**Acceptance criteria:**
+- Disabled gates skip execution and return `{ skipped: true }`
+- Warning gates execute but don't block phase transitions
+- Gate-level `blocking` overrides dimension-level severity
+- Existing gate handler tests pass without modification when config is absent
+
+### R4: VCS Provider Interface
+Abstract VCS operations behind a provider interface. Implement GitHub provider (extract from current hardcoded `gh` calls). Stub GitLab and Azure DevOps providers.
+**Acceptance criteria:**
+- GitHub provider passes existing synthesis/shepherd tests
+- Provider is selected from resolved config
+- GitLab/Azure DevOps providers return clear "not yet implemented" errors
+- All `gh` CLI calls in orchestrate handlers route through the provider
+
+### R5: Workflow Phase Skipping
+Apply `skip-phases` to HSM at initialization by rerouting transitions.
+**Acceptance criteria:**
+- Skipped phases are bypassed during workflow transitions
+- Guard on the skip target is preserved (transition inherits the outgoing guard)
+- `workflow.started` event still includes the original phase list for audit
+- Cannot skip initial or final phases (validation error)
+
+### R6: Tools Config
+Expose tool settings via resolved config. Synthesis and shepherd handlers read from config instead of hardcoded values.
+**Acceptance criteria:**
+- `default-branch`, `commit-style`, `auto-merge`, `pr-strategy` are configurable
+- Missing values fall back to current hardcoded behavior
+- `pr-template` path is validated to exist at config load time (warning if missing)
+
+### R7: Event Hooks
+Fire shell commands on matching event types. Fire-and-forget, non-blocking.
+**Acceptance criteria:**
+- Hooks receive event data as JSON on stdin
+- Environment variables are set correctly
+- Hook timeout kills the process after the configured duration
+- Hook failures are logged but don't block event processing
+- Hooks are not triggered during test runs (env guard)
+
+### R8: Config Describe
+Extend `exarchos_workflow describe` to return effective config with source annotations.
+**Acceptance criteria:**
+- Each config value annotated with `"default"` or `".exarchos.yml"`
+- Response includes all sections (review, vcs, workflow, tools, hooks)
+- Works when no `.exarchos.yml` exists (all values show `"default"`)
+
+## Testing Strategy
+
+### Unit Tests
+- YAML parsing: valid configs, edge cases, malformed YAML
+- Zod validation: each section, shorthand normalization, error messages
+- Config resolution: deep merge, precedence rules, frozen output
+- Gate severity resolution: all precedence combinations
+- Phase skipping: rerouting logic, validation of un-skippable phases
+- VCS provider factory: correct provider for each config value
+
+### Integration Tests
+- Full config load → resolve → dispatch flow
+- Gate handlers with various severity configs
+- Workflow transitions with skipped phases
+- Event hook execution with mock commands
+- Describe action with config overlay
+
+### Backwards Compatibility
+- All existing tests pass with no `.exarchos.yml` present
+- Explicit test: remove config file mid-test, verify defaults are restored
+
+## Open Questions
+
+1. **YAML parser dependency** — Use the `yaml` npm package (well-maintained, YAML 1.2 compliant) or a lighter alternative? The `yaml` package is ~150KB, which is acceptable for the MCP server but adds a runtime dependency.
+
+2. **Config file name** — `.exarchos.yml` vs `exarchos.yml` (no dot). Dotfile convention hides it from casual `ls` but is standard for config files. Leaning toward `.exarchos.yml`.
+
+3. **Hot reload** — Should the MCP server watch `.exarchos.yml` for changes? For v1, reload on server restart is sufficient. Hot reload can be added later.
+
+4. **Config in monorepos** — Should config walk up directories (like ESLint) or only check project root? For v1, project root only. Directory walking adds complexity for marginal benefit.
+
+5. **VCS provider implementation order** — Issue #1024 asks for GitLab and Azure DevOps. Should we implement all three providers in this feature, or ship the interface + GitHub provider first and add the others as follow-ups?

--- a/docs/designs/2026-03-13-project-config.md
+++ b/docs/designs/2026-03-13-project-config.md
@@ -273,7 +273,7 @@ export function loadProjectConfig(projectRoot: string): ProjectConfig {
 
 ### 2. Validation
 
-Zod schemas validate the parsed YAML. Invalid config fails fast with clear error messages.
+Zod schemas validate the parsed YAML. Invalid sections fall back to defaults with warnings; valid sections are preserved (partial failure model).
 
 ```typescript
 // config/yaml-schema.ts
@@ -511,21 +511,34 @@ export function applyPhaseSkips(
 ): HSMDefinition {
   if (skipPhases.length === 0) return hsm;
 
-  // For each skipped phase, reroute incoming transitions to the
-  // skipped phase's outgoing target
-  const modified = { ...hsm, transitions: [...hsm.transitions] };
+  let transitions = hsm.transitions.map(t => ({ ...t }));
 
   for (const skip of skipPhases) {
-    const outgoing = modified.transitions.find(t => t.from === skip);
-    if (!outgoing) continue;
+    // Collect ALL outgoing transitions (handles multi-branch phases)
+    const outgoings = transitions.filter(t => t.from === skip);
+    if (outgoings.length === 0) continue;
 
-    // Reroute all transitions targeting the skipped phase
-    modified.transitions = modified.transitions.map(t =>
-      t.to === skip ? { ...t, to: outgoing.to } : t,
-    ).filter(t => t.from !== skip);
+    // For each incoming, create replacement transitions to all outgoing targets
+    // Guard, effects, and isFixCycle are inherited from outgoing transitions
+    const newTransitions = [];
+    for (const t of transitions) {
+      if (t.to === skip) {
+        for (const outgoing of outgoings) {
+          newTransitions.push({
+            ...t, to: outgoing.to,
+            guard: outgoing.guard ?? t.guard,
+            effects: outgoing.effects ?? t.effects,
+            isFixCycle: outgoing.isFixCycle ?? t.isFixCycle,
+          });
+        }
+      } else if (t.from !== skip) {
+        newTransitions.push(t);
+      }
+    }
+    transitions = newTransitions;
   }
 
-  return modified;
+  return { ...hsm, transitions };
 }
 ```
 
@@ -731,6 +744,6 @@ Extend `exarchos_workflow describe` to return effective config with source annot
 
 3. **Hot reload** — Should the MCP server watch `.exarchos.yml` for changes? For v1, reload on server restart is sufficient. Hot reload can be added later.
 
-4. **Config in monorepos** — Should config walk up directories (like ESLint) or only check project root? For v1, project root only. Directory walking adds complexity for marginal benefit.
+4. **Config in monorepos** — ~~Should config walk up directories (like ESLint) or only check project root? For v1, project root only.~~ **Resolved:** Implementation uses directory walk-up (matching ESLint/Prettier convention) with env var override and git root fallback. See Project Root Discovery section.
 
 5. **VCS provider implementation order** — Issue #1024 asks for GitLab and Azure DevOps. Should we implement all three providers in this feature, or ship the interface + GitHub provider first and add the others as follow-ups?

--- a/docs/plans/2026-03-13-project-config.md
+++ b/docs/plans/2026-03-13-project-config.md
@@ -1,0 +1,518 @@
+# Implementation Plan: Per-Project Configuration via `.exarchos.yml`
+
+**Design:** `docs/designs/2026-03-13-project-config.md`
+**Issues:** #1024
+
+## Architecture Notes
+
+This feature adds a **new** `ProjectConfig` type (YAML-driven declarative overrides) alongside the existing `ExarchosConfig` (TypeScript-driven programmatic extensions). They are complementary:
+
+- `.exarchos.yml` → `ProjectConfig` → overrides built-in defaults (review criteria, VCS, workflow behavior, tools, hooks)
+- `exarchos.config.ts` → `ExarchosConfig` → adds new workflow types, events, views, tools
+
+Loading order: YAML overrides applied to defaults first, then TypeScript extensions registered on top.
+
+The existing `DispatchContext` already has a `config` field for `ExarchosConfig`. We add `projectConfig: ResolvedProjectConfig` alongside it.
+
+## Task Summary
+
+| Task | Description | Layer | Implements | Dependencies |
+|------|-------------|-------|-----------|--------------|
+| 001 | ProjectConfig Zod schema | MCP | R1 | None |
+| 002 | YAML loader + project root discovery | MCP | R1 | 001 |
+| 003 | Config resolution (deep merge + defaults) | MCP | R2 | 001 |
+| 004 | DispatchContext integration | MCP | R2 | 002, 003 |
+| 005 | Gate severity resolution | MCP | R3 | 003 |
+| 006 | Gate handler integration | MCP | R3 | 004, 005 |
+| 007 | VCS provider interface | MCP | R4 | None |
+| 008 | GitHub VCS provider | MCP | R4 | 007 |
+| 009 | VCS provider factory + config wiring | MCP | R4 | 004, 008 |
+| 010 | Workflow phase skipping | MCP | R5 | 003 |
+| 011 | Phase skip HSM integration | MCP | R5 | 004, 010 |
+| 012 | Tools config surface | MCP | R6 | 004 |
+| 013 | Event hook runner | MCP | R7 | 003 |
+| 014 | Event hook wiring to EventStore | MCP | R7 | 004, 013 |
+| 015 | Config describe action | MCP | R8 | 004 |
+
+## Parallelization Groups
+
+```
+Group A (sequential):  001 → 002 → 003 → 004   [Core config pipeline]
+Group B (sequential):  007 → 008                 [VCS provider — independent of config]
+Group C (independent): 005                        [Gate severity — needs 003 only]
+Group D (independent): 010                        [Phase skip logic — needs 003 only]
+Group E (independent): 013                        [Event hook runner — needs 003 only]
+
+After Group A:
+  Group F: 006 (gate handler integration — needs 004 + 005)
+  Group G: 009 (VCS factory wiring — needs 004 + 008)
+  Group H: 011 (phase skip HSM — needs 004 + 010)
+  Group I: 012 (tools config — needs 004)
+  Group J: 014 (hook wiring — needs 004 + 013)
+  Group K: 015 (config describe — needs 004)
+```
+
+Recommended agent assignment:
+- **Agent 1:** Tasks 001-004 (Core config pipeline — sequential chain)
+- **Agent 2:** Tasks 007-008, 009 (VCS provider interface + GitHub impl + factory)
+- **Agent 3:** Tasks 005, 006 (Gate severity resolution + handler integration)
+- **Agent 4:** Tasks 010, 011 (Phase skipping logic + HSM integration)
+- **Agent 5:** Tasks 013, 014 (Event hook runner + EventStore wiring)
+- **Agent 6:** Tasks 012, 015 (Tools config surface + config describe)
+
+---
+
+## Task Details
+
+### Task 001: ProjectConfig Zod Schema
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R1
+
+1. **[RED]** Write tests for the YAML config validation schema.
+   - File: `servers/exarchos-mcp/src/config/yaml-schema.test.ts`
+   - Tests:
+     - `ProjectConfigSchema_EmptyObject_Passes` — `{}` validates successfully
+     - `ProjectConfigSchema_FullConfig_Passes` — complete config with all sections validates
+     - `ProjectConfigSchema_DimensionShorthand_Passes` — `D3: "warning"` accepted
+     - `ProjectConfigSchema_DimensionLongform_Passes` — `D3: { severity: "warning" }` accepted
+     - `ProjectConfigSchema_InvalidDimensionKey_Fails` — `D6` rejected with error
+     - `ProjectConfigSchema_GateConfig_ValidatesParams` — gate with params passes
+     - `ProjectConfigSchema_RiskWeights_MustSumToOne` — weights summing to 0.85 rejected
+     - `ProjectConfigSchema_RiskWeights_SumToOne_Passes` — weights summing to 1.0 passes
+     - `ProjectConfigSchema_UnknownTopLevelKey_Fails` — `{ foo: 1 }` rejected (strict mode)
+     - `ProjectConfigSchema_VcsProvider_ValidatesEnum` — only github/gitlab/azure-devops accepted
+     - `ProjectConfigSchema_SkipPhases_AcceptsStringArray` — `["plan-review"]` passes
+     - `ProjectConfigSchema_MaxFixCycles_ValidatesRange` — 0 rejected, 1-10 accepted, 11 rejected
+     - `ProjectConfigSchema_HookAction_RequiresCommand` — hook without command rejected
+     - `ProjectConfigSchema_HookTimeout_ValidatesRange` — timeout 500 rejected (min 1000), 300001 rejected (max 300000)
+     - `ProjectConfigSchema_ToolsSection_ValidatesEnums` — commit-style and pr-strategy enum validation
+   - Expected failure: `ProjectConfigSchema` does not exist
+
+2. **[GREEN]** Implement the Zod schema.
+   - File: `servers/exarchos-mcp/src/config/yaml-schema.ts`
+   - Export: `ProjectConfigSchema`, `ProjectConfig` type, dimension/gate/routing/vcs/workflow/tools/hooks sub-schemas
+   - Use `z.union()` for dimension shorthand/longform
+   - Use `.strict()` on top-level object
+   - Use `.refine()` for risk-weights sum validation
+
+3. **[REFACTOR]** Extract shared dimension severity enum if reused elsewhere.
+
+**Dependencies:** None
+
+---
+
+### Task 002: YAML Loader + Project Root Discovery
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R1
+
+1. **[RED]** Write tests for YAML file loading and project root discovery.
+   - File: `servers/exarchos-mcp/src/config/yaml-loader.test.ts`
+   - Tests:
+     - `loadProjectConfig_NoFile_ReturnsEmptyConfig` — missing `.exarchos.yml` returns `{}`
+     - `loadProjectConfig_ValidYaml_ParsesAllSections` — full YAML file parsed correctly
+     - `loadProjectConfig_YmlExtension_Loaded` — `.exarchos.yml` discovered
+     - `loadProjectConfig_YamlExtension_Loaded` — `.exarchos.yaml` also discovered
+     - `loadProjectConfig_MalformedYaml_ThrowsWithMessage` — syntax error produces helpful error
+     - `loadProjectConfig_InvalidSchema_ReturnsPartialWithWarnings` — invalid section falls back to default, valid sections preserved
+     - `discoverProjectRoot_EnvVar_TakesPrecedence` — `$EXARCHOS_PROJECT_ROOT` used first
+     - `discoverProjectRoot_WalksUpForYml_FindsRoot` — walks up directories to find `.exarchos.yml`
+     - `discoverProjectRoot_FallsBackToGitRoot` — uses git root when no config file found
+     - `discoverProjectRoot_NothingFound_UsesCwd` — returns CWD as last resort
+   - Expected failure: `loadProjectConfig` and `discoverProjectRoot` do not exist
+
+2. **[GREEN]** Implement YAML loader and project root discovery.
+   - File: `servers/exarchos-mcp/src/config/yaml-loader.ts`
+   - Export: `loadProjectConfig(projectRoot: string): ProjectConfig`
+   - Export: `discoverProjectRoot(cwd?: string): string`
+   - Use `yaml` npm package for parsing
+   - Validate against `ProjectConfigSchema` from task 001
+   - Partial failure: catch per-section Zod errors, log warnings, return valid sections
+
+3. **[REFACTOR]** Ensure error messages include file path and line numbers where possible.
+
+**Dependencies:** 001
+
+---
+
+### Task 003: Config Resolution (Deep Merge + Defaults)
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R2
+
+1. **[RED]** Write tests for config resolution.
+   - File: `servers/exarchos-mcp/src/config/resolve.test.ts`
+   - Tests:
+     - `resolveConfig_EmptyProject_ReturnsAllDefaults` — `{}` produces full `ResolvedProjectConfig` with all defaults
+     - `resolveConfig_DimensionOverride_MergesOntoDefaults` — `D3: "warning"` overrides only D3, others remain "blocking"
+     - `resolveConfig_DimensionShorthand_NormalizesToObject` — `"warning"` normalized to `{ severity: "warning", enabled: true }`
+     - `resolveConfig_GateOverride_MergedOntoEmptyDefault` — gate config added to empty default gates map
+     - `resolveConfig_RoutingThreshold_OverridesDefault` — threshold 0.6 overrides default 0.4
+     - `resolveConfig_RiskWeights_FullReplace` — custom weights fully replace defaults (not merged)
+     - `resolveConfig_VcsProvider_OverridesDefault` — `gitlab` overrides default `github`
+     - `resolveConfig_SkipPhases_AddedToEmptyDefault` — skip phases added to empty default array
+     - `resolveConfig_MaxFixCycles_OverridesDefault` — custom value overrides default 3
+     - `resolveConfig_ToolsPartial_MergesWithDefaults` — setting only `auto-merge: false` preserves other tool defaults
+     - `resolveConfig_HooksOn_MergedByEventType` — hook handlers merged by event type key
+     - `resolveConfig_Result_IsFrozen` — returned object is deeply frozen (immutable)
+     - `resolveConfig_DefaultBranch_UndefinedByDefault` — defaults to undefined (auto-detect)
+   - Expected failure: `resolveConfig` and `ResolvedProjectConfig` do not exist
+
+2. **[GREEN]** Implement config resolution.
+   - File: `servers/exarchos-mcp/src/config/resolve.ts`
+   - Export: `resolveConfig(project: ProjectConfig): ResolvedProjectConfig`
+   - Export: `ResolvedProjectConfig` interface (all fields required, no optionals)
+   - Export: `DEFAULTS` constant
+   - Implement `normalize()` to convert shorthand forms to canonical
+   - Implement `deepMerge()` for overlay semantics
+   - Freeze the result with `Object.freeze()` recursively
+
+3. **[REFACTOR]** Extract `deepFreeze` utility if useful elsewhere.
+
+**Dependencies:** 001
+
+---
+
+### Task 004: DispatchContext Integration
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R2
+
+1. **[RED]** Write tests for project config flowing through dispatch context.
+   - File: `servers/exarchos-mcp/src/core/context.test.ts` (extend existing or create)
+   - Tests:
+     - `initializeContext_WithProjectRoot_LoadsProjectConfig` — resolved config available on ctx
+     - `initializeContext_NoYml_ProjectConfigIsDefaults` — missing YAML → all defaults
+     - `initializeContext_ProjectConfigBeforeExarchosConfig` — YAML loaded before `.config.ts`
+     - `dispatch_ProjectConfig_PassedToHandlers` — handlers receive `ctx.projectConfig`
+   - Expected failure: `projectConfig` not on `DispatchContext`
+
+2. **[GREEN]** Add `projectConfig` to DispatchContext and wire loading.
+   - File: `servers/exarchos-mcp/src/core/dispatch.ts` — add `projectConfig?: ResolvedProjectConfig` to interface
+   - File: `servers/exarchos-mcp/src/core/context.ts` — call `loadProjectConfig()` + `resolveConfig()` before existing config loading
+   - Ensure `projectConfig` is available on the context passed to composite handlers
+
+3. **[REFACTOR]** Clean up context initialization ordering if needed.
+
+**Dependencies:** 002, 003
+
+---
+
+### Task 005: Gate Severity Resolution
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R3
+
+1. **[RED]** Write tests for gate severity resolution logic.
+   - File: `servers/exarchos-mcp/src/orchestrate/gate-severity.test.ts`
+   - Tests:
+     - `resolveGateSeverity_NoOverrides_ReturnsBlocking` — default dimension blocking, no gate override → blocking
+     - `resolveGateSeverity_DimensionWarning_ReturnsWarning` — D3 set to warning → warning
+     - `resolveGateSeverity_DimensionDisabled_ReturnsDisabled` — D5 disabled → disabled
+     - `resolveGateSeverity_GateBlockingTrue_OverridesDimension` — gate blocking=true even when dimension is warning → blocking
+     - `resolveGateSeverity_GateBlockingFalse_OverridesDimension` — gate blocking=false even when dimension is blocking → warning
+     - `resolveGateSeverity_GateDisabled_OverridesDimension` — gate enabled=false even when dimension is blocking → disabled
+     - `resolveGateSeverity_GateEnabled_DimensionDisabled_RespectsGate` — gate enabled + dimension disabled → gate wins (blocking)
+     - `resolveGateSeverity_UnknownGate_FallsBackToDimension` — gate not in overrides → dimension severity
+     - `resolveGateSeverity_UnknownDimension_DefaultsBlocking` — unknown dimension key → blocking
+   - Expected failure: `resolveGateSeverity` does not exist
+
+2. **[GREEN]** Implement gate severity resolution.
+   - File: `servers/exarchos-mcp/src/orchestrate/gate-severity.ts`
+   - Export: `resolveGateSeverity(gateName: string, dimension: string, config: ResolvedProjectConfig): 'blocking' | 'warning' | 'disabled'`
+   - Gate-level overrides take precedence over dimension-level
+   - Unknown gates fall back to dimension; unknown dimensions default to blocking
+
+3. **[REFACTOR]** None expected.
+
+**Dependencies:** 003
+
+---
+
+### Task 006: Gate Handler Integration
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R3
+
+1. **[RED]** Write tests for config-aware gate handler behavior.
+   - File: `servers/exarchos-mcp/src/orchestrate/config-gate-integration.test.ts`
+   - Tests:
+     - `GateHandler_DisabledGate_SkipsExecution` — gate with severity=disabled returns `{ skipped: true }` without running check
+     - `GateHandler_WarningGate_ExecutesButDoesNotBlock` — gate fails but severity=warning → success=true with warning message
+     - `GateHandler_BlockingGate_FailureBlocks` — gate fails with severity=blocking → standard failure behavior
+     - `GateHandler_NoProjectConfig_DefaultBehavior` — when `projectConfig` is undefined, all gates behave as blocking (backwards compat)
+     - `GateHandler_GateParams_PassedToHandler` — gate params from config flow into handler logic
+   - Expected failure: gate handlers don't read `projectConfig`
+
+2. **[GREEN]** Update gate handler pattern to be config-aware.
+   - File: `servers/exarchos-mcp/src/orchestrate/gate-utils.ts` — add `withConfigSeverity()` wrapper
+   - The wrapper:
+     1. Reads severity from `resolveGateSeverity()`
+     2. If disabled: return skip result
+     3. If warning/blocking: run handler, then adjust result based on severity
+   - Update 2-3 representative gate handlers to use the wrapper (e.g., `static-analysis.ts`, `tdd-compliance.ts`, `security-scan.ts`)
+
+3. **[REFACTOR]** Ensure all gate handlers can be incrementally migrated to the wrapper pattern.
+
+**Dependencies:** 004, 005
+
+---
+
+### Task 007: VCS Provider Interface
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R4
+
+1. **[RED]** Write tests for the VCS provider interface contract.
+   - File: `servers/exarchos-mcp/src/vcs/provider.test.ts`
+   - Tests:
+     - `VcsProvider_Interface_DefinesRequiredMethods` — type-level test that all methods exist on interface
+     - `GitLabProvider_CreatePr_ThrowsNotImplemented` — stub provider returns clear error
+     - `AzureDevOpsProvider_CreatePr_ThrowsNotImplemented` — stub provider returns clear error
+   - Expected failure: `VcsProvider` interface does not exist
+
+2. **[GREEN]** Define the VCS provider interface and stub implementations.
+   - File: `servers/exarchos-mcp/src/vcs/provider.ts`
+   - Export: `VcsProvider` interface with methods: `createPr`, `checkCi`, `mergePr`, `addComment`, `getReviewStatus`
+   - Export: supporting types: `CreatePrOpts`, `PrResult`, `CiStatus`, `MergeResult`, `ReviewStatus`
+   - File: `servers/exarchos-mcp/src/vcs/gitlab.ts` — stub with "not yet implemented" errors
+   - File: `servers/exarchos-mcp/src/vcs/azure-devops.ts` — stub with "not yet implemented" errors
+
+3. **[REFACTOR]** None expected.
+
+**Dependencies:** None
+
+---
+
+### Task 008: GitHub VCS Provider
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R4
+
+1. **[RED]** Write tests for GitHub provider methods.
+   - File: `servers/exarchos-mcp/src/vcs/github.test.ts`
+   - Tests:
+     - `GitHubProvider_CreatePr_CallsGhWithCorrectArgs` — verifies `gh pr create` CLI invocation
+     - `GitHubProvider_CheckCi_ParsesGhOutput` — parses `gh pr checks` output to `CiStatus`
+     - `GitHubProvider_MergePr_UsesConfigStrategy` — merge strategy from settings used
+     - `GitHubProvider_AddComment_CallsGhPrComment` — correct `gh pr comment` invocation
+     - `GitHubProvider_GetReviewStatus_ParsesReviewState` — parses `gh pr view` review status
+     - `GitHubProvider_Settings_DefaultSquash` — no settings → squash merge
+   - Expected failure: `GitHubProvider` does not exist
+   - Note: tests should mock `child_process.execFile` to avoid real CLI calls
+
+2. **[GREEN]** Implement GitHubProvider.
+   - File: `servers/exarchos-mcp/src/vcs/github.ts`
+   - Wraps `gh` CLI for each method
+   - Reads `auto-merge-strategy` from settings (default: squash)
+
+3. **[REFACTOR]** Extract common CLI execution pattern if GitHub provider methods share boilerplate.
+
+**Dependencies:** 007
+
+---
+
+### Task 009: VCS Provider Factory + Config Wiring
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R4
+
+1. **[RED]** Write tests for provider factory and config wiring.
+   - File: `servers/exarchos-mcp/src/vcs/factory.test.ts`
+   - Tests:
+     - `createVcsProvider_GitHub_ReturnsGitHubProvider` — default config creates GitHub provider
+     - `createVcsProvider_GitLab_ReturnsGitLabProvider` — gitlab config creates GitLab provider
+     - `createVcsProvider_AzureDevOps_ReturnsAzureProvider` — azure-devops config creates Azure provider
+     - `createVcsProvider_PassesSettings_ToProvider` — settings from config forwarded to provider
+     - `createVcsProvider_NoProjectConfig_DefaultsToGitHub` — undefined config → GitHub
+   - Expected failure: `createVcsProvider` does not exist
+
+2. **[GREEN]** Implement factory and wire to DispatchContext.
+   - File: `servers/exarchos-mcp/src/vcs/factory.ts`
+   - Export: `createVcsProvider(config: ResolvedProjectConfig): VcsProvider`
+   - Wire into context initialization so `ctx.vcsProvider` is available
+
+3. **[REFACTOR]** None expected.
+
+**Dependencies:** 004, 008
+
+---
+
+### Task 010: Workflow Phase Skipping
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R5
+
+1. **[RED]** Write tests for phase skip transition rerouting.
+   - File: `servers/exarchos-mcp/src/workflow/phase-skip.test.ts`
+   - Tests:
+     - `applyPhaseSkips_EmptyList_ReturnsUnmodifiedHSM` — no skips → original HSM unchanged
+     - `applyPhaseSkips_SkipMiddlePhase_ReroutesTransitions` — skipping B in A→B→C produces A→C
+     - `applyPhaseSkips_SkipMultiplePhases_ReroutesAll` — skipping B,C in A→B→C→D produces A→D
+     - `applyPhaseSkips_SkippedPhaseGuard_InheritedByPredecessor` — guard from B→C transferred to A→C when B skipped
+     - `applyPhaseSkips_InitialPhase_RejectedWithError` — cannot skip initial phase (ideate)
+     - `applyPhaseSkips_FinalPhase_RejectedWithError` — cannot skip final phase (completed/cancelled)
+     - `applyPhaseSkips_NonexistentPhase_IgnoredSilently` — skipping unknown phase is a no-op
+     - `applyPhaseSkips_CompoundState_ChildrenSkipped` — skipping a compound state removes it and children
+   - Expected failure: `applyPhaseSkips` does not exist
+
+2. **[GREEN]** Implement phase skip logic.
+   - File: `servers/exarchos-mcp/src/workflow/phase-skip.ts`
+   - Export: `applyPhaseSkips(hsm: HSMDefinition, skipPhases: readonly string[]): HSMDefinition`
+   - Validate: reject initial/final phases with descriptive error
+   - Reroute: for each skipped phase, connect incoming transitions to outgoing target
+   - Guard inheritance: outgoing guard of skipped phase transferred to rerouted transition
+
+3. **[REFACTOR]** None expected.
+
+**Dependencies:** 003 (needs ResolvedProjectConfig type for the skipPhases field)
+
+---
+
+### Task 011: Phase Skip HSM Integration
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R5
+
+1. **[RED]** Write tests for phase skipping applied during workflow initialization.
+   - File: `servers/exarchos-mcp/src/workflow/phase-skip-integration.test.ts`
+   - Tests:
+     - `WorkflowInit_WithSkipPhases_AppliesSkips` — initializing workflow with config that skips plan-review → plan transitions directly to delegate
+     - `WorkflowTransition_SkippedPhase_Bypassed` — transitioning from plan goes to delegate (not plan-review)
+     - `WorkflowStartedEvent_IncludesOriginalPhases` — `workflow.started` event data includes the full phase list (before skips) for audit trail
+     - `WorkflowInit_NoProjectConfig_NoSkips` — undefined projectConfig → standard phase progression
+   - Expected failure: workflow init doesn't apply phase skips
+
+2. **[GREEN]** Wire phase skipping into workflow initialization.
+   - File: `servers/exarchos-mcp/src/workflow/` — update workflow init handler to call `applyPhaseSkips` when `projectConfig.workflow.skipPhases` is non-empty
+   - Store original phase list in `workflow.started` event data
+
+3. **[REFACTOR]** None expected.
+
+**Dependencies:** 004, 010
+
+---
+
+### Task 012: Tools Config Surface
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R6
+
+1. **[RED]** Write tests for tools config being read by handlers.
+   - File: `servers/exarchos-mcp/src/orchestrate/tools-config.test.ts`
+   - Tests:
+     - `PrepareSynthesis_AutoMergeFalse_OmitsAutoMergeFlag` — config `auto-merge: false` → synthesis handler doesn't set auto-merge
+     - `PrepareSynthesis_CommitStyleConventional_EnforcesPrefix` — conventional commit style enforced
+     - `PrepareSynthesis_PrStrategyGithubNative_UsesBaseTargeting` — stacked PR strategy read from config
+     - `PrepareSynthesis_PrStrategySingle_NoStacking` — single strategy → one PR per feature
+     - `PrepareSynthesis_DefaultBranch_UsedAsPrTarget` — configured default branch used instead of auto-detect
+     - `PrepareSynthesis_NoProjectConfig_UsesHardcodedDefaults` — undefined config → current behavior preserved
+   - Expected failure: handlers don't read tools config from projectConfig
+
+2. **[GREEN]** Update synthesis/shepherd orchestrate handlers to read from resolved config.
+   - Files: relevant handlers in `servers/exarchos-mcp/src/orchestrate/` (prepare-synthesis, assess-stack, etc.)
+   - Read `ctx.projectConfig.tools.*` instead of hardcoded values
+   - Fall back to defaults when `projectConfig` is undefined
+
+3. **[REFACTOR]** Extract tool defaults to a constant to avoid duplication with resolve.ts defaults.
+
+**Dependencies:** 004
+
+---
+
+### Task 013: Event Hook Runner
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R7
+
+1. **[RED]** Write tests for the event hook runner.
+   - File: `servers/exarchos-mcp/src/hooks/config-hooks.test.ts`
+   - Tests:
+     - `ConfigHookRunner_MatchingEvent_ExecutesCommand` — hook for `workflow.transition` fires when that event type occurs
+     - `ConfigHookRunner_NoMatchingHooks_Noop` — event type with no registered hooks does nothing
+     - `ConfigHookRunner_StdinReceivesEventJson` — hook command receives event data as JSON on stdin
+     - `ConfigHookRunner_EnvVarsSet_Correctly` — `EXARCHOS_FEATURE_ID`, `EXARCHOS_PHASE`, `EXARCHOS_EVENT_TYPE`, `EXARCHOS_WORKFLOW_TYPE` set
+     - `ConfigHookRunner_Timeout_KillsProcess` — process killed after timeout
+     - `ConfigHookRunner_CommandFailure_DoesNotThrow` — hook failure logged but doesn't propagate
+     - `ConfigHookRunner_MultipleHooks_AllFired` — multiple hooks for same event type all execute
+     - `ConfigHookRunner_TestEnv_SkipsExecution` — hooks not fired when `NODE_ENV=test` or `EXARCHOS_SKIP_HOOKS=true`
+   - Expected failure: `createConfigHookRunner` does not exist
+
+2. **[GREEN]** Implement the config hook runner.
+   - File: `servers/exarchos-mcp/src/hooks/config-hooks.ts`
+   - Export: `createConfigHookRunner(config: ResolvedProjectConfig): (event: WorkflowEvent) => Promise<void>`
+   - Fire-and-forget: hooks don't block event processing
+   - Spawn with timeout, pipe event JSON to stdin, set env vars
+   - Guard: skip if `NODE_ENV=test` or `EXARCHOS_SKIP_HOOKS=true`
+
+3. **[REFACTOR]** None expected.
+
+**Dependencies:** 003
+
+---
+
+### Task 014: Event Hook Wiring to EventStore
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R7
+
+1. **[RED]** Write tests for hooks being triggered on event append.
+   - File: `servers/exarchos-mcp/src/hooks/config-hooks-integration.test.ts`
+   - Tests:
+     - `EventStore_Append_TriggersConfigHook` — appending a `workflow.transition` event triggers the hook runner
+     - `EventStore_Append_NoProjectConfig_NoHooks` — no projectConfig → no hook execution
+     - `EventStore_BatchAppend_TriggersHooksForEach` — batch append triggers hooks for each event
+   - Expected failure: EventStore doesn't call hook runner
+
+2. **[GREEN]** Wire hook runner into EventStore or context initialization.
+   - File: `servers/exarchos-mcp/src/core/context.ts` — register hook runner as post-append callback
+   - File: `servers/exarchos-mcp/src/event-store/store.ts` — add optional `onAppend` callback support if not already present
+   - Alternative: wire at the handler level (after `emitGateEvent` calls) if EventStore callback is too invasive
+
+3. **[REFACTOR]** Choose between EventStore callback vs handler-level wiring based on implementation complexity.
+
+**Dependencies:** 004, 013
+
+---
+
+### Task 015: Config Describe Action
+**Phase:** RED → GREEN → REFACTOR
+**Implements:** R8
+
+1. **[RED]** Write tests for the config describe extension.
+   - File: `servers/exarchos-mcp/src/workflow/describe-config.test.ts`
+   - Tests:
+     - `DescribeConfig_NoYml_AllDefaults` — no `.exarchos.yml` → all values annotated with `source: "default"`
+     - `DescribeConfig_WithOverrides_SourceAnnotated` — overridden values show `source: ".exarchos.yml"`, others show `source: "default"`
+     - `DescribeConfig_AllSectionsPresent` — response includes review, vcs, workflow, tools, hooks sections
+     - `DescribeConfig_GateOverride_ShowsGateAndDimension` — gate override annotated distinctly from dimension default
+     - `DescribeConfig_DescribeAction_AcceptsConfigFlag` — `describe` action with `config: true` returns config section
+   - Expected failure: describe action doesn't support `config` flag
+
+2. **[GREEN]** Extend the describe action handler.
+   - File: `servers/exarchos-mcp/src/workflow/` — update describe handler to accept `config?: boolean` flag
+   - When `config: true`, return resolved config with source annotations
+   - Build annotation by comparing resolved config against `DEFAULTS` — matching values are "default", others are ".exarchos.yml"
+
+3. **[REFACTOR]** None expected.
+
+**Dependencies:** 004
+
+---
+
+## Dependency Graph
+
+```
+001 ─────┬─── 002 ──┬── 004 ──┬── 006 (needs 005)
+         │          │         ├── 009 (needs 008)
+         ├── 003 ──┤         ├── 011 (needs 010)
+         │          │         ├── 012
+         │          │         ├── 014 (needs 013)
+         │          │         └── 015
+         │          │
+         ├── 005 ──┘ (via 003)
+         ├── 010 ──┘ (via 003)
+         └── 013 ──┘ (via 003)
+
+007 ─── 008 ──── 009 (needs 004)
+```
+
+## Package Dependency
+
+Add `yaml` as an explicit dependency to `servers/exarchos-mcp/package.json`:
+```json
+"yaml": "^2.7.0"
+```
+
+This is currently available as a transitive dependency but must be explicit for production reliability.
+
+## Backwards Compatibility
+
+Every task must preserve this invariant: **all existing tests pass with no `.exarchos.yml` present**. When `projectConfig` is undefined on `DispatchContext`, all behavior must be identical to the current codebase.

--- a/docs/plans/2026-03-13-project-config.md
+++ b/docs/plans/2026-03-13-project-config.md
@@ -451,12 +451,11 @@ Recommended agent assignment:
      - `EventStore_BatchAppend_TriggersHooksForEach` — batch append triggers hooks for each event
    - Expected failure: EventStore doesn't call hook runner
 
-2. **[GREEN]** Wire hook runner into EventStore or context initialization.
-   - File: `servers/exarchos-mcp/src/core/context.ts` — register hook runner as post-append callback
-   - File: `servers/exarchos-mcp/src/event-store/store.ts` — add optional `onAppend` callback support if not already present
-   - Alternative: wire at the handler level (after `emitGateEvent` calls) if EventStore callback is too invasive
+2. **[GREEN]** Wire hook runner into event composite handler post-append.
+   - File: `servers/exarchos-mcp/src/core/context.ts` — create hook runner and attach to DispatchContext
+   - File: `servers/exarchos-mcp/src/event-store/composite.ts` — call hook runner after successful append/batch_append
 
-3. **[REFACTOR]** Choose between EventStore callback vs handler-level wiring based on implementation complexity.
+3. **[REFACTOR]** None expected.
 
 **Dependencies:** 004, 013
 

--- a/documentation/.vitepress/config.ts
+++ b/documentation/.vitepress/config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
             { text: 'Checkpoint & Resume', link: '/guide/checkpoint-resume' },
             { text: 'Agent Teams', link: '/guide/agent-teams' },
             { text: 'Review Process', link: '/guide/review-process' },
+            { text: 'Project Configuration', link: '/guide/project-config' },
           ],
         },
       ],

--- a/documentation/guide/project-config.md
+++ b/documentation/guide/project-config.md
@@ -1,0 +1,221 @@
+---
+outline: deep
+---
+
+# Project Configuration
+
+Exarchos ships with opinionated defaults. When you need to adjust behavior for a specific project, drop a `.exarchos.yml` file in your repository root. Only specify what you want to change. Everything else keeps its default value.
+
+## Before you start
+
+- Exarchos installed and running (see [Installation](/guide/installation))
+- A project repository where you want to customize behavior
+
+## Creating the config file
+
+Create `.exarchos.yml` (or `.exarchos.yaml`) at your project root:
+
+```yaml
+# .exarchos.yml
+# All sections are optional. Only specify what you want to change.
+
+review:
+  dimensions:
+    D3: warning         # Context economy — advisory instead of blocking
+
+vcs:
+  provider: github      # github | gitlab | azure-devops
+
+tools:
+  auto-merge: false     # Disable auto-merge after CI passes
+```
+
+That's it. The file is validated on load. Invalid sections fall back to defaults with a warning in the logs. A typo in one section won't break the rest of your config.
+
+## What you can configure
+
+### Review criteria
+
+Control which quality gates block your workflow and which ones just advise.
+
+Exarchos checks five quality dimensions during review (see [Convergence Gates](/reference/convergence-gates)). You can adjust severity at the dimension level, the gate level, or both.
+
+**Dimension-level control:**
+
+```yaml
+review:
+  dimensions:
+    D1: blocking        # Security and compliance (default)
+    D2: blocking        # Static quality (default)
+    D3: warning         # Context economy — downgrade to advisory
+    D4: blocking        # Operational resilience (default)
+    D5: disabled        # Workflow determinism — skip entirely
+```
+
+Three severity levels are available:
+- `blocking` (default) stops the workflow if the check fails
+- `warning` runs the check and reports findings, but lets the workflow continue
+- `disabled` skips the check entirely
+
+**Gate-level overrides:**
+
+Individual gates override their parent dimension. This lets you keep a dimension strict while relaxing a specific check:
+
+```yaml
+review:
+  gates:
+    tdd-compliance:
+      blocking: false           # Advisory only, even though D1 is blocking
+      params:
+        coverage-threshold: 80  # Custom parameter
+    error-handling-audit:
+      enabled: false            # Skip this gate entirely
+    security-scan:
+      enabled: true
+      blocking: true            # Always block on security findings
+```
+
+**Review routing:**
+
+Control how PRs are routed to reviewers based on risk score:
+
+```yaml
+review:
+  routing:
+    coderabbit-threshold: 0.6   # Score >= 0.6 routes to CodeRabbit (default: 0.4)
+    risk-weights:               # Customize how risk is scored (must sum to 1.0)
+      security-path: 0.30
+      api-surface: 0.20
+      diff-complexity: 0.15
+      new-files: 0.10
+      infra-config: 0.15
+      cross-module: 0.10
+```
+
+### VCS provider
+
+Select which version control platform Exarchos uses for PR creation, CI checks, merging, and review status:
+
+```yaml
+vcs:
+  provider: github              # github | gitlab | azure-devops
+  settings:
+    auto-merge-strategy: squash # squash | merge | rebase
+```
+
+GitHub is the default and fully implemented. GitLab and Azure DevOps support is tracked in [Issue #1024](https://github.com/lvlup-sw/exarchos/issues/1024).
+
+### Workflow behavior
+
+Adjust the workflow process itself:
+
+```yaml
+workflow:
+  skip-phases:
+    - plan-review               # Skip the plan-review checkpoint
+  max-fix-cycles: 2             # Reduce fix cycle limit (default: 3, range: 1-10)
+  phases:
+    plan-review:
+      human-checkpoint: true    # Require human approval (default)
+    synthesize:
+      human-checkpoint: false   # Auto-merge without asking
+```
+
+Phase skipping reroutes the workflow's state machine. When you skip a phase, its incoming transitions point directly to the next phase. Guards from the skipped phase transfer to the rerouted transition, so safety checks still apply.
+
+You cannot skip initial phases (like `ideate`) or final phases (like `completed`).
+
+### Tool settings
+
+Configure how Exarchos creates commits, PRs, and manages branches:
+
+```yaml
+tools:
+  default-branch: main          # PR base branch (default: auto-detect from git)
+  commit-style: conventional    # conventional | freeform
+  pr-template: .github/pull_request_template.md
+  auto-merge: true              # Enable auto-merge after CI (default: true)
+  pr-strategy: github-native    # github-native | single
+```
+
+The `github-native` PR strategy uses `--base` targeting for stacked PRs. The `single` strategy creates one PR per feature without stacking.
+
+### Event hooks
+
+Run shell commands when workflow events occur. Hooks are fire-and-forget: they run in the background and never block the workflow.
+
+```yaml
+hooks:
+  on:
+    workflow.transition:
+      - command: 'echo "Phase: $EXARCHOS_PHASE" | slack-notify'
+        timeout: 10000          # Kill after 10 seconds (default: 30000)
+    gate.executed:
+      - command: './scripts/report-gate-result.sh'
+    synthesis.complete:
+      - command: 'curl -X POST "$JIRA_WEBHOOK" -d @-'
+```
+
+Each hook command receives the event data as JSON on stdin. Four environment variables are set automatically:
+
+| Variable | Value |
+|----------|-------|
+| `EXARCHOS_FEATURE_ID` | Current workflow feature ID |
+| `EXARCHOS_PHASE` | Current workflow phase |
+| `EXARCHOS_EVENT_TYPE` | Event type that triggered the hook |
+| `EXARCHOS_WORKFLOW_TYPE` | Workflow type (feature, debug, refactor) |
+
+A failing notification script will not break your workflow. Errors are logged, but hooks never block the event pipeline.
+
+Set `EXARCHOS_SKIP_HOOKS=true` to disable all hooks (useful during testing).
+
+## How config is loaded
+
+Exarchos finds your config through this precedence chain:
+
+1. `$EXARCHOS_PROJECT_ROOT` environment variable (if set)
+2. Walk up from the working directory looking for `.exarchos.yml` or `.exarchos.yaml`
+3. Git repository root
+4. Current working directory
+
+The config is loaded once at MCP server startup. Changes require restarting the server (or restarting Claude Code).
+
+## Inspecting effective config
+
+To see the resolved config with source annotations showing which values are defaults and which come from your `.exarchos.yml`:
+
+```
+exarchos_workflow({ action: "describe", config: true })
+```
+
+Each value is annotated with its source:
+
+```json
+{
+  "review": {
+    "dimensions": {
+      "D1": { "value": "blocking", "source": "default" },
+      "D3": { "value": "warning", "source": ".exarchos.yml" }
+    }
+  }
+}
+```
+
+## Relationship to exarchos.config.ts
+
+There are two config files, and they do different things:
+
+| File | Format | Purpose |
+|------|--------|---------|
+| `.exarchos.yml` | YAML | Override built-in defaults (review, VCS, workflow, tools, hooks) |
+| `exarchos.config.ts` | TypeScript | Define new workflow types, custom events, views, and tools |
+
+Both can coexist in the same project. YAML overrides are applied first, then TypeScript extensions are registered on top. Custom workflows defined in TypeScript inherit the project's YAML settings.
+
+Most teams only need `.exarchos.yml`. The TypeScript config is for teams building custom workflow types or integrating domain-specific quality gates.
+
+## Next steps
+
+- [Convergence Gates](/reference/convergence-gates) for details on each quality dimension (D1-D5)
+- [Review Process](/guide/review-process) for how two-stage review works
+- [Configuration Reference](/reference/configuration) for plugin settings, hooks, and environment variables

--- a/documentation/guide/project-config.md
+++ b/documentation/guide/project-config.md
@@ -184,7 +184,7 @@ The config is loaded once at MCP server startup. Changes require restarting the 
 
 To see the resolved config with source annotations showing which values are defaults and which come from your `.exarchos.yml`:
 
-```
+```ts
 exarchos_workflow({ action: "describe", config: true })
 ```
 

--- a/documentation/reference/configuration.md
+++ b/documentation/reference/configuration.md
@@ -4,7 +4,7 @@ Exarchos configuration spans project settings, plugin settings, lifecycle hooks,
 
 ## Project configuration (.exarchos.yml) {#project-config}
 
-Drop a `.exarchos.yml` file in your repository root to customize Exarchos behavior per project. All fields are optional. Unspecified fields use built-in defaults. See the [Project Configuration guide](/guide/project-config) for usage examples.
+Drop a `.exarchos.yml` (or `.exarchos.yaml`) file in your repository root to customize Exarchos behavior per project. All fields are optional. Unspecified fields use built-in defaults. See the [Project Configuration guide](/guide/project-config) for usage examples.
 
 ### Schema reference
 

--- a/documentation/reference/configuration.md
+++ b/documentation/reference/configuration.md
@@ -1,6 +1,112 @@
 # Configuration
 
-Exarchos configuration spans plugin settings, lifecycle hooks, MCP server registration, and optional integrations.
+Exarchos configuration spans project settings, plugin settings, lifecycle hooks, MCP server registration, and optional integrations.
+
+## Project configuration (.exarchos.yml) {#project-config}
+
+Drop a `.exarchos.yml` file in your repository root to customize Exarchos behavior per project. All fields are optional. Unspecified fields use built-in defaults. See the [Project Configuration guide](/guide/project-config) for usage examples.
+
+### Schema reference
+
+#### review
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `dimensions` | `Record<D1-D5, severity>` | All `blocking` | Dimension-level severity: `blocking`, `warning`, or `disabled` |
+| `dimensions.<D>` | `string \| object` | `blocking` | Shorthand `"warning"` or longform `{ severity: "warning", enabled: true }` |
+| `gates` | `Record<string, GateConfig>` | `{}` | Per-gate overrides (take precedence over dimension) |
+| `gates.<name>.enabled` | `boolean` | `true` | Enable or disable the gate |
+| `gates.<name>.blocking` | `boolean` | Inherits dimension | Override whether gate blocks the workflow |
+| `gates.<name>.params` | `object` | `{}` | Gate-specific parameters (e.g., `coverage-threshold`) |
+| `routing.coderabbit-threshold` | `number` | `0.4` | Risk score threshold for CodeRabbit routing (0.0-1.0) |
+| `routing.risk-weights` | `object` | See below | Six risk factors, must sum to 1.0 |
+
+Default risk weights: `security-path: 0.30`, `api-surface: 0.20`, `diff-complexity: 0.15`, `new-files: 0.10`, `infra-config: 0.15`, `cross-module: 0.10`.
+
+#### vcs
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `provider` | `string` | `github` | VCS platform: `github`, `gitlab`, or `azure-devops` |
+| `settings` | `object` | `{}` | Provider-specific settings |
+| `settings.auto-merge-strategy` | `string` | `squash` | GitHub: `squash`, `merge`, or `rebase` |
+
+#### workflow
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `skip-phases` | `string[]` | `[]` | Phase names to skip (cannot skip initial or final phases) |
+| `max-fix-cycles` | `integer` | `3` | Max fix cycles before circuit breaker (1-10) |
+| `phases.<name>.human-checkpoint` | `boolean` | varies | Require human approval at this phase |
+
+#### tools
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `default-branch` | `string` | auto-detect | PR base branch |
+| `commit-style` | `string` | `conventional` | `conventional` or `freeform` |
+| `pr-template` | `string` | (none) | Path to PR template (relative to repo root) |
+| `auto-merge` | `boolean` | `true` | Auto-merge after CI passes |
+| `pr-strategy` | `string` | `github-native` | `github-native` (stacked) or `single` |
+
+#### hooks
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `on.<event-type>` | `HookAction[]` | `{}` | Shell commands to run when an event fires |
+| `on.<event-type>[].command` | `string` | (required) | Shell command (receives event JSON on stdin) |
+| `on.<event-type>[].timeout` | `integer` | `30000` | Timeout in ms (1000-300000) |
+
+Hooks are fire-and-forget. Failures are logged but never block the workflow. Set `EXARCHOS_SKIP_HOOKS=true` to disable all hooks.
+
+### Minimal example
+
+```yaml
+review:
+  dimensions:
+    D3: warning
+vcs:
+  provider: github
+tools:
+  auto-merge: false
+```
+
+### Full example
+
+```yaml
+review:
+  dimensions:
+    D1: blocking
+    D3: warning
+    D5: disabled
+  gates:
+    tdd-compliance:
+      blocking: false
+      params:
+        coverage-threshold: 80
+    security-scan:
+      enabled: true
+      blocking: true
+  routing:
+    coderabbit-threshold: 0.6
+vcs:
+  provider: github
+  settings:
+    auto-merge-strategy: squash
+workflow:
+  skip-phases: [plan-review]
+  max-fix-cycles: 2
+tools:
+  default-branch: main
+  commit-style: conventional
+  auto-merge: true
+  pr-strategy: github-native
+hooks:
+  on:
+    workflow.transition:
+      - command: 'echo "$EXARCHOS_PHASE" | slack-notify'
+        timeout: 10000
+```
 
 ## Plugin settings
 
@@ -102,4 +208,6 @@ These integrations run as separate MCP servers and are not required for core Exa
 |----------|---------|-------------|
 | `WORKFLOW_STATE_DIR` | `~/.claude/workflow-state` | Directory for workflow state files |
 | `EXARCHOS_PLUGIN_ROOT` | Set by Claude Code | Plugin installation root |
+| `EXARCHOS_PROJECT_ROOT` | (unset) | Override project root for `.exarchos.yml` discovery |
+| `EXARCHOS_SKIP_HOOKS` | (unset) | Set to `true` to disable all config hooks |
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | (unset) | Autocompact threshold percentage |

--- a/servers/exarchos-mcp/package-lock.json
+++ b/servers/exarchos-mcp/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@lvlup-sw/exarchos-mcp",
-  "version": "1.1.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lvlup-sw/exarchos-mcp",
-      "version": "1.1.0",
+      "version": "2.5.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "better-sqlite3": "^12.6.2",
         "commander": "^14.0.3",
         "pino": "^10.3.1",
+        "yaml": "^2.8.2",
         "zod": "^3.23.0",
         "zod-to-json-schema": "^3.25.1"
       },
@@ -11456,71 +11457,6 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
-    "node_modules/mongoose/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/mongoose/node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongoose/node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^5.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongoose/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/mongoose/node_modules/mongodb": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
@@ -16275,9 +16211,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/servers/exarchos-mcp/package.json
+++ b/servers/exarchos-mcp/package.json
@@ -19,6 +19,7 @@
     "better-sqlite3": "^12.6.2",
     "commander": "^14.0.3",
     "pino": "^10.3.1",
+    "yaml": "^2.8.2",
     "zod": "^3.23.0",
     "zod-to-json-schema": "^3.25.1"
   },

--- a/servers/exarchos-mcp/src/config/resolve.test.ts
+++ b/servers/exarchos-mcp/src/config/resolve.test.ts
@@ -181,4 +181,32 @@ describe('resolveConfig', () => {
     expect(DEFAULTS.tools).toBeDefined();
     expect(DEFAULTS.hooks).toBeDefined();
   });
+
+  it('resolveConfig_DoesNotFreezeCallerParams', () => {
+    const params: Record<string, unknown> = { 'coverage-threshold': 80 };
+    const project: ProjectConfig = {
+      review: { gates: { 'tdd-compliance': { blocking: true, params } } },
+    };
+
+    resolveConfig(project);
+
+    // The caller's params object should NOT be frozen by deepFreeze
+    expect(Object.isFrozen(params)).toBe(false);
+    // Should still be mutable
+    params['new-key'] = 'value';
+    expect(params['new-key']).toBe('value');
+  });
+
+  it('resolveConfig_DoesNotFreezeCallerSkipPhases', () => {
+    const skipPhases = ['plan-review', 'lint'];
+    const project: ProjectConfig = { workflow: { 'skip-phases': skipPhases } };
+
+    resolveConfig(project);
+
+    // The caller's skipPhases array should NOT be frozen by deepFreeze
+    expect(Object.isFrozen(skipPhases)).toBe(false);
+    // Should still be mutable
+    skipPhases.push('test');
+    expect(skipPhases).toHaveLength(3);
+  });
 });

--- a/servers/exarchos-mcp/src/config/resolve.test.ts
+++ b/servers/exarchos-mcp/src/config/resolve.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import type { ProjectConfig } from './yaml-schema.js';
+import { resolveConfig, DEFAULTS } from './resolve.js';
+
+describe('resolveConfig', () => {
+  it('resolveConfig_EmptyProject_ReturnsAllDefaults', () => {
+    const result = resolveConfig({});
+
+    // All dimensions should be blocking by default
+    for (const dim of ['D1', 'D2', 'D3', 'D4', 'D5'] as const) {
+      expect(result.review.dimensions[dim]).toEqual({ severity: 'blocking', enabled: true });
+    }
+
+    // Empty gates
+    expect(result.review.gates).toEqual({});
+
+    // Routing defaults
+    expect(result.review.routing.coderabbitThreshold).toBe(0.4);
+    expect(result.review.routing.riskWeights).toEqual({
+      'security-path': 0.30,
+      'api-surface': 0.20,
+      'diff-complexity': 0.15,
+      'new-files': 0.10,
+      'infra-config': 0.15,
+      'cross-module': 0.10,
+    });
+
+    // VCS defaults
+    expect(result.vcs.provider).toBe('github');
+    expect(result.vcs.settings).toEqual({});
+
+    // Workflow defaults
+    expect(result.workflow.skipPhases).toEqual([]);
+    expect(result.workflow.maxFixCycles).toBe(3);
+    expect(result.workflow.phases).toEqual({});
+
+    // Tools defaults
+    expect(result.tools.defaultBranch).toBeUndefined();
+    expect(result.tools.commitStyle).toBe('conventional');
+    expect(result.tools.prTemplate).toBeUndefined();
+    expect(result.tools.autoMerge).toBe(true);
+    expect(result.tools.prStrategy).toBe('github-native');
+
+    // Hooks defaults
+    expect(result.hooks.on).toEqual({});
+  });
+
+  it('resolveConfig_DimensionOverride_MergesOntoDefaults', () => {
+    const project: ProjectConfig = {
+      review: { dimensions: { D3: 'warning' } },
+    };
+    const result = resolveConfig(project);
+
+    expect(result.review.dimensions.D3).toEqual({ severity: 'warning', enabled: true });
+    expect(result.review.dimensions.D1).toEqual({ severity: 'blocking', enabled: true });
+    expect(result.review.dimensions.D2).toEqual({ severity: 'blocking', enabled: true });
+    expect(result.review.dimensions.D4).toEqual({ severity: 'blocking', enabled: true });
+    expect(result.review.dimensions.D5).toEqual({ severity: 'blocking', enabled: true });
+  });
+
+  it('resolveConfig_DimensionShorthand_NormalizesToObject', () => {
+    const project: ProjectConfig = {
+      review: { dimensions: { D1: 'warning' } },
+    };
+    const result = resolveConfig(project);
+    expect(result.review.dimensions.D1).toEqual({ severity: 'warning', enabled: true });
+  });
+
+  it('resolveConfig_DimensionLongform_Preserved', () => {
+    const project: ProjectConfig = {
+      review: { dimensions: { D2: { severity: 'disabled', enabled: false } } },
+    };
+    const result = resolveConfig(project);
+    expect(result.review.dimensions.D2).toEqual({ severity: 'disabled', enabled: false });
+  });
+
+  it('resolveConfig_GateOverride_MergedOntoEmptyDefault', () => {
+    const project: ProjectConfig = {
+      review: { gates: { 'tdd-compliance': { blocking: true, params: { 'coverage-threshold': 80 } } } },
+    };
+    const result = resolveConfig(project);
+    expect(result.review.gates['tdd-compliance']).toEqual({
+      enabled: true,
+      blocking: true,
+      params: { 'coverage-threshold': 80 },
+    });
+  });
+
+  it('resolveConfig_RoutingThreshold_OverridesDefault', () => {
+    const project: ProjectConfig = {
+      review: { routing: { 'coderabbit-threshold': 0.6 } },
+    };
+    const result = resolveConfig(project);
+    expect(result.review.routing.coderabbitThreshold).toBe(0.6);
+  });
+
+  it('resolveConfig_RiskWeights_FullReplace', () => {
+    const customWeights = {
+      'security-path': 0.50,
+      'api-surface': 0.20,
+      'diff-complexity': 0.10,
+      'new-files': 0.05,
+      'infra-config': 0.10,
+      'cross-module': 0.05,
+    };
+    const project: ProjectConfig = {
+      review: { routing: { 'risk-weights': customWeights } },
+    };
+    const result = resolveConfig(project);
+    expect(result.review.routing.riskWeights).toEqual(customWeights);
+  });
+
+  it('resolveConfig_VcsProvider_OverridesDefault', () => {
+    const project: ProjectConfig = { vcs: { provider: 'gitlab' } };
+    const result = resolveConfig(project);
+    expect(result.vcs.provider).toBe('gitlab');
+    expect(result.vcs.settings).toEqual({});
+  });
+
+  it('resolveConfig_SkipPhases_AddedToEmptyDefault', () => {
+    const project: ProjectConfig = { workflow: { 'skip-phases': ['plan-review', 'lint'] } };
+    const result = resolveConfig(project);
+    expect(result.workflow.skipPhases).toEqual(['plan-review', 'lint']);
+  });
+
+  it('resolveConfig_MaxFixCycles_OverridesDefault', () => {
+    const project: ProjectConfig = { workflow: { 'max-fix-cycles': 5 } };
+    const result = resolveConfig(project);
+    expect(result.workflow.maxFixCycles).toBe(5);
+  });
+
+  it('resolveConfig_ToolsPartial_MergesWithDefaults', () => {
+    const project: ProjectConfig = { tools: { 'auto-merge': false } };
+    const result = resolveConfig(project);
+    expect(result.tools.autoMerge).toBe(false);
+    expect(result.tools.commitStyle).toBe('conventional');
+    expect(result.tools.prStrategy).toBe('github-native');
+  });
+
+  it('resolveConfig_HooksOn_MergedByEventType', () => {
+    const project: ProjectConfig = {
+      hooks: {
+        on: {
+          'workflow.transition': [{ command: 'echo hello', timeout: 5000 }],
+          'review.complete': [{ command: 'echo done' }],
+        },
+      },
+    };
+    const result = resolveConfig(project);
+    expect(result.hooks.on['workflow.transition']).toHaveLength(1);
+    expect(result.hooks.on['workflow.transition'][0].command).toBe('echo hello');
+    expect(result.hooks.on['workflow.transition'][0].timeout).toBe(5000);
+    expect(result.hooks.on['review.complete']).toHaveLength(1);
+    expect(result.hooks.on['review.complete'][0].command).toBe('echo done');
+    // Default timeout for hooks without explicit timeout
+    expect(result.hooks.on['review.complete'][0].timeout).toBe(30000);
+  });
+
+  it('resolveConfig_Result_IsFrozen', () => {
+    const result = resolveConfig({});
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.review)).toBe(true);
+    expect(Object.isFrozen(result.review.dimensions)).toBe(true);
+    expect(Object.isFrozen(result.review.dimensions.D1)).toBe(true);
+    expect(Object.isFrozen(result.vcs)).toBe(true);
+    expect(Object.isFrozen(result.workflow)).toBe(true);
+    expect(Object.isFrozen(result.tools)).toBe(true);
+    expect(Object.isFrozen(result.hooks)).toBe(true);
+  });
+
+  it('resolveConfig_DefaultBranch_UndefinedByDefault', () => {
+    const result = resolveConfig({});
+    expect(result.tools.defaultBranch).toBeUndefined();
+  });
+
+  it('DEFAULTS_IsExported', () => {
+    expect(DEFAULTS).toBeDefined();
+    expect(DEFAULTS.review).toBeDefined();
+    expect(DEFAULTS.vcs).toBeDefined();
+    expect(DEFAULTS.workflow).toBeDefined();
+    expect(DEFAULTS.tools).toBeDefined();
+    expect(DEFAULTS.hooks).toBeDefined();
+  });
+});

--- a/servers/exarchos-mcp/src/config/resolve.ts
+++ b/servers/exarchos-mcp/src/config/resolve.ts
@@ -1,0 +1,238 @@
+import type { ProjectConfig } from './yaml-schema.js';
+
+// ─── Resolved Types ─────────────────────────────────────────────────────────
+
+export interface ResolvedDimensionConfig {
+  readonly severity: 'blocking' | 'warning' | 'disabled';
+  readonly enabled: boolean;
+}
+
+export interface ResolvedGateConfig {
+  readonly enabled: boolean;
+  readonly blocking: boolean;
+  readonly params: Readonly<Record<string, unknown>>;
+}
+
+export interface ResolvedProjectConfig {
+  readonly review: {
+    readonly dimensions: Readonly<Record<'D1' | 'D2' | 'D3' | 'D4' | 'D5', ResolvedDimensionConfig>>;
+    readonly gates: Readonly<Record<string, ResolvedGateConfig>>;
+    readonly routing: {
+      readonly coderabbitThreshold: number;
+      readonly riskWeights: Readonly<Record<string, number>>;
+    };
+  };
+  readonly vcs: {
+    readonly provider: 'github' | 'gitlab' | 'azure-devops';
+    readonly settings: Readonly<Record<string, unknown>>;
+  };
+  readonly workflow: {
+    readonly skipPhases: readonly string[];
+    readonly maxFixCycles: number;
+    readonly phases: Readonly<Record<string, { readonly humanCheckpoint: boolean }>>;
+  };
+  readonly tools: {
+    readonly defaultBranch: string | undefined;
+    readonly commitStyle: 'conventional' | 'freeform';
+    readonly prTemplate: string | undefined;
+    readonly autoMerge: boolean;
+    readonly prStrategy: 'github-native' | 'single';
+  };
+  readonly hooks: {
+    readonly on: Readonly<Record<string, readonly { readonly command: string; readonly timeout: number }[]>>;
+  };
+}
+
+// ─── Default Values ─────────────────────────────────────────────────────────
+
+const DEFAULT_DIMENSION: ResolvedDimensionConfig = { severity: 'blocking', enabled: true };
+
+const DEFAULT_RISK_WEIGHTS: Readonly<Record<string, number>> = {
+  'security-path': 0.30,
+  'api-surface': 0.20,
+  'diff-complexity': 0.15,
+  'new-files': 0.10,
+  'infra-config': 0.15,
+  'cross-module': 0.10,
+};
+
+const DEFAULT_HOOK_TIMEOUT = 30000;
+
+export const DEFAULTS: ResolvedProjectConfig = deepFreeze({
+  review: {
+    dimensions: {
+      D1: { ...DEFAULT_DIMENSION },
+      D2: { ...DEFAULT_DIMENSION },
+      D3: { ...DEFAULT_DIMENSION },
+      D4: { ...DEFAULT_DIMENSION },
+      D5: { ...DEFAULT_DIMENSION },
+    },
+    gates: {},
+    routing: {
+      coderabbitThreshold: 0.4,
+      riskWeights: { ...DEFAULT_RISK_WEIGHTS },
+    },
+  },
+  vcs: {
+    provider: 'github',
+    settings: {},
+  },
+  workflow: {
+    skipPhases: [],
+    maxFixCycles: 3,
+    phases: {},
+  },
+  tools: {
+    defaultBranch: undefined,
+    commitStyle: 'conventional',
+    prTemplate: undefined,
+    autoMerge: true,
+    prStrategy: 'github-native',
+  },
+  hooks: {
+    on: {},
+  },
+});
+
+// ─── Normalization ──────────────────────────────────────────────────────────
+
+/**
+ * Normalizes a dimension config value (shorthand string or longform object)
+ * into a canonical `ResolvedDimensionConfig`.
+ */
+function normalizeDimension(
+  value: string | { severity?: string; enabled?: boolean },
+): ResolvedDimensionConfig {
+  if (typeof value === 'string') {
+    return { severity: value as ResolvedDimensionConfig['severity'], enabled: true };
+  }
+  return {
+    severity: (value.severity as ResolvedDimensionConfig['severity']) ?? 'blocking',
+    enabled: value.enabled ?? true,
+  };
+}
+
+/**
+ * Normalizes a gate config into a canonical `ResolvedGateConfig`.
+ */
+function normalizeGate(
+  value: { enabled?: boolean; blocking?: boolean; params?: Record<string, unknown> },
+): ResolvedGateConfig {
+  return {
+    enabled: value.enabled ?? true,
+    blocking: value.blocking ?? false,
+    params: value.params ?? {},
+  };
+}
+
+/**
+ * Normalizes a hook action, applying default timeout.
+ */
+function normalizeHookAction(
+  action: { command: string; timeout?: number },
+): { readonly command: string; readonly timeout: number } {
+  return {
+    command: action.command,
+    timeout: action.timeout ?? DEFAULT_HOOK_TIMEOUT,
+  };
+}
+
+// ─── Deep Freeze ────────────────────────────────────────────────────────────
+
+/**
+ * Recursively freezes an object and all nested objects/arrays.
+ */
+function deepFreeze<T>(obj: T): T {
+  if (obj === null || obj === undefined || typeof obj !== 'object') return obj;
+
+  Object.freeze(obj);
+
+  for (const value of Object.values(obj as Record<string, unknown>)) {
+    if (typeof value === 'object' && value !== null && !Object.isFrozen(value)) {
+      deepFreeze(value);
+    }
+  }
+
+  return obj;
+}
+
+// ─── Resolve Config ─────────────────────────────────────────────────────────
+
+type DimensionKey = 'D1' | 'D2' | 'D3' | 'D4' | 'D5';
+const DIMENSION_KEYS: readonly DimensionKey[] = ['D1', 'D2', 'D3', 'D4', 'D5'];
+
+/**
+ * Resolves a partial `ProjectConfig` (from YAML) against defaults,
+ * producing a fully-populated, deeply-frozen `ResolvedProjectConfig`.
+ */
+export function resolveConfig(project: ProjectConfig): ResolvedProjectConfig {
+  // ── Review ──
+  const dimensions = {} as Record<DimensionKey, ResolvedDimensionConfig>;
+  for (const key of DIMENSION_KEYS) {
+    const override = project.review?.dimensions?.[key];
+    dimensions[key] = override !== undefined
+      ? normalizeDimension(override)
+      : { ...DEFAULT_DIMENSION };
+  }
+
+  const gates: Record<string, ResolvedGateConfig> = {};
+  if (project.review?.gates) {
+    for (const [name, gateConfig] of Object.entries(project.review.gates)) {
+      gates[name] = normalizeGate(gateConfig);
+    }
+  }
+
+  const coderabbitThreshold = project.review?.routing?.['coderabbit-threshold']
+    ?? DEFAULTS.review.routing.coderabbitThreshold;
+
+  const riskWeights = project.review?.routing?.['risk-weights']
+    ? { ...project.review.routing['risk-weights'] }
+    : { ...DEFAULT_RISK_WEIGHTS };
+
+  // ── VCS ──
+  const vcsProvider = project.vcs?.provider ?? DEFAULTS.vcs.provider;
+  const vcsSettings = project.vcs?.settings
+    ? { ...project.vcs.settings }
+    : {};
+
+  // ── Workflow ──
+  const skipPhases = project.workflow?.['skip-phases'] ?? [...DEFAULTS.workflow.skipPhases];
+  const maxFixCycles = project.workflow?.['max-fix-cycles'] ?? DEFAULTS.workflow.maxFixCycles;
+  const phases: Record<string, { readonly humanCheckpoint: boolean }> = {};
+  if (project.workflow?.phases) {
+    for (const [name, phaseConfig] of Object.entries(project.workflow.phases)) {
+      phases[name] = {
+        humanCheckpoint: phaseConfig['human-checkpoint'] ?? true,
+      };
+    }
+  }
+
+  // ── Tools ──
+  const defaultBranch = project.tools?.['default-branch'] ?? DEFAULTS.tools.defaultBranch;
+  const commitStyle = project.tools?.['commit-style'] ?? DEFAULTS.tools.commitStyle;
+  const prTemplate = project.tools?.['pr-template'] ?? DEFAULTS.tools.prTemplate;
+  const autoMerge = project.tools?.['auto-merge'] ?? DEFAULTS.tools.autoMerge;
+  const prStrategy = project.tools?.['pr-strategy'] ?? DEFAULTS.tools.prStrategy;
+
+  // ── Hooks ──
+  const hooksOn: Record<string, { readonly command: string; readonly timeout: number }[]> = {};
+  if (project.hooks?.on) {
+    for (const [event, actions] of Object.entries(project.hooks.on)) {
+      hooksOn[event] = actions.map(normalizeHookAction);
+    }
+  }
+
+  const resolved: ResolvedProjectConfig = {
+    review: {
+      dimensions,
+      gates,
+      routing: { coderabbitThreshold, riskWeights },
+    },
+    vcs: { provider: vcsProvider, settings: vcsSettings },
+    workflow: { skipPhases, maxFixCycles, phases },
+    tools: { defaultBranch, commitStyle, prTemplate, autoMerge, prStrategy },
+    hooks: { on: hooksOn },
+  };
+
+  return deepFreeze(resolved);
+}

--- a/servers/exarchos-mcp/src/config/resolve.ts
+++ b/servers/exarchos-mcp/src/config/resolve.ts
@@ -121,7 +121,7 @@ function normalizeGate(
   return {
     enabled: value.enabled ?? true,
     blocking: value.blocking ?? false,
-    params: value.params ?? {},
+    params: { ...(value.params ?? {}) },
   };
 }
 
@@ -196,7 +196,7 @@ export function resolveConfig(project: ProjectConfig): ResolvedProjectConfig {
     : {};
 
   // ── Workflow ──
-  const skipPhases = project.workflow?.['skip-phases'] ?? [...DEFAULTS.workflow.skipPhases];
+  const skipPhases = [...(project.workflow?.['skip-phases'] ?? DEFAULTS.workflow.skipPhases)];
   const maxFixCycles = project.workflow?.['max-fix-cycles'] ?? DEFAULTS.workflow.maxFixCycles;
   const phases: Record<string, { readonly humanCheckpoint: boolean }> = {};
   if (project.workflow?.phases) {

--- a/servers/exarchos-mcp/src/config/yaml-loader.test.ts
+++ b/servers/exarchos-mcp/src/config/yaml-loader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';

--- a/servers/exarchos-mcp/src/config/yaml-loader.test.ts
+++ b/servers/exarchos-mcp/src/config/yaml-loader.test.ts
@@ -90,10 +90,11 @@ hooks:
     expect(result.vcs?.provider).toBe('gitlab');
   });
 
-  it('loadProjectConfig_MalformedYaml_ThrowsWithMessage', async () => {
+  it('loadProjectConfig_MalformedYaml_ReturnsEmptyConfig', async () => {
     const { loadProjectConfig } = await import('./yaml-loader.js');
     fs.writeFileSync(path.join(tmpDir, '.exarchos.yml'), '{{{{invalid yaml: [[[', 'utf-8');
-    expect(() => loadProjectConfig(tmpDir)).toThrow();
+    const result = loadProjectConfig(tmpDir);
+    expect(result).toEqual({});
   });
 
   it('loadProjectConfig_InvalidSchema_ReturnsPartialWithWarnings', async () => {

--- a/servers/exarchos-mcp/src/config/yaml-loader.test.ts
+++ b/servers/exarchos-mcp/src/config/yaml-loader.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+describe('loadProjectConfig', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'yaml-loader-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('loadProjectConfig_NoFile_ReturnsEmptyConfig', async () => {
+    const { loadProjectConfig } = await import('./yaml-loader.js');
+    const result = loadProjectConfig(tmpDir);
+    expect(result).toEqual({});
+  });
+
+  it('loadProjectConfig_ValidYaml_ParsesAllSections', async () => {
+    const { loadProjectConfig } = await import('./yaml-loader.js');
+    const yaml = `
+review:
+  dimensions:
+    D1: blocking
+    D3: warning
+  gates:
+    security-scan:
+      enabled: true
+      blocking: true
+  routing:
+    coderabbit-threshold: 0.6
+    risk-weights:
+      security-path: 0.30
+      api-surface: 0.20
+      diff-complexity: 0.15
+      new-files: 0.10
+      infra-config: 0.15
+      cross-module: 0.10
+vcs:
+  provider: github
+  settings:
+    auto-merge-strategy: squash
+workflow:
+  skip-phases:
+    - plan-review
+  max-fix-cycles: 2
+  phases:
+    synthesize:
+      human-checkpoint: false
+tools:
+  default-branch: main
+  commit-style: conventional
+  auto-merge: true
+  pr-strategy: github-native
+hooks:
+  on:
+    workflow.transition:
+      - command: echo test
+        timeout: 5000
+`;
+    fs.writeFileSync(path.join(tmpDir, '.exarchos.yml'), yaml, 'utf-8');
+    const result = loadProjectConfig(tmpDir);
+    expect(result.review?.dimensions?.D1).toBe('blocking');
+    expect(result.review?.dimensions?.D3).toBe('warning');
+    expect(result.review?.gates?.['security-scan']?.enabled).toBe(true);
+    expect(result.review?.routing?.['coderabbit-threshold']).toBe(0.6);
+    expect(result.vcs?.provider).toBe('github');
+    expect(result.workflow?.['skip-phases']).toEqual(['plan-review']);
+    expect(result.workflow?.['max-fix-cycles']).toBe(2);
+    expect(result.tools?.['default-branch']).toBe('main');
+    expect(result.tools?.['commit-style']).toBe('conventional');
+    expect(result.hooks?.on?.['workflow.transition']).toHaveLength(1);
+  });
+
+  it('loadProjectConfig_YmlExtension_Loaded', async () => {
+    const { loadProjectConfig } = await import('./yaml-loader.js');
+    fs.writeFileSync(path.join(tmpDir, '.exarchos.yml'), 'vcs:\n  provider: github\n', 'utf-8');
+    const result = loadProjectConfig(tmpDir);
+    expect(result.vcs?.provider).toBe('github');
+  });
+
+  it('loadProjectConfig_YamlExtension_Loaded', async () => {
+    const { loadProjectConfig } = await import('./yaml-loader.js');
+    fs.writeFileSync(path.join(tmpDir, '.exarchos.yaml'), 'vcs:\n  provider: gitlab\n', 'utf-8');
+    const result = loadProjectConfig(tmpDir);
+    expect(result.vcs?.provider).toBe('gitlab');
+  });
+
+  it('loadProjectConfig_MalformedYaml_ThrowsWithMessage', async () => {
+    const { loadProjectConfig } = await import('./yaml-loader.js');
+    fs.writeFileSync(path.join(tmpDir, '.exarchos.yml'), '{{{{invalid yaml: [[[', 'utf-8');
+    expect(() => loadProjectConfig(tmpDir)).toThrow();
+  });
+
+  it('loadProjectConfig_InvalidSchema_ReturnsPartialWithWarnings', async () => {
+    const { loadProjectConfig } = await import('./yaml-loader.js');
+    // 'foo' is an unknown top-level key (strict mode rejects it)
+    // But valid sections should be returned via partial parsing
+    const yaml = `
+vcs:
+  provider: github
+foo: bar
+`;
+    fs.writeFileSync(path.join(tmpDir, '.exarchos.yml'), yaml, 'utf-8');
+    // loadProjectConfig logs warnings via structured logger (pino) — not console
+    const result = loadProjectConfig(tmpDir);
+    // When schema validation fails, we attempt section-level parse
+    // The valid vcs section should be preserved
+    expect(result.vcs?.provider).toBe('github');
+  });
+});
+
+describe('discoverProjectRoot', () => {
+  let tmpDir: string;
+  const originalEnv = process.env.EXARCHOS_PROJECT_ROOT;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'discover-root-'));
+    delete process.env.EXARCHOS_PROJECT_ROOT;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (originalEnv !== undefined) {
+      process.env.EXARCHOS_PROJECT_ROOT = originalEnv;
+    } else {
+      delete process.env.EXARCHOS_PROJECT_ROOT;
+    }
+  });
+
+  it('discoverProjectRoot_EnvVar_TakesPrecedence', async () => {
+    const { discoverProjectRoot } = await import('./yaml-loader.js');
+    process.env.EXARCHOS_PROJECT_ROOT = '/custom/project/root';
+    const result = discoverProjectRoot(tmpDir);
+    expect(result).toBe('/custom/project/root');
+  });
+
+  it('discoverProjectRoot_WalksUpForYml_FindsRoot', async () => {
+    const { discoverProjectRoot } = await import('./yaml-loader.js');
+    // Create a nested dir structure with config in parent
+    const childDir = path.join(tmpDir, 'src', 'deep');
+    fs.mkdirSync(childDir, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, '.exarchos.yml'), 'vcs:\n  provider: github\n', 'utf-8');
+    const result = discoverProjectRoot(childDir);
+    expect(result).toBe(tmpDir);
+  });
+
+  it('discoverProjectRoot_FallsBackToGitRoot', async () => {
+    const { discoverProjectRoot } = await import('./yaml-loader.js');
+    // Create a temp git repo without .exarchos.yml
+    const gitDir = fs.mkdtempSync(path.join(os.tmpdir(), 'discover-git-'));
+    try {
+      const { execSync } = await import('node:child_process');
+      execSync('git init', { cwd: gitDir, stdio: 'ignore' });
+      const childDir = path.join(gitDir, 'src');
+      fs.mkdirSync(childDir, { recursive: true });
+      const result = discoverProjectRoot(childDir);
+      expect(result).toBe(gitDir);
+    } finally {
+      fs.rmSync(gitDir, { recursive: true, force: true });
+    }
+  });
+
+  it('discoverProjectRoot_NothingFound_UsesCwd', async () => {
+    const { discoverProjectRoot } = await import('./yaml-loader.js');
+    // Use /tmp itself — no config file, no git root (most likely)
+    // Create an isolated dir that is NOT a git repo
+    const isolatedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'discover-isolated-'));
+    try {
+      const result = discoverProjectRoot(isolatedDir);
+      expect(result).toBe(isolatedDir);
+    } finally {
+      fs.rmSync(isolatedDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/config/yaml-loader.ts
+++ b/servers/exarchos-mcp/src/config/yaml-loader.ts
@@ -29,7 +29,14 @@ export function loadProjectConfig(projectRoot: string): ProjectConfig {
     const configPath = resolve(projectRoot, filename);
     if (existsSync(configPath)) {
       const raw = readFileSync(configPath, 'utf-8');
-      const parsed: unknown = parseYaml(raw);
+
+      let parsed: unknown;
+      try {
+        parsed = parseYaml(raw);
+      } catch (err) {
+        configLogger.warn({ error: err instanceof Error ? err.message : String(err), path: configPath }, 'Failed to parse YAML in .exarchos.yml — using defaults');
+        return {};
+      }
 
       if (parsed === null || parsed === undefined) return {};
 

--- a/servers/exarchos-mcp/src/config/yaml-loader.ts
+++ b/servers/exarchos-mcp/src/config/yaml-loader.ts
@@ -1,0 +1,113 @@
+import { parse as parseYaml } from 'yaml';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { execSync } from 'node:child_process';
+import { ProjectConfigSchema, type ProjectConfig } from './yaml-schema.js';
+import { logger } from '../logger.js';
+
+const configLogger = logger.child({ subsystem: 'config' });
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const YAML_FILENAMES = ['.exarchos.yml', '.exarchos.yaml'] as const;
+
+// ─── Section-level parsing keys ─────────────────────────────────────────────
+
+const SECTION_KEYS = ['review', 'vcs', 'workflow', 'tools', 'hooks'] as const;
+
+// ─── Load Project Config ────────────────────────────────────────────────────
+
+/**
+ * Loads and validates `.exarchos.yml` (or `.exarchos.yaml`) from the given
+ * project root directory. Returns an empty config if no file is found.
+ *
+ * When the full config fails validation, attempts section-by-section parsing
+ * to preserve valid sections and log warnings for invalid ones.
+ */
+export function loadProjectConfig(projectRoot: string): ProjectConfig {
+  for (const filename of YAML_FILENAMES) {
+    const configPath = resolve(projectRoot, filename);
+    if (existsSync(configPath)) {
+      const raw = readFileSync(configPath, 'utf-8');
+      const parsed: unknown = parseYaml(raw);
+
+      if (parsed === null || parsed === undefined) return {};
+
+      // Full-config validation
+      const result = ProjectConfigSchema.safeParse(parsed);
+      if (result.success) return result.data;
+
+      // Section-level fallback: extract valid sections
+      configLogger.warn({ issues: result.error.issues }, '.exarchos.yml validation errors');
+      return parseSections(parsed);
+    }
+  }
+  return {};
+}
+
+/**
+ * Attempts to parse each top-level section independently, returning
+ * only the sections that pass validation.
+ */
+function parseSections(parsed: unknown): ProjectConfig {
+  if (typeof parsed !== 'object' || parsed === null) return {};
+
+  const raw = parsed as Record<string, unknown>;
+  const partial: Record<string, unknown> = {};
+
+  for (const key of SECTION_KEYS) {
+    if (key in raw) {
+      // Try parsing just this section within a valid ProjectConfig shape
+      const sectionResult = ProjectConfigSchema.safeParse({ [key]: raw[key] });
+      if (sectionResult.success) {
+        partial[key] = sectionResult.data[key];
+      }
+    }
+  }
+
+  return partial as ProjectConfig;
+}
+
+// ─── Discover Project Root ──────────────────────────────────────────────────
+
+/**
+ * Discovers the project root directory using the following precedence:
+ *
+ * 1. `EXARCHOS_PROJECT_ROOT` environment variable
+ * 2. Walk up from `cwd` looking for `.exarchos.yml` / `.exarchos.yaml`
+ * 3. Git repository root (`git rev-parse --show-toplevel`)
+ * 4. Fall back to the provided `cwd` (or `process.cwd()`)
+ */
+export function discoverProjectRoot(cwd?: string): string {
+  const startDir = cwd ?? process.cwd();
+
+  // 1. Environment variable takes precedence
+  if (process.env.EXARCHOS_PROJECT_ROOT) {
+    return process.env.EXARCHOS_PROJECT_ROOT;
+  }
+
+  // 2. Walk up looking for config file
+  let dir = startDir;
+  while (true) {
+    for (const filename of YAML_FILENAMES) {
+      if (existsSync(resolve(dir, filename))) return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  // 3. Git root
+  try {
+    return execSync('git rev-parse --show-toplevel', {
+      cwd: startDir,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    // Not a git repo — fall through
+  }
+
+  // 4. CWD fallback
+  return startDir;
+}

--- a/servers/exarchos-mcp/src/config/yaml-loader.ts
+++ b/servers/exarchos-mcp/src/config/yaml-loader.ts
@@ -28,25 +28,30 @@ export function loadProjectConfig(projectRoot: string): ProjectConfig {
   for (const filename of YAML_FILENAMES) {
     const configPath = resolve(projectRoot, filename);
     if (existsSync(configPath)) {
-      const raw = readFileSync(configPath, 'utf-8');
-
-      let parsed: unknown;
       try {
-        parsed = parseYaml(raw);
+        const raw = readFileSync(configPath, 'utf-8');
+
+        let parsed: unknown;
+        try {
+          parsed = parseYaml(raw);
+        } catch (err) {
+          configLogger.warn({ error: err instanceof Error ? err.message : String(err), path: configPath }, 'Failed to parse YAML in .exarchos.yml — using defaults');
+          return {};
+        }
+
+        if (parsed === null || parsed === undefined) return {};
+
+        // Full-config validation
+        const result = ProjectConfigSchema.safeParse(parsed);
+        if (result.success) return result.data;
+
+        // Section-level fallback: extract valid sections
+        configLogger.warn({ issues: result.error.issues }, '.exarchos.yml validation errors');
+        return parseSections(parsed);
       } catch (err) {
-        configLogger.warn({ error: err instanceof Error ? err.message : String(err), path: configPath }, 'Failed to parse YAML in .exarchos.yml — using defaults');
+        configLogger.warn({ error: err instanceof Error ? err.message : String(err), path: configPath }, 'Failed to read .exarchos.yml');
         return {};
       }
-
-      if (parsed === null || parsed === undefined) return {};
-
-      // Full-config validation
-      const result = ProjectConfigSchema.safeParse(parsed);
-      if (result.success) return result.data;
-
-      // Section-level fallback: extract valid sections
-      configLogger.warn({ issues: result.error.issues }, '.exarchos.yml validation errors');
-      return parseSections(parsed);
     }
   }
   return {};

--- a/servers/exarchos-mcp/src/config/yaml-schema.test.ts
+++ b/servers/exarchos-mcp/src/config/yaml-schema.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { ProjectConfigSchema } from './yaml-schema.js';
+
+describe('ProjectConfigSchema', () => {
+  it('ProjectConfigSchema_EmptyObject_Passes', () => {
+    const result = ProjectConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('ProjectConfigSchema_FullConfig_Passes', () => {
+    const result = ProjectConfigSchema.safeParse({
+      review: {
+        dimensions: { D1: 'blocking', D3: 'warning', D5: 'disabled' },
+        gates: { 'security-scan': { enabled: true, blocking: true } },
+        routing: { 'coderabbit-threshold': 0.6, 'risk-weights': {
+          'security-path': 0.30, 'api-surface': 0.20, 'diff-complexity': 0.15,
+          'new-files': 0.10, 'infra-config': 0.15, 'cross-module': 0.10
+        }}
+      },
+      vcs: { provider: 'github', settings: { 'auto-merge-strategy': 'squash' } },
+      workflow: { 'skip-phases': ['plan-review'], 'max-fix-cycles': 2, phases: { synthesize: { 'human-checkpoint': false } } },
+      tools: { 'default-branch': 'main', 'commit-style': 'conventional', 'auto-merge': true, 'pr-strategy': 'github-native' },
+      hooks: { on: { 'workflow.transition': [{ command: 'echo test', timeout: 5000 }] } }
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('ProjectConfigSchema_DimensionShorthand_Passes', () => {
+    const result = ProjectConfigSchema.safeParse({ review: { dimensions: { D3: 'warning' } } });
+    expect(result.success).toBe(true);
+  });
+
+  it('ProjectConfigSchema_DimensionLongform_Passes', () => {
+    const result = ProjectConfigSchema.safeParse({ review: { dimensions: { D3: { severity: 'warning' } } } });
+    expect(result.success).toBe(true);
+  });
+
+  it('ProjectConfigSchema_InvalidDimensionKey_Fails', () => {
+    const result = ProjectConfigSchema.safeParse({ review: { dimensions: { D6: 'blocking' } } });
+    expect(result.success).toBe(false);
+  });
+
+  it('ProjectConfigSchema_GateConfig_ValidatesParams', () => {
+    const result = ProjectConfigSchema.safeParse({ review: { gates: { 'tdd-compliance': { blocking: false, params: { 'coverage-threshold': 80 } } } } });
+    expect(result.success).toBe(true);
+  });
+
+  it('ProjectConfigSchema_RiskWeights_MustSumToOne', () => {
+    const result = ProjectConfigSchema.safeParse({ review: { routing: { 'risk-weights': {
+      'security-path': 0.30, 'api-surface': 0.20, 'diff-complexity': 0.15,
+      'new-files': 0.10, 'infra-config': 0.05, 'cross-module': 0.05
+    }}}});
+    expect(result.success).toBe(false);
+  });
+
+  it('ProjectConfigSchema_RiskWeights_SumToOne_Passes', () => {
+    const result = ProjectConfigSchema.safeParse({ review: { routing: { 'risk-weights': {
+      'security-path': 0.30, 'api-surface': 0.20, 'diff-complexity': 0.15,
+      'new-files': 0.10, 'infra-config': 0.15, 'cross-module': 0.10
+    }}}});
+    expect(result.success).toBe(true);
+  });
+
+  it('ProjectConfigSchema_UnknownTopLevelKey_Fails', () => {
+    const result = ProjectConfigSchema.safeParse({ foo: 1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('ProjectConfigSchema_VcsProvider_ValidatesEnum', () => {
+    expect(ProjectConfigSchema.safeParse({ vcs: { provider: 'github' } }).success).toBe(true);
+    expect(ProjectConfigSchema.safeParse({ vcs: { provider: 'gitlab' } }).success).toBe(true);
+    expect(ProjectConfigSchema.safeParse({ vcs: { provider: 'azure-devops' } }).success).toBe(true);
+    expect(ProjectConfigSchema.safeParse({ vcs: { provider: 'bitbucket' } }).success).toBe(false);
+  });
+
+  it('ProjectConfigSchema_SkipPhases_AcceptsStringArray', () => {
+    const result = ProjectConfigSchema.safeParse({ workflow: { 'skip-phases': ['plan-review'] } });
+    expect(result.success).toBe(true);
+  });
+
+  it('ProjectConfigSchema_MaxFixCycles_ValidatesRange', () => {
+    expect(ProjectConfigSchema.safeParse({ workflow: { 'max-fix-cycles': 0 } }).success).toBe(false);
+    expect(ProjectConfigSchema.safeParse({ workflow: { 'max-fix-cycles': 5 } }).success).toBe(true);
+    expect(ProjectConfigSchema.safeParse({ workflow: { 'max-fix-cycles': 11 } }).success).toBe(false);
+  });
+
+  it('ProjectConfigSchema_HookAction_RequiresCommand', () => {
+    const result = ProjectConfigSchema.safeParse({ hooks: { on: { 'workflow.transition': [{ timeout: 5000 }] } } });
+    expect(result.success).toBe(false);
+  });
+
+  it('ProjectConfigSchema_HookTimeout_ValidatesRange', () => {
+    expect(ProjectConfigSchema.safeParse({ hooks: { on: { 'test': [{ command: 'echo', timeout: 500 }] } } }).success).toBe(false);
+    expect(ProjectConfigSchema.safeParse({ hooks: { on: { 'test': [{ command: 'echo', timeout: 300001 }] } } }).success).toBe(false);
+    expect(ProjectConfigSchema.safeParse({ hooks: { on: { 'test': [{ command: 'echo', timeout: 5000 }] } } }).success).toBe(true);
+  });
+
+  it('ProjectConfigSchema_ToolsSection_ValidatesEnums', () => {
+    expect(ProjectConfigSchema.safeParse({ tools: { 'commit-style': 'conventional' } }).success).toBe(true);
+    expect(ProjectConfigSchema.safeParse({ tools: { 'commit-style': 'invalid' } }).success).toBe(false);
+    expect(ProjectConfigSchema.safeParse({ tools: { 'pr-strategy': 'github-native' } }).success).toBe(true);
+    expect(ProjectConfigSchema.safeParse({ tools: { 'pr-strategy': 'invalid' } }).success).toBe(false);
+  });
+});

--- a/servers/exarchos-mcp/src/config/yaml-schema.ts
+++ b/servers/exarchos-mcp/src/config/yaml-schema.ts
@@ -1,0 +1,103 @@
+import { z } from 'zod';
+
+// ─── Dimension Configuration ────────────────────────────────────────────────
+
+const DimensionSeverity = z.enum(['blocking', 'warning', 'disabled']);
+
+const DimensionLongform = z.object({
+  severity: DimensionSeverity.optional(),
+  enabled: z.boolean().optional(),
+}).strict();
+
+const DimensionConfig = z.union([DimensionSeverity, DimensionLongform]);
+
+const DimensionKey = z.enum(['D1', 'D2', 'D3', 'D4', 'D5']);
+
+const DimensionsMap = z.record(DimensionKey, DimensionConfig);
+
+// ─── Gate Configuration ─────────────────────────────────────────────────────
+
+const GateConfig = z.object({
+  enabled: z.boolean().optional(),
+  blocking: z.boolean().optional(),
+  params: z.record(z.string(), z.unknown()).optional(),
+}).strict();
+
+// ─── Risk Weights ───────────────────────────────────────────────────────────
+
+const RiskWeights = z.record(z.string(), z.number()).refine(
+  (weights) => {
+    const values = Object.values(weights);
+    if (values.length === 0) return true;
+    const sum = values.reduce((acc, v) => acc + v, 0);
+    return Math.abs(sum - 1.0) < 0.001;
+  },
+  { message: 'Risk weights must sum to 1.0' },
+);
+
+// ─── Routing Configuration ──────────────────────────────────────────────────
+
+const RoutingConfig = z.object({
+  'coderabbit-threshold': z.number().min(0).max(1).optional(),
+  'risk-weights': RiskWeights.optional(),
+}).strict();
+
+// ─── Review Configuration ───────────────────────────────────────────────────
+
+const ReviewConfig = z.object({
+  dimensions: DimensionsMap.optional(),
+  gates: z.record(z.string(), GateConfig).optional(),
+  routing: RoutingConfig.optional(),
+}).strict();
+
+// ─── VCS Configuration ─────────────────────────────────────────────────────
+
+const VcsConfig = z.object({
+  provider: z.enum(['github', 'gitlab', 'azure-devops']).optional(),
+  settings: z.record(z.string(), z.unknown()).optional(),
+}).strict();
+
+// ─── Workflow Phase Configuration ───────────────────────────────────────────
+
+const PhaseConfig = z.object({
+  'human-checkpoint': z.boolean().optional(),
+}).strict();
+
+const WorkflowConfig = z.object({
+  'skip-phases': z.array(z.string()).optional(),
+  'max-fix-cycles': z.number().int().min(1).max(10).optional(),
+  phases: z.record(z.string(), PhaseConfig).optional(),
+}).strict();
+
+// ─── Tools Configuration ───────────────────────────────────────────────────
+
+const ToolsConfig = z.object({
+  'default-branch': z.string().optional(),
+  'commit-style': z.enum(['conventional', 'freeform']).optional(),
+  'pr-template': z.string().optional(),
+  'auto-merge': z.boolean().optional(),
+  'pr-strategy': z.enum(['github-native', 'single']).optional(),
+}).strict();
+
+// ─── Hook Configuration ────────────────────────────────────────────────────
+
+const HookAction = z.object({
+  command: z.string(),
+  timeout: z.number().int().min(1000).max(300000).optional(),
+}).strict();
+
+const HooksConfig = z.object({
+  on: z.record(z.string(), z.array(HookAction)).optional(),
+}).strict();
+
+// ─── Top-Level Project Config ──────────────────────────────────────────────
+
+export const ProjectConfigSchema = z.object({
+  review: ReviewConfig.optional(),
+  vcs: VcsConfig.optional(),
+  workflow: WorkflowConfig.optional(),
+  tools: ToolsConfig.optional(),
+  hooks: HooksConfig.optional(),
+}).strict();
+
+export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;

--- a/servers/exarchos-mcp/src/core/context.test.ts
+++ b/servers/exarchos-mcp/src/core/context.test.ts
@@ -293,4 +293,77 @@ describe('initializeContext — projectConfig (YAML)', () => {
       await fs.rm(projectRoot, { recursive: true, force: true });
     }
   });
+
+  // ─── Fix 1: VcsProvider wiring (R4) ──────────────────────────────────────
+
+  it('initializeContext_WithProjectRoot_VcsProviderAvailable', async () => {
+    const { initializeContext } = await import('./context.js');
+
+    // Create empty project root (defaults to GitHub)
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ctx-vcs-'));
+
+    try {
+      const ctx = await initializeContext(tmpDir, { projectRoot });
+
+      // VcsProvider should be created and default to GitHub
+      expect(ctx.vcsProvider).toBeDefined();
+      expect(ctx.vcsProvider!.name).toBe('github');
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('initializeContext_WithGitLabConfig_VcsProviderIsGitLab', async () => {
+    const { initializeContext } = await import('./context.js');
+
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ctx-vcs-gl-'));
+    await fs.writeFile(
+      path.join(projectRoot, '.exarchos.yml'),
+      `vcs:\n  provider: gitlab\n`,
+    );
+
+    try {
+      const ctx = await initializeContext(tmpDir, { projectRoot });
+
+      expect(ctx.vcsProvider).toBeDefined();
+      expect(ctx.vcsProvider!.name).toBe('gitlab');
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('initializeContext_NoProjectRoot_VcsProviderUndefined', async () => {
+    const { initializeContext } = await import('./context.js');
+
+    const ctx = await initializeContext(tmpDir);
+
+    // Without projectRoot, there's no projectConfig, so no vcsProvider
+    expect(ctx.vcsProvider).toBeUndefined();
+  });
+
+  // ─── Fix 4: HookRunner wiring (R7) ──────────────────────────────────────
+
+  it('initializeContext_WithProjectRoot_HookRunnerAvailable', async () => {
+    const { initializeContext } = await import('./context.js');
+
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ctx-hook-'));
+
+    try {
+      const ctx = await initializeContext(tmpDir, { projectRoot });
+
+      // HookRunner should be created
+      expect(ctx.hookRunner).toBeDefined();
+      expect(typeof ctx.hookRunner).toBe('function');
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('initializeContext_NoProjectRoot_HookRunnerUndefined', async () => {
+    const { initializeContext } = await import('./context.js');
+
+    const ctx = await initializeContext(tmpDir);
+
+    expect(ctx.hookRunner).toBeUndefined();
+  });
 });

--- a/servers/exarchos-mcp/src/core/context.test.ts
+++ b/servers/exarchos-mcp/src/core/context.test.ts
@@ -170,3 +170,127 @@ describe('initializeContext', () => {
     await fs.rm(projectRoot, { recursive: true, force: true });
   });
 });
+
+describe('initializeContext — projectConfig (YAML)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'context-yaml-'));
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('initializeContext_WithProjectRoot_LoadsProjectConfig', async () => {
+    const { initializeContext } = await import('./context.js');
+
+    // Create a temp dir with .exarchos.yml
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ctx-yaml-'));
+    await fs.writeFile(
+      path.join(projectRoot, '.exarchos.yml'),
+      `review:\n  dimensions:\n    D3: warning\nvcs:\n  provider: gitlab\n`,
+    );
+
+    try {
+      const ctx = await initializeContext(tmpDir, { projectRoot });
+
+      expect(ctx.projectConfig).toBeDefined();
+      // D3 overridden to warning
+      expect(ctx.projectConfig!.review.dimensions.D3.severity).toBe('warning');
+      // D1 retains default
+      expect(ctx.projectConfig!.review.dimensions.D1.severity).toBe('blocking');
+      // VCS overridden
+      expect(ctx.projectConfig!.vcs.provider).toBe('gitlab');
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('initializeContext_NoYml_ProjectConfigIsDefaults', async () => {
+    const { initializeContext } = await import('./context.js');
+
+    // Create empty project root (no .exarchos.yml)
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ctx-noml-'));
+
+    try {
+      const ctx = await initializeContext(tmpDir, { projectRoot });
+
+      expect(ctx.projectConfig).toBeDefined();
+      // All defaults
+      expect(ctx.projectConfig!.review.dimensions.D1.severity).toBe('blocking');
+      expect(ctx.projectConfig!.vcs.provider).toBe('github');
+      expect(ctx.projectConfig!.workflow.maxFixCycles).toBe(3);
+      expect(ctx.projectConfig!.tools.commitStyle).toBe('conventional');
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('initializeContext_ProjectConfigBeforeExarchosConfig', async () => {
+    const { initializeContext } = await import('./context.js');
+
+    // Create a project root with both YAML config and JS config
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ctx-order-'));
+    await fs.writeFile(
+      path.join(projectRoot, '.exarchos.yml'),
+      `tools:\n  commit-style: freeform\n`,
+    );
+    await fs.writeFile(
+      path.join(projectRoot, 'exarchos.config.js'),
+      `export default { workflows: { test: { phases: ['a'], initialPhase: 'a', transitions: [] } } };`,
+    );
+
+    try {
+      const ctx = await initializeContext(tmpDir, { projectRoot });
+
+      // YAML config loaded
+      expect(ctx.projectConfig).toBeDefined();
+      expect(ctx.projectConfig!.tools.commitStyle).toBe('freeform');
+      // JS config also loaded
+      expect(ctx.config).toBeDefined();
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('dispatch_ProjectConfig_PassedToHandlers', async () => {
+    const { initializeContext } = await import('./context.js');
+    const { COMPOSITE_HANDLERS, dispatch } = await import('./dispatch.js');
+
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ctx-dispatch-'));
+    await fs.writeFile(
+      path.join(projectRoot, '.exarchos.yml'),
+      `vcs:\n  provider: azure-devops\n`,
+    );
+
+    try {
+      const ctx = await initializeContext(tmpDir, { projectRoot });
+
+      // Verify projectConfig is on the context
+      expect(ctx.projectConfig).toBeDefined();
+      expect(ctx.projectConfig!.vcs.provider).toBe('azure-devops');
+
+      // Verify the context can be passed to dispatch
+      let receivedCtx: unknown;
+      const spy = async (_args: Record<string, unknown>, c: typeof ctx) => {
+        receivedCtx = c;
+        return { success: true as const, data: { ok: true } };
+      };
+      const original = (COMPOSITE_HANDLERS as Record<string, unknown>)['exarchos_workflow'];
+      (COMPOSITE_HANDLERS as Record<string, unknown>)['exarchos_workflow'] = spy;
+
+      try {
+        await dispatch('exarchos_workflow', { action: 'test' }, ctx);
+        const capturedCtx = receivedCtx as typeof ctx;
+        expect(capturedCtx.projectConfig).toBeDefined();
+        expect(capturedCtx.projectConfig!.vcs.provider).toBe('azure-devops');
+      } finally {
+        (COMPOSITE_HANDLERS as Record<string, unknown>)['exarchos_workflow'] = original;
+      }
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/core/context.ts
+++ b/servers/exarchos-mcp/src/core/context.ts
@@ -6,6 +6,8 @@ import { loadConfig } from '../config/loader.js';
 import { loadProjectConfig } from '../config/yaml-loader.js';
 import { resolveConfig } from '../config/resolve.js';
 import { registerCustomWorkflows, registerCustomViews, registerCustomTools } from '../config/register.js';
+import { createVcsProvider } from '../vcs/factory.js';
+import { createConfigHookRunner } from '../hooks/config-hooks.js';
 
 // EventStore is now threaded via DispatchContext — no module-level injection needed
 import { configureCleanupSnapshotStore } from '../workflow/cleanup.js';
@@ -69,5 +71,9 @@ export async function initializeContext(
     }
   }
 
-  return { stateDir, eventStore, enableTelemetry, config, projectConfig };
+  // Create VCS provider and hook runner from resolved project config
+  const vcsProvider = projectConfig ? createVcsProvider(projectConfig) : undefined;
+  const hookRunner = projectConfig ? createConfigHookRunner(projectConfig) : undefined;
+
+  return { stateDir, eventStore, enableTelemetry, config, projectConfig, vcsProvider, hookRunner };
 }

--- a/servers/exarchos-mcp/src/core/context.ts
+++ b/servers/exarchos-mcp/src/core/context.ts
@@ -3,6 +3,8 @@ import { SnapshotStore } from '../views/snapshot-store.js';
 import type { DispatchContext } from './dispatch.js';
 import type { StorageBackend } from '../storage/backend.js';
 import { loadConfig } from '../config/loader.js';
+import { loadProjectConfig } from '../config/yaml-loader.js';
+import { resolveConfig } from '../config/resolve.js';
 import { registerCustomWorkflows, registerCustomViews, registerCustomTools } from '../config/register.js';
 
 // EventStore is now threaded via DispatchContext — no module-level injection needed
@@ -44,6 +46,11 @@ export async function initializeContext(
 
   const enableTelemetry = process.env.EXARCHOS_TELEMETRY !== 'false';
 
+  // Load YAML project config (.exarchos.yml) before JS/TS config
+  const projectConfig = options?.projectRoot
+    ? resolveConfig(loadProjectConfig(options.projectRoot))
+    : undefined;
+
   // Load config from project root if provided
   const config = options?.projectRoot
     ? await loadConfig(options.projectRoot)
@@ -62,5 +69,5 @@ export async function initializeContext(
     }
   }
 
-  return { stateDir, eventStore, enableTelemetry, config };
+  return { stateDir, eventStore, enableTelemetry, config, projectConfig };
 }

--- a/servers/exarchos-mcp/src/core/dispatch.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.ts
@@ -1,6 +1,7 @@
 import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import type { ExarchosConfig } from '../config/define.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
 import { withTelemetry } from '../telemetry/middleware.js';
 import { hasCustomToolHandlers, getCustomToolActionHandler, getFullRegistry } from '../registry.js';
 
@@ -23,6 +24,7 @@ export interface DispatchContext {
   readonly eventStore: EventStore;
   readonly enableTelemetry: boolean;
   readonly config?: ExarchosConfig;
+  readonly projectConfig?: ResolvedProjectConfig;
   readonly slimRegistration?: boolean;
 }
 

--- a/servers/exarchos-mcp/src/core/dispatch.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.ts
@@ -2,6 +2,8 @@ import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import type { ExarchosConfig } from '../config/define.js';
 import type { ResolvedProjectConfig } from '../config/resolve.js';
+import type { VcsProvider } from '../vcs/provider.js';
+import type { ConfigHookRunner } from '../hooks/config-hooks.js';
 import { withTelemetry } from '../telemetry/middleware.js';
 import { hasCustomToolHandlers, getCustomToolActionHandler, getFullRegistry } from '../registry.js';
 
@@ -25,6 +27,8 @@ export interface DispatchContext {
   readonly enableTelemetry: boolean;
   readonly config?: ExarchosConfig;
   readonly projectConfig?: ResolvedProjectConfig;
+  readonly vcsProvider?: VcsProvider;
+  readonly hookRunner?: ConfigHookRunner;
   readonly slimRegistration?: boolean;
 }
 

--- a/servers/exarchos-mcp/src/describe/handler-config.test.ts
+++ b/servers/exarchos-mcp/src/describe/handler-config.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { handleDescribe } from './handler.js';
+import { DEFAULTS, resolveConfig } from '../config/resolve.js';
+import { TOOL_REGISTRY } from '../registry.js';
+
+const workflowActions = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow')!.actions;
+
+describe('handleDescribe — config wiring (R8)', () => {
+  it('describe_ConfigTrue_ReturnsAnnotatedConfig', async () => {
+    const projectConfig = resolveConfig({
+      vcs: { provider: 'gitlab' },
+      workflow: { 'max-fix-cycles': 5 },
+    });
+
+    const result = await handleDescribe(
+      { config: true },
+      workflowActions,
+      { projectConfig },
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.config).toBeDefined();
+
+    const config = data.config as Record<string, unknown>;
+    const vcs = config.vcs as Record<string, unknown>;
+    const provider = vcs.provider as { value: string; source: string };
+    expect(provider.value).toBe('gitlab');
+    expect(provider.source).toBe('.exarchos.yml');
+
+    const workflow = config.workflow as Record<string, unknown>;
+    const maxFixCycles = workflow.maxFixCycles as { value: number; source: string };
+    expect(maxFixCycles.value).toBe(5);
+    expect(maxFixCycles.source).toBe('.exarchos.yml');
+  });
+
+  it('describe_ConfigTrue_NoProjectConfig_ReturnsMessage', async () => {
+    const result = await handleDescribe(
+      { config: true },
+      workflowActions,
+      { includeStateSchema: true }, // no projectConfig
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.config).toBeDefined();
+
+    const config = data.config as Record<string, unknown>;
+    expect(config.message).toContain('No .exarchos.yml');
+  });
+
+  it('describe_ConfigTrueWithDefaults_AllSourcesAreDefault', async () => {
+    const result = await handleDescribe(
+      { config: true },
+      workflowActions,
+      { projectConfig: DEFAULTS },
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const config = data.config as Record<string, unknown>;
+    const vcs = config.vcs as Record<string, unknown>;
+    const provider = vcs.provider as { value: string; source: string };
+    expect(provider.value).toBe('github');
+    expect(provider.source).toBe('default');
+  });
+
+  it('describe_ConfigFalseOrAbsent_NoConfigInResponse', async () => {
+    // config: false should not include config
+    // But we still need at least one of actions/topology/playbook/config
+    // So config:false alone would fail validation. Let's combine with topology.
+    const result = await handleDescribe(
+      { topology: 'all' },
+      workflowActions,
+      { projectConfig: DEFAULTS },
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.config).toBeUndefined();
+    expect(data.topology).toBeDefined();
+  });
+
+  it('describe_ConfigWithTopology_ReturnsBoth', async () => {
+    const projectConfig = resolveConfig({ tools: { 'auto-merge': false } });
+
+    const result = await handleDescribe(
+      { config: true, topology: 'all' },
+      workflowActions,
+      { projectConfig },
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.config).toBeDefined();
+    expect(data.topology).toBeDefined();
+
+    const config = data.config as Record<string, unknown>;
+    const tools = config.tools as Record<string, unknown>;
+    const autoMerge = tools.autoMerge as { value: boolean; source: string };
+    expect(autoMerge.value).toBe(false);
+    expect(autoMerge.source).toBe('.exarchos.yml');
+  });
+});

--- a/servers/exarchos-mcp/src/describe/handler.ts
+++ b/servers/exarchos-mcp/src/describe/handler.ts
@@ -1,6 +1,7 @@
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import type { ToolAction } from '../registry.js';
 import type { ToolResult } from '../format.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
 import {
   EVENT_DATA_SCHEMAS,
   EVENT_EMISSION_REGISTRY,
@@ -10,6 +11,7 @@ import {
 } from '../event-store/schemas.js';
 import { serializeTopology, listWorkflowTypes } from '../workflow/state-machine.js';
 import { serializePlaybooks, listPlaybookWorkflowTypes } from '../workflow/playbooks.js';
+import { buildConfigDescription } from '../workflow/describe-config.js';
 import {
   WorktreeSchema,
   TaskSchema,
@@ -25,9 +27,9 @@ import {
  * `playbook` parameter is provided.
  */
 export async function handleDescribe(
-  args: { actions?: string[]; topology?: string; playbook?: string },
+  args: { actions?: string[]; topology?: string; playbook?: string; config?: boolean },
   toolActions: readonly ToolAction[],
-  options?: { includeStateSchema?: boolean },
+  options?: { includeStateSchema?: boolean; projectConfig?: ResolvedProjectConfig },
 ): Promise<ToolResult> {
   // Guard clauses: reject malformed values before computing flags
   if (args.actions !== undefined && (!Array.isArray(args.actions) || !args.actions.every((a: unknown) => typeof a === 'string'))) {
@@ -64,17 +66,19 @@ export async function handleDescribe(
   const hasActions = Array.isArray(args.actions) && args.actions.length > 0;
   const hasTopology = typeof args.topology === 'string' && args.topology.length > 0;
   const hasPlaybook = typeof args.playbook === 'string' && args.playbook.length > 0;
+  const hasConfig = args.config === true;
 
-  if (!hasActions && !hasTopology && !hasPlaybook) {
+  if (!hasActions && !hasTopology && !hasPlaybook && !hasConfig) {
     return {
       success: false,
       error: {
         code: 'INVALID_INPUT',
-        message: 'describe requires at least one of actions, topology, or playbook',
+        message: 'describe requires at least one of actions, topology, playbook, or config',
         expectedShape: {
           actions: ['action_name_1', 'action_name_2'],
           topology: 'feature | debug | refactor | all',
           playbook: 'feature | debug | refactor | all',
+          config: true,
         },
       },
     };
@@ -126,6 +130,14 @@ export async function handleDescribe(
     const playbookResult = handlePlaybookDescribe(args.playbook as string);
     if (!playbookResult.success) return playbookResult;
     results.playbook = playbookResult.data;
+  }
+
+  // Resolve config description if requested
+  if (hasConfig && options?.projectConfig) {
+    results.config = buildConfigDescription(options.projectConfig);
+  } else if (hasConfig) {
+    // Config requested but no project config available — return informative message
+    results.config = { message: 'No .exarchos.yml project config loaded. Using all defaults.' };
   }
 
   return { success: true, data: results };

--- a/servers/exarchos-mcp/src/describe/handler.ts
+++ b/servers/exarchos-mcp/src/describe/handler.ts
@@ -62,6 +62,16 @@ export async function handleDescribe(
       },
     };
   }
+  if (args.config !== undefined && typeof args.config !== 'boolean') {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'config must be a boolean',
+        expectedShape: { config: true },
+      },
+    };
+  }
 
   const hasActions = Array.isArray(args.actions) && args.actions.length > 0;
   const hasTopology = typeof args.topology === 'string' && args.topology.length > 0;

--- a/servers/exarchos-mcp/src/event-store/composite-hooks.test.ts
+++ b/servers/exarchos-mcp/src/event-store/composite-hooks.test.ts
@@ -140,4 +140,60 @@ describe('handleEvent — hook runner wiring (R7)', () => {
     expect(result.success).toBe(true);
     expect(hookRunner).toHaveBeenCalledTimes(1);
   });
+
+  it('handleEvent_BatchAppendWithHookRunner_FiresHookForEachEvent', async () => {
+    const hookRunner = vi.fn<ConfigHookRunner>();
+
+    const ctx: DispatchContext = {
+      stateDir: tmpDir,
+      eventStore,
+      enableTelemetry: false,
+      hookRunner,
+    };
+
+    const result = await handleEvent({
+      action: 'batch_append',
+      stream: 'test-feature',
+      events: [
+        { type: 'task.assigned', data: { taskId: 't1' } },
+        { type: 'task.completed', data: { taskId: 't1' } },
+      ],
+    }, ctx);
+
+    expect(result.success).toBe(true);
+
+    // Hook runner should have been called once for each event in the batch
+    expect(hookRunner).toHaveBeenCalledTimes(2);
+    expect(hookRunner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'task.assigned',
+        featureId: 'test-feature',
+      }),
+    );
+    expect(hookRunner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'task.completed',
+        featureId: 'test-feature',
+      }),
+    );
+  });
+
+  it('handleEvent_BatchAppendWithoutHookRunner_SucceedsNormally', async () => {
+    const ctx: DispatchContext = {
+      stateDir: tmpDir,
+      eventStore,
+      enableTelemetry: false,
+      // No hookRunner
+    };
+
+    const result = await handleEvent({
+      action: 'batch_append',
+      stream: 'test-feature',
+      events: [
+        { type: 'task.assigned', data: { taskId: 't1' } },
+      ],
+    }, ctx);
+
+    expect(result.success).toBe(true);
+  });
 });

--- a/servers/exarchos-mcp/src/event-store/composite-hooks.test.ts
+++ b/servers/exarchos-mcp/src/event-store/composite-hooks.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { handleEvent } from './composite.js';
+import { EventStore } from './store.js';
+import type { DispatchContext } from '../core/dispatch.js';
+import type { ConfigHookRunner } from '../hooks/config-hooks.js';
+
+describe('handleEvent — hook runner wiring (R7)', () => {
+  let tmpDir: string;
+  let eventStore: EventStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'composite-hooks-'));
+    eventStore = new EventStore(tmpDir);
+    await eventStore.initialize();
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('handleEvent_AppendWithHookRunner_FiresHookAfterAppend', async () => {
+    // Create a mock hook runner
+    const hookRunner = vi.fn<ConfigHookRunner>();
+
+    const ctx: DispatchContext = {
+      stateDir: tmpDir,
+      eventStore,
+      enableTelemetry: false,
+      hookRunner,
+    };
+
+    // Append an event
+    const result = await handleEvent({
+      action: 'append',
+      stream: 'test-feature',
+      event: {
+        type: 'workflow.started',
+        data: { featureId: 'test-feature', workflowType: 'feature' },
+      },
+    }, ctx);
+
+    expect(result.success).toBe(true);
+
+    // Hook runner should have been called with the event info
+    expect(hookRunner).toHaveBeenCalledTimes(1);
+    expect(hookRunner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'workflow.started',
+        featureId: 'test-feature',
+      }),
+    );
+  });
+
+  it('handleEvent_AppendWithoutHookRunner_SucceedsNormally', async () => {
+    const ctx: DispatchContext = {
+      stateDir: tmpDir,
+      eventStore,
+      enableTelemetry: false,
+      // No hookRunner
+    };
+
+    const result = await handleEvent({
+      action: 'append',
+      stream: 'test-feature',
+      event: {
+        type: 'workflow.started',
+        data: { featureId: 'test-feature', workflowType: 'feature' },
+      },
+    }, ctx);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('handleEvent_AppendFailure_DoesNotFireHook', async () => {
+    const hookRunner = vi.fn<ConfigHookRunner>();
+
+    const ctx: DispatchContext = {
+      stateDir: tmpDir,
+      eventStore,
+      enableTelemetry: false,
+      hookRunner,
+    };
+
+    // Append with invalid event (no type) — should fail
+    const result = await handleEvent({
+      action: 'append',
+      stream: 'test-feature',
+      event: {},
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    // Hook runner should NOT have been called on failure
+    expect(hookRunner).not.toHaveBeenCalled();
+  });
+
+  it('handleEvent_QueryAction_DoesNotFireHook', async () => {
+    const hookRunner = vi.fn<ConfigHookRunner>();
+
+    const ctx: DispatchContext = {
+      stateDir: tmpDir,
+      eventStore,
+      enableTelemetry: false,
+      hookRunner,
+    };
+
+    // Query action should not fire hooks
+    const result = await handleEvent({
+      action: 'query',
+      stream: 'test-feature',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(hookRunner).not.toHaveBeenCalled();
+  });
+
+  it('handleEvent_HookRunnerThrows_DoesNotAffectResult', async () => {
+    const hookRunner = vi.fn<ConfigHookRunner>().mockRejectedValue(new Error('hook error'));
+
+    const ctx: DispatchContext = {
+      stateDir: tmpDir,
+      eventStore,
+      enableTelemetry: false,
+      hookRunner,
+    };
+
+    // Append should still succeed even if hook throws
+    const result = await handleEvent({
+      action: 'append',
+      stream: 'test-feature',
+      event: {
+        type: 'workflow.started',
+        data: { featureId: 'test-feature', workflowType: 'feature' },
+      },
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(hookRunner).toHaveBeenCalledTimes(1);
+  });
+});

--- a/servers/exarchos-mcp/src/event-store/composite.ts
+++ b/servers/exarchos-mcp/src/event-store/composite.ts
@@ -63,11 +63,27 @@ export async function handleEvent(
     }
     case 'batch_append': {
       const { action: _, ...rest } = args;
-      return handleBatchAppend(
+      const result = await handleBatchAppend(
         rest as Parameters<typeof handleBatchAppend>[0],
         stateDir,
         eventStore,
       );
+      if (result.success && ctx?.hookRunner) {
+        const batchArgs = rest as { stream?: string; events?: Array<Record<string, unknown>> };
+        for (const event of batchArgs.events ?? []) {
+          try {
+            await ctx.hookRunner({
+              type: (event.type as string) ?? '',
+              data: (event.data as Record<string, unknown>) ?? {},
+              featureId: (batchArgs.stream as string) ?? '',
+              timestamp: new Date().toISOString(),
+            });
+          } catch {
+            // Hooks are fire-and-forget — never block the event pipeline
+          }
+        }
+      }
+      return result;
     }
     case 'describe': {
       const { action: _, ...rest } = args;

--- a/servers/exarchos-mcp/src/event-store/composite.ts
+++ b/servers/exarchos-mcp/src/event-store/composite.ts
@@ -9,6 +9,31 @@ type EventAction = (typeof VALID_ACTIONS)[number];
 
 const eventActions = TOOL_REGISTRY.find(t => t.name === 'exarchos_event')!.actions;
 
+/**
+ * Fire hook runner after a successful event append.
+ * Constructs a WorkflowEvent shape from the append args and result data,
+ * then calls the hook runner in a fire-and-forget manner.
+ */
+async function fireHookIfConfigured(
+  ctx: DispatchContext,
+  appendArgs: Record<string, unknown>,
+  result: ToolResult,
+): Promise<void> {
+  if (!ctx.hookRunner || !result.success) return;
+  try {
+    const event = appendArgs.event as Record<string, unknown> | undefined;
+    const data = result.data as Record<string, unknown> | undefined;
+    await ctx.hookRunner({
+      type: (event?.type as string) ?? '',
+      data: (event?.data as Record<string, unknown>) ?? {},
+      featureId: (appendArgs.stream as string) ?? '',
+      timestamp: (data?.timestamp as string) ?? new Date().toISOString(),
+    });
+  } catch {
+    // Hooks are fire-and-forget — never block the event pipeline
+  }
+}
+
 /** Composite handler that routes `action` to the appropriate event-store handler. */
 export async function handleEvent(
   args: Record<string, unknown>,
@@ -20,11 +45,13 @@ export async function handleEvent(
   switch (action as EventAction) {
     case 'append': {
       const { action: _, ...rest } = args;
-      return handleEventAppend(
+      const result = await handleEventAppend(
         rest as Parameters<typeof handleEventAppend>[0],
         stateDir,
         eventStore,
       );
+      await fireHookIfConfigured(ctx, rest, result);
+      return result;
     }
     case 'query': {
       const { action: _, ...rest } = args;

--- a/servers/exarchos-mcp/src/hooks/config-hooks-integration.test.ts
+++ b/servers/exarchos-mcp/src/hooks/config-hooks-integration.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createConfigHookRunner } from './config-hooks.js';
+import { DEFAULTS } from '../config/resolve.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(() => ({
+    stdin: { write: vi.fn(), end: vi.fn() },
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+  })),
+}));
+
+import { spawn } from 'child_process';
+
+describe('Config Hook Integration', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('EventStore_Append_TriggersConfigHook', async () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      hooks: {
+        on: { 'workflow.transition': [{ command: './notify.sh', timeout: 10000 }] },
+      },
+    };
+
+    const runner = createConfigHookRunner(config);
+
+    // Simulate what would happen when EventStore appends a workflow.transition event
+    const event = {
+      type: 'workflow.transition',
+      data: { phase: 'review', from: 'delegate', workflowType: 'feature' },
+      featureId: 'ext-points',
+      timestamp: new Date().toISOString(),
+    };
+
+    await runner(event);
+    expect(vi.mocked(spawn)).toHaveBeenCalledWith(
+      'sh',
+      ['-c', './notify.sh'],
+      expect.anything(),
+    );
+  });
+
+  it('EventStore_Append_NoProjectConfig_NoHooks', async () => {
+    // With default config (no hooks configured), nothing fires
+    const runner = createConfigHookRunner(DEFAULTS);
+
+    await runner({
+      type: 'workflow.transition',
+      data: {},
+      featureId: 'test',
+      timestamp: '',
+    });
+
+    expect(vi.mocked(spawn)).not.toHaveBeenCalled();
+  });
+
+  it('EventStore_BatchAppend_TriggersHooksForEach', async () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      hooks: {
+        on: { 'task.completed': [{ command: 'echo done', timeout: 30000 }] },
+      },
+    };
+
+    const runner = createConfigHookRunner(config);
+
+    // Simulate batch append of 3 events
+    const events = [
+      { type: 'task.completed', data: { taskId: '1' }, featureId: 'f', timestamp: '' },
+      { type: 'task.completed', data: { taskId: '2' }, featureId: 'f', timestamp: '' },
+      { type: 'task.completed', data: { taskId: '3' }, featureId: 'f', timestamp: '' },
+    ];
+
+    for (const event of events) {
+      await runner(event);
+    }
+
+    expect(vi.mocked(spawn)).toHaveBeenCalledTimes(3);
+  });
+});

--- a/servers/exarchos-mcp/src/hooks/config-hooks.test.ts
+++ b/servers/exarchos-mcp/src/hooks/config-hooks.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createConfigHookRunner } from './config-hooks.js';
+import { DEFAULTS } from '../config/resolve.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+
+// Mock child_process.spawn
+vi.mock('child_process', () => ({
+  spawn: vi.fn(() => ({
+    stdin: { write: vi.fn(), end: vi.fn() },
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn(),
+    kill: vi.fn(),
+  })),
+}));
+
+import { spawn } from 'child_process';
+const mockSpawn = vi.mocked(spawn);
+
+describe('createConfigHookRunner', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.EXARCHOS_SKIP_HOOKS;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('ConfigHookRunner_MatchingEvent_ExecutesCommand', async () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      hooks: { on: { 'workflow.transition': [{ command: 'echo test', timeout: 30000 }] } },
+    };
+
+    const runner = createConfigHookRunner(config);
+    await runner({
+      type: 'workflow.transition',
+      data: { phase: 'plan' },
+      featureId: 'test-feature',
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'sh',
+      ['-c', 'echo test'],
+      expect.objectContaining({
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }),
+    );
+  });
+
+  it('ConfigHookRunner_NoMatchingHooks_Noop', async () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      hooks: { on: { 'gate.executed': [{ command: 'echo gate', timeout: 30000 }] } },
+    };
+
+    const runner = createConfigHookRunner(config);
+    await runner({
+      type: 'workflow.transition',
+      data: {},
+      featureId: 'test',
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('ConfigHookRunner_StdinReceivesEventJson', async () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      hooks: { on: { 'task.completed': [{ command: 'cat', timeout: 30000 }] } },
+    };
+
+    const mockStdin = { write: vi.fn(), end: vi.fn() };
+    mockSpawn.mockReturnValue({
+      stdin: mockStdin,
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn(),
+      kill: vi.fn(),
+    } as unknown as ReturnType<typeof spawn>);
+
+    const event = {
+      type: 'task.completed',
+      data: { taskId: 't1' },
+      featureId: 'feat-1',
+      timestamp: '2026-01-01T00:00:00Z',
+    };
+    const runner = createConfigHookRunner(config);
+    await runner(event);
+
+    expect(mockStdin.write).toHaveBeenCalledWith(JSON.stringify(event));
+    expect(mockStdin.end).toHaveBeenCalled();
+  });
+
+  it('ConfigHookRunner_EnvVarsSet_Correctly', async () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      hooks: { on: { 'workflow.transition': [{ command: 'env', timeout: 30000 }] } },
+    };
+
+    const runner = createConfigHookRunner(config);
+    await runner({
+      type: 'workflow.transition',
+      data: { phase: 'review', workflowType: 'feature' },
+      featureId: 'my-feat',
+      timestamp: '',
+    });
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'sh',
+      ['-c', 'env'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          EXARCHOS_FEATURE_ID: 'my-feat',
+          EXARCHOS_PHASE: 'review',
+          EXARCHOS_EVENT_TYPE: 'workflow.transition',
+          EXARCHOS_WORKFLOW_TYPE: 'feature',
+        }),
+      }),
+    );
+  });
+
+  it('ConfigHookRunner_CommandFailure_DoesNotThrow', async () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      hooks: { on: { 'test.event': [{ command: 'false', timeout: 30000 }] } },
+    };
+
+    mockSpawn.mockReturnValue({
+      stdin: { write: vi.fn(), end: vi.fn() },
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+        if (event === 'error') cb(new Error('fail'));
+      }),
+      kill: vi.fn(),
+    } as unknown as ReturnType<typeof spawn>);
+
+    const runner = createConfigHookRunner(config);
+    // Should not throw
+    await expect(
+      runner({ type: 'test.event', data: {}, featureId: 'test', timestamp: '' }),
+    ).resolves.not.toThrow();
+  });
+
+  it('ConfigHookRunner_MultipleHooks_AllFired', async () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      hooks: {
+        on: {
+          'workflow.transition': [
+            { command: 'echo first', timeout: 30000 },
+            { command: 'echo second', timeout: 30000 },
+          ],
+        },
+      },
+    };
+
+    const runner = createConfigHookRunner(config);
+    await runner({
+      type: 'workflow.transition',
+      data: {},
+      featureId: 'test',
+      timestamp: '',
+    });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('ConfigHookRunner_TestEnv_SkipsExecution', async () => {
+    process.env.EXARCHOS_SKIP_HOOKS = 'true';
+
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      hooks: { on: { 'workflow.transition': [{ command: 'echo test', timeout: 30000 }] } },
+    };
+
+    const runner = createConfigHookRunner(config);
+    await runner({
+      type: 'workflow.transition',
+      data: {},
+      featureId: 'test',
+      timestamp: '',
+    });
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+});

--- a/servers/exarchos-mcp/src/hooks/config-hooks.test.ts
+++ b/servers/exarchos-mcp/src/hooks/config-hooks.test.ts
@@ -6,7 +6,7 @@ import type { ResolvedProjectConfig } from '../config/resolve.js';
 // Mock child_process.spawn
 vi.mock('child_process', () => ({
   spawn: vi.fn(() => ({
-    stdin: { write: vi.fn(), end: vi.fn() },
+    stdin: { write: vi.fn(), end: vi.fn(), on: vi.fn() },
     stdout: { on: vi.fn() },
     stderr: { on: vi.fn() },
     on: vi.fn(),
@@ -76,7 +76,7 @@ describe('createConfigHookRunner', () => {
       hooks: { on: { 'task.completed': [{ command: 'cat', timeout: 30000 }] } },
     };
 
-    const mockStdin = { write: vi.fn(), end: vi.fn() };
+    const mockStdin = { write: vi.fn(), end: vi.fn(), on: vi.fn() };
     mockSpawn.mockReturnValue({
       stdin: mockStdin,
       stdout: { on: vi.fn() },
@@ -94,6 +94,7 @@ describe('createConfigHookRunner', () => {
     const runner = createConfigHookRunner(config);
     await runner(event);
 
+    expect(mockStdin.on).toHaveBeenCalledWith('error', expect.any(Function));
     expect(mockStdin.write).toHaveBeenCalledWith(JSON.stringify(event));
     expect(mockStdin.end).toHaveBeenCalled();
   });
@@ -133,7 +134,7 @@ describe('createConfigHookRunner', () => {
     };
 
     mockSpawn.mockReturnValue({
-      stdin: { write: vi.fn(), end: vi.fn() },
+      stdin: { write: vi.fn(), end: vi.fn(), on: vi.fn() },
       stdout: { on: vi.fn() },
       stderr: { on: vi.fn() },
       on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {

--- a/servers/exarchos-mcp/src/hooks/config-hooks.ts
+++ b/servers/exarchos-mcp/src/hooks/config-hooks.ts
@@ -1,0 +1,75 @@
+import { spawn } from 'child_process';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface WorkflowEvent {
+  readonly type: string;
+  readonly data: Record<string, unknown>;
+  readonly featureId: string;
+  readonly timestamp: string;
+}
+
+export type ConfigHookRunner = (event: WorkflowEvent) => Promise<void>;
+
+// ─── Factory ─────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a fire-and-forget hook runner bound to the resolved project config.
+ *
+ * When an event is fired, the runner looks up matching hooks in
+ * `config.hooks.on[event.type]` and spawns each configured command via
+ * `sh -c`. The event JSON is written to each process's stdin. Hook
+ * failures are silently swallowed so they never block workflow operations.
+ *
+ * Environment variables injected into each hook process:
+ * - EXARCHOS_FEATURE_ID  — the feature stream being operated on
+ * - EXARCHOS_PHASE       — current workflow phase (from event.data.phase)
+ * - EXARCHOS_EVENT_TYPE  — the event type string
+ * - EXARCHOS_WORKFLOW_TYPE — workflow type (from event.data.workflowType)
+ *
+ * Set EXARCHOS_SKIP_HOOKS=true to disable all hook execution (useful in tests).
+ *
+ * Integration point: call the returned runner after EventStore.append() in
+ * orchestrate handlers to fire hooks on workflow events. Do NOT modify
+ * EventStore.append() itself — hooks are an external concern.
+ */
+export function createConfigHookRunner(
+  config: ResolvedProjectConfig,
+): ConfigHookRunner {
+  return async (event: WorkflowEvent): Promise<void> => {
+    // Skip hooks when env var is set (test/CI environments)
+    if (process.env.EXARCHOS_SKIP_HOOKS === 'true') return;
+
+    const handlers = config.hooks.on[event.type];
+    if (!handlers?.length) return;
+
+    const env = {
+      ...process.env,
+      EXARCHOS_FEATURE_ID: event.featureId,
+      EXARCHOS_PHASE: String(event.data?.phase ?? ''),
+      EXARCHOS_EVENT_TYPE: event.type,
+      EXARCHOS_WORKFLOW_TYPE: String(event.data?.workflowType ?? ''),
+    };
+
+    for (const handler of handlers) {
+      try {
+        const proc = spawn('sh', ['-c', handler.command], {
+          env,
+          stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: handler.timeout,
+        });
+
+        proc.stdin.write(JSON.stringify(event));
+        proc.stdin.end();
+
+        // Fire-and-forget — attach error handler to prevent unhandled exceptions
+        proc.on('error', () => {
+          // Silently ignore hook errors — hooks must never block workflow
+        });
+      } catch {
+        // Silently ignore spawn errors — hooks must never block workflow
+      }
+    }
+  };
+}

--- a/servers/exarchos-mcp/src/hooks/config-hooks.ts
+++ b/servers/exarchos-mcp/src/hooks/config-hooks.ts
@@ -60,6 +60,9 @@ export function createConfigHookRunner(
           timeout: handler.timeout,
         });
 
+        proc.stdin.on('error', () => {
+          // Prevent unhandled error events on stdin
+        });
         proc.stdin.write(JSON.stringify(event));
         proc.stdin.end();
 

--- a/servers/exarchos-mcp/src/orchestrate/config-gate-integration.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/config-gate-integration.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withConfigSeverity } from './gate-utils.js';
+import { DEFAULTS } from '../config/resolve.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+import type { ToolResult } from '../format.js';
+
+describe('withConfigSeverity', () => {
+  const mockGateHandler = vi.fn<() => Promise<ToolResult>>();
+
+  it('GateHandler_DisabledGate_SkipsExecution', async () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      review: {
+        ...DEFAULTS.review,
+        gates: { 'test-gate': { enabled: false, blocking: true, params: {} } },
+      },
+    };
+
+    const result = await withConfigSeverity('test-gate', 'D1', config, mockGateHandler);
+    expect(result.success).toBe(true);
+    expect((result.data as Record<string, unknown>).skipped).toBe(true);
+    expect(mockGateHandler).not.toHaveBeenCalled();
+  });
+
+  it('GateHandler_WarningGate_ExecutesButDoesNotBlock', async () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      review: {
+        ...DEFAULTS.review,
+        gates: { 'test-gate': { enabled: true, blocking: false, params: {} } },
+      },
+    };
+
+    mockGateHandler.mockResolvedValue({
+      success: false,
+      error: { code: 'GATE_FAILED', message: 'Gate failed' },
+    });
+
+    const result = await withConfigSeverity('test-gate', 'D1', config, mockGateHandler);
+    expect(result.success).toBe(true); // warning gates don't block
+    expect(result.warnings).toEqual(expect.arrayContaining([expect.stringContaining('warning-only')]));
+    expect(mockGateHandler).toHaveBeenCalled();
+  });
+
+  it('GateHandler_BlockingGate_FailureBlocks', async () => {
+    mockGateHandler.mockResolvedValue({
+      success: false,
+      error: { code: 'GATE_FAILED', message: 'Gate failed' },
+    });
+
+    const result = await withConfigSeverity('test-gate', 'D1', DEFAULTS, mockGateHandler);
+    expect(result.success).toBe(false); // blocking gates fail
+  });
+
+  it('GateHandler_NoProjectConfig_DefaultBehavior', async () => {
+    mockGateHandler.mockResolvedValue({
+      success: false,
+      error: { code: 'GATE_FAILED', message: 'Gate failed' },
+    });
+
+    const result = await withConfigSeverity('test-gate', 'D1', undefined, mockGateHandler);
+    expect(result.success).toBe(false); // no config = all blocking
+    expect(mockGateHandler).toHaveBeenCalled();
+  });
+
+  it('GateHandler_BlockingGate_PassStillPasses', async () => {
+    mockGateHandler.mockResolvedValue({
+      success: true,
+      data: { passed: true },
+    });
+
+    const result = await withConfigSeverity('test-gate', 'D1', DEFAULTS, mockGateHandler);
+    expect(result.success).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/gate-severity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-severity.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { resolveGateSeverity } from './gate-severity.js';
+import { DEFAULTS } from '../config/resolve.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+
+// Helper to create config with overrides
+function configWith(overrides: Partial<ResolvedProjectConfig['review']>): ResolvedProjectConfig {
+  return {
+    ...DEFAULTS,
+    review: { ...DEFAULTS.review, ...overrides },
+  };
+}
+
+describe('resolveGateSeverity', () => {
+  it('resolveGateSeverity_NoOverrides_ReturnsBlocking', () => {
+    const result = resolveGateSeverity('security-scan', 'D1', DEFAULTS);
+    expect(result).toBe('blocking');
+  });
+
+  it('resolveGateSeverity_DimensionWarning_ReturnsWarning', () => {
+    const config = configWith({
+      dimensions: { ...DEFAULTS.review.dimensions, D3: { severity: 'warning', enabled: true } },
+    });
+    expect(resolveGateSeverity('context-economy', 'D3', config)).toBe('warning');
+  });
+
+  it('resolveGateSeverity_DimensionDisabled_ReturnsDisabled', () => {
+    const config = configWith({
+      dimensions: { ...DEFAULTS.review.dimensions, D5: { severity: 'disabled', enabled: false } },
+    });
+    expect(resolveGateSeverity('workflow-determinism', 'D5', config)).toBe('disabled');
+  });
+
+  it('resolveGateSeverity_GateBlockingTrue_OverridesDimension', () => {
+    const config = configWith({
+      dimensions: { ...DEFAULTS.review.dimensions, D3: { severity: 'warning', enabled: true } },
+      gates: { 'context-economy': { enabled: true, blocking: true, params: {} } },
+    });
+    expect(resolveGateSeverity('context-economy', 'D3', config)).toBe('blocking');
+  });
+
+  it('resolveGateSeverity_GateBlockingFalse_OverridesDimension', () => {
+    const config = configWith({
+      gates: { 'tdd-compliance': { enabled: true, blocking: false, params: {} } },
+    });
+    expect(resolveGateSeverity('tdd-compliance', 'D1', config)).toBe('warning');
+  });
+
+  it('resolveGateSeverity_GateDisabled_OverridesDimension', () => {
+    const config = configWith({
+      gates: { 'error-handling-audit': { enabled: false, blocking: true, params: {} } },
+    });
+    expect(resolveGateSeverity('error-handling-audit', 'D4', config)).toBe('disabled');
+  });
+
+  it('resolveGateSeverity_GateEnabled_DimensionDisabled_RespectsGate', () => {
+    const config = configWith({
+      dimensions: { ...DEFAULTS.review.dimensions, D5: { severity: 'disabled', enabled: false } },
+      gates: { 'workflow-determinism': { enabled: true, blocking: true, params: {} } },
+    });
+    expect(resolveGateSeverity('workflow-determinism', 'D5', config)).toBe('blocking');
+  });
+
+  it('resolveGateSeverity_UnknownGate_FallsBackToDimension', () => {
+    const config = configWith({
+      dimensions: { ...DEFAULTS.review.dimensions, D3: { severity: 'warning', enabled: true } },
+    });
+    expect(resolveGateSeverity('unknown-gate', 'D3', config)).toBe('warning');
+  });
+
+  it('resolveGateSeverity_UnknownDimension_DefaultsBlocking', () => {
+    expect(resolveGateSeverity('some-gate', 'D99', DEFAULTS)).toBe('blocking');
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/gate-severity.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-severity.ts
@@ -1,0 +1,37 @@
+// ─── Gate Severity Resolution ───────────────────────────────────────────────
+//
+// Resolves the effective severity for a quality gate by layering gate-level
+// overrides on top of dimension-level settings from project config.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+
+type DimensionKey = 'D1' | 'D2' | 'D3' | 'D4' | 'D5';
+type Severity = 'blocking' | 'warning' | 'disabled';
+
+/**
+ * Resolves the effective severity for a named gate within a dimension.
+ *
+ * Resolution order (highest precedence first):
+ * 1. Gate-level override (`review.gates[gateName]`)
+ * 2. Dimension-level setting (`review.dimensions[dimension]`)
+ * 3. Default: `'blocking'` (unknown dimensions)
+ */
+export function resolveGateSeverity(
+  gateName: string,
+  dimension: string,
+  config: ResolvedProjectConfig,
+): Severity {
+  // Gate-level override takes precedence
+  const gateOverride = config.review.gates[gateName];
+  if (gateOverride) {
+    if (!gateOverride.enabled) return 'disabled';
+    return gateOverride.blocking ? 'blocking' : 'warning';
+  }
+
+  // Fall back to dimension-level setting
+  const dimKey = dimension as DimensionKey;
+  const dimConfig = config.review.dimensions[dimKey];
+  if (!dimConfig) return 'blocking'; // unknown dimension defaults to blocking
+  return dimConfig.severity;
+}

--- a/servers/exarchos-mcp/src/orchestrate/gate-severity.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-severity.ts
@@ -33,5 +33,6 @@ export function resolveGateSeverity(
   const dimKey = dimension as DimensionKey;
   const dimConfig = config.review.dimensions[dimKey];
   if (!dimConfig) return 'blocking'; // unknown dimension defaults to blocking
+  if (!dimConfig.enabled) return 'disabled';
   return dimConfig.severity;
 }

--- a/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
+++ b/servers/exarchos-mcp/src/orchestrate/gate-utils.ts
@@ -5,6 +5,9 @@
 
 import { execFileSync } from 'node:child_process';
 import type { EventStore } from '../event-store/store.js';
+import type { ToolResult } from '../format.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+import { resolveGateSeverity } from './gate-severity.js';
 
 /**
  * Fetch the unified diff between baseBranch and HEAD.
@@ -49,4 +52,53 @@ export async function emitGateEvent(
       ...(details !== undefined ? { details } : {}),
     },
   });
+}
+
+// ─── Config-Aware Gate Wrapper ──────────────────────────────────────────────
+
+/**
+ * Wraps a gate handler with config-aware severity resolution.
+ *
+ * - **disabled**: Skips execution entirely, returns success with `skipped: true`
+ * - **warning**: Executes handler; converts failures to success with a warning
+ * - **blocking**: Executes handler; failures remain failures (default behaviour)
+ *
+ * When `config` is `undefined`, defaults to blocking (backwards compatible).
+ */
+export async function withConfigSeverity(
+  gateName: string,
+  dimension: string,
+  config: ResolvedProjectConfig | undefined,
+  handler: () => Promise<ToolResult>,
+): Promise<ToolResult> {
+  // When no config, default to blocking (backwards compat)
+  if (!config) {
+    return handler();
+  }
+
+  const severity = resolveGateSeverity(gateName, dimension, config);
+
+  if (severity === 'disabled') {
+    return {
+      success: true,
+      data: { skipped: true, reason: `Gate '${gateName}' disabled by project config` },
+    };
+  }
+
+  const result = await handler();
+
+  // If gate passed, return as-is regardless of severity
+  if (result.success) return result;
+
+  // If severity is 'warning', convert failure to success with warning
+  if (severity === 'warning') {
+    return {
+      success: true,
+      data: result.data ?? result.error,
+      warnings: [`Gate '${gateName}' failed but is configured as warning-only`],
+    };
+  }
+
+  // Blocking: return failure as-is
+  return result;
 }

--- a/servers/exarchos-mcp/src/orchestrate/tools-config-wiring.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/tools-config-wiring.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { getToolsConfig } from './tools-config.js';
+import { DEFAULTS, resolveConfig } from '../config/resolve.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+
+describe('getToolsConfig — wiring validation (R6)', () => {
+  it('getToolsConfig_WithDefaults_ReturnsDefaultTools', () => {
+    const tools = getToolsConfig(DEFAULTS);
+
+    expect(tools.defaultBranch).toBeUndefined();
+    expect(tools.commitStyle).toBe('conventional');
+    expect(tools.autoMerge).toBe(true);
+    expect(tools.prStrategy).toBe('github-native');
+  });
+
+  it('getToolsConfig_WithOverrides_ReturnsOverriddenTools', () => {
+    const config = resolveConfig({
+      tools: {
+        'default-branch': 'develop',
+        'commit-style': 'freeform',
+        'auto-merge': false,
+        'pr-strategy': 'single',
+      },
+    });
+    const tools = getToolsConfig(config);
+
+    expect(tools.defaultBranch).toBe('develop');
+    expect(tools.commitStyle).toBe('freeform');
+    expect(tools.autoMerge).toBe(false);
+    expect(tools.prStrategy).toBe('single');
+  });
+
+  it('getToolsConfig_UndefinedConfig_ReturnsDefaults', () => {
+    const tools = getToolsConfig(undefined);
+
+    expect(tools.commitStyle).toBe('conventional');
+    expect(tools.autoMerge).toBe(true);
+  });
+
+  it('getToolsConfig_AccessibleFromProjectConfig_ViaContext', () => {
+    // Verify the function works with the config shape that comes from
+    // DispatchContext.projectConfig — ensuring end-to-end wiring
+    const projectConfig: ResolvedProjectConfig = resolveConfig({
+      tools: { 'auto-merge': false },
+    });
+
+    const tools = getToolsConfig(projectConfig);
+    expect(tools.autoMerge).toBe(false);
+
+    // Verify other defaults are preserved
+    expect(tools.commitStyle).toBe('conventional');
+    expect(tools.prStrategy).toBe('github-native');
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/tools-config.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/tools-config.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { getToolsConfig } from './tools-config.js';
+import { DEFAULTS } from '../config/resolve.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+
+describe('Tools Config', () => {
+  it('ToolsConfig_DefaultValues_MatchExpected', () => {
+    expect(DEFAULTS.tools.commitStyle).toBe('conventional');
+    expect(DEFAULTS.tools.autoMerge).toBe(true);
+    expect(DEFAULTS.tools.prStrategy).toBe('github-native');
+    expect(DEFAULTS.tools.defaultBranch).toBeUndefined();
+    expect(DEFAULTS.tools.prTemplate).toBeUndefined();
+  });
+
+  it('ToolsConfig_AutoMergeFalse_Configurable', () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      tools: { ...DEFAULTS.tools, autoMerge: false },
+    };
+    expect(config.tools.autoMerge).toBe(false);
+  });
+
+  it('ToolsConfig_CommitStyleConventional_IsDefault', () => {
+    expect(DEFAULTS.tools.commitStyle).toBe('conventional');
+  });
+
+  it('ToolsConfig_PrStrategyGithubNative_IsDefault', () => {
+    expect(DEFAULTS.tools.prStrategy).toBe('github-native');
+  });
+
+  it('ToolsConfig_PrStrategySingle_Configurable', () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      tools: { ...DEFAULTS.tools, prStrategy: 'single' },
+    };
+    expect(config.tools.prStrategy).toBe('single');
+  });
+
+  it('ToolsConfig_DefaultBranch_Configurable', () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      tools: { ...DEFAULTS.tools, defaultBranch: 'develop' },
+    };
+    expect(config.tools.defaultBranch).toBe('develop');
+  });
+
+  it('ToolsConfig_FreeformCommitStyle_Configurable', () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      tools: { ...DEFAULTS.tools, commitStyle: 'freeform' },
+    };
+    expect(config.tools.commitStyle).toBe('freeform');
+  });
+
+  it('getToolsConfig_WithConfig_ReturnsConfigTools', () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      tools: { ...DEFAULTS.tools, autoMerge: false, commitStyle: 'freeform' },
+    };
+    const tools = getToolsConfig(config);
+    expect(tools.autoMerge).toBe(false);
+    expect(tools.commitStyle).toBe('freeform');
+  });
+
+  it('getToolsConfig_WithoutConfig_ReturnsDefaults', () => {
+    const tools = getToolsConfig(undefined);
+    expect(tools.commitStyle).toBe('conventional');
+    expect(tools.autoMerge).toBe(true);
+    expect(tools.prStrategy).toBe('github-native');
+  });
+
+  it('getToolsConfig_WithDefaults_MatchesDefaultsTools', () => {
+    const tools = getToolsConfig(DEFAULTS);
+    expect(tools).toEqual(DEFAULTS.tools);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/tools-config.ts
+++ b/servers/exarchos-mcp/src/orchestrate/tools-config.ts
@@ -1,0 +1,6 @@
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+import { DEFAULTS } from '../config/resolve.js';
+
+export function getToolsConfig(config?: ResolvedProjectConfig): ResolvedProjectConfig['tools'] {
+  return config?.tools ?? DEFAULTS.tools;
+}

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -254,7 +254,7 @@ function makeDescribeAction(): ToolAction {
   };
 }
 
-/** Workflow-specific describe schema: supports actions, topology, and playbooks. */
+/** Workflow-specific describe schema: supports actions, topology, playbooks, and config. */
 const workflowDescribeSchema = z.object({
   actions: z.array(z.string()).min(1).max(10)
     .describe('Action names to describe. Returns full schema + description for each.')
@@ -265,13 +265,16 @@ const workflowDescribeSchema = z.object({
   playbook: z.string()
     .describe('Workflow type for phase playbooks. "all" lists types.')
     .optional(),
+  config: z.boolean()
+    .describe('When true, returns annotated project config showing values and sources (default vs .exarchos.yml).')
+    .optional(),
 });
 
-/** Creates a workflow-specific describe action with topology and playbook support. */
+/** Creates a workflow-specific describe action with topology, playbook, and config support. */
 function makeWorkflowDescribeAction(): ToolAction {
   return {
     name: 'describe',
-    description: 'Return full schemas, descriptions, gate metadata, and phase/role info for specific actions. Optionally return HSM topology or phase playbooks for a workflow type.',
+    description: 'Return full schemas, descriptions, gate metadata, and phase/role info for specific actions. Optionally return HSM topology, phase playbooks, or annotated project config.',
     schema: workflowDescribeSchema,
     phases: ALL_PHASES,
     roles: ROLE_ANY,

--- a/servers/exarchos-mcp/src/vcs/azure-devops.ts
+++ b/servers/exarchos-mcp/src/vcs/azure-devops.ts
@@ -1,0 +1,51 @@
+// ─── Azure DevOps VCS Provider (Stub) ────────────────────────────────────────
+//
+// Placeholder implementation for Azure DevOps support.
+// Track progress at https://github.com/lvlup-sw/exarchos/issues/1024
+
+import type {
+  VcsProvider,
+  CreatePrOpts,
+  PrResult,
+  CiStatus,
+  MergeResult,
+  ReviewStatus,
+} from './provider.js';
+
+export class AzureDevOpsProvider implements VcsProvider {
+  readonly name = 'azure-devops' as const;
+
+  constructor(_config: Record<string, unknown>) {
+    // Config reserved for future use
+  }
+
+  async createPr(_opts: CreatePrOpts): Promise<PrResult> {
+    throw new Error(
+      'Azure DevOps support is not yet implemented. Track progress at https://github.com/lvlup-sw/exarchos/issues/1024'
+    );
+  }
+
+  async checkCi(_prId: string): Promise<CiStatus> {
+    throw new Error(
+      'Azure DevOps support is not yet implemented. Track progress at https://github.com/lvlup-sw/exarchos/issues/1024'
+    );
+  }
+
+  async mergePr(_prId: string, _strategy: string): Promise<MergeResult> {
+    throw new Error(
+      'Azure DevOps support is not yet implemented. Track progress at https://github.com/lvlup-sw/exarchos/issues/1024'
+    );
+  }
+
+  async addComment(_prId: string, _body: string): Promise<void> {
+    throw new Error(
+      'Azure DevOps support is not yet implemented. Track progress at https://github.com/lvlup-sw/exarchos/issues/1024'
+    );
+  }
+
+  async getReviewStatus(_prId: string): Promise<ReviewStatus> {
+    throw new Error(
+      'Azure DevOps support is not yet implemented. Track progress at https://github.com/lvlup-sw/exarchos/issues/1024'
+    );
+  }
+}

--- a/servers/exarchos-mcp/src/vcs/factory.test.ts
+++ b/servers/exarchos-mcp/src/vcs/factory.test.ts
@@ -43,7 +43,7 @@ describe('createVcsProvider', () => {
   });
 
   it('createVcsProvider_NoProjectConfig_DefaultsToGitHub', () => {
-    const provider = createVcsProvider(undefined as unknown as ResolvedProjectConfig);
+    const provider = createVcsProvider(undefined);
     expect(provider).toBeInstanceOf(GitHubProvider);
   });
 });

--- a/servers/exarchos-mcp/src/vcs/factory.test.ts
+++ b/servers/exarchos-mcp/src/vcs/factory.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { createVcsProvider } from './factory.js';
+import { DEFAULTS } from '../config/resolve.js';
+import { GitHubProvider } from './github.js';
+import { GitLabProvider } from './gitlab.js';
+import { AzureDevOpsProvider } from './azure-devops.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+
+describe('createVcsProvider', () => {
+  it('createVcsProvider_GitHub_ReturnsGitHubProvider', () => {
+    const provider = createVcsProvider(DEFAULTS); // default is github
+    expect(provider).toBeInstanceOf(GitHubProvider);
+    expect(provider.name).toBe('github');
+  });
+
+  it('createVcsProvider_GitLab_ReturnsGitLabProvider', () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      vcs: { provider: 'gitlab', settings: {} },
+    };
+    const provider = createVcsProvider(config);
+    expect(provider).toBeInstanceOf(GitLabProvider);
+    expect(provider.name).toBe('gitlab');
+  });
+
+  it('createVcsProvider_AzureDevOps_ReturnsAzureProvider', () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      vcs: { provider: 'azure-devops', settings: {} },
+    };
+    const provider = createVcsProvider(config);
+    expect(provider).toBeInstanceOf(AzureDevOpsProvider);
+    expect(provider.name).toBe('azure-devops');
+  });
+
+  it('createVcsProvider_PassesSettings_ToProvider', () => {
+    const config: ResolvedProjectConfig = {
+      ...DEFAULTS,
+      vcs: { provider: 'github', settings: { 'auto-merge-strategy': 'rebase' } },
+    };
+    const provider = createVcsProvider(config);
+    expect(provider).toBeInstanceOf(GitHubProvider);
+  });
+
+  it('createVcsProvider_NoProjectConfig_DefaultsToGitHub', () => {
+    const provider = createVcsProvider(undefined as unknown as ResolvedProjectConfig);
+    expect(provider).toBeInstanceOf(GitHubProvider);
+  });
+});

--- a/servers/exarchos-mcp/src/vcs/factory.ts
+++ b/servers/exarchos-mcp/src/vcs/factory.ts
@@ -1,0 +1,17 @@
+import type { VcsProvider } from './provider.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+import { GitHubProvider } from './github.js';
+import { GitLabProvider } from './gitlab.js';
+import { AzureDevOpsProvider } from './azure-devops.js';
+
+export function createVcsProvider(config?: ResolvedProjectConfig): VcsProvider {
+  const provider = config?.vcs?.provider ?? 'github';
+  const settings = config?.vcs?.settings ?? {};
+
+  switch (provider) {
+    case 'github': return new GitHubProvider(settings);
+    case 'gitlab': return new GitLabProvider(settings);
+    case 'azure-devops': return new AzureDevOpsProvider(settings);
+    default: return new GitHubProvider(settings);
+  }
+}

--- a/servers/exarchos-mcp/src/vcs/github.test.ts
+++ b/servers/exarchos-mcp/src/vcs/github.test.ts
@@ -154,7 +154,11 @@ describe('GitHubProvider', () => {
   });
 
   it('GitHubProvider_MergePr_DefaultsToSquash', async () => {
-    mockExec.mockResolvedValue(JSON.stringify({ sha: 'abc123' }));
+    // First call: gh pr merge (human-readable output)
+    // Second call: gh pr view --json mergeCommit
+    mockExec
+      .mockResolvedValueOnce('Merged pull request #42')
+      .mockResolvedValueOnce(JSON.stringify({ mergeCommit: { oid: 'abc123' } }));
 
     await provider.mergePr('42', 'squash');
     expect(mockExec).toHaveBeenCalledWith(
@@ -164,7 +168,9 @@ describe('GitHubProvider', () => {
   });
 
   it('GitHubProvider_MergePr_UsesRebaseStrategy', async () => {
-    mockExec.mockResolvedValue(JSON.stringify({ sha: 'def456' }));
+    mockExec
+      .mockResolvedValueOnce('Merged pull request #42')
+      .mockResolvedValueOnce(JSON.stringify({ mergeCommit: { oid: 'def456' } }));
 
     await provider.mergePr('42', 'rebase');
     expect(mockExec).toHaveBeenCalledWith(
@@ -174,7 +180,9 @@ describe('GitHubProvider', () => {
   });
 
   it('GitHubProvider_MergePr_UsesMergeStrategy', async () => {
-    mockExec.mockResolvedValue(JSON.stringify({ sha: 'ghi789' }));
+    mockExec
+      .mockResolvedValueOnce('Merged pull request #42')
+      .mockResolvedValueOnce(JSON.stringify({ mergeCommit: { oid: 'ghi789' } }));
 
     await provider.mergePr('42', 'merge');
     expect(mockExec).toHaveBeenCalledWith(
@@ -184,11 +192,37 @@ describe('GitHubProvider', () => {
   });
 
   it('GitHubProvider_MergePr_ReturnsMergedResult', async () => {
-    mockExec.mockResolvedValue(JSON.stringify({ sha: 'abc123' }));
+    mockExec
+      .mockResolvedValueOnce('Merged pull request #42')
+      .mockResolvedValueOnce(JSON.stringify({ mergeCommit: { oid: 'abc123' } }));
 
     const result = await provider.mergePr('42', 'squash');
     expect(result.merged).toBe(true);
     expect(result.sha).toBe('abc123');
+  });
+
+  it('GitHubProvider_MergePr_ReturnsMergedWithoutSha_WhenViewFails', async () => {
+    mockExec
+      .mockResolvedValueOnce('Merged pull request #42')
+      .mockRejectedValueOnce(new Error('view failed'));
+
+    const result = await provider.mergePr('42', 'squash');
+    expect(result.merged).toBe(true);
+    expect(result.sha).toBeUndefined();
+  });
+
+  it('GitHubProvider_MergePr_FetchesShaViaGhPrView', async () => {
+    mockExec
+      .mockResolvedValueOnce('Merged pull request #42')
+      .mockResolvedValueOnce(JSON.stringify({ mergeCommit: { oid: 'sha-from-view' } }));
+
+    const result = await provider.mergePr('42', 'squash');
+    expect(result.sha).toBe('sha-from-view');
+
+    // Second call should be gh pr view --json mergeCommit
+    expect(mockExec).toHaveBeenNthCalledWith(2, 'gh', [
+      'pr', 'view', '42', '--json', 'mergeCommit',
+    ]);
   });
 
   it('GitHubProvider_MergePr_HandlesFailure', async () => {

--- a/servers/exarchos-mcp/src/vcs/github.test.ts
+++ b/servers/exarchos-mcp/src/vcs/github.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GitHubProvider } from './github.js';
+
+// Mock the shell execution helper
+vi.mock('./shell.js', () => ({
+  exec: vi.fn(),
+}));
+
+import { exec } from './shell.js';
+const mockExec = vi.mocked(exec);
+
+describe('GitHubProvider', () => {
+  let provider: GitHubProvider;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    provider = new GitHubProvider({});
+  });
+
+  it('GitHubProvider_Name_IsGithub', () => {
+    expect(provider.name).toBe('github');
+  });
+
+  it('GitHubProvider_CreatePr_CallsGhWithCorrectArgs', async () => {
+    mockExec.mockResolvedValue(
+      JSON.stringify({ url: 'https://github.com/test/repo/pull/42', number: 42 })
+    );
+
+    const result = await provider.createPr({
+      title: 'feat: test',
+      body: 'Test PR',
+      baseBranch: 'main',
+      headBranch: 'feat/test',
+    });
+
+    expect(mockExec).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining([
+        'pr',
+        'create',
+        '--title',
+        'feat: test',
+        '--body',
+        'Test PR',
+        '--base',
+        'main',
+        '--head',
+        'feat/test',
+        '--json',
+        'url,number',
+      ])
+    );
+    expect(result.url).toBe('https://github.com/test/repo/pull/42');
+    expect(result.number).toBe(42);
+  });
+
+  it('GitHubProvider_CreatePr_IncludesDraftFlag', async () => {
+    mockExec.mockResolvedValue(
+      JSON.stringify({ url: 'https://github.com/test/repo/pull/43', number: 43 })
+    );
+
+    await provider.createPr({
+      title: 'draft pr',
+      body: 'WIP',
+      baseBranch: 'main',
+      headBranch: 'feat/wip',
+      draft: true,
+    });
+
+    expect(mockExec).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining(['--draft'])
+    );
+  });
+
+  it('GitHubProvider_CreatePr_IncludesLabels', async () => {
+    mockExec.mockResolvedValue(
+      JSON.stringify({ url: 'https://github.com/test/repo/pull/44', number: 44 })
+    );
+
+    await provider.createPr({
+      title: 'labeled pr',
+      body: 'with labels',
+      baseBranch: 'main',
+      headBranch: 'feat/labels',
+      labels: ['bug', 'priority'],
+    });
+
+    expect(mockExec).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining(['--label', 'bug,priority'])
+    );
+  });
+
+  it('GitHubProvider_CheckCi_ParsesGhOutput', async () => {
+    mockExec.mockResolvedValue(
+      JSON.stringify([
+        { name: 'tests', conclusion: 'success', detailsUrl: 'https://ci/1' },
+        { name: 'lint', conclusion: 'failure', detailsUrl: 'https://ci/2' },
+      ])
+    );
+
+    const result = await provider.checkCi('42');
+    expect(result.status).toBe('fail');
+    expect(result.checks).toHaveLength(2);
+    expect(result.checks[0]).toEqual({
+      name: 'tests',
+      status: 'pass',
+      url: 'https://ci/1',
+    });
+    expect(result.checks[1]).toEqual({
+      name: 'lint',
+      status: 'fail',
+      url: 'https://ci/2',
+    });
+  });
+
+  it('GitHubProvider_CheckCi_AllPassing', async () => {
+    mockExec.mockResolvedValue(
+      JSON.stringify([
+        { name: 'tests', conclusion: 'success', detailsUrl: 'https://ci/1' },
+        { name: 'lint', conclusion: 'success', detailsUrl: 'https://ci/2' },
+      ])
+    );
+
+    const result = await provider.checkCi('42');
+    expect(result.status).toBe('pass');
+  });
+
+  it('GitHubProvider_CheckCi_PendingChecks', async () => {
+    mockExec.mockResolvedValue(
+      JSON.stringify([
+        { name: 'tests', conclusion: null, detailsUrl: 'https://ci/1' },
+        { name: 'lint', conclusion: 'success', detailsUrl: 'https://ci/2' },
+      ])
+    );
+
+    const result = await provider.checkCi('42');
+    expect(result.status).toBe('pending');
+    expect(result.checks[0].status).toBe('pending');
+  });
+
+  it('GitHubProvider_CheckCi_SkippedChecks', async () => {
+    mockExec.mockResolvedValue(
+      JSON.stringify([
+        { name: 'optional', conclusion: 'skipped', detailsUrl: 'https://ci/1' },
+      ])
+    );
+
+    const result = await provider.checkCi('42');
+    expect(result.checks[0].status).toBe('skipped');
+    // Skipped-only should be pass
+    expect(result.status).toBe('pass');
+  });
+
+  it('GitHubProvider_MergePr_DefaultsToSquash', async () => {
+    mockExec.mockResolvedValue(JSON.stringify({ sha: 'abc123' }));
+
+    await provider.mergePr('42', 'squash');
+    expect(mockExec).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining(['pr', 'merge', '42', '--squash'])
+    );
+  });
+
+  it('GitHubProvider_MergePr_UsesRebaseStrategy', async () => {
+    mockExec.mockResolvedValue(JSON.stringify({ sha: 'def456' }));
+
+    await provider.mergePr('42', 'rebase');
+    expect(mockExec).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining(['pr', 'merge', '42', '--rebase'])
+    );
+  });
+
+  it('GitHubProvider_MergePr_UsesMergeStrategy', async () => {
+    mockExec.mockResolvedValue(JSON.stringify({ sha: 'ghi789' }));
+
+    await provider.mergePr('42', 'merge');
+    expect(mockExec).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining(['pr', 'merge', '42', '--merge'])
+    );
+  });
+
+  it('GitHubProvider_MergePr_ReturnsMergedResult', async () => {
+    mockExec.mockResolvedValue(JSON.stringify({ sha: 'abc123' }));
+
+    const result = await provider.mergePr('42', 'squash');
+    expect(result.merged).toBe(true);
+    expect(result.sha).toBe('abc123');
+  });
+
+  it('GitHubProvider_MergePr_HandlesFailure', async () => {
+    mockExec.mockRejectedValue(new Error('merge conflict'));
+
+    const result = await provider.mergePr('42', 'squash');
+    expect(result.merged).toBe(false);
+    expect(result.error).toBe('merge conflict');
+  });
+
+  it('GitHubProvider_AddComment_CallsGhPrComment', async () => {
+    mockExec.mockResolvedValue('');
+
+    await provider.addComment('42', 'LGTM');
+    expect(mockExec).toHaveBeenCalledWith(
+      'gh',
+      expect.arrayContaining(['pr', 'comment', '42', '--body', 'LGTM'])
+    );
+  });
+
+  it('GitHubProvider_GetReviewStatus_ParsesApproved', async () => {
+    mockExec.mockResolvedValue(
+      JSON.stringify({
+        reviews: [{ author: { login: 'reviewer1' }, state: 'APPROVED' }],
+        reviewDecision: 'APPROVED',
+      })
+    );
+
+    const result = await provider.getReviewStatus('42');
+    expect(result.state).toBe('approved');
+    expect(result.reviewers).toHaveLength(1);
+    expect(result.reviewers[0].login).toBe('reviewer1');
+    expect(result.reviewers[0].state).toBe('approved');
+  });
+
+  it('GitHubProvider_GetReviewStatus_ParsesChangesRequested', async () => {
+    mockExec.mockResolvedValue(
+      JSON.stringify({
+        reviews: [
+          { author: { login: 'reviewer1' }, state: 'CHANGES_REQUESTED' },
+          { author: { login: 'reviewer2' }, state: 'APPROVED' },
+        ],
+        reviewDecision: 'CHANGES_REQUESTED',
+      })
+    );
+
+    const result = await provider.getReviewStatus('42');
+    expect(result.state).toBe('changes_requested');
+    expect(result.reviewers).toHaveLength(2);
+    expect(result.reviewers[0].state).toBe('changes_requested');
+    expect(result.reviewers[1].state).toBe('approved');
+  });
+
+  it('GitHubProvider_GetReviewStatus_ParsesPending', async () => {
+    mockExec.mockResolvedValue(
+      JSON.stringify({
+        reviews: [],
+        reviewDecision: 'REVIEW_REQUIRED',
+      })
+    );
+
+    const result = await provider.getReviewStatus('42');
+    expect(result.state).toBe('pending');
+    expect(result.reviewers).toHaveLength(0);
+  });
+});

--- a/servers/exarchos-mcp/src/vcs/github.ts
+++ b/servers/exarchos-mcp/src/vcs/github.ts
@@ -141,9 +141,25 @@ export class GitHubProvider implements VcsProvider {
     const strategyFlag = `--${strategy}`;
 
     try {
-      const output = await exec('gh', ['pr', 'merge', prId, strategyFlag]);
-      const parsed = JSON.parse(output) as { sha: string };
-      return { merged: true, sha: parsed.sha };
+      // gh pr merge outputs human-readable text, not JSON — don't parse it
+      await exec('gh', ['pr', 'merge', prId, strategyFlag]);
+
+      // Merge succeeded — fetch the merge commit SHA via gh pr view
+      try {
+        const viewOutput = await exec('gh', [
+          'pr',
+          'view',
+          prId,
+          '--json',
+          'mergeCommit',
+        ]);
+        const parsed = JSON.parse(viewOutput) as { mergeCommit?: { oid?: string } };
+        const sha = parsed.mergeCommit?.oid;
+        return sha ? { merged: true, sha } : { merged: true };
+      } catch {
+        // SHA retrieval failed — merge still succeeded
+        return { merged: true };
+      }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       return { merged: false, error: message };

--- a/servers/exarchos-mcp/src/vcs/github.ts
+++ b/servers/exarchos-mcp/src/vcs/github.ts
@@ -1,0 +1,177 @@
+// ─── GitHub VCS Provider ─────────────────────────────────────────────────────
+//
+// Implements VcsProvider by wrapping the `gh` CLI.
+// Requires `gh` to be installed and authenticated.
+
+import type {
+  VcsProvider,
+  CreatePrOpts,
+  PrResult,
+  CiCheck,
+  CiStatus,
+  MergeResult,
+  ReviewerStatus,
+  ReviewStatus,
+} from './provider.js';
+import { exec } from './shell.js';
+
+interface GhCheckEntry {
+  readonly name: string;
+  readonly conclusion: string | null;
+  readonly detailsUrl?: string;
+}
+
+interface GhReviewEntry {
+  readonly author: { readonly login: string };
+  readonly state: string;
+}
+
+interface GhReviewResponse {
+  readonly reviews: readonly GhReviewEntry[];
+  readonly reviewDecision: string;
+}
+
+function mapConclusion(conclusion: string | null): CiCheck['status'] {
+  if (conclusion === null) return 'pending';
+  switch (conclusion) {
+    case 'success':
+      return 'pass';
+    case 'failure':
+      return 'fail';
+    case 'skipped':
+      return 'skipped';
+    default:
+      return 'pending';
+  }
+}
+
+function computeOverallCiStatus(checks: readonly CiCheck[]): CiStatus['status'] {
+  const hasFailure = checks.some((c) => c.status === 'fail');
+  if (hasFailure) return 'fail';
+
+  const hasPending = checks.some((c) => c.status === 'pending');
+  if (hasPending) return 'pending';
+
+  return 'pass';
+}
+
+function mapReviewState(ghState: string): ReviewerStatus['state'] {
+  switch (ghState) {
+    case 'APPROVED':
+      return 'approved';
+    case 'CHANGES_REQUESTED':
+      return 'changes_requested';
+    case 'COMMENTED':
+      return 'commented';
+    default:
+      return 'pending';
+  }
+}
+
+function mapReviewDecision(decision: string): ReviewStatus['state'] {
+  switch (decision) {
+    case 'APPROVED':
+      return 'approved';
+    case 'CHANGES_REQUESTED':
+      return 'changes_requested';
+    default:
+      return 'pending';
+  }
+}
+
+export class GitHubProvider implements VcsProvider {
+  readonly name = 'github' as const;
+
+  constructor(_config: Record<string, unknown>) {
+    // Config reserved for future use (e.g., custom gh path)
+  }
+
+  async createPr(opts: CreatePrOpts): Promise<PrResult> {
+    const args = [
+      'pr',
+      'create',
+      '--title',
+      opts.title,
+      '--body',
+      opts.body,
+      '--base',
+      opts.baseBranch,
+      '--head',
+      opts.headBranch,
+      '--json',
+      'url,number',
+    ];
+
+    if (opts.draft) {
+      args.push('--draft');
+    }
+
+    if (opts.labels && opts.labels.length > 0) {
+      args.push('--label', opts.labels.join(','));
+    }
+
+    const output = await exec('gh', args);
+    const parsed = JSON.parse(output) as { url: string; number: number };
+    return { url: parsed.url, number: parsed.number };
+  }
+
+  async checkCi(prId: string): Promise<CiStatus> {
+    const output = await exec('gh', [
+      'pr',
+      'checks',
+      prId,
+      '--json',
+      'name,conclusion,detailsUrl',
+    ]);
+
+    const entries = JSON.parse(output) as readonly GhCheckEntry[];
+    const checks: CiCheck[] = entries.map((entry) => ({
+      name: entry.name,
+      status: mapConclusion(entry.conclusion),
+      url: entry.detailsUrl,
+    }));
+
+    return {
+      status: computeOverallCiStatus(checks),
+      checks,
+    };
+  }
+
+  async mergePr(prId: string, strategy: string): Promise<MergeResult> {
+    const strategyFlag = `--${strategy}`;
+
+    try {
+      const output = await exec('gh', ['pr', 'merge', prId, strategyFlag]);
+      const parsed = JSON.parse(output) as { sha: string };
+      return { merged: true, sha: parsed.sha };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { merged: false, error: message };
+    }
+  }
+
+  async addComment(prId: string, body: string): Promise<void> {
+    await exec('gh', ['pr', 'comment', prId, '--body', body]);
+  }
+
+  async getReviewStatus(prId: string): Promise<ReviewStatus> {
+    const output = await exec('gh', [
+      'pr',
+      'view',
+      prId,
+      '--json',
+      'reviews,reviewDecision',
+    ]);
+
+    const parsed = JSON.parse(output) as GhReviewResponse;
+    const reviewers: ReviewerStatus[] = parsed.reviews.map((r) => ({
+      login: r.author.login,
+      state: mapReviewState(r.state),
+    }));
+
+    return {
+      state: mapReviewDecision(parsed.reviewDecision),
+      reviewers,
+    };
+  }
+}

--- a/servers/exarchos-mcp/src/vcs/gitlab.ts
+++ b/servers/exarchos-mcp/src/vcs/gitlab.ts
@@ -1,0 +1,51 @@
+// ─── GitLab VCS Provider (Stub) ──────────────────────────────────────────────
+//
+// Placeholder implementation for GitLab support.
+// Track progress at https://github.com/lvlup-sw/exarchos/issues/1024
+
+import type {
+  VcsProvider,
+  CreatePrOpts,
+  PrResult,
+  CiStatus,
+  MergeResult,
+  ReviewStatus,
+} from './provider.js';
+
+export class GitLabProvider implements VcsProvider {
+  readonly name = 'gitlab' as const;
+
+  constructor(_config: Record<string, unknown>) {
+    // Config reserved for future use
+  }
+
+  async createPr(_opts: CreatePrOpts): Promise<PrResult> {
+    throw new Error(
+      'GitLab support is not yet implemented. Track progress at https://github.com/lvlup-sw/exarchos/issues/1024'
+    );
+  }
+
+  async checkCi(_prId: string): Promise<CiStatus> {
+    throw new Error(
+      'GitLab support is not yet implemented. Track progress at https://github.com/lvlup-sw/exarchos/issues/1024'
+    );
+  }
+
+  async mergePr(_prId: string, _strategy: string): Promise<MergeResult> {
+    throw new Error(
+      'GitLab support is not yet implemented. Track progress at https://github.com/lvlup-sw/exarchos/issues/1024'
+    );
+  }
+
+  async addComment(_prId: string, _body: string): Promise<void> {
+    throw new Error(
+      'GitLab support is not yet implemented. Track progress at https://github.com/lvlup-sw/exarchos/issues/1024'
+    );
+  }
+
+  async getReviewStatus(_prId: string): Promise<ReviewStatus> {
+    throw new Error(
+      'GitLab support is not yet implemented. Track progress at https://github.com/lvlup-sw/exarchos/issues/1024'
+    );
+  }
+}

--- a/servers/exarchos-mcp/src/vcs/provider.test.ts
+++ b/servers/exarchos-mcp/src/vcs/provider.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { GitLabProvider } from './gitlab.js';
+import { AzureDevOpsProvider } from './azure-devops.js';
+import type { VcsProvider } from './provider.js';
+
+describe('VcsProvider', () => {
+  it('VcsProvider_Interface_DefinesRequiredMethods', () => {
+    // Type-level test: verify interface is implementable
+    const provider: VcsProvider = {
+      name: 'github',
+      createPr: async () => ({ url: '', number: 0 }),
+      checkCi: async () => ({ status: 'pending', checks: [] }),
+      mergePr: async () => ({ merged: false }),
+      addComment: async () => {},
+      getReviewStatus: async () => ({ state: 'pending', reviewers: [] }),
+    };
+    expect(provider.name).toBe('github');
+  });
+
+  it('GitLabProvider_CreatePr_ThrowsNotImplemented', async () => {
+    const provider = new GitLabProvider({});
+    await expect(provider.createPr({
+      title: 'test', body: 'test', baseBranch: 'main', headBranch: 'feat'
+    })).rejects.toThrow(/not yet implemented/i);
+  });
+
+  it('AzureDevOpsProvider_CreatePr_ThrowsNotImplemented', async () => {
+    const provider = new AzureDevOpsProvider({});
+    await expect(provider.createPr({
+      title: 'test', body: 'test', baseBranch: 'main', headBranch: 'feat'
+    })).rejects.toThrow(/not yet implemented/i);
+  });
+
+  it('GitLabProvider_Name_IsGitlab', () => {
+    const provider = new GitLabProvider({});
+    expect(provider.name).toBe('gitlab');
+  });
+
+  it('AzureDevOpsProvider_Name_IsAzureDevOps', () => {
+    const provider = new AzureDevOpsProvider({});
+    expect(provider.name).toBe('azure-devops');
+  });
+
+  it('GitLabProvider_AllMethods_ThrowNotImplemented', async () => {
+    const provider = new GitLabProvider({});
+    await expect(provider.checkCi('1')).rejects.toThrow(/not yet implemented/i);
+    await expect(provider.mergePr('1', 'squash')).rejects.toThrow(/not yet implemented/i);
+    await expect(provider.addComment('1', 'test')).rejects.toThrow(/not yet implemented/i);
+    await expect(provider.getReviewStatus('1')).rejects.toThrow(/not yet implemented/i);
+  });
+
+  it('AzureDevOpsProvider_AllMethods_ThrowNotImplemented', async () => {
+    const provider = new AzureDevOpsProvider({});
+    await expect(provider.checkCi('1')).rejects.toThrow(/not yet implemented/i);
+    await expect(provider.mergePr('1', 'squash')).rejects.toThrow(/not yet implemented/i);
+    await expect(provider.addComment('1', 'test')).rejects.toThrow(/not yet implemented/i);
+    await expect(provider.getReviewStatus('1')).rejects.toThrow(/not yet implemented/i);
+  });
+});

--- a/servers/exarchos-mcp/src/vcs/provider.ts
+++ b/servers/exarchos-mcp/src/vcs/provider.ts
@@ -1,0 +1,54 @@
+// ─── VCS Provider Interface ──────────────────────────────────────────────────
+//
+// Abstraction layer for version control system operations.
+// Enables Exarchos to work with GitHub, GitLab, and Azure DevOps.
+
+export interface CreatePrOpts {
+  readonly title: string;
+  readonly body: string;
+  readonly baseBranch: string;
+  readonly headBranch: string;
+  readonly draft?: boolean;
+  readonly labels?: readonly string[];
+}
+
+export interface PrResult {
+  readonly url: string;
+  readonly number: number;
+}
+
+export interface CiCheck {
+  readonly name: string;
+  readonly status: 'pass' | 'fail' | 'pending' | 'skipped';
+  readonly url?: string;
+}
+
+export interface CiStatus {
+  readonly status: 'pass' | 'fail' | 'pending';
+  readonly checks: readonly CiCheck[];
+}
+
+export interface MergeResult {
+  readonly merged: boolean;
+  readonly sha?: string;
+  readonly error?: string;
+}
+
+export interface ReviewerStatus {
+  readonly login: string;
+  readonly state: 'approved' | 'changes_requested' | 'pending' | 'commented';
+}
+
+export interface ReviewStatus {
+  readonly state: 'approved' | 'changes_requested' | 'pending';
+  readonly reviewers: readonly ReviewerStatus[];
+}
+
+export interface VcsProvider {
+  readonly name: 'github' | 'gitlab' | 'azure-devops';
+  createPr(opts: CreatePrOpts): Promise<PrResult>;
+  checkCi(prId: string): Promise<CiStatus>;
+  mergePr(prId: string, strategy: string): Promise<MergeResult>;
+  addComment(prId: string, body: string): Promise<void>;
+  getReviewStatus(prId: string): Promise<ReviewStatus>;
+}

--- a/servers/exarchos-mcp/src/vcs/shell.ts
+++ b/servers/exarchos-mcp/src/vcs/shell.ts
@@ -9,6 +9,10 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 
 export async function exec(command: string, args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync(command, args, { encoding: 'utf-8' });
+  const { stdout } = await execFileAsync(command, args, {
+    encoding: 'utf-8',
+    timeout: 30_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
   return stdout.trim();
 }

--- a/servers/exarchos-mcp/src/vcs/shell.ts
+++ b/servers/exarchos-mcp/src/vcs/shell.ts
@@ -1,0 +1,14 @@
+// ─── Shell Execution Helper ──────────────────────────────────────────────────
+//
+// Thin wrapper around child_process.execFile for CLI invocations.
+// Separated for easy mocking in tests.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export async function exec(command: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync(command, args, { encoding: 'utf-8' });
+  return stdout.trim();
+}

--- a/servers/exarchos-mcp/src/workflow/composite.test.ts
+++ b/servers/exarchos-mcp/src/workflow/composite.test.ts
@@ -69,6 +69,7 @@ describe('handleWorkflow', () => {
         { featureId: 'test', phase: 'delegate', updates: { track: 'polish' } },
         stateDir,
         ctx.eventStore,
+        undefined,
       );
       expect(result).toEqual({ success: true, data: { phase: 'set-result' } });
     });

--- a/servers/exarchos-mcp/src/workflow/composite.ts
+++ b/servers/exarchos-mcp/src/workflow/composite.ts
@@ -24,8 +24,15 @@ export async function handleWorkflow(
       return handleInit(rest as Parameters<typeof handleInit>[0], stateDir, eventStore);
     case 'get':
       return handleGet(rest as Parameters<typeof handleGet>[0], stateDir, eventStore);
-    case 'set':
-      return handleSet(rest as Parameters<typeof handleSet>[0], stateDir, eventStore);
+    case 'set': {
+      const skipPhases = ctx.projectConfig?.workflow.skipPhases;
+      return handleSet(
+        rest as Parameters<typeof handleSet>[0],
+        stateDir,
+        eventStore,
+        skipPhases?.length ? { skipPhases } : undefined,
+      );
+    }
     case 'cancel':
       return handleCancel(rest as Parameters<typeof handleCancel>[0], stateDir, eventStore);
     case 'cleanup':
@@ -33,7 +40,11 @@ export async function handleWorkflow(
     case 'reconcile':
       return handleReconcileState(rest as Parameters<typeof handleReconcileState>[0], stateDir, eventStore);
     case 'describe':
-      return handleDescribe(rest as { actions?: string[]; topology?: string; playbook?: string }, workflowActions, { includeStateSchema: true });
+      return handleDescribe(
+        rest as { actions?: string[]; topology?: string; playbook?: string; config?: boolean },
+        workflowActions,
+        { includeStateSchema: true, projectConfig: ctx.projectConfig },
+      );
     default:
       return {
         success: false,

--- a/servers/exarchos-mcp/src/workflow/describe-config.test.ts
+++ b/servers/exarchos-mcp/src/workflow/describe-config.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { buildConfigDescription } from './describe-config.js';
+import { DEFAULTS, resolveConfig } from '../config/resolve.js';
+
+describe('buildConfigDescription', () => {
+  it('DescribeConfig_NoYml_AllDefaults', () => {
+    const result = buildConfigDescription(DEFAULTS);
+    expect(result.review.dimensions.D1.value).toBe('blocking');
+    expect(result.review.dimensions.D1.source).toBe('default');
+    expect(result.vcs.provider.source).toBe('default');
+  });
+
+  it('DescribeConfig_WithOverrides_SourceAnnotated', () => {
+    const config = resolveConfig({ review: { dimensions: { D3: 'warning' } } });
+    const result = buildConfigDescription(config);
+
+    expect(result.review.dimensions.D3.value).toBe('warning');
+    expect(result.review.dimensions.D3.source).toBe('.exarchos.yml');
+    // Unchanged dimensions should be 'default'
+    expect(result.review.dimensions.D1.source).toBe('default');
+  });
+
+  it('DescribeConfig_AllSectionsPresent', () => {
+    const result = buildConfigDescription(DEFAULTS);
+    expect(result).toHaveProperty('review');
+    expect(result).toHaveProperty('vcs');
+    expect(result).toHaveProperty('workflow');
+    expect(result).toHaveProperty('tools');
+    expect(result).toHaveProperty('hooks');
+  });
+
+  it('DescribeConfig_GateOverride_ShowsGateAndDimension', () => {
+    const config = resolveConfig({
+      review: { gates: { 'tdd-compliance': { blocking: false } } },
+    });
+    const result = buildConfigDescription(config);
+
+    expect(result.review.gates['tdd-compliance'].blocking.value).toBe(false);
+    expect(result.review.gates['tdd-compliance'].blocking.source).toBe('.exarchos.yml');
+  });
+
+  it('DescribeConfig_VcsOverride_ShowsSource', () => {
+    const config = resolveConfig({ vcs: { provider: 'gitlab' } });
+    const result = buildConfigDescription(config);
+
+    expect(result.vcs.provider.value).toBe('gitlab');
+    expect(result.vcs.provider.source).toBe('.exarchos.yml');
+  });
+
+  it('DescribeConfig_ToolsDefaults_AllDefault', () => {
+    const result = buildConfigDescription(DEFAULTS);
+    expect(result.tools.commitStyle.value).toBe('conventional');
+    expect(result.tools.commitStyle.source).toBe('default');
+    expect(result.tools.autoMerge.value).toBe(true);
+    expect(result.tools.autoMerge.source).toBe('default');
+    expect(result.tools.prStrategy.value).toBe('github-native');
+    expect(result.tools.prStrategy.source).toBe('default');
+  });
+
+  it('DescribeConfig_ToolsOverride_ShowsSource', () => {
+    const config = resolveConfig({ tools: { 'auto-merge': false } });
+    const result = buildConfigDescription(config);
+
+    expect(result.tools.autoMerge.value).toBe(false);
+    expect(result.tools.autoMerge.source).toBe('.exarchos.yml');
+    // Non-overridden tools stay default
+    expect(result.tools.commitStyle.source).toBe('default');
+  });
+
+  it('DescribeConfig_WorkflowDefaults_AllDefault', () => {
+    const result = buildConfigDescription(DEFAULTS);
+    expect(result.workflow.skipPhases.value).toEqual([]);
+    expect(result.workflow.skipPhases.source).toBe('default');
+    expect(result.workflow.maxFixCycles.value).toBe(3);
+    expect(result.workflow.maxFixCycles.source).toBe('default');
+  });
+
+  it('DescribeConfig_WorkflowOverride_ShowsSource', () => {
+    const config = resolveConfig({ workflow: { 'max-fix-cycles': 5 } });
+    const result = buildConfigDescription(config);
+
+    expect(result.workflow.maxFixCycles.value).toBe(5);
+    expect(result.workflow.maxFixCycles.source).toBe('.exarchos.yml');
+  });
+
+  it('DescribeConfig_HooksDefaults_AllDefault', () => {
+    const result = buildConfigDescription(DEFAULTS);
+    expect(result.hooks.on.value).toEqual({});
+    expect(result.hooks.on.source).toBe('default');
+  });
+
+  it('DescribeConfig_HooksOverride_ShowsSource', () => {
+    const config = resolveConfig({
+      hooks: { on: { 'workflow.transition': [{ command: 'echo test' }] } },
+    });
+    const result = buildConfigDescription(config);
+
+    expect(result.hooks.on.source).toBe('.exarchos.yml');
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/describe-config.ts
+++ b/servers/exarchos-mcp/src/workflow/describe-config.ts
@@ -1,0 +1,80 @@
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+import { DEFAULTS } from '../config/resolve.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface AnnotatedValue<T> {
+  readonly value: T;
+  readonly source: 'default' | '.exarchos.yml';
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function annotate<T>(value: T, defaultValue: T): AnnotatedValue<T> {
+  const isDefault = JSON.stringify(value) === JSON.stringify(defaultValue);
+  return { value, source: isDefault ? 'default' : '.exarchos.yml' };
+}
+
+// ─── Builder ────────────────────────────────────────────────────────────────
+
+type DimensionKey = 'D1' | 'D2' | 'D3' | 'D4' | 'D5';
+const DIMENSION_KEYS: readonly DimensionKey[] = ['D1', 'D2', 'D3', 'D4', 'D5'];
+
+export function buildConfigDescription(config: ResolvedProjectConfig) {
+  // ── Review Dimensions ──
+  const dimensions = Object.fromEntries(
+    DIMENSION_KEYS.map((dim) => [
+      dim,
+      annotate(
+        config.review.dimensions[dim].severity,
+        DEFAULTS.review.dimensions[dim].severity,
+      ),
+    ]),
+  ) as Record<DimensionKey, AnnotatedValue<string>>;
+
+  // ── Review Gates ──
+  // Any gate present was defined in config (defaults has empty gates)
+  const gates = Object.fromEntries(
+    Object.entries(config.review.gates).map(([name, gate]) => {
+      const defaultGate = DEFAULTS.review.gates[name];
+      return [
+        name,
+        {
+          enabled: annotate(gate.enabled, defaultGate?.enabled ?? true),
+          blocking: annotate(gate.blocking, defaultGate?.blocking ?? true),
+          params: annotate(gate.params, defaultGate?.params ?? {}),
+        },
+      ];
+    }),
+  );
+
+  return {
+    review: {
+      dimensions,
+      gates,
+      routing: {
+        coderabbitThreshold: annotate(
+          config.review.routing.coderabbitThreshold,
+          DEFAULTS.review.routing.coderabbitThreshold,
+        ),
+      },
+    },
+    vcs: {
+      provider: annotate(config.vcs.provider, DEFAULTS.vcs.provider),
+      settings: annotate(config.vcs.settings, DEFAULTS.vcs.settings),
+    },
+    workflow: {
+      skipPhases: annotate(config.workflow.skipPhases, DEFAULTS.workflow.skipPhases),
+      maxFixCycles: annotate(config.workflow.maxFixCycles, DEFAULTS.workflow.maxFixCycles),
+    },
+    tools: {
+      defaultBranch: annotate(config.tools.defaultBranch, DEFAULTS.tools.defaultBranch),
+      commitStyle: annotate(config.tools.commitStyle, DEFAULTS.tools.commitStyle),
+      autoMerge: annotate(config.tools.autoMerge, DEFAULTS.tools.autoMerge),
+      prStrategy: annotate(config.tools.prStrategy, DEFAULTS.tools.prStrategy),
+    },
+    hooks: {
+      on: annotate(config.hooks.on, DEFAULTS.hooks.on),
+    },
+  };
+}

--- a/servers/exarchos-mcp/src/workflow/phase-skip-integration.test.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-skip-integration.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { applyPhaseSkips } from './phase-skip.js';
+import { createFeatureHSM, createDebugHSM, createRefactorHSM } from './hsm-definitions.js';
+import type { HSMDefinition } from './state-machine.js';
+
+describe('Phase Skip Integration', () => {
+  describe('Feature workflow', () => {
+    let featureHsm: HSMDefinition;
+
+    beforeEach(() => {
+      featureHsm = createFeatureHSM();
+    });
+
+    it('WorkflowInit_WithSkipPhases_PlanReviewSkipped', () => {
+      const modified = applyPhaseSkips(featureHsm, ['plan-review']);
+
+      // plan should now go to delegate (plan-review's outgoing target)
+      const planTransition = modified.transitions.find(t => t.from === 'plan');
+      expect(planTransition?.to).toBe('delegate');
+      expect(planTransition?.to).not.toBe('plan-review');
+
+      // plan-review's outgoing guard (planReviewComplete) should be inherited
+      expect(planTransition?.guard?.id).toBe('plan-review-complete');
+
+      // No transitions should originate from plan-review
+      const planReviewTransitions = modified.transitions.filter(t => t.from === 'plan-review');
+      expect(planReviewTransitions).toHaveLength(0);
+    });
+
+    it('WorkflowInit_SkipPlanReview_RemovesAllPlanReviewTransitions', () => {
+      const modified = applyPhaseSkips(featureHsm, ['plan-review']);
+
+      // The original has 3 transitions from plan-review:
+      //   plan-review -> delegate, plan-review -> plan, plan-review -> blocked
+      // All should be removed
+      const fromPlanReview = modified.transitions.filter(t => t.from === 'plan-review');
+      expect(fromPlanReview).toHaveLength(0);
+    });
+
+    it('WorkflowStartedEvent_IncludesOriginalPhases', () => {
+      // Verify that applying skips does not mutate the original HSM
+      const modified = applyPhaseSkips(featureHsm, ['plan-review']);
+
+      // The original HSM should still have plan-review as a state
+      expect(featureHsm.states['plan-review']).toBeDefined();
+
+      // The modified HSM should have different transitions
+      expect(modified.transitions).not.toEqual(featureHsm.transitions);
+
+      // Original transitions count should be unchanged
+      const original = createFeatureHSM();
+      expect(featureHsm.transitions).toHaveLength(original.transitions.length);
+    });
+
+    it('WorkflowInit_NoSkipPhases_NoChange', () => {
+      const modified = applyPhaseSkips(featureHsm, []);
+      expect(modified).toEqual(featureHsm);
+    });
+
+    it('WorkflowInit_SkipIdeate_Rejected', () => {
+      // ideate is the initial phase (no incoming transitions)
+      expect(() => applyPhaseSkips(featureHsm, ['ideate'])).toThrow(/cannot skip initial/i);
+    });
+
+    it('WorkflowInit_SkipCompleted_Rejected', () => {
+      expect(() => applyPhaseSkips(featureHsm, ['completed'])).toThrow(/cannot skip final/i);
+    });
+
+    it('WorkflowInit_SkipCancelled_Rejected', () => {
+      expect(() => applyPhaseSkips(featureHsm, ['cancelled'])).toThrow(/cannot skip final/i);
+    });
+
+    it('WorkflowInit_SkipImplementationCompound_RejectedAsNoDirectIncoming', () => {
+      // The 'implementation' compound state has no direct incoming transitions
+      // (transitions go to its child 'delegate' instead), so it is treated
+      // as having no incoming transitions and is rejected as an initial phase.
+      expect(() => applyPhaseSkips(featureHsm, ['implementation'])).toThrow(/cannot skip initial/i);
+    });
+
+    it('WorkflowInit_SkipSynthesize_ReroutesIncomingTransitions', () => {
+      // synthesize has multiple outgoing transitions:
+      //   synthesize -> delegate (synthesizeRetryable)
+      //   synthesize -> completed (prUrlExists)
+      // The first outgoing found is used for rerouting.
+      const modified = applyPhaseSkips(featureHsm, ['synthesize']);
+
+      // No transitions from synthesize should remain
+      const fromSynthesize = modified.transitions.filter(t => t.from === 'synthesize');
+      expect(fromSynthesize).toHaveLength(0);
+
+      // Transitions that previously targeted synthesize should be rerouted
+      // to the first outgoing target (delegate), inheriting synthesizeRetryable guard
+      const toSynthesize = modified.transitions.filter(t => t.to === 'synthesize');
+      expect(toSynthesize).toHaveLength(0);
+    });
+  });
+
+  describe('Debug workflow', () => {
+    let debugHsm: HSMDefinition;
+
+    beforeEach(() => {
+      debugHsm = createDebugHSM();
+    });
+
+    it('WorkflowInit_SkipTriage_Rejected', () => {
+      // triage is the initial phase of the debug workflow
+      expect(() => applyPhaseSkips(debugHsm, ['triage'])).toThrow(/cannot skip initial/i);
+    });
+
+    it('WorkflowInit_NoSkipPhases_DebugUnchanged', () => {
+      const modified = applyPhaseSkips(debugHsm, []);
+      expect(modified).toEqual(debugHsm);
+    });
+  });
+
+  describe('Refactor workflow', () => {
+    let refactorHsm: HSMDefinition;
+
+    beforeEach(() => {
+      refactorHsm = createRefactorHSM();
+    });
+
+    it('WorkflowInit_SkipExplore_Rejected', () => {
+      // explore is the initial phase of the refactor workflow
+      expect(() => applyPhaseSkips(refactorHsm, ['explore'])).toThrow(/cannot skip initial/i);
+    });
+
+    it('WorkflowInit_NoSkipPhases_RefactorUnchanged', () => {
+      const modified = applyPhaseSkips(refactorHsm, []);
+      expect(modified).toEqual(refactorHsm);
+    });
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/phase-skip-wiring.test.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-skip-wiring.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { handleInit, handleSet } from './tools.js';
+import { EventStore } from '../event-store/store.js';
+
+describe('handleSet — phase skip wiring (R5)', () => {
+  let tmpDir: string;
+  let eventStore: EventStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'phase-skip-wiring-'));
+    eventStore = new EventStore(tmpDir);
+    await eventStore.initialize();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Helper: Initialize a feature workflow and advance to 'plan' phase.
+   * Satisfies the designArtifactExists guard (ideate->plan) and
+   * planArtifactExists guard (plan->plan-review) by setting artifacts.
+   */
+  async function initAndAdvanceToPlan(featureId: string): Promise<void> {
+    await handleInit({ featureId, workflowType: 'feature' }, tmpDir, eventStore);
+
+    // Set design artifact to satisfy ideate->plan guard
+    await handleSet(
+      { featureId, updates: { 'artifacts.design': 'design.md' } },
+      tmpDir,
+      eventStore,
+    );
+
+    // Transition ideate -> plan
+    const toPlan = await handleSet(
+      { featureId, phase: 'plan' },
+      tmpDir,
+      eventStore,
+    );
+    expect(toPlan.success).toBe(true);
+    expect((toPlan.data as Record<string, unknown>).phase).toBe('plan');
+
+    // Set plan artifact to satisfy plan->plan-review guard
+    await handleSet(
+      { featureId, updates: { 'artifacts.plan': 'plan.md' } },
+      tmpDir,
+      eventStore,
+    );
+  }
+
+  it('handleSet_WithSkipPlanReview_PlanGoesDirectlyToDelegate', async () => {
+    await initAndAdvanceToPlan('test-skip');
+
+    // With plan-review skipped, plan -> delegate should work because
+    // plan-review is bypassed. The guard from plan-review's outgoing
+    // transition (planReviewComplete) is inherited by the rerouted
+    // predecessor transition (plan -> delegate).
+    //
+    // The planReviewComplete guard (inherited from the skipped plan-review
+    // outgoing transition) checks for state.planReview.approved === true.
+    await handleSet(
+      { featureId: 'test-skip', updates: { 'planReview.approved': true } },
+      tmpDir,
+      eventStore,
+    );
+
+    const toDelegate = await handleSet(
+      { featureId: 'test-skip', phase: 'delegate' },
+      tmpDir,
+      eventStore,
+      { skipPhases: ['plan-review'] },
+    );
+
+    expect(toDelegate.success).toBe(true);
+    expect((toDelegate.data as Record<string, unknown>).phase).toBe('delegate');
+  });
+
+  it('handleSet_WithoutSkipPhases_PlanCannotSkipToDelegate', async () => {
+    await initAndAdvanceToPlan('test-normal');
+
+    // Without skipPhases, plan -> delegate is not a valid transition
+    // (plan -> plan-review is the only valid transition from plan)
+    const toDelegate = await handleSet(
+      { featureId: 'test-normal', phase: 'delegate' },
+      tmpDir,
+      eventStore,
+    );
+
+    expect(toDelegate.success).toBe(false);
+    expect(toDelegate.error?.code).toBeDefined();
+  });
+
+  it('handleSet_EmptySkipPhases_BehavesLikeNoSkipPhases', async () => {
+    await initAndAdvanceToPlan('test-empty');
+
+    // Empty skipPhases should behave the same as no skipPhases
+    const toDelegate = await handleSet(
+      { featureId: 'test-empty', phase: 'delegate' },
+      tmpDir,
+      eventStore,
+      { skipPhases: [] },
+    );
+
+    expect(toDelegate.success).toBe(false);
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/phase-skip.test.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-skip.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { applyPhaseSkips } from './phase-skip.js';
+import type { HSMDefinition, State, Transition } from './state-machine.js';
+
+describe('applyPhaseSkips', () => {
+  // Minimal test HSM: A → B → C → D(final)
+  const testHsm: HSMDefinition = {
+    id: 'test',
+    states: {
+      A: { id: 'A', type: 'atomic' as const },
+      B: { id: 'B', type: 'atomic' as const },
+      C: { id: 'C', type: 'atomic' as const },
+      D: { id: 'D', type: 'final' as const },
+    },
+    transitions: [
+      { from: 'A', to: 'B' },
+      { from: 'B', to: 'C', guard: { id: 'b-to-c-guard', description: 'test guard', evaluate: () => true as const } },
+      { from: 'C', to: 'D' },
+    ],
+  };
+
+  it('applyPhaseSkips_EmptyList_ReturnsUnmodifiedHSM', () => {
+    const result = applyPhaseSkips(testHsm, []);
+    expect(result.transitions).toHaveLength(3);
+    expect(result).toEqual(testHsm);
+  });
+
+  it('applyPhaseSkips_SkipMiddlePhase_ReroutesTransitions', () => {
+    const result = applyPhaseSkips(testHsm, ['B']);
+    // A should now go directly to C, B transitions removed
+    const aTransition = result.transitions.find(t => t.from === 'A');
+    expect(aTransition?.to).toBe('C');
+    expect(result.transitions.find(t => t.from === 'B')).toBeUndefined();
+  });
+
+  it('applyPhaseSkips_SkipMultiplePhases_ReroutesAll', () => {
+    const result = applyPhaseSkips(testHsm, ['B', 'C']);
+    // A should now go directly to D
+    const aTransition = result.transitions.find(t => t.from === 'A');
+    expect(aTransition?.to).toBe('D');
+  });
+
+  it('applyPhaseSkips_SkippedPhaseGuard_InheritedByPredecessor', () => {
+    // B→C has a guard. If B is skipped, A→C should inherit that guard
+    const result = applyPhaseSkips(testHsm, ['B']);
+    const aTransition = result.transitions.find(t => t.from === 'A');
+    expect(aTransition?.guard?.id).toBe('b-to-c-guard');
+  });
+
+  it('applyPhaseSkips_InitialPhase_RejectedWithError', () => {
+    // First state in the HSM (A) has no incoming transitions, so it's the initial phase
+    expect(() => applyPhaseSkips(testHsm, ['A'])).toThrow(/cannot skip initial/i);
+  });
+
+  it('applyPhaseSkips_FinalPhase_RejectedWithError', () => {
+    expect(() => applyPhaseSkips(testHsm, ['D'])).toThrow(/cannot skip final/i);
+  });
+
+  it('applyPhaseSkips_NonexistentPhase_IgnoredSilently', () => {
+    const result = applyPhaseSkips(testHsm, ['nonexistent']);
+    expect(result.transitions).toHaveLength(3);
+  });
+
+  it('applyPhaseSkips_CompoundState_ChildrenSkipped', () => {
+    const hsmWithCompound: HSMDefinition = {
+      id: 'test-compound',
+      states: {
+        start: { id: 'start', type: 'atomic' as const },
+        impl: { id: 'impl', type: 'compound' as const, initial: 'delegate' },
+        delegate: { id: 'delegate', type: 'atomic' as const, parent: 'impl' },
+        review: { id: 'review', type: 'atomic' as const, parent: 'impl' },
+        done: { id: 'done', type: 'final' as const },
+      },
+      transitions: [
+        { from: 'start', to: 'impl' },
+        { from: 'delegate', to: 'review' },
+        { from: 'impl', to: 'done' },
+      ],
+    };
+
+    const result = applyPhaseSkips(hsmWithCompound, ['impl']);
+    const startTransition = result.transitions.find(t => t.from === 'start');
+    expect(startTransition?.to).toBe('done');
+    // Child transitions should also be removed
+    expect(result.transitions.find(t => t.from === 'delegate')).toBeUndefined();
+  });
+
+  it('applyPhaseSkips_PredecessorGuardPreserved_WhenSkippedHasNoGuard', () => {
+    // When the skipped phase's outgoing transition has no guard,
+    // the predecessor's existing guard should be preserved
+    const hsmWithGuardOnPredecessor: HSMDefinition = {
+      id: 'test-guard-preserve',
+      states: {
+        X: { id: 'X', type: 'atomic' as const },
+        Y: { id: 'Y', type: 'atomic' as const },
+        Z: { id: 'Z', type: 'final' as const },
+      },
+      transitions: [
+        { from: 'X', to: 'Y', guard: { id: 'x-guard', description: 'predecessor guard', evaluate: () => true as const } },
+        { from: 'Y', to: 'Z' }, // no guard on outgoing
+      ],
+    };
+
+    const result = applyPhaseSkips(hsmWithGuardOnPredecessor, ['Y']);
+    const xTransition = result.transitions.find(t => t.from === 'X');
+    expect(xTransition?.to).toBe('Z');
+    // Should keep the predecessor's guard since skipped phase has no outgoing guard
+    expect(xTransition?.guard?.id).toBe('x-guard');
+  });
+
+  it('applyPhaseSkips_DoesNotMutateOriginalHSM', () => {
+    const originalTransitionCount = testHsm.transitions.length;
+    applyPhaseSkips(testHsm, ['B']);
+    expect(testHsm.transitions).toHaveLength(originalTransitionCount);
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/phase-skip.test.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-skip.test.ts
@@ -113,4 +113,44 @@ describe('applyPhaseSkips', () => {
     applyPhaseSkips(testHsm, ['B']);
     expect(testHsm.transitions).toHaveLength(originalTransitionCount);
   });
+
+  it('applyPhaseSkips_MultiBranch_AllOutgoingTransitionsPreserved', () => {
+    // HSM where B has two outgoing transitions (e.g., success and failure paths)
+    // A → B, B → C (success), B → E (failure), C → D(final), E → D(final)
+    const multiBranchHsm: HSMDefinition = {
+      id: 'test-multi-branch',
+      states: {
+        A: { id: 'A', type: 'atomic' as const },
+        B: { id: 'B', type: 'atomic' as const },
+        C: { id: 'C', type: 'atomic' as const },
+        E: { id: 'E', type: 'atomic' as const },
+        D: { id: 'D', type: 'final' as const },
+      },
+      transitions: [
+        { from: 'A', to: 'B' },
+        { from: 'B', to: 'C', guard: { id: 'success-guard', description: 'success path', evaluate: () => true as const } },
+        { from: 'B', to: 'E', guard: { id: 'failure-guard', description: 'failure path', evaluate: () => true as const } },
+        { from: 'C', to: 'D' },
+        { from: 'E', to: 'D' },
+      ],
+    };
+
+    const result = applyPhaseSkips(multiBranchHsm, ['B']);
+
+    // A should now have transitions to both C and E
+    const aTransitions = result.transitions.filter(t => t.from === 'A');
+    expect(aTransitions).toHaveLength(2);
+
+    const toC = aTransitions.find(t => t.to === 'C');
+    const toE = aTransitions.find(t => t.to === 'E');
+    expect(toC).toBeDefined();
+    expect(toE).toBeDefined();
+
+    // Guards should be inherited from the skipped phase's outgoing transitions
+    expect(toC?.guard?.id).toBe('success-guard');
+    expect(toE?.guard?.id).toBe('failure-guard');
+
+    // No transitions from B should remain
+    expect(result.transitions.find(t => t.from === 'B')).toBeUndefined();
+  });
 });

--- a/servers/exarchos-mcp/src/workflow/phase-skip.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-skip.ts
@@ -74,7 +74,9 @@ export function applyPhaseSkips(
         .map(s => s.id),
     );
     if (childIds.size > 0) {
-      transitions = transitions.filter(t => !childIds.has(t.from));
+      transitions = transitions.filter(
+        t => !childIds.has(t.from) && !childIds.has(t.to),
+      );
     }
   }
 

--- a/servers/exarchos-mcp/src/workflow/phase-skip.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-skip.ts
@@ -52,7 +52,13 @@ export function applyPhaseSkips(
       if (t.to === skip) {
         // Replace this incoming transition with one per outgoing
         for (const outgoing of outgoings) {
-          newTransitions.push({ ...t, to: outgoing.to, guard: outgoing.guard ?? t.guard });
+          newTransitions.push({
+            ...t,
+            to: outgoing.to,
+            guard: outgoing.guard ?? t.guard,
+            effects: outgoing.effects ?? t.effects,
+            isFixCycle: outgoing.isFixCycle ?? t.isFixCycle,
+          });
         }
       } else if (t.from !== skip) {
         newTransitions.push(t);

--- a/servers/exarchos-mcp/src/workflow/phase-skip.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-skip.ts
@@ -1,0 +1,77 @@
+import type { HSMDefinition, Transition } from './state-machine.js';
+
+/**
+ * Apply phase skipping to an HSM definition by rerouting transitions
+ * around skipped phases. Returns a new HSMDefinition; the original is
+ * not mutated.
+ *
+ * Rules:
+ * - Cannot skip the initial phase (no incoming transitions).
+ * - Cannot skip a final phase.
+ * - Nonexistent phase names are silently ignored.
+ * - Skipping a compound state also removes transitions from its children.
+ * - Guards on the skipped phase's outgoing transition are inherited by
+ *   the predecessor transition. If the outgoing has no guard, the
+ *   predecessor keeps its own guard.
+ */
+export function applyPhaseSkips(
+  hsm: HSMDefinition,
+  skipPhases: readonly string[],
+): HSMDefinition {
+  if (skipPhases.length === 0) return hsm;
+
+  // Validate: cannot skip initial or final phases
+  for (const skip of skipPhases) {
+    const state = hsm.states[skip];
+    if (!state) continue; // nonexistent = ignore
+
+    if (state.type === 'final') {
+      throw new Error(`Cannot skip final phase '${skip}'`);
+    }
+
+    // A phase with no incoming transitions is the initial phase
+    const hasIncoming = hsm.transitions.some(t => t.to === skip);
+    if (!hasIncoming) {
+      throw new Error(`Cannot skip initial phase '${skip}'`);
+    }
+  }
+
+  let transitions: Transition[] = hsm.transitions.map(t => ({ ...t }));
+
+  for (const skip of skipPhases) {
+    if (!hsm.states[skip]) continue;
+
+    // Find the outgoing transition from the skipped phase
+    const outgoing = transitions.find(t => t.from === skip);
+    if (!outgoing) continue;
+
+    // Reroute incoming transitions: point them to the skipped phase's target.
+    // Guard inheritance: use the skipped phase's outgoing guard if it exists,
+    // otherwise keep the predecessor's existing guard.
+    transitions = transitions.map(t => {
+      if (t.to === skip) {
+        return {
+          ...t,
+          to: outgoing.to,
+          guard: outgoing.guard ?? t.guard,
+        };
+      }
+      return t;
+    });
+
+    // Remove all transitions originating from the skipped phase
+    transitions = transitions.filter(t => t.from !== skip);
+
+    // Also remove transitions from child states of compound states
+    const childIds = new Set(
+      Object.values(hsm.states)
+        .filter(s => s.parent === skip)
+        .map(s => s.id),
+    );
+    if (childIds.size > 0) {
+      transitions = transitions.filter(t => !childIds.has(t.from));
+    }
+  }
+
+  return { ...hsm, transitions };
+}

--- a/servers/exarchos-mcp/src/workflow/phase-skip.ts
+++ b/servers/exarchos-mcp/src/workflow/phase-skip.ts
@@ -41,26 +41,25 @@ export function applyPhaseSkips(
   for (const skip of skipPhases) {
     if (!hsm.states[skip]) continue;
 
-    // Find the outgoing transition from the skipped phase
-    const outgoing = transitions.find(t => t.from === skip);
-    if (!outgoing) continue;
+    // Find all outgoing transitions from the skipped phase
+    const outgoings = transitions.filter(t => t.from === skip);
+    if (outgoings.length === 0) continue;
 
-    // Reroute incoming transitions: point them to the skipped phase's target.
-    // Guard inheritance: use the skipped phase's outgoing guard if it exists,
-    // otherwise keep the predecessor's existing guard.
-    transitions = transitions.map(t => {
+    // For each incoming transition to the skipped phase, create
+    // new transitions to ALL outgoing targets
+    const newTransitions: typeof transitions = [];
+    for (const t of transitions) {
       if (t.to === skip) {
-        return {
-          ...t,
-          to: outgoing.to,
-          guard: outgoing.guard ?? t.guard,
-        };
+        // Replace this incoming transition with one per outgoing
+        for (const outgoing of outgoings) {
+          newTransitions.push({ ...t, to: outgoing.to, guard: outgoing.guard ?? t.guard });
+        }
+      } else if (t.from !== skip) {
+        newTransitions.push(t);
       }
-      return t;
-    });
-
-    // Remove all transitions originating from the skipped phase
-    transitions = transitions.filter(t => t.from !== skip);
+      // Skip transitions FROM the skipped phase (they're replaced)
+    }
+    transitions = newTransitions;
 
     // Also remove transitions from child states of compound states
     const childIds = new Set(

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -29,6 +29,7 @@ import {
 } from './checkpoint.js';
 import { mapInternalToExternalType } from './events.js';
 import { getHSMDefinition, executeTransition, findTransition, isBuiltInWorkflowType } from './state-machine.js';
+import { applyPhaseSkips } from './phase-skip.js';
 import { getRegisteredGuard } from '../config/register.js';
 import { executeGuard } from '../config/guards.js';
 import { getPlaybook } from './playbooks.js';
@@ -414,6 +415,7 @@ export async function handleSet(
   input: SetInput,
   stateDir: string,
   eventStore: EventStore | null,
+  options?: { skipPhases?: readonly string[] },
 ): Promise<ToolResult> {
   const stateFile = path.join(stateDir, `${input.featureId}.state.json`);
 
@@ -481,7 +483,12 @@ export async function handleSet(
     let pendingTransitionEvents: TransitionEventRecord[] = [];
 
     if (input.phase) {
-      const hsm = getHSMDefinition(state.workflowType);
+      let hsm = getHSMDefinition(state.workflowType);
+
+      // Apply phase skips from project config if configured
+      if (options?.skipPhases && options.skipPhases.length > 0) {
+        hsm = applyPhaseSkips(hsm, options.skipPhases);
+      }
 
       // ─── Custom guard pre-check (async) ──────────────────────────────
       // Custom guards run shell commands (async) so they execute here at

--- a/skills/delegation/SKILL.md
+++ b/skills/delegation/SKILL.md
@@ -284,6 +284,8 @@ For the full transition table, consult `@skills/workflow-state/references/phase-
 
 **Quick reference:** The `delegate` → `review` transition requires guard `all-tasks-complete` — all `tasks[].status` must be `"complete"` in workflow state.
 
+> **Before transitioning to review:** You MUST first update all task statuses to `"complete"` via `exarchos_workflow set` with the tasks array. The phase transition will be rejected by the guard if any task is still pending/in_progress/failed. Update tasks first, then set the phase in a separate call.
+
 ### Task Status Values
 
 | Status | When to use |

--- a/skills/refactor/SKILL.md
+++ b/skills/refactor/SKILL.md
@@ -128,7 +128,7 @@ Use `describe` to discover the full state schema at runtime: `exarchos_workflow(
 
 ### Phase Transitions and Guards
 
-> **Sequential traversal required.** Every phase MUST be traversed in order — you cannot skip phases. For example, from `brief` you must go to `polish-implement`, not directly to `completed`. Each transition requires its guard to be satisfied via `updates` sent alongside the `phase` parameter in a single `set` call. See `@skills/refactor/references/polish-track.md` or `@skills/refactor/references/overhaul-track.md` for the exact tool call at each step.
+> **Sequential traversal required.** Every phase MUST be traversed in order — you cannot skip phases, even if you have all the data for a later phase ready. For example, `explore` must transition to `brief` before `overhaul-plan` — attempting `explore` → `overhaul-plan` directly will be rejected by the HSM. From `brief` you must go to `polish-implement` or `overhaul-plan`, not directly to `completed`. Each transition requires its guard to be satisfied via `updates` sent alongside the `phase` parameter in a single `set` call. See `@skills/refactor/references/polish-track.md` or `@skills/refactor/references/overhaul-track.md` for the exact tool call at each step.
 
 Every phase transition has a guard that must be satisfied. Before transitioning, consult `@skills/workflow-state/references/phase-transitions.md` for the exact prerequisite for each guard.
 


### PR DESCRIPTION
## Summary

- Add `.exarchos.yml` per-project declarative config with Zod validation, YAML loading, and deep-merge resolution onto built-in defaults
- Implement gate severity resolution (blocking/warning/disabled) with dimension and gate-level precedence overrides
- Add VCS provider abstraction with GitHub implementation and GitLab/Azure DevOps stubs (Issue #1024)
- Implement workflow phase skipping via HSM transition rerouting with guard inheritance
- Add fire-and-forget event hook runner for external notifications on workflow events
- Wire all extension points into runtime: DispatchContext, workflow init, event pipeline, describe action

## Test plan

- [x] 4,617 tests passing (95 new), zero regressions
- [x] Zod schema validation: shorthand/longform dimensions, risk-weight sum, gate params, enum validation
- [x] YAML loader: missing file, valid/invalid YAML, partial section fallback, project root discovery
- [x] Config resolution: deep merge, defaults, frozen output, normalization
- [x] Gate severity: precedence (gate > dimension > default), disabled/warning/blocking, backwards compat
- [x] VCS provider: GitHub CLI wrapping, GitLab/Azure stubs, factory routing
- [x] Phase skipping: rerouting, guard inheritance, initial/final rejection, compound states
- [x] Event hooks: fire-and-forget, stdin JSON, env vars, skip in tests, failure isolation
- [x] Config describe: source annotations (default vs .exarchos.yml)
- [x] Wiring: VcsProvider on context, phase skip in workflow init, hooks in event pipeline, describe config flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)