### PR TITLE
fix: resolve 5 open bugs and eliminate test flakiness

### DIFF
--- a/documentation/architecture/platform-portability.md
+++ b/documentation/architecture/platform-portability.md
@@ -99,7 +99,7 @@ Point any MCP client at the stdio server:
 ```
 
 You get all four composite tools:
-- `exarchos_workflow` -- init, get, set, cancel, cleanup, reconcile
+- `exarchos_workflow` -- init, get, set, cancel, cleanup, reconcile, checkpoint
 - `exarchos_event` -- append, query, batch
 - `exarchos_orchestrate` -- convergence gates, runbooks, agent specs, script execution
 - `exarchos_view` -- pipeline, tasks, telemetry, convergence status

--- a/servers/exarchos-mcp/src/__tests__/workflow/integration.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/integration.test.ts
@@ -202,11 +202,14 @@ describe('Integration', () => {
       expect(toReview.success).toBe(true);
       expect((toReview.data as Record<string, unknown>).phase).toBe('review');
 
-      // review -> synthesize: requires all reviews passed (reviews is z.record -- schema field)
+      // review -> synthesize: requires all reviews passed with required dimensions
       await handleSet(
         {
           featureId: 'full-saga',
-          updates: { 'reviews.quality': { passed: true, reviewer: 'bot' } },
+          updates: {
+            'reviews.spec-compliance': { status: 'pass', reviewer: 'bot' },
+            'reviews.code-quality': { status: 'pass', reviewer: 'bot' },
+          },
         },
         stateDir,
         eventStore,

--- a/servers/exarchos-mcp/src/adapters/mcp.test.ts
+++ b/servers/exarchos-mcp/src/adapters/mcp.test.ts
@@ -22,6 +22,7 @@ describe('createMcpServer', () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-adapter-test-'));
     const eventStore = new EventStore(tmpDir);
+    await eventStore.initialize();
     ctx = { stateDir: tmpDir, eventStore, enableTelemetry: false };
   });
 

--- a/servers/exarchos-mcp/src/config/resolve.ts
+++ b/servers/exarchos-mcp/src/config/resolve.ts
@@ -29,6 +29,7 @@ export interface ResolvedProjectConfig {
   readonly workflow: {
     readonly skipPhases: readonly string[];
     readonly maxFixCycles: number;
+    readonly requiredReviews: readonly string[];
     readonly phases: Readonly<Record<string, { readonly humanCheckpoint: boolean }>>;
   };
   readonly tools: {
@@ -80,6 +81,7 @@ export const DEFAULTS: ResolvedProjectConfig = deepFreeze({
   workflow: {
     skipPhases: [],
     maxFixCycles: 3,
+    requiredReviews: [],
     phases: {},
   },
   tools: {
@@ -198,6 +200,7 @@ export function resolveConfig(project: ProjectConfig): ResolvedProjectConfig {
   // ── Workflow ──
   const skipPhases = [...(project.workflow?.['skip-phases'] ?? DEFAULTS.workflow.skipPhases)];
   const maxFixCycles = project.workflow?.['max-fix-cycles'] ?? DEFAULTS.workflow.maxFixCycles;
+  const requiredReviews = [...(project.workflow?.['required-reviews'] ?? DEFAULTS.workflow.requiredReviews)];
   const phases: Record<string, { readonly humanCheckpoint: boolean }> = {};
   if (project.workflow?.phases) {
     for (const [name, phaseConfig] of Object.entries(project.workflow.phases)) {
@@ -229,7 +232,7 @@ export function resolveConfig(project: ProjectConfig): ResolvedProjectConfig {
       routing: { coderabbitThreshold, riskWeights },
     },
     vcs: { provider: vcsProvider, settings: vcsSettings },
-    workflow: { skipPhases, maxFixCycles, phases },
+    workflow: { skipPhases, maxFixCycles, requiredReviews, phases },
     tools: { defaultBranch, commitStyle, prTemplate, autoMerge, prStrategy },
     hooks: { on: hooksOn },
   };

--- a/servers/exarchos-mcp/src/config/yaml-schema.ts
+++ b/servers/exarchos-mcp/src/config/yaml-schema.ts
@@ -66,6 +66,7 @@ const PhaseConfig = z.object({
 const WorkflowConfig = z.object({
   'skip-phases': z.array(z.string()).optional(),
   'max-fix-cycles': z.number().int().min(1).max(10).optional(),
+  'required-reviews': z.array(z.string().min(1)).optional(),
   phases: z.record(z.string(), PhaseConfig).optional(),
 }).strict();
 

--- a/servers/exarchos-mcp/src/core/dispatch.test.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.test.ts
@@ -20,6 +20,7 @@ describe('dispatch', () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dispatch-test-'));
     eventStore = new EventStore(tmpDir);
+    await eventStore.initialize();
   });
 
   afterEach(async () => {

--- a/servers/exarchos-mcp/src/event-store/tools.test.ts
+++ b/servers/exarchos-mcp/src/event-store/tools.test.ts
@@ -64,6 +64,92 @@ describe('handleEventAppend data validation', () => {
   });
 });
 
+// ─── Misplaced Event Fields Detection ────────────────────────────────────────
+
+describe('handleEventAppend misplaced fields', () => {
+  it('rejects event with type-specific fields at top level', async () => {
+    const result = await handleEventAppend(
+      {
+        stream: 'misplaced-test',
+        event: {
+          type: 'gate.executed',
+          gateName: 'static-analysis',
+          layer: 'D2',
+          passed: true,
+          details: { reason: 'builds clean' },
+        },
+      },
+      tempDir,
+      eventStore,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error!.code).toBe('VALIDATION_ERROR');
+    expect(result.error!.message).toContain('should be inside "data"');
+    expect(result.error!.message).toContain('gateName');
+  });
+
+  it('accepts event with fields correctly inside data envelope', async () => {
+    const result = await handleEventAppend(
+      {
+        stream: 'correct-test',
+        event: {
+          type: 'gate.executed',
+          data: {
+            gateName: 'static-analysis',
+            layer: 'D2',
+            passed: true,
+            details: { reason: 'builds clean' },
+          },
+        },
+      },
+      tempDir,
+      eventStore,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it('allows unknown top-level fields for events without data schema', async () => {
+    const result = await handleEventAppend(
+      {
+        stream: 'unknown-test',
+        event: {
+          type: 'workflow.started',
+          data: { featureId: 'test', workflowType: 'feature' },
+          correlationId: 'corr-123',
+        },
+      },
+      tempDir,
+      eventStore,
+    );
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('handleBatchAppend misplaced fields', () => {
+  it('rejects batch with misplaced fields in any event', async () => {
+    const result = await handleBatchAppend(
+      {
+        stream: 'batch-misplaced',
+        events: [
+          { type: 'task.assigned', data: { taskId: 't1' } },
+          { type: 'gate.executed', gateName: 'lint', layer: 'D2', passed: true },
+        ],
+      },
+      tempDir,
+      eventStore,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('VALIDATION_ERROR');
+    expect(result.error!.message).toContain('events[1]');
+    expect(result.error!.message).toContain('gateName');
+  });
+});
+
 // ─── Prototype Pollution Prevention ─────────────────────────────────────────
 
 describe('handleEventQuery field projection', () => {

--- a/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/servers/exarchos-mcp/src/event-store/tools.ts
@@ -2,9 +2,46 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z, ZodError } from 'zod';
 import { coercedStringArray } from '../coerce.js';
 import { EventStore, SequenceConflictError } from './store.js';
-import type { EventType } from './schemas.js';
+import { EVENT_DATA_SCHEMAS, type EventType } from './schemas.js';
 import { formatResult, pickFields, toEventAck, type ToolResult } from '../format.js';
 import { buildValidatedEvent } from './event-factory.js';
+
+// ─── Misplaced Field Detection ──────────────────────────────────────────────
+
+/** Known envelope fields that belong at the top level of an event. */
+const ENVELOPE_FIELDS = new Set([
+  'type', 'data', 'correlationId', 'causationId', 'agentId', 'agentRole',
+  'tenantId', 'organizationId', 'source', 'timestamp', 'idempotencyKey',
+  'schemaVersion',
+]);
+
+/**
+ * Detect event-type-specific fields that were placed at the top level
+ * instead of inside the `data` envelope. Returns misplaced field names
+ * or an empty array if none are found.
+ */
+function detectMisplacedFields(event: Record<string, unknown>): string[] {
+  const eventType = event.type as EventType | undefined;
+  if (!eventType) return [];
+
+  const dataSchema = EVENT_DATA_SCHEMAS[eventType];
+  if (!dataSchema) return [];
+
+  // Extract known field names from the Zod schema
+  const schemaShape = (dataSchema as z.ZodObject<z.ZodRawShape>).shape;
+  if (!schemaShape || typeof schemaShape !== 'object') return [];
+
+  const dataFieldNames = new Set(Object.keys(schemaShape));
+  const misplaced: string[] = [];
+
+  for (const key of Object.keys(event)) {
+    if (!ENVELOPE_FIELDS.has(key) && dataFieldNames.has(key)) {
+      misplaced.push(key);
+    }
+  }
+
+  return misplaced;
+}
 
 // ─── Module-Level EventStore (removed — now threaded via DispatchContext) ─────
 
@@ -37,6 +74,18 @@ export async function handleEventAppend(
   }
 
   const store = eventStore;
+
+  // Detect fields that should be inside data but were placed at the top level
+  const misplaced = detectMisplacedFields(args.event);
+  if (misplaced.length > 0) {
+    return {
+      success: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: `Event fields placed at wrong level — ${misplaced.map(f => `"${f}"`).join(', ')} should be inside "data", not at the top level. Wrap them: { type: "${eventType}", data: { ${misplaced.join(', ')}: ... } }`,
+      },
+    };
+  }
 
   try {
     // Validate at the system boundary (MCP tool handler = untrusted input)
@@ -121,13 +170,24 @@ export async function handleBatchAppend(
     };
   }
 
-  // Validate all events have a type before passing to store
+  // Validate all events have a type and no misplaced fields
   for (let i = 0; i < args.events.length; i++) {
     const eventType = args.events[i]?.type as EventType | undefined;
     if (!eventType) {
       return {
         success: false,
         error: { code: 'INVALID_INPUT', message: `events[${i}].type is required` },
+      };
+    }
+
+    const misplaced = detectMisplacedFields(args.events[i]);
+    if (misplaced.length > 0) {
+      return {
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: `events[${i}]: fields placed at wrong level — ${misplaced.map(f => `"${f}"`).join(', ')} should be inside "data", not at the top level. Wrap them: { type: "${eventType}", data: { ${misplaced.join(', ')}: ... } }`,
+        },
       };
     }
   }

--- a/servers/exarchos-mcp/src/orchestrate/check-event-emissions.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/check-event-emissions.test.ts
@@ -270,9 +270,11 @@ describe('handleOrchestrate integration', () => {
     const isolatedDir = mkdtempSync(join(tmpdir(), 'check-event-emissions-route-'));
     try {
       const { EventStore } = await import('../event-store/store.js');
+      const eventStore = new EventStore(isolatedDir);
+      await eventStore.initialize();
       const result = await handleOrchestrate(
         { action: 'check_event_emissions', featureId: 'test' },
-        { stateDir: isolatedDir, eventStore: new EventStore(isolatedDir), enableTelemetry: false },
+        { stateDir: isolatedDir, eventStore, enableTelemetry: false },
       );
 
       // Should NOT return UNKNOWN_ACTION — meaning the handler is registered

--- a/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.parity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.parity.test.ts
@@ -52,6 +52,7 @@ describe('behavioral parity with static-analysis-gate.sh', () => {
         '## Static Analysis Report',
         '',
         '**Repository:** `/fake/repo`',
+        '**Project type:** Node.js',
         '',
         '- **PASS**: Lint',
         '- **PASS**: Typecheck',
@@ -63,6 +64,7 @@ describe('behavioral parity with static-analysis-gate.sh', () => {
       ].join('\n'),
       passCount: 2,
       failCount: 0,
+      projectType: 'Node.js',
     });
   });
 
@@ -76,6 +78,7 @@ describe('behavioral parity with static-analysis-gate.sh', () => {
         '## Static Analysis Report',
         '',
         '**Repository:** `/fake/repo`',
+        '**Project type:** Node.js',
         '',
         '- **FAIL**: Lint — Lint errors found',
         '- **PASS**: Typecheck',
@@ -87,6 +90,7 @@ describe('behavioral parity with static-analysis-gate.sh', () => {
       ].join('\n'),
       passCount: 1,
       failCount: 1,
+      projectType: 'Node.js',
     });
   });
 
@@ -101,6 +105,7 @@ describe('behavioral parity with static-analysis-gate.sh', () => {
         '## Static Analysis Report',
         '',
         '**Repository:** `/fake/repo`',
+        '**Project type:** Node.js',
         '',
         '- **SKIP**: Lint — --skip-lint',
         '- **PASS**: Typecheck',
@@ -112,6 +117,7 @@ describe('behavioral parity with static-analysis-gate.sh', () => {
       ].join('\n'),
       passCount: 1,
       failCount: 0,
+      projectType: 'Node.js',
     });
   });
 
@@ -126,6 +132,7 @@ describe('behavioral parity with static-analysis-gate.sh', () => {
         '## Static Analysis Report',
         '',
         '**Repository:** `/fake/repo`',
+        '**Project type:** Node.js',
         '',
         '- **PASS**: Lint',
         '- **SKIP**: Typecheck — --skip-typecheck',
@@ -137,6 +144,7 @@ describe('behavioral parity with static-analysis-gate.sh', () => {
       ].join('\n'),
       passCount: 1,
       failCount: 0,
+      projectType: 'Node.js',
     });
   });
 
@@ -177,6 +185,7 @@ describe('quality-check path', () => {
         '## Static Analysis Report',
         '',
         '**Repository:** `/fake/repo`',
+        '**Project type:** Node.js',
         '',
         '- **PASS**: Lint',
         '- **PASS**: Typecheck',
@@ -188,6 +197,7 @@ describe('quality-check path', () => {
       ].join('\n'),
       passCount: 3,
       failCount: 0,
+      projectType: 'Node.js',
     });
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.parity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.parity.test.ts
@@ -23,6 +23,7 @@ vi.mock('node:fs', () => ({
     })
   ),
   existsSync: vi.fn(() => true),
+  statSync: vi.fn(() => ({ isDirectory: () => true })),
 }));
 
 function makePassRunner(): RunCommandFn {

--- a/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.test.ts
@@ -321,14 +321,14 @@ describe('runStaticAnalysis', () => {
       expect(result.output).toContain('No recognized project type');
     });
 
-    it('non-existent repo root returns pass (no applicable toolchain)', () => {
+    it('non-existent repo root returns error', () => {
       const result = runStaticAnalysis({
         repoRoot: path.join(tmpDir, 'nonexistent'),
         runCommand: successRunner(),
       });
 
-      expect(result.status).toBe('pass');
-      expect(result.projectType).toBeUndefined();
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('does not exist');
     });
   });
 

--- a/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.test.ts
@@ -307,7 +307,7 @@ describe('runStaticAnalysis', () => {
   // ============================================================
 
   describe('usage errors', () => {
-    it('missing package.json returns error', () => {
+    it('empty directory with no project files returns pass (no applicable toolchain)', () => {
       const emptyDir = path.join(tmpDir, 'empty');
       fs.mkdirSync(emptyDir, { recursive: true });
 
@@ -316,18 +316,19 @@ describe('runStaticAnalysis', () => {
         runCommand: successRunner(),
       });
 
-      expect(result.status).toBe('error');
-      expect(result.error).toMatch(/package\.json/i);
+      expect(result.status).toBe('pass');
+      expect(result.projectType).toBeUndefined();
+      expect(result.output).toContain('No recognized project type');
     });
 
-    it('non-existent repo root returns error', () => {
+    it('non-existent repo root returns pass (no applicable toolchain)', () => {
       const result = runStaticAnalysis({
         repoRoot: path.join(tmpDir, 'nonexistent'),
         runCommand: successRunner(),
       });
 
-      expect(result.status).toBe('error');
-      expect(result.error).toMatch(/package\.json/i);
+      expect(result.status).toBe('pass');
+      expect(result.projectType).toBeUndefined();
     });
   });
 
@@ -387,6 +388,138 @@ describe('runStaticAnalysis', () => {
 
       // Should show something like "2/2 checks passed"
       expect(result.output).toMatch(/\d+\/\d+ checks passed/);
+    });
+  });
+
+  // ============================================================
+  // PLATFORM DETECTION — NON-NODE.JS PROJECTS
+  // ============================================================
+
+  describe('platform detection', () => {
+    function createProjectDir(files: Record<string, string>): string {
+      const repoRoot = path.join(tmpDir, 'project-' + Math.random().toString(36).slice(2));
+      fs.mkdirSync(repoRoot, { recursive: true });
+      for (const [name, content] of Object.entries(files)) {
+        fs.writeFileSync(path.join(repoRoot, name), content, 'utf-8');
+      }
+      return repoRoot;
+    }
+
+    it('detects Node.js project and sets projectType', () => {
+      const repoRoot = createPackageJson({ lint: 'eslint .' });
+
+      const result = runStaticAnalysis({
+        repoRoot,
+        runCommand: successRunner(),
+      });
+
+      expect(result.projectType).toBe('Node.js');
+    });
+
+    it('.NET project (*.csproj) runs dotnet build', () => {
+      const repoRoot = createProjectDir({ 'MyApp.csproj': '<Project />' });
+
+      const runner = successRunner();
+      const result = runStaticAnalysis({
+        repoRoot,
+        runCommand: runner,
+      });
+
+      expect(result.status).toBe('pass');
+      expect(result.projectType).toBe('.NET');
+      expect(result.output).toContain('.NET');
+      // Should call dotnet, not npm
+      const calls = (runner as ReturnType<typeof vi.fn>).mock.calls;
+      expect(calls.some((c: unknown[]) => c[0] === 'dotnet')).toBe(true);
+      expect(calls.some((c: unknown[]) => c[0] === 'npm')).toBe(false);
+    });
+
+    it('.NET project (*.sln) is detected', () => {
+      const repoRoot = createProjectDir({ 'MyApp.sln': '' });
+
+      const result = runStaticAnalysis({
+        repoRoot,
+        runCommand: successRunner(),
+      });
+
+      expect(result.projectType).toBe('.NET');
+    });
+
+    it('Go project (go.mod) runs go vet', () => {
+      const repoRoot = createProjectDir({ 'go.mod': 'module example.com/myapp' });
+
+      const runner = successRunner();
+      const result = runStaticAnalysis({
+        repoRoot,
+        runCommand: runner,
+      });
+
+      expect(result.status).toBe('pass');
+      expect(result.projectType).toBe('Go');
+      const calls = (runner as ReturnType<typeof vi.fn>).mock.calls;
+      expect(calls.some((c: unknown[]) => c[0] === 'go')).toBe(true);
+    });
+
+    it('Rust project (Cargo.toml) runs cargo check and clippy', () => {
+      const repoRoot = createProjectDir({ 'Cargo.toml': '[package]\nname = "myapp"' });
+
+      const runner = successRunner();
+      const result = runStaticAnalysis({
+        repoRoot,
+        runCommand: runner,
+      });
+
+      expect(result.status).toBe('pass');
+      expect(result.projectType).toBe('Rust');
+      const calls = (runner as ReturnType<typeof vi.fn>).mock.calls;
+      expect(calls.some((c: unknown[]) => c[0] === 'cargo')).toBe(true);
+    });
+
+    it('unrecognized project type returns pass with no checks', () => {
+      const repoRoot = createProjectDir({ 'README.md': '# Hello' });
+
+      const result = runStaticAnalysis({
+        repoRoot,
+        runCommand: successRunner(),
+      });
+
+      expect(result.status).toBe('pass');
+      expect(result.projectType).toBeUndefined();
+      expect(result.passCount).toBe(0);
+      expect(result.failCount).toBe(0);
+    });
+
+    it('.NET project reports failure when dotnet build fails', () => {
+      const repoRoot = createProjectDir({ 'MyApp.csproj': '<Project />' });
+
+      const runner = failingRunner({ 'build': { stderr: 'error CS1002: ; expected' } });
+      const result = runStaticAnalysis({
+        repoRoot,
+        runCommand: runner,
+      });
+
+      expect(result.status).toBe('fail');
+      expect(result.failCount).toBeGreaterThan(0);
+    });
+
+    it('Node.js takes priority over other project files', () => {
+      // A project with both package.json and Cargo.toml should be detected as Node.js
+      const repoRoot = createProjectDir({
+        'Cargo.toml': '[package]',
+      });
+      // Also add package.json
+      fs.writeFileSync(
+        path.join(repoRoot, 'package.json'),
+        JSON.stringify({ name: 'hybrid', scripts: { lint: 'eslint .' } }),
+        'utf-8',
+      );
+
+      const result = runStaticAnalysis({
+        repoRoot,
+        runCommand: successRunner(),
+      });
+
+      expect(result.projectType).toBe('Node.js');
     });
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.ts
@@ -249,7 +249,7 @@ function runGoChecks(
   skipTypecheck: boolean,
 ): CheckResult[] {
   return [
-    runGenericCheck('Vet', 'go', ['vet', './...'], repoRoot, runCommand, skipTypecheck),
+    runGenericCheck('Vet', 'go', ['vet', './...'], repoRoot, runCommand, skipLint),
   ];
 }
 
@@ -277,6 +277,28 @@ export function runStaticAnalysis(input: StaticAnalysisInput): StaticAnalysisRes
       status: 'error',
       output: '',
       error: 'Missing repoRoot',
+      passCount: 0,
+      failCount: 0,
+    };
+  }
+
+  // Validate repoRoot exists on disk
+  try {
+    if (!fs.existsSync(repoRoot) || !fs.statSync(repoRoot).isDirectory()) {
+      return {
+        status: 'error',
+        output: '',
+        error: `Invalid repoRoot: ${repoRoot} does not exist or is not a directory`,
+        passCount: 0,
+        failCount: 0,
+      };
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      status: 'error',
+      output: '',
+      error: `Invalid repoRoot: ${message}`,
       passCount: 0,
       failCount: 0,
     };

--- a/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.ts
@@ -41,7 +41,7 @@ export type RunCommandFn = (
 ) => CommandResult;
 
 export interface StaticAnalysisInput {
-  /** Repository root containing package.json. */
+  /** Repository root to analyze. */
   readonly repoRoot: string;
   /** Skip lint check. */
   readonly skipLint?: boolean;
@@ -62,6 +62,8 @@ export interface StaticAnalysisResult {
   readonly passCount: number;
   /** Number of checks that failed. */
   readonly failCount: number;
+  /** Detected project type (undefined if no recognized project). */
+  readonly projectType?: string;
 }
 
 // ============================================================
@@ -143,6 +145,127 @@ function runNpmCheck(
 }
 
 // ============================================================
+// PROJECT TYPE DETECTION
+// ============================================================
+
+type ProjectType = 'Node.js' | '.NET' | 'Rust' | 'Go';
+
+/**
+ * Detect project type from files present in the repository root.
+ * Returns undefined if no recognized project type is found.
+ */
+function detectProjectType(repoRoot: string): ProjectType | undefined {
+  if (fs.existsSync(path.join(repoRoot, 'package.json'))) {
+    return 'Node.js';
+  }
+
+  try {
+    const entries = fs.readdirSync(repoRoot);
+    if (entries.some((e) => String(e).endsWith('.csproj') || String(e).endsWith('.sln'))) {
+      return '.NET';
+    }
+  } catch {
+    // readdirSync failure — fall through
+  }
+
+  if (fs.existsSync(path.join(repoRoot, 'go.mod'))) {
+    return 'Go';
+  }
+
+  if (fs.existsSync(path.join(repoRoot, 'Cargo.toml'))) {
+    return 'Rust';
+  }
+
+  return undefined;
+}
+
+// ============================================================
+// GENERIC CHECK RUNNER
+// ============================================================
+
+function runGenericCheck(
+  name: string,
+  cmd: string,
+  args: readonly string[],
+  repoRoot: string,
+  runCommand: RunCommandFn,
+  skip: boolean,
+): CheckResult {
+  if (skip) {
+    return { name, status: 'SKIP', detail: 'skipped by flag' };
+  }
+
+  try {
+    const result = runCommand(cmd, args, { cwd: repoRoot });
+    if (result.exitCode === 0) {
+      return { name, status: 'PASS' };
+    }
+    const detail = result.stderr.trim() || result.stdout.trim() || `${cmd} ${args.join(' ')} failed`;
+    return { name, status: 'FAIL', detail };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { name, status: 'FAIL', detail: message };
+  }
+}
+
+// ============================================================
+// PLATFORM-SPECIFIC CHECK RUNNERS
+// ============================================================
+
+function runNodeChecks(
+  repoRoot: string,
+  runCommand: RunCommandFn,
+  skipLint: boolean,
+  skipTypecheck: boolean,
+): CheckResult[] {
+  const pkgResult = readPackageJson(repoRoot);
+  if ('error' in pkgResult) {
+    return [{ name: 'package.json', status: 'FAIL', detail: pkgResult.error }];
+  }
+  const { packageJson } = pkgResult;
+
+  return [
+    runNpmCheck('Lint', 'lint', packageJson, repoRoot, runCommand, skipLint),
+    runNpmCheck('Typecheck', 'typecheck', packageJson, repoRoot, runCommand, skipTypecheck),
+    runNpmCheck('Quality check', 'quality-check', packageJson, repoRoot, runCommand, false),
+  ];
+}
+
+function runDotnetChecks(
+  repoRoot: string,
+  runCommand: RunCommandFn,
+  skipLint: boolean,
+  skipTypecheck: boolean,
+): CheckResult[] {
+  return [
+    runGenericCheck('Build', 'dotnet', ['build', '--no-restore', '-warnaserror'], repoRoot, runCommand, skipLint && skipTypecheck),
+  ];
+}
+
+function runGoChecks(
+  repoRoot: string,
+  runCommand: RunCommandFn,
+  skipLint: boolean,
+  skipTypecheck: boolean,
+): CheckResult[] {
+  return [
+    runGenericCheck('Vet', 'go', ['vet', './...'], repoRoot, runCommand, skipTypecheck),
+  ];
+}
+
+function runRustChecks(
+  repoRoot: string,
+  runCommand: RunCommandFn,
+  skipLint: boolean,
+  skipTypecheck: boolean,
+): CheckResult[] {
+  return [
+    runGenericCheck('Check', 'cargo', ['check'], repoRoot, runCommand, skipTypecheck),
+    runGenericCheck('Clippy', 'cargo', ['clippy', '--', '-D', 'warnings'], repoRoot, runCommand, skipLint),
+  ];
+}
+
+// ============================================================
 // MAIN FUNCTION
 // ============================================================
 
@@ -159,31 +282,47 @@ export function runStaticAnalysis(input: StaticAnalysisInput): StaticAnalysisRes
     };
   }
 
-  // Validate repo root
-  const pkgResult = readPackageJson(repoRoot);
-  if ('error' in pkgResult) {
+  // Detect project type
+  const projectType = detectProjectType(repoRoot);
+
+  if (!projectType) {
+    const output = [
+      '## Static Analysis Report',
+      '',
+      `**Repository:** \`${repoRoot}\``,
+      '',
+      '- **SKIP**: No recognized project type (no package.json, *.csproj, go.mod, or Cargo.toml)',
+      '',
+      '---',
+      '',
+      '**Result: PASS** (0/0 checks — no applicable toolchain detected)',
+    ].join('\n');
+
     return {
-      status: 'error',
-      output: '',
-      error: pkgResult.error,
+      status: 'pass',
+      output,
       passCount: 0,
       failCount: 0,
+      projectType: undefined,
     };
   }
-  const { packageJson } = pkgResult;
 
-  // Run checks
-  const checks: CheckResult[] = [];
-
-  checks.push(
-    runNpmCheck('Lint', 'lint', packageJson, repoRoot, runCommand, skipLint)
-  );
-  checks.push(
-    runNpmCheck('Typecheck', 'typecheck', packageJson, repoRoot, runCommand, skipTypecheck)
-  );
-  checks.push(
-    runNpmCheck('Quality check', 'quality-check', packageJson, repoRoot, runCommand, false)
-  );
+  // Run platform-specific checks
+  let checks: CheckResult[];
+  switch (projectType) {
+    case 'Node.js':
+      checks = runNodeChecks(repoRoot, runCommand, skipLint, skipTypecheck);
+      break;
+    case '.NET':
+      checks = runDotnetChecks(repoRoot, runCommand, skipLint, skipTypecheck);
+      break;
+    case 'Go':
+      checks = runGoChecks(repoRoot, runCommand, skipLint, skipTypecheck);
+      break;
+    case 'Rust':
+      checks = runRustChecks(repoRoot, runCommand, skipLint, skipTypecheck);
+      break;
+  }
 
   // Tally results
   let passCount = 0;
@@ -199,6 +338,7 @@ export function runStaticAnalysis(input: StaticAnalysisInput): StaticAnalysisRes
     '## Static Analysis Report',
     '',
     `**Repository:** \`${repoRoot}\``,
+    `**Project type:** ${projectType}`,
     '',
   ];
 
@@ -230,5 +370,6 @@ export function runStaticAnalysis(input: StaticAnalysisInput): StaticAnalysisRes
     output,
     passCount,
     failCount,
+    projectType,
   };
 }

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -308,11 +308,11 @@ describe('TOOL_REGISTRY', () => {
   });
 
   describe('exarchos_workflow', () => {
-    it('should have 7 actions: init, get, set, cancel, cleanup, reconcile, describe', () => {
+    it('should have 8 actions: init, get, set, cancel, cleanup, reconcile, checkpoint, describe', () => {
       const composite = findComposite('exarchos_workflow');
       expect(composite).toBeDefined();
       const actionNames = composite!.actions.map((a) => a.name);
-      expect(actionNames).toEqual(['init', 'get', 'set', 'cancel', 'cleanup', 'reconcile', 'describe']);
+      expect(actionNames).toEqual(['init', 'get', 'set', 'cancel', 'cleanup', 'reconcile', 'checkpoint', 'describe']);
     });
   });
 

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -397,6 +397,19 @@ const workflowActions: readonly ToolAction[] = [
     phases: ALL_PHASES,
     roles: ROLE_LEAD,
   },
+  {
+    name: 'checkpoint',
+    description: 'Create an explicit checkpoint, resetting the operation counter. Persists checkpoint metadata to workflow state and emits workflow.checkpoint event',
+    schema: z.object({
+      featureId: featureIdSchema,
+      summary: z.string().optional(),
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_LEAD,
+    autoEmits: [
+      { event: 'workflow.checkpoint', condition: 'always' },
+    ],
+  },
   makeWorkflowDescribeAction(),
 ];
 
@@ -1251,10 +1264,10 @@ const syncActions: readonly ToolAction[] = [
 export const TOOL_REGISTRY: readonly CompositeTool[] = [
   {
     name: 'exarchos_workflow',
-    description: 'Workflow lifecycle management — init, read, update, cancel, cleanup, and reconcile workflows',
+    description: 'Workflow lifecycle management — init, read, update, cancel, cleanup, checkpoint, and reconcile workflows',
     actions: workflowActions,
     cli: { alias: 'wf' },
-    slimDescription: 'Workflow lifecycle management. Use describe(actions) for schemas.\n\nActions: init, get, set, cancel, cleanup, reconcile',
+    slimDescription: 'Workflow lifecycle management. Use describe(actions) for schemas.\n\nActions: init, get, set, cancel, cleanup, reconcile, checkpoint',
   },
   {
     name: 'exarchos_event',

--- a/servers/exarchos-mcp/src/review/tools.test.ts
+++ b/servers/exarchos-mcp/src/review/tools.test.ts
@@ -250,7 +250,9 @@ describe('orchestrate review_triage action', () => {
     };
 
     const { EventStore } = await import('../event-store/store.js');
-    const result = await handleOrchestrate(args as Record<string, unknown>, { stateDir: tmpDir, eventStore: new EventStore(tmpDir), enableTelemetry: false });
+    const eventStore = new EventStore(tmpDir);
+    await eventStore.initialize();
+    const result = await handleOrchestrate(args as Record<string, unknown>, { stateDir: tmpDir, eventStore, enableTelemetry: false });
 
     expect(result.success).toBe(true);
     const data = result.data as {

--- a/servers/exarchos-mcp/src/workflow/composite.ts
+++ b/servers/exarchos-mcp/src/workflow/composite.ts
@@ -1,4 +1,4 @@
-import { handleInit, handleGet, handleSet, handleReconcileState } from './tools.js';
+import { handleInit, handleGet, handleSet, handleReconcileState, handleCheckpoint } from './tools.js';
 import { handleCancel } from './cancel.js';
 import { handleCleanup } from './cleanup.js';
 import { handleDescribe } from '../describe/handler.js';
@@ -26,11 +26,17 @@ export async function handleWorkflow(
       return handleGet(rest as Parameters<typeof handleGet>[0], stateDir, eventStore);
     case 'set': {
       const skipPhases = ctx.projectConfig?.workflow.skipPhases;
+      const requiredReviews = ctx.projectConfig?.workflow.requiredReviews;
+      const setOptions: Record<string, unknown> = {};
+      if (skipPhases?.length) setOptions.skipPhases = skipPhases;
+      if (requiredReviews?.length) setOptions.requiredReviews = requiredReviews;
       return handleSet(
         rest as Parameters<typeof handleSet>[0],
         stateDir,
         eventStore,
-        skipPhases?.length ? { skipPhases } : undefined,
+        Object.keys(setOptions).length > 0
+          ? setOptions as { skipPhases?: readonly string[]; requiredReviews?: readonly string[] }
+          : undefined,
       );
     }
     case 'cancel':
@@ -39,6 +45,8 @@ export async function handleWorkflow(
       return handleCleanup(rest as Parameters<typeof handleCleanup>[0], stateDir, eventStore);
     case 'reconcile':
       return handleReconcileState(rest as Parameters<typeof handleReconcileState>[0], stateDir, eventStore);
+    case 'checkpoint':
+      return handleCheckpoint(rest as Parameters<typeof handleCheckpoint>[0], stateDir, eventStore);
     case 'describe':
       return handleDescribe(
         rest as { actions?: string[]; topology?: string; playbook?: string; config?: boolean },
@@ -50,7 +58,7 @@ export async function handleWorkflow(
         success: false,
         error: {
           code: 'UNKNOWN_ACTION',
-          message: `Unknown action: ${String(action)}. Valid actions: init, get, set, cancel, cleanup, reconcile, describe`,
+          message: `Unknown action: ${String(action)}. Valid actions: init, get, set, cancel, cleanup, reconcile, checkpoint, describe`,
         },
       };
   }

--- a/servers/exarchos-mcp/src/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.test.ts
@@ -480,4 +480,75 @@ describe('allReviewsPassed (synthesis ready)', () => {
     expect(failure.passed).toBe(false);
     expect(failure.reason).toContain('state.reviews is missing');
   });
+
+  it('SynthesisReadyGuard_MissingRequiredDimensions_ReturnsFailed', () => {
+    // Agent sets only one review but two are required
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      phase: 'review',
+      reviews: {
+        'spec-compliance': { status: 'pass' },
+      },
+      _requiredReviews: ['spec-compliance', 'code-quality'],
+    };
+
+    const result = guards.allReviewsPassed.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('Missing required review dimensions');
+    expect(failure.reason).toContain('code-quality');
+    expect(failure.expectedShape).toBeDefined();
+    expect(failure.suggestedFix).toBeDefined();
+  });
+
+  it('SynthesisReadyGuard_AllRequiredDimensionsPresent_Passes', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      phase: 'review',
+      reviews: {
+        'spec-compliance': { status: 'pass' },
+        'code-quality': { status: 'approved' },
+      },
+      _requiredReviews: ['spec-compliance', 'code-quality'],
+    };
+
+    const result = guards.allReviewsPassed.evaluate(state);
+    expect(result).toBe(true);
+  });
+
+  it('SynthesisReadyGuard_RequiredDimensionPresentButFailed_ReturnsFailed', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      phase: 'review',
+      reviews: {
+        'spec-compliance': { status: 'pass' },
+        'code-quality': { status: 'fail' },
+      },
+      _requiredReviews: ['spec-compliance', 'code-quality'],
+    };
+
+    const result = guards.allReviewsPassed.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('Reviews not passed');
+    expect(failure.reason).toContain('code-quality');
+  });
+
+  it('SynthesisReadyGuard_NoRequiredReviewsConfigured_FallsBackToExistingBehavior', () => {
+    // Without _requiredReviews, any passing reviews should satisfy the guard
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      phase: 'review',
+      reviews: {
+        'arbitrary-review': { status: 'pass' },
+      },
+    };
+
+    const result = guards.allReviewsPassed.evaluate(state);
+    expect(result).toBe(true);
+  });
 });

--- a/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.ts
@@ -202,7 +202,7 @@ export const guards = {
 
   allReviewsPassed: {
     id: 'all-reviews-passed',
-    description: 'All reviews must have passed',
+    description: 'All required reviews must be present and have passed',
     evaluate: (state: Record<string, unknown>): GuardResult => {
       const reviews = state.reviews as Record<string, unknown> | undefined;
       if (!reviews) {
@@ -213,6 +213,37 @@ export const guards = {
           expectedShape: REVIEW_EXPECTED_SHAPE,
         };
       }
+
+      // Enforce required review dimensions if configured
+      const requiredReviews = state._requiredReviews as readonly string[] | undefined;
+      if (requiredReviews && requiredReviews.length > 0) {
+        const missing = requiredReviews.filter((key) => !reviews[key]);
+        if (missing.length > 0) {
+          const featureId = (typeof state.featureId === 'string' ? state.featureId : '<featureId>');
+          const expectedUpdates: Record<string, unknown> = {};
+          for (const key of missing) {
+            expectedUpdates[`reviews.${key}.status`] = 'pass';
+          }
+          return {
+            passed: false,
+            reason: `Missing required review dimensions: ${missing.join(', ')}. Run the review skills for these dimensions before transitioning.`,
+            expectedShape: {
+              reviews: Object.fromEntries(
+                missing.map((key) => [key, { status: 'pass' }]),
+              ),
+            },
+            suggestedFix: {
+              tool: 'exarchos_workflow',
+              params: {
+                action: 'set',
+                featureId,
+                updates: expectedUpdates,
+              },
+            },
+          };
+        }
+      }
+
       const statuses = collectReviewStatuses(reviews);
       if (statuses.length === 0) {
         return {

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -415,7 +415,7 @@ export async function handleSet(
   input: SetInput,
   stateDir: string,
   eventStore: EventStore | null,
-  options?: { skipPhases?: readonly string[] },
+  options?: { skipPhases?: readonly string[]; requiredReviews?: readonly string[] },
 ): Promise<ToolResult> {
   const stateFile = path.join(stateDir, `${input.featureId}.state.json`);
 
@@ -459,6 +459,28 @@ export async function handleSet(
 
       for (const [dotPath, value] of Object.entries(input.updates)) {
         applyDotPath(mutableState, dotPath, value);
+      }
+    }
+
+    // ─── Inject required reviews for guard evaluation ──────────────────
+    // The allReviewsPassed guard reads _requiredReviews to enforce that
+    // specific review dimensions exist (not just that present reviews pass).
+    // Explicit config overrides workflow-type defaults.
+    if (input.phase) {
+      if (options?.requiredReviews?.length) {
+        // Explicit config: use as-is
+        mutableState._requiredReviews = options.requiredReviews;
+      } else {
+        // Workflow-type-aware defaults: feature workflows require both
+        // review stages per the documented two-stage review process
+        const workflowType = state.workflowType as string;
+        const defaults: Record<string, readonly string[]> = {
+          feature: ['spec-compliance', 'code-quality'],
+        };
+        const typeDefaults = defaults[workflowType];
+        if (typeDefaults?.length) {
+          mutableState._requiredReviews = typeDefaults;
+        }
       }
     }
 

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -608,6 +608,9 @@ export async function handleSet(
           result.newPhase,
         );
       }
+
+      // Clean up transient guard-evaluation field — not persisted to state
+      delete mutableState._requiredReviews;
     }
 
     // ─── Event-first: append transition events BEFORE CAS write ───────

--- a/servers/exarchos-mcp/vitest.config.ts
+++ b/servers/exarchos-mcp/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: false,
     environment: 'node',
+    pool: 'forks',
     include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
     coverage: {
       provider: 'v8',

--- a/skills/refactor/phases/polish-implement.md
+++ b/skills/refactor/phases/polish-implement.md
@@ -45,7 +45,7 @@ Must return: `"polish"`
 ```
 action: "get", featureId: "refactor-<slug>", query: ".phase"
 ```
-Must return: `"implement"`
+Must return: `"polish-implement"`
 
 **Check goals:**
 ```
@@ -58,7 +58,7 @@ Must return: populated array
 | Field | Requirement |
 |-------|-------------|
 | `.track` | "polish" |
-| `.phase` | "implement" |
+| `.phase` | "polish-implement" |
 | `.brief.problem` | Non-empty string |
 | `.brief.goals` | 1-3 items |
 | `.brief.affectedAreas` | 1-5 files |

--- a/skills/refactor/phases/polish-validate.md
+++ b/skills/refactor/phases/polish-validate.md
@@ -143,7 +143,7 @@ action: "set", featureId: "refactor-<slug>", updates: {
 action: "set", featureId: "refactor-<slug>", updates: {
   "validation.testsPass": false,
   "validation.failureReason": "<reason>"
-}, phase: "implement"
+}, phase: "polish-implement"
 ```
 
 ## Pass/Fail Handling


### PR DESCRIPTION
## Summary

Resolves 5 open bugs (platform-agnosticity, silent data loss, missing MCP action, wrong phase names, review guard bypass) and eliminates intermittent test flakiness from module-level state leaks.

## Changes

- **static-analysis.ts** — Add `detectProjectType()` supporting Node.js/.NET/Go/Rust; gracefully pass for unrecognized projects instead of failing on missing `package.json` (#1037)
- **event-store/tools.ts** — Add `detectMisplacedFields()` that returns `VALIDATION_ERROR` when event-type-specific fields appear at top level instead of inside `data` envelope (#1038)
- **workflow/composite.ts** — Add `checkpoint` case to composite tool switch, exposing existing `handleCheckpoint` handler via MCP (#1040)
- **registry.ts** — Register `checkpoint` action with schema and update descriptions
- **refactor skill files** — Fix `"implement"` → `"polish-implement"` in `polish-implement.md` and `polish-validate.md` (#1041)
- **workflow/guards.ts** — `allReviewsPassed` guard enforces required review dimensions from config; feature workflows default to `[spec-compliance, code-quality]` per documented two-stage review process (#1044)
- **config/yaml-schema.ts + resolve.ts** — Add `required-reviews` workflow config field with empty default (feature workflow defaults applied in `handleSet`)
- **workflow/tools.ts** — Inject `_requiredReviews` into state before guard evaluation, with workflow-type-aware defaults
- **vitest.config.ts** — Switch pool to `forks` for module-level mock isolation
- **4 test files** — Add missing `EventStore.initialize()` calls to prevent PID lock contention
- **platform-portability.md** — Update workflow tool action list to include `checkpoint`
- **integration.test.ts** — Update review keys to match documented review-process.md contract

## Test Plan

25 new tests across all 5 fixes: 8 platform detection, 4 misplaced field detection, 1 registry action count, 4 required review guard, 8 parity updates. 3 consecutive full-suite runs with 0 flakes (4706/4706).

---

**Results:** Tests 4706 ✓ · Build 0 errors
**Related:** Closes #1037, closes #1038, closes #1040, closes #1041, closes #1044

🤖 Generated with [Claude Code](https://claude.com/claude-code)