### PR TITLE
feat: add exa, playwright, and Copilot CLI to create-exarchos

### DIFF
--- a/packages/create-exarchos/src/cli.test.ts
+++ b/packages/create-exarchos/src/cli.test.ts
@@ -24,6 +24,11 @@ describe('CLI Arg Parsing', () => {
     expect(args.env).toBe('claude-code');
   });
 
+  it('parseArgs_EnvCopilotCli_SetsEnvironment', () => {
+    const args = parseArgs(['--env', 'copilot-cli']);
+    expect(args.env).toBe('copilot-cli');
+  });
+
   it('parseArgs_EnvCursor_SetsEnvironment', () => {
     const args = parseArgs(['--env', 'cursor']);
     expect(args.env).toBe('cursor');

--- a/packages/create-exarchos/src/cli.ts
+++ b/packages/create-exarchos/src/cli.ts
@@ -1,6 +1,6 @@
 import type { CliArgs, Environment } from './types.js';
 
-const VALID_ENVS: Environment[] = ['claude-code', 'cursor', 'generic-mcp', 'cli'];
+const VALID_ENVS: Environment[] = ['claude-code', 'copilot-cli', 'cursor', 'generic-mcp', 'cli'];
 
 export function parseArgs(argv: string[]): CliArgs {
   const result: CliArgs = {

--- a/packages/create-exarchos/src/companions.test.ts
+++ b/packages/create-exarchos/src/companions.test.ts
@@ -9,20 +9,22 @@ import {
 import type { Environment } from './types.js';
 
 describe('Companion Registry', () => {
-  it('getCompanions_All_ReturnsFiveCompanions', () => {
+  it('getCompanions_All_ReturnsSevenCompanions', () => {
     const all = getCompanions();
-    expect(all).toHaveLength(5);
+    expect(all).toHaveLength(7);
     const ids = all.map(c => c.id);
     expect(ids).toContain('axiom');
     expect(ids).toContain('impeccable');
     expect(ids).toContain('serena');
     expect(ids).toContain('context7');
+    expect(ids).toContain('exa');
+    expect(ids).toContain('playwright');
     expect(ids).toContain('microsoft-learn');
   });
 
-  it('getDefaultCompanions_DefaultsOnly_ReturnsFour', () => {
+  it('getDefaultCompanions_DefaultsOnly_ReturnsSix', () => {
     const defaults = getDefaultCompanions();
-    expect(defaults).toHaveLength(4);
+    expect(defaults).toHaveLength(6);
     const ids = defaults.map(c => c.id);
     expect(ids).not.toContain('microsoft-learn');
   });
@@ -31,7 +33,7 @@ describe('Companion Registry', () => {
     const all = getCompanions();
     const filtered = filterCompanions(all, ['axiom']);
     expect(filtered.map(c => c.id)).not.toContain('axiom');
-    expect(filtered).toHaveLength(4);
+    expect(filtered).toHaveLength(6);
   });
 
   it('filterCompanions_IncludeNonDefault_AddsWhenSelected', () => {
@@ -40,7 +42,7 @@ describe('Companion Registry', () => {
     const all = getCompanions();
     const msLearn = all.find(c => c.id === 'microsoft-learn')!;
     const result = [...defaults, msLearn];
-    expect(result).toHaveLength(5);
+    expect(result).toHaveLength(7);
   });
 
   it('getCompanionInstall_ClaudeCodeEnv_ReturnsPluginConfig', () => {
@@ -68,6 +70,46 @@ describe('Companion Registry', () => {
   it('getCompanionInstall_CliEnv_ReturnsUndefined', () => {
     const axiom = COMPANIONS.find(c => c.id === 'axiom')!;
     const install = getCompanionInstall(axiom, 'cli');
+    expect(install).toBeUndefined();
+  });
+
+  it('getCompanionInstall_Exa_ClaudeCode_ReturnsHttpMcp', () => {
+    const exa = COMPANIONS.find(c => c.id === 'exa')!;
+    const install = getCompanionInstall(exa, 'claude-code');
+    expect(install?.mcp).toBeDefined();
+    expect(install?.mcp?.type).toBe('http');
+    expect(install?.mcp?.url).toBe('https://mcp.exa.ai/mcp');
+  });
+
+  it('getCompanionInstall_Exa_Cursor_ReturnsHttpMcp', () => {
+    const exa = COMPANIONS.find(c => c.id === 'exa')!;
+    const install = getCompanionInstall(exa, 'cursor');
+    expect(install?.mcp).toBeDefined();
+    expect(install?.mcp?.type).toBe('http');
+    expect(install?.mcp?.url).toBe('https://mcp.exa.ai/mcp');
+  });
+
+  it('getCompanionInstall_Playwright_ClaudeCode_CommandsOnly', () => {
+    const pw = COMPANIONS.find(c => c.id === 'playwright')!;
+    const install = getCompanionInstall(pw, 'claude-code');
+    expect(install?.plugin).toBeUndefined();
+    expect(install?.mcp).toBeUndefined();
+    expect(install?.commands).toContain('npx @playwright/cli install');
+    expect(install?.commands).toContain('npx @playwright/cli install --skills');
+  });
+
+  it('getCompanionInstall_Playwright_Cursor_CommandsOnly', () => {
+    const pw = COMPANIONS.find(c => c.id === 'playwright')!;
+    const install = getCompanionInstall(pw, 'cursor');
+    expect(install?.plugin).toBeUndefined();
+    expect(install?.mcp).toBeUndefined();
+    expect(install?.commands).toContain('npx @playwright/cli install');
+    expect(install?.commands).toContain('npx @playwright/cli install --skills');
+  });
+
+  it('getCompanionInstall_Playwright_GenericMcp_Undefined', () => {
+    const pw = COMPANIONS.find(c => c.id === 'playwright')!;
+    const install = getCompanionInstall(pw, 'generic-mcp');
     expect(install).toBeUndefined();
   });
 });

--- a/packages/create-exarchos/src/companions.ts
+++ b/packages/create-exarchos/src/companions.ts
@@ -5,25 +5,68 @@ export const COMPANIONS: Companion[] = [
     id: 'axiom', name: 'axiom',
     description: 'backend quality checks (8 dimensions incl. prose quality)',
     default: true,
-    install: { 'claude-code': { plugin: 'axiom@lvlup-sw' }, cursor: { skills: 'lvlup-sw/axiom' } },
+    install: {
+      'claude-code': { plugin: 'axiom@lvlup-sw' },
+      'copilot-cli': { skills: 'lvlup-sw/axiom' },
+      cursor: { skills: 'lvlup-sw/axiom' },
+    },
   },
   {
     id: 'impeccable', name: 'impeccable',
     description: 'frontend design quality (17 skills)',
     default: true,
-    install: { 'claude-code': { plugin: 'impeccable@impeccable' }, cursor: { skills: 'pbakaus/impeccable' } },
+    install: {
+      'claude-code': { plugin: 'impeccable@impeccable' },
+      'copilot-cli': { skills: 'pbakaus/impeccable' },
+      cursor: { skills: 'pbakaus/impeccable' },
+    },
   },
   {
     id: 'serena', name: 'serena',
     description: 'semantic code analysis',
     default: true,
-    install: { 'claude-code': { plugin: 'serena@claude-plugins-official' } },
+    install: {
+      'claude-code': { plugin: 'serena@claude-plugins-official' },
+      'copilot-cli': { mcp: { type: 'stdio', command: 'uvx', args: ['--from', 'git+https://github.com/oraios/serena', 'serena', 'start-mcp-server'] } },
+      cursor: { mcp: { type: 'stdio', command: 'uvx', args: ['--from', 'git+https://github.com/oraios/serena', 'serena', 'start-mcp-server'] } },
+    },
   },
   {
     id: 'context7', name: 'context7',
     description: 'library documentation',
     default: true,
-    install: { 'claude-code': { plugin: 'context7@claude-plugins-official' } },
+    install: {
+      'claude-code': { plugin: 'context7@claude-plugins-official' },
+      'copilot-cli': { mcp: { type: 'stdio', command: 'npx', args: ['-y', '@upstash/context7-mcp'] } },
+      cursor: { mcp: { type: 'stdio', command: 'npx', args: ['-y', '@upstash/context7-mcp'] } },
+    },
+  },
+  {
+    id: 'exa', name: 'exa',
+    description: 'web search and crawling',
+    default: true,
+    install: {
+      'claude-code': { mcp: { type: 'http', url: 'https://mcp.exa.ai/mcp' } },
+      'copilot-cli': { mcp: { type: 'http', url: 'https://mcp.exa.ai/mcp' } },
+      cursor: { mcp: { type: 'http', url: 'https://mcp.exa.ai/mcp' } },
+      'generic-mcp': { mcp: { type: 'http', url: 'https://mcp.exa.ai/mcp' } },
+    },
+  },
+  {
+    id: 'playwright', name: 'playwright',
+    description: 'browser automation and testing via CLI',
+    default: true,
+    install: {
+      'claude-code': {
+        commands: ['npx @playwright/cli install', 'npx @playwright/cli install --skills'],
+      },
+      'copilot-cli': {
+        commands: ['npx @playwright/cli install', 'npx @playwright/cli install --skills'],
+      },
+      cursor: {
+        commands: ['npx @playwright/cli install', 'npx @playwright/cli install --skills'],
+      },
+    },
   },
   {
     id: 'microsoft-learn', name: 'microsoft-learn',
@@ -31,6 +74,7 @@ export const COMPANIONS: Companion[] = [
     default: false,
     install: {
       'claude-code': { mcp: { type: 'http', url: 'https://learn.microsoft.com/api/mcp' } },
+      'copilot-cli': { mcp: { type: 'http', url: 'https://learn.microsoft.com/api/mcp' } },
       'generic-mcp': { mcp: { type: 'http', url: 'https://learn.microsoft.com/api/mcp' } },
     },
   },

--- a/packages/create-exarchos/src/detect.test.ts
+++ b/packages/create-exarchos/src/detect.test.ts
@@ -20,12 +20,21 @@ describe('Environment Detection', () => {
     vi.resetAllMocks();
   });
 
-  it('detectEnvironment_ClaudeDirPresent_ReturnsClaudeCode', () => {
+  it('detectEnvironment_ClaudeJsonPresent_ReturnsClaudeCode', () => {
     vi.mocked(existsSync).mockImplementation((p) =>
-      typeof p === 'string' && p.includes('.claude')
+      typeof p === 'string' && p.endsWith('.claude.json')
     );
 
     expect(detectEnvironment()).toBe('claude-code');
+  });
+
+  it('detectEnvironment_ClaudeDirOnly_DoesNotDetectClaudeCode', () => {
+    // ~/.claude/ directory alone (e.g. from playwright skills) should not trigger claude-code
+    vi.mocked(existsSync).mockImplementation((p) =>
+      typeof p === 'string' && p.endsWith('/.claude')
+    );
+
+    expect(detectEnvironment()).toBeNull();
   });
 
   it('detectEnvironment_CopilotDirPresent_ReturnsCopilotCli', () => {

--- a/packages/create-exarchos/src/detect.test.ts
+++ b/packages/create-exarchos/src/detect.test.ts
@@ -28,6 +28,14 @@ describe('Environment Detection', () => {
     expect(detectEnvironment()).toBe('claude-code');
   });
 
+  it('detectEnvironment_CopilotDirPresent_ReturnsCopilotCli', () => {
+    vi.mocked(existsSync).mockImplementation((p) =>
+      typeof p === 'string' && p.includes('.copilot')
+    );
+
+    expect(detectEnvironment()).toBe('copilot-cli');
+  });
+
   it('detectEnvironment_CursorDirInHome_ReturnsCursor', () => {
     vi.mocked(existsSync).mockImplementation((p) =>
       typeof p === 'string' && p.includes('.cursor')

--- a/packages/create-exarchos/src/detect.ts
+++ b/packages/create-exarchos/src/detect.ts
@@ -5,8 +5,10 @@ import { homedir } from 'node:os';
 import type { Environment } from './types.js';
 
 export function detectEnvironment(): Environment | null {
-  const claudeDir = join(homedir(), '.claude');
-  if (existsSync(claudeDir)) return 'claude-code';
+  // Check for ~/.claude.json (Claude Code config) rather than ~/.claude/ directory,
+  // which can be created by tools like playwright-cli installing skills.
+  const claudeConfig = join(homedir(), '.claude.json');
+  if (existsSync(claudeConfig)) return 'claude-code';
   const copilotDir = join(homedir(), '.copilot');
   if (existsSync(copilotDir)) return 'copilot-cli';
   const cursorHome = join(homedir(), '.cursor');

--- a/packages/create-exarchos/src/detect.ts
+++ b/packages/create-exarchos/src/detect.ts
@@ -7,6 +7,8 @@ import type { Environment } from './types.js';
 export function detectEnvironment(): Environment | null {
   const claudeDir = join(homedir(), '.claude');
   if (existsSync(claudeDir)) return 'claude-code';
+  const copilotDir = join(homedir(), '.copilot');
+  if (existsSync(copilotDir)) return 'copilot-cli';
   const cursorHome = join(homedir(), '.cursor');
   const cursorCwd = join(process.cwd(), '.cursor');
   if (existsSync(cursorHome) || existsSync(cursorCwd)) return 'cursor';

--- a/packages/create-exarchos/src/index.test.ts
+++ b/packages/create-exarchos/src/index.test.ts
@@ -16,6 +16,11 @@ vi.mock('./installers/claude-code.js', () => ({
   installCompanion: vi.fn((c) => ({ success: true, name: c.name })),
 }));
 
+vi.mock('./installers/copilot-cli.js', () => ({
+  installExarchos: vi.fn(() => ({ success: true, name: 'exarchos' })),
+  installCompanion: vi.fn((c) => ({ success: true, name: c.name })),
+}));
+
 vi.mock('./installers/cursor.js', () => ({
   installExarchos: vi.fn(() => ({ success: true, name: 'exarchos' })),
   installCompanion: vi.fn((c) => ({ success: true, name: c.name })),
@@ -50,8 +55,8 @@ describe('Main Orchestration', () => {
     await run(['--yes']);
 
     expect(claudeCodeInstaller.installExarchos).toHaveBeenCalled();
-    // Should install default companions (axiom, impeccable, serena, context7)
-    expect(claudeCodeInstaller.installCompanion).toHaveBeenCalledTimes(4);
+    // Should install default companions (axiom, impeccable, serena, context7, exa, playwright)
+    expect(claudeCodeInstaller.installCompanion).toHaveBeenCalledTimes(6);
   });
 
   it('run_NonInteractive_WithEnvFlag_UsesSpecifiedEnv', async () => {
@@ -67,8 +72,8 @@ describe('Main Orchestration', () => {
     await run(['--yes', '--no-axiom']);
 
     expect(claudeCodeInstaller.installExarchos).toHaveBeenCalled();
-    // Should install 3 companions (impeccable, serena, context7) — axiom excluded
-    expect(claudeCodeInstaller.installCompanion).toHaveBeenCalledTimes(3);
+    // Should install 5 companions (impeccable, serena, context7, exa, playwright) — axiom excluded
+    expect(claudeCodeInstaller.installCompanion).toHaveBeenCalledTimes(5);
     const calls = vi.mocked(claudeCodeInstaller.installCompanion).mock.calls;
     const companionIds = calls.map(c => c[0].id);
     expect(companionIds).not.toContain('axiom');
@@ -95,7 +100,7 @@ describe('Main Orchestration', () => {
 
     await run(['--yes']);
 
-    // Should have tried all 4 companions despite first failure
-    expect(claudeCodeInstaller.installCompanion).toHaveBeenCalledTimes(4);
+    // Should have tried all 6 companions despite first failure
+    expect(claudeCodeInstaller.installCompanion).toHaveBeenCalledTimes(6);
   });
 });

--- a/packages/create-exarchos/src/index.ts
+++ b/packages/create-exarchos/src/index.ts
@@ -9,6 +9,7 @@ import { getDefaultCompanions, getCompanions, filterCompanions, getCompanionInst
 import { buildEnvironmentChoices, buildCompanionChoices } from './prompts.js';
 
 import * as claudeCode from './installers/claude-code.js';
+import * as copilotCli from './installers/copilot-cli.js';
 import * as cursor from './installers/cursor.js';
 import * as genericMcp from './installers/generic-mcp.js';
 import * as cli from './installers/cli.js';
@@ -27,6 +28,7 @@ function getInstaller(env: Environment): Installer {
   // without optional args (which is how run() uses them).
   switch (env) {
     case 'claude-code': return claudeCode as Installer;
+    case 'copilot-cli': return copilotCli as Installer;
     case 'cursor': return cursor as Installer;
     case 'generic-mcp': return genericMcp as Installer;
     case 'cli': return cli as Installer;

--- a/packages/create-exarchos/src/installers/claude-code.ts
+++ b/packages/create-exarchos/src/installers/claude-code.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { Companion, InstallResult } from '../types.js';
 import { runCommand } from '../utils.js';
-import { mergeMcpServer } from './shared.js';
+import { mergeMcpServer, runPostInstallCommands } from './shared.js';
 
 export function installExarchos(): InstallResult {
   const result = runCommand('claude plugin install exarchos@lvlup-sw');
@@ -14,12 +14,16 @@ export function installCompanion(companion: Companion, claudeJsonPath?: string):
   if (!install) return { success: true, name: companion.name, skipped: true };
   if (install.plugin) {
     const result = runCommand(`claude plugin install ${install.plugin}`);
-    return { success: result.success, name: companion.name, error: result.error };
+    if (!result.success) return { success: false, name: companion.name, error: result.error };
   }
   if (install.mcp) {
     const configPath = claudeJsonPath ?? join(homedir(), '.claude.json');
     mergeMcpServer(configPath, '.claude.json', companion.id, install.mcp);
-    return { success: true, name: companion.name };
   }
-  return { success: true, name: companion.name, skipped: true };
+  const cmdErr = runPostInstallCommands(install, companion.name);
+  if (cmdErr) return cmdErr;
+  if (!install.plugin && !install.mcp && !install.commands?.length) {
+    return { success: true, name: companion.name, skipped: true };
+  }
+  return { success: true, name: companion.name };
 }

--- a/packages/create-exarchos/src/installers/copilot-cli.test.ts
+++ b/packages/create-exarchos/src/installers/copilot-cli.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return { ...actual, execSync: vi.fn() };
+});
+
+import { execSync } from 'node:child_process';
+import { installExarchos, installCompanion } from './copilot-cli.js';
+
+describe('Copilot CLI Installer', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    testDir = join(tmpdir(), `copilot-cli-installer-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    vi.mocked(execSync).mockReturnValue('');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('installExarchos_CopilotCli_WritesMcpConfigWithExarchosServer', () => {
+    const mcpJsonPath = join(testDir, 'mcp-config.json');
+
+    const result = installExarchos(mcpJsonPath);
+    expect(result.success).toBe(true);
+
+    const config = JSON.parse(readFileSync(mcpJsonPath, 'utf-8'));
+    expect(config.mcpServers?.exarchos).toBeDefined();
+    expect(config.mcpServers.exarchos.command).toBe('npx');
+    expect(config.mcpServers.exarchos.args).toContain('@lvlup-sw/exarchos');
+  });
+
+  it('installCompanion_McpType_AddsToMcpConfig', () => {
+    const mcpJsonPath = join(testDir, 'mcp-config.json');
+    writeFileSync(mcpJsonPath, JSON.stringify({ mcpServers: {} }));
+
+    const result = installCompanion(
+      {
+        id: 'exa', name: 'exa', description: '', default: true,
+        install: { 'copilot-cli': { mcp: { type: 'http', url: 'https://mcp.exa.ai/mcp' } } }
+      },
+      mcpJsonPath
+    );
+    expect(result.success).toBe(true);
+    const config = JSON.parse(readFileSync(mcpJsonPath, 'utf-8'));
+    expect(config.mcpServers?.exa).toBeDefined();
+    expect(config.mcpServers.exa.url).toBe('https://mcp.exa.ai/mcp');
+  });
+
+  it('installCompanion_CommandsType_RunsShellCommands', () => {
+    const result = installCompanion({
+      id: 'playwright', name: 'playwright', description: '', default: true,
+      install: { 'copilot-cli': { commands: ['npx @playwright/cli install', 'npx @playwright/cli install --skills'] } }
+    });
+    expect(result.success).toBe(true);
+    expect(vi.mocked(execSync)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(execSync)).toHaveBeenCalledWith(
+      'npx @playwright/cli install',
+      expect.any(Object)
+    );
+    expect(vi.mocked(execSync)).toHaveBeenCalledWith(
+      'npx @playwright/cli install --skills',
+      expect.any(Object)
+    );
+  });
+
+  it('installCompanion_SkillsType_RunsNpxSkillsAdd', () => {
+    const result = installCompanion({
+      id: 'axiom', name: 'axiom', description: '', default: true,
+      install: { 'copilot-cli': { skills: 'lvlup-sw/axiom' } }
+    });
+    expect(result.success).toBe(true);
+    expect(vi.mocked(execSync)).toHaveBeenCalledWith(
+      expect.stringContaining('npx skills add lvlup-sw/axiom'),
+      expect.any(Object)
+    );
+  });
+
+  it('installCompanion_NoCopilotCliConfig_Skipped', () => {
+    const result = installCompanion({
+      id: 'test', name: 'test', description: '', default: true,
+      install: { 'claude-code': { plugin: 'test@test' } }
+    });
+    expect(result.success).toBe(true);
+    expect(result.skipped).toBe(true);
+  });
+
+  it('installExarchos_ExistingMcpConfig_MergesConfig', () => {
+    const mcpJsonPath = join(testDir, 'mcp-config.json');
+    writeFileSync(mcpJsonPath, JSON.stringify({ mcpServers: { existing: { command: 'node' } } }));
+
+    const result = installExarchos(mcpJsonPath);
+    expect(result.success).toBe(true);
+
+    const config = JSON.parse(readFileSync(mcpJsonPath, 'utf-8'));
+    expect(config.mcpServers.existing).toBeDefined();
+    expect(config.mcpServers.exarchos).toBeDefined();
+  });
+});

--- a/packages/create-exarchos/src/installers/copilot-cli.ts
+++ b/packages/create-exarchos/src/installers/copilot-cli.ts
@@ -5,21 +5,21 @@ import { runCommand } from '../utils.js';
 import { mergeMcpServer, runPostInstallCommands, EXARCHOS_SERVER_CONFIG } from './shared.js';
 
 export function installExarchos(mcpJsonPath?: string): InstallResult {
-  const configPath = mcpJsonPath ?? join(homedir(), '.cursor', 'mcp.json');
-  mergeMcpServer(configPath, '.cursor/mcp.json', 'exarchos', EXARCHOS_SERVER_CONFIG);
+  const configPath = mcpJsonPath ?? join(homedir(), '.copilot', 'mcp-config.json');
+  mergeMcpServer(configPath, '.copilot/mcp-config.json', 'exarchos', EXARCHOS_SERVER_CONFIG);
   return { success: true, name: 'exarchos' };
 }
 
 export function installCompanion(companion: Companion, mcpJsonPath?: string): InstallResult {
-  const install = companion.install.cursor;
+  const install = companion.install['copilot-cli'];
   if (!install) return { success: true, name: companion.name, skipped: true };
   if (install.skills) {
     const result = runCommand(`npx skills add ${install.skills}`);
     if (!result.success) return { success: false, name: companion.name, error: result.error };
   }
   if (install.mcp) {
-    const configPath = mcpJsonPath ?? join(homedir(), '.cursor', 'mcp.json');
-    mergeMcpServer(configPath, '.cursor/mcp.json', companion.id, install.mcp);
+    const configPath = mcpJsonPath ?? join(homedir(), '.copilot', 'mcp-config.json');
+    mergeMcpServer(configPath, '.copilot/mcp-config.json', companion.id, install.mcp);
   }
   const cmdErr = runPostInstallCommands(install, companion.name);
   if (cmdErr) return cmdErr;

--- a/packages/create-exarchos/src/installers/generic-mcp.ts
+++ b/packages/create-exarchos/src/installers/generic-mcp.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import type { Companion, InstallResult } from '../types.js';
-import { mergeMcpServer, EXARCHOS_SERVER_CONFIG } from './shared.js';
+import { mergeMcpServer, runPostInstallCommands, EXARCHOS_SERVER_CONFIG } from './shared.js';
 
 export function installExarchos(mcpJsonPath?: string): InstallResult {
   const configPath = mcpJsonPath ?? join(process.cwd(), '.mcp.json');
@@ -14,7 +14,11 @@ export function installCompanion(companion: Companion, mcpJsonPath?: string): In
   if (install.mcp) {
     const configPath = mcpJsonPath ?? join(process.cwd(), '.mcp.json');
     mergeMcpServer(configPath, '.mcp.json', companion.id, install.mcp);
-    return { success: true, name: companion.name };
   }
-  return { success: true, name: companion.name, skipped: true };
+  const cmdErr = runPostInstallCommands(install, companion.name);
+  if (cmdErr) return cmdErr;
+  if (!install.mcp && !install.commands?.length) {
+    return { success: true, name: companion.name, skipped: true };
+  }
+  return { success: true, name: companion.name };
 }

--- a/packages/create-exarchos/src/installers/shared.ts
+++ b/packages/create-exarchos/src/installers/shared.ts
@@ -1,4 +1,5 @@
-import { parseJsonFile, writeJsonFile } from '../utils.js';
+import type { CompanionInstall, InstallResult } from '../types.js';
+import { parseJsonFile, writeJsonFile, runCommand } from '../utils.js';
 
 interface McpJson { mcpServers?: Record<string, unknown>; }
 
@@ -9,4 +10,13 @@ export function mergeMcpServer(configPath: string, label: string, serverId: stri
   if (!config.mcpServers) config.mcpServers = {};
   config.mcpServers[serverId] = serverConfig;
   writeJsonFile(configPath, config);
+}
+
+export function runPostInstallCommands(install: CompanionInstall, name: string): InstallResult | null {
+  if (!install.commands?.length) return null;
+  for (const cmd of install.commands) {
+    const result = runCommand(cmd);
+    if (!result.success) return { success: false, name, error: result.error };
+  }
+  return null;
 }

--- a/packages/create-exarchos/src/prompts.test.ts
+++ b/packages/create-exarchos/src/prompts.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { buildEnvironmentChoices, buildCompanionChoices } from './prompts.js';
 
 describe('Prompts', () => {
-  it('buildEnvironmentChoices_AllFourOptions_ReturnsFourChoices', () => {
+  it('buildEnvironmentChoices_AllFiveOptions_ReturnsFiveChoices', () => {
     const choices = buildEnvironmentChoices(null);
-    expect(choices).toHaveLength(4);
+    expect(choices).toHaveLength(5);
     const values = choices.map(c => c.value);
     expect(values).toContain('claude-code');
+    expect(values).toContain('copilot-cli');
     expect(values).toContain('cursor');
     expect(values).toContain('generic-mcp');
     expect(values).toContain('cli');

--- a/packages/create-exarchos/src/prompts.ts
+++ b/packages/create-exarchos/src/prompts.ts
@@ -10,6 +10,7 @@ export interface Choice<T> {
 export function buildEnvironmentChoices(_detected: Environment | null): Choice<Environment>[] {
   return [
     { name: 'Claude Code', value: 'claude-code' },
+    { name: 'Copilot CLI', value: 'copilot-cli' },
     { name: 'Cursor', value: 'cursor' },
     { name: 'Other MCP client', value: 'generic-mcp' },
     { name: 'Terminal (CLI only)', value: 'cli' },

--- a/packages/create-exarchos/src/types.ts
+++ b/packages/create-exarchos/src/types.ts
@@ -1,16 +1,19 @@
-export type Environment = 'claude-code' | 'cursor' | 'generic-mcp' | 'cli';
+export type Environment = 'claude-code' | 'copilot-cli' | 'cursor' | 'generic-mcp' | 'cli';
 
 export interface McpServerConfig {
   type: string;
   url?: string;
   command?: string;
   args?: string[];
+  env?: Record<string, string>;
 }
 
 export interface CompanionInstall {
   plugin?: string;
   mcp?: McpServerConfig;
   skills?: string;
+  /** Shell command to run (e.g. npx @playwright/cli install --skills). Runs after plugin/mcp/skills. */
+  commands?: string[];
 }
 
 export interface Companion {


### PR DESCRIPTION
## Summary

Expands the `create-exarchos` interactive installer with 2 new default companions (exa, playwright), a new target environment (GitHub Copilot CLI), and full cross-platform companion availability for all three coding agents (Claude Code, Copilot CLI, Cursor).

## Changes

**New companions:**
- **exa** — web search and crawling via hosted HTTP MCP endpoint (`https://mcp.exa.ai/mcp`) with OAuth. Available on all environments except CLI.
- **playwright** — browser automation via `@playwright/cli` (not the MCP server). Runs `npx @playwright/cli install` + `install --skills` to set up the CLI and agent skills. Available on Claude Code, Copilot CLI, and Cursor.

**New environment: `copilot-cli`**
- Auto-detects `~/.copilot` directory
- MCP server config merges into `~/.copilot/mcp-config.json`
- Skills install via `npx skills add` (agentskills spec — writes to `.claude/skills/` which Copilot reads)
- All 7 companions now available: axiom/impeccable via skills, serena/context7 via direct MCP configs, exa/microsoft-learn via HTTP MCP, playwright via CLI commands

**Expanded companion coverage for cursor:**
- serena: now available via MCP (`uvx serena start-mcp-server`)
- context7: now available via MCP (`npx -y @upstash/context7-mcp`)

**Type/installer changes:**
- `McpServerConfig` gains `env?: Record<string, string>` for stdio servers needing env vars
- `CompanionInstall` gains `commands?: string[]` for post-install shell commands
- All installers (claude-code, cursor, generic-mcp) now run install phases sequentially (plugin → mcp → skills → commands) with short-circuit on failure
- New `runPostInstallCommands` shared helper

**Companion availability matrix:**

| Companion | claude-code | copilot-cli | cursor | generic-mcp |
|---|---|---|---|---|
| axiom | plugin | skills | skills | — |
| impeccable | plugin | skills | skills | — |
| serena | plugin | MCP (uvx) | MCP (uvx) | — |
| context7 | plugin | MCP (npx) | MCP (npx) | — |
| exa | HTTP MCP | HTTP MCP | HTTP MCP | HTTP MCP |
| playwright | CLI cmds | CLI cmds | CLI cmds | — |
| microsoft-learn | HTTP MCP | HTTP MCP | — | HTTP MCP |

## Test Plan

- [x] All 67 tests pass (`npx vitest run` — 11 test files)
- [x] TypeScript strict mode clean (`npx tsc --noEmit`)
- [x] New `copilot-cli.test.ts` covers: MCP merge, skills install, CLI commands, skip behavior, idempotent merge
- [x] Updated companion tests verify new exa/playwright entries and copilot-cli/cursor coverage
- [x] Updated index tests verify correct companion counts (6 defaults for claude-code)
- [x] Verified `npx @playwright/cli install --skills` is idempotent (re-run overwrites cleanly)
- [x] Verified exa hosted endpoint uses OAuth (no API key baked into config)

**Results:** 67 passed, 0 failed

**Related:** #1042 (original create-exarchos)