### PR TITLE
feat: Channel Integration Phases 0-1 (#1049)

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/event-store/tools.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/tools.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as path from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { EventStore } from '../../event-store/store.js';
-import { handleEventAppend, handleEventQuery, registerEventTools } from '../../event-store/tools.js';
+import { handleEventAppend, handleEventQuery } from '../../event-store/tools.js';
 
 let tempDir: string;
 let eventStore: EventStore;
@@ -485,52 +485,3 @@ describe('handleEventQuery Fields Projection', () => {
   });
 });
 
-// ─── EventStore Consolidation ────────────────────────────────────────────────
-
-describe('registerEventTools', () => {
-  it('should accept eventStore parameter in registration', () => {
-    const mockServer = { tool: vi.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
-    const store = new EventStore(tempDir);
-    expect(() => registerEventTools(mockServer, tempDir, store)).not.toThrow();
-    expect(registerEventTools.length).toBe(3);
-  });
-
-  it('should register handlers that use the provided EventStore', async () => {
-    const store = new EventStore(tempDir);
-    const mockServer = { tool: vi.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
-    registerEventTools(mockServer, tempDir, store);
-
-    const result = await handleEventAppend(
-      { stream: 'wf-consolidation', event: { type: 'workflow.started', data: { featureId: 'test', workflowType: 'feature' } } },
-      tempDir,
-      store,
-    );
-    expect(result.success).toBe(true);
-
-    const events = await store.query('wf-consolidation');
-    expect(events).toHaveLength(1);
-  });
-
-  it('eventStore threaded via parameter ensures consistent store usage', async () => {
-    // EventStore is now threaded via DispatchContext — multiple calls with
-    // the same store instance should share state (no orphan instances)
-    const result1 = await handleEventAppend(
-      { stream: 'wf-cache-test', event: { type: 'workflow.started', data: { featureId: 'cache1', workflowType: 'feature' } } },
-      tempDir,
-      eventStore,
-    );
-    expect(result1.success).toBe(true);
-
-    const result2 = await handleEventAppend(
-      { stream: 'wf-cache-test', event: { type: 'task.assigned', data: { taskId: 'task-1', title: 'Test' } } },
-      tempDir,
-      eventStore,
-    );
-    expect(result2.success).toBe(true);
-
-    // Both events should be visible via query (same store instance)
-    const queryResult = await handleEventQuery({ stream: 'wf-cache-test' }, tempDir, eventStore);
-    expect(queryResult.success).toBe(true);
-    expect(queryResult.data).toHaveLength(2);
-  });
-});

--- a/servers/exarchos-mcp/src/adapters/mcp.test.ts
+++ b/servers/exarchos-mcp/src/adapters/mcp.test.ts
@@ -57,6 +57,32 @@ describe('createMcpServer', () => {
     expect(TOOL_REGISTRY.length).toBe(5);
   });
 
+  it('createMcpServer_declaresChannelCapability', async () => {
+    // Arrange
+    const { createMcpServer } = await import('./mcp.js');
+
+    // Act
+    const server = createMcpServer(ctx);
+    const capabilities = server.server.getCapabilities();
+
+    // Assert — experimental capabilities should include claude/channel
+    expect(capabilities.experimental).toBeDefined();
+    expect(capabilities.experimental).toHaveProperty('claude/channel');
+    expect(capabilities.experimental!['claude/channel']).toEqual({});
+  });
+
+  it('createMcpServer_exposesServerForNotifications', async () => {
+    // Arrange
+    const { createMcpServer } = await import('./mcp.js');
+
+    // Act
+    const server = createMcpServer(ctx);
+
+    // Assert — server.server should be accessible and have a notification method
+    expect(server.server).toBeDefined();
+    expect(typeof server.server.notification).toBe('function');
+  });
+
   it('CreateMcpServer_SlimRegistration_UsesSlimDescriptions', async () => {
     // Arrange: create context with slimRegistration enabled
     const slimCtx: DispatchContext = { ...ctx, slimRegistration: true };

--- a/servers/exarchos-mcp/src/adapters/mcp.ts
+++ b/servers/exarchos-mcp/src/adapters/mcp.ts
@@ -18,7 +18,16 @@ const SERVER_VERSION = '1.1.0';
  * 2. Wraps the ToolResult with formatResult() for MCP wire format
  */
 export function createMcpServer(ctx: DispatchContext): McpServer {
-  const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
+  const server = new McpServer(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    {
+      capabilities: {
+        experimental: {
+          'claude/channel': {},
+        },
+      },
+    },
+  );
 
   for (const tool of getFullRegistry()) {
     if (tool.hidden) continue;

--- a/servers/exarchos-mcp/src/channel/emitter.test.ts
+++ b/servers/exarchos-mcp/src/channel/emitter.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ChannelEmitter } from './emitter.js';
+
+// Minimal mock of MCP Server's notification method
+function createMockServer() {
+  return {
+    notification: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('ChannelEmitter', () => {
+  it('push calls server notification for events meeting threshold', async () => {
+    const server = createMockServer();
+    const emitter = new ChannelEmitter(server as never);
+
+    await emitter.push(
+      { streamId: 'wf-1', sequence: 1, type: 'task.completed', data: {}, timestamp: '2026-04-05T00:00:00Z' },
+      'success',
+    );
+
+    expect(server.notification).toHaveBeenCalledTimes(1);
+    expect(server.notification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'notifications/claude/channel',
+        params: expect.objectContaining({
+          content: expect.any(String),
+          meta: expect.objectContaining({ type: 'task.completed' }),
+        }),
+      }),
+    );
+  });
+
+  it('push does NOT call server notification for events below threshold', async () => {
+    const server = createMockServer();
+    const emitter = new ChannelEmitter(server as never);
+
+    await emitter.push(
+      { streamId: 'wf-1', sequence: 1, type: 'task.progressed', data: {}, timestamp: '2026-04-05T00:00:00Z' },
+      'info',
+    );
+
+    expect(server.notification).not.toHaveBeenCalled();
+  });
+
+  it('push does not throw when server.notification rejects', async () => {
+    const server = createMockServer();
+    server.notification.mockRejectedValue(new Error('not connected'));
+    const emitter = new ChannelEmitter(server as never);
+
+    // Should not throw
+    await expect(
+      emitter.push(
+        { streamId: 'wf-1', sequence: 1, type: 'task.completed', data: {}, timestamp: '2026-04-05T00:00:00Z' },
+        'success',
+      ),
+    ).resolves.not.toThrow();
+  });
+
+  it('respects custom threshold option', async () => {
+    const server = createMockServer();
+    const emitter = new ChannelEmitter(server as never, { threshold: 'warning' });
+
+    await emitter.push(
+      { streamId: 'wf-1', sequence: 1, type: 'task.completed', data: {}, timestamp: '2026-04-05T00:00:00Z' },
+      'success',
+    );
+
+    // success < warning threshold, so should NOT push
+    expect(server.notification).not.toHaveBeenCalled();
+  });
+
+  it('pushes when priority equals custom threshold', async () => {
+    const server = createMockServer();
+    const emitter = new ChannelEmitter(server as never, { threshold: 'warning' });
+
+    await emitter.push(
+      { streamId: 'wf-1', sequence: 1, type: 'task.failed', data: {}, timestamp: '2026-04-05T00:00:00Z' },
+      'warning',
+    );
+
+    expect(server.notification).toHaveBeenCalledTimes(1);
+  });
+});

--- a/servers/exarchos-mcp/src/channel/emitter.ts
+++ b/servers/exarchos-mcp/src/channel/emitter.ts
@@ -1,0 +1,55 @@
+/**
+ * Channel Emitter — fire-and-forget push of notifications via MCP Channel.
+ *
+ * Receives events, applies priority filtering against a configurable threshold,
+ * and pushes via `notifications/claude/channel` on the MCP Server instance.
+ * Errors are logged, never propagated.
+ */
+
+import type { NotificationPriority } from './priority.js';
+import { shouldPush } from './priority.js';
+import { formatNotification } from './formatter.js';
+
+interface ServerLike {
+  notification(notification: { method: string; params?: Record<string, unknown> }): Promise<void>;
+}
+
+interface EventLike {
+  streamId: string;
+  sequence: number;
+  type: string;
+  data: Record<string, unknown>;
+  timestamp: string;
+}
+
+export interface ChannelEmitterOptions {
+  threshold?: NotificationPriority;
+}
+
+export class ChannelEmitter {
+  private readonly server: ServerLike;
+  private readonly threshold: NotificationPriority;
+
+  constructor(server: ServerLike, options?: ChannelEmitterOptions) {
+    this.server = server;
+    this.threshold = options?.threshold ?? 'success';
+  }
+
+  async push(event: EventLike, priority: NotificationPriority): Promise<void> {
+    if (!shouldPush(priority, this.threshold)) return;
+
+    const notification = formatNotification(event, priority);
+
+    try {
+      await this.server.notification({
+        method: 'notifications/claude/channel',
+        params: {
+          content: notification.content,
+          meta: notification.meta,
+        },
+      });
+    } catch {
+      // Fire-and-forget: errors are swallowed, never propagated
+    }
+  }
+}

--- a/servers/exarchos-mcp/src/channel/formatter.test.ts
+++ b/servers/exarchos-mcp/src/channel/formatter.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { formatNotification, type ChannelNotification } from './formatter.js';
+
+describe('formatNotification', () => {
+  const baseEvent = {
+    streamId: 'my-feature',
+    sequence: 5,
+    type: 'task.completed',
+    data: { taskId: 'task-003', summary: 'Implemented auth handler' },
+    timestamp: '2026-04-05T12:00:00Z',
+  };
+
+  it('formats task.completed with taskId and summary', () => {
+    const result = formatNotification(baseEvent, 'success');
+    expect(result.content).toContain('task.completed');
+    expect(result.content).toContain('my-feature');
+  });
+
+  it('formats task.failed with error reason', () => {
+    const event = {
+      ...baseEvent,
+      type: 'task.failed',
+      data: { taskId: 'task-003', error: 'Test assertion failed' },
+    };
+    const result = formatNotification(event, 'warning');
+    expect(result.content).toContain('task.failed');
+    expect(result.content).toContain('Test assertion failed');
+  });
+
+  it('includes workflow_id from streamId in meta', () => {
+    const result = formatNotification(baseEvent, 'success');
+    expect(result.meta.workflow_id).toBe('my-feature');
+  });
+
+  it('includes type and priority in meta', () => {
+    const result = formatNotification(baseEvent, 'success');
+    expect(result.meta.type).toBe('task.completed');
+    expect(result.meta.priority).toBe('success');
+  });
+
+  it('includes task_id in meta when present in data', () => {
+    const result = formatNotification(baseEvent, 'success');
+    expect(result.meta.task_id).toBe('task-003');
+  });
+
+  it('omits task_id from meta when not in data', () => {
+    const event = { ...baseEvent, data: {} };
+    const result = formatNotification(event, 'info');
+    expect(result.meta.task_id).toBeUndefined();
+  });
+
+  it('includes branch in meta when present in data', () => {
+    const event = { ...baseEvent, data: { ...baseEvent.data, branch: 'feat/auth' } };
+    const result = formatNotification(event, 'success');
+    expect(result.meta.branch).toBe('feat/auth');
+  });
+
+  it('ensures all meta keys are alphanumeric/underscore only', () => {
+    const result = formatNotification(baseEvent, 'success');
+    const keyPattern = /^[a-zA-Z0-9_]+$/;
+    for (const key of Object.keys(result.meta)) {
+      expect(key).toMatch(keyPattern);
+    }
+  });
+
+  it('returns ChannelNotification shape with content and meta', () => {
+    const result = formatNotification(baseEvent, 'success');
+    expect(typeof result.content).toBe('string');
+    expect(typeof result.meta).toBe('object');
+    expect(result.content.length).toBeGreaterThan(0);
+  });
+
+  it('formats workflow.failed with critical details', () => {
+    const event = {
+      ...baseEvent,
+      type: 'workflow.failed',
+      data: { error: 'CI pipeline broken', phase: 'synthesize' },
+    };
+    const result = formatNotification(event, 'critical');
+    expect(result.content).toContain('workflow.failed');
+    expect(result.content).toContain('CI pipeline broken');
+  });
+
+  it('handles events with minimal data gracefully', () => {
+    const event = { streamId: 'wf-1', sequence: 1, type: 'workflow.started', data: {}, timestamp: '2026-04-05T00:00:00Z' };
+    const result = formatNotification(event, 'info');
+    expect(result.content).toBeTruthy();
+    expect(result.meta.workflow_id).toBe('wf-1');
+  });
+});

--- a/servers/exarchos-mcp/src/channel/formatter.ts
+++ b/servers/exarchos-mcp/src/channel/formatter.ts
@@ -1,0 +1,62 @@
+/**
+ * Event-to-notification content formatter.
+ *
+ * Converts workflow events into Channel notification payloads with
+ * human-readable content and structured meta attributes.
+ * Meta keys conform to Channel spec: `[a-zA-Z0-9_]` only.
+ */
+
+import type { NotificationPriority } from './priority.js';
+
+export interface ChannelNotification {
+  content: string;
+  meta: Record<string, string>;
+}
+
+interface EventLike {
+  streamId: string;
+  sequence: number;
+  type: string;
+  data: Record<string, unknown>;
+  timestamp: string;
+}
+
+export function formatNotification(
+  event: EventLike,
+  priority: NotificationPriority,
+): ChannelNotification {
+  const meta: Record<string, string> = {
+    type: event.type,
+    priority,
+    workflow_id: event.streamId,
+  };
+
+  const data = event.data;
+  if (typeof data.taskId === 'string') meta.task_id = data.taskId;
+  if (typeof data.branch === 'string') meta.branch = data.branch;
+
+  const content = buildContent(event, data);
+
+  return { content, meta };
+}
+
+function buildContent(
+  event: EventLike,
+  data: Record<string, unknown>,
+): string {
+  const prefix = `[${event.streamId}] ${event.type}`;
+
+  // Error/failure events: include the error reason
+  const error = data.error ?? data.reason;
+  if (typeof error === 'string') {
+    return `${prefix}: ${error}`;
+  }
+
+  // Success events with summary
+  const summary = data.summary ?? data.message;
+  if (typeof summary === 'string') {
+    return `${prefix}: ${summary}`;
+  }
+
+  return prefix;
+}

--- a/servers/exarchos-mcp/src/channel/priority.test.ts
+++ b/servers/exarchos-mcp/src/channel/priority.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { classifyPriority, shouldPush, PRIORITY_ORDER, type NotificationPriority } from './priority.js';
+
+describe('classifyPriority', () => {
+  // Info-level events (low noise)
+  it('classifies task.progressed as info', () => {
+    expect(classifyPriority('task.progressed')).toBe('info');
+  });
+  it('classifies workflow.event as info', () => {
+    expect(classifyPriority('workflow.event')).toBe('info');
+  });
+
+  // Success events
+  it('classifies task.completed as success', () => {
+    expect(classifyPriority('task.completed')).toBe('success');
+  });
+  it('classifies workflow.completed as success', () => {
+    expect(classifyPriority('workflow.completed')).toBe('success');
+  });
+
+  // Warning events
+  it('classifies task.failed as warning', () => {
+    expect(classifyPriority('task.failed')).toBe('warning');
+  });
+  it('classifies sync.conflict as warning', () => {
+    expect(classifyPriority('sync.conflict')).toBe('warning');
+  });
+
+  // Action-required events
+  it('classifies review.requested as action-required', () => {
+    expect(classifyPriority('review.requested')).toBe('action-required');
+  });
+  it('classifies review.changes_requested as action-required', () => {
+    expect(classifyPriority('review.changes_requested')).toBe('action-required');
+  });
+
+  // Critical events
+  it('classifies workflow.failed as critical', () => {
+    expect(classifyPriority('workflow.failed')).toBe('critical');
+  });
+  it('classifies circuit_breaker.tripped as critical', () => {
+    expect(classifyPriority('circuit_breaker.tripped')).toBe('critical');
+  });
+
+  // Unknown events default to info
+  it('classifies unknown event types as info', () => {
+    expect(classifyPriority('some.unknown.event')).toBe('info');
+  });
+});
+
+describe('shouldPush', () => {
+  it('returns true when priority meets threshold', () => {
+    expect(shouldPush('warning', 'warning')).toBe(true);
+  });
+  it('returns true when priority exceeds threshold', () => {
+    expect(shouldPush('critical', 'warning')).toBe(true);
+  });
+  it('returns false when priority is below threshold', () => {
+    expect(shouldPush('info', 'success')).toBe(false);
+  });
+  it('uses success as default threshold', () => {
+    expect(shouldPush('success', 'success')).toBe(true);
+    expect(shouldPush('info', 'success')).toBe(false);
+  });
+});
+
+describe('PRIORITY_ORDER', () => {
+  it('defines correct ordering', () => {
+    expect(PRIORITY_ORDER.info).toBe(0);
+    expect(PRIORITY_ORDER.success).toBe(1);
+    expect(PRIORITY_ORDER.warning).toBe(2);
+    expect(PRIORITY_ORDER['action-required']).toBe(3);
+    expect(PRIORITY_ORDER.critical).toBe(4);
+  });
+});

--- a/servers/exarchos-mcp/src/channel/priority.ts
+++ b/servers/exarchos-mcp/src/channel/priority.ts
@@ -1,0 +1,41 @@
+export type NotificationPriority = 'info' | 'success' | 'warning' | 'action-required' | 'critical';
+
+export const PRIORITY_ORDER: Readonly<Record<NotificationPriority, number>> = {
+  'info': 0,
+  'success': 1,
+  'warning': 2,
+  'action-required': 3,
+  'critical': 4,
+};
+
+const EVENT_PRIORITY_MAP: Record<string, NotificationPriority> = {
+  // Success
+  'task.completed': 'success',
+  'workflow.completed': 'success',
+  'review.approved': 'success',
+  'synthesis.merged': 'success',
+
+  // Warning
+  'task.failed': 'warning',
+  'sync.conflict': 'warning',
+  'review.rejected': 'warning',
+
+  // Action required
+  'review.requested': 'action-required',
+  'review.changes_requested': 'action-required',
+
+  // Critical
+  'workflow.failed': 'critical',
+  'circuit_breaker.tripped': 'critical',
+};
+
+export function classifyPriority(eventType: string): NotificationPriority {
+  return EVENT_PRIORITY_MAP[eventType] ?? 'info';
+}
+
+export function shouldPush(
+  priority: NotificationPriority,
+  threshold: NotificationPriority = 'success',
+): boolean {
+  return PRIORITY_ORDER[priority] >= PRIORITY_ORDER[threshold];
+}

--- a/servers/exarchos-mcp/src/core/dispatch.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.ts
@@ -5,6 +5,7 @@ import type { ResolvedProjectConfig } from '../config/resolve.js';
 import type { VcsProvider } from '../vcs/provider.js';
 import type { ConfigHookRunner } from '../hooks/config-hooks.js';
 import type { Outbox } from '../sync/outbox.js';
+import type { ChannelEmitter } from '../channel/emitter.js';
 import { withTelemetry } from '../telemetry/middleware.js';
 import { hasCustomToolHandlers, getCustomToolActionHandler, getFullRegistry } from '../registry.js';
 
@@ -32,6 +33,7 @@ export interface DispatchContext {
   readonly hookRunner?: ConfigHookRunner;
   readonly slimRegistration?: boolean;
   readonly outbox?: Outbox;
+  readonly channelEmitter?: ChannelEmitter;
 }
 
 // ─── Composite Handler Map ──────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/core/dispatch.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.ts
@@ -4,6 +4,7 @@ import type { ExarchosConfig } from '../config/define.js';
 import type { ResolvedProjectConfig } from '../config/resolve.js';
 import type { VcsProvider } from '../vcs/provider.js';
 import type { ConfigHookRunner } from '../hooks/config-hooks.js';
+import type { Outbox } from '../sync/outbox.js';
 import { withTelemetry } from '../telemetry/middleware.js';
 import { hasCustomToolHandlers, getCustomToolActionHandler, getFullRegistry } from '../registry.js';
 
@@ -30,6 +31,7 @@ export interface DispatchContext {
   readonly vcsProvider?: VcsProvider;
   readonly hookRunner?: ConfigHookRunner;
   readonly slimRegistration?: boolean;
+  readonly outbox?: Outbox;
 }
 
 // ─── Composite Handler Map ──────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/composite.test.ts
+++ b/servers/exarchos-mcp/src/event-store/composite.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ToolResult } from '../format.js';
 import type { DispatchContext } from '../core/dispatch.js';
 import { EventStore } from './store.js';
+import { ChannelEmitter } from '../channel/emitter.js';
 
 vi.mock('./tools.js', () => ({
   handleEventAppend: vi.fn().mockResolvedValue({
@@ -12,10 +13,17 @@ vi.mock('./tools.js', () => ({
     success: true,
     data: [{ streamId: 'test', sequence: 1, type: 'test.event' }],
   } satisfies ToolResult),
+  handleBatchAppend: vi.fn().mockResolvedValue({
+    success: true,
+    data: [
+      { streamId: 'test', sequence: 1, type: 'task.completed' },
+      { streamId: 'test', sequence: 2, type: 'task.progressed' },
+    ],
+  } satisfies ToolResult),
 }));
 
 import { handleEvent } from './composite.js';
-import { handleEventAppend, handleEventQuery } from './tools.js';
+import { handleEventAppend, handleEventQuery, handleBatchAppend } from './tools.js';
 
 function makeCtx(stateDir: string): DispatchContext {
   return { stateDir, eventStore: new EventStore(stateDir), enableTelemetry: false };
@@ -114,5 +122,117 @@ describe('handleEvent', () => {
       expect(handleEventAppend).not.toHaveBeenCalled();
       expect(handleEventQuery).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('handleEvent channel integration', () => {
+  const stateDir = '/tmp/test-channel';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pushes qualifying event to channelEmitter after successful append', async () => {
+    const mockServer = { notification: vi.fn().mockResolvedValue(undefined) };
+    const emitter = new ChannelEmitter(mockServer);
+    const ctx: DispatchContext = {
+      stateDir,
+      eventStore: new EventStore(stateDir),
+      enableTelemetry: false,
+      channelEmitter: emitter,
+    };
+
+    await handleEvent(
+      { action: 'append', stream: 'test-wf', event: { type: 'task.completed', data: {} } },
+      ctx,
+    );
+
+    expect(mockServer.notification).toHaveBeenCalledTimes(1);
+    expect(mockServer.notification).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'notifications/claude/channel' }),
+    );
+  });
+
+  it('does not push info-level events (below default threshold)', async () => {
+    const mockServer = { notification: vi.fn().mockResolvedValue(undefined) };
+    const emitter = new ChannelEmitter(mockServer);
+    const ctx: DispatchContext = {
+      stateDir,
+      eventStore: new EventStore(stateDir),
+      enableTelemetry: false,
+      channelEmitter: emitter,
+    };
+
+    // task.progressed is not in the priority map, so it defaults to 'info'
+    // which is below the default 'success' threshold
+    await handleEvent(
+      { action: 'append', stream: 'test-wf', event: { type: 'task.progressed', data: {} } },
+      ctx,
+    );
+
+    expect(mockServer.notification).not.toHaveBeenCalled();
+  });
+
+  it('does not fail when channelEmitter is not configured', async () => {
+    const ctx: DispatchContext = {
+      stateDir,
+      eventStore: new EventStore(stateDir),
+      enableTelemetry: false,
+    };
+
+    const result = await handleEvent(
+      { action: 'append', stream: 'test-wf', event: { type: 'task.completed', data: {} } },
+      ctx,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it('pushes channel notifications for qualifying events in batch_append', async () => {
+    const mockServer = { notification: vi.fn().mockResolvedValue(undefined) };
+    const emitter = new ChannelEmitter(mockServer);
+    const ctx: DispatchContext = {
+      stateDir,
+      eventStore: new EventStore(stateDir),
+      enableTelemetry: false,
+      channelEmitter: emitter,
+    };
+
+    await handleEvent(
+      {
+        action: 'batch_append',
+        stream: 'test-wf',
+        events: [
+          { type: 'task.completed', data: {} },
+          { type: 'task.progressed', data: {} },
+        ],
+      },
+      ctx,
+    );
+
+    // Only task.completed qualifies (success level); task.progressed is info (below threshold)
+    expect(mockServer.notification).toHaveBeenCalledTimes(1);
+    expect(mockServer.notification).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'notifications/claude/channel' }),
+    );
+  });
+
+  it('does not propagate channelEmitter errors to caller', async () => {
+    const mockServer = { notification: vi.fn().mockRejectedValue(new Error('channel down')) };
+    const emitter = new ChannelEmitter(mockServer);
+    const ctx: DispatchContext = {
+      stateDir,
+      eventStore: new EventStore(stateDir),
+      enableTelemetry: false,
+      channelEmitter: emitter,
+    };
+
+    const result = await handleEvent(
+      { action: 'append', stream: 'test-wf', event: { type: 'task.completed', data: {} } },
+      ctx,
+    );
+
+    // The event append itself should still succeed
+    expect(result.success).toBe(true);
   });
 });

--- a/servers/exarchos-mcp/src/event-store/composite.ts
+++ b/servers/exarchos-mcp/src/event-store/composite.ts
@@ -3,6 +3,7 @@ import type { DispatchContext } from '../core/dispatch.js';
 import { handleEventAppend, handleEventQuery, handleBatchAppend } from './tools.js';
 import { handleEventDescribe } from '../describe/handler.js';
 import { TOOL_REGISTRY } from '../registry.js';
+import { classifyPriority } from '../channel/priority.js';
 
 const VALID_ACTIONS = ['append', 'query', 'batch_append', 'describe'] as const;
 type EventAction = (typeof VALID_ACTIONS)[number];
@@ -34,6 +35,37 @@ async function fireHookIfConfigured(
   }
 }
 
+/**
+ * Push a successfully-appended event to the Channel Emitter (if configured).
+ * Priority is derived from the event type. Fire-and-forget — errors are
+ * swallowed so the event pipeline is never blocked.
+ */
+async function pushToChannelIfConfigured(
+  ctx: DispatchContext,
+  appendArgs: Record<string, unknown>,
+  result: ToolResult,
+): Promise<void> {
+  if (!ctx.channelEmitter || !result.success) return;
+  try {
+    const event = appendArgs.event as Record<string, unknown> | undefined;
+    const data = result.data as Record<string, unknown> | undefined;
+    const eventType = (event?.type as string) ?? '';
+    const priority = classifyPriority(eventType);
+    await ctx.channelEmitter.push(
+      {
+        streamId: (appendArgs.stream as string) ?? '',
+        sequence: (data?.sequence as number) ?? 0,
+        type: eventType,
+        data: (event?.data as Record<string, unknown>) ?? {},
+        timestamp: (data?.timestamp as string) ?? new Date().toISOString(),
+      },
+      priority,
+    );
+  } catch {
+    // Channel push is fire-and-forget — never block the event pipeline
+  }
+}
+
 /** Composite handler that routes `action` to the appropriate event-store handler. */
 export async function handleEvent(
   args: Record<string, unknown>,
@@ -51,6 +83,7 @@ export async function handleEvent(
         eventStore,
       );
       await fireHookIfConfigured(ctx, rest, result);
+      await pushToChannelIfConfigured(ctx, rest, result);
       return result;
     }
     case 'query': {
@@ -68,18 +101,44 @@ export async function handleEvent(
         stateDir,
         eventStore,
       );
-      if (result.success && ctx?.hookRunner) {
+      if (result.success) {
         const batchArgs = rest as { stream?: string; events?: Array<Record<string, unknown>> };
-        for (const event of batchArgs.events ?? []) {
-          try {
-            await ctx.hookRunner({
-              type: (event.type as string) ?? '',
-              data: (event.data as Record<string, unknown>) ?? {},
-              featureId: (batchArgs.stream as string) ?? '',
-              timestamp: new Date().toISOString(),
-            });
-          } catch {
-            // Hooks are fire-and-forget — never block the event pipeline
+        const events = batchArgs.events ?? [];
+        const resultData = result.data as Array<Record<string, unknown>> | undefined;
+        for (let i = 0; i < events.length; i++) {
+          const event = events[i];
+          const ack = resultData?.[i];
+          // Fire hooks
+          if (ctx?.hookRunner) {
+            try {
+              await ctx.hookRunner({
+                type: (event.type as string) ?? '',
+                data: (event.data as Record<string, unknown>) ?? {},
+                featureId: (batchArgs.stream as string) ?? '',
+                timestamp: new Date().toISOString(),
+              });
+            } catch {
+              // Hooks are fire-and-forget — never block the event pipeline
+            }
+          }
+          // Push to channel
+          if (ctx.channelEmitter) {
+            try {
+              const eventType = (event.type as string) ?? '';
+              const priority = classifyPriority(eventType);
+              await ctx.channelEmitter.push(
+                {
+                  streamId: (batchArgs.stream as string) ?? '',
+                  sequence: (ack?.sequence as number) ?? 0,
+                  type: eventType,
+                  data: (event.data as Record<string, unknown>) ?? {},
+                  timestamp: (ack?.timestamp as string) ?? new Date().toISOString(),
+                },
+                priority,
+              );
+            } catch {
+              // Channel push is fire-and-forget — never block the event pipeline
+            }
           }
         }
       }

--- a/servers/exarchos-mcp/src/event-store/store.test.ts
+++ b/servers/exarchos-mcp/src/event-store/store.test.ts
@@ -1527,6 +1527,47 @@ describe('EventStore Outbox Integration', () => {
     expect(parsed.streamId).toBe('my-workflow');
     expect(parsed.sequence).toBe(1);
   });
+
+  it('batchAppend writes entries to outbox when outbox is set', async () => {
+    const store = new EventStore(tempDir);
+    const outbox = new Outbox(tempDir);
+    const addEntrySpy = vi.spyOn(outbox, 'addEntry');
+
+    store.setOutbox(outbox);
+
+    const events = await store.batchAppend('my-workflow', [
+      { type: 'workflow.started', data: { featureId: 'test' } },
+      { type: 'workflow.transition', data: { from: 'triage', to: 'investigate' } },
+    ]);
+
+    expect(events).toHaveLength(2);
+    expect(addEntrySpy).toHaveBeenCalledTimes(2);
+    expect(addEntrySpy).toHaveBeenCalledWith('my-workflow', events[0]);
+    expect(addEntrySpy).toHaveBeenCalledWith('my-workflow', events[1]);
+  });
+
+  it('batchAppend outbox failure does not fail the append', async () => {
+    const store = new EventStore(tempDir);
+    const outbox = new Outbox(tempDir);
+    vi.spyOn(outbox, 'addEntry').mockRejectedValue(new Error('Outbox disk full'));
+
+    store.setOutbox(outbox);
+
+    const events = await store.batchAppend('my-workflow', [
+      { type: 'workflow.started', data: { featureId: 'test' } },
+      { type: 'workflow.transition', data: { from: 'triage', to: 'investigate' } },
+    ]);
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe('workflow.started');
+    expect(events[1].type).toBe('workflow.transition');
+
+    // Verify JSONL was still written successfully
+    const filePath = path.join(tempDir, 'my-workflow.events.jsonl');
+    const content = await fs.readFile(filePath, 'utf-8');
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(2);
+  });
 });
 
 // ─── EventStore Query with Event Migration ──────────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -10,6 +10,7 @@ import { migrateEvent } from './event-migration.js';
 import { storeLogger } from '../logger.js';
 import { isPidAlive } from '../utils/process.js';
 import { getSidecarPath } from './hook-event-writer.js';
+import { validateStreamId } from '../shared/validation.js';
 
 // ─── Sequence Conflict Error ────────────────────────────────────────────────
 
@@ -56,21 +57,8 @@ export interface QueryFilters {
   offset?: number;
 }
 
-// ─── Stream ID Validation ────────────────────────────────────────────────────
-
-const SAFE_STREAM_ID_PATTERN = /^[a-z0-9-]+$/;
-
 /** Pre-compiled regex for extracting the sequence number from a JSONL line before JSON.parse. */
 const SEQUENCE_REGEX = /"sequence":(\d+)/;
-
-/** Validates that a stream ID matches the safe pattern (lowercase alphanumeric and hyphens). */
-function validateStreamId(streamId: string): void {
-  if (!SAFE_STREAM_ID_PATTERN.test(streamId)) {
-    throw new Error(
-      `Invalid streamId "${streamId}": must match ${SAFE_STREAM_ID_PATTERN} (lowercase alphanumeric and hyphens only)`,
-    );
-  }
-}
 
 /** Parse an integer from an environment variable with a fallback default. */
 function parseEnvInt(envVar: string, defaultValue: number): number {

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -502,6 +502,20 @@ export class EventStore {
             );
           }
         }
+
+        // Outbox replication: write entries for at-least-once delivery
+        if (this.outbox) {
+          for (const fullEvent of toAppend) {
+            try {
+              await this.outbox.addEntry(streamId, fullEvent);
+            } catch (err) {
+              storeLogger.error(
+                { err: err instanceof Error ? err.message : String(err) },
+                'Outbox entry failed during batch append',
+              );
+            }
+          }
+        }
       }
 
       return toAppend;

--- a/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/servers/exarchos-mcp/src/event-store/tools.ts
@@ -1,9 +1,7 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z, ZodError } from 'zod';
-import { coercedStringArray } from '../coerce.js';
 import { EventStore, SequenceConflictError } from './store.js';
 import { EVENT_DATA_SCHEMAS, type EventType } from './schemas.js';
-import { formatResult, pickFields, toEventAck, type ToolResult } from '../format.js';
+import { pickFields, toEventAck, type ToolResult } from '../format.js';
 import { buildValidatedEvent } from './event-factory.js';
 
 // ─── Misplaced Field Detection ──────────────────────────────────────────────
@@ -287,32 +285,3 @@ export async function handleEventQuery(
   }
 }
 
-// ─── Registration Function ──────────────────────────────────────────────────
-
-export function registerEventTools(server: McpServer, stateDir: string, eventStore: EventStore): void {
-  // moduleEventStore removed — EventStore now threaded via DispatchContext
-  server.tool(
-    'exarchos_event_append',
-    'Append an event to the event store with optional optimistic concurrency and idempotency key',
-    {
-      stream: z.string().min(1),
-      event: z.record(z.string(), z.unknown()),
-      expectedSequence: z.number().int().optional(),
-      idempotencyKey: z.string().optional(),
-    },
-    async (args) => formatResult(await handleEventAppend(args, stateDir, eventStore)),
-  );
-
-  server.tool(
-    'exarchos_event_query',
-    'Query events from the event store with optional filters (type, sinceSequence, since, until), pagination (limit, offset), and field projection (fields)',
-    {
-      stream: z.string().min(1),
-      filter: z.record(z.string(), z.unknown()).optional(),
-      limit: z.number().int().positive().optional(),
-      offset: z.number().int().nonnegative().optional(),
-      fields: coercedStringArray().optional(),
-    },
-    async (args) => formatResult(await handleEventQuery(args, stateDir, eventStore)),
-  );
-}

--- a/servers/exarchos-mcp/src/shared/validation.test.ts
+++ b/servers/exarchos-mcp/src/shared/validation.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { validateStreamId, SAFE_STREAM_ID_PATTERN } from './validation.js';
+
+describe('SAFE_STREAM_ID_PATTERN', () => {
+  it('matches the expected regex', () => {
+    expect(SAFE_STREAM_ID_PATTERN).toEqual(/^[a-zA-Z0-9._-]+$/);
+  });
+});
+
+describe('validateStreamId', () => {
+  it('accepts lowercase alphanumeric strings', () => {
+    expect(() => validateStreamId('abc123')).not.toThrow();
+  });
+
+  it('accepts uppercase alphanumeric strings', () => {
+    expect(() => validateStreamId('ABC123')).not.toThrow();
+  });
+
+  it('accepts mixed case alphanumeric strings', () => {
+    expect(() => validateStreamId('aBc123')).not.toThrow();
+  });
+
+  it('accepts hyphens', () => {
+    expect(() => validateStreamId('my-stream-id')).not.toThrow();
+  });
+
+  it('accepts dots', () => {
+    expect(() => validateStreamId('my.stream.id')).not.toThrow();
+  });
+
+  it('accepts underscores', () => {
+    expect(() => validateStreamId('my_stream_id')).not.toThrow();
+  });
+
+  it('accepts a combination of all valid characters', () => {
+    expect(() => validateStreamId('My-stream_1.0')).not.toThrow();
+  });
+
+  it('rejects empty strings', () => {
+    expect(() => validateStreamId('')).toThrow(/Invalid streamId/);
+  });
+
+  it('rejects strings with spaces', () => {
+    expect(() => validateStreamId('my stream')).toThrow(/Invalid streamId/);
+  });
+
+  it('rejects strings with slashes', () => {
+    expect(() => validateStreamId('my/stream')).toThrow(/Invalid streamId/);
+  });
+
+  it('rejects strings with backslashes', () => {
+    expect(() => validateStreamId('my\\stream')).toThrow(/Invalid streamId/);
+  });
+
+  it('rejects strings with special characters', () => {
+    expect(() => validateStreamId('stream!@#$%')).toThrow(/Invalid streamId/);
+  });
+
+  it('rejects strings with path traversal', () => {
+    expect(() => validateStreamId('../etc/passwd')).toThrow(/Invalid streamId/);
+  });
+
+  it('includes the invalid streamId in the error message', () => {
+    expect(() => validateStreamId('bad stream!')).toThrow('bad stream!');
+  });
+});

--- a/servers/exarchos-mcp/src/shared/validation.ts
+++ b/servers/exarchos-mcp/src/shared/validation.ts
@@ -1,0 +1,18 @@
+// ─── Stream ID Validation ────────────────────────────────────────────────────
+//
+// Shared validation for stream IDs used across EventStore, Outbox, and SyncState.
+// Superset pattern that accepts lowercase/uppercase alphanumeric, hyphens, dots,
+// and underscores — covering all previously divergent patterns.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Pattern for safe stream IDs: alphanumeric, hyphens, dots, and underscores. */
+export const SAFE_STREAM_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+/** Validates that a stream ID matches the safe pattern. Throws on invalid IDs. */
+export function validateStreamId(streamId: string): void {
+  if (!SAFE_STREAM_ID_PATTERN.test(streamId)) {
+    throw new Error(
+      `Invalid streamId "${streamId}": must match ${SAFE_STREAM_ID_PATTERN} (alphanumeric, hyphens, dots, and underscores only)`,
+    );
+  }
+}

--- a/servers/exarchos-mcp/src/sync/composite.test.ts
+++ b/servers/exarchos-mcp/src/sync/composite.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { handleSyncNow } from './sync-handler.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
+import type { EventSender } from './types.js';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
@@ -57,7 +58,11 @@ describe('handleSyncNow', () => {
       JSON.stringify(entries2),
     );
 
-    const result = await handleSyncNow(tmpDir);
+    const mockSender: EventSender = {
+      appendEvents: vi.fn().mockResolvedValue({ accepted: 1, streamVersion: 1 }),
+    };
+
+    const result = await handleSyncNow(tmpDir, undefined, mockSender);
 
     expect(result.success).toBe(true);
     const data = result.data as Record<string, unknown>;
@@ -80,7 +85,11 @@ describe('handleSyncNow', () => {
       JSON.stringify(entries),
     );
 
-    const result = await handleSyncNow(tmpDir);
+    const mockSender: EventSender = {
+      appendEvents: vi.fn().mockResolvedValue({ accepted: 1, streamVersion: 1 }),
+    };
+
+    const result = await handleSyncNow(tmpDir, undefined, mockSender);
 
     expect(result.success).toBe(true);
     const data = result.data as Record<string, unknown>;
@@ -88,7 +97,7 @@ describe('handleSyncNow', () => {
     const results = data.results as Array<{ streamId: string; sent: number; failed: number }>;
     expect(results).toHaveLength(1);
     expect(results[0].streamId).toBe('test-stream');
-    // The no-op sender successfully "sends" each entry
+    // The mock sender successfully "sends" each entry
     expect(results[0].sent).toBe(2);
     expect(results[0].failed).toBe(0);
   });
@@ -104,19 +113,20 @@ describe('handleSyncNow', () => {
   });
 
   it('handleSyncNow_SenderFailure_ReportsFailedCount', async () => {
-    // The built-in no-op sender doesn't fail, so instead we test
-    // the path where the stateDir doesn't exist (which also succeeds with 0 streams).
-    // For a true sender failure test, we need to verify the error path in handleSyncNow
-    // by providing a directory that causes drain to fail.
-    //
-    // We can trigger this by writing an invalid JSON outbox file that the Outbox.loadEntries
-    // will fail to parse, which gets caught by the try/catch in handleSyncNow.
+    // Trigger a drain failure by writing invalid JSON to an outbox file.
+    // The Outbox.loadEntries will fail to parse, which gets caught by
+    // the try/catch in handleSyncNow.
+    // A sender must be provided so the drain path is exercised.
     await fs.writeFile(
       path.join(tmpDir, 'broken-stream.outbox.json'),
       'NOT_VALID_JSON{{{',
     );
 
-    const result = await handleSyncNow(tmpDir);
+    const mockSender: EventSender = {
+      appendEvents: vi.fn().mockResolvedValue({ accepted: 0, streamVersion: 0 }),
+    };
+
+    const result = await handleSyncNow(tmpDir, undefined, mockSender);
 
     // The outer try/catch in handleSyncNow catches the error
     expect(result.success).toBe(false);

--- a/servers/exarchos-mcp/src/sync/composite.ts
+++ b/servers/exarchos-mcp/src/sync/composite.ts
@@ -20,7 +20,7 @@ export async function handleSync(
 
   switch (action) {
     case 'now':
-      return handleSyncNow(stateDir);
+      return handleSyncNow(stateDir, ctx.outbox);
 
     default:
       return {

--- a/servers/exarchos-mcp/src/sync/outbox.ts
+++ b/servers/exarchos-mcp/src/sync/outbox.ts
@@ -4,10 +4,7 @@ import * as crypto from 'node:crypto';
 import type { WorkflowEvent } from '../event-store/schemas.js';
 import type { OutboxEntry, EventSender } from './types.js';
 import type { StorageBackend } from '../storage/backend.js';
-
-// ─── Stream ID Validation ────────────────────────────────────────────────────
-
-const SAFE_STREAM_ID = /^[A-Za-z0-9._-]+$/;
+import { validateStreamId } from '../shared/validation.js';
 
 // ─── Outbox Options ─────────────────────────────────────────────────────────
 
@@ -46,9 +43,7 @@ export class Outbox {
   // ─── File Path ──────────────────────────────────────────────────────────
 
   private getFilePath(streamId: string): string {
-    if (!SAFE_STREAM_ID.test(streamId)) {
-      throw new Error(`Invalid streamId: ${streamId}`);
-    }
+    validateStreamId(streamId);
     return path.join(this.stateDir, `${streamId}.outbox.json`);
   }
 

--- a/servers/exarchos-mcp/src/sync/sync-handler.test.ts
+++ b/servers/exarchos-mcp/src/sync/sync-handler.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { handleSyncNow } from './sync-handler.js';
 import { Outbox } from './outbox.js';
+import type { EventSender, OutboxEntry } from './types.js';
 
 describe('handleSyncNow', () => {
   let tempDir: string;
@@ -16,7 +17,7 @@ describe('handleSyncNow', () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it('should drain pending outbox entries for discovered streams', async () => {
+  it('should drain pending outbox entries for discovered streams when sender provided', async () => {
     // Arrange: create outbox files with pending entries for two streams
     const outbox1 = [
       {
@@ -62,13 +63,19 @@ describe('handleSyncNow', () => {
       'utf-8',
     );
 
-    // Act
-    const result = await handleSyncNow(tempDir);
+    // Arrange: mock sender that succeeds
+    const mockSender: EventSender = {
+      appendEvents: vi.fn().mockResolvedValue({ accepted: 1, streamVersion: 1 }),
+    };
+
+    // Act: pass sender to trigger actual drain
+    const result = await handleSyncNow(tempDir, undefined, mockSender);
 
     // Assert: result should indicate success and report drained streams
     expect(result.success).toBe(true);
-    const data = result.data as { streams: number; message: string };
+    const data = result.data as { streams: number; results: Array<Record<string, unknown>>; message: string };
     expect(data.streams).toBe(2);
+    expect(data.results).toHaveLength(2);
   });
 
   it('should return success with 0 streams when no outbox files exist', async () => {
@@ -109,16 +116,21 @@ describe('handleSyncNow', () => {
     const sharedOutbox = new Outbox(tempDir);
     const drainSpy = vi.spyOn(sharedOutbox, 'drain');
 
-    // Act: pass the shared outbox to handleSyncNow
-    const result = await handleSyncNow(tempDir, sharedOutbox);
+    // Arrange: mock sender so drain actually happens
+    const mockSender: EventSender = {
+      appendEvents: vi.fn().mockResolvedValue({ accepted: 1, streamVersion: 1 }),
+    };
+
+    // Act: pass the shared outbox and sender to handleSyncNow
+    const result = await handleSyncNow(tempDir, sharedOutbox, mockSender);
 
     // Assert: the shared outbox's drain was called (not a new instance's)
     expect(result.success).toBe(true);
     expect(drainSpy).toHaveBeenCalledTimes(1);
-    expect(drainSpy).toHaveBeenCalledWith(expect.anything(), 'shared-stream');
+    expect(drainSpy).toHaveBeenCalledWith(mockSender, 'shared-stream');
   });
 
-  it('should include no-remote-configured message when no remote is configured', async () => {
+  it('should include local-mode message when no sender is provided', async () => {
     // Arrange: create an outbox file
     const outbox = [
       {
@@ -142,12 +154,119 @@ describe('handleSyncNow', () => {
       'utf-8',
     );
 
-    // Act
+    // Act: no sender passed (local mode)
     const result = await handleSyncNow(tempDir);
 
     // Assert
     expect(result.success).toBe(true);
     const data = result.data as { message: string };
-    expect(data.message).toContain('no remote configured');
+    expect(data.message).toContain('Local mode');
+    expect(data.message).toContain('drain skipped');
+  });
+
+  it('should skip outbox drain in local mode and leave entries pending', async () => {
+    // Arrange: create outbox file with pending entries
+    const outboxEntries = [
+      {
+        id: 'entry-local-1',
+        streamId: 'local-stream',
+        event: {
+          streamId: 'local-stream',
+          sequence: 1,
+          timestamp: '2026-02-15T00:00:00Z',
+          type: 'task.completed',
+          schemaVersion: '1.0',
+        },
+        status: 'pending',
+        attempts: 0,
+        createdAt: '2026-02-15T00:00:00Z',
+      },
+      {
+        id: 'entry-local-2',
+        streamId: 'local-stream',
+        event: {
+          streamId: 'local-stream',
+          sequence: 2,
+          timestamp: '2026-02-15T00:01:00Z',
+          type: 'task.completed',
+          schemaVersion: '1.0',
+        },
+        status: 'pending',
+        attempts: 0,
+        createdAt: '2026-02-15T00:01:00Z',
+      },
+    ];
+    await writeFile(
+      path.join(tempDir, 'local-stream.outbox.json'),
+      JSON.stringify(outboxEntries),
+      'utf-8',
+    );
+
+    // Act: call without sender (local mode)
+    const result = await handleSyncNow(tempDir);
+
+    // Assert: result indicates local mode
+    expect(result.success).toBe(true);
+
+    // Assert: entries remain pending (not confirmed)
+    const raw = await readFile(
+      path.join(tempDir, 'local-stream.outbox.json'),
+      'utf-8',
+    );
+    const entries = JSON.parse(raw) as OutboxEntry[];
+    expect(entries).toHaveLength(2);
+    expect(entries[0].status).toBe('pending');
+    expect(entries[1].status).toBe('pending');
+  });
+
+  it('should drain outbox when a sender is provided', async () => {
+    // Arrange: create outbox file with pending entries
+    const outboxEntries = [
+      {
+        id: 'entry-remote-1',
+        streamId: 'remote-stream',
+        event: {
+          streamId: 'remote-stream',
+          sequence: 1,
+          timestamp: '2026-02-15T00:00:00Z',
+          type: 'task.completed',
+          schemaVersion: '1.0',
+        },
+        status: 'pending',
+        attempts: 0,
+        createdAt: '2026-02-15T00:00:00Z',
+      },
+    ];
+    await writeFile(
+      path.join(tempDir, 'remote-stream.outbox.json'),
+      JSON.stringify(outboxEntries),
+      'utf-8',
+    );
+
+    // Create a mock sender that succeeds
+    const mockSender: EventSender = {
+      appendEvents: vi.fn().mockResolvedValue({ accepted: 1, streamVersion: 1 }),
+    };
+
+    // Act: pass a sender to trigger drain
+    const result = await handleSyncNow(tempDir, undefined, mockSender);
+
+    // Assert: result indicates drain happened
+    expect(result.success).toBe(true);
+    const data = result.data as { streams: number; results: Array<{ sent: number; failed: number }> };
+    expect(data.streams).toBe(1);
+    expect(data.results[0].sent).toBe(1);
+    expect(data.results[0].failed).toBe(0);
+
+    // Assert: sender was actually called
+    expect(mockSender.appendEvents).toHaveBeenCalledTimes(1);
+
+    // Assert: entry is now confirmed
+    const raw = await readFile(
+      path.join(tempDir, 'remote-stream.outbox.json'),
+      'utf-8',
+    );
+    const entries = JSON.parse(raw) as OutboxEntry[];
+    expect(entries[0].status).toBe('confirmed');
   });
 });

--- a/servers/exarchos-mcp/src/sync/sync-handler.test.ts
+++ b/servers/exarchos-mcp/src/sync/sync-handler.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { handleSyncNow } from './sync-handler.js';
+import { Outbox } from './outbox.js';
 
 describe('handleSyncNow', () => {
   let tempDir: string;
@@ -78,6 +79,43 @@ describe('handleSyncNow', () => {
     expect(result.success).toBe(true);
     const data = result.data as { streams: number; message: string };
     expect(data.streams).toBe(0);
+  });
+
+  it('should use ctx.outbox when provided instead of creating a new instance', async () => {
+    // Arrange: create an outbox file with a pending entry
+    const outboxEntries = [
+      {
+        id: 'entry-shared',
+        streamId: 'shared-stream',
+        event: {
+          streamId: 'shared-stream',
+          sequence: 1,
+          timestamp: '2026-02-15T00:00:00Z',
+          type: 'task.completed',
+          schemaVersion: '1.0',
+        },
+        status: 'pending',
+        attempts: 0,
+        createdAt: '2026-02-15T00:00:00Z',
+      },
+    ];
+    await writeFile(
+      path.join(tempDir, 'shared-stream.outbox.json'),
+      JSON.stringify(outboxEntries),
+      'utf-8',
+    );
+
+    // Create a shared Outbox instance and spy on its drain method
+    const sharedOutbox = new Outbox(tempDir);
+    const drainSpy = vi.spyOn(sharedOutbox, 'drain');
+
+    // Act: pass the shared outbox to handleSyncNow
+    const result = await handleSyncNow(tempDir, sharedOutbox);
+
+    // Assert: the shared outbox's drain was called (not a new instance's)
+    expect(result.success).toBe(true);
+    expect(drainSpy).toHaveBeenCalledTimes(1);
+    expect(drainSpy).toHaveBeenCalledWith(expect.anything(), 'shared-stream');
   });
 
   it('should include no-remote-configured message when no remote is configured', async () => {

--- a/servers/exarchos-mcp/src/sync/sync-handler.ts
+++ b/servers/exarchos-mcp/src/sync/sync-handler.ts
@@ -38,7 +38,7 @@ async function discoverOutboxStreams(stateDir: string): Promise<string[]> {
  * Since no remote client is configured yet, uses a no-op sender that
  * marks entries as confirmed locally without actually sending.
  */
-export async function handleSyncNow(stateDir: string): Promise<ToolResult> {
+export async function handleSyncNow(stateDir: string, outbox?: Outbox): Promise<ToolResult> {
   try {
     const streamIds = await discoverOutboxStreams(stateDir);
 
@@ -52,11 +52,11 @@ export async function handleSyncNow(stateDir: string): Promise<ToolResult> {
       };
     }
 
-    const outbox = new Outbox(stateDir);
+    const effectiveOutbox = outbox ?? new Outbox(stateDir);
     const results: Array<{ streamId: string; sent: number; failed: number }> = [];
 
     for (const streamId of streamIds) {
-      const result = await outbox.drain(noopSender, streamId);
+      const result = await effectiveOutbox.drain(noopSender, streamId);
       results.push({ streamId, ...result });
     }
 

--- a/servers/exarchos-mcp/src/sync/sync-handler.ts
+++ b/servers/exarchos-mcp/src/sync/sync-handler.ts
@@ -3,20 +3,7 @@
 import * as fs from 'node:fs/promises';
 import type { ToolResult } from '../format.js';
 import { Outbox } from './outbox.js';
-import type { EventSender, AppendEventsResponse, ExarchosEventDto } from './types.js';
-
-// ─── No-Op Event Sender ─────────────────────────────────────────────────────
-
-/** A no-op sender used when no remote is configured. Logs but does not send. */
-const noopSender: EventSender = {
-  async appendEvents(
-    _streamId: string,
-    _events: ExarchosEventDto[],
-  ): Promise<AppendEventsResponse> {
-    // No remote configured; events marked confirmed locally (no actual send)
-    return { accepted: 0, streamVersion: 0 };
-  },
-};
+import type { EventSender } from './types.js';
 
 // ─── Stream Discovery ───────────────────────────────────────────────────────
 
@@ -35,10 +22,15 @@ async function discoverOutboxStreams(stateDir: string): Promise<string[]> {
 
 /**
  * Discovers all outbox streams in stateDir and drains pending entries.
- * Since no remote client is configured yet, uses a no-op sender that
- * marks entries as confirmed locally without actually sending.
+ * When no sender is provided (local mode), skips the drain entirely so
+ * pending entries are preserved. When a sender IS provided, drains
+ * pending entries through it.
  */
-export async function handleSyncNow(stateDir: string, outbox?: Outbox): Promise<ToolResult> {
+export async function handleSyncNow(
+  stateDir: string,
+  outbox?: Outbox,
+  sender?: EventSender,
+): Promise<ToolResult> {
   try {
     const streamIds = await discoverOutboxStreams(stateDir);
 
@@ -52,11 +44,23 @@ export async function handleSyncNow(stateDir: string, outbox?: Outbox): Promise<
       };
     }
 
+    // Local mode: no sender available, skip drain to preserve pending entries
+    if (!sender) {
+      return {
+        success: true,
+        data: {
+          streams: streamIds.length,
+          message: `Local mode: ${streamIds.length} stream(s) with pending entries (drain skipped)`,
+        },
+      };
+    }
+
+    // Remote/dual mode: drain pending entries through the sender
     const effectiveOutbox = outbox ?? new Outbox(stateDir);
     const results: Array<{ streamId: string; sent: number; failed: number }> = [];
 
     for (const streamId of streamIds) {
-      const result = await effectiveOutbox.drain(noopSender, streamId);
+      const result = await effectiveOutbox.drain(sender, streamId);
       results.push({ streamId, ...result });
     }
 
@@ -65,7 +69,7 @@ export async function handleSyncNow(stateDir: string, outbox?: Outbox): Promise<
       data: {
         streams: streamIds.length,
         results,
-        message: `Drained ${streamIds.length} stream(s); no remote configured`,
+        message: `Drained ${streamIds.length} stream(s)`,
       },
     };
   } catch (err) {

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -167,12 +167,12 @@ export async function handleInit(
       _meta: buildCheckpointMeta(state._checkpoint),
     };
   } catch (err) {
-    if (err instanceof StateStoreError && err.code === ErrorCode.STATE_ALREADY_EXISTS) {
+    if (err instanceof StateStoreError) {
       return {
         success: false,
         error: {
-          code: ErrorCode.STATE_ALREADY_EXISTS,
-          message: `State already exists for feature: ${input.featureId}`,
+          code: err.code,
+          message: err.message,
         },
       };
     }


### PR DESCRIPTION
## Summary

Complete implementation of Epic #1049 (Claude Code Channel Integration, Phases 0-1):

**Phase 0: Foundation Audit Fixes**
- **#1050** Extract shared stream ID validation — unifies divergent regex between EventStore and Outbox
- **#1051** Fix batchAppend outbox replication — restores at-least-once delivery for batch-appended events
- **#1052** Thread Outbox through DispatchContext — eliminates disconnected Outbox instances
- **#1053** Fix no-op sender false confirms — skips outbox drain in local mode
- **#1054** Remove dead `registerEventTools` function

**Phase 1: Channel Emitter**
- **#1055** Declare `claude/channel` experimental capability on MCP server
- **#1056** Implement Notification Priority Router — classifies events into 5 priority levels with configurable threshold
- **#1057** Implement event-to-notification content formatter — human-readable content with Channel-spec-compliant meta keys
- **#1058** Implement Channel Emitter — fire-and-forget push via `notifications/claude/channel`
- **#1059** Wire Channel Emitter into event pipeline — qualifying events pushed after successful append/batch_append

## Changes

### New files
- `src/shared/validation.ts` — shared `validateStreamId()` and `SAFE_STREAM_ID_PATTERN`
- `src/channel/priority.ts` — `classifyPriority()`, `shouldPush()`, `NotificationPriority` type
- `src/channel/formatter.ts` — `formatNotification()` producing `ChannelNotification` payloads
- `src/channel/emitter.ts` — `ChannelEmitter` class with priority filtering and fire-and-forget push

### Modified files
- `src/core/dispatch.ts` — `DispatchContext` gains `outbox?` and `channelEmitter?` fields
- `src/event-store/store.ts` — outbox replication in `batchAppend()`, shared validation import
- `src/event-store/composite.ts` — `pushToChannelIfConfigured()` after append/batch_append
- `src/sync/outbox.ts` — shared validation import
- `src/sync/sync-handler.ts` — accepts Outbox + EventSender params, skips drain in local mode
- `src/sync/composite.ts` — passes ctx.outbox to sync handler
- `src/adapters/mcp.ts` — declares `claude/channel` experimental capability
- `src/workflow/tools.ts` — `handleInit` catches all `StateStoreError` variants
- `src/event-store/tools.ts` — dead `registerEventTools` and unused imports removed

## Test Plan

- [x] 15 tests: shared stream ID validation
- [x] 2 tests: batchAppend outbox replication
- [x] 1 test: DispatchContext outbox threading
- [x] 3 tests: local-mode drain skip
- [x] 2 tests: channel capability declaration
- [x] 16 tests: priority router classification and threshold
- [x] 11 tests: content formatter with meta key compliance
- [x] 5 tests: Channel Emitter push, filtering, and error resilience
- [x] 5 tests: pipeline wiring (append + batch_append + graceful degradation)
- [x] Full suite: **4792 passed**, 0 failed, 21 skipped

Closes #1050, closes #1051, closes #1052, closes #1053, closes #1054, closes #1055, closes #1056, closes #1057, closes #1058, closes #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)