### PR TITLE
fix: converge review-state contract (#1073, #1074, #1075)

### DIFF
--- a/docs/rca/2026-04-10-review-guard-contract-drift.md
+++ b/docs/rca/2026-04-10-review-guard-contract-drift.md
@@ -187,14 +187,14 @@ Converge on **one** canonical contract across engine, playbook, and skills; make
 | Issues filed | 2026-04-10 05:28-05:29Z | #1073, #1074, #1075 |
 | Triage (this debug workflow) | 2026-04-10 | Thorough track, bundled all three |
 | Investigated | 2026-04-10 | RCA written (this doc) |
-| Fixed | TBD | PR link pending |
-| Verified | TBD | Re-run review→synthesize transition against test workflow |
+| Fixed | 2026-04-10 | PR [#1076](https://github.com/lvlup-sw/exarchos/pull/1076) — initial commit `f50389aa` (engine + playbook + guard + tests + skill doc cleanup); CodeRabbit-addressed follow-up adds behavioral tests, explicit-empty `requiredReviews` override, and extends `suggestedFix` to cover present-but-failing reviews. |
+| Verified | 2026-04-10 | Regression tests added in `guards.test.ts` (uppercase verdict accepted, mixed missing+failing aggregation asserts full `suggestedFix`), `tools.playbook.test.ts` (tools-facing contract wiring through `handleSet`, explicit empty override honored), and `playbooks.test.ts` (cross-file consistency between `review-contract.ts`, `tools.ts`, and `playbooks.ts`). All 4822 MCP server tests green. |
 
 ## Related
 
 - Issues: [#1073](https://github.com/lvlup-sw/exarchos/issues/1073), [#1074](https://github.com/lvlup-sw/exarchos/issues/1074), [#1075](https://github.com/lvlup-sw/exarchos/issues/1075)
 - Originating commit: `5f4f726b` (PR #1045)
 - Earlier related hardening: #1004 (added `verdict` as `status` synonym — the case-insensitivity miss here is the sister bug that #1004 should have fixed)
-- Design note on intended contract (not matched by current engine): `docs/designs/2026-04-09-stabilization-sweep.md:78` — claims the engine accepts `reviews.spec-review` / `reviews.quality-review`; reality in `tools.ts:479` is `spec-compliance` / `code-quality`
+- Design note on intended contract: `docs/designs/2026-04-09-stabilization-sweep.md:78` — stated the engine should accept `reviews.spec-review` / `reviews.quality-review`. This PR restores that intent after PR #1045's unilateral rename broke it.
 - Repro state (read-only): `~/.claude/workflow-state/strategos-2-4-0-migration.{state.json,events.jsonl}`
 - Workflow ID for this debug: `debug-review-guard-contract`

--- a/docs/rca/2026-04-10-review-guard-contract-drift.md
+++ b/docs/rca/2026-04-10-review-guard-contract-drift.md
@@ -1,0 +1,200 @@
+# RCA: review-phase guard contract drift (issues #1073, #1074, #1075)
+
+## Summary
+
+The `all-reviews-passed` guard, the review-phase playbook, and the spec-review / quality-review skills each encode a *different* contract for the `reviews.*` state shape. An agent that follows the documented playbook or skill guidance cannot satisfy the guard, because the guard was updated in #1045 to require dimension names that no playbook, skill, or agent is told about. The guard's case-sensitive status comparison and its short-circuit error reporting make the failure look like three separate bugs; they are one root cause with three surfaces.
+
+## Symptom
+
+Three issues filed 2026-04-10 from the same session on workflow `strategos-2-4-0-migration` (basileus repo), all at the `review → synthesize` transition:
+
+- **#1073** — playbook documents `reviews.spec-review.passed AND reviews.quality-review.passed`; guard expects `reviews.spec-compliance` and `reviews.code-quality` (and checks `.status`, not `.passed`).
+- **#1075** — guard rejected reviewer agent output even though agent wrote `passed: true` and `verdict: "PASS"`. Reported error: `"Reviews not passed: spec (status: \"PASS\")"`. Guard *did* find the `verdict`; the comparison failed on case.
+- **#1074** — guard surfaces one failure at a time (missing-dimensions check first, then not-passed check), forcing discovery-by-retry.
+
+### Reproduction Steps
+
+From `~/.claude/workflow-state/strategos-2-4-0-migration.*` (repro evidence):
+
+1. Agent completed both review stages and emitted `review.completed` events at **05:21:17Z**.
+2. Agent wrote state: `reviews.spec = { passed: true, verdict: "PASS", reviewer: "exarchos-reviewer", ... }` and `reviews.quality = { passed: true, verdict: "APPROVED", ... }`.
+3. Agent called `exarchos_workflow set phase=synthesize` → **guard rejected at 05:21:20Z** (`workflow.guard-failed`, guard=`all-reviews-passed`).
+4. Agent retried 05:21:25Z → rejected again (same contract violation).
+5. Agent retried 05:21:35Z → rejected. 
+6. Human patched `reviews.spec-compliance.status = "pass"` and `reviews.code-quality.status = "pass"` at 05:21:39Z (`state.patched` event).
+7. Retry at 05:21:42Z → **still rejected**: the original `reviews.spec.verdict = "PASS"` (uppercase) now surfaced as the next failing check once the missing-dimensions check passed.
+8. Human patched `reviews.spec.status = "pass"` and `reviews.quality.status = "pass"` at 05:21:47Z.
+9. Retry at 05:21:50Z → **transition finally succeeded**. 4 rejections, 2 human state patches.
+
+Final workflow state still contains all four review entries (`spec`, `quality`, `spec-compliance`, `code-quality`) as a fossil of the repair session.
+
+### Observed Behavior
+
+- Guard rejects transition even though the reviewer agent has done its job correctly per the skill documentation.
+- Guard rejection messages cite only the *first* failing check, masking downstream failures.
+- Human must manually reverse-engineer the real contract from guard.ts source and patch state to appease the guard.
+
+### Expected Behavior
+
+- Agent writes reviews using documented field names. Guard accepts them. Transition proceeds.
+- If multiple contract violations exist, all are reported in one error so they can be fixed in one pass.
+- Guard's status-value comparison is case-insensitive (reviewer-written values and the PASSED_STATUSES set should be normalized).
+
+## Root Cause
+
+**Three conflicting dimension naming conventions exist simultaneously for the feature review phase, with no single source of truth. The guard was updated in #1045 to pick a new convention, and neither the playbook documentation nor the skill prompts were updated to match.**
+
+### The three conventions in the repo today
+
+| Authority | File | Names used | Field |
+|---|---|---|---|
+| **Engine hardcode** (`_requiredReviews`) | `servers/exarchos-mcp/src/workflow/tools.ts:479` | `spec-compliance`, `code-quality` | `.status` |
+| **Phase playbook** (`guardPrerequisites`) | `servers/exarchos-mcp/src/workflow/playbooks.ts:266` | `spec-review`, `quality-review` | `.passed` |
+| **Skill prompts** (what agents read) | `skills-src/spec-review/SKILL.md:213`, `skills-src/quality-review/SKILL.md:267-272` | `spec-review`, `quality-review` | `.status` |
+| **Agent actual output** (basileus repro) | runtime | `spec`, `quality` | `.verdict` (uppercase), `.passed`, later `.status` |
+
+The agent in the repro matched *none* of these — it invented a fourth convention by copying the uppercase verdict from `check_review_verdict`'s return value (`'APPROVED' | 'NEEDS_FIXES' | 'BLOCKED'`) directly into state.
+
+### Code Location
+
+**1. Engine hardcode (the unilateral change that caused drift):**
+
+`servers/exarchos-mcp/src/workflow/tools.ts:477-484`
+```ts
+const workflowType = state.workflowType as string;
+const defaults: Record<string, readonly string[]> = {
+  feature: ['spec-compliance', 'code-quality'],
+};
+const typeDefaults = defaults[workflowType];
+if (typeDefaults?.length) {
+  mutableState._requiredReviews = typeDefaults;
+}
+```
+
+Git blame: commit `5f4f726b` ("fix: resolve 5 open bugs and eliminate test flakiness" — PR #1045). This commit introduced `spec-compliance`/`code-quality` as the required dimension names but did not update `playbooks.ts`, `skills-src/spec-review/SKILL.md`, or `skills-src/quality-review/SKILL.md`.
+
+**2. Wrong playbook docs (#1073):**
+
+`servers/exarchos-mcp/src/workflow/playbooks.ts:265-266`
+```ts
+guardPrerequisites:
+  'reviews.spec-review.passed AND reviews.quality-review.passed',
+```
+Wrong on *both* the dimension names (`spec-review`/`quality-review` instead of `spec-compliance`/`code-quality`) and the field (`.passed` is a legacy shape; current canonical field is `.status`).
+
+**3. Case-sensitive status comparison (the mechanism behind #1075):**
+
+`servers/exarchos-mcp/src/workflow/guards.ts:73, 85-89, 256`
+```ts
+export const PASSED_STATUSES = new Set(['pass', 'passed', 'approved', 'fixes-applied']);
+...
+function extractStatus(entry: Record<string, unknown>): string | undefined {
+  if (typeof entry.status === 'string') return entry.status;
+  if (typeof entry.verdict === 'string') return entry.verdict;
+  return undefined;
+}
+...
+const notPassed = statuses.filter((s) => !PASSED_STATUSES.has(s.status));
+```
+
+The guard already handles `verdict` as a `status` synonym (per GitHub #1004), but `PASSED_STATUSES.has(s.status)` is a raw `Set` membership check — case-sensitive. The reviewer agent copies `verdict: "PASS"` / `"APPROVED"` straight out of `check_review_verdict`'s return type (`'APPROVED' | 'NEEDS_FIXES' | 'BLOCKED'`), which is defined uppercase in `servers/exarchos-mcp/src/orchestrate/review-verdict.ts:26`. Lowercase set + uppercase value = silent membership miss.
+
+**4. Short-circuit error reporting (#1074):**
+
+`servers/exarchos-mcp/src/workflow/guards.ts:203-266`
+
+The `allReviewsPassed.evaluate` function has three early-return paths: (a) `reviews` missing, (b) required dimensions missing, (c) any status not in `PASSED_STATUSES`. Each returns on the first failure — there is no accumulation of failures into a single `GuardFailure`. An agent fixing one failure triggers a new error for the next, which looks like a moving target.
+
+### Analysis
+
+The interaction between the four bugs makes the user-visible failure look mysterious:
+
+1. **Agent reads skill docs**, sees `reviews["spec-review"]` / `reviews["quality-review"]` guidance but doesn't follow it precisely — it writes `reviews.spec` / `reviews.quality` (plain, not kebab), copies `verdict: "PASS"` from the orchestrate response.
+2. **Guard checks required dimensions** → `spec-compliance`/`code-quality` missing → returns first failure. Agent hasn't been told these names anywhere.
+3. **Agent or human adds the missing dimension entries** with `status: "pass"` — that gets past the missing-dimensions check.
+4. **Guard then runs `collectReviewStatuses` over the entire `reviews` object** (not just required dimensions) → picks up the pre-existing `reviews.spec.verdict = "PASS"` → set-membership check fails on case → returns second failure with cryptic message `Reviews not passed: spec (status: "PASS")`.
+5. **Human sees the error, manually patches `reviews.spec.status = "pass"`** to override. Now `extractStatus` picks the lowercase `status` before `verdict` → passes.
+
+Every layer contributed to the compounding failure.
+
+## Contributing Factors
+
+- [x] **Inadequate code review on PR #1045** — the commit introduced a new required-dimensions hardcode without updating the playbook or skill docs that it invalidated. No lint or test caught the cross-file drift.
+- [x] **Missing test coverage** — the existing guards test (`guards.test.ts:490-542`) uses `spec-compliance`/`code-quality` and tests the guard in isolation, so it never catches the mismatch between guard, playbook, and skill docs.
+- [x] **Multiple sources of truth** — the contract for what field names/values appear in `reviews.*` is described in three places with no single authority. Any change to the contract requires coordinated updates that are easy to miss.
+- [x] **Case-sensitive comparison on a user-supplied string** — `PASSED_STATUSES.has(raw)` does not normalize. This is a classic string-comparison smell.
+- [x] **Short-circuit error reporting on a multi-condition guard** — error-surface design assumes one fix per retry; penalizes well-meaning agents.
+- [x] **Orchestrate return type leaks into state shape** — `check_review_verdict` returns `verdict: 'APPROVED' | 'NEEDS_FIXES' | 'BLOCKED'` (uppercase, discriminated-union style), and the skill prompts invite the agent to copy it into state. But the guard expects lowercase action-state values. There is no canonical translation layer.
+
+## Fix Approach
+
+Converge on **one** canonical contract across engine, playbook, and skills; make the guard tolerant and transparent.
+
+### Canonical contract decision
+
+**The skill folder name is the single source of truth.** `skills-src/spec-review/` → dimension key `spec-review`; `skills-src/quality-review/` → dimension key `quality-review`. Any other choice forces a translation layer between "the skill I'm running" and "the state key I'm writing", which is exactly the drift that caused this bug.
+
+- **Dimension names:** `spec-review` and `quality-review` (match skill folder names, match playbook doc intent, match design in `docs/designs/2026-04-09-stabilization-sweep.md:78`). **Revert the engine hardcode at `tools.ts:479`**, which introduced `spec-compliance`/`code-quality` unilaterally in PR #1045 without any companion update.
+- **Required field:** `status` (the guard's primary field). `verdict` remains a backward-compat synonym (already supported).
+- **Canonical values:** `"pass"`, `"approved"`, `"passed"`, `"fixes-applied"` for success; `"fail"`, `"failed"`, `"needs_fixes"` for failure. **Case-insensitive on read** — the guard normalizes before set-membership check.
+- **Legacy `passed: boolean` shape:** keep reading it as a fallback (already supported).
+- **Uppercase `"PASS"` / `"APPROVED"` / `"NEEDS_FIXES"` from `check_review_verdict`:** these are routing-decision discriminated-union values, idiomatic TypeScript, and should **not** be changed. The guard is the authoritative normalization boundary; any string status the guard receives gets `.toLowerCase()` applied before comparison. Normalization at the read boundary is strictly better than pushing it onto every caller.
+
+### Changes Required
+
+| File | Change | Fixes |
+|------|--------|-------|
+| `servers/exarchos-mcp/src/workflow/tools.ts:479` | Change `feature: ['spec-compliance', 'code-quality']` → `feature: ['spec-review', 'quality-review']`. Revert PR #1045's unilateral rename. | #1073 (engine side) |
+| `servers/exarchos-mcp/src/workflow/guards.ts:85-89` | In `extractStatus`, normalize to lowercase before returning (single point; both `status` and `verdict` paths). | #1075 mechanism |
+| `servers/exarchos-mcp/src/workflow/guards.ts:203-266` | Refactor `allReviewsPassed.evaluate` to accumulate all failures (missing dimensions + failing statuses) into a single `GuardFailure.reason` and `expectedShape`. Do not early-return on the first mismatch. | #1074 |
+| `servers/exarchos-mcp/src/workflow/playbooks.ts:265-266` | Update `guardPrerequisites` to describe the real contract: `reviews.spec-review.status AND reviews.quality-review.status (pass|approved|passed|fixes-applied)`. | #1073 (playbook side) |
+| `servers/exarchos-mcp/src/workflow/guards.test.ts:490+` | Update fixtures from `spec-compliance`/`code-quality` → `spec-review`/`quality-review` to match new engine contract. | contract alignment |
+| `servers/exarchos-mcp/src/workflow/guards.test.ts` (new) | Add test: reviewer writes `verdict: "PASS"` (uppercase) → guard accepts. | #1075 regression |
+| `servers/exarchos-mcp/src/workflow/guards.test.ts` (new) | Add test: guard reports missing-dimensions AND not-passed failures in the same error when both are present. | #1074 regression |
+| `servers/exarchos-mcp/src/workflow/playbooks.test.ts` (new) | Add cross-file consistency test: for each workflow-type hardcode in `tools.ts` (`_requiredReviews`), `playbooks.ts`'s `guardPrerequisites` must mention the same dimension names. | prevention |
+| `servers/exarchos-mcp/src/__tests__/workflow/integration.test.ts:210-211` | Update `reviews.spec-compliance` / `reviews.code-quality` fixtures to `reviews.spec-review` / `reviews.quality-review`. | contract alignment |
+| `skills-src/spec-review/SKILL.md` | No rename needed (already uses `reviews["spec-review"]`). Audit for any stray `spec-compliance` references. | #1073 verify |
+| `skills-src/quality-review/SKILL.md` | No rename needed (already uses `reviews["quality-review"]`). Audit for any stray `code-quality` references. | #1073 verify |
+| `npm run build:skills` | Regenerate `skills/<runtime>/**` from source to absorb any audit fixes. `skills:guard` CI will enforce this. | CI |
+
+### Risks
+
+- **Skill renames are visible to agents running mid-workflow.** Any in-flight workflow that wrote `reviews["spec-review"]` state based on old skill guidance will have stale-named entries after the change. Mitigation: guard remains permissive (reads any entry name, but `_requiredReviews` is enforced), so stale entries don't block; they're just inert. Fresh workflows will use the new names. Document the transition in CHANGELOG.
+- **Case-insensitive normalization has a theoretical attack surface** — if a downstream consumer reads status and distinguishes `"pass"` from `"PASS"`. Grep confirms no such consumer exists (the guard is the only place reading `reviews.*.status`). Safe.
+- **Skills renderer drift** — after editing `skills-src/*`, must run `npm run build:skills` and commit the regenerated `skills/<runtime>/**`. `skills:guard` CI will fail the PR otherwise.
+
+## Prevention
+
+### Immediate Actions
+
+- [ ] Add the cross-file consistency test described above so any future change to `_requiredReviews` in `tools.ts` forces a corresponding update in `playbooks.ts`.
+- [ ] Update the PR template or PR review checklist: any change to review-phase dimension names must touch engine + playbook + skills in one PR.
+- [ ] Add to `skills-src/_shared/references/coding-standards.md` (or equivalent): the review-state contract is defined by `guards.ts` canonical values; skill docs must match verbatim.
+
+### Long-term Improvements
+
+- [ ] **Single source of truth for review contract.** Extract dimension names into a shared constant module (e.g., `servers/exarchos-mcp/src/workflow/review-contract.ts`) consumed by `guards.ts`, `tools.ts`, `playbooks.ts`, and exported for documentation generation. Skill docs become generated from the same source.
+- [ ] **Playbook docs generated from code, not hand-written strings.** `guardPrerequisites` in `playbooks.ts` is a free-form string that can silently drift from the guard it describes. Generate it from guard metadata at build time.
+- [ ] **Guard diagnostic mode** — when a guard fails, emit a `workflow.guard-failed` event that *includes the rejection reason and expectedShape*, not just the guard name. The current event (see repro: 4 rejections with no reason field) is too thin to debug.
+- [ ] **`check_review_verdict` should either return lowercase values or provide a state-translator helper** so agents don't paste uppercase literals into state writes.
+
+## Timeline
+
+| Event | Date | Notes |
+|-------|------|-------|
+| Hardcode introduced (root cause) | ~2026-03 | PR #1045, commit `5f4f726b` adds `['spec-compliance', 'code-quality']` to tools.ts without updating playbook/skills |
+| First observed failure | 2026-04-10 05:21:20Z | `strategos-2-4-0-migration` workflow, review→synthesize transition, 4 guard-failed events in 30 seconds |
+| Issues filed | 2026-04-10 05:28-05:29Z | #1073, #1074, #1075 |
+| Triage (this debug workflow) | 2026-04-10 | Thorough track, bundled all three |
+| Investigated | 2026-04-10 | RCA written (this doc) |
+| Fixed | TBD | PR link pending |
+| Verified | TBD | Re-run review→synthesize transition against test workflow |
+
+## Related
+
+- Issues: [#1073](https://github.com/lvlup-sw/exarchos/issues/1073), [#1074](https://github.com/lvlup-sw/exarchos/issues/1074), [#1075](https://github.com/lvlup-sw/exarchos/issues/1075)
+- Originating commit: `5f4f726b` (PR #1045)
+- Earlier related hardening: #1004 (added `verdict` as `status` synonym — the case-insensitivity miss here is the sister bug that #1004 should have fixed)
+- Design note on intended contract (not matched by current engine): `docs/designs/2026-04-09-stabilization-sweep.md:78` — claims the engine accepts `reviews.spec-review` / `reviews.quality-review`; reality in `tools.ts:479` is `spec-compliance` / `code-quality`
+- Repro state (read-only): `~/.claude/workflow-state/strategos-2-4-0-migration.{state.json,events.jsonl}`
+- Workflow ID for this debug: `debug-review-guard-contract`

--- a/docs/rca/2026-04-10-review-guard-contract-drift.md
+++ b/docs/rca/2026-04-10-review-guard-contract-drift.md
@@ -147,7 +147,7 @@ Converge on **one** canonical contract across engine, playbook, and skills; make
 | `servers/exarchos-mcp/src/workflow/tools.ts:479` | Change `feature: ['spec-compliance', 'code-quality']` → `feature: ['spec-review', 'quality-review']`. Revert PR #1045's unilateral rename. | #1073 (engine side) |
 | `servers/exarchos-mcp/src/workflow/guards.ts:85-89` | In `extractStatus`, normalize to lowercase before returning (single point; both `status` and `verdict` paths). | #1075 mechanism |
 | `servers/exarchos-mcp/src/workflow/guards.ts:203-266` | Refactor `allReviewsPassed.evaluate` to accumulate all failures (missing dimensions + failing statuses) into a single `GuardFailure.reason` and `expectedShape`. Do not early-return on the first mismatch. | #1074 |
-| `servers/exarchos-mcp/src/workflow/playbooks.ts:265-266` | Update `guardPrerequisites` to describe the real contract: `reviews.spec-review.status AND reviews.quality-review.status (pass|approved|passed|fixes-applied)`. | #1073 (playbook side) |
+| `servers/exarchos-mcp/src/workflow/playbooks.ts:265-266` | Update `guardPrerequisites` to describe the real contract: `reviews.spec-review.status` AND `reviews.quality-review.status` must be one of `pass`, `approved`, `passed`, `fixes-applied`. | #1073 (playbook side) |
 | `servers/exarchos-mcp/src/workflow/guards.test.ts:490+` | Update fixtures from `spec-compliance`/`code-quality` → `spec-review`/`quality-review` to match new engine contract. | contract alignment |
 | `servers/exarchos-mcp/src/workflow/guards.test.ts` (new) | Add test: reviewer writes `verdict: "PASS"` (uppercase) → guard accepts. | #1075 regression |
 | `servers/exarchos-mcp/src/workflow/guards.test.ts` (new) | Add test: guard reports missing-dimensions AND not-passed failures in the same error when both are present. | #1074 regression |
@@ -165,18 +165,18 @@ Converge on **one** canonical contract across engine, playbook, and skills; make
 
 ## Prevention
 
-### Immediate Actions
+### Shipped in this PR (#1076)
 
-- [ ] Add the cross-file consistency test described above so any future change to `_requiredReviews` in `tools.ts` forces a corresponding update in `playbooks.ts`.
-- [ ] Update the PR template or PR review checklist: any change to review-phase dimension names must touch engine + playbook + skills in one PR.
-- [ ] Add to `skills-src/_shared/references/coding-standards.md` (or equivalent): the review-state contract is defined by `guards.ts` canonical values; skill docs must match verbatim.
+- [x] **Single source of truth for review contract.** `servers/exarchos-mcp/src/workflow/review-contract.ts` now owns `REQUIRED_REVIEWS_BY_WORKFLOW_TYPE`. Consumed by `tools.ts` (runtime injection) and `playbooks.ts` (doc generation). Skill folder names under `skills-src/` are the authoritative identifiers — `tools.ts` would drift from the contract only if a regression reintroduced hardcoded dimension names.
+- [x] **Playbook docs generated from code, not hand-written strings.** `playbooks.ts:267` now calls `getRequiredReviewsPrerequisite('feature')` instead of a hand-written string. Any future rename propagates automatically.
+- [x] **Cross-file consistency test.** `playbooks.test.ts` asserts every dimension declared in `REQUIRED_REVIEWS_BY_WORKFLOW_TYPE` appears in the corresponding `review` phase's `guardPrerequisites` string, and that feature-workflow names match skill folder names. `tools.playbook.test.ts` adds behavioral tests that exercise `handleSet` → guard so a regression hardcoding names inside `tools.ts` (bypassing `review-contract.ts`) is caught end-to-end.
+- [x] **Guard hardening.** `extractStatus` normalizes case (uppercase verdicts from `check_review_verdict` now pass); `allReviewsPassed.evaluate` aggregates failures into one error with a merged `suggestedFix` covering both missing and present-but-failing reviews; required-review membership check uses `hasOwnProperty` + status-extractability + `UNSAFE_KEYS` filter so empty `{}` and proto-pollution keys are treated as missing.
 
-### Long-term Improvements
+### Follow-up (deferred)
 
-- [ ] **Single source of truth for review contract.** Extract dimension names into a shared constant module (e.g., `servers/exarchos-mcp/src/workflow/review-contract.ts`) consumed by `guards.ts`, `tools.ts`, `playbooks.ts`, and exported for documentation generation. Skill docs become generated from the same source.
-- [ ] **Playbook docs generated from code, not hand-written strings.** `guardPrerequisites` in `playbooks.ts` is a free-form string that can silently drift from the guard it describes. Generate it from guard metadata at build time.
-- [ ] **Guard diagnostic mode** — when a guard fails, emit a `workflow.guard-failed` event that *includes the rejection reason and expectedShape*, not just the guard name. The current event (see repro: 4 rejections with no reason field) is too thin to debug.
-- [ ] **`check_review_verdict` should either return lowercase values or provide a state-translator helper** so agents don't paste uppercase literals into state writes.
+- [ ] **Guard diagnostic events.** When a guard fails, the `workflow.guard-failed` event should include the rejection reason and `expectedShape`, not just the guard name. The strategos repro shows 4 rejections with no reason field, which made debugging harder than necessary.
+- [ ] **PR template checklist nudge.** Add to the PR template: "Any change to review-phase dimension names must update `review-contract.ts` (not `tools.ts` directly)." Structural enforcement via the consistency tests is primary; the nudge is defense-in-depth.
+- [ ] **Lowercase values for `check_review_verdict`?** Decided **no** in this PR — the guard-side normalization is the correct boundary and `check_review_verdict`'s uppercase discriminated union is idiomatic TypeScript. Revisit only if a new call site reveals a need.
 
 ## Timeline
 

--- a/docs/rca/2026-04-10-review-guard-contract-drift.md
+++ b/docs/rca/2026-04-10-review-guard-contract-drift.md
@@ -159,7 +159,7 @@ Converge on **one** canonical contract across engine, playbook, and skills; make
 
 ### Risks
 
-- **Skill renames are visible to agents running mid-workflow.** Any in-flight workflow that wrote `reviews["spec-review"]` state based on old skill guidance will have stale-named entries after the change. Mitigation: guard remains permissive (reads any entry name, but `_requiredReviews` is enforced), so stale entries don't block; they're just inert. Fresh workflows will use the new names. Document the transition in CHANGELOG.
+- **Stale review entries from in-flight workflows.** Any workflow that was mid-review before this PR may have `reviews.spec` / `reviews.quality` (or other off-name) entries from the old contract. `allReviewsPassed` still scans *every* entry in `state.reviews` via `collectReviewStatuses`, so a **stale entry with a passing status is inert** (no effect on the guard), but a **stale entry with a failing status (`fail`/`needs_fixes`) will block the transition** even though it is not one of the `_requiredReviews` dimensions. Cleanup for any in-flight workflow hitting this: use `exarchos_workflow set` to patch the stale entry to `status: "pass"` or remove it from state. Fresh workflows started after this PR will use the new names and are not affected.
 - **Case-insensitive normalization has a theoretical attack surface** — if a downstream consumer reads status and distinguishes `"pass"` from `"PASS"`. Grep confirms no such consumer exists (the guard is the only place reading `reviews.*.status`). Safe.
 - **Skills renderer drift** — after editing `skills-src/*`, must run `npm run build:skills` and commit the regenerated `skills/<runtime>/**`. `skills:guard` CI will fail the PR otherwise.
 

--- a/servers/exarchos-mcp/src/__tests__/workflow/integration.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/integration.test.ts
@@ -207,8 +207,8 @@ describe('Integration', () => {
         {
           featureId: 'full-saga',
           updates: {
-            'reviews.spec-compliance': { status: 'pass', reviewer: 'bot' },
-            'reviews.code-quality': { status: 'pass', reviewer: 'bot' },
+            'reviews.spec-review': { status: 'pass', reviewer: 'bot' },
+            'reviews.quality-review': { status: 'pass', reviewer: 'bot' },
           },
         },
         stateDir,

--- a/servers/exarchos-mcp/src/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.test.ts
@@ -662,6 +662,22 @@ describe('allReviewsPassed (synthesis ready)', () => {
     expect(failure.reason).toContain('Missing required review dimensions');
     // __proto__ is an unsafe key — guard must treat it as missing
     expect(failure.reason).toContain('__proto__');
+
+    // ALSO: the emitted expectedShape and suggestedFix must NOT contain
+    // `__proto__` (or any UNSAFE_KEY) as an own property. Even though
+    // the reason reports the missing dim, an agent blindly applying
+    // suggestedFix.params.updates must not be tricked into assigning
+    // `reviews.__proto__.status = 'pass'` — that's prototype pollution.
+    const reviewsShape = (failure.expectedShape?.reviews ?? {}) as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(reviewsShape, '__proto__')).toBe(false);
+
+    const updates = (failure.suggestedFix?.params.updates ?? {}) as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(updates, 'reviews.__proto__.status')).toBe(false);
+    for (const key of Object.keys(updates)) {
+      expect(key).not.toContain('__proto__');
+      expect(key).not.toContain('constructor');
+      expect(key).not.toContain('prototype');
+    }
   });
 
   // ─── Regression: suggestedFix must cover BOTH missing and failing reviews.

--- a/servers/exarchos-mcp/src/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.test.ts
@@ -615,4 +615,35 @@ describe('allReviewsPassed (synthesis ready)', () => {
     expect(failure.reason).toContain('Reviews not passed');
     expect(failure.reason).toContain('stray-review');
   });
+
+  // ─── Regression: suggestedFix must cover BOTH missing and failing reviews.
+  // An agent applying the fix should be able to resolve the guard in ONE
+  // retry for mixed states (some missing, some present-but-failing).
+  // CodeRabbit finding on PR #1076.
+  it('SynthesisReadyGuard_MixedFailures_SuggestedFixCoversMissingAndFailing', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      phase: 'review',
+      reviews: {
+        // One required dim present but failing
+        'spec-review': { status: 'fail' },
+        // One stray that's also failing (not required, but guard sees it)
+        'stray-review': { status: 'needs_fixes' },
+        // quality-review is missing
+      },
+      _requiredReviews: ['spec-review', 'quality-review'],
+    };
+
+    const result = guards.allReviewsPassed.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.suggestedFix).toBeDefined();
+    const updates = failure.suggestedFix!.params.updates as Record<string, unknown>;
+    // Missing dimension patch
+    expect(updates['reviews.quality-review.status']).toBe('pass');
+    // Failing dimension patches (both required and stray)
+    expect(updates['reviews.spec-review.status']).toBe('pass');
+    expect(updates['reviews.stray-review.status']).toBe('pass');
+  });
 });

--- a/servers/exarchos-mcp/src/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.test.ts
@@ -487,9 +487,9 @@ describe('allReviewsPassed (synthesis ready)', () => {
       featureId: 'test-feature',
       phase: 'review',
       reviews: {
-        'spec-compliance': { status: 'pass' },
+        'spec-review': { status: 'pass' },
       },
-      _requiredReviews: ['spec-compliance', 'code-quality'],
+      _requiredReviews: ['spec-review', 'quality-review'],
     };
 
     const result = guards.allReviewsPassed.evaluate(state);
@@ -498,7 +498,7 @@ describe('allReviewsPassed (synthesis ready)', () => {
     const failure = result as GuardFailure;
     expect(failure.passed).toBe(false);
     expect(failure.reason).toContain('Missing required review dimensions');
-    expect(failure.reason).toContain('code-quality');
+    expect(failure.reason).toContain('quality-review');
     expect(failure.expectedShape).toBeDefined();
     expect(failure.suggestedFix).toBeDefined();
   });
@@ -508,10 +508,10 @@ describe('allReviewsPassed (synthesis ready)', () => {
       featureId: 'test-feature',
       phase: 'review',
       reviews: {
-        'spec-compliance': { status: 'pass' },
-        'code-quality': { status: 'approved' },
+        'spec-review': { status: 'pass' },
+        'quality-review': { status: 'approved' },
       },
-      _requiredReviews: ['spec-compliance', 'code-quality'],
+      _requiredReviews: ['spec-review', 'quality-review'],
     };
 
     const result = guards.allReviewsPassed.evaluate(state);
@@ -523,10 +523,10 @@ describe('allReviewsPassed (synthesis ready)', () => {
       featureId: 'test-feature',
       phase: 'review',
       reviews: {
-        'spec-compliance': { status: 'pass' },
-        'code-quality': { status: 'fail' },
+        'spec-review': { status: 'pass' },
+        'quality-review': { status: 'fail' },
       },
-      _requiredReviews: ['spec-compliance', 'code-quality'],
+      _requiredReviews: ['spec-review', 'quality-review'],
     };
 
     const result = guards.allReviewsPassed.evaluate(state);
@@ -535,7 +535,7 @@ describe('allReviewsPassed (synthesis ready)', () => {
     const failure = result as GuardFailure;
     expect(failure.passed).toBe(false);
     expect(failure.reason).toContain('Reviews not passed');
-    expect(failure.reason).toContain('code-quality');
+    expect(failure.reason).toContain('quality-review');
   });
 
   it('SynthesisReadyGuard_NoRequiredReviewsConfigured_FallsBackToExistingBehavior', () => {
@@ -550,5 +550,69 @@ describe('allReviewsPassed (synthesis ready)', () => {
 
     const result = guards.allReviewsPassed.evaluate(state);
     expect(result).toBe(true);
+  });
+
+  // ─── Regression: #1075 case-insensitive verdict handling ───────────────
+  // Reviewer agents copy check_review_verdict's uppercase return values
+  // ('APPROVED' | 'NEEDS_FIXES' | 'BLOCKED') directly into state. The guard
+  // must normalize case before set-membership check so uppercase verdicts
+  // don't silently fail.
+  it('SynthesisReadyGuard_UppercaseVerdictPass_Accepts', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      phase: 'review',
+      reviews: {
+        'spec-review': { verdict: 'PASS', reviewer: 'exarchos-reviewer' },
+        'quality-review': { verdict: 'APPROVED', reviewer: 'exarchos-reviewer' },
+      },
+      _requiredReviews: ['spec-review', 'quality-review'],
+    };
+
+    const result = guards.allReviewsPassed.evaluate(state);
+    expect(result).toBe(true);
+  });
+
+  it('SynthesisReadyGuard_UppercaseStatusApproved_Accepts', () => {
+    // Even when the field is `status` (not `verdict`), uppercase must be accepted.
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      phase: 'review',
+      reviews: {
+        'spec-review': { status: 'APPROVED' },
+        'quality-review': { status: 'Pass' },
+      },
+      _requiredReviews: ['spec-review', 'quality-review'],
+    };
+
+    const result = guards.allReviewsPassed.evaluate(state);
+    expect(result).toBe(true);
+  });
+
+  // ─── Regression: #1074 aggregated failure reporting ────────────────────
+  // When multiple contract violations exist, the guard must report all of
+  // them in a single error message so agents can fix everything in one
+  // retry instead of peeling failures one layer at a time.
+  it('SynthesisReadyGuard_MissingDimensionsAndFailedStatus_AggregatesIntoSingleError', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      phase: 'review',
+      reviews: {
+        // Stray entry from earlier round — legitimately failing
+        'stray-review': { status: 'fail' },
+      },
+      _requiredReviews: ['spec-review', 'quality-review'],
+    };
+
+    const result = guards.allReviewsPassed.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    // Both failure modes must appear in the same reason string
+    expect(failure.reason).toContain('Missing required review dimensions');
+    expect(failure.reason).toContain('spec-review');
+    expect(failure.reason).toContain('quality-review');
+    expect(failure.reason).toContain('Reviews not passed');
+    expect(failure.reason).toContain('stray-review');
   });
 });

--- a/servers/exarchos-mcp/src/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.test.ts
@@ -616,6 +616,54 @@ describe('allReviewsPassed (synthesis ready)', () => {
     expect(failure.reason).toContain('stray-review');
   });
 
+  // ─── Regression: empty review object must be treated as missing.
+  // Before the hardening, `!reviews[key]` treated `{}` as present (truthy),
+  // silently satisfying the missing-dimensions check. The guard then
+  // skipped the empty entry in collectReviewStatuses and returned true.
+  // CodeRabbit finding on PR #1076.
+  it('SynthesisReadyGuard_RequiredDimensionPresentButEmptyObject_TreatedAsMissing', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      phase: 'review',
+      reviews: {
+        'spec-review': {}, // present key but no status / verdict / passed
+        'quality-review': { status: 'pass' },
+      },
+      _requiredReviews: ['spec-review', 'quality-review'],
+    };
+
+    const result = guards.allReviewsPassed.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.reason).toContain('Missing required review dimensions');
+    expect(failure.reason).toContain('spec-review');
+  });
+
+  // ─── Regression: prototype-pollution keys must not satisfy the check.
+  // If a caller passes `_requiredReviews: ['__proto__']` and no actual
+  // reviews are set, the `__proto__` key is inherited on every object
+  // and would previously have tricked `reviews[key]` into returning a
+  // truthy value. Guard must skip UNSAFE_KEYS and treat them as missing.
+  it('SynthesisReadyGuard_RequiredDimensionIsProtoPollution_TreatedAsMissing', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      phase: 'review',
+      reviews: {
+        'spec-review': { status: 'pass' },
+      },
+      _requiredReviews: ['spec-review', '__proto__'],
+    };
+
+    const result = guards.allReviewsPassed.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.reason).toContain('Missing required review dimensions');
+    // __proto__ is an unsafe key — guard must treat it as missing
+    expect(failure.reason).toContain('__proto__');
+  });
+
   // ─── Regression: suggestedFix must cover BOTH missing and failing reviews.
   // An agent applying the fix should be able to resolve the guard in ONE
   // retry for mixed states (some missing, some present-but-failing).

--- a/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.ts
@@ -275,6 +275,15 @@ export const guards = {
             expectedReviews[k] = v;
           }
         }
+        // Include failing entries in the suggestedFix dot-path patch so
+        // an agent applying the fix can resolve BOTH missing dimensions
+        // AND present-but-failing entries in a single retry (CodeRabbit
+        // finding on PR #1076). `s.path` may be dotted for nested
+        // reviews (e.g., "A1.specReview"), which dot-path assignment
+        // handles correctly downstream.
+        for (const s of notPassed) {
+          suggestedUpdates[`reviews.${s.path}.status`] = 'pass';
+        }
       }
 
       if (reasons.length === 0) return true;

--- a/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.ts
@@ -265,7 +265,13 @@ export const guards = {
           reasons.push(
             `Missing required review dimensions: ${missing.join(', ')}. Run the review skills for these dimensions before transitioning.`,
           );
+          // Populate expectedShape and suggestedFix payloads, but filter
+          // UNSAFE_KEYS out — an agent blindly applying the suggestedFix
+          // must not be tricked into writing `reviews.__proto__.status`
+          // (prototype pollution). The reason string still names the
+          // unsafe key so the caller understands what was rejected.
           for (const key of missing) {
+            if (UNSAFE_KEYS.has(key)) continue;
             expectedReviews[key] = { status: 'pass' };
             suggestedUpdates[`reviews.${key}.status`] = 'pass';
           }
@@ -307,8 +313,12 @@ export const guards = {
         // AND present-but-failing entries in a single retry (CodeRabbit
         // finding on PR #1076). `s.path` may be dotted for nested
         // reviews (e.g., "A1.specReview"), which dot-path assignment
-        // handles correctly downstream.
+        // handles correctly downstream. Skip any path whose segments
+        // contain an UNSAFE_KEY for the same prototype-pollution reason
+        // as the missing-dimensions loop above.
         for (const s of notPassed) {
+          const segments = s.path.split('.');
+          if (segments.some((seg) => UNSAFE_KEYS.has(seg))) continue;
           suggestedUpdates[`reviews.${s.path}.status`] = 'pass';
         }
       }

--- a/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.ts
@@ -80,11 +80,15 @@ const REVIEW_EXPECTED_SHAPE: Record<string, unknown> = {
 
 /**
  * Extract the review status string from an entry, checking `status` first,
- * then `verdict` as a synonym (see GitHub #1004).
+ * then `verdict` as a synonym (see GitHub #1004). Values are normalized to
+ * lowercase so that uppercase verdicts like `"PASS"` / `"APPROVED"` —
+ * commonly produced by agents copying `check_review_verdict`'s uppercase
+ * discriminated-union return values into state — match the lowercase
+ * PASSED_STATUSES / FAILED_STATUSES sets (see GitHub #1075).
  */
 function extractStatus(entry: Record<string, unknown>): string | undefined {
-  if (typeof entry.status === 'string') return entry.status;
-  if (typeof entry.verdict === 'string') return entry.verdict;
+  if (typeof entry.status === 'string') return entry.status.toLowerCase();
+  if (typeof entry.verdict === 'string') return entry.verdict.toLowerCase();
   return undefined;
 }
 
@@ -214,54 +218,80 @@ export const guards = {
         };
       }
 
-      // Enforce required review dimensions if configured
+      // Accumulate ALL failures rather than short-circuiting on the first
+      // one (see GitHub #1074). An agent hitting multiple contract violations
+      // should see everything wrong in one error message so it can fix
+      // everything in a single retry.
+      const featureId = typeof state.featureId === 'string' ? state.featureId : '<featureId>';
+      const reasons: string[] = [];
+      const expectedReviews: Record<string, unknown> = {};
+      const suggestedUpdates: Record<string, unknown> = {};
+
+      // Check 1: required review dimensions present?
       const requiredReviews = state._requiredReviews as readonly string[] | undefined;
+      const missing: string[] = [];
       if (requiredReviews && requiredReviews.length > 0) {
-        const missing = requiredReviews.filter((key) => !reviews[key]);
+        for (const key of requiredReviews) {
+          if (!reviews[key]) missing.push(key);
+        }
         if (missing.length > 0) {
-          const featureId = (typeof state.featureId === 'string' ? state.featureId : '<featureId>');
-          const expectedUpdates: Record<string, unknown> = {};
+          reasons.push(
+            `Missing required review dimensions: ${missing.join(', ')}. Run the review skills for these dimensions before transitioning.`,
+          );
           for (const key of missing) {
-            expectedUpdates[`reviews.${key}.status`] = 'pass';
+            expectedReviews[key] = { status: 'pass' };
+            suggestedUpdates[`reviews.${key}.status`] = 'pass';
           }
+        }
+      }
+
+      // Check 2: at least one recognizable review entry exists.
+      const statuses = collectReviewStatuses(reviews);
+      if (statuses.length === 0) {
+        // If no entries AND required dimensions were missing, the "missing
+        // dimensions" message is more actionable. Only surface the
+        // no-entries message when it adds information.
+        if (missing.length === 0) {
           return {
             passed: false,
-            reason: `Missing required review dimensions: ${missing.join(', ')}. Run the review skills for these dimensions before transitioning.`,
-            expectedShape: {
-              reviews: Object.fromEntries(
-                missing.map((key) => [key, { status: 'pass' }]),
-              ),
-            },
-            suggestedFix: {
-              tool: 'exarchos_workflow',
-              params: {
-                action: 'set',
-                featureId,
-                updates: expectedUpdates,
-              },
-            },
+            reason:
+              'state.reviews has no recognizable review entries — each review needs a status field ("pass", "approved", "fail", "needs_fixes")',
+            expectedShape: REVIEW_EXPECTED_SHAPE,
           };
         }
       }
 
-      const statuses = collectReviewStatuses(reviews);
-      if (statuses.length === 0) {
-        return {
-          passed: false,
-          reason:
-            'state.reviews has no recognizable review entries — each review needs a status field ("pass", "approved", "fail", "needs_fixes")',
-          expectedShape: REVIEW_EXPECTED_SHAPE,
-        };
-      }
+      // Check 3: every present review entry passes.
       const notPassed = statuses.filter((s) => !PASSED_STATUSES.has(s.status));
       if (notPassed.length > 0) {
-        return {
-          passed: false,
-          reason: `Reviews not passed: ${notPassed.map((s) => `${s.path} (status: "${s.status}")`).join(', ')}`,
-          expectedShape: buildFailedReviewsExpectedShape(notPassed),
-        };
+        reasons.push(
+          `Reviews not passed: ${notPassed.map((s) => `${s.path} (status: "${s.status}")`).join(', ')}`,
+        );
+        const failedShape = buildFailedReviewsExpectedShape(notPassed).reviews as
+          | Record<string, unknown>
+          | undefined;
+        if (failedShape) {
+          for (const [k, v] of Object.entries(failedShape)) {
+            expectedReviews[k] = v;
+          }
+        }
       }
-      return true;
+
+      if (reasons.length === 0) return true;
+
+      return {
+        passed: false,
+        reason: reasons.join(' | '),
+        expectedShape: { reviews: expectedReviews },
+        ...(Object.keys(suggestedUpdates).length > 0
+          ? {
+              suggestedFix: {
+                tool: 'exarchos_workflow',
+                params: { action: 'set', featureId, updates: suggestedUpdates },
+              },
+            }
+          : {}),
+      };
     },
   },
 

--- a/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.ts
@@ -227,12 +227,39 @@ export const guards = {
       const expectedReviews: Record<string, unknown> = {};
       const suggestedUpdates: Record<string, unknown> = {};
 
-      // Check 1: required review dimensions present?
+      // Check 1: required review dimensions present AND have a
+      // recognizable status? `!reviews[key]` is not enough — it accepts
+      // `{}` (truthy but no status field) and prototype-inherited keys
+      // like `__proto__`. A present-but-empty entry would then be
+      // skipped by `collectReviewStatuses` and the guard would return
+      // true with nothing actually verified. CodeRabbit finding on #1076.
       const requiredReviews = state._requiredReviews as readonly string[] | undefined;
       const missing: string[] = [];
       if (requiredReviews && requiredReviews.length > 0) {
         for (const key of requiredReviews) {
-          if (!reviews[key]) missing.push(key);
+          if (UNSAFE_KEYS.has(key)) {
+            // Never trust proto-pollution keys as "present" — they're
+            // inherited on every object.
+            missing.push(key);
+            continue;
+          }
+          if (!Object.prototype.hasOwnProperty.call(reviews, key)) {
+            missing.push(key);
+            continue;
+          }
+          const entry = reviews[key];
+          if (typeof entry !== 'object' || entry === null) {
+            missing.push(key);
+            continue;
+          }
+          const entryObj = entry as Record<string, unknown>;
+          // Must carry at least one recognizable shape: status, verdict,
+          // or legacy `passed: boolean`. An empty `{}` is not present.
+          const hasStatus = extractStatus(entryObj) !== undefined;
+          const hasLegacyPassed = typeof entryObj.passed === 'boolean';
+          if (!hasStatus && !hasLegacyPassed) {
+            missing.push(key);
+          }
         }
         if (missing.length > 0) {
           reasons.push(

--- a/servers/exarchos-mcp/src/workflow/playbooks.test.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { getPlaybook, renderPlaybook, serializePlaybooks, listPlaybookWorkflowTypes } from './playbooks.js';
 import type { SerializedPlaybooks, SerializedPhasePlaybook } from './playbooks.js';
+import { getRequiredReviews, REQUIRED_REVIEWS_BY_WORKFLOW_TYPE } from './review-contract.js';
 
 // ─── Task 1: Core getPlaybook / renderPlaybook ──────────────────────────────
 
@@ -330,6 +331,50 @@ describe('compactGuidance describe hint', () => {
         `Expected compactGuidance to reference describe or exarchos_event for phase with events`,
       ).toBe(true);
     }
+  });
+});
+
+// ─── Review contract consistency (prevents #1073 drift) ───────────────────
+//
+// The review-state contract is shared between three places that must agree:
+//   1. `review-contract.ts`   → REQUIRED_REVIEWS_BY_WORKFLOW_TYPE (source of truth)
+//   2. `tools.ts`             → _requiredReviews injection (calls getRequiredReviews)
+//   3. `playbooks.ts`         → review-phase guardPrerequisites string
+//
+// PR #1045 drifted these apart by updating (2) without updating (3) or the
+// skill documentation. This suite asserts that every dimension declared in
+// the source of truth appears in the corresponding phase playbook's
+// guardPrerequisites, so any future rename forces a coordinated update.
+
+describe('Review contract consistency across playbooks and tools.ts', () => {
+  it('ReviewContract_EveryWorkflowType_HasMatchingReviewPlaybook', () => {
+    for (const workflowType of Object.keys(REQUIRED_REVIEWS_BY_WORKFLOW_TYPE)) {
+      const playbook = getPlaybook(workflowType, 'review');
+      expect(
+        playbook,
+        `Workflow type "${workflowType}" declares required reviews but has no "review" phase playbook`,
+      ).not.toBeNull();
+    }
+  });
+
+  it('ReviewContract_GuardPrerequisites_MentionsEveryRequiredDimension', () => {
+    for (const workflowType of Object.keys(REQUIRED_REVIEWS_BY_WORKFLOW_TYPE)) {
+      const playbook = getPlaybook(workflowType, 'review')!;
+      const dimensions = getRequiredReviews(workflowType);
+      for (const dim of dimensions) {
+        expect(
+          playbook.guardPrerequisites,
+          `${workflowType}:review guardPrerequisites does not mention required dimension "${dim}" — tools.ts and playbooks.ts have drifted`,
+        ).toContain(dim);
+      }
+    }
+  });
+
+  it('ReviewContract_FeatureWorkflow_UsesSkillFolderNames', () => {
+    // The dimension names MUST match skill folder names under skills-src/
+    // so the skill an agent runs and the state key it writes are identical.
+    // Changing this assertion requires renaming skill folders too.
+    expect(getRequiredReviews('feature')).toEqual(['spec-review', 'quality-review']);
   });
 });
 

--- a/servers/exarchos-mcp/src/workflow/playbooks.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.ts
@@ -1,3 +1,5 @@
+import { getRequiredReviewsPrerequisite } from './review-contract.js';
+
 // ─── Phase Playbook Types ──────────────────────────────────────────────────
 
 export interface ToolInstruction {
@@ -262,8 +264,7 @@ register({
   ],
   transitionCriteria:
     'All reviews passed → synthesize | Any review failed → delegate',
-  guardPrerequisites:
-    'reviews.spec-review.passed AND reviews.quality-review.passed',
+  guardPrerequisites: getRequiredReviewsPrerequisite('feature'),
   validationScripts: [],
   humanCheckpoint: false,
   compactGuidance:

--- a/servers/exarchos-mcp/src/workflow/review-contract.ts
+++ b/servers/exarchos-mcp/src/workflow/review-contract.ts
@@ -1,0 +1,51 @@
+// ─── Review Contract (Single Source of Truth) ───────────────────────────
+//
+// Review dimension names are derived from the skill folder names under
+// `skills-src/`. The engine, the phase playbook, and every consumer that
+// describes the review-state contract MUST reference the constants in this
+// file rather than hardcoding strings. This prevents the drift that caused
+// GitHub issues #1073, #1074, #1075 — where PR #1045 introduced new
+// dimension names in `tools.ts` without updating `playbooks.ts` or the
+// skill documentation, silently breaking the review → synthesize transition.
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Required review dimensions per workflow type.
+ *
+ * The dimension key MUST match the skill folder name (kebab-case) under
+ * `skills-src/`. This keeps three things aligned by construction:
+ *   1. The skill an agent runs          (`skills-src/<name>/SKILL.md`)
+ *   2. The state key the agent writes   (`reviews[<name>].status`)
+ *   3. The dimension the engine expects (`_requiredReviews: [<name>, …]`)
+ *
+ * If you need to add a required dimension for a workflow type, add its
+ * skill folder under `skills-src/<name>/` first, then add the name here.
+ * Do not introduce new dimension naming conventions.
+ */
+export const REQUIRED_REVIEWS_BY_WORKFLOW_TYPE: Readonly<Record<string, readonly string[]>> = {
+  feature: ['spec-review', 'quality-review'],
+};
+
+/**
+ * Returns the required review dimensions for a given workflow type, or
+ * an empty array if the workflow type does not enforce required reviews.
+ */
+export function getRequiredReviews(workflowType: string): readonly string[] {
+  return REQUIRED_REVIEWS_BY_WORKFLOW_TYPE[workflowType] ?? [];
+}
+
+/**
+ * Renders the review contract as a human-readable `guardPrerequisites`
+ * string for use in phase playbook documentation. Consumers must not
+ * hand-write this string — it MUST be generated from the constants above
+ * so any change to the required dimensions is reflected everywhere.
+ *
+ * Example: `getRequiredReviewsPrerequisite('feature')` →
+ *   `reviews.spec-review.status AND reviews.quality-review.status pass`
+ */
+export function getRequiredReviewsPrerequisite(workflowType: string): string {
+  const dimensions = getRequiredReviews(workflowType);
+  if (dimensions.length === 0) return 'no required reviews';
+  const clauses = dimensions.map((d) => `reviews.${d}.status`);
+  return `${clauses.join(' AND ')} must be a passing value (pass|passed|approved|fixes-applied, case-insensitive)`;
+}

--- a/servers/exarchos-mcp/src/workflow/tools.playbook.test.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.playbook.test.ts
@@ -8,6 +8,7 @@ import {
   handleSet,
   configureWorkflowMaterializer,
 } from './tools.js';
+import { getRequiredReviews } from './review-contract.js';
 
 describe('handleGet playbook field', () => {
   let tmpDir: string;
@@ -122,5 +123,102 @@ describe('handleGet playbook field', () => {
     expect(playbook).not.toBeNull();
     expect((playbook as Record<string, unknown>).phase).toBe('triage');
     expect((playbook as Record<string, unknown>).skill).toBe('debug');
+  });
+});
+
+// ─── Review contract wiring (behavioral — exercises tools.ts path) ─────────
+//
+// These tests exercise the full handleSet → guard path rather than reading
+// the review-contract module directly. `_requiredReviews` is a transient
+// guard-evaluation field and is deleted from state after the guard runs
+// (tools.ts, `delete mutableState._requiredReviews`), so the only
+// observable effect of the contract wiring is whether the guard accepts or
+// rejects the review → synthesize transition.
+//
+// If a future regression replaces the `getRequiredReviews(workflowType)`
+// call in tools.ts with an inline hardcoded list — say, the old
+// `spec-compliance`/`code-quality` — these tests fail because the guard
+// will reject a state that contains `spec-review`/`quality-review`.
+// Addresses CodeRabbit nitpick on PR #1076.
+
+describe('review-contract wiring through handleSet', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'review-contract-wiring-'));
+  });
+
+  afterEach(async () => {
+    configureWorkflowMaterializer(null);
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Seed a feature workflow directly at the `review` phase with the
+   * given reviews map. Bypasses the full state machine walk (ideate →
+   * plan → … → review) which isn't what these tests care about — we're
+   * testing the `review → synthesize` injection of `_requiredReviews`
+   * from `review-contract.ts`. Keeps `tasks: []` so `all-tasks-complete`
+   * (if ever composed into this transition) is trivially satisfied.
+   */
+  async function seedFeatureAtReview(
+    featureId: string,
+    reviews: Record<string, unknown>,
+  ): Promise<void> {
+    // Init through handleInit so schema bootstrap (version, timestamps,
+    // _events arrays, etc.) is handled correctly.
+    await handleInit({ featureId, workflowType: 'feature' }, tmpDir, null);
+
+    // Patch phase + reviews directly on disk. Preserves the init-written
+    // schema-compliant shape for every other field.
+    const stateFile = path.join(tmpDir, `${featureId}.state.json`);
+    const raw = JSON.parse(await fs.readFile(stateFile, 'utf8')) as Record<string, unknown>;
+    raw.phase = 'review';
+    raw.reviews = reviews;
+    raw.updatedAt = new Date().toISOString();
+    await fs.writeFile(stateFile, JSON.stringify(raw, null, 2));
+  }
+
+  it('HandleSet_FeatureReviewToSynthesize_CanonicalDimensions_AdvancesPastGuard', async () => {
+    // Arrange: seed review phase with canonical contract dimension names.
+    await seedFeatureAtReview('contract-wiring-canonical', {
+      'spec-review': { status: 'pass' },
+      'quality-review': { status: 'pass' },
+    });
+
+    // Act: attempt review → synthesize. tools.ts MUST inject
+    // _requiredReviews from getRequiredReviews('feature') for the guard
+    // to pass. If a future regression hardcodes a different list the
+    // guard will reject with "Missing required review dimensions".
+    const result = await handleSet(
+      { featureId: 'contract-wiring-canonical', phase: 'synthesize' },
+      tmpDir, null,
+    );
+
+    expect(result.success).toBe(true);
+    // Sanity check that the contract still returns the names this test
+    // wrote — any rename forces a rename here too.
+    expect(getRequiredReviews('feature')).toEqual(['spec-review', 'quality-review']);
+  });
+
+  it('HandleSet_FeatureReviewToSynthesize_ExplicitEmptyRequiredReviews_OverridesDefaults', async () => {
+    // Arrange: seed review phase with ONLY an arbitrary review entry —
+    // no canonical contract dimensions. Under default config the guard
+    // rejects (spec-review + quality-review missing), but with the
+    // explicit empty override no dimensions are required.
+    await seedFeatureAtReview('contract-wiring-empty-override', {
+      arbitrary: { status: 'pass' },
+    });
+
+    // Act: transition with explicit empty override. Prior to the fix,
+    // `options.requiredReviews?.length` treated `[]` as "not provided"
+    // and fell back to workflow defaults, silently ignoring the caller.
+    const result = await handleSet(
+      { featureId: 'contract-wiring-empty-override', phase: 'synthesize' },
+      tmpDir, null,
+      { requiredReviews: [] },
+    );
+
+    expect(result.success).toBe(true);
   });
 });

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -34,6 +34,7 @@ import { applyPhaseSkips } from './phase-skip.js';
 import { getRegisteredGuard } from '../config/register.js';
 import { executeGuard } from '../config/guards.js';
 import { getPlaybook } from './playbooks.js';
+import { getRequiredReviews } from './review-contract.js';
 import { formatResult, type ToolResult } from '../format.js';
 import * as fs from 'node:fs/promises';
 import type { EventStore } from '../event-store/store.js';
@@ -467,19 +468,19 @@ export async function handleSet(
     // The allReviewsPassed guard reads _requiredReviews to enforce that
     // specific review dimensions exist (not just that present reviews pass).
     // Explicit config overrides workflow-type defaults.
+    //
+    // Dimension names are owned by `review-contract.ts`, which is the
+    // single source of truth shared with `playbooks.ts`. Do NOT hardcode
+    // names here — changing the contract requires a one-line edit in
+    // `review-contract.ts` so every consumer stays aligned (see #1073).
     if (input.phase) {
       if (options?.requiredReviews?.length) {
         // Explicit config: use as-is
         mutableState._requiredReviews = options.requiredReviews;
       } else {
-        // Workflow-type-aware defaults: feature workflows require both
-        // review stages per the documented two-stage review process
         const workflowType = state.workflowType as string;
-        const defaults: Record<string, readonly string[]> = {
-          feature: ['spec-compliance', 'code-quality'],
-        };
-        const typeDefaults = defaults[workflowType];
-        if (typeDefaults?.length) {
+        const typeDefaults = getRequiredReviews(workflowType);
+        if (typeDefaults.length) {
           mutableState._requiredReviews = typeDefaults;
         }
       }

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -469,13 +469,18 @@ export async function handleSet(
     // specific review dimensions exist (not just that present reviews pass).
     // Explicit config overrides workflow-type defaults.
     //
+    // Presence check — NOT length — so an explicit empty array disables
+    // required reviews for this transition. Treating `[]` as "not
+    // provided" would silently fall back to defaults, contradicting the
+    // caller's intent (CodeRabbit finding on PR #1076).
+    //
     // Dimension names are owned by `review-contract.ts`, which is the
     // single source of truth shared with `playbooks.ts`. Do NOT hardcode
     // names here — changing the contract requires a one-line edit in
     // `review-contract.ts` so every consumer stays aligned (see #1073).
     if (input.phase) {
-      if (options?.requiredReviews?.length) {
-        // Explicit config: use as-is
+      if (options?.requiredReviews !== undefined) {
+        // Explicit config (including explicit empty): use as-is
         mutableState._requiredReviews = options.requiredReviews;
       } else {
         const workflowType = state.workflowType as string;

--- a/skills-src/delegation/references/troubleshooting.md
+++ b/skills-src/delegation/references/troubleshooting.md
@@ -60,8 +60,8 @@ If `exarchos_orchestrate` with `action: "task_claim"` returns ALREADY_CLAIMED:
 ```json
 {
   "reviews": {
-    "spec-compliance": { "status": "pass", "issues": [] },
-    "code-quality": { "status": "pass", "issues": [] }
+    "spec-review": { "status": "pass", "issues": [] },
+    "quality-review": { "status": "pass", "issues": [] }
   }
 }
 ```

--- a/skills/claude/delegation/references/troubleshooting.md
+++ b/skills/claude/delegation/references/troubleshooting.md
@@ -60,8 +60,8 @@ If `exarchos_orchestrate` with `action: "task_claim"` returns ALREADY_CLAIMED:
 ```json
 {
   "reviews": {
-    "spec-compliance": { "status": "pass", "issues": [] },
-    "code-quality": { "status": "pass", "issues": [] }
+    "spec-review": { "status": "pass", "issues": [] },
+    "quality-review": { "status": "pass", "issues": [] }
   }
 }
 ```

--- a/skills/codex/delegation/references/troubleshooting.md
+++ b/skills/codex/delegation/references/troubleshooting.md
@@ -60,8 +60,8 @@ If `exarchos_orchestrate` with `action: "task_claim"` returns ALREADY_CLAIMED:
 ```json
 {
   "reviews": {
-    "spec-compliance": { "status": "pass", "issues": [] },
-    "code-quality": { "status": "pass", "issues": [] }
+    "spec-review": { "status": "pass", "issues": [] },
+    "quality-review": { "status": "pass", "issues": [] }
   }
 }
 ```

--- a/skills/copilot/delegation/references/troubleshooting.md
+++ b/skills/copilot/delegation/references/troubleshooting.md
@@ -60,8 +60,8 @@ If `exarchos_orchestrate` with `action: "task_claim"` returns ALREADY_CLAIMED:
 ```json
 {
   "reviews": {
-    "spec-compliance": { "status": "pass", "issues": [] },
-    "code-quality": { "status": "pass", "issues": [] }
+    "spec-review": { "status": "pass", "issues": [] },
+    "quality-review": { "status": "pass", "issues": [] }
   }
 }
 ```

--- a/skills/cursor/delegation/references/troubleshooting.md
+++ b/skills/cursor/delegation/references/troubleshooting.md
@@ -60,8 +60,8 @@ If `exarchos_orchestrate` with `action: "task_claim"` returns ALREADY_CLAIMED:
 ```json
 {
   "reviews": {
-    "spec-compliance": { "status": "pass", "issues": [] },
-    "code-quality": { "status": "pass", "issues": [] }
+    "spec-review": { "status": "pass", "issues": [] },
+    "quality-review": { "status": "pass", "issues": [] }
   }
 }
 ```

--- a/skills/generic/delegation/references/troubleshooting.md
+++ b/skills/generic/delegation/references/troubleshooting.md
@@ -60,8 +60,8 @@ If `exarchos_orchestrate` with `action: "task_claim"` returns ALREADY_CLAIMED:
 ```json
 {
   "reviews": {
-    "spec-compliance": { "status": "pass", "issues": [] },
-    "code-quality": { "status": "pass", "issues": [] }
+    "spec-review": { "status": "pass", "issues": [] },
+    "quality-review": { "status": "pass", "issues": [] }
   }
 }
 ```

--- a/skills/opencode/delegation/references/troubleshooting.md
+++ b/skills/opencode/delegation/references/troubleshooting.md
@@ -60,8 +60,8 @@ If `exarchos_orchestrate` with `action: "task_claim"` returns ALREADY_CLAIMED:
 ```json
 {
   "reviews": {
-    "spec-compliance": { "status": "pass", "issues": [] },
-    "code-quality": { "status": "pass", "issues": [] }
+    "spec-review": { "status": "pass", "issues": [] },
+    "quality-review": { "status": "pass", "issues": [] }
   }
 }
 ```


### PR DESCRIPTION
## Summary

Fixes three issues (#1073, #1074, #1075) that all traced to one root cause: PR #1045 added `_requiredReviews: ['spec-compliance', 'code-quality']` to `tools.ts` without updating the playbook docs or skill prompts that described the same contract, while the guard's case-sensitive status check and short-circuit error reporting made the failure look like three bugs.

Repro evidence from `strategos-2-4-0-migration` workflow (basileus repo, 4 `workflow.guard-failed` events at 05:21:20-05:21:42Z, 2 manual `state.patched` events). Full RCA in [`docs/rca/2026-04-10-review-guard-contract-drift.md`](../blob/fix/review-guard-contract-drift/docs/rca/2026-04-10-review-guard-contract-drift.md).

## Changes

### New single source of truth (prevents future drift)
- **`servers/exarchos-mcp/src/workflow/review-contract.ts`** (new) — `REQUIRED_REVIEWS_BY_WORKFLOW_TYPE = { feature: ['spec-review', 'quality-review'] }` + `getRequiredReviews()` + `getRequiredReviewsPrerequisite()`. Dimension keys match skill folder names under `skills-src/` by construction, so the skill an agent runs and the state key it writes are identical.
- **`tools.ts`** — imports `getRequiredReviews` instead of hardcoding dimension names. Reverts #1045's unilateral drift.
- **`playbooks.ts`** — review-phase `guardPrerequisites` generated by `getRequiredReviewsPrerequisite('feature')` rather than a hand-written string that can silently drift from the engine.

### Guard hardening
- **`guards.ts:extractStatus`** — normalizes `status` / `verdict` values to lowercase so uppercase verdicts from `check_review_verdict` (`"PASS"` / `"APPROVED"` / `"NEEDS_FIXES"`) pass the `PASSED_STATUSES` / `FAILED_STATUSES` set-membership check. The boundary is the right place to normalize — `check_review_verdict` keeps its idiomatic TypeScript discriminated-union return type. Closes #1075.
- **`guards.ts:allReviewsPassed.evaluate`** — refactored to accumulate missing-dimensions and not-passed failures into a single `GuardFailure` with a merged `expectedShape` and `suggestedFix`, rather than short-circuiting on the first failure. Agents hitting multiple contract violations fix them in one retry instead of peeling failures one layer at a time. Closes #1074.

### Documentation alignment (closes #1073)
- **`skills-src/delegation/references/troubleshooting.md`** — fixed example that used stale `spec-compliance` / `code-quality` names.
- **`skills/<6 runtimes>/delegation/references/troubleshooting.md`** — regenerated via `npm run build:skills`.

### Tests
- **`guards.test.ts`** — 3 new regression tests (`_UppercaseVerdictPass_Accepts`, `_UppercaseStatusApproved_Accepts`, `_MissingDimensionsAndFailedStatus_AggregatesIntoSingleError`). Existing fixtures renamed to canonical contract.
- **`playbooks.test.ts`** — 3 new cross-file consistency tests (`ReviewContract_EveryWorkflowType_HasMatchingReviewPlaybook`, `_GuardPrerequisites_MentionsEveryRequiredDimension`, `_FeatureWorkflow_UsesSkillFolderNames`) — fail if `tools.ts` and `playbooks.ts` drift apart in the future.
- **`integration.test.ts`** — review-state fixtures renamed.

## Test Plan

- [x] `npm run typecheck` — PASS
- [x] `cd servers/exarchos-mcp && npm run test:run` — **4822/4843 pass** (21 pre-existing skips)
- [x] `npm run test:run` (root) — 527/532 pass. 1 pre-existing unrelated failure in `install.test.ts:356` (hardcoded regex expects repo root to end in `exarchos`; fails when running from `exarchos-worktrees/` — confirmed passes on main, not a regression from this PR)
- [x] `npm run build` — PASS (497 modules bundled)
- [x] `npm run build:skills` — 78 variants across 8 runtimes
- [x] `npm run skills:guard` — PASS (exit 0, no drift)
- [x] Manual verification: RED phase — 3 new tests fail against pre-fix code; GREEN phase — all 95 guard + playbook tests pass after fix
- [x] Repro from basileus `strategos-2-4-0-migration` workflow state confirmed and documented in RCA

## Related

- Debug workflow: `debug-review-guard-contract` (thorough track)
- RCA: [`docs/rca/2026-04-10-review-guard-contract-drift.md`](../blob/fix/review-guard-contract-drift/docs/rca/2026-04-10-review-guard-contract-drift.md)
- Originating regression: #1045 (`5f4f726b`)

Closes #1073
Closes #1074
Closes #1075