### PR TITLE
feat: oneshot workflow type + stale-workflow pruning (#1010, #1077)

### DIFF
--- a/commands/oneshot.md
+++ b/commands/oneshot.md
@@ -1,0 +1,178 @@
+---
+description: Run a lightweight oneshot workflow — plan + TDD implement + optional PR
+---
+
+# Oneshot
+
+Start a lightweight oneshot workflow for: "$ARGUMENTS"
+
+## When to use
+
+Reach for `/exarchos:oneshot` when the change is:
+
+- Bounded — single file or 2-3 tightly-coupled files
+- Self-contained — no subagent dispatch needed
+- Obvious — no design exploration required
+- Small — direct-commit acceptable, or a single PR review will suffice
+
+Examples: typo fixes, dependency bumps, single-function null checks, CI YAML
+tweaks, config key renames, exploratory spikes.
+
+For anything cross-cutting, multi-file, or needing two-stage review, use
+`/exarchos:ideate` instead.
+
+## Skill Reference
+
+Follow the oneshot workflow skill: `@skills/oneshot-workflow/SKILL.md`
+
+## Iron Law
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+TDD applies to oneshot workflows. There is no exemption for "small" changes —
+the test is what makes the change auditable.
+
+## Workflow position
+
+```
+plan ──► implementing ──┬── [direct-commit] ──► completed
+                        │
+                        └── [opt-in PR]     ──► synthesize ──► completed
+```
+
+Choice state at the end of `implementing` is decided by `synthesisPolicy`
+(set at init) plus any `synthesize.requested` events on the stream.
+
+## Process
+
+### Step 1: Init
+
+Initialize a oneshot workflow using
+`mcp__plugin_exarchos_exarchos__exarchos_workflow` with
+`action: "init"`, `workflowType: "oneshot"`, a `featureId`, and optionally
+`synthesisPolicy: "always" | "never" | "on-request"` (default: `"on-request"`).
+
+If the user has stated a clear preference ("I want a PR for this" → `always`;
+"don't open a PR" → `never`), pass it explicitly. Otherwise rely on the
+default and let the user opt in mid-implementing if they change their mind.
+
+### Step 2: Plan
+
+Produce a one-page plan with four sections:
+
+1. **Goal** — what the user is trying to accomplish (1-2 lines)
+2. **Approach** — implementation strategy (1-2 lines)
+3. **Files** — which files will change (1-5)
+4. **Tests** — which tests will be added (named, not described)
+
+Persist via `mcp__plugin_exarchos_exarchos__exarchos_workflow` with
+`action: "set"`:
+
+- Set `artifacts.plan` to the plan text
+- Set `oneshot.planSummary` to a one-line summary
+- Set `phase` to `"implementing"`
+
+### Step 3: Implementing — in-session TDD loop
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run it. Confirm it fails for the right reason.
+2. **[GREEN]** Write minimum code to pass. Run the test. Confirm green.
+3. **[REFACTOR]** Clean up while keeping tests green.
+
+Commit each cycle as a single atomic commit. No subagent dispatch — the main
+agent does the work directly.
+
+### Step 4: Mid-implementing opt-in (optional)
+
+If the user says something like "actually, let's open a PR for this" or "I
+want a review on this", call:
+
+```typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "<id>",
+  reason: "<why the user wants a PR>"
+})
+```
+
+This appends a `synthesize.requested` event. The workflow stays in
+`implementing` — the choice is only acted on at finalize.
+
+### Step 5: Finalize
+
+When all tests pass and typecheck is clean, call:
+
+```typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "<id>"
+})
+```
+
+The handler evaluates `synthesisPolicy` + events and transitions to either
+`synthesize` (PR path) or `completed` (direct-commit path). Outcomes:
+
+| Policy | Event present? | Resolved phase |
+|---|---|---|
+| `always` | (any) | `synthesize` |
+| `never` | (any) | `completed` |
+| `on-request` | yes | `synthesize` |
+| `on-request` | no | `completed` |
+
+### Step 6a: Direct-commit path (`completed`)
+
+Push the commits if not already pushed:
+
+```bash
+git push
+```
+
+Workflow is terminal — done.
+
+### Step 6b: Synthesize path
+
+Hand off to the standard synthesis flow: `@skills/synthesis/SKILL.md`. The
+existing `prepare_synthesis` / `validate_pr_body` / `gh pr create` machinery
+applies. After PR merge, the workflow transitions `synthesize → completed`.
+
+You do **not** need to run `/exarchos:delegate` or `/exarchos:review` for an
+opt-in oneshot synthesize — those phases are not in the oneshot playbook.
+
+## When NOT to use oneshot
+
+| Symptom | Use instead |
+|---|---|
+| Cross-cutting refactor | `/exarchos:refactor` or `/exarchos:ideate` |
+| Multi-file feature | `/exarchos:ideate` |
+| Needs design exploration | `/exarchos:ideate` |
+| Needs two-stage review | `/exarchos:ideate` |
+| Coordinates multiple agents | `/exarchos:ideate` + `/exarchos:delegate` |
+| Should land in stages | `/exarchos:ideate` (stacked PRs) |
+
+If you start a oneshot and discover it's bigger than expected: cancel and
+restart with `/exarchos:ideate`. Don't try to grow a oneshot into a feature
+workflow mid-stream.
+
+## Output
+
+Direct-commit path:
+```markdown
+## Oneshot Complete (direct-commit)
+
+Workflow: <featureId>
+Plan: <one-line summary>
+Tests added: N
+Commits: <hash list>
+Path: direct-commit
+```
+
+Synthesize path:
+```markdown
+## Oneshot Complete (synthesize)
+
+Workflow: <featureId>
+PR: <url>
+Tests: X pass | Build: 0 errors
+Path: synthesize → PR review → merge
+```

--- a/commands/prune.md
+++ b/commands/prune.md
@@ -1,0 +1,90 @@
+---
+description: Prune stale workflows from the pipeline (dry-run → confirm → apply)
+---
+
+# Prune
+
+Prune stale non-terminal workflows from the pipeline. Wraps the `prune_stale_workflows` orchestrate action with an interactive dry-run-then-confirm flow.
+
+## When to Use
+
+Use `/exarchos:prune` when:
+- `exarchos_view pipeline` shows many inactive workflows
+- The pipeline has accumulated abandoned plans, debug branches, or one-shots
+- Periodic maintenance to keep the pipeline view actionable
+
+## Skill Reference
+
+Follow the prune-workflows skill: `@skills/prune-workflows/SKILL.md`
+
+## Process
+
+### Step 1: Dry-Run
+
+Invoke the orchestrate action in dry-run mode (default):
+
+```typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: { dryRun: true }
+})
+```
+
+### Step 2: Display Candidates
+
+Render a table of `candidates` (feature ID, type, phase, staleness in minutes) and `skipped` (feature ID, reason). If both are empty, report "No stale workflows to prune" and exit.
+
+### Step 3: Prompt
+
+Ask the user one of:
+- **proceed** — prune the listed candidates
+- **abort** — exit without changes
+- **force** — bypass safeguards and prune skipped workflows too
+
+### Step 4: Apply
+
+On `proceed`:
+```typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: { dryRun: false }
+})
+```
+
+On `force`:
+```typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: { dryRun: false, force: true }
+})
+```
+
+On `abort`: exit.
+
+### Step 5: Report
+
+Output the `pruned` array as a summary table along with any safeguards that were bypassed.
+
+## Output
+
+```markdown
+## Prune Complete
+
+**Pruned:** <count> workflows transitioned to cancelled
+**Skipped:** <count> workflows preserved by safeguards
+**Force bypass:** <yes/no>
+```
+
+## Safeguards
+
+By default the orchestrate handler skips workflows that have:
+- An open PR on the inferred branch (`open-pr`)
+- Recent commits in the last 24 hours (`active-branch`)
+
+`force: true` bypasses both, but the bypassed safeguard names are still recorded in the `workflow.pruned` event payload for audit.
+
+## Error Handling
+
+- **No state directory:** Initialize an exarchos workflow first.
+- **gh/git not available:** Safeguards short-circuit with errors; consider `force: true` after manually verifying no PRs are open.
+- **All workflows clean:** Output "No stale workflows to prune" and exit.

--- a/docs/designs/2026-02-18-hybrid-review-strategy.md
+++ b/docs/designs/2026-02-18-hybrid-review-strategy.md
@@ -427,12 +427,22 @@ Verifies:
 
 ## Implementation Phases
 
+> **⚠️ PHASE 4 SUPERSEDED (2026-04-11):** The architectural pivot in
+> `lvlup-sw/basileus#146` moved semantic review scoring into basileus as the
+> Phronesis Code Review agent. The `augmentWithSemanticScore()` stub and the
+> `basileusConnected` guard documented in the Dispatch Logic section above
+> are removed as of this commit (#1077). The semantic augmentation flow is
+> no longer the responsibility of exarchos; see `lvlup-sw/basileus#147` for
+> the replacement. Phases 1–3 remain valid — only Phase 4 is retired. The
+> `basileusConnected` parameter on `review_triage` and the `_basileusConnected`
+> argument on `dispatchReviews()` were dead scaffolding and have been deleted.
+
 | Phase | Scope | Dependency |
 |---|---|---|
 | **Phase 1: Deterministic Router** | Scoring function, velocity detection, dispatch logic, `ReviewRouted` events, label-based CodeRabbit gating | None — implementable now |
 | **Phase 2: Self-Hosted Review Agent** | Review agent prompts, finding emission, review merge gate | Phase 1 |
 | **Phase 3: Merge Gate Extension** | `coderabbit-review-gate.sh` updates, escalation path, `ReviewEscalated` events | Phase 2 |
-| **Phase 4: Semantic Augmentation** | Basileus vector search integration, Cohere rerank, `review-findings` collection | Basileus Phase 4 (ADR timeline) |
+| **~~Phase 4: Semantic Augmentation~~** | ~~Basileus vector search integration, Cohere rerank, `review-findings` collection~~ — **superseded, see note above** | ~~Basileus Phase 4 (ADR timeline)~~ |
 
 ## Open Questions
 

--- a/docs/designs/2026-04-11-oneshot-and-pruning.md
+++ b/docs/designs/2026-04-11-oneshot-and-pruning.md
@@ -1,0 +1,320 @@
+# One-Shot Workflow Type + Stale-Workflow Pruning
+
+**Date:** 2026-04-11
+**Issues:** #1010 (prune + one-shot follow-up), #1077 (Phase 4 deprecation, sibling scope), #1049 (epic closeout, sibling scope)
+**Type:** Feature (new workflow type) + maintenance command + cleanup
+**Branch:** `feat/oneshot-and-pruning`
+
+## Problem
+
+Two related pains in workflow lifecycle management:
+
+1. **Pipeline accumulation.** `exarchos_view pipeline` currently returns 56 workflows, many inactive for hundreds of minutes. There is no bulk operation to clear abandoned/stale state. Manual `handleCancel` one-by-one is untenable. The existing `handleList` already surfaces `stale: boolean` per entry (via `isStale(_checkpoint)` at `workflow/tools.ts:198`), but nothing consumes it.
+
+2. **Feature-workflow is too heavy for simple changes.** The canonical `feature` flow (`ideate → plan → delegate → review → synthesize → completed`) is correct for real features but wasteful for one-line fixes, config tweaks, or exploratory tweaks that don't warrant subagent dispatch or a full two-stage review. Users currently either (a) run the full flow and pay the ceremony cost, or (b) bypass workflows entirely and lose auditability.
+
+Both concerns touch the same substrate (workflow state machine, terminal-phase semantics, pipeline-view filtering), which is why they ship together.
+
+## Goals
+
+- Add a `oneshot` workflow type with a **lightweight lifecycle** that still has planning and is still event-sourced/auditable, but defaults to direct-commit with an opt-in PR path.
+- Add a **batch prune** orchestrate action that finds stale non-terminal workflows, applies safeguards, and bulk-cancels with a pruned-stale marker — with dry-run by default.
+- Route #1077 (Hybrid Review Phase 4 deprecation) and #1049 (Channel Integration epic closeout) as sibling scope items in the same PR stack (they share the "lifecycle hygiene" theme and have no design surface).
+
+## Non-Goals
+
+- Redesigning the feature/debug/refactor workflows (out of scope — this adds a new type alongside).
+- Adding a new `archived` terminal phase (axiom:distill — `cancelled` with `reason: 'pruned-stale'` is sufficient; archival is a future addition if restore-after-prune becomes a real need).
+- Live suggestion layer (LOC counting, rubric-based PR recommendations) — Approach B from ideation, deferred per heuristic-drift pitfall documented in research.
+- Restoring pruned workflows (forward-only; restoration would need event-log replay semantics that don't exist yet).
+
+---
+
+## Part 1 — Stale-Workflow Pruning (#1010 primary)
+
+### Design
+
+A new orchestrate handler `prune-stale-workflows` that wraps `handleCancel` in a batch loop. Lives at `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts`. Exposed as a new action on the `exarchos_orchestrate` composite tool.
+
+**Pure-vs-IO separation:** the *candidate-selection* logic is pure (takes a list of workflow summaries + config, returns candidates). The *safeguard checks* (open PR, recent commits) are orchestrate-layer IO, isolated in helper functions that can be mocked in tests. This matches the existing `prepare-synthesis.ts:54-73` pattern where orchestrate handlers run IO and emit events while pure decision logic stays separate.
+
+### Algorithm
+
+```
+prune-stale-workflows(config):
+  entries = handleList(stateDir)                                  # existing
+  candidates = entries.filter(e =>
+    !TERMINAL_PHASES.includes(e.phase) &&                         # existing constant
+    isStale(e._checkpoint, staleAfterMinutes = config.threshold)  # existing function
+  )
+  for c in candidates:
+    if hasOpenPR(c.featureId)            → skip (reason: open-pr)
+    if hasRecentCommits(c.branch, window) → skip (reason: active-branch)
+  if config.dryRun:
+    return { candidates, skipped }
+  for c in approved:
+    handleCancel({ featureId: c.featureId, reason: 'pruned-stale' })
+    eventStore.append('workflow.pruned', { featureId, stalenessMinutes, reason })
+  return { pruned, skipped }
+```
+
+### New tool surface
+
+```ts
+exarchos_orchestrate({
+  action: 'prune-stale-workflows',
+  args: {
+    thresholdMinutes?: number,    // default: 10080 (7d)
+    dryRun?: boolean,             // default: true
+    force?: boolean,              // default: false — bypass safeguards
+    includeOneShot?: boolean,     // default: true
+  }
+})
+```
+
+**Return shape** (both dry-run and apply):
+```ts
+{
+  candidates: [{ featureId, phase, stalenessMinutes, reason }],
+  skipped:    [{ featureId, reason: 'open-pr' | 'active-branch' }],
+  pruned?:    [{ featureId, previousPhase }]   // apply mode only
+}
+```
+
+### Safeguards
+
+- **`hasOpenPR(featureId)`**: `gh pr list --head <inferred-branch> --state open --json number` — if any match, skip. Infers branch from workflow state's `branchName` field (set during delegation), falls back to `feat/<featureId>` convention.
+- **`hasRecentCommits(branch, windowHours = 24)`**: `git log --since "24 hours ago" --format=%H origin/<branch>` — if any commits, skip.
+- **`force: true`** bypasses both safeguards but still records the reason in the `workflow.pruned` event (`force: true, skippedSafeguards: [...]`).
+
+### Events
+
+New event type: `workflow.pruned` with schema `{ featureId, stalenessMinutes, triggeredBy: 'manual' | 'scheduled', skippedSafeguards?: string[] }`. Emitted once per pruned workflow, in addition to the `handleCancel`-emitted `workflow.cancelled` event. The two events are distinguishable downstream: `workflow.cancelled` means user-intent, `workflow.pruned` means batch-cleanup.
+
+### UX — slash command wrapper
+
+A new skill `skills-src/prune-workflows/SKILL.md` (standards skill, no MCP dep marker since it invokes MCP via the composite) renders a slash command `/exarchos:prune`:
+1. Runs `prune-stale-workflows` in dry-run mode
+2. Displays the candidate table with stalenessMinutes + skipped reasons
+3. Asks user to confirm (`proceed?` / `abort` / `force bypass safeguards`)
+4. On confirm, invokes apply mode
+
+No custom skill logic beyond prompt-and-confirm — the decision surface lives entirely in the orchestrate handler.
+
+### Tests
+
+- Pure selection logic tested against fixture lists of `WorkflowSummary` records.
+- Safeguard functions stubbed via DI so tests don't touch `gh`/`git`.
+- Integration test: init 3 fake workflows with varied staleness, run prune in dry-run, assert candidates; run apply, assert phases transitioned to `cancelled`.
+- Property test: `force: true` always bypasses safeguards; `force: false` never prunes a workflow whose safeguard check returns true.
+
+---
+
+## Part 2 — One-Shot Workflow Type (#1010 follow-up)
+
+### Design
+
+New `workflowType: 'oneshot'` with playbook phases `plan → implementing → {completed | synthesize → completed}`. The `implementing → ?` branch is a **choice state** (UML statecharts terminology) implemented using the codebase's existing **pure-guard multi-transition pattern** from the debug workflow (`hsm-definitions.ts:118-172`).
+
+**The decision is event-sourced, not heuristic-based, not IO-backed.** Guards are pure functions of `state` (with `state._events` pre-hydrated from the event store at `tools.ts:494-513`). This is mandated by:
+1. **Codebase precedent** — `guards.teamDisbandedEmitted` at `guards.ts:537-542` is the canonical event-stream guard.
+2. **External research convergence** — Temporal, Azure Durable Functions, Camunda, AWS Step Functions, and the UML spec all prescribe pure guards for choice states; live IO at decision points causes non-determinism on replay (Temporal raises `NonDeterministicWorkflowError`).
+3. **Axiom dimensions** — determinism, verifiability, low coupling all demand pure event-derived guards.
+
+### Lifecycle
+
+```
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+```
+
+| Phase | Description | Exit criteria |
+|---|---|---|
+| `plan` | Lightweight planning — user or skill produces a one-page plan (goal, approach, files to touch, tests to add). No design doc required; no subagent dispatch. | `artifacts.plan` set → transition to `implementing` |
+| `implementing` | In-session TDD implementation. User writes code (or the main agent does). TDD rules still apply (rules are orthogonal to workflow type). | Tests pass + typecheck clean → choice state evaluates |
+| `synthesize` | Only reached on opt-in. Reuses the existing synthesize pipeline (`skills-src/synthesis/`). PR created via `gh pr create`, merges auto-enabled, CI gates apply. | PR merged → `completed` |
+| `completed` | Terminal. For direct-commit path, commits are pushed to main (or current branch) directly — no PR. For synthesize path, the PR merge event terminates the workflow. | — |
+
+### Choice-state mechanism (Approach A from ideation)
+
+**Declared intent at init:**
+```ts
+exarchos_workflow_init({
+  featureId: 'fix-typo-readme',
+  workflowType: 'oneshot',
+  // NEW:
+  synthesisPolicy?: 'always' | 'never' | 'on-request'  // default: 'on-request'
+})
+```
+
+The policy is persisted to `state.oneshot.synthesisPolicy`.
+
+**Runtime opt-in event:** a new orchestrate action `request-synthesize`:
+```ts
+exarchos_orchestrate({
+  action: 'request-synthesize',
+  args: { featureId, reason?: string }
+})
+```
+Appends a `synthesize.requested` event to the stream with `{ featureId, reason, timestamp }`. Idempotent — multiple calls append multiple events but the guard treats presence as boolean.
+
+**Guards** (new, in `servers/exarchos-mcp/src/workflow/guards.ts`):
+```ts
+synthesisOptedIn: {
+  id: 'synthesis-opted-in',
+  description: 'synthesisPolicy=always OR synthesize.requested event exists',
+  evaluate: (state) => {
+    const policy = (state as any).oneshot?.synthesisPolicy ?? 'on-request';
+    if (policy === 'always') return true;
+    if (policy === 'never') return { passed: false, reason: 'synthesisPolicy=never' };
+    // on-request: look for the event
+    const events = (state._events as Array<{ type: string }> | undefined) ?? [];
+    if (events.some(e => e.type === 'synthesize.requested')) return true;
+    return { passed: false, reason: 'synthesize.requested event not emitted' };
+  }
+},
+
+synthesisOptedOut: {
+  id: 'synthesis-opted-out',
+  description: 'inverse of synthesisOptedIn — direct-commit path',
+  evaluate: (state) => {
+    // Mirror logic (same inputs, negated result) to keep transitions orthogonal.
+    // Inline rather than composing to avoid the "missing inverse-guard" pitfall
+    // flagged in the existing hotfixTrackSelected/thoroughTrackSelected pattern.
+    const optedIn = /* ... same policy + event check ... */;
+    return optedIn ? { passed: false, reason: 'synthesis opted in' } : true;
+  }
+}
+```
+
+**HSM transitions** (new, in `servers/exarchos-mcp/src/workflow/hsm-definitions.ts`):
+```ts
+// oneshot workflow
+{ from: 'plan',         to: 'implementing', guard: guards.planApproved },
+{ from: 'implementing', to: 'synthesize',   guard: guards.synthesisOptedIn },
+{ from: 'implementing', to: 'completed',    guard: guards.synthesisOptedOut },
+{ from: 'synthesize',   to: 'completed',    guard: guards.mergeVerified },  // existing guard
+```
+
+### New files
+
+- `servers/exarchos-mcp/src/workflow/playbooks.ts` — add `oneshotPlaybook` entries for `plan`, `implementing`, `synthesize`, `completed` phases
+- `servers/exarchos-mcp/src/workflow/schemas.ts` — register `'oneshot'` in `BUILT_IN_WORKFLOW_TYPES`; add `OneshotStateSchema` discriminated union; add `synthesisPolicy` field
+- `skills-src/oneshot-workflow/SKILL.md` — the `/exarchos:oneshot` slash command. Prompts user for task description, inits the workflow, runs `plan → implementing` in-session, at the end of implementing prompts "direct-commit or open PR?" and optionally appends `synthesize.requested`
+- `commands/exarchos/oneshot.md` — thin wrapper that invokes the skill
+
+### Schema changes
+
+`OneshotStateSchema` (new discriminated union branch in `workflow/schemas.ts`):
+```ts
+{
+  featureId: string,
+  workflowType: 'oneshot',
+  phase: 'plan' | 'implementing' | 'synthesize' | 'completed' | 'cancelled',
+  oneshot: {
+    synthesisPolicy: 'always' | 'never' | 'on-request',
+    planSummary?: string,
+  },
+  artifacts: { plan?: string, pr?: string },
+  // standard workflow fields (checkpoint, events, etc.)
+}
+```
+
+### Event catalog additions
+
+| Event type | Emitted by | Payload |
+|---|---|---|
+| `synthesize.requested` | `exarchos_orchestrate.request-synthesize` | `{ featureId, reason?, timestamp }` |
+| `workflow.pruned` | `exarchos_orchestrate.prune-stale-workflows` | `{ featureId, stalenessMinutes, triggeredBy, skippedSafeguards? }` |
+
+Both need registration in `event-store/` schemas and `workflow-state-projection.ts`.
+
+### Tests
+
+**State machine:**
+- HSM test: from `implementing`, assert that `synthesisOptedIn` guard selects `synthesize` transition when `synthesize.requested` event present; asserts `synthesisOptedOut` selects `completed` when absent.
+- HSM test: `synthesisPolicy: 'always'` bypasses the event check (both paths verify).
+- HSM test: `synthesisPolicy: 'never'` forces `completed` even if `synthesize.requested` was emitted.
+- Property test: for any `synthesisPolicy × event-stream` combination, exactly one of `synthesisOptedIn`/`synthesisOptedOut` returns true (mutual exclusivity).
+
+**Playbooks:**
+- Playbook validator: all phases reachable from `plan`; both `completed` paths terminate; `synthesisPolicy: 'never'` + `synthesize.requested` → still terminates at `completed` (not deadlocked).
+
+**Integration:**
+- End-to-end test: init oneshot with `on-request`, emit `synthesize.requested`, transition through phases, assert final phase is `completed` via synthesize.
+- End-to-end test: init oneshot with no policy (default `on-request`), never emit the event, transition through phases, assert direct-commit path.
+
+---
+
+## Part 3 — Related Cleanup (sibling scope)
+
+### #1077 — Hybrid Review Phase 4 deprecation
+
+Clear acceptance criteria in the issue. No design surface. Route directly in the plan phase as a sibling task:
+- Remove `augmentWithSemanticScore()` stub from `servers/exarchos-mcp/src/review/tools.ts`
+- Remove `basileusConnected` guard from `servers/exarchos-mcp/src/review/dispatch.ts`
+- Update test references in `review/tools.test.ts` + `review/review-triage.test.ts`
+- Add superseding note to `docs/designs/2026-02-18-hybrid-review-strategy.md` Phase 4 section, pointing at `lvlup-sw/basileus#146`
+
+Bundled into the same PR stack under the "workflow lifecycle hygiene" theme. Could land as its own PR or bundled with pruning (both are cleanup-shaped). The plan phase decides.
+
+### #1049 — Channel Integration epic closeout
+
+All 10 sub-issues (#1050-1059) are closed as of 2026-04-03. The epic is just janitorial — close with a comment summarizing shipped scope and pointing at the design/impl docs. No code change. No design surface. Execute in the plan phase as a one-line task: `gh issue close 1049 --comment "..."`.
+
+---
+
+## Migration & Compatibility
+
+- **New workflow type:** adding `'oneshot'` to `BUILT_IN_WORKFLOW_TYPES` is additive — existing feature/debug/refactor workflows are unaffected.
+- **Pipeline view:** already filters terminal phases. Pruned workflows land in `cancelled`, so they disappear from the default pipeline view automatically.
+- **Pre-existing stale workflows:** can be cleaned up with `/exarchos:prune` after this ships. No one-shot migration needed.
+- **Event store schema:** `synthesize.requested` and `workflow.pruned` are new event types — registering them is additive. Older event logs that don't contain them behave identically.
+
+## Risks & Open Questions
+
+1. **Direct-commit UX for `oneshot` completed path.** Currently, the `completed` phase in feature workflows is reached via synthesize (PR merge). For `oneshot` direct-commit, what actually triggers the transition to `completed`? Proposed: a new orchestrate action `finalize-oneshot` that the `/exarchos:oneshot` skill calls after committing. This avoids a new guard type. **Decision for plan phase.**
+
+2. **Branch inference for pruning safeguards.** The `hasOpenPR` check needs to know the branch name. Feature workflows store this in `state.branchName` set during delegation/worktree setup. For workflows that never reached delegation (abandoned at ideate/plan), there is no branch. Proposal: skip the PR safeguard for such workflows (they can't have PRs). **Decision for plan phase.**
+
+3. **Scheduled pruning.** Out of scope for v1 (manual trigger only), but should be easy to layer on top: a cron/trigger that invokes `prune-stale-workflows` with `dryRun: false`. Noted for future.
+
+4. **`synthesize.requested` event dedup.** Per external research, at-least-once semantics mean duplicate events are possible during restarts. The guard treats any count ≥ 1 as true, so duplicates are benign. Noted for awareness.
+
+5. **One-shot cancellation semantics.** If a user abandons mid-`implementing`, the existing `handleCancel` should work unchanged. Verify in integration tests.
+
+## Acceptance Criteria
+
+- [ ] `exarchos_orchestrate.prune-stale-workflows` action ships with dry-run (default), apply, and `force` modes
+- [ ] `hasOpenPR` and `hasRecentCommits` safeguards work against live `gh`/`git` and are unit-testable via DI
+- [ ] `workflow.pruned` event is registered and projected into `_events`
+- [ ] `/exarchos:prune` slash command prompts + confirms + applies
+- [ ] `oneshot` workflow type is registered; `BUILT_IN_WORKFLOW_TYPES` updated
+- [ ] `oneshotPlaybook` declared for all four phases
+- [ ] `synthesisOptedIn` / `synthesisOptedOut` guards implemented as pure event-derived predicates (no IO)
+- [ ] `exarchos_orchestrate.request-synthesize` action ships
+- [ ] `synthesize.requested` event is registered and projected
+- [ ] HSM transitions for oneshot declared in `hsm-definitions.ts`
+- [ ] Property test: `synthesisOptedIn` / `synthesisOptedOut` mutual exclusivity across all policy × event combinations
+- [ ] `/exarchos:oneshot` slash command ships with end-to-end flow (init → plan → implement → choice)
+- [ ] #1077 deprecation lands (stub removed, superseding note added)
+- [ ] #1049 epic closed with closeout comment
+
+## References
+
+- **Codebase patterns:**
+  - Multi-transition branching: `servers/exarchos-mcp/src/workflow/hsm-definitions.ts:118-172` (debug workflow `investigate → rca | hotfix-implement`)
+  - Event-stream guards: `servers/exarchos-mcp/src/workflow/guards.ts:537-542` (`teamDisbandedEmitted`)
+  - Event hydration pre-transition: `servers/exarchos-mcp/src/workflow/tools.ts:494-513`
+  - Terminal phase filter: `servers/exarchos-mcp/src/views/tools.ts:322` (`TERMINAL_PHASES`)
+  - Stale detection: `servers/exarchos-mcp/src/workflow/checkpoint.ts:53` (`isStale`)
+  - Orchestrate handler with IO: `servers/exarchos-mcp/src/orchestrate/prepare-synthesis.ts:54-73`
+  - Existing cancel with compensation: `servers/exarchos-mcp/src/workflow/cancel.ts:37`
+
+- **External research:**
+  - UML statecharts — guards must be pure expressions without side effects
+  - Microsoft Learn — Durable Functions orchestrator code constraints (determinism, replay-safety)
+  - Temporal — `NonDeterministicWorkflowError` on live IO at decision points
+  - AWS Step Functions — Choice state reads from input/history
+  - Camunda BPMN — exclusive gateway with conditional sequence flow reading process variables

--- a/docs/plans/2026-04-11-oneshot-and-pruning.md
+++ b/docs/plans/2026-04-11-oneshot-and-pruning.md
@@ -1,0 +1,594 @@
+# Implementation Plan — One-Shot Workflow + Stale-Workflow Pruning
+
+**Design:** `docs/designs/2026-04-11-oneshot-and-pruning.md`
+**Feature ID:** `oneshot-and-pruning`
+**Branch:** `feat/oneshot-and-pruning`
+**Issues:** #1010 (primary), #1077 (sibling scope), #1049 (sibling scope)
+
+## Iron Law
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+Every task below follows RED → GREEN → REFACTOR. No exceptions except the two admin tasks (T17, T18) which have no production code (pure issue-management / doc edits).
+
+---
+
+## Task Overview
+
+| Group | Tasks | Parallel? | Depends on |
+|---|---|---|---|
+| **A** — Schema & event foundations | T1, T2, T6, T7 | ✅ parallel | — |
+| **B** — Pure guards + playbook + projections | T8, T10, T13 | ✅ parallel | A |
+| **C** — Orchestrate handlers + HSM wiring | T3, T9, T11, T12 | ✅ parallel | B |
+| **D** — Composite + registry + skills | T4, T5, T14 | ✅ parallel | C |
+| **E** — Integration tests | T15, T16 | ✅ parallel | D |
+| **F** — Skills build & sibling scope | T17, T18, T19, T20 | ✅ parallel | E (T17 only) |
+
+Estimated count: **20 tasks**. Three of them (T17, T18, T20) are admin/cleanup — no TDD cycle.
+
+---
+
+## Group A — Schema & Event Foundations (parallel, no deps)
+
+### Task T1: Register `workflow.pruned` event type
+
+**Phase:** RED → GREEN → REFACTOR
+**Parallelizable:** Yes
+**Dependencies:** None
+
+1. **[RED]** Write test: `eventSchema_workflowPruned_acceptsValidPayload`
+   - File: `servers/exarchos-mcp/src/event-store/schemas.test.ts`
+   - Expected failure: `workflow.pruned` not in event type union
+   - Also write: `eventSchema_workflowPruned_rejectsMissingFeatureId`
+
+2. **[GREEN]** Add `'workflow.pruned'` to the event types array
+   - File: `servers/exarchos-mcp/src/event-store/schemas.ts` (around line 40, after `workflow.cas-failed`)
+   - Payload schema: `{ featureId: string, stalenessMinutes: number, triggeredBy: 'manual' | 'scheduled', skippedSafeguards?: string[] }`
+   - Add to the `autoEmits` registry as `'manual'` (explicit emission only)
+
+3. **[REFACTOR]** — no cleanup needed
+
+---
+
+### Task T2: Register `synthesize.requested` event type
+
+**Phase:** RED → GREEN → REFACTOR
+**Parallelizable:** Yes
+**Dependencies:** None
+
+1. **[RED]** Write test: `eventSchema_synthesizeRequested_acceptsValidPayload`
+   - File: `servers/exarchos-mcp/src/event-store/schemas.test.ts`
+   - Expected failure: event type not in union
+   - Also write: `eventSchema_synthesizeRequested_rejectsMissingFeatureId`
+
+2. **[GREEN]** Add `'synthesize.requested'` to event types array
+   - File: `servers/exarchos-mcp/src/event-store/schemas.ts`
+   - Payload schema: `{ featureId: string, reason?: string, timestamp: string }`
+   - Add to `autoEmits` registry as `'manual'`
+
+3. **[REFACTOR]** — none
+
+---
+
+### Task T6: Register `oneshot` workflow type + schema
+
+**Phase:** RED → GREEN → REFACTOR
+**Parallelizable:** Yes
+**Dependencies:** None
+
+1. **[RED]** Write tests:
+   - `workflowType_oneshotAcceptedInInit`: `exarchos_workflow init` with `workflowType: 'oneshot'` returns success
+   - `oneshotStateSchema_rejectsInvalidSynthesisPolicy`: schema validation fails on `synthesisPolicy: 'maybe'`
+   - `oneshotStateSchema_defaultsSynthesisPolicyToOnRequest`: policy field is optional and defaults
+   - File: `servers/exarchos-mcp/src/workflow/schemas.test.ts` (create if absent) or inline in `__tests__/workflow/`
+
+2. **[GREEN]** Register the workflow type
+   - File: `servers/exarchos-mcp/src/workflow/schemas.ts:199`
+   - Add `'oneshot'` to `BUILT_IN_WORKFLOW_TYPES`
+   - Add `OneshotStateSchema` discriminated-union branch (after `RefactorStateSchema` at line ~282):
+     ```ts
+     const OneshotStateSchema = BaseWorkflowStateSchema.extend({
+       workflowType: z.literal('oneshot'),
+       oneshot: z.object({
+         synthesisPolicy: z.enum(['always', 'never', 'on-request']).default('on-request'),
+         planSummary: z.string().optional(),
+       }).optional(),
+     });
+     ```
+   - Update `WorkflowStateSchema` discriminated union to include `OneshotStateSchema`
+
+3. **[REFACTOR]** — none
+
+---
+
+### Task T7: Pure selection logic for prune candidates
+
+**Phase:** RED → GREEN → REFACTOR
+**Parallelizable:** Yes
+**Dependencies:** None (pure function, no schema reads)
+
+1. **[RED]** Write tests:
+   - `selectPruneCandidates_excludesTerminalPhases` — `completed` and `cancelled` entries filtered out
+   - `selectPruneCandidates_excludesFreshWorkflows` — entries with recent `_checkpoint.lastActivityTimestamp` excluded
+   - `selectPruneCandidates_includesStaleNonTerminal` — stale + active entries selected
+   - `selectPruneCandidates_respectsCustomThreshold` — 7d default, 1h custom
+   - `selectPruneCandidates_excludesOneShotWhenFlagFalse` — `includeOneShot: false` filters `workflowType: 'oneshot'`
+   - File: `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts`
+   - Use fixture `WorkflowSummary[]` arrays; no FS access
+
+2. **[GREEN]** Implement pure function
+   - File: `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts`
+   - Export `selectPruneCandidates(entries: WorkflowSummary[], config: PruneConfig): { candidates, excluded }`
+   - Pure — no IO, no event store, no git/gh. Takes the list from outside.
+
+3. **[REFACTOR]** — extract `isBeyondThreshold(checkpoint, thresholdMinutes)` helper if selection logic grows
+
+---
+
+## Group B — Guards, Playbook, Projections (parallel, depends on A)
+
+### Task T8: `synthesisOptedIn` / `synthesisOptedOut` guards
+
+**Phase:** RED → GREEN → REFACTOR
+**Parallelizable:** Yes
+**Dependencies:** T2 (synthesize.requested event type), T6 (oneshot state schema)
+
+1. **[RED]** Write tests:
+   - `synthesisOptedIn_policyAlways_returnsTrue`
+   - `synthesisOptedIn_policyNever_returnsFalseWithReason`
+   - `synthesisOptedIn_policyOnRequestWithEvent_returnsTrue`
+   - `synthesisOptedIn_policyOnRequestNoEvent_returnsFalseWithReason`
+   - `synthesisOptedIn_policyDefaultsToOnRequest_whenFieldMissing`
+   - `synthesisOptedOut_isInverseOfSynthesisOptedIn` — parameterized over all 8 combinations, asserts exactly one is true
+   - File: `servers/exarchos-mcp/src/workflow/guards.test.ts`
+
+2. **[GREEN]** Implement both guards
+   - File: `servers/exarchos-mcp/src/workflow/guards.ts`
+   - Add `synthesisOptedIn` and `synthesisOptedOut` to the `guards` export
+   - Read `state.oneshot?.synthesisPolicy` (default `'on-request'`)
+   - Read `state._events` (already hydrated pre-transition per `tools.ts:494-513`) — look for `type === 'synthesize.requested'`
+   - Return `true` or `{ passed: false, reason: string }` per existing guard shape
+   - `synthesisOptedOut` explicitly inlines inverted logic (NOT composed via `!synthesisOptedIn`) — matches research recommendation to avoid the "missing inverse guard" pitfall
+
+3. **[REFACTOR]** — extract `hasSynthesizeRequestEvent(events)` helper if inversion duplicates logic
+
+---
+
+### Task T10: `oneshotPlaybook` phase entries
+
+**Phase:** RED → GREEN → REFACTOR
+**Parallelizable:** Yes
+**Dependencies:** T6 (workflow type registered)
+
+1. **[RED]** Write tests:
+   - `oneshotPlaybook_declaresAllPhases` — `plan`, `implementing`, `synthesize`, `completed` all present
+   - `oneshotPlaybook_phaseTransitionCriteria_describesChoiceStateAtImplementing`
+   - `oneshotPlaybook_allPhasesReachableFromPlan` (use existing playbook validator property test)
+   - `oneshotPlaybook_completedReachableFromBothImplementingBranches`
+   - File: `servers/exarchos-mcp/src/workflow/playbooks.test.ts` + `playbooks.property.test.ts`
+
+2. **[GREEN]** Declare the playbook
+   - File: `servers/exarchos-mcp/src/workflow/playbooks.ts`
+   - Add `oneshotPlaybook: PhasePlaybook[]` with entries for `plan`, `implementing`, `synthesize`, `completed`
+   - `implementing.transitionCriteria`: `"synthesize opted in → synthesize | opted out → completed"`
+   - `implementing.guardPrerequisites`: `"Tests pass + synthesis choice made (policy or event)"`
+   - Register in the `workflowPlaybooks` map at the bottom of the file
+
+3. **[REFACTOR]** — none
+
+---
+
+### Task T13: Event projection for `synthesize.requested` + `workflow.pruned`
+
+**Phase:** RED → GREEN → REFACTOR
+**Parallelizable:** Yes
+**Dependencies:** T1, T2 (events registered)
+
+1. **[RED]** Write tests:
+   - `workflowStateProjection_synthesizeRequested_appendsToEvents`
+   - `workflowStateProjection_workflowPruned_appendsToEvents` (though terminal — still appended for audit)
+   - File: `servers/exarchos-mcp/src/views/workflow-state-projection.test.ts`
+
+2. **[GREEN]** Add projection cases
+   - File: `servers/exarchos-mcp/src/views/workflow-state-projection.ts`
+   - In the event reducer switch (around line 264-275, where `team.*` cases live), add cases for `'synthesize.requested'` and `'workflow.pruned'`
+   - Both append to `state._events` without mutating other state fields
+   - Follows the same shape as the `team.*` fix from stabilization sweep
+
+3. **[REFACTOR]** — none
+
+---
+
+## Group C — Orchestrate Handlers + HSM Wiring (parallel, depends on B)
+
+### Task T3: Implement `prune-stale-workflows` orchestrate handler
+
+**Phase:** RED → GREEN → REFACTOR
+**Parallelizable:** Yes
+**Dependencies:** T7 (pure selection logic), T1 (workflow.pruned event)
+
+1. **[RED]** Write tests:
+   - `handlePruneStaleWorkflows_dryRunReturnsCandidatesWithoutMutation`
+   - `handlePruneStaleWorkflows_applyModeCallsCancelForEachApproved`
+   - `handlePruneStaleWorkflows_safeguardOpenPRSkipsCandidate`
+   - `handlePruneStaleWorkflows_safeguardRecentCommitsSkipsCandidate`
+   - `handlePruneStaleWorkflows_forceTrueBypassesSafeguards`
+   - `handlePruneStaleWorkflows_emitsPrunedEventPerCancel`
+   - File: `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts`
+   - Inject `hasOpenPR` and `hasRecentCommits` via optional config param (DI pattern) — default production impls shell out to `gh`/`git`, test impls are stubs
+
+2. **[GREEN]** Implement handler
+   - File: `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts` (same file as T7)
+   - Export `handlePruneStaleWorkflows(args, stateDir, ctx)` matching ActionHandler signature
+   - Calls `handleList` → `selectPruneCandidates` → safeguard loop → `handleCancel` loop
+   - Each cancel emits `workflow.pruned` via `ctx.eventStore.append()`
+   - Returns `{ candidates, skipped, pruned? }` shape from design
+   - Production safeguards: `hasOpenPR` runs `execSync('gh pr list --head <branch> --state open --json number')`; `hasRecentCommits` runs `execSync('git log --since ...')`. Both isolated in helper functions for DI.
+
+3. **[REFACTOR]** — extract safeguard helpers to `prune-safeguards.ts` if the file grows past ~200 lines
+
+---
+
+### Task T9: Declare oneshot HSM transitions
+
+**Phase:** RED → GREEN → REFACTOR
+**Parallelizable:** Yes
+**Dependencies:** T8 (guards), T6 (workflow type)
+
+1. **[RED]** Write tests:
+   - `hsmDefinitions_oneshotHasFourTransitions` — `plan→implementing`, `implementing→synthesize`, `implementing→completed`, `synthesize→completed`
+   - `hsmDefinitions_oneshotChoiceStateHasMutuallyExclusiveGuards` — property test: for all policy × event combos, exactly one transition's guard passes
+   - `hsmDefinitions_oneshotIncludesUniversalCancelTransition` — inherited from state machine base (cancelled universal per state-machine.ts:423)
+   - File: `servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts` or a new file
+
+2. **[GREEN]** Add transitions
+   - File: `servers/exarchos-mcp/src/workflow/hsm-definitions.ts`
+   - Add a new `oneshotTransitions` array with the four transitions per design
+   - Use `guards.planApproved` for `plan → implementing` (reuse existing guard if present; else create new one in T8's scope)
+   - Use `guards.synthesisOptedIn` / `guards.synthesisOptedOut` for the choice state
+   - Use `guards.mergeVerified` for `synthesize → completed` (existing guard)
+   - Register `oneshotTransitions` in the HSM definitions export
+
+3. **[REFACTOR]** — if `planApproved` guard doesn't exist, may need a lightweight variant for oneshot (e.g., `oneshotPlanSet` checking `state.artifacts.plan` presence) — decision in GREEN
+
+---
+
+### Task T11: Implement `request-synthesize` orchestrate action
+
+**Phase:** RED → GREEN → REFACTOR
+**Parallelizable:** Yes
+**Dependencies:** T2 (event type), T13 (projection)
+
+1. **[RED]** Write tests:
+   - `handleRequestSynthesize_appendsSynthesizeRequestedEvent`
+   - `handleRequestSynthesize_isIdempotentAcrossMultipleCalls` — two calls append two events, guard still returns true (any-count semantics)
+   - `handleRequestSynthesize_rejectsNonOneshotWorkflow` — feature/debug/refactor return error
+   - `handleRequestSynthesize_capturesOptionalReason`
+   - File: `servers/exarchos-mcp/src/orchestrate/request-synthesize.test.ts`
+
+2. **[GREEN]** Implement handler
+   - File: `servers/exarchos-mcp/src/orchestrate/request-synthesize.ts`
+   - Signature: `handleRequestSynthesize(args: { featureId, reason? }, _stateDir, ctx)`
+   - Reads current workflow state (via `handleGet` or direct state read), verifies `workflowType === 'oneshot'`
+   - Appends `synthesize.requested` event to stream via `ctx.eventStore`
+   - Returns `{ success: true, data: { eventAppended: true, reason } }`
+
+3. **[REFACTOR]** — none
+
+---
+
+### Task T12: Implement `finalize-oneshot` orchestrate action
+
+**Phase:** RED → GREEN → REFACTOR
+**Parallelizable:** Yes
+**Dependencies:** T9 (HSM transitions) — resolves design Open Question #1
+
+1. **[RED]** Write tests:
+   - `handleFinalizeOneshot_transitionsImplementingToCompleted_whenOptedOut`
+   - `handleFinalizeOneshot_transitionsImplementingToSynthesize_whenOptedIn`
+   - `handleFinalizeOneshot_rejectsNonOneshotWorkflow`
+   - `handleFinalizeOneshot_rejectsFromWrongPhase` — must be in `implementing`
+   - File: `servers/exarchos-mcp/src/orchestrate/finalize-oneshot.test.ts`
+
+2. **[GREEN]** Implement handler
+   - File: `servers/exarchos-mcp/src/orchestrate/finalize-oneshot.ts`
+   - Reads state, verifies `workflowType === 'oneshot'` and `phase === 'implementing'`
+   - Calls `handleSet({ featureId, phase: <next> })` where `<next>` is determined by the HSM's guard evaluation — i.e., delegates the decision to the state machine, not duplicating guard logic
+   - Alternatively: calls `handleSet({ featureId, phase: 'completed' })` and lets the HSM reject + fall through to `'synthesize'` via multi-transition evaluation
+
+3. **[REFACTOR]** — consolidate with existing `handleCleanup` if shape overlaps significantly (check before merging)
+
+---
+
+## Group D — Composite, Registry, Skills (parallel, depends on C)
+
+### Task T4: Register new actions in composite + registry
+
+**Phase:** RED → GREEN → REFACTOR
+**Parallelizable:** Yes
+**Dependencies:** T3, T11, T12
+
+1. **[RED]** Write tests:
+   - `compositeHandler_pruneStaleWorkflowsAction_dispatches`
+   - `compositeHandler_requestSynthesizeAction_dispatches`
+   - `compositeHandler_finalizeOneshotAction_dispatches`
+   - `registrySync_allHandlerKeysHaveActionDeclarations` — existing sync test should cover this
+   - File: `servers/exarchos-mcp/src/orchestrate/composite.test.ts` + `registry.test.ts`
+
+2. **[GREEN]** Register in both locations
+   - File: `servers/exarchos-mcp/src/orchestrate/composite.ts:91` — add to `ACTION_HANDLERS`:
+     ```ts
+     prune_stale_workflows: adaptArgsWithEventStore(handlePruneStaleWorkflows),
+     request_synthesize:     adaptArgsWithEventStore(handleRequestSynthesize),
+     finalize_oneshot:       adapt(handleFinalizeOneshot),
+     ```
+   - File: `servers/exarchos-mcp/src/registry.ts:462` (`orchestrateActions` array) — add ToolAction declarations with schemas, phases, roles, autoEmits
+     - `prune_stale_workflows` autoEmits `workflow.pruned` conditionally
+     - `request_synthesize` autoEmits `synthesize.requested` always
+
+3. **[REFACTOR]** — none
+
+---
+
+### Task T5: Create `/exarchos:prune` skill
+
+**Phase:** RED → GREEN → REFACTOR (REFACTOR skipped for skill edits)
+**Parallelizable:** Yes
+**Dependencies:** T4 (action registered)
+
+1. **[RED]** Write tests:
+   - `pruneSkill_frontmatterHasKebabCaseName`
+   - `pruneSkill_descriptionBelow1024Chars`
+   - `pruneSkill_metadataHasMcpServerExarchos`
+   - `pruneSkill_includesDryRunAndApplySteps`
+   - File: `src/__tests__/skills/prune-workflows.test.ts` (or the existing skills-guard tests if they cover structural checks)
+   - Validate via the existing skills-build-src validator
+
+2. **[GREEN]** Write the skill
+   - File: `skills-src/prune-workflows/SKILL.md`
+   - Frontmatter: `name: prune-workflows`, `description: ...`, `metadata: { mcp-server: exarchos }`
+   - Steps: (1) invoke `prune_stale_workflows` in dry-run, (2) display candidate table, (3) prompt user for confirm/abort/force, (4) invoke apply
+   - File: `commands/exarchos/prune.md` — thin wrapper that invokes the skill
+
+3. **[REFACTOR]** — N/A (prose)
+
+**Note:** Skill files MUST be edited in `skills-src/` only. The generated `skills/` tree is produced by T19 (`npm run build:skills`).
+
+---
+
+### Task T14: Create `/exarchos:oneshot` skill
+
+**Phase:** RED → GREEN → (skip REFACTOR)
+**Parallelizable:** Yes
+**Dependencies:** T4 (all three actions registered)
+
+1. **[RED]** Write tests:
+   - `oneshotSkill_frontmatterHasKebabCaseName`
+   - `oneshotSkill_descriptionBelow1024Chars`
+   - `oneshotSkill_metadataHasMcpServerExarchos`
+   - `oneshotSkill_includesPlanImplementingChoicePhases`
+   - `oneshotSkill_documentsSynthesizePolicyChoice`
+   - File: same skills test harness as T5
+
+2. **[GREEN]** Write the skill
+   - File: `skills-src/oneshot-workflow/SKILL.md`
+   - Steps: (1) accept task description + optional `--pr` flag, (2) invoke `exarchos_workflow init` with `workflowType: 'oneshot'` and `synthesisPolicy`, (3) produce one-page plan, (4) set `artifacts.plan` + transition to `implementing`, (5) run in-session TDD loop, (6) after implementing, prompt "direct commit or open PR?" — if PR, call `request_synthesize` then `finalize_oneshot`; if direct, call `finalize_oneshot` directly
+   - File: `commands/exarchos/oneshot.md` — thin wrapper
+
+3. **[REFACTOR]** — N/A
+
+---
+
+## Group E — Integration Tests (parallel, depends on D)
+
+### Task T15: End-to-end integration test — pruning
+
+**Phase:** Integration (no RED/GREEN split — test IS the deliverable)
+**Parallelizable:** Yes
+**Dependencies:** T4 (action registered)
+
+1. Write test `pruneIntegration_dryRunThenApply_cleansStaleWorkflows`
+   - File: `servers/exarchos-mcp/src/__tests__/integration/prune-stale-workflows.test.ts`
+   - Setup: init 3 workflows via `handleInit`, manipulate `_checkpoint.lastActivityTimestamp` to make 2 stale
+   - Dry-run: assert 2 candidates returned
+   - Apply with `force: true` (safeguards stubbed): assert 2 workflows now in `cancelled` phase, `workflow.pruned` events present in stream
+
+2. Write test `pruneIntegration_safeguardRespectsOpenPR`
+   - Stub `hasOpenPR` to return `true` for one of the stale workflows
+   - Apply: assert only 1 workflow pruned, 1 in `skipped` list
+
+---
+
+### Task T16: End-to-end integration test — oneshot workflow
+
+**Phase:** Integration
+**Parallelizable:** Yes
+**Dependencies:** T4
+
+1. Write test `oneshotIntegration_defaultPolicy_directCommitPath`
+   - File: `servers/exarchos-mcp/src/__tests__/integration/oneshot-workflow.test.ts`
+   - Init oneshot with no policy (default `on-request`)
+   - Transition `plan → implementing` (via `handleSet`)
+   - Call `finalize_oneshot`
+   - Assert phase is now `completed`, not `synthesize`
+
+2. Write test `oneshotIntegration_onRequestPolicyWithEvent_synthesizePath`
+   - Init oneshot, transition through `plan → implementing`
+   - Call `request_synthesize`
+   - Call `finalize_oneshot`
+   - Assert phase is now `synthesize`
+
+3. Write test `oneshotIntegration_policyAlways_synthesizePathWithoutEvent`
+   - Init with `synthesisPolicy: 'always'`, no event emitted
+   - `finalize_oneshot` → assert `synthesize` phase
+
+4. Write test `oneshotIntegration_policyNeverWithEvent_stillDirectCommit`
+   - Init with `synthesisPolicy: 'never'`, emit `synthesize.requested` anyway
+   - `finalize_oneshot` → assert `completed` phase (policy wins over event)
+
+5. Write test `oneshotIntegration_cancelMidImplementing_transitionsToCancelled`
+   - Init, advance to implementing, call `handleCancel`
+   - Assert phase is `cancelled`, existing compensation machinery runs
+
+---
+
+## Group F — Cleanup, Sibling Scope, Skills Build
+
+### Task T17: #1077 — Remove Hybrid Review Phase 4 deprecation stubs
+
+**Phase:** Direct edit (no TDD — removing dead code)
+**Parallelizable:** Yes
+**Dependencies:** None (independent of main design)
+
+1. Remove `augmentWithSemanticScore()` function from `servers/exarchos-mcp/src/review/tools.ts`
+2. Remove `basileusConnected` guard/branch from `servers/exarchos-mcp/src/review/dispatch.ts`
+3. Update `servers/exarchos-mcp/src/review/tools.test.ts` — remove tests referencing the stub; keep the file, retain other tests
+4. Update `servers/exarchos-mcp/src/review/review-triage.test.ts` — remove stub-related branches; retain deterministic router tests
+5. Add superseding note to `docs/designs/2026-02-18-hybrid-review-strategy.md` Phase 4 section pointing at `lvlup-sw/basileus#146`
+6. Verify `npm run test:run` passes (tests that were stub-only removed, others untouched)
+
+---
+
+### Task T18: #1049 — Close Channel Integration epic
+
+**Phase:** Admin (no code)
+**Parallelizable:** Yes
+**Dependencies:** None
+
+1. Run `gh issue close 1049 --comment "All sub-issues (#1050-1059) closed across PRs #1060, #1049. Channel Integration Phases 0-1 shipped. Phases 2-4 tracked in lvlup-sw/basileus."`
+
+(Execute during the plan phase — this is a one-line admin task.)
+
+---
+
+### Task T19: Build + lint skills
+
+**Phase:** Build verification
+**Parallelizable:** No (must run after T5 and T14)
+**Dependencies:** T5, T14
+
+1. Run `npm run build:skills` — regenerates `skills/<runtime>/` per-runtime variants from `skills-src/`
+2. Run `npm run skills:guard` — CI-facing drift check; must pass
+3. Commit both `skills-src/` sources AND the regenerated `skills/` tree (per CLAUDE.md convention)
+
+---
+
+### Task T20: Verify full test suite + typecheck
+
+**Phase:** Build verification
+**Parallelizable:** No (final gate before PR)
+**Dependencies:** All prior tasks
+
+1. Run `npm run typecheck` at repo root
+2. Run `npm run test:run` at repo root
+3. Run `cd servers/exarchos-mcp && npm run test:run`
+4. Run `npm run build`
+5. All four must pass green
+
+---
+
+## Parallelization Diagram
+
+```
+Group A (parallel, no deps):
+  T1 ──┐
+  T2 ──┤
+  T6 ──┤
+  T7 ──┘
+       │
+Group B (parallel, depends on A):
+  T8  ──┐
+  T10 ──┤  (T8 depends on T2, T6; T10 on T6; T13 on T1, T2)
+  T13 ──┘
+       │
+Group C (parallel, depends on B):
+  T3  ──┐  (T3 depends on T7, T1)
+  T9  ──┤  (T9 depends on T8, T6)
+  T11 ──┤  (T11 depends on T2, T13)
+  T12 ──┘  (T12 depends on T9)
+       │
+Group D (parallel, depends on C):
+  T4  ──┐
+  T5  ──┤
+  T14 ──┘
+       │
+Group E (parallel, depends on D):
+  T15 ──┐
+  T16 ──┘
+       │
+Group F (sibling scope + gates):
+  T17 ── parallel, independent — can run at ANY point
+  T18 ── admin, run during plan phase
+  T19 ── depends on T5, T14
+  T20 ── depends on all
+```
+
+**Recommended delegation:** Split tasks across 4-5 subagent worktrees for groups A/B/C/D. Groups E/F run sequentially on the integration branch after merge-down.
+
+---
+
+## Files Touched (expected surface)
+
+**New files (production):**
+- `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts`
+- `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts`
+- `servers/exarchos-mcp/src/orchestrate/request-synthesize.ts`
+- `servers/exarchos-mcp/src/orchestrate/request-synthesize.test.ts`
+- `servers/exarchos-mcp/src/orchestrate/finalize-oneshot.ts`
+- `servers/exarchos-mcp/src/orchestrate/finalize-oneshot.test.ts`
+- `servers/exarchos-mcp/src/__tests__/integration/prune-stale-workflows.test.ts`
+- `servers/exarchos-mcp/src/__tests__/integration/oneshot-workflow.test.ts`
+- `skills-src/prune-workflows/SKILL.md`
+- `skills-src/oneshot-workflow/SKILL.md`
+- `commands/exarchos/prune.md`
+- `commands/exarchos/oneshot.md`
+
+**Modified files:**
+- `servers/exarchos-mcp/src/event-store/schemas.ts` — add 2 event types
+- `servers/exarchos-mcp/src/event-store/schemas.test.ts` — tests for new types
+- `servers/exarchos-mcp/src/workflow/schemas.ts` — register `oneshot` type, add state schema
+- `servers/exarchos-mcp/src/workflow/guards.ts` — add 2 guards
+- `servers/exarchos-mcp/src/workflow/guards.test.ts` — guard tests
+- `servers/exarchos-mcp/src/workflow/playbooks.ts` — add `oneshotPlaybook`
+- `servers/exarchos-mcp/src/workflow/playbooks.test.ts` + `.property.test.ts`
+- `servers/exarchos-mcp/src/workflow/hsm-definitions.ts` — add oneshot transitions
+- `servers/exarchos-mcp/src/views/workflow-state-projection.ts` — project new events
+- `servers/exarchos-mcp/src/views/workflow-state-projection.test.ts`
+- `servers/exarchos-mcp/src/orchestrate/composite.ts` — register 3 new actions
+- `servers/exarchos-mcp/src/orchestrate/composite.test.ts`
+- `servers/exarchos-mcp/src/registry.ts` — 3 new action declarations
+- `servers/exarchos-mcp/src/registry.test.ts`
+- `servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts` — oneshot HSM tests
+- `servers/exarchos-mcp/src/review/tools.ts` — remove `augmentWithSemanticScore`
+- `servers/exarchos-mcp/src/review/dispatch.ts` — remove `basileusConnected`
+- `servers/exarchos-mcp/src/review/tools.test.ts` — remove stub tests
+- `servers/exarchos-mcp/src/review/review-triage.test.ts` — remove stub branches
+- `docs/designs/2026-02-18-hybrid-review-strategy.md` — superseding note
+- `skills/**` — regenerated by `npm run build:skills`
+
+**Admin (no code):**
+- `gh issue close 1049` — one-line
+
+---
+
+## Open Questions Resolved (Since Design)
+
+1. **Direct-commit UX for oneshot completed path** → Resolved: new `finalize_oneshot` orchestrate action (T12). Skill calls it at end of implementing; it delegates transition to HSM which evaluates guards.
+
+2. **Branch inference for pruning safeguards** → Resolved in T3: `hasOpenPR` skips workflows without `state.branchName`; pre-delegation workflows can't have PRs, so skipping is safe.
+
+3. **Scheduled pruning** → Confirmed out of scope for v1 (manual trigger only). Noted in design.
+
+---
+
+## Risks
+
+1. **HSM transition order sensitivity.** The state machine tries transitions in declaration order (per research). If `implementing → synthesize` is declared after `implementing → completed`, an opted-in workflow might hit the `completed` guard first and fail, then fall through to `synthesize`. Resolution: T9 tests explicitly cover both orderings with property tests.
+
+2. **Skill-build drift.** Skills must be edited in `skills-src/` only. T19 runs `skills:guard`; CI will catch drift. Worth flagging in the implementer agent's prompt.
+
+3. **Review test coupling** (T17). Removing `augmentWithSemanticScore` tests may cascade into seemingly-unrelated review tests if the stub was used as a fixture-generator. Mitigation: T17 runs `test:run` immediately after the removal to catch fallout.
+
+4. **`handleCancel` in prune batch** (T3). If one cancel fails mid-batch, subsequent cancels still attempt. Acceptable — errors captured in return shape. Property test should verify partial-failure semantics.
+
+5. **`planApproved` guard may not exist.** T9's REFACTOR notes the possibility. If absent, the implementer creates a lightweight `oneshotPlanSet` guard as part of T8.

--- a/documentation/reference/tools/orchestrate.md
+++ b/documentation/reference/tools/orchestrate.md
@@ -112,7 +112,6 @@ Score PRs by risk and dispatch to review. Uses velocity metrics to decide routin
 | `prs[].newFiles` | yes | integer | Number of new files |
 | `activeWorkflows` | no | object[] | Active workflows for load balancing |
 | `pendingCodeRabbitReviews` | no | integer | Current CodeRabbit review queue depth |
-| `basileusConnected` | no | boolean | Whether the Basileus review service is available |
 
 Phases: review, overhaul-review, debug-review. Role: `lead`.
 

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -405,8 +405,12 @@ describe('StackEnqueuedData', () => {
 // ─── EventTypes Discriminated Union (A03) ───────────────────────────────────
 
 describe('EventTypes', () => {
-  it('EventTypes_AllEventTypes_CountIs59', () => {
-    expect(EventTypes).toHaveLength(59);
+  it('EventTypes_CountMatchesRegisteredTypes', () => {
+    // Locked to the current registered-type count (61 as of T1+T2 which
+    // added `workflow.pruned` and `synthesize.requested` to the existing
+    // 59). When new event types are added, bump this number alongside
+    // their registration in `event-store/schemas.ts`.
+    expect(EventTypes).toHaveLength(61);
   });
 
   it('should include workflow-level types', () => {

--- a/servers/exarchos-mcp/src/__tests__/integration/oneshot-workflow.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/integration/oneshot-workflow.test.ts
@@ -1,0 +1,242 @@
+// ─── Oneshot Workflow — End-to-End Integration Tests (T16) ─────────────────
+//
+// Exercises the full init → plan → implementing → finalize chain for the
+// `oneshot` workflow type against real tmpdir state + a real EventStore,
+// covering the four synthesisPolicy × event combinations and the mid-
+// implementing cancel path.
+//
+// Unlike the unit tests in `orchestrate/finalize-oneshot.test.ts`, these
+// tests wire the orchestrate handlers together exactly as the composite
+// dispatcher does at runtime: `handleInit` → `handleSet` (plan artifact) →
+// `handleSet` (phase transition) → `handleRequestSynthesize` (optional) →
+// `handleFinalizeOneshot` / `handleCancel`. This verifies the choice-state
+// mechanism resolves correctly through the real HSM pipeline, not just at
+// the handler boundary.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { handleInit, handleSet } from '../../workflow/tools.js';
+import { handleCancel } from '../../workflow/cancel.js';
+import { EventStore } from '../../event-store/store.js';
+import { handleFinalizeOneshot } from '../../orchestrate/finalize-oneshot.js';
+import { handleRequestSynthesize } from '../../orchestrate/request-synthesize.js';
+
+// ─── Shared fixtures ────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let eventStore: EventStore;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'oneshot-integration-'));
+  eventStore = new EventStore(tmpDir);
+  await eventStore.initialize();
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Initialize a oneshot workflow and drive it through plan → implementing.
+ *
+ * synthesisPolicy is applied via the dot-path `oneshot.synthesisPolicy` on
+ * a `handleSet` field-update call — the init schema defaults to
+ * `on-request` when the `oneshot` object is absent, and the workflow-init
+ * API does not accept synthesisPolicy directly. Writing it via `handleSet`
+ * after init populates `state.oneshot.synthesisPolicy` in exactly the same
+ * shape the guards expect.
+ */
+async function setupOneshotInImplementing(
+  featureId: string,
+  synthesisPolicy?: 'always' | 'never' | 'on-request',
+): Promise<void> {
+  const initResult = await handleInit(
+    { featureId, workflowType: 'oneshot' },
+    tmpDir,
+    eventStore,
+  );
+  if (!initResult.success) {
+    throw new Error(
+      `init failed: ${initResult.error?.message ?? 'unknown error'}`,
+    );
+  }
+
+  if (synthesisPolicy !== undefined) {
+    const policyResult = await handleSet(
+      {
+        featureId,
+        updates: { 'oneshot.synthesisPolicy': synthesisPolicy },
+      },
+      tmpDir,
+      eventStore,
+    );
+    if (!policyResult.success) {
+      throw new Error(
+        `set synthesisPolicy failed: ${policyResult.error?.message ?? 'unknown error'}`,
+      );
+    }
+  }
+
+  // Satisfy the `oneshotPlanSet` guard on plan → implementing
+  const planResult = await handleSet(
+    {
+      featureId,
+      updates: { 'artifacts.plan': 'one-page plan content' },
+    },
+    tmpDir,
+    eventStore,
+  );
+  if (!planResult.success) {
+    throw new Error(
+      `set plan artifact failed: ${planResult.error?.message ?? 'unknown error'}`,
+    );
+  }
+
+  const transitionResult = await handleSet(
+    { featureId, phase: 'implementing' },
+    tmpDir,
+    eventStore,
+  );
+  if (!transitionResult.success) {
+    throw new Error(
+      `advance to implementing failed: ${transitionResult.error?.message ?? 'unknown error'}`,
+    );
+  }
+}
+
+/**
+ * Read the raw phase directly from the state file on disk, bypassing any
+ * projection or view-layer caching. Tests assert against this to verify
+ * the HSM persisted the expected transition.
+ */
+async function readPhase(featureId: string): Promise<string> {
+  const stateFile = path.join(tmpDir, `${featureId}.state.json`);
+  const raw = await fs.readFile(stateFile, 'utf-8');
+  const parsed = JSON.parse(raw) as { phase?: string };
+  return parsed.phase ?? '';
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('oneshot workflow integration (T16)', () => {
+  it('oneshotIntegration_defaultPolicy_directCommitPath', async () => {
+    const featureId = 'oneshot-default';
+
+    // Init with no policy override — schema default is `on-request`.
+    await setupOneshotInImplementing(featureId);
+
+    // No synthesize.requested event emitted; default policy = on-request
+    // with no opt-in event → synthesisOptedOut guard passes → completed.
+    const result = await handleFinalizeOneshot({
+      featureId,
+      stateDir: tmpDir,
+      eventStore,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { previousPhase: string; newPhase: string };
+    expect(data.previousPhase).toBe('implementing');
+    expect(data.newPhase).toBe('completed');
+    expect(await readPhase(featureId)).toBe('completed');
+  });
+
+  it('oneshotIntegration_onRequestPolicyWithEvent_synthesizePath', async () => {
+    const featureId = 'oneshot-on-request-event';
+
+    await setupOneshotInImplementing(featureId, 'on-request');
+
+    // Runtime opt-in: appending synthesize.requested flips the guard toward
+    // the synthesize branch.
+    const requestResult = await handleRequestSynthesize({
+      featureId,
+      reason: 'needs review before commit',
+      stateFile: path.join(tmpDir, `${featureId}.state.json`),
+      eventStore,
+    });
+    expect(requestResult.success).toBe(true);
+
+    const result = await handleFinalizeOneshot({
+      featureId,
+      stateDir: tmpDir,
+      eventStore,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { previousPhase: string; newPhase: string };
+    expect(data.previousPhase).toBe('implementing');
+    expect(data.newPhase).toBe('synthesize');
+    expect(await readPhase(featureId)).toBe('synthesize');
+  });
+
+  it('oneshotIntegration_policyAlways_synthesizePathWithoutEvent', async () => {
+    const featureId = 'oneshot-always';
+
+    await setupOneshotInImplementing(featureId, 'always');
+
+    // Policy `always` should route to synthesize with no event needed.
+    const result = await handleFinalizeOneshot({
+      featureId,
+      stateDir: tmpDir,
+      eventStore,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { newPhase: string };
+    expect(data.newPhase).toBe('synthesize');
+    expect(await readPhase(featureId)).toBe('synthesize');
+  });
+
+  it('oneshotIntegration_policyNeverWithEvent_stillDirectCommit', async () => {
+    const featureId = 'oneshot-never-with-event';
+
+    await setupOneshotInImplementing(featureId, 'never');
+
+    // Attempt runtime opt-in. The event will be appended to the stream
+    // (request-synthesize does not inspect policy) — but the downstream
+    // guard short-circuits on `never`, so the direct-commit path wins.
+    const requestResult = await handleRequestSynthesize({
+      featureId,
+      reason: 'policy should override this',
+      stateFile: path.join(tmpDir, `${featureId}.state.json`),
+      eventStore,
+    });
+    expect(requestResult.success).toBe(true);
+
+    const result = await handleFinalizeOneshot({
+      featureId,
+      stateDir: tmpDir,
+      eventStore,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { newPhase: string };
+    expect(data.newPhase).toBe('completed');
+    expect(await readPhase(featureId)).toBe('completed');
+  });
+
+  it('oneshotIntegration_cancelMidImplementing_transitionsToCancelled', async () => {
+    const featureId = 'oneshot-cancel-mid';
+
+    await setupOneshotInImplementing(featureId);
+
+    // Mid-flight cancel via the universal cancelled transition that the
+    // HSM base installs on every workflow type.
+    const cancelResult = await handleCancel(
+      { featureId, reason: 'abandoning mid-implement for test' },
+      tmpDir,
+      eventStore,
+    );
+
+    expect(cancelResult.success).toBe(true);
+    const data = cancelResult.data as { phase: string; previousPhase: string };
+    expect(data.phase).toBe('cancelled');
+    expect(data.previousPhase).toBe('implementing');
+    expect(await readPhase(featureId)).toBe('cancelled');
+  });
+});

--- a/servers/exarchos-mcp/src/__tests__/integration/oneshot-workflow.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/integration/oneshot-workflow.test.ts
@@ -45,19 +45,22 @@ afterEach(async () => {
 /**
  * Initialize a oneshot workflow and drive it through plan → implementing.
  *
- * synthesisPolicy is applied via the dot-path `oneshot.synthesisPolicy` on
- * a `handleSet` field-update call — the init schema defaults to
- * `on-request` when the `oneshot` object is absent, and the workflow-init
- * API does not accept synthesisPolicy directly. Writing it via `handleSet`
- * after init populates `state.oneshot.synthesisPolicy` in exactly the same
- * shape the guards expect.
+ * `synthesisPolicy` is passed directly to `handleInit` — the init schema
+ * accepts it for oneshot workflows and seeds `state.oneshot.synthesisPolicy`
+ * before the workflow exits `plan`. The `handleSet` mid-workflow override
+ * path is still supported for runtime policy changes; these tests use the
+ * init-time path because that is the primary documented API.
  */
 async function setupOneshotInImplementing(
   featureId: string,
   synthesisPolicy?: 'always' | 'never' | 'on-request',
 ): Promise<void> {
   const initResult = await handleInit(
-    { featureId, workflowType: 'oneshot' },
+    {
+      featureId,
+      workflowType: 'oneshot',
+      ...(synthesisPolicy !== undefined ? { synthesisPolicy } : {}),
+    },
     tmpDir,
     eventStore,
   );
@@ -65,22 +68,6 @@ async function setupOneshotInImplementing(
     throw new Error(
       `init failed: ${initResult.error?.message ?? 'unknown error'}`,
     );
-  }
-
-  if (synthesisPolicy !== undefined) {
-    const policyResult = await handleSet(
-      {
-        featureId,
-        updates: { 'oneshot.synthesisPolicy': synthesisPolicy },
-      },
-      tmpDir,
-      eventStore,
-    );
-    if (!policyResult.success) {
-      throw new Error(
-        `set synthesisPolicy failed: ${policyResult.error?.message ?? 'unknown error'}`,
-      );
-    }
   }
 
   // Satisfy the `oneshotPlanSet` guard on plan → implementing

--- a/servers/exarchos-mcp/src/__tests__/integration/prune-stale-workflows.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/integration/prune-stale-workflows.test.ts
@@ -109,26 +109,21 @@ function daysAgoIso(days: number): string {
 }
 
 /**
- * NOTE — handler bug surfaced by this integration test:
+ * NOTE — handler bug fixed by this integration test:
  *
- * `handleList` (in `workflow/tools.ts`) does NOT return the `_checkpoint`
- * field in its output payload — only `featureId`, `workflowType`, `phase`,
- * `stateFile`, `stale`. The `prune-stale-workflows` handler then passes
- * that payload to `extractListEntries`, which tries to read
- * `obj._checkpoint.lastActivityTimestamp` and falls back to `new Date(0)`
- * (the epoch) on miss. Net effect: in production, the handler treats
- * EVERY non-terminal workflow as maximally stale. The freshness filter
- * is effectively disabled.
+ * `handleList` in `workflow/tools.ts` now includes `_checkpoint` on each
+ * entry so that `extractListEntries` in the prune handler can read
+ * `lastActivityTimestamp` directly. Before the fix, `_checkpoint` was
+ * stripped and `extractListEntries` fell back to `new Date(0)` (the
+ * epoch), which made every non-terminal workflow look maximally stale and
+ * silently disabled the freshness filter in production.
  *
- * This test therefore exercises the *terminal-phase* exclusion as the
- * true "exclude a non-candidate" path, rather than the freshness path,
- * until the bug is fixed. The unit tests in
- * `orchestrate/prune-stale-workflows.test.ts` cover the pure selector's
- * freshness logic with synthetic entry arrays, so the algorithm is still
- * tested — just not the full `handleList → extract → select` wiring
- * for freshness.
- *
- * Reported in the T15 return message; fix is out of scope for this task.
+ * The `pruneIntegration_respectsThresholdInProduction` test below pins
+ * that wiring: it uses real `handleInit` + real `handleList` (no stubs)
+ * and backdates only one workflow, then asserts only the backdated
+ * workflow is pruned. If `handleList` ever stops returning `_checkpoint`
+ * the fresh workflows would re-collapse to the epoch and this test would
+ * start pruning them too — regression protection for T15.
  */
 
 beforeEach(async () => {
@@ -316,4 +311,73 @@ describe('pruneIntegration_safeguardOpenPrSkipsOneCandidate', () => {
     });
     expect(skippedEvents).toEqual([]);
   });
+});
+
+// ─── Test 3: Production threshold filter — the regression the bug note warned
+// about. Uses real `handleList` with NO stubs of its own; backdates ONE of
+// three initialized workflows and asserts only that one is pruned. If
+// `handleList` regresses to dropping `_checkpoint`, the two "fresh" workflows
+// would fall through to the epoch and get pruned, making this test fail
+// loudly. That's the exact bug this ticket fixes.
+describe('pruneIntegration_respectsThresholdInProduction', () => {
+  it(
+    'handlePruneStaleWorkflows_respectsThresholdInProduction_readingRealStateFiles',
+    async () => {
+      // Arrange: three newly-initialized workflows. Only the third is
+      // backdated past the 7-day default threshold.
+      for (const featureId of ['fresh-a', 'fresh-b', 'stale-c']) {
+        const initResult = await handleInit(
+          { featureId, workflowType: 'feature' },
+          tmpDir,
+          eventStore,
+        );
+        expect(initResult.success).toBe(true);
+      }
+      await backdateCheckpoint(tmpDir, 'stale-c', daysAgoIso(30));
+
+      // Stubbed safeguards — we want the selection filter to be the only gate.
+      const safeguards: PruneSafeguards = {
+        hasOpenPR: async () => false,
+        hasRecentCommits: async () => false,
+      };
+      const deps = makeRealDeps(tmpDir, eventStore, safeguards);
+
+      // Act: apply mode with default threshold (10080 min = 7 days).
+      const applyResult = await handlePruneStaleWorkflows(
+        { dryRun: false, force: true },
+        tmpDir,
+        ctx,
+        deps,
+      );
+
+      // Assert: only stale-c was pruned. fresh-a/fresh-b must remain
+      // non-terminal on disk. This assertion fails against the pre-fix
+      // code because `handleList` dropped `_checkpoint`, making ALL three
+      // workflows appear stale (epoch fallback) and thus all three would
+      // be pruned.
+      expect(applyResult.success).toBe(true);
+      const applyData = applyResult.data as PruneHandlerResult;
+      const prunedIds = applyData.pruned.map((p) => p.featureId).sort();
+      expect(prunedIds).toEqual(['stale-c']);
+
+      expect(await readPhase(tmpDir, 'stale-c')).toBe('cancelled');
+      for (const featureId of ['fresh-a', 'fresh-b']) {
+        const phase = await readPhase(tmpDir, featureId);
+        expect(phase).not.toBe('cancelled');
+        expect(phase).not.toBe('completed');
+      }
+
+      // And only stale-c's stream has a workflow.pruned event.
+      const staleEvents = await eventStore.query('stale-c', {
+        type: 'workflow.pruned',
+      });
+      expect(staleEvents.length).toBe(1);
+      for (const featureId of ['fresh-a', 'fresh-b']) {
+        const events = await eventStore.query(featureId, {
+          type: 'workflow.pruned',
+        });
+        expect(events).toEqual([]);
+      }
+    },
+  );
 });

--- a/servers/exarchos-mcp/src/__tests__/integration/prune-stale-workflows.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/integration/prune-stale-workflows.test.ts
@@ -201,7 +201,9 @@ describe('pruneIntegration_dryRunThenApply_cleansStaleWorkflows', () => {
     const dryIds = dryData.candidates.map((c) => c.featureId).sort();
     expect(dryIds).toEqual(['stale-wf-2', 'stale-wf-3']);
     expect(dryIds).not.toContain('terminal-wf-1');
-    expect(dryData.pruned).toEqual([]);
+    // Dry-run must omit `pruned` entirely — surfacing `[]` would blur the
+    // distinction between "preview" and "nothing was pruned in apply mode".
+    expect(dryData.pruned).toBeUndefined();
     expect(dryData.skipped).toEqual([]);
 
     // Disk state must be untouched after dry-run.

--- a/servers/exarchos-mcp/src/__tests__/integration/prune-stale-workflows.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/integration/prune-stale-workflows.test.ts
@@ -1,0 +1,319 @@
+// ─── T15: End-to-End Integration Test — Prune Stale Workflows ───────────────
+//
+// Complements the unit tests in
+// `orchestrate/prune-stale-workflows.test.ts` by exercising the handler
+// against real on-disk state files via `handleInit`/`handleCancel` plus a
+// real `EventStore` rooted at a `mkdtemp` directory. The only seams we
+// stub are the safeguards (`hasOpenPR`, `hasRecentCommits`) — everything
+// else is production wiring.
+//
+// What this test exists to catch that the unit test can't:
+//   1. `handleList`'s state-file reader produces the exact `_checkpoint`
+//      shape `selectPruneCandidates` expects (no schema drift).
+//   2. Direct JSON mutation of `_checkpoint.lastActivityTimestamp` is
+//      round-tripped through `readStateFile` cleanly.
+//   3. `handleCancel` flips phase to `cancelled` on disk.
+//   4. `workflow.pruned` events land in the real event stream and are
+//      queryable via `EventStore.query`.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { handleInit } from '../../workflow/tools.js';
+import {
+  handlePruneStaleWorkflows,
+  type PruneHandlerDeps,
+  type PruneHandlerResult,
+  type PruneSafeguards,
+} from '../../orchestrate/prune-stale-workflows.js';
+import { handleList } from '../../workflow/tools.js';
+import { handleCancel } from '../../workflow/cancel.js';
+import { EventStore } from '../../event-store/store.js';
+import type { DispatchContext } from '../../core/dispatch.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Direct write-through mutation of `_checkpoint.lastActivityTimestamp` on
+ * an already-initialized state file. We deliberately read the JSON, patch
+ * the nested field, and write it back rather than going through any helper
+ * — the whole point of an integration test is to simulate what the
+ * filesystem looks like after the workflow has been idle for N days,
+ * without relying on the production write path.
+ */
+async function backdateCheckpoint(
+  stateDir: string,
+  featureId: string,
+  timestamp: string,
+): Promise<void> {
+  const stateFile = path.join(stateDir, `${featureId}.state.json`);
+  const raw = await fs.readFile(stateFile, 'utf-8');
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  const checkpoint = parsed._checkpoint as Record<string, unknown> | undefined;
+  if (!checkpoint) {
+    throw new Error(`State file for ${featureId} missing _checkpoint`);
+  }
+  checkpoint.lastActivityTimestamp = timestamp;
+  // Also backdate the top-level timestamp so nothing else in the read path
+  // flags it as freshly written.
+  checkpoint.timestamp = timestamp;
+  await fs.writeFile(stateFile, JSON.stringify(parsed, null, 2), 'utf-8');
+}
+
+/** Read the phase field directly from disk. */
+async function readPhase(stateDir: string, featureId: string): Promise<string> {
+  const stateFile = path.join(stateDir, `${featureId}.state.json`);
+  const raw = await fs.readFile(stateFile, 'utf-8');
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  return String(parsed.phase);
+}
+
+/**
+ * Build a PruneHandlerDeps bundle that uses real `handleList`/`handleCancel`
+ * (wired to the temp stateDir and real EventStore) but injects stubbed
+ * safeguards. Branch name is read via the default handler path.
+ */
+function makeRealDeps(
+  stateDir: string,
+  eventStore: EventStore,
+  safeguards: PruneSafeguards,
+): PruneHandlerDeps {
+  return {
+    handleList: (dir) => handleList({}, dir),
+    handleCancel: (args, dir) =>
+      handleCancel(
+        { featureId: args.featureId, reason: args.reason ?? 'stale-prune' },
+        dir,
+        eventStore,
+      ),
+    // Workflows initialized via `handleInit` don't carry a `branchName`
+    // field at the top level, so safeguards would be short-circuited. Force
+    // a non-undefined value so safeguard stubs are actually consulted.
+    readBranchName: async (featureId) => `feat/${featureId}`,
+    safeguards,
+  };
+}
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let eventStore: EventStore;
+let ctx: DispatchContext;
+
+// NB: `handleInit` stamps `lastActivityTimestamp` to "now". Fresh workflows
+// use that stamp; stale workflows get their checkpoint overwritten
+// post-init via `backdateCheckpoint`.
+function daysAgoIso(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/**
+ * NOTE — handler bug surfaced by this integration test:
+ *
+ * `handleList` (in `workflow/tools.ts`) does NOT return the `_checkpoint`
+ * field in its output payload — only `featureId`, `workflowType`, `phase`,
+ * `stateFile`, `stale`. The `prune-stale-workflows` handler then passes
+ * that payload to `extractListEntries`, which tries to read
+ * `obj._checkpoint.lastActivityTimestamp` and falls back to `new Date(0)`
+ * (the epoch) on miss. Net effect: in production, the handler treats
+ * EVERY non-terminal workflow as maximally stale. The freshness filter
+ * is effectively disabled.
+ *
+ * This test therefore exercises the *terminal-phase* exclusion as the
+ * true "exclude a non-candidate" path, rather than the freshness path,
+ * until the bug is fixed. The unit tests in
+ * `orchestrate/prune-stale-workflows.test.ts` cover the pure selector's
+ * freshness logic with synthetic entry arrays, so the algorithm is still
+ * tested — just not the full `handleList → extract → select` wiring
+ * for freshness.
+ *
+ * Reported in the T15 return message; fix is out of scope for this task.
+ */
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prune-integration-'));
+  eventStore = new EventStore(tmpDir);
+  ctx = { stateDir: tmpDir, eventStore, enableTelemetry: false };
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+// ─── Test 1: Dry-run then apply ─────────────────────────────────────────────
+
+describe('pruneIntegration_dryRunThenApply_cleansStaleWorkflows', () => {
+  it('lists 2 stale candidates on dry-run and cancels them on apply', async () => {
+    // Arrange: three workflows.
+    //   terminal-wf-1 — initialized then cancelled (terminal; excluded by
+    //                   the pure selector's terminal-phase filter)
+    //   stale-wf-2    — initialized, then backdated to 30 days ago
+    //   stale-wf-3    — initialized, then backdated to 20 days ago
+    //
+    // Why `terminal-wf-1` instead of a "fresh" one? See the handler-bug
+    // note above — `handleList` doesn't return `_checkpoint`, so the
+    // freshness filter is currently a no-op. We rely on terminal-phase
+    // exclusion to prove the handler actually filters *something* in the
+    // end-to-end path.
+    for (const featureId of ['terminal-wf-1', 'stale-wf-2', 'stale-wf-3']) {
+      const initResult = await handleInit(
+        { featureId, workflowType: 'feature' },
+        tmpDir,
+        eventStore,
+      );
+      expect(initResult.success).toBe(true);
+    }
+    await backdateCheckpoint(tmpDir, 'stale-wf-2', daysAgoIso(30));
+    await backdateCheckpoint(tmpDir, 'stale-wf-3', daysAgoIso(20));
+
+    // Flip terminal-wf-1 into the 'cancelled' terminal phase BEFORE the
+    // prune run, using the real `handleCancel` path.
+    const preCancelResult = await handleCancel(
+      { featureId: 'terminal-wf-1', reason: 'pre-test-setup' },
+      tmpDir,
+      eventStore,
+    );
+    expect(preCancelResult.success).toBe(true);
+    expect(await readPhase(tmpDir, 'terminal-wf-1')).toBe('cancelled');
+
+    // Sanity: the two stale workflows are still non-terminal at this point.
+    for (const featureId of ['stale-wf-2', 'stale-wf-3']) {
+      const phase = await readPhase(tmpDir, featureId);
+      expect(phase).not.toBe('cancelled');
+      expect(phase).not.toBe('completed');
+    }
+
+    // Stubbed safeguards — always clear so selection is the only filter.
+    const safeguards: PruneSafeguards = {
+      hasOpenPR: async () => false,
+      hasRecentCommits: async () => false,
+    };
+    const deps = makeRealDeps(tmpDir, eventStore, safeguards);
+
+    // Act: dry-run phase.
+    const dryRunResult = await handlePruneStaleWorkflows(
+      { dryRun: true },
+      tmpDir,
+      ctx,
+      deps,
+    );
+
+    // Assert: dry-run surfaces the two stale workflows as candidates and
+    // excludes terminal-wf-1 (terminal phase filter).
+    expect(dryRunResult.success).toBe(true);
+    const dryData = dryRunResult.data as PruneHandlerResult;
+    const dryIds = dryData.candidates.map((c) => c.featureId).sort();
+    expect(dryIds).toEqual(['stale-wf-2', 'stale-wf-3']);
+    expect(dryIds).not.toContain('terminal-wf-1');
+    expect(dryData.pruned).toEqual([]);
+    expect(dryData.skipped).toEqual([]);
+
+    // Disk state must be untouched after dry-run.
+    expect(await readPhase(tmpDir, 'terminal-wf-1')).toBe('cancelled'); // unchanged
+    for (const featureId of ['stale-wf-2', 'stale-wf-3']) {
+      const phase = await readPhase(tmpDir, featureId);
+      expect(phase).not.toBe('cancelled');
+      expect(phase).not.toBe('completed');
+    }
+
+    // Act: apply phase, `force: true` bypasses safeguards entirely.
+    const applyResult = await handlePruneStaleWorkflows(
+      { dryRun: false, force: true },
+      tmpDir,
+      ctx,
+      deps,
+    );
+
+    // Assert: both stale workflows cancelled on disk.
+    expect(applyResult.success).toBe(true);
+    const applyData = applyResult.data as PruneHandlerResult;
+    const prunedIds = applyData.pruned.map((p) => p.featureId).sort();
+    expect(prunedIds).toEqual(['stale-wf-2', 'stale-wf-3']);
+    expect(applyData.skipped).toEqual([]);
+
+    expect(await readPhase(tmpDir, 'stale-wf-2')).toBe('cancelled');
+    expect(await readPhase(tmpDir, 'stale-wf-3')).toBe('cancelled');
+
+    // Assert: workflow.pruned events landed in the real event stream.
+    const staleEvents2 = await eventStore.query('stale-wf-2', {
+      type: 'workflow.pruned',
+    });
+    const staleEvents3 = await eventStore.query('stale-wf-3', {
+      type: 'workflow.pruned',
+    });
+    expect(staleEvents2.length).toBe(1);
+    expect(staleEvents3.length).toBe(1);
+    expect(staleEvents2[0]?.data).toMatchObject({
+      featureId: 'stale-wf-2',
+      triggeredBy: 'manual',
+    });
+    // force:true causes the skippedSafeguards marker to be recorded.
+    expect(staleEvents2[0]?.data).toHaveProperty('skippedSafeguards');
+
+    // terminal-wf-1 should have NO workflow.pruned event in its stream
+    // (it was excluded from candidates).
+    const terminalEvents = await eventStore.query('terminal-wf-1', {
+      type: 'workflow.pruned',
+    });
+    expect(terminalEvents).toEqual([]);
+  });
+});
+
+// ─── Test 2: open-PR safeguard gates one of the candidates ──────────────────
+
+describe('pruneIntegration_safeguardOpenPrSkipsOneCandidate', () => {
+  it('skips the candidate with an open PR and prunes the other', async () => {
+    // Arrange: three stale workflows. All past threshold; no `force`, so
+    // safeguards are consulted for each.
+    for (const featureId of ['stale-wf-1', 'stale-wf-2', 'stale-wf-3']) {
+      const initResult = await handleInit(
+        { featureId, workflowType: 'feature' },
+        tmpDir,
+        eventStore,
+      );
+      expect(initResult.success).toBe(true);
+      await backdateCheckpoint(tmpDir, featureId, daysAgoIso(30));
+    }
+
+    // Stub only `stale-wf-2` as having an open PR.
+    const safeguards: PruneSafeguards = {
+      hasOpenPR: async (featureId: string) => featureId === 'stale-wf-2',
+      hasRecentCommits: async () => false,
+    };
+    const deps = makeRealDeps(tmpDir, eventStore, safeguards);
+
+    // Act: apply mode (safeguards engaged).
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: false },
+      tmpDir,
+      ctx,
+      deps,
+    );
+
+    // Assert: stale-wf-2 was skipped, the other two were pruned.
+    expect(result.success).toBe(true);
+    const data = result.data as PruneHandlerResult;
+    const prunedIds = data.pruned.map((p) => p.featureId).sort();
+    expect(prunedIds).toEqual(['stale-wf-1', 'stale-wf-3']);
+
+    expect(data.skipped).toHaveLength(1);
+    expect(data.skipped[0]?.featureId).toBe('stale-wf-2');
+    expect(data.skipped[0]?.reason).toBe('open-pr');
+
+    // stale-wf-2 still non-terminal on disk (proof: skip did not cancel).
+    const skippedPhase = await readPhase(tmpDir, 'stale-wf-2');
+    expect(skippedPhase).not.toBe('cancelled');
+    expect(skippedPhase).not.toBe('completed');
+
+    // The other two are cancelled.
+    expect(await readPhase(tmpDir, 'stale-wf-1')).toBe('cancelled');
+    expect(await readPhase(tmpDir, 'stale-wf-3')).toBe('cancelled');
+
+    // And no workflow.pruned event was emitted for the skipped one.
+    const skippedEvents = await eventStore.query('stale-wf-2', {
+      type: 'workflow.pruned',
+    });
+    expect(skippedEvents).toEqual([]);
+  });
+});

--- a/servers/exarchos-mcp/src/__tests__/skills/oneshot-workflow.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/skills/oneshot-workflow.test.ts
@@ -1,0 +1,157 @@
+// ─── Oneshot workflow skill structural tests (T14) ──────────────────────────
+//
+// These tests assert structural and frontmatter invariants of the canonical
+// `skills-src/oneshot-workflow/SKILL.md` source — NOT the generated runtime
+// variants under `skills/<runtime>/`. Per CLAUDE.md, source-of-truth for
+// skills lives in `skills-src/`; the renderer (T19) produces byte-identical
+// per-runtime copies of the body, so semantic invariants only need to be
+// checked once on the source.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const skillsSrcDir = resolve(__dirname, '../../../../../skills-src');
+const skillPath = resolve(skillsSrcDir, 'oneshot-workflow/SKILL.md');
+
+function readSkill(): string {
+  return readFileSync(skillPath, 'utf-8');
+}
+
+interface ParsedSkill {
+  frontmatter: string;
+  body: string;
+  fields: Record<string, string>;
+}
+
+function parseSkill(raw: string): ParsedSkill {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) {
+    throw new Error('SKILL.md does not have a YAML frontmatter block');
+  }
+  const frontmatter = match[1];
+  const body = match[2];
+
+  // Crude key: value extraction for top-level keys (sufficient for the
+  // assertions we need — we explicitly do NOT want to depend on a YAML
+  // library here for a tiny structural sniff).
+  const fields: Record<string, string> = {};
+  for (const line of frontmatter.split('\n')) {
+    const m = line.match(/^([a-zA-Z0-9_-]+):\s*(.*)$/);
+    if (m) {
+      fields[m[1]] = m[2].trim();
+    }
+  }
+
+  return { frontmatter, body, fields };
+}
+
+describe('oneshot-workflow skill — frontmatter', () => {
+  it('oneshotSkill_hasValidFrontmatter', () => {
+    const raw = readSkill();
+    const parsed = parseSkill(raw);
+    expect(parsed.fields.name).toBeDefined();
+    // kebab-case
+    expect(parsed.fields.name).toMatch(/^[a-z][a-z0-9-]*$/);
+    expect(parsed.fields.name).toBe('oneshot-workflow');
+  });
+
+  it('oneshotSkill_descriptionIsPresentAndUnder1024Chars', () => {
+    const raw = readSkill();
+    const parsed = parseSkill(raw);
+    const description = parsed.fields.description ?? '';
+    expect(description.length).toBeGreaterThan(0);
+    // Strip surrounding quotes if present for the length check
+    const stripped = description.replace(/^["']/, '').replace(/["']$/, '');
+    expect(stripped.length).toBeLessThanOrEqual(1024);
+  });
+
+  it('oneshotSkill_metadataIncludesMcpServerExarchos', () => {
+    const raw = readSkill();
+    const parsed = parseSkill(raw);
+    // metadata block contains `mcp-server: exarchos` line
+    expect(parsed.frontmatter).toMatch(/mcp-server:\s*exarchos/);
+  });
+});
+
+describe('oneshot-workflow skill — body content invariants', () => {
+  it('oneshotSkill_bodyDocumentsAllFourPhases', () => {
+    const raw = readSkill();
+    const { body } = parseSkill(raw);
+    // The four lifecycle phases: plan, implementing, synthesize (opt-in only),
+    // and completed (terminal). Skill prose must walk the agent through each.
+    expect(body).toMatch(/\bplan\b/i);
+    expect(body).toMatch(/\bimplementing\b/i);
+    expect(body).toMatch(/\bsynthesize\b/i);
+    expect(body).toMatch(/\bcompleted\b/i);
+  });
+
+  it('oneshotSkill_bodyDocumentsSynthesisPolicy', () => {
+    const raw = readSkill();
+    const { body } = parseSkill(raw);
+    // Three valid synthesisPolicy values must be named so the agent knows
+    // what to pass at init.
+    expect(body).toContain('always');
+    expect(body).toContain('never');
+    expect(body).toContain('on-request');
+    expect(body).toMatch(/synthesisPolicy/);
+  });
+
+  it('oneshotSkill_bodyReferencesRequestSynthesizeAction', () => {
+    const raw = readSkill();
+    const { body } = parseSkill(raw);
+    // The mid-implementing opt-in trigger must be discoverable by name.
+    expect(body).toContain('request_synthesize');
+  });
+
+  it('oneshotSkill_bodyReferencesFinalizeOneshotAction', () => {
+    const raw = readSkill();
+    const { body } = parseSkill(raw);
+    // The choice-state resolver must be discoverable by name.
+    expect(body).toContain('finalize_oneshot');
+  });
+
+  it('oneshotSkill_bodyMentionsTddIronLaw', () => {
+    const raw = readSkill();
+    const { body } = parseSkill(raw);
+    // TDD is mandatory even for oneshot — guarded explicitly so a future
+    // edit can't quietly drop it.
+    expect(body).toMatch(/TDD|test.first|failing test/i);
+  });
+
+  it('oneshotSkill_bodyDescribesWhenNotToUseOneshot', () => {
+    const raw = readSkill();
+    const { body } = parseSkill(raw);
+    // Must steer agents away from cross-cutting refactors / multi-file features.
+    expect(body).toMatch(/when not to use|don't use|do not use|not for/i);
+  });
+
+  it('oneshotSkill_bodyReferencesOneshotWorkflowType', () => {
+    const raw = readSkill();
+    const { body } = parseSkill(raw);
+    // The init call must reference workflowType: 'oneshot'.
+    expect(body).toMatch(/workflowType.*oneshot/);
+  });
+});
+
+describe('oneshot-workflow skill — slash command wrapper', () => {
+  const commandPath = resolve(
+    __dirname,
+    '../../../../../commands/oneshot.md',
+  );
+
+  it('oneshotCommand_existsAndHasFrontmatter', () => {
+    const raw = readFileSync(commandPath, 'utf-8');
+    expect(raw).toMatch(/^---\n[\s\S]*?\n---\n/);
+  });
+
+  it('oneshotCommand_referencesOneshotSkill', () => {
+    const raw = readFileSync(commandPath, 'utf-8');
+    // Wrapper should point at the canonical skill so the runtime renderer
+    // wires up the @skills/oneshot-workflow/SKILL.md include.
+    expect(raw).toMatch(/oneshot-workflow/);
+  });
+});

--- a/servers/exarchos-mcp/src/__tests__/skills/prune-workflows.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/skills/prune-workflows.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Structural tests for the prune-workflows skill.
+ *
+ * Validates the skills-src/prune-workflows/SKILL.md frontmatter and body
+ * against the conventions documented in CLAUDE.md and the T5 task spec
+ * in docs/plans/2026-04-11-oneshot-and-pruning.md:
+ *
+ *   - name is kebab-case
+ *   - description is <= 1024 chars
+ *   - metadata.mcp-server is "exarchos" (skill invokes MCP tools)
+ *   - body references the prune_stale_workflows orchestrate action
+ *   - body documents both dry-run and apply phases
+ *
+ * Reads from skills-src/ (canonical source) per the same convention used
+ * by runbooks/skill-coverage.test.ts. The generated skills/ tree is
+ * verified separately by the skills-guard CI check.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const skillPath = resolve(
+  __dirname,
+  '../../../../../skills-src/prune-workflows/SKILL.md',
+);
+
+interface SkillFrontmatter {
+  name?: unknown;
+  description?: unknown;
+  metadata?: { 'mcp-server'?: unknown } & Record<string, unknown>;
+}
+
+function loadSkill(): { frontmatter: SkillFrontmatter; body: string; raw: string } {
+  const raw = readFileSync(skillPath, 'utf-8');
+  // Frontmatter must be a YAML block delimited by --- on its own lines
+  // at the start of the file.
+  const match = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/.exec(raw);
+  if (!match) {
+    throw new Error(`SKILL.md missing YAML frontmatter delimited by ---: ${skillPath}`);
+  }
+  const frontmatter = parseYaml(match[1]) as SkillFrontmatter;
+  return { frontmatter, body: match[2], raw };
+}
+
+describe('prune-workflows skill', () => {
+  it('pruneSkill_frontmatterHasKebabCaseName', () => {
+    const { frontmatter } = loadSkill();
+    expect(typeof frontmatter.name).toBe('string');
+    expect(frontmatter.name).toBe('prune-workflows');
+    // kebab-case: lowercase letters/digits, words joined by single hyphens.
+    expect(frontmatter.name as string).toMatch(/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/);
+  });
+
+  it('pruneSkill_descriptionBelow1024Chars', () => {
+    const { frontmatter } = loadSkill();
+    expect(typeof frontmatter.description).toBe('string');
+    const description = frontmatter.description as string;
+    expect(description.length).toBeGreaterThan(0);
+    expect(description.length).toBeLessThanOrEqual(1024);
+  });
+
+  it('pruneSkill_metadataHasMcpServerExarchos', () => {
+    const { frontmatter } = loadSkill();
+    expect(frontmatter.metadata).toBeDefined();
+    expect(frontmatter.metadata?.['mcp-server']).toBe('exarchos');
+  });
+
+  it('pruneSkill_bodyReferencesPruneAction', () => {
+    const { body } = loadSkill();
+    // The skill must reference the orchestrate action by its registered name.
+    expect(body).toContain('prune_stale_workflows');
+  });
+
+  it('pruneSkill_includesDryRunAndApplySteps', () => {
+    const { body } = loadSkill();
+    // Both phases of the prune flow must be documented.
+    expect(body).toMatch(/dryRun:\s*true/);
+    expect(body).toMatch(/dryRun:\s*false/);
+  });
+
+  it('pruneSkill_documentsForceBypassOption', () => {
+    const { body } = loadSkill();
+    // The user-facing safeguard bypass must be documented per design Part 1.
+    expect(body).toMatch(/force/);
+  });
+
+  it('pruneSkill_documentsConfirmationPrompt', () => {
+    const { body } = loadSkill();
+    // The skill is interactive — it must prompt the user before applying.
+    expect(body.toLowerCase()).toMatch(/proceed|confirm|abort/);
+  });
+});

--- a/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/state-machine.test.ts
@@ -3007,6 +3007,9 @@ describe('HSM Registry Extension', () => {
     expect(() => registerWorkflowType('refactor', definition)).toThrow(
       'Cannot override built-in workflow type: refactor',
     );
+    expect(() => registerWorkflowType('oneshot', definition)).toThrow(
+      'Cannot override built-in workflow type: oneshot',
+    );
   });
 });
 
@@ -3047,5 +3050,241 @@ describe('findTransition', () => {
     } finally {
       unregisterWorkflowType('find-test');
     }
+  });
+});
+
+// ─── Task T9: Oneshot Workflow HSM Tests ────────────────────────────────────
+//
+// The oneshot workflow uses a choice-state pattern at `implementing`:
+// exactly one of `synthesisOptedIn` / `synthesisOptedOut` must pass for any
+// (synthesisPolicy, synthesize.requested event) combination. The decision
+// is fully event-sourced — no live IO in guards.
+
+describe('Oneshot Workflow HSM', () => {
+  it('oneshot_hsmHasFourTransitions', () => {
+    const hsm = getHSMDefinition('oneshot');
+    expect(hsm).toBeDefined();
+    expect(hsm.id).toBe('oneshot');
+
+    // plan → implementing
+    const planToImpl = hsm.transitions.find(
+      (t) => t.from === 'plan' && t.to === 'implementing',
+    );
+    expect(planToImpl).toBeDefined();
+    expect(planToImpl!.guard).toBeDefined();
+
+    // implementing → synthesize (guarded by synthesisOptedIn)
+    const implToSynth = hsm.transitions.find(
+      (t) => t.from === 'implementing' && t.to === 'synthesize',
+    );
+    expect(implToSynth).toBeDefined();
+    expect(implToSynth!.guard).toBeDefined();
+    expect(implToSynth!.guard!.id).toBe('synthesis-opted-in');
+
+    // implementing → completed (guarded by synthesisOptedOut)
+    const implToCompleted = hsm.transitions.find(
+      (t) => t.from === 'implementing' && t.to === 'completed',
+    );
+    expect(implToCompleted).toBeDefined();
+    expect(implToCompleted!.guard).toBeDefined();
+    expect(implToCompleted!.guard!.id).toBe('synthesis-opted-out');
+
+    // synthesize → completed (guarded by mergeVerified)
+    const synthToCompleted = hsm.transitions.find(
+      (t) => t.from === 'synthesize' && t.to === 'completed',
+    );
+    expect(synthToCompleted).toBeDefined();
+    expect(synthToCompleted!.guard).toBeDefined();
+    expect(synthToCompleted!.guard!.id).toBe('merge-verified');
+  });
+
+  it('oneshot_initialPhaseIsPlan', () => {
+    const hsm = getHSMDefinition('oneshot');
+    expect(hsm.states['plan']).toBeDefined();
+    expect(hsm.states['plan'].type).toBe('atomic');
+    expect(hsm.states['implementing']).toBeDefined();
+    expect(hsm.states['synthesize']).toBeDefined();
+    expect(hsm.states['completed']).toBeDefined();
+    expect(hsm.states['completed'].type).toBe('final');
+    expect(hsm.states['cancelled']).toBeDefined();
+    expect(hsm.states['cancelled'].type).toBe('final');
+  });
+
+  it('oneshot_planToImplementing_requiresPlanArtifact', () => {
+    const hsm = getHSMDefinition('oneshot');
+
+    // No plan set → guard fails
+    const noPlan: Record<string, unknown> = {
+      phase: 'plan',
+      workflowType: 'oneshot',
+      oneshot: { synthesisPolicy: 'on-request' },
+      artifacts: {},
+      _events: [],
+      _history: {},
+    };
+    const failResult = executeTransition(hsm, noPlan, 'implementing');
+    expect(failResult.success).toBe(false);
+    expect(failResult.errorCode).toBe('GUARD_FAILED');
+
+    // Plan set → transitions successfully
+    const withPlan: Record<string, unknown> = {
+      phase: 'plan',
+      workflowType: 'oneshot',
+      oneshot: { synthesisPolicy: 'on-request', planSummary: 'One-page plan' },
+      artifacts: { plan: 'One-page plan' },
+      _events: [],
+      _history: {},
+    };
+    const okResult = executeTransition(hsm, withPlan, 'implementing');
+    expect(okResult.success).toBe(true);
+    expect(okResult.newPhase).toBe('implementing');
+  });
+
+  it('oneshot_implementingChoiceStateMutuallyExclusive', () => {
+    // Parameterized over (synthesisPolicy × synthesize.requested event present).
+    // For each of the 8 combinations (including the "policy field missing"
+    // default case), assert that executeTransition from `implementing` to
+    // exactly one of {synthesize, completed} succeeds.
+    const hsm = getHSMDefinition('oneshot');
+
+    const policies: Array<{
+      label: string;
+      oneshot: Record<string, unknown> | undefined;
+    }> = [
+      { label: 'always', oneshot: { synthesisPolicy: 'always' } },
+      { label: 'never', oneshot: { synthesisPolicy: 'never' } },
+      { label: 'on-request', oneshot: { synthesisPolicy: 'on-request' } },
+      { label: 'default (undefined)', oneshot: undefined },
+    ];
+    const eventStreams: Array<{
+      label: string;
+      events: Array<Record<string, unknown>>;
+    }> = [
+      { label: 'no events', events: [] },
+      {
+        label: 'synthesize.requested present',
+        events: [{ type: 'synthesize.requested' }],
+      },
+    ];
+
+    for (const policy of policies) {
+      for (const stream of eventStreams) {
+        const state: Record<string, unknown> = {
+          phase: 'implementing',
+          workflowType: 'oneshot',
+          artifacts: { plan: 'captured' },
+          _events: stream.events,
+          _history: {},
+        };
+        if (policy.oneshot !== undefined) {
+          state.oneshot = policy.oneshot;
+        }
+
+        const toSynth = executeTransition(hsm, state, 'synthesize');
+        const toCompleted = executeTransition(hsm, state, 'completed');
+
+        const synthOk = toSynth.success === true;
+        const completedOk = toCompleted.success === true;
+
+        // Exactly one branch must succeed.
+        const caseLabel = `policy=${policy.label}, events=${stream.label}`;
+        expect(
+          synthOk !== completedOk,
+          `Expected exactly one reachable target from implementing for ${caseLabel}, got synth=${synthOk}, completed=${completedOk}`,
+        ).toBe(true);
+
+        // Cross-check expected target per the choice-state semantics:
+        // - policy=always → synthesize (regardless of events)
+        // - policy=never → completed (regardless of events)
+        // - policy=on-request + event → synthesize
+        // - policy=on-request + no event → completed
+        // - policy missing → defaults to on-request semantics
+        const effectivePolicy =
+          policy.oneshot === undefined
+            ? 'on-request'
+            : (policy.oneshot.synthesisPolicy as string);
+        const hasEvent = stream.events.some(
+          (e) => e.type === 'synthesize.requested',
+        );
+
+        let expectedTarget: 'synthesize' | 'completed';
+        if (effectivePolicy === 'always') expectedTarget = 'synthesize';
+        else if (effectivePolicy === 'never') expectedTarget = 'completed';
+        else expectedTarget = hasEvent ? 'synthesize' : 'completed';
+
+        expect(
+          expectedTarget === 'synthesize' ? synthOk : completedOk,
+          `Expected ${expectedTarget} to be reachable for ${caseLabel}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('oneshot_synthesizeToCompleted_requiresMergeVerified', () => {
+    const hsm = getHSMDefinition('oneshot');
+
+    // Without merge verification → guard fails
+    const pending: Record<string, unknown> = {
+      phase: 'synthesize',
+      workflowType: 'oneshot',
+      artifacts: { plan: 'captured' },
+      _events: [],
+      _history: {},
+    };
+    const pendingResult = executeTransition(hsm, pending, 'completed');
+    expect(pendingResult.success).toBe(false);
+
+    // With merge verification → guard passes
+    const verified: Record<string, unknown> = {
+      phase: 'synthesize',
+      workflowType: 'oneshot',
+      artifacts: { plan: 'captured' },
+      _cleanup: { mergeVerified: true },
+      _events: [],
+      _history: {},
+    };
+    const verifiedResult = executeTransition(hsm, verified, 'completed');
+    expect(verifiedResult.success).toBe(true);
+    expect(verifiedResult.newPhase).toBe('completed');
+  });
+
+  it('oneshot_inheritsUniversalCancelTransition', () => {
+    const hsm = getHSMDefinition('oneshot');
+
+    // Cancel must be reachable from every non-terminal phase.
+    const nonFinalPhases = ['plan', 'implementing', 'synthesize'];
+    for (const phase of nonFinalPhases) {
+      const state: Record<string, unknown> = {
+        phase,
+        workflowType: 'oneshot',
+        artifacts: { plan: 'captured' },
+        _events: [],
+        _history: {},
+      };
+
+      const result = executeTransition(hsm, state, 'cancelled');
+
+      expect(result.success, `Cancel should succeed from ${phase}`).toBe(true);
+      expect(result.newPhase).toBe('cancelled');
+    }
+
+    // getValidTransitions must also advertise cancelled as universal.
+    const targets = getValidTransitions(hsm, 'plan');
+    const cancelTarget = targets.find((t) => t.phase === 'cancelled');
+    expect(cancelTarget).toBeDefined();
+    expect(cancelTarget!.universal).toBe(true);
+  });
+
+  it('oneshot_cannotTransitionFromFinalCompleted', () => {
+    const hsm = getHSMDefinition('oneshot');
+    const state: Record<string, unknown> = {
+      phase: 'completed',
+      workflowType: 'oneshot',
+      _events: [],
+      _history: {},
+    };
+    const result = executeTransition(hsm, state, 'implementing');
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('INVALID_TRANSITION');
   });
 });

--- a/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -199,6 +199,102 @@ describe('Core Tools', () => {
     });
   });
 
+  describe('handleInit_oneshotWithPolicy_persistsInEventStream', () => {
+    it('should include synthesisPolicy in the workflow.started event data', async () => {
+      const eventStore = new EventStore(tmpDir);
+
+      const result = await handleInit(
+        {
+          featureId: 'os-policy-event',
+          workflowType: 'oneshot',
+          synthesisPolicy: 'always',
+        },
+        tmpDir,
+        eventStore,
+      );
+      expect(result.success).toBe(true);
+
+      const events = await eventStore.query('os-policy-event');
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe('workflow.started');
+      const data = events[0].data as {
+        workflowType?: string;
+        synthesisPolicy?: string;
+      };
+      expect(data.workflowType).toBe('oneshot');
+      expect(data.synthesisPolicy).toBe('always');
+    });
+
+    it('should omit synthesisPolicy from the event when workflowType is not oneshot', async () => {
+      const eventStore = new EventStore(tmpDir);
+
+      await handleInit(
+        {
+          featureId: 'feat-policy-ignored',
+          workflowType: 'feature',
+          // Accepted by the input schema but MUST NOT leak into the event
+          // payload for non-oneshot workflows — the projection only reads
+          // synthesisPolicy for oneshot, and other consumers shouldn't see
+          // it either.
+          synthesisPolicy: 'always',
+        },
+        tmpDir,
+        eventStore,
+      );
+
+      const events = await eventStore.query('feat-policy-ignored');
+      expect(events).toHaveLength(1);
+      const data = events[0].data as Record<string, unknown>;
+      expect(data.synthesisPolicy).toBeUndefined();
+    });
+
+    it('should omit synthesisPolicy from the event when oneshot init omits it', async () => {
+      const eventStore = new EventStore(tmpDir);
+
+      await handleInit(
+        { featureId: 'os-default-event', workflowType: 'oneshot' },
+        tmpDir,
+        eventStore,
+      );
+
+      const events = await eventStore.query('os-default-event');
+      expect(events).toHaveLength(1);
+      const data = events[0].data as Record<string, unknown>;
+      expect(data.synthesisPolicy).toBeUndefined();
+    });
+  });
+
+  describe('workflowMaterialization_oneshotPolicy_roundTripsViaEvents', () => {
+    it('should surface synthesisPolicy on the projected view after rematerialization', async () => {
+      const eventStore = new EventStore(tmpDir);
+
+      await handleInit(
+        {
+          featureId: 'os-roundtrip',
+          workflowType: 'oneshot',
+          synthesisPolicy: 'always',
+        },
+        tmpDir,
+        eventStore,
+      );
+
+      // Rematerialize the state from events alone, mimicking the ES v2
+      // rehydrate path used by handleGet.
+      const events = await eventStore.query('os-roundtrip');
+      let view = workflowStateProjection.init();
+      for (const event of events) {
+        view = workflowStateProjection.apply(view, event);
+      }
+
+      const oneshot = (view as unknown as {
+        oneshot?: { synthesisPolicy?: string };
+      }).oneshot;
+      expect(view.workflowType).toBe('oneshot');
+      expect(view.phase).toBe('plan');
+      expect(oneshot?.synthesisPolicy).toBe('always');
+    });
+  });
+
   describe('handleInit_oneshotWorkflow_defaultsSynthesisPolicyWhenOmitted', () => {
     it('should leave state.oneshot unset when synthesisPolicy omitted (schema default is on-request when read)', async () => {
       const result = await handleInit(

--- a/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -182,6 +182,57 @@ describe('Core Tools', () => {
     });
   });
 
+  // ─── handleInit synthesisPolicy threading (HIGH-1) ──────────────────────────
+
+  describe('handleInit_oneshotWorkflow_persistsSynthesisPolicyFromInput', () => {
+    it('should persist state.oneshot.synthesisPolicy when passed at init for oneshot workflow', async () => {
+      const result = await handleInit(
+        { featureId: 'os-policy', workflowType: 'oneshot', synthesisPolicy: 'always' },
+        tmpDir,
+        null,
+      );
+      expect(result.success).toBe(true);
+
+      const state = await readStateFile(path.join(tmpDir, 'os-policy.state.json'));
+      const oneshot = (state as unknown as { oneshot?: { synthesisPolicy?: string } }).oneshot;
+      expect(oneshot?.synthesisPolicy).toBe('always');
+    });
+  });
+
+  describe('handleInit_oneshotWorkflow_defaultsSynthesisPolicyWhenOmitted', () => {
+    it('should leave state.oneshot unset when synthesisPolicy omitted (schema default is on-request when read)', async () => {
+      const result = await handleInit(
+        { featureId: 'os-default', workflowType: 'oneshot' },
+        tmpDir,
+        null,
+      );
+      expect(result.success).toBe(true);
+
+      const state = await readStateFile(path.join(tmpDir, 'os-default.state.json'));
+      const oneshot = (state as unknown as { oneshot?: { synthesisPolicy?: string } }).oneshot;
+      // When unset, the schema's default `on-request` applies at finalize-time
+      // via the guard. The persisted state may omit the `oneshot` key entirely
+      // or carry no `synthesisPolicy` field — both are valid.
+      expect(oneshot?.synthesisPolicy === undefined || oneshot?.synthesisPolicy === 'on-request').toBe(true);
+    });
+  });
+
+  describe('handleInit_featureWorkflow_ignoresSynthesisPolicyArg', () => {
+    it('should silently drop synthesisPolicy arg when workflowType is not oneshot', async () => {
+      const result = await handleInit(
+        // `synthesisPolicy` is accepted by the input schema for uniformity but
+        // has no effect on non-oneshot workflow types.
+        { featureId: 'feat-ignore', workflowType: 'feature', synthesisPolicy: 'always' },
+        tmpDir,
+        null,
+      );
+      expect(result.success).toBe(true);
+
+      const state = await readStateFile(path.join(tmpDir, 'feat-ignore.state.json'));
+      expect((state as unknown as { oneshot?: unknown }).oneshot).toBeUndefined();
+    });
+  });
+
   // ─── ToolList ───────────────────────────────────────────────────────────────
 
   describe('ToolList_ActiveWorkflows_ReturnsWithStaleness', () => {

--- a/servers/exarchos-mcp/src/cli-commands/subagent-context.test.ts
+++ b/servers/exarchos-mcp/src/cli-commands/subagent-context.test.ts
@@ -108,8 +108,10 @@ describe('subagent-context', () => {
       expect(deniedOrchestrate!.actions).toContain('prepare_delegation');
       expect(deniedOrchestrate!.actions).toContain('prepare_synthesis');
       expect(deniedOrchestrate!.actions).toContain('assess_stack');
-      // 4 original + 13 check_ actions + 20 new handler actions denied for delegate+teammate
-      expect(deniedOrchestrate!.actions).toHaveLength(37);
+      // 4 original + 13 check_ actions + 20 new handler actions + 3 oneshot/prune actions
+      // (prune_stale_workflows, request_synthesize, finalize_oneshot) denied for delegate+teammate.
+      // Bump this number when new lead-only actions are registered.
+      expect(deniedOrchestrate!.actions).toHaveLength(40);
     });
 
     it('should include event actions for delegate phase with teammate role', () => {
@@ -158,11 +160,13 @@ describe('subagent-context', () => {
       // + prepare_synthesis (lead role only)
       // + assess_stack (lead role only)
       // + 13 check_ actions (lead role only)
+      // + 3 oneshot/prune actions: prune_stale_workflows, request_synthesize,
+      //   finalize_oneshot (lead role only, added by T4)
       const deniedOrchestrate = result.denied.find(
         (c) => c.name === 'exarchos_orchestrate',
       );
       expect(deniedOrchestrate).toBeDefined();
-      expect(deniedOrchestrate!.actions.length).toBe(42);
+      expect(deniedOrchestrate!.actions.length).toBe(45);
     });
 
     it('should deny workflow init and cancel for teammate role', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -29,6 +29,8 @@ import {
   TaskProgressedData,
   TaskCompletedData,
   TaskFailedData,
+  WorkflowPrunedData,
+  SynthesizeRequestedData,
   SessionTaggedData,
   StackRestackedData,
   WorktreeCreatedData,
@@ -447,7 +449,7 @@ describe('EventTypes', () => {
   });
 
   it('EventTypes_HasExpectedCount', () => {
-    expect(EventTypes).toHaveLength(59);
+    expect(EventTypes).toHaveLength(61);
   });
 
   it('EventTypes_IncludesSessionTagged', () => {
@@ -1971,5 +1973,121 @@ describe('TaskCompletedData acceptanceTestRef', () => {
     if (result.success) {
       expect(result.data.acceptanceTestRef).toBeUndefined();
     }
+  });
+});
+
+// ─── T1: workflow.pruned event type ─────────────────────────────────────────
+
+describe('WorkflowPrunedData', () => {
+  it('eventSchema_workflowPruned_acceptsValidPayload', () => {
+    const result = WorkflowPrunedData.safeParse({
+      featureId: 'stale-feature',
+      stalenessMinutes: 10080,
+      triggeredBy: 'manual',
+      skippedSafeguards: ['open-pr'],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.featureId).toBe('stale-feature');
+      expect(result.data.stalenessMinutes).toBe(10080);
+      expect(result.data.triggeredBy).toBe('manual');
+      expect(result.data.skippedSafeguards).toEqual(['open-pr']);
+    }
+  });
+
+  it('eventSchema_workflowPruned_acceptsPayloadWithoutSkippedSafeguards', () => {
+    const result = WorkflowPrunedData.safeParse({
+      featureId: 'stale-feature',
+      stalenessMinutes: 60,
+      triggeredBy: 'scheduled',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.skippedSafeguards).toBeUndefined();
+    }
+  });
+
+  it('eventSchema_workflowPruned_rejectsMissingFeatureId', () => {
+    const result = WorkflowPrunedData.safeParse({
+      stalenessMinutes: 60,
+      triggeredBy: 'manual',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('eventSchema_workflowPruned_rejectsInvalidTriggeredBy', () => {
+    const result = WorkflowPrunedData.safeParse({
+      featureId: 'stale-feature',
+      stalenessMinutes: 60,
+      triggeredBy: 'automatic',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('eventSchema_workflowPruned_isRegisteredInEventTypeUnion', () => {
+    expect(EventTypes).toContain('workflow.pruned');
+  });
+
+  it('eventSchema_workflowPruned_hasEmissionSourceClassification', () => {
+    expect(EVENT_EMISSION_REGISTRY).toHaveProperty('workflow.pruned');
+  });
+
+  it('eventSchema_workflowPruned_isListedInEventDataSchemas', () => {
+    expect(EVENT_DATA_SCHEMAS['workflow.pruned']).toBeDefined();
+  });
+});
+
+// ─── T2: synthesize.requested event type ────────────────────────────────────
+
+describe('SynthesizeRequestedData', () => {
+  it('eventSchema_synthesizeRequested_acceptsValidPayload', () => {
+    const result = SynthesizeRequestedData.safeParse({
+      featureId: 'feat-1',
+      reason: 'user requested PR instead of direct commit',
+      timestamp: '2026-04-11T12:00:00Z',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.featureId).toBe('feat-1');
+      expect(result.data.reason).toBe('user requested PR instead of direct commit');
+      expect(result.data.timestamp).toBe('2026-04-11T12:00:00Z');
+    }
+  });
+
+  it('eventSchema_synthesizeRequested_acceptsPayloadWithoutReason', () => {
+    const result = SynthesizeRequestedData.safeParse({
+      featureId: 'feat-1',
+      timestamp: '2026-04-11T12:00:00Z',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.reason).toBeUndefined();
+    }
+  });
+
+  it('eventSchema_synthesizeRequested_rejectsMissingFeatureId', () => {
+    const result = SynthesizeRequestedData.safeParse({
+      timestamp: '2026-04-11T12:00:00Z',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('eventSchema_synthesizeRequested_rejectsMissingTimestamp', () => {
+    const result = SynthesizeRequestedData.safeParse({
+      featureId: 'feat-1',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('eventSchema_synthesizeRequested_isRegisteredInEventTypeUnion', () => {
+    expect(EventTypes).toContain('synthesize.requested');
+  });
+
+  it('eventSchema_synthesizeRequested_hasEmissionSourceClassification', () => {
+    expect(EVENT_EMISSION_REGISTRY).toHaveProperty('synthesize.requested');
+  });
+
+  it('eventSchema_synthesizeRequested_isListedInEventDataSchemas', () => {
+    expect(EVENT_DATA_SCHEMAS['synthesize.requested']).toBeDefined();
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -252,6 +252,12 @@ export const WorkflowStartedData = z.object({
   featureId: z.string(),
   workflowType: WorkflowTypeSchema,
   designPath: z.string().optional(),
+  // Oneshot-only: the synthesisPolicy chosen at init time. Must be persisted
+  // in the event stream so ES v2 rematerialization reconstructs the policy
+  // — otherwise the workflow silently reverts to the schema default
+  // (`on-request`) after `handleInit` → rehydrate round-trips. Silently
+  // accepted for non-oneshot workflow types but never populated by them.
+  synthesisPolicy: z.enum(['always', 'never', 'on-request']).optional(),
 });
 
 export const TaskAssignedData = z.object({

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -38,6 +38,8 @@ export const EventTypes = [
   'team.teammate.dispatched',
   'quality.regression',
   'workflow.cas-failed',
+  'workflow.pruned',
+  'synthesize.requested',
   'review.completed',
   'review.routed',
   'review.finding',
@@ -163,6 +165,8 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   'workflow.compensation': 'auto',
   'workflow.circuit-open': 'auto',
   'workflow.cas-failed': 'auto',
+  'workflow.pruned': 'auto',
+  'synthesize.requested': 'auto',
   'task.claimed': 'auto',
   'task.completed': 'auto',
   'task.failed': 'auto',
@@ -409,6 +413,19 @@ export const WorkflowCasFailedData = z.object({
   featureId: z.string(),
   phase: z.string(),
   retries: z.number().int(),
+});
+
+export const WorkflowPrunedData = z.object({
+  featureId: z.string(),
+  stalenessMinutes: z.number().nonnegative(),
+  triggeredBy: z.enum(['manual', 'scheduled']),
+  skippedSafeguards: z.array(z.string()).optional(),
+});
+
+export const SynthesizeRequestedData = z.object({
+  featureId: z.string(),
+  reason: z.string().optional(),
+  timestamp: z.string().datetime(),
 });
 
 // ─── Review Event Data ─────────────────────────────────────────────────────
@@ -741,6 +758,8 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
   'workflow.compensation': WorkflowCompensationData,
   'workflow.circuit-open': WorkflowCircuitOpenData,
   'workflow.cas-failed': WorkflowCasFailedData,
+  'workflow.pruned': WorkflowPrunedData,
+  'synthesize.requested': SynthesizeRequestedData,
 
   // Task-level
   'task.assigned': TaskAssignedData,
@@ -840,6 +859,8 @@ export type WorkflowCancel = z.infer<typeof WorkflowCancelData>;
 export type WorkflowCompensation = z.infer<typeof WorkflowCompensationData>;
 export type WorkflowCircuitOpen = z.infer<typeof WorkflowCircuitOpenData>;
 export type WorkflowCasFailed = z.infer<typeof WorkflowCasFailedData>;
+export type WorkflowPruned = z.infer<typeof WorkflowPrunedData>;
+export type SynthesizeRequested = z.infer<typeof SynthesizeRequestedData>;
 export type ToolInvoked = z.infer<typeof ToolInvokedData>;
 export type ToolCompleted = z.infer<typeof ToolCompletedData>;
 export type ToolErrored = z.infer<typeof ToolErroredData>;
@@ -915,6 +936,8 @@ export type EventDataMap = {
   'team.teammate.dispatched': TeamTeammateDispatched;
   'quality.regression': QualityRegression;
   'workflow.cas-failed': WorkflowCasFailed;
+  'workflow.pruned': WorkflowPruned;
+  'synthesize.requested': SynthesizeRequested;
   'review.completed': ReviewCompleted;
   'review.routed': ReviewRouted;
   'review.finding': ReviewFinding;

--- a/servers/exarchos-mcp/src/orchestrate/composite.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.test.ts
@@ -45,6 +45,18 @@ vi.mock('./post-merge.js', () => ({
   handlePostMerge: vi.fn(),
 }));
 
+vi.mock('./prune-stale-workflows.js', () => ({
+  handlePruneStaleWorkflows: vi.fn(),
+}));
+
+vi.mock('./request-synthesize.js', () => ({
+  handleRequestSynthesize: vi.fn(),
+}));
+
+vi.mock('./finalize-oneshot.js', () => ({
+  handleFinalizeOneshot: vi.fn(),
+}));
+
 vi.mock('../agents/handler.js', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>;
   return {
@@ -68,6 +80,9 @@ import { handleTddCompliance } from './tdd-compliance.js';
 import { handlePostMerge } from './post-merge.js';
 import { handleAgentSpec } from '../agents/handler.js';
 import { handleRunbook } from '../runbooks/handler.js';
+import { handlePruneStaleWorkflows } from './prune-stale-workflows.js';
+import { handleRequestSynthesize } from './request-synthesize.js';
+import { handleFinalizeOneshot } from './finalize-oneshot.js';
 import { handleOrchestrate } from './composite.js';
 
 const STATE_DIR = '/tmp/test-state';
@@ -401,6 +416,84 @@ describe('handleOrchestrate', () => {
       // Assert
       expect(result).toBe(expected);
       expect(handleRunbook).toHaveBeenCalledWith({ id: 'task-completion' });
+    });
+  });
+
+  // ─── Oneshot + Pruning Actions ───────────────────────────────────────────
+
+  describe('oneshot and pruning actions', () => {
+    it('compositeHandler_pruneStaleWorkflowsAction_dispatches', async () => {
+      // Arrange
+      const expected = successResult({ candidates: [], skipped: [], pruned: [] });
+      vi.mocked(handlePruneStaleWorkflows).mockResolvedValue(expected);
+      const args = {
+        action: 'prune_stale_workflows',
+        thresholdMinutes: 10080,
+        dryRun: true,
+        includeOneShot: false,
+      };
+
+      // Act
+      const result = await handleOrchestrate(args, CTX);
+
+      // Assert — handler is registered directly so it receives (args, stateDir, ctx)
+      expect(result).toBe(expected);
+      expect(handlePruneStaleWorkflows).toHaveBeenCalledTimes(1);
+      const call = vi.mocked(handlePruneStaleWorkflows).mock.calls[0];
+      expect(call[0]).toEqual({
+        thresholdMinutes: 10080,
+        dryRun: true,
+        includeOneShot: false,
+      });
+      expect(call[1]).toBe(STATE_DIR);
+      expect(call[2]).toBe(CTX);
+    });
+
+    it('compositeHandler_requestSynthesizeAction_dispatches', async () => {
+      // Arrange
+      const expected = successResult({ eventAppended: true });
+      vi.mocked(handleRequestSynthesize).mockResolvedValue(expected);
+      const args = {
+        action: 'request_synthesize',
+        featureId: 'feat-oneshot-1',
+        reason: 'user requested PR review',
+      };
+
+      // Act
+      const result = await handleOrchestrate(args, CTX);
+
+      // Assert — adapter injects eventStore from ctx into args
+      expect(result).toBe(expected);
+      expect(handleRequestSynthesize).toHaveBeenCalledTimes(1);
+      const call = vi.mocked(handleRequestSynthesize).mock.calls[0][0];
+      expect(call.featureId).toBe('feat-oneshot-1');
+      expect(call.reason).toBe('user requested PR review');
+      expect(call.eventStore).toBe(CTX.eventStore);
+    });
+
+    it('compositeHandler_finalizeOneshotAction_dispatches', async () => {
+      // Arrange
+      const expected = successResult({
+        featureId: 'feat-oneshot-2',
+        previousPhase: 'implementing',
+        newPhase: 'completed',
+      });
+      vi.mocked(handleFinalizeOneshot).mockResolvedValue(expected);
+      const args = {
+        action: 'finalize_oneshot',
+        featureId: 'feat-oneshot-2',
+      };
+
+      // Act
+      const result = await handleOrchestrate(args, CTX);
+
+      // Assert — adapter injects BOTH stateDir and eventStore from ctx into args
+      expect(result).toBe(expected);
+      expect(handleFinalizeOneshot).toHaveBeenCalledTimes(1);
+      const call = vi.mocked(handleFinalizeOneshot).mock.calls[0][0];
+      expect(call.featureId).toBe('feat-oneshot-2');
+      expect(call.stateDir).toBe(STATE_DIR);
+      expect(call.eventStore).toBe(CTX.eventStore);
     });
   });
 

--- a/servers/exarchos-mcp/src/orchestrate/composite.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.test.ts
@@ -462,13 +462,17 @@ describe('handleOrchestrate', () => {
       // Act
       const result = await handleOrchestrate(args, CTX);
 
-      // Assert — adapter injects eventStore from ctx into args
+      // Assert — adapter injects both stateDir and eventStore from ctx
+      // into args, matching the finalize_oneshot pattern. The stateDir
+      // injection replaces the old hardcoded `.exarchos/state/...`
+      // fallback inside the handler.
       expect(result).toBe(expected);
       expect(handleRequestSynthesize).toHaveBeenCalledTimes(1);
       const call = vi.mocked(handleRequestSynthesize).mock.calls[0][0];
       expect(call.featureId).toBe('feat-oneshot-1');
       expect(call.reason).toBe('user requested PR review');
       expect(call.eventStore).toBe(CTX.eventStore);
+      expect(call.stateDir).toBe(STATE_DIR);
     });
 
     it('compositeHandler_finalizeOneshotAction_dispatches', async () => {

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -65,6 +65,9 @@ import { handleNeedsSchemaSync } from './needs-schema-sync.js';
 import { handleVerifyDocLinks } from './verify-doc-links.js';
 import { handleVerifyReviewTriage } from './verify-review-triage.js';
 import { handlePrepareReview } from './prepare-review.js';
+import { handlePruneStaleWorkflows } from './prune-stale-workflows.js';
+import { handleRequestSynthesize } from './request-synthesize.js';
+import { handleFinalizeOneshot } from './finalize-oneshot.js';
 
 // ─── Action Router ──────────────────────────────────────────────────────────
 
@@ -84,6 +87,26 @@ function adaptArgs<T>(handler: (args: T) => ToolResult | Promise<ToolResult>): A
 function adaptArgsWithEventStore<T>(handler: (args: T) => ToolResult | Promise<ToolResult>): ActionHandler {
   return async (args, _stateDir, ctx) => {
     const enriched = ctx?.eventStore ? { ...args, eventStore: ctx.eventStore } : args;
+    return handler(enriched as unknown as T);
+  };
+}
+
+/**
+ * Wraps a typed handler that needs BOTH `stateDir` and `eventStore` from
+ * DispatchContext injected into a single args object. Use this when the
+ * underlying handler accepts a single bag of args containing all dependencies
+ * (rather than the conventional `(args, stateDir)` positional shape) — e.g.,
+ * `handleFinalizeOneshot` whose `FinalizeOneshotArgs` includes both fields.
+ */
+function adaptArgsWithStateDirAndEventStore<T>(
+  handler: (args: T) => ToolResult | Promise<ToolResult>,
+): ActionHandler {
+  return async (args, stateDir, ctx) => {
+    const enriched = {
+      ...args,
+      stateDir,
+      ...(ctx?.eventStore ? { eventStore: ctx.eventStore } : {}),
+    };
     return handler(enriched as unknown as T);
   };
 }
@@ -138,6 +161,13 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   verify_doc_links: adaptArgs(handleVerifyDocLinks),
   verify_review_triage: adaptArgs(handleVerifyReviewTriage),
   prepare_review: adapt(handlePrepareReview),
+  // Oneshot + pruning (T4): handlePruneStaleWorkflows already matches the
+  // ActionHandler `(args, stateDir, ctx?)` shape, so it is registered directly
+  // without an adapter. The other two need their dependencies injected from
+  // DispatchContext into a single args bag.
+  prune_stale_workflows: handlePruneStaleWorkflows as ActionHandler,
+  request_synthesize: adaptArgsWithEventStore(handleRequestSynthesize),
+  finalize_oneshot: adaptArgsWithStateDirAndEventStore(handleFinalizeOneshot),
 };
 
 /** Exported for sync test — ensures registry.ts stays in sync with handler keys. */

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -178,7 +178,7 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   // minimal bridge. An adapter wrapper would just re-spread the same three
   // args with no narrowing benefit.
   prune_stale_workflows: handlePruneStaleWorkflows as ActionHandler,
-  request_synthesize: adaptArgsWithEventStore(handleRequestSynthesize),
+  request_synthesize: adaptArgsWithStateDirAndEventStore(handleRequestSynthesize),
   finalize_oneshot: adaptArgsWithStateDirAndEventStore(handleFinalizeOneshot),
 };
 

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -165,6 +165,18 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   // ActionHandler `(args, stateDir, ctx?)` shape, so it is registered directly
   // without an adapter. The other two need their dependencies injected from
   // DispatchContext into a single args bag.
+  //
+  // The `as ActionHandler` cast is safe because:
+  //   1. The handler's signature is `(args, stateDir, ctx?, deps?)` where
+  //      `deps` has a default (`productionDeps(ctx)`) — meaning at runtime
+  //      the router's 3-arg call `(args, stateDir, ctx)` produces a fully
+  //      wired handler that matches `ActionHandler`'s `(args, stateDir, ctx)`.
+  //   2. The 4th param is a testability seam only; production code never
+  //      passes it, and no ActionHandler caller has reason to.
+  // TypeScript's structural typing sees the extra optional parameter as a
+  // mismatch with the strict `ActionHandler` signature, so the cast is the
+  // minimal bridge. An adapter wrapper would just re-spread the same three
+  // args with no narrowing benefit.
   prune_stale_workflows: handlePruneStaleWorkflows as ActionHandler,
   request_synthesize: adaptArgsWithEventStore(handleRequestSynthesize),
   finalize_oneshot: adaptArgsWithStateDirAndEventStore(handleFinalizeOneshot),

--- a/servers/exarchos-mcp/src/orchestrate/finalize-oneshot.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/finalize-oneshot.test.ts
@@ -1,0 +1,261 @@
+// ─── Finalize Oneshot Handler Tests (T12) ──────────────────────────────────
+//
+// Exercises handleFinalizeOneshot — the orchestrate action that resolves
+// the oneshot choice state at the end of `implementing`. Determines the
+// next phase from the synthesisOptedIn / synthesisOptedOut guards and
+// transitions via handleSet, delegating guard evaluation to the HSM.
+//
+// Tests use real tmpdir state + EventStore to drive the full HSM pipeline,
+// ensuring the handler interacts with state-store/event-store the same way
+// the production composite handler will.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import { handleInit, handleSet } from '../workflow/tools.js';
+import { EventStore } from '../event-store/store.js';
+import { handleFinalizeOneshot } from './finalize-oneshot.js';
+
+// ─── Fixture helpers ────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let eventStore: EventStore;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'finalize-oneshot-'));
+  eventStore = new EventStore(tmpDir);
+  await eventStore.initialize();
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * Initialize a oneshot workflow, set the plan, and advance to `implementing`.
+ * Optionally set the synthesisPolicy via `oneshot.synthesisPolicy` updates.
+ */
+async function initOneshotInImplementing(
+  featureId: string,
+  synthesisPolicy?: 'always' | 'never' | 'on-request',
+): Promise<void> {
+  await handleInit({ featureId, workflowType: 'oneshot' }, tmpDir, eventStore);
+
+  // Set synthesisPolicy via top-level oneshot field if specified.
+  if (synthesisPolicy !== undefined) {
+    await handleSet(
+      {
+        featureId,
+        updates: { 'oneshot.synthesisPolicy': synthesisPolicy },
+      },
+      tmpDir,
+      eventStore,
+    );
+  }
+
+  // Set the plan artifact to satisfy oneshotPlanSet guard
+  await handleSet(
+    {
+      featureId,
+      updates: { 'artifacts.plan': 'one-page plan' },
+    },
+    tmpDir,
+    eventStore,
+  );
+
+  // Transition plan -> implementing
+  const result = await handleSet(
+    { featureId, phase: 'implementing' },
+    tmpDir,
+    eventStore,
+  );
+  if (!result.success) {
+    throw new Error(
+      `Failed to advance to implementing: ${result.error?.message ?? 'unknown'}`,
+    );
+  }
+}
+
+async function appendSynthesizeRequested(featureId: string): Promise<void> {
+  await eventStore.append(featureId, {
+    type: 'synthesize.requested',
+    data: {
+      featureId,
+      timestamp: new Date().toISOString(),
+    },
+  });
+}
+
+async function readPhase(featureId: string): Promise<string> {
+  const stateFile = path.join(tmpDir, `${featureId}.state.json`);
+  const raw = await fs.readFile(stateFile, 'utf-8');
+  const parsed = JSON.parse(raw) as { phase?: string };
+  return parsed.phase ?? '';
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('handleFinalizeOneshot', () => {
+  it('handleFinalizeOneshot_policyAlways_transitionsToSynthesize', async () => {
+    const featureId = 'oneshot-always';
+    await initOneshotInImplementing(featureId, 'always');
+
+    const result = await handleFinalizeOneshot(
+      { featureId, stateDir: tmpDir, eventStore },
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as { previousPhase: string; newPhase: string };
+    expect(data.previousPhase).toBe('implementing');
+    expect(data.newPhase).toBe('synthesize');
+
+    expect(await readPhase(featureId)).toBe('synthesize');
+  });
+
+  it('handleFinalizeOneshot_policyNever_transitionsToCompleted', async () => {
+    const featureId = 'oneshot-never';
+    await initOneshotInImplementing(featureId, 'never');
+
+    const result = await handleFinalizeOneshot(
+      { featureId, stateDir: tmpDir, eventStore },
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as { previousPhase: string; newPhase: string };
+    expect(data.previousPhase).toBe('implementing');
+    expect(data.newPhase).toBe('completed');
+
+    expect(await readPhase(featureId)).toBe('completed');
+  });
+
+  it('handleFinalizeOneshot_onRequestWithEvent_transitionsToSynthesize', async () => {
+    const featureId = 'oneshot-on-request-event';
+    await initOneshotInImplementing(featureId, 'on-request');
+    await appendSynthesizeRequested(featureId);
+
+    const result = await handleFinalizeOneshot(
+      { featureId, stateDir: tmpDir, eventStore },
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as { previousPhase: string; newPhase: string };
+    expect(data.newPhase).toBe('synthesize');
+    expect(await readPhase(featureId)).toBe('synthesize');
+  });
+
+  it('handleFinalizeOneshot_onRequestNoEvent_transitionsToCompleted', async () => {
+    const featureId = 'oneshot-on-request-no-event';
+    await initOneshotInImplementing(featureId, 'on-request');
+
+    const result = await handleFinalizeOneshot(
+      { featureId, stateDir: tmpDir, eventStore },
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as { previousPhase: string; newPhase: string };
+    expect(data.newPhase).toBe('completed');
+    expect(await readPhase(featureId)).toBe('completed');
+  });
+
+  it('handleFinalizeOneshot_defaultsToOnRequestWhenPolicyMissing', async () => {
+    // No explicit synthesisPolicy set — should default to on-request behavior.
+    // Without a synthesize.requested event, the direct-commit path is taken.
+    const featureId = 'oneshot-default-policy';
+    await initOneshotInImplementing(featureId);
+
+    const result = await handleFinalizeOneshot(
+      { featureId, stateDir: tmpDir, eventStore },
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as { newPhase: string };
+    expect(data.newPhase).toBe('completed');
+  });
+
+  it('handleFinalizeOneshot_rejectsNonOneshotWorkflow', async () => {
+    const featureId = 'feat-non-oneshot';
+    // Initialize as feature workflow, not oneshot
+    await handleInit(
+      { featureId, workflowType: 'feature' },
+      tmpDir,
+      eventStore,
+    );
+
+    const result = await handleFinalizeOneshot(
+      { featureId, stateDir: tmpDir, eventStore },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_WORKFLOW_TYPE');
+    expect(result.error?.message).toMatch(/oneshot/);
+  });
+
+  it('handleFinalizeOneshot_rejectsFromWrongPhase', async () => {
+    const featureId = 'oneshot-wrong-phase';
+    // Init oneshot but stay in `plan` (do not advance to implementing)
+    await handleInit(
+      { featureId, workflowType: 'oneshot' },
+      tmpDir,
+      eventStore,
+    );
+
+    const result = await handleFinalizeOneshot(
+      { featureId, stateDir: tmpDir, eventStore },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_PHASE');
+    expect(result.error?.message).toMatch(/implementing/);
+  });
+
+  it('handleFinalizeOneshot_rejectsMissingState', async () => {
+    const result = await handleFinalizeOneshot(
+      { featureId: 'does-not-exist', stateDir: tmpDir, eventStore },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('STATE_NOT_FOUND');
+  });
+
+  it('handleFinalizeOneshot_rejectsMissingFeatureId', async () => {
+    const result = await handleFinalizeOneshot(
+      { featureId: '', stateDir: tmpDir, eventStore },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('handleFinalizeOneshot_policyAlwaysOverridesEvent', async () => {
+    // Verifies that synthesisPolicy=always wins regardless of events.
+    const featureId = 'oneshot-always-event';
+    await initOneshotInImplementing(featureId, 'always');
+    await appendSynthesizeRequested(featureId);
+
+    const result = await handleFinalizeOneshot(
+      { featureId, stateDir: tmpDir, eventStore },
+    );
+
+    expect(result.success).toBe(true);
+    expect((result.data as { newPhase: string }).newPhase).toBe('synthesize');
+  });
+
+  it('handleFinalizeOneshot_policyNeverOverridesEvent', async () => {
+    // Verifies that synthesisPolicy=never wins even when synthesize.requested
+    // was emitted (the event is recorded for audit but the policy short-
+    // circuits the choice state).
+    const featureId = 'oneshot-never-event';
+    await initOneshotInImplementing(featureId, 'never');
+    await appendSynthesizeRequested(featureId);
+
+    const result = await handleFinalizeOneshot(
+      { featureId, stateDir: tmpDir, eventStore },
+    );
+
+    expect(result.success).toBe(true);
+    expect((result.data as { newPhase: string }).newPhase).toBe('completed');
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/finalize-oneshot.ts
+++ b/servers/exarchos-mcp/src/orchestrate/finalize-oneshot.ts
@@ -1,0 +1,156 @@
+// ─── Finalize Oneshot Orchestrate Handler (T12) ────────────────────────────
+//
+// Resolves the oneshot workflow choice state at the end of the `implementing`
+// phase, transitioning to either `synthesize` (PR-based path) or `completed`
+// (direct-commit path) based on the synthesisOptedIn / synthesisOptedOut
+// guards declared in T9.
+//
+// Approach: evaluate the synthesisOptedIn guard directly against the loaded
+// state (the guard is pure — see workflow/guards.ts) to determine the
+// target phase, then call handleSet to drive the HSM transition. This keeps
+// the handler explicit about the choice and lets the state machine enforce
+// guard semantics on the actual transition.
+//
+// Why not retry-with-fallthrough? An "attempt synthesize, on guard-fail try
+// completed" approach would be more decoupled but produces a guard-failed
+// event in the audit log on every direct-commit path, polluting the stream
+// with diagnostic noise. Direct guard evaluation produces a single clean
+// transition event.
+// ────────────────────────────────────────────────────────────────────────────
+
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+
+import type { ToolResult } from '../format.js';
+import type { EventStore } from '../event-store/store.js';
+import { handleSet } from '../workflow/tools.js';
+import { guards } from '../workflow/guards.js';
+import { hydrateEventsFromStore } from '../workflow/state-store.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface FinalizeOneshotArgs {
+  readonly featureId: string;
+  readonly stateDir: string;
+  readonly eventStore: EventStore;
+}
+
+// ─── Handler ────────────────────────────────────────────────────────────────
+
+export async function handleFinalizeOneshot(
+  args: FinalizeOneshotArgs,
+): Promise<ToolResult> {
+  const { featureId, stateDir, eventStore } = args;
+
+  if (!featureId) {
+    return {
+      success: false,
+      error: { code: 'INVALID_INPUT', message: 'featureId is required' },
+    };
+  }
+
+  if (!eventStore) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'eventStore is required for finalize_oneshot',
+      },
+    };
+  }
+
+  // ─── Read current workflow state ──────────────────────────────────────────
+  const stateFile = path.join(stateDir, `${featureId}.state.json`);
+  let state: Record<string, unknown>;
+  try {
+    const raw = await fs.readFile(stateFile, 'utf-8');
+    state = JSON.parse(raw) as Record<string, unknown>;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {
+        success: false,
+        error: {
+          code: 'STATE_NOT_FOUND',
+          message: `State not found for feature: ${featureId}`,
+        },
+      };
+    }
+    return {
+      success: false,
+      error: {
+        code: 'STATE_READ_FAILED',
+        message: `Failed to read workflow state: ${err instanceof Error ? err.message : String(err)}`,
+      },
+    };
+  }
+
+  // ─── Verify workflow type ─────────────────────────────────────────────────
+  const workflowType = state.workflowType;
+  if (workflowType !== 'oneshot') {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_WORKFLOW_TYPE',
+        message: `finalize_oneshot is only valid for oneshot workflows; got workflowType=${String(workflowType)}`,
+      },
+    };
+  }
+
+  // ─── Verify current phase ─────────────────────────────────────────────────
+  const currentPhase = state.phase;
+  if (currentPhase !== 'implementing') {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_PHASE',
+        message: `finalize_oneshot may only be invoked from the implementing phase; got phase=${String(currentPhase)}`,
+      },
+    };
+  }
+
+  // ─── Hydrate _events from the event store so the choice-state guards
+  //     observe the same view that the HSM will see during the actual
+  //     transition. Without this, an opt-in event appended after the state
+  //     file was last written would be invisible to the inline guard check.
+  try {
+    state._events = await hydrateEventsFromStore(featureId, eventStore);
+  } catch {
+    // Best-effort: fall back to whatever events are already on the state.
+    // The HSM will re-hydrate when handleSet executes the transition, so
+    // any miss here is corrected before the actual phase change.
+    state._events = state._events ?? [];
+  }
+
+  // ─── Resolve target phase via the synthesisOptedIn guard ─────────────────
+  // Guards are pure — see workflow/guards.ts. We delegate to the guard
+  // rather than re-implementing the policy/event logic so any future
+  // change to the choice-state semantics happens in one place.
+  const optedInResult = guards.synthesisOptedIn.evaluate(state);
+  const targetPhase: 'synthesize' | 'completed' =
+    optedInResult === true ? 'synthesize' : 'completed';
+
+  // ─── Drive the transition through handleSet ──────────────────────────────
+  // handleSet re-evaluates the corresponding HSM transition guard
+  // (synthesisOptedIn / synthesisOptedOut) against the current state, so a
+  // race that flips the policy or events between our read and the
+  // transition is caught at the state-machine boundary rather than
+  // silently driving an inconsistent target.
+  const setResult = await handleSet(
+    { featureId, phase: targetPhase },
+    stateDir,
+    eventStore,
+  );
+
+  if (!setResult.success) {
+    return setResult;
+  }
+
+  return {
+    success: true,
+    data: {
+      featureId,
+      previousPhase: 'implementing',
+      newPhase: targetPhase,
+    },
+  };
+}

--- a/servers/exarchos-mcp/src/orchestrate/finalize-oneshot.ts
+++ b/servers/exarchos-mcp/src/orchestrate/finalize-oneshot.ts
@@ -19,13 +19,13 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import * as path from 'node:path';
-import * as fs from 'node:fs/promises';
 
 import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { handleSet } from '../workflow/tools.js';
 import { guards } from '../workflow/guards.js';
 import { hydrateEventsFromStore } from '../workflow/state-store.js';
+import { resolveWorkflowState } from './resolve-state.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -60,13 +60,25 @@ export async function handleFinalizeOneshot(
   }
 
   // ─── Read current workflow state ──────────────────────────────────────────
+  // Delegate to the shared resolver used by sibling handlers (notably
+  // request-synthesize). The resolver tries the state file first and falls
+  // back to materializing from the event store, which means finalize_oneshot
+  // now works identically whether the workflow is file-backed or purely
+  // event-sourced. Previously this used raw `fs.readFile`, duplicating the
+  // state-read pattern.
   const stateFile = path.join(stateDir, `${featureId}.state.json`);
-  let state: Record<string, unknown>;
-  try {
-    const raw = await fs.readFile(stateFile, 'utf-8');
-    state = JSON.parse(raw) as Record<string, unknown>;
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+  const resolved = await resolveWorkflowState({
+    stateFile,
+    featureId,
+    eventStore,
+  });
+
+  if ('error' in resolved) {
+    // Translate the resolver's NO_STATE_SOURCE / EVENT_STORE_ERROR codes
+    // into the STATE_NOT_FOUND taxonomy the rest of this handler (and its
+    // callers) expects, matching what request-synthesize.ts does.
+    const code = resolved.error.error?.code;
+    if (code === 'NO_STATE_SOURCE' || code === 'EVENT_STORE_ERROR') {
       return {
         success: false,
         error: {
@@ -75,11 +87,30 @@ export async function handleFinalizeOneshot(
         },
       };
     }
+    return resolved.error;
+  }
+
+  const state: Record<string, unknown> = resolved.state;
+
+  // The resolver falls back to the event store when the state file is
+  // missing, returning a projection-initialized view seeded with default
+  // values (featureId: '', workflowType: 'feature', createdAt: '').
+  // For finalize_oneshot, an empty projection — no `workflow.started`
+  // event ever applied — is indistinguishable from "workflow does not
+  // exist". Use `createdAt === ''` / `featureId === ''` as a sentinel
+  // that no events populated the view, and translate to STATE_NOT_FOUND
+  // so callers cannot silently finalize a workflow that was never created.
+  if (
+    state.workflowType === undefined ||
+    state.workflowType === null ||
+    state.createdAt === '' ||
+    state.featureId === ''
+  ) {
     return {
       success: false,
       error: {
-        code: 'STATE_READ_FAILED',
-        message: `Failed to read workflow state: ${err instanceof Error ? err.message : String(err)}`,
+        code: 'STATE_NOT_FOUND',
+        message: `State not found for feature: ${featureId}`,
       },
     };
   }

--- a/servers/exarchos-mcp/src/orchestrate/prune-safeguards.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-safeguards.ts
@@ -1,0 +1,90 @@
+// ─── Prune Safeguards (DI-friendly) ─────────────────────────────────────────
+//
+// Production implementations for the open-PR and recent-commits safeguards
+// used by `handlePruneStaleWorkflows`. Both shell out to `gh`/`git` through
+// `execSync`; the handler takes these as injectable deps so unit tests can
+// swap stubs rather than shelling out.
+//
+// Isolation rationale: keeping the IO helpers in a separate module lets
+// `prune-stale-workflows.ts` stay focused on orchestration + pure-selection
+// composition, and makes the tests explicit about which IO is being bypassed.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { execSync } from 'node:child_process';
+
+/**
+ * Pluggable safeguard backends. Both accept optional `branchName` so callers
+ * can hand through `undefined` for pre-delegation workflows — the handler
+ * short-circuits those checks rather than invoking the safeguard at all.
+ */
+export interface PruneSafeguards {
+  /** Returns true if there is an OPEN pull request whose head is `branchName`. */
+  hasOpenPR: (featureId: string, branchName: string | undefined) => Promise<boolean>;
+  /** Returns true if `branchName` has commits inside the last `windowHours`. */
+  hasRecentCommits: (branchName: string | undefined, windowHours: number) => Promise<boolean>;
+}
+
+/** Sanitize a branch name before embedding it in a shell argument. */
+function isSafeBranchName(branch: string): boolean {
+  // Matches git's allowed ref characters: alphanumerics, slash, dash, dot, underscore.
+  return /^[A-Za-z0-9/_.\-]+$/.test(branch) && !branch.includes('..');
+}
+
+async function defaultHasOpenPR(
+  _featureId: string,
+  branchName: string | undefined,
+): Promise<boolean> {
+  if (!branchName || !isSafeBranchName(branchName)) return false;
+  try {
+    const output = execSync(
+      `gh pr list --head ${branchName} --state open --json number`,
+      {
+        encoding: 'utf-8',
+        timeout: 10_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    ).trim();
+    if (!output) return false;
+    const parsed: unknown = JSON.parse(output);
+    return Array.isArray(parsed) && parsed.length > 0;
+  } catch {
+    // When `gh` fails, be conservative: report "no open PR" rather than
+    // blocking the prune. The handler's `force` flag is the escape hatch
+    // for environments where `gh` is unavailable.
+    return false;
+  }
+}
+
+async function defaultHasRecentCommits(
+  branchName: string | undefined,
+  windowHours: number,
+): Promise<boolean> {
+  if (!branchName || !isSafeBranchName(branchName)) return false;
+  try {
+    const output = execSync(
+      `git log --since "${windowHours} hours ago" --format=%H origin/${branchName}`,
+      {
+        encoding: 'utf-8',
+        timeout: 10_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    ).trim();
+    return output.length > 0;
+  } catch {
+    // If the remote branch doesn't exist or git errors out, treat as no
+    // recent activity (conservative toward allowing prune; `force` is the
+    // override if the user wants to bypass both safeguards anyway).
+    return false;
+  }
+}
+
+/**
+ * Build the default production safeguard bundle. Tests pass their own
+ * `PruneSafeguards` object instead of calling this.
+ */
+export function defaultSafeguards(): PruneSafeguards {
+  return {
+    hasOpenPR: defaultHasOpenPR,
+    hasRecentCommits: defaultHasRecentCommits,
+  };
+}

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
@@ -428,6 +428,89 @@ describe('handlePruneStaleWorkflows', () => {
     expect(data.pruned.map((p) => p.featureId)).toEqual(['nobrn']);
   });
 
+  it('handlePruneStaleWorkflows_eventAppendThrows_recordsInSkippedNotPruned', async () => {
+    // HIGH-2 regression: when eventStore.append throws after a successful
+    // cancel, the feature must appear in `skipped` with reason
+    // `event-append-failed` and MUST NOT appear in `pruned`.
+    const append = vi.fn().mockRejectedValue(new Error('append boom'));
+    const ctx = { eventStore: { append } };
+    const deps = makeDeps();
+    deps.listSpy.mockResolvedValue(
+      makeListResult([
+        { featureId: 'ea-fail', lastActivityTimestamp: staleIso(20_000) },
+      ]),
+    );
+
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      ctx as unknown as Parameters<typeof handlePruneStaleWorkflows>[2],
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    // The cancel MUST still have been invoked — the append failure happens
+    // AFTER the cancel succeeds.
+    expect(deps.cancelSpy).toHaveBeenCalledTimes(1);
+
+    const data = result.data as {
+      pruned: Array<{ featureId: string }>;
+      skipped: Array<{ featureId: string; reason: string; message?: string }>;
+    };
+    // NOT in pruned (this is the core HIGH-2 assertion)
+    expect(data.pruned).toEqual([]);
+    // IS in skipped with the new distinct reason
+    expect(data.skipped).toHaveLength(1);
+    expect(data.skipped[0]?.featureId).toBe('ea-fail');
+    expect(data.skipped[0]?.reason).toBe('event-append-failed');
+    expect(data.skipped[0]?.message).toContain('append boom');
+  });
+
+  it('handlePruneStaleWorkflows_applyModeWithoutEventStore_returnsStructuredError', async () => {
+    // MEDIUM-1 regression: apply mode without ctx must not silently no-op
+    // on the append — it must refuse upfront with a structured error.
+    const deps = makeDeps();
+    deps.listSpy.mockResolvedValue(
+      makeListResult([
+        { featureId: 'missing-ctx', lastActivityTimestamp: staleIso(20_000) },
+      ]),
+    );
+
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      undefined, // no ctx
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('MISSING_CONTEXT');
+    expect(result.error?.message).toContain('eventStore');
+    // Must refuse BEFORE touching handleCancel (no partial mutations).
+    expect(deps.cancelSpy).not.toHaveBeenCalled();
+  });
+
+  it('handlePruneStaleWorkflows_dryRunWithoutEventStore_stillAllowed', async () => {
+    // Dry-run is read-only — no event emission needed, so the precondition
+    // does not apply. This guards against overly-broad refusals.
+    const deps = makeDeps();
+    deps.listSpy.mockResolvedValue(
+      makeListResult([
+        { featureId: 'dry', lastActivityTimestamp: staleIso(20_000) },
+      ]),
+    );
+
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: true, now: NOW_ISO },
+      STATE_DIR,
+      undefined,
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(deps.cancelSpy).not.toHaveBeenCalled();
+  });
+
   it('reports partial failure when one of several cancels fails', async () => {
     const { append, ctx } = makeEventStoreStub();
     const deps = makeDeps();

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  selectPruneCandidates,
+  type WorkflowListEntry,
+} from './prune-stale-workflows.js';
+
+/**
+ * Build a minimal WorkflowListEntry fixture.
+ * Staleness is computed from `_checkpoint.lastActivityTimestamp` vs an
+ * injectable `now` in the tests, so fixtures only need to set the timestamp.
+ */
+function makeEntry(overrides: {
+  featureId: string;
+  workflowType?: string;
+  phase?: string;
+  lastActivityTimestamp: string;
+}): WorkflowListEntry {
+  return {
+    featureId: overrides.featureId,
+    workflowType: overrides.workflowType ?? 'feature',
+    phase: overrides.phase ?? 'implementing',
+    stateFile: `/tmp/${overrides.featureId}.state.json`,
+    _checkpoint: {
+      lastActivityTimestamp: overrides.lastActivityTimestamp,
+    },
+  };
+}
+
+// A fixed "now" for deterministic tests.
+const NOW = new Date('2026-04-11T12:00:00.000Z');
+
+// Helper: minutes-before-now as ISO string
+function minutesAgo(mins: number): string {
+  return new Date(NOW.getTime() - mins * 60 * 1000).toISOString();
+}
+
+describe('selectPruneCandidates', () => {
+  it('excludes terminal phases (completed, cancelled)', () => {
+    // Very stale so they'd otherwise qualify (> 10080 min default threshold)
+    const stale = minutesAgo(20_000);
+    const entries: WorkflowListEntry[] = [
+      makeEntry({ featureId: 'a', phase: 'completed', lastActivityTimestamp: stale }),
+      makeEntry({ featureId: 'b', phase: 'cancelled', lastActivityTimestamp: stale }),
+      makeEntry({ featureId: 'c', phase: 'implementing', lastActivityTimestamp: stale }),
+    ];
+
+    const { candidates, excluded } = selectPruneCandidates(entries, {}, NOW);
+
+    expect(candidates.map((c) => c.featureId).sort()).toEqual(['c']);
+    const terminalExclusions = excluded.filter((e) => e.reason === 'terminal');
+    expect(terminalExclusions.map((e) => e.featureId).sort()).toEqual(['a', 'b']);
+  });
+
+  it('excludes fresh workflows (within default threshold)', () => {
+    // Default threshold is 10080 minutes (7 days)
+    const entries: WorkflowListEntry[] = [
+      makeEntry({ featureId: 'fresh', lastActivityTimestamp: minutesAgo(60) }), // 1h
+      makeEntry({ featureId: 'stale', lastActivityTimestamp: minutesAgo(20_000) }),
+    ];
+
+    const { candidates, excluded } = selectPruneCandidates(entries, {}, NOW);
+
+    expect(candidates.map((c) => c.featureId)).toEqual(['stale']);
+    const freshExclusions = excluded.filter((e) => e.reason === 'fresh');
+    expect(freshExclusions.map((e) => e.featureId)).toEqual(['fresh']);
+  });
+
+  it('includes stale non-terminal entries', () => {
+    const entries: WorkflowListEntry[] = [
+      makeEntry({
+        featureId: 'a',
+        phase: 'implementing',
+        lastActivityTimestamp: minutesAgo(20_000),
+      }),
+      makeEntry({
+        featureId: 'b',
+        phase: 'plan',
+        lastActivityTimestamp: minutesAgo(20_000),
+      }),
+    ];
+
+    const { candidates } = selectPruneCandidates(entries, {}, NOW);
+
+    expect(candidates.map((c) => c.featureId).sort()).toEqual(['a', 'b']);
+    for (const candidate of candidates) {
+      expect(candidate.stalenessMinutes).toBeGreaterThan(0);
+      expect(candidate.workflowType).toBe('feature');
+    }
+  });
+
+  it('respects a custom threshold (60 min)', () => {
+    const entries: WorkflowListEntry[] = [
+      makeEntry({ featureId: 'a', lastActivityTimestamp: minutesAgo(30) }), // fresh vs 60
+      makeEntry({ featureId: 'b', lastActivityTimestamp: minutesAgo(120) }), // stale vs 60
+    ];
+
+    const { candidates, excluded } = selectPruneCandidates(
+      entries,
+      { thresholdMinutes: 60 },
+      NOW,
+    );
+
+    expect(candidates.map((c) => c.featureId)).toEqual(['b']);
+    expect(excluded.map((e) => e.featureId)).toEqual(['a']);
+    expect(excluded[0]?.reason).toBe('fresh');
+  });
+
+  it('excludes oneshot workflows when includeOneShot is false', () => {
+    const stale = minutesAgo(20_000);
+    const entries: WorkflowListEntry[] = [
+      makeEntry({ featureId: 'os1', workflowType: 'oneshot', lastActivityTimestamp: stale }),
+      makeEntry({ featureId: 'f1', workflowType: 'feature', lastActivityTimestamp: stale }),
+    ];
+
+    const { candidates, excluded } = selectPruneCandidates(
+      entries,
+      { includeOneShot: false },
+      NOW,
+    );
+
+    expect(candidates.map((c) => c.featureId)).toEqual(['f1']);
+    const oneshotExclusions = excluded.filter((e) => e.reason === 'oneshot-excluded');
+    expect(oneshotExclusions.map((e) => e.featureId)).toEqual(['os1']);
+  });
+
+  it('includes oneshot workflows by default (includeOneShot defaults to true)', () => {
+    const stale = minutesAgo(20_000);
+    const entries: WorkflowListEntry[] = [
+      makeEntry({ featureId: 'os1', workflowType: 'oneshot', lastActivityTimestamp: stale }),
+      makeEntry({ featureId: 'f1', workflowType: 'feature', lastActivityTimestamp: stale }),
+    ];
+
+    const { candidates, excluded } = selectPruneCandidates(entries, {}, NOW);
+
+    expect(candidates.map((c) => c.featureId).sort()).toEqual(['f1', 'os1']);
+    expect(excluded.filter((e) => e.reason === 'oneshot-excluded')).toEqual([]);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
@@ -6,6 +6,7 @@ import {
   type PruneHandlerDeps,
   type PruneSafeguards,
 } from './prune-stale-workflows.js';
+import { orchestrateLogger } from '../logger.js';
 import type { ToolResult } from '../format.js';
 
 /**
@@ -548,5 +549,252 @@ describe('handlePruneStaleWorkflows', () => {
     expect(failed?.reason).toBe('cancel-failed');
     // Only successful cancels emit events.
     expect(append).toHaveBeenCalledTimes(2);
+  });
+
+  // ─── F1: fail-closed malformed-entry validation ───────────────────────────
+  // Shepherd iter 2 (CodeRabbit finding): the handler must refuse to prune
+  // handleList entries that are missing required fields. Previously, missing
+  // `_checkpoint` was coerced to `new Date(0)` which made them look
+  // maximally stale — if handleList ever regressed (as it did in T15), every
+  // workflow would be bulk-cancelled in apply mode. The handler now moves
+  // malformed entries to a separate `malformed` bucket and excludes them
+  // from candidates/pruned entirely.
+  it('handlePruneStaleWorkflows_malformedEntries_excludedFromCandidates', async () => {
+    const { ctx } = makeEventStoreStub();
+    const deps = makeDeps();
+    // Bypass makeListResult() — it always produces valid entries — and
+    // construct a raw mixed payload directly so we can inject malformed
+    // shapes.
+    deps.listSpy.mockResolvedValue({
+      success: true,
+      data: [
+        // Valid, stale → should land in candidates + pruned
+        {
+          featureId: 'valid-stale',
+          workflowType: 'feature',
+          phase: 'implementing',
+          stateFile: '/tmp/valid-stale.state.json',
+          _checkpoint: { lastActivityTimestamp: staleIso(20_000) },
+        },
+        // Missing _checkpoint → malformed
+        {
+          featureId: 'no-checkpoint',
+          workflowType: 'feature',
+          phase: 'implementing',
+          stateFile: '/tmp/no-checkpoint.state.json',
+        },
+        // Missing featureId → malformed (and featureId omitted in report)
+        {
+          workflowType: 'feature',
+          phase: 'implementing',
+          stateFile: '/tmp/anon.state.json',
+          _checkpoint: { lastActivityTimestamp: staleIso(20_000) },
+        },
+        // Invalid timestamp string → malformed
+        {
+          featureId: 'bad-timestamp',
+          workflowType: 'feature',
+          phase: 'implementing',
+          stateFile: '/tmp/bad-timestamp.state.json',
+          _checkpoint: { lastActivityTimestamp: 'not-a-date' },
+        },
+        // Missing workflowType → malformed
+        {
+          featureId: 'no-type',
+          phase: 'implementing',
+          stateFile: '/tmp/no-type.state.json',
+          _checkpoint: { lastActivityTimestamp: staleIso(20_000) },
+        },
+      ],
+    });
+
+    // Silence the malformed-entries warning for the duration of the test —
+    // we assert on the return shape, not stderr. Also asserts the warning
+    // path fires: handler must call orchestrateLogger.warn when malformed
+    // entries are present so operators see the upstream regression.
+    const warnSpy = vi.spyOn(orchestrateLogger, 'warn').mockImplementation((() => {}) as never);
+
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      candidates: Array<{ featureId: string }>;
+      pruned: Array<{ featureId: string }>;
+      skipped: unknown[];
+      malformed: Array<{ featureId?: string; reason: string }>;
+    };
+
+    // Only the valid entry made it to candidates + pruned.
+    expect(data.candidates.map((c) => c.featureId)).toEqual(['valid-stale']);
+    expect(data.pruned.map((p) => p.featureId)).toEqual(['valid-stale']);
+
+    // The 4 malformed entries are reported separately.
+    expect(data.malformed).toHaveLength(4);
+    const malformedIds = data.malformed
+      .map((m) => m.featureId)
+      .filter((id): id is string => id !== undefined)
+      .sort();
+    // `no-checkpoint`, `bad-timestamp`, `no-type` all have featureId; the
+    // missing-featureId entry reports undefined.
+    expect(malformedIds).toEqual(['bad-timestamp', 'no-checkpoint', 'no-type']);
+    // One malformed entry has no featureId (it's the first field checked,
+    // so the missing-featureId case omits it from the report).
+    expect(
+      data.malformed.filter((m) => m.featureId === undefined),
+    ).toHaveLength(1);
+    // Every malformed entry has a human-readable reason string.
+    for (const m of data.malformed) {
+      expect(typeof m.reason).toBe('string');
+      expect(m.reason.length).toBeGreaterThan(0);
+    }
+
+    // Critical: malformed entries must NOT appear in candidates or pruned,
+    // and must NOT have been cancelled.
+    const allMalformedIds = new Set(['no-checkpoint', 'bad-timestamp', 'no-type']);
+    expect(
+      data.candidates.some((c) => allMalformedIds.has(c.featureId)),
+    ).toBe(false);
+    expect(data.pruned.some((p) => allMalformedIds.has(p.featureId))).toBe(false);
+    // handleCancel called exactly once — for the valid-stale entry only.
+    expect(deps.cancelSpy).toHaveBeenCalledTimes(1);
+    expect(
+      (deps.cancelSpy.mock.calls[0]?.[0] as { featureId: string }).featureId,
+    ).toBe('valid-stale');
+  });
+
+  // ─── F2: thresholdMinutes + now input validation ──────────────────────────
+  // Shepherd iter 2 (CodeRabbit finding): invalid `thresholdMinutes` or
+  // `now` must be rejected up front with a structured INVALID_INPUT error,
+  // BEFORE touching handleList, cancel, or the event store. A negative or
+  // NaN threshold would otherwise cause bulk-cancel in apply mode.
+  it('handlePruneStaleWorkflows_rejectsNegativeThreshold', async () => {
+    const { ctx } = makeEventStoreStub();
+    const deps = makeDeps();
+
+    const result = await handlePruneStaleWorkflows(
+      { thresholdMinutes: -1, dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toContain('thresholdMinutes');
+    // Refuses BEFORE touching handleList — no partial state changes.
+    expect(deps.listSpy).not.toHaveBeenCalled();
+    expect(deps.cancelSpy).not.toHaveBeenCalled();
+  });
+
+  it('handlePruneStaleWorkflows_rejectsZeroThreshold', async () => {
+    const { ctx } = makeEventStoreStub();
+    const deps = makeDeps();
+
+    const result = await handlePruneStaleWorkflows(
+      { thresholdMinutes: 0, dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(deps.listSpy).not.toHaveBeenCalled();
+  });
+
+  it('handlePruneStaleWorkflows_rejectsNaNThreshold', async () => {
+    const { ctx } = makeEventStoreStub();
+    const deps = makeDeps();
+
+    const result = await handlePruneStaleWorkflows(
+      { thresholdMinutes: Number.NaN, dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(deps.listSpy).not.toHaveBeenCalled();
+  });
+
+  it('handlePruneStaleWorkflows_rejectsInfiniteThreshold', async () => {
+    const { ctx } = makeEventStoreStub();
+    const deps = makeDeps();
+
+    const result = await handlePruneStaleWorkflows(
+      { thresholdMinutes: Number.POSITIVE_INFINITY, dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('handlePruneStaleWorkflows_rejectsNonIntegerThreshold', async () => {
+    const { ctx } = makeEventStoreStub();
+    const deps = makeDeps();
+
+    const result = await handlePruneStaleWorkflows(
+      { thresholdMinutes: 1.5, dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('handlePruneStaleWorkflows_rejectsInvalidNow', async () => {
+    const { ctx } = makeEventStoreStub();
+    const deps = makeDeps();
+
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: false, now: 'not-a-date' },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    expect(result.error?.message).toContain('now');
+    expect(deps.listSpy).not.toHaveBeenCalled();
+  });
+
+  it('handlePruneStaleWorkflows_defaultThreshold_appliedWhenOmitted', async () => {
+    // When `thresholdMinutes` is omitted, the handler should default to
+    // 10080 (7 days). Verify by constructing an entry that is just barely
+    // stale vs the default (10081 min) — it should be a candidate.
+    const { ctx } = makeEventStoreStub();
+    const deps = makeDeps();
+    deps.listSpy.mockResolvedValue(
+      makeListResult([
+        { featureId: 'just-stale', lastActivityTimestamp: staleIso(10_081) },
+        { featureId: 'just-fresh', lastActivityTimestamp: staleIso(10_079) },
+      ]),
+    );
+
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: true, now: NOW_ISO }, // thresholdMinutes intentionally omitted
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as { candidates: Array<{ featureId: string }> };
+    expect(data.candidates.map((c) => c.featureId)).toEqual(['just-stale']);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   selectPruneCandidates,
+  handlePruneStaleWorkflows,
   type WorkflowListEntry,
+  type PruneHandlerDeps,
+  type PruneSafeguards,
 } from './prune-stale-workflows.js';
+import type { ToolResult } from '../format.js';
 
 /**
  * Build a minimal WorkflowListEntry fixture.
@@ -134,5 +138,329 @@ describe('selectPruneCandidates', () => {
 
     expect(candidates.map((c) => c.featureId).sort()).toEqual(['f1', 'os1']);
     expect(excluded.filter((e) => e.reason === 'oneshot-excluded')).toEqual([]);
+  });
+});
+
+// ─── Handler Tests ──────────────────────────────────────────────────────────
+
+/**
+ * Build a `handleList`-shaped ToolResult payload from minimal fixture data.
+ * Includes all fields the handler's pipeline reads (featureId, workflowType,
+ * phase, stateFile, _checkpoint.lastActivityTimestamp).
+ */
+function makeListResult(
+  items: Array<{
+    featureId: string;
+    workflowType?: string;
+    phase?: string;
+    lastActivityTimestamp: string;
+  }>,
+): ToolResult {
+  return {
+    success: true,
+    data: items.map((i) => ({
+      featureId: i.featureId,
+      workflowType: i.workflowType ?? 'feature',
+      phase: i.phase ?? 'implementing',
+      stateFile: `/tmp/${i.featureId}.state.json`,
+      _checkpoint: {
+        lastActivityTimestamp: i.lastActivityTimestamp,
+      },
+    })),
+  };
+}
+
+/** Minimal append-spy stubbing the shape handler reaches through `ctx.eventStore`. */
+function makeEventStoreStub(): {
+  append: ReturnType<typeof vi.fn>;
+  ctx: { eventStore: { append: ReturnType<typeof vi.fn> } };
+} {
+  const append = vi.fn().mockResolvedValue({ sequence: 1, type: 'workflow.pruned' });
+  return { append, ctx: { eventStore: { append } } };
+}
+
+/** Build a DI bundle with stubs. Defaults: safeguards always pass, branchName present. */
+function makeDeps(overrides: Partial<PruneHandlerDeps> = {}): PruneHandlerDeps & {
+  listSpy: ReturnType<typeof vi.fn>;
+  cancelSpy: ReturnType<typeof vi.fn>;
+  branchSpy: ReturnType<typeof vi.fn>;
+  safeguards: PruneSafeguards;
+} {
+  const listSpy = vi.fn().mockResolvedValue(makeListResult([]));
+  const cancelSpy = vi
+    .fn()
+    .mockResolvedValue({ success: true, data: { phase: 'cancelled' } });
+  const branchSpy = vi.fn().mockResolvedValue('feat/x');
+  const safeguards: PruneSafeguards = {
+    hasOpenPR: vi.fn().mockResolvedValue(false),
+    hasRecentCommits: vi.fn().mockResolvedValue(false),
+  };
+  return {
+    handleList: listSpy,
+    handleCancel: cancelSpy,
+    readBranchName: branchSpy,
+    safeguards,
+    listSpy,
+    cancelSpy,
+    branchSpy,
+    ...overrides,
+  } as PruneHandlerDeps & {
+    listSpy: ReturnType<typeof vi.fn>;
+    cancelSpy: ReturnType<typeof vi.fn>;
+    branchSpy: ReturnType<typeof vi.fn>;
+    safeguards: PruneSafeguards;
+  };
+}
+
+describe('handlePruneStaleWorkflows', () => {
+  const STATE_DIR = '/tmp/exarchos-test';
+  const NOW_ISO = '2026-04-11T12:00:00.000Z';
+  function staleIso(mins: number): string {
+    return new Date(new Date(NOW_ISO).getTime() - mins * 60 * 1000).toISOString();
+  }
+
+  it('dry run returns candidates without calling cancel', async () => {
+    const { ctx } = makeEventStoreStub();
+    const deps = makeDeps();
+    deps.listSpy.mockResolvedValue(
+      makeListResult([
+        { featureId: 'stale1', lastActivityTimestamp: staleIso(20_000) },
+        { featureId: 'fresh1', lastActivityTimestamp: staleIso(60) },
+      ]),
+    );
+
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: true, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      candidates: Array<{ featureId: string }>;
+      skipped: unknown[];
+      pruned: unknown[];
+    };
+    expect(data.candidates.map((c) => c.featureId)).toEqual(['stale1']);
+    expect(data.pruned).toEqual([]);
+    expect(deps.cancelSpy).not.toHaveBeenCalled();
+    expect(ctx.eventStore.append).not.toHaveBeenCalled();
+  });
+
+  it('apply mode calls handleCancel for each approved candidate', async () => {
+    const { ctx } = makeEventStoreStub();
+    const deps = makeDeps();
+    deps.listSpy.mockResolvedValue(
+      makeListResult([
+        { featureId: 'a', lastActivityTimestamp: staleIso(20_000) },
+        { featureId: 'b', lastActivityTimestamp: staleIso(20_000) },
+      ]),
+    );
+
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect(deps.cancelSpy).toHaveBeenCalledTimes(2);
+    const calledIds = deps.cancelSpy.mock.calls.map((c) => (c[0] as { featureId: string }).featureId);
+    expect(calledIds.sort()).toEqual(['a', 'b']);
+    const data = result.data as { pruned: Array<{ featureId: string }> };
+    expect(data.pruned.map((p) => p.featureId).sort()).toEqual(['a', 'b']);
+  });
+
+  it('safeguard (open PR) skips candidate and records reason', async () => {
+    const { ctx } = makeEventStoreStub();
+    const deps = makeDeps({
+      safeguards: {
+        hasOpenPR: vi.fn().mockImplementation(async (featureId: string) => featureId === 'a'),
+        hasRecentCommits: vi.fn().mockResolvedValue(false),
+      },
+    });
+    deps.listSpy.mockResolvedValue(
+      makeListResult([
+        { featureId: 'a', lastActivityTimestamp: staleIso(20_000) },
+        { featureId: 'b', lastActivityTimestamp: staleIso(20_000) },
+      ]),
+    );
+
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    const data = result.data as {
+      pruned: Array<{ featureId: string }>;
+      skipped: Array<{ featureId: string; reason: string }>;
+    };
+    expect(data.pruned.map((p) => p.featureId)).toEqual(['b']);
+    expect(data.skipped.map((s) => s.featureId)).toEqual(['a']);
+    expect(data.skipped[0]?.reason).toBe('open-pr');
+  });
+
+  it('safeguard (recent commits) skips candidate and records reason', async () => {
+    const { ctx } = makeEventStoreStub();
+    const deps = makeDeps({
+      safeguards: {
+        hasOpenPR: vi.fn().mockResolvedValue(false),
+        hasRecentCommits: vi
+          .fn()
+          .mockImplementation(async (branch: string | undefined) => branch === 'feat/b'),
+      },
+      readBranchName: vi.fn().mockImplementation(async (id: string) => `feat/${id}`),
+    });
+    deps.listSpy.mockResolvedValue(
+      makeListResult([
+        { featureId: 'a', lastActivityTimestamp: staleIso(20_000) },
+        { featureId: 'b', lastActivityTimestamp: staleIso(20_000) },
+      ]),
+    );
+
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    const data = result.data as {
+      pruned: Array<{ featureId: string }>;
+      skipped: Array<{ featureId: string; reason: string }>;
+    };
+    expect(data.pruned.map((p) => p.featureId)).toEqual(['a']);
+    expect(data.skipped.map((s) => s.featureId)).toEqual(['b']);
+    expect(data.skipped[0]?.reason).toBe('recent-commits');
+  });
+
+  it('force=true bypasses safeguards and emits skippedSafeguards in event payload', async () => {
+    const { append, ctx } = makeEventStoreStub();
+    const deps = makeDeps({
+      safeguards: {
+        hasOpenPR: vi.fn().mockResolvedValue(true),
+        hasRecentCommits: vi.fn().mockResolvedValue(true),
+      },
+    });
+    deps.listSpy.mockResolvedValue(
+      makeListResult([{ featureId: 'a', lastActivityTimestamp: staleIso(20_000) }]),
+    );
+
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: false, force: true, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    // When forced, safeguards must not even be consulted.
+    expect(deps.safeguards.hasOpenPR).not.toHaveBeenCalled();
+    expect(deps.safeguards.hasRecentCommits).not.toHaveBeenCalled();
+    const data = result.data as { pruned: Array<{ featureId: string }> };
+    expect(data.pruned.map((p) => p.featureId)).toEqual(['a']);
+
+    // Emitted event carries the skippedSafeguards marker
+    expect(append).toHaveBeenCalledTimes(1);
+    const [streamId, payload] = append.mock.calls[0];
+    expect(streamId).toBe('a');
+    const envelope = payload as { type: string; data: Record<string, unknown> };
+    expect(envelope.type).toBe('workflow.pruned');
+    expect(envelope.data.featureId).toBe('a');
+    expect(envelope.data.skippedSafeguards).toEqual(['open-pr', 'recent-commits']);
+  });
+
+  it('emits workflow.pruned event per successful cancel', async () => {
+    const { append, ctx } = makeEventStoreStub();
+    const deps = makeDeps();
+    deps.listSpy.mockResolvedValue(
+      makeListResult([
+        { featureId: 'x', lastActivityTimestamp: staleIso(20_000) },
+        { featureId: 'y', lastActivityTimestamp: staleIso(20_000) },
+      ]),
+    );
+
+    await handlePruneStaleWorkflows(
+      { dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(append).toHaveBeenCalledTimes(2);
+    for (const call of append.mock.calls) {
+      const envelope = call[1] as { type: string; data: Record<string, unknown> };
+      expect(envelope.type).toBe('workflow.pruned');
+      expect(typeof envelope.data.featureId).toBe('string');
+      expect(envelope.data.triggeredBy).toBe('manual');
+      expect(typeof envelope.data.stalenessMinutes).toBe('number');
+    }
+  });
+
+  it('skips both safeguards when branchName missing, still prunes', async () => {
+    const { ctx } = makeEventStoreStub();
+    const deps = makeDeps({
+      readBranchName: vi.fn().mockResolvedValue(undefined),
+      safeguards: {
+        // Purposely throwing — they must not be called.
+        hasOpenPR: vi.fn().mockRejectedValue(new Error('must-not-be-called')),
+        hasRecentCommits: vi.fn().mockRejectedValue(new Error('must-not-be-called')),
+      },
+    });
+    deps.listSpy.mockResolvedValue(
+      makeListResult([{ featureId: 'nobrn', lastActivityTimestamp: staleIso(20_000) }]),
+    );
+
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(deps.safeguards.hasOpenPR).not.toHaveBeenCalled();
+    expect(deps.safeguards.hasRecentCommits).not.toHaveBeenCalled();
+    const data = result.data as { pruned: Array<{ featureId: string }> };
+    expect(data.pruned.map((p) => p.featureId)).toEqual(['nobrn']);
+  });
+
+  it('reports partial failure when one of several cancels fails', async () => {
+    const { append, ctx } = makeEventStoreStub();
+    const deps = makeDeps();
+    deps.listSpy.mockResolvedValue(
+      makeListResult([
+        { featureId: 'a', lastActivityTimestamp: staleIso(20_000) },
+        { featureId: 'b', lastActivityTimestamp: staleIso(20_000) },
+        { featureId: 'c', lastActivityTimestamp: staleIso(20_000) },
+      ]),
+    );
+    deps.cancelSpy.mockImplementation(async (args: { featureId: string }) => {
+      if (args.featureId === 'b') {
+        return { success: false, error: { code: 'CANCEL_FAILED', message: 'boom' } };
+      }
+      return { success: true, data: { phase: 'cancelled' } };
+    });
+
+    const result = await handlePruneStaleWorkflows(
+      { dryRun: false, now: NOW_ISO },
+      STATE_DIR,
+      ctx,
+      deps,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      pruned: Array<{ featureId: string }>;
+      skipped: Array<{ featureId: string; reason: string; message?: string }>;
+    };
+    expect(data.pruned.map((p) => p.featureId).sort()).toEqual(['a', 'c']);
+    const failed = data.skipped.find((s) => s.featureId === 'b');
+    expect(failed?.reason).toBe('cancel-failed');
+    // Only successful cancels emit events.
+    expect(append).toHaveBeenCalledTimes(2);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
@@ -240,10 +240,13 @@ describe('handlePruneStaleWorkflows', () => {
     const data = result.data as {
       candidates: Array<{ featureId: string }>;
       skipped: unknown[];
-      pruned: unknown[];
+      pruned?: unknown[];
     };
     expect(data.candidates.map((c) => c.featureId)).toEqual(['stale1']);
-    expect(data.pruned).toEqual([]);
+    // Dry-run must omit `pruned` entirely — surfacing an empty array would
+    // blur the distinction between "preview" and "nothing was pruned in
+    // apply mode". The design spec shape has `pruned?` for this reason.
+    expect(data).not.toHaveProperty('pruned');
     expect(deps.cancelSpy).not.toHaveBeenCalled();
     expect(ctx.eventStore.append).not.toHaveBeenCalled();
   });

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
@@ -338,7 +338,7 @@ describe('handlePruneStaleWorkflows', () => {
     };
     expect(data.pruned.map((p) => p.featureId)).toEqual(['a']);
     expect(data.skipped.map((s) => s.featureId)).toEqual(['b']);
-    expect(data.skipped[0]?.reason).toBe('recent-commits');
+    expect(data.skipped[0]?.reason).toBe('active-branch');
   });
 
   it('force=true bypasses safeguards and emits skippedSafeguards in event payload', async () => {
@@ -374,7 +374,7 @@ describe('handlePruneStaleWorkflows', () => {
     const envelope = payload as { type: string; data: Record<string, unknown> };
     expect(envelope.type).toBe('workflow.pruned');
     expect(envelope.data.featureId).toBe('a');
-    expect(envelope.data.skippedSafeguards).toEqual(['open-pr', 'recent-commits']);
+    expect(envelope.data.skippedSafeguards).toEqual(['open-pr', 'active-branch']);
   });
 
   it('emits workflow.pruned event per successful cancel', async () => {

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure selection logic for stale-workflow pruning (T7).
+ *
+ * This file intentionally contains no IO: no FS reads, no event store,
+ * no `git`/`gh` shell-outs, no `Date.now()` at module scope. Tests inject
+ * a `now` Date for deterministic staleness computation. The orchestrate
+ * handler (`handlePruneStaleWorkflows`, added later in T3) will live in
+ * the same file and compose this function with real IO.
+ */
+
+// Terminal phases are redeclared locally (rather than imported from
+// views/tools.ts where they live inside a handler scope). Values must
+// match `views/tools.ts:322`; change both in lockstep.
+const TERMINAL_PHASES = ['completed', 'cancelled'] as const;
+
+// 7 days in minutes — matches the plan's v1 default threshold.
+const DEFAULT_THRESHOLD_MINUTES = 10_080;
+
+/**
+ * Minimal subset of a workflow list entry needed for prune selection.
+ * Mirrors the shape produced by `handleList` in `workflow/tools.ts`,
+ * but only includes the fields this pure function actually reads so
+ * fixtures stay lightweight.
+ */
+export interface WorkflowListEntry {
+  featureId: string;
+  workflowType: string;
+  phase: string;
+  stateFile: string;
+  _checkpoint: {
+    lastActivityTimestamp: string;
+  };
+}
+
+export interface PruneConfig {
+  /** Minutes of inactivity before a workflow is considered stale. Default 10080 (7 days). */
+  thresholdMinutes?: number;
+  /** When false, oneshot workflows are excluded from candidates. Default true. */
+  includeOneShot?: boolean;
+}
+
+export interface PruneCandidate {
+  featureId: string;
+  workflowType: string;
+  phase: string;
+  /** Minutes since `_checkpoint.lastActivityTimestamp` at selection time. */
+  stalenessMinutes: number;
+}
+
+export interface PruneExclusion {
+  featureId: string;
+  reason: 'terminal' | 'fresh' | 'oneshot-excluded';
+}
+
+export interface PruneSelection {
+  candidates: PruneCandidate[];
+  excluded: PruneExclusion[];
+}
+
+/**
+ * Compute minutes since a checkpoint's last activity.
+ *
+ * Pure helper — takes `now` as a parameter rather than calling
+ * `Date.now()`, so callers (and tests) can inject a deterministic clock.
+ */
+function minutesSince(lastActivityTimestamp: string, now: Date): number {
+  const last = new Date(lastActivityTimestamp).getTime();
+  if (Number.isNaN(last)) return 0;
+  const diffMs = Math.max(0, now.getTime() - last);
+  return Math.floor(diffMs / (60 * 1000));
+}
+
+/** True if the entry has been inactive longer than `thresholdMinutes`. */
+function isBeyondThreshold(
+  checkpoint: { lastActivityTimestamp: string },
+  thresholdMinutes: number,
+  now: Date,
+): boolean {
+  return minutesSince(checkpoint.lastActivityTimestamp, now) > thresholdMinutes;
+}
+
+function isTerminalPhase(phase: string): boolean {
+  return (TERMINAL_PHASES as readonly string[]).includes(phase);
+}
+
+/**
+ * Pure function: given a list of workflow entries and a config, partition
+ * them into prune candidates and exclusions (with reasons).
+ *
+ * Exclusion precedence (highest first):
+ *   1. terminal phase  → reason: 'terminal'
+ *   2. oneshot filter  → reason: 'oneshot-excluded' (only when `includeOneShot === false`)
+ *   3. freshness       → reason: 'fresh'
+ *
+ * @param entries  Workflow summaries (typically from `handleList`).
+ * @param config   Threshold + oneshot toggle; all fields optional.
+ * @param now      Injectable clock for deterministic tests. Defaults to `new Date()`.
+ */
+export function selectPruneCandidates(
+  entries: WorkflowListEntry[],
+  config: PruneConfig = {},
+  now: Date = new Date(),
+): PruneSelection {
+  const thresholdMinutes = config.thresholdMinutes ?? DEFAULT_THRESHOLD_MINUTES;
+  const includeOneShot = config.includeOneShot ?? true;
+
+  const candidates: PruneCandidate[] = [];
+  const excluded: PruneExclusion[] = [];
+
+  for (const entry of entries) {
+    if (isTerminalPhase(entry.phase)) {
+      excluded.push({ featureId: entry.featureId, reason: 'terminal' });
+      continue;
+    }
+
+    if (!includeOneShot && entry.workflowType === 'oneshot') {
+      excluded.push({ featureId: entry.featureId, reason: 'oneshot-excluded' });
+      continue;
+    }
+
+    if (!isBeyondThreshold(entry._checkpoint, thresholdMinutes, now)) {
+      excluded.push({ featureId: entry.featureId, reason: 'fresh' });
+      continue;
+    }
+
+    candidates.push({
+      featureId: entry.featureId,
+      workflowType: entry.workflowType,
+      phase: entry.phase,
+      stalenessMinutes: minutesSince(entry._checkpoint.lastActivityTimestamp, now),
+    });
+  }
+
+  return { candidates, excluded };
+}

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
@@ -22,13 +22,9 @@ import type { DispatchContext } from '../core/dispatch.js';
 import type { EventType } from '../event-store/schemas.js';
 import { handleList } from '../workflow/tools.js';
 import { handleCancel } from '../workflow/cancel.js';
+import { isTerminalPhase as baseIsTerminalPhase } from '../workflow/terminal-phases.js';
 import { defaultSafeguards, type PruneSafeguards } from './prune-safeguards.js';
 export type { PruneSafeguards } from './prune-safeguards.js';
-
-// Terminal phases are redeclared locally (rather than imported from
-// views/tools.ts where they live inside a handler scope). Values must
-// match `views/tools.ts:322`; change both in lockstep.
-const TERMINAL_PHASES = ['completed', 'cancelled'] as const;
 
 // 7 days in minutes — matches the plan's v1 default threshold.
 const DEFAULT_THRESHOLD_MINUTES = 10_080;
@@ -97,7 +93,7 @@ function isBeyondThreshold(
 }
 
 function isTerminalPhase(phase: string): boolean {
-  return (TERMINAL_PHASES as readonly string[]).includes(phase);
+  return baseIsTerminalPhase(phase);
 }
 
 /**
@@ -194,7 +190,17 @@ export interface PruneHandlerDeps {
 
 export interface PruneSkipped {
   featureId: string;
-  reason: 'open-pr' | 'recent-commits' | 'cancel-failed';
+  /**
+   * Why this candidate was skipped rather than pruned.
+   * - `open-pr`              — safeguard: an open PR exists for the branch
+   * - `recent-commits`       — safeguard: commits landed within the recency window
+   * - `cancel-failed`        — `handleCancel` returned `success: false`
+   * - `event-append-failed`  — cancel succeeded but appending `workflow.pruned`
+   *                            to the event store threw; the workflow is
+   *                            cancelled on disk but NOT counted as pruned,
+   *                            because the audit trail is incomplete
+   */
+  reason: 'open-pr' | 'recent-commits' | 'cancel-failed' | 'event-append-failed';
   message?: string;
 }
 
@@ -293,6 +299,103 @@ function extractListEntries(result: ToolResult): WorkflowListEntry[] {
  * and get `productionDeps(ctx)` with real `handleList`, `handleCancel`, and
  * `gh`/`git`-backed safeguards.
  */
+// All safeguards, in evaluation order, echoed on the audit event when
+// `force` bypasses them.
+const ALL_SKIPPED_SAFEGUARDS = ['open-pr', 'recent-commits'] as const;
+
+/**
+ * Per-candidate classification returned by {@link prunePruneCandidate}. The
+ * main loop consumes this into `skipped` / `pruned` result arrays; the shape
+ * mirrors the union so double-accounting is structurally impossible.
+ */
+type CandidateOutcome =
+  | { kind: 'skipped'; entry: PruneSkipped }
+  | { kind: 'pruned'; entry: PrunePruned };
+
+/**
+ * Apply-mode body for a single prune candidate. Evaluates safeguards, calls
+ * cancel, and emits the `workflow.pruned` audit event. Returns exactly one
+ * `CandidateOutcome` — either `skipped` (with a reason) or `pruned`. HIGH-2
+ * fix: event-append failure records a distinct `event-append-failed` reason
+ * and does NOT also push onto `pruned`.
+ */
+async function prunePruneCandidate(
+  candidate: PruneCandidate,
+  deps: PruneHandlerDeps,
+  eventStore: NonNullable<DispatchContext['eventStore']>,
+  force: boolean,
+  stateDir: string,
+): Promise<CandidateOutcome> {
+  const branchName = await deps.readBranchName(candidate.featureId, stateDir);
+
+  // Safeguard evaluation. `force` bypasses them entirely but records the
+  // marker list on the emitted event for audit. A missing branchName also
+  // short-circuits both checks (nothing to look up).
+  if (!force && branchName !== undefined) {
+    if (await deps.safeguards.hasOpenPR(candidate.featureId, branchName)) {
+      return { kind: 'skipped', entry: { featureId: candidate.featureId, reason: 'open-pr' } };
+    }
+    if (await deps.safeguards.hasRecentCommits(branchName, RECENT_COMMITS_WINDOW_HOURS)) {
+      return {
+        kind: 'skipped',
+        entry: { featureId: candidate.featureId, reason: 'recent-commits' },
+      };
+    }
+  }
+
+  // Cancel. On failure, record in `skipped` and move on — partial batches
+  // are acceptable per design (risk #4 in the plan).
+  const cancelResult = await deps.handleCancel(
+    { featureId: candidate.featureId, reason: 'stale-prune' },
+    stateDir,
+  );
+  if (!cancelResult.success) {
+    return {
+      kind: 'skipped',
+      entry: {
+        featureId: candidate.featureId,
+        reason: 'cancel-failed',
+        ...(cancelResult.error?.message ? { message: cancelResult.error.message } : {}),
+      },
+    };
+  }
+
+  // Emit workflow.pruned audit event. If this throws, the cancel already
+  // landed on disk but the audit trail is incomplete — we classify the
+  // feature as `event-append-failed` and do NOT record it in `pruned`.
+  // Previously we did both, which meant a single feature could appear in
+  // two result arrays with contradictory semantics (HIGH-2).
+  try {
+    await eventStore.append(candidate.featureId, {
+      type: 'workflow.pruned' as EventType,
+      data: {
+        featureId: candidate.featureId,
+        stalenessMinutes: candidate.stalenessMinutes,
+        triggeredBy: 'manual',
+        ...(force ? { skippedSafeguards: [...ALL_SKIPPED_SAFEGUARDS] } : {}),
+      },
+    });
+  } catch (err) {
+    return {
+      kind: 'skipped',
+      entry: {
+        featureId: candidate.featureId,
+        reason: 'event-append-failed',
+        message: `Pruned but event append failed: ${err instanceof Error ? err.message : String(err)}`,
+      },
+    };
+  }
+
+  return {
+    kind: 'pruned',
+    entry: {
+      featureId: candidate.featureId,
+      stalenessMinutes: candidate.stalenessMinutes,
+      ...(force ? { skippedSafeguards: [...ALL_SKIPPED_SAFEGUARDS] } : {}),
+    },
+  };
+}
+
 export async function handlePruneStaleWorkflows(
   args: PruneHandlerArgs,
   stateDir: string,
@@ -304,6 +407,22 @@ export async function handlePruneStaleWorkflows(
   const dryRun = args.dryRun ?? true;
   const force = args.force ?? false;
   const now = args.now ? new Date(args.now) : new Date();
+
+  // Apply-mode precondition: we MUST have an eventStore to emit the
+  // `workflow.pruned` audit event. Silently no-opping on the append (the
+  // previous behavior via `ctx?.eventStore.append(...)`) would let the
+  // cancel land on disk while the audit trail stayed blank — a contract
+  // break. Return a structured error instead. (MEDIUM-1)
+  if (!dryRun && !ctx?.eventStore) {
+    return {
+      success: false,
+      error: {
+        code: 'MISSING_CONTEXT',
+        message:
+          'prune-stale-workflows: ctx.eventStore is required in apply mode; refusing to cancel workflows without an audit trail',
+      },
+    };
+  }
 
   // 1. Fetch the full workflow list.
   const listResult = await deps.handleList(stateDir);
@@ -334,71 +453,19 @@ export async function handlePruneStaleWorkflows(
     return { success: true, data: result };
   }
 
-  // 4. Apply mode: safeguard loop → cancel loop → event emission.
+  // 4. Apply mode: classify each candidate via the per-candidate helper.
   const skipped: PruneSkipped[] = [];
   const pruned: PrunePruned[] = [];
-  const allSkippedSafeguards = ['open-pr', 'recent-commits'] as const;
+  // Narrowed above — the early return guarantees `ctx.eventStore` exists.
+  const eventStore = ctx!.eventStore!;
 
   for (const candidate of candidates) {
-    const branchName = await deps.readBranchName(candidate.featureId, stateDir);
-
-    // Safeguard evaluation. `force` bypasses them entirely but records the
-    // marker list on the emitted event for audit. A missing branchName also
-    // short-circuits both checks (nothing to look up).
-    if (!force && branchName !== undefined) {
-      if (await deps.safeguards.hasOpenPR(candidate.featureId, branchName)) {
-        skipped.push({ featureId: candidate.featureId, reason: 'open-pr' });
-        continue;
-      }
-      if (await deps.safeguards.hasRecentCommits(branchName, RECENT_COMMITS_WINDOW_HOURS)) {
-        skipped.push({ featureId: candidate.featureId, reason: 'recent-commits' });
-        continue;
-      }
+    const outcome = await prunePruneCandidate(candidate, deps, eventStore, force, stateDir);
+    if (outcome.kind === 'skipped') {
+      skipped.push(outcome.entry);
+    } else {
+      pruned.push(outcome.entry);
     }
-
-    // Cancel. On failure, record in `skipped` and move on — partial batches
-    // are acceptable per design (risk #4 in the plan).
-    const cancelResult = await deps.handleCancel(
-      { featureId: candidate.featureId, reason: 'stale-prune' },
-      stateDir,
-    );
-    if (!cancelResult.success) {
-      skipped.push({
-        featureId: candidate.featureId,
-        reason: 'cancel-failed',
-        ...(cancelResult.error?.message ? { message: cancelResult.error.message } : {}),
-      });
-      continue;
-    }
-
-    // Emit workflow.pruned audit event.
-    const eventPayload: PrunePruned = {
-      featureId: candidate.featureId,
-      stalenessMinutes: candidate.stalenessMinutes,
-      ...(force ? { skippedSafeguards: [...allSkippedSafeguards] } : {}),
-    };
-    try {
-      await ctx?.eventStore.append(candidate.featureId, {
-        type: 'workflow.pruned' as EventType,
-        data: {
-          featureId: candidate.featureId,
-          stalenessMinutes: candidate.stalenessMinutes,
-          triggeredBy: 'manual',
-          ...(force ? { skippedSafeguards: [...allSkippedSafeguards] } : {}),
-        },
-      });
-    } catch (err) {
-      // Event append failure is non-fatal: the cancel already happened.
-      // Record the feature in `pruned` anyway so the caller sees it, and
-      // annotate the event emission failure in an adjacent `skipped` entry
-      // so auditing is not silent.
-      skipped.push({
-        featureId: candidate.featureId,
-        reason: 'cancel-failed',
-        message: `Pruned but event append failed: ${err instanceof Error ? err.message : String(err)}`,
-      });
-    }
-    pruned.push(eventPayload);
   }
 
   const result: PruneHandlerResult = { candidates, skipped, pruned };

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
@@ -193,14 +193,19 @@ export interface PruneSkipped {
   /**
    * Why this candidate was skipped rather than pruned.
    * - `open-pr`              — safeguard: an open PR exists for the branch
-   * - `recent-commits`       — safeguard: commits landed within the recency window
+   * - `active-branch`        — safeguard: commits landed on the branch
+   *                            within the recency window
+   *                            (user-facing name from the prune-workflows
+   *                            skill and design doc; the implementation
+   *                            detail — a `git log --since` window — is
+   *                            on the `hasRecentCommits` backend)
    * - `cancel-failed`        — `handleCancel` returned `success: false`
    * - `event-append-failed`  — cancel succeeded but appending `workflow.pruned`
    *                            to the event store threw; the workflow is
    *                            cancelled on disk but NOT counted as pruned,
    *                            because the audit trail is incomplete
    */
-  reason: 'open-pr' | 'recent-commits' | 'cancel-failed' | 'event-append-failed';
+  reason: 'open-pr' | 'active-branch' | 'cancel-failed' | 'event-append-failed';
   message?: string;
 }
 
@@ -306,8 +311,11 @@ function extractListEntries(result: ToolResult): WorkflowListEntry[] {
  * `gh`/`git`-backed safeguards.
  */
 // All safeguards, in evaluation order, echoed on the audit event when
-// `force` bypasses them.
-const ALL_SKIPPED_SAFEGUARDS = ['open-pr', 'recent-commits'] as const;
+// `force` bypasses them. The names here are the user-facing reason keys
+// (matching the `prune-workflows` skill and design doc); internal backends
+// may use different names (e.g. `hasRecentCommits` is the git-backed
+// implementation for `active-branch`).
+const ALL_SKIPPED_SAFEGUARDS = ['open-pr', 'active-branch'] as const;
 
 /**
  * Per-candidate classification returned by {@link prunePruneCandidate}. The
@@ -344,7 +352,7 @@ async function prunePruneCandidate(
     if (await deps.safeguards.hasRecentCommits(branchName, RECENT_COMMITS_WINDOW_HOURS)) {
       return {
         kind: 'skipped',
-        entry: { featureId: candidate.featureId, reason: 'recent-commits' },
+        entry: { featureId: candidate.featureId, reason: 'active-branch' },
       };
     }
   }

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
@@ -23,6 +23,7 @@ import type { EventType } from '../event-store/schemas.js';
 import { handleList } from '../workflow/tools.js';
 import { handleCancel } from '../workflow/cancel.js';
 import { isTerminalPhase as baseIsTerminalPhase } from '../workflow/terminal-phases.js';
+import { orchestrateLogger } from '../logger.js';
 import { defaultSafeguards, type PruneSafeguards } from './prune-safeguards.js';
 export type { PruneSafeguards } from './prune-safeguards.js';
 
@@ -68,6 +69,20 @@ export interface PruneExclusion {
 export interface PruneSelection {
   candidates: PruneCandidate[];
   excluded: PruneExclusion[];
+}
+
+/**
+ * Describes a `handleList` entry that failed structural validation. These
+ * entries are excluded from prune selection entirely — the handler will
+ * never consider them candidates, so a regressed `handleList` shape cannot
+ * silently cause bulk-cancellation of active work (see T15 integration bug).
+ *
+ * `featureId` is optional because the entry may be missing that field —
+ * it's the first thing we'd want to look up, so we include it when we have it.
+ */
+export interface PruneMalformedEntry {
+  featureId?: string;
+  reason: string;
 }
 
 /**
@@ -225,6 +240,17 @@ export interface PruneHandlerResult {
    * this was a preview". Matches the shape in the 2026-04-11 design.
    */
   pruned?: PrunePruned[];
+  /**
+   * `handleList` entries that failed structural validation (missing
+   * `featureId`, `workflowType`, `phase`, or a parsable
+   * `_checkpoint.lastActivityTimestamp`). Present when at least one entry
+   * was rejected. Malformed entries are NEVER considered candidates or
+   * pruned — this is fail-closed behavior: if `handleList` regresses, we
+   * refuse to guess at identity/staleness rather than silently cancelling
+   * active workflows. Operators should see this field and fix the upstream
+   * shape.
+   */
+  malformed?: PruneMalformedEntry[];
 }
 
 /** Default branch-name reader: reads the state JSON and returns a top-level
@@ -263,33 +289,108 @@ function productionDeps(_ctx?: DispatchContext): PruneHandlerDeps {
 /**
  * Narrow `handleList`'s opaque payload to the entry shape this module needs.
  *
- * `handleList` in `workflow/tools.ts` exposes `_checkpoint` on each entry so
- * we can read `lastActivityTimestamp` directly. Earlier revisions omitted
- * `_checkpoint`, which made every non-terminal workflow fall through to the
- * epoch fallback and appear maximally stale — the freshness filter became a
- * no-op. The fallback below is now only a last-resort guard for legacy or
- * malformed entries; see the T15 integration test for an end-to-end gate.
+ * Fail-closed validation (F1, shepherd iter 2): every entry must supply a
+ * non-empty `featureId`, non-empty `workflowType`, string `phase`, and a
+ * parsable `_checkpoint.lastActivityTimestamp`. Entries missing any of
+ * those fields are moved to a separate `malformed` bucket and excluded
+ * from selection entirely.
+ *
+ * Earlier revisions coerced missing fields with defaults (`new Date(0)`,
+ * `'feature'`, `'unknown'`). That meant a single upstream regression in
+ * `handleList` — which already happened once, see the T15 integration
+ * test — could silently classify every active workflow as "maximally
+ * stale" and bulk-cancel them in apply mode. We now refuse to guess.
  */
-function extractListEntries(result: ToolResult): WorkflowListEntry[] {
-  if (!result.success || !Array.isArray(result.data)) return [];
+function extractListEntries(result: ToolResult): {
+  entries: WorkflowListEntry[];
+  malformed: PruneMalformedEntry[];
+} {
+  if (!result.success || !Array.isArray(result.data)) {
+    return { entries: [], malformed: [] };
+  }
+
   const entries: WorkflowListEntry[] = [];
+  const malformed: PruneMalformedEntry[] = [];
+
   for (const raw of result.data) {
-    if (typeof raw !== 'object' || raw === null) continue;
+    if (typeof raw !== 'object' || raw === null) {
+      malformed.push({ reason: 'entry is not an object' });
+      continue;
+    }
     const obj = raw as Record<string, unknown>;
-    const checkpoint = obj._checkpoint as { lastActivityTimestamp?: unknown } | undefined;
-    const lastActivityTimestamp =
-      typeof checkpoint?.lastActivityTimestamp === 'string'
-        ? checkpoint.lastActivityTimestamp
-        : new Date(0).toISOString();
+
+    // Capture featureId eagerly (even if invalid) so malformed reports can
+    // reference *which* entry failed — critical for operators debugging
+    // handleList regressions.
+    const featureIdRaw = obj.featureId;
+    const featureIdForReport =
+      typeof featureIdRaw === 'string' && featureIdRaw.length > 0 ? featureIdRaw : undefined;
+
+    if (typeof featureIdRaw !== 'string' || featureIdRaw.length === 0) {
+      malformed.push({ reason: 'missing or empty featureId' });
+      continue;
+    }
+
+    const workflowTypeRaw = obj.workflowType;
+    if (typeof workflowTypeRaw !== 'string' || workflowTypeRaw.length === 0) {
+      malformed.push({
+        featureId: featureIdForReport,
+        reason: 'missing or empty workflowType',
+      });
+      continue;
+    }
+
+    const phaseRaw = obj.phase;
+    if (typeof phaseRaw !== 'string') {
+      malformed.push({
+        featureId: featureIdForReport,
+        reason: 'missing or non-string phase',
+      });
+      continue;
+    }
+
+    const checkpointRaw = obj._checkpoint;
+    if (typeof checkpointRaw !== 'object' || checkpointRaw === null) {
+      malformed.push({
+        featureId: featureIdForReport,
+        reason: 'missing _checkpoint',
+      });
+      continue;
+    }
+    const checkpoint = checkpointRaw as Record<string, unknown>;
+
+    const lastActivityTimestampRaw = checkpoint.lastActivityTimestamp;
+    if (typeof lastActivityTimestampRaw !== 'string') {
+      malformed.push({
+        featureId: featureIdForReport,
+        reason: 'missing _checkpoint.lastActivityTimestamp',
+      });
+      continue;
+    }
+    // Reject unparsable ISO strings — `new Date("not-a-date").valueOf()`
+    // is NaN. If we accepted these, `minutesSince()` would return 0 via
+    // its own NaN guard and the entry would be classified as fresh, which
+    // is silent misclassification, not fail-closed.
+    if (Number.isNaN(new Date(lastActivityTimestampRaw).valueOf())) {
+      malformed.push({
+        featureId: featureIdForReport,
+        reason: 'unparsable _checkpoint.lastActivityTimestamp',
+      });
+      continue;
+    }
+
+    const stateFile = typeof obj.stateFile === 'string' ? obj.stateFile : '';
+
     entries.push({
-      featureId: String(obj.featureId ?? ''),
-      workflowType: String(obj.workflowType ?? 'feature'),
-      phase: String(obj.phase ?? 'unknown'),
-      stateFile: String(obj.stateFile ?? ''),
-      _checkpoint: { lastActivityTimestamp },
+      featureId: featureIdRaw,
+      workflowType: workflowTypeRaw,
+      phase: phaseRaw,
+      stateFile,
+      _checkpoint: { lastActivityTimestamp: lastActivityTimestampRaw },
     });
   }
-  return entries;
+
+  return { entries, malformed };
 }
 
 /**
@@ -416,7 +517,44 @@ export async function handlePruneStaleWorkflows(
   ctx?: DispatchContext,
   deps: PruneHandlerDeps = productionDeps(ctx),
 ): Promise<ToolResult> {
-  const thresholdMinutes = args.thresholdMinutes;
+  // ─── F2: up-front input validation ──────────────────────────────────────
+  // We reject invalid inputs BEFORE touching `handleList`, cancel, or the
+  // event store. A negative/NaN/Infinity `thresholdMinutes` or unparsable
+  // `now` would otherwise skew selection semantics — in apply mode, a
+  // `thresholdMinutes: -1` would classify every workflow as stale and
+  // bulk-cancel them. Fail closed with a structured error instead.
+  if (args.thresholdMinutes !== undefined) {
+    const t = args.thresholdMinutes;
+    if (
+      typeof t !== 'number' ||
+      !Number.isFinite(t) ||
+      !Number.isInteger(t) ||
+      t <= 0
+    ) {
+      return {
+        success: false,
+        error: {
+          code: 'INVALID_INPUT',
+          message: `thresholdMinutes must be a positive integer (got: ${String(t)})`,
+        },
+      };
+    }
+  }
+  if (args.now !== undefined) {
+    if (typeof args.now !== 'string' || Number.isNaN(new Date(args.now).valueOf())) {
+      return {
+        success: false,
+        error: {
+          code: 'INVALID_INPUT',
+          message: `now must be a valid ISO datetime string (got: ${String(args.now)})`,
+        },
+      };
+    }
+  }
+
+  // Apply validated/defaulted values. `thresholdMinutes` defaults to the
+  // v1 spec default (7 days) when absent; `now` defaults to `new Date()`.
+  const thresholdMinutes = args.thresholdMinutes ?? DEFAULT_THRESHOLD_MINUTES;
   const includeOneShot = args.includeOneShot;
   const dryRun = args.dryRun ?? true;
   const force = args.force ?? false;
@@ -449,13 +587,29 @@ export async function handlePruneStaleWorkflows(
       },
     };
   }
-  const entries = extractListEntries(listResult);
+  const { entries, malformed } = extractListEntries(listResult);
+
+  // Loud warning when malformed entries are present: operators need to
+  // see this in logs, not just in the return shape. Failing closed means
+  // these entries won't be pruned — but if it's a systemic regression in
+  // `handleList`, *every* entry may be malformed and nothing will be
+  // pruned, which looks the same as "nothing to prune" unless we log.
+  if (malformed.length > 0) {
+    orchestrateLogger.warn(
+      {
+        action: 'prune_stale_workflows',
+        malformedCount: malformed.length,
+        firstMalformed: malformed[0],
+      },
+      'malformed handleList entries excluded from prune consideration',
+    );
+  }
 
   // 2. Pure selection.
   const { candidates } = selectPruneCandidates(
     entries,
     {
-      ...(thresholdMinutes !== undefined ? { thresholdMinutes } : {}),
+      thresholdMinutes,
       ...(includeOneShot !== undefined ? { includeOneShot } : {}),
     },
     now,
@@ -465,7 +619,11 @@ export async function handlePruneStaleWorkflows(
   // comment on PruneHandlerResult. Callers can distinguish dry-run from
   // apply mode by the presence/absence of the field.
   if (dryRun) {
-    const result: PruneHandlerResult = { candidates, skipped: [] };
+    const result: PruneHandlerResult = {
+      candidates,
+      skipped: [],
+      ...(malformed.length > 0 ? { malformed } : {}),
+    };
     return { success: true, data: result };
   }
 
@@ -484,6 +642,11 @@ export async function handlePruneStaleWorkflows(
     }
   }
 
-  const result: PruneHandlerResult = { candidates, skipped, pruned };
+  const result: PruneHandlerResult = {
+    candidates,
+    skipped,
+    pruned,
+    ...(malformed.length > 0 ? { malformed } : {}),
+  };
   return { success: true, data: result };
 }

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
@@ -1,12 +1,29 @@
 /**
- * Pure selection logic for stale-workflow pruning (T7).
+ * Stale-workflow pruning.
  *
- * This file intentionally contains no IO: no FS reads, no event store,
- * no `git`/`gh` shell-outs, no `Date.now()` at module scope. Tests inject
- * a `now` Date for deterministic staleness computation. The orchestrate
- * handler (`handlePruneStaleWorkflows`, added later in T3) will live in
- * the same file and compose this function with real IO.
+ * Two layers in this module:
+ *
+ * 1. `selectPruneCandidates` (T7) — a pure function. No IO, no clock,
+ *    no shell-outs. Takes an entry list and returns candidates + exclusions.
+ *    Tests inject a deterministic `now`.
+ *
+ * 2. `handlePruneStaleWorkflows` (T3) — the orchestrate handler that
+ *    composes the pure selector with real IO: `handleList`, `handleCancel`,
+ *    a `ctx.eventStore` for emitting `workflow.pruned`, and the safeguard
+ *    backends in `prune-safeguards.ts`. All IO seams are wrapped in a
+ *    `PruneHandlerDeps` bundle that defaults to production implementations,
+ *    so tests can pass stubs instead of shelling out to `gh`/`git`.
  */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { ToolResult } from '../format.js';
+import type { DispatchContext } from '../core/dispatch.js';
+import type { EventType } from '../event-store/schemas.js';
+import { handleList } from '../workflow/tools.js';
+import { handleCancel } from '../workflow/cancel.js';
+import { defaultSafeguards, type PruneSafeguards } from './prune-safeguards.js';
+export type { PruneSafeguards } from './prune-safeguards.js';
 
 // Terminal phases are redeclared locally (rather than imported from
 // views/tools.ts where they live inside a handler scope). Values must
@@ -132,4 +149,249 @@ export function selectPruneCandidates(
   }
 
   return { candidates, excluded };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Handler (T3)
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Window used when asking `hasRecentCommits`. The design locks this at 24h
+// for v1; expose it as a constant so tests can see the contract even though
+// the value isn't configurable through the public handler args yet.
+const RECENT_COMMITS_WINDOW_HOURS = 24;
+
+/**
+ * Input args accepted by the handler. All fields optional with safe defaults:
+ *   thresholdMinutes → 10080 (7 days)
+ *   dryRun           → true   (refuses to mutate unless explicitly disabled)
+ *   force            → false  (bypass safeguards)
+ *   includeOneShot   → true
+ *   now              → current time (injectable as ISO string for tests)
+ */
+export interface PruneHandlerArgs {
+  thresholdMinutes?: number;
+  dryRun?: boolean;
+  force?: boolean;
+  includeOneShot?: boolean;
+  /** Test-only override for the selection clock. */
+  now?: string;
+}
+
+/**
+ * Injectable IO seams. Production wiring is `productionDeps(stateDir, ctx)`.
+ * Tests construct their own instance and pass it as the 4th handler arg.
+ */
+export interface PruneHandlerDeps {
+  handleList: (stateDir: string) => Promise<ToolResult>;
+  handleCancel: (
+    args: { featureId: string; reason?: string },
+    stateDir: string,
+  ) => Promise<ToolResult>;
+  /** Reads the top-level branchName from a workflow state file. */
+  readBranchName: (featureId: string, stateDir: string) => Promise<string | undefined>;
+  safeguards: PruneSafeguards;
+}
+
+export interface PruneSkipped {
+  featureId: string;
+  reason: 'open-pr' | 'recent-commits' | 'cancel-failed';
+  message?: string;
+}
+
+export interface PrunePruned {
+  featureId: string;
+  stalenessMinutes: number;
+  skippedSafeguards?: string[];
+}
+
+export interface PruneHandlerResult {
+  candidates: PruneCandidate[];
+  skipped: PruneSkipped[];
+  pruned: PrunePruned[];
+}
+
+/** Default branch-name reader: reads the state JSON and returns a top-level
+ *  `branchName` field if present. Workflows without one get `undefined`,
+ *  which short-circuits both safeguards in the handler. */
+async function defaultReadBranchName(
+  featureId: string,
+  stateDir: string,
+): Promise<string | undefined> {
+  try {
+    const stateFile = path.join(stateDir, `${featureId}.state.json`);
+    const raw = await fs.readFile(stateFile, 'utf-8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const branchName = parsed.branchName;
+    return typeof branchName === 'string' && branchName.length > 0 ? branchName : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Production dep bundle — real `handleList`/`handleCancel` + default safeguards. */
+function productionDeps(_ctx?: DispatchContext): PruneHandlerDeps {
+  return {
+    handleList: (stateDir) => handleList({}, stateDir),
+    handleCancel: (args, stateDir) =>
+      handleCancel(
+        { featureId: args.featureId, reason: args.reason ?? 'stale-prune' },
+        stateDir,
+        _ctx?.eventStore ?? null,
+      ),
+    readBranchName: defaultReadBranchName,
+    safeguards: defaultSafeguards(),
+  };
+}
+
+/** Narrow `handleList`'s opaque payload to the entry shape this module needs. */
+function extractListEntries(result: ToolResult): WorkflowListEntry[] {
+  if (!result.success || !Array.isArray(result.data)) return [];
+  const entries: WorkflowListEntry[] = [];
+  for (const raw of result.data) {
+    if (typeof raw !== 'object' || raw === null) continue;
+    const obj = raw as Record<string, unknown>;
+    const checkpoint = obj._checkpoint as { lastActivityTimestamp?: unknown } | undefined;
+    const lastActivityTimestamp =
+      typeof checkpoint?.lastActivityTimestamp === 'string'
+        ? checkpoint.lastActivityTimestamp
+        : new Date(0).toISOString();
+    entries.push({
+      featureId: String(obj.featureId ?? ''),
+      workflowType: String(obj.workflowType ?? 'feature'),
+      phase: String(obj.phase ?? 'unknown'),
+      stateFile: String(obj.stateFile ?? ''),
+      _checkpoint: { lastActivityTimestamp },
+    });
+  }
+  return entries;
+}
+
+/**
+ * Orchestrate-action handler for `prune_stale_workflows`.
+ *
+ * Pipeline:
+ *   1. `handleList` → flatten entries
+ *   2. `selectPruneCandidates` (pure) → candidates
+ *   3. If dryRun → return candidates + empty pruned
+ *   4. Otherwise, for each candidate:
+ *      a. Read branchName from state (undefined skips safeguards)
+ *      b. Unless `force`, evaluate `hasOpenPR` → `hasRecentCommits` in order
+ *      c. On approval, invoke `handleCancel`
+ *      d. On successful cancel, emit `workflow.pruned` via `ctx.eventStore`
+ *   5. Return `{ candidates, skipped, pruned }`
+ *
+ * Deps are injected (4th arg) for testability; production callers omit it
+ * and get `productionDeps(ctx)` with real `handleList`, `handleCancel`, and
+ * `gh`/`git`-backed safeguards.
+ */
+export async function handlePruneStaleWorkflows(
+  args: PruneHandlerArgs,
+  stateDir: string,
+  ctx?: DispatchContext,
+  deps: PruneHandlerDeps = productionDeps(ctx),
+): Promise<ToolResult> {
+  const thresholdMinutes = args.thresholdMinutes;
+  const includeOneShot = args.includeOneShot;
+  const dryRun = args.dryRun ?? true;
+  const force = args.force ?? false;
+  const now = args.now ? new Date(args.now) : new Date();
+
+  // 1. Fetch the full workflow list.
+  const listResult = await deps.handleList(stateDir);
+  if (!listResult.success) {
+    return {
+      success: false,
+      error: {
+        code: 'PRUNE_LIST_FAILED',
+        message: listResult.error?.message ?? 'handleList failed',
+      },
+    };
+  }
+  const entries = extractListEntries(listResult);
+
+  // 2. Pure selection.
+  const { candidates } = selectPruneCandidates(
+    entries,
+    {
+      ...(thresholdMinutes !== undefined ? { thresholdMinutes } : {}),
+      ...(includeOneShot !== undefined ? { includeOneShot } : {}),
+    },
+    now,
+  );
+
+  // 3. Dry run short-circuit.
+  if (dryRun) {
+    const result: PruneHandlerResult = { candidates, skipped: [], pruned: [] };
+    return { success: true, data: result };
+  }
+
+  // 4. Apply mode: safeguard loop → cancel loop → event emission.
+  const skipped: PruneSkipped[] = [];
+  const pruned: PrunePruned[] = [];
+  const allSkippedSafeguards = ['open-pr', 'recent-commits'] as const;
+
+  for (const candidate of candidates) {
+    const branchName = await deps.readBranchName(candidate.featureId, stateDir);
+
+    // Safeguard evaluation. `force` bypasses them entirely but records the
+    // marker list on the emitted event for audit. A missing branchName also
+    // short-circuits both checks (nothing to look up).
+    if (!force && branchName !== undefined) {
+      if (await deps.safeguards.hasOpenPR(candidate.featureId, branchName)) {
+        skipped.push({ featureId: candidate.featureId, reason: 'open-pr' });
+        continue;
+      }
+      if (await deps.safeguards.hasRecentCommits(branchName, RECENT_COMMITS_WINDOW_HOURS)) {
+        skipped.push({ featureId: candidate.featureId, reason: 'recent-commits' });
+        continue;
+      }
+    }
+
+    // Cancel. On failure, record in `skipped` and move on — partial batches
+    // are acceptable per design (risk #4 in the plan).
+    const cancelResult = await deps.handleCancel(
+      { featureId: candidate.featureId, reason: 'stale-prune' },
+      stateDir,
+    );
+    if (!cancelResult.success) {
+      skipped.push({
+        featureId: candidate.featureId,
+        reason: 'cancel-failed',
+        ...(cancelResult.error?.message ? { message: cancelResult.error.message } : {}),
+      });
+      continue;
+    }
+
+    // Emit workflow.pruned audit event.
+    const eventPayload: PrunePruned = {
+      featureId: candidate.featureId,
+      stalenessMinutes: candidate.stalenessMinutes,
+      ...(force ? { skippedSafeguards: [...allSkippedSafeguards] } : {}),
+    };
+    try {
+      await ctx?.eventStore.append(candidate.featureId, {
+        type: 'workflow.pruned' as EventType,
+        data: {
+          featureId: candidate.featureId,
+          stalenessMinutes: candidate.stalenessMinutes,
+          triggeredBy: 'manual',
+          ...(force ? { skippedSafeguards: [...allSkippedSafeguards] } : {}),
+        },
+      });
+    } catch (err) {
+      // Event append failure is non-fatal: the cancel already happened.
+      // Record the feature in `pruned` anyway so the caller sees it, and
+      // annotate the event emission failure in an adjacent `skipped` entry
+      // so auditing is not silent.
+      skipped.push({
+        featureId: candidate.featureId,
+        reason: 'cancel-failed',
+        message: `Pruned but event append failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+    pruned.push(eventPayload);
+  }
+
+  const result: PruneHandlerResult = { candidates, skipped, pruned };
+  return { success: true, data: result };
 }

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
@@ -243,7 +243,16 @@ function productionDeps(_ctx?: DispatchContext): PruneHandlerDeps {
   };
 }
 
-/** Narrow `handleList`'s opaque payload to the entry shape this module needs. */
+/**
+ * Narrow `handleList`'s opaque payload to the entry shape this module needs.
+ *
+ * `handleList` in `workflow/tools.ts` exposes `_checkpoint` on each entry so
+ * we can read `lastActivityTimestamp` directly. Earlier revisions omitted
+ * `_checkpoint`, which made every non-terminal workflow fall through to the
+ * epoch fallback and appear maximally stale — the freshness filter became a
+ * no-op. The fallback below is now only a last-resort guard for legacy or
+ * malformed entries; see the T15 integration test for an end-to-end gate.
+ */
 function extractListEntries(result: ToolResult): WorkflowListEntry[] {
   if (!result.success || !Array.isArray(result.data)) return [];
   const entries: WorkflowListEntry[] = [];

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
@@ -213,7 +213,13 @@ export interface PrunePruned {
 export interface PruneHandlerResult {
   candidates: PruneCandidate[];
   skipped: PruneSkipped[];
-  pruned: PrunePruned[];
+  /**
+   * Only present in apply mode. Dry-run returns omit this field entirely
+   * rather than surfacing an empty array — it would misleadingly suggest
+   * "nothing was pruned" instead of "nothing could have been pruned because
+   * this was a preview". Matches the shape in the 2026-04-11 design.
+   */
+  pruned?: PrunePruned[];
 }
 
 /** Default branch-name reader: reads the state JSON and returns a top-level
@@ -287,7 +293,7 @@ function extractListEntries(result: ToolResult): WorkflowListEntry[] {
  * Pipeline:
  *   1. `handleList` → flatten entries
  *   2. `selectPruneCandidates` (pure) → candidates
- *   3. If dryRun → return candidates + empty pruned
+ *   3. If dryRun → return candidates only (pruned field omitted)
  *   4. Otherwise, for each candidate:
  *      a. Read branchName from state (undefined skips safeguards)
  *      b. Unless `force`, evaluate `hasOpenPR` → `hasRecentCommits` in order
@@ -447,9 +453,11 @@ export async function handlePruneStaleWorkflows(
     now,
   );
 
-  // 3. Dry run short-circuit.
+  // 3. Dry run short-circuit. Intentionally omit `pruned` — see type
+  // comment on PruneHandlerResult. Callers can distinguish dry-run from
+  // apply mode by the presence/absence of the field.
   if (dryRun) {
-    const result: PruneHandlerResult = { candidates, skipped: [], pruned: [] };
+    const result: PruneHandlerResult = { candidates, skipped: [] };
     return { success: true, data: result };
   }
 

--- a/servers/exarchos-mcp/src/orchestrate/request-synthesize.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/request-synthesize.test.ts
@@ -1,0 +1,209 @@
+// ─── Request Synthesize Handler Tests (T11) ────────────────────────────────
+//
+// Exercises handleRequestSynthesize:
+//   - Appends `synthesize.requested` event when workflow is oneshot
+//   - Rejects non-oneshot workflow types (feature/debug/refactor)
+//   - Rejects missing workflow state
+//   - Idempotent across multiple calls (append semantics; count >= 1 suffices
+//     for the downstream guard)
+//   - Captures optional `reason` in event data
+//   - Emits an ISO-8601 timestamp parseable as a Date
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ToolResult } from '../format.js';
+import type { EventStore } from '../event-store/store.js';
+
+// ─── Mock fs (resolve-state reads workflow state via node:fs) ──────────────
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+import { existsSync, readFileSync } from 'node:fs';
+import { handleRequestSynthesize } from './request-synthesize.js';
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeOneshotState(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    featureId: 'feat-oneshot-1',
+    workflowType: 'oneshot',
+    phase: 'delegate',
+    oneshot: { synthesisPolicy: 'on-request' },
+    ...overrides,
+  });
+}
+
+function makeFeatureState(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    featureId: 'feat-full-1',
+    workflowType: 'feature',
+    phase: 'delegate',
+    ...overrides,
+  });
+}
+
+interface AppendCall {
+  streamId: string;
+  event: {
+    type: string;
+    data?: Record<string, unknown>;
+  };
+}
+
+/** Minimal EventStore stub exposing append() as a spy that records each call. */
+function makeMockEventStore(): {
+  store: EventStore;
+  calls: AppendCall[];
+  appendSpy: ReturnType<typeof vi.fn>;
+} {
+  const calls: AppendCall[] = [];
+  const appendSpy = vi.fn(async (streamId: string, event: AppendCall['event']) => {
+    calls.push({ streamId, event });
+    return {
+      streamId,
+      sequence: calls.length,
+      type: event.type,
+      timestamp: new Date().toISOString(),
+      data: event.data ?? {},
+    };
+  });
+  const store = { append: appendSpy } as unknown as EventStore;
+  return { store, calls, appendSpy };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('handleRequestSynthesize', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('handleRequestSynthesize_appendsSynthesizeRequestedEvent', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(makeOneshotState());
+    const { store, calls } = makeMockEventStore();
+
+    const result: ToolResult = await handleRequestSynthesize({
+      featureId: 'feat-oneshot-1',
+      stateFile: '/tmp/feat-oneshot-1.state.json',
+      eventStore: store,
+    });
+
+    expect(result.success).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].streamId).toBe('feat-oneshot-1');
+    expect(calls[0].event.type).toBe('synthesize.requested');
+    const data = calls[0].event.data as Record<string, unknown>;
+    expect(data.featureId).toBe('feat-oneshot-1');
+    expect(typeof data.timestamp).toBe('string');
+
+    const resultData = result.data as { eventAppended: boolean; reason?: string };
+    expect(resultData.eventAppended).toBe(true);
+  });
+
+  it('handleRequestSynthesize_isIdempotentAcrossMultipleCalls', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(makeOneshotState());
+    const { store, calls } = makeMockEventStore();
+
+    const first = await handleRequestSynthesize({
+      featureId: 'feat-oneshot-1',
+      stateFile: '/tmp/feat-oneshot-1.state.json',
+      eventStore: store,
+    });
+    const second = await handleRequestSynthesize({
+      featureId: 'feat-oneshot-1',
+      stateFile: '/tmp/feat-oneshot-1.state.json',
+      eventStore: store,
+    });
+
+    // Both calls succeed — append semantics, not dedup
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    // Two events appended; downstream guard uses count >= 1 semantics,
+    // so replays remain safe even with multiple requests.
+    expect(calls).toHaveLength(2);
+    expect(calls[0].event.type).toBe('synthesize.requested');
+    expect(calls[1].event.type).toBe('synthesize.requested');
+  });
+
+  it('handleRequestSynthesize_rejectsNonOneshotWorkflow', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(makeFeatureState());
+    const { store, calls } = makeMockEventStore();
+
+    const result: ToolResult = await handleRequestSynthesize({
+      featureId: 'feat-full-1',
+      stateFile: '/tmp/feat-full-1.state.json',
+      eventStore: store,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_WORKFLOW_TYPE');
+    expect(result.error?.message).toMatch(/oneshot/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('handleRequestSynthesize_capturesOptionalReason', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(makeOneshotState());
+    const { store, calls } = makeMockEventStore();
+
+    const reason = 'Reviewer asked for a PR instead of direct commit';
+    const result: ToolResult = await handleRequestSynthesize({
+      featureId: 'feat-oneshot-1',
+      reason,
+      stateFile: '/tmp/feat-oneshot-1.state.json',
+      eventStore: store,
+    });
+
+    expect(result.success).toBe(true);
+    expect(calls).toHaveLength(1);
+    const data = calls[0].event.data as Record<string, unknown>;
+    expect(data.reason).toBe(reason);
+
+    const resultData = result.data as { eventAppended: boolean; reason?: string };
+    expect(resultData.reason).toBe(reason);
+  });
+
+  it('handleRequestSynthesize_rejectsNonExistentWorkflow', async () => {
+    mockExistsSync.mockReturnValue(false);
+    const { store, calls } = makeMockEventStore();
+
+    const result: ToolResult = await handleRequestSynthesize({
+      featureId: 'feat-missing',
+      stateFile: '/tmp/feat-missing.state.json',
+      eventStore: store,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('STATE_NOT_FOUND');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('handleRequestSynthesize_timestampIsISOString', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(makeOneshotState());
+    const { store, calls } = makeMockEventStore();
+
+    await handleRequestSynthesize({
+      featureId: 'feat-oneshot-1',
+      stateFile: '/tmp/feat-oneshot-1.state.json',
+      eventStore: store,
+    });
+
+    expect(calls).toHaveLength(1);
+    const data = calls[0].event.data as Record<string, unknown>;
+    const ts = data.timestamp as string;
+    const parsed = new Date(ts);
+    expect(Number.isNaN(parsed.getTime())).toBe(false);
+    // Confirm it's a full ISO-8601 string (Zod datetime() accepts only this form).
+    expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/request-synthesize.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/request-synthesize.test.ts
@@ -33,7 +33,11 @@ function makeOneshotState(overrides: Record<string, unknown> = {}): string {
   return JSON.stringify({
     featureId: 'feat-oneshot-1',
     workflowType: 'oneshot',
-    phase: 'delegate',
+    // `implementing` is the primary request-synthesize phase per the
+    // registry gating + runtime guard. `plan` is also accepted for the
+    // "I already know I'll want a PR" early-signal path.
+    phase: 'implementing',
+    createdAt: '2026-04-11T00:00:00.000Z',
     oneshot: { synthesisPolicy: 'on-request' },
     ...overrides,
   });
@@ -44,6 +48,7 @@ function makeFeatureState(overrides: Record<string, unknown> = {}): string {
     featureId: 'feat-full-1',
     workflowType: 'feature',
     phase: 'delegate',
+    createdAt: '2026-04-11T00:00:00.000Z',
     ...overrides,
   });
 }
@@ -56,7 +61,13 @@ interface AppendCall {
   };
 }
 
-/** Minimal EventStore stub exposing append() as a spy that records each call. */
+/**
+ * Minimal EventStore stub exposing `append()` and `query()`. The resolver
+ * falls back to the event-store path when the on-disk state file is
+ * missing, so we also stub `query()` to return an empty event list —
+ * the resulting zero-initialized projection then trips the STATE_NOT_FOUND
+ * sentinel in `handleRequestSynthesize`.
+ */
 function makeMockEventStore(): {
   store: EventStore;
   calls: AppendCall[];
@@ -73,7 +84,8 @@ function makeMockEventStore(): {
       data: event.data ?? {},
     };
   });
-  const store = { append: appendSpy } as unknown as EventStore;
+  const querySpy = vi.fn(async () => []);
+  const store = { append: appendSpy, query: querySpy } as unknown as EventStore;
   return { store, calls, appendSpy };
 }
 
@@ -205,5 +217,94 @@ describe('handleRequestSynthesize', () => {
     expect(Number.isNaN(parsed.getTime())).toBe(false);
     // Confirm it's a full ISO-8601 string (Zod datetime() accepts only this form).
     expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  // ─── Runtime phase guard (mirrors the registry gating) ────────────────────
+
+  it('handleRequestSynthesize_acceptsPlanPhase', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(makeOneshotState({ phase: 'plan' }));
+    const { store, calls } = makeMockEventStore();
+
+    const result = await handleRequestSynthesize({
+      featureId: 'feat-oneshot-1',
+      stateFile: '/tmp/feat-oneshot-1.state.json',
+      eventStore: store,
+    });
+
+    expect(result.success).toBe(true);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('handleRequestSynthesize_rejectsTerminalPhases_completed', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(makeOneshotState({ phase: 'completed' }));
+    const { store, calls } = makeMockEventStore();
+
+    const result = await handleRequestSynthesize({
+      featureId: 'feat-oneshot-1',
+      stateFile: '/tmp/feat-oneshot-1.state.json',
+      eventStore: store,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_PHASE');
+    expect(result.error?.message).toMatch(/completed/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('handleRequestSynthesize_rejectsTerminalPhases_cancelled', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(makeOneshotState({ phase: 'cancelled' }));
+    const { store, calls } = makeMockEventStore();
+
+    const result = await handleRequestSynthesize({
+      featureId: 'feat-oneshot-1',
+      stateFile: '/tmp/feat-oneshot-1.state.json',
+      eventStore: store,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_PHASE');
+    expect(result.error?.message).toMatch(/cancelled/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('handleRequestSynthesize_rejectsTerminalPhases_synthesize', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(makeOneshotState({ phase: 'synthesize' }));
+    const { store, calls } = makeMockEventStore();
+
+    const result = await handleRequestSynthesize({
+      featureId: 'feat-oneshot-1',
+      stateFile: '/tmp/feat-oneshot-1.state.json',
+      eventStore: store,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_PHASE');
+    expect(calls).toHaveLength(0);
+  });
+
+  // ─── stateDir fallback (replaces hardcoded .exarchos/state path) ──────────
+
+  it('handleRequestSynthesize_derivesStateFileFromStateDir', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(makeOneshotState());
+    const { store, calls } = makeMockEventStore();
+
+    // No `stateFile` provided; the handler should derive one from
+    // `stateDir + featureId` rather than the old hardcoded
+    // `.exarchos/state/...` path.
+    const result = await handleRequestSynthesize({
+      featureId: 'feat-oneshot-1',
+      stateDir: '/custom/state/dir',
+      eventStore: store,
+    });
+
+    expect(result.success).toBe(true);
+    expect(calls).toHaveLength(1);
+    // Resolver should have been asked to read from the derived path.
+    expect(mockExistsSync).toHaveBeenCalledWith('/custom/state/dir/feat-oneshot-1.state.json');
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/request-synthesize.ts
+++ b/servers/exarchos-mcp/src/orchestrate/request-synthesize.ts
@@ -1,0 +1,123 @@
+// ─── Request Synthesize Orchestrate Handler (T11) ──────────────────────────
+//
+// Runtime opt-in path for oneshot workflows with `synthesisPolicy: 'on-request'`.
+// Appending a `synthesize.requested` event flips the `synthesisOptedIn` guard
+// and routes the choice-state toward the synthesize phase instead of direct
+// commit. For `synthesisPolicy: 'always'`, this event is redundant but not
+// harmful; for `synthesisPolicy: 'never'`, the guard still short-circuits to
+// opted-out, so this handler simply records the (ignored) intent.
+//
+// Append semantics are intentional: the downstream guard uses count >= 1
+// semantics, so calling the handler twice is safe — multiple events collapse
+// to a single "opted in" decision.
+// ────────────────────────────────────────────────────────────────────────────
+
+import type { ToolResult } from '../format.js';
+import type { EventStore } from '../event-store/store.js';
+import { resolveWorkflowState } from './resolve-state.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface RequestSynthesizeArgs {
+  readonly featureId: string;
+  readonly reason?: string;
+  readonly stateFile?: string;
+  readonly eventStore?: EventStore;
+}
+
+// ─── Handler ────────────────────────────────────────────────────────────────
+
+export async function handleRequestSynthesize(
+  args: RequestSynthesizeArgs,
+): Promise<ToolResult> {
+  const { featureId, reason, eventStore } = args;
+
+  if (!featureId) {
+    return {
+      success: false,
+      error: { code: 'INVALID_INPUT', message: 'featureId is required' },
+    };
+  }
+
+  if (!eventStore) {
+    return {
+      success: false,
+      error: {
+        code: 'NO_EVENT_STORE',
+        message: 'eventStore is required to append synthesize.requested',
+      },
+    };
+  }
+
+  // Derive a default state-file path from featureId when the caller has not
+  // supplied one explicitly. This matches how other orchestrate handlers
+  // (e.g. reconcile-state) resolve workflow state on disk.
+  const stateFile =
+    args.stateFile ?? `.exarchos/state/${featureId}.state.json`;
+
+  const resolved = await resolveWorkflowState({
+    stateFile,
+    featureId,
+    eventStore,
+  });
+
+  if ('error' in resolved) {
+    // resolveWorkflowState returns NO_STATE_SOURCE when no source resolves;
+    // translate that into STATE_NOT_FOUND so the error taxonomy matches
+    // handleGet / cleanup / cancel.
+    const code = resolved.error.error?.code;
+    if (code === 'NO_STATE_SOURCE' || code === 'EVENT_STORE_ERROR') {
+      return {
+        success: false,
+        error: {
+          code: 'STATE_NOT_FOUND',
+          message: `State not found for feature: ${featureId}`,
+        },
+      };
+    }
+    return resolved.error;
+  }
+
+  const state = resolved.state;
+  const workflowType = state.workflowType;
+
+  if (workflowType !== 'oneshot') {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_WORKFLOW_TYPE',
+        message: `request_synthesize is only valid for oneshot workflows; got workflowType=${String(workflowType)}`,
+      },
+    };
+  }
+
+  // Append the synthesize.requested event. Payload matches
+  // SynthesizeRequestedData in event-store/schemas.ts (T2).
+  const timestamp = new Date().toISOString();
+  try {
+    await eventStore.append(featureId, {
+      type: 'synthesize.requested',
+      data: {
+        featureId,
+        ...(reason !== undefined ? { reason } : {}),
+        timestamp,
+      },
+    });
+  } catch (err) {
+    return {
+      success: false,
+      error: {
+        code: 'APPEND_FAILED',
+        message: `Failed to append synthesize.requested: ${err instanceof Error ? err.message : String(err)}`,
+      },
+    };
+  }
+
+  return {
+    success: true,
+    data: {
+      eventAppended: true,
+      ...(reason !== undefined ? { reason } : {}),
+    },
+  };
+}

--- a/servers/exarchos-mcp/src/orchestrate/request-synthesize.ts
+++ b/servers/exarchos-mcp/src/orchestrate/request-synthesize.ts
@@ -12,6 +12,8 @@
 // to a single "opted in" decision.
 // ────────────────────────────────────────────────────────────────────────────
 
+import * as path from 'node:path';
+
 import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { resolveWorkflowState } from './resolve-state.js';
@@ -21,9 +23,32 @@ import { resolveWorkflowState } from './resolve-state.js';
 export interface RequestSynthesizeArgs {
   readonly featureId: string;
   readonly reason?: string;
+  /**
+   * Explicit state-file path. When omitted, the handler derives one from
+   * `stateDir` + `featureId` (the composite dispatcher injects `stateDir`
+   * from the DispatchContext). When `stateDir` is also omitted, the
+   * resolver falls back to event-store materialization using only
+   * `featureId` + `eventStore`.
+   */
   readonly stateFile?: string;
+  readonly stateDir?: string;
   readonly eventStore?: EventStore;
 }
+
+/**
+ * Phases from which `request_synthesize` may be invoked. Matches the phase
+ * gating in `registry.ts:request_synthesize`: the event is idempotent and
+ * sits in the stream until `finalize_oneshot` reads it, so emitting it
+ * from `plan` (before implementing starts) is legal. Any terminal phase
+ * — `synthesize`, `completed`, `cancelled`, or any non-oneshot phase
+ * reachable via cancel — MUST be rejected at the handler boundary so a
+ * direct handler call (bypassing the registry layer) cannot corrupt the
+ * audit stream after the workflow has already been resolved.
+ */
+const REQUEST_SYNTHESIZE_ALLOWED_PHASES: ReadonlySet<string> = new Set([
+  'plan',
+  'implementing',
+]);
 
 // ─── Handler ────────────────────────────────────────────────────────────────
 
@@ -49,14 +74,21 @@ export async function handleRequestSynthesize(
     };
   }
 
-  // Derive a default state-file path from featureId when the caller has not
-  // supplied one explicitly. This matches how other orchestrate handlers
-  // (e.g. reconcile-state) resolve workflow state on disk.
+  // Defer state-file path derivation to the caller (explicit `stateFile`)
+  // or the composite dispatcher (injected `stateDir`). When neither is
+  // provided, the resolver falls back to event-store materialization from
+  // `featureId` + `eventStore`, matching the `finalize_oneshot` pattern.
+  // Previously this used a hardcoded `.exarchos/state/...` fallback that
+  // didn't match the configured workflow-state location — callers running
+  // under a non-default `stateDir` saw bogus "state not found" errors.
   const stateFile =
-    args.stateFile ?? `.exarchos/state/${featureId}.state.json`;
+    args.stateFile
+    ?? (args.stateDir
+      ? path.join(args.stateDir, `${featureId}.state.json`)
+      : undefined);
 
   const resolved = await resolveWorkflowState({
-    stateFile,
+    ...(stateFile !== undefined ? { stateFile } : {}),
     featureId,
     eventStore,
   });
@@ -81,12 +113,54 @@ export async function handleRequestSynthesize(
   const state = resolved.state;
   const workflowType = state.workflowType;
 
+  // The resolver falls back to the event-store projection when no state
+  // file exists, returning a zero-initialized view (`featureId: ''`,
+  // `createdAt: ''`, `workflowType: 'feature'`) even for feature IDs that
+  // have never emitted a single event. Treat the empty projection as
+  // "no workflow exists" so callers see a proper STATE_NOT_FOUND instead
+  // of tripping the downstream workflow-type check. Matches the sentinel
+  // used by `finalize-oneshot.ts`.
+  if (
+    state.workflowType === undefined ||
+    state.workflowType === null ||
+    state.createdAt === '' ||
+    state.featureId === ''
+  ) {
+    return {
+      success: false,
+      error: {
+        code: 'STATE_NOT_FOUND',
+        message: `State not found for feature: ${featureId}`,
+      },
+    };
+  }
+
   if (workflowType !== 'oneshot') {
     return {
       success: false,
       error: {
         code: 'INVALID_WORKFLOW_TYPE',
         message: `request_synthesize is only valid for oneshot workflows; got workflowType=${String(workflowType)}`,
+      },
+    };
+  }
+
+  // Runtime phase guard. The registry layer gates this action at the MCP
+  // tool boundary, but direct handler calls (e.g. from composite tests
+  // or sibling orchestrate handlers) bypass the registry. Without this
+  // check a terminal-phase workflow could receive a `synthesize.requested`
+  // event after `finalize_oneshot` already resolved the choice state —
+  // permanently corrupting the audit stream with a phantom opt-in signal
+  // that could be replayed on rematerialization. Explicit reject mirrors
+  // the registry's `phases: ['plan', 'implementing']` restriction.
+  const currentPhase =
+    typeof state.phase === 'string' ? state.phase : String(state.phase);
+  if (!REQUEST_SYNTHESIZE_ALLOWED_PHASES.has(currentPhase)) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_PHASE',
+        message: `request_synthesize may only be invoked from 'plan' or 'implementing'; got phase=${currentPhase}`,
       },
     };
   }

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -1178,4 +1178,17 @@ describe('Plugin Integration Registry Wiring', () => {
     });
     expect(resultWithout.success).toBe(true);
   });
+
+  it('RegistryActions_RequestSynthesize_AllowsPlanAndImplementingPhases', () => {
+    // request_synthesize must be callable from both `plan` and `implementing`
+    // phases. The synthesisOptedIn guard only fires at the implementing →
+    // choice-state boundary, so appending the event earlier (during planning)
+    // is idempotent — the event sits in the stream until finalize_oneshot
+    // reads it. Restricting to `implementing` only broke the "I know I'll
+    // want a PR" signal during planning.
+    const action = findAction('exarchos_orchestrate', 'request_synthesize');
+    expect(action, 'exarchos_orchestrate should have a request_synthesize action').toBeDefined();
+    expect(action!.phases.has('plan')).toBe(true);
+    expect(action!.phases.has('implementing')).toBe(true);
+  });
 });

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -317,10 +317,10 @@ describe('TOOL_REGISTRY', () => {
   });
 
   describe('exarchos_orchestrate', () => {
-    it('should have 51 actions for task management, review triage, gate checks, validation handlers, runbooks, agent spec, and composite actions', () => {
+    it('should have 54 actions for task management, review triage, gate checks, validation handlers, runbooks, agent spec, oneshot/pruning, and composite actions', () => {
       const composite = findComposite('exarchos_orchestrate');
       expect(composite).toBeDefined();
-      expect(composite!.actions).toHaveLength(51);
+      expect(composite!.actions).toHaveLength(54);
 
       const actionNames = composite!.actions.map((a) => a.name);
       expect(actionNames).toEqual(
@@ -373,6 +373,9 @@ describe('TOOL_REGISTRY', () => {
           'verify_doc_links',
           'verify_review_triage',
           'prepare_review',
+          'prune_stale_workflows',
+          'request_synthesize',
+          'finalize_oneshot',
         ]),
       );
     });

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -308,16 +308,20 @@ function makeEventDescribeAction(): ToolAction {
 const workflowActions: readonly ToolAction[] = [
   {
     name: 'init',
-    description: 'Initialize a new workflow. Auto-emits workflow.started event',
+    description: 'Initialize a new workflow. Auto-emits workflow.started event. For workflowType=oneshot, an optional synthesisPolicy (always | never | on-request) seeds state.oneshot.synthesisPolicy; silently ignored for other workflow types.',
     schema: z.object({
       featureId: featureIdSchema,
       workflowType: WorkflowTypeSchema,
+      synthesisPolicy: z.enum(['always', 'never', 'on-request']).optional(),
     }),
     phases: new Set<string>(),
     roles: ROLE_LEAD,
     cli: {
       flags: { featureId: { alias: 'f' }, workflowType: { alias: 't' } },
-      examples: ['exarchos wf init -f my-feature -t feature'],
+      examples: [
+        'exarchos wf init -f my-feature -t feature',
+        'exarchos wf init -f my-oneshot -t oneshot --synthesisPolicy always',
+      ],
     },
     autoEmits: [
       { event: 'workflow.started', condition: 'always' },

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -522,7 +522,6 @@ const orchestrateActions: readonly ToolAction[] = [
       })),
       activeWorkflows: z.array(z.object({ phase: z.string() })).optional(),
       pendingCodeRabbitReviews: z.number().int().nonnegative().optional(),
-      basileusConnected: z.boolean().optional(),
     }),
     phases: REVIEW_PHASES,
     roles: ROLE_LEAD,

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -1117,7 +1117,12 @@ const orchestrateActions: readonly ToolAction[] = [
       featureId: featureIdSchema,
       reason: z.string().optional(),
     }),
-    phases: new Set<string>(['implementing']),
+    // Allowed from `plan` as well as `implementing`: the synthesisOptedIn
+    // guard only fires at the `implementing → ?` choice-state boundary, so
+    // emitting the event earlier is idempotent — it sits in the event stream
+    // until finalize_oneshot reads it. Restricting to `implementing` broke
+    // the "I know I'll want a PR" signal during planning.
+    phases: new Set<string>(['plan', 'implementing']),
     roles: ROLE_LEAD,
     autoEmits: [
       { event: 'synthesize.requested', condition: 'always' },

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -1093,6 +1093,43 @@ const orchestrateActions: readonly ToolAction[] = [
     gate: { blocking: false },
   },
   {
+    name: 'prune_stale_workflows',
+    description: 'Find stale non-terminal workflows and cancel them. Defaults to dry-run; pass dryRun:false to actually prune. Auto-emits workflow.pruned event per pruned workflow.',
+    schema: z.object({
+      thresholdMinutes: z.number().int().positive().optional(),
+      dryRun: z.boolean().optional(),
+      force: z.boolean().optional(),
+      includeOneShot: z.boolean().optional(),
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_LEAD,
+    autoEmits: [
+      { event: 'workflow.pruned', condition: 'conditional', description: 'Per pruned workflow when dryRun is false' },
+    ],
+  },
+  {
+    name: 'request_synthesize',
+    description: 'Opt-in event for oneshot workflows with synthesisPolicy:on-request. Appending a synthesize.requested event flips the choice-state guard so finalize_oneshot routes to the synthesize phase. Auto-emits synthesize.requested.',
+    schema: z.object({
+      featureId: featureIdSchema,
+      reason: z.string().optional(),
+    }),
+    phases: new Set<string>(['implementing']),
+    roles: ROLE_LEAD,
+    autoEmits: [
+      { event: 'synthesize.requested', condition: 'always' },
+    ],
+  },
+  {
+    name: 'finalize_oneshot',
+    description: 'Resolve the oneshot choice-state at the end of implementing: transitions to synthesize (PR path) or completed (direct-commit path) based on the synthesisOptedIn / synthesisOptedOut guards. The transition itself is emitted by the workflow set handler.',
+    schema: z.object({
+      featureId: featureIdSchema,
+    }),
+    phases: new Set<string>(['implementing']),
+    roles: ROLE_LEAD,
+  },
+  {
     name: 'runbook',
     description: 'List available runbooks or get a resolved runbook with schemas',
     schema: z.object({

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -196,6 +196,12 @@ export const ALL_PHASES: ReadonlySet<string> = new Set([
   'overhaul-delegate',
   'overhaul-review',
   'overhaul-update-docs',
+  // Oneshot workflow (compressed lifecycle: plan → implementing →
+  // synthesize|completed). `plan` is already present above from the
+  // feature workflow; `implementing` is oneshot-exclusive and MUST be in
+  // this set so generic actions gated by ALL_PHASES (get / set / cancel /
+  // event append / etc.) remain callable while a oneshot is mid-flight.
+  'implementing',
   // Shared
   'blocked',
 ]);

--- a/servers/exarchos-mcp/src/review/dispatch.ts
+++ b/servers/exarchos-mcp/src/review/dispatch.ts
@@ -10,7 +10,6 @@ export const THRESHOLDS: Record<VelocityTier, number> = {
 export function dispatchReviews(
   prs: PRDiffMetadata[],
   velocity: VelocityTier,
-  _basileusConnected: boolean
 ): ReviewDispatch[] {
   const threshold = THRESHOLDS[velocity];
   return prs.map(pr => {

--- a/servers/exarchos-mcp/src/review/review-triage.test.ts
+++ b/servers/exarchos-mcp/src/review/review-triage.test.ts
@@ -323,13 +323,13 @@ describe('dispatchReviews', () => {
   };
 
   it('should send all PRs to CodeRabbit at normal velocity', () => {
-    const dispatches = dispatchReviews([lowRiskPR, highRiskPR], 'normal', false);
+    const dispatches = dispatchReviews([lowRiskPR, highRiskPR], 'normal');
     expect(dispatches).toHaveLength(2);
     expect(dispatches.every(d => d.coderabbit)).toBe(true);
   });
 
   it('should filter by threshold at elevated velocity', () => {
-    const dispatches = dispatchReviews([lowRiskPR, highRiskPR], 'elevated', false);
+    const dispatches = dispatchReviews([lowRiskPR, highRiskPR], 'elevated');
     const lowRiskDispatch = dispatches.find(d => d.pr === 100);
     const highRiskDispatch = dispatches.find(d => d.pr === 200);
     // lowRiskPR score = 0.0 < 0.3 threshold → no CodeRabbit
@@ -339,7 +339,7 @@ describe('dispatchReviews', () => {
   });
 
   it('should only send high-risk PRs to CodeRabbit at high velocity', () => {
-    const dispatches = dispatchReviews([lowRiskPR, highRiskPR], 'high', false);
+    const dispatches = dispatchReviews([lowRiskPR, highRiskPR], 'high');
     const lowRiskDispatch = dispatches.find(d => d.pr === 100);
     const highRiskDispatch = dispatches.find(d => d.pr === 200);
     expect(lowRiskDispatch?.coderabbit).toBe(false);
@@ -347,21 +347,14 @@ describe('dispatchReviews', () => {
   });
 
   it('should always set selfHosted to true for all PRs', () => {
-    const dispatches = dispatchReviews([lowRiskPR, highRiskPR], 'high', false);
+    const dispatches = dispatchReviews([lowRiskPR, highRiskPR], 'high');
     expect(dispatches.every(d => d.selfHosted === true)).toBe(true);
   });
 
   it('should include score and threshold in reason', () => {
-    const dispatches = dispatchReviews([highRiskPR], 'elevated', false);
+    const dispatches = dispatchReviews([highRiskPR], 'elevated');
     const dispatch = dispatches[0];
     expect(dispatch.reason).toContain(dispatch.riskScore.score.toFixed(2));
     expect(dispatch.reason).toContain(String(THRESHOLDS.elevated));
-  });
-
-  it('should work normally when basileusConnected is false', () => {
-    const dispatches = dispatchReviews([lowRiskPR], 'normal', false);
-    expect(dispatches).toHaveLength(1);
-    expect(dispatches[0].coderabbit).toBe(true);
-    expect(dispatches[0].selfHosted).toBe(true);
   });
 });

--- a/servers/exarchos-mcp/src/review/tools.test.ts
+++ b/servers/exarchos-mcp/src/review/tools.test.ts
@@ -57,7 +57,6 @@ describe('handleReviewTriage', () => {
       prs: [lowRiskPR(1), medRiskPR(2), highRiskPR(3)],
       activeWorkflows: [],
       pendingCodeRabbitReviews: 0,
-      basileusConnected: false,
     };
 
     const result = await handleReviewTriage(args as Record<string, unknown>, tmpDir);
@@ -83,7 +82,6 @@ describe('handleReviewTriage', () => {
       prs: [lowRiskPR(10), highRiskPR(20)],
       activeWorkflows: [],
       pendingCodeRabbitReviews: 0,
-      basileusConnected: false,
     };
 
     await handleReviewTriage(args as Record<string, unknown>, tmpDir);
@@ -109,7 +107,6 @@ describe('handleReviewTriage', () => {
       prs: [highRiskPR(42)],
       activeWorkflows: [],
       pendingCodeRabbitReviews: 0,
-      basileusConnected: false,
     };
 
     await handleReviewTriage(args as Record<string, unknown>, tmpDir);
@@ -145,7 +142,6 @@ describe('handleReviewTriage', () => {
       prs: [lowRiskPR(1), highRiskPR(2)],
       activeWorkflows: [],
       pendingCodeRabbitReviews: 8, // >6 triggers 'high' velocity
-      basileusConnected: false,
     };
 
     const result = await handleReviewTriage(args as Record<string, unknown>, tmpDir);
@@ -206,27 +202,6 @@ describe('handleReviewTriage', () => {
     await expect(fs.access(eventsPath)).rejects.toThrow();
   });
 
-  it('should default basileusConnected to false when omitted', async () => {
-    const handleReviewTriage = await importHandler();
-    const args = {
-      featureId: 'test-default-basileus',
-      prs: [lowRiskPR()],
-      activeWorkflows: [],
-      pendingCodeRabbitReviews: 0,
-      // basileusConnected deliberately omitted
-    };
-
-    const result = await handleReviewTriage(args as Record<string, unknown>, tmpDir);
-
-    // Should succeed — basileusConnected defaults to false
-    expect(result.success).toBe(true);
-    const data = result.data as {
-      dispatches: Array<{ pr: number; coderabbit: boolean; selfHosted: boolean }>;
-    };
-    expect(data.dispatches).toHaveLength(1);
-    // The dispatch should work correctly with default basileusConnected=false
-    expect(data.dispatches[0].selfHosted).toBe(true);
-  });
 });
 
 // ─── Orchestrate Composite Integration ──────────────────────────────────────
@@ -246,7 +221,6 @@ describe('orchestrate review_triage action', () => {
       prs: [lowRiskPR()],
       activeWorkflows: [],
       pendingCodeRabbitReviews: 0,
-      basileusConnected: false,
     };
 
     const { EventStore } = await import('../event-store/store.js');

--- a/servers/exarchos-mcp/src/review/tools.ts
+++ b/servers/exarchos-mcp/src/review/tools.ts
@@ -17,7 +17,6 @@ interface ReviewTriageInput {
   prs: PRDiffMetadata[];
   activeWorkflows?: Array<{ phase: string }>;
   pendingCodeRabbitReviews?: number;
-  basileusConnected?: boolean;
 }
 
 function parseInput(args: Record<string, unknown>): ReviewTriageInput | ToolResult {
@@ -42,7 +41,6 @@ function parseInput(args: Record<string, unknown>): ReviewTriageInput | ToolResu
     prs,
     activeWorkflows: (args.activeWorkflows as Array<{ phase: string }>) ?? [],
     pendingCodeRabbitReviews: (args.pendingCodeRabbitReviews as number) ?? 0,
-    basileusConnected: (args.basileusConnected as boolean) ?? false,
   };
 }
 
@@ -105,7 +103,7 @@ export async function handleReviewTriage(
   };
 
   const velocity = detectVelocity(context);
-  const dispatches = dispatchReviews(input.prs, velocity, input.basileusConnected ?? false);
+  const dispatches = dispatchReviews(input.prs, velocity);
 
   // Emit review.routed events (skip if no dispatches)
   if (dispatches.length > 0) {

--- a/servers/exarchos-mcp/src/views/tools.ts
+++ b/servers/exarchos-mcp/src/views/tools.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import { EventStore } from '../event-store/store.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
 import { formatResult, pickFields, type ToolResult } from '../format.js';
+import { TERMINAL_PHASES } from '../workflow/terminal-phases.js';
 import { ViewMaterializer } from './materializer.js';
 import { SnapshotStore } from './snapshot-store.js';
 import {
@@ -319,7 +320,6 @@ export async function handleViewPipeline(
   stateDir: string,
   eventStore: EventStore,
 ): Promise<ToolResult> {
-  const TERMINAL_PHASES = ['completed', 'cancelled'];
   try {
     const store = eventStore;
     const materializer = getOrCreateMaterializer(stateDir);
@@ -341,7 +341,7 @@ export async function handleViewPipeline(
     // Filter out terminal-state workflows unless explicitly requested
     const filtered = args.includeCompleted
       ? allWorkflows
-      : allWorkflows.filter((w) => !TERMINAL_PHASES.includes(w.phase));
+      : allWorkflows.filter((w) => !(TERMINAL_PHASES as readonly string[]).includes(w.phase));
 
     // Paginate the filtered results
     const total = filtered.length;

--- a/servers/exarchos-mcp/src/views/workflow-state-projection.test.ts
+++ b/servers/exarchos-mcp/src/views/workflow-state-projection.test.ts
@@ -507,6 +507,150 @@ describe('WorkflowStateProjection team events', () => {
   });
 });
 
+// ─── Oneshot / Pruning Events (_events projection) ────────────────────────
+
+describe('WorkflowStateProjection oneshot/pruning events', () => {
+  describe('workflowStateProjection_synthesizeRequested_appendsToEvents', () => {
+    it('should append synthesize.requested to view._events', () => {
+      const state = workflowStateProjection.init();
+      const ts = '2026-04-11T10:00:00.000Z';
+
+      const event = makeEvent(
+        'synthesize.requested',
+        { featureId: 'oneshot-feature', reason: 'all-tasks-complete' },
+        { timestamp: ts },
+      );
+      const next = workflowStateProjection.apply(state, event);
+
+      expect(next._events).toBeDefined();
+      expect(Array.isArray(next._events)).toBe(true);
+      expect(next._events).toHaveLength(1);
+      expect(next._events[0]).toMatchObject({
+        type: 'synthesize.requested',
+        timestamp: ts,
+      });
+      expect((next._events[0].data as Record<string, unknown>).featureId).toBe(
+        'oneshot-feature',
+      );
+    });
+  });
+
+  describe('workflowStateProjection_synthesizeRequested_doesNotMutateOtherFields', () => {
+    it('should leave phase, featureId, tasks, and other fields unchanged', () => {
+      let state = workflowStateProjection.init();
+      state = workflowStateProjection.apply(
+        state,
+        makeEvent(
+          'workflow.started',
+          { featureId: 'f-synth', workflowType: 'feature' },
+          { timestamp: '2026-04-11T09:00:00.000Z' },
+        ),
+      );
+      state = workflowStateProjection.apply(
+        state,
+        makeEvent('task.assigned', { taskId: 'task-A', title: 'A', branch: 'feat/a' }),
+      );
+
+      const before = {
+        featureId: state.featureId,
+        workflowType: state.workflowType,
+        phase: state.phase,
+        createdAt: state.createdAt,
+        tasks: state.tasks,
+        artifacts: state.artifacts,
+        synthesis: state.synthesis,
+        reviews: state.reviews,
+        integration: state.integration,
+      };
+
+      const next = workflowStateProjection.apply(
+        state,
+        makeEvent('synthesize.requested', { featureId: 'f-synth' }),
+      );
+
+      expect(next.featureId).toBe(before.featureId);
+      expect(next.workflowType).toBe(before.workflowType);
+      expect(next.phase).toBe(before.phase);
+      expect(next.createdAt).toBe(before.createdAt);
+      expect(next.tasks).toEqual(before.tasks);
+      expect(next.artifacts).toEqual(before.artifacts);
+      expect(next.synthesis).toEqual(before.synthesis);
+      expect(next.reviews).toEqual(before.reviews);
+      expect(next.integration).toEqual(before.integration);
+    });
+  });
+
+  describe('workflowStateProjection_workflowPruned_appendsToEvents', () => {
+    it('should append workflow.pruned to view._events for audit trail', () => {
+      const state = workflowStateProjection.init();
+      const ts = '2026-04-11T11:00:00.000Z';
+
+      const event = makeEvent(
+        'workflow.pruned',
+        { featureId: 'stale-feature', reason: 'stale-timeout', prunedAt: ts },
+        { timestamp: ts },
+      );
+      const next = workflowStateProjection.apply(state, event);
+
+      expect(next._events).toBeDefined();
+      expect(Array.isArray(next._events)).toBe(true);
+      expect(next._events).toHaveLength(1);
+      expect(next._events[0]).toMatchObject({
+        type: 'workflow.pruned',
+        timestamp: ts,
+      });
+      expect((next._events[0].data as Record<string, unknown>).reason).toBe(
+        'stale-timeout',
+      );
+    });
+  });
+
+  describe('workflowStateProjection_workflowPruned_doesNotMutateOtherFields', () => {
+    it('should leave phase, featureId, tasks, and other fields unchanged', () => {
+      let state = workflowStateProjection.init();
+      state = workflowStateProjection.apply(
+        state,
+        makeEvent(
+          'workflow.started',
+          { featureId: 'f-prune', workflowType: 'feature' },
+          { timestamp: '2026-04-11T09:00:00.000Z' },
+        ),
+      );
+      state = workflowStateProjection.apply(
+        state,
+        makeEvent('task.assigned', { taskId: 'task-B', title: 'B', branch: 'feat/b' }),
+      );
+
+      const before = {
+        featureId: state.featureId,
+        workflowType: state.workflowType,
+        phase: state.phase,
+        createdAt: state.createdAt,
+        tasks: state.tasks,
+        artifacts: state.artifacts,
+        synthesis: state.synthesis,
+        reviews: state.reviews,
+        integration: state.integration,
+      };
+
+      const next = workflowStateProjection.apply(
+        state,
+        makeEvent('workflow.pruned', { featureId: 'f-prune', reason: 'stale' }),
+      );
+
+      expect(next.featureId).toBe(before.featureId);
+      expect(next.workflowType).toBe(before.workflowType);
+      expect(next.phase).toBe(before.phase);
+      expect(next.createdAt).toBe(before.createdAt);
+      expect(next.tasks).toEqual(before.tasks);
+      expect(next.artifacts).toEqual(before.artifacts);
+      expect(next.synthesis).toEqual(before.synthesis);
+      expect(next.reviews).toEqual(before.reviews);
+      expect(next.integration).toEqual(before.integration);
+    });
+  });
+});
+
 // ─── Observability and Unknown Events ──────────────────────────────────────
 
 describe('WorkflowStateProjection passthrough events', () => {

--- a/servers/exarchos-mcp/src/views/workflow-state-projection.ts
+++ b/servers/exarchos-mcp/src/views/workflow-state-projection.ts
@@ -265,6 +265,8 @@ export const workflowStateProjection: ViewProjection<WorkflowStateView> = {
 
       case 'team.spawned':
       case 'team.disbanded':
+      case 'synthesize.requested':
+      case 'workflow.pruned':
         return {
           ...view,
           _events: [...(view._events ?? []), { type: event.type, timestamp: event.timestamp, data: event.data }],

--- a/servers/exarchos-mcp/src/views/workflow-state-projection.ts
+++ b/servers/exarchos-mcp/src/views/workflow-state-projection.ts
@@ -7,11 +7,16 @@ import { deepMerge, isPlainObject } from '../workflow/state-store.js';
 export const WORKFLOW_STATE_VIEW = 'workflow-state';
 
 // ─── Initial Phase by Workflow Type ────────────────────────────────────────
+// Kept in sync with `getInitialPhase` in `workflow/state-machine.ts`. If a
+// new built-in workflow type is added there, mirror it here so the
+// event-sourced projection agrees with the file-based state store on the
+// initial phase seeded by `workflow.started`.
 
 const INITIAL_PHASE: Record<string, string> = {
   feature: 'ideate',
   debug: 'triage',
   refactor: 'explore',
+  oneshot: 'plan',
 };
 
 // ─── WorkflowState View Shape ──────────────────────────────────────────────
@@ -122,11 +127,28 @@ export const workflowStateProjection: ViewProjection<WorkflowStateView> = {
         const data = event.data as {
           featureId?: string;
           workflowType?: string;
+          synthesisPolicy?: 'always' | 'never' | 'on-request';
         } | undefined;
         if (!data) return view;
 
         const workflowType = data.workflowType ?? view.workflowType;
         const phase = INITIAL_PHASE[workflowType] ?? view.phase;
+
+        // Oneshot-only: surface the init-time `synthesisPolicy` on the
+        // projected view under `state.oneshot.synthesisPolicy` so the
+        // `synthesisOptedIn` / `synthesisOptedOut` guards see the same
+        // value after rematerialization that they would on a fresh state
+        // file. The guards read `state.oneshot.synthesisPolicy` directly
+        // via `readSynthesisPolicy` in `workflow/guards.ts`.
+        const nextOneshot =
+          workflowType === 'oneshot' && data.synthesisPolicy !== undefined
+            ? {
+                ...((view as unknown as Record<string, unknown>).oneshot as
+                  | Record<string, unknown>
+                  | undefined),
+                synthesisPolicy: data.synthesisPolicy,
+              }
+            : undefined;
 
         return {
           ...view,
@@ -135,6 +157,7 @@ export const workflowStateProjection: ViewProjection<WorkflowStateView> = {
           phase,
           createdAt: event.timestamp,
           updatedAt: event.timestamp,
+          ...(nextOneshot !== undefined ? { oneshot: nextOneshot } : {}),
         };
       }
 

--- a/servers/exarchos-mcp/src/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.test.ts
@@ -978,4 +978,30 @@ describe('oneshotPlanSet', () => {
     const result = guards.oneshotPlanSet.evaluate(state);
     expect(result).not.toBe(true);
   });
+
+  it('oneshotPlanSet_rejectsWhitespaceOnlyPlan', () => {
+    // Shepherd iter 2 (CodeRabbit F3): whitespace-only plan strings are
+    // not real plan artifacts. `'   '` satisfies `.length > 0` but carries
+    // no content — the guard must reject it on `.trim().length > 0`.
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      oneshot: { synthesisPolicy: 'on-request', planSummary: 'summary' },
+      artifacts: { plan: '   ' },
+    };
+    const result = guards.oneshotPlanSet.evaluate(state);
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('artifacts.plan');
+  });
+
+  it('oneshotPlanSet_rejectsPlanWithOnlyNewlinesAndTabs', () => {
+    // Defensive: "\n\t\n " is whitespace-only too. Same rejection.
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      artifacts: { plan: '\n\t\n ' },
+    };
+    const result = guards.oneshotPlanSet.evaluate(state);
+    expect(result).not.toBe(true);
+  });
 });

--- a/servers/exarchos-mcp/src/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.test.ts
@@ -711,3 +711,191 @@ describe('allReviewsPassed (synthesis ready)', () => {
     expect(updates['reviews.stray-review.status']).toBe('pass');
   });
 });
+
+// ─── synthesisOptedIn / synthesisOptedOut Guard Tests ───────────────────────
+
+describe('synthesisOptedIn', () => {
+  it('synthesisOptedIn_policyAlways_returnsTrue', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      workflowType: 'oneshot',
+      oneshot: { synthesisPolicy: 'always' },
+      _events: [],
+    };
+
+    const result = guards.synthesisOptedIn.evaluate(state);
+
+    expect(result).toBe(true);
+  });
+
+  it('synthesisOptedIn_policyNever_returnsFalseWithReason', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      workflowType: 'oneshot',
+      oneshot: { synthesisPolicy: 'never' },
+      _events: [{ type: 'synthesize.requested' }],
+    };
+
+    const result = guards.synthesisOptedIn.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('never');
+  });
+
+  it('synthesisOptedIn_policyOnRequestWithEvent_returnsTrue', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      workflowType: 'oneshot',
+      oneshot: { synthesisPolicy: 'on-request' },
+      _events: [
+        { type: 'phase.changed' },
+        { type: 'synthesize.requested', data: { reason: 'reviewer asked for PR' } },
+      ],
+    };
+
+    const result = guards.synthesisOptedIn.evaluate(state);
+
+    expect(result).toBe(true);
+  });
+
+  it('synthesisOptedIn_policyOnRequestNoEvent_returnsFalseWithReason', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      workflowType: 'oneshot',
+      oneshot: { synthesisPolicy: 'on-request' },
+      _events: [{ type: 'phase.changed' }],
+    };
+
+    const result = guards.synthesisOptedIn.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('synthesize.requested');
+  });
+
+  it('synthesisOptedIn_policyDefaultsToOnRequest_whenFieldMissing', () => {
+    // No `oneshot` field at all — must default to 'on-request' semantics
+    const stateWithoutEvent: Record<string, unknown> = {
+      featureId: 'test-feature',
+      workflowType: 'oneshot',
+      _events: [],
+    };
+
+    const resultNoEvent = guards.synthesisOptedIn.evaluate(stateWithoutEvent);
+    expect(resultNoEvent).not.toBe(true);
+    expect((resultNoEvent as GuardFailure).passed).toBe(false);
+
+    const stateWithEvent: Record<string, unknown> = {
+      featureId: 'test-feature',
+      workflowType: 'oneshot',
+      _events: [{ type: 'synthesize.requested' }],
+    };
+
+    const resultWithEvent = guards.synthesisOptedIn.evaluate(stateWithEvent);
+    expect(resultWithEvent).toBe(true);
+  });
+});
+
+describe('synthesisOptedOut', () => {
+  it('synthesisOptedOut_isInverseOfSynthesisOptedIn', () => {
+    // Table-driven: 8 combinations of (policy ∈ {always, never, on-request}) ×
+    // (event present ∈ {true, false}), plus the default (no oneshot field) case.
+    // For every row, exactly one of the two guards must return true.
+    type Row = {
+      label: string;
+      oneshot: Record<string, unknown> | undefined;
+      eventPresent: boolean;
+    };
+
+    const rows: Row[] = [
+      { label: 'always + event',          oneshot: { synthesisPolicy: 'always' },     eventPresent: true  },
+      { label: 'always + no event',       oneshot: { synthesisPolicy: 'always' },     eventPresent: false },
+      { label: 'never + event',           oneshot: { synthesisPolicy: 'never' },      eventPresent: true  },
+      { label: 'never + no event',        oneshot: { synthesisPolicy: 'never' },      eventPresent: false },
+      { label: 'on-request + event',      oneshot: { synthesisPolicy: 'on-request' }, eventPresent: true  },
+      { label: 'on-request + no event',   oneshot: { synthesisPolicy: 'on-request' }, eventPresent: false },
+      { label: 'default (no oneshot) + event',    oneshot: undefined, eventPresent: true  },
+      { label: 'default (no oneshot) + no event', oneshot: undefined, eventPresent: false },
+    ];
+
+    for (const row of rows) {
+      const state: Record<string, unknown> = {
+        featureId: 'test-feature',
+        workflowType: 'oneshot',
+        _events: row.eventPresent ? [{ type: 'synthesize.requested' }] : [],
+      };
+      if (row.oneshot !== undefined) {
+        state.oneshot = row.oneshot;
+      }
+
+      const inResult = guards.synthesisOptedIn.evaluate(state);
+      const outResult = guards.synthesisOptedOut.evaluate(state);
+
+      const inPassed = inResult === true;
+      const outPassed = outResult === true;
+
+      // Mutual exclusivity: exactly one is true
+      expect(
+        inPassed !== outPassed,
+        `row "${row.label}": expected exactly one guard to pass (in=${inPassed}, out=${outPassed})`,
+      ).toBe(true);
+    }
+  });
+
+  it('synthesisOptedOut_policyNever_returnsTrue', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      workflowType: 'oneshot',
+      oneshot: { synthesisPolicy: 'never' },
+      _events: [],
+    };
+
+    expect(guards.synthesisOptedOut.evaluate(state)).toBe(true);
+  });
+
+  it('synthesisOptedOut_policyAlways_returnsFalseWithReason', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      workflowType: 'oneshot',
+      oneshot: { synthesisPolicy: 'always' },
+      _events: [],
+    };
+
+    const result = guards.synthesisOptedOut.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('always');
+  });
+
+  it('synthesisOptedOut_policyOnRequestNoEvent_returnsTrue', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      workflowType: 'oneshot',
+      oneshot: { synthesisPolicy: 'on-request' },
+      _events: [{ type: 'phase.changed' }],
+    };
+
+    expect(guards.synthesisOptedOut.evaluate(state)).toBe(true);
+  });
+
+  it('synthesisOptedOut_policyOnRequestWithEvent_returnsFalseWithReason', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      workflowType: 'oneshot',
+      oneshot: { synthesisPolicy: 'on-request' },
+      _events: [{ type: 'synthesize.requested' }],
+    };
+
+    const result = guards.synthesisOptedOut.evaluate(state);
+
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('synthesize.requested');
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.test.ts
@@ -901,14 +901,22 @@ describe('synthesisOptedOut', () => {
 });
 
 // ─── oneshotPlanSet Guard Tests (T9) ────────────────────────────────────────
+// Tightened (post CodeRabbit review on PR #1078): the guard now requires
+// `state.artifacts.plan` as the primary condition. `oneshot.planSummary`
+// remains useful as a pipeline-view label but is no longer accepted as a
+// plan substitute on its own. These tests are flipped accordingly.
 
 describe('oneshotPlanSet', () => {
-  it('oneshotPlanSet_planSummarySet_returnsTrue', () => {
+  it('oneshotPlanSet_planSummaryAloneIsInsufficient', () => {
     const state: Record<string, unknown> = {
       featureId: 'test-feature',
       oneshot: { synthesisPolicy: 'on-request', planSummary: 'A one-page plan' },
     };
-    expect(guards.oneshotPlanSet.evaluate(state)).toBe(true);
+    const result = guards.oneshotPlanSet.evaluate(state);
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('artifacts.plan');
   });
 
   it('oneshotPlanSet_artifactsPlanSet_returnsTrue', () => {
@@ -920,6 +928,9 @@ describe('oneshotPlanSet', () => {
   });
 
   it('oneshotPlanSet_bothPlanSummaryAndArtifactsPlan_returnsTrue', () => {
+    // artifacts.plan is sufficient; planSummary is allowed alongside as
+    // a pipeline-view label but is not required. The guard passes because
+    // artifacts.plan is set, not because planSummary is.
     const state: Record<string, unknown> = {
       featureId: 'test-feature',
       oneshot: { synthesisPolicy: 'always', planSummary: 'summary' },
@@ -928,13 +939,12 @@ describe('oneshotPlanSet', () => {
     expect(guards.oneshotPlanSet.evaluate(state)).toBe(true);
   });
 
-  it('oneshotPlanSet_emptyPlanSummary_fallsThrough', () => {
-    // An empty planSummary must NOT count as set — require a non-empty string.
-    // If artifacts.plan is absent, the guard fails.
+  it('oneshotPlanSet_emptyArtifactsPlan_fallsThrough', () => {
+    // An empty artifacts.plan string must NOT count as set.
     const state: Record<string, unknown> = {
       featureId: 'test-feature',
-      oneshot: { synthesisPolicy: 'on-request', planSummary: '' },
-      artifacts: {},
+      oneshot: { synthesisPolicy: 'on-request', planSummary: 'summary' },
+      artifacts: { plan: '' },
     };
     const result = guards.oneshotPlanSet.evaluate(state);
     expect(result).not.toBe(true);
@@ -942,10 +952,10 @@ describe('oneshotPlanSet', () => {
     expect(failure.passed).toBe(false);
   });
 
-  it('oneshotPlanSet_neitherSet_returnsFailureWithSuggestedFix', () => {
+  it('oneshotPlanSet_planSummaryWithoutArtifacts_returnsFailureWithSuggestedFix', () => {
     const state: Record<string, unknown> = {
       featureId: 'fix-readme',
-      oneshot: { synthesisPolicy: 'on-request' },
+      oneshot: { synthesisPolicy: 'on-request', planSummary: 'one-liner' },
       artifacts: {},
     };
     const result = guards.oneshotPlanSet.evaluate(state);
@@ -956,6 +966,9 @@ describe('oneshotPlanSet', () => {
     expect(failure.suggestedFix).toBeDefined();
     expect(failure.suggestedFix!.tool).toBe('exarchos_workflow');
     expect(failure.suggestedFix!.params.featureId).toBe('fix-readme');
+    // The suggested fix now points at artifacts.plan, not oneshot.planSummary.
+    const updates = failure.suggestedFix!.params.updates as Record<string, unknown>;
+    expect(updates).toHaveProperty('artifacts.plan');
   });
 
   it('oneshotPlanSet_missingOneshotAndArtifacts_returnsFailure', () => {

--- a/servers/exarchos-mcp/src/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.test.ts
@@ -899,3 +899,70 @@ describe('synthesisOptedOut', () => {
     expect(failure.reason).toContain('synthesize.requested');
   });
 });
+
+// ─── oneshotPlanSet Guard Tests (T9) ────────────────────────────────────────
+
+describe('oneshotPlanSet', () => {
+  it('oneshotPlanSet_planSummarySet_returnsTrue', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      oneshot: { synthesisPolicy: 'on-request', planSummary: 'A one-page plan' },
+    };
+    expect(guards.oneshotPlanSet.evaluate(state)).toBe(true);
+  });
+
+  it('oneshotPlanSet_artifactsPlanSet_returnsTrue', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      artifacts: { plan: 'Plan contents or path' },
+    };
+    expect(guards.oneshotPlanSet.evaluate(state)).toBe(true);
+  });
+
+  it('oneshotPlanSet_bothPlanSummaryAndArtifactsPlan_returnsTrue', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      oneshot: { synthesisPolicy: 'always', planSummary: 'summary' },
+      artifacts: { plan: 'path/to/plan.md' },
+    };
+    expect(guards.oneshotPlanSet.evaluate(state)).toBe(true);
+  });
+
+  it('oneshotPlanSet_emptyPlanSummary_fallsThrough', () => {
+    // An empty planSummary must NOT count as set — require a non-empty string.
+    // If artifacts.plan is absent, the guard fails.
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+      oneshot: { synthesisPolicy: 'on-request', planSummary: '' },
+      artifacts: {},
+    };
+    const result = guards.oneshotPlanSet.evaluate(state);
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+  });
+
+  it('oneshotPlanSet_neitherSet_returnsFailureWithSuggestedFix', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'fix-readme',
+      oneshot: { synthesisPolicy: 'on-request' },
+      artifacts: {},
+    };
+    const result = guards.oneshotPlanSet.evaluate(state);
+    expect(result).not.toBe(true);
+    const failure = result as GuardFailure;
+    expect(failure.passed).toBe(false);
+    expect(failure.reason).toContain('oneshot-plan-set');
+    expect(failure.suggestedFix).toBeDefined();
+    expect(failure.suggestedFix!.tool).toBe('exarchos_workflow');
+    expect(failure.suggestedFix!.params.featureId).toBe('fix-readme');
+  });
+
+  it('oneshotPlanSet_missingOneshotAndArtifacts_returnsFailure', () => {
+    const state: Record<string, unknown> = {
+      featureId: 'test-feature',
+    };
+    const result = guards.oneshotPlanSet.evaluate(state);
+    expect(result).not.toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.ts
@@ -167,6 +167,32 @@ function buildFailedReviewsExpectedShape(
 export const MAX_PLAN_REVISIONS = 3;
 const MAX_SYNTHESIZE_RETRIES = 3;
 
+// ─── Synthesis Guard Helpers ────────────────────────────────────────────────
+
+/**
+ * Returns true if `state._events` contains at least one `synthesize.requested` event.
+ * Pure: reads only the provided events array. Used by both synthesisOptedIn and
+ * synthesisOptedOut; do NOT use it to compose one guard from the other — each
+ * guard must inline its own branch logic to avoid the "missing inverse guard"
+ * anti-pattern seen in hotfixTrackSelected/thoroughTrackSelected.
+ */
+function hasSynthesizeRequestEvent(state: Record<string, unknown>): boolean {
+  const events = (state._events as readonly Record<string, unknown>[]) ?? [];
+  return events.some((e) => e.type === 'synthesize.requested');
+}
+
+/**
+ * Reads `state.oneshot?.synthesisPolicy`, defaulting to `'on-request'` when the
+ * oneshot object or its policy field is missing. Returns one of the three
+ * policy literals; unrecognized values collapse to the default.
+ */
+function readSynthesisPolicy(state: Record<string, unknown>): 'always' | 'never' | 'on-request' {
+  const oneshot = state.oneshot as Record<string, unknown> | undefined;
+  const raw = oneshot?.synthesisPolicy;
+  if (raw === 'always' || raw === 'never' || raw === 'on-request') return raw;
+  return 'on-request';
+}
+
 // ─── Guards ─────────────────────────────────────────────────────────────────
 
 export const guards = {
@@ -710,6 +736,63 @@ export const guards = {
             },
           },
         },
+      };
+    },
+  },
+
+  synthesisOptedIn: {
+    id: 'synthesis-opted-in',
+    description:
+      'Oneshot workflow opted into synthesis: synthesisPolicy=always OR a synthesize.requested event has been emitted on an on-request policy',
+    evaluate: (state: Record<string, unknown>): GuardResult => {
+      const policy = readSynthesisPolicy(state);
+      if (policy === 'always') return true;
+      if (policy === 'never') {
+        return {
+          passed: false,
+          reason: 'synthesis-opted-in not satisfied: synthesisPolicy=never (direct-commit path)',
+        };
+      }
+      // policy === 'on-request'
+      if (hasSynthesizeRequestEvent(state)) return true;
+      const featureId = typeof state.featureId === 'string' ? state.featureId : '<featureId>';
+      return {
+        passed: false,
+        reason:
+          'synthesis-opted-in not satisfied: synthesisPolicy=on-request but no synthesize.requested event in _events',
+        expectedShape: {
+          type: 'synthesize.requested',
+          data: { featureId: '<featureId>', timestamp: '<ISO-8601>' },
+        },
+        suggestedFix: {
+          tool: 'exarchos_orchestrate',
+          params: { action: 'request_synthesize', featureId },
+        },
+      };
+    },
+  },
+
+  synthesisOptedOut: {
+    id: 'synthesis-opted-out',
+    description:
+      'Oneshot workflow opted out of synthesis: synthesisPolicy=never OR an on-request policy with no synthesize.requested event (direct-commit path)',
+    evaluate: (state: Record<string, unknown>): GuardResult => {
+      // Inlined inverse of synthesisOptedIn — NOT composed via `!synthesisOptedIn.evaluate`
+      // so that refactoring one guard cannot silently skew the other.
+      const policy = readSynthesisPolicy(state);
+      if (policy === 'never') return true;
+      if (policy === 'always') {
+        return {
+          passed: false,
+          reason: 'synthesis-opted-out not satisfied: synthesisPolicy=always (synthesize path)',
+        };
+      }
+      // policy === 'on-request'
+      if (!hasSynthesizeRequestEvent(state)) return true;
+      return {
+        passed: false,
+        reason:
+          'synthesis-opted-out not satisfied: synthesisPolicy=on-request with a synthesize.requested event present — opted into synthesis',
       };
     },
   },

--- a/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.ts
@@ -743,26 +743,32 @@ export const guards = {
   oneshotPlanSet: {
     id: 'oneshot-plan-set',
     description:
-      'Oneshot workflow plan is captured: state.oneshot.planSummary OR state.artifacts.plan is set',
+      'Oneshot workflow plan artifact is captured in state.artifacts.plan. `oneshot.planSummary` is a pipeline-view hint, not a plan, and is not sufficient alone to transition plan → implementing.',
     evaluate: (state: Record<string, unknown>): GuardResult => {
-      const oneshot = state.oneshot as Record<string, unknown> | undefined;
-      if (oneshot != null && typeof oneshot.planSummary === 'string' && oneshot.planSummary.length > 0) {
-        return true;
-      }
+      // Tightened: require `artifacts.plan` as the primary (and only
+      // sufficient) condition. Previously either `oneshot.planSummary`
+      // OR `artifacts.plan` satisfied the guard, but `planSummary` is a
+      // one-line pipeline-view hint — not a real plan — and accepting it
+      // as a substitute meant oneshot workflows could enter `implementing`
+      // with no persisted plan artifact at all. `planSummary` is still
+      // recommended as a human-readable label, but it is not the artifact
+      // the guard enforces.
       const artifacts = state.artifacts as Record<string, unknown> | undefined;
-      if (artifacts != null && artifacts.plan != null) return true;
+      const plan = artifacts?.plan;
+      if (typeof plan === 'string' && plan.length > 0) return true;
+      if (plan != null && typeof plan !== 'string') return true;
       const featureId = typeof state.featureId === 'string' ? state.featureId : '<featureId>';
       return {
         passed: false,
         reason:
-          'oneshot-plan-set not satisfied: set state.oneshot.planSummary or state.artifacts.plan before transitioning to implementing',
-        expectedShape: { oneshot: { planSummary: '<one-page plan>' } },
+          'oneshot-plan-set not satisfied: state.artifacts.plan is required (a non-empty plan artifact) before transitioning plan → implementing. `oneshot.planSummary` alone does not satisfy this guard.',
+        expectedShape: { artifacts: { plan: '<one-page plan contents or path>' } },
         suggestedFix: {
           tool: 'exarchos_workflow',
           params: {
             action: 'set',
             featureId,
-            updates: { oneshot: { planSummary: '<one-page plan>' } },
+            updates: { 'artifacts.plan': '<one-page plan contents or path>' },
           },
         },
       };

--- a/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.ts
@@ -740,6 +740,35 @@ export const guards = {
     },
   },
 
+  oneshotPlanSet: {
+    id: 'oneshot-plan-set',
+    description:
+      'Oneshot workflow plan is captured: state.oneshot.planSummary OR state.artifacts.plan is set',
+    evaluate: (state: Record<string, unknown>): GuardResult => {
+      const oneshot = state.oneshot as Record<string, unknown> | undefined;
+      if (oneshot != null && typeof oneshot.planSummary === 'string' && oneshot.planSummary.length > 0) {
+        return true;
+      }
+      const artifacts = state.artifacts as Record<string, unknown> | undefined;
+      if (artifacts != null && artifacts.plan != null) return true;
+      const featureId = typeof state.featureId === 'string' ? state.featureId : '<featureId>';
+      return {
+        passed: false,
+        reason:
+          'oneshot-plan-set not satisfied: set state.oneshot.planSummary or state.artifacts.plan before transitioning to implementing',
+        expectedShape: { oneshot: { planSummary: '<one-page plan>' } },
+        suggestedFix: {
+          tool: 'exarchos_workflow',
+          params: {
+            action: 'set',
+            featureId,
+            updates: { oneshot: { planSummary: '<one-page plan>' } },
+          },
+        },
+      };
+    },
+  },
+
   synthesisOptedIn: {
     id: 'synthesis-opted-in',
     description:

--- a/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.ts
@@ -755,7 +755,11 @@ export const guards = {
       // the guard enforces.
       const artifacts = state.artifacts as Record<string, unknown> | undefined;
       const plan = artifacts?.plan;
-      if (typeof plan === 'string' && plan.length > 0) return true;
+      // Whitespace-only plan strings are not a real plan artifact — they
+      // satisfy `.length > 0` but carry no content, which would let a
+      // oneshot transition `plan → implementing` with a blank document.
+      // Require at least one non-whitespace character.
+      if (typeof plan === 'string' && plan.trim().length > 0) return true;
       if (plan != null && typeof plan !== 'string') return true;
       const featureId = typeof state.featureId === 'string' ? state.featureId : '<featureId>';
       return {

--- a/servers/exarchos-mcp/src/workflow/hsm-definitions.ts
+++ b/servers/exarchos-mcp/src/workflow/hsm-definitions.ts
@@ -173,6 +173,39 @@ export function createDebugHSM(): HSMDefinition {
   return { id: 'debug', states, transitions };
 }
 
+// ─── Oneshot Workflow HSM ───────────────────────────────────────────────────
+//
+// Lightweight lifecycle for small changes: plan → implementing → (choice state).
+// The `implementing` phase evaluates two mutually exclusive guards
+// (synthesisOptedIn / synthesisOptedOut) which are pure functions of
+// (synthesisPolicy, synthesize.requested events) per the design doc.
+//
+// Declaration order matters: the state machine tries transitions in array
+// order. We keep both branches listed so getValidTransitions advertises
+// both to callers; exactly one will pass its guard for any given state
+// (enforced by the choice-state mutual-exclusivity property test in
+// state-machine.test.ts and the inverse-guard property test in
+// guards.test.ts).
+
+export const oneshotTransitions: readonly Transition[] = [
+  { from: 'plan', to: 'implementing', guard: guards.oneshotPlanSet },
+  { from: 'implementing', to: 'synthesize', guard: guards.synthesisOptedIn },
+  { from: 'implementing', to: 'completed', guard: guards.synthesisOptedOut },
+  { from: 'synthesize', to: 'completed', guard: guards.mergeVerified },
+];
+
+export function createOneshotHSM(): HSMDefinition {
+  const states: Record<string, State> = {
+    plan: { id: 'plan', type: 'atomic' },
+    implementing: { id: 'implementing', type: 'atomic' },
+    synthesize: { id: 'synthesize', type: 'atomic' },
+    completed: { id: 'completed', type: 'final' },
+    cancelled: { id: 'cancelled', type: 'final' },
+  };
+
+  return { id: 'oneshot', states, transitions: [...oneshotTransitions] };
+}
+
 // ─── Refactor Workflow HSM ──────────────────────────────────────────────────
 
 export function createRefactorHSM(): HSMDefinition {

--- a/servers/exarchos-mcp/src/workflow/playbooks.property.test.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.property.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { FeaturePhaseSchema, DebugPhaseSchema, RefactorPhaseSchema } from './schemas.js';
-import { getPlaybook, renderPlaybook } from './playbooks.js';
+import { getPlaybook, renderPlaybook, oneshotPlaybook } from './playbooks.js';
 
 describe('HSM-Playbook Coverage', () => {
   const workflowPhases: Record<string, readonly string[]> = {
@@ -160,5 +160,98 @@ describe('Neuroanatomy pattern enrichment', () => {
     expect(playbook).not.toBeNull();
     const guidance = playbook!.compactGuidance.toLowerCase();
     expect(guidance.includes('review-strategy')).toBe(true);
+  });
+});
+
+// ─── T10: Oneshot playbook property assertions ─────────────────────────────
+//
+// The main HSM-Playbook Coverage suite above enumerates phases via the
+// three enum schemas (Feature/Debug/Refactor). Oneshot uses `z.string()`
+// for its phase field (choice-state semantics mean the set of reachable
+// phases depends on synthesisPolicy + events), so we assert the playbook
+// invariants directly against the exported `oneshotPlaybook` array.
+
+describe('Oneshot playbook invariants', () => {
+  const terminalPhases = ['completed', 'cancelled'];
+
+  it('oneshotPlaybook_nonTerminalPhases_HaveNonEmptyTransitionCriteria', () => {
+    const nonTerminal = oneshotPlaybook.filter(
+      (p) => !terminalPhases.includes(p.phase),
+    );
+    expect(nonTerminal.length).toBeGreaterThan(0);
+    for (const pb of nonTerminal) {
+      expect(
+        pb.transitionCriteria.length,
+        `oneshot:${pb.phase} has empty transitionCriteria`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('oneshotPlaybook_nonTerminalPhases_HaveGuardPrerequisites', () => {
+    const nonTerminal = oneshotPlaybook.filter(
+      (p) => !terminalPhases.includes(p.phase),
+    );
+    for (const pb of nonTerminal) {
+      expect(
+        pb.guardPrerequisites.length,
+        `oneshot:${pb.phase} has empty guardPrerequisites`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('oneshotPlaybook_AllPhasesReachableFromPlan', () => {
+    // Build transition graph from the declared transitionCriteria strings.
+    // plan → implementing, implementing → {synthesize, completed}, synthesize → completed.
+    const phases = new Set(oneshotPlaybook.map((p) => p.phase));
+    expect(phases.has('plan')).toBe(true);
+
+    const edges: Record<string, string[]> = {};
+    for (const pb of oneshotPlaybook) {
+      const next: string[] = [];
+      for (const candidate of phases) {
+        if (candidate === pb.phase) continue;
+        // Match phase name as whole word in transitionCriteria
+        const rx = new RegExp(`\\b${candidate}\\b`, 'i');
+        if (rx.test(pb.transitionCriteria)) next.push(candidate);
+      }
+      edges[pb.phase] = next;
+    }
+
+    const visited = new Set<string>();
+    const stack = ['plan'];
+    while (stack.length > 0) {
+      const cur = stack.pop()!;
+      if (visited.has(cur)) continue;
+      visited.add(cur);
+      for (const n of edges[cur] ?? []) stack.push(n);
+    }
+
+    for (const phase of phases) {
+      expect(
+        visited.has(phase),
+        `oneshot:${phase} is not reachable from plan via transitionCriteria graph`,
+      ).toBe(true);
+    }
+  });
+
+  it('oneshotPlaybook_CompletedReachableFromBothImplementingBranches', () => {
+    const implementing = oneshotPlaybook.find((p) => p.phase === 'implementing');
+    expect(implementing).toBeDefined();
+    // Direct branch: implementing → completed (opted out)
+    expect(implementing!.transitionCriteria).toMatch(/completed/i);
+    // Indirect branch: implementing → synthesize → completed
+    expect(implementing!.transitionCriteria).toMatch(/synthesize/i);
+    const synthesize = oneshotPlaybook.find((p) => p.phase === 'synthesize');
+    expect(synthesize).toBeDefined();
+    expect(synthesize!.transitionCriteria).toMatch(/completed/i);
+  });
+
+  it('oneshotPlaybook_RendersWithoutErrorForEveryPhase', () => {
+    for (const pb of oneshotPlaybook) {
+      expect(() => renderPlaybook(pb)).not.toThrow();
+      const rendered = renderPlaybook(pb);
+      expect(typeof rendered).toBe('string');
+      expect(rendered.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/servers/exarchos-mcp/src/workflow/playbooks.test.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { getPlaybook, renderPlaybook, serializePlaybooks, listPlaybookWorkflowTypes } from './playbooks.js';
+import {
+  getPlaybook,
+  renderPlaybook,
+  serializePlaybooks,
+  listPlaybookWorkflowTypes,
+  oneshotPlaybook,
+  workflowPlaybooks,
+} from './playbooks.js';
 import type { SerializedPlaybooks, SerializedPhasePlaybook } from './playbooks.js';
 import { getRequiredReviews, REQUIRED_REVIEWS_BY_WORKFLOW_TYPE } from './review-contract.js';
 
@@ -483,5 +490,95 @@ describe('compactGuidance drift tests', () => {
         `${p.workflowType}:${p.phase} compactGuidance does not mention any tool or action keyword`,
       ).toBe(true);
     }
+  });
+});
+
+// ─── T10: Oneshot workflow playbook entries ────────────────────────────────
+
+describe('Oneshot workflow playbooks', () => {
+  it('oneshotPlaybook_declaresAllFourPhases', () => {
+    expect(Array.isArray(oneshotPlaybook)).toBe(true);
+    const phases = oneshotPlaybook.map((p) => p.phase);
+    expect(phases).toContain('plan');
+    expect(phases).toContain('implementing');
+    expect(phases).toContain('synthesize');
+    expect(phases).toContain('completed');
+  });
+
+  it('oneshotPlaybook_allEntriesDeclareWorkflowTypeOneshot', () => {
+    expect(oneshotPlaybook.length).toBeGreaterThan(0);
+    for (const entry of oneshotPlaybook) {
+      expect(entry.workflowType).toBe('oneshot');
+    }
+  });
+
+  it('oneshotPlaybook_implementingTransitionCriteria_mentionsChoiceState', () => {
+    const implementing = oneshotPlaybook.find((p) => p.phase === 'implementing');
+    expect(implementing).toBeDefined();
+    // The choice-state transition criteria must mention both branches:
+    // opted-in → synthesize AND opted-out → completed.
+    expect(implementing!.transitionCriteria).toMatch(/synthesize/i);
+    expect(implementing!.transitionCriteria).toMatch(/completed/i);
+  });
+
+  it('oneshotPlaybook_implementingGuardPrerequisites_mentionsSynthesisChoice', () => {
+    const implementing = oneshotPlaybook.find((p) => p.phase === 'implementing');
+    expect(implementing).toBeDefined();
+    const guard = implementing!.guardPrerequisites.toLowerCase();
+    // Design: "Tests pass + synthesis choice made (policy or event)".
+    expect(guard).toMatch(/synthesi/);
+  });
+
+  it('oneshotPlaybook_planTransitionCriteria_reachesImplementing', () => {
+    const plan = oneshotPlaybook.find((p) => p.phase === 'plan');
+    expect(plan).toBeDefined();
+    expect(plan!.transitionCriteria).toMatch(/implementing/);
+  });
+
+  it('oneshotPlaybook_synthesizeTransitionCriteria_reachesCompleted', () => {
+    const synthesize = oneshotPlaybook.find((p) => p.phase === 'synthesize');
+    expect(synthesize).toBeDefined();
+    expect(synthesize!.transitionCriteria).toMatch(/completed/);
+  });
+
+  it('oneshotPlaybook_completedIsTerminal', () => {
+    const completed = oneshotPlaybook.find((p) => p.phase === 'completed');
+    expect(completed).toBeDefined();
+    expect(completed!.tools).toHaveLength(0);
+    expect(completed!.events).toHaveLength(0);
+  });
+
+  it('oneshotPlaybook_registeredInWorkflowPlaybooksMap', () => {
+    const entries = workflowPlaybooks.get('oneshot');
+    expect(entries).toBeDefined();
+    expect(entries!.length).toBeGreaterThan(0);
+    // Same reference as the exported array (single source of truth)
+    expect(entries).toBe(oneshotPlaybook);
+  });
+
+  it('oneshotPlaybook_lookupsViaGetPlaybook_ReturnSameEntries', () => {
+    for (const entry of oneshotPlaybook) {
+      const looked = getPlaybook('oneshot', entry.phase);
+      expect(looked).not.toBeNull();
+      expect(looked!.phase).toBe(entry.phase);
+      expect(looked!.workflowType).toBe('oneshot');
+    }
+  });
+
+  it('oneshotPlaybook_RegisteredWorkflowType_ListedByHelper', () => {
+    const types = listPlaybookWorkflowTypes();
+    expect(types).toContain('oneshot');
+  });
+
+  it('oneshotPlaybook_Serialization_IncludesAllPhases', () => {
+    const serialized: SerializedPlaybooks = serializePlaybooks('oneshot');
+    expect(serialized.workflowType).toBe('oneshot');
+    expect(serialized.phases).toHaveProperty('plan');
+    expect(serialized.phases).toHaveProperty('implementing');
+    expect(serialized.phases).toHaveProperty('synthesize');
+    expect(serialized.phases).toHaveProperty('completed');
+    const planPhase: SerializedPhasePlaybook = serialized.phases['plan'];
+    expect(typeof planPhase.transitionCriteria).toBe('string');
+    expect(planPhase.transitionCriteria.length).toBeGreaterThan(0);
   });
 });

--- a/servers/exarchos-mcp/src/workflow/playbooks.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.ts
@@ -945,6 +945,154 @@ register({
     'Workflow is blocked waiting for human intervention. Wait for user to provide unblock decision. Use exarchos_workflow set to record the decision.',
 });
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Oneshot Workflow Playbooks (T10)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// The oneshot workflow is a lightweight in-session flow for one-line fixes,
+// config tweaks, and exploratory changes that do not warrant the ceremony of
+// the feature workflow. Lifecycle:
+//
+//   plan ──► implementing ──┬── [synthesisOptedOut] ──► completed
+//                           └── [synthesisOptedIn]  ──► synthesize ──► completed
+//
+// The `implementing → ?` branch is a choice state resolved by pure guards
+// over (synthesisPolicy, synthesize.requested events). See T8 / T11 for the
+// guard implementations and HSM transitions.
+//
+// The `plan` and `implementing` playbooks reference the `oneshot-workflow`
+// skill which is authored in T17 — the skillRef is declared here so that
+// the skill-ref check in compactGuidance drift tests skips min-length /
+// tool-keyword assertions for these in-session phases whose guidance is
+// delegated to the skill.
+
+export const oneshotPlaybook: readonly PhasePlaybook[] = [
+  {
+    phase: 'plan',
+    workflowType: 'oneshot',
+    skill: 'oneshot-workflow',
+    skillRef: '@skills/oneshot-workflow/SKILL.md',
+    tools: [
+      {
+        tool: 'exarchos_workflow',
+        action: 'set',
+        purpose: 'Record the one-page plan summary in state.oneshot.planSummary',
+      },
+    ],
+    events: [],
+    transitionCriteria: 'Plan ready → implementing',
+    guardPrerequisites:
+      "state.oneshot.planSummary set (or artifacts.plan set) — a one-page plan captured before implementation",
+    validationScripts: [],
+    humanCheckpoint: false,
+    compactGuidance:
+      'Lightweight in-session planning for a oneshot workflow. Capture a one-page plan (goal, approach, files to touch, tests to add) via exarchos_workflow set using updates: { oneshot: { planSummary: "..." } }. No design doc required; no subagent dispatch. Transition to implementing once the plan summary is recorded. Follow the oneshot-workflow skill for the full procedure.',
+  },
+  {
+    phase: 'implementing',
+    workflowType: 'oneshot',
+    skill: 'oneshot-workflow',
+    skillRef: '@skills/oneshot-workflow/SKILL.md',
+    tools: [
+      {
+        tool: 'exarchos_workflow',
+        action: 'set',
+        purpose: 'Record implementation progress and synthesis choice',
+      },
+      {
+        tool: 'exarchos_event',
+        action: 'append',
+        purpose:
+          'Optionally append synthesize.requested to opt into PR-based synthesis at runtime',
+      },
+    ],
+    events: [
+      {
+        type: 'synthesize.requested',
+        when: 'On opt-in to the synthesize path at the end of implementation',
+      },
+    ],
+    transitionCriteria:
+      'synthesize opted in → synthesize | opted out → completed',
+    guardPrerequisites:
+      'Tests pass + synthesis choice made (policy or event): synthesisPolicy=always|on-request+synthesize.requested → synthesize; synthesisPolicy=never or on-request without event → completed',
+    validationScripts: [],
+    humanCheckpoint: false,
+    compactGuidance:
+      'In-session TDD implementation for a oneshot workflow. Write failing test first, then implement, then refactor — TDD rules remain mandatory. After tests pass, the main agent resolves the choice state using pure guards over (synthesisPolicy, synthesize.requested events). If opting into the synthesize path at runtime, append a synthesize.requested event via exarchos_event append. The HSM evaluates the choice state on the next transition attempt. Follow the oneshot-workflow skill for the full procedure.',
+  },
+  {
+    phase: 'synthesize',
+    workflowType: 'oneshot',
+    skill: 'synthesis',
+    skillRef: '@skills/synthesis/SKILL.md',
+    tools: [
+      {
+        tool: 'exarchos_workflow',
+        action: 'get',
+        purpose: 'Read synthesis state',
+      },
+      {
+        tool: 'exarchos_workflow',
+        action: 'set',
+        purpose: 'Record PR URLs and synthesis metadata',
+      },
+      {
+        tool: 'exarchos_event',
+        action: 'append',
+        purpose: 'Emit gate.executed for pre-synthesis checks',
+      },
+    ],
+    events: [
+      {
+        type: 'gate.executed',
+        when: 'After pre-synthesis-check.sh runs',
+        fields: ['gateName', 'layer', 'passed'],
+      },
+    ],
+    transitionCriteria: 'PR merged → completed',
+    guardPrerequisites:
+      'artifacts.pr exists AND PR merge verified (merge.verified or shepherd.completed event)',
+    validationScripts: ['pre_synthesis_check'],
+    humanCheckpoint: true,
+    compactGuidance:
+      'Oneshot synthesis reuses the existing synthesize pipeline. Create the PR via GitHub CLI (gh pr create), run pre-synthesis-check.sh, emit gate.executed via exarchos_event. Wait for merge verification before transitioning to completed. This is a human checkpoint — pause and confirm before merge. Anti-pattern: merging without CI green.',
+  },
+  terminalPlaybook(
+    'oneshot',
+    'completed',
+    'Workflow is complete. No further actions needed.',
+  ),
+];
+
+for (const pb of oneshotPlaybook) {
+  register(pb);
+}
+
+// ─── Aggregate Export: workflowPlaybooks ─────────────────────────────────────
+//
+// Map of workflow type → the declared playbook entries for that type, for
+// consumers that want to iterate phase-by-phase without touching the private
+// registry. The oneshot entry is the canonical example used by T10 tests; the
+// built-in feature/debug/refactor entries are derived from the registry on
+// first access so they stay in sync with the individual register() calls.
+
+function collectRegisteredForType(workflowType: string): readonly PhasePlaybook[] {
+  const out: PhasePlaybook[] = [];
+  for (const pb of registry.values()) {
+    if (pb.workflowType === workflowType) out.push(pb);
+  }
+  return out;
+}
+
+export const workflowPlaybooks: ReadonlyMap<string, readonly PhasePlaybook[]> =
+  new Map<string, readonly PhasePlaybook[]>([
+    ['feature', collectRegisteredForType('feature')],
+    ['debug', collectRegisteredForType('debug')],
+    ['refactor', collectRegisteredForType('refactor')],
+    ['oneshot', oneshotPlaybook],
+  ]);
+
 // ─── Serialization Types ─────────────────────────────────────────────────────
 
 export interface SerializedPlaybooks {

--- a/servers/exarchos-mcp/src/workflow/playbooks.ts
+++ b/servers/exarchos-mcp/src/workflow/playbooks.ts
@@ -976,17 +976,17 @@ export const oneshotPlaybook: readonly PhasePlaybook[] = [
       {
         tool: 'exarchos_workflow',
         action: 'set',
-        purpose: 'Record the one-page plan summary in state.oneshot.planSummary',
+        purpose: 'Persist the one-page plan to state.artifacts.plan (required by the oneshot-plan-set guard); oneshot.planSummary is an optional pipeline-view label',
       },
     ],
     events: [],
     transitionCriteria: 'Plan ready → implementing',
     guardPrerequisites:
-      "state.oneshot.planSummary set (or artifacts.plan set) — a one-page plan captured before implementation",
+      "state.artifacts.plan set — a one-page plan captured before implementation. oneshot.planSummary is a pipeline-view hint, not a substitute.",
     validationScripts: [],
     humanCheckpoint: false,
     compactGuidance:
-      'Lightweight in-session planning for a oneshot workflow. Capture a one-page plan (goal, approach, files to touch, tests to add) via exarchos_workflow set using updates: { oneshot: { planSummary: "..." } }. No design doc required; no subagent dispatch. Transition to implementing once the plan summary is recorded. Follow the oneshot-workflow skill for the full procedure.',
+      'Lightweight in-session planning for a oneshot workflow. Capture a one-page plan (goal, approach, files to touch, tests to add) via exarchos_workflow set using updates: { "artifacts.plan": "..." }. Optionally also set oneshot.planSummary for a one-line pipeline-view label, but artifacts.plan is the guard-required artifact. No design doc required; no subagent dispatch. Transition to implementing once the plan artifact is recorded. Follow the oneshot-workflow skill for the full procedure.',
   },
   {
     phase: 'implementing',

--- a/servers/exarchos-mcp/src/workflow/schemas.test.ts
+++ b/servers/exarchos-mcp/src/workflow/schemas.test.ts
@@ -365,6 +365,97 @@ describe('TaskSchema agent tracking fields', () => {
   });
 });
 
+// T6: oneshot workflow type + schema
+describe('Oneshot workflow type and schema', () => {
+  const baseOneshotFixture = {
+    version: '1.1',
+    workflowType: 'oneshot' as const,
+    featureId: 'oneshot-test',
+    phase: 'plan',
+    createdAt: '2026-04-11T00:00:00Z',
+    updatedAt: '2026-04-11T00:00:00Z',
+    artifacts: { design: null, plan: null, pr: null },
+    tasks: [],
+    worktrees: {},
+    reviews: {},
+    integration: null,
+    synthesis: {
+      integrationBranch: null,
+      mergeOrder: [],
+      mergedBranches: [],
+      prUrl: null,
+      prFeedback: [],
+    },
+  };
+
+  it('workflowTypeSchema_acceptsOneshot', async () => {
+    const { WorkflowTypeSchema } = await import('./schemas.js');
+    const result = WorkflowTypeSchema.safeParse('oneshot');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBe('oneshot');
+    }
+  });
+
+  it('workflowTypeSchema_getValidWorkflowTypesIncludesOneshot', async () => {
+    const { getValidWorkflowTypes } = await import('./schemas.js');
+    expect(getValidWorkflowTypes()).toContain('oneshot');
+  });
+
+  it('oneshotStateSchema_acceptsValidState', async () => {
+    const { WorkflowStateSchema } = await import('./schemas.js');
+    const input = {
+      ...baseOneshotFixture,
+      oneshot: {
+        synthesisPolicy: 'always',
+        planSummary: 'Add a config flag',
+      },
+    };
+    const result = WorkflowStateSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as Record<string, unknown>;
+      expect(data.workflowType).toBe('oneshot');
+      const oneshot = data.oneshot as Record<string, unknown> | undefined;
+      expect(oneshot?.synthesisPolicy).toBe('always');
+      expect(oneshot?.planSummary).toBe('Add a config flag');
+    }
+  });
+
+  it('oneshotStateSchema_rejectsInvalidSynthesisPolicy', async () => {
+    const { WorkflowStateSchema } = await import('./schemas.js');
+    const input = {
+      ...baseOneshotFixture,
+      oneshot: {
+        synthesisPolicy: 'maybe',
+      },
+    };
+    const result = WorkflowStateSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  it('oneshotStateSchema_defaultsSynthesisPolicyToOnRequest', async () => {
+    const { WorkflowStateSchema } = await import('./schemas.js');
+    const input = {
+      ...baseOneshotFixture,
+      oneshot: {},
+    };
+    const result = WorkflowStateSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as Record<string, unknown>;
+      const oneshot = data.oneshot as Record<string, unknown> | undefined;
+      expect(oneshot?.synthesisPolicy).toBe('on-request');
+    }
+  });
+
+  it('oneshotStateSchema_oneshotFieldIsOptional', async () => {
+    const { WorkflowStateSchema } = await import('./schemas.js');
+    const result = WorkflowStateSchema.safeParse(baseOneshotFixture);
+    expect(result.success).toBe(true);
+  });
+});
+
 // T3: WorkflowState integration validation
 describe('WorkflowState integration', () => {
   it('WorkflowState_TasksWithTestingStrategy_Parses', async () => {

--- a/servers/exarchos-mcp/src/workflow/schemas.test.ts
+++ b/servers/exarchos-mcp/src/workflow/schemas.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { ArtifactsSchema, SynthesisSchema, TaskStatusSchema } from './schemas.js';
+import {
+  ArtifactsSchema,
+  SynthesisSchema,
+  TaskStatusSchema,
+  OneshotPhaseSchema,
+} from './schemas.js';
 import { z } from 'zod';
 
 // ─── TaskStatusSchema alias tests ─────────────────────────────────────────
@@ -453,6 +458,32 @@ describe('Oneshot workflow type and schema', () => {
     const { WorkflowStateSchema } = await import('./schemas.js');
     const result = WorkflowStateSchema.safeParse(baseOneshotFixture);
     expect(result.success).toBe(true);
+  });
+
+  it('oneshotPhaseSchema_acceptsAllKnownPhases', () => {
+    for (const phase of ['plan', 'implementing', 'synthesize', 'completed', 'cancelled']) {
+      const result = OneshotPhaseSchema.safeParse(phase);
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('oneshotPhaseSchema_rejectsUnknownPhase', () => {
+    expect(OneshotPhaseSchema.safeParse('bogus').success).toBe(false);
+    expect(OneshotPhaseSchema.safeParse('').success).toBe(false);
+    expect(OneshotPhaseSchema.safeParse('ideate').success).toBe(false);
+  });
+
+  it('oneshotStateSchema_rejectsUnknownPhaseValue', async () => {
+    const { WorkflowStateSchema } = await import('./schemas.js');
+    const input = {
+      ...baseOneshotFixture,
+      phase: 'bogus-phase',
+    };
+    const result = WorkflowStateSchema.safeParse(input);
+    // Even with union fallback to CustomWorkflowStateSchema, `oneshot` is a
+    // built-in type so CustomWorkflowStateSchema explicitly rejects it, and
+    // OneshotWorkflowStateSchema rejects unknown phase values.
+    expect(result.success).toBe(false);
   });
 });
 

--- a/servers/exarchos-mcp/src/workflow/schemas.ts
+++ b/servers/exarchos-mcp/src/workflow/schemas.ts
@@ -196,7 +196,7 @@ export const FeatureIdSchema = z.string().min(1).regex(/^[a-z0-9-]+$/);
 
 // ─── Workflow Type ──────────────────────────────────────────────────────────
 
-const BUILT_IN_WORKFLOW_TYPES = ['feature', 'debug', 'refactor'] as const;
+const BUILT_IN_WORKFLOW_TYPES = ['feature', 'debug', 'refactor', 'oneshot'] as const;
 const customWorkflowTypes = new Set<string>();
 
 export const WorkflowTypeSchema = z.string().refine(
@@ -283,6 +283,15 @@ export const RefactorWorkflowStateSchema = BaseWorkflowStateSchema.extend({
   phase: RefactorPhaseSchema,
 });
 
+export const OneshotWorkflowStateSchema = BaseWorkflowStateSchema.extend({
+  workflowType: z.literal('oneshot'),
+  phase: z.string(),
+  oneshot: z.object({
+    synthesisPolicy: z.enum(['always', 'never', 'on-request']).default('on-request'),
+    planSummary: z.string().optional(),
+  }).optional(),
+});
+
 // ─── Custom Workflow State Schema ───────────────────────────────────────────
 
 export const CustomWorkflowStateSchema = BaseWorkflowStateSchema.extend({
@@ -299,6 +308,7 @@ export const WorkflowStateSchema = z.union([
   FeatureWorkflowStateSchema,
   DebugWorkflowStateSchema,
   RefactorWorkflowStateSchema,
+  OneshotWorkflowStateSchema,
   CustomWorkflowStateSchema,
 ]);
 

--- a/servers/exarchos-mcp/src/workflow/schemas.ts
+++ b/servers/exarchos-mcp/src/workflow/schemas.ts
@@ -109,6 +109,16 @@ export const RefactorPhaseSchema = z.enum([
   'blocked',
 ]);
 
+export const OneshotPhaseSchema = z.enum([
+  'plan',
+  'implementing',
+  'synthesize',
+  'completed',
+  'cancelled',
+]);
+
+export const SynthesisPolicySchema = z.enum(['always', 'never', 'on-request']);
+
 // ─── Performance SLA Schema ────────────────────────────────────────────────
 
 export const PerformanceSLASchema = z.object({
@@ -285,9 +295,9 @@ export const RefactorWorkflowStateSchema = BaseWorkflowStateSchema.extend({
 
 export const OneshotWorkflowStateSchema = BaseWorkflowStateSchema.extend({
   workflowType: z.literal('oneshot'),
-  phase: z.string(),
+  phase: OneshotPhaseSchema,
   oneshot: z.object({
-    synthesisPolicy: z.enum(['always', 'never', 'on-request']).default('on-request'),
+    synthesisPolicy: SynthesisPolicySchema.default('on-request'),
     planSummary: z.string().optional(),
   }).optional(),
 });
@@ -317,6 +327,12 @@ export const WorkflowStateSchema = z.union([
 export const InitInputSchema = z.object({
   featureId: FeatureIdSchema,
   workflowType: WorkflowTypeSchema,
+  /**
+   * Initial synthesis policy for oneshot workflows. Silently ignored for
+   * non-oneshot workflow types. Defaults (when omitted) to `on-request`
+   * via {@link OneshotWorkflowStateSchema}.
+   */
+  synthesisPolicy: SynthesisPolicySchema.optional(),
 });
 
 export const ListInputSchema = z.object({});

--- a/servers/exarchos-mcp/src/workflow/state-machine.ts
+++ b/servers/exarchos-mcp/src/workflow/state-machine.ts
@@ -1,6 +1,11 @@
 import type { Guard, GuardResult } from './guards.js';
 import { guards } from './guards.js';
-import { createFeatureHSM, createDebugHSM, createRefactorHSM } from './hsm-definitions.js';
+import {
+  createFeatureHSM,
+  createDebugHSM,
+  createRefactorHSM,
+  createOneshotHSM,
+} from './hsm-definitions.js';
 
 // Re-export guard types for consumers
 export type { Guard, GuardResult };
@@ -102,18 +107,20 @@ export interface WorkflowTypeSummary {
 
 // ─── HSM Registry ───────────────────────────────────────────────────────────
 
-const BUILT_IN_TYPES = new Set(['feature', 'debug', 'refactor']);
+const BUILT_IN_TYPES = new Set(['feature', 'debug', 'refactor', 'oneshot']);
 
 const hsmRegistry: Record<string, HSMDefinition> = {
   feature: createFeatureHSM(),
   debug: createDebugHSM(),
   refactor: createRefactorHSM(),
+  oneshot: createOneshotHSM(),
 };
 
 const initialPhaseRegistry: Record<string, string> = {
   feature: 'ideate',
   debug: 'triage',
   refactor: 'explore',
+  oneshot: 'plan',
 };
 
 export function isBuiltInWorkflowType(workflowType: string): boolean {

--- a/servers/exarchos-mcp/src/workflow/terminal-phases.ts
+++ b/servers/exarchos-mcp/src/workflow/terminal-phases.ts
@@ -1,0 +1,22 @@
+/**
+ * Terminal phases shared across workflow types.
+ *
+ * A workflow in a terminal phase is complete — no further transitions are
+ * expected — and is excluded from pipeline views, pruning candidates, and
+ * session-start context assembly. Every built-in workflow type ends in one
+ * of these phases via the universal cancel transition or its
+ * type-specific completion guard.
+ *
+ * This constant is the single source of truth; consumers MUST import from
+ * here rather than redeclare the tuple locally. Adding a new terminal phase
+ * requires updating every phase schema in `schemas.ts` AND this constant in
+ * lockstep.
+ */
+export const TERMINAL_PHASES = ['completed', 'cancelled'] as const;
+
+export type TerminalPhase = (typeof TERMINAL_PHASES)[number];
+
+/** True when `phase` is a terminal phase (completed or cancelled). */
+export function isTerminalPhase(phase: string): boolean {
+  return (TERMINAL_PHASES as readonly string[]).includes(phase);
+}

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -152,11 +152,23 @@ export async function handleInit(
       }
     }
 
+    // Oneshot-only: thread `synthesisPolicy` into the initial state under
+    // `state.oneshot`. For non-oneshot workflow types the field is silently
+    // dropped — the `InitInputSchema` accepts it for uniformity but only the
+    // oneshot state shape has a `.oneshot.synthesisPolicy` slot.
+    const extraFields: Record<string, unknown> = {
+      _eventSequence: eventSequence,
+      _esVersion: CURRENT_ES_VERSION,
+    };
+    if (input.workflowType === 'oneshot' && input.synthesisPolicy !== undefined) {
+      extraFields.oneshot = { synthesisPolicy: input.synthesisPolicy };
+    }
+
     const { state } = await initStateFile(
       stateDir,
       input.featureId,
       input.workflowType,
-      { _eventSequence: eventSequence, _esVersion: CURRENT_ES_VERSION },
+      extraFields,
     );
 
     return {

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -196,6 +196,11 @@ export async function handleList(
     phase: entry.state.phase,
     stateFile: entry.stateFile,
     stale: isStale(entry.state._checkpoint),
+    // Expose `_checkpoint` so downstream consumers (e.g. prune-stale-workflows
+    // `extractListEntries`) can read `lastActivityTimestamp` directly. Before
+    // this field was added the prune handler saw every non-terminal workflow
+    // as maximally stale because the fallback was `new Date(0)`.
+    _checkpoint: entry.state._checkpoint,
   }));
 
   return {

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -126,7 +126,14 @@ export async function handleInit(
       // File doesn't exist — proceed with init
     }
 
-    // Event-first: append workflow.started event BEFORE creating state file
+    // Event-first: append workflow.started event BEFORE creating state file.
+    // For oneshot workflows with an explicit `synthesisPolicy`, include it on
+    // the event data so ES v2 rematerialization reconstructs the policy —
+    // without this, rehydrating a state from events alone silently reverts
+    // the workflow to the schema default (`on-request`), losing an
+    // init-time decision that drives the choice-state guard at finalize.
+    const isOneshotWithPolicy =
+      input.workflowType === 'oneshot' && input.synthesisPolicy !== undefined;
     let eventSequence = 0;
     if (eventStore) {
       try {
@@ -137,6 +144,7 @@ export async function handleInit(
           data: {
             featureId: input.featureId,
             workflowType: input.workflowType,
+            ...(isOneshotWithPolicy ? { synthesisPolicy: input.synthesisPolicy } : {}),
           },
         }, { idempotencyKey: `${input.featureId}:workflow.started` });
         eventSequence = event.sequence;

--- a/skills-src/_shared/references/mcp-tool-guidance.md
+++ b/skills-src/_shared/references/mcp-tool-guidance.md
@@ -26,6 +26,8 @@ The four Exarchos composite tools (`exarchos_workflow`, `exarchos_event`, `exarc
 
 This eliminates trial-and-error discovery. One `describe` call costs fewer tokens than a failed call + retry.
 
+> **Note on `describe playbook="oneshot"`:** The MCP server is data-driven, so `describe` works automatically for all workflow types including `oneshot`. For oneshot specifically, the output shows the 4-phase choice-state lifecycle: `plan → implementing → (completed | synthesize → completed)` with the `synthesis-opted-in` / `synthesis-opted-out` guards on the fork.
+
 ## Quick Reference — `exarchos_workflow`
 
 Before calling, consult `@skills/workflow-state/references/mcp-tool-reference.md` for full action signatures, error handling, and anti-patterns.
@@ -34,6 +36,6 @@ Before calling, consult `@skills/workflow-state/references/mcp-tool-reference.md
 |--------|---------------|
 | `get` | `featureId`, optional `query` (dot-path) or `fields` (string array for projection) |
 | `set` | `featureId`, `updates` (object), `phase` (string) — send both in one call for guarded transitions |
-| `init` | `featureId`, `workflowType` (`"feature"` / `"debug"` / `"refactor"`) |
+| `init` | `featureId`, `workflowType` (`"feature"` / `"debug"` / `"refactor"` / `"oneshot"`); for `oneshot`, optional `synthesisPolicy` (`"always"` / `"never"` / `"on-request"`, default `"on-request"`) |
 | `cleanup` | `featureId`, `mergeVerified: true`, `prUrl`, `mergedBranches` |
 | `cancel` | `featureId`, optional `dryRun: true` |

--- a/skills-src/cleanup/SKILL.md
+++ b/skills-src/cleanup/SKILL.md
@@ -15,6 +15,12 @@ metadata:
 
 Resolve merged workflows to `completed` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
 
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use `@skills/prune-workflows/SKILL.md`. That skill invokes `exarchos_orchestrate prune_stale_workflows` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → `completed`); prune is bulk (N inactive workflows → `cancelled`). They are complementary, not alternatives.
+
 ## Triggers
 
 Activate this skill when:

--- a/skills-src/delegation/SKILL.md
+++ b/skills-src/delegation/SKILL.md
@@ -20,6 +20,8 @@ Activate this skill when:
 - Implementation plan is ready with extractable tasks
 - User wants to parallelize work across subagents
 
+**Exception — oneshot workflows skip delegation entirely.** The oneshot playbook runs an in-session TDD loop in the main agent's context, with no subagent dispatch or review phase. If `workflowType === "oneshot"`, do not call this skill — see `@skills/oneshot-workflow/SKILL.md` for the lightweight path.
+
 ## Core Principles
 
 ### Fresh Context Per Task (MANDATORY)

--- a/skills-src/oneshot-workflow/SKILL.md
+++ b/skills-src/oneshot-workflow/SKILL.md
@@ -144,23 +144,26 @@ plan should answer four questions in 5-10 lines each:
 3. **Files** — which files will be touched? (1-5 typically)
 4. **Tests** — which test cases will be added? (named, not described)
 
-Persist the plan and transition to `implementing` in a single set call:
+Persist the plan and transition to `implementing` in a single set call.
+`phase` is a top-level argument of `set`, not a field inside `updates`:
 
 ```typescript
 {{MCP_PREFIX}}exarchos_workflow({
   action: "set",
   featureId: "fix-readme-typo",
+  phase: "implementing",
   updates: {
-    "artifacts": { "plan": "<plan text>" },
-    "oneshot": { "planSummary": "<one-line summary>" },
-    "phase": "implementing"
+    "artifacts.plan": "<plan text>",
+    "oneshot.planSummary": "<one-line summary>"
   }
 })
 ```
 
 The plan goes on `artifacts.plan` for parity with the `feature` workflow;
 the human-readable one-liner goes on `oneshot.planSummary` for the
-pipeline view.
+pipeline view. Only `artifacts.plan` is enforced by the
+`oneshot-plan-set` guard — `planSummary` is an optional pipeline-view
+label and is not a substitute for a real plan artifact.
 
 ### Step 3 — Implementing phase
 
@@ -292,7 +295,14 @@ Agent:
      → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
   2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
      tests=[readme has no occurrence of 'recieve']
-  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",                   // top-level
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "..."
+       }
+     }
   4. [RED] writes test that greps README for 'recieve' and expects 0 matches
         — fails (1 match exists)
   5. [GREEN] edits README, fixes typo

--- a/skills-src/oneshot-workflow/SKILL.md
+++ b/skills-src/oneshot-workflow/SKILL.md
@@ -12,8 +12,8 @@ metadata:
 # Oneshot Workflow Skill
 
 A lean, four-phase workflow type for changes that are too small to justify the
-full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
-still deserve event-sourced auditability and a planning step. The workflow is
+full `feature` flow (`ideate → plan → plan-review → delegate → review → synthesize → completed`)
+but still deserve event-sourced auditability and a planning step. The workflow is
 **direct-commit by default** with an opt-in PR path; the choice between the
 two is resolved at the end of `implementing` via a pure event-sourced guard,
 not a heuristic.
@@ -88,7 +88,7 @@ and overrides runtime signal.
 
 ## Lifecycle
 
-```
+```text
      plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
                                  │
                                  └── [synthesisOptedIn]  ──► synthesize ──► completed
@@ -286,7 +286,7 @@ do not exist in the oneshot playbook. The PR review is the only review.
 
 ### Example A — Direct-commit (default `on-request` policy, no opt-in)
 
-```
+```text
 User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
        Use oneshot."
 
@@ -317,7 +317,7 @@ Agent:
 
 ### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
 
-```
+```text
 User: "Add input validation to the parseConfig helper. Oneshot."
 
 Agent:
@@ -347,7 +347,7 @@ Agent:
 
 ### Example C — `synthesisPolicy: 'always'` (PR mandatory)
 
-```
+```text
 User: "I want a PR for any change to the auth module, even small ones.
        Use oneshot but always make a PR."
 

--- a/skills-src/oneshot-workflow/SKILL.md
+++ b/skills-src/oneshot-workflow/SKILL.md
@@ -214,13 +214,22 @@ for phrases like:
 When you hear any of those, call `request_synthesize` immediately. The
 handler appends a `synthesize.requested` event to the workflow's event
 stream; the `synthesisOptedIn` guard reads the stream at finalize and
-routes accordingly. This is **idempotent** — calling
-`request_synthesize` twice appends two events but the guard treats any
-count >= 1 as "opted in", so duplicate calls are benign.
+routes accordingly.
+
+`request_synthesize` is accepted from both `plan` and `implementing`
+phases — call it whenever you know you want the PR path, even before
+`implementing` starts. Terminal phases (`synthesize`, `completed`,
+`cancelled`) are rejected.
+
+Duplicate calls are **routing-idempotent** but not event-idempotent:
+each call appends a new `synthesize.requested` event, but the guard
+treats any count >= 1 as "opted in", so the routing decision is the
+same whether you call once or five times. The event stream will
+contain each duplicate for audit purposes.
 
 Calling `request_synthesize` does **not** transition the phase. The
-workflow stays in `implementing`. The decision is only acted on when
-you call `finalize_oneshot` in step 4.
+workflow stays in its current phase. The decision is only acted on
+when you call `finalize_oneshot` in step 4.
 
 ### Step 4 — Finalize (the choice point)
 
@@ -393,7 +402,7 @@ For the full transition table for oneshot, consult
 
 | From | To | Guard |
 |---|---|---|
-| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `plan` | `implementing` | `oneshotPlanSet` (requires non-empty `artifacts.plan`) |
 | `implementing` | `synthesize` | `synthesisOptedIn` |
 | `implementing` | `completed` | `synthesisOptedOut` |
 | `synthesize` | `completed` | `mergeVerified` |
@@ -401,9 +410,10 @@ For the full transition table for oneshot, consult
 
 `synthesisOptedIn` and `synthesisOptedOut` are pure functions of
 `state.oneshot.synthesisPolicy` and `state._events`. They are mutually
-exclusive across all 8 (3 policies × event-present/absent, with `always`
-and `never` ignoring the event flag) combinations — exactly one returns
-true at any given time.
+exclusive across all 4 meaningful combinations — `always` and `never`
+each map to one outcome (ignoring the event flag), and `on-request`
+branches on whether a `synthesize.requested` event is present or
+absent. Exactly one guard returns true at any given time.
 
 ### Schema discovery
 

--- a/skills-src/oneshot-workflow/SKILL.md
+++ b/skills-src/oneshot-workflow/SKILL.md
@@ -189,11 +189,11 @@ work directly. There is **no separate review phase**. Quality is
 maintained by the TDD loop and (if the user opts in) the synthesize PR
 review.
 
-#### Mid-implementing: opting in to a PR
+#### Mid-workflow: opting in to a PR
 
-If at any point during implementing the user decides they want a PR
-after all (policy is `on-request`, default), they can opt in by calling
-the `request_synthesize` orchestrate action:
+If at any point during `plan` or `implementing` the user decides they
+want a PR after all (policy is `on-request`, default), they can opt in
+by calling the `request_synthesize` orchestrate action:
 
 ```typescript
 {{MCP_PREFIX}}exarchos_orchestrate({
@@ -397,6 +397,12 @@ explicitly is recommended when the user has stated a preference.
 
 For the full transition table for oneshot, consult
 `@skills/workflow-state/references/phase-transitions.md`.
+
+> **Note:** The engine's `exarchos_workflow describe playbook="oneshot"`
+> output and the HSM definitions in `hsm-definitions.ts` are the
+> canonical sources for transition behavior. `phase-transitions.md` is
+> a prose reference that can drift — when discrepancies arise, prefer
+> engine `describe` output.
 
 **Quick reference for oneshot:**
 

--- a/skills-src/oneshot-workflow/SKILL.md
+++ b/skills-src/oneshot-workflow/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: oneshot-workflow
+description: "Lightweight workflow for straightforward changes — plan → implement → optional PR. Direct-commit by default; synthesize is opt-in via synthesisPolicy or a runtime request_synthesize event. Use for trivial fixes, config tweaks, single-file changes, or exploratory work that doesn't warrant subagent dispatch or two-stage review. Triggers: 'oneshot', 'quick fix', 'small change', or {{COMMAND_PREFIX}}oneshot."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: plan
+---
+
+# Oneshot Workflow Skill
+
+A lean, four-phase workflow type for changes that are too small to justify the
+full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
+still deserve event-sourced auditability and a planning step. The workflow is
+**direct-commit by default** with an opt-in PR path; the choice between the
+two is resolved at the end of `implementing` via a pure event-sourced guard,
+not a heuristic.
+
+> **Read this first if you have never run a oneshot:** the workflow has a
+> *choice state* at the end of `implementing`. Whether you land on
+> `completed` (direct commit) or transition through `synthesize` (PR) is
+> decided by two inputs: the `synthesisPolicy` set at init, and whether the
+> user emitted a `synthesize.requested` event during implementing. Both
+> inputs are persisted; the decision is replay-safe.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically a single file, or a tightly-coupled
+  cluster of 2-3 files
+- No subagent dispatch is needed — the work fits comfortably in one TDD
+  loop in a single session
+- No design document is required — the goal is obvious from the task
+  description, and a one-page plan is enough scaffolding
+- No two-stage review is required — either the change is trivial enough
+  that direct-commit is acceptable, or a single PR review will suffice
+
+Concrete examples that fit oneshot:
+- Fixing a typo in a README
+- Bumping a dependency version
+- Adding a missing null-check in one function
+- Tweaking a CI workflow YAML
+- Renaming a config key everywhere it's referenced
+- Adding a one-off helper script
+- Exploratory spikes that may or may not be kept
+
+## When NOT to use oneshot
+
+Do not use oneshot for any of the following — use the full `feature`
+workflow instead (`{{COMMAND_PREFIX}}ideate`):
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+- Anything where you'd want a written design doc to look back at
+
+If you start a oneshot and discover the change is bigger than expected, the
+right move is `{{COMMAND_PREFIX}}cancel` and restart with `{{COMMAND_PREFIX}}ideate`.
+Don't try to grow a oneshot into a feature workflow mid-stream; the
+playbooks have different shapes and you'll fight the state machine.
+
+## Synthesis policy — three options
+
+The `synthesisPolicy` field on a oneshot workflow declares the user's
+intent up front about whether the change should be turned into a PR. It
+takes one of three values, persisted on `state.oneshot.synthesisPolicy`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| `always` | Always transition `implementing → synthesize` at finalize, regardless of events. A PR is always created. | The user wants a paper trail / review for every change in this workflow, even small ones. |
+| `never` | Always transition `implementing → completed` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | The user is iterating on personal/scratch work and explicitly opts out of PRs. |
+| `on-request` *(default)* | Direct-commit by default. The user can opt in to a PR mid-implementing by calling `request_synthesize`; if any `synthesize.requested` event is on the stream at finalize, the workflow transitions to `synthesize` instead of `completed`. | The common case: start with the assumption of direct-commit, but leave the door open for the user to change their mind once they see the diff. |
+
+The default is `on-request` because it's the least surprising: the user
+gets the lightweight path until they explicitly ask for the heavy one.
+
+**Policy wins over event.** If `synthesisPolicy: 'never'` is set and a
+`synthesize.requested` event is somehow on the stream (e.g. the user
+called the action on a workflow they thought was `on-request`), the
+guard still routes to `completed`. Policy is the user's declared intent
+and overrides runtime signal.
+
+## Lifecycle
+
+```
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+```
+
+Four phases. The fork after `implementing` is a UML *choice state*,
+implemented via two mutually-exclusive HSM transitions whose guards are
+pure functions of `state.oneshot.synthesisPolicy` and the
+`synthesize.requested` event count.
+
+| Phase | What happens | Exit criteria |
+|---|---|---|
+| `plan` | Lightweight one-page plan: goal, approach, files to touch, tests to add. No design doc. No subagent dispatch. | `artifacts.plan` set → transition to `implementing` |
+| `implementing` | In-session TDD loop. Write a failing test, make it pass, refactor. Commit as you go. The TDD iron law applies — *no production code without a failing test first*. | Tests pass + typecheck clean + finalize_oneshot called |
+| `synthesize` | Reached **only** when `synthesisOptedIn` is true. Hands off to the existing synthesis flow — see `@skills/synthesis/SKILL.md`. PR created via `gh pr create`, auto-merge enabled, CI gates apply. | PR merged → `completed` |
+| `completed` | Terminal. For direct-commit path, commits are already on the branch — there's nothing more to do. For synthesize path, the PR merge event terminates the workflow. | — |
+
+`cancelled` is also reachable from any phase via the universal cancel
+transition, same as every other workflow type.
+
+## Step-by-step
+
+### Step 1 — Init
+
+Call `exarchos_workflow` with `action: 'init'`, `workflowType: 'oneshot'`,
+and an optional `synthesisPolicy`:
+
+```typescript
+{{MCP_PREFIX}}exarchos_workflow({
+  action: "init",
+  featureId: "fix-readme-typo",
+  workflowType: "oneshot",
+  synthesisPolicy: "on-request" // optional — defaults to 'on-request'
+})
+```
+
+If the user has been clear up front ("I want a PR for this"), pass
+`synthesisPolicy: "always"`. If they've been clear ("don't open a PR,
+just commit it"), pass `synthesisPolicy: "never"`. Otherwise, omit the
+field and rely on the `on-request` default — you can always escalate
+later in the implementing phase.
+
+The init returns the new workflow state; the workflow lands in `plan`.
+
+### Step 2 — Plan phase
+
+Produce a one-page plan. This is intentionally lightweight — no design
+doc, no parallelization analysis, no decomposition into N tasks. The
+plan should answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to `implementing` in a single set call:
+
+```typescript
+{{MCP_PREFIX}}exarchos_workflow({
+  action: "set",
+  featureId: "fix-readme-typo",
+  updates: {
+    "artifacts": { "plan": "<plan text>" },
+    "oneshot": { "planSummary": "<one-line summary>" },
+    "phase": "implementing"
+  }
+})
+```
+
+The plan goes on `artifacts.plan` for parity with the `feature` workflow;
+the human-readable one-liner goes on `oneshot.planSummary` for the
+pipeline view.
+
+### Step 3 — Implementing phase
+
+Run an in-session TDD loop. Same iron law as every other workflow:
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run the test. Confirm it fails for
+   the right reason.
+2. **[GREEN]** Write the minimum production code to make the test pass.
+   Run the test. Confirm it passes.
+3. **[REFACTOR]** Clean up while keeping the test green.
+
+Commit each red-green-refactor cycle as a single commit. Do not batch
+multiple unrelated changes into one commit — keeping commits atomic
+matters even more in oneshot, where there's no separate review phase
+to catch bundled changes.
+
+There is **no subagent dispatch** in oneshot. The main agent does the
+work directly. There is **no separate review phase**. Quality is
+maintained by the TDD loop and (if the user opts in) the synthesize PR
+review.
+
+#### Mid-implementing: opting in to a PR
+
+If at any point during implementing the user decides they want a PR
+after all (policy is `on-request`, default), they can opt in by calling
+the `request_synthesize` orchestrate action:
+
+```typescript
+{{MCP_PREFIX}}exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+```
+
+**The trigger for this is conversational, not a magic keyword.** Listen
+for phrases like:
+- "actually, let's open a PR for this"
+- "I want a review on this before it lands"
+- "make this a PR"
+- "let's get eyes on this"
+- "synthesize this"
+
+When you hear any of those, call `request_synthesize` immediately. The
+handler appends a `synthesize.requested` event to the workflow's event
+stream; the `synthesisOptedIn` guard reads the stream at finalize and
+routes accordingly. This is **idempotent** — calling
+`request_synthesize` twice appends two events but the guard treats any
+count >= 1 as "opted in", so duplicate calls are benign.
+
+Calling `request_synthesize` does **not** transition the phase. The
+workflow stays in `implementing`. The decision is only acted on when
+you call `finalize_oneshot` in step 4.
+
+### Step 4 — Finalize (the choice point)
+
+When the implementing loop is done — tests pass, typecheck clean, all
+commits made — call `finalize_oneshot` to resolve the choice state:
+
+```typescript
+{{MCP_PREFIX}}exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+```
+
+The handler:
+
+1. Reads the current state and verifies `workflowType === 'oneshot'` and
+   `phase === 'implementing'`.
+2. Hydrates `_events` from the event store so the guard sees the same
+   view the HSM will see during the actual transition.
+3. Evaluates `guards.synthesisOptedIn` against the state. The guard
+   inspects `state.oneshot.synthesisPolicy` and the `_events` array.
+4. Calls `handleSet` with the resolved target phase (`synthesize` or
+   `completed`). The HSM re-evaluates the guard at the transition
+   boundary, so any race between the read and the transition is caught
+   safely.
+
+Possible outcomes:
+
+| `synthesisPolicy` | `synthesize.requested` event present? | Resolved target | Path |
+|---|---|---|---|
+| `always` | (any) | `synthesize` | PR path |
+| `never` | (any) | `completed` | direct-commit path |
+| `on-request` (default) | yes | `synthesize` | PR path |
+| `on-request` (default) | no | `completed` | direct-commit path |
+
+### Step 5a — Direct-commit path (terminal)
+
+If finalize resolved to `completed`, you're done. The commits made
+during implementing are already on the current branch. Push them if
+they aren't already pushed:
+
+```bash
+git push
+```
+
+The workflow is now in `completed` and will not appear in the default
+pipeline view.
+
+### Step 5b — Synthesize path
+
+If finalize resolved to `synthesize`, hand off to the standard synthesis
+flow — see `@skills/synthesis/SKILL.md`. The same `prepare_synthesis` /
+`validate_pr_body` / `gh pr create` machinery used by the `feature`
+workflow applies. After the PR merges, the workflow transitions
+`synthesize → completed` via the existing `mergeVerified` guard, same as
+every other workflow type.
+
+You do **not** need to run `{{COMMAND_PREFIX}}delegate` or
+`{{COMMAND_PREFIX}}review` for an opt-in oneshot synthesize. Those phases
+do not exist in the oneshot playbook. The PR review is the only review.
+
+## Example invocations
+
+### Example A — Direct-commit (default `on-request` policy, no opt-in)
+
+```
+User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
+       Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
+  2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  4. [RED] writes test that greps README for 'recieve' and expects 0 matches
+        — fails (1 match exists)
+  5. [GREEN] edits README, fixes typo
+        — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+```
+
+### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
+
+```
+User: "Add input validation to the parseConfig helper. Oneshot."
+
+Agent:
+  1. exarchos_workflow init { workflowType: "oneshot" }
+     → 'plan' phase, default 'on-request'
+  2. plans (goal: validate input, files: [parser.ts, parser.test.ts])
+  3. transitions to 'implementing'
+  4. [RED] writes test for null-input case
+  5. [GREEN] adds null check
+  6. [REFACTOR] extracts validateInput helper
+  7. commits
+
+User: "Actually, this is touching the parser — I want a review on it before
+       it lands."
+
+Agent:
+  8. exarchos_orchestrate request_synthesize {
+       featureId, reason: "user requested review of parser changes"
+     }
+     → appends synthesize.requested event
+  9. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='on-request' + 1 synthesize.requested event
+     → resolves to 'synthesize'
+ 10. hands off to @skills/synthesis/SKILL.md → prepare_synthesis →
+     validate_pr_body → gh pr create → merge
+```
+
+### Example C — `synthesisPolicy: 'always'` (PR mandatory)
+
+```
+User: "I want a PR for any change to the auth module, even small ones.
+       Use oneshot but always make a PR."
+
+Agent:
+  1. exarchos_workflow init {
+       workflowType: "oneshot",
+       synthesisPolicy: "always"
+     }
+  2-7. plan + TDD + commits, identical to Example A
+  8. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='always' (short-circuits — no event check needed)
+     → resolves to 'synthesize'
+  9. synthesis flow → PR
+```
+
+## State management
+
+Track oneshot-specific state under the `oneshot` key on the workflow state:
+
+```typescript
+{{MCP_PREFIX}}exarchos_workflow({
+  action: "set",
+  featureId: "<id>",
+  updates: {
+    "oneshot": {
+      "synthesisPolicy": "on-request",
+      "planSummary": "Fix off-by-one in pagination helper"
+    }
+  }
+})
+```
+
+The `synthesisPolicy` field is optional and defaults to `'on-request'` per
+the schema in `servers/exarchos-mcp/src/workflow/schemas.ts`. Setting it
+explicitly is recommended when the user has stated a preference.
+
+## Phase Transitions and Guards
+
+For the full transition table for oneshot, consult
+`@skills/workflow-state/references/phase-transitions.md`.
+
+**Quick reference for oneshot:**
+
+| From | To | Guard |
+|---|---|---|
+| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `implementing` | `synthesize` | `synthesisOptedIn` |
+| `implementing` | `completed` | `synthesisOptedOut` |
+| `synthesize` | `completed` | `mergeVerified` |
+| (any) | `cancelled` | universal — always allowed |
+
+`synthesisOptedIn` and `synthesisOptedOut` are pure functions of
+`state.oneshot.synthesisPolicy` and `state._events`. They are mutually
+exclusive across all 8 (3 policies × event-present/absent, with `always`
+and `never` ignoring the event flag) combinations — exactly one returns
+true at any given time.
+
+### Schema discovery
+
+Use `exarchos_workflow({ action: "describe", actions: ["init", "set"] })`
+for parameter schemas (including the `synthesisPolicy` enum) and
+`exarchos_workflow({ action: "describe", playbook: "oneshot" })` for the
+phase transitions, guard names, and playbook prose. Use
+`exarchos_orchestrate({ action: "describe", actions: ["request_synthesize", "finalize_oneshot"] })`
+for the orchestrate action schemas.
+
+## TDD is still mandatory
+
+The iron law from `@rules/tdd.md` applies to oneshot. There is no
+exemption for "small" changes. Specifically:
+
+- Every behavior change starts with a failing test
+- Every test must fail before its implementation is written
+- Tests must be run after each change to verify state
+- Commits stay atomic — one logical change per commit
+
+The temptation in a oneshot is to skip the test "because it's just one
+line". Resist that. The test is what makes the change auditable, and
+auditability is the entire reason oneshot exists alongside the lighter
+"bypass workflows entirely" path.
+
+## Anti-patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip the plan phase ("it's obvious") | Write the four-line plan anyway — it's the artifact future-you reads |
+| Skip the TDD loop in implementing | Always RED → GREEN → REFACTOR, even for one-liners |
+| Use oneshot for multi-file refactors | Use `{{COMMAND_PREFIX}}ideate` and the full feature workflow |
+| Try to grow a oneshot into a feature workflow mid-stream | Cancel and restart with `{{COMMAND_PREFIX}}ideate` |
+| Call `request_synthesize` without listening for the user's intent | Wait for the user to ask for a PR, then call it |
+| Bundle unrelated changes into one commit "since it's a oneshot" | Keep commits atomic — there's no review phase to catch bundling |
+| Forget to call `finalize_oneshot` at the end | The workflow stays in `implementing` forever otherwise — call it explicitly |
+
+## Completion criteria
+
+- [ ] `exarchos_workflow init` called with `workflowType: "oneshot"`
+- [ ] One-page plan persisted to `artifacts.plan`
+- [ ] Phase transitioned to `implementing`
+- [ ] All planned behaviors implemented via TDD with atomic commits
+- [ ] `finalize_oneshot` called and resolved to either `completed` or `synthesize`
+- [ ] If direct-commit path: commits pushed
+- [ ] If synthesize path: PR created via `@skills/synthesis/SKILL.md` and merged

--- a/skills-src/oneshot-workflow/references/choice-state.md
+++ b/skills-src/oneshot-workflow/references/choice-state.md
@@ -1,0 +1,65 @@
+---
+name: oneshot-choice-state
+---
+
+# Oneshot Choice State: `implementing → ?`
+
+The oneshot workflow has a UML *choice state* at the end of `implementing`.
+Whether the workflow lands on `completed` (direct-commit) or transitions
+through `synthesize` (PR) is decided by two mutually-exclusive pure-function
+guards: `synthesisOptedIn` and `synthesisOptedOut`. Both are evaluated against
+the current workflow state at the transition boundary; exactly one returns
+`true` for every possible input.
+
+## Inputs read by the guards
+
+Both guards read exactly two things from state:
+
+1. `state.oneshot.synthesisPolicy` — one of `'always' | 'never' | 'on-request'`,
+   defaulted to `'on-request'` by the init schema.
+2. `state._events` — the hydrated event stream. The guard counts
+   `synthesize.requested` events on the stream (any count ≥ 1 means "opted in").
+
+Nothing else. No clock reads, no filesystem, no network, no git state. This
+is load-bearing for replay safety: given the same persisted state, the same
+target resolves every time, and re-running finalize is idempotent.
+
+## Decision table
+
+| `synthesisPolicy` | `synthesize.requested` count | `synthesisOptedIn` | `synthesisOptedOut` | Resolved target |
+|---|---|---|---|---|
+| `'always'`     | 0  | `true`  | `false` | `synthesize` |
+| `'always'`     | ≥1 | `true`  | `false` | `synthesize` |
+| `'never'`      | 0  | `false` | `true`  | `completed`  |
+| `'never'`      | ≥1 | `false` | `true`  | `completed`  |
+| `'on-request'` | 0  | `false` | `true`  | `completed`  |
+| `'on-request'` | ≥1 | `true`  | `false` | `synthesize` |
+
+**Policy wins over event.** On `'never'`, even if a stray `synthesize.requested`
+event is on the stream, the guard still routes to `completed`. Policy is the
+user's declared intent; runtime events only matter when the policy explicitly
+defers to them (`'on-request'`).
+
+## Why a choice state, not a single transition with branching logic
+
+Keeping the fork at the HSM level (two transitions, two mutually-exclusive
+guards) means:
+
+- The state machine graph visibly encodes both paths — operators reading
+  `hsm-definitions.ts` see `implementing → completed` and `implementing →
+  synthesize` as sibling transitions, not a hidden conditional.
+- The HSM re-evaluates guards at the transition boundary, so any race
+  between `finalize_oneshot` reading state and `handleSet` performing the
+  transition is caught safely — if a last-millisecond event changed the
+  evaluation, the HSM will refuse the wrong transition.
+- Guard logic stays testable in isolation (`guards.test.ts`) without
+  needing to spin up the handler.
+
+## See also
+
+- `servers/exarchos-mcp/src/workflow/guards.ts` — `synthesisOptedIn`,
+  `synthesisOptedOut`, `oneshotPlanSet` guard implementations.
+- `servers/exarchos-mcp/src/workflow/hsm-definitions.ts` — the oneshot HSM
+  with the two sibling transitions from `implementing`.
+- `servers/exarchos-mcp/src/orchestrate/finalize-oneshot.ts` — the handler
+  that resolves the choice state and calls `handleSet`.

--- a/skills-src/prune-workflows/SKILL.md
+++ b/skills-src/prune-workflows/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: prune-workflows
+description: "Interactively prune stale non-terminal workflows from the pipeline. Use when the user says 'prune workflows', 'clean stale workflows', 'pipeline cleanup', or runs /prune. Runs a dry-run preview, displays candidates with staleness and safeguard skips, prompts the user to proceed/abort/force, then bulk-cancels approved workflows with a workflow.pruned audit event. Safeguards skip workflows with open PRs or recent commits unless force is set."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: maintenance
+---
+
+# Prune Workflows Skill
+
+## Overview
+
+Bulk-cancel stale non-terminal workflows that have accumulated in the pipeline. Wraps the `prune_stale_workflows` orchestrate action with an interactive dry-run-then-confirm UX so the user always sees the candidate set before any state mutates.
+
+Pruning is a maintenance operation -- not a workflow phase. It produces `workflow.pruned` events alongside the standard `workflow.cancelled` events emitted by the underlying cancel path, so downstream views can distinguish user-intent cancellations from batch cleanup.
+
+## Triggers
+
+Activate this skill when:
+- User runs `{{COMMAND_PREFIX}}prune` command
+- User says "prune workflows", "clean stale workflows", "pipeline cleanup"
+- `{{MCP_PREFIX}}exarchos_view({ action: "pipeline" })` shows many inactive workflows the user wants to clear in bulk
+
+## Prerequisites
+
+- An exarchos state directory with one or more non-terminal workflows
+- For safeguard checks against live PRs: `gh` available in PATH (the orchestrate handler shells out)
+- For safeguard checks against branch activity: `git` available in PATH
+
+## Process
+
+### Step 1: Dry-Run Preview
+
+Always start with `dryRun: true`. This call performs candidate selection and safeguard evaluation but does not mutate any workflow state.
+
+```typescript
+{{MCP_PREFIX}}exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: true
+  }
+})
+```
+
+The response shape is:
+
+```ts
+{
+  candidates: [
+    { featureId: string, phase: string, workflowType: string, stalenessMinutes: number }
+  ],
+  skipped: [
+    { featureId: string, reason: "open-pr" | "active-branch" }
+  ]
+}
+```
+
+Optional args:
+- `thresholdMinutes` -- staleness cutoff. Default is 10080 (7 days).
+- `includeOneShot` -- whether to include `oneshot` workflows in the candidate set. Default `true`.
+- `force` -- not relevant in dry-run; only honored in apply mode (Step 4).
+
+### Step 2: Display Candidate Table
+
+Render a table to the user so they can review what would be pruned. Use this format:
+
+```markdown
+## Prune Candidates ({{count}})
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-experiment | feature | implementing | 14430 |
+| oneshot-typo-fix | oneshot | plan | 9120 |
+| debug-flaky-test | debug | investigate | 8650 |
+
+## Skipped by Safeguards ({{skippedCount}})
+
+| Feature ID | Reason |
+|---|---|
+| feat-active-pr | open-pr |
+| feat-recent-work | active-branch |
+```
+
+If `candidates.length === 0` AND `skipped.length === 0`, output:
+
+> No stale workflows to prune. Pipeline is clean.
+
+Then exit -- no further action.
+
+### Step 3: Prompt for Confirmation
+
+Ask the user one of three choices:
+
+> **proceed** -- prune the listed candidates (skipped workflows stay)
+> **abort** -- exit without changes
+> **force** -- bypass safeguards and prune skipped workflows too
+
+Wait for explicit user input. Do **not** auto-proceed.
+
+### Step 4a: Apply (proceed)
+
+On `proceed`, invoke the same action with `dryRun: false`. Pass through `thresholdMinutes` and `includeOneShot` if the user set them in Step 1.
+
+```typescript
+{{MCP_PREFIX}}exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false
+  }
+})
+```
+
+The response now includes a `pruned` array:
+
+```ts
+{
+  candidates: [...],
+  skipped: [...],
+  pruned: [
+    { featureId: string, previousPhase: string }
+  ]
+}
+```
+
+Each entry in `pruned` corresponds to a workflow that transitioned to `cancelled` and emitted a `workflow.pruned` event.
+
+### Step 4b: Apply (force)
+
+On `force`, set `force: true`. Safeguards are bypassed but the bypass is recorded in the `workflow.pruned` event payload as `skippedSafeguards: [...]` so the audit trail is intact.
+
+```typescript
+{{MCP_PREFIX}}exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false,
+    force: true
+  }
+})
+```
+
+In force mode, workflows that were in the `skipped` list during dry-run are now eligible for pruning.
+
+### Step 4c: Apply (abort)
+
+On `abort`, exit without invoking the action a second time. The dry-run has not mutated any state.
+
+### Step 5: Report Results
+
+After the apply call returns, summarize the outcome:
+
+```markdown
+## Prune Complete
+
+**Pruned:** {{prunedCount}} workflows transitioned to cancelled
+**Skipped:** {{skippedCount}} workflows preserved by safeguards
+**Force bypass:** {{yes/no}}
+
+### Pruned Workflows
+- feat-old-experiment (was: implementing)
+- oneshot-typo-fix (was: plan)
+- debug-flaky-test (was: investigate)
+```
+
+If `force` was used, also list any safeguards that were bypassed:
+
+```markdown
+### Safeguards Bypassed
+- feat-active-pr: open-pr
+- feat-recent-work: active-branch
+```
+
+## Safeguards Explained
+
+Two safeguards run automatically in the orchestrate handler before each cancel:
+
+| Safeguard | Behavior | Reason key |
+|---|---|---|
+| **Open PR** | Skip if `gh pr list --head <branch> --state open` returns any results | `open-pr` |
+| **Recent commits** | Skip if `git log --since "24 hours ago" origin/<branch>` shows commits | `active-branch` |
+
+A workflow without a `branchName` in state (e.g., abandoned at ideate/plan before delegation) cannot have a PR or branch activity, so safeguards short-circuit and the workflow is eligible for pruning.
+
+`force: true` bypasses both checks but does not bypass the audit -- the bypassed safeguard names are recorded in the `workflow.pruned` event payload.
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|---|---|
+| Skip the dry-run step | Always start with `dryRun: true` so the user sees candidates first |
+| Auto-confirm without showing the table | Render the candidate table and wait for explicit user input |
+| Use `force: true` by default | Reserve `force` for cases where the user has explicitly opted in |
+| Manually call `cancel` for each stale workflow | Use this skill -- it batches the cancel loop and emits the `workflow.pruned` audit event |
+| Run on every session | Pruning is a maintenance operation; run when pipeline accumulation is observable |
+
+## Examples
+
+### Example 1: Clean dry-run, user proceeds
+
+```
+> {{COMMAND_PREFIX}}prune
+
+## Prune Candidates (2)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-spike | feature | plan | 12880 |
+| oneshot-readme-tweak | oneshot | implementing | 9700 |
+
+## Skipped by Safeguards (0)
+
+(none)
+
+Proceed? (proceed/abort/force)
+
+> proceed
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** no
+
+### Pruned Workflows
+- feat-old-spike (was: plan)
+- oneshot-readme-tweak (was: implementing)
+```
+
+### Example 2: Safeguard skip, user forces
+
+```
+> {{COMMAND_PREFIX}}prune
+
+## Prune Candidates (1)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-stale-no-pr | feature | implementing | 11200 |
+
+## Skipped by Safeguards (1)
+
+| Feature ID | Reason |
+|---|---|
+| feat-stale-with-pr | open-pr |
+
+Proceed? (proceed/abort/force)
+
+> force
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** yes
+
+### Pruned Workflows
+- feat-stale-no-pr (was: implementing)
+- feat-stale-with-pr (was: implementing)
+
+### Safeguards Bypassed
+- feat-stale-with-pr: open-pr
+```
+
+### Example 3: Empty pipeline
+
+```
+> {{COMMAND_PREFIX}}prune
+
+No stale workflows to prune. Pipeline is clean.
+```
+
+## Schema Discovery
+
+For the canonical argument schema and any future fields, use:
+
+```typescript
+{{MCP_PREFIX}}exarchos_orchestrate({
+  action: "describe",
+  actions: ["prune_stale_workflows"]
+})
+```
+
+## Exarchos Integration
+
+The `prune_stale_workflows` action emits two events per pruned workflow:
+- `workflow.cancelled` (auto-emitted by the underlying `handleCancel` path)
+- `workflow.pruned` (emitted by this handler with `triggeredBy: 'manual'` and optional `skippedSafeguards`)
+
+Both are projected into the workflow state's `_events` array by the standard projection. Downstream views can filter on `workflow.pruned` to identify batch cleanups versus user-initiated cancels.

--- a/skills-src/prune-workflows/references/safeguards.md
+++ b/skills-src/prune-workflows/references/safeguards.md
@@ -1,0 +1,74 @@
+---
+name: prune-safeguards
+---
+
+# Prune Safeguards
+
+The `prune_stale_workflows` orchestrate action runs two safeguards on each
+candidate before it will actually cancel the workflow. Both must pass for
+the candidate to be pruned, unless the caller passes `force: true` to
+bypass them.
+
+## Safeguard 1: `hasOpenPR`
+
+Checks whether there's an open pull request targeting the workflow's
+branch. Implementation: `gh pr list --state open --head <branchName>` —
+if the list is non-empty, the safeguard fails and the candidate is
+skipped with reason `open-pr`.
+
+Rationale: an open PR means human work is still in-flight on this feature.
+Cancelling the workflow would orphan the PR from its event-sourced state,
+which makes it invisible to `exarchos_view` and breaks auto-merge gates.
+We refuse to prune workflows with open PRs by default.
+
+## Safeguard 2: `hasRecentCommits` (user-facing: `active-branch`)
+
+Checks whether any commits landed on the workflow's branch within a
+24-hour window. Implementation: `git log --since="24 hours ago"
+<branchName>` — if the output is non-empty, the safeguard fails and the
+candidate is skipped with reason `active-branch`.
+
+Rationale: commits on the branch mean the workflow isn't actually stale,
+it just missed the last event checkpoint. The underlying branch is the
+ground truth for "is this work still alive?" — if someone is committing,
+we don't care what the checkpoint timestamp says.
+
+The window is locked at 24 hours for v1. It's exposed as a module
+constant (`RECENT_COMMITS_WINDOW_HOURS` in `prune-stale-workflows.ts`)
+so tests can see the contract, but it's not yet configurable through
+the public handler args.
+
+## Short-circuit: missing `branchName`
+
+If the workflow state has no top-level `branchName` field, both
+safeguards are skipped entirely (they have nothing to look up). The
+candidate still proceeds to cancel. This is safe because a workflow
+without a branch can't have an open PR or recent commits by definition.
+
+## `force: true` bypass semantics
+
+Passing `force: true` skips safeguard evaluation for every candidate.
+The handler still does everything else — the cancel, the event emission,
+the audit trail — but `hasOpenPR` and `hasRecentCommits` are never
+called.
+
+Every `workflow.pruned` event emitted during a `force: true` run carries
+a `skippedSafeguards: ['open-pr', 'active-branch']` marker on its payload.
+This makes forced prunes distinguishable in the audit stream from
+safeguard-approved ones, so operators reviewing the event log can see
+exactly which workflows were cancelled despite having open PRs or active
+branches.
+
+The marker list is intentionally hardcoded to *all* safeguards, not just
+the ones that would have failed. Running `force: true` is a blanket
+"I know what I'm doing" override — we want the audit trail to reflect
+that the user chose to bypass the whole safeguard layer, not to imply
+selective bypassing.
+
+## See also
+
+- `servers/exarchos-mcp/src/orchestrate/prune-safeguards.ts` — the
+  default implementations (gh/git backends) and the `PruneSafeguards`
+  interface for DI.
+- `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts` —
+  the handler that composes safeguards with selection and cancel.

--- a/skills-src/shepherd/SKILL.md
+++ b/skills-src/shepherd/SKILL.md
@@ -21,6 +21,10 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Pipeline Hygiene
+
+When `{{MCP_PREFIX}}exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:

--- a/skills-src/synthesis/SKILL.md
+++ b/skills-src/synthesis/SKILL.md
@@ -22,12 +22,22 @@ Submit stacked PRs after review phase completes. The `prepare_synthesis` composi
 
 Do NOT proceed if either review is incomplete or failed -- return to `{{COMMAND_PREFIX}}review` first.
 
+**Entry points:** Synthesis is normally reached from the `review` phase of
+feature / debug / refactor workflows. It is also reachable from `oneshot`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during `plan` or `implementing`, the `request_synthesize` event is
+appended, and `finalize_oneshot` then resolves the choice state and
+transitions the workflow to `synthesize`. See
+`@skills/oneshot-workflow/SKILL.md` for the opt-in mechanics and
+`synthesisPolicy` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs `{{COMMAND_PREFIX}}synthesize` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to `synthesize` via `finalize_oneshot`
 
 ## Process
 

--- a/skills-src/workflow-state/SKILL.md
+++ b/skills-src/workflow-state/SKILL.md
@@ -38,7 +38,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use `exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })` for
 parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its `implementing → synthesize|completed` choice state
+driven by `synthesisPolicy`), call `exarchos_workflow({ action: "describe", playbook: "oneshot" })`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 `exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })`
 for event data schemas.
 
@@ -126,6 +129,23 @@ exarchos_orchestrate({
 | Review complete | Update `reviews` object |
 | PR created | Set `artifacts.pr`, `synthesis.prUrl` |
 | PR feedback | Append to `synthesis.prFeedback` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| `plan` (oneshot) | `oneshot.planSummary`, `artifacts.plan`, optional `oneshot.synthesisPolicy` | `workflow.transition` |
+| `implementing` (oneshot) | `tasks[].status`, `artifacts.tests` | `task.*`, optional `synthesize.requested` (via `request_synthesize`) |
+| `synthesize` (oneshot) | `synthesis.prUrl`, `artifacts.pr` | `workflow.transition`, `stack.submitted` |
+| `completed` (oneshot) | — | `workflow.transition` (to `completed`) |
+
+The `implementing → synthesize | completed` fork is a choice state resolved
+by `finalize_oneshot`, which reads the `synthesisOptedIn` guard
+(`synthesisPolicy` + `synthesize.requested` events). See
+`@skills/oneshot-workflow/SKILL.md` for the full opt-in mechanics.
 
 ### Automatic State Updates
 

--- a/skills-src/workflow-state/SKILL.md
+++ b/skills-src/workflow-state/SKILL.md
@@ -54,9 +54,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see `references
 
 At the start of `{{COMMAND_PREFIX}}ideate`, use `{{MCP_PREFIX}}exarchos_workflow` with `action: "init"` with:
 - `featureId`: the workflow identifier (e.g., `"user-authentication"`)
-- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`
+- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
+- `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- `feature` — full `ideate → plan → delegate → review → synthesize` for real features with subagent dispatch and two-stage review
+- `debug` — `triage → investigate → (thorough | hotfix)` for bug workflows with track selection
+- `refactor` — `explore → brief → (polish | overhaul)` for code improvements, polish for small and overhaul for multi-task
+- `oneshot` — `plan → implementing → (completed | synthesize)` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by `synthesisPolicy` and the `synthesize.requested` event
+
+See `@skills/oneshot-workflow/SKILL.md` for the lightweight variant's full prose, including the choice-state mechanics and `finalize_oneshot` trigger.
 
 ### Read State
 
@@ -154,7 +164,7 @@ See `docs/schemas/workflow-state.schema.json` for full schema.
 Key sections:
 - `version`: Schema version (currently "1.1")
 - `featureId`: Unique workflow identifier
-- `workflowType`: Required. One of "feature", "debug", or "refactor"
+- `workflowType`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - `phase`: Current workflow phase
 - `artifacts`: Paths to design, plan, PR
 - `tasks`: Task list with status

--- a/skills-src/workflow-state/SKILL.md
+++ b/skills-src/workflow-state/SKILL.md
@@ -60,7 +60,13 @@ At the start of `{{COMMAND_PREFIX}}ideate`, use `{{MCP_PREFIX}}exarchos_workflow
 - `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
 - `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+`workflowType`:
+
+- `feature` → starts in `ideate`
+- `debug` → starts in `triage`
+- `refactor` → starts in `explore`
+- `oneshot` → starts in `plan` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 

--- a/skills-src/workflow-state/references/phase-transitions.md
+++ b/skills-src/workflow-state/references/phase-transitions.md
@@ -127,7 +127,7 @@ plan → implementing ─┬→ completed              (direct-commit path)
 
 | From | To | Guard | Prerequisite |
 |------|----|-------|-------------|
-| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` (non-empty string; `oneshot.planSummary` is optional metadata but does **not** satisfy the guard) |
 | `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
 | `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
 | `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |

--- a/skills-src/workflow-state/references/phase-transitions.md
+++ b/skills-src/workflow-state/references/phase-transitions.md
@@ -118,6 +118,28 @@ explore → brief → [polish-track | overhaul-track] → completed
 
 **Compound state:** `overhaul-track` contains `overhaul-plan`, `overhaul-plan-review`, `overhaul-delegate`, `overhaul-review`, and `overhaul-update-docs`. Max 3 fix cycles.
 
+## Oneshot Workflow
+
+```
+plan → implementing ─┬→ completed              (direct-commit path)
+                     └→ synthesize → completed (PR path, opt-in)
+```
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
+| `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
+| `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+**Choice state (end of `implementing`).** The fork after `implementing` is a UML choice state, implemented as two mutually-exclusive HSM transitions whose guards are pure functions of `state.oneshot.synthesisPolicy` and the `synthesize.requested` event count on the stream. At init, the user declares intent via `synthesisPolicy` (`always`, `never`, or `on-request` — default). During implementing, the user can opt in at any time by calling `exarchos_orchestrate request_synthesize`, which appends a `synthesize.requested` event without changing the phase. The decision is only evaluated when `finalize_oneshot` is called: the handler hydrates events, runs the guards, and calls `handleSet` with the resolved target. **Policy wins over event** — if policy is `never`, any `synthesize.requested` event is ignored and the guard routes to `completed`. Policy `always` short-circuits the event check and always routes to `synthesize`.
+
+**How to trigger:** `exarchos_orchestrate finalize_oneshot { featureId }` — this is the only way to exit `implementing`. The handler evaluates the choice state and calls `handleSet` with the correct target phase. The HSM re-evaluates the guard at the transition boundary, so any race between read and transition is caught safely.
+
+**No compound state.** Oneshot has no multi-agent loop, no review-fix cycle, and therefore no circuit breaker. If the in-session TDD loop gets stuck, cancel via `exarchos_workflow cancel` and restart with a different approach (or escalate to the full `feature` workflow).
+
+See `@skills/oneshot-workflow/SKILL.md` for the full prose walkthrough including worked examples.
+
 ## Circuit Breaker
 
 Compound states enforce a maximum number of fix cycles to prevent infinite review-fix loops. When the limit is exceeded, the HSM rejects the transition with a `CIRCUIT_OPEN` error and emits a `workflow.circuit-open` event.

--- a/skills/claude/cleanup/SKILL.md
+++ b/skills/claude/cleanup/SKILL.md
@@ -15,6 +15,12 @@ metadata:
 
 Resolve merged workflows to `completed` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
 
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use `@skills/prune-workflows/SKILL.md`. That skill invokes `exarchos_orchestrate prune_stale_workflows` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → `completed`); prune is bulk (N inactive workflows → `cancelled`). They are complementary, not alternatives.
+
 ## Triggers
 
 Activate this skill when:

--- a/skills/claude/delegation/SKILL.md
+++ b/skills/claude/delegation/SKILL.md
@@ -20,6 +20,8 @@ Activate this skill when:
 - Implementation plan is ready with extractable tasks
 - User wants to parallelize work across subagents
 
+**Exception — oneshot workflows skip delegation entirely.** The oneshot playbook runs an in-session TDD loop in the main agent's context, with no subagent dispatch or review phase. If `workflowType === "oneshot"`, do not call this skill — see `@skills/oneshot-workflow/SKILL.md` for the lightweight path.
+
 ## Core Principles
 
 ### Fresh Context Per Task (MANDATORY)

--- a/skills/claude/oneshot-workflow/SKILL.md
+++ b/skills/claude/oneshot-workflow/SKILL.md
@@ -12,8 +12,8 @@ metadata:
 # Oneshot Workflow Skill
 
 A lean, four-phase workflow type for changes that are too small to justify the
-full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
-still deserve event-sourced auditability and a planning step. The workflow is
+full `feature` flow (`ideate → plan → plan-review → delegate → review → synthesize → completed`)
+but still deserve event-sourced auditability and a planning step. The workflow is
 **direct-commit by default** with an opt-in PR path; the choice between the
 two is resolved at the end of `implementing` via a pure event-sourced guard,
 not a heuristic.
@@ -88,7 +88,7 @@ and overrides runtime signal.
 
 ## Lifecycle
 
-```
+```text
      plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
                                  │
                                  └── [synthesisOptedIn]  ──► synthesize ──► completed
@@ -286,7 +286,7 @@ do not exist in the oneshot playbook. The PR review is the only review.
 
 ### Example A — Direct-commit (default `on-request` policy, no opt-in)
 
-```
+```text
 User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
        Use oneshot."
 
@@ -317,7 +317,7 @@ Agent:
 
 ### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
 
-```
+```text
 User: "Add input validation to the parseConfig helper. Oneshot."
 
 Agent:
@@ -347,7 +347,7 @@ Agent:
 
 ### Example C — `synthesisPolicy: 'always'` (PR mandatory)
 
-```
+```text
 User: "I want a PR for any change to the auth module, even small ones.
        Use oneshot but always make a PR."
 

--- a/skills/claude/oneshot-workflow/SKILL.md
+++ b/skills/claude/oneshot-workflow/SKILL.md
@@ -214,13 +214,22 @@ for phrases like:
 When you hear any of those, call `request_synthesize` immediately. The
 handler appends a `synthesize.requested` event to the workflow's event
 stream; the `synthesisOptedIn` guard reads the stream at finalize and
-routes accordingly. This is **idempotent** — calling
-`request_synthesize` twice appends two events but the guard treats any
-count >= 1 as "opted in", so duplicate calls are benign.
+routes accordingly.
+
+`request_synthesize` is accepted from both `plan` and `implementing`
+phases — call it whenever you know you want the PR path, even before
+`implementing` starts. Terminal phases (`synthesize`, `completed`,
+`cancelled`) are rejected.
+
+Duplicate calls are **routing-idempotent** but not event-idempotent:
+each call appends a new `synthesize.requested` event, but the guard
+treats any count >= 1 as "opted in", so the routing decision is the
+same whether you call once or five times. The event stream will
+contain each duplicate for audit purposes.
 
 Calling `request_synthesize` does **not** transition the phase. The
-workflow stays in `implementing`. The decision is only acted on when
-you call `finalize_oneshot` in step 4.
+workflow stays in its current phase. The decision is only acted on
+when you call `finalize_oneshot` in step 4.
 
 ### Step 4 — Finalize (the choice point)
 
@@ -393,7 +402,7 @@ For the full transition table for oneshot, consult
 
 | From | To | Guard |
 |---|---|---|
-| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `plan` | `implementing` | `oneshotPlanSet` (requires non-empty `artifacts.plan`) |
 | `implementing` | `synthesize` | `synthesisOptedIn` |
 | `implementing` | `completed` | `synthesisOptedOut` |
 | `synthesize` | `completed` | `mergeVerified` |
@@ -401,9 +410,10 @@ For the full transition table for oneshot, consult
 
 `synthesisOptedIn` and `synthesisOptedOut` are pure functions of
 `state.oneshot.synthesisPolicy` and `state._events`. They are mutually
-exclusive across all 8 (3 policies × event-present/absent, with `always`
-and `never` ignoring the event flag) combinations — exactly one returns
-true at any given time.
+exclusive across all 4 meaningful combinations — `always` and `never`
+each map to one outcome (ignoring the event flag), and `on-request`
+branches on whether a `synthesize.requested` event is present or
+absent. Exactly one guard returns true at any given time.
 
 ### Schema discovery
 

--- a/skills/claude/oneshot-workflow/SKILL.md
+++ b/skills/claude/oneshot-workflow/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: oneshot-workflow
+description: "Lightweight workflow for straightforward changes — plan → implement → optional PR. Direct-commit by default; synthesize is opt-in via synthesisPolicy or a runtime request_synthesize event. Use for trivial fixes, config tweaks, single-file changes, or exploratory work that doesn't warrant subagent dispatch or two-stage review. Triggers: 'oneshot', 'quick fix', 'small change', or /exarchos:oneshot."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: plan
+---
+
+# Oneshot Workflow Skill
+
+A lean, four-phase workflow type for changes that are too small to justify the
+full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
+still deserve event-sourced auditability and a planning step. The workflow is
+**direct-commit by default** with an opt-in PR path; the choice between the
+two is resolved at the end of `implementing` via a pure event-sourced guard,
+not a heuristic.
+
+> **Read this first if you have never run a oneshot:** the workflow has a
+> *choice state* at the end of `implementing`. Whether you land on
+> `completed` (direct commit) or transition through `synthesize` (PR) is
+> decided by two inputs: the `synthesisPolicy` set at init, and whether the
+> user emitted a `synthesize.requested` event during implementing. Both
+> inputs are persisted; the decision is replay-safe.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically a single file, or a tightly-coupled
+  cluster of 2-3 files
+- No subagent dispatch is needed — the work fits comfortably in one TDD
+  loop in a single session
+- No design document is required — the goal is obvious from the task
+  description, and a one-page plan is enough scaffolding
+- No two-stage review is required — either the change is trivial enough
+  that direct-commit is acceptable, or a single PR review will suffice
+
+Concrete examples that fit oneshot:
+- Fixing a typo in a README
+- Bumping a dependency version
+- Adding a missing null-check in one function
+- Tweaking a CI workflow YAML
+- Renaming a config key everywhere it's referenced
+- Adding a one-off helper script
+- Exploratory spikes that may or may not be kept
+
+## When NOT to use oneshot
+
+Do not use oneshot for any of the following — use the full `feature`
+workflow instead (`/exarchos:ideate`):
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+- Anything where you'd want a written design doc to look back at
+
+If you start a oneshot and discover the change is bigger than expected, the
+right move is `/exarchos:cancel` and restart with `/exarchos:ideate`.
+Don't try to grow a oneshot into a feature workflow mid-stream; the
+playbooks have different shapes and you'll fight the state machine.
+
+## Synthesis policy — three options
+
+The `synthesisPolicy` field on a oneshot workflow declares the user's
+intent up front about whether the change should be turned into a PR. It
+takes one of three values, persisted on `state.oneshot.synthesisPolicy`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| `always` | Always transition `implementing → synthesize` at finalize, regardless of events. A PR is always created. | The user wants a paper trail / review for every change in this workflow, even small ones. |
+| `never` | Always transition `implementing → completed` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | The user is iterating on personal/scratch work and explicitly opts out of PRs. |
+| `on-request` *(default)* | Direct-commit by default. The user can opt in to a PR mid-implementing by calling `request_synthesize`; if any `synthesize.requested` event is on the stream at finalize, the workflow transitions to `synthesize` instead of `completed`. | The common case: start with the assumption of direct-commit, but leave the door open for the user to change their mind once they see the diff. |
+
+The default is `on-request` because it's the least surprising: the user
+gets the lightweight path until they explicitly ask for the heavy one.
+
+**Policy wins over event.** If `synthesisPolicy: 'never'` is set and a
+`synthesize.requested` event is somehow on the stream (e.g. the user
+called the action on a workflow they thought was `on-request`), the
+guard still routes to `completed`. Policy is the user's declared intent
+and overrides runtime signal.
+
+## Lifecycle
+
+```
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+```
+
+Four phases. The fork after `implementing` is a UML *choice state*,
+implemented via two mutually-exclusive HSM transitions whose guards are
+pure functions of `state.oneshot.synthesisPolicy` and the
+`synthesize.requested` event count.
+
+| Phase | What happens | Exit criteria |
+|---|---|---|
+| `plan` | Lightweight one-page plan: goal, approach, files to touch, tests to add. No design doc. No subagent dispatch. | `artifacts.plan` set → transition to `implementing` |
+| `implementing` | In-session TDD loop. Write a failing test, make it pass, refactor. Commit as you go. The TDD iron law applies — *no production code without a failing test first*. | Tests pass + typecheck clean + finalize_oneshot called |
+| `synthesize` | Reached **only** when `synthesisOptedIn` is true. Hands off to the existing synthesis flow — see `@skills/synthesis/SKILL.md`. PR created via `gh pr create`, auto-merge enabled, CI gates apply. | PR merged → `completed` |
+| `completed` | Terminal. For direct-commit path, commits are already on the branch — there's nothing more to do. For synthesize path, the PR merge event terminates the workflow. | — |
+
+`cancelled` is also reachable from any phase via the universal cancel
+transition, same as every other workflow type.
+
+## Step-by-step
+
+### Step 1 — Init
+
+Call `exarchos_workflow` with `action: 'init'`, `workflowType: 'oneshot'`,
+and an optional `synthesisPolicy`:
+
+```typescript
+mcp__plugin_exarchos_exarchos__exarchos_workflow({
+  action: "init",
+  featureId: "fix-readme-typo",
+  workflowType: "oneshot",
+  synthesisPolicy: "on-request" // optional — defaults to 'on-request'
+})
+```
+
+If the user has been clear up front ("I want a PR for this"), pass
+`synthesisPolicy: "always"`. If they've been clear ("don't open a PR,
+just commit it"), pass `synthesisPolicy: "never"`. Otherwise, omit the
+field and rely on the `on-request` default — you can always escalate
+later in the implementing phase.
+
+The init returns the new workflow state; the workflow lands in `plan`.
+
+### Step 2 — Plan phase
+
+Produce a one-page plan. This is intentionally lightweight — no design
+doc, no parallelization analysis, no decomposition into N tasks. The
+plan should answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to `implementing` in a single set call:
+
+```typescript
+mcp__plugin_exarchos_exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "fix-readme-typo",
+  updates: {
+    "artifacts": { "plan": "<plan text>" },
+    "oneshot": { "planSummary": "<one-line summary>" },
+    "phase": "implementing"
+  }
+})
+```
+
+The plan goes on `artifacts.plan` for parity with the `feature` workflow;
+the human-readable one-liner goes on `oneshot.planSummary` for the
+pipeline view.
+
+### Step 3 — Implementing phase
+
+Run an in-session TDD loop. Same iron law as every other workflow:
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run the test. Confirm it fails for
+   the right reason.
+2. **[GREEN]** Write the minimum production code to make the test pass.
+   Run the test. Confirm it passes.
+3. **[REFACTOR]** Clean up while keeping the test green.
+
+Commit each red-green-refactor cycle as a single commit. Do not batch
+multiple unrelated changes into one commit — keeping commits atomic
+matters even more in oneshot, where there's no separate review phase
+to catch bundled changes.
+
+There is **no subagent dispatch** in oneshot. The main agent does the
+work directly. There is **no separate review phase**. Quality is
+maintained by the TDD loop and (if the user opts in) the synthesize PR
+review.
+
+#### Mid-implementing: opting in to a PR
+
+If at any point during implementing the user decides they want a PR
+after all (policy is `on-request`, default), they can opt in by calling
+the `request_synthesize` orchestrate action:
+
+```typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+```
+
+**The trigger for this is conversational, not a magic keyword.** Listen
+for phrases like:
+- "actually, let's open a PR for this"
+- "I want a review on this before it lands"
+- "make this a PR"
+- "let's get eyes on this"
+- "synthesize this"
+
+When you hear any of those, call `request_synthesize` immediately. The
+handler appends a `synthesize.requested` event to the workflow's event
+stream; the `synthesisOptedIn` guard reads the stream at finalize and
+routes accordingly. This is **idempotent** — calling
+`request_synthesize` twice appends two events but the guard treats any
+count >= 1 as "opted in", so duplicate calls are benign.
+
+Calling `request_synthesize` does **not** transition the phase. The
+workflow stays in `implementing`. The decision is only acted on when
+you call `finalize_oneshot` in step 4.
+
+### Step 4 — Finalize (the choice point)
+
+When the implementing loop is done — tests pass, typecheck clean, all
+commits made — call `finalize_oneshot` to resolve the choice state:
+
+```typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+```
+
+The handler:
+
+1. Reads the current state and verifies `workflowType === 'oneshot'` and
+   `phase === 'implementing'`.
+2. Hydrates `_events` from the event store so the guard sees the same
+   view the HSM will see during the actual transition.
+3. Evaluates `guards.synthesisOptedIn` against the state. The guard
+   inspects `state.oneshot.synthesisPolicy` and the `_events` array.
+4. Calls `handleSet` with the resolved target phase (`synthesize` or
+   `completed`). The HSM re-evaluates the guard at the transition
+   boundary, so any race between the read and the transition is caught
+   safely.
+
+Possible outcomes:
+
+| `synthesisPolicy` | `synthesize.requested` event present? | Resolved target | Path |
+|---|---|---|---|
+| `always` | (any) | `synthesize` | PR path |
+| `never` | (any) | `completed` | direct-commit path |
+| `on-request` (default) | yes | `synthesize` | PR path |
+| `on-request` (default) | no | `completed` | direct-commit path |
+
+### Step 5a — Direct-commit path (terminal)
+
+If finalize resolved to `completed`, you're done. The commits made
+during implementing are already on the current branch. Push them if
+they aren't already pushed:
+
+```bash
+git push
+```
+
+The workflow is now in `completed` and will not appear in the default
+pipeline view.
+
+### Step 5b — Synthesize path
+
+If finalize resolved to `synthesize`, hand off to the standard synthesis
+flow — see `@skills/synthesis/SKILL.md`. The same `prepare_synthesis` /
+`validate_pr_body` / `gh pr create` machinery used by the `feature`
+workflow applies. After the PR merges, the workflow transitions
+`synthesize → completed` via the existing `mergeVerified` guard, same as
+every other workflow type.
+
+You do **not** need to run `/exarchos:delegate` or
+`/exarchos:review` for an opt-in oneshot synthesize. Those phases
+do not exist in the oneshot playbook. The PR review is the only review.
+
+## Example invocations
+
+### Example A — Direct-commit (default `on-request` policy, no opt-in)
+
+```
+User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
+       Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
+  2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  4. [RED] writes test that greps README for 'recieve' and expects 0 matches
+        — fails (1 match exists)
+  5. [GREEN] edits README, fixes typo
+        — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+```
+
+### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
+
+```
+User: "Add input validation to the parseConfig helper. Oneshot."
+
+Agent:
+  1. exarchos_workflow init { workflowType: "oneshot" }
+     → 'plan' phase, default 'on-request'
+  2. plans (goal: validate input, files: [parser.ts, parser.test.ts])
+  3. transitions to 'implementing'
+  4. [RED] writes test for null-input case
+  5. [GREEN] adds null check
+  6. [REFACTOR] extracts validateInput helper
+  7. commits
+
+User: "Actually, this is touching the parser — I want a review on it before
+       it lands."
+
+Agent:
+  8. exarchos_orchestrate request_synthesize {
+       featureId, reason: "user requested review of parser changes"
+     }
+     → appends synthesize.requested event
+  9. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='on-request' + 1 synthesize.requested event
+     → resolves to 'synthesize'
+ 10. hands off to @skills/synthesis/SKILL.md → prepare_synthesis →
+     validate_pr_body → gh pr create → merge
+```
+
+### Example C — `synthesisPolicy: 'always'` (PR mandatory)
+
+```
+User: "I want a PR for any change to the auth module, even small ones.
+       Use oneshot but always make a PR."
+
+Agent:
+  1. exarchos_workflow init {
+       workflowType: "oneshot",
+       synthesisPolicy: "always"
+     }
+  2-7. plan + TDD + commits, identical to Example A
+  8. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='always' (short-circuits — no event check needed)
+     → resolves to 'synthesize'
+  9. synthesis flow → PR
+```
+
+## State management
+
+Track oneshot-specific state under the `oneshot` key on the workflow state:
+
+```typescript
+mcp__plugin_exarchos_exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "<id>",
+  updates: {
+    "oneshot": {
+      "synthesisPolicy": "on-request",
+      "planSummary": "Fix off-by-one in pagination helper"
+    }
+  }
+})
+```
+
+The `synthesisPolicy` field is optional and defaults to `'on-request'` per
+the schema in `servers/exarchos-mcp/src/workflow/schemas.ts`. Setting it
+explicitly is recommended when the user has stated a preference.
+
+## Phase Transitions and Guards
+
+For the full transition table for oneshot, consult
+`@skills/workflow-state/references/phase-transitions.md`.
+
+**Quick reference for oneshot:**
+
+| From | To | Guard |
+|---|---|---|
+| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `implementing` | `synthesize` | `synthesisOptedIn` |
+| `implementing` | `completed` | `synthesisOptedOut` |
+| `synthesize` | `completed` | `mergeVerified` |
+| (any) | `cancelled` | universal — always allowed |
+
+`synthesisOptedIn` and `synthesisOptedOut` are pure functions of
+`state.oneshot.synthesisPolicy` and `state._events`. They are mutually
+exclusive across all 8 (3 policies × event-present/absent, with `always`
+and `never` ignoring the event flag) combinations — exactly one returns
+true at any given time.
+
+### Schema discovery
+
+Use `exarchos_workflow({ action: "describe", actions: ["init", "set"] })`
+for parameter schemas (including the `synthesisPolicy` enum) and
+`exarchos_workflow({ action: "describe", playbook: "oneshot" })` for the
+phase transitions, guard names, and playbook prose. Use
+`exarchos_orchestrate({ action: "describe", actions: ["request_synthesize", "finalize_oneshot"] })`
+for the orchestrate action schemas.
+
+## TDD is still mandatory
+
+The iron law from `@rules/tdd.md` applies to oneshot. There is no
+exemption for "small" changes. Specifically:
+
+- Every behavior change starts with a failing test
+- Every test must fail before its implementation is written
+- Tests must be run after each change to verify state
+- Commits stay atomic — one logical change per commit
+
+The temptation in a oneshot is to skip the test "because it's just one
+line". Resist that. The test is what makes the change auditable, and
+auditability is the entire reason oneshot exists alongside the lighter
+"bypass workflows entirely" path.
+
+## Anti-patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip the plan phase ("it's obvious") | Write the four-line plan anyway — it's the artifact future-you reads |
+| Skip the TDD loop in implementing | Always RED → GREEN → REFACTOR, even for one-liners |
+| Use oneshot for multi-file refactors | Use `/exarchos:ideate` and the full feature workflow |
+| Try to grow a oneshot into a feature workflow mid-stream | Cancel and restart with `/exarchos:ideate` |
+| Call `request_synthesize` without listening for the user's intent | Wait for the user to ask for a PR, then call it |
+| Bundle unrelated changes into one commit "since it's a oneshot" | Keep commits atomic — there's no review phase to catch bundling |
+| Forget to call `finalize_oneshot` at the end | The workflow stays in `implementing` forever otherwise — call it explicitly |
+
+## Completion criteria
+
+- [ ] `exarchos_workflow init` called with `workflowType: "oneshot"`
+- [ ] One-page plan persisted to `artifacts.plan`
+- [ ] Phase transitioned to `implementing`
+- [ ] All planned behaviors implemented via TDD with atomic commits
+- [ ] `finalize_oneshot` called and resolved to either `completed` or `synthesize`
+- [ ] If direct-commit path: commits pushed
+- [ ] If synthesize path: PR created via `@skills/synthesis/SKILL.md` and merged

--- a/skills/claude/oneshot-workflow/SKILL.md
+++ b/skills/claude/oneshot-workflow/SKILL.md
@@ -144,23 +144,26 @@ plan should answer four questions in 5-10 lines each:
 3. **Files** — which files will be touched? (1-5 typically)
 4. **Tests** — which test cases will be added? (named, not described)
 
-Persist the plan and transition to `implementing` in a single set call:
+Persist the plan and transition to `implementing` in a single set call.
+`phase` is a top-level argument of `set`, not a field inside `updates`:
 
 ```typescript
 mcp__plugin_exarchos_exarchos__exarchos_workflow({
   action: "set",
   featureId: "fix-readme-typo",
+  phase: "implementing",
   updates: {
-    "artifacts": { "plan": "<plan text>" },
-    "oneshot": { "planSummary": "<one-line summary>" },
-    "phase": "implementing"
+    "artifacts.plan": "<plan text>",
+    "oneshot.planSummary": "<one-line summary>"
   }
 })
 ```
 
 The plan goes on `artifacts.plan` for parity with the `feature` workflow;
 the human-readable one-liner goes on `oneshot.planSummary` for the
-pipeline view.
+pipeline view. Only `artifacts.plan` is enforced by the
+`oneshot-plan-set` guard — `planSummary` is an optional pipeline-view
+label and is not a substitute for a real plan artifact.
 
 ### Step 3 — Implementing phase
 
@@ -292,7 +295,14 @@ Agent:
      → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
   2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
      tests=[readme has no occurrence of 'recieve']
-  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",                   // top-level
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "..."
+       }
+     }
   4. [RED] writes test that greps README for 'recieve' and expects 0 matches
         — fails (1 match exists)
   5. [GREEN] edits README, fixes typo

--- a/skills/claude/oneshot-workflow/SKILL.md
+++ b/skills/claude/oneshot-workflow/SKILL.md
@@ -189,11 +189,11 @@ work directly. There is **no separate review phase**. Quality is
 maintained by the TDD loop and (if the user opts in) the synthesize PR
 review.
 
-#### Mid-implementing: opting in to a PR
+#### Mid-workflow: opting in to a PR
 
-If at any point during implementing the user decides they want a PR
-after all (policy is `on-request`, default), they can opt in by calling
-the `request_synthesize` orchestrate action:
+If at any point during `plan` or `implementing` the user decides they
+want a PR after all (policy is `on-request`, default), they can opt in
+by calling the `request_synthesize` orchestrate action:
 
 ```typescript
 mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
@@ -397,6 +397,12 @@ explicitly is recommended when the user has stated a preference.
 
 For the full transition table for oneshot, consult
 `@skills/workflow-state/references/phase-transitions.md`.
+
+> **Note:** The engine's `exarchos_workflow describe playbook="oneshot"`
+> output and the HSM definitions in `hsm-definitions.ts` are the
+> canonical sources for transition behavior. `phase-transitions.md` is
+> a prose reference that can drift — when discrepancies arise, prefer
+> engine `describe` output.
 
 **Quick reference for oneshot:**
 

--- a/skills/claude/oneshot-workflow/references/choice-state.md
+++ b/skills/claude/oneshot-workflow/references/choice-state.md
@@ -1,0 +1,65 @@
+---
+name: oneshot-choice-state
+---
+
+# Oneshot Choice State: `implementing → ?`
+
+The oneshot workflow has a UML *choice state* at the end of `implementing`.
+Whether the workflow lands on `completed` (direct-commit) or transitions
+through `synthesize` (PR) is decided by two mutually-exclusive pure-function
+guards: `synthesisOptedIn` and `synthesisOptedOut`. Both are evaluated against
+the current workflow state at the transition boundary; exactly one returns
+`true` for every possible input.
+
+## Inputs read by the guards
+
+Both guards read exactly two things from state:
+
+1. `state.oneshot.synthesisPolicy` — one of `'always' | 'never' | 'on-request'`,
+   defaulted to `'on-request'` by the init schema.
+2. `state._events` — the hydrated event stream. The guard counts
+   `synthesize.requested` events on the stream (any count ≥ 1 means "opted in").
+
+Nothing else. No clock reads, no filesystem, no network, no git state. This
+is load-bearing for replay safety: given the same persisted state, the same
+target resolves every time, and re-running finalize is idempotent.
+
+## Decision table
+
+| `synthesisPolicy` | `synthesize.requested` count | `synthesisOptedIn` | `synthesisOptedOut` | Resolved target |
+|---|---|---|---|---|
+| `'always'`     | 0  | `true`  | `false` | `synthesize` |
+| `'always'`     | ≥1 | `true`  | `false` | `synthesize` |
+| `'never'`      | 0  | `false` | `true`  | `completed`  |
+| `'never'`      | ≥1 | `false` | `true`  | `completed`  |
+| `'on-request'` | 0  | `false` | `true`  | `completed`  |
+| `'on-request'` | ≥1 | `true`  | `false` | `synthesize` |
+
+**Policy wins over event.** On `'never'`, even if a stray `synthesize.requested`
+event is on the stream, the guard still routes to `completed`. Policy is the
+user's declared intent; runtime events only matter when the policy explicitly
+defers to them (`'on-request'`).
+
+## Why a choice state, not a single transition with branching logic
+
+Keeping the fork at the HSM level (two transitions, two mutually-exclusive
+guards) means:
+
+- The state machine graph visibly encodes both paths — operators reading
+  `hsm-definitions.ts` see `implementing → completed` and `implementing →
+  synthesize` as sibling transitions, not a hidden conditional.
+- The HSM re-evaluates guards at the transition boundary, so any race
+  between `finalize_oneshot` reading state and `handleSet` performing the
+  transition is caught safely — if a last-millisecond event changed the
+  evaluation, the HSM will refuse the wrong transition.
+- Guard logic stays testable in isolation (`guards.test.ts`) without
+  needing to spin up the handler.
+
+## See also
+
+- `servers/exarchos-mcp/src/workflow/guards.ts` — `synthesisOptedIn`,
+  `synthesisOptedOut`, `oneshotPlanSet` guard implementations.
+- `servers/exarchos-mcp/src/workflow/hsm-definitions.ts` — the oneshot HSM
+  with the two sibling transitions from `implementing`.
+- `servers/exarchos-mcp/src/orchestrate/finalize-oneshot.ts` — the handler
+  that resolves the choice state and calls `handleSet`.

--- a/skills/claude/prune-workflows/SKILL.md
+++ b/skills/claude/prune-workflows/SKILL.md
@@ -19,9 +19,9 @@ Pruning is a maintenance operation -- not a workflow phase. It produces `workflo
 ## Triggers
 
 Activate this skill when:
-- User runs `{{COMMAND_PREFIX}}prune` command
+- User runs `/exarchos:prune` command
 - User says "prune workflows", "clean stale workflows", "pipeline cleanup"
-- `{{MCP_PREFIX}}exarchos_view({ action: "pipeline" })` shows many inactive workflows the user wants to clear in bulk
+- `mcp__plugin_exarchos_exarchos__exarchos_view({ action: "pipeline" })` shows many inactive workflows the user wants to clear in bulk
 
 ## Prerequisites
 
@@ -36,7 +36,7 @@ Activate this skill when:
 Always start with `dryRun: true`. This call performs candidate selection and safeguard evaluation but does not mutate any workflow state.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: true
@@ -104,7 +104,7 @@ Wait for explicit user input. Do **not** auto-proceed.
 On `proceed`, invoke the same action with `dryRun: false`. Pass through `thresholdMinutes` and `includeOneShot` if the user set them in Step 1.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: false
@@ -131,7 +131,7 @@ Each entry in `pruned` corresponds to a workflow that transitioned to `cancelled
 On `force`, set `force: true`. Safeguards are bypassed but the bypass is recorded in the `workflow.pruned` event payload as `skippedSafeguards: [...]` so the audit trail is intact.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: false,
@@ -199,7 +199,7 @@ A workflow without a `branchName` in state (e.g., abandoned at ideate/plan befor
 ### Example 1: Clean dry-run, user proceeds
 
 ```
-> {{COMMAND_PREFIX}}prune
+> /exarchos:prune
 
 ## Prune Candidates (2)
 
@@ -230,7 +230,7 @@ Proceed? (proceed/abort/force)
 ### Example 2: Safeguard skip, user forces
 
 ```
-> {{COMMAND_PREFIX}}prune
+> /exarchos:prune
 
 ## Prune Candidates (1)
 
@@ -265,7 +265,7 @@ Proceed? (proceed/abort/force)
 ### Example 3: Empty pipeline
 
 ```
-> {{COMMAND_PREFIX}}prune
+> /exarchos:prune
 
 No stale workflows to prune. Pipeline is clean.
 ```
@@ -275,7 +275,7 @@ No stale workflows to prune. Pipeline is clean.
 For the canonical argument schema and any future fields, use:
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "describe",
   actions: ["prune_stale_workflows"]
 })

--- a/skills/claude/prune-workflows/references/safeguards.md
+++ b/skills/claude/prune-workflows/references/safeguards.md
@@ -1,0 +1,74 @@
+---
+name: prune-safeguards
+---
+
+# Prune Safeguards
+
+The `prune_stale_workflows` orchestrate action runs two safeguards on each
+candidate before it will actually cancel the workflow. Both must pass for
+the candidate to be pruned, unless the caller passes `force: true` to
+bypass them.
+
+## Safeguard 1: `hasOpenPR`
+
+Checks whether there's an open pull request targeting the workflow's
+branch. Implementation: `gh pr list --state open --head <branchName>` —
+if the list is non-empty, the safeguard fails and the candidate is
+skipped with reason `open-pr`.
+
+Rationale: an open PR means human work is still in-flight on this feature.
+Cancelling the workflow would orphan the PR from its event-sourced state,
+which makes it invisible to `exarchos_view` and breaks auto-merge gates.
+We refuse to prune workflows with open PRs by default.
+
+## Safeguard 2: `hasRecentCommits` (user-facing: `active-branch`)
+
+Checks whether any commits landed on the workflow's branch within a
+24-hour window. Implementation: `git log --since="24 hours ago"
+<branchName>` — if the output is non-empty, the safeguard fails and the
+candidate is skipped with reason `active-branch`.
+
+Rationale: commits on the branch mean the workflow isn't actually stale,
+it just missed the last event checkpoint. The underlying branch is the
+ground truth for "is this work still alive?" — if someone is committing,
+we don't care what the checkpoint timestamp says.
+
+The window is locked at 24 hours for v1. It's exposed as a module
+constant (`RECENT_COMMITS_WINDOW_HOURS` in `prune-stale-workflows.ts`)
+so tests can see the contract, but it's not yet configurable through
+the public handler args.
+
+## Short-circuit: missing `branchName`
+
+If the workflow state has no top-level `branchName` field, both
+safeguards are skipped entirely (they have nothing to look up). The
+candidate still proceeds to cancel. This is safe because a workflow
+without a branch can't have an open PR or recent commits by definition.
+
+## `force: true` bypass semantics
+
+Passing `force: true` skips safeguard evaluation for every candidate.
+The handler still does everything else — the cancel, the event emission,
+the audit trail — but `hasOpenPR` and `hasRecentCommits` are never
+called.
+
+Every `workflow.pruned` event emitted during a `force: true` run carries
+a `skippedSafeguards: ['open-pr', 'active-branch']` marker on its payload.
+This makes forced prunes distinguishable in the audit stream from
+safeguard-approved ones, so operators reviewing the event log can see
+exactly which workflows were cancelled despite having open PRs or active
+branches.
+
+The marker list is intentionally hardcoded to *all* safeguards, not just
+the ones that would have failed. Running `force: true` is a blanket
+"I know what I'm doing" override — we want the audit trail to reflect
+that the user chose to bypass the whole safeguard layer, not to imply
+selective bypassing.
+
+## See also
+
+- `servers/exarchos-mcp/src/orchestrate/prune-safeguards.ts` — the
+  default implementations (gh/git backends) and the `PruneSafeguards`
+  interface for DI.
+- `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts` —
+  the handler that composes safeguards with selection and cancel.

--- a/skills/claude/shepherd/SKILL.md
+++ b/skills/claude/shepherd/SKILL.md
@@ -21,6 +21,10 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Pipeline Hygiene
+
+When `mcp__plugin_exarchos_exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:

--- a/skills/claude/synthesis/SKILL.md
+++ b/skills/claude/synthesis/SKILL.md
@@ -22,12 +22,22 @@ Submit stacked PRs after review phase completes. The `prepare_synthesis` composi
 
 Do NOT proceed if either review is incomplete or failed -- return to `/exarchos:review` first.
 
+**Entry points:** Synthesis is normally reached from the `review` phase of
+feature / debug / refactor workflows. It is also reachable from `oneshot`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during `plan` or `implementing`, the `request_synthesize` event is
+appended, and `finalize_oneshot` then resolves the choice state and
+transitions the workflow to `synthesize`. See
+`@skills/oneshot-workflow/SKILL.md` for the opt-in mechanics and
+`synthesisPolicy` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs `/exarchos:synthesize` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to `synthesize` via `finalize_oneshot`
 
 ## Process
 

--- a/skills/claude/workflow-state/SKILL.md
+++ b/skills/claude/workflow-state/SKILL.md
@@ -38,7 +38,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use `exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })` for
 parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its `implementing → synthesize|completed` choice state
+driven by `synthesisPolicy`), call `exarchos_workflow({ action: "describe", playbook: "oneshot" })`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 `exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })`
 for event data schemas.
 
@@ -126,6 +129,23 @@ exarchos_orchestrate({
 | Review complete | Update `reviews` object |
 | PR created | Set `artifacts.pr`, `synthesis.prUrl` |
 | PR feedback | Append to `synthesis.prFeedback` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| `plan` (oneshot) | `oneshot.planSummary`, `artifacts.plan`, optional `oneshot.synthesisPolicy` | `workflow.transition` |
+| `implementing` (oneshot) | `tasks[].status`, `artifacts.tests` | `task.*`, optional `synthesize.requested` (via `request_synthesize`) |
+| `synthesize` (oneshot) | `synthesis.prUrl`, `artifacts.pr` | `workflow.transition`, `stack.submitted` |
+| `completed` (oneshot) | — | `workflow.transition` (to `completed`) |
+
+The `implementing → synthesize | completed` fork is a choice state resolved
+by `finalize_oneshot`, which reads the `synthesisOptedIn` guard
+(`synthesisPolicy` + `synthesize.requested` events). See
+`@skills/oneshot-workflow/SKILL.md` for the full opt-in mechanics.
 
 ### Automatic State Updates
 

--- a/skills/claude/workflow-state/SKILL.md
+++ b/skills/claude/workflow-state/SKILL.md
@@ -60,7 +60,13 @@ At the start of `/exarchos:ideate`, use `mcp__plugin_exarchos_exarchos__exarchos
 - `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
 - `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+`workflowType`:
+
+- `feature` → starts in `ideate`
+- `debug` → starts in `triage`
+- `refactor` → starts in `explore`
+- `oneshot` → starts in `plan` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 

--- a/skills/claude/workflow-state/SKILL.md
+++ b/skills/claude/workflow-state/SKILL.md
@@ -54,9 +54,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see `references
 
 At the start of `/exarchos:ideate`, use `mcp__plugin_exarchos_exarchos__exarchos_workflow` with `action: "init"` with:
 - `featureId`: the workflow identifier (e.g., `"user-authentication"`)
-- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`
+- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
+- `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- `feature` — full `ideate → plan → delegate → review → synthesize` for real features with subagent dispatch and two-stage review
+- `debug` — `triage → investigate → (thorough | hotfix)` for bug workflows with track selection
+- `refactor` — `explore → brief → (polish | overhaul)` for code improvements, polish for small and overhaul for multi-task
+- `oneshot` — `plan → implementing → (completed | synthesize)` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by `synthesisPolicy` and the `synthesize.requested` event
+
+See `@skills/oneshot-workflow/SKILL.md` for the lightweight variant's full prose, including the choice-state mechanics and `finalize_oneshot` trigger.
 
 ### Read State
 
@@ -154,7 +164,7 @@ See `docs/schemas/workflow-state.schema.json` for full schema.
 Key sections:
 - `version`: Schema version (currently "1.1")
 - `featureId`: Unique workflow identifier
-- `workflowType`: Required. One of "feature", "debug", or "refactor"
+- `workflowType`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - `phase`: Current workflow phase
 - `artifacts`: Paths to design, plan, PR
 - `tasks`: Task list with status

--- a/skills/claude/workflow-state/references/phase-transitions.md
+++ b/skills/claude/workflow-state/references/phase-transitions.md
@@ -127,7 +127,7 @@ plan → implementing ─┬→ completed              (direct-commit path)
 
 | From | To | Guard | Prerequisite |
 |------|----|-------|-------------|
-| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` (non-empty string; `oneshot.planSummary` is optional metadata but does **not** satisfy the guard) |
 | `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
 | `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
 | `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |

--- a/skills/claude/workflow-state/references/phase-transitions.md
+++ b/skills/claude/workflow-state/references/phase-transitions.md
@@ -118,6 +118,28 @@ explore → brief → [polish-track | overhaul-track] → completed
 
 **Compound state:** `overhaul-track` contains `overhaul-plan`, `overhaul-plan-review`, `overhaul-delegate`, `overhaul-review`, and `overhaul-update-docs`. Max 3 fix cycles.
 
+## Oneshot Workflow
+
+```
+plan → implementing ─┬→ completed              (direct-commit path)
+                     └→ synthesize → completed (PR path, opt-in)
+```
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
+| `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
+| `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+**Choice state (end of `implementing`).** The fork after `implementing` is a UML choice state, implemented as two mutually-exclusive HSM transitions whose guards are pure functions of `state.oneshot.synthesisPolicy` and the `synthesize.requested` event count on the stream. At init, the user declares intent via `synthesisPolicy` (`always`, `never`, or `on-request` — default). During implementing, the user can opt in at any time by calling `exarchos_orchestrate request_synthesize`, which appends a `synthesize.requested` event without changing the phase. The decision is only evaluated when `finalize_oneshot` is called: the handler hydrates events, runs the guards, and calls `handleSet` with the resolved target. **Policy wins over event** — if policy is `never`, any `synthesize.requested` event is ignored and the guard routes to `completed`. Policy `always` short-circuits the event check and always routes to `synthesize`.
+
+**How to trigger:** `exarchos_orchestrate finalize_oneshot { featureId }` — this is the only way to exit `implementing`. The handler evaluates the choice state and calls `handleSet` with the correct target phase. The HSM re-evaluates the guard at the transition boundary, so any race between read and transition is caught safely.
+
+**No compound state.** Oneshot has no multi-agent loop, no review-fix cycle, and therefore no circuit breaker. If the in-session TDD loop gets stuck, cancel via `exarchos_workflow cancel` and restart with a different approach (or escalate to the full `feature` workflow).
+
+See `@skills/oneshot-workflow/SKILL.md` for the full prose walkthrough including worked examples.
+
 ## Circuit Breaker
 
 Compound states enforce a maximum number of fix cycles to prevent infinite review-fix loops. When the limit is exceeded, the HSM rejects the transition with a `CIRCUIT_OPEN` error and emits a `workflow.circuit-open` event.

--- a/skills/codex/cleanup/SKILL.md
+++ b/skills/codex/cleanup/SKILL.md
@@ -15,6 +15,12 @@ metadata:
 
 Resolve merged workflows to `completed` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
 
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use `@skills/prune-workflows/SKILL.md`. That skill invokes `exarchos_orchestrate prune_stale_workflows` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → `completed`); prune is bulk (N inactive workflows → `cancelled`). They are complementary, not alternatives.
+
 ## Triggers
 
 Activate this skill when:

--- a/skills/codex/delegation/SKILL.md
+++ b/skills/codex/delegation/SKILL.md
@@ -20,6 +20,8 @@ Activate this skill when:
 - Implementation plan is ready with extractable tasks
 - User wants to parallelize work across subagents
 
+**Exception — oneshot workflows skip delegation entirely.** The oneshot playbook runs an in-session TDD loop in the main agent's context, with no subagent dispatch or review phase. If `workflowType === "oneshot"`, do not call this skill — see `@skills/oneshot-workflow/SKILL.md` for the lightweight path.
+
 ## Core Principles
 
 ### Fresh Context Per Task (MANDATORY)

--- a/skills/codex/oneshot-workflow/SKILL.md
+++ b/skills/codex/oneshot-workflow/SKILL.md
@@ -12,8 +12,8 @@ metadata:
 # Oneshot Workflow Skill
 
 A lean, four-phase workflow type for changes that are too small to justify the
-full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
-still deserve event-sourced auditability and a planning step. The workflow is
+full `feature` flow (`ideate → plan → plan-review → delegate → review → synthesize → completed`)
+but still deserve event-sourced auditability and a planning step. The workflow is
 **direct-commit by default** with an opt-in PR path; the choice between the
 two is resolved at the end of `implementing` via a pure event-sourced guard,
 not a heuristic.
@@ -88,7 +88,7 @@ and overrides runtime signal.
 
 ## Lifecycle
 
-```
+```text
      plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
                                  │
                                  └── [synthesisOptedIn]  ──► synthesize ──► completed
@@ -286,7 +286,7 @@ do not exist in the oneshot playbook. The PR review is the only review.
 
 ### Example A — Direct-commit (default `on-request` policy, no opt-in)
 
-```
+```text
 User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
        Use oneshot."
 
@@ -317,7 +317,7 @@ Agent:
 
 ### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
 
-```
+```text
 User: "Add input validation to the parseConfig helper. Oneshot."
 
 Agent:
@@ -347,7 +347,7 @@ Agent:
 
 ### Example C — `synthesisPolicy: 'always'` (PR mandatory)
 
-```
+```text
 User: "I want a PR for any change to the auth module, even small ones.
        Use oneshot but always make a PR."
 

--- a/skills/codex/oneshot-workflow/SKILL.md
+++ b/skills/codex/oneshot-workflow/SKILL.md
@@ -214,13 +214,22 @@ for phrases like:
 When you hear any of those, call `request_synthesize` immediately. The
 handler appends a `synthesize.requested` event to the workflow's event
 stream; the `synthesisOptedIn` guard reads the stream at finalize and
-routes accordingly. This is **idempotent** — calling
-`request_synthesize` twice appends two events but the guard treats any
-count >= 1 as "opted in", so duplicate calls are benign.
+routes accordingly.
+
+`request_synthesize` is accepted from both `plan` and `implementing`
+phases — call it whenever you know you want the PR path, even before
+`implementing` starts. Terminal phases (`synthesize`, `completed`,
+`cancelled`) are rejected.
+
+Duplicate calls are **routing-idempotent** but not event-idempotent:
+each call appends a new `synthesize.requested` event, but the guard
+treats any count >= 1 as "opted in", so the routing decision is the
+same whether you call once or five times. The event stream will
+contain each duplicate for audit purposes.
 
 Calling `request_synthesize` does **not** transition the phase. The
-workflow stays in `implementing`. The decision is only acted on when
-you call `finalize_oneshot` in step 4.
+workflow stays in its current phase. The decision is only acted on
+when you call `finalize_oneshot` in step 4.
 
 ### Step 4 — Finalize (the choice point)
 
@@ -393,7 +402,7 @@ For the full transition table for oneshot, consult
 
 | From | To | Guard |
 |---|---|---|
-| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `plan` | `implementing` | `oneshotPlanSet` (requires non-empty `artifacts.plan`) |
 | `implementing` | `synthesize` | `synthesisOptedIn` |
 | `implementing` | `completed` | `synthesisOptedOut` |
 | `synthesize` | `completed` | `mergeVerified` |
@@ -401,9 +410,10 @@ For the full transition table for oneshot, consult
 
 `synthesisOptedIn` and `synthesisOptedOut` are pure functions of
 `state.oneshot.synthesisPolicy` and `state._events`. They are mutually
-exclusive across all 8 (3 policies × event-present/absent, with `always`
-and `never` ignoring the event flag) combinations — exactly one returns
-true at any given time.
+exclusive across all 4 meaningful combinations — `always` and `never`
+each map to one outcome (ignoring the event flag), and `on-request`
+branches on whether a `synthesize.requested` event is present or
+absent. Exactly one guard returns true at any given time.
 
 ### Schema discovery
 

--- a/skills/codex/oneshot-workflow/SKILL.md
+++ b/skills/codex/oneshot-workflow/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: oneshot-workflow
+description: "Lightweight workflow for straightforward changes — plan → implement → optional PR. Direct-commit by default; synthesize is opt-in via synthesisPolicy or a runtime request_synthesize event. Use for trivial fixes, config tweaks, single-file changes, or exploratory work that doesn't warrant subagent dispatch or two-stage review. Triggers: 'oneshot', 'quick fix', 'small change', or oneshot."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: plan
+---
+
+# Oneshot Workflow Skill
+
+A lean, four-phase workflow type for changes that are too small to justify the
+full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
+still deserve event-sourced auditability and a planning step. The workflow is
+**direct-commit by default** with an opt-in PR path; the choice between the
+two is resolved at the end of `implementing` via a pure event-sourced guard,
+not a heuristic.
+
+> **Read this first if you have never run a oneshot:** the workflow has a
+> *choice state* at the end of `implementing`. Whether you land on
+> `completed` (direct commit) or transition through `synthesize` (PR) is
+> decided by two inputs: the `synthesisPolicy` set at init, and whether the
+> user emitted a `synthesize.requested` event during implementing. Both
+> inputs are persisted; the decision is replay-safe.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically a single file, or a tightly-coupled
+  cluster of 2-3 files
+- No subagent dispatch is needed — the work fits comfortably in one TDD
+  loop in a single session
+- No design document is required — the goal is obvious from the task
+  description, and a one-page plan is enough scaffolding
+- No two-stage review is required — either the change is trivial enough
+  that direct-commit is acceptable, or a single PR review will suffice
+
+Concrete examples that fit oneshot:
+- Fixing a typo in a README
+- Bumping a dependency version
+- Adding a missing null-check in one function
+- Tweaking a CI workflow YAML
+- Renaming a config key everywhere it's referenced
+- Adding a one-off helper script
+- Exploratory spikes that may or may not be kept
+
+## When NOT to use oneshot
+
+Do not use oneshot for any of the following — use the full `feature`
+workflow instead (`ideate`):
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+- Anything where you'd want a written design doc to look back at
+
+If you start a oneshot and discover the change is bigger than expected, the
+right move is `cancel` and restart with `ideate`.
+Don't try to grow a oneshot into a feature workflow mid-stream; the
+playbooks have different shapes and you'll fight the state machine.
+
+## Synthesis policy — three options
+
+The `synthesisPolicy` field on a oneshot workflow declares the user's
+intent up front about whether the change should be turned into a PR. It
+takes one of three values, persisted on `state.oneshot.synthesisPolicy`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| `always` | Always transition `implementing → synthesize` at finalize, regardless of events. A PR is always created. | The user wants a paper trail / review for every change in this workflow, even small ones. |
+| `never` | Always transition `implementing → completed` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | The user is iterating on personal/scratch work and explicitly opts out of PRs. |
+| `on-request` *(default)* | Direct-commit by default. The user can opt in to a PR mid-implementing by calling `request_synthesize`; if any `synthesize.requested` event is on the stream at finalize, the workflow transitions to `synthesize` instead of `completed`. | The common case: start with the assumption of direct-commit, but leave the door open for the user to change their mind once they see the diff. |
+
+The default is `on-request` because it's the least surprising: the user
+gets the lightweight path until they explicitly ask for the heavy one.
+
+**Policy wins over event.** If `synthesisPolicy: 'never'` is set and a
+`synthesize.requested` event is somehow on the stream (e.g. the user
+called the action on a workflow they thought was `on-request`), the
+guard still routes to `completed`. Policy is the user's declared intent
+and overrides runtime signal.
+
+## Lifecycle
+
+```
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+```
+
+Four phases. The fork after `implementing` is a UML *choice state*,
+implemented via two mutually-exclusive HSM transitions whose guards are
+pure functions of `state.oneshot.synthesisPolicy` and the
+`synthesize.requested` event count.
+
+| Phase | What happens | Exit criteria |
+|---|---|---|
+| `plan` | Lightweight one-page plan: goal, approach, files to touch, tests to add. No design doc. No subagent dispatch. | `artifacts.plan` set → transition to `implementing` |
+| `implementing` | In-session TDD loop. Write a failing test, make it pass, refactor. Commit as you go. The TDD iron law applies — *no production code without a failing test first*. | Tests pass + typecheck clean + finalize_oneshot called |
+| `synthesize` | Reached **only** when `synthesisOptedIn` is true. Hands off to the existing synthesis flow — see `@skills/synthesis/SKILL.md`. PR created via `gh pr create`, auto-merge enabled, CI gates apply. | PR merged → `completed` |
+| `completed` | Terminal. For direct-commit path, commits are already on the branch — there's nothing more to do. For synthesize path, the PR merge event terminates the workflow. | — |
+
+`cancelled` is also reachable from any phase via the universal cancel
+transition, same as every other workflow type.
+
+## Step-by-step
+
+### Step 1 — Init
+
+Call `exarchos_workflow` with `action: 'init'`, `workflowType: 'oneshot'`,
+and an optional `synthesisPolicy`:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "init",
+  featureId: "fix-readme-typo",
+  workflowType: "oneshot",
+  synthesisPolicy: "on-request" // optional — defaults to 'on-request'
+})
+```
+
+If the user has been clear up front ("I want a PR for this"), pass
+`synthesisPolicy: "always"`. If they've been clear ("don't open a PR,
+just commit it"), pass `synthesisPolicy: "never"`. Otherwise, omit the
+field and rely on the `on-request` default — you can always escalate
+later in the implementing phase.
+
+The init returns the new workflow state; the workflow lands in `plan`.
+
+### Step 2 — Plan phase
+
+Produce a one-page plan. This is intentionally lightweight — no design
+doc, no parallelization analysis, no decomposition into N tasks. The
+plan should answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to `implementing` in a single set call:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "fix-readme-typo",
+  updates: {
+    "artifacts": { "plan": "<plan text>" },
+    "oneshot": { "planSummary": "<one-line summary>" },
+    "phase": "implementing"
+  }
+})
+```
+
+The plan goes on `artifacts.plan` for parity with the `feature` workflow;
+the human-readable one-liner goes on `oneshot.planSummary` for the
+pipeline view.
+
+### Step 3 — Implementing phase
+
+Run an in-session TDD loop. Same iron law as every other workflow:
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run the test. Confirm it fails for
+   the right reason.
+2. **[GREEN]** Write the minimum production code to make the test pass.
+   Run the test. Confirm it passes.
+3. **[REFACTOR]** Clean up while keeping the test green.
+
+Commit each red-green-refactor cycle as a single commit. Do not batch
+multiple unrelated changes into one commit — keeping commits atomic
+matters even more in oneshot, where there's no separate review phase
+to catch bundled changes.
+
+There is **no subagent dispatch** in oneshot. The main agent does the
+work directly. There is **no separate review phase**. Quality is
+maintained by the TDD loop and (if the user opts in) the synthesize PR
+review.
+
+#### Mid-implementing: opting in to a PR
+
+If at any point during implementing the user decides they want a PR
+after all (policy is `on-request`, default), they can opt in by calling
+the `request_synthesize` orchestrate action:
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+```
+
+**The trigger for this is conversational, not a magic keyword.** Listen
+for phrases like:
+- "actually, let's open a PR for this"
+- "I want a review on this before it lands"
+- "make this a PR"
+- "let's get eyes on this"
+- "synthesize this"
+
+When you hear any of those, call `request_synthesize` immediately. The
+handler appends a `synthesize.requested` event to the workflow's event
+stream; the `synthesisOptedIn` guard reads the stream at finalize and
+routes accordingly. This is **idempotent** — calling
+`request_synthesize` twice appends two events but the guard treats any
+count >= 1 as "opted in", so duplicate calls are benign.
+
+Calling `request_synthesize` does **not** transition the phase. The
+workflow stays in `implementing`. The decision is only acted on when
+you call `finalize_oneshot` in step 4.
+
+### Step 4 — Finalize (the choice point)
+
+When the implementing loop is done — tests pass, typecheck clean, all
+commits made — call `finalize_oneshot` to resolve the choice state:
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+```
+
+The handler:
+
+1. Reads the current state and verifies `workflowType === 'oneshot'` and
+   `phase === 'implementing'`.
+2. Hydrates `_events` from the event store so the guard sees the same
+   view the HSM will see during the actual transition.
+3. Evaluates `guards.synthesisOptedIn` against the state. The guard
+   inspects `state.oneshot.synthesisPolicy` and the `_events` array.
+4. Calls `handleSet` with the resolved target phase (`synthesize` or
+   `completed`). The HSM re-evaluates the guard at the transition
+   boundary, so any race between the read and the transition is caught
+   safely.
+
+Possible outcomes:
+
+| `synthesisPolicy` | `synthesize.requested` event present? | Resolved target | Path |
+|---|---|---|---|
+| `always` | (any) | `synthesize` | PR path |
+| `never` | (any) | `completed` | direct-commit path |
+| `on-request` (default) | yes | `synthesize` | PR path |
+| `on-request` (default) | no | `completed` | direct-commit path |
+
+### Step 5a — Direct-commit path (terminal)
+
+If finalize resolved to `completed`, you're done. The commits made
+during implementing are already on the current branch. Push them if
+they aren't already pushed:
+
+```bash
+git push
+```
+
+The workflow is now in `completed` and will not appear in the default
+pipeline view.
+
+### Step 5b — Synthesize path
+
+If finalize resolved to `synthesize`, hand off to the standard synthesis
+flow — see `@skills/synthesis/SKILL.md`. The same `prepare_synthesis` /
+`validate_pr_body` / `gh pr create` machinery used by the `feature`
+workflow applies. After the PR merges, the workflow transitions
+`synthesize → completed` via the existing `mergeVerified` guard, same as
+every other workflow type.
+
+You do **not** need to run `delegate` or
+`review` for an opt-in oneshot synthesize. Those phases
+do not exist in the oneshot playbook. The PR review is the only review.
+
+## Example invocations
+
+### Example A — Direct-commit (default `on-request` policy, no opt-in)
+
+```
+User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
+       Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
+  2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  4. [RED] writes test that greps README for 'recieve' and expects 0 matches
+        — fails (1 match exists)
+  5. [GREEN] edits README, fixes typo
+        — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+```
+
+### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
+
+```
+User: "Add input validation to the parseConfig helper. Oneshot."
+
+Agent:
+  1. exarchos_workflow init { workflowType: "oneshot" }
+     → 'plan' phase, default 'on-request'
+  2. plans (goal: validate input, files: [parser.ts, parser.test.ts])
+  3. transitions to 'implementing'
+  4. [RED] writes test for null-input case
+  5. [GREEN] adds null check
+  6. [REFACTOR] extracts validateInput helper
+  7. commits
+
+User: "Actually, this is touching the parser — I want a review on it before
+       it lands."
+
+Agent:
+  8. exarchos_orchestrate request_synthesize {
+       featureId, reason: "user requested review of parser changes"
+     }
+     → appends synthesize.requested event
+  9. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='on-request' + 1 synthesize.requested event
+     → resolves to 'synthesize'
+ 10. hands off to @skills/synthesis/SKILL.md → prepare_synthesis →
+     validate_pr_body → gh pr create → merge
+```
+
+### Example C — `synthesisPolicy: 'always'` (PR mandatory)
+
+```
+User: "I want a PR for any change to the auth module, even small ones.
+       Use oneshot but always make a PR."
+
+Agent:
+  1. exarchos_workflow init {
+       workflowType: "oneshot",
+       synthesisPolicy: "always"
+     }
+  2-7. plan + TDD + commits, identical to Example A
+  8. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='always' (short-circuits — no event check needed)
+     → resolves to 'synthesize'
+  9. synthesis flow → PR
+```
+
+## State management
+
+Track oneshot-specific state under the `oneshot` key on the workflow state:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "<id>",
+  updates: {
+    "oneshot": {
+      "synthesisPolicy": "on-request",
+      "planSummary": "Fix off-by-one in pagination helper"
+    }
+  }
+})
+```
+
+The `synthesisPolicy` field is optional and defaults to `'on-request'` per
+the schema in `servers/exarchos-mcp/src/workflow/schemas.ts`. Setting it
+explicitly is recommended when the user has stated a preference.
+
+## Phase Transitions and Guards
+
+For the full transition table for oneshot, consult
+`@skills/workflow-state/references/phase-transitions.md`.
+
+**Quick reference for oneshot:**
+
+| From | To | Guard |
+|---|---|---|
+| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `implementing` | `synthesize` | `synthesisOptedIn` |
+| `implementing` | `completed` | `synthesisOptedOut` |
+| `synthesize` | `completed` | `mergeVerified` |
+| (any) | `cancelled` | universal — always allowed |
+
+`synthesisOptedIn` and `synthesisOptedOut` are pure functions of
+`state.oneshot.synthesisPolicy` and `state._events`. They are mutually
+exclusive across all 8 (3 policies × event-present/absent, with `always`
+and `never` ignoring the event flag) combinations — exactly one returns
+true at any given time.
+
+### Schema discovery
+
+Use `exarchos_workflow({ action: "describe", actions: ["init", "set"] })`
+for parameter schemas (including the `synthesisPolicy` enum) and
+`exarchos_workflow({ action: "describe", playbook: "oneshot" })` for the
+phase transitions, guard names, and playbook prose. Use
+`exarchos_orchestrate({ action: "describe", actions: ["request_synthesize", "finalize_oneshot"] })`
+for the orchestrate action schemas.
+
+## TDD is still mandatory
+
+The iron law from `@rules/tdd.md` applies to oneshot. There is no
+exemption for "small" changes. Specifically:
+
+- Every behavior change starts with a failing test
+- Every test must fail before its implementation is written
+- Tests must be run after each change to verify state
+- Commits stay atomic — one logical change per commit
+
+The temptation in a oneshot is to skip the test "because it's just one
+line". Resist that. The test is what makes the change auditable, and
+auditability is the entire reason oneshot exists alongside the lighter
+"bypass workflows entirely" path.
+
+## Anti-patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip the plan phase ("it's obvious") | Write the four-line plan anyway — it's the artifact future-you reads |
+| Skip the TDD loop in implementing | Always RED → GREEN → REFACTOR, even for one-liners |
+| Use oneshot for multi-file refactors | Use `ideate` and the full feature workflow |
+| Try to grow a oneshot into a feature workflow mid-stream | Cancel and restart with `ideate` |
+| Call `request_synthesize` without listening for the user's intent | Wait for the user to ask for a PR, then call it |
+| Bundle unrelated changes into one commit "since it's a oneshot" | Keep commits atomic — there's no review phase to catch bundling |
+| Forget to call `finalize_oneshot` at the end | The workflow stays in `implementing` forever otherwise — call it explicitly |
+
+## Completion criteria
+
+- [ ] `exarchos_workflow init` called with `workflowType: "oneshot"`
+- [ ] One-page plan persisted to `artifacts.plan`
+- [ ] Phase transitioned to `implementing`
+- [ ] All planned behaviors implemented via TDD with atomic commits
+- [ ] `finalize_oneshot` called and resolved to either `completed` or `synthesize`
+- [ ] If direct-commit path: commits pushed
+- [ ] If synthesize path: PR created via `@skills/synthesis/SKILL.md` and merged

--- a/skills/codex/oneshot-workflow/SKILL.md
+++ b/skills/codex/oneshot-workflow/SKILL.md
@@ -189,11 +189,11 @@ work directly. There is **no separate review phase**. Quality is
 maintained by the TDD loop and (if the user opts in) the synthesize PR
 review.
 
-#### Mid-implementing: opting in to a PR
+#### Mid-workflow: opting in to a PR
 
-If at any point during implementing the user decides they want a PR
-after all (policy is `on-request`, default), they can opt in by calling
-the `request_synthesize` orchestrate action:
+If at any point during `plan` or `implementing` the user decides they
+want a PR after all (policy is `on-request`, default), they can opt in
+by calling the `request_synthesize` orchestrate action:
 
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
@@ -397,6 +397,12 @@ explicitly is recommended when the user has stated a preference.
 
 For the full transition table for oneshot, consult
 `@skills/workflow-state/references/phase-transitions.md`.
+
+> **Note:** The engine's `exarchos_workflow describe playbook="oneshot"`
+> output and the HSM definitions in `hsm-definitions.ts` are the
+> canonical sources for transition behavior. `phase-transitions.md` is
+> a prose reference that can drift — when discrepancies arise, prefer
+> engine `describe` output.
 
 **Quick reference for oneshot:**
 

--- a/skills/codex/oneshot-workflow/SKILL.md
+++ b/skills/codex/oneshot-workflow/SKILL.md
@@ -144,23 +144,26 @@ plan should answer four questions in 5-10 lines each:
 3. **Files** — which files will be touched? (1-5 typically)
 4. **Tests** — which test cases will be added? (named, not described)
 
-Persist the plan and transition to `implementing` in a single set call:
+Persist the plan and transition to `implementing` in a single set call.
+`phase` is a top-level argument of `set`, not a field inside `updates`:
 
 ```typescript
 mcp__exarchos__exarchos_workflow({
   action: "set",
   featureId: "fix-readme-typo",
+  phase: "implementing",
   updates: {
-    "artifacts": { "plan": "<plan text>" },
-    "oneshot": { "planSummary": "<one-line summary>" },
-    "phase": "implementing"
+    "artifacts.plan": "<plan text>",
+    "oneshot.planSummary": "<one-line summary>"
   }
 })
 ```
 
 The plan goes on `artifacts.plan` for parity with the `feature` workflow;
 the human-readable one-liner goes on `oneshot.planSummary` for the
-pipeline view.
+pipeline view. Only `artifacts.plan` is enforced by the
+`oneshot-plan-set` guard — `planSummary` is an optional pipeline-view
+label and is not a substitute for a real plan artifact.
 
 ### Step 3 — Implementing phase
 
@@ -292,7 +295,14 @@ Agent:
      → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
   2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
      tests=[readme has no occurrence of 'recieve']
-  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",                   // top-level
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "..."
+       }
+     }
   4. [RED] writes test that greps README for 'recieve' and expects 0 matches
         — fails (1 match exists)
   5. [GREEN] edits README, fixes typo

--- a/skills/codex/oneshot-workflow/references/choice-state.md
+++ b/skills/codex/oneshot-workflow/references/choice-state.md
@@ -1,0 +1,65 @@
+---
+name: oneshot-choice-state
+---
+
+# Oneshot Choice State: `implementing → ?`
+
+The oneshot workflow has a UML *choice state* at the end of `implementing`.
+Whether the workflow lands on `completed` (direct-commit) or transitions
+through `synthesize` (PR) is decided by two mutually-exclusive pure-function
+guards: `synthesisOptedIn` and `synthesisOptedOut`. Both are evaluated against
+the current workflow state at the transition boundary; exactly one returns
+`true` for every possible input.
+
+## Inputs read by the guards
+
+Both guards read exactly two things from state:
+
+1. `state.oneshot.synthesisPolicy` — one of `'always' | 'never' | 'on-request'`,
+   defaulted to `'on-request'` by the init schema.
+2. `state._events` — the hydrated event stream. The guard counts
+   `synthesize.requested` events on the stream (any count ≥ 1 means "opted in").
+
+Nothing else. No clock reads, no filesystem, no network, no git state. This
+is load-bearing for replay safety: given the same persisted state, the same
+target resolves every time, and re-running finalize is idempotent.
+
+## Decision table
+
+| `synthesisPolicy` | `synthesize.requested` count | `synthesisOptedIn` | `synthesisOptedOut` | Resolved target |
+|---|---|---|---|---|
+| `'always'`     | 0  | `true`  | `false` | `synthesize` |
+| `'always'`     | ≥1 | `true`  | `false` | `synthesize` |
+| `'never'`      | 0  | `false` | `true`  | `completed`  |
+| `'never'`      | ≥1 | `false` | `true`  | `completed`  |
+| `'on-request'` | 0  | `false` | `true`  | `completed`  |
+| `'on-request'` | ≥1 | `true`  | `false` | `synthesize` |
+
+**Policy wins over event.** On `'never'`, even if a stray `synthesize.requested`
+event is on the stream, the guard still routes to `completed`. Policy is the
+user's declared intent; runtime events only matter when the policy explicitly
+defers to them (`'on-request'`).
+
+## Why a choice state, not a single transition with branching logic
+
+Keeping the fork at the HSM level (two transitions, two mutually-exclusive
+guards) means:
+
+- The state machine graph visibly encodes both paths — operators reading
+  `hsm-definitions.ts` see `implementing → completed` and `implementing →
+  synthesize` as sibling transitions, not a hidden conditional.
+- The HSM re-evaluates guards at the transition boundary, so any race
+  between `finalize_oneshot` reading state and `handleSet` performing the
+  transition is caught safely — if a last-millisecond event changed the
+  evaluation, the HSM will refuse the wrong transition.
+- Guard logic stays testable in isolation (`guards.test.ts`) without
+  needing to spin up the handler.
+
+## See also
+
+- `servers/exarchos-mcp/src/workflow/guards.ts` — `synthesisOptedIn`,
+  `synthesisOptedOut`, `oneshotPlanSet` guard implementations.
+- `servers/exarchos-mcp/src/workflow/hsm-definitions.ts` — the oneshot HSM
+  with the two sibling transitions from `implementing`.
+- `servers/exarchos-mcp/src/orchestrate/finalize-oneshot.ts` — the handler
+  that resolves the choice state and calls `handleSet`.

--- a/skills/codex/prune-workflows/SKILL.md
+++ b/skills/codex/prune-workflows/SKILL.md
@@ -19,9 +19,9 @@ Pruning is a maintenance operation -- not a workflow phase. It produces `workflo
 ## Triggers
 
 Activate this skill when:
-- User runs `{{COMMAND_PREFIX}}prune` command
+- User runs `prune` command
 - User says "prune workflows", "clean stale workflows", "pipeline cleanup"
-- `{{MCP_PREFIX}}exarchos_view({ action: "pipeline" })` shows many inactive workflows the user wants to clear in bulk
+- `mcp__exarchos__exarchos_view({ action: "pipeline" })` shows many inactive workflows the user wants to clear in bulk
 
 ## Prerequisites
 
@@ -36,7 +36,7 @@ Activate this skill when:
 Always start with `dryRun: true`. This call performs candidate selection and safeguard evaluation but does not mutate any workflow state.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: true
@@ -104,7 +104,7 @@ Wait for explicit user input. Do **not** auto-proceed.
 On `proceed`, invoke the same action with `dryRun: false`. Pass through `thresholdMinutes` and `includeOneShot` if the user set them in Step 1.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: false
@@ -131,7 +131,7 @@ Each entry in `pruned` corresponds to a workflow that transitioned to `cancelled
 On `force`, set `force: true`. Safeguards are bypassed but the bypass is recorded in the `workflow.pruned` event payload as `skippedSafeguards: [...]` so the audit trail is intact.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: false,
@@ -199,7 +199,7 @@ A workflow without a `branchName` in state (e.g., abandoned at ideate/plan befor
 ### Example 1: Clean dry-run, user proceeds
 
 ```
-> {{COMMAND_PREFIX}}prune
+> prune
 
 ## Prune Candidates (2)
 
@@ -230,7 +230,7 @@ Proceed? (proceed/abort/force)
 ### Example 2: Safeguard skip, user forces
 
 ```
-> {{COMMAND_PREFIX}}prune
+> prune
 
 ## Prune Candidates (1)
 
@@ -265,7 +265,7 @@ Proceed? (proceed/abort/force)
 ### Example 3: Empty pipeline
 
 ```
-> {{COMMAND_PREFIX}}prune
+> prune
 
 No stale workflows to prune. Pipeline is clean.
 ```
@@ -275,7 +275,7 @@ No stale workflows to prune. Pipeline is clean.
 For the canonical argument schema and any future fields, use:
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "describe",
   actions: ["prune_stale_workflows"]
 })

--- a/skills/codex/prune-workflows/references/safeguards.md
+++ b/skills/codex/prune-workflows/references/safeguards.md
@@ -1,0 +1,74 @@
+---
+name: prune-safeguards
+---
+
+# Prune Safeguards
+
+The `prune_stale_workflows` orchestrate action runs two safeguards on each
+candidate before it will actually cancel the workflow. Both must pass for
+the candidate to be pruned, unless the caller passes `force: true` to
+bypass them.
+
+## Safeguard 1: `hasOpenPR`
+
+Checks whether there's an open pull request targeting the workflow's
+branch. Implementation: `gh pr list --state open --head <branchName>` —
+if the list is non-empty, the safeguard fails and the candidate is
+skipped with reason `open-pr`.
+
+Rationale: an open PR means human work is still in-flight on this feature.
+Cancelling the workflow would orphan the PR from its event-sourced state,
+which makes it invisible to `exarchos_view` and breaks auto-merge gates.
+We refuse to prune workflows with open PRs by default.
+
+## Safeguard 2: `hasRecentCommits` (user-facing: `active-branch`)
+
+Checks whether any commits landed on the workflow's branch within a
+24-hour window. Implementation: `git log --since="24 hours ago"
+<branchName>` — if the output is non-empty, the safeguard fails and the
+candidate is skipped with reason `active-branch`.
+
+Rationale: commits on the branch mean the workflow isn't actually stale,
+it just missed the last event checkpoint. The underlying branch is the
+ground truth for "is this work still alive?" — if someone is committing,
+we don't care what the checkpoint timestamp says.
+
+The window is locked at 24 hours for v1. It's exposed as a module
+constant (`RECENT_COMMITS_WINDOW_HOURS` in `prune-stale-workflows.ts`)
+so tests can see the contract, but it's not yet configurable through
+the public handler args.
+
+## Short-circuit: missing `branchName`
+
+If the workflow state has no top-level `branchName` field, both
+safeguards are skipped entirely (they have nothing to look up). The
+candidate still proceeds to cancel. This is safe because a workflow
+without a branch can't have an open PR or recent commits by definition.
+
+## `force: true` bypass semantics
+
+Passing `force: true` skips safeguard evaluation for every candidate.
+The handler still does everything else — the cancel, the event emission,
+the audit trail — but `hasOpenPR` and `hasRecentCommits` are never
+called.
+
+Every `workflow.pruned` event emitted during a `force: true` run carries
+a `skippedSafeguards: ['open-pr', 'active-branch']` marker on its payload.
+This makes forced prunes distinguishable in the audit stream from
+safeguard-approved ones, so operators reviewing the event log can see
+exactly which workflows were cancelled despite having open PRs or active
+branches.
+
+The marker list is intentionally hardcoded to *all* safeguards, not just
+the ones that would have failed. Running `force: true` is a blanket
+"I know what I'm doing" override — we want the audit trail to reflect
+that the user chose to bypass the whole safeguard layer, not to imply
+selective bypassing.
+
+## See also
+
+- `servers/exarchos-mcp/src/orchestrate/prune-safeguards.ts` — the
+  default implementations (gh/git backends) and the `PruneSafeguards`
+  interface for DI.
+- `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts` —
+  the handler that composes safeguards with selection and cancel.

--- a/skills/codex/shepherd/SKILL.md
+++ b/skills/codex/shepherd/SKILL.md
@@ -21,6 +21,10 @@ synthesize → shepherd (assess → fix → resubmit → loop) → cleanup
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Pipeline Hygiene
+
+When `mcp__exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:

--- a/skills/codex/synthesis/SKILL.md
+++ b/skills/codex/synthesis/SKILL.md
@@ -22,12 +22,22 @@ Submit stacked PRs after review phase completes. The `prepare_synthesis` composi
 
 Do NOT proceed if either review is incomplete or failed -- return to `review` first.
 
+**Entry points:** Synthesis is normally reached from the `review` phase of
+feature / debug / refactor workflows. It is also reachable from `oneshot`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during `plan` or `implementing`, the `request_synthesize` event is
+appended, and `finalize_oneshot` then resolves the choice state and
+transitions the workflow to `synthesize`. See
+`@skills/oneshot-workflow/SKILL.md` for the opt-in mechanics and
+`synthesisPolicy` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs `synthesize` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to `synthesize` via `finalize_oneshot`
 
 ## Process
 

--- a/skills/codex/workflow-state/SKILL.md
+++ b/skills/codex/workflow-state/SKILL.md
@@ -38,7 +38,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use `exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })` for
 parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its `implementing → synthesize|completed` choice state
+driven by `synthesisPolicy`), call `exarchos_workflow({ action: "describe", playbook: "oneshot" })`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 `exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })`
 for event data schemas.
 
@@ -126,6 +129,23 @@ exarchos_orchestrate({
 | Review complete | Update `reviews` object |
 | PR created | Set `artifacts.pr`, `synthesis.prUrl` |
 | PR feedback | Append to `synthesis.prFeedback` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| `plan` (oneshot) | `oneshot.planSummary`, `artifacts.plan`, optional `oneshot.synthesisPolicy` | `workflow.transition` |
+| `implementing` (oneshot) | `tasks[].status`, `artifacts.tests` | `task.*`, optional `synthesize.requested` (via `request_synthesize`) |
+| `synthesize` (oneshot) | `synthesis.prUrl`, `artifacts.pr` | `workflow.transition`, `stack.submitted` |
+| `completed` (oneshot) | — | `workflow.transition` (to `completed`) |
+
+The `implementing → synthesize | completed` fork is a choice state resolved
+by `finalize_oneshot`, which reads the `synthesisOptedIn` guard
+(`synthesisPolicy` + `synthesize.requested` events). See
+`@skills/oneshot-workflow/SKILL.md` for the full opt-in mechanics.
 
 ### Automatic State Updates
 

--- a/skills/codex/workflow-state/SKILL.md
+++ b/skills/codex/workflow-state/SKILL.md
@@ -54,9 +54,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see `references
 
 At the start of `ideate`, use `mcp__exarchos__exarchos_workflow` with `action: "init"` with:
 - `featureId`: the workflow identifier (e.g., `"user-authentication"`)
-- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`
+- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
+- `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- `feature` — full `ideate → plan → delegate → review → synthesize` for real features with subagent dispatch and two-stage review
+- `debug` — `triage → investigate → (thorough | hotfix)` for bug workflows with track selection
+- `refactor` — `explore → brief → (polish | overhaul)` for code improvements, polish for small and overhaul for multi-task
+- `oneshot` — `plan → implementing → (completed | synthesize)` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by `synthesisPolicy` and the `synthesize.requested` event
+
+See `@skills/oneshot-workflow/SKILL.md` for the lightweight variant's full prose, including the choice-state mechanics and `finalize_oneshot` trigger.
 
 ### Read State
 
@@ -154,7 +164,7 @@ See `docs/schemas/workflow-state.schema.json` for full schema.
 Key sections:
 - `version`: Schema version (currently "1.1")
 - `featureId`: Unique workflow identifier
-- `workflowType`: Required. One of "feature", "debug", or "refactor"
+- `workflowType`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - `phase`: Current workflow phase
 - `artifacts`: Paths to design, plan, PR
 - `tasks`: Task list with status

--- a/skills/codex/workflow-state/SKILL.md
+++ b/skills/codex/workflow-state/SKILL.md
@@ -60,7 +60,13 @@ At the start of `ideate`, use `mcp__exarchos__exarchos_workflow` with `action: "
 - `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
 - `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+`workflowType`:
+
+- `feature` → starts in `ideate`
+- `debug` → starts in `triage`
+- `refactor` → starts in `explore`
+- `oneshot` → starts in `plan` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 

--- a/skills/codex/workflow-state/references/phase-transitions.md
+++ b/skills/codex/workflow-state/references/phase-transitions.md
@@ -127,7 +127,7 @@ plan → implementing ─┬→ completed              (direct-commit path)
 
 | From | To | Guard | Prerequisite |
 |------|----|-------|-------------|
-| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` (non-empty string; `oneshot.planSummary` is optional metadata but does **not** satisfy the guard) |
 | `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
 | `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
 | `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |

--- a/skills/codex/workflow-state/references/phase-transitions.md
+++ b/skills/codex/workflow-state/references/phase-transitions.md
@@ -118,6 +118,28 @@ explore → brief → [polish-track | overhaul-track] → completed
 
 **Compound state:** `overhaul-track` contains `overhaul-plan`, `overhaul-plan-review`, `overhaul-delegate`, `overhaul-review`, and `overhaul-update-docs`. Max 3 fix cycles.
 
+## Oneshot Workflow
+
+```
+plan → implementing ─┬→ completed              (direct-commit path)
+                     └→ synthesize → completed (PR path, opt-in)
+```
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
+| `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
+| `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+**Choice state (end of `implementing`).** The fork after `implementing` is a UML choice state, implemented as two mutually-exclusive HSM transitions whose guards are pure functions of `state.oneshot.synthesisPolicy` and the `synthesize.requested` event count on the stream. At init, the user declares intent via `synthesisPolicy` (`always`, `never`, or `on-request` — default). During implementing, the user can opt in at any time by calling `exarchos_orchestrate request_synthesize`, which appends a `synthesize.requested` event without changing the phase. The decision is only evaluated when `finalize_oneshot` is called: the handler hydrates events, runs the guards, and calls `handleSet` with the resolved target. **Policy wins over event** — if policy is `never`, any `synthesize.requested` event is ignored and the guard routes to `completed`. Policy `always` short-circuits the event check and always routes to `synthesize`.
+
+**How to trigger:** `exarchos_orchestrate finalize_oneshot { featureId }` — this is the only way to exit `implementing`. The handler evaluates the choice state and calls `handleSet` with the correct target phase. The HSM re-evaluates the guard at the transition boundary, so any race between read and transition is caught safely.
+
+**No compound state.** Oneshot has no multi-agent loop, no review-fix cycle, and therefore no circuit breaker. If the in-session TDD loop gets stuck, cancel via `exarchos_workflow cancel` and restart with a different approach (or escalate to the full `feature` workflow).
+
+See `@skills/oneshot-workflow/SKILL.md` for the full prose walkthrough including worked examples.
+
 ## Circuit Breaker
 
 Compound states enforce a maximum number of fix cycles to prevent infinite review-fix loops. When the limit is exceeded, the HSM rejects the transition with a `CIRCUIT_OPEN` error and emits a `workflow.circuit-open` event.

--- a/skills/copilot/cleanup/SKILL.md
+++ b/skills/copilot/cleanup/SKILL.md
@@ -15,6 +15,12 @@ metadata:
 
 Resolve merged workflows to `completed` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
 
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use `@skills/prune-workflows/SKILL.md`. That skill invokes `exarchos_orchestrate prune_stale_workflows` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → `completed`); prune is bulk (N inactive workflows → `cancelled`). They are complementary, not alternatives.
+
 ## Triggers
 
 Activate this skill when:

--- a/skills/copilot/delegation/SKILL.md
+++ b/skills/copilot/delegation/SKILL.md
@@ -20,6 +20,8 @@ Activate this skill when:
 - Implementation plan is ready with extractable tasks
 - User wants to parallelize work across subagents
 
+**Exception — oneshot workflows skip delegation entirely.** The oneshot playbook runs an in-session TDD loop in the main agent's context, with no subagent dispatch or review phase. If `workflowType === "oneshot"`, do not call this skill — see `@skills/oneshot-workflow/SKILL.md` for the lightweight path.
+
 ## Core Principles
 
 ### Fresh Context Per Task (MANDATORY)

--- a/skills/copilot/oneshot-workflow/SKILL.md
+++ b/skills/copilot/oneshot-workflow/SKILL.md
@@ -12,8 +12,8 @@ metadata:
 # Oneshot Workflow Skill
 
 A lean, four-phase workflow type for changes that are too small to justify the
-full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
-still deserve event-sourced auditability and a planning step. The workflow is
+full `feature` flow (`ideate → plan → plan-review → delegate → review → synthesize → completed`)
+but still deserve event-sourced auditability and a planning step. The workflow is
 **direct-commit by default** with an opt-in PR path; the choice between the
 two is resolved at the end of `implementing` via a pure event-sourced guard,
 not a heuristic.
@@ -88,7 +88,7 @@ and overrides runtime signal.
 
 ## Lifecycle
 
-```
+```text
      plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
                                  │
                                  └── [synthesisOptedIn]  ──► synthesize ──► completed
@@ -286,7 +286,7 @@ do not exist in the oneshot playbook. The PR review is the only review.
 
 ### Example A — Direct-commit (default `on-request` policy, no opt-in)
 
-```
+```text
 User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
        Use oneshot."
 
@@ -317,7 +317,7 @@ Agent:
 
 ### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
 
-```
+```text
 User: "Add input validation to the parseConfig helper. Oneshot."
 
 Agent:
@@ -347,7 +347,7 @@ Agent:
 
 ### Example C — `synthesisPolicy: 'always'` (PR mandatory)
 
-```
+```text
 User: "I want a PR for any change to the auth module, even small ones.
        Use oneshot but always make a PR."
 

--- a/skills/copilot/oneshot-workflow/SKILL.md
+++ b/skills/copilot/oneshot-workflow/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: oneshot-workflow
+description: "Lightweight workflow for straightforward changes — plan → implement → optional PR. Direct-commit by default; synthesize is opt-in via synthesisPolicy or a runtime request_synthesize event. Use for trivial fixes, config tweaks, single-file changes, or exploratory work that doesn't warrant subagent dispatch or two-stage review. Triggers: 'oneshot', 'quick fix', 'small change', or /oneshot."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: plan
+---
+
+# Oneshot Workflow Skill
+
+A lean, four-phase workflow type for changes that are too small to justify the
+full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
+still deserve event-sourced auditability and a planning step. The workflow is
+**direct-commit by default** with an opt-in PR path; the choice between the
+two is resolved at the end of `implementing` via a pure event-sourced guard,
+not a heuristic.
+
+> **Read this first if you have never run a oneshot:** the workflow has a
+> *choice state* at the end of `implementing`. Whether you land on
+> `completed` (direct commit) or transition through `synthesize` (PR) is
+> decided by two inputs: the `synthesisPolicy` set at init, and whether the
+> user emitted a `synthesize.requested` event during implementing. Both
+> inputs are persisted; the decision is replay-safe.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically a single file, or a tightly-coupled
+  cluster of 2-3 files
+- No subagent dispatch is needed — the work fits comfortably in one TDD
+  loop in a single session
+- No design document is required — the goal is obvious from the task
+  description, and a one-page plan is enough scaffolding
+- No two-stage review is required — either the change is trivial enough
+  that direct-commit is acceptable, or a single PR review will suffice
+
+Concrete examples that fit oneshot:
+- Fixing a typo in a README
+- Bumping a dependency version
+- Adding a missing null-check in one function
+- Tweaking a CI workflow YAML
+- Renaming a config key everywhere it's referenced
+- Adding a one-off helper script
+- Exploratory spikes that may or may not be kept
+
+## When NOT to use oneshot
+
+Do not use oneshot for any of the following — use the full `feature`
+workflow instead (`/ideate`):
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+- Anything where you'd want a written design doc to look back at
+
+If you start a oneshot and discover the change is bigger than expected, the
+right move is `/cancel` and restart with `/ideate`.
+Don't try to grow a oneshot into a feature workflow mid-stream; the
+playbooks have different shapes and you'll fight the state machine.
+
+## Synthesis policy — three options
+
+The `synthesisPolicy` field on a oneshot workflow declares the user's
+intent up front about whether the change should be turned into a PR. It
+takes one of three values, persisted on `state.oneshot.synthesisPolicy`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| `always` | Always transition `implementing → synthesize` at finalize, regardless of events. A PR is always created. | The user wants a paper trail / review for every change in this workflow, even small ones. |
+| `never` | Always transition `implementing → completed` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | The user is iterating on personal/scratch work and explicitly opts out of PRs. |
+| `on-request` *(default)* | Direct-commit by default. The user can opt in to a PR mid-implementing by calling `request_synthesize`; if any `synthesize.requested` event is on the stream at finalize, the workflow transitions to `synthesize` instead of `completed`. | The common case: start with the assumption of direct-commit, but leave the door open for the user to change their mind once they see the diff. |
+
+The default is `on-request` because it's the least surprising: the user
+gets the lightweight path until they explicitly ask for the heavy one.
+
+**Policy wins over event.** If `synthesisPolicy: 'never'` is set and a
+`synthesize.requested` event is somehow on the stream (e.g. the user
+called the action on a workflow they thought was `on-request`), the
+guard still routes to `completed`. Policy is the user's declared intent
+and overrides runtime signal.
+
+## Lifecycle
+
+```
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+```
+
+Four phases. The fork after `implementing` is a UML *choice state*,
+implemented via two mutually-exclusive HSM transitions whose guards are
+pure functions of `state.oneshot.synthesisPolicy` and the
+`synthesize.requested` event count.
+
+| Phase | What happens | Exit criteria |
+|---|---|---|
+| `plan` | Lightweight one-page plan: goal, approach, files to touch, tests to add. No design doc. No subagent dispatch. | `artifacts.plan` set → transition to `implementing` |
+| `implementing` | In-session TDD loop. Write a failing test, make it pass, refactor. Commit as you go. The TDD iron law applies — *no production code without a failing test first*. | Tests pass + typecheck clean + finalize_oneshot called |
+| `synthesize` | Reached **only** when `synthesisOptedIn` is true. Hands off to the existing synthesis flow — see `@skills/synthesis/SKILL.md`. PR created via `gh pr create`, auto-merge enabled, CI gates apply. | PR merged → `completed` |
+| `completed` | Terminal. For direct-commit path, commits are already on the branch — there's nothing more to do. For synthesize path, the PR merge event terminates the workflow. | — |
+
+`cancelled` is also reachable from any phase via the universal cancel
+transition, same as every other workflow type.
+
+## Step-by-step
+
+### Step 1 — Init
+
+Call `exarchos_workflow` with `action: 'init'`, `workflowType: 'oneshot'`,
+and an optional `synthesisPolicy`:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "init",
+  featureId: "fix-readme-typo",
+  workflowType: "oneshot",
+  synthesisPolicy: "on-request" // optional — defaults to 'on-request'
+})
+```
+
+If the user has been clear up front ("I want a PR for this"), pass
+`synthesisPolicy: "always"`. If they've been clear ("don't open a PR,
+just commit it"), pass `synthesisPolicy: "never"`. Otherwise, omit the
+field and rely on the `on-request` default — you can always escalate
+later in the implementing phase.
+
+The init returns the new workflow state; the workflow lands in `plan`.
+
+### Step 2 — Plan phase
+
+Produce a one-page plan. This is intentionally lightweight — no design
+doc, no parallelization analysis, no decomposition into N tasks. The
+plan should answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to `implementing` in a single set call:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "fix-readme-typo",
+  updates: {
+    "artifacts": { "plan": "<plan text>" },
+    "oneshot": { "planSummary": "<one-line summary>" },
+    "phase": "implementing"
+  }
+})
+```
+
+The plan goes on `artifacts.plan` for parity with the `feature` workflow;
+the human-readable one-liner goes on `oneshot.planSummary` for the
+pipeline view.
+
+### Step 3 — Implementing phase
+
+Run an in-session TDD loop. Same iron law as every other workflow:
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run the test. Confirm it fails for
+   the right reason.
+2. **[GREEN]** Write the minimum production code to make the test pass.
+   Run the test. Confirm it passes.
+3. **[REFACTOR]** Clean up while keeping the test green.
+
+Commit each red-green-refactor cycle as a single commit. Do not batch
+multiple unrelated changes into one commit — keeping commits atomic
+matters even more in oneshot, where there's no separate review phase
+to catch bundled changes.
+
+There is **no subagent dispatch** in oneshot. The main agent does the
+work directly. There is **no separate review phase**. Quality is
+maintained by the TDD loop and (if the user opts in) the synthesize PR
+review.
+
+#### Mid-implementing: opting in to a PR
+
+If at any point during implementing the user decides they want a PR
+after all (policy is `on-request`, default), they can opt in by calling
+the `request_synthesize` orchestrate action:
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+```
+
+**The trigger for this is conversational, not a magic keyword.** Listen
+for phrases like:
+- "actually, let's open a PR for this"
+- "I want a review on this before it lands"
+- "make this a PR"
+- "let's get eyes on this"
+- "synthesize this"
+
+When you hear any of those, call `request_synthesize` immediately. The
+handler appends a `synthesize.requested` event to the workflow's event
+stream; the `synthesisOptedIn` guard reads the stream at finalize and
+routes accordingly. This is **idempotent** — calling
+`request_synthesize` twice appends two events but the guard treats any
+count >= 1 as "opted in", so duplicate calls are benign.
+
+Calling `request_synthesize` does **not** transition the phase. The
+workflow stays in `implementing`. The decision is only acted on when
+you call `finalize_oneshot` in step 4.
+
+### Step 4 — Finalize (the choice point)
+
+When the implementing loop is done — tests pass, typecheck clean, all
+commits made — call `finalize_oneshot` to resolve the choice state:
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+```
+
+The handler:
+
+1. Reads the current state and verifies `workflowType === 'oneshot'` and
+   `phase === 'implementing'`.
+2. Hydrates `_events` from the event store so the guard sees the same
+   view the HSM will see during the actual transition.
+3. Evaluates `guards.synthesisOptedIn` against the state. The guard
+   inspects `state.oneshot.synthesisPolicy` and the `_events` array.
+4. Calls `handleSet` with the resolved target phase (`synthesize` or
+   `completed`). The HSM re-evaluates the guard at the transition
+   boundary, so any race between the read and the transition is caught
+   safely.
+
+Possible outcomes:
+
+| `synthesisPolicy` | `synthesize.requested` event present? | Resolved target | Path |
+|---|---|---|---|
+| `always` | (any) | `synthesize` | PR path |
+| `never` | (any) | `completed` | direct-commit path |
+| `on-request` (default) | yes | `synthesize` | PR path |
+| `on-request` (default) | no | `completed` | direct-commit path |
+
+### Step 5a — Direct-commit path (terminal)
+
+If finalize resolved to `completed`, you're done. The commits made
+during implementing are already on the current branch. Push them if
+they aren't already pushed:
+
+```bash
+git push
+```
+
+The workflow is now in `completed` and will not appear in the default
+pipeline view.
+
+### Step 5b — Synthesize path
+
+If finalize resolved to `synthesize`, hand off to the standard synthesis
+flow — see `@skills/synthesis/SKILL.md`. The same `prepare_synthesis` /
+`validate_pr_body` / `gh pr create` machinery used by the `feature`
+workflow applies. After the PR merges, the workflow transitions
+`synthesize → completed` via the existing `mergeVerified` guard, same as
+every other workflow type.
+
+You do **not** need to run `/delegate` or
+`/review` for an opt-in oneshot synthesize. Those phases
+do not exist in the oneshot playbook. The PR review is the only review.
+
+## Example invocations
+
+### Example A — Direct-commit (default `on-request` policy, no opt-in)
+
+```
+User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
+       Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
+  2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  4. [RED] writes test that greps README for 'recieve' and expects 0 matches
+        — fails (1 match exists)
+  5. [GREEN] edits README, fixes typo
+        — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+```
+
+### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
+
+```
+User: "Add input validation to the parseConfig helper. Oneshot."
+
+Agent:
+  1. exarchos_workflow init { workflowType: "oneshot" }
+     → 'plan' phase, default 'on-request'
+  2. plans (goal: validate input, files: [parser.ts, parser.test.ts])
+  3. transitions to 'implementing'
+  4. [RED] writes test for null-input case
+  5. [GREEN] adds null check
+  6. [REFACTOR] extracts validateInput helper
+  7. commits
+
+User: "Actually, this is touching the parser — I want a review on it before
+       it lands."
+
+Agent:
+  8. exarchos_orchestrate request_synthesize {
+       featureId, reason: "user requested review of parser changes"
+     }
+     → appends synthesize.requested event
+  9. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='on-request' + 1 synthesize.requested event
+     → resolves to 'synthesize'
+ 10. hands off to @skills/synthesis/SKILL.md → prepare_synthesis →
+     validate_pr_body → gh pr create → merge
+```
+
+### Example C — `synthesisPolicy: 'always'` (PR mandatory)
+
+```
+User: "I want a PR for any change to the auth module, even small ones.
+       Use oneshot but always make a PR."
+
+Agent:
+  1. exarchos_workflow init {
+       workflowType: "oneshot",
+       synthesisPolicy: "always"
+     }
+  2-7. plan + TDD + commits, identical to Example A
+  8. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='always' (short-circuits — no event check needed)
+     → resolves to 'synthesize'
+  9. synthesis flow → PR
+```
+
+## State management
+
+Track oneshot-specific state under the `oneshot` key on the workflow state:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "<id>",
+  updates: {
+    "oneshot": {
+      "synthesisPolicy": "on-request",
+      "planSummary": "Fix off-by-one in pagination helper"
+    }
+  }
+})
+```
+
+The `synthesisPolicy` field is optional and defaults to `'on-request'` per
+the schema in `servers/exarchos-mcp/src/workflow/schemas.ts`. Setting it
+explicitly is recommended when the user has stated a preference.
+
+## Phase Transitions and Guards
+
+For the full transition table for oneshot, consult
+`@skills/workflow-state/references/phase-transitions.md`.
+
+**Quick reference for oneshot:**
+
+| From | To | Guard |
+|---|---|---|
+| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `implementing` | `synthesize` | `synthesisOptedIn` |
+| `implementing` | `completed` | `synthesisOptedOut` |
+| `synthesize` | `completed` | `mergeVerified` |
+| (any) | `cancelled` | universal — always allowed |
+
+`synthesisOptedIn` and `synthesisOptedOut` are pure functions of
+`state.oneshot.synthesisPolicy` and `state._events`. They are mutually
+exclusive across all 8 (3 policies × event-present/absent, with `always`
+and `never` ignoring the event flag) combinations — exactly one returns
+true at any given time.
+
+### Schema discovery
+
+Use `exarchos_workflow({ action: "describe", actions: ["init", "set"] })`
+for parameter schemas (including the `synthesisPolicy` enum) and
+`exarchos_workflow({ action: "describe", playbook: "oneshot" })` for the
+phase transitions, guard names, and playbook prose. Use
+`exarchos_orchestrate({ action: "describe", actions: ["request_synthesize", "finalize_oneshot"] })`
+for the orchestrate action schemas.
+
+## TDD is still mandatory
+
+The iron law from `@rules/tdd.md` applies to oneshot. There is no
+exemption for "small" changes. Specifically:
+
+- Every behavior change starts with a failing test
+- Every test must fail before its implementation is written
+- Tests must be run after each change to verify state
+- Commits stay atomic — one logical change per commit
+
+The temptation in a oneshot is to skip the test "because it's just one
+line". Resist that. The test is what makes the change auditable, and
+auditability is the entire reason oneshot exists alongside the lighter
+"bypass workflows entirely" path.
+
+## Anti-patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip the plan phase ("it's obvious") | Write the four-line plan anyway — it's the artifact future-you reads |
+| Skip the TDD loop in implementing | Always RED → GREEN → REFACTOR, even for one-liners |
+| Use oneshot for multi-file refactors | Use `/ideate` and the full feature workflow |
+| Try to grow a oneshot into a feature workflow mid-stream | Cancel and restart with `/ideate` |
+| Call `request_synthesize` without listening for the user's intent | Wait for the user to ask for a PR, then call it |
+| Bundle unrelated changes into one commit "since it's a oneshot" | Keep commits atomic — there's no review phase to catch bundling |
+| Forget to call `finalize_oneshot` at the end | The workflow stays in `implementing` forever otherwise — call it explicitly |
+
+## Completion criteria
+
+- [ ] `exarchos_workflow init` called with `workflowType: "oneshot"`
+- [ ] One-page plan persisted to `artifacts.plan`
+- [ ] Phase transitioned to `implementing`
+- [ ] All planned behaviors implemented via TDD with atomic commits
+- [ ] `finalize_oneshot` called and resolved to either `completed` or `synthesize`
+- [ ] If direct-commit path: commits pushed
+- [ ] If synthesize path: PR created via `@skills/synthesis/SKILL.md` and merged

--- a/skills/copilot/oneshot-workflow/SKILL.md
+++ b/skills/copilot/oneshot-workflow/SKILL.md
@@ -214,13 +214,22 @@ for phrases like:
 When you hear any of those, call `request_synthesize` immediately. The
 handler appends a `synthesize.requested` event to the workflow's event
 stream; the `synthesisOptedIn` guard reads the stream at finalize and
-routes accordingly. This is **idempotent** — calling
-`request_synthesize` twice appends two events but the guard treats any
-count >= 1 as "opted in", so duplicate calls are benign.
+routes accordingly.
+
+`request_synthesize` is accepted from both `plan` and `implementing`
+phases — call it whenever you know you want the PR path, even before
+`implementing` starts. Terminal phases (`synthesize`, `completed`,
+`cancelled`) are rejected.
+
+Duplicate calls are **routing-idempotent** but not event-idempotent:
+each call appends a new `synthesize.requested` event, but the guard
+treats any count >= 1 as "opted in", so the routing decision is the
+same whether you call once or five times. The event stream will
+contain each duplicate for audit purposes.
 
 Calling `request_synthesize` does **not** transition the phase. The
-workflow stays in `implementing`. The decision is only acted on when
-you call `finalize_oneshot` in step 4.
+workflow stays in its current phase. The decision is only acted on
+when you call `finalize_oneshot` in step 4.
 
 ### Step 4 — Finalize (the choice point)
 
@@ -393,7 +402,7 @@ For the full transition table for oneshot, consult
 
 | From | To | Guard |
 |---|---|---|
-| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `plan` | `implementing` | `oneshotPlanSet` (requires non-empty `artifacts.plan`) |
 | `implementing` | `synthesize` | `synthesisOptedIn` |
 | `implementing` | `completed` | `synthesisOptedOut` |
 | `synthesize` | `completed` | `mergeVerified` |
@@ -401,9 +410,10 @@ For the full transition table for oneshot, consult
 
 `synthesisOptedIn` and `synthesisOptedOut` are pure functions of
 `state.oneshot.synthesisPolicy` and `state._events`. They are mutually
-exclusive across all 8 (3 policies × event-present/absent, with `always`
-and `never` ignoring the event flag) combinations — exactly one returns
-true at any given time.
+exclusive across all 4 meaningful combinations — `always` and `never`
+each map to one outcome (ignoring the event flag), and `on-request`
+branches on whether a `synthesize.requested` event is present or
+absent. Exactly one guard returns true at any given time.
 
 ### Schema discovery
 

--- a/skills/copilot/oneshot-workflow/SKILL.md
+++ b/skills/copilot/oneshot-workflow/SKILL.md
@@ -189,11 +189,11 @@ work directly. There is **no separate review phase**. Quality is
 maintained by the TDD loop and (if the user opts in) the synthesize PR
 review.
 
-#### Mid-implementing: opting in to a PR
+#### Mid-workflow: opting in to a PR
 
-If at any point during implementing the user decides they want a PR
-after all (policy is `on-request`, default), they can opt in by calling
-the `request_synthesize` orchestrate action:
+If at any point during `plan` or `implementing` the user decides they
+want a PR after all (policy is `on-request`, default), they can opt in
+by calling the `request_synthesize` orchestrate action:
 
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
@@ -397,6 +397,12 @@ explicitly is recommended when the user has stated a preference.
 
 For the full transition table for oneshot, consult
 `@skills/workflow-state/references/phase-transitions.md`.
+
+> **Note:** The engine's `exarchos_workflow describe playbook="oneshot"`
+> output and the HSM definitions in `hsm-definitions.ts` are the
+> canonical sources for transition behavior. `phase-transitions.md` is
+> a prose reference that can drift — when discrepancies arise, prefer
+> engine `describe` output.
 
 **Quick reference for oneshot:**
 

--- a/skills/copilot/oneshot-workflow/SKILL.md
+++ b/skills/copilot/oneshot-workflow/SKILL.md
@@ -144,23 +144,26 @@ plan should answer four questions in 5-10 lines each:
 3. **Files** — which files will be touched? (1-5 typically)
 4. **Tests** — which test cases will be added? (named, not described)
 
-Persist the plan and transition to `implementing` in a single set call:
+Persist the plan and transition to `implementing` in a single set call.
+`phase` is a top-level argument of `set`, not a field inside `updates`:
 
 ```typescript
 mcp__exarchos__exarchos_workflow({
   action: "set",
   featureId: "fix-readme-typo",
+  phase: "implementing",
   updates: {
-    "artifacts": { "plan": "<plan text>" },
-    "oneshot": { "planSummary": "<one-line summary>" },
-    "phase": "implementing"
+    "artifacts.plan": "<plan text>",
+    "oneshot.planSummary": "<one-line summary>"
   }
 })
 ```
 
 The plan goes on `artifacts.plan` for parity with the `feature` workflow;
 the human-readable one-liner goes on `oneshot.planSummary` for the
-pipeline view.
+pipeline view. Only `artifacts.plan` is enforced by the
+`oneshot-plan-set` guard — `planSummary` is an optional pipeline-view
+label and is not a substitute for a real plan artifact.
 
 ### Step 3 — Implementing phase
 
@@ -292,7 +295,14 @@ Agent:
      → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
   2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
      tests=[readme has no occurrence of 'recieve']
-  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",                   // top-level
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "..."
+       }
+     }
   4. [RED] writes test that greps README for 'recieve' and expects 0 matches
         — fails (1 match exists)
   5. [GREEN] edits README, fixes typo

--- a/skills/copilot/oneshot-workflow/references/choice-state.md
+++ b/skills/copilot/oneshot-workflow/references/choice-state.md
@@ -1,0 +1,65 @@
+---
+name: oneshot-choice-state
+---
+
+# Oneshot Choice State: `implementing → ?`
+
+The oneshot workflow has a UML *choice state* at the end of `implementing`.
+Whether the workflow lands on `completed` (direct-commit) or transitions
+through `synthesize` (PR) is decided by two mutually-exclusive pure-function
+guards: `synthesisOptedIn` and `synthesisOptedOut`. Both are evaluated against
+the current workflow state at the transition boundary; exactly one returns
+`true` for every possible input.
+
+## Inputs read by the guards
+
+Both guards read exactly two things from state:
+
+1. `state.oneshot.synthesisPolicy` — one of `'always' | 'never' | 'on-request'`,
+   defaulted to `'on-request'` by the init schema.
+2. `state._events` — the hydrated event stream. The guard counts
+   `synthesize.requested` events on the stream (any count ≥ 1 means "opted in").
+
+Nothing else. No clock reads, no filesystem, no network, no git state. This
+is load-bearing for replay safety: given the same persisted state, the same
+target resolves every time, and re-running finalize is idempotent.
+
+## Decision table
+
+| `synthesisPolicy` | `synthesize.requested` count | `synthesisOptedIn` | `synthesisOptedOut` | Resolved target |
+|---|---|---|---|---|
+| `'always'`     | 0  | `true`  | `false` | `synthesize` |
+| `'always'`     | ≥1 | `true`  | `false` | `synthesize` |
+| `'never'`      | 0  | `false` | `true`  | `completed`  |
+| `'never'`      | ≥1 | `false` | `true`  | `completed`  |
+| `'on-request'` | 0  | `false` | `true`  | `completed`  |
+| `'on-request'` | ≥1 | `true`  | `false` | `synthesize` |
+
+**Policy wins over event.** On `'never'`, even if a stray `synthesize.requested`
+event is on the stream, the guard still routes to `completed`. Policy is the
+user's declared intent; runtime events only matter when the policy explicitly
+defers to them (`'on-request'`).
+
+## Why a choice state, not a single transition with branching logic
+
+Keeping the fork at the HSM level (two transitions, two mutually-exclusive
+guards) means:
+
+- The state machine graph visibly encodes both paths — operators reading
+  `hsm-definitions.ts` see `implementing → completed` and `implementing →
+  synthesize` as sibling transitions, not a hidden conditional.
+- The HSM re-evaluates guards at the transition boundary, so any race
+  between `finalize_oneshot` reading state and `handleSet` performing the
+  transition is caught safely — if a last-millisecond event changed the
+  evaluation, the HSM will refuse the wrong transition.
+- Guard logic stays testable in isolation (`guards.test.ts`) without
+  needing to spin up the handler.
+
+## See also
+
+- `servers/exarchos-mcp/src/workflow/guards.ts` — `synthesisOptedIn`,
+  `synthesisOptedOut`, `oneshotPlanSet` guard implementations.
+- `servers/exarchos-mcp/src/workflow/hsm-definitions.ts` — the oneshot HSM
+  with the two sibling transitions from `implementing`.
+- `servers/exarchos-mcp/src/orchestrate/finalize-oneshot.ts` — the handler
+  that resolves the choice state and calls `handleSet`.

--- a/skills/copilot/prune-workflows/SKILL.md
+++ b/skills/copilot/prune-workflows/SKILL.md
@@ -19,9 +19,9 @@ Pruning is a maintenance operation -- not a workflow phase. It produces `workflo
 ## Triggers
 
 Activate this skill when:
-- User runs `{{COMMAND_PREFIX}}prune` command
+- User runs `/prune` command
 - User says "prune workflows", "clean stale workflows", "pipeline cleanup"
-- `{{MCP_PREFIX}}exarchos_view({ action: "pipeline" })` shows many inactive workflows the user wants to clear in bulk
+- `mcp__exarchos__exarchos_view({ action: "pipeline" })` shows many inactive workflows the user wants to clear in bulk
 
 ## Prerequisites
 
@@ -36,7 +36,7 @@ Activate this skill when:
 Always start with `dryRun: true`. This call performs candidate selection and safeguard evaluation but does not mutate any workflow state.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: true
@@ -104,7 +104,7 @@ Wait for explicit user input. Do **not** auto-proceed.
 On `proceed`, invoke the same action with `dryRun: false`. Pass through `thresholdMinutes` and `includeOneShot` if the user set them in Step 1.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: false
@@ -131,7 +131,7 @@ Each entry in `pruned` corresponds to a workflow that transitioned to `cancelled
 On `force`, set `force: true`. Safeguards are bypassed but the bypass is recorded in the `workflow.pruned` event payload as `skippedSafeguards: [...]` so the audit trail is intact.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: false,
@@ -199,7 +199,7 @@ A workflow without a `branchName` in state (e.g., abandoned at ideate/plan befor
 ### Example 1: Clean dry-run, user proceeds
 
 ```
-> {{COMMAND_PREFIX}}prune
+> /prune
 
 ## Prune Candidates (2)
 
@@ -230,7 +230,7 @@ Proceed? (proceed/abort/force)
 ### Example 2: Safeguard skip, user forces
 
 ```
-> {{COMMAND_PREFIX}}prune
+> /prune
 
 ## Prune Candidates (1)
 
@@ -265,7 +265,7 @@ Proceed? (proceed/abort/force)
 ### Example 3: Empty pipeline
 
 ```
-> {{COMMAND_PREFIX}}prune
+> /prune
 
 No stale workflows to prune. Pipeline is clean.
 ```
@@ -275,7 +275,7 @@ No stale workflows to prune. Pipeline is clean.
 For the canonical argument schema and any future fields, use:
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "describe",
   actions: ["prune_stale_workflows"]
 })

--- a/skills/copilot/prune-workflows/references/safeguards.md
+++ b/skills/copilot/prune-workflows/references/safeguards.md
@@ -1,0 +1,74 @@
+---
+name: prune-safeguards
+---
+
+# Prune Safeguards
+
+The `prune_stale_workflows` orchestrate action runs two safeguards on each
+candidate before it will actually cancel the workflow. Both must pass for
+the candidate to be pruned, unless the caller passes `force: true` to
+bypass them.
+
+## Safeguard 1: `hasOpenPR`
+
+Checks whether there's an open pull request targeting the workflow's
+branch. Implementation: `gh pr list --state open --head <branchName>` —
+if the list is non-empty, the safeguard fails and the candidate is
+skipped with reason `open-pr`.
+
+Rationale: an open PR means human work is still in-flight on this feature.
+Cancelling the workflow would orphan the PR from its event-sourced state,
+which makes it invisible to `exarchos_view` and breaks auto-merge gates.
+We refuse to prune workflows with open PRs by default.
+
+## Safeguard 2: `hasRecentCommits` (user-facing: `active-branch`)
+
+Checks whether any commits landed on the workflow's branch within a
+24-hour window. Implementation: `git log --since="24 hours ago"
+<branchName>` — if the output is non-empty, the safeguard fails and the
+candidate is skipped with reason `active-branch`.
+
+Rationale: commits on the branch mean the workflow isn't actually stale,
+it just missed the last event checkpoint. The underlying branch is the
+ground truth for "is this work still alive?" — if someone is committing,
+we don't care what the checkpoint timestamp says.
+
+The window is locked at 24 hours for v1. It's exposed as a module
+constant (`RECENT_COMMITS_WINDOW_HOURS` in `prune-stale-workflows.ts`)
+so tests can see the contract, but it's not yet configurable through
+the public handler args.
+
+## Short-circuit: missing `branchName`
+
+If the workflow state has no top-level `branchName` field, both
+safeguards are skipped entirely (they have nothing to look up). The
+candidate still proceeds to cancel. This is safe because a workflow
+without a branch can't have an open PR or recent commits by definition.
+
+## `force: true` bypass semantics
+
+Passing `force: true` skips safeguard evaluation for every candidate.
+The handler still does everything else — the cancel, the event emission,
+the audit trail — but `hasOpenPR` and `hasRecentCommits` are never
+called.
+
+Every `workflow.pruned` event emitted during a `force: true` run carries
+a `skippedSafeguards: ['open-pr', 'active-branch']` marker on its payload.
+This makes forced prunes distinguishable in the audit stream from
+safeguard-approved ones, so operators reviewing the event log can see
+exactly which workflows were cancelled despite having open PRs or active
+branches.
+
+The marker list is intentionally hardcoded to *all* safeguards, not just
+the ones that would have failed. Running `force: true` is a blanket
+"I know what I'm doing" override — we want the audit trail to reflect
+that the user chose to bypass the whole safeguard layer, not to imply
+selective bypassing.
+
+## See also
+
+- `servers/exarchos-mcp/src/orchestrate/prune-safeguards.ts` — the
+  default implementations (gh/git backends) and the `PruneSafeguards`
+  interface for DI.
+- `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts` —
+  the handler that composes safeguards with selection and cancel.

--- a/skills/copilot/shepherd/SKILL.md
+++ b/skills/copilot/shepherd/SKILL.md
@@ -21,6 +21,10 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Pipeline Hygiene
+
+When `mcp__exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:

--- a/skills/copilot/synthesis/SKILL.md
+++ b/skills/copilot/synthesis/SKILL.md
@@ -22,12 +22,22 @@ Submit stacked PRs after review phase completes. The `prepare_synthesis` composi
 
 Do NOT proceed if either review is incomplete or failed -- return to `/review` first.
 
+**Entry points:** Synthesis is normally reached from the `review` phase of
+feature / debug / refactor workflows. It is also reachable from `oneshot`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during `plan` or `implementing`, the `request_synthesize` event is
+appended, and `finalize_oneshot` then resolves the choice state and
+transitions the workflow to `synthesize`. See
+`@skills/oneshot-workflow/SKILL.md` for the opt-in mechanics and
+`synthesisPolicy` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs `/synthesize` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to `synthesize` via `finalize_oneshot`
 
 ## Process
 

--- a/skills/copilot/workflow-state/SKILL.md
+++ b/skills/copilot/workflow-state/SKILL.md
@@ -38,7 +38,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use `exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })` for
 parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its `implementing → synthesize|completed` choice state
+driven by `synthesisPolicy`), call `exarchos_workflow({ action: "describe", playbook: "oneshot" })`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 `exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })`
 for event data schemas.
 
@@ -126,6 +129,23 @@ exarchos_orchestrate({
 | Review complete | Update `reviews` object |
 | PR created | Set `artifacts.pr`, `synthesis.prUrl` |
 | PR feedback | Append to `synthesis.prFeedback` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| `plan` (oneshot) | `oneshot.planSummary`, `artifacts.plan`, optional `oneshot.synthesisPolicy` | `workflow.transition` |
+| `implementing` (oneshot) | `tasks[].status`, `artifacts.tests` | `task.*`, optional `synthesize.requested` (via `request_synthesize`) |
+| `synthesize` (oneshot) | `synthesis.prUrl`, `artifacts.pr` | `workflow.transition`, `stack.submitted` |
+| `completed` (oneshot) | — | `workflow.transition` (to `completed`) |
+
+The `implementing → synthesize | completed` fork is a choice state resolved
+by `finalize_oneshot`, which reads the `synthesisOptedIn` guard
+(`synthesisPolicy` + `synthesize.requested` events). See
+`@skills/oneshot-workflow/SKILL.md` for the full opt-in mechanics.
 
 ### Automatic State Updates
 

--- a/skills/copilot/workflow-state/SKILL.md
+++ b/skills/copilot/workflow-state/SKILL.md
@@ -60,7 +60,13 @@ At the start of `/ideate`, use `mcp__exarchos__exarchos_workflow` with `action: 
 - `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
 - `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+`workflowType`:
+
+- `feature` → starts in `ideate`
+- `debug` → starts in `triage`
+- `refactor` → starts in `explore`
+- `oneshot` → starts in `plan` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 

--- a/skills/copilot/workflow-state/SKILL.md
+++ b/skills/copilot/workflow-state/SKILL.md
@@ -54,9 +54,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see `references
 
 At the start of `/ideate`, use `mcp__exarchos__exarchos_workflow` with `action: "init"` with:
 - `featureId`: the workflow identifier (e.g., `"user-authentication"`)
-- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`
+- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
+- `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- `feature` — full `ideate → plan → delegate → review → synthesize` for real features with subagent dispatch and two-stage review
+- `debug` — `triage → investigate → (thorough | hotfix)` for bug workflows with track selection
+- `refactor` — `explore → brief → (polish | overhaul)` for code improvements, polish for small and overhaul for multi-task
+- `oneshot` — `plan → implementing → (completed | synthesize)` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by `synthesisPolicy` and the `synthesize.requested` event
+
+See `@skills/oneshot-workflow/SKILL.md` for the lightweight variant's full prose, including the choice-state mechanics and `finalize_oneshot` trigger.
 
 ### Read State
 
@@ -154,7 +164,7 @@ See `docs/schemas/workflow-state.schema.json` for full schema.
 Key sections:
 - `version`: Schema version (currently "1.1")
 - `featureId`: Unique workflow identifier
-- `workflowType`: Required. One of "feature", "debug", or "refactor"
+- `workflowType`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - `phase`: Current workflow phase
 - `artifacts`: Paths to design, plan, PR
 - `tasks`: Task list with status

--- a/skills/copilot/workflow-state/references/phase-transitions.md
+++ b/skills/copilot/workflow-state/references/phase-transitions.md
@@ -127,7 +127,7 @@ plan → implementing ─┬→ completed              (direct-commit path)
 
 | From | To | Guard | Prerequisite |
 |------|----|-------|-------------|
-| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` (non-empty string; `oneshot.planSummary` is optional metadata but does **not** satisfy the guard) |
 | `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
 | `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
 | `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |

--- a/skills/copilot/workflow-state/references/phase-transitions.md
+++ b/skills/copilot/workflow-state/references/phase-transitions.md
@@ -118,6 +118,28 @@ explore → brief → [polish-track | overhaul-track] → completed
 
 **Compound state:** `overhaul-track` contains `overhaul-plan`, `overhaul-plan-review`, `overhaul-delegate`, `overhaul-review`, and `overhaul-update-docs`. Max 3 fix cycles.
 
+## Oneshot Workflow
+
+```
+plan → implementing ─┬→ completed              (direct-commit path)
+                     └→ synthesize → completed (PR path, opt-in)
+```
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
+| `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
+| `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+**Choice state (end of `implementing`).** The fork after `implementing` is a UML choice state, implemented as two mutually-exclusive HSM transitions whose guards are pure functions of `state.oneshot.synthesisPolicy` and the `synthesize.requested` event count on the stream. At init, the user declares intent via `synthesisPolicy` (`always`, `never`, or `on-request` — default). During implementing, the user can opt in at any time by calling `exarchos_orchestrate request_synthesize`, which appends a `synthesize.requested` event without changing the phase. The decision is only evaluated when `finalize_oneshot` is called: the handler hydrates events, runs the guards, and calls `handleSet` with the resolved target. **Policy wins over event** — if policy is `never`, any `synthesize.requested` event is ignored and the guard routes to `completed`. Policy `always` short-circuits the event check and always routes to `synthesize`.
+
+**How to trigger:** `exarchos_orchestrate finalize_oneshot { featureId }` — this is the only way to exit `implementing`. The handler evaluates the choice state and calls `handleSet` with the correct target phase. The HSM re-evaluates the guard at the transition boundary, so any race between read and transition is caught safely.
+
+**No compound state.** Oneshot has no multi-agent loop, no review-fix cycle, and therefore no circuit breaker. If the in-session TDD loop gets stuck, cancel via `exarchos_workflow cancel` and restart with a different approach (or escalate to the full `feature` workflow).
+
+See `@skills/oneshot-workflow/SKILL.md` for the full prose walkthrough including worked examples.
+
 ## Circuit Breaker
 
 Compound states enforce a maximum number of fix cycles to prevent infinite review-fix loops. When the limit is exceeded, the HSM rejects the transition with a `CIRCUIT_OPEN` error and emits a `workflow.circuit-open` event.

--- a/skills/cursor/cleanup/SKILL.md
+++ b/skills/cursor/cleanup/SKILL.md
@@ -15,6 +15,12 @@ metadata:
 
 Resolve merged workflows to `completed` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
 
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use `@skills/prune-workflows/SKILL.md`. That skill invokes `exarchos_orchestrate prune_stale_workflows` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → `completed`); prune is bulk (N inactive workflows → `cancelled`). They are complementary, not alternatives.
+
 ## Triggers
 
 Activate this skill when:

--- a/skills/cursor/delegation/SKILL.md
+++ b/skills/cursor/delegation/SKILL.md
@@ -20,6 +20,8 @@ Activate this skill when:
 - Implementation plan is ready with extractable tasks
 - User wants to parallelize work across subagents
 
+**Exception — oneshot workflows skip delegation entirely.** The oneshot playbook runs an in-session TDD loop in the main agent's context, with no subagent dispatch or review phase. If `workflowType === "oneshot"`, do not call this skill — see `@skills/oneshot-workflow/SKILL.md` for the lightweight path.
+
 ## Core Principles
 
 ### Fresh Context Per Task (MANDATORY)

--- a/skills/cursor/oneshot-workflow/SKILL.md
+++ b/skills/cursor/oneshot-workflow/SKILL.md
@@ -12,8 +12,8 @@ metadata:
 # Oneshot Workflow Skill
 
 A lean, four-phase workflow type for changes that are too small to justify the
-full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
-still deserve event-sourced auditability and a planning step. The workflow is
+full `feature` flow (`ideate → plan → plan-review → delegate → review → synthesize → completed`)
+but still deserve event-sourced auditability and a planning step. The workflow is
 **direct-commit by default** with an opt-in PR path; the choice between the
 two is resolved at the end of `implementing` via a pure event-sourced guard,
 not a heuristic.
@@ -88,7 +88,7 @@ and overrides runtime signal.
 
 ## Lifecycle
 
-```
+```text
      plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
                                  │
                                  └── [synthesisOptedIn]  ──► synthesize ──► completed
@@ -286,7 +286,7 @@ do not exist in the oneshot playbook. The PR review is the only review.
 
 ### Example A — Direct-commit (default `on-request` policy, no opt-in)
 
-```
+```text
 User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
        Use oneshot."
 
@@ -317,7 +317,7 @@ Agent:
 
 ### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
 
-```
+```text
 User: "Add input validation to the parseConfig helper. Oneshot."
 
 Agent:
@@ -347,7 +347,7 @@ Agent:
 
 ### Example C — `synthesisPolicy: 'always'` (PR mandatory)
 
-```
+```text
 User: "I want a PR for any change to the auth module, even small ones.
        Use oneshot but always make a PR."
 

--- a/skills/cursor/oneshot-workflow/SKILL.md
+++ b/skills/cursor/oneshot-workflow/SKILL.md
@@ -214,13 +214,22 @@ for phrases like:
 When you hear any of those, call `request_synthesize` immediately. The
 handler appends a `synthesize.requested` event to the workflow's event
 stream; the `synthesisOptedIn` guard reads the stream at finalize and
-routes accordingly. This is **idempotent** — calling
-`request_synthesize` twice appends two events but the guard treats any
-count >= 1 as "opted in", so duplicate calls are benign.
+routes accordingly.
+
+`request_synthesize` is accepted from both `plan` and `implementing`
+phases — call it whenever you know you want the PR path, even before
+`implementing` starts. Terminal phases (`synthesize`, `completed`,
+`cancelled`) are rejected.
+
+Duplicate calls are **routing-idempotent** but not event-idempotent:
+each call appends a new `synthesize.requested` event, but the guard
+treats any count >= 1 as "opted in", so the routing decision is the
+same whether you call once or five times. The event stream will
+contain each duplicate for audit purposes.
 
 Calling `request_synthesize` does **not** transition the phase. The
-workflow stays in `implementing`. The decision is only acted on when
-you call `finalize_oneshot` in step 4.
+workflow stays in its current phase. The decision is only acted on
+when you call `finalize_oneshot` in step 4.
 
 ### Step 4 — Finalize (the choice point)
 
@@ -393,7 +402,7 @@ For the full transition table for oneshot, consult
 
 | From | To | Guard |
 |---|---|---|
-| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `plan` | `implementing` | `oneshotPlanSet` (requires non-empty `artifacts.plan`) |
 | `implementing` | `synthesize` | `synthesisOptedIn` |
 | `implementing` | `completed` | `synthesisOptedOut` |
 | `synthesize` | `completed` | `mergeVerified` |
@@ -401,9 +410,10 @@ For the full transition table for oneshot, consult
 
 `synthesisOptedIn` and `synthesisOptedOut` are pure functions of
 `state.oneshot.synthesisPolicy` and `state._events`. They are mutually
-exclusive across all 8 (3 policies × event-present/absent, with `always`
-and `never` ignoring the event flag) combinations — exactly one returns
-true at any given time.
+exclusive across all 4 meaningful combinations — `always` and `never`
+each map to one outcome (ignoring the event flag), and `on-request`
+branches on whether a `synthesize.requested` event is present or
+absent. Exactly one guard returns true at any given time.
 
 ### Schema discovery
 

--- a/skills/cursor/oneshot-workflow/SKILL.md
+++ b/skills/cursor/oneshot-workflow/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: oneshot-workflow
+description: "Lightweight workflow for straightforward changes — plan → implement → optional PR. Direct-commit by default; synthesize is opt-in via synthesisPolicy or a runtime request_synthesize event. Use for trivial fixes, config tweaks, single-file changes, or exploratory work that doesn't warrant subagent dispatch or two-stage review. Triggers: 'oneshot', 'quick fix', 'small change', or oneshot."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: plan
+---
+
+# Oneshot Workflow Skill
+
+A lean, four-phase workflow type for changes that are too small to justify the
+full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
+still deserve event-sourced auditability and a planning step. The workflow is
+**direct-commit by default** with an opt-in PR path; the choice between the
+two is resolved at the end of `implementing` via a pure event-sourced guard,
+not a heuristic.
+
+> **Read this first if you have never run a oneshot:** the workflow has a
+> *choice state* at the end of `implementing`. Whether you land on
+> `completed` (direct commit) or transition through `synthesize` (PR) is
+> decided by two inputs: the `synthesisPolicy` set at init, and whether the
+> user emitted a `synthesize.requested` event during implementing. Both
+> inputs are persisted; the decision is replay-safe.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically a single file, or a tightly-coupled
+  cluster of 2-3 files
+- No subagent dispatch is needed — the work fits comfortably in one TDD
+  loop in a single session
+- No design document is required — the goal is obvious from the task
+  description, and a one-page plan is enough scaffolding
+- No two-stage review is required — either the change is trivial enough
+  that direct-commit is acceptable, or a single PR review will suffice
+
+Concrete examples that fit oneshot:
+- Fixing a typo in a README
+- Bumping a dependency version
+- Adding a missing null-check in one function
+- Tweaking a CI workflow YAML
+- Renaming a config key everywhere it's referenced
+- Adding a one-off helper script
+- Exploratory spikes that may or may not be kept
+
+## When NOT to use oneshot
+
+Do not use oneshot for any of the following — use the full `feature`
+workflow instead (`ideate`):
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+- Anything where you'd want a written design doc to look back at
+
+If you start a oneshot and discover the change is bigger than expected, the
+right move is `cancel` and restart with `ideate`.
+Don't try to grow a oneshot into a feature workflow mid-stream; the
+playbooks have different shapes and you'll fight the state machine.
+
+## Synthesis policy — three options
+
+The `synthesisPolicy` field on a oneshot workflow declares the user's
+intent up front about whether the change should be turned into a PR. It
+takes one of three values, persisted on `state.oneshot.synthesisPolicy`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| `always` | Always transition `implementing → synthesize` at finalize, regardless of events. A PR is always created. | The user wants a paper trail / review for every change in this workflow, even small ones. |
+| `never` | Always transition `implementing → completed` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | The user is iterating on personal/scratch work and explicitly opts out of PRs. |
+| `on-request` *(default)* | Direct-commit by default. The user can opt in to a PR mid-implementing by calling `request_synthesize`; if any `synthesize.requested` event is on the stream at finalize, the workflow transitions to `synthesize` instead of `completed`. | The common case: start with the assumption of direct-commit, but leave the door open for the user to change their mind once they see the diff. |
+
+The default is `on-request` because it's the least surprising: the user
+gets the lightweight path until they explicitly ask for the heavy one.
+
+**Policy wins over event.** If `synthesisPolicy: 'never'` is set and a
+`synthesize.requested` event is somehow on the stream (e.g. the user
+called the action on a workflow they thought was `on-request`), the
+guard still routes to `completed`. Policy is the user's declared intent
+and overrides runtime signal.
+
+## Lifecycle
+
+```
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+```
+
+Four phases. The fork after `implementing` is a UML *choice state*,
+implemented via two mutually-exclusive HSM transitions whose guards are
+pure functions of `state.oneshot.synthesisPolicy` and the
+`synthesize.requested` event count.
+
+| Phase | What happens | Exit criteria |
+|---|---|---|
+| `plan` | Lightweight one-page plan: goal, approach, files to touch, tests to add. No design doc. No subagent dispatch. | `artifacts.plan` set → transition to `implementing` |
+| `implementing` | In-session TDD loop. Write a failing test, make it pass, refactor. Commit as you go. The TDD iron law applies — *no production code without a failing test first*. | Tests pass + typecheck clean + finalize_oneshot called |
+| `synthesize` | Reached **only** when `synthesisOptedIn` is true. Hands off to the existing synthesis flow — see `@skills/synthesis/SKILL.md`. PR created via `gh pr create`, auto-merge enabled, CI gates apply. | PR merged → `completed` |
+| `completed` | Terminal. For direct-commit path, commits are already on the branch — there's nothing more to do. For synthesize path, the PR merge event terminates the workflow. | — |
+
+`cancelled` is also reachable from any phase via the universal cancel
+transition, same as every other workflow type.
+
+## Step-by-step
+
+### Step 1 — Init
+
+Call `exarchos_workflow` with `action: 'init'`, `workflowType: 'oneshot'`,
+and an optional `synthesisPolicy`:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "init",
+  featureId: "fix-readme-typo",
+  workflowType: "oneshot",
+  synthesisPolicy: "on-request" // optional — defaults to 'on-request'
+})
+```
+
+If the user has been clear up front ("I want a PR for this"), pass
+`synthesisPolicy: "always"`. If they've been clear ("don't open a PR,
+just commit it"), pass `synthesisPolicy: "never"`. Otherwise, omit the
+field and rely on the `on-request` default — you can always escalate
+later in the implementing phase.
+
+The init returns the new workflow state; the workflow lands in `plan`.
+
+### Step 2 — Plan phase
+
+Produce a one-page plan. This is intentionally lightweight — no design
+doc, no parallelization analysis, no decomposition into N tasks. The
+plan should answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to `implementing` in a single set call:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "fix-readme-typo",
+  updates: {
+    "artifacts": { "plan": "<plan text>" },
+    "oneshot": { "planSummary": "<one-line summary>" },
+    "phase": "implementing"
+  }
+})
+```
+
+The plan goes on `artifacts.plan` for parity with the `feature` workflow;
+the human-readable one-liner goes on `oneshot.planSummary` for the
+pipeline view.
+
+### Step 3 — Implementing phase
+
+Run an in-session TDD loop. Same iron law as every other workflow:
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run the test. Confirm it fails for
+   the right reason.
+2. **[GREEN]** Write the minimum production code to make the test pass.
+   Run the test. Confirm it passes.
+3. **[REFACTOR]** Clean up while keeping the test green.
+
+Commit each red-green-refactor cycle as a single commit. Do not batch
+multiple unrelated changes into one commit — keeping commits atomic
+matters even more in oneshot, where there's no separate review phase
+to catch bundled changes.
+
+There is **no subagent dispatch** in oneshot. The main agent does the
+work directly. There is **no separate review phase**. Quality is
+maintained by the TDD loop and (if the user opts in) the synthesize PR
+review.
+
+#### Mid-implementing: opting in to a PR
+
+If at any point during implementing the user decides they want a PR
+after all (policy is `on-request`, default), they can opt in by calling
+the `request_synthesize` orchestrate action:
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+```
+
+**The trigger for this is conversational, not a magic keyword.** Listen
+for phrases like:
+- "actually, let's open a PR for this"
+- "I want a review on this before it lands"
+- "make this a PR"
+- "let's get eyes on this"
+- "synthesize this"
+
+When you hear any of those, call `request_synthesize` immediately. The
+handler appends a `synthesize.requested` event to the workflow's event
+stream; the `synthesisOptedIn` guard reads the stream at finalize and
+routes accordingly. This is **idempotent** — calling
+`request_synthesize` twice appends two events but the guard treats any
+count >= 1 as "opted in", so duplicate calls are benign.
+
+Calling `request_synthesize` does **not** transition the phase. The
+workflow stays in `implementing`. The decision is only acted on when
+you call `finalize_oneshot` in step 4.
+
+### Step 4 — Finalize (the choice point)
+
+When the implementing loop is done — tests pass, typecheck clean, all
+commits made — call `finalize_oneshot` to resolve the choice state:
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+```
+
+The handler:
+
+1. Reads the current state and verifies `workflowType === 'oneshot'` and
+   `phase === 'implementing'`.
+2. Hydrates `_events` from the event store so the guard sees the same
+   view the HSM will see during the actual transition.
+3. Evaluates `guards.synthesisOptedIn` against the state. The guard
+   inspects `state.oneshot.synthesisPolicy` and the `_events` array.
+4. Calls `handleSet` with the resolved target phase (`synthesize` or
+   `completed`). The HSM re-evaluates the guard at the transition
+   boundary, so any race between the read and the transition is caught
+   safely.
+
+Possible outcomes:
+
+| `synthesisPolicy` | `synthesize.requested` event present? | Resolved target | Path |
+|---|---|---|---|
+| `always` | (any) | `synthesize` | PR path |
+| `never` | (any) | `completed` | direct-commit path |
+| `on-request` (default) | yes | `synthesize` | PR path |
+| `on-request` (default) | no | `completed` | direct-commit path |
+
+### Step 5a — Direct-commit path (terminal)
+
+If finalize resolved to `completed`, you're done. The commits made
+during implementing are already on the current branch. Push them if
+they aren't already pushed:
+
+```bash
+git push
+```
+
+The workflow is now in `completed` and will not appear in the default
+pipeline view.
+
+### Step 5b — Synthesize path
+
+If finalize resolved to `synthesize`, hand off to the standard synthesis
+flow — see `@skills/synthesis/SKILL.md`. The same `prepare_synthesis` /
+`validate_pr_body` / `gh pr create` machinery used by the `feature`
+workflow applies. After the PR merges, the workflow transitions
+`synthesize → completed` via the existing `mergeVerified` guard, same as
+every other workflow type.
+
+You do **not** need to run `delegate` or
+`review` for an opt-in oneshot synthesize. Those phases
+do not exist in the oneshot playbook. The PR review is the only review.
+
+## Example invocations
+
+### Example A — Direct-commit (default `on-request` policy, no opt-in)
+
+```
+User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
+       Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
+  2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  4. [RED] writes test that greps README for 'recieve' and expects 0 matches
+        — fails (1 match exists)
+  5. [GREEN] edits README, fixes typo
+        — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+```
+
+### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
+
+```
+User: "Add input validation to the parseConfig helper. Oneshot."
+
+Agent:
+  1. exarchos_workflow init { workflowType: "oneshot" }
+     → 'plan' phase, default 'on-request'
+  2. plans (goal: validate input, files: [parser.ts, parser.test.ts])
+  3. transitions to 'implementing'
+  4. [RED] writes test for null-input case
+  5. [GREEN] adds null check
+  6. [REFACTOR] extracts validateInput helper
+  7. commits
+
+User: "Actually, this is touching the parser — I want a review on it before
+       it lands."
+
+Agent:
+  8. exarchos_orchestrate request_synthesize {
+       featureId, reason: "user requested review of parser changes"
+     }
+     → appends synthesize.requested event
+  9. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='on-request' + 1 synthesize.requested event
+     → resolves to 'synthesize'
+ 10. hands off to @skills/synthesis/SKILL.md → prepare_synthesis →
+     validate_pr_body → gh pr create → merge
+```
+
+### Example C — `synthesisPolicy: 'always'` (PR mandatory)
+
+```
+User: "I want a PR for any change to the auth module, even small ones.
+       Use oneshot but always make a PR."
+
+Agent:
+  1. exarchos_workflow init {
+       workflowType: "oneshot",
+       synthesisPolicy: "always"
+     }
+  2-7. plan + TDD + commits, identical to Example A
+  8. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='always' (short-circuits — no event check needed)
+     → resolves to 'synthesize'
+  9. synthesis flow → PR
+```
+
+## State management
+
+Track oneshot-specific state under the `oneshot` key on the workflow state:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "<id>",
+  updates: {
+    "oneshot": {
+      "synthesisPolicy": "on-request",
+      "planSummary": "Fix off-by-one in pagination helper"
+    }
+  }
+})
+```
+
+The `synthesisPolicy` field is optional and defaults to `'on-request'` per
+the schema in `servers/exarchos-mcp/src/workflow/schemas.ts`. Setting it
+explicitly is recommended when the user has stated a preference.
+
+## Phase Transitions and Guards
+
+For the full transition table for oneshot, consult
+`@skills/workflow-state/references/phase-transitions.md`.
+
+**Quick reference for oneshot:**
+
+| From | To | Guard |
+|---|---|---|
+| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `implementing` | `synthesize` | `synthesisOptedIn` |
+| `implementing` | `completed` | `synthesisOptedOut` |
+| `synthesize` | `completed` | `mergeVerified` |
+| (any) | `cancelled` | universal — always allowed |
+
+`synthesisOptedIn` and `synthesisOptedOut` are pure functions of
+`state.oneshot.synthesisPolicy` and `state._events`. They are mutually
+exclusive across all 8 (3 policies × event-present/absent, with `always`
+and `never` ignoring the event flag) combinations — exactly one returns
+true at any given time.
+
+### Schema discovery
+
+Use `exarchos_workflow({ action: "describe", actions: ["init", "set"] })`
+for parameter schemas (including the `synthesisPolicy` enum) and
+`exarchos_workflow({ action: "describe", playbook: "oneshot" })` for the
+phase transitions, guard names, and playbook prose. Use
+`exarchos_orchestrate({ action: "describe", actions: ["request_synthesize", "finalize_oneshot"] })`
+for the orchestrate action schemas.
+
+## TDD is still mandatory
+
+The iron law from `@rules/tdd.md` applies to oneshot. There is no
+exemption for "small" changes. Specifically:
+
+- Every behavior change starts with a failing test
+- Every test must fail before its implementation is written
+- Tests must be run after each change to verify state
+- Commits stay atomic — one logical change per commit
+
+The temptation in a oneshot is to skip the test "because it's just one
+line". Resist that. The test is what makes the change auditable, and
+auditability is the entire reason oneshot exists alongside the lighter
+"bypass workflows entirely" path.
+
+## Anti-patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip the plan phase ("it's obvious") | Write the four-line plan anyway — it's the artifact future-you reads |
+| Skip the TDD loop in implementing | Always RED → GREEN → REFACTOR, even for one-liners |
+| Use oneshot for multi-file refactors | Use `ideate` and the full feature workflow |
+| Try to grow a oneshot into a feature workflow mid-stream | Cancel and restart with `ideate` |
+| Call `request_synthesize` without listening for the user's intent | Wait for the user to ask for a PR, then call it |
+| Bundle unrelated changes into one commit "since it's a oneshot" | Keep commits atomic — there's no review phase to catch bundling |
+| Forget to call `finalize_oneshot` at the end | The workflow stays in `implementing` forever otherwise — call it explicitly |
+
+## Completion criteria
+
+- [ ] `exarchos_workflow init` called with `workflowType: "oneshot"`
+- [ ] One-page plan persisted to `artifacts.plan`
+- [ ] Phase transitioned to `implementing`
+- [ ] All planned behaviors implemented via TDD with atomic commits
+- [ ] `finalize_oneshot` called and resolved to either `completed` or `synthesize`
+- [ ] If direct-commit path: commits pushed
+- [ ] If synthesize path: PR created via `@skills/synthesis/SKILL.md` and merged

--- a/skills/cursor/oneshot-workflow/SKILL.md
+++ b/skills/cursor/oneshot-workflow/SKILL.md
@@ -189,11 +189,11 @@ work directly. There is **no separate review phase**. Quality is
 maintained by the TDD loop and (if the user opts in) the synthesize PR
 review.
 
-#### Mid-implementing: opting in to a PR
+#### Mid-workflow: opting in to a PR
 
-If at any point during implementing the user decides they want a PR
-after all (policy is `on-request`, default), they can opt in by calling
-the `request_synthesize` orchestrate action:
+If at any point during `plan` or `implementing` the user decides they
+want a PR after all (policy is `on-request`, default), they can opt in
+by calling the `request_synthesize` orchestrate action:
 
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
@@ -397,6 +397,12 @@ explicitly is recommended when the user has stated a preference.
 
 For the full transition table for oneshot, consult
 `@skills/workflow-state/references/phase-transitions.md`.
+
+> **Note:** The engine's `exarchos_workflow describe playbook="oneshot"`
+> output and the HSM definitions in `hsm-definitions.ts` are the
+> canonical sources for transition behavior. `phase-transitions.md` is
+> a prose reference that can drift — when discrepancies arise, prefer
+> engine `describe` output.
 
 **Quick reference for oneshot:**
 

--- a/skills/cursor/oneshot-workflow/SKILL.md
+++ b/skills/cursor/oneshot-workflow/SKILL.md
@@ -144,23 +144,26 @@ plan should answer four questions in 5-10 lines each:
 3. **Files** — which files will be touched? (1-5 typically)
 4. **Tests** — which test cases will be added? (named, not described)
 
-Persist the plan and transition to `implementing` in a single set call:
+Persist the plan and transition to `implementing` in a single set call.
+`phase` is a top-level argument of `set`, not a field inside `updates`:
 
 ```typescript
 mcp__exarchos__exarchos_workflow({
   action: "set",
   featureId: "fix-readme-typo",
+  phase: "implementing",
   updates: {
-    "artifacts": { "plan": "<plan text>" },
-    "oneshot": { "planSummary": "<one-line summary>" },
-    "phase": "implementing"
+    "artifacts.plan": "<plan text>",
+    "oneshot.planSummary": "<one-line summary>"
   }
 })
 ```
 
 The plan goes on `artifacts.plan` for parity with the `feature` workflow;
 the human-readable one-liner goes on `oneshot.planSummary` for the
-pipeline view.
+pipeline view. Only `artifacts.plan` is enforced by the
+`oneshot-plan-set` guard — `planSummary` is an optional pipeline-view
+label and is not a substitute for a real plan artifact.
 
 ### Step 3 — Implementing phase
 
@@ -292,7 +295,14 @@ Agent:
      → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
   2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
      tests=[readme has no occurrence of 'recieve']
-  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",                   // top-level
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "..."
+       }
+     }
   4. [RED] writes test that greps README for 'recieve' and expects 0 matches
         — fails (1 match exists)
   5. [GREEN] edits README, fixes typo

--- a/skills/cursor/oneshot-workflow/references/choice-state.md
+++ b/skills/cursor/oneshot-workflow/references/choice-state.md
@@ -1,0 +1,65 @@
+---
+name: oneshot-choice-state
+---
+
+# Oneshot Choice State: `implementing → ?`
+
+The oneshot workflow has a UML *choice state* at the end of `implementing`.
+Whether the workflow lands on `completed` (direct-commit) or transitions
+through `synthesize` (PR) is decided by two mutually-exclusive pure-function
+guards: `synthesisOptedIn` and `synthesisOptedOut`. Both are evaluated against
+the current workflow state at the transition boundary; exactly one returns
+`true` for every possible input.
+
+## Inputs read by the guards
+
+Both guards read exactly two things from state:
+
+1. `state.oneshot.synthesisPolicy` — one of `'always' | 'never' | 'on-request'`,
+   defaulted to `'on-request'` by the init schema.
+2. `state._events` — the hydrated event stream. The guard counts
+   `synthesize.requested` events on the stream (any count ≥ 1 means "opted in").
+
+Nothing else. No clock reads, no filesystem, no network, no git state. This
+is load-bearing for replay safety: given the same persisted state, the same
+target resolves every time, and re-running finalize is idempotent.
+
+## Decision table
+
+| `synthesisPolicy` | `synthesize.requested` count | `synthesisOptedIn` | `synthesisOptedOut` | Resolved target |
+|---|---|---|---|---|
+| `'always'`     | 0  | `true`  | `false` | `synthesize` |
+| `'always'`     | ≥1 | `true`  | `false` | `synthesize` |
+| `'never'`      | 0  | `false` | `true`  | `completed`  |
+| `'never'`      | ≥1 | `false` | `true`  | `completed`  |
+| `'on-request'` | 0  | `false` | `true`  | `completed`  |
+| `'on-request'` | ≥1 | `true`  | `false` | `synthesize` |
+
+**Policy wins over event.** On `'never'`, even if a stray `synthesize.requested`
+event is on the stream, the guard still routes to `completed`. Policy is the
+user's declared intent; runtime events only matter when the policy explicitly
+defers to them (`'on-request'`).
+
+## Why a choice state, not a single transition with branching logic
+
+Keeping the fork at the HSM level (two transitions, two mutually-exclusive
+guards) means:
+
+- The state machine graph visibly encodes both paths — operators reading
+  `hsm-definitions.ts` see `implementing → completed` and `implementing →
+  synthesize` as sibling transitions, not a hidden conditional.
+- The HSM re-evaluates guards at the transition boundary, so any race
+  between `finalize_oneshot` reading state and `handleSet` performing the
+  transition is caught safely — if a last-millisecond event changed the
+  evaluation, the HSM will refuse the wrong transition.
+- Guard logic stays testable in isolation (`guards.test.ts`) without
+  needing to spin up the handler.
+
+## See also
+
+- `servers/exarchos-mcp/src/workflow/guards.ts` — `synthesisOptedIn`,
+  `synthesisOptedOut`, `oneshotPlanSet` guard implementations.
+- `servers/exarchos-mcp/src/workflow/hsm-definitions.ts` — the oneshot HSM
+  with the two sibling transitions from `implementing`.
+- `servers/exarchos-mcp/src/orchestrate/finalize-oneshot.ts` — the handler
+  that resolves the choice state and calls `handleSet`.

--- a/skills/cursor/prune-workflows/SKILL.md
+++ b/skills/cursor/prune-workflows/SKILL.md
@@ -19,9 +19,9 @@ Pruning is a maintenance operation -- not a workflow phase. It produces `workflo
 ## Triggers
 
 Activate this skill when:
-- User runs `{{COMMAND_PREFIX}}prune` command
+- User runs `prune` command
 - User says "prune workflows", "clean stale workflows", "pipeline cleanup"
-- `{{MCP_PREFIX}}exarchos_view({ action: "pipeline" })` shows many inactive workflows the user wants to clear in bulk
+- `mcp__exarchos__exarchos_view({ action: "pipeline" })` shows many inactive workflows the user wants to clear in bulk
 
 ## Prerequisites
 
@@ -36,7 +36,7 @@ Activate this skill when:
 Always start with `dryRun: true`. This call performs candidate selection and safeguard evaluation but does not mutate any workflow state.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: true
@@ -104,7 +104,7 @@ Wait for explicit user input. Do **not** auto-proceed.
 On `proceed`, invoke the same action with `dryRun: false`. Pass through `thresholdMinutes` and `includeOneShot` if the user set them in Step 1.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: false
@@ -131,7 +131,7 @@ Each entry in `pruned` corresponds to a workflow that transitioned to `cancelled
 On `force`, set `force: true`. Safeguards are bypassed but the bypass is recorded in the `workflow.pruned` event payload as `skippedSafeguards: [...]` so the audit trail is intact.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: false,
@@ -199,7 +199,7 @@ A workflow without a `branchName` in state (e.g., abandoned at ideate/plan befor
 ### Example 1: Clean dry-run, user proceeds
 
 ```
-> {{COMMAND_PREFIX}}prune
+> prune
 
 ## Prune Candidates (2)
 
@@ -230,7 +230,7 @@ Proceed? (proceed/abort/force)
 ### Example 2: Safeguard skip, user forces
 
 ```
-> {{COMMAND_PREFIX}}prune
+> prune
 
 ## Prune Candidates (1)
 
@@ -265,7 +265,7 @@ Proceed? (proceed/abort/force)
 ### Example 3: Empty pipeline
 
 ```
-> {{COMMAND_PREFIX}}prune
+> prune
 
 No stale workflows to prune. Pipeline is clean.
 ```
@@ -275,7 +275,7 @@ No stale workflows to prune. Pipeline is clean.
 For the canonical argument schema and any future fields, use:
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "describe",
   actions: ["prune_stale_workflows"]
 })

--- a/skills/cursor/prune-workflows/references/safeguards.md
+++ b/skills/cursor/prune-workflows/references/safeguards.md
@@ -1,0 +1,74 @@
+---
+name: prune-safeguards
+---
+
+# Prune Safeguards
+
+The `prune_stale_workflows` orchestrate action runs two safeguards on each
+candidate before it will actually cancel the workflow. Both must pass for
+the candidate to be pruned, unless the caller passes `force: true` to
+bypass them.
+
+## Safeguard 1: `hasOpenPR`
+
+Checks whether there's an open pull request targeting the workflow's
+branch. Implementation: `gh pr list --state open --head <branchName>` —
+if the list is non-empty, the safeguard fails and the candidate is
+skipped with reason `open-pr`.
+
+Rationale: an open PR means human work is still in-flight on this feature.
+Cancelling the workflow would orphan the PR from its event-sourced state,
+which makes it invisible to `exarchos_view` and breaks auto-merge gates.
+We refuse to prune workflows with open PRs by default.
+
+## Safeguard 2: `hasRecentCommits` (user-facing: `active-branch`)
+
+Checks whether any commits landed on the workflow's branch within a
+24-hour window. Implementation: `git log --since="24 hours ago"
+<branchName>` — if the output is non-empty, the safeguard fails and the
+candidate is skipped with reason `active-branch`.
+
+Rationale: commits on the branch mean the workflow isn't actually stale,
+it just missed the last event checkpoint. The underlying branch is the
+ground truth for "is this work still alive?" — if someone is committing,
+we don't care what the checkpoint timestamp says.
+
+The window is locked at 24 hours for v1. It's exposed as a module
+constant (`RECENT_COMMITS_WINDOW_HOURS` in `prune-stale-workflows.ts`)
+so tests can see the contract, but it's not yet configurable through
+the public handler args.
+
+## Short-circuit: missing `branchName`
+
+If the workflow state has no top-level `branchName` field, both
+safeguards are skipped entirely (they have nothing to look up). The
+candidate still proceeds to cancel. This is safe because a workflow
+without a branch can't have an open PR or recent commits by definition.
+
+## `force: true` bypass semantics
+
+Passing `force: true` skips safeguard evaluation for every candidate.
+The handler still does everything else — the cancel, the event emission,
+the audit trail — but `hasOpenPR` and `hasRecentCommits` are never
+called.
+
+Every `workflow.pruned` event emitted during a `force: true` run carries
+a `skippedSafeguards: ['open-pr', 'active-branch']` marker on its payload.
+This makes forced prunes distinguishable in the audit stream from
+safeguard-approved ones, so operators reviewing the event log can see
+exactly which workflows were cancelled despite having open PRs or active
+branches.
+
+The marker list is intentionally hardcoded to *all* safeguards, not just
+the ones that would have failed. Running `force: true` is a blanket
+"I know what I'm doing" override — we want the audit trail to reflect
+that the user chose to bypass the whole safeguard layer, not to imply
+selective bypassing.
+
+## See also
+
+- `servers/exarchos-mcp/src/orchestrate/prune-safeguards.ts` — the
+  default implementations (gh/git backends) and the `PruneSafeguards`
+  interface for DI.
+- `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts` —
+  the handler that composes safeguards with selection and cancel.

--- a/skills/cursor/shepherd/SKILL.md
+++ b/skills/cursor/shepherd/SKILL.md
@@ -21,6 +21,10 @@ synthesize → shepherd (assess → fix → resubmit → loop) → cleanup
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Pipeline Hygiene
+
+When `mcp__exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:

--- a/skills/cursor/synthesis/SKILL.md
+++ b/skills/cursor/synthesis/SKILL.md
@@ -22,12 +22,22 @@ Submit stacked PRs after review phase completes. The `prepare_synthesis` composi
 
 Do NOT proceed if either review is incomplete or failed -- return to `review` first.
 
+**Entry points:** Synthesis is normally reached from the `review` phase of
+feature / debug / refactor workflows. It is also reachable from `oneshot`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during `plan` or `implementing`, the `request_synthesize` event is
+appended, and `finalize_oneshot` then resolves the choice state and
+transitions the workflow to `synthesize`. See
+`@skills/oneshot-workflow/SKILL.md` for the opt-in mechanics and
+`synthesisPolicy` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs `synthesize` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to `synthesize` via `finalize_oneshot`
 
 ## Process
 

--- a/skills/cursor/workflow-state/SKILL.md
+++ b/skills/cursor/workflow-state/SKILL.md
@@ -38,7 +38,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use `exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })` for
 parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its `implementing → synthesize|completed` choice state
+driven by `synthesisPolicy`), call `exarchos_workflow({ action: "describe", playbook: "oneshot" })`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 `exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })`
 for event data schemas.
 
@@ -126,6 +129,23 @@ exarchos_orchestrate({
 | Review complete | Update `reviews` object |
 | PR created | Set `artifacts.pr`, `synthesis.prUrl` |
 | PR feedback | Append to `synthesis.prFeedback` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| `plan` (oneshot) | `oneshot.planSummary`, `artifacts.plan`, optional `oneshot.synthesisPolicy` | `workflow.transition` |
+| `implementing` (oneshot) | `tasks[].status`, `artifacts.tests` | `task.*`, optional `synthesize.requested` (via `request_synthesize`) |
+| `synthesize` (oneshot) | `synthesis.prUrl`, `artifacts.pr` | `workflow.transition`, `stack.submitted` |
+| `completed` (oneshot) | — | `workflow.transition` (to `completed`) |
+
+The `implementing → synthesize | completed` fork is a choice state resolved
+by `finalize_oneshot`, which reads the `synthesisOptedIn` guard
+(`synthesisPolicy` + `synthesize.requested` events). See
+`@skills/oneshot-workflow/SKILL.md` for the full opt-in mechanics.
 
 ### Automatic State Updates
 

--- a/skills/cursor/workflow-state/SKILL.md
+++ b/skills/cursor/workflow-state/SKILL.md
@@ -54,9 +54,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see `references
 
 At the start of `ideate`, use `mcp__exarchos__exarchos_workflow` with `action: "init"` with:
 - `featureId`: the workflow identifier (e.g., `"user-authentication"`)
-- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`
+- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
+- `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- `feature` — full `ideate → plan → delegate → review → synthesize` for real features with subagent dispatch and two-stage review
+- `debug` — `triage → investigate → (thorough | hotfix)` for bug workflows with track selection
+- `refactor` — `explore → brief → (polish | overhaul)` for code improvements, polish for small and overhaul for multi-task
+- `oneshot` — `plan → implementing → (completed | synthesize)` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by `synthesisPolicy` and the `synthesize.requested` event
+
+See `@skills/oneshot-workflow/SKILL.md` for the lightweight variant's full prose, including the choice-state mechanics and `finalize_oneshot` trigger.
 
 ### Read State
 
@@ -154,7 +164,7 @@ See `docs/schemas/workflow-state.schema.json` for full schema.
 Key sections:
 - `version`: Schema version (currently "1.1")
 - `featureId`: Unique workflow identifier
-- `workflowType`: Required. One of "feature", "debug", or "refactor"
+- `workflowType`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - `phase`: Current workflow phase
 - `artifacts`: Paths to design, plan, PR
 - `tasks`: Task list with status

--- a/skills/cursor/workflow-state/SKILL.md
+++ b/skills/cursor/workflow-state/SKILL.md
@@ -60,7 +60,13 @@ At the start of `ideate`, use `mcp__exarchos__exarchos_workflow` with `action: "
 - `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
 - `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+`workflowType`:
+
+- `feature` → starts in `ideate`
+- `debug` → starts in `triage`
+- `refactor` → starts in `explore`
+- `oneshot` → starts in `plan` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 

--- a/skills/cursor/workflow-state/references/phase-transitions.md
+++ b/skills/cursor/workflow-state/references/phase-transitions.md
@@ -127,7 +127,7 @@ plan → implementing ─┬→ completed              (direct-commit path)
 
 | From | To | Guard | Prerequisite |
 |------|----|-------|-------------|
-| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` (non-empty string; `oneshot.planSummary` is optional metadata but does **not** satisfy the guard) |
 | `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
 | `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
 | `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |

--- a/skills/cursor/workflow-state/references/phase-transitions.md
+++ b/skills/cursor/workflow-state/references/phase-transitions.md
@@ -118,6 +118,28 @@ explore → brief → [polish-track | overhaul-track] → completed
 
 **Compound state:** `overhaul-track` contains `overhaul-plan`, `overhaul-plan-review`, `overhaul-delegate`, `overhaul-review`, and `overhaul-update-docs`. Max 3 fix cycles.
 
+## Oneshot Workflow
+
+```
+plan → implementing ─┬→ completed              (direct-commit path)
+                     └→ synthesize → completed (PR path, opt-in)
+```
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
+| `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
+| `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+**Choice state (end of `implementing`).** The fork after `implementing` is a UML choice state, implemented as two mutually-exclusive HSM transitions whose guards are pure functions of `state.oneshot.synthesisPolicy` and the `synthesize.requested` event count on the stream. At init, the user declares intent via `synthesisPolicy` (`always`, `never`, or `on-request` — default). During implementing, the user can opt in at any time by calling `exarchos_orchestrate request_synthesize`, which appends a `synthesize.requested` event without changing the phase. The decision is only evaluated when `finalize_oneshot` is called: the handler hydrates events, runs the guards, and calls `handleSet` with the resolved target. **Policy wins over event** — if policy is `never`, any `synthesize.requested` event is ignored and the guard routes to `completed`. Policy `always` short-circuits the event check and always routes to `synthesize`.
+
+**How to trigger:** `exarchos_orchestrate finalize_oneshot { featureId }` — this is the only way to exit `implementing`. The handler evaluates the choice state and calls `handleSet` with the correct target phase. The HSM re-evaluates the guard at the transition boundary, so any race between read and transition is caught safely.
+
+**No compound state.** Oneshot has no multi-agent loop, no review-fix cycle, and therefore no circuit breaker. If the in-session TDD loop gets stuck, cancel via `exarchos_workflow cancel` and restart with a different approach (or escalate to the full `feature` workflow).
+
+See `@skills/oneshot-workflow/SKILL.md` for the full prose walkthrough including worked examples.
+
 ## Circuit Breaker
 
 Compound states enforce a maximum number of fix cycles to prevent infinite review-fix loops. When the limit is exceeded, the HSM rejects the transition with a `CIRCUIT_OPEN` error and emits a `workflow.circuit-open` event.

--- a/skills/generic/cleanup/SKILL.md
+++ b/skills/generic/cleanup/SKILL.md
@@ -15,6 +15,12 @@ metadata:
 
 Resolve merged workflows to `completed` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
 
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use `@skills/prune-workflows/SKILL.md`. That skill invokes `exarchos_orchestrate prune_stale_workflows` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → `completed`); prune is bulk (N inactive workflows → `cancelled`). They are complementary, not alternatives.
+
 ## Triggers
 
 Activate this skill when:

--- a/skills/generic/delegation/SKILL.md
+++ b/skills/generic/delegation/SKILL.md
@@ -20,6 +20,8 @@ Activate this skill when:
 - Implementation plan is ready with extractable tasks
 - User wants to parallelize work across subagents
 
+**Exception — oneshot workflows skip delegation entirely.** The oneshot playbook runs an in-session TDD loop in the main agent's context, with no subagent dispatch or review phase. If `workflowType === "oneshot"`, do not call this skill — see `@skills/oneshot-workflow/SKILL.md` for the lightweight path.
+
 ## Core Principles
 
 ### Fresh Context Per Task (MANDATORY)

--- a/skills/generic/oneshot-workflow/SKILL.md
+++ b/skills/generic/oneshot-workflow/SKILL.md
@@ -12,8 +12,8 @@ metadata:
 # Oneshot Workflow Skill
 
 A lean, four-phase workflow type for changes that are too small to justify the
-full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
-still deserve event-sourced auditability and a planning step. The workflow is
+full `feature` flow (`ideate → plan → plan-review → delegate → review → synthesize → completed`)
+but still deserve event-sourced auditability and a planning step. The workflow is
 **direct-commit by default** with an opt-in PR path; the choice between the
 two is resolved at the end of `implementing` via a pure event-sourced guard,
 not a heuristic.
@@ -88,7 +88,7 @@ and overrides runtime signal.
 
 ## Lifecycle
 
-```
+```text
      plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
                                  │
                                  └── [synthesisOptedIn]  ──► synthesize ──► completed
@@ -286,7 +286,7 @@ do not exist in the oneshot playbook. The PR review is the only review.
 
 ### Example A — Direct-commit (default `on-request` policy, no opt-in)
 
-```
+```text
 User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
        Use oneshot."
 
@@ -317,7 +317,7 @@ Agent:
 
 ### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
 
-```
+```text
 User: "Add input validation to the parseConfig helper. Oneshot."
 
 Agent:
@@ -347,7 +347,7 @@ Agent:
 
 ### Example C — `synthesisPolicy: 'always'` (PR mandatory)
 
-```
+```text
 User: "I want a PR for any change to the auth module, even small ones.
        Use oneshot but always make a PR."
 

--- a/skills/generic/oneshot-workflow/SKILL.md
+++ b/skills/generic/oneshot-workflow/SKILL.md
@@ -214,13 +214,22 @@ for phrases like:
 When you hear any of those, call `request_synthesize` immediately. The
 handler appends a `synthesize.requested` event to the workflow's event
 stream; the `synthesisOptedIn` guard reads the stream at finalize and
-routes accordingly. This is **idempotent** — calling
-`request_synthesize` twice appends two events but the guard treats any
-count >= 1 as "opted in", so duplicate calls are benign.
+routes accordingly.
+
+`request_synthesize` is accepted from both `plan` and `implementing`
+phases — call it whenever you know you want the PR path, even before
+`implementing` starts. Terminal phases (`synthesize`, `completed`,
+`cancelled`) are rejected.
+
+Duplicate calls are **routing-idempotent** but not event-idempotent:
+each call appends a new `synthesize.requested` event, but the guard
+treats any count >= 1 as "opted in", so the routing decision is the
+same whether you call once or five times. The event stream will
+contain each duplicate for audit purposes.
 
 Calling `request_synthesize` does **not** transition the phase. The
-workflow stays in `implementing`. The decision is only acted on when
-you call `finalize_oneshot` in step 4.
+workflow stays in its current phase. The decision is only acted on
+when you call `finalize_oneshot` in step 4.
 
 ### Step 4 — Finalize (the choice point)
 
@@ -393,7 +402,7 @@ For the full transition table for oneshot, consult
 
 | From | To | Guard |
 |---|---|---|
-| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `plan` | `implementing` | `oneshotPlanSet` (requires non-empty `artifacts.plan`) |
 | `implementing` | `synthesize` | `synthesisOptedIn` |
 | `implementing` | `completed` | `synthesisOptedOut` |
 | `synthesize` | `completed` | `mergeVerified` |
@@ -401,9 +410,10 @@ For the full transition table for oneshot, consult
 
 `synthesisOptedIn` and `synthesisOptedOut` are pure functions of
 `state.oneshot.synthesisPolicy` and `state._events`. They are mutually
-exclusive across all 8 (3 policies × event-present/absent, with `always`
-and `never` ignoring the event flag) combinations — exactly one returns
-true at any given time.
+exclusive across all 4 meaningful combinations — `always` and `never`
+each map to one outcome (ignoring the event flag), and `on-request`
+branches on whether a `synthesize.requested` event is present or
+absent. Exactly one guard returns true at any given time.
 
 ### Schema discovery
 

--- a/skills/generic/oneshot-workflow/SKILL.md
+++ b/skills/generic/oneshot-workflow/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: oneshot-workflow
+description: "Lightweight workflow for straightforward changes — plan → implement → optional PR. Direct-commit by default; synthesize is opt-in via synthesisPolicy or a runtime request_synthesize event. Use for trivial fixes, config tweaks, single-file changes, or exploratory work that doesn't warrant subagent dispatch or two-stage review. Triggers: 'oneshot', 'quick fix', 'small change', or oneshot."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: plan
+---
+
+# Oneshot Workflow Skill
+
+A lean, four-phase workflow type for changes that are too small to justify the
+full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
+still deserve event-sourced auditability and a planning step. The workflow is
+**direct-commit by default** with an opt-in PR path; the choice between the
+two is resolved at the end of `implementing` via a pure event-sourced guard,
+not a heuristic.
+
+> **Read this first if you have never run a oneshot:** the workflow has a
+> *choice state* at the end of `implementing`. Whether you land on
+> `completed` (direct commit) or transition through `synthesize` (PR) is
+> decided by two inputs: the `synthesisPolicy` set at init, and whether the
+> user emitted a `synthesize.requested` event during implementing. Both
+> inputs are persisted; the decision is replay-safe.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically a single file, or a tightly-coupled
+  cluster of 2-3 files
+- No subagent dispatch is needed — the work fits comfortably in one TDD
+  loop in a single session
+- No design document is required — the goal is obvious from the task
+  description, and a one-page plan is enough scaffolding
+- No two-stage review is required — either the change is trivial enough
+  that direct-commit is acceptable, or a single PR review will suffice
+
+Concrete examples that fit oneshot:
+- Fixing a typo in a README
+- Bumping a dependency version
+- Adding a missing null-check in one function
+- Tweaking a CI workflow YAML
+- Renaming a config key everywhere it's referenced
+- Adding a one-off helper script
+- Exploratory spikes that may or may not be kept
+
+## When NOT to use oneshot
+
+Do not use oneshot for any of the following — use the full `feature`
+workflow instead (`ideate`):
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+- Anything where you'd want a written design doc to look back at
+
+If you start a oneshot and discover the change is bigger than expected, the
+right move is `cancel` and restart with `ideate`.
+Don't try to grow a oneshot into a feature workflow mid-stream; the
+playbooks have different shapes and you'll fight the state machine.
+
+## Synthesis policy — three options
+
+The `synthesisPolicy` field on a oneshot workflow declares the user's
+intent up front about whether the change should be turned into a PR. It
+takes one of three values, persisted on `state.oneshot.synthesisPolicy`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| `always` | Always transition `implementing → synthesize` at finalize, regardless of events. A PR is always created. | The user wants a paper trail / review for every change in this workflow, even small ones. |
+| `never` | Always transition `implementing → completed` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | The user is iterating on personal/scratch work and explicitly opts out of PRs. |
+| `on-request` *(default)* | Direct-commit by default. The user can opt in to a PR mid-implementing by calling `request_synthesize`; if any `synthesize.requested` event is on the stream at finalize, the workflow transitions to `synthesize` instead of `completed`. | The common case: start with the assumption of direct-commit, but leave the door open for the user to change their mind once they see the diff. |
+
+The default is `on-request` because it's the least surprising: the user
+gets the lightweight path until they explicitly ask for the heavy one.
+
+**Policy wins over event.** If `synthesisPolicy: 'never'` is set and a
+`synthesize.requested` event is somehow on the stream (e.g. the user
+called the action on a workflow they thought was `on-request`), the
+guard still routes to `completed`. Policy is the user's declared intent
+and overrides runtime signal.
+
+## Lifecycle
+
+```
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+```
+
+Four phases. The fork after `implementing` is a UML *choice state*,
+implemented via two mutually-exclusive HSM transitions whose guards are
+pure functions of `state.oneshot.synthesisPolicy` and the
+`synthesize.requested` event count.
+
+| Phase | What happens | Exit criteria |
+|---|---|---|
+| `plan` | Lightweight one-page plan: goal, approach, files to touch, tests to add. No design doc. No subagent dispatch. | `artifacts.plan` set → transition to `implementing` |
+| `implementing` | In-session TDD loop. Write a failing test, make it pass, refactor. Commit as you go. The TDD iron law applies — *no production code without a failing test first*. | Tests pass + typecheck clean + finalize_oneshot called |
+| `synthesize` | Reached **only** when `synthesisOptedIn` is true. Hands off to the existing synthesis flow — see `@skills/synthesis/SKILL.md`. PR created via `gh pr create`, auto-merge enabled, CI gates apply. | PR merged → `completed` |
+| `completed` | Terminal. For direct-commit path, commits are already on the branch — there's nothing more to do. For synthesize path, the PR merge event terminates the workflow. | — |
+
+`cancelled` is also reachable from any phase via the universal cancel
+transition, same as every other workflow type.
+
+## Step-by-step
+
+### Step 1 — Init
+
+Call `exarchos_workflow` with `action: 'init'`, `workflowType: 'oneshot'`,
+and an optional `synthesisPolicy`:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "init",
+  featureId: "fix-readme-typo",
+  workflowType: "oneshot",
+  synthesisPolicy: "on-request" // optional — defaults to 'on-request'
+})
+```
+
+If the user has been clear up front ("I want a PR for this"), pass
+`synthesisPolicy: "always"`. If they've been clear ("don't open a PR,
+just commit it"), pass `synthesisPolicy: "never"`. Otherwise, omit the
+field and rely on the `on-request` default — you can always escalate
+later in the implementing phase.
+
+The init returns the new workflow state; the workflow lands in `plan`.
+
+### Step 2 — Plan phase
+
+Produce a one-page plan. This is intentionally lightweight — no design
+doc, no parallelization analysis, no decomposition into N tasks. The
+plan should answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to `implementing` in a single set call:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "fix-readme-typo",
+  updates: {
+    "artifacts": { "plan": "<plan text>" },
+    "oneshot": { "planSummary": "<one-line summary>" },
+    "phase": "implementing"
+  }
+})
+```
+
+The plan goes on `artifacts.plan` for parity with the `feature` workflow;
+the human-readable one-liner goes on `oneshot.planSummary` for the
+pipeline view.
+
+### Step 3 — Implementing phase
+
+Run an in-session TDD loop. Same iron law as every other workflow:
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run the test. Confirm it fails for
+   the right reason.
+2. **[GREEN]** Write the minimum production code to make the test pass.
+   Run the test. Confirm it passes.
+3. **[REFACTOR]** Clean up while keeping the test green.
+
+Commit each red-green-refactor cycle as a single commit. Do not batch
+multiple unrelated changes into one commit — keeping commits atomic
+matters even more in oneshot, where there's no separate review phase
+to catch bundled changes.
+
+There is **no subagent dispatch** in oneshot. The main agent does the
+work directly. There is **no separate review phase**. Quality is
+maintained by the TDD loop and (if the user opts in) the synthesize PR
+review.
+
+#### Mid-implementing: opting in to a PR
+
+If at any point during implementing the user decides they want a PR
+after all (policy is `on-request`, default), they can opt in by calling
+the `request_synthesize` orchestrate action:
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+```
+
+**The trigger for this is conversational, not a magic keyword.** Listen
+for phrases like:
+- "actually, let's open a PR for this"
+- "I want a review on this before it lands"
+- "make this a PR"
+- "let's get eyes on this"
+- "synthesize this"
+
+When you hear any of those, call `request_synthesize` immediately. The
+handler appends a `synthesize.requested` event to the workflow's event
+stream; the `synthesisOptedIn` guard reads the stream at finalize and
+routes accordingly. This is **idempotent** — calling
+`request_synthesize` twice appends two events but the guard treats any
+count >= 1 as "opted in", so duplicate calls are benign.
+
+Calling `request_synthesize` does **not** transition the phase. The
+workflow stays in `implementing`. The decision is only acted on when
+you call `finalize_oneshot` in step 4.
+
+### Step 4 — Finalize (the choice point)
+
+When the implementing loop is done — tests pass, typecheck clean, all
+commits made — call `finalize_oneshot` to resolve the choice state:
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+```
+
+The handler:
+
+1. Reads the current state and verifies `workflowType === 'oneshot'` and
+   `phase === 'implementing'`.
+2. Hydrates `_events` from the event store so the guard sees the same
+   view the HSM will see during the actual transition.
+3. Evaluates `guards.synthesisOptedIn` against the state. The guard
+   inspects `state.oneshot.synthesisPolicy` and the `_events` array.
+4. Calls `handleSet` with the resolved target phase (`synthesize` or
+   `completed`). The HSM re-evaluates the guard at the transition
+   boundary, so any race between the read and the transition is caught
+   safely.
+
+Possible outcomes:
+
+| `synthesisPolicy` | `synthesize.requested` event present? | Resolved target | Path |
+|---|---|---|---|
+| `always` | (any) | `synthesize` | PR path |
+| `never` | (any) | `completed` | direct-commit path |
+| `on-request` (default) | yes | `synthesize` | PR path |
+| `on-request` (default) | no | `completed` | direct-commit path |
+
+### Step 5a — Direct-commit path (terminal)
+
+If finalize resolved to `completed`, you're done. The commits made
+during implementing are already on the current branch. Push them if
+they aren't already pushed:
+
+```bash
+git push
+```
+
+The workflow is now in `completed` and will not appear in the default
+pipeline view.
+
+### Step 5b — Synthesize path
+
+If finalize resolved to `synthesize`, hand off to the standard synthesis
+flow — see `@skills/synthesis/SKILL.md`. The same `prepare_synthesis` /
+`validate_pr_body` / `gh pr create` machinery used by the `feature`
+workflow applies. After the PR merges, the workflow transitions
+`synthesize → completed` via the existing `mergeVerified` guard, same as
+every other workflow type.
+
+You do **not** need to run `delegate` or
+`review` for an opt-in oneshot synthesize. Those phases
+do not exist in the oneshot playbook. The PR review is the only review.
+
+## Example invocations
+
+### Example A — Direct-commit (default `on-request` policy, no opt-in)
+
+```
+User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
+       Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
+  2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  4. [RED] writes test that greps README for 'recieve' and expects 0 matches
+        — fails (1 match exists)
+  5. [GREEN] edits README, fixes typo
+        — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+```
+
+### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
+
+```
+User: "Add input validation to the parseConfig helper. Oneshot."
+
+Agent:
+  1. exarchos_workflow init { workflowType: "oneshot" }
+     → 'plan' phase, default 'on-request'
+  2. plans (goal: validate input, files: [parser.ts, parser.test.ts])
+  3. transitions to 'implementing'
+  4. [RED] writes test for null-input case
+  5. [GREEN] adds null check
+  6. [REFACTOR] extracts validateInput helper
+  7. commits
+
+User: "Actually, this is touching the parser — I want a review on it before
+       it lands."
+
+Agent:
+  8. exarchos_orchestrate request_synthesize {
+       featureId, reason: "user requested review of parser changes"
+     }
+     → appends synthesize.requested event
+  9. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='on-request' + 1 synthesize.requested event
+     → resolves to 'synthesize'
+ 10. hands off to @skills/synthesis/SKILL.md → prepare_synthesis →
+     validate_pr_body → gh pr create → merge
+```
+
+### Example C — `synthesisPolicy: 'always'` (PR mandatory)
+
+```
+User: "I want a PR for any change to the auth module, even small ones.
+       Use oneshot but always make a PR."
+
+Agent:
+  1. exarchos_workflow init {
+       workflowType: "oneshot",
+       synthesisPolicy: "always"
+     }
+  2-7. plan + TDD + commits, identical to Example A
+  8. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='always' (short-circuits — no event check needed)
+     → resolves to 'synthesize'
+  9. synthesis flow → PR
+```
+
+## State management
+
+Track oneshot-specific state under the `oneshot` key on the workflow state:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "<id>",
+  updates: {
+    "oneshot": {
+      "synthesisPolicy": "on-request",
+      "planSummary": "Fix off-by-one in pagination helper"
+    }
+  }
+})
+```
+
+The `synthesisPolicy` field is optional and defaults to `'on-request'` per
+the schema in `servers/exarchos-mcp/src/workflow/schemas.ts`. Setting it
+explicitly is recommended when the user has stated a preference.
+
+## Phase Transitions and Guards
+
+For the full transition table for oneshot, consult
+`@skills/workflow-state/references/phase-transitions.md`.
+
+**Quick reference for oneshot:**
+
+| From | To | Guard |
+|---|---|---|
+| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `implementing` | `synthesize` | `synthesisOptedIn` |
+| `implementing` | `completed` | `synthesisOptedOut` |
+| `synthesize` | `completed` | `mergeVerified` |
+| (any) | `cancelled` | universal — always allowed |
+
+`synthesisOptedIn` and `synthesisOptedOut` are pure functions of
+`state.oneshot.synthesisPolicy` and `state._events`. They are mutually
+exclusive across all 8 (3 policies × event-present/absent, with `always`
+and `never` ignoring the event flag) combinations — exactly one returns
+true at any given time.
+
+### Schema discovery
+
+Use `exarchos_workflow({ action: "describe", actions: ["init", "set"] })`
+for parameter schemas (including the `synthesisPolicy` enum) and
+`exarchos_workflow({ action: "describe", playbook: "oneshot" })` for the
+phase transitions, guard names, and playbook prose. Use
+`exarchos_orchestrate({ action: "describe", actions: ["request_synthesize", "finalize_oneshot"] })`
+for the orchestrate action schemas.
+
+## TDD is still mandatory
+
+The iron law from `@rules/tdd.md` applies to oneshot. There is no
+exemption for "small" changes. Specifically:
+
+- Every behavior change starts with a failing test
+- Every test must fail before its implementation is written
+- Tests must be run after each change to verify state
+- Commits stay atomic — one logical change per commit
+
+The temptation in a oneshot is to skip the test "because it's just one
+line". Resist that. The test is what makes the change auditable, and
+auditability is the entire reason oneshot exists alongside the lighter
+"bypass workflows entirely" path.
+
+## Anti-patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip the plan phase ("it's obvious") | Write the four-line plan anyway — it's the artifact future-you reads |
+| Skip the TDD loop in implementing | Always RED → GREEN → REFACTOR, even for one-liners |
+| Use oneshot for multi-file refactors | Use `ideate` and the full feature workflow |
+| Try to grow a oneshot into a feature workflow mid-stream | Cancel and restart with `ideate` |
+| Call `request_synthesize` without listening for the user's intent | Wait for the user to ask for a PR, then call it |
+| Bundle unrelated changes into one commit "since it's a oneshot" | Keep commits atomic — there's no review phase to catch bundling |
+| Forget to call `finalize_oneshot` at the end | The workflow stays in `implementing` forever otherwise — call it explicitly |
+
+## Completion criteria
+
+- [ ] `exarchos_workflow init` called with `workflowType: "oneshot"`
+- [ ] One-page plan persisted to `artifacts.plan`
+- [ ] Phase transitioned to `implementing`
+- [ ] All planned behaviors implemented via TDD with atomic commits
+- [ ] `finalize_oneshot` called and resolved to either `completed` or `synthesize`
+- [ ] If direct-commit path: commits pushed
+- [ ] If synthesize path: PR created via `@skills/synthesis/SKILL.md` and merged

--- a/skills/generic/oneshot-workflow/SKILL.md
+++ b/skills/generic/oneshot-workflow/SKILL.md
@@ -189,11 +189,11 @@ work directly. There is **no separate review phase**. Quality is
 maintained by the TDD loop and (if the user opts in) the synthesize PR
 review.
 
-#### Mid-implementing: opting in to a PR
+#### Mid-workflow: opting in to a PR
 
-If at any point during implementing the user decides they want a PR
-after all (policy is `on-request`, default), they can opt in by calling
-the `request_synthesize` orchestrate action:
+If at any point during `plan` or `implementing` the user decides they
+want a PR after all (policy is `on-request`, default), they can opt in
+by calling the `request_synthesize` orchestrate action:
 
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
@@ -397,6 +397,12 @@ explicitly is recommended when the user has stated a preference.
 
 For the full transition table for oneshot, consult
 `@skills/workflow-state/references/phase-transitions.md`.
+
+> **Note:** The engine's `exarchos_workflow describe playbook="oneshot"`
+> output and the HSM definitions in `hsm-definitions.ts` are the
+> canonical sources for transition behavior. `phase-transitions.md` is
+> a prose reference that can drift — when discrepancies arise, prefer
+> engine `describe` output.
 
 **Quick reference for oneshot:**
 

--- a/skills/generic/oneshot-workflow/SKILL.md
+++ b/skills/generic/oneshot-workflow/SKILL.md
@@ -144,23 +144,26 @@ plan should answer four questions in 5-10 lines each:
 3. **Files** — which files will be touched? (1-5 typically)
 4. **Tests** — which test cases will be added? (named, not described)
 
-Persist the plan and transition to `implementing` in a single set call:
+Persist the plan and transition to `implementing` in a single set call.
+`phase` is a top-level argument of `set`, not a field inside `updates`:
 
 ```typescript
 mcp__exarchos__exarchos_workflow({
   action: "set",
   featureId: "fix-readme-typo",
+  phase: "implementing",
   updates: {
-    "artifacts": { "plan": "<plan text>" },
-    "oneshot": { "planSummary": "<one-line summary>" },
-    "phase": "implementing"
+    "artifacts.plan": "<plan text>",
+    "oneshot.planSummary": "<one-line summary>"
   }
 })
 ```
 
 The plan goes on `artifacts.plan` for parity with the `feature` workflow;
 the human-readable one-liner goes on `oneshot.planSummary` for the
-pipeline view.
+pipeline view. Only `artifacts.plan` is enforced by the
+`oneshot-plan-set` guard — `planSummary` is an optional pipeline-view
+label and is not a substitute for a real plan artifact.
 
 ### Step 3 — Implementing phase
 
@@ -292,7 +295,14 @@ Agent:
      → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
   2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
      tests=[readme has no occurrence of 'recieve']
-  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",                   // top-level
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "..."
+       }
+     }
   4. [RED] writes test that greps README for 'recieve' and expects 0 matches
         — fails (1 match exists)
   5. [GREEN] edits README, fixes typo

--- a/skills/generic/oneshot-workflow/references/choice-state.md
+++ b/skills/generic/oneshot-workflow/references/choice-state.md
@@ -1,0 +1,65 @@
+---
+name: oneshot-choice-state
+---
+
+# Oneshot Choice State: `implementing → ?`
+
+The oneshot workflow has a UML *choice state* at the end of `implementing`.
+Whether the workflow lands on `completed` (direct-commit) or transitions
+through `synthesize` (PR) is decided by two mutually-exclusive pure-function
+guards: `synthesisOptedIn` and `synthesisOptedOut`. Both are evaluated against
+the current workflow state at the transition boundary; exactly one returns
+`true` for every possible input.
+
+## Inputs read by the guards
+
+Both guards read exactly two things from state:
+
+1. `state.oneshot.synthesisPolicy` — one of `'always' | 'never' | 'on-request'`,
+   defaulted to `'on-request'` by the init schema.
+2. `state._events` — the hydrated event stream. The guard counts
+   `synthesize.requested` events on the stream (any count ≥ 1 means "opted in").
+
+Nothing else. No clock reads, no filesystem, no network, no git state. This
+is load-bearing for replay safety: given the same persisted state, the same
+target resolves every time, and re-running finalize is idempotent.
+
+## Decision table
+
+| `synthesisPolicy` | `synthesize.requested` count | `synthesisOptedIn` | `synthesisOptedOut` | Resolved target |
+|---|---|---|---|---|
+| `'always'`     | 0  | `true`  | `false` | `synthesize` |
+| `'always'`     | ≥1 | `true`  | `false` | `synthesize` |
+| `'never'`      | 0  | `false` | `true`  | `completed`  |
+| `'never'`      | ≥1 | `false` | `true`  | `completed`  |
+| `'on-request'` | 0  | `false` | `true`  | `completed`  |
+| `'on-request'` | ≥1 | `true`  | `false` | `synthesize` |
+
+**Policy wins over event.** On `'never'`, even if a stray `synthesize.requested`
+event is on the stream, the guard still routes to `completed`. Policy is the
+user's declared intent; runtime events only matter when the policy explicitly
+defers to them (`'on-request'`).
+
+## Why a choice state, not a single transition with branching logic
+
+Keeping the fork at the HSM level (two transitions, two mutually-exclusive
+guards) means:
+
+- The state machine graph visibly encodes both paths — operators reading
+  `hsm-definitions.ts` see `implementing → completed` and `implementing →
+  synthesize` as sibling transitions, not a hidden conditional.
+- The HSM re-evaluates guards at the transition boundary, so any race
+  between `finalize_oneshot` reading state and `handleSet` performing the
+  transition is caught safely — if a last-millisecond event changed the
+  evaluation, the HSM will refuse the wrong transition.
+- Guard logic stays testable in isolation (`guards.test.ts`) without
+  needing to spin up the handler.
+
+## See also
+
+- `servers/exarchos-mcp/src/workflow/guards.ts` — `synthesisOptedIn`,
+  `synthesisOptedOut`, `oneshotPlanSet` guard implementations.
+- `servers/exarchos-mcp/src/workflow/hsm-definitions.ts` — the oneshot HSM
+  with the two sibling transitions from `implementing`.
+- `servers/exarchos-mcp/src/orchestrate/finalize-oneshot.ts` — the handler
+  that resolves the choice state and calls `handleSet`.

--- a/skills/generic/prune-workflows/SKILL.md
+++ b/skills/generic/prune-workflows/SKILL.md
@@ -19,9 +19,9 @@ Pruning is a maintenance operation -- not a workflow phase. It produces `workflo
 ## Triggers
 
 Activate this skill when:
-- User runs `{{COMMAND_PREFIX}}prune` command
+- User runs `prune` command
 - User says "prune workflows", "clean stale workflows", "pipeline cleanup"
-- `{{MCP_PREFIX}}exarchos_view({ action: "pipeline" })` shows many inactive workflows the user wants to clear in bulk
+- `mcp__exarchos__exarchos_view({ action: "pipeline" })` shows many inactive workflows the user wants to clear in bulk
 
 ## Prerequisites
 
@@ -36,7 +36,7 @@ Activate this skill when:
 Always start with `dryRun: true`. This call performs candidate selection and safeguard evaluation but does not mutate any workflow state.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: true
@@ -104,7 +104,7 @@ Wait for explicit user input. Do **not** auto-proceed.
 On `proceed`, invoke the same action with `dryRun: false`. Pass through `thresholdMinutes` and `includeOneShot` if the user set them in Step 1.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: false
@@ -131,7 +131,7 @@ Each entry in `pruned` corresponds to a workflow that transitioned to `cancelled
 On `force`, set `force: true`. Safeguards are bypassed but the bypass is recorded in the `workflow.pruned` event payload as `skippedSafeguards: [...]` so the audit trail is intact.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: false,
@@ -199,7 +199,7 @@ A workflow without a `branchName` in state (e.g., abandoned at ideate/plan befor
 ### Example 1: Clean dry-run, user proceeds
 
 ```
-> {{COMMAND_PREFIX}}prune
+> prune
 
 ## Prune Candidates (2)
 
@@ -230,7 +230,7 @@ Proceed? (proceed/abort/force)
 ### Example 2: Safeguard skip, user forces
 
 ```
-> {{COMMAND_PREFIX}}prune
+> prune
 
 ## Prune Candidates (1)
 
@@ -265,7 +265,7 @@ Proceed? (proceed/abort/force)
 ### Example 3: Empty pipeline
 
 ```
-> {{COMMAND_PREFIX}}prune
+> prune
 
 No stale workflows to prune. Pipeline is clean.
 ```
@@ -275,7 +275,7 @@ No stale workflows to prune. Pipeline is clean.
 For the canonical argument schema and any future fields, use:
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "describe",
   actions: ["prune_stale_workflows"]
 })

--- a/skills/generic/prune-workflows/references/safeguards.md
+++ b/skills/generic/prune-workflows/references/safeguards.md
@@ -1,0 +1,74 @@
+---
+name: prune-safeguards
+---
+
+# Prune Safeguards
+
+The `prune_stale_workflows` orchestrate action runs two safeguards on each
+candidate before it will actually cancel the workflow. Both must pass for
+the candidate to be pruned, unless the caller passes `force: true` to
+bypass them.
+
+## Safeguard 1: `hasOpenPR`
+
+Checks whether there's an open pull request targeting the workflow's
+branch. Implementation: `gh pr list --state open --head <branchName>` —
+if the list is non-empty, the safeguard fails and the candidate is
+skipped with reason `open-pr`.
+
+Rationale: an open PR means human work is still in-flight on this feature.
+Cancelling the workflow would orphan the PR from its event-sourced state,
+which makes it invisible to `exarchos_view` and breaks auto-merge gates.
+We refuse to prune workflows with open PRs by default.
+
+## Safeguard 2: `hasRecentCommits` (user-facing: `active-branch`)
+
+Checks whether any commits landed on the workflow's branch within a
+24-hour window. Implementation: `git log --since="24 hours ago"
+<branchName>` — if the output is non-empty, the safeguard fails and the
+candidate is skipped with reason `active-branch`.
+
+Rationale: commits on the branch mean the workflow isn't actually stale,
+it just missed the last event checkpoint. The underlying branch is the
+ground truth for "is this work still alive?" — if someone is committing,
+we don't care what the checkpoint timestamp says.
+
+The window is locked at 24 hours for v1. It's exposed as a module
+constant (`RECENT_COMMITS_WINDOW_HOURS` in `prune-stale-workflows.ts`)
+so tests can see the contract, but it's not yet configurable through
+the public handler args.
+
+## Short-circuit: missing `branchName`
+
+If the workflow state has no top-level `branchName` field, both
+safeguards are skipped entirely (they have nothing to look up). The
+candidate still proceeds to cancel. This is safe because a workflow
+without a branch can't have an open PR or recent commits by definition.
+
+## `force: true` bypass semantics
+
+Passing `force: true` skips safeguard evaluation for every candidate.
+The handler still does everything else — the cancel, the event emission,
+the audit trail — but `hasOpenPR` and `hasRecentCommits` are never
+called.
+
+Every `workflow.pruned` event emitted during a `force: true` run carries
+a `skippedSafeguards: ['open-pr', 'active-branch']` marker on its payload.
+This makes forced prunes distinguishable in the audit stream from
+safeguard-approved ones, so operators reviewing the event log can see
+exactly which workflows were cancelled despite having open PRs or active
+branches.
+
+The marker list is intentionally hardcoded to *all* safeguards, not just
+the ones that would have failed. Running `force: true` is a blanket
+"I know what I'm doing" override — we want the audit trail to reflect
+that the user chose to bypass the whole safeguard layer, not to imply
+selective bypassing.
+
+## See also
+
+- `servers/exarchos-mcp/src/orchestrate/prune-safeguards.ts` — the
+  default implementations (gh/git backends) and the `PruneSafeguards`
+  interface for DI.
+- `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts` —
+  the handler that composes safeguards with selection and cancel.

--- a/skills/generic/shepherd/SKILL.md
+++ b/skills/generic/shepherd/SKILL.md
@@ -21,6 +21,10 @@ synthesize → shepherd (assess → fix → resubmit → loop) → cleanup
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Pipeline Hygiene
+
+When `mcp__exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:

--- a/skills/generic/synthesis/SKILL.md
+++ b/skills/generic/synthesis/SKILL.md
@@ -22,12 +22,22 @@ Submit stacked PRs after review phase completes. The `prepare_synthesis` composi
 
 Do NOT proceed if either review is incomplete or failed -- return to `review` first.
 
+**Entry points:** Synthesis is normally reached from the `review` phase of
+feature / debug / refactor workflows. It is also reachable from `oneshot`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during `plan` or `implementing`, the `request_synthesize` event is
+appended, and `finalize_oneshot` then resolves the choice state and
+transitions the workflow to `synthesize`. See
+`@skills/oneshot-workflow/SKILL.md` for the opt-in mechanics and
+`synthesisPolicy` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs `synthesize` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to `synthesize` via `finalize_oneshot`
 
 ## Process
 

--- a/skills/generic/workflow-state/SKILL.md
+++ b/skills/generic/workflow-state/SKILL.md
@@ -38,7 +38,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use `exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })` for
 parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its `implementing → synthesize|completed` choice state
+driven by `synthesisPolicy`), call `exarchos_workflow({ action: "describe", playbook: "oneshot" })`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 `exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })`
 for event data schemas.
 
@@ -126,6 +129,23 @@ exarchos_orchestrate({
 | Review complete | Update `reviews` object |
 | PR created | Set `artifacts.pr`, `synthesis.prUrl` |
 | PR feedback | Append to `synthesis.prFeedback` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| `plan` (oneshot) | `oneshot.planSummary`, `artifacts.plan`, optional `oneshot.synthesisPolicy` | `workflow.transition` |
+| `implementing` (oneshot) | `tasks[].status`, `artifacts.tests` | `task.*`, optional `synthesize.requested` (via `request_synthesize`) |
+| `synthesize` (oneshot) | `synthesis.prUrl`, `artifacts.pr` | `workflow.transition`, `stack.submitted` |
+| `completed` (oneshot) | — | `workflow.transition` (to `completed`) |
+
+The `implementing → synthesize | completed` fork is a choice state resolved
+by `finalize_oneshot`, which reads the `synthesisOptedIn` guard
+(`synthesisPolicy` + `synthesize.requested` events). See
+`@skills/oneshot-workflow/SKILL.md` for the full opt-in mechanics.
 
 ### Automatic State Updates
 

--- a/skills/generic/workflow-state/SKILL.md
+++ b/skills/generic/workflow-state/SKILL.md
@@ -54,9 +54,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see `references
 
 At the start of `ideate`, use `mcp__exarchos__exarchos_workflow` with `action: "init"` with:
 - `featureId`: the workflow identifier (e.g., `"user-authentication"`)
-- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`
+- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
+- `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- `feature` — full `ideate → plan → delegate → review → synthesize` for real features with subagent dispatch and two-stage review
+- `debug` — `triage → investigate → (thorough | hotfix)` for bug workflows with track selection
+- `refactor` — `explore → brief → (polish | overhaul)` for code improvements, polish for small and overhaul for multi-task
+- `oneshot` — `plan → implementing → (completed | synthesize)` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by `synthesisPolicy` and the `synthesize.requested` event
+
+See `@skills/oneshot-workflow/SKILL.md` for the lightweight variant's full prose, including the choice-state mechanics and `finalize_oneshot` trigger.
 
 ### Read State
 
@@ -154,7 +164,7 @@ See `docs/schemas/workflow-state.schema.json` for full schema.
 Key sections:
 - `version`: Schema version (currently "1.1")
 - `featureId`: Unique workflow identifier
-- `workflowType`: Required. One of "feature", "debug", or "refactor"
+- `workflowType`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - `phase`: Current workflow phase
 - `artifacts`: Paths to design, plan, PR
 - `tasks`: Task list with status

--- a/skills/generic/workflow-state/SKILL.md
+++ b/skills/generic/workflow-state/SKILL.md
@@ -60,7 +60,13 @@ At the start of `ideate`, use `mcp__exarchos__exarchos_workflow` with `action: "
 - `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
 - `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+`workflowType`:
+
+- `feature` → starts in `ideate`
+- `debug` → starts in `triage`
+- `refactor` → starts in `explore`
+- `oneshot` → starts in `plan` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 

--- a/skills/generic/workflow-state/references/phase-transitions.md
+++ b/skills/generic/workflow-state/references/phase-transitions.md
@@ -127,7 +127,7 @@ plan → implementing ─┬→ completed              (direct-commit path)
 
 | From | To | Guard | Prerequisite |
 |------|----|-------|-------------|
-| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` (non-empty string; `oneshot.planSummary` is optional metadata but does **not** satisfy the guard) |
 | `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
 | `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
 | `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |

--- a/skills/generic/workflow-state/references/phase-transitions.md
+++ b/skills/generic/workflow-state/references/phase-transitions.md
@@ -118,6 +118,28 @@ explore → brief → [polish-track | overhaul-track] → completed
 
 **Compound state:** `overhaul-track` contains `overhaul-plan`, `overhaul-plan-review`, `overhaul-delegate`, `overhaul-review`, and `overhaul-update-docs`. Max 3 fix cycles.
 
+## Oneshot Workflow
+
+```
+plan → implementing ─┬→ completed              (direct-commit path)
+                     └→ synthesize → completed (PR path, opt-in)
+```
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
+| `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
+| `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+**Choice state (end of `implementing`).** The fork after `implementing` is a UML choice state, implemented as two mutually-exclusive HSM transitions whose guards are pure functions of `state.oneshot.synthesisPolicy` and the `synthesize.requested` event count on the stream. At init, the user declares intent via `synthesisPolicy` (`always`, `never`, or `on-request` — default). During implementing, the user can opt in at any time by calling `exarchos_orchestrate request_synthesize`, which appends a `synthesize.requested` event without changing the phase. The decision is only evaluated when `finalize_oneshot` is called: the handler hydrates events, runs the guards, and calls `handleSet` with the resolved target. **Policy wins over event** — if policy is `never`, any `synthesize.requested` event is ignored and the guard routes to `completed`. Policy `always` short-circuits the event check and always routes to `synthesize`.
+
+**How to trigger:** `exarchos_orchestrate finalize_oneshot { featureId }` — this is the only way to exit `implementing`. The handler evaluates the choice state and calls `handleSet` with the correct target phase. The HSM re-evaluates the guard at the transition boundary, so any race between read and transition is caught safely.
+
+**No compound state.** Oneshot has no multi-agent loop, no review-fix cycle, and therefore no circuit breaker. If the in-session TDD loop gets stuck, cancel via `exarchos_workflow cancel` and restart with a different approach (or escalate to the full `feature` workflow).
+
+See `@skills/oneshot-workflow/SKILL.md` for the full prose walkthrough including worked examples.
+
 ## Circuit Breaker
 
 Compound states enforce a maximum number of fix cycles to prevent infinite review-fix loops. When the limit is exceeded, the HSM rejects the transition with a `CIRCUIT_OPEN` error and emits a `workflow.circuit-open` event.

--- a/skills/opencode/cleanup/SKILL.md
+++ b/skills/opencode/cleanup/SKILL.md
@@ -15,6 +15,12 @@ metadata:
 
 Resolve merged workflows to `completed` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
 
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use `@skills/prune-workflows/SKILL.md`. That skill invokes `exarchos_orchestrate prune_stale_workflows` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → `completed`); prune is bulk (N inactive workflows → `cancelled`). They are complementary, not alternatives.
+
 ## Triggers
 
 Activate this skill when:

--- a/skills/opencode/delegation/SKILL.md
+++ b/skills/opencode/delegation/SKILL.md
@@ -20,6 +20,8 @@ Activate this skill when:
 - Implementation plan is ready with extractable tasks
 - User wants to parallelize work across subagents
 
+**Exception — oneshot workflows skip delegation entirely.** The oneshot playbook runs an in-session TDD loop in the main agent's context, with no subagent dispatch or review phase. If `workflowType === "oneshot"`, do not call this skill — see `@skills/oneshot-workflow/SKILL.md` for the lightweight path.
+
 ## Core Principles
 
 ### Fresh Context Per Task (MANDATORY)

--- a/skills/opencode/oneshot-workflow/SKILL.md
+++ b/skills/opencode/oneshot-workflow/SKILL.md
@@ -12,8 +12,8 @@ metadata:
 # Oneshot Workflow Skill
 
 A lean, four-phase workflow type for changes that are too small to justify the
-full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
-still deserve event-sourced auditability and a planning step. The workflow is
+full `feature` flow (`ideate → plan → plan-review → delegate → review → synthesize → completed`)
+but still deserve event-sourced auditability and a planning step. The workflow is
 **direct-commit by default** with an opt-in PR path; the choice between the
 two is resolved at the end of `implementing` via a pure event-sourced guard,
 not a heuristic.
@@ -88,7 +88,7 @@ and overrides runtime signal.
 
 ## Lifecycle
 
-```
+```text
      plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
                                  │
                                  └── [synthesisOptedIn]  ──► synthesize ──► completed
@@ -286,7 +286,7 @@ do not exist in the oneshot playbook. The PR review is the only review.
 
 ### Example A — Direct-commit (default `on-request` policy, no opt-in)
 
-```
+```text
 User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
        Use oneshot."
 
@@ -317,7 +317,7 @@ Agent:
 
 ### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
 
-```
+```text
 User: "Add input validation to the parseConfig helper. Oneshot."
 
 Agent:
@@ -347,7 +347,7 @@ Agent:
 
 ### Example C — `synthesisPolicy: 'always'` (PR mandatory)
 
-```
+```text
 User: "I want a PR for any change to the auth module, even small ones.
        Use oneshot but always make a PR."
 

--- a/skills/opencode/oneshot-workflow/SKILL.md
+++ b/skills/opencode/oneshot-workflow/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: oneshot-workflow
+description: "Lightweight workflow for straightforward changes — plan → implement → optional PR. Direct-commit by default; synthesize is opt-in via synthesisPolicy or a runtime request_synthesize event. Use for trivial fixes, config tweaks, single-file changes, or exploratory work that doesn't warrant subagent dispatch or two-stage review. Triggers: 'oneshot', 'quick fix', 'small change', or /oneshot."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: plan
+---
+
+# Oneshot Workflow Skill
+
+A lean, four-phase workflow type for changes that are too small to justify the
+full `feature` flow (`ideate → plan → delegate → review → synthesize`) but
+still deserve event-sourced auditability and a planning step. The workflow is
+**direct-commit by default** with an opt-in PR path; the choice between the
+two is resolved at the end of `implementing` via a pure event-sourced guard,
+not a heuristic.
+
+> **Read this first if you have never run a oneshot:** the workflow has a
+> *choice state* at the end of `implementing`. Whether you land on
+> `completed` (direct commit) or transition through `synthesize` (PR) is
+> decided by two inputs: the `synthesisPolicy` set at init, and whether the
+> user emitted a `synthesize.requested` event during implementing. Both
+> inputs are persisted; the decision is replay-safe.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically a single file, or a tightly-coupled
+  cluster of 2-3 files
+- No subagent dispatch is needed — the work fits comfortably in one TDD
+  loop in a single session
+- No design document is required — the goal is obvious from the task
+  description, and a one-page plan is enough scaffolding
+- No two-stage review is required — either the change is trivial enough
+  that direct-commit is acceptable, or a single PR review will suffice
+
+Concrete examples that fit oneshot:
+- Fixing a typo in a README
+- Bumping a dependency version
+- Adding a missing null-check in one function
+- Tweaking a CI workflow YAML
+- Renaming a config key everywhere it's referenced
+- Adding a one-off helper script
+- Exploratory spikes that may or may not be kept
+
+## When NOT to use oneshot
+
+Do not use oneshot for any of the following — use the full `feature`
+workflow instead (`/ideate`):
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+- Anything where you'd want a written design doc to look back at
+
+If you start a oneshot and discover the change is bigger than expected, the
+right move is `/cancel` and restart with `/ideate`.
+Don't try to grow a oneshot into a feature workflow mid-stream; the
+playbooks have different shapes and you'll fight the state machine.
+
+## Synthesis policy — three options
+
+The `synthesisPolicy` field on a oneshot workflow declares the user's
+intent up front about whether the change should be turned into a PR. It
+takes one of three values, persisted on `state.oneshot.synthesisPolicy`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| `always` | Always transition `implementing → synthesize` at finalize, regardless of events. A PR is always created. | The user wants a paper trail / review for every change in this workflow, even small ones. |
+| `never` | Always transition `implementing → completed` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | The user is iterating on personal/scratch work and explicitly opts out of PRs. |
+| `on-request` *(default)* | Direct-commit by default. The user can opt in to a PR mid-implementing by calling `request_synthesize`; if any `synthesize.requested` event is on the stream at finalize, the workflow transitions to `synthesize` instead of `completed`. | The common case: start with the assumption of direct-commit, but leave the door open for the user to change their mind once they see the diff. |
+
+The default is `on-request` because it's the least surprising: the user
+gets the lightweight path until they explicitly ask for the heavy one.
+
+**Policy wins over event.** If `synthesisPolicy: 'never'` is set and a
+`synthesize.requested` event is somehow on the stream (e.g. the user
+called the action on a workflow they thought was `on-request`), the
+guard still routes to `completed`. Policy is the user's declared intent
+and overrides runtime signal.
+
+## Lifecycle
+
+```
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+```
+
+Four phases. The fork after `implementing` is a UML *choice state*,
+implemented via two mutually-exclusive HSM transitions whose guards are
+pure functions of `state.oneshot.synthesisPolicy` and the
+`synthesize.requested` event count.
+
+| Phase | What happens | Exit criteria |
+|---|---|---|
+| `plan` | Lightweight one-page plan: goal, approach, files to touch, tests to add. No design doc. No subagent dispatch. | `artifacts.plan` set → transition to `implementing` |
+| `implementing` | In-session TDD loop. Write a failing test, make it pass, refactor. Commit as you go. The TDD iron law applies — *no production code without a failing test first*. | Tests pass + typecheck clean + finalize_oneshot called |
+| `synthesize` | Reached **only** when `synthesisOptedIn` is true. Hands off to the existing synthesis flow — see `@skills/synthesis/SKILL.md`. PR created via `gh pr create`, auto-merge enabled, CI gates apply. | PR merged → `completed` |
+| `completed` | Terminal. For direct-commit path, commits are already on the branch — there's nothing more to do. For synthesize path, the PR merge event terminates the workflow. | — |
+
+`cancelled` is also reachable from any phase via the universal cancel
+transition, same as every other workflow type.
+
+## Step-by-step
+
+### Step 1 — Init
+
+Call `exarchos_workflow` with `action: 'init'`, `workflowType: 'oneshot'`,
+and an optional `synthesisPolicy`:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "init",
+  featureId: "fix-readme-typo",
+  workflowType: "oneshot",
+  synthesisPolicy: "on-request" // optional — defaults to 'on-request'
+})
+```
+
+If the user has been clear up front ("I want a PR for this"), pass
+`synthesisPolicy: "always"`. If they've been clear ("don't open a PR,
+just commit it"), pass `synthesisPolicy: "never"`. Otherwise, omit the
+field and rely on the `on-request` default — you can always escalate
+later in the implementing phase.
+
+The init returns the new workflow state; the workflow lands in `plan`.
+
+### Step 2 — Plan phase
+
+Produce a one-page plan. This is intentionally lightweight — no design
+doc, no parallelization analysis, no decomposition into N tasks. The
+plan should answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to `implementing` in a single set call:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "fix-readme-typo",
+  updates: {
+    "artifacts": { "plan": "<plan text>" },
+    "oneshot": { "planSummary": "<one-line summary>" },
+    "phase": "implementing"
+  }
+})
+```
+
+The plan goes on `artifacts.plan` for parity with the `feature` workflow;
+the human-readable one-liner goes on `oneshot.planSummary` for the
+pipeline view.
+
+### Step 3 — Implementing phase
+
+Run an in-session TDD loop. Same iron law as every other workflow:
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run the test. Confirm it fails for
+   the right reason.
+2. **[GREEN]** Write the minimum production code to make the test pass.
+   Run the test. Confirm it passes.
+3. **[REFACTOR]** Clean up while keeping the test green.
+
+Commit each red-green-refactor cycle as a single commit. Do not batch
+multiple unrelated changes into one commit — keeping commits atomic
+matters even more in oneshot, where there's no separate review phase
+to catch bundled changes.
+
+There is **no subagent dispatch** in oneshot. The main agent does the
+work directly. There is **no separate review phase**. Quality is
+maintained by the TDD loop and (if the user opts in) the synthesize PR
+review.
+
+#### Mid-implementing: opting in to a PR
+
+If at any point during implementing the user decides they want a PR
+after all (policy is `on-request`, default), they can opt in by calling
+the `request_synthesize` orchestrate action:
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+```
+
+**The trigger for this is conversational, not a magic keyword.** Listen
+for phrases like:
+- "actually, let's open a PR for this"
+- "I want a review on this before it lands"
+- "make this a PR"
+- "let's get eyes on this"
+- "synthesize this"
+
+When you hear any of those, call `request_synthesize` immediately. The
+handler appends a `synthesize.requested` event to the workflow's event
+stream; the `synthesisOptedIn` guard reads the stream at finalize and
+routes accordingly. This is **idempotent** — calling
+`request_synthesize` twice appends two events but the guard treats any
+count >= 1 as "opted in", so duplicate calls are benign.
+
+Calling `request_synthesize` does **not** transition the phase. The
+workflow stays in `implementing`. The decision is only acted on when
+you call `finalize_oneshot` in step 4.
+
+### Step 4 — Finalize (the choice point)
+
+When the implementing loop is done — tests pass, typecheck clean, all
+commits made — call `finalize_oneshot` to resolve the choice state:
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+```
+
+The handler:
+
+1. Reads the current state and verifies `workflowType === 'oneshot'` and
+   `phase === 'implementing'`.
+2. Hydrates `_events` from the event store so the guard sees the same
+   view the HSM will see during the actual transition.
+3. Evaluates `guards.synthesisOptedIn` against the state. The guard
+   inspects `state.oneshot.synthesisPolicy` and the `_events` array.
+4. Calls `handleSet` with the resolved target phase (`synthesize` or
+   `completed`). The HSM re-evaluates the guard at the transition
+   boundary, so any race between the read and the transition is caught
+   safely.
+
+Possible outcomes:
+
+| `synthesisPolicy` | `synthesize.requested` event present? | Resolved target | Path |
+|---|---|---|---|
+| `always` | (any) | `synthesize` | PR path |
+| `never` | (any) | `completed` | direct-commit path |
+| `on-request` (default) | yes | `synthesize` | PR path |
+| `on-request` (default) | no | `completed` | direct-commit path |
+
+### Step 5a — Direct-commit path (terminal)
+
+If finalize resolved to `completed`, you're done. The commits made
+during implementing are already on the current branch. Push them if
+they aren't already pushed:
+
+```bash
+git push
+```
+
+The workflow is now in `completed` and will not appear in the default
+pipeline view.
+
+### Step 5b — Synthesize path
+
+If finalize resolved to `synthesize`, hand off to the standard synthesis
+flow — see `@skills/synthesis/SKILL.md`. The same `prepare_synthesis` /
+`validate_pr_body` / `gh pr create` machinery used by the `feature`
+workflow applies. After the PR merges, the workflow transitions
+`synthesize → completed` via the existing `mergeVerified` guard, same as
+every other workflow type.
+
+You do **not** need to run `/delegate` or
+`/review` for an opt-in oneshot synthesize. Those phases
+do not exist in the oneshot playbook. The PR review is the only review.
+
+## Example invocations
+
+### Example A — Direct-commit (default `on-request` policy, no opt-in)
+
+```
+User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
+       Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
+  2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  4. [RED] writes test that greps README for 'recieve' and expects 0 matches
+        — fails (1 match exists)
+  5. [GREEN] edits README, fixes typo
+        — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+```
+
+### Example B — Mid-implementing opt-in (`on-request` → user changes mind)
+
+```
+User: "Add input validation to the parseConfig helper. Oneshot."
+
+Agent:
+  1. exarchos_workflow init { workflowType: "oneshot" }
+     → 'plan' phase, default 'on-request'
+  2. plans (goal: validate input, files: [parser.ts, parser.test.ts])
+  3. transitions to 'implementing'
+  4. [RED] writes test for null-input case
+  5. [GREEN] adds null check
+  6. [REFACTOR] extracts validateInput helper
+  7. commits
+
+User: "Actually, this is touching the parser — I want a review on it before
+       it lands."
+
+Agent:
+  8. exarchos_orchestrate request_synthesize {
+       featureId, reason: "user requested review of parser changes"
+     }
+     → appends synthesize.requested event
+  9. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='on-request' + 1 synthesize.requested event
+     → resolves to 'synthesize'
+ 10. hands off to @skills/synthesis/SKILL.md → prepare_synthesis →
+     validate_pr_body → gh pr create → merge
+```
+
+### Example C — `synthesisPolicy: 'always'` (PR mandatory)
+
+```
+User: "I want a PR for any change to the auth module, even small ones.
+       Use oneshot but always make a PR."
+
+Agent:
+  1. exarchos_workflow init {
+       workflowType: "oneshot",
+       synthesisPolicy: "always"
+     }
+  2-7. plan + TDD + commits, identical to Example A
+  8. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='always' (short-circuits — no event check needed)
+     → resolves to 'synthesize'
+  9. synthesis flow → PR
+```
+
+## State management
+
+Track oneshot-specific state under the `oneshot` key on the workflow state:
+
+```typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "<id>",
+  updates: {
+    "oneshot": {
+      "synthesisPolicy": "on-request",
+      "planSummary": "Fix off-by-one in pagination helper"
+    }
+  }
+})
+```
+
+The `synthesisPolicy` field is optional and defaults to `'on-request'` per
+the schema in `servers/exarchos-mcp/src/workflow/schemas.ts`. Setting it
+explicitly is recommended when the user has stated a preference.
+
+## Phase Transitions and Guards
+
+For the full transition table for oneshot, consult
+`@skills/workflow-state/references/phase-transitions.md`.
+
+**Quick reference for oneshot:**
+
+| From | To | Guard |
+|---|---|---|
+| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `implementing` | `synthesize` | `synthesisOptedIn` |
+| `implementing` | `completed` | `synthesisOptedOut` |
+| `synthesize` | `completed` | `mergeVerified` |
+| (any) | `cancelled` | universal — always allowed |
+
+`synthesisOptedIn` and `synthesisOptedOut` are pure functions of
+`state.oneshot.synthesisPolicy` and `state._events`. They are mutually
+exclusive across all 8 (3 policies × event-present/absent, with `always`
+and `never` ignoring the event flag) combinations — exactly one returns
+true at any given time.
+
+### Schema discovery
+
+Use `exarchos_workflow({ action: "describe", actions: ["init", "set"] })`
+for parameter schemas (including the `synthesisPolicy` enum) and
+`exarchos_workflow({ action: "describe", playbook: "oneshot" })` for the
+phase transitions, guard names, and playbook prose. Use
+`exarchos_orchestrate({ action: "describe", actions: ["request_synthesize", "finalize_oneshot"] })`
+for the orchestrate action schemas.
+
+## TDD is still mandatory
+
+The iron law from `@rules/tdd.md` applies to oneshot. There is no
+exemption for "small" changes. Specifically:
+
+- Every behavior change starts with a failing test
+- Every test must fail before its implementation is written
+- Tests must be run after each change to verify state
+- Commits stay atomic — one logical change per commit
+
+The temptation in a oneshot is to skip the test "because it's just one
+line". Resist that. The test is what makes the change auditable, and
+auditability is the entire reason oneshot exists alongside the lighter
+"bypass workflows entirely" path.
+
+## Anti-patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip the plan phase ("it's obvious") | Write the four-line plan anyway — it's the artifact future-you reads |
+| Skip the TDD loop in implementing | Always RED → GREEN → REFACTOR, even for one-liners |
+| Use oneshot for multi-file refactors | Use `/ideate` and the full feature workflow |
+| Try to grow a oneshot into a feature workflow mid-stream | Cancel and restart with `/ideate` |
+| Call `request_synthesize` without listening for the user's intent | Wait for the user to ask for a PR, then call it |
+| Bundle unrelated changes into one commit "since it's a oneshot" | Keep commits atomic — there's no review phase to catch bundling |
+| Forget to call `finalize_oneshot` at the end | The workflow stays in `implementing` forever otherwise — call it explicitly |
+
+## Completion criteria
+
+- [ ] `exarchos_workflow init` called with `workflowType: "oneshot"`
+- [ ] One-page plan persisted to `artifacts.plan`
+- [ ] Phase transitioned to `implementing`
+- [ ] All planned behaviors implemented via TDD with atomic commits
+- [ ] `finalize_oneshot` called and resolved to either `completed` or `synthesize`
+- [ ] If direct-commit path: commits pushed
+- [ ] If synthesize path: PR created via `@skills/synthesis/SKILL.md` and merged

--- a/skills/opencode/oneshot-workflow/SKILL.md
+++ b/skills/opencode/oneshot-workflow/SKILL.md
@@ -214,13 +214,22 @@ for phrases like:
 When you hear any of those, call `request_synthesize` immediately. The
 handler appends a `synthesize.requested` event to the workflow's event
 stream; the `synthesisOptedIn` guard reads the stream at finalize and
-routes accordingly. This is **idempotent** — calling
-`request_synthesize` twice appends two events but the guard treats any
-count >= 1 as "opted in", so duplicate calls are benign.
+routes accordingly.
+
+`request_synthesize` is accepted from both `plan` and `implementing`
+phases — call it whenever you know you want the PR path, even before
+`implementing` starts. Terminal phases (`synthesize`, `completed`,
+`cancelled`) are rejected.
+
+Duplicate calls are **routing-idempotent** but not event-idempotent:
+each call appends a new `synthesize.requested` event, but the guard
+treats any count >= 1 as "opted in", so the routing decision is the
+same whether you call once or five times. The event stream will
+contain each duplicate for audit purposes.
 
 Calling `request_synthesize` does **not** transition the phase. The
-workflow stays in `implementing`. The decision is only acted on when
-you call `finalize_oneshot` in step 4.
+workflow stays in its current phase. The decision is only acted on
+when you call `finalize_oneshot` in step 4.
 
 ### Step 4 — Finalize (the choice point)
 
@@ -393,7 +402,7 @@ For the full transition table for oneshot, consult
 
 | From | To | Guard |
 |---|---|---|
-| `plan` | `implementing` | `planApproved` (or `oneshotPlanSet`, checks `artifacts.plan` presence) |
+| `plan` | `implementing` | `oneshotPlanSet` (requires non-empty `artifacts.plan`) |
 | `implementing` | `synthesize` | `synthesisOptedIn` |
 | `implementing` | `completed` | `synthesisOptedOut` |
 | `synthesize` | `completed` | `mergeVerified` |
@@ -401,9 +410,10 @@ For the full transition table for oneshot, consult
 
 `synthesisOptedIn` and `synthesisOptedOut` are pure functions of
 `state.oneshot.synthesisPolicy` and `state._events`. They are mutually
-exclusive across all 8 (3 policies × event-present/absent, with `always`
-and `never` ignoring the event flag) combinations — exactly one returns
-true at any given time.
+exclusive across all 4 meaningful combinations — `always` and `never`
+each map to one outcome (ignoring the event flag), and `on-request`
+branches on whether a `synthesize.requested` event is present or
+absent. Exactly one guard returns true at any given time.
 
 ### Schema discovery
 

--- a/skills/opencode/oneshot-workflow/SKILL.md
+++ b/skills/opencode/oneshot-workflow/SKILL.md
@@ -189,11 +189,11 @@ work directly. There is **no separate review phase**. Quality is
 maintained by the TDD loop and (if the user opts in) the synthesize PR
 review.
 
-#### Mid-implementing: opting in to a PR
+#### Mid-workflow: opting in to a PR
 
-If at any point during implementing the user decides they want a PR
-after all (policy is `on-request`, default), they can opt in by calling
-the `request_synthesize` orchestrate action:
+If at any point during `plan` or `implementing` the user decides they
+want a PR after all (policy is `on-request`, default), they can opt in
+by calling the `request_synthesize` orchestrate action:
 
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
@@ -397,6 +397,12 @@ explicitly is recommended when the user has stated a preference.
 
 For the full transition table for oneshot, consult
 `@skills/workflow-state/references/phase-transitions.md`.
+
+> **Note:** The engine's `exarchos_workflow describe playbook="oneshot"`
+> output and the HSM definitions in `hsm-definitions.ts` are the
+> canonical sources for transition behavior. `phase-transitions.md` is
+> a prose reference that can drift — when discrepancies arise, prefer
+> engine `describe` output.
 
 **Quick reference for oneshot:**
 

--- a/skills/opencode/oneshot-workflow/SKILL.md
+++ b/skills/opencode/oneshot-workflow/SKILL.md
@@ -144,23 +144,26 @@ plan should answer four questions in 5-10 lines each:
 3. **Files** — which files will be touched? (1-5 typically)
 4. **Tests** — which test cases will be added? (named, not described)
 
-Persist the plan and transition to `implementing` in a single set call:
+Persist the plan and transition to `implementing` in a single set call.
+`phase` is a top-level argument of `set`, not a field inside `updates`:
 
 ```typescript
 mcp__exarchos__exarchos_workflow({
   action: "set",
   featureId: "fix-readme-typo",
+  phase: "implementing",
   updates: {
-    "artifacts": { "plan": "<plan text>" },
-    "oneshot": { "planSummary": "<one-line summary>" },
-    "phase": "implementing"
+    "artifacts.plan": "<plan text>",
+    "oneshot.planSummary": "<one-line summary>"
   }
 })
 ```
 
 The plan goes on `artifacts.plan` for parity with the `feature` workflow;
 the human-readable one-liner goes on `oneshot.planSummary` for the
-pipeline view.
+pipeline view. Only `artifacts.plan` is enforced by the
+`oneshot-plan-set` guard — `planSummary` is an optional pipeline-view
+label and is not a substitute for a real plan artifact.
 
 ### Step 3 — Implementing phase
 
@@ -292,7 +295,14 @@ Agent:
      → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
   2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
      tests=[readme has no occurrence of 'recieve']
-  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",                   // top-level
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "..."
+       }
+     }
   4. [RED] writes test that greps README for 'recieve' and expects 0 matches
         — fails (1 match exists)
   5. [GREEN] edits README, fixes typo

--- a/skills/opencode/oneshot-workflow/references/choice-state.md
+++ b/skills/opencode/oneshot-workflow/references/choice-state.md
@@ -1,0 +1,65 @@
+---
+name: oneshot-choice-state
+---
+
+# Oneshot Choice State: `implementing → ?`
+
+The oneshot workflow has a UML *choice state* at the end of `implementing`.
+Whether the workflow lands on `completed` (direct-commit) or transitions
+through `synthesize` (PR) is decided by two mutually-exclusive pure-function
+guards: `synthesisOptedIn` and `synthesisOptedOut`. Both are evaluated against
+the current workflow state at the transition boundary; exactly one returns
+`true` for every possible input.
+
+## Inputs read by the guards
+
+Both guards read exactly two things from state:
+
+1. `state.oneshot.synthesisPolicy` — one of `'always' | 'never' | 'on-request'`,
+   defaulted to `'on-request'` by the init schema.
+2. `state._events` — the hydrated event stream. The guard counts
+   `synthesize.requested` events on the stream (any count ≥ 1 means "opted in").
+
+Nothing else. No clock reads, no filesystem, no network, no git state. This
+is load-bearing for replay safety: given the same persisted state, the same
+target resolves every time, and re-running finalize is idempotent.
+
+## Decision table
+
+| `synthesisPolicy` | `synthesize.requested` count | `synthesisOptedIn` | `synthesisOptedOut` | Resolved target |
+|---|---|---|---|---|
+| `'always'`     | 0  | `true`  | `false` | `synthesize` |
+| `'always'`     | ≥1 | `true`  | `false` | `synthesize` |
+| `'never'`      | 0  | `false` | `true`  | `completed`  |
+| `'never'`      | ≥1 | `false` | `true`  | `completed`  |
+| `'on-request'` | 0  | `false` | `true`  | `completed`  |
+| `'on-request'` | ≥1 | `true`  | `false` | `synthesize` |
+
+**Policy wins over event.** On `'never'`, even if a stray `synthesize.requested`
+event is on the stream, the guard still routes to `completed`. Policy is the
+user's declared intent; runtime events only matter when the policy explicitly
+defers to them (`'on-request'`).
+
+## Why a choice state, not a single transition with branching logic
+
+Keeping the fork at the HSM level (two transitions, two mutually-exclusive
+guards) means:
+
+- The state machine graph visibly encodes both paths — operators reading
+  `hsm-definitions.ts` see `implementing → completed` and `implementing →
+  synthesize` as sibling transitions, not a hidden conditional.
+- The HSM re-evaluates guards at the transition boundary, so any race
+  between `finalize_oneshot` reading state and `handleSet` performing the
+  transition is caught safely — if a last-millisecond event changed the
+  evaluation, the HSM will refuse the wrong transition.
+- Guard logic stays testable in isolation (`guards.test.ts`) without
+  needing to spin up the handler.
+
+## See also
+
+- `servers/exarchos-mcp/src/workflow/guards.ts` — `synthesisOptedIn`,
+  `synthesisOptedOut`, `oneshotPlanSet` guard implementations.
+- `servers/exarchos-mcp/src/workflow/hsm-definitions.ts` — the oneshot HSM
+  with the two sibling transitions from `implementing`.
+- `servers/exarchos-mcp/src/orchestrate/finalize-oneshot.ts` — the handler
+  that resolves the choice state and calls `handleSet`.

--- a/skills/opencode/prune-workflows/SKILL.md
+++ b/skills/opencode/prune-workflows/SKILL.md
@@ -19,9 +19,9 @@ Pruning is a maintenance operation -- not a workflow phase. It produces `workflo
 ## Triggers
 
 Activate this skill when:
-- User runs `{{COMMAND_PREFIX}}prune` command
+- User runs `/prune` command
 - User says "prune workflows", "clean stale workflows", "pipeline cleanup"
-- `{{MCP_PREFIX}}exarchos_view({ action: "pipeline" })` shows many inactive workflows the user wants to clear in bulk
+- `mcp__exarchos__exarchos_view({ action: "pipeline" })` shows many inactive workflows the user wants to clear in bulk
 
 ## Prerequisites
 
@@ -36,7 +36,7 @@ Activate this skill when:
 Always start with `dryRun: true`. This call performs candidate selection and safeguard evaluation but does not mutate any workflow state.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: true
@@ -104,7 +104,7 @@ Wait for explicit user input. Do **not** auto-proceed.
 On `proceed`, invoke the same action with `dryRun: false`. Pass through `thresholdMinutes` and `includeOneShot` if the user set them in Step 1.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: false
@@ -131,7 +131,7 @@ Each entry in `pruned` corresponds to a workflow that transitioned to `cancelled
 On `force`, set `force: true`. Safeguards are bypassed but the bypass is recorded in the `workflow.pruned` event payload as `skippedSafeguards: [...]` so the audit trail is intact.
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "prune_stale_workflows",
   args: {
     dryRun: false,
@@ -199,7 +199,7 @@ A workflow without a `branchName` in state (e.g., abandoned at ideate/plan befor
 ### Example 1: Clean dry-run, user proceeds
 
 ```
-> {{COMMAND_PREFIX}}prune
+> /prune
 
 ## Prune Candidates (2)
 
@@ -230,7 +230,7 @@ Proceed? (proceed/abort/force)
 ### Example 2: Safeguard skip, user forces
 
 ```
-> {{COMMAND_PREFIX}}prune
+> /prune
 
 ## Prune Candidates (1)
 
@@ -265,7 +265,7 @@ Proceed? (proceed/abort/force)
 ### Example 3: Empty pipeline
 
 ```
-> {{COMMAND_PREFIX}}prune
+> /prune
 
 No stale workflows to prune. Pipeline is clean.
 ```
@@ -275,7 +275,7 @@ No stale workflows to prune. Pipeline is clean.
 For the canonical argument schema and any future fields, use:
 
 ```typescript
-{{MCP_PREFIX}}exarchos_orchestrate({
+mcp__exarchos__exarchos_orchestrate({
   action: "describe",
   actions: ["prune_stale_workflows"]
 })

--- a/skills/opencode/prune-workflows/references/safeguards.md
+++ b/skills/opencode/prune-workflows/references/safeguards.md
@@ -1,0 +1,74 @@
+---
+name: prune-safeguards
+---
+
+# Prune Safeguards
+
+The `prune_stale_workflows` orchestrate action runs two safeguards on each
+candidate before it will actually cancel the workflow. Both must pass for
+the candidate to be pruned, unless the caller passes `force: true` to
+bypass them.
+
+## Safeguard 1: `hasOpenPR`
+
+Checks whether there's an open pull request targeting the workflow's
+branch. Implementation: `gh pr list --state open --head <branchName>` —
+if the list is non-empty, the safeguard fails and the candidate is
+skipped with reason `open-pr`.
+
+Rationale: an open PR means human work is still in-flight on this feature.
+Cancelling the workflow would orphan the PR from its event-sourced state,
+which makes it invisible to `exarchos_view` and breaks auto-merge gates.
+We refuse to prune workflows with open PRs by default.
+
+## Safeguard 2: `hasRecentCommits` (user-facing: `active-branch`)
+
+Checks whether any commits landed on the workflow's branch within a
+24-hour window. Implementation: `git log --since="24 hours ago"
+<branchName>` — if the output is non-empty, the safeguard fails and the
+candidate is skipped with reason `active-branch`.
+
+Rationale: commits on the branch mean the workflow isn't actually stale,
+it just missed the last event checkpoint. The underlying branch is the
+ground truth for "is this work still alive?" — if someone is committing,
+we don't care what the checkpoint timestamp says.
+
+The window is locked at 24 hours for v1. It's exposed as a module
+constant (`RECENT_COMMITS_WINDOW_HOURS` in `prune-stale-workflows.ts`)
+so tests can see the contract, but it's not yet configurable through
+the public handler args.
+
+## Short-circuit: missing `branchName`
+
+If the workflow state has no top-level `branchName` field, both
+safeguards are skipped entirely (they have nothing to look up). The
+candidate still proceeds to cancel. This is safe because a workflow
+without a branch can't have an open PR or recent commits by definition.
+
+## `force: true` bypass semantics
+
+Passing `force: true` skips safeguard evaluation for every candidate.
+The handler still does everything else — the cancel, the event emission,
+the audit trail — but `hasOpenPR` and `hasRecentCommits` are never
+called.
+
+Every `workflow.pruned` event emitted during a `force: true` run carries
+a `skippedSafeguards: ['open-pr', 'active-branch']` marker on its payload.
+This makes forced prunes distinguishable in the audit stream from
+safeguard-approved ones, so operators reviewing the event log can see
+exactly which workflows were cancelled despite having open PRs or active
+branches.
+
+The marker list is intentionally hardcoded to *all* safeguards, not just
+the ones that would have failed. Running `force: true` is a blanket
+"I know what I'm doing" override — we want the audit trail to reflect
+that the user chose to bypass the whole safeguard layer, not to imply
+selective bypassing.
+
+## See also
+
+- `servers/exarchos-mcp/src/orchestrate/prune-safeguards.ts` — the
+  default implementations (gh/git backends) and the `PruneSafeguards`
+  interface for DI.
+- `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts` —
+  the handler that composes safeguards with selection and cancel.

--- a/skills/opencode/shepherd/SKILL.md
+++ b/skills/opencode/shepherd/SKILL.md
@@ -21,6 +21,10 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Pipeline Hygiene
+
+When `mcp__exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:

--- a/skills/opencode/synthesis/SKILL.md
+++ b/skills/opencode/synthesis/SKILL.md
@@ -22,12 +22,22 @@ Submit stacked PRs after review phase completes. The `prepare_synthesis` composi
 
 Do NOT proceed if either review is incomplete or failed -- return to `/review` first.
 
+**Entry points:** Synthesis is normally reached from the `review` phase of
+feature / debug / refactor workflows. It is also reachable from `oneshot`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during `plan` or `implementing`, the `request_synthesize` event is
+appended, and `finalize_oneshot` then resolves the choice state and
+transitions the workflow to `synthesize`. See
+`@skills/oneshot-workflow/SKILL.md` for the opt-in mechanics and
+`synthesisPolicy` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs `/synthesize` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to `synthesize` via `finalize_oneshot`
 
 ## Process
 

--- a/skills/opencode/workflow-state/SKILL.md
+++ b/skills/opencode/workflow-state/SKILL.md
@@ -38,7 +38,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use `exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })` for
 parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its `implementing → synthesize|completed` choice state
+driven by `synthesisPolicy`), call `exarchos_workflow({ action: "describe", playbook: "oneshot" })`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 `exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })`
 for event data schemas.
 
@@ -126,6 +129,23 @@ exarchos_orchestrate({
 | Review complete | Update `reviews` object |
 | PR created | Set `artifacts.pr`, `synthesis.prUrl` |
 | PR feedback | Append to `synthesis.prFeedback` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| `plan` (oneshot) | `oneshot.planSummary`, `artifacts.plan`, optional `oneshot.synthesisPolicy` | `workflow.transition` |
+| `implementing` (oneshot) | `tasks[].status`, `artifacts.tests` | `task.*`, optional `synthesize.requested` (via `request_synthesize`) |
+| `synthesize` (oneshot) | `synthesis.prUrl`, `artifacts.pr` | `workflow.transition`, `stack.submitted` |
+| `completed` (oneshot) | — | `workflow.transition` (to `completed`) |
+
+The `implementing → synthesize | completed` fork is a choice state resolved
+by `finalize_oneshot`, which reads the `synthesisOptedIn` guard
+(`synthesisPolicy` + `synthesize.requested` events). See
+`@skills/oneshot-workflow/SKILL.md` for the full opt-in mechanics.
 
 ### Automatic State Updates
 

--- a/skills/opencode/workflow-state/SKILL.md
+++ b/skills/opencode/workflow-state/SKILL.md
@@ -60,7 +60,13 @@ At the start of `/ideate`, use `mcp__exarchos__exarchos_workflow` with `action: 
 - `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
 - `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+`workflowType`:
+
+- `feature` → starts in `ideate`
+- `debug` → starts in `triage`
+- `refactor` → starts in `explore`
+- `oneshot` → starts in `plan` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 

--- a/skills/opencode/workflow-state/SKILL.md
+++ b/skills/opencode/workflow-state/SKILL.md
@@ -54,9 +54,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see `references
 
 At the start of `/ideate`, use `mcp__exarchos__exarchos_workflow` with `action: "init"` with:
 - `featureId`: the workflow identifier (e.g., `"user-authentication"`)
-- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`
+- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
+- `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- `feature` — full `ideate → plan → delegate → review → synthesize` for real features with subagent dispatch and two-stage review
+- `debug` — `triage → investigate → (thorough | hotfix)` for bug workflows with track selection
+- `refactor` — `explore → brief → (polish | overhaul)` for code improvements, polish for small and overhaul for multi-task
+- `oneshot` — `plan → implementing → (completed | synthesize)` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by `synthesisPolicy` and the `synthesize.requested` event
+
+See `@skills/oneshot-workflow/SKILL.md` for the lightweight variant's full prose, including the choice-state mechanics and `finalize_oneshot` trigger.
 
 ### Read State
 
@@ -154,7 +164,7 @@ See `docs/schemas/workflow-state.schema.json` for full schema.
 Key sections:
 - `version`: Schema version (currently "1.1")
 - `featureId`: Unique workflow identifier
-- `workflowType`: Required. One of "feature", "debug", or "refactor"
+- `workflowType`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - `phase`: Current workflow phase
 - `artifacts`: Paths to design, plan, PR
 - `tasks`: Task list with status

--- a/skills/opencode/workflow-state/references/phase-transitions.md
+++ b/skills/opencode/workflow-state/references/phase-transitions.md
@@ -127,7 +127,7 @@ plan → implementing ─┬→ completed              (direct-commit path)
 
 | From | To | Guard | Prerequisite |
 |------|----|-------|-------------|
-| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` (non-empty string; `oneshot.planSummary` is optional metadata but does **not** satisfy the guard) |
 | `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
 | `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
 | `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |

--- a/skills/opencode/workflow-state/references/phase-transitions.md
+++ b/skills/opencode/workflow-state/references/phase-transitions.md
@@ -118,6 +118,28 @@ explore → brief → [polish-track | overhaul-track] → completed
 
 **Compound state:** `overhaul-track` contains `overhaul-plan`, `overhaul-plan-review`, `overhaul-delegate`, `overhaul-review`, and `overhaul-update-docs`. Max 3 fix cycles.
 
+## Oneshot Workflow
+
+```
+plan → implementing ─┬→ completed              (direct-commit path)
+                     └→ synthesize → completed (PR path, opt-in)
+```
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|-------------|
+| `plan` | `implementing` | `oneshot-plan-set` | Set `artifacts.plan` OR `oneshot.planSummary` |
+| `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + `synthesize.requested` event) |
+| `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no event) |
+| `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+**Choice state (end of `implementing`).** The fork after `implementing` is a UML choice state, implemented as two mutually-exclusive HSM transitions whose guards are pure functions of `state.oneshot.synthesisPolicy` and the `synthesize.requested` event count on the stream. At init, the user declares intent via `synthesisPolicy` (`always`, `never`, or `on-request` — default). During implementing, the user can opt in at any time by calling `exarchos_orchestrate request_synthesize`, which appends a `synthesize.requested` event without changing the phase. The decision is only evaluated when `finalize_oneshot` is called: the handler hydrates events, runs the guards, and calls `handleSet` with the resolved target. **Policy wins over event** — if policy is `never`, any `synthesize.requested` event is ignored and the guard routes to `completed`. Policy `always` short-circuits the event check and always routes to `synthesize`.
+
+**How to trigger:** `exarchos_orchestrate finalize_oneshot { featureId }` — this is the only way to exit `implementing`. The handler evaluates the choice state and calls `handleSet` with the correct target phase. The HSM re-evaluates the guard at the transition boundary, so any race between read and transition is caught safely.
+
+**No compound state.** Oneshot has no multi-agent loop, no review-fix cycle, and therefore no circuit breaker. If the in-session TDD loop gets stuck, cancel via `exarchos_workflow cancel` and restart with a different approach (or escalate to the full `feature` workflow).
+
+See `@skills/oneshot-workflow/SKILL.md` for the full prose walkthrough including worked examples.
+
 ## Circuit Breaker
 
 Compound states enforce a maximum number of fix cycles to prevent infinite review-fix loops. When the limit is exceeded, the HSM rejects the transition with a `CIRCUIT_OPEN` error and emits a `workflow.circuit-open` event.

--- a/test/migration/__fixtures__/batch-baselines/cleanup.md
+++ b/test/migration/__fixtures__/batch-baselines/cleanup.md
@@ -15,6 +15,12 @@ metadata:
 
 Resolve merged workflows to `completed` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
 
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use `@skills/prune-workflows/SKILL.md`. That skill invokes `exarchos_orchestrate prune_stale_workflows` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → `completed`); prune is bulk (N inactive workflows → `cancelled`). They are complementary, not alternatives.
+
 ## Triggers
 
 Activate this skill when:

--- a/test/migration/__fixtures__/batch-baselines/shepherd.md
+++ b/test/migration/__fixtures__/batch-baselines/shepherd.md
@@ -21,6 +21,10 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 ```
 
+## Pipeline Hygiene
+
+When `mcp__plugin_exarchos_exarchos__exarchos_view pipeline` accumulates stale workflows (inactive > 7 days), run `@skills/prune-workflows/SKILL.md` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:

--- a/test/migration/__fixtures__/batch-baselines/synthesis.md
+++ b/test/migration/__fixtures__/batch-baselines/synthesis.md
@@ -22,12 +22,22 @@ Submit stacked PRs after review phase completes. The `prepare_synthesis` composi
 
 Do NOT proceed if either review is incomplete or failed -- return to `/exarchos:review` first.
 
+**Entry points:** Synthesis is normally reached from the `review` phase of
+feature / debug / refactor workflows. It is also reachable from `oneshot`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during `plan` or `implementing`, the `request_synthesize` event is
+appended, and `finalize_oneshot` then resolves the choice state and
+transitions the workflow to `synthesize`. See
+`@skills/oneshot-workflow/SKILL.md` for the opt-in mechanics and
+`synthesisPolicy` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs `/exarchos:synthesize` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to `synthesize` via `finalize_oneshot`
 
 ## Process
 

--- a/test/migration/__fixtures__/batch-baselines/workflow-state.md
+++ b/test/migration/__fixtures__/batch-baselines/workflow-state.md
@@ -38,7 +38,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use `exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })` for
 parameter schemas and `exarchos_workflow({ action: "describe", playbook: "feature" })`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its `implementing → synthesize|completed` choice state
+driven by `synthesisPolicy`), call `exarchos_workflow({ action: "describe", playbook: "oneshot" })`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 `exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })`
 for event data schemas.
 
@@ -126,6 +129,23 @@ exarchos_orchestrate({
 | Review complete | Update `reviews` object |
 | PR created | Set `artifacts.pr`, `synthesis.prUrl` |
 | PR feedback | Append to `synthesis.prFeedback` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| `plan` (oneshot) | `oneshot.planSummary`, `artifacts.plan`, optional `oneshot.synthesisPolicy` | `workflow.transition` |
+| `implementing` (oneshot) | `tasks[].status`, `artifacts.tests` | `task.*`, optional `synthesize.requested` (via `request_synthesize`) |
+| `synthesize` (oneshot) | `synthesis.prUrl`, `artifacts.pr` | `workflow.transition`, `stack.submitted` |
+| `completed` (oneshot) | — | `workflow.transition` (to `completed`) |
+
+The `implementing → synthesize | completed` fork is a choice state resolved
+by `finalize_oneshot`, which reads the `synthesisOptedIn` guard
+(`synthesisPolicy` + `synthesize.requested` events). See
+`@skills/oneshot-workflow/SKILL.md` for the full opt-in mechanics.
 
 ### Automatic State Updates
 

--- a/test/migration/__fixtures__/batch-baselines/workflow-state.md
+++ b/test/migration/__fixtures__/batch-baselines/workflow-state.md
@@ -60,7 +60,13 @@ At the start of `/exarchos:ideate`, use `mcp__plugin_exarchos_exarchos__exarchos
 - `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
 - `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+`workflowType`:
+
+- `feature` → starts in `ideate`
+- `debug` → starts in `triage`
+- `refactor` → starts in `explore`
+- `oneshot` → starts in `plan` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 

--- a/test/migration/__fixtures__/batch-baselines/workflow-state.md
+++ b/test/migration/__fixtures__/batch-baselines/workflow-state.md
@@ -54,9 +54,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see `references
 
 At the start of `/exarchos:ideate`, use `mcp__plugin_exarchos_exarchos__exarchos_workflow` with `action: "init"` with:
 - `featureId`: the workflow identifier (e.g., `"user-authentication"`)
-- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`
+- `workflowType`: one of `"feature"`, `"debug"`, `"refactor"`, `"oneshot"`
+- `synthesisPolicy` *(optional, oneshot only)*: one of `"always"`, `"never"`, `"on-request"` (default `"on-request"`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- `feature` — full `ideate → plan → delegate → review → synthesize` for real features with subagent dispatch and two-stage review
+- `debug` — `triage → investigate → (thorough | hotfix)` for bug workflows with track selection
+- `refactor` — `explore → brief → (polish | overhaul)` for code improvements, polish for small and overhaul for multi-task
+- `oneshot` — `plan → implementing → (completed | synthesize)` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by `synthesisPolicy` and the `synthesize.requested` event
+
+See `@skills/oneshot-workflow/SKILL.md` for the lightweight variant's full prose, including the choice-state mechanics and `finalize_oneshot` trigger.
 
 ### Read State
 
@@ -154,7 +164,7 @@ See `docs/schemas/workflow-state.schema.json` for full schema.
 Key sections:
 - `version`: Schema version (currently "1.1")
 - `featureId`: Unique workflow identifier
-- `workflowType`: Required. One of "feature", "debug", or "refactor"
+- `workflowType`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - `phase`: Current workflow phase
 - `artifacts`: Paths to design, plan, PR
 - `tasks`: Task list with status

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -1715,8 +1715,8 @@ metadata:
 # Oneshot Workflow Skill
 
 A lean, four-phase workflow type for changes that are too small to justify the
-full \`feature\` flow (\`ideate → plan → delegate → review → synthesize\`) but
-still deserve event-sourced auditability and a planning step. The workflow is
+full \`feature\` flow (\`ideate → plan → plan-review → delegate → review → synthesize → completed\`)
+but still deserve event-sourced auditability and a planning step. The workflow is
 **direct-commit by default** with an opt-in PR path; the choice between the
 two is resolved at the end of \`implementing\` via a pure event-sourced guard,
 not a heuristic.
@@ -1791,7 +1791,7 @@ and overrides runtime signal.
 
 ## Lifecycle
 
-\`\`\`
+\`\`\`text
      plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
                                  │
                                  └── [synthesisOptedIn]  ──► synthesize ──► completed
@@ -1989,7 +1989,7 @@ do not exist in the oneshot playbook. The PR review is the only review.
 
 ### Example A — Direct-commit (default \`on-request\` policy, no opt-in)
 
-\`\`\`
+\`\`\`text
 User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
        Use oneshot."
 
@@ -2020,7 +2020,7 @@ Agent:
 
 ### Example B — Mid-implementing opt-in (\`on-request\` → user changes mind)
 
-\`\`\`
+\`\`\`text
 User: "Add input validation to the parseConfig helper. Oneshot."
 
 Agent:
@@ -2050,7 +2050,7 @@ Agent:
 
 ### Example C — \`synthesisPolicy: 'always'\` (PR mandatory)
 
-\`\`\`
+\`\`\`text
 User: "I want a PR for any change to the auth module, even small ones.
        Use oneshot but always make a PR."
 
@@ -5768,8 +5768,8 @@ metadata:
 # Oneshot Workflow Skill
 
 A lean, four-phase workflow type for changes that are too small to justify the
-full \`feature\` flow (\`ideate → plan → delegate → review → synthesize\`) but
-still deserve event-sourced auditability and a planning step. The workflow is
+full \`feature\` flow (\`ideate → plan → plan-review → delegate → review → synthesize → completed\`)
+but still deserve event-sourced auditability and a planning step. The workflow is
 **direct-commit by default** with an opt-in PR path; the choice between the
 two is resolved at the end of \`implementing\` via a pure event-sourced guard,
 not a heuristic.
@@ -5844,7 +5844,7 @@ and overrides runtime signal.
 
 ## Lifecycle
 
-\`\`\`
+\`\`\`text
      plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
                                  │
                                  └── [synthesisOptedIn]  ──► synthesize ──► completed
@@ -6042,7 +6042,7 @@ do not exist in the oneshot playbook. The PR review is the only review.
 
 ### Example A — Direct-commit (default \`on-request\` policy, no opt-in)
 
-\`\`\`
+\`\`\`text
 User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
        Use oneshot."
 
@@ -6073,7 +6073,7 @@ Agent:
 
 ### Example B — Mid-implementing opt-in (\`on-request\` → user changes mind)
 
-\`\`\`
+\`\`\`text
 User: "Add input validation to the parseConfig helper. Oneshot."
 
 Agent:
@@ -6103,7 +6103,7 @@ Agent:
 
 ### Example C — \`synthesisPolicy: 'always'\` (PR mandatory)
 
-\`\`\`
+\`\`\`text
 User: "I want a PR for any change to the auth module, even small ones.
        Use oneshot but always make a PR."
 
@@ -9813,8 +9813,8 @@ metadata:
 # Oneshot Workflow Skill
 
 A lean, four-phase workflow type for changes that are too small to justify the
-full \`feature\` flow (\`ideate → plan → delegate → review → synthesize\`) but
-still deserve event-sourced auditability and a planning step. The workflow is
+full \`feature\` flow (\`ideate → plan → plan-review → delegate → review → synthesize → completed\`)
+but still deserve event-sourced auditability and a planning step. The workflow is
 **direct-commit by default** with an opt-in PR path; the choice between the
 two is resolved at the end of \`implementing\` via a pure event-sourced guard,
 not a heuristic.
@@ -9889,7 +9889,7 @@ and overrides runtime signal.
 
 ## Lifecycle
 
-\`\`\`
+\`\`\`text
      plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
                                  │
                                  └── [synthesisOptedIn]  ──► synthesize ──► completed
@@ -10087,7 +10087,7 @@ do not exist in the oneshot playbook. The PR review is the only review.
 
 ### Example A — Direct-commit (default \`on-request\` policy, no opt-in)
 
-\`\`\`
+\`\`\`text
 User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
        Use oneshot."
 
@@ -10118,7 +10118,7 @@ Agent:
 
 ### Example B — Mid-implementing opt-in (\`on-request\` → user changes mind)
 
-\`\`\`
+\`\`\`text
 User: "Add input validation to the parseConfig helper. Oneshot."
 
 Agent:
@@ -10148,7 +10148,7 @@ Agent:
 
 ### Example C — \`synthesisPolicy: 'always'\` (PR mandatory)
 
-\`\`\`
+\`\`\`text
 User: "I want a PR for any change to the auth module, even small ones.
        Use oneshot but always make a PR."
 
@@ -13864,8 +13864,8 @@ metadata:
 # Oneshot Workflow Skill
 
 A lean, four-phase workflow type for changes that are too small to justify the
-full \`feature\` flow (\`ideate → plan → delegate → review → synthesize\`) but
-still deserve event-sourced auditability and a planning step. The workflow is
+full \`feature\` flow (\`ideate → plan → plan-review → delegate → review → synthesize → completed\`)
+but still deserve event-sourced auditability and a planning step. The workflow is
 **direct-commit by default** with an opt-in PR path; the choice between the
 two is resolved at the end of \`implementing\` via a pure event-sourced guard,
 not a heuristic.
@@ -13940,7 +13940,7 @@ and overrides runtime signal.
 
 ## Lifecycle
 
-\`\`\`
+\`\`\`text
      plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
                                  │
                                  └── [synthesisOptedIn]  ──► synthesize ──► completed
@@ -14138,7 +14138,7 @@ do not exist in the oneshot playbook. The PR review is the only review.
 
 ### Example A — Direct-commit (default \`on-request\` policy, no opt-in)
 
-\`\`\`
+\`\`\`text
 User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
        Use oneshot."
 
@@ -14169,7 +14169,7 @@ Agent:
 
 ### Example B — Mid-implementing opt-in (\`on-request\` → user changes mind)
 
-\`\`\`
+\`\`\`text
 User: "Add input validation to the parseConfig helper. Oneshot."
 
 Agent:
@@ -14199,7 +14199,7 @@ Agent:
 
 ### Example C — \`synthesisPolicy: 'always'\` (PR mandatory)
 
-\`\`\`
+\`\`\`text
 User: "I want a PR for any change to the auth module, even small ones.
        Use oneshot but always make a PR."
 
@@ -17909,8 +17909,8 @@ metadata:
 # Oneshot Workflow Skill
 
 A lean, four-phase workflow type for changes that are too small to justify the
-full \`feature\` flow (\`ideate → plan → delegate → review → synthesize\`) but
-still deserve event-sourced auditability and a planning step. The workflow is
+full \`feature\` flow (\`ideate → plan → plan-review → delegate → review → synthesize → completed\`)
+but still deserve event-sourced auditability and a planning step. The workflow is
 **direct-commit by default** with an opt-in PR path; the choice between the
 two is resolved at the end of \`implementing\` via a pure event-sourced guard,
 not a heuristic.
@@ -17985,7 +17985,7 @@ and overrides runtime signal.
 
 ## Lifecycle
 
-\`\`\`
+\`\`\`text
      plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
                                  │
                                  └── [synthesisOptedIn]  ──► synthesize ──► completed
@@ -18183,7 +18183,7 @@ do not exist in the oneshot playbook. The PR review is the only review.
 
 ### Example A — Direct-commit (default \`on-request\` policy, no opt-in)
 
-\`\`\`
+\`\`\`text
 User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
        Use oneshot."
 
@@ -18214,7 +18214,7 @@ Agent:
 
 ### Example B — Mid-implementing opt-in (\`on-request\` → user changes mind)
 
-\`\`\`
+\`\`\`text
 User: "Add input validation to the parseConfig helper. Oneshot."
 
 Agent:
@@ -18244,7 +18244,7 @@ Agent:
 
 ### Example C — \`synthesisPolicy: 'always'\` (PR mandatory)
 
-\`\`\`
+\`\`\`text
 User: "I want a PR for any change to the auth module, even small ones.
        Use oneshot but always make a PR."
 
@@ -21962,8 +21962,8 @@ metadata:
 # Oneshot Workflow Skill
 
 A lean, four-phase workflow type for changes that are too small to justify the
-full \`feature\` flow (\`ideate → plan → delegate → review → synthesize\`) but
-still deserve event-sourced auditability and a planning step. The workflow is
+full \`feature\` flow (\`ideate → plan → plan-review → delegate → review → synthesize → completed\`)
+but still deserve event-sourced auditability and a planning step. The workflow is
 **direct-commit by default** with an opt-in PR path; the choice between the
 two is resolved at the end of \`implementing\` via a pure event-sourced guard,
 not a heuristic.
@@ -22038,7 +22038,7 @@ and overrides runtime signal.
 
 ## Lifecycle
 
-\`\`\`
+\`\`\`text
      plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
                                  │
                                  └── [synthesisOptedIn]  ──► synthesize ──► completed
@@ -22236,7 +22236,7 @@ do not exist in the oneshot playbook. The PR review is the only review.
 
 ### Example A — Direct-commit (default \`on-request\` policy, no opt-in)
 
-\`\`\`
+\`\`\`text
 User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
        Use oneshot."
 
@@ -22267,7 +22267,7 @@ Agent:
 
 ### Example B — Mid-implementing opt-in (\`on-request\` → user changes mind)
 
-\`\`\`
+\`\`\`text
 User: "Add input validation to the parseConfig helper. Oneshot."
 
 Agent:
@@ -22297,7 +22297,7 @@ Agent:
 
 ### Example C — \`synthesisPolicy: 'always'\` (PR mandatory)
 
-\`\`\`
+\`\`\`text
 User: "I want a PR for any change to the auth module, even small ones.
        Use oneshot but always make a PR."
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -1847,23 +1847,26 @@ plan should answer four questions in 5-10 lines each:
 3. **Files** — which files will be touched? (1-5 typically)
 4. **Tests** — which test cases will be added? (named, not described)
 
-Persist the plan and transition to \`implementing\` in a single set call:
+Persist the plan and transition to \`implementing\` in a single set call.
+\`phase\` is a top-level argument of \`set\`, not a field inside \`updates\`:
 
 \`\`\`typescript
 mcp__plugin_exarchos_exarchos__exarchos_workflow({
   action: "set",
   featureId: "fix-readme-typo",
+  phase: "implementing",
   updates: {
-    "artifacts": { "plan": "<plan text>" },
-    "oneshot": { "planSummary": "<one-line summary>" },
-    "phase": "implementing"
+    "artifacts.plan": "<plan text>",
+    "oneshot.planSummary": "<one-line summary>"
   }
 })
 \`\`\`
 
 The plan goes on \`artifacts.plan\` for parity with the \`feature\` workflow;
 the human-readable one-liner goes on \`oneshot.planSummary\` for the
-pipeline view.
+pipeline view. Only \`artifacts.plan\` is enforced by the
+\`oneshot-plan-set\` guard — \`planSummary\` is an optional pipeline-view
+label and is not a substitute for a real plan artifact.
 
 ### Step 3 — Implementing phase
 
@@ -1995,7 +1998,14 @@ Agent:
      → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
   2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
      tests=[readme has no occurrence of 'recieve']
-  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",                   // top-level
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "..."
+       }
+     }
   4. [RED] writes test that greps README for 'recieve' and expects 0 matches
         — fails (1 match exists)
   5. [GREEN] edits README, fixes typo
@@ -3852,7 +3862,13 @@ At the start of \`/exarchos:ideate\`, use \`mcp__plugin_exarchos_exarchos__exarc
 - \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`, \`"oneshot"\`
 - \`synthesisPolicy\` *(optional, oneshot only)*: one of \`"always"\`, \`"never"\`, \`"on-request"\` (default \`"on-request"\`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+\`workflowType\`:
+
+- \`feature\` → starts in \`ideate\`
+- \`debug\` → starts in \`triage\`
+- \`refactor\` → starts in \`explore\`
+- \`oneshot\` → starts in \`plan\` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 
@@ -5884,23 +5900,26 @@ plan should answer four questions in 5-10 lines each:
 3. **Files** — which files will be touched? (1-5 typically)
 4. **Tests** — which test cases will be added? (named, not described)
 
-Persist the plan and transition to \`implementing\` in a single set call:
+Persist the plan and transition to \`implementing\` in a single set call.
+\`phase\` is a top-level argument of \`set\`, not a field inside \`updates\`:
 
 \`\`\`typescript
 mcp__exarchos__exarchos_workflow({
   action: "set",
   featureId: "fix-readme-typo",
+  phase: "implementing",
   updates: {
-    "artifacts": { "plan": "<plan text>" },
-    "oneshot": { "planSummary": "<one-line summary>" },
-    "phase": "implementing"
+    "artifacts.plan": "<plan text>",
+    "oneshot.planSummary": "<one-line summary>"
   }
 })
 \`\`\`
 
 The plan goes on \`artifacts.plan\` for parity with the \`feature\` workflow;
 the human-readable one-liner goes on \`oneshot.planSummary\` for the
-pipeline view.
+pipeline view. Only \`artifacts.plan\` is enforced by the
+\`oneshot-plan-set\` guard — \`planSummary\` is an optional pipeline-view
+label and is not a substitute for a real plan artifact.
 
 ### Step 3 — Implementing phase
 
@@ -6032,7 +6051,14 @@ Agent:
      → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
   2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
      tests=[readme has no occurrence of 'recieve']
-  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",                   // top-level
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "..."
+       }
+     }
   4. [RED] writes test that greps README for 'recieve' and expects 0 matches
         — fails (1 match exists)
   5. [GREEN] edits README, fixes typo
@@ -7889,7 +7915,13 @@ At the start of \`ideate\`, use \`mcp__exarchos__exarchos_workflow\` with \`acti
 - \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`, \`"oneshot"\`
 - \`synthesisPolicy\` *(optional, oneshot only)*: one of \`"always"\`, \`"never"\`, \`"on-request"\` (default \`"on-request"\`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+\`workflowType\`:
+
+- \`feature\` → starts in \`ideate\`
+- \`debug\` → starts in \`triage\`
+- \`refactor\` → starts in \`explore\`
+- \`oneshot\` → starts in \`plan\` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 
@@ -9913,23 +9945,26 @@ plan should answer four questions in 5-10 lines each:
 3. **Files** — which files will be touched? (1-5 typically)
 4. **Tests** — which test cases will be added? (named, not described)
 
-Persist the plan and transition to \`implementing\` in a single set call:
+Persist the plan and transition to \`implementing\` in a single set call.
+\`phase\` is a top-level argument of \`set\`, not a field inside \`updates\`:
 
 \`\`\`typescript
 mcp__exarchos__exarchos_workflow({
   action: "set",
   featureId: "fix-readme-typo",
+  phase: "implementing",
   updates: {
-    "artifacts": { "plan": "<plan text>" },
-    "oneshot": { "planSummary": "<one-line summary>" },
-    "phase": "implementing"
+    "artifacts.plan": "<plan text>",
+    "oneshot.planSummary": "<one-line summary>"
   }
 })
 \`\`\`
 
 The plan goes on \`artifacts.plan\` for parity with the \`feature\` workflow;
 the human-readable one-liner goes on \`oneshot.planSummary\` for the
-pipeline view.
+pipeline view. Only \`artifacts.plan\` is enforced by the
+\`oneshot-plan-set\` guard — \`planSummary\` is an optional pipeline-view
+label and is not a substitute for a real plan artifact.
 
 ### Step 3 — Implementing phase
 
@@ -10061,7 +10096,14 @@ Agent:
      → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
   2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
      tests=[readme has no occurrence of 'recieve']
-  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",                   // top-level
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "..."
+       }
+     }
   4. [RED] writes test that greps README for 'recieve' and expects 0 matches
         — fails (1 match exists)
   5. [GREEN] edits README, fixes typo
@@ -11918,7 +11960,13 @@ At the start of \`/ideate\`, use \`mcp__exarchos__exarchos_workflow\` with \`act
 - \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`, \`"oneshot"\`
 - \`synthesisPolicy\` *(optional, oneshot only)*: one of \`"always"\`, \`"never"\`, \`"on-request"\` (default \`"on-request"\`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+\`workflowType\`:
+
+- \`feature\` → starts in \`ideate\`
+- \`debug\` → starts in \`triage\`
+- \`refactor\` → starts in \`explore\`
+- \`oneshot\` → starts in \`plan\` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 
@@ -13948,23 +13996,26 @@ plan should answer four questions in 5-10 lines each:
 3. **Files** — which files will be touched? (1-5 typically)
 4. **Tests** — which test cases will be added? (named, not described)
 
-Persist the plan and transition to \`implementing\` in a single set call:
+Persist the plan and transition to \`implementing\` in a single set call.
+\`phase\` is a top-level argument of \`set\`, not a field inside \`updates\`:
 
 \`\`\`typescript
 mcp__exarchos__exarchos_workflow({
   action: "set",
   featureId: "fix-readme-typo",
+  phase: "implementing",
   updates: {
-    "artifacts": { "plan": "<plan text>" },
-    "oneshot": { "planSummary": "<one-line summary>" },
-    "phase": "implementing"
+    "artifacts.plan": "<plan text>",
+    "oneshot.planSummary": "<one-line summary>"
   }
 })
 \`\`\`
 
 The plan goes on \`artifacts.plan\` for parity with the \`feature\` workflow;
 the human-readable one-liner goes on \`oneshot.planSummary\` for the
-pipeline view.
+pipeline view. Only \`artifacts.plan\` is enforced by the
+\`oneshot-plan-set\` guard — \`planSummary\` is an optional pipeline-view
+label and is not a substitute for a real plan artifact.
 
 ### Step 3 — Implementing phase
 
@@ -14096,7 +14147,14 @@ Agent:
      → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
   2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
      tests=[readme has no occurrence of 'recieve']
-  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",                   // top-level
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "..."
+       }
+     }
   4. [RED] writes test that greps README for 'recieve' and expects 0 matches
         — fails (1 match exists)
   5. [GREEN] edits README, fixes typo
@@ -15953,7 +16011,13 @@ At the start of \`ideate\`, use \`mcp__exarchos__exarchos_workflow\` with \`acti
 - \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`, \`"oneshot"\`
 - \`synthesisPolicy\` *(optional, oneshot only)*: one of \`"always"\`, \`"never"\`, \`"on-request"\` (default \`"on-request"\`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+\`workflowType\`:
+
+- \`feature\` → starts in \`ideate\`
+- \`debug\` → starts in \`triage\`
+- \`refactor\` → starts in \`explore\`
+- \`oneshot\` → starts in \`plan\` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 
@@ -17977,23 +18041,26 @@ plan should answer four questions in 5-10 lines each:
 3. **Files** — which files will be touched? (1-5 typically)
 4. **Tests** — which test cases will be added? (named, not described)
 
-Persist the plan and transition to \`implementing\` in a single set call:
+Persist the plan and transition to \`implementing\` in a single set call.
+\`phase\` is a top-level argument of \`set\`, not a field inside \`updates\`:
 
 \`\`\`typescript
 mcp__exarchos__exarchos_workflow({
   action: "set",
   featureId: "fix-readme-typo",
+  phase: "implementing",
   updates: {
-    "artifacts": { "plan": "<plan text>" },
-    "oneshot": { "planSummary": "<one-line summary>" },
-    "phase": "implementing"
+    "artifacts.plan": "<plan text>",
+    "oneshot.planSummary": "<one-line summary>"
   }
 })
 \`\`\`
 
 The plan goes on \`artifacts.plan\` for parity with the \`feature\` workflow;
 the human-readable one-liner goes on \`oneshot.planSummary\` for the
-pipeline view.
+pipeline view. Only \`artifacts.plan\` is enforced by the
+\`oneshot-plan-set\` guard — \`planSummary\` is an optional pipeline-view
+label and is not a substitute for a real plan artifact.
 
 ### Step 3 — Implementing phase
 
@@ -18125,7 +18192,14 @@ Agent:
      → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
   2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
      tests=[readme has no occurrence of 'recieve']
-  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",                   // top-level
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "..."
+       }
+     }
   4. [RED] writes test that greps README for 'recieve' and expects 0 matches
         — fails (1 match exists)
   5. [GREEN] edits README, fixes typo
@@ -19982,7 +20056,13 @@ At the start of \`ideate\`, use \`mcp__exarchos__exarchos_workflow\` with \`acti
 - \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`, \`"oneshot"\`
 - \`synthesisPolicy\` *(optional, oneshot only)*: one of \`"always"\`, \`"never"\`, \`"on-request"\` (default \`"on-request"\`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+\`workflowType\`:
+
+- \`feature\` → starts in \`ideate\`
+- \`debug\` → starts in \`triage\`
+- \`refactor\` → starts in \`explore\`
+- \`oneshot\` → starts in \`plan\` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 
@@ -22014,23 +22094,26 @@ plan should answer four questions in 5-10 lines each:
 3. **Files** — which files will be touched? (1-5 typically)
 4. **Tests** — which test cases will be added? (named, not described)
 
-Persist the plan and transition to \`implementing\` in a single set call:
+Persist the plan and transition to \`implementing\` in a single set call.
+\`phase\` is a top-level argument of \`set\`, not a field inside \`updates\`:
 
 \`\`\`typescript
 mcp__exarchos__exarchos_workflow({
   action: "set",
   featureId: "fix-readme-typo",
+  phase: "implementing",
   updates: {
-    "artifacts": { "plan": "<plan text>" },
-    "oneshot": { "planSummary": "<one-line summary>" },
-    "phase": "implementing"
+    "artifacts.plan": "<plan text>",
+    "oneshot.planSummary": "<one-line summary>"
   }
 })
 \`\`\`
 
 The plan goes on \`artifacts.plan\` for parity with the \`feature\` workflow;
 the human-readable one-liner goes on \`oneshot.planSummary\` for the
-pipeline view.
+pipeline view. Only \`artifacts.plan\` is enforced by the
+\`oneshot-plan-set\` guard — \`planSummary\` is an optional pipeline-view
+label and is not a substitute for a real plan artifact.
 
 ### Step 3 — Implementing phase
 
@@ -22162,7 +22245,14 @@ Agent:
      → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
   2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
      tests=[readme has no occurrence of 'recieve']
-  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",                   // top-level
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "..."
+       }
+     }
   4. [RED] writes test that greps README for 'recieve' and expects 0 matches
         — fails (1 match exists)
   5. [GREEN] edits README, fixes typo
@@ -24019,7 +24109,13 @@ At the start of \`/ideate\`, use \`mcp__exarchos__exarchos_workflow\` with \`act
 - \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`, \`"oneshot"\`
 - \`synthesisPolicy\` *(optional, oneshot only)*: one of \`"always"\`, \`"never"\`, \`"on-request"\` (default \`"on-request"\`) — silently ignored for non-oneshot types
 
-This creates a new state file with phase "ideate".
+This creates a new workflow state entry. The initial phase depends on
+\`workflowType\`:
+
+- \`feature\` → starts in \`ideate\`
+- \`debug\` → starts in \`triage\`
+- \`refactor\` → starts in \`explore\`
+- \`oneshot\` → starts in \`plan\` (skips ideate entirely)
 
 ### Workflow Types at a Glance
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -1692,6 +1692,746 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 "
 `;
 
+exports[`task 025 — per-runtime snapshot baselines > runtime: claude > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/claude/oneshot-workflow/SKILL.md > skills/claude/oneshot-workflow/SKILL.md 1`] = `
+"---
+name: oneshot-workflow
+description: "Lightweight workflow for straightforward changes — plan → implement → optional PR. Direct-commit by default; synthesize is opt-in via synthesisPolicy or a runtime request_synthesize event. Use for trivial fixes, config tweaks, single-file changes, or exploratory work that doesn't warrant subagent dispatch or two-stage review. Triggers: 'oneshot', 'quick fix', 'small change', or /exarchos:oneshot."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: plan
+---
+
+# Oneshot Workflow Skill
+
+A lean, four-phase workflow type for changes that are too small to justify the
+full \`feature\` flow (\`ideate → plan → delegate → review → synthesize\`) but
+still deserve event-sourced auditability and a planning step. The workflow is
+**direct-commit by default** with an opt-in PR path; the choice between the
+two is resolved at the end of \`implementing\` via a pure event-sourced guard,
+not a heuristic.
+
+> **Read this first if you have never run a oneshot:** the workflow has a
+> *choice state* at the end of \`implementing\`. Whether you land on
+> \`completed\` (direct commit) or transition through \`synthesize\` (PR) is
+> decided by two inputs: the \`synthesisPolicy\` set at init, and whether the
+> user emitted a \`synthesize.requested\` event during implementing. Both
+> inputs are persisted; the decision is replay-safe.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically a single file, or a tightly-coupled
+  cluster of 2-3 files
+- No subagent dispatch is needed — the work fits comfortably in one TDD
+  loop in a single session
+- No design document is required — the goal is obvious from the task
+  description, and a one-page plan is enough scaffolding
+- No two-stage review is required — either the change is trivial enough
+  that direct-commit is acceptable, or a single PR review will suffice
+
+Concrete examples that fit oneshot:
+- Fixing a typo in a README
+- Bumping a dependency version
+- Adding a missing null-check in one function
+- Tweaking a CI workflow YAML
+- Renaming a config key everywhere it's referenced
+- Adding a one-off helper script
+- Exploratory spikes that may or may not be kept
+
+## When NOT to use oneshot
+
+Do not use oneshot for any of the following — use the full \`feature\`
+workflow instead (\`/exarchos:ideate\`):
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+- Anything where you'd want a written design doc to look back at
+
+If you start a oneshot and discover the change is bigger than expected, the
+right move is \`/exarchos:cancel\` and restart with \`/exarchos:ideate\`.
+Don't try to grow a oneshot into a feature workflow mid-stream; the
+playbooks have different shapes and you'll fight the state machine.
+
+## Synthesis policy — three options
+
+The \`synthesisPolicy\` field on a oneshot workflow declares the user's
+intent up front about whether the change should be turned into a PR. It
+takes one of three values, persisted on \`state.oneshot.synthesisPolicy\`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| \`always\` | Always transition \`implementing → synthesize\` at finalize, regardless of events. A PR is always created. | The user wants a paper trail / review for every change in this workflow, even small ones. |
+| \`never\` | Always transition \`implementing → completed\` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | The user is iterating on personal/scratch work and explicitly opts out of PRs. |
+| \`on-request\` *(default)* | Direct-commit by default. The user can opt in to a PR mid-implementing by calling \`request_synthesize\`; if any \`synthesize.requested\` event is on the stream at finalize, the workflow transitions to \`synthesize\` instead of \`completed\`. | The common case: start with the assumption of direct-commit, but leave the door open for the user to change their mind once they see the diff. |
+
+The default is \`on-request\` because it's the least surprising: the user
+gets the lightweight path until they explicitly ask for the heavy one.
+
+**Policy wins over event.** If \`synthesisPolicy: 'never'\` is set and a
+\`synthesize.requested\` event is somehow on the stream (e.g. the user
+called the action on a workflow they thought was \`on-request\`), the
+guard still routes to \`completed\`. Policy is the user's declared intent
+and overrides runtime signal.
+
+## Lifecycle
+
+\`\`\`
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+\`\`\`
+
+Four phases. The fork after \`implementing\` is a UML *choice state*,
+implemented via two mutually-exclusive HSM transitions whose guards are
+pure functions of \`state.oneshot.synthesisPolicy\` and the
+\`synthesize.requested\` event count.
+
+| Phase | What happens | Exit criteria |
+|---|---|---|
+| \`plan\` | Lightweight one-page plan: goal, approach, files to touch, tests to add. No design doc. No subagent dispatch. | \`artifacts.plan\` set → transition to \`implementing\` |
+| \`implementing\` | In-session TDD loop. Write a failing test, make it pass, refactor. Commit as you go. The TDD iron law applies — *no production code without a failing test first*. | Tests pass + typecheck clean + finalize_oneshot called |
+| \`synthesize\` | Reached **only** when \`synthesisOptedIn\` is true. Hands off to the existing synthesis flow — see \`@skills/synthesis/SKILL.md\`. PR created via \`gh pr create\`, auto-merge enabled, CI gates apply. | PR merged → \`completed\` |
+| \`completed\` | Terminal. For direct-commit path, commits are already on the branch — there's nothing more to do. For synthesize path, the PR merge event terminates the workflow. | — |
+
+\`cancelled\` is also reachable from any phase via the universal cancel
+transition, same as every other workflow type.
+
+## Step-by-step
+
+### Step 1 — Init
+
+Call \`exarchos_workflow\` with \`action: 'init'\`, \`workflowType: 'oneshot'\`,
+and an optional \`synthesisPolicy\`:
+
+\`\`\`typescript
+mcp__plugin_exarchos_exarchos__exarchos_workflow({
+  action: "init",
+  featureId: "fix-readme-typo",
+  workflowType: "oneshot",
+  synthesisPolicy: "on-request" // optional — defaults to 'on-request'
+})
+\`\`\`
+
+If the user has been clear up front ("I want a PR for this"), pass
+\`synthesisPolicy: "always"\`. If they've been clear ("don't open a PR,
+just commit it"), pass \`synthesisPolicy: "never"\`. Otherwise, omit the
+field and rely on the \`on-request\` default — you can always escalate
+later in the implementing phase.
+
+The init returns the new workflow state; the workflow lands in \`plan\`.
+
+### Step 2 — Plan phase
+
+Produce a one-page plan. This is intentionally lightweight — no design
+doc, no parallelization analysis, no decomposition into N tasks. The
+plan should answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to \`implementing\` in a single set call:
+
+\`\`\`typescript
+mcp__plugin_exarchos_exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "fix-readme-typo",
+  updates: {
+    "artifacts": { "plan": "<plan text>" },
+    "oneshot": { "planSummary": "<one-line summary>" },
+    "phase": "implementing"
+  }
+})
+\`\`\`
+
+The plan goes on \`artifacts.plan\` for parity with the \`feature\` workflow;
+the human-readable one-liner goes on \`oneshot.planSummary\` for the
+pipeline view.
+
+### Step 3 — Implementing phase
+
+Run an in-session TDD loop. Same iron law as every other workflow:
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run the test. Confirm it fails for
+   the right reason.
+2. **[GREEN]** Write the minimum production code to make the test pass.
+   Run the test. Confirm it passes.
+3. **[REFACTOR]** Clean up while keeping the test green.
+
+Commit each red-green-refactor cycle as a single commit. Do not batch
+multiple unrelated changes into one commit — keeping commits atomic
+matters even more in oneshot, where there's no separate review phase
+to catch bundled changes.
+
+There is **no subagent dispatch** in oneshot. The main agent does the
+work directly. There is **no separate review phase**. Quality is
+maintained by the TDD loop and (if the user opts in) the synthesize PR
+review.
+
+#### Mid-implementing: opting in to a PR
+
+If at any point during implementing the user decides they want a PR
+after all (policy is \`on-request\`, default), they can opt in by calling
+the \`request_synthesize\` orchestrate action:
+
+\`\`\`typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+\`\`\`
+
+**The trigger for this is conversational, not a magic keyword.** Listen
+for phrases like:
+- "actually, let's open a PR for this"
+- "I want a review on this before it lands"
+- "make this a PR"
+- "let's get eyes on this"
+- "synthesize this"
+
+When you hear any of those, call \`request_synthesize\` immediately. The
+handler appends a \`synthesize.requested\` event to the workflow's event
+stream; the \`synthesisOptedIn\` guard reads the stream at finalize and
+routes accordingly. This is **idempotent** — calling
+\`request_synthesize\` twice appends two events but the guard treats any
+count >= 1 as "opted in", so duplicate calls are benign.
+
+Calling \`request_synthesize\` does **not** transition the phase. The
+workflow stays in \`implementing\`. The decision is only acted on when
+you call \`finalize_oneshot\` in step 4.
+
+### Step 4 — Finalize (the choice point)
+
+When the implementing loop is done — tests pass, typecheck clean, all
+commits made — call \`finalize_oneshot\` to resolve the choice state:
+
+\`\`\`typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+\`\`\`
+
+The handler:
+
+1. Reads the current state and verifies \`workflowType === 'oneshot'\` and
+   \`phase === 'implementing'\`.
+2. Hydrates \`_events\` from the event store so the guard sees the same
+   view the HSM will see during the actual transition.
+3. Evaluates \`guards.synthesisOptedIn\` against the state. The guard
+   inspects \`state.oneshot.synthesisPolicy\` and the \`_events\` array.
+4. Calls \`handleSet\` with the resolved target phase (\`synthesize\` or
+   \`completed\`). The HSM re-evaluates the guard at the transition
+   boundary, so any race between the read and the transition is caught
+   safely.
+
+Possible outcomes:
+
+| \`synthesisPolicy\` | \`synthesize.requested\` event present? | Resolved target | Path |
+|---|---|---|---|
+| \`always\` | (any) | \`synthesize\` | PR path |
+| \`never\` | (any) | \`completed\` | direct-commit path |
+| \`on-request\` (default) | yes | \`synthesize\` | PR path |
+| \`on-request\` (default) | no | \`completed\` | direct-commit path |
+
+### Step 5a — Direct-commit path (terminal)
+
+If finalize resolved to \`completed\`, you're done. The commits made
+during implementing are already on the current branch. Push them if
+they aren't already pushed:
+
+\`\`\`bash
+git push
+\`\`\`
+
+The workflow is now in \`completed\` and will not appear in the default
+pipeline view.
+
+### Step 5b — Synthesize path
+
+If finalize resolved to \`synthesize\`, hand off to the standard synthesis
+flow — see \`@skills/synthesis/SKILL.md\`. The same \`prepare_synthesis\` /
+\`validate_pr_body\` / \`gh pr create\` machinery used by the \`feature\`
+workflow applies. After the PR merges, the workflow transitions
+\`synthesize → completed\` via the existing \`mergeVerified\` guard, same as
+every other workflow type.
+
+You do **not** need to run \`/exarchos:delegate\` or
+\`/exarchos:review\` for an opt-in oneshot synthesize. Those phases
+do not exist in the oneshot playbook. The PR review is the only review.
+
+## Example invocations
+
+### Example A — Direct-commit (default \`on-request\` policy, no opt-in)
+
+\`\`\`
+User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
+       Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
+  2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  4. [RED] writes test that greps README for 'recieve' and expects 0 matches
+        — fails (1 match exists)
+  5. [GREEN] edits README, fixes typo
+        — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+\`\`\`
+
+### Example B — Mid-implementing opt-in (\`on-request\` → user changes mind)
+
+\`\`\`
+User: "Add input validation to the parseConfig helper. Oneshot."
+
+Agent:
+  1. exarchos_workflow init { workflowType: "oneshot" }
+     → 'plan' phase, default 'on-request'
+  2. plans (goal: validate input, files: [parser.ts, parser.test.ts])
+  3. transitions to 'implementing'
+  4. [RED] writes test for null-input case
+  5. [GREEN] adds null check
+  6. [REFACTOR] extracts validateInput helper
+  7. commits
+
+User: "Actually, this is touching the parser — I want a review on it before
+       it lands."
+
+Agent:
+  8. exarchos_orchestrate request_synthesize {
+       featureId, reason: "user requested review of parser changes"
+     }
+     → appends synthesize.requested event
+  9. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='on-request' + 1 synthesize.requested event
+     → resolves to 'synthesize'
+ 10. hands off to @skills/synthesis/SKILL.md → prepare_synthesis →
+     validate_pr_body → gh pr create → merge
+\`\`\`
+
+### Example C — \`synthesisPolicy: 'always'\` (PR mandatory)
+
+\`\`\`
+User: "I want a PR for any change to the auth module, even small ones.
+       Use oneshot but always make a PR."
+
+Agent:
+  1. exarchos_workflow init {
+       workflowType: "oneshot",
+       synthesisPolicy: "always"
+     }
+  2-7. plan + TDD + commits, identical to Example A
+  8. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='always' (short-circuits — no event check needed)
+     → resolves to 'synthesize'
+  9. synthesis flow → PR
+\`\`\`
+
+## State management
+
+Track oneshot-specific state under the \`oneshot\` key on the workflow state:
+
+\`\`\`typescript
+mcp__plugin_exarchos_exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "<id>",
+  updates: {
+    "oneshot": {
+      "synthesisPolicy": "on-request",
+      "planSummary": "Fix off-by-one in pagination helper"
+    }
+  }
+})
+\`\`\`
+
+The \`synthesisPolicy\` field is optional and defaults to \`'on-request'\` per
+the schema in \`servers/exarchos-mcp/src/workflow/schemas.ts\`. Setting it
+explicitly is recommended when the user has stated a preference.
+
+## Phase Transitions and Guards
+
+For the full transition table for oneshot, consult
+\`@skills/workflow-state/references/phase-transitions.md\`.
+
+**Quick reference for oneshot:**
+
+| From | To | Guard |
+|---|---|---|
+| \`plan\` | \`implementing\` | \`planApproved\` (or \`oneshotPlanSet\`, checks \`artifacts.plan\` presence) |
+| \`implementing\` | \`synthesize\` | \`synthesisOptedIn\` |
+| \`implementing\` | \`completed\` | \`synthesisOptedOut\` |
+| \`synthesize\` | \`completed\` | \`mergeVerified\` |
+| (any) | \`cancelled\` | universal — always allowed |
+
+\`synthesisOptedIn\` and \`synthesisOptedOut\` are pure functions of
+\`state.oneshot.synthesisPolicy\` and \`state._events\`. They are mutually
+exclusive across all 8 (3 policies × event-present/absent, with \`always\`
+and \`never\` ignoring the event flag) combinations — exactly one returns
+true at any given time.
+
+### Schema discovery
+
+Use \`exarchos_workflow({ action: "describe", actions: ["init", "set"] })\`
+for parameter schemas (including the \`synthesisPolicy\` enum) and
+\`exarchos_workflow({ action: "describe", playbook: "oneshot" })\` for the
+phase transitions, guard names, and playbook prose. Use
+\`exarchos_orchestrate({ action: "describe", actions: ["request_synthesize", "finalize_oneshot"] })\`
+for the orchestrate action schemas.
+
+## TDD is still mandatory
+
+The iron law from \`@rules/tdd.md\` applies to oneshot. There is no
+exemption for "small" changes. Specifically:
+
+- Every behavior change starts with a failing test
+- Every test must fail before its implementation is written
+- Tests must be run after each change to verify state
+- Commits stay atomic — one logical change per commit
+
+The temptation in a oneshot is to skip the test "because it's just one
+line". Resist that. The test is what makes the change auditable, and
+auditability is the entire reason oneshot exists alongside the lighter
+"bypass workflows entirely" path.
+
+## Anti-patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip the plan phase ("it's obvious") | Write the four-line plan anyway — it's the artifact future-you reads |
+| Skip the TDD loop in implementing | Always RED → GREEN → REFACTOR, even for one-liners |
+| Use oneshot for multi-file refactors | Use \`/exarchos:ideate\` and the full feature workflow |
+| Try to grow a oneshot into a feature workflow mid-stream | Cancel and restart with \`/exarchos:ideate\` |
+| Call \`request_synthesize\` without listening for the user's intent | Wait for the user to ask for a PR, then call it |
+| Bundle unrelated changes into one commit "since it's a oneshot" | Keep commits atomic — there's no review phase to catch bundling |
+| Forget to call \`finalize_oneshot\` at the end | The workflow stays in \`implementing\` forever otherwise — call it explicitly |
+
+## Completion criteria
+
+- [ ] \`exarchos_workflow init\` called with \`workflowType: "oneshot"\`
+- [ ] One-page plan persisted to \`artifacts.plan\`
+- [ ] Phase transitioned to \`implementing\`
+- [ ] All planned behaviors implemented via TDD with atomic commits
+- [ ] \`finalize_oneshot\` called and resolved to either \`completed\` or \`synthesize\`
+- [ ] If direct-commit path: commits pushed
+- [ ] If synthesize path: PR created via \`@skills/synthesis/SKILL.md\` and merged
+"
+`;
+
+exports[`task 025 — per-runtime snapshot baselines > runtime: claude > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/claude/prune-workflows/SKILL.md > skills/claude/prune-workflows/SKILL.md 1`] = `
+"---
+name: prune-workflows
+description: "Interactively prune stale non-terminal workflows from the pipeline. Use when the user says 'prune workflows', 'clean stale workflows', 'pipeline cleanup', or runs /prune. Runs a dry-run preview, displays candidates with staleness and safeguard skips, prompts the user to proceed/abort/force, then bulk-cancels approved workflows with a workflow.pruned audit event. Safeguards skip workflows with open PRs or recent commits unless force is set."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: maintenance
+---
+
+# Prune Workflows Skill
+
+## Overview
+
+Bulk-cancel stale non-terminal workflows that have accumulated in the pipeline. Wraps the \`prune_stale_workflows\` orchestrate action with an interactive dry-run-then-confirm UX so the user always sees the candidate set before any state mutates.
+
+Pruning is a maintenance operation -- not a workflow phase. It produces \`workflow.pruned\` events alongside the standard \`workflow.cancelled\` events emitted by the underlying cancel path, so downstream views can distinguish user-intent cancellations from batch cleanup.
+
+## Triggers
+
+Activate this skill when:
+- User runs \`/exarchos:prune\` command
+- User says "prune workflows", "clean stale workflows", "pipeline cleanup"
+- \`mcp__plugin_exarchos_exarchos__exarchos_view({ action: "pipeline" })\` shows many inactive workflows the user wants to clear in bulk
+
+## Prerequisites
+
+- An exarchos state directory with one or more non-terminal workflows
+- For safeguard checks against live PRs: \`gh\` available in PATH (the orchestrate handler shells out)
+- For safeguard checks against branch activity: \`git\` available in PATH
+
+## Process
+
+### Step 1: Dry-Run Preview
+
+Always start with \`dryRun: true\`. This call performs candidate selection and safeguard evaluation but does not mutate any workflow state.
+
+\`\`\`typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: true
+  }
+})
+\`\`\`
+
+The response shape is:
+
+\`\`\`ts
+{
+  candidates: [
+    { featureId: string, phase: string, workflowType: string, stalenessMinutes: number }
+  ],
+  skipped: [
+    { featureId: string, reason: "open-pr" | "active-branch" }
+  ]
+}
+\`\`\`
+
+Optional args:
+- \`thresholdMinutes\` -- staleness cutoff. Default is 10080 (7 days).
+- \`includeOneShot\` -- whether to include \`oneshot\` workflows in the candidate set. Default \`true\`.
+- \`force\` -- not relevant in dry-run; only honored in apply mode (Step 4).
+
+### Step 2: Display Candidate Table
+
+Render a table to the user so they can review what would be pruned. Use this format:
+
+\`\`\`markdown
+## Prune Candidates (3)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-experiment | feature | implementing | 14430 |
+| oneshot-typo-fix | oneshot | plan | 9120 |
+| debug-flaky-test | debug | investigate | 8650 |
+
+## Skipped by Safeguards (2)
+
+| Feature ID | Reason |
+|---|---|
+| feat-active-pr | open-pr |
+| feat-recent-work | active-branch |
+\`\`\`
+
+If \`candidates.length === 0\` AND \`skipped.length === 0\`, output:
+
+> No stale workflows to prune. Pipeline is clean.
+
+Then exit -- no further action.
+
+### Step 3: Prompt for Confirmation
+
+Ask the user one of three choices:
+
+> **proceed** -- prune the listed candidates (skipped workflows stay)
+> **abort** -- exit without changes
+> **force** -- bypass safeguards and prune skipped workflows too
+
+Wait for explicit user input. Do **not** auto-proceed.
+
+### Step 4a: Apply (proceed)
+
+On \`proceed\`, invoke the same action with \`dryRun: false\`. Pass through \`thresholdMinutes\` and \`includeOneShot\` if the user set them in Step 1.
+
+\`\`\`typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false
+  }
+})
+\`\`\`
+
+The response now includes a \`pruned\` array:
+
+\`\`\`ts
+{
+  candidates: [...],
+  skipped: [...],
+  pruned: [
+    { featureId: string, previousPhase: string }
+  ]
+}
+\`\`\`
+
+Each entry in \`pruned\` corresponds to a workflow that transitioned to \`cancelled\` and emitted a \`workflow.pruned\` event.
+
+### Step 4b: Apply (force)
+
+On \`force\`, set \`force: true\`. Safeguards are bypassed but the bypass is recorded in the \`workflow.pruned\` event payload as \`skippedSafeguards: [...]\` so the audit trail is intact.
+
+\`\`\`typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false,
+    force: true
+  }
+})
+\`\`\`
+
+In force mode, workflows that were in the \`skipped\` list during dry-run are now eligible for pruning.
+
+### Step 4c: Apply (abort)
+
+On \`abort\`, exit without invoking the action a second time. The dry-run has not mutated any state.
+
+### Step 5: Report Results
+
+After the apply call returns, summarize the outcome:
+
+\`\`\`markdown
+## Prune Complete
+
+**Pruned:** 3 workflows transitioned to cancelled
+**Skipped:** 2 workflows preserved by safeguards
+**Force bypass:** no
+
+### Pruned Workflows
+- feat-old-experiment (was: implementing)
+- oneshot-typo-fix (was: plan)
+- debug-flaky-test (was: investigate)
+\`\`\`
+
+If \`force\` was used, also list any safeguards that were bypassed:
+
+\`\`\`markdown
+### Safeguards Bypassed
+- feat-active-pr: open-pr
+- feat-recent-work: active-branch
+\`\`\`
+
+## Safeguards Explained
+
+Two safeguards run automatically in the orchestrate handler before each cancel:
+
+| Safeguard | Behavior | Reason key |
+|---|---|---|
+| **Open PR** | Skip if \`gh pr list --head <branch> --state open\` returns any results | \`open-pr\` |
+| **Recent commits** | Skip if \`git log --since "24 hours ago" origin/<branch>\` shows commits | \`active-branch\` |
+
+A workflow without a \`branchName\` in state (e.g., abandoned at ideate/plan before delegation) cannot have a PR or branch activity, so safeguards short-circuit and the workflow is eligible for pruning.
+
+\`force: true\` bypasses both checks but does not bypass the audit -- the bypassed safeguard names are recorded in the \`workflow.pruned\` event payload.
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|---|---|
+| Skip the dry-run step | Always start with \`dryRun: true\` so the user sees candidates first |
+| Auto-confirm without showing the table | Render the candidate table and wait for explicit user input |
+| Use \`force: true\` by default | Reserve \`force\` for cases where the user has explicitly opted in |
+| Manually call \`cancel\` for each stale workflow | Use this skill -- it batches the cancel loop and emits the \`workflow.pruned\` audit event |
+| Run on every session | Pruning is a maintenance operation; run when pipeline accumulation is observable |
+
+## Examples
+
+### Example 1: Clean dry-run, user proceeds
+
+\`\`\`
+> /exarchos:prune
+
+## Prune Candidates (2)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-spike | feature | plan | 12880 |
+| oneshot-readme-tweak | oneshot | implementing | 9700 |
+
+## Skipped by Safeguards (0)
+
+(none)
+
+Proceed? (proceed/abort/force)
+
+> proceed
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** no
+
+### Pruned Workflows
+- feat-old-spike (was: plan)
+- oneshot-readme-tweak (was: implementing)
+\`\`\`
+
+### Example 2: Safeguard skip, user forces
+
+\`\`\`
+> /exarchos:prune
+
+## Prune Candidates (1)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-stale-no-pr | feature | implementing | 11200 |
+
+## Skipped by Safeguards (1)
+
+| Feature ID | Reason |
+|---|---|
+| feat-stale-with-pr | open-pr |
+
+Proceed? (proceed/abort/force)
+
+> force
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** yes
+
+### Pruned Workflows
+- feat-stale-no-pr (was: implementing)
+- feat-stale-with-pr (was: implementing)
+
+### Safeguards Bypassed
+- feat-stale-with-pr: open-pr
+\`\`\`
+
+### Example 3: Empty pipeline
+
+\`\`\`
+> /exarchos:prune
+
+No stale workflows to prune. Pipeline is clean.
+\`\`\`
+
+## Schema Discovery
+
+For the canonical argument schema and any future fields, use:
+
+\`\`\`typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "describe",
+  actions: ["prune_stale_workflows"]
+})
+\`\`\`
+
+## Exarchos Integration
+
+The \`prune_stale_workflows\` action emits two events per pruned workflow:
+- \`workflow.cancelled\` (auto-emitted by the underlying \`handleCancel\` path)
+- \`workflow.pruned\` (emitted by this handler with \`triggeredBy: 'manual'\` and optional \`skippedSafeguards\`)
+
+Both are projected into the workflow state's \`_events\` array by the standard projection. Downstream views can filter on \`workflow.pruned\` to identify batch cleanups versus user-initiated cancels.
+"
+`;
+
 exports[`task 025 — per-runtime snapshot baselines > runtime: claude > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/claude/quality-review/SKILL.md > skills/claude/quality-review/SKILL.md 1`] = `
 "---
 name: quality-review
@@ -4937,6 +5677,746 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 "
 `;
 
+exports[`task 025 — per-runtime snapshot baselines > runtime: codex > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/codex/oneshot-workflow/SKILL.md > skills/codex/oneshot-workflow/SKILL.md 1`] = `
+"---
+name: oneshot-workflow
+description: "Lightweight workflow for straightforward changes — plan → implement → optional PR. Direct-commit by default; synthesize is opt-in via synthesisPolicy or a runtime request_synthesize event. Use for trivial fixes, config tweaks, single-file changes, or exploratory work that doesn't warrant subagent dispatch or two-stage review. Triggers: 'oneshot', 'quick fix', 'small change', or oneshot."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: plan
+---
+
+# Oneshot Workflow Skill
+
+A lean, four-phase workflow type for changes that are too small to justify the
+full \`feature\` flow (\`ideate → plan → delegate → review → synthesize\`) but
+still deserve event-sourced auditability and a planning step. The workflow is
+**direct-commit by default** with an opt-in PR path; the choice between the
+two is resolved at the end of \`implementing\` via a pure event-sourced guard,
+not a heuristic.
+
+> **Read this first if you have never run a oneshot:** the workflow has a
+> *choice state* at the end of \`implementing\`. Whether you land on
+> \`completed\` (direct commit) or transition through \`synthesize\` (PR) is
+> decided by two inputs: the \`synthesisPolicy\` set at init, and whether the
+> user emitted a \`synthesize.requested\` event during implementing. Both
+> inputs are persisted; the decision is replay-safe.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically a single file, or a tightly-coupled
+  cluster of 2-3 files
+- No subagent dispatch is needed — the work fits comfortably in one TDD
+  loop in a single session
+- No design document is required — the goal is obvious from the task
+  description, and a one-page plan is enough scaffolding
+- No two-stage review is required — either the change is trivial enough
+  that direct-commit is acceptable, or a single PR review will suffice
+
+Concrete examples that fit oneshot:
+- Fixing a typo in a README
+- Bumping a dependency version
+- Adding a missing null-check in one function
+- Tweaking a CI workflow YAML
+- Renaming a config key everywhere it's referenced
+- Adding a one-off helper script
+- Exploratory spikes that may or may not be kept
+
+## When NOT to use oneshot
+
+Do not use oneshot for any of the following — use the full \`feature\`
+workflow instead (\`ideate\`):
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+- Anything where you'd want a written design doc to look back at
+
+If you start a oneshot and discover the change is bigger than expected, the
+right move is \`cancel\` and restart with \`ideate\`.
+Don't try to grow a oneshot into a feature workflow mid-stream; the
+playbooks have different shapes and you'll fight the state machine.
+
+## Synthesis policy — three options
+
+The \`synthesisPolicy\` field on a oneshot workflow declares the user's
+intent up front about whether the change should be turned into a PR. It
+takes one of three values, persisted on \`state.oneshot.synthesisPolicy\`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| \`always\` | Always transition \`implementing → synthesize\` at finalize, regardless of events. A PR is always created. | The user wants a paper trail / review for every change in this workflow, even small ones. |
+| \`never\` | Always transition \`implementing → completed\` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | The user is iterating on personal/scratch work and explicitly opts out of PRs. |
+| \`on-request\` *(default)* | Direct-commit by default. The user can opt in to a PR mid-implementing by calling \`request_synthesize\`; if any \`synthesize.requested\` event is on the stream at finalize, the workflow transitions to \`synthesize\` instead of \`completed\`. | The common case: start with the assumption of direct-commit, but leave the door open for the user to change their mind once they see the diff. |
+
+The default is \`on-request\` because it's the least surprising: the user
+gets the lightweight path until they explicitly ask for the heavy one.
+
+**Policy wins over event.** If \`synthesisPolicy: 'never'\` is set and a
+\`synthesize.requested\` event is somehow on the stream (e.g. the user
+called the action on a workflow they thought was \`on-request\`), the
+guard still routes to \`completed\`. Policy is the user's declared intent
+and overrides runtime signal.
+
+## Lifecycle
+
+\`\`\`
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+\`\`\`
+
+Four phases. The fork after \`implementing\` is a UML *choice state*,
+implemented via two mutually-exclusive HSM transitions whose guards are
+pure functions of \`state.oneshot.synthesisPolicy\` and the
+\`synthesize.requested\` event count.
+
+| Phase | What happens | Exit criteria |
+|---|---|---|
+| \`plan\` | Lightweight one-page plan: goal, approach, files to touch, tests to add. No design doc. No subagent dispatch. | \`artifacts.plan\` set → transition to \`implementing\` |
+| \`implementing\` | In-session TDD loop. Write a failing test, make it pass, refactor. Commit as you go. The TDD iron law applies — *no production code without a failing test first*. | Tests pass + typecheck clean + finalize_oneshot called |
+| \`synthesize\` | Reached **only** when \`synthesisOptedIn\` is true. Hands off to the existing synthesis flow — see \`@skills/synthesis/SKILL.md\`. PR created via \`gh pr create\`, auto-merge enabled, CI gates apply. | PR merged → \`completed\` |
+| \`completed\` | Terminal. For direct-commit path, commits are already on the branch — there's nothing more to do. For synthesize path, the PR merge event terminates the workflow. | — |
+
+\`cancelled\` is also reachable from any phase via the universal cancel
+transition, same as every other workflow type.
+
+## Step-by-step
+
+### Step 1 — Init
+
+Call \`exarchos_workflow\` with \`action: 'init'\`, \`workflowType: 'oneshot'\`,
+and an optional \`synthesisPolicy\`:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "init",
+  featureId: "fix-readme-typo",
+  workflowType: "oneshot",
+  synthesisPolicy: "on-request" // optional — defaults to 'on-request'
+})
+\`\`\`
+
+If the user has been clear up front ("I want a PR for this"), pass
+\`synthesisPolicy: "always"\`. If they've been clear ("don't open a PR,
+just commit it"), pass \`synthesisPolicy: "never"\`. Otherwise, omit the
+field and rely on the \`on-request\` default — you can always escalate
+later in the implementing phase.
+
+The init returns the new workflow state; the workflow lands in \`plan\`.
+
+### Step 2 — Plan phase
+
+Produce a one-page plan. This is intentionally lightweight — no design
+doc, no parallelization analysis, no decomposition into N tasks. The
+plan should answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to \`implementing\` in a single set call:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "fix-readme-typo",
+  updates: {
+    "artifacts": { "plan": "<plan text>" },
+    "oneshot": { "planSummary": "<one-line summary>" },
+    "phase": "implementing"
+  }
+})
+\`\`\`
+
+The plan goes on \`artifacts.plan\` for parity with the \`feature\` workflow;
+the human-readable one-liner goes on \`oneshot.planSummary\` for the
+pipeline view.
+
+### Step 3 — Implementing phase
+
+Run an in-session TDD loop. Same iron law as every other workflow:
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run the test. Confirm it fails for
+   the right reason.
+2. **[GREEN]** Write the minimum production code to make the test pass.
+   Run the test. Confirm it passes.
+3. **[REFACTOR]** Clean up while keeping the test green.
+
+Commit each red-green-refactor cycle as a single commit. Do not batch
+multiple unrelated changes into one commit — keeping commits atomic
+matters even more in oneshot, where there's no separate review phase
+to catch bundled changes.
+
+There is **no subagent dispatch** in oneshot. The main agent does the
+work directly. There is **no separate review phase**. Quality is
+maintained by the TDD loop and (if the user opts in) the synthesize PR
+review.
+
+#### Mid-implementing: opting in to a PR
+
+If at any point during implementing the user decides they want a PR
+after all (policy is \`on-request\`, default), they can opt in by calling
+the \`request_synthesize\` orchestrate action:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+\`\`\`
+
+**The trigger for this is conversational, not a magic keyword.** Listen
+for phrases like:
+- "actually, let's open a PR for this"
+- "I want a review on this before it lands"
+- "make this a PR"
+- "let's get eyes on this"
+- "synthesize this"
+
+When you hear any of those, call \`request_synthesize\` immediately. The
+handler appends a \`synthesize.requested\` event to the workflow's event
+stream; the \`synthesisOptedIn\` guard reads the stream at finalize and
+routes accordingly. This is **idempotent** — calling
+\`request_synthesize\` twice appends two events but the guard treats any
+count >= 1 as "opted in", so duplicate calls are benign.
+
+Calling \`request_synthesize\` does **not** transition the phase. The
+workflow stays in \`implementing\`. The decision is only acted on when
+you call \`finalize_oneshot\` in step 4.
+
+### Step 4 — Finalize (the choice point)
+
+When the implementing loop is done — tests pass, typecheck clean, all
+commits made — call \`finalize_oneshot\` to resolve the choice state:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+\`\`\`
+
+The handler:
+
+1. Reads the current state and verifies \`workflowType === 'oneshot'\` and
+   \`phase === 'implementing'\`.
+2. Hydrates \`_events\` from the event store so the guard sees the same
+   view the HSM will see during the actual transition.
+3. Evaluates \`guards.synthesisOptedIn\` against the state. The guard
+   inspects \`state.oneshot.synthesisPolicy\` and the \`_events\` array.
+4. Calls \`handleSet\` with the resolved target phase (\`synthesize\` or
+   \`completed\`). The HSM re-evaluates the guard at the transition
+   boundary, so any race between the read and the transition is caught
+   safely.
+
+Possible outcomes:
+
+| \`synthesisPolicy\` | \`synthesize.requested\` event present? | Resolved target | Path |
+|---|---|---|---|
+| \`always\` | (any) | \`synthesize\` | PR path |
+| \`never\` | (any) | \`completed\` | direct-commit path |
+| \`on-request\` (default) | yes | \`synthesize\` | PR path |
+| \`on-request\` (default) | no | \`completed\` | direct-commit path |
+
+### Step 5a — Direct-commit path (terminal)
+
+If finalize resolved to \`completed\`, you're done. The commits made
+during implementing are already on the current branch. Push them if
+they aren't already pushed:
+
+\`\`\`bash
+git push
+\`\`\`
+
+The workflow is now in \`completed\` and will not appear in the default
+pipeline view.
+
+### Step 5b — Synthesize path
+
+If finalize resolved to \`synthesize\`, hand off to the standard synthesis
+flow — see \`@skills/synthesis/SKILL.md\`. The same \`prepare_synthesis\` /
+\`validate_pr_body\` / \`gh pr create\` machinery used by the \`feature\`
+workflow applies. After the PR merges, the workflow transitions
+\`synthesize → completed\` via the existing \`mergeVerified\` guard, same as
+every other workflow type.
+
+You do **not** need to run \`delegate\` or
+\`review\` for an opt-in oneshot synthesize. Those phases
+do not exist in the oneshot playbook. The PR review is the only review.
+
+## Example invocations
+
+### Example A — Direct-commit (default \`on-request\` policy, no opt-in)
+
+\`\`\`
+User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
+       Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
+  2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  4. [RED] writes test that greps README for 'recieve' and expects 0 matches
+        — fails (1 match exists)
+  5. [GREEN] edits README, fixes typo
+        — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+\`\`\`
+
+### Example B — Mid-implementing opt-in (\`on-request\` → user changes mind)
+
+\`\`\`
+User: "Add input validation to the parseConfig helper. Oneshot."
+
+Agent:
+  1. exarchos_workflow init { workflowType: "oneshot" }
+     → 'plan' phase, default 'on-request'
+  2. plans (goal: validate input, files: [parser.ts, parser.test.ts])
+  3. transitions to 'implementing'
+  4. [RED] writes test for null-input case
+  5. [GREEN] adds null check
+  6. [REFACTOR] extracts validateInput helper
+  7. commits
+
+User: "Actually, this is touching the parser — I want a review on it before
+       it lands."
+
+Agent:
+  8. exarchos_orchestrate request_synthesize {
+       featureId, reason: "user requested review of parser changes"
+     }
+     → appends synthesize.requested event
+  9. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='on-request' + 1 synthesize.requested event
+     → resolves to 'synthesize'
+ 10. hands off to @skills/synthesis/SKILL.md → prepare_synthesis →
+     validate_pr_body → gh pr create → merge
+\`\`\`
+
+### Example C — \`synthesisPolicy: 'always'\` (PR mandatory)
+
+\`\`\`
+User: "I want a PR for any change to the auth module, even small ones.
+       Use oneshot but always make a PR."
+
+Agent:
+  1. exarchos_workflow init {
+       workflowType: "oneshot",
+       synthesisPolicy: "always"
+     }
+  2-7. plan + TDD + commits, identical to Example A
+  8. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='always' (short-circuits — no event check needed)
+     → resolves to 'synthesize'
+  9. synthesis flow → PR
+\`\`\`
+
+## State management
+
+Track oneshot-specific state under the \`oneshot\` key on the workflow state:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "<id>",
+  updates: {
+    "oneshot": {
+      "synthesisPolicy": "on-request",
+      "planSummary": "Fix off-by-one in pagination helper"
+    }
+  }
+})
+\`\`\`
+
+The \`synthesisPolicy\` field is optional and defaults to \`'on-request'\` per
+the schema in \`servers/exarchos-mcp/src/workflow/schemas.ts\`. Setting it
+explicitly is recommended when the user has stated a preference.
+
+## Phase Transitions and Guards
+
+For the full transition table for oneshot, consult
+\`@skills/workflow-state/references/phase-transitions.md\`.
+
+**Quick reference for oneshot:**
+
+| From | To | Guard |
+|---|---|---|
+| \`plan\` | \`implementing\` | \`planApproved\` (or \`oneshotPlanSet\`, checks \`artifacts.plan\` presence) |
+| \`implementing\` | \`synthesize\` | \`synthesisOptedIn\` |
+| \`implementing\` | \`completed\` | \`synthesisOptedOut\` |
+| \`synthesize\` | \`completed\` | \`mergeVerified\` |
+| (any) | \`cancelled\` | universal — always allowed |
+
+\`synthesisOptedIn\` and \`synthesisOptedOut\` are pure functions of
+\`state.oneshot.synthesisPolicy\` and \`state._events\`. They are mutually
+exclusive across all 8 (3 policies × event-present/absent, with \`always\`
+and \`never\` ignoring the event flag) combinations — exactly one returns
+true at any given time.
+
+### Schema discovery
+
+Use \`exarchos_workflow({ action: "describe", actions: ["init", "set"] })\`
+for parameter schemas (including the \`synthesisPolicy\` enum) and
+\`exarchos_workflow({ action: "describe", playbook: "oneshot" })\` for the
+phase transitions, guard names, and playbook prose. Use
+\`exarchos_orchestrate({ action: "describe", actions: ["request_synthesize", "finalize_oneshot"] })\`
+for the orchestrate action schemas.
+
+## TDD is still mandatory
+
+The iron law from \`@rules/tdd.md\` applies to oneshot. There is no
+exemption for "small" changes. Specifically:
+
+- Every behavior change starts with a failing test
+- Every test must fail before its implementation is written
+- Tests must be run after each change to verify state
+- Commits stay atomic — one logical change per commit
+
+The temptation in a oneshot is to skip the test "because it's just one
+line". Resist that. The test is what makes the change auditable, and
+auditability is the entire reason oneshot exists alongside the lighter
+"bypass workflows entirely" path.
+
+## Anti-patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip the plan phase ("it's obvious") | Write the four-line plan anyway — it's the artifact future-you reads |
+| Skip the TDD loop in implementing | Always RED → GREEN → REFACTOR, even for one-liners |
+| Use oneshot for multi-file refactors | Use \`ideate\` and the full feature workflow |
+| Try to grow a oneshot into a feature workflow mid-stream | Cancel and restart with \`ideate\` |
+| Call \`request_synthesize\` without listening for the user's intent | Wait for the user to ask for a PR, then call it |
+| Bundle unrelated changes into one commit "since it's a oneshot" | Keep commits atomic — there's no review phase to catch bundling |
+| Forget to call \`finalize_oneshot\` at the end | The workflow stays in \`implementing\` forever otherwise — call it explicitly |
+
+## Completion criteria
+
+- [ ] \`exarchos_workflow init\` called with \`workflowType: "oneshot"\`
+- [ ] One-page plan persisted to \`artifacts.plan\`
+- [ ] Phase transitioned to \`implementing\`
+- [ ] All planned behaviors implemented via TDD with atomic commits
+- [ ] \`finalize_oneshot\` called and resolved to either \`completed\` or \`synthesize\`
+- [ ] If direct-commit path: commits pushed
+- [ ] If synthesize path: PR created via \`@skills/synthesis/SKILL.md\` and merged
+"
+`;
+
+exports[`task 025 — per-runtime snapshot baselines > runtime: codex > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/codex/prune-workflows/SKILL.md > skills/codex/prune-workflows/SKILL.md 1`] = `
+"---
+name: prune-workflows
+description: "Interactively prune stale non-terminal workflows from the pipeline. Use when the user says 'prune workflows', 'clean stale workflows', 'pipeline cleanup', or runs /prune. Runs a dry-run preview, displays candidates with staleness and safeguard skips, prompts the user to proceed/abort/force, then bulk-cancels approved workflows with a workflow.pruned audit event. Safeguards skip workflows with open PRs or recent commits unless force is set."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: maintenance
+---
+
+# Prune Workflows Skill
+
+## Overview
+
+Bulk-cancel stale non-terminal workflows that have accumulated in the pipeline. Wraps the \`prune_stale_workflows\` orchestrate action with an interactive dry-run-then-confirm UX so the user always sees the candidate set before any state mutates.
+
+Pruning is a maintenance operation -- not a workflow phase. It produces \`workflow.pruned\` events alongside the standard \`workflow.cancelled\` events emitted by the underlying cancel path, so downstream views can distinguish user-intent cancellations from batch cleanup.
+
+## Triggers
+
+Activate this skill when:
+- User runs \`prune\` command
+- User says "prune workflows", "clean stale workflows", "pipeline cleanup"
+- \`mcp__exarchos__exarchos_view({ action: "pipeline" })\` shows many inactive workflows the user wants to clear in bulk
+
+## Prerequisites
+
+- An exarchos state directory with one or more non-terminal workflows
+- For safeguard checks against live PRs: \`gh\` available in PATH (the orchestrate handler shells out)
+- For safeguard checks against branch activity: \`git\` available in PATH
+
+## Process
+
+### Step 1: Dry-Run Preview
+
+Always start with \`dryRun: true\`. This call performs candidate selection and safeguard evaluation but does not mutate any workflow state.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: true
+  }
+})
+\`\`\`
+
+The response shape is:
+
+\`\`\`ts
+{
+  candidates: [
+    { featureId: string, phase: string, workflowType: string, stalenessMinutes: number }
+  ],
+  skipped: [
+    { featureId: string, reason: "open-pr" | "active-branch" }
+  ]
+}
+\`\`\`
+
+Optional args:
+- \`thresholdMinutes\` -- staleness cutoff. Default is 10080 (7 days).
+- \`includeOneShot\` -- whether to include \`oneshot\` workflows in the candidate set. Default \`true\`.
+- \`force\` -- not relevant in dry-run; only honored in apply mode (Step 4).
+
+### Step 2: Display Candidate Table
+
+Render a table to the user so they can review what would be pruned. Use this format:
+
+\`\`\`markdown
+## Prune Candidates (3)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-experiment | feature | implementing | 14430 |
+| oneshot-typo-fix | oneshot | plan | 9120 |
+| debug-flaky-test | debug | investigate | 8650 |
+
+## Skipped by Safeguards (2)
+
+| Feature ID | Reason |
+|---|---|
+| feat-active-pr | open-pr |
+| feat-recent-work | active-branch |
+\`\`\`
+
+If \`candidates.length === 0\` AND \`skipped.length === 0\`, output:
+
+> No stale workflows to prune. Pipeline is clean.
+
+Then exit -- no further action.
+
+### Step 3: Prompt for Confirmation
+
+Ask the user one of three choices:
+
+> **proceed** -- prune the listed candidates (skipped workflows stay)
+> **abort** -- exit without changes
+> **force** -- bypass safeguards and prune skipped workflows too
+
+Wait for explicit user input. Do **not** auto-proceed.
+
+### Step 4a: Apply (proceed)
+
+On \`proceed\`, invoke the same action with \`dryRun: false\`. Pass through \`thresholdMinutes\` and \`includeOneShot\` if the user set them in Step 1.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false
+  }
+})
+\`\`\`
+
+The response now includes a \`pruned\` array:
+
+\`\`\`ts
+{
+  candidates: [...],
+  skipped: [...],
+  pruned: [
+    { featureId: string, previousPhase: string }
+  ]
+}
+\`\`\`
+
+Each entry in \`pruned\` corresponds to a workflow that transitioned to \`cancelled\` and emitted a \`workflow.pruned\` event.
+
+### Step 4b: Apply (force)
+
+On \`force\`, set \`force: true\`. Safeguards are bypassed but the bypass is recorded in the \`workflow.pruned\` event payload as \`skippedSafeguards: [...]\` so the audit trail is intact.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false,
+    force: true
+  }
+})
+\`\`\`
+
+In force mode, workflows that were in the \`skipped\` list during dry-run are now eligible for pruning.
+
+### Step 4c: Apply (abort)
+
+On \`abort\`, exit without invoking the action a second time. The dry-run has not mutated any state.
+
+### Step 5: Report Results
+
+After the apply call returns, summarize the outcome:
+
+\`\`\`markdown
+## Prune Complete
+
+**Pruned:** 3 workflows transitioned to cancelled
+**Skipped:** 2 workflows preserved by safeguards
+**Force bypass:** no
+
+### Pruned Workflows
+- feat-old-experiment (was: implementing)
+- oneshot-typo-fix (was: plan)
+- debug-flaky-test (was: investigate)
+\`\`\`
+
+If \`force\` was used, also list any safeguards that were bypassed:
+
+\`\`\`markdown
+### Safeguards Bypassed
+- feat-active-pr: open-pr
+- feat-recent-work: active-branch
+\`\`\`
+
+## Safeguards Explained
+
+Two safeguards run automatically in the orchestrate handler before each cancel:
+
+| Safeguard | Behavior | Reason key |
+|---|---|---|
+| **Open PR** | Skip if \`gh pr list --head <branch> --state open\` returns any results | \`open-pr\` |
+| **Recent commits** | Skip if \`git log --since "24 hours ago" origin/<branch>\` shows commits | \`active-branch\` |
+
+A workflow without a \`branchName\` in state (e.g., abandoned at ideate/plan before delegation) cannot have a PR or branch activity, so safeguards short-circuit and the workflow is eligible for pruning.
+
+\`force: true\` bypasses both checks but does not bypass the audit -- the bypassed safeguard names are recorded in the \`workflow.pruned\` event payload.
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|---|---|
+| Skip the dry-run step | Always start with \`dryRun: true\` so the user sees candidates first |
+| Auto-confirm without showing the table | Render the candidate table and wait for explicit user input |
+| Use \`force: true\` by default | Reserve \`force\` for cases where the user has explicitly opted in |
+| Manually call \`cancel\` for each stale workflow | Use this skill -- it batches the cancel loop and emits the \`workflow.pruned\` audit event |
+| Run on every session | Pruning is a maintenance operation; run when pipeline accumulation is observable |
+
+## Examples
+
+### Example 1: Clean dry-run, user proceeds
+
+\`\`\`
+> prune
+
+## Prune Candidates (2)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-spike | feature | plan | 12880 |
+| oneshot-readme-tweak | oneshot | implementing | 9700 |
+
+## Skipped by Safeguards (0)
+
+(none)
+
+Proceed? (proceed/abort/force)
+
+> proceed
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** no
+
+### Pruned Workflows
+- feat-old-spike (was: plan)
+- oneshot-readme-tweak (was: implementing)
+\`\`\`
+
+### Example 2: Safeguard skip, user forces
+
+\`\`\`
+> prune
+
+## Prune Candidates (1)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-stale-no-pr | feature | implementing | 11200 |
+
+## Skipped by Safeguards (1)
+
+| Feature ID | Reason |
+|---|---|
+| feat-stale-with-pr | open-pr |
+
+Proceed? (proceed/abort/force)
+
+> force
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** yes
+
+### Pruned Workflows
+- feat-stale-no-pr (was: implementing)
+- feat-stale-with-pr (was: implementing)
+
+### Safeguards Bypassed
+- feat-stale-with-pr: open-pr
+\`\`\`
+
+### Example 3: Empty pipeline
+
+\`\`\`
+> prune
+
+No stale workflows to prune. Pipeline is clean.
+\`\`\`
+
+## Schema Discovery
+
+For the canonical argument schema and any future fields, use:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "describe",
+  actions: ["prune_stale_workflows"]
+})
+\`\`\`
+
+## Exarchos Integration
+
+The \`prune_stale_workflows\` action emits two events per pruned workflow:
+- \`workflow.cancelled\` (auto-emitted by the underlying \`handleCancel\` path)
+- \`workflow.pruned\` (emitted by this handler with \`triggeredBy: 'manual'\` and optional \`skippedSafeguards\`)
+
+Both are projected into the workflow state's \`_events\` array by the standard projection. Downstream views can filter on \`workflow.pruned\` to identify batch cleanups versus user-initiated cancels.
+"
+`;
+
 exports[`task 025 — per-runtime snapshot baselines > runtime: codex > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/codex/quality-review/SKILL.md > skills/codex/quality-review/SKILL.md 1`] = `
 "---
 name: quality-review
@@ -8171,6 +9651,746 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 - Complete each step fully before advancing — quality over speed
 - Do not skip validation checks even when the change appears trivial
 - Trace every design section to at least one task. Do not leave uncovered sections without explicit rationale.
+"
+`;
+
+exports[`task 025 — per-runtime snapshot baselines > runtime: copilot > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/copilot/oneshot-workflow/SKILL.md > skills/copilot/oneshot-workflow/SKILL.md 1`] = `
+"---
+name: oneshot-workflow
+description: "Lightweight workflow for straightforward changes — plan → implement → optional PR. Direct-commit by default; synthesize is opt-in via synthesisPolicy or a runtime request_synthesize event. Use for trivial fixes, config tweaks, single-file changes, or exploratory work that doesn't warrant subagent dispatch or two-stage review. Triggers: 'oneshot', 'quick fix', 'small change', or /oneshot."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: plan
+---
+
+# Oneshot Workflow Skill
+
+A lean, four-phase workflow type for changes that are too small to justify the
+full \`feature\` flow (\`ideate → plan → delegate → review → synthesize\`) but
+still deserve event-sourced auditability and a planning step. The workflow is
+**direct-commit by default** with an opt-in PR path; the choice between the
+two is resolved at the end of \`implementing\` via a pure event-sourced guard,
+not a heuristic.
+
+> **Read this first if you have never run a oneshot:** the workflow has a
+> *choice state* at the end of \`implementing\`. Whether you land on
+> \`completed\` (direct commit) or transition through \`synthesize\` (PR) is
+> decided by two inputs: the \`synthesisPolicy\` set at init, and whether the
+> user emitted a \`synthesize.requested\` event during implementing. Both
+> inputs are persisted; the decision is replay-safe.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically a single file, or a tightly-coupled
+  cluster of 2-3 files
+- No subagent dispatch is needed — the work fits comfortably in one TDD
+  loop in a single session
+- No design document is required — the goal is obvious from the task
+  description, and a one-page plan is enough scaffolding
+- No two-stage review is required — either the change is trivial enough
+  that direct-commit is acceptable, or a single PR review will suffice
+
+Concrete examples that fit oneshot:
+- Fixing a typo in a README
+- Bumping a dependency version
+- Adding a missing null-check in one function
+- Tweaking a CI workflow YAML
+- Renaming a config key everywhere it's referenced
+- Adding a one-off helper script
+- Exploratory spikes that may or may not be kept
+
+## When NOT to use oneshot
+
+Do not use oneshot for any of the following — use the full \`feature\`
+workflow instead (\`/ideate\`):
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+- Anything where you'd want a written design doc to look back at
+
+If you start a oneshot and discover the change is bigger than expected, the
+right move is \`/cancel\` and restart with \`/ideate\`.
+Don't try to grow a oneshot into a feature workflow mid-stream; the
+playbooks have different shapes and you'll fight the state machine.
+
+## Synthesis policy — three options
+
+The \`synthesisPolicy\` field on a oneshot workflow declares the user's
+intent up front about whether the change should be turned into a PR. It
+takes one of three values, persisted on \`state.oneshot.synthesisPolicy\`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| \`always\` | Always transition \`implementing → synthesize\` at finalize, regardless of events. A PR is always created. | The user wants a paper trail / review for every change in this workflow, even small ones. |
+| \`never\` | Always transition \`implementing → completed\` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | The user is iterating on personal/scratch work and explicitly opts out of PRs. |
+| \`on-request\` *(default)* | Direct-commit by default. The user can opt in to a PR mid-implementing by calling \`request_synthesize\`; if any \`synthesize.requested\` event is on the stream at finalize, the workflow transitions to \`synthesize\` instead of \`completed\`. | The common case: start with the assumption of direct-commit, but leave the door open for the user to change their mind once they see the diff. |
+
+The default is \`on-request\` because it's the least surprising: the user
+gets the lightweight path until they explicitly ask for the heavy one.
+
+**Policy wins over event.** If \`synthesisPolicy: 'never'\` is set and a
+\`synthesize.requested\` event is somehow on the stream (e.g. the user
+called the action on a workflow they thought was \`on-request\`), the
+guard still routes to \`completed\`. Policy is the user's declared intent
+and overrides runtime signal.
+
+## Lifecycle
+
+\`\`\`
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+\`\`\`
+
+Four phases. The fork after \`implementing\` is a UML *choice state*,
+implemented via two mutually-exclusive HSM transitions whose guards are
+pure functions of \`state.oneshot.synthesisPolicy\` and the
+\`synthesize.requested\` event count.
+
+| Phase | What happens | Exit criteria |
+|---|---|---|
+| \`plan\` | Lightweight one-page plan: goal, approach, files to touch, tests to add. No design doc. No subagent dispatch. | \`artifacts.plan\` set → transition to \`implementing\` |
+| \`implementing\` | In-session TDD loop. Write a failing test, make it pass, refactor. Commit as you go. The TDD iron law applies — *no production code without a failing test first*. | Tests pass + typecheck clean + finalize_oneshot called |
+| \`synthesize\` | Reached **only** when \`synthesisOptedIn\` is true. Hands off to the existing synthesis flow — see \`@skills/synthesis/SKILL.md\`. PR created via \`gh pr create\`, auto-merge enabled, CI gates apply. | PR merged → \`completed\` |
+| \`completed\` | Terminal. For direct-commit path, commits are already on the branch — there's nothing more to do. For synthesize path, the PR merge event terminates the workflow. | — |
+
+\`cancelled\` is also reachable from any phase via the universal cancel
+transition, same as every other workflow type.
+
+## Step-by-step
+
+### Step 1 — Init
+
+Call \`exarchos_workflow\` with \`action: 'init'\`, \`workflowType: 'oneshot'\`,
+and an optional \`synthesisPolicy\`:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "init",
+  featureId: "fix-readme-typo",
+  workflowType: "oneshot",
+  synthesisPolicy: "on-request" // optional — defaults to 'on-request'
+})
+\`\`\`
+
+If the user has been clear up front ("I want a PR for this"), pass
+\`synthesisPolicy: "always"\`. If they've been clear ("don't open a PR,
+just commit it"), pass \`synthesisPolicy: "never"\`. Otherwise, omit the
+field and rely on the \`on-request\` default — you can always escalate
+later in the implementing phase.
+
+The init returns the new workflow state; the workflow lands in \`plan\`.
+
+### Step 2 — Plan phase
+
+Produce a one-page plan. This is intentionally lightweight — no design
+doc, no parallelization analysis, no decomposition into N tasks. The
+plan should answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to \`implementing\` in a single set call:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "fix-readme-typo",
+  updates: {
+    "artifacts": { "plan": "<plan text>" },
+    "oneshot": { "planSummary": "<one-line summary>" },
+    "phase": "implementing"
+  }
+})
+\`\`\`
+
+The plan goes on \`artifacts.plan\` for parity with the \`feature\` workflow;
+the human-readable one-liner goes on \`oneshot.planSummary\` for the
+pipeline view.
+
+### Step 3 — Implementing phase
+
+Run an in-session TDD loop. Same iron law as every other workflow:
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run the test. Confirm it fails for
+   the right reason.
+2. **[GREEN]** Write the minimum production code to make the test pass.
+   Run the test. Confirm it passes.
+3. **[REFACTOR]** Clean up while keeping the test green.
+
+Commit each red-green-refactor cycle as a single commit. Do not batch
+multiple unrelated changes into one commit — keeping commits atomic
+matters even more in oneshot, where there's no separate review phase
+to catch bundled changes.
+
+There is **no subagent dispatch** in oneshot. The main agent does the
+work directly. There is **no separate review phase**. Quality is
+maintained by the TDD loop and (if the user opts in) the synthesize PR
+review.
+
+#### Mid-implementing: opting in to a PR
+
+If at any point during implementing the user decides they want a PR
+after all (policy is \`on-request\`, default), they can opt in by calling
+the \`request_synthesize\` orchestrate action:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+\`\`\`
+
+**The trigger for this is conversational, not a magic keyword.** Listen
+for phrases like:
+- "actually, let's open a PR for this"
+- "I want a review on this before it lands"
+- "make this a PR"
+- "let's get eyes on this"
+- "synthesize this"
+
+When you hear any of those, call \`request_synthesize\` immediately. The
+handler appends a \`synthesize.requested\` event to the workflow's event
+stream; the \`synthesisOptedIn\` guard reads the stream at finalize and
+routes accordingly. This is **idempotent** — calling
+\`request_synthesize\` twice appends two events but the guard treats any
+count >= 1 as "opted in", so duplicate calls are benign.
+
+Calling \`request_synthesize\` does **not** transition the phase. The
+workflow stays in \`implementing\`. The decision is only acted on when
+you call \`finalize_oneshot\` in step 4.
+
+### Step 4 — Finalize (the choice point)
+
+When the implementing loop is done — tests pass, typecheck clean, all
+commits made — call \`finalize_oneshot\` to resolve the choice state:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+\`\`\`
+
+The handler:
+
+1. Reads the current state and verifies \`workflowType === 'oneshot'\` and
+   \`phase === 'implementing'\`.
+2. Hydrates \`_events\` from the event store so the guard sees the same
+   view the HSM will see during the actual transition.
+3. Evaluates \`guards.synthesisOptedIn\` against the state. The guard
+   inspects \`state.oneshot.synthesisPolicy\` and the \`_events\` array.
+4. Calls \`handleSet\` with the resolved target phase (\`synthesize\` or
+   \`completed\`). The HSM re-evaluates the guard at the transition
+   boundary, so any race between the read and the transition is caught
+   safely.
+
+Possible outcomes:
+
+| \`synthesisPolicy\` | \`synthesize.requested\` event present? | Resolved target | Path |
+|---|---|---|---|
+| \`always\` | (any) | \`synthesize\` | PR path |
+| \`never\` | (any) | \`completed\` | direct-commit path |
+| \`on-request\` (default) | yes | \`synthesize\` | PR path |
+| \`on-request\` (default) | no | \`completed\` | direct-commit path |
+
+### Step 5a — Direct-commit path (terminal)
+
+If finalize resolved to \`completed\`, you're done. The commits made
+during implementing are already on the current branch. Push them if
+they aren't already pushed:
+
+\`\`\`bash
+git push
+\`\`\`
+
+The workflow is now in \`completed\` and will not appear in the default
+pipeline view.
+
+### Step 5b — Synthesize path
+
+If finalize resolved to \`synthesize\`, hand off to the standard synthesis
+flow — see \`@skills/synthesis/SKILL.md\`. The same \`prepare_synthesis\` /
+\`validate_pr_body\` / \`gh pr create\` machinery used by the \`feature\`
+workflow applies. After the PR merges, the workflow transitions
+\`synthesize → completed\` via the existing \`mergeVerified\` guard, same as
+every other workflow type.
+
+You do **not** need to run \`/delegate\` or
+\`/review\` for an opt-in oneshot synthesize. Those phases
+do not exist in the oneshot playbook. The PR review is the only review.
+
+## Example invocations
+
+### Example A — Direct-commit (default \`on-request\` policy, no opt-in)
+
+\`\`\`
+User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
+       Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
+  2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  4. [RED] writes test that greps README for 'recieve' and expects 0 matches
+        — fails (1 match exists)
+  5. [GREEN] edits README, fixes typo
+        — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+\`\`\`
+
+### Example B — Mid-implementing opt-in (\`on-request\` → user changes mind)
+
+\`\`\`
+User: "Add input validation to the parseConfig helper. Oneshot."
+
+Agent:
+  1. exarchos_workflow init { workflowType: "oneshot" }
+     → 'plan' phase, default 'on-request'
+  2. plans (goal: validate input, files: [parser.ts, parser.test.ts])
+  3. transitions to 'implementing'
+  4. [RED] writes test for null-input case
+  5. [GREEN] adds null check
+  6. [REFACTOR] extracts validateInput helper
+  7. commits
+
+User: "Actually, this is touching the parser — I want a review on it before
+       it lands."
+
+Agent:
+  8. exarchos_orchestrate request_synthesize {
+       featureId, reason: "user requested review of parser changes"
+     }
+     → appends synthesize.requested event
+  9. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='on-request' + 1 synthesize.requested event
+     → resolves to 'synthesize'
+ 10. hands off to @skills/synthesis/SKILL.md → prepare_synthesis →
+     validate_pr_body → gh pr create → merge
+\`\`\`
+
+### Example C — \`synthesisPolicy: 'always'\` (PR mandatory)
+
+\`\`\`
+User: "I want a PR for any change to the auth module, even small ones.
+       Use oneshot but always make a PR."
+
+Agent:
+  1. exarchos_workflow init {
+       workflowType: "oneshot",
+       synthesisPolicy: "always"
+     }
+  2-7. plan + TDD + commits, identical to Example A
+  8. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='always' (short-circuits — no event check needed)
+     → resolves to 'synthesize'
+  9. synthesis flow → PR
+\`\`\`
+
+## State management
+
+Track oneshot-specific state under the \`oneshot\` key on the workflow state:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "<id>",
+  updates: {
+    "oneshot": {
+      "synthesisPolicy": "on-request",
+      "planSummary": "Fix off-by-one in pagination helper"
+    }
+  }
+})
+\`\`\`
+
+The \`synthesisPolicy\` field is optional and defaults to \`'on-request'\` per
+the schema in \`servers/exarchos-mcp/src/workflow/schemas.ts\`. Setting it
+explicitly is recommended when the user has stated a preference.
+
+## Phase Transitions and Guards
+
+For the full transition table for oneshot, consult
+\`@skills/workflow-state/references/phase-transitions.md\`.
+
+**Quick reference for oneshot:**
+
+| From | To | Guard |
+|---|---|---|
+| \`plan\` | \`implementing\` | \`planApproved\` (or \`oneshotPlanSet\`, checks \`artifacts.plan\` presence) |
+| \`implementing\` | \`synthesize\` | \`synthesisOptedIn\` |
+| \`implementing\` | \`completed\` | \`synthesisOptedOut\` |
+| \`synthesize\` | \`completed\` | \`mergeVerified\` |
+| (any) | \`cancelled\` | universal — always allowed |
+
+\`synthesisOptedIn\` and \`synthesisOptedOut\` are pure functions of
+\`state.oneshot.synthesisPolicy\` and \`state._events\`. They are mutually
+exclusive across all 8 (3 policies × event-present/absent, with \`always\`
+and \`never\` ignoring the event flag) combinations — exactly one returns
+true at any given time.
+
+### Schema discovery
+
+Use \`exarchos_workflow({ action: "describe", actions: ["init", "set"] })\`
+for parameter schemas (including the \`synthesisPolicy\` enum) and
+\`exarchos_workflow({ action: "describe", playbook: "oneshot" })\` for the
+phase transitions, guard names, and playbook prose. Use
+\`exarchos_orchestrate({ action: "describe", actions: ["request_synthesize", "finalize_oneshot"] })\`
+for the orchestrate action schemas.
+
+## TDD is still mandatory
+
+The iron law from \`@rules/tdd.md\` applies to oneshot. There is no
+exemption for "small" changes. Specifically:
+
+- Every behavior change starts with a failing test
+- Every test must fail before its implementation is written
+- Tests must be run after each change to verify state
+- Commits stay atomic — one logical change per commit
+
+The temptation in a oneshot is to skip the test "because it's just one
+line". Resist that. The test is what makes the change auditable, and
+auditability is the entire reason oneshot exists alongside the lighter
+"bypass workflows entirely" path.
+
+## Anti-patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip the plan phase ("it's obvious") | Write the four-line plan anyway — it's the artifact future-you reads |
+| Skip the TDD loop in implementing | Always RED → GREEN → REFACTOR, even for one-liners |
+| Use oneshot for multi-file refactors | Use \`/ideate\` and the full feature workflow |
+| Try to grow a oneshot into a feature workflow mid-stream | Cancel and restart with \`/ideate\` |
+| Call \`request_synthesize\` without listening for the user's intent | Wait for the user to ask for a PR, then call it |
+| Bundle unrelated changes into one commit "since it's a oneshot" | Keep commits atomic — there's no review phase to catch bundling |
+| Forget to call \`finalize_oneshot\` at the end | The workflow stays in \`implementing\` forever otherwise — call it explicitly |
+
+## Completion criteria
+
+- [ ] \`exarchos_workflow init\` called with \`workflowType: "oneshot"\`
+- [ ] One-page plan persisted to \`artifacts.plan\`
+- [ ] Phase transitioned to \`implementing\`
+- [ ] All planned behaviors implemented via TDD with atomic commits
+- [ ] \`finalize_oneshot\` called and resolved to either \`completed\` or \`synthesize\`
+- [ ] If direct-commit path: commits pushed
+- [ ] If synthesize path: PR created via \`@skills/synthesis/SKILL.md\` and merged
+"
+`;
+
+exports[`task 025 — per-runtime snapshot baselines > runtime: copilot > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/copilot/prune-workflows/SKILL.md > skills/copilot/prune-workflows/SKILL.md 1`] = `
+"---
+name: prune-workflows
+description: "Interactively prune stale non-terminal workflows from the pipeline. Use when the user says 'prune workflows', 'clean stale workflows', 'pipeline cleanup', or runs /prune. Runs a dry-run preview, displays candidates with staleness and safeguard skips, prompts the user to proceed/abort/force, then bulk-cancels approved workflows with a workflow.pruned audit event. Safeguards skip workflows with open PRs or recent commits unless force is set."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: maintenance
+---
+
+# Prune Workflows Skill
+
+## Overview
+
+Bulk-cancel stale non-terminal workflows that have accumulated in the pipeline. Wraps the \`prune_stale_workflows\` orchestrate action with an interactive dry-run-then-confirm UX so the user always sees the candidate set before any state mutates.
+
+Pruning is a maintenance operation -- not a workflow phase. It produces \`workflow.pruned\` events alongside the standard \`workflow.cancelled\` events emitted by the underlying cancel path, so downstream views can distinguish user-intent cancellations from batch cleanup.
+
+## Triggers
+
+Activate this skill when:
+- User runs \`/prune\` command
+- User says "prune workflows", "clean stale workflows", "pipeline cleanup"
+- \`mcp__exarchos__exarchos_view({ action: "pipeline" })\` shows many inactive workflows the user wants to clear in bulk
+
+## Prerequisites
+
+- An exarchos state directory with one or more non-terminal workflows
+- For safeguard checks against live PRs: \`gh\` available in PATH (the orchestrate handler shells out)
+- For safeguard checks against branch activity: \`git\` available in PATH
+
+## Process
+
+### Step 1: Dry-Run Preview
+
+Always start with \`dryRun: true\`. This call performs candidate selection and safeguard evaluation but does not mutate any workflow state.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: true
+  }
+})
+\`\`\`
+
+The response shape is:
+
+\`\`\`ts
+{
+  candidates: [
+    { featureId: string, phase: string, workflowType: string, stalenessMinutes: number }
+  ],
+  skipped: [
+    { featureId: string, reason: "open-pr" | "active-branch" }
+  ]
+}
+\`\`\`
+
+Optional args:
+- \`thresholdMinutes\` -- staleness cutoff. Default is 10080 (7 days).
+- \`includeOneShot\` -- whether to include \`oneshot\` workflows in the candidate set. Default \`true\`.
+- \`force\` -- not relevant in dry-run; only honored in apply mode (Step 4).
+
+### Step 2: Display Candidate Table
+
+Render a table to the user so they can review what would be pruned. Use this format:
+
+\`\`\`markdown
+## Prune Candidates (3)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-experiment | feature | implementing | 14430 |
+| oneshot-typo-fix | oneshot | plan | 9120 |
+| debug-flaky-test | debug | investigate | 8650 |
+
+## Skipped by Safeguards (2)
+
+| Feature ID | Reason |
+|---|---|
+| feat-active-pr | open-pr |
+| feat-recent-work | active-branch |
+\`\`\`
+
+If \`candidates.length === 0\` AND \`skipped.length === 0\`, output:
+
+> No stale workflows to prune. Pipeline is clean.
+
+Then exit -- no further action.
+
+### Step 3: Prompt for Confirmation
+
+Ask the user one of three choices:
+
+> **proceed** -- prune the listed candidates (skipped workflows stay)
+> **abort** -- exit without changes
+> **force** -- bypass safeguards and prune skipped workflows too
+
+Wait for explicit user input. Do **not** auto-proceed.
+
+### Step 4a: Apply (proceed)
+
+On \`proceed\`, invoke the same action with \`dryRun: false\`. Pass through \`thresholdMinutes\` and \`includeOneShot\` if the user set them in Step 1.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false
+  }
+})
+\`\`\`
+
+The response now includes a \`pruned\` array:
+
+\`\`\`ts
+{
+  candidates: [...],
+  skipped: [...],
+  pruned: [
+    { featureId: string, previousPhase: string }
+  ]
+}
+\`\`\`
+
+Each entry in \`pruned\` corresponds to a workflow that transitioned to \`cancelled\` and emitted a \`workflow.pruned\` event.
+
+### Step 4b: Apply (force)
+
+On \`force\`, set \`force: true\`. Safeguards are bypassed but the bypass is recorded in the \`workflow.pruned\` event payload as \`skippedSafeguards: [...]\` so the audit trail is intact.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false,
+    force: true
+  }
+})
+\`\`\`
+
+In force mode, workflows that were in the \`skipped\` list during dry-run are now eligible for pruning.
+
+### Step 4c: Apply (abort)
+
+On \`abort\`, exit without invoking the action a second time. The dry-run has not mutated any state.
+
+### Step 5: Report Results
+
+After the apply call returns, summarize the outcome:
+
+\`\`\`markdown
+## Prune Complete
+
+**Pruned:** 3 workflows transitioned to cancelled
+**Skipped:** 2 workflows preserved by safeguards
+**Force bypass:** no
+
+### Pruned Workflows
+- feat-old-experiment (was: implementing)
+- oneshot-typo-fix (was: plan)
+- debug-flaky-test (was: investigate)
+\`\`\`
+
+If \`force\` was used, also list any safeguards that were bypassed:
+
+\`\`\`markdown
+### Safeguards Bypassed
+- feat-active-pr: open-pr
+- feat-recent-work: active-branch
+\`\`\`
+
+## Safeguards Explained
+
+Two safeguards run automatically in the orchestrate handler before each cancel:
+
+| Safeguard | Behavior | Reason key |
+|---|---|---|
+| **Open PR** | Skip if \`gh pr list --head <branch> --state open\` returns any results | \`open-pr\` |
+| **Recent commits** | Skip if \`git log --since "24 hours ago" origin/<branch>\` shows commits | \`active-branch\` |
+
+A workflow without a \`branchName\` in state (e.g., abandoned at ideate/plan before delegation) cannot have a PR or branch activity, so safeguards short-circuit and the workflow is eligible for pruning.
+
+\`force: true\` bypasses both checks but does not bypass the audit -- the bypassed safeguard names are recorded in the \`workflow.pruned\` event payload.
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|---|---|
+| Skip the dry-run step | Always start with \`dryRun: true\` so the user sees candidates first |
+| Auto-confirm without showing the table | Render the candidate table and wait for explicit user input |
+| Use \`force: true\` by default | Reserve \`force\` for cases where the user has explicitly opted in |
+| Manually call \`cancel\` for each stale workflow | Use this skill -- it batches the cancel loop and emits the \`workflow.pruned\` audit event |
+| Run on every session | Pruning is a maintenance operation; run when pipeline accumulation is observable |
+
+## Examples
+
+### Example 1: Clean dry-run, user proceeds
+
+\`\`\`
+> /prune
+
+## Prune Candidates (2)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-spike | feature | plan | 12880 |
+| oneshot-readme-tweak | oneshot | implementing | 9700 |
+
+## Skipped by Safeguards (0)
+
+(none)
+
+Proceed? (proceed/abort/force)
+
+> proceed
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** no
+
+### Pruned Workflows
+- feat-old-spike (was: plan)
+- oneshot-readme-tweak (was: implementing)
+\`\`\`
+
+### Example 2: Safeguard skip, user forces
+
+\`\`\`
+> /prune
+
+## Prune Candidates (1)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-stale-no-pr | feature | implementing | 11200 |
+
+## Skipped by Safeguards (1)
+
+| Feature ID | Reason |
+|---|---|
+| feat-stale-with-pr | open-pr |
+
+Proceed? (proceed/abort/force)
+
+> force
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** yes
+
+### Pruned Workflows
+- feat-stale-no-pr (was: implementing)
+- feat-stale-with-pr (was: implementing)
+
+### Safeguards Bypassed
+- feat-stale-with-pr: open-pr
+\`\`\`
+
+### Example 3: Empty pipeline
+
+\`\`\`
+> /prune
+
+No stale workflows to prune. Pipeline is clean.
+\`\`\`
+
+## Schema Discovery
+
+For the canonical argument schema and any future fields, use:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "describe",
+  actions: ["prune_stale_workflows"]
+})
+\`\`\`
+
+## Exarchos Integration
+
+The \`prune_stale_workflows\` action emits two events per pruned workflow:
+- \`workflow.cancelled\` (auto-emitted by the underlying \`handleCancel\` path)
+- \`workflow.pruned\` (emitted by this handler with \`triggeredBy: 'manual'\` and optional \`skippedSafeguards\`)
+
+Both are projected into the workflow state's \`_events\` array by the standard projection. Downstream views can filter on \`workflow.pruned\` to identify batch cleanups versus user-initiated cancels.
 "
 `;
 
@@ -11417,6 +13637,746 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 "
 `;
 
+exports[`task 025 — per-runtime snapshot baselines > runtime: cursor > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/cursor/oneshot-workflow/SKILL.md > skills/cursor/oneshot-workflow/SKILL.md 1`] = `
+"---
+name: oneshot-workflow
+description: "Lightweight workflow for straightforward changes — plan → implement → optional PR. Direct-commit by default; synthesize is opt-in via synthesisPolicy or a runtime request_synthesize event. Use for trivial fixes, config tweaks, single-file changes, or exploratory work that doesn't warrant subagent dispatch or two-stage review. Triggers: 'oneshot', 'quick fix', 'small change', or oneshot."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: plan
+---
+
+# Oneshot Workflow Skill
+
+A lean, four-phase workflow type for changes that are too small to justify the
+full \`feature\` flow (\`ideate → plan → delegate → review → synthesize\`) but
+still deserve event-sourced auditability and a planning step. The workflow is
+**direct-commit by default** with an opt-in PR path; the choice between the
+two is resolved at the end of \`implementing\` via a pure event-sourced guard,
+not a heuristic.
+
+> **Read this first if you have never run a oneshot:** the workflow has a
+> *choice state* at the end of \`implementing\`. Whether you land on
+> \`completed\` (direct commit) or transition through \`synthesize\` (PR) is
+> decided by two inputs: the \`synthesisPolicy\` set at init, and whether the
+> user emitted a \`synthesize.requested\` event during implementing. Both
+> inputs are persisted; the decision is replay-safe.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically a single file, or a tightly-coupled
+  cluster of 2-3 files
+- No subagent dispatch is needed — the work fits comfortably in one TDD
+  loop in a single session
+- No design document is required — the goal is obvious from the task
+  description, and a one-page plan is enough scaffolding
+- No two-stage review is required — either the change is trivial enough
+  that direct-commit is acceptable, or a single PR review will suffice
+
+Concrete examples that fit oneshot:
+- Fixing a typo in a README
+- Bumping a dependency version
+- Adding a missing null-check in one function
+- Tweaking a CI workflow YAML
+- Renaming a config key everywhere it's referenced
+- Adding a one-off helper script
+- Exploratory spikes that may or may not be kept
+
+## When NOT to use oneshot
+
+Do not use oneshot for any of the following — use the full \`feature\`
+workflow instead (\`ideate\`):
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+- Anything where you'd want a written design doc to look back at
+
+If you start a oneshot and discover the change is bigger than expected, the
+right move is \`cancel\` and restart with \`ideate\`.
+Don't try to grow a oneshot into a feature workflow mid-stream; the
+playbooks have different shapes and you'll fight the state machine.
+
+## Synthesis policy — three options
+
+The \`synthesisPolicy\` field on a oneshot workflow declares the user's
+intent up front about whether the change should be turned into a PR. It
+takes one of three values, persisted on \`state.oneshot.synthesisPolicy\`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| \`always\` | Always transition \`implementing → synthesize\` at finalize, regardless of events. A PR is always created. | The user wants a paper trail / review for every change in this workflow, even small ones. |
+| \`never\` | Always transition \`implementing → completed\` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | The user is iterating on personal/scratch work and explicitly opts out of PRs. |
+| \`on-request\` *(default)* | Direct-commit by default. The user can opt in to a PR mid-implementing by calling \`request_synthesize\`; if any \`synthesize.requested\` event is on the stream at finalize, the workflow transitions to \`synthesize\` instead of \`completed\`. | The common case: start with the assumption of direct-commit, but leave the door open for the user to change their mind once they see the diff. |
+
+The default is \`on-request\` because it's the least surprising: the user
+gets the lightweight path until they explicitly ask for the heavy one.
+
+**Policy wins over event.** If \`synthesisPolicy: 'never'\` is set and a
+\`synthesize.requested\` event is somehow on the stream (e.g. the user
+called the action on a workflow they thought was \`on-request\`), the
+guard still routes to \`completed\`. Policy is the user's declared intent
+and overrides runtime signal.
+
+## Lifecycle
+
+\`\`\`
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+\`\`\`
+
+Four phases. The fork after \`implementing\` is a UML *choice state*,
+implemented via two mutually-exclusive HSM transitions whose guards are
+pure functions of \`state.oneshot.synthesisPolicy\` and the
+\`synthesize.requested\` event count.
+
+| Phase | What happens | Exit criteria |
+|---|---|---|
+| \`plan\` | Lightweight one-page plan: goal, approach, files to touch, tests to add. No design doc. No subagent dispatch. | \`artifacts.plan\` set → transition to \`implementing\` |
+| \`implementing\` | In-session TDD loop. Write a failing test, make it pass, refactor. Commit as you go. The TDD iron law applies — *no production code without a failing test first*. | Tests pass + typecheck clean + finalize_oneshot called |
+| \`synthesize\` | Reached **only** when \`synthesisOptedIn\` is true. Hands off to the existing synthesis flow — see \`@skills/synthesis/SKILL.md\`. PR created via \`gh pr create\`, auto-merge enabled, CI gates apply. | PR merged → \`completed\` |
+| \`completed\` | Terminal. For direct-commit path, commits are already on the branch — there's nothing more to do. For synthesize path, the PR merge event terminates the workflow. | — |
+
+\`cancelled\` is also reachable from any phase via the universal cancel
+transition, same as every other workflow type.
+
+## Step-by-step
+
+### Step 1 — Init
+
+Call \`exarchos_workflow\` with \`action: 'init'\`, \`workflowType: 'oneshot'\`,
+and an optional \`synthesisPolicy\`:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "init",
+  featureId: "fix-readme-typo",
+  workflowType: "oneshot",
+  synthesisPolicy: "on-request" // optional — defaults to 'on-request'
+})
+\`\`\`
+
+If the user has been clear up front ("I want a PR for this"), pass
+\`synthesisPolicy: "always"\`. If they've been clear ("don't open a PR,
+just commit it"), pass \`synthesisPolicy: "never"\`. Otherwise, omit the
+field and rely on the \`on-request\` default — you can always escalate
+later in the implementing phase.
+
+The init returns the new workflow state; the workflow lands in \`plan\`.
+
+### Step 2 — Plan phase
+
+Produce a one-page plan. This is intentionally lightweight — no design
+doc, no parallelization analysis, no decomposition into N tasks. The
+plan should answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to \`implementing\` in a single set call:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "fix-readme-typo",
+  updates: {
+    "artifacts": { "plan": "<plan text>" },
+    "oneshot": { "planSummary": "<one-line summary>" },
+    "phase": "implementing"
+  }
+})
+\`\`\`
+
+The plan goes on \`artifacts.plan\` for parity with the \`feature\` workflow;
+the human-readable one-liner goes on \`oneshot.planSummary\` for the
+pipeline view.
+
+### Step 3 — Implementing phase
+
+Run an in-session TDD loop. Same iron law as every other workflow:
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run the test. Confirm it fails for
+   the right reason.
+2. **[GREEN]** Write the minimum production code to make the test pass.
+   Run the test. Confirm it passes.
+3. **[REFACTOR]** Clean up while keeping the test green.
+
+Commit each red-green-refactor cycle as a single commit. Do not batch
+multiple unrelated changes into one commit — keeping commits atomic
+matters even more in oneshot, where there's no separate review phase
+to catch bundled changes.
+
+There is **no subagent dispatch** in oneshot. The main agent does the
+work directly. There is **no separate review phase**. Quality is
+maintained by the TDD loop and (if the user opts in) the synthesize PR
+review.
+
+#### Mid-implementing: opting in to a PR
+
+If at any point during implementing the user decides they want a PR
+after all (policy is \`on-request\`, default), they can opt in by calling
+the \`request_synthesize\` orchestrate action:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+\`\`\`
+
+**The trigger for this is conversational, not a magic keyword.** Listen
+for phrases like:
+- "actually, let's open a PR for this"
+- "I want a review on this before it lands"
+- "make this a PR"
+- "let's get eyes on this"
+- "synthesize this"
+
+When you hear any of those, call \`request_synthesize\` immediately. The
+handler appends a \`synthesize.requested\` event to the workflow's event
+stream; the \`synthesisOptedIn\` guard reads the stream at finalize and
+routes accordingly. This is **idempotent** — calling
+\`request_synthesize\` twice appends two events but the guard treats any
+count >= 1 as "opted in", so duplicate calls are benign.
+
+Calling \`request_synthesize\` does **not** transition the phase. The
+workflow stays in \`implementing\`. The decision is only acted on when
+you call \`finalize_oneshot\` in step 4.
+
+### Step 4 — Finalize (the choice point)
+
+When the implementing loop is done — tests pass, typecheck clean, all
+commits made — call \`finalize_oneshot\` to resolve the choice state:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+\`\`\`
+
+The handler:
+
+1. Reads the current state and verifies \`workflowType === 'oneshot'\` and
+   \`phase === 'implementing'\`.
+2. Hydrates \`_events\` from the event store so the guard sees the same
+   view the HSM will see during the actual transition.
+3. Evaluates \`guards.synthesisOptedIn\` against the state. The guard
+   inspects \`state.oneshot.synthesisPolicy\` and the \`_events\` array.
+4. Calls \`handleSet\` with the resolved target phase (\`synthesize\` or
+   \`completed\`). The HSM re-evaluates the guard at the transition
+   boundary, so any race between the read and the transition is caught
+   safely.
+
+Possible outcomes:
+
+| \`synthesisPolicy\` | \`synthesize.requested\` event present? | Resolved target | Path |
+|---|---|---|---|
+| \`always\` | (any) | \`synthesize\` | PR path |
+| \`never\` | (any) | \`completed\` | direct-commit path |
+| \`on-request\` (default) | yes | \`synthesize\` | PR path |
+| \`on-request\` (default) | no | \`completed\` | direct-commit path |
+
+### Step 5a — Direct-commit path (terminal)
+
+If finalize resolved to \`completed\`, you're done. The commits made
+during implementing are already on the current branch. Push them if
+they aren't already pushed:
+
+\`\`\`bash
+git push
+\`\`\`
+
+The workflow is now in \`completed\` and will not appear in the default
+pipeline view.
+
+### Step 5b — Synthesize path
+
+If finalize resolved to \`synthesize\`, hand off to the standard synthesis
+flow — see \`@skills/synthesis/SKILL.md\`. The same \`prepare_synthesis\` /
+\`validate_pr_body\` / \`gh pr create\` machinery used by the \`feature\`
+workflow applies. After the PR merges, the workflow transitions
+\`synthesize → completed\` via the existing \`mergeVerified\` guard, same as
+every other workflow type.
+
+You do **not** need to run \`delegate\` or
+\`review\` for an opt-in oneshot synthesize. Those phases
+do not exist in the oneshot playbook. The PR review is the only review.
+
+## Example invocations
+
+### Example A — Direct-commit (default \`on-request\` policy, no opt-in)
+
+\`\`\`
+User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
+       Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
+  2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  4. [RED] writes test that greps README for 'recieve' and expects 0 matches
+        — fails (1 match exists)
+  5. [GREEN] edits README, fixes typo
+        — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+\`\`\`
+
+### Example B — Mid-implementing opt-in (\`on-request\` → user changes mind)
+
+\`\`\`
+User: "Add input validation to the parseConfig helper. Oneshot."
+
+Agent:
+  1. exarchos_workflow init { workflowType: "oneshot" }
+     → 'plan' phase, default 'on-request'
+  2. plans (goal: validate input, files: [parser.ts, parser.test.ts])
+  3. transitions to 'implementing'
+  4. [RED] writes test for null-input case
+  5. [GREEN] adds null check
+  6. [REFACTOR] extracts validateInput helper
+  7. commits
+
+User: "Actually, this is touching the parser — I want a review on it before
+       it lands."
+
+Agent:
+  8. exarchos_orchestrate request_synthesize {
+       featureId, reason: "user requested review of parser changes"
+     }
+     → appends synthesize.requested event
+  9. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='on-request' + 1 synthesize.requested event
+     → resolves to 'synthesize'
+ 10. hands off to @skills/synthesis/SKILL.md → prepare_synthesis →
+     validate_pr_body → gh pr create → merge
+\`\`\`
+
+### Example C — \`synthesisPolicy: 'always'\` (PR mandatory)
+
+\`\`\`
+User: "I want a PR for any change to the auth module, even small ones.
+       Use oneshot but always make a PR."
+
+Agent:
+  1. exarchos_workflow init {
+       workflowType: "oneshot",
+       synthesisPolicy: "always"
+     }
+  2-7. plan + TDD + commits, identical to Example A
+  8. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='always' (short-circuits — no event check needed)
+     → resolves to 'synthesize'
+  9. synthesis flow → PR
+\`\`\`
+
+## State management
+
+Track oneshot-specific state under the \`oneshot\` key on the workflow state:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "<id>",
+  updates: {
+    "oneshot": {
+      "synthesisPolicy": "on-request",
+      "planSummary": "Fix off-by-one in pagination helper"
+    }
+  }
+})
+\`\`\`
+
+The \`synthesisPolicy\` field is optional and defaults to \`'on-request'\` per
+the schema in \`servers/exarchos-mcp/src/workflow/schemas.ts\`. Setting it
+explicitly is recommended when the user has stated a preference.
+
+## Phase Transitions and Guards
+
+For the full transition table for oneshot, consult
+\`@skills/workflow-state/references/phase-transitions.md\`.
+
+**Quick reference for oneshot:**
+
+| From | To | Guard |
+|---|---|---|
+| \`plan\` | \`implementing\` | \`planApproved\` (or \`oneshotPlanSet\`, checks \`artifacts.plan\` presence) |
+| \`implementing\` | \`synthesize\` | \`synthesisOptedIn\` |
+| \`implementing\` | \`completed\` | \`synthesisOptedOut\` |
+| \`synthesize\` | \`completed\` | \`mergeVerified\` |
+| (any) | \`cancelled\` | universal — always allowed |
+
+\`synthesisOptedIn\` and \`synthesisOptedOut\` are pure functions of
+\`state.oneshot.synthesisPolicy\` and \`state._events\`. They are mutually
+exclusive across all 8 (3 policies × event-present/absent, with \`always\`
+and \`never\` ignoring the event flag) combinations — exactly one returns
+true at any given time.
+
+### Schema discovery
+
+Use \`exarchos_workflow({ action: "describe", actions: ["init", "set"] })\`
+for parameter schemas (including the \`synthesisPolicy\` enum) and
+\`exarchos_workflow({ action: "describe", playbook: "oneshot" })\` for the
+phase transitions, guard names, and playbook prose. Use
+\`exarchos_orchestrate({ action: "describe", actions: ["request_synthesize", "finalize_oneshot"] })\`
+for the orchestrate action schemas.
+
+## TDD is still mandatory
+
+The iron law from \`@rules/tdd.md\` applies to oneshot. There is no
+exemption for "small" changes. Specifically:
+
+- Every behavior change starts with a failing test
+- Every test must fail before its implementation is written
+- Tests must be run after each change to verify state
+- Commits stay atomic — one logical change per commit
+
+The temptation in a oneshot is to skip the test "because it's just one
+line". Resist that. The test is what makes the change auditable, and
+auditability is the entire reason oneshot exists alongside the lighter
+"bypass workflows entirely" path.
+
+## Anti-patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip the plan phase ("it's obvious") | Write the four-line plan anyway — it's the artifact future-you reads |
+| Skip the TDD loop in implementing | Always RED → GREEN → REFACTOR, even for one-liners |
+| Use oneshot for multi-file refactors | Use \`ideate\` and the full feature workflow |
+| Try to grow a oneshot into a feature workflow mid-stream | Cancel and restart with \`ideate\` |
+| Call \`request_synthesize\` without listening for the user's intent | Wait for the user to ask for a PR, then call it |
+| Bundle unrelated changes into one commit "since it's a oneshot" | Keep commits atomic — there's no review phase to catch bundling |
+| Forget to call \`finalize_oneshot\` at the end | The workflow stays in \`implementing\` forever otherwise — call it explicitly |
+
+## Completion criteria
+
+- [ ] \`exarchos_workflow init\` called with \`workflowType: "oneshot"\`
+- [ ] One-page plan persisted to \`artifacts.plan\`
+- [ ] Phase transitioned to \`implementing\`
+- [ ] All planned behaviors implemented via TDD with atomic commits
+- [ ] \`finalize_oneshot\` called and resolved to either \`completed\` or \`synthesize\`
+- [ ] If direct-commit path: commits pushed
+- [ ] If synthesize path: PR created via \`@skills/synthesis/SKILL.md\` and merged
+"
+`;
+
+exports[`task 025 — per-runtime snapshot baselines > runtime: cursor > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/cursor/prune-workflows/SKILL.md > skills/cursor/prune-workflows/SKILL.md 1`] = `
+"---
+name: prune-workflows
+description: "Interactively prune stale non-terminal workflows from the pipeline. Use when the user says 'prune workflows', 'clean stale workflows', 'pipeline cleanup', or runs /prune. Runs a dry-run preview, displays candidates with staleness and safeguard skips, prompts the user to proceed/abort/force, then bulk-cancels approved workflows with a workflow.pruned audit event. Safeguards skip workflows with open PRs or recent commits unless force is set."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: maintenance
+---
+
+# Prune Workflows Skill
+
+## Overview
+
+Bulk-cancel stale non-terminal workflows that have accumulated in the pipeline. Wraps the \`prune_stale_workflows\` orchestrate action with an interactive dry-run-then-confirm UX so the user always sees the candidate set before any state mutates.
+
+Pruning is a maintenance operation -- not a workflow phase. It produces \`workflow.pruned\` events alongside the standard \`workflow.cancelled\` events emitted by the underlying cancel path, so downstream views can distinguish user-intent cancellations from batch cleanup.
+
+## Triggers
+
+Activate this skill when:
+- User runs \`prune\` command
+- User says "prune workflows", "clean stale workflows", "pipeline cleanup"
+- \`mcp__exarchos__exarchos_view({ action: "pipeline" })\` shows many inactive workflows the user wants to clear in bulk
+
+## Prerequisites
+
+- An exarchos state directory with one or more non-terminal workflows
+- For safeguard checks against live PRs: \`gh\` available in PATH (the orchestrate handler shells out)
+- For safeguard checks against branch activity: \`git\` available in PATH
+
+## Process
+
+### Step 1: Dry-Run Preview
+
+Always start with \`dryRun: true\`. This call performs candidate selection and safeguard evaluation but does not mutate any workflow state.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: true
+  }
+})
+\`\`\`
+
+The response shape is:
+
+\`\`\`ts
+{
+  candidates: [
+    { featureId: string, phase: string, workflowType: string, stalenessMinutes: number }
+  ],
+  skipped: [
+    { featureId: string, reason: "open-pr" | "active-branch" }
+  ]
+}
+\`\`\`
+
+Optional args:
+- \`thresholdMinutes\` -- staleness cutoff. Default is 10080 (7 days).
+- \`includeOneShot\` -- whether to include \`oneshot\` workflows in the candidate set. Default \`true\`.
+- \`force\` -- not relevant in dry-run; only honored in apply mode (Step 4).
+
+### Step 2: Display Candidate Table
+
+Render a table to the user so they can review what would be pruned. Use this format:
+
+\`\`\`markdown
+## Prune Candidates (3)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-experiment | feature | implementing | 14430 |
+| oneshot-typo-fix | oneshot | plan | 9120 |
+| debug-flaky-test | debug | investigate | 8650 |
+
+## Skipped by Safeguards (2)
+
+| Feature ID | Reason |
+|---|---|
+| feat-active-pr | open-pr |
+| feat-recent-work | active-branch |
+\`\`\`
+
+If \`candidates.length === 0\` AND \`skipped.length === 0\`, output:
+
+> No stale workflows to prune. Pipeline is clean.
+
+Then exit -- no further action.
+
+### Step 3: Prompt for Confirmation
+
+Ask the user one of three choices:
+
+> **proceed** -- prune the listed candidates (skipped workflows stay)
+> **abort** -- exit without changes
+> **force** -- bypass safeguards and prune skipped workflows too
+
+Wait for explicit user input. Do **not** auto-proceed.
+
+### Step 4a: Apply (proceed)
+
+On \`proceed\`, invoke the same action with \`dryRun: false\`. Pass through \`thresholdMinutes\` and \`includeOneShot\` if the user set them in Step 1.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false
+  }
+})
+\`\`\`
+
+The response now includes a \`pruned\` array:
+
+\`\`\`ts
+{
+  candidates: [...],
+  skipped: [...],
+  pruned: [
+    { featureId: string, previousPhase: string }
+  ]
+}
+\`\`\`
+
+Each entry in \`pruned\` corresponds to a workflow that transitioned to \`cancelled\` and emitted a \`workflow.pruned\` event.
+
+### Step 4b: Apply (force)
+
+On \`force\`, set \`force: true\`. Safeguards are bypassed but the bypass is recorded in the \`workflow.pruned\` event payload as \`skippedSafeguards: [...]\` so the audit trail is intact.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false,
+    force: true
+  }
+})
+\`\`\`
+
+In force mode, workflows that were in the \`skipped\` list during dry-run are now eligible for pruning.
+
+### Step 4c: Apply (abort)
+
+On \`abort\`, exit without invoking the action a second time. The dry-run has not mutated any state.
+
+### Step 5: Report Results
+
+After the apply call returns, summarize the outcome:
+
+\`\`\`markdown
+## Prune Complete
+
+**Pruned:** 3 workflows transitioned to cancelled
+**Skipped:** 2 workflows preserved by safeguards
+**Force bypass:** no
+
+### Pruned Workflows
+- feat-old-experiment (was: implementing)
+- oneshot-typo-fix (was: plan)
+- debug-flaky-test (was: investigate)
+\`\`\`
+
+If \`force\` was used, also list any safeguards that were bypassed:
+
+\`\`\`markdown
+### Safeguards Bypassed
+- feat-active-pr: open-pr
+- feat-recent-work: active-branch
+\`\`\`
+
+## Safeguards Explained
+
+Two safeguards run automatically in the orchestrate handler before each cancel:
+
+| Safeguard | Behavior | Reason key |
+|---|---|---|
+| **Open PR** | Skip if \`gh pr list --head <branch> --state open\` returns any results | \`open-pr\` |
+| **Recent commits** | Skip if \`git log --since "24 hours ago" origin/<branch>\` shows commits | \`active-branch\` |
+
+A workflow without a \`branchName\` in state (e.g., abandoned at ideate/plan before delegation) cannot have a PR or branch activity, so safeguards short-circuit and the workflow is eligible for pruning.
+
+\`force: true\` bypasses both checks but does not bypass the audit -- the bypassed safeguard names are recorded in the \`workflow.pruned\` event payload.
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|---|---|
+| Skip the dry-run step | Always start with \`dryRun: true\` so the user sees candidates first |
+| Auto-confirm without showing the table | Render the candidate table and wait for explicit user input |
+| Use \`force: true\` by default | Reserve \`force\` for cases where the user has explicitly opted in |
+| Manually call \`cancel\` for each stale workflow | Use this skill -- it batches the cancel loop and emits the \`workflow.pruned\` audit event |
+| Run on every session | Pruning is a maintenance operation; run when pipeline accumulation is observable |
+
+## Examples
+
+### Example 1: Clean dry-run, user proceeds
+
+\`\`\`
+> prune
+
+## Prune Candidates (2)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-spike | feature | plan | 12880 |
+| oneshot-readme-tweak | oneshot | implementing | 9700 |
+
+## Skipped by Safeguards (0)
+
+(none)
+
+Proceed? (proceed/abort/force)
+
+> proceed
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** no
+
+### Pruned Workflows
+- feat-old-spike (was: plan)
+- oneshot-readme-tweak (was: implementing)
+\`\`\`
+
+### Example 2: Safeguard skip, user forces
+
+\`\`\`
+> prune
+
+## Prune Candidates (1)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-stale-no-pr | feature | implementing | 11200 |
+
+## Skipped by Safeguards (1)
+
+| Feature ID | Reason |
+|---|---|
+| feat-stale-with-pr | open-pr |
+
+Proceed? (proceed/abort/force)
+
+> force
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** yes
+
+### Pruned Workflows
+- feat-stale-no-pr (was: implementing)
+- feat-stale-with-pr (was: implementing)
+
+### Safeguards Bypassed
+- feat-stale-with-pr: open-pr
+\`\`\`
+
+### Example 3: Empty pipeline
+
+\`\`\`
+> prune
+
+No stale workflows to prune. Pipeline is clean.
+\`\`\`
+
+## Schema Discovery
+
+For the canonical argument schema and any future fields, use:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "describe",
+  actions: ["prune_stale_workflows"]
+})
+\`\`\`
+
+## Exarchos Integration
+
+The \`prune_stale_workflows\` action emits two events per pruned workflow:
+- \`workflow.cancelled\` (auto-emitted by the underlying \`handleCancel\` path)
+- \`workflow.pruned\` (emitted by this handler with \`triggeredBy: 'manual'\` and optional \`skippedSafeguards\`)
+
+Both are projected into the workflow state's \`_events\` array by the standard projection. Downstream views can filter on \`workflow.pruned\` to identify batch cleanups versus user-initiated cancels.
+"
+`;
+
 exports[`task 025 — per-runtime snapshot baselines > runtime: cursor > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/cursor/quality-review/SKILL.md > skills/cursor/quality-review/SKILL.md 1`] = `
 "---
 name: quality-review
@@ -14651,6 +17611,746 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 - Complete each step fully before advancing — quality over speed
 - Do not skip validation checks even when the change appears trivial
 - Trace every design section to at least one task. Do not leave uncovered sections without explicit rationale.
+"
+`;
+
+exports[`task 025 — per-runtime snapshot baselines > runtime: generic > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/generic/oneshot-workflow/SKILL.md > skills/generic/oneshot-workflow/SKILL.md 1`] = `
+"---
+name: oneshot-workflow
+description: "Lightweight workflow for straightforward changes — plan → implement → optional PR. Direct-commit by default; synthesize is opt-in via synthesisPolicy or a runtime request_synthesize event. Use for trivial fixes, config tweaks, single-file changes, or exploratory work that doesn't warrant subagent dispatch or two-stage review. Triggers: 'oneshot', 'quick fix', 'small change', or oneshot."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: plan
+---
+
+# Oneshot Workflow Skill
+
+A lean, four-phase workflow type for changes that are too small to justify the
+full \`feature\` flow (\`ideate → plan → delegate → review → synthesize\`) but
+still deserve event-sourced auditability and a planning step. The workflow is
+**direct-commit by default** with an opt-in PR path; the choice between the
+two is resolved at the end of \`implementing\` via a pure event-sourced guard,
+not a heuristic.
+
+> **Read this first if you have never run a oneshot:** the workflow has a
+> *choice state* at the end of \`implementing\`. Whether you land on
+> \`completed\` (direct commit) or transition through \`synthesize\` (PR) is
+> decided by two inputs: the \`synthesisPolicy\` set at init, and whether the
+> user emitted a \`synthesize.requested\` event during implementing. Both
+> inputs are persisted; the decision is replay-safe.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically a single file, or a tightly-coupled
+  cluster of 2-3 files
+- No subagent dispatch is needed — the work fits comfortably in one TDD
+  loop in a single session
+- No design document is required — the goal is obvious from the task
+  description, and a one-page plan is enough scaffolding
+- No two-stage review is required — either the change is trivial enough
+  that direct-commit is acceptable, or a single PR review will suffice
+
+Concrete examples that fit oneshot:
+- Fixing a typo in a README
+- Bumping a dependency version
+- Adding a missing null-check in one function
+- Tweaking a CI workflow YAML
+- Renaming a config key everywhere it's referenced
+- Adding a one-off helper script
+- Exploratory spikes that may or may not be kept
+
+## When NOT to use oneshot
+
+Do not use oneshot for any of the following — use the full \`feature\`
+workflow instead (\`ideate\`):
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+- Anything where you'd want a written design doc to look back at
+
+If you start a oneshot and discover the change is bigger than expected, the
+right move is \`cancel\` and restart with \`ideate\`.
+Don't try to grow a oneshot into a feature workflow mid-stream; the
+playbooks have different shapes and you'll fight the state machine.
+
+## Synthesis policy — three options
+
+The \`synthesisPolicy\` field on a oneshot workflow declares the user's
+intent up front about whether the change should be turned into a PR. It
+takes one of three values, persisted on \`state.oneshot.synthesisPolicy\`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| \`always\` | Always transition \`implementing → synthesize\` at finalize, regardless of events. A PR is always created. | The user wants a paper trail / review for every change in this workflow, even small ones. |
+| \`never\` | Always transition \`implementing → completed\` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | The user is iterating on personal/scratch work and explicitly opts out of PRs. |
+| \`on-request\` *(default)* | Direct-commit by default. The user can opt in to a PR mid-implementing by calling \`request_synthesize\`; if any \`synthesize.requested\` event is on the stream at finalize, the workflow transitions to \`synthesize\` instead of \`completed\`. | The common case: start with the assumption of direct-commit, but leave the door open for the user to change their mind once they see the diff. |
+
+The default is \`on-request\` because it's the least surprising: the user
+gets the lightweight path until they explicitly ask for the heavy one.
+
+**Policy wins over event.** If \`synthesisPolicy: 'never'\` is set and a
+\`synthesize.requested\` event is somehow on the stream (e.g. the user
+called the action on a workflow they thought was \`on-request\`), the
+guard still routes to \`completed\`. Policy is the user's declared intent
+and overrides runtime signal.
+
+## Lifecycle
+
+\`\`\`
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+\`\`\`
+
+Four phases. The fork after \`implementing\` is a UML *choice state*,
+implemented via two mutually-exclusive HSM transitions whose guards are
+pure functions of \`state.oneshot.synthesisPolicy\` and the
+\`synthesize.requested\` event count.
+
+| Phase | What happens | Exit criteria |
+|---|---|---|
+| \`plan\` | Lightweight one-page plan: goal, approach, files to touch, tests to add. No design doc. No subagent dispatch. | \`artifacts.plan\` set → transition to \`implementing\` |
+| \`implementing\` | In-session TDD loop. Write a failing test, make it pass, refactor. Commit as you go. The TDD iron law applies — *no production code without a failing test first*. | Tests pass + typecheck clean + finalize_oneshot called |
+| \`synthesize\` | Reached **only** when \`synthesisOptedIn\` is true. Hands off to the existing synthesis flow — see \`@skills/synthesis/SKILL.md\`. PR created via \`gh pr create\`, auto-merge enabled, CI gates apply. | PR merged → \`completed\` |
+| \`completed\` | Terminal. For direct-commit path, commits are already on the branch — there's nothing more to do. For synthesize path, the PR merge event terminates the workflow. | — |
+
+\`cancelled\` is also reachable from any phase via the universal cancel
+transition, same as every other workflow type.
+
+## Step-by-step
+
+### Step 1 — Init
+
+Call \`exarchos_workflow\` with \`action: 'init'\`, \`workflowType: 'oneshot'\`,
+and an optional \`synthesisPolicy\`:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "init",
+  featureId: "fix-readme-typo",
+  workflowType: "oneshot",
+  synthesisPolicy: "on-request" // optional — defaults to 'on-request'
+})
+\`\`\`
+
+If the user has been clear up front ("I want a PR for this"), pass
+\`synthesisPolicy: "always"\`. If they've been clear ("don't open a PR,
+just commit it"), pass \`synthesisPolicy: "never"\`. Otherwise, omit the
+field and rely on the \`on-request\` default — you can always escalate
+later in the implementing phase.
+
+The init returns the new workflow state; the workflow lands in \`plan\`.
+
+### Step 2 — Plan phase
+
+Produce a one-page plan. This is intentionally lightweight — no design
+doc, no parallelization analysis, no decomposition into N tasks. The
+plan should answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to \`implementing\` in a single set call:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "fix-readme-typo",
+  updates: {
+    "artifacts": { "plan": "<plan text>" },
+    "oneshot": { "planSummary": "<one-line summary>" },
+    "phase": "implementing"
+  }
+})
+\`\`\`
+
+The plan goes on \`artifacts.plan\` for parity with the \`feature\` workflow;
+the human-readable one-liner goes on \`oneshot.planSummary\` for the
+pipeline view.
+
+### Step 3 — Implementing phase
+
+Run an in-session TDD loop. Same iron law as every other workflow:
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run the test. Confirm it fails for
+   the right reason.
+2. **[GREEN]** Write the minimum production code to make the test pass.
+   Run the test. Confirm it passes.
+3. **[REFACTOR]** Clean up while keeping the test green.
+
+Commit each red-green-refactor cycle as a single commit. Do not batch
+multiple unrelated changes into one commit — keeping commits atomic
+matters even more in oneshot, where there's no separate review phase
+to catch bundled changes.
+
+There is **no subagent dispatch** in oneshot. The main agent does the
+work directly. There is **no separate review phase**. Quality is
+maintained by the TDD loop and (if the user opts in) the synthesize PR
+review.
+
+#### Mid-implementing: opting in to a PR
+
+If at any point during implementing the user decides they want a PR
+after all (policy is \`on-request\`, default), they can opt in by calling
+the \`request_synthesize\` orchestrate action:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+\`\`\`
+
+**The trigger for this is conversational, not a magic keyword.** Listen
+for phrases like:
+- "actually, let's open a PR for this"
+- "I want a review on this before it lands"
+- "make this a PR"
+- "let's get eyes on this"
+- "synthesize this"
+
+When you hear any of those, call \`request_synthesize\` immediately. The
+handler appends a \`synthesize.requested\` event to the workflow's event
+stream; the \`synthesisOptedIn\` guard reads the stream at finalize and
+routes accordingly. This is **idempotent** — calling
+\`request_synthesize\` twice appends two events but the guard treats any
+count >= 1 as "opted in", so duplicate calls are benign.
+
+Calling \`request_synthesize\` does **not** transition the phase. The
+workflow stays in \`implementing\`. The decision is only acted on when
+you call \`finalize_oneshot\` in step 4.
+
+### Step 4 — Finalize (the choice point)
+
+When the implementing loop is done — tests pass, typecheck clean, all
+commits made — call \`finalize_oneshot\` to resolve the choice state:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+\`\`\`
+
+The handler:
+
+1. Reads the current state and verifies \`workflowType === 'oneshot'\` and
+   \`phase === 'implementing'\`.
+2. Hydrates \`_events\` from the event store so the guard sees the same
+   view the HSM will see during the actual transition.
+3. Evaluates \`guards.synthesisOptedIn\` against the state. The guard
+   inspects \`state.oneshot.synthesisPolicy\` and the \`_events\` array.
+4. Calls \`handleSet\` with the resolved target phase (\`synthesize\` or
+   \`completed\`). The HSM re-evaluates the guard at the transition
+   boundary, so any race between the read and the transition is caught
+   safely.
+
+Possible outcomes:
+
+| \`synthesisPolicy\` | \`synthesize.requested\` event present? | Resolved target | Path |
+|---|---|---|---|
+| \`always\` | (any) | \`synthesize\` | PR path |
+| \`never\` | (any) | \`completed\` | direct-commit path |
+| \`on-request\` (default) | yes | \`synthesize\` | PR path |
+| \`on-request\` (default) | no | \`completed\` | direct-commit path |
+
+### Step 5a — Direct-commit path (terminal)
+
+If finalize resolved to \`completed\`, you're done. The commits made
+during implementing are already on the current branch. Push them if
+they aren't already pushed:
+
+\`\`\`bash
+git push
+\`\`\`
+
+The workflow is now in \`completed\` and will not appear in the default
+pipeline view.
+
+### Step 5b — Synthesize path
+
+If finalize resolved to \`synthesize\`, hand off to the standard synthesis
+flow — see \`@skills/synthesis/SKILL.md\`. The same \`prepare_synthesis\` /
+\`validate_pr_body\` / \`gh pr create\` machinery used by the \`feature\`
+workflow applies. After the PR merges, the workflow transitions
+\`synthesize → completed\` via the existing \`mergeVerified\` guard, same as
+every other workflow type.
+
+You do **not** need to run \`delegate\` or
+\`review\` for an opt-in oneshot synthesize. Those phases
+do not exist in the oneshot playbook. The PR review is the only review.
+
+## Example invocations
+
+### Example A — Direct-commit (default \`on-request\` policy, no opt-in)
+
+\`\`\`
+User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
+       Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
+  2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  4. [RED] writes test that greps README for 'recieve' and expects 0 matches
+        — fails (1 match exists)
+  5. [GREEN] edits README, fixes typo
+        — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+\`\`\`
+
+### Example B — Mid-implementing opt-in (\`on-request\` → user changes mind)
+
+\`\`\`
+User: "Add input validation to the parseConfig helper. Oneshot."
+
+Agent:
+  1. exarchos_workflow init { workflowType: "oneshot" }
+     → 'plan' phase, default 'on-request'
+  2. plans (goal: validate input, files: [parser.ts, parser.test.ts])
+  3. transitions to 'implementing'
+  4. [RED] writes test for null-input case
+  5. [GREEN] adds null check
+  6. [REFACTOR] extracts validateInput helper
+  7. commits
+
+User: "Actually, this is touching the parser — I want a review on it before
+       it lands."
+
+Agent:
+  8. exarchos_orchestrate request_synthesize {
+       featureId, reason: "user requested review of parser changes"
+     }
+     → appends synthesize.requested event
+  9. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='on-request' + 1 synthesize.requested event
+     → resolves to 'synthesize'
+ 10. hands off to @skills/synthesis/SKILL.md → prepare_synthesis →
+     validate_pr_body → gh pr create → merge
+\`\`\`
+
+### Example C — \`synthesisPolicy: 'always'\` (PR mandatory)
+
+\`\`\`
+User: "I want a PR for any change to the auth module, even small ones.
+       Use oneshot but always make a PR."
+
+Agent:
+  1. exarchos_workflow init {
+       workflowType: "oneshot",
+       synthesisPolicy: "always"
+     }
+  2-7. plan + TDD + commits, identical to Example A
+  8. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='always' (short-circuits — no event check needed)
+     → resolves to 'synthesize'
+  9. synthesis flow → PR
+\`\`\`
+
+## State management
+
+Track oneshot-specific state under the \`oneshot\` key on the workflow state:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "<id>",
+  updates: {
+    "oneshot": {
+      "synthesisPolicy": "on-request",
+      "planSummary": "Fix off-by-one in pagination helper"
+    }
+  }
+})
+\`\`\`
+
+The \`synthesisPolicy\` field is optional and defaults to \`'on-request'\` per
+the schema in \`servers/exarchos-mcp/src/workflow/schemas.ts\`. Setting it
+explicitly is recommended when the user has stated a preference.
+
+## Phase Transitions and Guards
+
+For the full transition table for oneshot, consult
+\`@skills/workflow-state/references/phase-transitions.md\`.
+
+**Quick reference for oneshot:**
+
+| From | To | Guard |
+|---|---|---|
+| \`plan\` | \`implementing\` | \`planApproved\` (or \`oneshotPlanSet\`, checks \`artifacts.plan\` presence) |
+| \`implementing\` | \`synthesize\` | \`synthesisOptedIn\` |
+| \`implementing\` | \`completed\` | \`synthesisOptedOut\` |
+| \`synthesize\` | \`completed\` | \`mergeVerified\` |
+| (any) | \`cancelled\` | universal — always allowed |
+
+\`synthesisOptedIn\` and \`synthesisOptedOut\` are pure functions of
+\`state.oneshot.synthesisPolicy\` and \`state._events\`. They are mutually
+exclusive across all 8 (3 policies × event-present/absent, with \`always\`
+and \`never\` ignoring the event flag) combinations — exactly one returns
+true at any given time.
+
+### Schema discovery
+
+Use \`exarchos_workflow({ action: "describe", actions: ["init", "set"] })\`
+for parameter schemas (including the \`synthesisPolicy\` enum) and
+\`exarchos_workflow({ action: "describe", playbook: "oneshot" })\` for the
+phase transitions, guard names, and playbook prose. Use
+\`exarchos_orchestrate({ action: "describe", actions: ["request_synthesize", "finalize_oneshot"] })\`
+for the orchestrate action schemas.
+
+## TDD is still mandatory
+
+The iron law from \`@rules/tdd.md\` applies to oneshot. There is no
+exemption for "small" changes. Specifically:
+
+- Every behavior change starts with a failing test
+- Every test must fail before its implementation is written
+- Tests must be run after each change to verify state
+- Commits stay atomic — one logical change per commit
+
+The temptation in a oneshot is to skip the test "because it's just one
+line". Resist that. The test is what makes the change auditable, and
+auditability is the entire reason oneshot exists alongside the lighter
+"bypass workflows entirely" path.
+
+## Anti-patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip the plan phase ("it's obvious") | Write the four-line plan anyway — it's the artifact future-you reads |
+| Skip the TDD loop in implementing | Always RED → GREEN → REFACTOR, even for one-liners |
+| Use oneshot for multi-file refactors | Use \`ideate\` and the full feature workflow |
+| Try to grow a oneshot into a feature workflow mid-stream | Cancel and restart with \`ideate\` |
+| Call \`request_synthesize\` without listening for the user's intent | Wait for the user to ask for a PR, then call it |
+| Bundle unrelated changes into one commit "since it's a oneshot" | Keep commits atomic — there's no review phase to catch bundling |
+| Forget to call \`finalize_oneshot\` at the end | The workflow stays in \`implementing\` forever otherwise — call it explicitly |
+
+## Completion criteria
+
+- [ ] \`exarchos_workflow init\` called with \`workflowType: "oneshot"\`
+- [ ] One-page plan persisted to \`artifacts.plan\`
+- [ ] Phase transitioned to \`implementing\`
+- [ ] All planned behaviors implemented via TDD with atomic commits
+- [ ] \`finalize_oneshot\` called and resolved to either \`completed\` or \`synthesize\`
+- [ ] If direct-commit path: commits pushed
+- [ ] If synthesize path: PR created via \`@skills/synthesis/SKILL.md\` and merged
+"
+`;
+
+exports[`task 025 — per-runtime snapshot baselines > runtime: generic > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/generic/prune-workflows/SKILL.md > skills/generic/prune-workflows/SKILL.md 1`] = `
+"---
+name: prune-workflows
+description: "Interactively prune stale non-terminal workflows from the pipeline. Use when the user says 'prune workflows', 'clean stale workflows', 'pipeline cleanup', or runs /prune. Runs a dry-run preview, displays candidates with staleness and safeguard skips, prompts the user to proceed/abort/force, then bulk-cancels approved workflows with a workflow.pruned audit event. Safeguards skip workflows with open PRs or recent commits unless force is set."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: maintenance
+---
+
+# Prune Workflows Skill
+
+## Overview
+
+Bulk-cancel stale non-terminal workflows that have accumulated in the pipeline. Wraps the \`prune_stale_workflows\` orchestrate action with an interactive dry-run-then-confirm UX so the user always sees the candidate set before any state mutates.
+
+Pruning is a maintenance operation -- not a workflow phase. It produces \`workflow.pruned\` events alongside the standard \`workflow.cancelled\` events emitted by the underlying cancel path, so downstream views can distinguish user-intent cancellations from batch cleanup.
+
+## Triggers
+
+Activate this skill when:
+- User runs \`prune\` command
+- User says "prune workflows", "clean stale workflows", "pipeline cleanup"
+- \`mcp__exarchos__exarchos_view({ action: "pipeline" })\` shows many inactive workflows the user wants to clear in bulk
+
+## Prerequisites
+
+- An exarchos state directory with one or more non-terminal workflows
+- For safeguard checks against live PRs: \`gh\` available in PATH (the orchestrate handler shells out)
+- For safeguard checks against branch activity: \`git\` available in PATH
+
+## Process
+
+### Step 1: Dry-Run Preview
+
+Always start with \`dryRun: true\`. This call performs candidate selection and safeguard evaluation but does not mutate any workflow state.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: true
+  }
+})
+\`\`\`
+
+The response shape is:
+
+\`\`\`ts
+{
+  candidates: [
+    { featureId: string, phase: string, workflowType: string, stalenessMinutes: number }
+  ],
+  skipped: [
+    { featureId: string, reason: "open-pr" | "active-branch" }
+  ]
+}
+\`\`\`
+
+Optional args:
+- \`thresholdMinutes\` -- staleness cutoff. Default is 10080 (7 days).
+- \`includeOneShot\` -- whether to include \`oneshot\` workflows in the candidate set. Default \`true\`.
+- \`force\` -- not relevant in dry-run; only honored in apply mode (Step 4).
+
+### Step 2: Display Candidate Table
+
+Render a table to the user so they can review what would be pruned. Use this format:
+
+\`\`\`markdown
+## Prune Candidates (3)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-experiment | feature | implementing | 14430 |
+| oneshot-typo-fix | oneshot | plan | 9120 |
+| debug-flaky-test | debug | investigate | 8650 |
+
+## Skipped by Safeguards (2)
+
+| Feature ID | Reason |
+|---|---|
+| feat-active-pr | open-pr |
+| feat-recent-work | active-branch |
+\`\`\`
+
+If \`candidates.length === 0\` AND \`skipped.length === 0\`, output:
+
+> No stale workflows to prune. Pipeline is clean.
+
+Then exit -- no further action.
+
+### Step 3: Prompt for Confirmation
+
+Ask the user one of three choices:
+
+> **proceed** -- prune the listed candidates (skipped workflows stay)
+> **abort** -- exit without changes
+> **force** -- bypass safeguards and prune skipped workflows too
+
+Wait for explicit user input. Do **not** auto-proceed.
+
+### Step 4a: Apply (proceed)
+
+On \`proceed\`, invoke the same action with \`dryRun: false\`. Pass through \`thresholdMinutes\` and \`includeOneShot\` if the user set them in Step 1.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false
+  }
+})
+\`\`\`
+
+The response now includes a \`pruned\` array:
+
+\`\`\`ts
+{
+  candidates: [...],
+  skipped: [...],
+  pruned: [
+    { featureId: string, previousPhase: string }
+  ]
+}
+\`\`\`
+
+Each entry in \`pruned\` corresponds to a workflow that transitioned to \`cancelled\` and emitted a \`workflow.pruned\` event.
+
+### Step 4b: Apply (force)
+
+On \`force\`, set \`force: true\`. Safeguards are bypassed but the bypass is recorded in the \`workflow.pruned\` event payload as \`skippedSafeguards: [...]\` so the audit trail is intact.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false,
+    force: true
+  }
+})
+\`\`\`
+
+In force mode, workflows that were in the \`skipped\` list during dry-run are now eligible for pruning.
+
+### Step 4c: Apply (abort)
+
+On \`abort\`, exit without invoking the action a second time. The dry-run has not mutated any state.
+
+### Step 5: Report Results
+
+After the apply call returns, summarize the outcome:
+
+\`\`\`markdown
+## Prune Complete
+
+**Pruned:** 3 workflows transitioned to cancelled
+**Skipped:** 2 workflows preserved by safeguards
+**Force bypass:** no
+
+### Pruned Workflows
+- feat-old-experiment (was: implementing)
+- oneshot-typo-fix (was: plan)
+- debug-flaky-test (was: investigate)
+\`\`\`
+
+If \`force\` was used, also list any safeguards that were bypassed:
+
+\`\`\`markdown
+### Safeguards Bypassed
+- feat-active-pr: open-pr
+- feat-recent-work: active-branch
+\`\`\`
+
+## Safeguards Explained
+
+Two safeguards run automatically in the orchestrate handler before each cancel:
+
+| Safeguard | Behavior | Reason key |
+|---|---|---|
+| **Open PR** | Skip if \`gh pr list --head <branch> --state open\` returns any results | \`open-pr\` |
+| **Recent commits** | Skip if \`git log --since "24 hours ago" origin/<branch>\` shows commits | \`active-branch\` |
+
+A workflow without a \`branchName\` in state (e.g., abandoned at ideate/plan before delegation) cannot have a PR or branch activity, so safeguards short-circuit and the workflow is eligible for pruning.
+
+\`force: true\` bypasses both checks but does not bypass the audit -- the bypassed safeguard names are recorded in the \`workflow.pruned\` event payload.
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|---|---|
+| Skip the dry-run step | Always start with \`dryRun: true\` so the user sees candidates first |
+| Auto-confirm without showing the table | Render the candidate table and wait for explicit user input |
+| Use \`force: true\` by default | Reserve \`force\` for cases where the user has explicitly opted in |
+| Manually call \`cancel\` for each stale workflow | Use this skill -- it batches the cancel loop and emits the \`workflow.pruned\` audit event |
+| Run on every session | Pruning is a maintenance operation; run when pipeline accumulation is observable |
+
+## Examples
+
+### Example 1: Clean dry-run, user proceeds
+
+\`\`\`
+> prune
+
+## Prune Candidates (2)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-spike | feature | plan | 12880 |
+| oneshot-readme-tweak | oneshot | implementing | 9700 |
+
+## Skipped by Safeguards (0)
+
+(none)
+
+Proceed? (proceed/abort/force)
+
+> proceed
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** no
+
+### Pruned Workflows
+- feat-old-spike (was: plan)
+- oneshot-readme-tweak (was: implementing)
+\`\`\`
+
+### Example 2: Safeguard skip, user forces
+
+\`\`\`
+> prune
+
+## Prune Candidates (1)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-stale-no-pr | feature | implementing | 11200 |
+
+## Skipped by Safeguards (1)
+
+| Feature ID | Reason |
+|---|---|
+| feat-stale-with-pr | open-pr |
+
+Proceed? (proceed/abort/force)
+
+> force
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** yes
+
+### Pruned Workflows
+- feat-stale-no-pr (was: implementing)
+- feat-stale-with-pr (was: implementing)
+
+### Safeguards Bypassed
+- feat-stale-with-pr: open-pr
+\`\`\`
+
+### Example 3: Empty pipeline
+
+\`\`\`
+> prune
+
+No stale workflows to prune. Pipeline is clean.
+\`\`\`
+
+## Schema Discovery
+
+For the canonical argument schema and any future fields, use:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "describe",
+  actions: ["prune_stale_workflows"]
+})
+\`\`\`
+
+## Exarchos Integration
+
+The \`prune_stale_workflows\` action emits two events per pruned workflow:
+- \`workflow.cancelled\` (auto-emitted by the underlying \`handleCancel\` path)
+- \`workflow.pruned\` (emitted by this handler with \`triggeredBy: 'manual'\` and optional \`skippedSafeguards\`)
+
+Both are projected into the workflow state's \`_events\` array by the standard projection. Downstream views can filter on \`workflow.pruned\` to identify batch cleanups versus user-initiated cancels.
 "
 `;
 
@@ -17896,6 +21596,746 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 - Complete each step fully before advancing — quality over speed
 - Do not skip validation checks even when the change appears trivial
 - Trace every design section to at least one task. Do not leave uncovered sections without explicit rationale.
+"
+`;
+
+exports[`task 025 — per-runtime snapshot baselines > runtime: opencode > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/opencode/oneshot-workflow/SKILL.md > skills/opencode/oneshot-workflow/SKILL.md 1`] = `
+"---
+name: oneshot-workflow
+description: "Lightweight workflow for straightforward changes — plan → implement → optional PR. Direct-commit by default; synthesize is opt-in via synthesisPolicy or a runtime request_synthesize event. Use for trivial fixes, config tweaks, single-file changes, or exploratory work that doesn't warrant subagent dispatch or two-stage review. Triggers: 'oneshot', 'quick fix', 'small change', or /oneshot."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: workflow
+  phase-affinity: plan
+---
+
+# Oneshot Workflow Skill
+
+A lean, four-phase workflow type for changes that are too small to justify the
+full \`feature\` flow (\`ideate → plan → delegate → review → synthesize\`) but
+still deserve event-sourced auditability and a planning step. The workflow is
+**direct-commit by default** with an opt-in PR path; the choice between the
+two is resolved at the end of \`implementing\` via a pure event-sourced guard,
+not a heuristic.
+
+> **Read this first if you have never run a oneshot:** the workflow has a
+> *choice state* at the end of \`implementing\`. Whether you land on
+> \`completed\` (direct commit) or transition through \`synthesize\` (PR) is
+> decided by two inputs: the \`synthesisPolicy\` set at init, and whether the
+> user emitted a \`synthesize.requested\` event during implementing. Both
+> inputs are persisted; the decision is replay-safe.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically a single file, or a tightly-coupled
+  cluster of 2-3 files
+- No subagent dispatch is needed — the work fits comfortably in one TDD
+  loop in a single session
+- No design document is required — the goal is obvious from the task
+  description, and a one-page plan is enough scaffolding
+- No two-stage review is required — either the change is trivial enough
+  that direct-commit is acceptable, or a single PR review will suffice
+
+Concrete examples that fit oneshot:
+- Fixing a typo in a README
+- Bumping a dependency version
+- Adding a missing null-check in one function
+- Tweaking a CI workflow YAML
+- Renaming a config key everywhere it's referenced
+- Adding a one-off helper script
+- Exploratory spikes that may or may not be kept
+
+## When NOT to use oneshot
+
+Do not use oneshot for any of the following — use the full \`feature\`
+workflow instead (\`/ideate\`):
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+- Anything where you'd want a written design doc to look back at
+
+If you start a oneshot and discover the change is bigger than expected, the
+right move is \`/cancel\` and restart with \`/ideate\`.
+Don't try to grow a oneshot into a feature workflow mid-stream; the
+playbooks have different shapes and you'll fight the state machine.
+
+## Synthesis policy — three options
+
+The \`synthesisPolicy\` field on a oneshot workflow declares the user's
+intent up front about whether the change should be turned into a PR. It
+takes one of three values, persisted on \`state.oneshot.synthesisPolicy\`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| \`always\` | Always transition \`implementing → synthesize\` at finalize, regardless of events. A PR is always created. | The user wants a paper trail / review for every change in this workflow, even small ones. |
+| \`never\` | Always transition \`implementing → completed\` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | The user is iterating on personal/scratch work and explicitly opts out of PRs. |
+| \`on-request\` *(default)* | Direct-commit by default. The user can opt in to a PR mid-implementing by calling \`request_synthesize\`; if any \`synthesize.requested\` event is on the stream at finalize, the workflow transitions to \`synthesize\` instead of \`completed\`. | The common case: start with the assumption of direct-commit, but leave the door open for the user to change their mind once they see the diff. |
+
+The default is \`on-request\` because it's the least surprising: the user
+gets the lightweight path until they explicitly ask for the heavy one.
+
+**Policy wins over event.** If \`synthesisPolicy: 'never'\` is set and a
+\`synthesize.requested\` event is somehow on the stream (e.g. the user
+called the action on a workflow they thought was \`on-request\`), the
+guard still routes to \`completed\`. Policy is the user's declared intent
+and overrides runtime signal.
+
+## Lifecycle
+
+\`\`\`
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+\`\`\`
+
+Four phases. The fork after \`implementing\` is a UML *choice state*,
+implemented via two mutually-exclusive HSM transitions whose guards are
+pure functions of \`state.oneshot.synthesisPolicy\` and the
+\`synthesize.requested\` event count.
+
+| Phase | What happens | Exit criteria |
+|---|---|---|
+| \`plan\` | Lightweight one-page plan: goal, approach, files to touch, tests to add. No design doc. No subagent dispatch. | \`artifacts.plan\` set → transition to \`implementing\` |
+| \`implementing\` | In-session TDD loop. Write a failing test, make it pass, refactor. Commit as you go. The TDD iron law applies — *no production code without a failing test first*. | Tests pass + typecheck clean + finalize_oneshot called |
+| \`synthesize\` | Reached **only** when \`synthesisOptedIn\` is true. Hands off to the existing synthesis flow — see \`@skills/synthesis/SKILL.md\`. PR created via \`gh pr create\`, auto-merge enabled, CI gates apply. | PR merged → \`completed\` |
+| \`completed\` | Terminal. For direct-commit path, commits are already on the branch — there's nothing more to do. For synthesize path, the PR merge event terminates the workflow. | — |
+
+\`cancelled\` is also reachable from any phase via the universal cancel
+transition, same as every other workflow type.
+
+## Step-by-step
+
+### Step 1 — Init
+
+Call \`exarchos_workflow\` with \`action: 'init'\`, \`workflowType: 'oneshot'\`,
+and an optional \`synthesisPolicy\`:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "init",
+  featureId: "fix-readme-typo",
+  workflowType: "oneshot",
+  synthesisPolicy: "on-request" // optional — defaults to 'on-request'
+})
+\`\`\`
+
+If the user has been clear up front ("I want a PR for this"), pass
+\`synthesisPolicy: "always"\`. If they've been clear ("don't open a PR,
+just commit it"), pass \`synthesisPolicy: "never"\`. Otherwise, omit the
+field and rely on the \`on-request\` default — you can always escalate
+later in the implementing phase.
+
+The init returns the new workflow state; the workflow lands in \`plan\`.
+
+### Step 2 — Plan phase
+
+Produce a one-page plan. This is intentionally lightweight — no design
+doc, no parallelization analysis, no decomposition into N tasks. The
+plan should answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to \`implementing\` in a single set call:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "fix-readme-typo",
+  updates: {
+    "artifacts": { "plan": "<plan text>" },
+    "oneshot": { "planSummary": "<one-line summary>" },
+    "phase": "implementing"
+  }
+})
+\`\`\`
+
+The plan goes on \`artifacts.plan\` for parity with the \`feature\` workflow;
+the human-readable one-liner goes on \`oneshot.planSummary\` for the
+pipeline view.
+
+### Step 3 — Implementing phase
+
+Run an in-session TDD loop. Same iron law as every other workflow:
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+For each behavior in the plan:
+
+1. **[RED]** Write a failing test. Run the test. Confirm it fails for
+   the right reason.
+2. **[GREEN]** Write the minimum production code to make the test pass.
+   Run the test. Confirm it passes.
+3. **[REFACTOR]** Clean up while keeping the test green.
+
+Commit each red-green-refactor cycle as a single commit. Do not batch
+multiple unrelated changes into one commit — keeping commits atomic
+matters even more in oneshot, where there's no separate review phase
+to catch bundled changes.
+
+There is **no subagent dispatch** in oneshot. The main agent does the
+work directly. There is **no separate review phase**. Quality is
+maintained by the TDD loop and (if the user opts in) the synthesize PR
+review.
+
+#### Mid-implementing: opting in to a PR
+
+If at any point during implementing the user decides they want a PR
+after all (policy is \`on-request\`, default), they can opt in by calling
+the \`request_synthesize\` orchestrate action:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+\`\`\`
+
+**The trigger for this is conversational, not a magic keyword.** Listen
+for phrases like:
+- "actually, let's open a PR for this"
+- "I want a review on this before it lands"
+- "make this a PR"
+- "let's get eyes on this"
+- "synthesize this"
+
+When you hear any of those, call \`request_synthesize\` immediately. The
+handler appends a \`synthesize.requested\` event to the workflow's event
+stream; the \`synthesisOptedIn\` guard reads the stream at finalize and
+routes accordingly. This is **idempotent** — calling
+\`request_synthesize\` twice appends two events but the guard treats any
+count >= 1 as "opted in", so duplicate calls are benign.
+
+Calling \`request_synthesize\` does **not** transition the phase. The
+workflow stays in \`implementing\`. The decision is only acted on when
+you call \`finalize_oneshot\` in step 4.
+
+### Step 4 — Finalize (the choice point)
+
+When the implementing loop is done — tests pass, typecheck clean, all
+commits made — call \`finalize_oneshot\` to resolve the choice state:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+\`\`\`
+
+The handler:
+
+1. Reads the current state and verifies \`workflowType === 'oneshot'\` and
+   \`phase === 'implementing'\`.
+2. Hydrates \`_events\` from the event store so the guard sees the same
+   view the HSM will see during the actual transition.
+3. Evaluates \`guards.synthesisOptedIn\` against the state. The guard
+   inspects \`state.oneshot.synthesisPolicy\` and the \`_events\` array.
+4. Calls \`handleSet\` with the resolved target phase (\`synthesize\` or
+   \`completed\`). The HSM re-evaluates the guard at the transition
+   boundary, so any race between the read and the transition is caught
+   safely.
+
+Possible outcomes:
+
+| \`synthesisPolicy\` | \`synthesize.requested\` event present? | Resolved target | Path |
+|---|---|---|---|
+| \`always\` | (any) | \`synthesize\` | PR path |
+| \`never\` | (any) | \`completed\` | direct-commit path |
+| \`on-request\` (default) | yes | \`synthesize\` | PR path |
+| \`on-request\` (default) | no | \`completed\` | direct-commit path |
+
+### Step 5a — Direct-commit path (terminal)
+
+If finalize resolved to \`completed\`, you're done. The commits made
+during implementing are already on the current branch. Push them if
+they aren't already pushed:
+
+\`\`\`bash
+git push
+\`\`\`
+
+The workflow is now in \`completed\` and will not appear in the default
+pipeline view.
+
+### Step 5b — Synthesize path
+
+If finalize resolved to \`synthesize\`, hand off to the standard synthesis
+flow — see \`@skills/synthesis/SKILL.md\`. The same \`prepare_synthesis\` /
+\`validate_pr_body\` / \`gh pr create\` machinery used by the \`feature\`
+workflow applies. After the PR merges, the workflow transitions
+\`synthesize → completed\` via the existing \`mergeVerified\` guard, same as
+every other workflow type.
+
+You do **not** need to run \`/delegate\` or
+\`/review\` for an opt-in oneshot synthesize. Those phases
+do not exist in the oneshot playbook. The PR review is the only review.
+
+## Example invocations
+
+### Example A — Direct-commit (default \`on-request\` policy, no opt-in)
+
+\`\`\`
+User: "Quick fix — there's a typo in the README, 'recieve' should be 'receive'.
+       Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan' phase, synthesisPolicy defaults to 'on-request'
+  2. Produces a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set { artifacts.plan, oneshot.planSummary, phase: 'implementing' }
+  4. [RED] writes test that greps README for 'recieve' and expects 0 matches
+        — fails (1 match exists)
+  5. [GREEN] edits README, fixes typo
+        — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+\`\`\`
+
+### Example B — Mid-implementing opt-in (\`on-request\` → user changes mind)
+
+\`\`\`
+User: "Add input validation to the parseConfig helper. Oneshot."
+
+Agent:
+  1. exarchos_workflow init { workflowType: "oneshot" }
+     → 'plan' phase, default 'on-request'
+  2. plans (goal: validate input, files: [parser.ts, parser.test.ts])
+  3. transitions to 'implementing'
+  4. [RED] writes test for null-input case
+  5. [GREEN] adds null check
+  6. [REFACTOR] extracts validateInput helper
+  7. commits
+
+User: "Actually, this is touching the parser — I want a review on it before
+       it lands."
+
+Agent:
+  8. exarchos_orchestrate request_synthesize {
+       featureId, reason: "user requested review of parser changes"
+     }
+     → appends synthesize.requested event
+  9. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='on-request' + 1 synthesize.requested event
+     → resolves to 'synthesize'
+ 10. hands off to @skills/synthesis/SKILL.md → prepare_synthesis →
+     validate_pr_body → gh pr create → merge
+\`\`\`
+
+### Example C — \`synthesisPolicy: 'always'\` (PR mandatory)
+
+\`\`\`
+User: "I want a PR for any change to the auth module, even small ones.
+       Use oneshot but always make a PR."
+
+Agent:
+  1. exarchos_workflow init {
+       workflowType: "oneshot",
+       synthesisPolicy: "always"
+     }
+  2-7. plan + TDD + commits, identical to Example A
+  8. exarchos_orchestrate finalize_oneshot { featureId }
+     → guard sees policy='always' (short-circuits — no event check needed)
+     → resolves to 'synthesize'
+  9. synthesis flow → PR
+\`\`\`
+
+## State management
+
+Track oneshot-specific state under the \`oneshot\` key on the workflow state:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_workflow({
+  action: "set",
+  featureId: "<id>",
+  updates: {
+    "oneshot": {
+      "synthesisPolicy": "on-request",
+      "planSummary": "Fix off-by-one in pagination helper"
+    }
+  }
+})
+\`\`\`
+
+The \`synthesisPolicy\` field is optional and defaults to \`'on-request'\` per
+the schema in \`servers/exarchos-mcp/src/workflow/schemas.ts\`. Setting it
+explicitly is recommended when the user has stated a preference.
+
+## Phase Transitions and Guards
+
+For the full transition table for oneshot, consult
+\`@skills/workflow-state/references/phase-transitions.md\`.
+
+**Quick reference for oneshot:**
+
+| From | To | Guard |
+|---|---|---|
+| \`plan\` | \`implementing\` | \`planApproved\` (or \`oneshotPlanSet\`, checks \`artifacts.plan\` presence) |
+| \`implementing\` | \`synthesize\` | \`synthesisOptedIn\` |
+| \`implementing\` | \`completed\` | \`synthesisOptedOut\` |
+| \`synthesize\` | \`completed\` | \`mergeVerified\` |
+| (any) | \`cancelled\` | universal — always allowed |
+
+\`synthesisOptedIn\` and \`synthesisOptedOut\` are pure functions of
+\`state.oneshot.synthesisPolicy\` and \`state._events\`. They are mutually
+exclusive across all 8 (3 policies × event-present/absent, with \`always\`
+and \`never\` ignoring the event flag) combinations — exactly one returns
+true at any given time.
+
+### Schema discovery
+
+Use \`exarchos_workflow({ action: "describe", actions: ["init", "set"] })\`
+for parameter schemas (including the \`synthesisPolicy\` enum) and
+\`exarchos_workflow({ action: "describe", playbook: "oneshot" })\` for the
+phase transitions, guard names, and playbook prose. Use
+\`exarchos_orchestrate({ action: "describe", actions: ["request_synthesize", "finalize_oneshot"] })\`
+for the orchestrate action schemas.
+
+## TDD is still mandatory
+
+The iron law from \`@rules/tdd.md\` applies to oneshot. There is no
+exemption for "small" changes. Specifically:
+
+- Every behavior change starts with a failing test
+- Every test must fail before its implementation is written
+- Tests must be run after each change to verify state
+- Commits stay atomic — one logical change per commit
+
+The temptation in a oneshot is to skip the test "because it's just one
+line". Resist that. The test is what makes the change auditable, and
+auditability is the entire reason oneshot exists alongside the lighter
+"bypass workflows entirely" path.
+
+## Anti-patterns
+
+| Don't | Do Instead |
+|-------|------------|
+| Skip the plan phase ("it's obvious") | Write the four-line plan anyway — it's the artifact future-you reads |
+| Skip the TDD loop in implementing | Always RED → GREEN → REFACTOR, even for one-liners |
+| Use oneshot for multi-file refactors | Use \`/ideate\` and the full feature workflow |
+| Try to grow a oneshot into a feature workflow mid-stream | Cancel and restart with \`/ideate\` |
+| Call \`request_synthesize\` without listening for the user's intent | Wait for the user to ask for a PR, then call it |
+| Bundle unrelated changes into one commit "since it's a oneshot" | Keep commits atomic — there's no review phase to catch bundling |
+| Forget to call \`finalize_oneshot\` at the end | The workflow stays in \`implementing\` forever otherwise — call it explicitly |
+
+## Completion criteria
+
+- [ ] \`exarchos_workflow init\` called with \`workflowType: "oneshot"\`
+- [ ] One-page plan persisted to \`artifacts.plan\`
+- [ ] Phase transitioned to \`implementing\`
+- [ ] All planned behaviors implemented via TDD with atomic commits
+- [ ] \`finalize_oneshot\` called and resolved to either \`completed\` or \`synthesize\`
+- [ ] If direct-commit path: commits pushed
+- [ ] If synthesize path: PR created via \`@skills/synthesis/SKILL.md\` and merged
+"
+`;
+
+exports[`task 025 — per-runtime snapshot baselines > runtime: opencode > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/opencode/prune-workflows/SKILL.md > skills/opencode/prune-workflows/SKILL.md 1`] = `
+"---
+name: prune-workflows
+description: "Interactively prune stale non-terminal workflows from the pipeline. Use when the user says 'prune workflows', 'clean stale workflows', 'pipeline cleanup', or runs /prune. Runs a dry-run preview, displays candidates with staleness and safeguard skips, prompts the user to proceed/abort/force, then bulk-cancels approved workflows with a workflow.pruned audit event. Safeguards skip workflows with open PRs or recent commits unless force is set."
+metadata:
+  author: exarchos
+  version: 1.0.0
+  mcp-server: exarchos
+  category: maintenance
+---
+
+# Prune Workflows Skill
+
+## Overview
+
+Bulk-cancel stale non-terminal workflows that have accumulated in the pipeline. Wraps the \`prune_stale_workflows\` orchestrate action with an interactive dry-run-then-confirm UX so the user always sees the candidate set before any state mutates.
+
+Pruning is a maintenance operation -- not a workflow phase. It produces \`workflow.pruned\` events alongside the standard \`workflow.cancelled\` events emitted by the underlying cancel path, so downstream views can distinguish user-intent cancellations from batch cleanup.
+
+## Triggers
+
+Activate this skill when:
+- User runs \`/prune\` command
+- User says "prune workflows", "clean stale workflows", "pipeline cleanup"
+- \`mcp__exarchos__exarchos_view({ action: "pipeline" })\` shows many inactive workflows the user wants to clear in bulk
+
+## Prerequisites
+
+- An exarchos state directory with one or more non-terminal workflows
+- For safeguard checks against live PRs: \`gh\` available in PATH (the orchestrate handler shells out)
+- For safeguard checks against branch activity: \`git\` available in PATH
+
+## Process
+
+### Step 1: Dry-Run Preview
+
+Always start with \`dryRun: true\`. This call performs candidate selection and safeguard evaluation but does not mutate any workflow state.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: true
+  }
+})
+\`\`\`
+
+The response shape is:
+
+\`\`\`ts
+{
+  candidates: [
+    { featureId: string, phase: string, workflowType: string, stalenessMinutes: number }
+  ],
+  skipped: [
+    { featureId: string, reason: "open-pr" | "active-branch" }
+  ]
+}
+\`\`\`
+
+Optional args:
+- \`thresholdMinutes\` -- staleness cutoff. Default is 10080 (7 days).
+- \`includeOneShot\` -- whether to include \`oneshot\` workflows in the candidate set. Default \`true\`.
+- \`force\` -- not relevant in dry-run; only honored in apply mode (Step 4).
+
+### Step 2: Display Candidate Table
+
+Render a table to the user so they can review what would be pruned. Use this format:
+
+\`\`\`markdown
+## Prune Candidates (3)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-experiment | feature | implementing | 14430 |
+| oneshot-typo-fix | oneshot | plan | 9120 |
+| debug-flaky-test | debug | investigate | 8650 |
+
+## Skipped by Safeguards (2)
+
+| Feature ID | Reason |
+|---|---|
+| feat-active-pr | open-pr |
+| feat-recent-work | active-branch |
+\`\`\`
+
+If \`candidates.length === 0\` AND \`skipped.length === 0\`, output:
+
+> No stale workflows to prune. Pipeline is clean.
+
+Then exit -- no further action.
+
+### Step 3: Prompt for Confirmation
+
+Ask the user one of three choices:
+
+> **proceed** -- prune the listed candidates (skipped workflows stay)
+> **abort** -- exit without changes
+> **force** -- bypass safeguards and prune skipped workflows too
+
+Wait for explicit user input. Do **not** auto-proceed.
+
+### Step 4a: Apply (proceed)
+
+On \`proceed\`, invoke the same action with \`dryRun: false\`. Pass through \`thresholdMinutes\` and \`includeOneShot\` if the user set them in Step 1.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false
+  }
+})
+\`\`\`
+
+The response now includes a \`pruned\` array:
+
+\`\`\`ts
+{
+  candidates: [...],
+  skipped: [...],
+  pruned: [
+    { featureId: string, previousPhase: string }
+  ]
+}
+\`\`\`
+
+Each entry in \`pruned\` corresponds to a workflow that transitioned to \`cancelled\` and emitted a \`workflow.pruned\` event.
+
+### Step 4b: Apply (force)
+
+On \`force\`, set \`force: true\`. Safeguards are bypassed but the bypass is recorded in the \`workflow.pruned\` event payload as \`skippedSafeguards: [...]\` so the audit trail is intact.
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "prune_stale_workflows",
+  args: {
+    dryRun: false,
+    force: true
+  }
+})
+\`\`\`
+
+In force mode, workflows that were in the \`skipped\` list during dry-run are now eligible for pruning.
+
+### Step 4c: Apply (abort)
+
+On \`abort\`, exit without invoking the action a second time. The dry-run has not mutated any state.
+
+### Step 5: Report Results
+
+After the apply call returns, summarize the outcome:
+
+\`\`\`markdown
+## Prune Complete
+
+**Pruned:** 3 workflows transitioned to cancelled
+**Skipped:** 2 workflows preserved by safeguards
+**Force bypass:** no
+
+### Pruned Workflows
+- feat-old-experiment (was: implementing)
+- oneshot-typo-fix (was: plan)
+- debug-flaky-test (was: investigate)
+\`\`\`
+
+If \`force\` was used, also list any safeguards that were bypassed:
+
+\`\`\`markdown
+### Safeguards Bypassed
+- feat-active-pr: open-pr
+- feat-recent-work: active-branch
+\`\`\`
+
+## Safeguards Explained
+
+Two safeguards run automatically in the orchestrate handler before each cancel:
+
+| Safeguard | Behavior | Reason key |
+|---|---|---|
+| **Open PR** | Skip if \`gh pr list --head <branch> --state open\` returns any results | \`open-pr\` |
+| **Recent commits** | Skip if \`git log --since "24 hours ago" origin/<branch>\` shows commits | \`active-branch\` |
+
+A workflow without a \`branchName\` in state (e.g., abandoned at ideate/plan before delegation) cannot have a PR or branch activity, so safeguards short-circuit and the workflow is eligible for pruning.
+
+\`force: true\` bypasses both checks but does not bypass the audit -- the bypassed safeguard names are recorded in the \`workflow.pruned\` event payload.
+
+## Anti-Patterns
+
+| Don't | Do Instead |
+|---|---|
+| Skip the dry-run step | Always start with \`dryRun: true\` so the user sees candidates first |
+| Auto-confirm without showing the table | Render the candidate table and wait for explicit user input |
+| Use \`force: true\` by default | Reserve \`force\` for cases where the user has explicitly opted in |
+| Manually call \`cancel\` for each stale workflow | Use this skill -- it batches the cancel loop and emits the \`workflow.pruned\` audit event |
+| Run on every session | Pruning is a maintenance operation; run when pipeline accumulation is observable |
+
+## Examples
+
+### Example 1: Clean dry-run, user proceeds
+
+\`\`\`
+> /prune
+
+## Prune Candidates (2)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-old-spike | feature | plan | 12880 |
+| oneshot-readme-tweak | oneshot | implementing | 9700 |
+
+## Skipped by Safeguards (0)
+
+(none)
+
+Proceed? (proceed/abort/force)
+
+> proceed
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** no
+
+### Pruned Workflows
+- feat-old-spike (was: plan)
+- oneshot-readme-tweak (was: implementing)
+\`\`\`
+
+### Example 2: Safeguard skip, user forces
+
+\`\`\`
+> /prune
+
+## Prune Candidates (1)
+
+| Feature ID | Type | Phase | Stale (min) |
+|---|---|---|---|
+| feat-stale-no-pr | feature | implementing | 11200 |
+
+## Skipped by Safeguards (1)
+
+| Feature ID | Reason |
+|---|---|
+| feat-stale-with-pr | open-pr |
+
+Proceed? (proceed/abort/force)
+
+> force
+
+## Prune Complete
+
+**Pruned:** 2 workflows transitioned to cancelled
+**Skipped:** 0
+**Force bypass:** yes
+
+### Pruned Workflows
+- feat-stale-no-pr (was: implementing)
+- feat-stale-with-pr (was: implementing)
+
+### Safeguards Bypassed
+- feat-stale-with-pr: open-pr
+\`\`\`
+
+### Example 3: Empty pipeline
+
+\`\`\`
+> /prune
+
+No stale workflows to prune. Pipeline is clean.
+\`\`\`
+
+## Schema Discovery
+
+For the canonical argument schema and any future fields, use:
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "describe",
+  actions: ["prune_stale_workflows"]
+})
+\`\`\`
+
+## Exarchos Integration
+
+The \`prune_stale_workflows\` action emits two events per pruned workflow:
+- \`workflow.cancelled\` (auto-emitted by the underlying \`handleCancel\` path)
+- \`workflow.pruned\` (emitted by this handler with \`triggeredBy: 'manual'\` and optional \`skippedSafeguards\`)
+
+Both are projected into the workflow state's \`_events\` array by the standard projection. Downstream views can filter on \`workflow.pruned\` to identify batch cleanups versus user-initiated cancels.
 "
 `;
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -204,6 +204,12 @@ metadata:
 
 Resolve merged workflows to \`completed\` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
 
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use \`@skills/prune-workflows/SKILL.md\`. That skill invokes \`exarchos_orchestrate prune_stale_workflows\` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → \`completed\`); prune is bulk (N inactive workflows → \`cancelled\`). They are complementary, not alternatives.
+
 ## Triggers
 
 Activate this skill when:
@@ -626,6 +632,8 @@ Activate this skill when:
 - User runs \`/exarchos:delegate\` command
 - Implementation plan is ready with extractable tasks
 - User wants to parallelize work across subagents
+
+**Exception — oneshot workflows skip delegation entirely.** The oneshot playbook runs an in-session TDD loop in the main agent's context, with no subagent dispatch or review phase. If \`workflowType === "oneshot"\`, do not call this skill — see \`@skills/oneshot-workflow/SKILL.md\` for the lightweight path.
 
 ## Core Principles
 
@@ -3031,6 +3039,10 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 \`\`\`
 
+## Pipeline Hygiene
+
+When \`mcp__plugin_exarchos_exarchos__exarchos_view pipeline\` accumulates stale workflows (inactive > 7 days), run \`@skills/prune-workflows/SKILL.md\` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:
@@ -3824,9 +3836,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see \`reference
 
 At the start of \`/exarchos:ideate\`, use \`mcp__plugin_exarchos_exarchos__exarchos_workflow\` with \`action: "init"\` with:
 - \`featureId\`: the workflow identifier (e.g., \`"user-authentication"\`)
-- \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`
+- \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`, \`"oneshot"\`
+- \`synthesisPolicy\` *(optional, oneshot only)*: one of \`"always"\`, \`"never"\`, \`"on-request"\` (default \`"on-request"\`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- \`feature\` — full \`ideate → plan → delegate → review → synthesize\` for real features with subagent dispatch and two-stage review
+- \`debug\` — \`triage → investigate → (thorough | hotfix)\` for bug workflows with track selection
+- \`refactor\` — \`explore → brief → (polish | overhaul)\` for code improvements, polish for small and overhaul for multi-task
+- \`oneshot\` — \`plan → implementing → (completed | synthesize)\` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by \`synthesisPolicy\` and the \`synthesize.requested\` event
+
+See \`@skills/oneshot-workflow/SKILL.md\` for the lightweight variant's full prose, including the choice-state mechanics and \`finalize_oneshot\` trigger.
 
 ### Read State
 
@@ -3924,7 +3946,7 @@ See \`docs/schemas/workflow-state.schema.json\` for full schema.
 Key sections:
 - \`version\`: Schema version (currently "1.1")
 - \`featureId\`: Unique workflow identifier
-- \`workflowType\`: Required. One of "feature", "debug", or "refactor"
+- \`workflowType\`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - \`phase\`: Current workflow phase
 - \`artifacts\`: Paths to design, plan, PR
 - \`tasks\`: Task list with status
@@ -4192,6 +4214,12 @@ metadata:
 ## Overview
 
 Resolve merged workflows to \`completed\` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
+
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use \`@skills/prune-workflows/SKILL.md\`. That skill invokes \`exarchos_orchestrate prune_stale_workflows\` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → \`completed\`); prune is bulk (N inactive workflows → \`cancelled\`). They are complementary, not alternatives.
 
 ## Triggers
 
@@ -4615,6 +4643,8 @@ Activate this skill when:
 - User runs \`delegate\` command
 - Implementation plan is ready with extractable tasks
 - User wants to parallelize work across subagents
+
+**Exception — oneshot workflows skip delegation entirely.** The oneshot playbook runs an in-session TDD loop in the main agent's context, with no subagent dispatch or review phase. If \`workflowType === "oneshot"\`, do not call this skill — see \`@skills/oneshot-workflow/SKILL.md\` for the lightweight path.
 
 ## Core Principles
 
@@ -7016,6 +7046,10 @@ synthesize → shepherd (assess → fix → resubmit → loop) → cleanup
               ^^^^^^^^^ runs within synthesize phase
 \`\`\`
 
+## Pipeline Hygiene
+
+When \`mcp__exarchos__exarchos_view pipeline\` accumulates stale workflows (inactive > 7 days), run \`@skills/prune-workflows/SKILL.md\` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:
@@ -7809,9 +7843,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see \`reference
 
 At the start of \`ideate\`, use \`mcp__exarchos__exarchos_workflow\` with \`action: "init"\` with:
 - \`featureId\`: the workflow identifier (e.g., \`"user-authentication"\`)
-- \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`
+- \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`, \`"oneshot"\`
+- \`synthesisPolicy\` *(optional, oneshot only)*: one of \`"always"\`, \`"never"\`, \`"on-request"\` (default \`"on-request"\`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- \`feature\` — full \`ideate → plan → delegate → review → synthesize\` for real features with subagent dispatch and two-stage review
+- \`debug\` — \`triage → investigate → (thorough | hotfix)\` for bug workflows with track selection
+- \`refactor\` — \`explore → brief → (polish | overhaul)\` for code improvements, polish for small and overhaul for multi-task
+- \`oneshot\` — \`plan → implementing → (completed | synthesize)\` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by \`synthesisPolicy\` and the \`synthesize.requested\` event
+
+See \`@skills/oneshot-workflow/SKILL.md\` for the lightweight variant's full prose, including the choice-state mechanics and \`finalize_oneshot\` trigger.
 
 ### Read State
 
@@ -7909,7 +7953,7 @@ See \`docs/schemas/workflow-state.schema.json\` for full schema.
 Key sections:
 - \`version\`: Schema version (currently "1.1")
 - \`featureId\`: Unique workflow identifier
-- \`workflowType\`: Required. One of "feature", "debug", or "refactor"
+- \`workflowType\`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - \`phase\`: Current workflow phase
 - \`artifacts\`: Paths to design, plan, PR
 - \`tasks\`: Task list with status
@@ -8177,6 +8221,12 @@ metadata:
 ## Overview
 
 Resolve merged workflows to \`completed\` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
+
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use \`@skills/prune-workflows/SKILL.md\`. That skill invokes \`exarchos_orchestrate prune_stale_workflows\` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → \`completed\`); prune is bulk (N inactive workflows → \`cancelled\`). They are complementary, not alternatives.
 
 ## Triggers
 
@@ -8600,6 +8650,8 @@ Activate this skill when:
 - User runs \`/delegate\` command
 - Implementation plan is ready with extractable tasks
 - User wants to parallelize work across subagents
+
+**Exception — oneshot workflows skip delegation entirely.** The oneshot playbook runs an in-session TDD loop in the main agent's context, with no subagent dispatch or review phase. If \`workflowType === "oneshot"\`, do not call this skill — see \`@skills/oneshot-workflow/SKILL.md\` for the lightweight path.
 
 ## Core Principles
 
@@ -10993,6 +11045,10 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 \`\`\`
 
+## Pipeline Hygiene
+
+When \`mcp__exarchos__exarchos_view pipeline\` accumulates stale workflows (inactive > 7 days), run \`@skills/prune-workflows/SKILL.md\` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:
@@ -11786,9 +11842,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see \`reference
 
 At the start of \`/ideate\`, use \`mcp__exarchos__exarchos_workflow\` with \`action: "init"\` with:
 - \`featureId\`: the workflow identifier (e.g., \`"user-authentication"\`)
-- \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`
+- \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`, \`"oneshot"\`
+- \`synthesisPolicy\` *(optional, oneshot only)*: one of \`"always"\`, \`"never"\`, \`"on-request"\` (default \`"on-request"\`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- \`feature\` — full \`ideate → plan → delegate → review → synthesize\` for real features with subagent dispatch and two-stage review
+- \`debug\` — \`triage → investigate → (thorough | hotfix)\` for bug workflows with track selection
+- \`refactor\` — \`explore → brief → (polish | overhaul)\` for code improvements, polish for small and overhaul for multi-task
+- \`oneshot\` — \`plan → implementing → (completed | synthesize)\` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by \`synthesisPolicy\` and the \`synthesize.requested\` event
+
+See \`@skills/oneshot-workflow/SKILL.md\` for the lightweight variant's full prose, including the choice-state mechanics and \`finalize_oneshot\` trigger.
 
 ### Read State
 
@@ -11886,7 +11952,7 @@ See \`docs/schemas/workflow-state.schema.json\` for full schema.
 Key sections:
 - \`version\`: Schema version (currently "1.1")
 - \`featureId\`: Unique workflow identifier
-- \`workflowType\`: Required. One of "feature", "debug", or "refactor"
+- \`workflowType\`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - \`phase\`: Current workflow phase
 - \`artifacts\`: Paths to design, plan, PR
 - \`tasks\`: Task list with status
@@ -12154,6 +12220,12 @@ metadata:
 ## Overview
 
 Resolve merged workflows to \`completed\` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
+
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use \`@skills/prune-workflows/SKILL.md\`. That skill invokes \`exarchos_orchestrate prune_stale_workflows\` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → \`completed\`); prune is bulk (N inactive workflows → \`cancelled\`). They are complementary, not alternatives.
 
 ## Triggers
 
@@ -12577,6 +12649,8 @@ Activate this skill when:
 - User runs \`delegate\` command
 - Implementation plan is ready with extractable tasks
 - User wants to parallelize work across subagents
+
+**Exception — oneshot workflows skip delegation entirely.** The oneshot playbook runs an in-session TDD loop in the main agent's context, with no subagent dispatch or review phase. If \`workflowType === "oneshot"\`, do not call this skill — see \`@skills/oneshot-workflow/SKILL.md\` for the lightweight path.
 
 ## Core Principles
 
@@ -14976,6 +15050,10 @@ synthesize → shepherd (assess → fix → resubmit → loop) → cleanup
               ^^^^^^^^^ runs within synthesize phase
 \`\`\`
 
+## Pipeline Hygiene
+
+When \`mcp__exarchos__exarchos_view pipeline\` accumulates stale workflows (inactive > 7 days), run \`@skills/prune-workflows/SKILL.md\` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:
@@ -15769,9 +15847,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see \`reference
 
 At the start of \`ideate\`, use \`mcp__exarchos__exarchos_workflow\` with \`action: "init"\` with:
 - \`featureId\`: the workflow identifier (e.g., \`"user-authentication"\`)
-- \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`
+- \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`, \`"oneshot"\`
+- \`synthesisPolicy\` *(optional, oneshot only)*: one of \`"always"\`, \`"never"\`, \`"on-request"\` (default \`"on-request"\`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- \`feature\` — full \`ideate → plan → delegate → review → synthesize\` for real features with subagent dispatch and two-stage review
+- \`debug\` — \`triage → investigate → (thorough | hotfix)\` for bug workflows with track selection
+- \`refactor\` — \`explore → brief → (polish | overhaul)\` for code improvements, polish for small and overhaul for multi-task
+- \`oneshot\` — \`plan → implementing → (completed | synthesize)\` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by \`synthesisPolicy\` and the \`synthesize.requested\` event
+
+See \`@skills/oneshot-workflow/SKILL.md\` for the lightweight variant's full prose, including the choice-state mechanics and \`finalize_oneshot\` trigger.
 
 ### Read State
 
@@ -15869,7 +15957,7 @@ See \`docs/schemas/workflow-state.schema.json\` for full schema.
 Key sections:
 - \`version\`: Schema version (currently "1.1")
 - \`featureId\`: Unique workflow identifier
-- \`workflowType\`: Required. One of "feature", "debug", or "refactor"
+- \`workflowType\`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - \`phase\`: Current workflow phase
 - \`artifacts\`: Paths to design, plan, PR
 - \`tasks\`: Task list with status
@@ -16137,6 +16225,12 @@ metadata:
 ## Overview
 
 Resolve merged workflows to \`completed\` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
+
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use \`@skills/prune-workflows/SKILL.md\`. That skill invokes \`exarchos_orchestrate prune_stale_workflows\` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → \`completed\`); prune is bulk (N inactive workflows → \`cancelled\`). They are complementary, not alternatives.
 
 ## Triggers
 
@@ -16560,6 +16654,8 @@ Activate this skill when:
 - User runs \`delegate\` command
 - Implementation plan is ready with extractable tasks
 - User wants to parallelize work across subagents
+
+**Exception — oneshot workflows skip delegation entirely.** The oneshot playbook runs an in-session TDD loop in the main agent's context, with no subagent dispatch or review phase. If \`workflowType === "oneshot"\`, do not call this skill — see \`@skills/oneshot-workflow/SKILL.md\` for the lightweight path.
 
 ## Core Principles
 
@@ -18953,6 +19049,10 @@ synthesize → shepherd (assess → fix → resubmit → loop) → cleanup
               ^^^^^^^^^ runs within synthesize phase
 \`\`\`
 
+## Pipeline Hygiene
+
+When \`mcp__exarchos__exarchos_view pipeline\` accumulates stale workflows (inactive > 7 days), run \`@skills/prune-workflows/SKILL.md\` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:
@@ -19746,9 +19846,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see \`reference
 
 At the start of \`ideate\`, use \`mcp__exarchos__exarchos_workflow\` with \`action: "init"\` with:
 - \`featureId\`: the workflow identifier (e.g., \`"user-authentication"\`)
-- \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`
+- \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`, \`"oneshot"\`
+- \`synthesisPolicy\` *(optional, oneshot only)*: one of \`"always"\`, \`"never"\`, \`"on-request"\` (default \`"on-request"\`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- \`feature\` — full \`ideate → plan → delegate → review → synthesize\` for real features with subagent dispatch and two-stage review
+- \`debug\` — \`triage → investigate → (thorough | hotfix)\` for bug workflows with track selection
+- \`refactor\` — \`explore → brief → (polish | overhaul)\` for code improvements, polish for small and overhaul for multi-task
+- \`oneshot\` — \`plan → implementing → (completed | synthesize)\` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by \`synthesisPolicy\` and the \`synthesize.requested\` event
+
+See \`@skills/oneshot-workflow/SKILL.md\` for the lightweight variant's full prose, including the choice-state mechanics and \`finalize_oneshot\` trigger.
 
 ### Read State
 
@@ -19846,7 +19956,7 @@ See \`docs/schemas/workflow-state.schema.json\` for full schema.
 Key sections:
 - \`version\`: Schema version (currently "1.1")
 - \`featureId\`: Unique workflow identifier
-- \`workflowType\`: Required. One of "feature", "debug", or "refactor"
+- \`workflowType\`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - \`phase\`: Current workflow phase
 - \`artifacts\`: Paths to design, plan, PR
 - \`tasks\`: Task list with status
@@ -20114,6 +20224,12 @@ metadata:
 ## Overview
 
 Resolve merged workflows to \`completed\` state in a single operation. Replaces the manual multi-step process of navigating HSM guards after PR stacks merge.
+
+## Batch Pruning for Stale Workflows
+
+For bulk cleanup of accumulated stale or abandoned workflows (as opposed to resolving a single merged workflow), use \`@skills/prune-workflows/SKILL.md\`. That skill invokes \`exarchos_orchestrate prune_stale_workflows\` in dry-run mode, displays candidates, and applies after user confirmation. Safeguards automatically skip workflows with open PRs or recent commits.
+
+**Rule of thumb:** cleanup is per-workflow (one merged feature → \`completed\`); prune is bulk (N inactive workflows → \`cancelled\`). They are complementary, not alternatives.
 
 ## Triggers
 
@@ -20537,6 +20653,8 @@ Activate this skill when:
 - User runs \`/delegate\` command
 - Implementation plan is ready with extractable tasks
 - User wants to parallelize work across subagents
+
+**Exception — oneshot workflows skip delegation entirely.** The oneshot playbook runs an in-session TDD loop in the main agent's context, with no subagent dispatch or review phase. If \`workflowType === "oneshot"\`, do not call this skill — see \`@skills/oneshot-workflow/SKILL.md\` for the lightweight path.
 
 ## Core Principles
 
@@ -22938,6 +23056,10 @@ Iterative loop that shepherds published PRs through CI checks and code reviews t
               ^^^^^^^^^ runs within synthesize phase
 \`\`\`
 
+## Pipeline Hygiene
+
+When \`mcp__exarchos__exarchos_view pipeline\` accumulates stale workflows (inactive > 7 days), run \`@skills/prune-workflows/SKILL.md\` to bulk-cancel abandoned workflows before starting a new shepherd cycle. Safeguards skip workflows with open PRs or recent commits, so active shepherd targets are never touched. A clean pipeline makes shepherd iteration reporting easier to read and reduces noise in the stale-count view.
+
 ## Triggers
 
 Activate when:
@@ -23731,9 +23853,19 @@ For full MCP tool signatures, error handling, and anti-patterns, see \`reference
 
 At the start of \`/ideate\`, use \`mcp__exarchos__exarchos_workflow\` with \`action: "init"\` with:
 - \`featureId\`: the workflow identifier (e.g., \`"user-authentication"\`)
-- \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`
+- \`workflowType\`: one of \`"feature"\`, \`"debug"\`, \`"refactor"\`, \`"oneshot"\`
+- \`synthesisPolicy\` *(optional, oneshot only)*: one of \`"always"\`, \`"never"\`, \`"on-request"\` (default \`"on-request"\`) — silently ignored for non-oneshot types
 
 This creates a new state file with phase "ideate".
+
+### Workflow Types at a Glance
+
+- \`feature\` — full \`ideate → plan → delegate → review → synthesize\` for real features with subagent dispatch and two-stage review
+- \`debug\` — \`triage → investigate → (thorough | hotfix)\` for bug workflows with track selection
+- \`refactor\` — \`explore → brief → (polish | overhaul)\` for code improvements, polish for small and overhaul for multi-task
+- \`oneshot\` — \`plan → implementing → (completed | synthesize)\` for trivial changes; direct-commit by default with an opt-in PR path resolved via a choice-state guard driven by \`synthesisPolicy\` and the \`synthesize.requested\` event
+
+See \`@skills/oneshot-workflow/SKILL.md\` for the lightweight variant's full prose, including the choice-state mechanics and \`finalize_oneshot\` trigger.
 
 ### Read State
 
@@ -23831,7 +23963,7 @@ See \`docs/schemas/workflow-state.schema.json\` for full schema.
 Key sections:
 - \`version\`: Schema version (currently "1.1")
 - \`featureId\`: Unique workflow identifier
-- \`workflowType\`: Required. One of "feature", "debug", or "refactor"
+- \`workflowType\`: Required. One of "feature", "debug", "refactor", or "oneshot"
 - \`phase\`: Current workflow phase
 - \`artifacts\`: Paths to design, plan, PR
 - \`tasks\`: Task list with status

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -1917,13 +1917,22 @@ for phrases like:
 When you hear any of those, call \`request_synthesize\` immediately. The
 handler appends a \`synthesize.requested\` event to the workflow's event
 stream; the \`synthesisOptedIn\` guard reads the stream at finalize and
-routes accordingly. This is **idempotent** — calling
-\`request_synthesize\` twice appends two events but the guard treats any
-count >= 1 as "opted in", so duplicate calls are benign.
+routes accordingly.
+
+\`request_synthesize\` is accepted from both \`plan\` and \`implementing\`
+phases — call it whenever you know you want the PR path, even before
+\`implementing\` starts. Terminal phases (\`synthesize\`, \`completed\`,
+\`cancelled\`) are rejected.
+
+Duplicate calls are **routing-idempotent** but not event-idempotent:
+each call appends a new \`synthesize.requested\` event, but the guard
+treats any count >= 1 as "opted in", so the routing decision is the
+same whether you call once or five times. The event stream will
+contain each duplicate for audit purposes.
 
 Calling \`request_synthesize\` does **not** transition the phase. The
-workflow stays in \`implementing\`. The decision is only acted on when
-you call \`finalize_oneshot\` in step 4.
+workflow stays in its current phase. The decision is only acted on
+when you call \`finalize_oneshot\` in step 4.
 
 ### Step 4 — Finalize (the choice point)
 
@@ -2096,7 +2105,7 @@ For the full transition table for oneshot, consult
 
 | From | To | Guard |
 |---|---|---|
-| \`plan\` | \`implementing\` | \`planApproved\` (or \`oneshotPlanSet\`, checks \`artifacts.plan\` presence) |
+| \`plan\` | \`implementing\` | \`oneshotPlanSet\` (requires non-empty \`artifacts.plan\`) |
 | \`implementing\` | \`synthesize\` | \`synthesisOptedIn\` |
 | \`implementing\` | \`completed\` | \`synthesisOptedOut\` |
 | \`synthesize\` | \`completed\` | \`mergeVerified\` |
@@ -2104,9 +2113,10 @@ For the full transition table for oneshot, consult
 
 \`synthesisOptedIn\` and \`synthesisOptedOut\` are pure functions of
 \`state.oneshot.synthesisPolicy\` and \`state._events\`. They are mutually
-exclusive across all 8 (3 policies × event-present/absent, with \`always\`
-and \`never\` ignoring the event flag) combinations — exactly one returns
-true at any given time.
+exclusive across all 4 meaningful combinations — \`always\` and \`never\`
+each map to one outcome (ignoring the event flag), and \`on-request\`
+branches on whether a \`synthesize.requested\` event is present or
+absent. Exactly one guard returns true at any given time.
 
 ### Schema discovery
 
@@ -5970,13 +5980,22 @@ for phrases like:
 When you hear any of those, call \`request_synthesize\` immediately. The
 handler appends a \`synthesize.requested\` event to the workflow's event
 stream; the \`synthesisOptedIn\` guard reads the stream at finalize and
-routes accordingly. This is **idempotent** — calling
-\`request_synthesize\` twice appends two events but the guard treats any
-count >= 1 as "opted in", so duplicate calls are benign.
+routes accordingly.
+
+\`request_synthesize\` is accepted from both \`plan\` and \`implementing\`
+phases — call it whenever you know you want the PR path, even before
+\`implementing\` starts. Terminal phases (\`synthesize\`, \`completed\`,
+\`cancelled\`) are rejected.
+
+Duplicate calls are **routing-idempotent** but not event-idempotent:
+each call appends a new \`synthesize.requested\` event, but the guard
+treats any count >= 1 as "opted in", so the routing decision is the
+same whether you call once or five times. The event stream will
+contain each duplicate for audit purposes.
 
 Calling \`request_synthesize\` does **not** transition the phase. The
-workflow stays in \`implementing\`. The decision is only acted on when
-you call \`finalize_oneshot\` in step 4.
+workflow stays in its current phase. The decision is only acted on
+when you call \`finalize_oneshot\` in step 4.
 
 ### Step 4 — Finalize (the choice point)
 
@@ -6149,7 +6168,7 @@ For the full transition table for oneshot, consult
 
 | From | To | Guard |
 |---|---|---|
-| \`plan\` | \`implementing\` | \`planApproved\` (or \`oneshotPlanSet\`, checks \`artifacts.plan\` presence) |
+| \`plan\` | \`implementing\` | \`oneshotPlanSet\` (requires non-empty \`artifacts.plan\`) |
 | \`implementing\` | \`synthesize\` | \`synthesisOptedIn\` |
 | \`implementing\` | \`completed\` | \`synthesisOptedOut\` |
 | \`synthesize\` | \`completed\` | \`mergeVerified\` |
@@ -6157,9 +6176,10 @@ For the full transition table for oneshot, consult
 
 \`synthesisOptedIn\` and \`synthesisOptedOut\` are pure functions of
 \`state.oneshot.synthesisPolicy\` and \`state._events\`. They are mutually
-exclusive across all 8 (3 policies × event-present/absent, with \`always\`
-and \`never\` ignoring the event flag) combinations — exactly one returns
-true at any given time.
+exclusive across all 4 meaningful combinations — \`always\` and \`never\`
+each map to one outcome (ignoring the event flag), and \`on-request\`
+branches on whether a \`synthesize.requested\` event is present or
+absent. Exactly one guard returns true at any given time.
 
 ### Schema discovery
 
@@ -10015,13 +10035,22 @@ for phrases like:
 When you hear any of those, call \`request_synthesize\` immediately. The
 handler appends a \`synthesize.requested\` event to the workflow's event
 stream; the \`synthesisOptedIn\` guard reads the stream at finalize and
-routes accordingly. This is **idempotent** — calling
-\`request_synthesize\` twice appends two events but the guard treats any
-count >= 1 as "opted in", so duplicate calls are benign.
+routes accordingly.
+
+\`request_synthesize\` is accepted from both \`plan\` and \`implementing\`
+phases — call it whenever you know you want the PR path, even before
+\`implementing\` starts. Terminal phases (\`synthesize\`, \`completed\`,
+\`cancelled\`) are rejected.
+
+Duplicate calls are **routing-idempotent** but not event-idempotent:
+each call appends a new \`synthesize.requested\` event, but the guard
+treats any count >= 1 as "opted in", so the routing decision is the
+same whether you call once or five times. The event stream will
+contain each duplicate for audit purposes.
 
 Calling \`request_synthesize\` does **not** transition the phase. The
-workflow stays in \`implementing\`. The decision is only acted on when
-you call \`finalize_oneshot\` in step 4.
+workflow stays in its current phase. The decision is only acted on
+when you call \`finalize_oneshot\` in step 4.
 
 ### Step 4 — Finalize (the choice point)
 
@@ -10194,7 +10223,7 @@ For the full transition table for oneshot, consult
 
 | From | To | Guard |
 |---|---|---|
-| \`plan\` | \`implementing\` | \`planApproved\` (or \`oneshotPlanSet\`, checks \`artifacts.plan\` presence) |
+| \`plan\` | \`implementing\` | \`oneshotPlanSet\` (requires non-empty \`artifacts.plan\`) |
 | \`implementing\` | \`synthesize\` | \`synthesisOptedIn\` |
 | \`implementing\` | \`completed\` | \`synthesisOptedOut\` |
 | \`synthesize\` | \`completed\` | \`mergeVerified\` |
@@ -10202,9 +10231,10 @@ For the full transition table for oneshot, consult
 
 \`synthesisOptedIn\` and \`synthesisOptedOut\` are pure functions of
 \`state.oneshot.synthesisPolicy\` and \`state._events\`. They are mutually
-exclusive across all 8 (3 policies × event-present/absent, with \`always\`
-and \`never\` ignoring the event flag) combinations — exactly one returns
-true at any given time.
+exclusive across all 4 meaningful combinations — \`always\` and \`never\`
+each map to one outcome (ignoring the event flag), and \`on-request\`
+branches on whether a \`synthesize.requested\` event is present or
+absent. Exactly one guard returns true at any given time.
 
 ### Schema discovery
 
@@ -14066,13 +14096,22 @@ for phrases like:
 When you hear any of those, call \`request_synthesize\` immediately. The
 handler appends a \`synthesize.requested\` event to the workflow's event
 stream; the \`synthesisOptedIn\` guard reads the stream at finalize and
-routes accordingly. This is **idempotent** — calling
-\`request_synthesize\` twice appends two events but the guard treats any
-count >= 1 as "opted in", so duplicate calls are benign.
+routes accordingly.
+
+\`request_synthesize\` is accepted from both \`plan\` and \`implementing\`
+phases — call it whenever you know you want the PR path, even before
+\`implementing\` starts. Terminal phases (\`synthesize\`, \`completed\`,
+\`cancelled\`) are rejected.
+
+Duplicate calls are **routing-idempotent** but not event-idempotent:
+each call appends a new \`synthesize.requested\` event, but the guard
+treats any count >= 1 as "opted in", so the routing decision is the
+same whether you call once or five times. The event stream will
+contain each duplicate for audit purposes.
 
 Calling \`request_synthesize\` does **not** transition the phase. The
-workflow stays in \`implementing\`. The decision is only acted on when
-you call \`finalize_oneshot\` in step 4.
+workflow stays in its current phase. The decision is only acted on
+when you call \`finalize_oneshot\` in step 4.
 
 ### Step 4 — Finalize (the choice point)
 
@@ -14245,7 +14284,7 @@ For the full transition table for oneshot, consult
 
 | From | To | Guard |
 |---|---|---|
-| \`plan\` | \`implementing\` | \`planApproved\` (or \`oneshotPlanSet\`, checks \`artifacts.plan\` presence) |
+| \`plan\` | \`implementing\` | \`oneshotPlanSet\` (requires non-empty \`artifacts.plan\`) |
 | \`implementing\` | \`synthesize\` | \`synthesisOptedIn\` |
 | \`implementing\` | \`completed\` | \`synthesisOptedOut\` |
 | \`synthesize\` | \`completed\` | \`mergeVerified\` |
@@ -14253,9 +14292,10 @@ For the full transition table for oneshot, consult
 
 \`synthesisOptedIn\` and \`synthesisOptedOut\` are pure functions of
 \`state.oneshot.synthesisPolicy\` and \`state._events\`. They are mutually
-exclusive across all 8 (3 policies × event-present/absent, with \`always\`
-and \`never\` ignoring the event flag) combinations — exactly one returns
-true at any given time.
+exclusive across all 4 meaningful combinations — \`always\` and \`never\`
+each map to one outcome (ignoring the event flag), and \`on-request\`
+branches on whether a \`synthesize.requested\` event is present or
+absent. Exactly one guard returns true at any given time.
 
 ### Schema discovery
 
@@ -18111,13 +18151,22 @@ for phrases like:
 When you hear any of those, call \`request_synthesize\` immediately. The
 handler appends a \`synthesize.requested\` event to the workflow's event
 stream; the \`synthesisOptedIn\` guard reads the stream at finalize and
-routes accordingly. This is **idempotent** — calling
-\`request_synthesize\` twice appends two events but the guard treats any
-count >= 1 as "opted in", so duplicate calls are benign.
+routes accordingly.
+
+\`request_synthesize\` is accepted from both \`plan\` and \`implementing\`
+phases — call it whenever you know you want the PR path, even before
+\`implementing\` starts. Terminal phases (\`synthesize\`, \`completed\`,
+\`cancelled\`) are rejected.
+
+Duplicate calls are **routing-idempotent** but not event-idempotent:
+each call appends a new \`synthesize.requested\` event, but the guard
+treats any count >= 1 as "opted in", so the routing decision is the
+same whether you call once or five times. The event stream will
+contain each duplicate for audit purposes.
 
 Calling \`request_synthesize\` does **not** transition the phase. The
-workflow stays in \`implementing\`. The decision is only acted on when
-you call \`finalize_oneshot\` in step 4.
+workflow stays in its current phase. The decision is only acted on
+when you call \`finalize_oneshot\` in step 4.
 
 ### Step 4 — Finalize (the choice point)
 
@@ -18290,7 +18339,7 @@ For the full transition table for oneshot, consult
 
 | From | To | Guard |
 |---|---|---|
-| \`plan\` | \`implementing\` | \`planApproved\` (or \`oneshotPlanSet\`, checks \`artifacts.plan\` presence) |
+| \`plan\` | \`implementing\` | \`oneshotPlanSet\` (requires non-empty \`artifacts.plan\`) |
 | \`implementing\` | \`synthesize\` | \`synthesisOptedIn\` |
 | \`implementing\` | \`completed\` | \`synthesisOptedOut\` |
 | \`synthesize\` | \`completed\` | \`mergeVerified\` |
@@ -18298,9 +18347,10 @@ For the full transition table for oneshot, consult
 
 \`synthesisOptedIn\` and \`synthesisOptedOut\` are pure functions of
 \`state.oneshot.synthesisPolicy\` and \`state._events\`. They are mutually
-exclusive across all 8 (3 policies × event-present/absent, with \`always\`
-and \`never\` ignoring the event flag) combinations — exactly one returns
-true at any given time.
+exclusive across all 4 meaningful combinations — \`always\` and \`never\`
+each map to one outcome (ignoring the event flag), and \`on-request\`
+branches on whether a \`synthesize.requested\` event is present or
+absent. Exactly one guard returns true at any given time.
 
 ### Schema discovery
 
@@ -22164,13 +22214,22 @@ for phrases like:
 When you hear any of those, call \`request_synthesize\` immediately. The
 handler appends a \`synthesize.requested\` event to the workflow's event
 stream; the \`synthesisOptedIn\` guard reads the stream at finalize and
-routes accordingly. This is **idempotent** — calling
-\`request_synthesize\` twice appends two events but the guard treats any
-count >= 1 as "opted in", so duplicate calls are benign.
+routes accordingly.
+
+\`request_synthesize\` is accepted from both \`plan\` and \`implementing\`
+phases — call it whenever you know you want the PR path, even before
+\`implementing\` starts. Terminal phases (\`synthesize\`, \`completed\`,
+\`cancelled\`) are rejected.
+
+Duplicate calls are **routing-idempotent** but not event-idempotent:
+each call appends a new \`synthesize.requested\` event, but the guard
+treats any count >= 1 as "opted in", so the routing decision is the
+same whether you call once or five times. The event stream will
+contain each duplicate for audit purposes.
 
 Calling \`request_synthesize\` does **not** transition the phase. The
-workflow stays in \`implementing\`. The decision is only acted on when
-you call \`finalize_oneshot\` in step 4.
+workflow stays in its current phase. The decision is only acted on
+when you call \`finalize_oneshot\` in step 4.
 
 ### Step 4 — Finalize (the choice point)
 
@@ -22343,7 +22402,7 @@ For the full transition table for oneshot, consult
 
 | From | To | Guard |
 |---|---|---|
-| \`plan\` | \`implementing\` | \`planApproved\` (or \`oneshotPlanSet\`, checks \`artifacts.plan\` presence) |
+| \`plan\` | \`implementing\` | \`oneshotPlanSet\` (requires non-empty \`artifacts.plan\`) |
 | \`implementing\` | \`synthesize\` | \`synthesisOptedIn\` |
 | \`implementing\` | \`completed\` | \`synthesisOptedOut\` |
 | \`synthesize\` | \`completed\` | \`mergeVerified\` |
@@ -22351,9 +22410,10 @@ For the full transition table for oneshot, consult
 
 \`synthesisOptedIn\` and \`synthesisOptedOut\` are pure functions of
 \`state.oneshot.synthesisPolicy\` and \`state._events\`. They are mutually
-exclusive across all 8 (3 policies × event-present/absent, with \`always\`
-and \`never\` ignoring the event flag) combinations — exactly one returns
-true at any given time.
+exclusive across all 4 meaningful combinations — \`always\` and \`never\`
+each map to one outcome (ignoring the event flag), and \`on-request\`
+branches on whether a \`synthesize.requested\` event is present or
+absent. Exactly one guard returns true at any given time.
 
 ### Schema discovery
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -3593,12 +3593,22 @@ Submit stacked PRs after review phase completes. The \`prepare_synthesis\` compo
 
 Do NOT proceed if either review is incomplete or failed -- return to \`/exarchos:review\` first.
 
+**Entry points:** Synthesis is normally reached from the \`review\` phase of
+feature / debug / refactor workflows. It is also reachable from \`oneshot\`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during \`plan\` or \`implementing\`, the \`request_synthesize\` event is
+appended, and \`finalize_oneshot\` then resolves the choice state and
+transitions the workflow to \`synthesize\`. See
+\`@skills/oneshot-workflow/SKILL.md\` for the opt-in mechanics and
+\`synthesisPolicy\` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs \`/exarchos:synthesize\` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to \`synthesize\` via \`finalize_oneshot\`
 
 ## Process
 
@@ -3820,7 +3830,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use \`exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })\` for
 parameter schemas and \`exarchos_workflow({ action: "describe", playbook: "feature" })\`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its \`implementing → synthesize|completed\` choice state
+driven by \`synthesisPolicy\`), call \`exarchos_workflow({ action: "describe", playbook: "oneshot" })\`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 \`exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })\`
 for event data schemas.
 
@@ -3908,6 +3921,23 @@ exarchos_orchestrate({
 | Review complete | Update \`reviews\` object |
 | PR created | Set \`artifacts.pr\`, \`synthesis.prUrl\` |
 | PR feedback | Append to \`synthesis.prFeedback\` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| \`plan\` (oneshot) | \`oneshot.planSummary\`, \`artifacts.plan\`, optional \`oneshot.synthesisPolicy\` | \`workflow.transition\` |
+| \`implementing\` (oneshot) | \`tasks[].status\`, \`artifacts.tests\` | \`task.*\`, optional \`synthesize.requested\` (via \`request_synthesize\`) |
+| \`synthesize\` (oneshot) | \`synthesis.prUrl\`, \`artifacts.pr\` | \`workflow.transition\`, \`stack.submitted\` |
+| \`completed\` (oneshot) | — | \`workflow.transition\` (to \`completed\`) |
+
+The \`implementing → synthesize | completed\` fork is a choice state resolved
+by \`finalize_oneshot\`, which reads the \`synthesisOptedIn\` guard
+(\`synthesisPolicy\` + \`synthesize.requested\` events). See
+\`@skills/oneshot-workflow/SKILL.md\` for the full opt-in mechanics.
 
 ### Automatic State Updates
 
@@ -7600,12 +7630,22 @@ Submit stacked PRs after review phase completes. The \`prepare_synthesis\` compo
 
 Do NOT proceed if either review is incomplete or failed -- return to \`review\` first.
 
+**Entry points:** Synthesis is normally reached from the \`review\` phase of
+feature / debug / refactor workflows. It is also reachable from \`oneshot\`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during \`plan\` or \`implementing\`, the \`request_synthesize\` event is
+appended, and \`finalize_oneshot\` then resolves the choice state and
+transitions the workflow to \`synthesize\`. See
+\`@skills/oneshot-workflow/SKILL.md\` for the opt-in mechanics and
+\`synthesisPolicy\` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs \`synthesize\` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to \`synthesize\` via \`finalize_oneshot\`
 
 ## Process
 
@@ -7827,7 +7867,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use \`exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })\` for
 parameter schemas and \`exarchos_workflow({ action: "describe", playbook: "feature" })\`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its \`implementing → synthesize|completed\` choice state
+driven by \`synthesisPolicy\`), call \`exarchos_workflow({ action: "describe", playbook: "oneshot" })\`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 \`exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })\`
 for event data schemas.
 
@@ -7915,6 +7958,23 @@ exarchos_orchestrate({
 | Review complete | Update \`reviews\` object |
 | PR created | Set \`artifacts.pr\`, \`synthesis.prUrl\` |
 | PR feedback | Append to \`synthesis.prFeedback\` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| \`plan\` (oneshot) | \`oneshot.planSummary\`, \`artifacts.plan\`, optional \`oneshot.synthesisPolicy\` | \`workflow.transition\` |
+| \`implementing\` (oneshot) | \`tasks[].status\`, \`artifacts.tests\` | \`task.*\`, optional \`synthesize.requested\` (via \`request_synthesize\`) |
+| \`synthesize\` (oneshot) | \`synthesis.prUrl\`, \`artifacts.pr\` | \`workflow.transition\`, \`stack.submitted\` |
+| \`completed\` (oneshot) | — | \`workflow.transition\` (to \`completed\`) |
+
+The \`implementing → synthesize | completed\` fork is a choice state resolved
+by \`finalize_oneshot\`, which reads the \`synthesisOptedIn\` guard
+(\`synthesisPolicy\` + \`synthesize.requested\` events). See
+\`@skills/oneshot-workflow/SKILL.md\` for the full opt-in mechanics.
 
 ### Automatic State Updates
 
@@ -11599,12 +11659,22 @@ Submit stacked PRs after review phase completes. The \`prepare_synthesis\` compo
 
 Do NOT proceed if either review is incomplete or failed -- return to \`/review\` first.
 
+**Entry points:** Synthesis is normally reached from the \`review\` phase of
+feature / debug / refactor workflows. It is also reachable from \`oneshot\`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during \`plan\` or \`implementing\`, the \`request_synthesize\` event is
+appended, and \`finalize_oneshot\` then resolves the choice state and
+transitions the workflow to \`synthesize\`. See
+\`@skills/oneshot-workflow/SKILL.md\` for the opt-in mechanics and
+\`synthesisPolicy\` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs \`/synthesize\` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to \`synthesize\` via \`finalize_oneshot\`
 
 ## Process
 
@@ -11826,7 +11896,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use \`exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })\` for
 parameter schemas and \`exarchos_workflow({ action: "describe", playbook: "feature" })\`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its \`implementing → synthesize|completed\` choice state
+driven by \`synthesisPolicy\`), call \`exarchos_workflow({ action: "describe", playbook: "oneshot" })\`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 \`exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })\`
 for event data schemas.
 
@@ -11914,6 +11987,23 @@ exarchos_orchestrate({
 | Review complete | Update \`reviews\` object |
 | PR created | Set \`artifacts.pr\`, \`synthesis.prUrl\` |
 | PR feedback | Append to \`synthesis.prFeedback\` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| \`plan\` (oneshot) | \`oneshot.planSummary\`, \`artifacts.plan\`, optional \`oneshot.synthesisPolicy\` | \`workflow.transition\` |
+| \`implementing\` (oneshot) | \`tasks[].status\`, \`artifacts.tests\` | \`task.*\`, optional \`synthesize.requested\` (via \`request_synthesize\`) |
+| \`synthesize\` (oneshot) | \`synthesis.prUrl\`, \`artifacts.pr\` | \`workflow.transition\`, \`stack.submitted\` |
+| \`completed\` (oneshot) | — | \`workflow.transition\` (to \`completed\`) |
+
+The \`implementing → synthesize | completed\` fork is a choice state resolved
+by \`finalize_oneshot\`, which reads the \`synthesisOptedIn\` guard
+(\`synthesisPolicy\` + \`synthesize.requested\` events). See
+\`@skills/oneshot-workflow/SKILL.md\` for the full opt-in mechanics.
 
 ### Automatic State Updates
 
@@ -15604,12 +15694,22 @@ Submit stacked PRs after review phase completes. The \`prepare_synthesis\` compo
 
 Do NOT proceed if either review is incomplete or failed -- return to \`review\` first.
 
+**Entry points:** Synthesis is normally reached from the \`review\` phase of
+feature / debug / refactor workflows. It is also reachable from \`oneshot\`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during \`plan\` or \`implementing\`, the \`request_synthesize\` event is
+appended, and \`finalize_oneshot\` then resolves the choice state and
+transitions the workflow to \`synthesize\`. See
+\`@skills/oneshot-workflow/SKILL.md\` for the opt-in mechanics and
+\`synthesisPolicy\` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs \`synthesize\` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to \`synthesize\` via \`finalize_oneshot\`
 
 ## Process
 
@@ -15831,7 +15931,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use \`exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })\` for
 parameter schemas and \`exarchos_workflow({ action: "describe", playbook: "feature" })\`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its \`implementing → synthesize|completed\` choice state
+driven by \`synthesisPolicy\`), call \`exarchos_workflow({ action: "describe", playbook: "oneshot" })\`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 \`exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })\`
 for event data schemas.
 
@@ -15919,6 +16022,23 @@ exarchos_orchestrate({
 | Review complete | Update \`reviews\` object |
 | PR created | Set \`artifacts.pr\`, \`synthesis.prUrl\` |
 | PR feedback | Append to \`synthesis.prFeedback\` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| \`plan\` (oneshot) | \`oneshot.planSummary\`, \`artifacts.plan\`, optional \`oneshot.synthesisPolicy\` | \`workflow.transition\` |
+| \`implementing\` (oneshot) | \`tasks[].status\`, \`artifacts.tests\` | \`task.*\`, optional \`synthesize.requested\` (via \`request_synthesize\`) |
+| \`synthesize\` (oneshot) | \`synthesis.prUrl\`, \`artifacts.pr\` | \`workflow.transition\`, \`stack.submitted\` |
+| \`completed\` (oneshot) | — | \`workflow.transition\` (to \`completed\`) |
+
+The \`implementing → synthesize | completed\` fork is a choice state resolved
+by \`finalize_oneshot\`, which reads the \`synthesisOptedIn\` guard
+(\`synthesisPolicy\` + \`synthesize.requested\` events). See
+\`@skills/oneshot-workflow/SKILL.md\` for the full opt-in mechanics.
 
 ### Automatic State Updates
 
@@ -19603,12 +19723,22 @@ Submit stacked PRs after review phase completes. The \`prepare_synthesis\` compo
 
 Do NOT proceed if either review is incomplete or failed -- return to \`review\` first.
 
+**Entry points:** Synthesis is normally reached from the \`review\` phase of
+feature / debug / refactor workflows. It is also reachable from \`oneshot\`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during \`plan\` or \`implementing\`, the \`request_synthesize\` event is
+appended, and \`finalize_oneshot\` then resolves the choice state and
+transitions the workflow to \`synthesize\`. See
+\`@skills/oneshot-workflow/SKILL.md\` for the opt-in mechanics and
+\`synthesisPolicy\` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs \`synthesize\` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to \`synthesize\` via \`finalize_oneshot\`
 
 ## Process
 
@@ -19830,7 +19960,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use \`exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })\` for
 parameter schemas and \`exarchos_workflow({ action: "describe", playbook: "feature" })\`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its \`implementing → synthesize|completed\` choice state
+driven by \`synthesisPolicy\`), call \`exarchos_workflow({ action: "describe", playbook: "oneshot" })\`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 \`exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })\`
 for event data schemas.
 
@@ -19918,6 +20051,23 @@ exarchos_orchestrate({
 | Review complete | Update \`reviews\` object |
 | PR created | Set \`artifacts.pr\`, \`synthesis.prUrl\` |
 | PR feedback | Append to \`synthesis.prFeedback\` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| \`plan\` (oneshot) | \`oneshot.planSummary\`, \`artifacts.plan\`, optional \`oneshot.synthesisPolicy\` | \`workflow.transition\` |
+| \`implementing\` (oneshot) | \`tasks[].status\`, \`artifacts.tests\` | \`task.*\`, optional \`synthesize.requested\` (via \`request_synthesize\`) |
+| \`synthesize\` (oneshot) | \`synthesis.prUrl\`, \`artifacts.pr\` | \`workflow.transition\`, \`stack.submitted\` |
+| \`completed\` (oneshot) | — | \`workflow.transition\` (to \`completed\`) |
+
+The \`implementing → synthesize | completed\` fork is a choice state resolved
+by \`finalize_oneshot\`, which reads the \`synthesisOptedIn\` guard
+(\`synthesisPolicy\` + \`synthesize.requested\` events). See
+\`@skills/oneshot-workflow/SKILL.md\` for the full opt-in mechanics.
 
 ### Automatic State Updates
 
@@ -23610,12 +23760,22 @@ Submit stacked PRs after review phase completes. The \`prepare_synthesis\` compo
 
 Do NOT proceed if either review is incomplete or failed -- return to \`/review\` first.
 
+**Entry points:** Synthesis is normally reached from the \`review\` phase of
+feature / debug / refactor workflows. It is also reachable from \`oneshot\`
+workflows via the opt-in path — when a user signals "let's open a PR for
+this" during \`plan\` or \`implementing\`, the \`request_synthesize\` event is
+appended, and \`finalize_oneshot\` then resolves the choice state and
+transitions the workflow to \`synthesize\`. See
+\`@skills/oneshot-workflow/SKILL.md\` for the opt-in mechanics and
+\`synthesisPolicy\` semantics.
+
 ## Triggers
 
 Activate this skill when:
 - User runs \`/synthesize\` command
 - All reviews have passed successfully
 - Ready to submit PRs
+- Oneshot workflow resolved to \`synthesize\` via \`finalize_oneshot\`
 
 ## Process
 
@@ -23837,7 +23997,10 @@ Valid transitions, guards, and prerequisites for all workflow types are document
 
 Use \`exarchos_workflow({ action: "describe", actions: ["set", "init", "get"] })\` for
 parameter schemas and \`exarchos_workflow({ action: "describe", playbook: "feature" })\`
-for phase transitions, guards, and playbook guidance. Use
+for phase transitions, guards, and playbook guidance. For the lightweight
+oneshot variant (with its \`implementing → synthesize|completed\` choice state
+driven by \`synthesisPolicy\`), call \`exarchos_workflow({ action: "describe", playbook: "oneshot" })\`
+— oneshot is a first-class playbook alongside feature/debug/refactor. Use
 \`exarchos_event({ action: "describe", eventTypes: ["workflow.transition", "task.completed"] })\`
 for event data schemas.
 
@@ -23925,6 +24088,23 @@ exarchos_orchestrate({
 | Review complete | Update \`reviews\` object |
 | PR created | Set \`artifacts.pr\`, \`synthesis.prUrl\` |
 | PR feedback | Append to \`synthesis.prFeedback\` |
+
+#### Oneshot-specific state updates
+
+Oneshot is a first-class workflow type with a compressed lifecycle and an
+opt-in PR path. The rows below mirror the feature-workflow table above.
+
+| Phase | State updates | Events emitted |
+|-------|---------------|----------------|
+| \`plan\` (oneshot) | \`oneshot.planSummary\`, \`artifacts.plan\`, optional \`oneshot.synthesisPolicy\` | \`workflow.transition\` |
+| \`implementing\` (oneshot) | \`tasks[].status\`, \`artifacts.tests\` | \`task.*\`, optional \`synthesize.requested\` (via \`request_synthesize\`) |
+| \`synthesize\` (oneshot) | \`synthesis.prUrl\`, \`artifacts.pr\` | \`workflow.transition\`, \`stack.submitted\` |
+| \`completed\` (oneshot) | — | \`workflow.transition\` (to \`completed\`) |
+
+The \`implementing → synthesize | completed\` fork is a choice state resolved
+by \`finalize_oneshot\`, which reads the \`synthesisOptedIn\` guard
+(\`synthesisPolicy\` + \`synthesize.requested\` events). See
+\`@skills/oneshot-workflow/SKILL.md\` for the full opt-in mechanics.
 
 ### Automatic State Updates
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -1892,11 +1892,11 @@ work directly. There is **no separate review phase**. Quality is
 maintained by the TDD loop and (if the user opts in) the synthesize PR
 review.
 
-#### Mid-implementing: opting in to a PR
+#### Mid-workflow: opting in to a PR
 
-If at any point during implementing the user decides they want a PR
-after all (policy is \`on-request\`, default), they can opt in by calling
-the \`request_synthesize\` orchestrate action:
+If at any point during \`plan\` or \`implementing\` the user decides they
+want a PR after all (policy is \`on-request\`, default), they can opt in
+by calling the \`request_synthesize\` orchestrate action:
 
 \`\`\`typescript
 mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
@@ -2100,6 +2100,12 @@ explicitly is recommended when the user has stated a preference.
 
 For the full transition table for oneshot, consult
 \`@skills/workflow-state/references/phase-transitions.md\`.
+
+> **Note:** The engine's \`exarchos_workflow describe playbook="oneshot"\`
+> output and the HSM definitions in \`hsm-definitions.ts\` are the
+> canonical sources for transition behavior. \`phase-transitions.md\` is
+> a prose reference that can drift — when discrepancies arise, prefer
+> engine \`describe\` output.
 
 **Quick reference for oneshot:**
 
@@ -5955,11 +5961,11 @@ work directly. There is **no separate review phase**. Quality is
 maintained by the TDD loop and (if the user opts in) the synthesize PR
 review.
 
-#### Mid-implementing: opting in to a PR
+#### Mid-workflow: opting in to a PR
 
-If at any point during implementing the user decides they want a PR
-after all (policy is \`on-request\`, default), they can opt in by calling
-the \`request_synthesize\` orchestrate action:
+If at any point during \`plan\` or \`implementing\` the user decides they
+want a PR after all (policy is \`on-request\`, default), they can opt in
+by calling the \`request_synthesize\` orchestrate action:
 
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
@@ -6163,6 +6169,12 @@ explicitly is recommended when the user has stated a preference.
 
 For the full transition table for oneshot, consult
 \`@skills/workflow-state/references/phase-transitions.md\`.
+
+> **Note:** The engine's \`exarchos_workflow describe playbook="oneshot"\`
+> output and the HSM definitions in \`hsm-definitions.ts\` are the
+> canonical sources for transition behavior. \`phase-transitions.md\` is
+> a prose reference that can drift — when discrepancies arise, prefer
+> engine \`describe\` output.
 
 **Quick reference for oneshot:**
 
@@ -10010,11 +10022,11 @@ work directly. There is **no separate review phase**. Quality is
 maintained by the TDD loop and (if the user opts in) the synthesize PR
 review.
 
-#### Mid-implementing: opting in to a PR
+#### Mid-workflow: opting in to a PR
 
-If at any point during implementing the user decides they want a PR
-after all (policy is \`on-request\`, default), they can opt in by calling
-the \`request_synthesize\` orchestrate action:
+If at any point during \`plan\` or \`implementing\` the user decides they
+want a PR after all (policy is \`on-request\`, default), they can opt in
+by calling the \`request_synthesize\` orchestrate action:
 
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
@@ -10218,6 +10230,12 @@ explicitly is recommended when the user has stated a preference.
 
 For the full transition table for oneshot, consult
 \`@skills/workflow-state/references/phase-transitions.md\`.
+
+> **Note:** The engine's \`exarchos_workflow describe playbook="oneshot"\`
+> output and the HSM definitions in \`hsm-definitions.ts\` are the
+> canonical sources for transition behavior. \`phase-transitions.md\` is
+> a prose reference that can drift — when discrepancies arise, prefer
+> engine \`describe\` output.
 
 **Quick reference for oneshot:**
 
@@ -14071,11 +14089,11 @@ work directly. There is **no separate review phase**. Quality is
 maintained by the TDD loop and (if the user opts in) the synthesize PR
 review.
 
-#### Mid-implementing: opting in to a PR
+#### Mid-workflow: opting in to a PR
 
-If at any point during implementing the user decides they want a PR
-after all (policy is \`on-request\`, default), they can opt in by calling
-the \`request_synthesize\` orchestrate action:
+If at any point during \`plan\` or \`implementing\` the user decides they
+want a PR after all (policy is \`on-request\`, default), they can opt in
+by calling the \`request_synthesize\` orchestrate action:
 
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
@@ -14279,6 +14297,12 @@ explicitly is recommended when the user has stated a preference.
 
 For the full transition table for oneshot, consult
 \`@skills/workflow-state/references/phase-transitions.md\`.
+
+> **Note:** The engine's \`exarchos_workflow describe playbook="oneshot"\`
+> output and the HSM definitions in \`hsm-definitions.ts\` are the
+> canonical sources for transition behavior. \`phase-transitions.md\` is
+> a prose reference that can drift — when discrepancies arise, prefer
+> engine \`describe\` output.
 
 **Quick reference for oneshot:**
 
@@ -18126,11 +18150,11 @@ work directly. There is **no separate review phase**. Quality is
 maintained by the TDD loop and (if the user opts in) the synthesize PR
 review.
 
-#### Mid-implementing: opting in to a PR
+#### Mid-workflow: opting in to a PR
 
-If at any point during implementing the user decides they want a PR
-after all (policy is \`on-request\`, default), they can opt in by calling
-the \`request_synthesize\` orchestrate action:
+If at any point during \`plan\` or \`implementing\` the user decides they
+want a PR after all (policy is \`on-request\`, default), they can opt in
+by calling the \`request_synthesize\` orchestrate action:
 
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
@@ -18334,6 +18358,12 @@ explicitly is recommended when the user has stated a preference.
 
 For the full transition table for oneshot, consult
 \`@skills/workflow-state/references/phase-transitions.md\`.
+
+> **Note:** The engine's \`exarchos_workflow describe playbook="oneshot"\`
+> output and the HSM definitions in \`hsm-definitions.ts\` are the
+> canonical sources for transition behavior. \`phase-transitions.md\` is
+> a prose reference that can drift — when discrepancies arise, prefer
+> engine \`describe\` output.
 
 **Quick reference for oneshot:**
 
@@ -22189,11 +22219,11 @@ work directly. There is **no separate review phase**. Quality is
 maintained by the TDD loop and (if the user opts in) the synthesize PR
 review.
 
-#### Mid-implementing: opting in to a PR
+#### Mid-workflow: opting in to a PR
 
-If at any point during implementing the user decides they want a PR
-after all (policy is \`on-request\`, default), they can opt in by calling
-the \`request_synthesize\` orchestrate action:
+If at any point during \`plan\` or \`implementing\` the user decides they
+want a PR after all (policy is \`on-request\`, default), they can opt in
+by calling the \`request_synthesize\` orchestrate action:
 
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
@@ -22397,6 +22427,12 @@ explicitly is recommended when the user has stated a preference.
 
 For the full transition table for oneshot, consult
 \`@skills/workflow-state/references/phase-transitions.md\`.
+
+> **Note:** The engine's \`exarchos_workflow describe playbook="oneshot"\`
+> output and the HSM definitions in \`hsm-definitions.ts\` are the
+> canonical sources for transition behavior. \`phase-transitions.md\` is
+> a prose reference that can drift — when discrepancies arise, prefer
+> engine \`describe\` output.
 
 **Quick reference for oneshot:**
 

--- a/test/migration/snapshots.test.ts
+++ b/test/migration/snapshots.test.ts
@@ -195,12 +195,14 @@ describe('task 025 — per-runtime snapshot baselines', () => {
   }
 
   it('Snapshots_AllSkillsAllRuntimes_SetCardinality', () => {
-    // Guard against silent drift in the total count. The plan assumed
-    // 16 × 6 = 96, but the actual migration landed with 13 × 6 = 78.
+    // Guard against silent drift in the total count. The plan originally
+    // assumed 16 × 6 = 96, the initial migration landed with 13 × 6 = 78,
+    // and the 2026-04-11 #1010 feature added prune-workflows and
+    // oneshot-workflow, bringing the count to 15 × 6 = 90.
     // If this number ever changes, the implementer needs to make a
     // conscious decision about seeding new snapshots — don't let a
     // silent off-by-one sneak past the baseline comparison.
-    expect(allFiles.length).toBe(78);
+    expect(allFiles.length).toBe(90);
   });
 
   for (const runtime of RUNTIME_NAMES) {

--- a/test/migration/structural-invariant.test.ts
+++ b/test/migration/structural-invariant.test.ts
@@ -101,15 +101,16 @@ function findAllSkillMdFiles(root: string, excludeFragments: string[] = []): str
 }
 
 describe('task 018 — post-migration structural invariants', () => {
-  it('PostMigration_SkillsTree_Contains78SkillMdFiles', () => {
-    // 13 skills × 6 runtimes = 78 SKILL.md files under `skills/`.
-    // `test-fixtures/` is excluded because those are validator test
-    // fixtures, not deployable skills.
+  it('PostMigration_SkillsTree_ContainsExpectedSkillMdFiles', () => {
+    // 15 skills × 6 runtimes = 90 SKILL.md files under `skills/`.
+    // Updated in 2026-04-11 to add prune-workflows and oneshot-workflow
+    // per #1010. `test-fixtures/` is excluded because those are
+    // validator test fixtures, not deployable skills.
     const files = findAllSkillMdFiles(SKILLS_DIR, ['/test-fixtures/']);
     expect(
       files.length,
-      `expected 78 SKILL.md files under skills/ (13 skills × 6 runtimes), found ${files.length}`,
-    ).toBe(78);
+      `expected 90 SKILL.md files under skills/ (15 skills × 6 runtimes), found ${files.length}`,
+    ).toBe(90);
   });
 
   it('PostMigration_SkillsSrcTree_ContainsNoCommittedGeneratedFiles', () => {


### PR DESCRIPTION
## Summary

Adds the `oneshot` lightweight workflow type for trivial changes, plus a `prune_stale_workflows` orchestrate action for bulk pipeline hygiene. Addresses #1010 (primary), #1077 (sibling deprecation cleanup), #1049 (epic closeout — already closed via admin action during delegation).

One-shot uses a **pure event-derived choice state** at the end of `implementing`: the state machine branches to `completed` (direct-commit) or `synthesize` (PR) based on a `synthesisPolicy` declared at init plus optional runtime `synthesize.requested` events. The guards are pure functions of event-hydrated state with no IO — following the codebase's `teamDisbandedEmitted` precedent and external research (Temporal, Azure Durable Functions, Camunda, UML statecharts) which all prescribe this pattern.

Pruning is a thin bulk wrapper over the existing `handleCancel` with DI-testable safeguards (open-PR check, recent-commits check, both injectable for testing), emitting `workflow.pruned` events for audit.

## Changes

### New workflow type: `oneshot`
- `oneshot` registered in `BUILT_IN_WORKFLOW_TYPES`; `OneshotWorkflowStateSchema` with enum-typed `OneshotPhaseSchema`
- `oneshotPlaybook` with 4 phases: `plan → implementing → {synthesize | completed}`
- HSM transitions in `hsm-definitions.ts` using pure guards `synthesisOptedIn` / `synthesisOptedOut` (inline-inverted, not composed)
- `init` action extended to accept optional `synthesisPolicy: 'always' | 'never' | 'on-request'` (design-aligned)

### New orchestrate actions
- `prune_stale_workflows` — lists, filters, safeguards, bulk-cancels; emits `workflow.pruned` per cancel. Dry-run default. `force: true` bypasses safeguards with audit-trail marker.
- `request_synthesize` — appends `synthesize.requested` event for oneshot workflows
- `finalize_oneshot` — evaluates choice state and transitions to `synthesize` or `completed`

### New event types
- `workflow.pruned` — `{ featureId, stalenessMinutes, triggeredBy, skippedSafeguards? }`
- `synthesize.requested` — `{ featureId, reason?, timestamp }`

### New skills
- `skills-src/oneshot-workflow/` — `/exarchos:oneshot` slash command skill
- `skills-src/prune-workflows/` — `/exarchos:prune` slash command skill with dry-run → confirm → apply UX

### Skill-layer capability extension
Existing skills updated to thread the new capability:
- `workflow-state/SKILL.md` + `phase-transitions.md` — enumerate oneshot, add HSM section
- `_shared/references/mcp-tool-guidance.md` — document oneshot + `synthesisPolicy` arg
- `cleanup/SKILL.md` + `shepherd/SKILL.md` — cross-link `prune-workflows` as bulk alternative
- `delegation/SKILL.md` — note oneshot exception (in-session, no delegation)

### Sibling scope (#1077)
- Removed `augmentWithSemanticScore()` stub-adjacent plumbing (`basileusConnected` guard/param/test fixtures)
- Added superseding note to `docs/designs/2026-02-18-hybrid-review-strategy.md` Phase 4 pointing at `lvlup-sw/basileus#146`

### Bugs found and fixed mid-flight
- `handleList` was dropping `_checkpoint` field, making the prune threshold a no-op in production (unit tests missed it because they stubbed `handleList`; caught by integration test). Fixed with regression-guarding integration test.
- `handlePruneStaleWorkflows` had a double-accounting bug on event-append failure (same feature in both `skipped[]` and `pruned[]`). Structurally impossible now via tagged-union helper.

### Infrastructure
- `TERMINAL_PHASES` extracted to shared `workflow/terminal-phases.ts` (was duplicated)
- `handlePruneStaleWorkflows` decomposed via `prunePruneCandidate` helper (was 110 lines)

## Test Plan

- [x] Unit tests for every new guard, schema, handler, and orchestrate action (RED → GREEN → REFACTOR)
- [x] Property tests for choice-state mutual exclusivity across all 8 `policy × event` combinations
- [x] Integration tests for prune (dry-run → apply, safeguards, threshold respect with real state files)
- [x] Integration tests for oneshot workflow (5 paths: default/on-request/always/never/cancel-mid-implementing)
- [x] Regression test for the `handleList._checkpoint` bug
- [x] Regression test for the prune event-append double-accounting bug
- [x] Full server suite: 4958/4958 passing (serial mode to avoid pre-existing parallel SQLite contention)
- [x] Root suite: 540/540 passing
- [x] Typecheck clean at both root and `servers/exarchos-mcp`
- [x] `skills:guard` in sync (90 skill variants across 6 runtimes)
- [x] Batch migration baselines updated for edited skills
- [x] Snapshot baselines regenerated

Closes #1010
Closes #1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)