### PR TITLE
docs: v2.6.0 coverage pass (oneshot workflow + pruning)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Exarchos is local agent governance for Claude Code. It provides event-sourced SD
 
 | Directory | Purpose |
 |-----------|---------|
-| `commands/` | Slash commands (`/ideate`, `/plan`, `/delegate`, `/debug`, `/refactor`, `/review`, `/synthesize`, `/checkpoint`, `/rehydrate`, `/tdd`) |
+| `commands/` | Slash commands (`/ideate`, `/plan`, `/delegate`, `/debug`, `/refactor`, `/oneshot`, `/review`, `/synthesize`, `/prune`, `/checkpoint`, `/rehydrate`, `/tdd`) |
 | `skills/` | Reusable workflow modules with `SKILL.md` and `references/` subdirectories |
 | `rules/` | Global behavioral constraints (coding standards, TDD, orchestrator constraints) |
 | `scripts/` | Deterministic validation scripts replacing prose checklists in skills |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to Exarchos are documented in this file. Organized by semver
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-04-12
+
 ### Features
+- `oneshot` workflow type with pure event-derived choice state (plan → implementing → {completed | synthesize}) (#1010)
+- `prune_stale_workflows` orchestrate action for bulk pipeline hygiene (dry-run default, DI-testable safeguards, `workflow.pruned` audit event) (#1010)
+- `request_synthesize` + `finalize_oneshot` orchestrate actions for oneshot choice state (#1010)
+- `synthesize.requested` + `workflow.pruned` event types (#1010)
+- `synthesisPolicy` optional init arg (`always` / `never` / `on-request`) for oneshot workflows, persisted in `workflow.started` event (#1010)
+- `/exarchos:oneshot` and `/exarchos:prune` slash command skills with `references/` subdirectories (#1010)
+- `OneshotPhaseSchema` enum for type-safe phase validation (#1010)
+- Skill layer extensions threading oneshot through workflow-state, cleanup, shepherd, delegation skills (#1010)
 - HSM topology introspection via `exarchos_workflow describe` with `topology` parameter (#979)
 - Event emission catalog via `exarchos_event describe` with `emissionGuide` parameter (#979)
 - CLI `topology [type]` and `emissions` commands for plugin-free introspection (#979)
@@ -13,7 +23,25 @@ All notable changes to Exarchos are documented in this file. Organized by semver
 - Cursor sequential-fallback mode for runtimes without an in-session subagent primitive (#1071)
 - Build pipeline: `npm run build:skills` orchestrator with placeholder substitution, reference copying, override detection, and stale-source cleanup (#1071)
 
+### Bug Fixes
+- `handleList` now returns `_checkpoint` so `prune_stale_workflows` threshold filter works in production (caught by integration test; unit tests missed it due to stubbing) (#1010)
+- `INITIAL_PHASE` now includes `oneshot → plan` so ES v2 rematerialized oneshot workflows start in the correct phase (#1010)
+- `handlePruneStaleWorkflows` no longer double-accounts on event-append failure (caught by CodeRabbit review) (#1010)
+- Removed `augmentWithSemanticScore` Phase 4 deprecation stubs and `basileusConnected` parameter plumbing from review triage (#1077)
+
+### Hardening
+- Fail-closed validation on malformed `handleList` entries (malformed entries bucketed separately, never reach `candidates` or `pruned`) (#1010)
+- Input validation on `thresholdMinutes` (positive integer) and `now` (valid ISO) before batch runs (#1010)
+- `oneshotPlanSet` guard tightened to require non-empty `artifacts.plan` (`planSummary` alone is insufficient, whitespace trimmed) (#1010)
+- `request_synthesize` runtime phase guard rejects terminal phases (#1010)
+
+### Internal
+- `TERMINAL_PHASES` extracted to shared `workflow/terminal-phases.ts` (was duplicated) (#1010)
+- `handlePruneStaleWorkflows` decomposed via `prunePruneCandidate` helper (~110 → ~60 lines) (#1010)
+- New `adaptArgsWithStateDirAndEventStore` adapter in composite router for handlers needing both `stateDir` and `eventStore` (#1010)
+
 ### Documentation
+- Comprehensive documentation coverage pass for v2.6.0: new oneshot-workflow guide, updated reference/learn/architecture pages
 - Placeholder vocabulary reference (`docs/references/placeholder-vocabulary.md`) and runtime notes (`docs/references/runtime-notes.md`) (#1071)
 - Skill authoring guide (`docs/skills-authoring.md`) covering edit workflow, vocabulary, adding runtimes, and CI checks (#1071)
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Requires Node.js >= 20.
 
 ## What you get
 
-Three workflow types (feature, debug, refactor) with enforced phase transitions. You approve the design and you approve the merge. Everything between auto-continues.
+Four workflow types (feature, debug, refactor, oneshot) with enforced phase transitions. You approve the design and you approve the merge. Everything between auto-continues. For trivial changes, `oneshot` skips straight to plan → implement with an opt-in PR path.
 
 **Checkpoint and resume.** `/checkpoint` saves mid-task. `/rehydrate` restores it in ~2-3k tokens.
 
@@ -138,6 +138,7 @@ Structured input over natural language. Strict schema validation over loose pars
 | Build a feature | `/ideate` | Design exploration, TDD plan, parallel implementation |
 | Fix a bug | `/debug` | Triage, investigate, fix, validate (hotfix or thorough) |
 | Improve code | `/refactor` | Assess scope, brief, implement (polish or full overhaul) |
+| Make a trivial change | `/oneshot` | Lightweight in-session plan → implementing → direct-commit (or opt-in PR) |
 
 **Lifecycle commands:**
 
@@ -149,6 +150,7 @@ Structured input over natural language. Strict schema validation over loose pars
 | `/synthesize` | Create PR from feature branch |
 | `/shepherd` | Push PRs through CI and reviews to merge readiness |
 | `/cleanup` | Resolve merged workflow to completed state |
+| `/prune` | Interactively bulk-cancel stale non-terminal workflows |
 | `/checkpoint` | Save workflow state for later resumption |
 | `/rehydrate` | Restore workflow state after compaction or session break |
 | `/reload` | Re-inject context after degradation |

--- a/documentation/.vitepress/config.ts
+++ b/documentation/.vitepress/config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
             { text: 'Feature Development', link: '/guide/feature-workflow' },
             { text: 'Debugging', link: '/guide/debug-workflow' },
             { text: 'Refactoring', link: '/guide/refactor-workflow' },
+            { text: 'Oneshot', link: '/guide/oneshot-workflow' },
           ],
         },
         {

--- a/documentation/architecture/state-machine.md
+++ b/documentation/architecture/state-machine.md
@@ -55,6 +55,30 @@ graph LR
 
 Refactoring also branches by scope. Polish track is for small, focused changes done directly by the orchestrator. Overhaul track mirrors the feature workflow with planning, delegation, and review phases.
 
+### Oneshot workflow
+
+```mermaid
+graph LR
+    plan --> implementing
+    implementing -->|synthesisOptedOut| completed
+    implementing -->|synthesisOptedIn| synthesize --> completed
+```
+
+Introduced in v2.6.0. The oneshot workflow is a lightweight four-phase path for trivial changes that don't warrant the ceremony of the feature pipeline. Everything runs in-session — no subagent dispatch, no two-stage review, no compound state, no fix-cycle circuit breaker.
+
+The fork after `implementing` is a **choice state** (UML terminology) implemented as two mutually-exclusive HSM transitions. The guards are pure functions of `state.oneshot.synthesisPolicy` (declared at init) and the count of `synthesize.requested` events on the stream. The `finalize_oneshot` orchestrate action evaluates the guards and calls `handleSet` with the resolved target phase. The HSM re-evaluates the guard at the transition boundary as a safety net.
+
+| From | To | Guard | Prerequisite |
+|------|----|-------|--------------|
+| `plan` | `implementing` | `oneshot-plan-set` | Set non-empty `artifacts.plan` (`oneshot.planSummary` is optional metadata but does not satisfy the guard on its own) |
+| `implementing` | `synthesize` | `synthesis-opted-in` | Policy `always` OR (`on-request` + at least one `synthesize.requested` event) |
+| `implementing` | `completed` | `synthesis-opted-out` | Policy `never` OR (`on-request` + no `synthesize.requested` event) |
+| `synthesize` | `completed` | `pr-url-exists` | Set `synthesis.prUrl` or `artifacts.pr` |
+
+**Policy precedence.** `synthesisPolicy = "never"` causes `synthesis-opted-out` to short-circuit regardless of events — any `synthesize.requested` events on the stream are ignored. `synthesisPolicy = "always"` causes `synthesis-opted-in` to short-circuit to `synthesize` regardless of events. Only `"on-request"` (default) consults the event stream.
+
+The policy value is embedded in the `workflow.started` event payload so it survives ES v2 rematerialization — rehydrating a oneshot workflow from events alone preserves the init-time routing intent.
+
 ## Guards
 
 Guards are preconditions checked before a transition is allowed. Each guard is a pure function that inspects the current state and returns either `true` or a structured failure with an explanation, the expected state shape, and a suggested fix.

--- a/documentation/guide/oneshot-workflow.md
+++ b/documentation/guide/oneshot-workflow.md
@@ -1,0 +1,197 @@
+---
+outline: deep
+---
+
+# Oneshot Workflow
+
+The oneshot workflow is a lightweight path for changes that are too small to justify the full `feature` pipeline (`ideate → plan → plan-review → delegate → review → synthesize → completed`) but still deserve event-sourced auditability and a planning step. It skips subagent dispatch and two-stage review, runs everything in-session, and commits directly by default — with an opt-in escape hatch to the standard synthesis flow if the user decides they want a PR mid-stream.
+
+Introduced in v2.6.0 (#1010) alongside the `prune_stale_workflows` maintenance action.
+
+## Phase chain
+
+```text
+     plan ──────► implementing ──┬── [synthesisOptedOut] ──► completed
+                                 │
+                                 └── [synthesisOptedIn]  ──► synthesize ──► completed
+```
+
+Four phases. The fork after `implementing` is a UML choice state implemented as two mutually-exclusive HSM transitions whose guards are pure functions of `state.oneshot.synthesisPolicy` and the `synthesize.requested` event count. Both `completed` branches are terminal; `cancelled` is reachable from any non-terminal phase via the universal cancel transition.
+
+## When to use oneshot
+
+Reach for oneshot when **all** of the following are true:
+
+- The change is bounded — typically one file, or a tightly-coupled cluster of 2-3 files
+- No subagent dispatch is needed — the work fits in one TDD loop in a single session
+- No design document is required — the goal is obvious from the task description
+- No two-stage review is required — either direct-commit is acceptable, or a single PR review suffices
+
+Concrete fits: fixing a typo, bumping a dependency version, adding a missing null-check in one function, tweaking a CI workflow YAML, renaming a config key, adding a one-off helper script, exploratory spikes.
+
+### When NOT to use oneshot
+
+Use the full `feature` workflow (`/exarchos:ideate`) instead for:
+
+- Cross-cutting refactors that touch many files or modules
+- Multi-file features that benefit from subagent decomposition
+- Anything that needs design exploration or competing approaches weighed
+- Anything that needs spec-review + quality-review (two-stage)
+- Anything that needs to coordinate with another agent team
+- Changes that should land in stages (stacked PRs)
+
+If you start a oneshot and the change turns out bigger than expected, cancel it and restart with `/exarchos:ideate`. Do not try to grow a oneshot into a feature workflow mid-stream — the playbooks have different shapes.
+
+## Synthesis policy
+
+The `synthesisPolicy` field on a oneshot workflow declares up-front intent about whether the change should be turned into a PR. It takes one of three values, persisted on `state.oneshot.synthesisPolicy`:
+
+| Policy | Behavior | When to use |
+|---|---|---|
+| `always` | Always route `implementing → synthesize` at finalize, regardless of events. A PR is always created. | User wants a review paper trail for every change in this workflow. |
+| `never` | Always route `implementing → completed` at finalize, regardless of events. No PR is created — commits go directly to the current branch. | User is iterating on scratch work and explicitly opts out of PRs. |
+| `on-request` *(default)* | Direct-commit by default. The user can opt in mid-`implementing` by calling `request_synthesize`; if any `synthesize.requested` event is on the stream at finalize, the workflow routes to `synthesize` instead of `completed`. | The common case: start lightweight, leave the door open for the user to change their mind once they see the diff. |
+
+**Policy wins over event.** If `synthesisPolicy: 'never'` is set and a `synthesize.requested` event somehow lands on the stream, the guard still routes to `completed`. The user's declared intent overrides runtime signal.
+
+The default is `on-request` because it is the least surprising: the user gets the lightweight path until they explicitly ask for the heavy one.
+
+## Planning phase
+
+A oneshot plan is intentionally minimal — no design doc, no parallelization analysis, no decomposition into N tasks. Answer four questions in 5-10 lines each:
+
+1. **Goal** — what is the user trying to accomplish?
+2. **Approach** — what's the one-line implementation strategy?
+3. **Files** — which files will be touched? (1-5 typically)
+4. **Tests** — which test cases will be added? (named, not described)
+
+Persist the plan and transition to `implementing` in a single call. The `oneshotPlanSet` guard requires `artifacts.plan` to be a non-empty string (whitespace trimmed); `oneshot.planSummary` is an optional pipeline-view label but does **not** satisfy the guard on its own.
+
+## Implementing phase
+
+Run an in-session TDD loop. The iron law from `@rules/tdd.md` applies unchanged:
+
+> NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
+
+For each behavior in the plan:
+
+1. **RED** — write a failing test; confirm it fails for the right reason
+2. **GREEN** — write the minimum production code to make the test pass
+3. **REFACTOR** — clean up while keeping the test green
+
+Commit each RED-GREEN-REFACTOR cycle as a single atomic commit. In oneshot there is no separate review phase to catch bundled changes, so commit hygiene matters more, not less.
+
+There is **no subagent dispatch** in oneshot. The main agent does the work directly. There is **no separate review phase**. Quality is maintained by the TDD loop and (if the user opts in) the synthesize PR review.
+
+## The choice point
+
+When the implementing loop is done — tests pass, typecheck clean, all commits made — call `finalize_oneshot` to resolve the choice state:
+
+```ts
+exarchos_orchestrate({
+  action: "finalize_oneshot",
+  featureId: "fix-readme-typo"
+})
+```
+
+The handler:
+
+1. Reads current state and verifies `workflowType === 'oneshot'` and `phase === 'implementing'`
+2. Hydrates `_events` from the event store so the guard sees the same view the HSM will see at the transition boundary
+3. Evaluates `guards.synthesisOptedIn` against the state (pure function of policy + events)
+4. Calls `handleSet` with the resolved target phase (`synthesize` or `completed`)
+
+The HSM re-evaluates the guard at the transition boundary, so any race between the read and the transition is caught safely. The choice is replay-safe: the decision is a pure function of inputs already persisted in the state and event store.
+
+| `synthesisPolicy` | `synthesize.requested` event present? | Resolved target | Path |
+|---|---|---|---|
+| `always` | (any) | `synthesize` | PR path |
+| `never` | (any) | `completed` | direct-commit path |
+| `on-request` (default) | yes | `synthesize` | PR path |
+| `on-request` (default) | no | `completed` | direct-commit path |
+
+## Direct-commit path
+
+If finalize resolved to `completed`, the commits made during implementing are already on the current branch — push them if they aren't pushed already:
+
+```bash
+git push
+```
+
+The workflow is now in `completed` and will not appear in the default pipeline view. There is no PR, no review, no synthesize phase. The audit trail lives in the event stream.
+
+## Synthesize path (opt-in)
+
+If at any point during `plan` or `implementing` the user asks for a PR ("actually, let's open a PR for this", "I want a review on this before it lands", "make this a PR"), call the runtime opt-in action:
+
+```ts
+exarchos_orchestrate({
+  action: "request_synthesize",
+  featureId: "fix-readme-typo",
+  reason: "user requested review of the parser changes"
+})
+```
+
+This appends a `synthesize.requested` event to the workflow's stream. Calling it does **not** transition the phase — the workflow stays in its current phase and the decision is only acted on at finalize.
+
+`request_synthesize` is accepted from both `plan` and `implementing` phases. Terminal phases (`synthesize`, `completed`, `cancelled`) are rejected at the handler boundary. Duplicate calls are routing-idempotent but not event-idempotent: each call appends a new event, but the guard treats any count `>= 1` as "opted in" so the routing is unchanged.
+
+When `finalize_oneshot` resolves to `synthesize`, hand off to the standard synthesis flow ([Review Process](/guide/review-process), plus the `synthesis` skill). The same `prepare_synthesis` / `validate_pr_body` / `gh pr create` machinery used by the `feature` workflow applies. After the PR merges, the workflow transitions `synthesize → completed` via the existing `mergeVerified` / `pr-url-exists` guard.
+
+You do **not** run `/exarchos:delegate` or `/exarchos:review` on an opt-in oneshot synthesize. Those phases do not exist in the oneshot playbook. The PR review is the only review.
+
+## Comparison with feature workflow
+
+| Aspect | `feature` | `oneshot` |
+|---|---|---|
+| Phases | ideate → plan → plan-review → delegate → review → synthesize → completed | plan → implementing → {completed \| synthesize → completed} |
+| Initial phase | `ideate` | `plan` |
+| Design doc | required (`artifacts.design`) | not required |
+| Plan-review | yes (human checkpoint) | no |
+| Subagent dispatch | yes (`delegate`) | no — main agent only |
+| Two-stage review | yes (spec + quality) | no — PR review only (if opted in) |
+| Fix-cycle circuit breaker | yes (3 cycles) | no |
+| PR creation | always | opt-in via `synthesisPolicy` / `request_synthesize` |
+| Compound states | `implementation` (delegate + review) | none |
+| Choice states | no | yes (end of `implementing`) |
+| Checkpoint-resume | yes | yes |
+| Human checkpoints | plan approval, merge confirmation | none (direct-commit) or merge confirmation (synthesize path) |
+
+## Example end-to-end
+
+```text
+User: "Quick fix — typo in the README, 'recieve' should be 'receive'. Use oneshot."
+
+Agent:
+  1. exarchos_workflow init { featureId: "fix-readme-typo", workflowType: "oneshot" }
+     → workflow created in 'plan', synthesisPolicy defaults to 'on-request'
+  2. Writes a 4-line plan: goal=fix typo, approach=sed, files=[README.md],
+     tests=[readme has no occurrence of 'recieve']
+  3. exarchos_workflow set {
+       featureId: "fix-readme-typo",
+       phase: "implementing",
+       updates: {
+         "artifacts.plan": "...",
+         "oneshot.planSummary": "Fix 'recieve' typo in README"
+       }
+     }
+  4. [RED] writes a test that greps README for 'recieve', expects 0 matches — fails
+  5. [GREEN] edits README, fixes typo — test passes
+  6. git commit -m "docs: fix 'recieve' typo in README"
+  7. exarchos_orchestrate finalize_oneshot { featureId: "fix-readme-typo" }
+     → guard sees policy='on-request' + no synthesize.requested event
+     → resolves to 'completed'
+  8. git push
+     "Done. Workflow completed via direct-commit path."
+```
+
+For a mid-implementing opt-in walkthrough and a `synthesisPolicy: 'always'` example, see `@skills/oneshot-workflow/SKILL.md`.
+
+## References
+
+- Skill: `@skills/oneshot-workflow/SKILL.md` — full prose walkthrough with worked examples
+- HSM reference: `@skills/workflow-state/references/phase-transitions.md` — transition table, guards, prerequisites
+- Design doc: `docs/designs/2026-04-11-oneshot-and-pruning.md` — rationale, non-goals, research links
+- Orchestrate actions: [`request_synthesize`, `finalize_oneshot`](/reference/tools/orchestrate)
+- Events: [`synthesize.requested`, `workflow.pruned`](/reference/events)
+- State machine reference: [State Machine — Oneshot Workflow](/architecture/state-machine)

--- a/documentation/guide/project-config.md
+++ b/documentation/guide/project-config.md
@@ -163,7 +163,7 @@ Each hook command receives the event data as JSON on stdin. Four environment var
 | `EXARCHOS_FEATURE_ID` | Current workflow feature ID |
 | `EXARCHOS_PHASE` | Current workflow phase |
 | `EXARCHOS_EVENT_TYPE` | Event type that triggered the hook |
-| `EXARCHOS_WORKFLOW_TYPE` | Workflow type (feature, debug, refactor) |
+| `EXARCHOS_WORKFLOW_TYPE` | Workflow type (feature, debug, refactor, oneshot) |
 
 A failing notification script will not break your workflow. Errors are logged, but hooks never block the event pipeline.
 

--- a/documentation/learn/core-concepts.md
+++ b/documentation/learn/core-concepts.md
@@ -6,13 +6,15 @@ outline: deep
 
 ## Workflows
 
-A workflow is a structured sequence of phases that takes a unit of work from idea to shipped code. Exarchos supports three workflow types:
+A workflow is a structured sequence of phases that takes a unit of work from idea to shipped code. Exarchos supports four workflow types:
 
 Feature workflows move through: ideate, plan, plan-review, delegate, review, synthesize, completed. This is the full path from design exploration through a merged PR.
 
 Debug workflows move through: triage, investigate, root cause analysis, design, then branch into either a hotfix track (implement, validate) or a thorough track (implement, validate, review). Use this when something is broken and you need to fix it.
 
 Refactor workflows move through: explore, brief, then branch into either a polish track (implement, validate, update docs) or an overhaul track (plan, plan-review, delegate, review, update docs). The branch depends on scope.
+
+Oneshot workflows (introduced in v2.6.0) move through: plan, implementing, and then a runtime choice state that forks to either `completed` (direct-commit) or `synthesize → completed` (PR). No subagent dispatch, no two-stage review — everything runs in-session within a single TDD loop. Use oneshot for trivial changes like typo fixes, config tweaks, or exploratory spikes where the ceremony of the feature workflow would be wasteful. The choice between direct-commit and PR is resolved at the end of `implementing` by evaluating a pure event-sourced guard against the `synthesisPolicy` declared at init (`always`, `never`, or `on-request` default) plus any `synthesize.requested` events emitted at runtime.
 
 Each type has its own phase sequence and transition rules. You pick the type when you start a workflow, and the state machine handles the rest.
 

--- a/documentation/learn/how-it-works.md
+++ b/documentation/learn/how-it-works.md
@@ -29,7 +29,7 @@ If the state file gets corrupted or deleted, `reconcile` rebuilds it by replayin
 
 ## State machine enforcing phase transitions
 
-The workflow state machine defines valid transitions for each workflow type. Feature workflows can move from `ideate` to `plan`, but not from `ideate` to `review`. Debug workflows branch into hotfix and thorough tracks. Refactor workflows branch into polish and overhaul tracks.
+The workflow state machine defines valid transitions for each workflow type. Feature workflows can move from `ideate` to `plan`, but not from `ideate` to `review`. Debug workflows branch into hotfix and thorough tracks. Refactor workflows branch into polish and overhaul tracks. Oneshot workflows (v2.6.0+) have a four-phase lightweight lifecycle with a choice state at the end of `implementing` that forks to either `completed` (direct-commit) or `synthesize → completed` (PR), evaluated against a pure event-sourced guard at finalize time.
 
 Guards check preconditions before each transition: does a plan document exist? Have all tasks completed? Did convergence gates pass? If a guard fails, the transition is rejected with a message explaining what's missing.
 

--- a/documentation/reference/commands.md
+++ b/documentation/reference/commands.md
@@ -1,6 +1,6 @@
 # Commands
 
-Exarchos provides 15 slash commands. As a Claude Code plugin, they are namespaced under `/exarchos:`.
+Exarchos provides 17 slash commands. As a Claude Code plugin, they are namespaced under `/exarchos:`.
 
 ## Workflow start commands
 
@@ -48,6 +48,23 @@ Code improvement. Assess scope, write brief, implement, validate.
 | `--polish` | Direct implementation, 5 files or fewer, single concern |
 | `--explore` | Assess scope before selecting a track |
 | `--switch-overhaul` | Switch from polish to overhaul mid-workflow |
+
+### `/exarchos:oneshot`
+
+Lightweight in-session workflow for trivial changes. Plans, implements, and either direct-commits or opens a PR — all within a single TDD loop with no subagent dispatch. Introduced in v2.6.0.
+
+```bash
+/exarchos:oneshot "Fix typo in README install section"
+/exarchos:oneshot --pr "Add missing null-check to formatDate"
+```
+
+| Flag | Effect |
+|------|--------|
+| (none) | Policy `on-request` (default) — direct-commit unless `request_synthesize` is called mid-stream |
+| `--pr` | Policy `always` — always transition through `synthesize` to create a PR |
+| `--no-pr` | Policy `never` — always direct-commit, ignore `synthesize.requested` events |
+
+The fork after `implementing` is a pure event-sourced choice state. Call `exarchos_orchestrate { action: "request_synthesize" }` at any time during `plan` or `implementing` to opt into the PR path. Terminal `finalize_oneshot` resolves the decision. See [Oneshot Workflow](/guide/oneshot-workflow) for the full flow.
 
 ## Lifecycle commands
 
@@ -151,6 +168,20 @@ Toggle autocompact on/off or set a threshold percentage. Manages the `CLAUDE_AUT
 /exarchos:autocompact off       # Disable
 /exarchos:autocompact 80        # Set to 80%
 ```
+
+## Maintenance commands
+
+### `/exarchos:prune`
+
+Bulk-cancel stale non-terminal workflows from the pipeline view. Interactive dry-run → confirm → apply UX. Introduced in v2.6.0.
+
+```bash
+/exarchos:prune                        # dry-run, default 7-day threshold
+/exarchos:prune --threshold 1440       # 1-day threshold (minutes)
+/exarchos:prune --force                # bypass safeguards (still audited)
+```
+
+Invokes `exarchos_orchestrate { action: "prune_stale_workflows" }`. Safeguards skip workflows with open PRs or recent commits unless `--force` is passed. Each pruned workflow emits a `workflow.pruned` event carrying `stalenessMinutes`, `triggeredBy`, and optional `skippedSafeguards` for audit. See [prune_stale_workflows](/reference/tools/orchestrate#prune_stale_workflows) for the underlying action.
 
 ## Attribution
 

--- a/documentation/reference/events.md
+++ b/documentation/reference/events.md
@@ -35,13 +35,13 @@ Each event type has a designated emission source:
 
 Events marked `auto` should not be duplicated via manual `exarchos_event` calls. The MCP server emits them as side effects of workflow operations.
 
-## Event types (58 total)
+## Event types (60 total)
 
-### Workflow (12)
+### Workflow (13)
 
 | Type | Source | Description |
 |------|--------|-------------|
-| `workflow.started` | auto | Workflow initialized |
+| `workflow.started` | auto | Workflow initialized. For `oneshot` workflows, the event data includes `synthesisPolicy` so it survives ES v2 rematerialization |
 | `workflow.transition` | auto | Phase transition |
 | `workflow.fix-cycle` | auto | Fix cycle incremented |
 | `workflow.guard-failed` | auto | Transition guard rejected |
@@ -53,6 +53,7 @@ Events marked `auto` should not be duplicated via manual `exarchos_event` calls.
 | `workflow.compensation` | auto | Saga compensation action |
 | `workflow.circuit-open` | auto | Circuit breaker tripped |
 | `workflow.cas-failed` | auto | Compare-and-swap retry exhausted |
+| `workflow.pruned` | auto | Batch-cancelled by `prune_stale_workflows`. Payload: `{ featureId, stalenessMinutes, triggeredBy: "manual" \| "scheduled", skippedSafeguards? }`. Introduced in v2.6.0 |
 
 ### Task (5)
 
@@ -153,6 +154,12 @@ Events marked `auto` should not be duplicated via manual `exarchos_event` calls.
 | `ci.status` | model | CI status for a PR |
 | `comment.posted` | model | PR comment posted |
 | `comment.resolved` | model | PR comment thread resolved |
+
+### Oneshot choice state (1)
+
+| Type | Source | Description |
+|------|--------|-------------|
+| `synthesize.requested` | auto | Appended by `request_synthesize`. Consumed by the `synthesisOptedIn` guard at `finalize_oneshot` time. Payload: `{ featureId, reason?, timestamp }`. Duplicate appends are benign (any count ≥ 1 → opted in). Introduced in v2.6.0 |
 
 ### Other (1)
 

--- a/documentation/reference/skills.md
+++ b/documentation/reference/skills.md
@@ -44,6 +44,8 @@ Skills that invoke Exarchos MCP tools must include `metadata.mcp-server: exarcho
 | `delegation` | Task dispatch to agent teammates in worktrees | delegate |
 | `git-worktrees` | Worktree management for parallel work | delegate |
 | `implementation-planning` | TDD-based task planning from design docs | plan |
+| `oneshot-workflow` | Lightweight in-session workflow for trivial changes with opt-in PR path (v2.6.0) | plan, implementing |
+| `prune-workflows` | Bulk-cancel stale non-terminal workflows from the pipeline view (v2.6.0) | maintenance |
 | `quality-review` | Stage 2 code quality review (+ axiom/impeccable if installed) | review |
 | `refactor` | Code improvement (polish/overhaul tracks) | explore, synthesize |
 | `shepherd` | PR shepherding through CI and reviews | synthesize |

--- a/documentation/reference/tools/orchestrate.md
+++ b/documentation/reference/tools/orchestrate.md
@@ -170,6 +170,107 @@ Phases: synthesize, review, overhaul-review, debug-review. Role: `lead`.
 
 ---
 
+## Oneshot choice state
+
+Actions specific to the oneshot workflow type. Both introduced in v2.6.0.
+
+### request_synthesize
+
+Opt-in event for the oneshot choice state. Appends a `synthesize.requested` event to the workflow's event stream so that when `finalize_oneshot` is later called, the `synthesisOptedIn` guard routes to the `synthesize` phase instead of directly `completed`.
+
+```json
+{
+  "action": "request_synthesize",
+  "featureId": "fix-readme-typo",
+  "reason": "user requested review after parser changes"
+}
+```
+
+| Parameter | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `featureId` | yes | string | Workflow identifier (must be a oneshot workflow) |
+| `reason` | no | string | Human-readable rationale (captured in event payload for audit) |
+
+**Idempotency.** Each call appends a separate `synthesize.requested` event (the stream is not deduplicated), but the guard treats any count ≥ 1 as "opted in". Duplicate calls therefore produce the same routing decision with additional audit breadcrumbs.
+
+**Phase acceptance.** The handler accepts `request_synthesize` from `plan` or `implementing`. Terminal phases (`synthesize`, `completed`, `cancelled`) are rejected with `INVALID_PHASE` — the event has no effect on an already-terminated workflow.
+
+Auto-emits: `synthesize.requested`. Phases: plan, implementing. Role: `lead`.
+
+### finalize_oneshot
+
+Resolve the oneshot `implementing → ?` choice state. Evaluates `synthesisOptedIn` / `synthesisOptedOut` against the hydrated event stream and calls `handleSet` with the resolved target phase.
+
+```json
+{
+  "action": "finalize_oneshot",
+  "featureId": "fix-readme-typo"
+}
+```
+
+| Parameter | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `featureId` | yes | string | Workflow identifier (must be a oneshot workflow in `implementing`) |
+
+The handler:
+1. Reads current state and verifies `workflowType === 'oneshot'` and `phase === 'implementing'`
+2. Hydrates `_events` from the event store
+3. Evaluates the choice-state guards (pure functions of `state.oneshot.synthesisPolicy` and the `synthesize.requested` count)
+4. Calls `handleSet` with the resolved target (`synthesize` or `completed`)
+5. The HSM re-evaluates the guard at the transition boundary as a safety net
+
+**Policy precedence.** `synthesisPolicy = "always"` short-circuits to `synthesize` regardless of events. `synthesisPolicy = "never"` short-circuits to `completed` — any emitted `synthesize.requested` events are ignored. Only `"on-request"` (default) consults the event stream.
+
+Phases: implementing. Role: `lead`.
+
+---
+
+## Maintenance
+
+### prune_stale_workflows
+
+Bulk-maintenance action that finds non-terminal workflows beyond a staleness threshold, applies safeguards, and batch-cancels the approved candidates. Each pruned workflow emits a `workflow.pruned` event. Introduced in v2.6.0.
+
+```json
+{
+  "action": "prune_stale_workflows",
+  "thresholdMinutes": 10080,
+  "dryRun": true
+}
+```
+
+| Parameter | Required | Type | Default | Description |
+|-----------|----------|------|---------|-------------|
+| `thresholdMinutes` | no | integer (positive) | `10080` (7 days) | Staleness cutoff — workflows with `_checkpoint.lastActivityTimestamp` older than this are candidates. Rejected if negative/zero/NaN/Infinity/non-integer |
+| `dryRun` | no | boolean | `true` | Preview mode: compute candidates + safeguard filtering without mutating state |
+| `force` | no | boolean | `false` | Bypass safeguards but record bypass in the audit event via `skippedSafeguards` |
+| `includeOneShot` | no | boolean | `true` | Whether to include `workflowType: "oneshot"` workflows in the candidate set |
+
+**Safeguards (default behavior, bypassed only by `force: true`):**
+
+- `hasOpenPR(featureId, branchName)` — skips candidates whose inferred branch has an open PR on GitHub
+- `hasRecentCommits(branchName, windowHours)` — skips candidates with commits pushed to the branch within the last 24 hours
+- Workflows without a `branchName` in state (e.g., abandoned pre-delegation) automatically skip both safeguards (nothing to check) and are eligible for pruning
+
+**Fail-closed validation.** Entries from `handleList` with missing or invalid fields (missing `featureId`, unparsable timestamp, etc.) are routed to a `malformed` bucket and never reach `candidates` or `pruned`. A warning is emitted via the orchestrate logger.
+
+**Return shape (dry-run):**
+```json
+{
+  "candidates": [{ "featureId": "...", "workflowType": "...", "phase": "...", "stalenessMinutes": 14430 }],
+  "skipped":    [{ "featureId": "...", "reason": "open-pr" | "active-branch" | "terminal" | "fresh" | "oneshot-excluded" }],
+  "malformed":  [{ "featureId": "...", "reason": "..." }]
+}
+```
+
+**Return shape (apply mode):** same as dry-run plus a `pruned` array with `{ featureId, previousPhase }` per successfully cancelled workflow. The `pruned` field is omitted entirely in dry-run.
+
+**Apply-mode preconditions.** The handler requires `ctx.eventStore` to be present when `dryRun: false`. Invoking apply mode without an event store returns a structured `MISSING_CONTEXT` error rather than silently swallowing the audit event.
+
+Auto-emits: `workflow.pruned` (per cancelled workflow). Phases: all. Role: `lead`.
+
+---
+
 ## Quality gates
 
 Gates check specific quality dimensions. Each gate emits a `gate.executed` event. Gates are classified as **blocking** (must pass to proceed) or **informational** (findings reported but do not block progress).

--- a/documentation/reference/tools/workflow.md
+++ b/documentation/reference/tools/workflow.md
@@ -6,7 +6,7 @@ Workflow lifecycle management -- init, read, update, cancel, cleanup, and reconc
 
 ### init
 
-Initialize a new workflow. Auto-emits a `workflow.started` event.
+Initialize a new workflow. Auto-emits a `workflow.started` event. For `oneshot` workflows, the optional `synthesisPolicy` is embedded in the event payload so it survives ES v2 rematerialization.
 
 ```json
 {
@@ -16,12 +16,22 @@ Initialize a new workflow. Auto-emits a `workflow.started` event.
 }
 ```
 
+```json
+{
+  "action": "init",
+  "featureId": "fix-readme-typo",
+  "workflowType": "oneshot",
+  "synthesisPolicy": "on-request"
+}
+```
+
 | Parameter | Required | Type | Description |
 |-----------|----------|------|-------------|
 | `featureId` | yes | string | Kebab-case identifier (`^[a-z0-9-]+$`) |
-| `workflowType` | yes | `"feature"` \| `"debug"` \| `"refactor"` | Determines phase graph and initial phase |
+| `workflowType` | yes | `"feature"` \| `"debug"` \| `"refactor"` \| `"oneshot"` | Determines phase graph and initial phase |
+| `synthesisPolicy` | no | `"always"` \| `"never"` \| `"on-request"` | **oneshot only.** Default `"on-request"`. Determines whether the `implementing → ?` choice state routes to `synthesize` or `completed`. Silently ignored for non-oneshot workflow types |
 
-Returns: `{ featureId, workflowType, phase }` where `phase` is the initial phase for the workflow type (`ideate` for feature, `triage` for debug, `explore` for refactor).
+Returns: `{ featureId, workflowType, phase }` where `phase` is the initial phase for the workflow type (`ideate` for feature, `triage` for debug, `explore` for refactor, `plan` for oneshot).
 
 Phases: none (creates the workflow). Role: `lead`.
 


### PR DESCRIPTION
## Summary

Brings the documentation site and top-level project docs to full v2.6.0 feature coverage. v2.6.0 shipped via #1078 with the new oneshot workflow type and stale-workflow pruning, but at release time only the skill layer was updated — the VitePress documentation site at https://lvlup-sw.github.io/exarchos/ still showed zero coverage of the new features.

This PR closes that documentation gap. **No code changes** — docs only.

## Changes

### Top-level

- `CHANGELOG.md` — new `[2.6.0] - 2026-04-12` section with Features, Bug Fixes, Hardening, Internal, and Documentation subsections
- `README.md` — oneshot/prune added to workflow lists and command enumeration
- `AGENTS.md` — commands list updated

### Documentation site (VitePress)

- **NEW** `documentation/guide/oneshot-workflow.md` (197 lines) — full guide page modeled after `feature-workflow.md`. Covers phase chain, use cases, synthesis policy, planning/implementing phases, choice point mechanics, comparison with feature workflow, and a worked example.
- `documentation/.vitepress/config.ts` — Oneshot sidebar entry added under Workflows
- `documentation/guide/project-config.md` — `EXARCHOS_WORKFLOW_TYPE` env var enum updated
- `documentation/reference/commands.md` — `/exarchos:oneshot` and `/exarchos:prune` entries (with flag tables), command count 15→17, new "Maintenance commands" section
- `documentation/reference/tools/workflow.md` — `init` action's `workflowType` enum + optional `synthesisPolicy` parameter + oneshot initial phase documented
- `documentation/reference/tools/orchestrate.md` — three new actions: `request_synthesize`, `finalize_oneshot`, `prune_stale_workflows` with parameter tables, return shapes, safeguard semantics, fail-closed validation notes
- `documentation/reference/events.md` — `workflow.pruned` (Workflow section), `synthesize.requested` (new Oneshot choice state section), total event count 58→60
- `documentation/reference/skills.md` — `oneshot-workflow` and `prune-workflows` rows added
- `documentation/learn/core-concepts.md` — Workflows section now describes four types (added oneshot)
- `documentation/learn/how-it-works.md` — oneshot mentioned in the state machine section
- `documentation/architecture/state-machine.md` — NEW "Oneshot workflow" section with mermaid diagram, transition table, choice state mechanics, policy precedence explanation

## Test Plan

- [x] `npm run typecheck` — clean (touched `.vitepress/config.ts`)
- [x] All edits preserve existing document structure (tables, section numbering, sidebar nav)
- [x] Cross-links between pages validated (oneshot-workflow.md ↔ orchestrate.md ↔ events.md ↔ state-machine.md)
- [x] `grep -r "oneshot\|prune_stale\|request_synthesize\|finalize_oneshot\|workflow\.pruned\|synthesize\.requested" documentation/` — was zero matches before this PR; full coverage now

🤖 Generated with [Claude Code](https://claude.com/claude-code)