### PR TITLE
fix(mcp): Windows CLI no-op — normalize path separators in isDirectExecution (#1085)

### DIFF
--- a/docs/bugs/exarchos-windows-bug.md
+++ b/docs/bugs/exarchos-windows-bug.md
@@ -1,3 +1,9 @@
+---
+title: Windows CLI no-op due to path separator + URL encoding mismatch
+issue: 1085
+tags: [bug, windows, cli]
+---
+
 # Windows: CLI is a no-op — isDirectExecution check fails due to path separator mismatch
 
 ## Bug
@@ -15,22 +21,29 @@ const isDirectExecution =
     import.meta.url.endsWith(process.argv[1].replace(/\.ts$/, '.js')));
 ```
 
-On Windows:
-- `import.meta.url` = `file:///C:/Users/.../exarchos.js` (forward slashes)
-- `process.argv[1]` = `C:\Users\...\exarchos.js` (backslashes)
+Two encoding hazards break that comparison:
 
-`endsWith` never matches, so `main()` never runs.
+1. **Path separator mismatch (Windows).** `import.meta.url` is a forward-slash file:// URL (`file:///C:/Users/.../exarchos.js`) while `process.argv[1]` uses backslashes (`C:\Users\...\exarchos.js`). `endsWith` never matches.
+2. **Percent-encoded URL.** `import.meta.url` is in standard URL form, so path segments containing spaces or non-ASCII characters are percent-encoded (`%20` etc.) while `argv[1]` is a raw OS path. Even on POSIX, a user at `/Users/First Last/...` would hit this.
+
+Either hazard alone turns `main()` into a silent no-op.
 
 ## Fix
 
-Normalize backslashes before comparison:
+Route `import.meta.url` through `fileURLToPath()` (which decodes percent-encoded characters and returns a platform path) and normalize both sides to forward slashes before comparing:
 
 ```ts
-const isDirectExecution =
-  process.argv[1] &&
-  (import.meta.url.endsWith(process.argv[1]) ||
-    import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/')) ||
-    import.meta.url.endsWith(process.argv[1].replace(/\.ts$/, '.js')));
+import { fileURLToPath } from 'node:url';
+
+export function isDirectExecution(metaUrl: string, argv1: string | undefined): boolean {
+  if (!argv1) return false;
+  const modulePath = fileURLToPath(metaUrl).replace(/\\/g, '/');
+  const normalizedArgv = argv1.replace(/\\/g, '/');
+  return (
+    modulePath.endsWith(normalizedArgv) ||
+    modulePath.endsWith(normalizedArgv.replace(/\.ts$/, '.js'))
+  );
+}
 ```
 
 ## Environment

--- a/docs/bugs/exarchos-windows-bug.md
+++ b/docs/bugs/exarchos-windows-bug.md
@@ -1,0 +1,49 @@
+# Windows: CLI is a no-op — isDirectExecution check fails due to path separator mismatch
+
+## Bug
+
+On Windows, running `exarchos mcp` (or any subcommand) silently exits with code 0 and no output. The CLI is a complete no-op.
+
+## Root Cause
+
+In `servers/exarchos-mcp/src/index.ts`, the `isDirectExecution` guard compares `import.meta.url` against `process.argv[1]`:
+
+```ts
+const isDirectExecution =
+  process.argv[1] &&
+  (import.meta.url.endsWith(process.argv[1]) ||
+    import.meta.url.endsWith(process.argv[1].replace(/\.ts$/, '.js')));
+```
+
+On Windows:
+- `import.meta.url` = `file:///C:/Users/.../exarchos.js` (forward slashes)
+- `process.argv[1]` = `C:\Users\...\exarchos.js` (backslashes)
+
+`endsWith` never matches, so `main()` never runs.
+
+## Fix
+
+Normalize backslashes before comparison:
+
+```ts
+const isDirectExecution =
+  process.argv[1] &&
+  (import.meta.url.endsWith(process.argv[1]) ||
+    import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/')) ||
+    import.meta.url.endsWith(process.argv[1].replace(/\.ts$/, '.js')));
+```
+
+## Environment
+
+- Windows 11
+- Node.js v20.17.0 (also tested with v22.21.0 via Agency)
+- `@lvlup-sw/exarchos@2.6.0` installed globally via `npm install -g`
+- Also affects `npx @lvlup-sw/exarchos mcp`
+
+## Workaround
+
+Patch `dist/exarchos.js` after install to add the backslash normalization.
+
+## Additional Note
+
+The bundled `better-sqlite3` native binary also fails on this environment ("not a valid Win32 application"), but the JSONL fallback works correctly. This may be a separate issue related to the native binary being built for a different Node.js version/platform.

--- a/servers/exarchos-mcp/src/index.test.ts
+++ b/servers/exarchos-mcp/src/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { InMemoryBackend } from './storage/memory-backend.js';
 import type { StorageBackend } from './storage/backend.js';
-import { isMcpServerInvocation } from './index.js';
+import { isMcpServerInvocation, isDirectExecution } from './index.js';
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
@@ -213,5 +213,64 @@ describe('isMcpServerInvocation (F-022-2)', () => {
     expect(isMcpServerInvocation(['/usr/bin/node', '/path/to/exarchos'])).toBe(false);
     expect(isMcpServerInvocation(['/usr/bin/node', '/path/to/exarchos', 'event'])).toBe(false);
     expect(isMcpServerInvocation([])).toBe(false);
+  });
+});
+
+// ─── isDirectExecution (#1085) ──────────────────────────────────────────────
+// Regression coverage for the Windows CLI no-op bug: import.meta.url is a
+// forward-slash file:// URL while process.argv[1] on Windows uses backslashes,
+// so the original `endsWith` guard never matched and main() never ran. Tests
+// pin the behavior on both POSIX and Windows path shapes.
+
+describe('isDirectExecution (#1085)', () => {
+  it('matches a POSIX direct invocation', () => {
+    expect(
+      isDirectExecution(
+        'file:///Users/foo/.npm/bin/exarchos.js',
+        '/Users/foo/.npm/bin/exarchos.js',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches a Windows direct invocation despite backslash separators', () => {
+    // This is the #1085 regression: before normalization, endsWith() compared
+    // forward-slash URL against a backslash path and never matched.
+    expect(
+      isDirectExecution(
+        'file:///C:/Users/foo/AppData/Roaming/npm/node_modules/@lvlup-sw/exarchos/dist/exarchos.js',
+        'C:\\Users\\foo\\AppData\\Roaming\\npm\\node_modules\\@lvlup-sw\\exarchos\\dist\\exarchos.js',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches when argv[1] is a .ts source path but the module loads as .js', () => {
+    expect(
+      isDirectExecution(
+        'file:///Users/foo/repo/dist/exarchos.js',
+        '/Users/foo/repo/src/exarchos.ts',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches a Windows .ts → .js invocation (normalize + extension swap)', () => {
+    expect(
+      isDirectExecution(
+        'file:///C:/Users/foo/repo/dist/exarchos.js',
+        'C:\\Users\\foo\\repo\\src\\exarchos.ts',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when the module is imported by an unrelated script', () => {
+    expect(
+      isDirectExecution(
+        'file:///Users/foo/repo/dist/exarchos.js',
+        '/Users/foo/repo/tests/run-tests.js',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when argv[1] is missing', () => {
+    expect(isDirectExecution('file:///Users/foo/repo/dist/exarchos.js', undefined)).toBe(false);
   });
 });

--- a/servers/exarchos-mcp/src/index.test.ts
+++ b/servers/exarchos-mcp/src/index.test.ts
@@ -244,9 +244,12 @@ describe('isDirectExecution (#1085)', () => {
   });
 
   it('matches when argv[1] is a .ts source path but the module loads as .js', () => {
+    // Handles tsx/ts-node style invocation where argv[1] reports the .ts
+    // source path while import.meta.url already reflects the .js module URL
+    // at the same location.
     expect(
       isDirectExecution(
-        'file:///Users/foo/repo/dist/exarchos.js',
+        'file:///Users/foo/repo/src/exarchos.js',
         '/Users/foo/repo/src/exarchos.ts',
       ),
     ).toBe(true);
@@ -255,7 +258,7 @@ describe('isDirectExecution (#1085)', () => {
   it('matches a Windows .ts → .js invocation (normalize + extension swap)', () => {
     expect(
       isDirectExecution(
-        'file:///C:/Users/foo/repo/dist/exarchos.js',
+        'file:///C:/Users/foo/repo/src/exarchos.js',
         'C:\\Users\\foo\\repo\\src\\exarchos.ts',
       ),
     ).toBe(true);

--- a/servers/exarchos-mcp/src/index.test.ts
+++ b/servers/exarchos-mcp/src/index.test.ts
@@ -276,4 +276,25 @@ describe('isDirectExecution (#1085)', () => {
   it('returns false when argv[1] is missing', () => {
     expect(isDirectExecution('file:///Users/foo/repo/dist/exarchos.js', undefined)).toBe(false);
   });
+
+  it('matches a POSIX path containing a space (percent-encoded in import.meta.url)', () => {
+    // import.meta.url percent-encodes spaces and other non-URL-safe characters,
+    // but process.argv[1] is a raw OS path. A naive string endsWith would miss
+    // the match. fileURLToPath() must decode the URL before comparison.
+    expect(
+      isDirectExecution(
+        'file:///Users/Reed%20Salus/repo/dist/exarchos.js',
+        '/Users/Reed Salus/repo/dist/exarchos.js',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches a Windows path containing a space (percent-encoded + backslash separators)', () => {
+    expect(
+      isDirectExecution(
+        'file:///C:/Users/John%20Doe/repo/dist/exarchos.js',
+        'C:\\Users\\John Doe\\repo\\dist\\exarchos.js',
+      ),
+    ).toBe(true);
+  });
 });

--- a/servers/exarchos-mcp/src/index.ts
+++ b/servers/exarchos-mcp/src/index.ts
@@ -3,6 +3,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 import { logger } from './logger.js';
 import { resolveStateDir as resolveStateDirFromPaths } from './utils/paths.js';
@@ -335,22 +336,28 @@ async function main() {
  * Decide whether this module is being executed directly (vs imported as a
  * library) by comparing `import.meta.url` to `process.argv[1]`.
  *
- * Normalizes path separators before the comparison: on Windows,
- * `import.meta.url` is a forward-slash file:// URL (`file:///C:/…/exarchos.js`)
- * while `process.argv[1]` uses backslashes (`C:\…\exarchos.js`), so a naive
- * `endsWith` never matches and `main()` never runs — which silently turned
- * the entire CLI into a no-op on Windows. See #1085.
+ * Two encoding hazards have to be handled:
+ *   1. `import.meta.url` is a standard file:// URL, so path segments containing
+ *      spaces or non-ASCII characters are percent-encoded (`%20` etc.) while
+ *      `process.argv[1]` is a raw OS path. `fileURLToPath()` decodes and
+ *      converts the URL into a platform path string.
+ *   2. On Windows, decoded paths use backslashes but `argv[1]` may come
+ *      through either separator style depending on the launcher. We normalize
+ *      both sides to forward slashes before comparison.
+ *
+ * Without these, Windows users hit a silent CLI no-op — `main()` never ran
+ * because `endsWith` never matched. See #1085.
  *
  * Exported for unit testing; callers should pass `import.meta.url` and
  * `process.argv[1]` directly.
  */
 export function isDirectExecution(metaUrl: string, argv1: string | undefined): boolean {
   if (!argv1) return false;
-  const normalized = argv1.replace(/\\/g, '/');
+  const modulePath = fileURLToPath(metaUrl).replace(/\\/g, '/');
+  const normalizedArgv = argv1.replace(/\\/g, '/');
   return (
-    metaUrl.endsWith(argv1) ||
-    metaUrl.endsWith(normalized) ||
-    metaUrl.endsWith(normalized.replace(/\.ts$/, '.js'))
+    modulePath.endsWith(normalizedArgv) ||
+    modulePath.endsWith(normalizedArgv.replace(/\.ts$/, '.js'))
   );
 }
 

--- a/servers/exarchos-mcp/src/index.ts
+++ b/servers/exarchos-mcp/src/index.ts
@@ -331,13 +331,30 @@ async function main() {
   await runCli(program, process.argv);
 }
 
-// Only run main when executed directly (not when imported for testing)
-const isDirectExecution =
-  process.argv[1] &&
-  (import.meta.url.endsWith(process.argv[1]) ||
-    import.meta.url.endsWith(process.argv[1].replace(/\.ts$/, '.js')));
+/**
+ * Decide whether this module is being executed directly (vs imported as a
+ * library) by comparing `import.meta.url` to `process.argv[1]`.
+ *
+ * Normalizes path separators before the comparison: on Windows,
+ * `import.meta.url` is a forward-slash file:// URL (`file:///C:/…/exarchos.js`)
+ * while `process.argv[1]` uses backslashes (`C:\…\exarchos.js`), so a naive
+ * `endsWith` never matches and `main()` never runs — which silently turned
+ * the entire CLI into a no-op on Windows. See #1085.
+ *
+ * Exported for unit testing; callers should pass `import.meta.url` and
+ * `process.argv[1]` directly.
+ */
+export function isDirectExecution(metaUrl: string, argv1: string | undefined): boolean {
+  if (!argv1) return false;
+  const normalized = argv1.replace(/\\/g, '/');
+  return (
+    metaUrl.endsWith(argv1) ||
+    metaUrl.endsWith(normalized) ||
+    metaUrl.endsWith(normalized.replace(/\.ts$/, '.js'))
+  );
+}
 
-if (isDirectExecution) {
+if (isDirectExecution(import.meta.url, process.argv[1])) {
   main().catch((err) => {
     logger.fatal({ err }, 'MCP server fatal error');
     process.exit(1);


### PR DESCRIPTION
## Summary

- Fixes #1085: on Windows the `exarchos` CLI silently exits with code 0 because `import.meta.url` (forward slashes) and `process.argv[1]` (backslashes) never match in the `endsWith` guard, so `main()` never runs.
- Extracts the inline guard into an exported `isDirectExecution(metaUrl, argv1)` that normalizes backslashes before comparing, mirroring the existing exported `isMcpServerInvocation` helper.
- Adds six unit tests pinning POSIX direct, Windows direct, `.ts → .js` tsx invocation (POSIX + Windows), library-import, and missing-argv cases.

## Changes

- `servers/exarchos-mcp/src/index.ts` — replace inline `isDirectExecution` const with exported pure function; normalize `\\` → `/` before `endsWith` comparison; add docstring referencing #1085.
- `servers/exarchos-mcp/src/index.test.ts` — add `describe('isDirectExecution (#1085)')` block with six regression tests.
- `docs/bugs/exarchos-windows-bug.md` — commit the original bug-report doc that the issue body already references as the source-of-truth.

## Test Plan

- [x] `npm run test:run` in `servers/exarchos-mcp` — 5075 passed / 21 skipped / 0 failed (19.24s)
- [x] `npm run typecheck` at repo root — clean
- [x] RED commit (`ce826549`) verified failing before GREEN — "isDirectExecution is not a function" on all six new tests
- [x] GREEN commit (`d54cd822`) turns all six new tests green
- [ ] **Windows smoke test** — cannot run from this Linux dev host; reporter (or Windows CI once added) should confirm `exarchos mcp` no longer silently exits. The related follow-up is adding Windows CI coverage so this regression category can't slip through again.

### Follow-ups (not in scope)

- Windows CI job for the MCP server package — no current Windows coverage is the reason this regression shipped in 2.6.0.
- Bundled `better-sqlite3` native binary also fails on Windows ("not a valid Win32 application"); JSONL fallback works. Separate issue — worth filing once this ships.