### PR TITLE
feat(config): configurable subagent model selection (#1113)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -21,7 +21,8 @@
   "agents": [
     "./agents/implementer.md",
     "./agents/fixer.md",
-    "./agents/reviewer.md"
+    "./agents/reviewer.md",
+    "./agents/scaffolder.md"
   ],
   "commands": "./commands/",
   "skills": "./skills/",

--- a/.exarchos.yml
+++ b/.exarchos.yml
@@ -1,0 +1,35 @@
+# Exarchos project configuration
+# See: docs/guide/configuration.md
+
+agents:
+  default-model: opus
+  models:
+    implementer: opus
+    fixer: opus
+    reviewer: sonnet
+    scaffolder: haiku
+
+review:
+  dimensions:
+    D1: blocking
+    D2: blocking
+    D3: blocking
+    D4: blocking
+    D5: blocking
+
+vcs:
+  provider: github
+
+workflow:
+  max-fix-cycles: 3
+
+tools:
+  commit-style: conventional
+  auto-merge: true
+  pr-strategy: github-native
+
+plugins:
+  axiom:
+    enabled: true
+  impeccable:
+    enabled: true

--- a/agents/fixer.md
+++ b/agents/fixer.md
@@ -12,9 +12,10 @@ description: |
   </commentary>
   </example>
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: opus
+model: inherit
 color: red
 disallowedTools: ["Agent"]
+mcpServers: ["exarchos"]
 skills:
   - tdd-patterns
 hooks:

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -12,11 +12,12 @@ description: |
   </commentary>
   </example>
 tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-model: opus
+model: inherit
 color: blue
 disallowedTools: ["Agent"]
 isolation: worktree
 memory: project
+mcpServers: ["exarchos"]
 skills:
   - tdd-patterns
   - testing-patterns

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -12,9 +12,10 @@ description: |
   </commentary>
   </example>
 tools: ["Read", "Grep", "Glob", "Bash"]
-model: opus
+model: inherit
 color: green
 disallowedTools: ["Write", "Edit", "Agent"]
+mcpServers: ["exarchos"]
 ---
 
 You are a code reviewer agent. You analyze code for quality, correctness, and design compliance.

--- a/agents/scaffolder.md
+++ b/agents/scaffolder.md
@@ -1,0 +1,55 @@
+---
+name: exarchos-scaffolder
+description: |
+  Use this agent for low-complexity scaffolding tasks — file creation, boilerplate generation, and structural setup.
+  
+  <example>
+  Context: Orchestrator needs new files or boilerplate created
+  user: "Create the directory structure and stub files for the new feature"
+  assistant: "I'll dispatch the exarchos-scaffolder agent to generate the scaffolding in an isolated worktree."
+  <commentary>
+  Simple file creation and boilerplate generation triggers the scaffolder agent with concise output.
+  </commentary>
+  </example>
+tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+model: sonnet
+color: cyan
+disallowedTools: ["Agent"]
+isolation: worktree
+mcpServers: ["exarchos"]
+---
+
+You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.
+
+## Worktree Verification
+Before making ANY file changes:
+1. Run: `pwd`
+2. Verify the path contains `.worktrees/`
+3. If NOT in worktree: STOP and report error
+
+## Task
+{{taskDescription}}
+
+## Files
+{{filePaths}}
+
+## Protocol
+1. Read existing code to understand conventions
+2. Generate requested files following project patterns
+3. Keep output concise — no verbose explanations
+
+Rules:
+- Be concise: minimal commentary, focus on file generation
+- Follow existing project conventions and patterns
+- Verify generated files are syntactically valid
+
+## Completion Report
+When done, output a JSON completion report:
+```json
+{
+  "status": "complete",
+  "implements": ["<design requirement IDs>"],
+  "tests": [{"name": "<test name>", "file": "<path>"}],
+  "files": ["<created/modified files>"]
+}
+```

--- a/servers/exarchos-mcp/src/agents/generate-cc-agents.test.ts
+++ b/servers/exarchos-mcp/src/agents/generate-cc-agents.test.ts
@@ -103,6 +103,21 @@ describe('GenerateAgentMarkdown', () => {
     // Assert: disallowedTools present in JSON array format
     expect(fm.disallowedTools).toBe('["Agent"]');
   });
+
+  it('GenerateAgentMarkdown_Implementer_ModelMatchesDefinition', () => {
+    const spec = ALL_AGENT_SPECS.find(s => s.id === 'implementer')!;
+    const md = generateAgentMarkdown(spec);
+    const fm = parseFrontmatter(md);
+    expect(fm.model).toBe(spec.model); // 'inherit', not 'opus'
+    expect(fm.model).toBe('inherit');
+  });
+
+  it('GenerateAgentMarkdown_Scaffolder_ModelMatchesDefinition', () => {
+    const spec = ALL_AGENT_SPECS.find(s => s.id === 'scaffolder')!;
+    const md = generateAgentMarkdown(spec);
+    const fm = parseFrontmatter(md);
+    expect(fm.model).toBe('sonnet');
+  });
 });
 
 describe('BuildHooksFromRules', () => {

--- a/servers/exarchos-mcp/src/config/resolve.test.ts
+++ b/servers/exarchos-mcp/src/config/resolve.test.ts
@@ -239,4 +239,36 @@ describe('resolveConfig', () => {
     expect(resolved.plugins.axiom.enabled).toBe(true);
     expect(resolved.plugins.impeccable.enabled).toBe(true);
   });
+
+  describe('agents resolution', () => {
+    it('resolveConfig_EmptyProject_ReturnsAgentDefaults', () => {
+      const resolved = resolveConfig({});
+      expect(resolved.agents.defaultModel).toBe('opus');
+      expect(resolved.agents.models).toMatchObject({ scaffolder: 'haiku', reviewer: 'sonnet' });
+    });
+
+    it('resolveConfig_AgentsDefaultModel_OverridesDefault', () => {
+      const resolved = resolveConfig({ agents: { 'default-model': 'sonnet' } });
+      expect(resolved.agents.defaultModel).toBe('sonnet');
+    });
+
+    it('resolveConfig_AgentsModels_OverridesPerAgent', () => {
+      const resolved = resolveConfig({ agents: { models: { implementer: 'haiku' } } });
+      expect(resolved.agents.models.implementer).toBe('haiku');
+      // Other defaults preserved
+      expect(resolved.agents.models.scaffolder).toBe('haiku');
+      expect(resolved.agents.models.reviewer).toBe('sonnet');
+    });
+
+    it('resolveConfig_AgentsModels_PartialOverride_MergesWithDefaults', () => {
+      const resolved = resolveConfig({ agents: { models: { reviewer: 'haiku' } } });
+      expect(resolved.agents.models.reviewer).toBe('haiku');
+      expect(resolved.agents.models.scaffolder).toBe('haiku');
+    });
+
+    it('resolveConfig_AgentsFrozen_CannotMutate', () => {
+      const resolved = resolveConfig({});
+      expect(() => { (resolved.agents as Record<string, unknown>).defaultModel = 'haiku'; }).toThrow();
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/config/resolve.ts
+++ b/servers/exarchos-mcp/src/config/resolve.ts
@@ -18,6 +18,10 @@ export interface ResolvedPluginConfig {
 }
 
 export interface ResolvedProjectConfig {
+  readonly agents: {
+    readonly defaultModel: 'opus' | 'sonnet' | 'haiku';
+    readonly models: Readonly<Record<string, 'opus' | 'sonnet' | 'haiku'>>;
+  };
   readonly review: {
     readonly dimensions: Readonly<Record<'D1' | 'D2' | 'D3' | 'D4' | 'D5', ResolvedDimensionConfig>>;
     readonly gates: Readonly<Record<string, ResolvedGateConfig>>;
@@ -68,6 +72,13 @@ const DEFAULT_RISK_WEIGHTS: Readonly<Record<string, number>> = {
 const DEFAULT_HOOK_TIMEOUT = 30000;
 
 export const DEFAULTS: ResolvedProjectConfig = deepFreeze({
+  agents: {
+    defaultModel: 'opus',
+    models: {
+      scaffolder: 'haiku',
+      reviewer: 'sonnet',
+    },
+  },
   review: {
     dimensions: {
       D1: { ...DEFAULT_DIMENSION },
@@ -180,6 +191,13 @@ const DIMENSION_KEYS: readonly DimensionKey[] = ['D1', 'D2', 'D3', 'D4', 'D5'];
  * producing a fully-populated, deeply-frozen `ResolvedProjectConfig`.
  */
 export function resolveConfig(project: ProjectConfig): ResolvedProjectConfig {
+  // ── Agents ──
+  const agentDefaultModel = (project.agents?.['default-model'] as 'opus' | 'sonnet' | 'haiku') ?? DEFAULTS.agents.defaultModel;
+  const agentModels: Record<string, 'opus' | 'sonnet' | 'haiku'> = {
+    ...DEFAULTS.agents.models,
+    ...(project.agents?.models as Record<string, 'opus' | 'sonnet' | 'haiku'> ?? {}),
+  };
+
   // ── Review ──
   const dimensions = {} as Record<DimensionKey, ResolvedDimensionConfig>;
   for (const key of DIMENSION_KEYS) {
@@ -242,6 +260,7 @@ export function resolveConfig(project: ProjectConfig): ResolvedProjectConfig {
   const impeccableEnabled = project.plugins?.impeccable?.enabled ?? DEFAULTS.plugins.impeccable.enabled;
 
   const resolved: ResolvedProjectConfig = {
+    agents: { defaultModel: agentDefaultModel, models: agentModels },
     review: {
       dimensions,
       gates,

--- a/servers/exarchos-mcp/src/config/yaml-loader.ts
+++ b/servers/exarchos-mcp/src/config/yaml-loader.ts
@@ -13,7 +13,7 @@ const YAML_FILENAMES = ['.exarchos.yml', '.exarchos.yaml'] as const;
 
 // ─── Section-level parsing keys ─────────────────────────────────────────────
 
-const SECTION_KEYS = ['review', 'vcs', 'workflow', 'tools', 'hooks', 'plugins'] as const;
+const SECTION_KEYS = ['agents', 'review', 'vcs', 'workflow', 'tools', 'hooks', 'plugins'] as const;
 
 // ─── Load Project Config ────────────────────────────────────────────────────
 

--- a/servers/exarchos-mcp/src/config/yaml-schema.test.ts
+++ b/servers/exarchos-mcp/src/config/yaml-schema.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
 import { ProjectConfigSchema } from './yaml-schema.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe('ProjectConfigSchema', () => {
   it('ProjectConfigSchema_EmptyObject_Passes', () => {
@@ -156,6 +162,14 @@ describe('ProjectConfigSchema', () => {
         plugins: { axiom: { enabled: true, extra: 'value' } },
       });
       expect(result.success).toBe(false);
+    });
+  });
+
+  describe('default .exarchos.yml', () => {
+    it('ProjectConfigSchema_DefaultExarchosYml_ParsesSuccessfully', () => {
+      const content = readFileSync(resolve(__dirname, '../../../../.exarchos.yml'), 'utf-8');
+      const parsed = parseYaml(content);
+      expect(ProjectConfigSchema.safeParse(parsed).success).toBe(true);
     });
   });
 

--- a/servers/exarchos-mcp/src/config/yaml-schema.test.ts
+++ b/servers/exarchos-mcp/src/config/yaml-schema.test.ts
@@ -158,4 +158,49 @@ describe('ProjectConfigSchema', () => {
       expect(result.success).toBe(false);
     });
   });
+
+  describe('agents section', () => {
+    it('ProjectConfigSchema_AgentsSection_AcceptsValidConfig', () => {
+      const result = ProjectConfigSchema.safeParse({
+        agents: {
+          'default-model': 'opus',
+          models: { implementer: 'opus', reviewer: 'sonnet', scaffolder: 'haiku' },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('ProjectConfigSchema_AgentsSection_AcceptsPartialConfig', () => {
+      const result = ProjectConfigSchema.safeParse({
+        agents: { 'default-model': 'sonnet' },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('ProjectConfigSchema_AgentsSection_RejectsInvalidModel', () => {
+      const result = ProjectConfigSchema.safeParse({
+        agents: { 'default-model': 'gpt4' },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('ProjectConfigSchema_AgentsSection_RejectsInvalidAgentKey', () => {
+      const result = ProjectConfigSchema.safeParse({
+        agents: { models: { orchestrator: 'opus' } },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('ProjectConfigSchema_AgentsSection_OmittedIsValid', () => {
+      const result = ProjectConfigSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+
+    it('ProjectConfigSchema_AgentsSection_RejectsUnknownKeys', () => {
+      const result = ProjectConfigSchema.safeParse({
+        agents: { 'default-model': 'opus', extra: true },
+      });
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/config/yaml-schema.ts
+++ b/servers/exarchos-mcp/src/config/yaml-schema.ts
@@ -70,6 +70,16 @@ const WorkflowConfig = z.object({
   phases: z.record(z.string(), PhaseConfig).optional(),
 }).strict();
 
+// ─── Agents Configuration ──────────────────────────────────────────────────
+
+const AgentModelValue = z.enum(['opus', 'sonnet', 'haiku']);
+const AgentSpecIdKey = z.enum(['implementer', 'fixer', 'reviewer', 'scaffolder']);
+
+const AgentsConfig = z.object({
+  'default-model': AgentModelValue.optional(),
+  models: z.record(AgentSpecIdKey, AgentModelValue).optional(),
+}).strict();
+
 // ─── Tools Configuration ───────────────────────────────────────────────────
 
 const ToolsConfig = z.object({
@@ -105,6 +115,7 @@ const PluginsConfig = z.object({
 // ─── Top-Level Project Config ──────────────────────────────────────────────
 
 export const ProjectConfigSchema = z.object({
+  agents: AgentsConfig.optional(),
   review: ReviewConfig.optional(),
   vcs: VcsConfig.optional(),
   workflow: WorkflowConfig.optional(),

--- a/servers/exarchos-mcp/src/orchestrate/composite.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.test.ts
@@ -240,6 +240,7 @@ describe('handleOrchestrate', () => {
       expect(handlePrepareDelegation).toHaveBeenCalledWith(
         { featureId: 'feat-123', tasks: [{ id: 't1', title: 'Task 1' }] },
         STATE_DIR,
+        CTX,
       );
     });
 

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -100,6 +100,13 @@ function adaptArgs<T>(handler: (args: T) => ToolResult | Promise<ToolResult>): A
   return async (args) => handler(args as unknown as T);
 }
 
+/** Wraps a typed handler that receives (args, stateDir, ctx?). */
+function adaptWithCtx<T>(
+  handler: (args: T, stateDir: string, ctx?: DispatchContext) => Promise<ToolResult>,
+): ActionHandler {
+  return async (args, stateDir, ctx) => handler(args as unknown as T, stateDir, ctx);
+}
+
 /** Wraps a typed handler that needs eventStore from DispatchContext injected into args. */
 function adaptArgsWithEventStore<T>(handler: (args: T) => ToolResult | Promise<ToolResult>): ActionHandler {
   return async (args, _stateDir, ctx) => {
@@ -133,7 +140,7 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   task_complete: adapt(handleTaskComplete),
   task_fail: adapt(handleTaskFail),
   review_triage: handleReviewTriage,
-  prepare_delegation: adapt(handlePrepareDelegation),
+  prepare_delegation: adaptWithCtx(handlePrepareDelegation),
   prepare_synthesis: adapt(handlePrepareSynthesis),
   assess_stack: adapt(handleAssessStack),
   check_design_completeness: adapt(handleDesignCompleteness),

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -36,6 +36,7 @@ import { generateQualityHints } from '../quality/hints.js';
 import { emitGateEvent } from './gate-utils.js';
 import { handlePrepareDelegation, classifyTask } from './prepare-delegation.js';
 import type { TaskClassification } from './prepare-delegation.js';
+import { DEFAULTS } from '../config/resolve.js';
 
 const STATE_DIR = '/tmp/test-state';
 
@@ -814,11 +815,51 @@ describe('handlePrepareDelegation', () => {
       const task = { id: 'T-004', title: 'stub boilerplate' };
 
       // Act
-      const classification = classifyTask(task);
+      const classification = classifyTask(task, DEFAULTS.agents);
 
       // Assert — existing scaffolding behavior preserved
       expect(classification.effort).toBe('low');
       expect(classification.recommendedAgent).toBe('scaffolder');
+    });
+  });
+
+  describe('classifyTask model resolution', () => {
+    it('classifyTask_WithAgentConfig_ScaffolderGetsConfiguredModel', () => {
+      const config = { defaultModel: 'opus' as const, models: { scaffolder: 'haiku' as const } };
+      const result = classifyTask({ id: '001', title: 'Stub out the API interface' }, config);
+      expect(result.recommendedModel).toBe('haiku');
+    });
+
+    it('classifyTask_WithAgentConfig_ImplementerGetsConfiguredModel', () => {
+      const config = { defaultModel: 'opus' as const, models: { implementer: 'opus' as const } };
+      const result = classifyTask({ id: '002', title: 'Implement auth handler' }, config);
+      expect(result.recommendedModel).toBe('opus');
+    });
+
+    it('classifyTask_WithAgentConfig_FallsBackToDefaultModel', () => {
+      const config = { defaultModel: 'sonnet' as const, models: {} };
+      const result = classifyTask({ id: '003', title: 'Implement feature X' }, config);
+      expect(result.recommendedModel).toBe('sonnet');
+    });
+
+    it('classifyTask_WithAgentConfig_PerAgentOverridesDefault', () => {
+      const config = { defaultModel: 'opus' as const, models: { scaffolder: 'haiku' as const } };
+      // scaffolder task -> 'haiku'
+      const scaffolderResult = classifyTask({ id: '004a', title: 'Scaffold the test harness' }, config);
+      expect(scaffolderResult.recommendedModel).toBe('haiku');
+      // implementer task -> 'opus' (from defaultModel)
+      const implementerResult = classifyTask({ id: '004b', title: 'Implement handler' }, config);
+      expect(implementerResult.recommendedModel).toBe('opus');
+    });
+
+    it('classifyTask_WithDefaultConfig_ScaffolderGetsHaiku', () => {
+      const result = classifyTask({ id: '005', title: 'Scaffold boilerplate' }, DEFAULTS.agents);
+      expect(result.recommendedModel).toBe('haiku');
+    });
+
+    it('classifyTask_WithDefaultConfig_ImplementerGetsOpus', () => {
+      const result = classifyTask({ id: '006', title: 'Implement handler' }, DEFAULTS.agents);
+      expect(result.recommendedModel).toBe('opus');
     });
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -823,6 +823,95 @@ describe('handlePrepareDelegation', () => {
     });
   });
 
+  describe('handler config threading', () => {
+    it('PrepareDelegation_WithTasks_ClassificationsIncludeRecommendedModel', async () => {
+      // Arrange
+      const state = readyWorkflowState();
+      setupMaterializer(state);
+      vi.mocked(generateQualityHints).mockReturnValue([]);
+      const args = {
+        featureId: 'test-feature',
+        tasks: [
+          { id: 'task-1', title: 'Implement widget' },
+          { id: 'task-2', title: 'Stub boilerplate' },
+        ],
+      };
+
+      // Act
+      const result = await handlePrepareDelegation(args, STATE_DIR);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as { taskClassifications: TaskClassification[] };
+      expect(data.taskClassifications).toBeDefined();
+      for (const tc of data.taskClassifications) {
+        expect(tc.recommendedModel).toBeDefined();
+        expect(['opus', 'sonnet', 'haiku']).toContain(tc.recommendedModel);
+      }
+    });
+
+    it('PrepareDelegation_WithCtx_UsesProjectConfigForModelResolution', async () => {
+      // Arrange
+      const state = readyWorkflowState();
+      setupMaterializer(state);
+      vi.mocked(generateQualityHints).mockReturnValue([]);
+      const args = {
+        featureId: 'test-feature',
+        tasks: [
+          { id: 'task-1', title: 'Scaffold the interface' },
+          { id: 'task-2', title: 'Implement handler' },
+        ],
+      };
+      const ctx = {
+        stateDir: STATE_DIR,
+        eventStore: {} as never,
+        enableTelemetry: false,
+        projectConfig: {
+          agents: {
+            defaultModel: 'sonnet' as const,
+            models: { scaffolder: 'haiku' as const },
+          },
+        } as never,
+      };
+
+      // Act
+      const result = await handlePrepareDelegation(args, STATE_DIR, ctx as never);
+
+      // Assert
+      expect(result.success).toBe(true);
+      const data = result.data as { taskClassifications: TaskClassification[] };
+      const scaffolderTask = data.taskClassifications.find(tc => tc.recommendedAgent === 'scaffolder');
+      const implementerTask = data.taskClassifications.find(tc => tc.recommendedAgent === 'implementer');
+      expect(scaffolderTask?.recommendedModel).toBe('haiku');
+      expect(implementerTask?.recommendedModel).toBe('sonnet');
+    });
+
+    it('PrepareDelegation_WithoutCtx_UsesDefaults', async () => {
+      // Arrange
+      const state = readyWorkflowState();
+      setupMaterializer(state);
+      vi.mocked(generateQualityHints).mockReturnValue([]);
+      const args = {
+        featureId: 'test-feature',
+        tasks: [
+          { id: 'task-1', title: 'Scaffold boilerplate' },
+          { id: 'task-2', title: 'Implement handler' },
+        ],
+      };
+
+      // Act -- no ctx passed
+      const result = await handlePrepareDelegation(args, STATE_DIR);
+
+      // Assert -- uses DEFAULTS.agents
+      expect(result.success).toBe(true);
+      const data = result.data as { taskClassifications: TaskClassification[] };
+      const scaffolderTask = data.taskClassifications.find(tc => tc.recommendedAgent === 'scaffolder');
+      const implementerTask = data.taskClassifications.find(tc => tc.recommendedAgent === 'implementer');
+      expect(scaffolderTask?.recommendedModel).toBe('haiku');   // DEFAULTS.agents.models.scaffolder
+      expect(implementerTask?.recommendedModel).toBe('opus');   // DEFAULTS.agents.defaultModel
+    });
+  });
+
   describe('classifyTask model resolution', () => {
     it('classifyTask_WithAgentConfig_ScaffolderGetsConfiguredModel', () => {
       const config = { defaultModel: 'opus' as const, models: { scaffolder: 'haiku' as const } };

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -9,6 +9,7 @@
 import type { ToolResult } from '../format.js';
 import type { ResolvedProjectConfig } from '../config/resolve.js';
 import { DEFAULTS } from '../config/resolve.js';
+import type { DispatchContext } from '../core/dispatch.js';
 import {
   getOrCreateMaterializer,
   getOrCreateEventStore,
@@ -216,6 +217,7 @@ function assembleQualityHints(
 export async function handlePrepareDelegation(
   args: { featureId: string; tasks?: TaskInput[]; nativeIsolation?: boolean },
   stateDir: string,
+  ctx?: DispatchContext,
 ): Promise<ToolResult> {
   // Validate input
   if (!args.featureId) {
@@ -314,7 +316,7 @@ export async function handlePrepareDelegation(
     } catch { /* fire-and-forget */ }
 
     // Compute task classifications when tasks are provided (advisory)
-    const agentConfig = DEFAULTS.agents;
+    const agentConfig = ctx?.projectConfig?.agents ?? DEFAULTS.agents;
     const taskClassifications = args.tasks
       ? args.tasks.map(t => classifyTask(t, agentConfig))
       : undefined;

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -7,6 +7,8 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import type { ToolResult } from '../format.js';
+import type { ResolvedProjectConfig } from '../config/resolve.js';
+import { DEFAULTS } from '../config/resolve.js';
 import {
   getOrCreateMaterializer,
   getOrCreateEventStore,
@@ -53,6 +55,7 @@ export interface TaskClassification {
   readonly taskId: string;
   readonly complexity: 'low' | 'medium' | 'high';
   readonly recommendedAgent: 'scaffolder' | 'implementer';
+  readonly recommendedModel: 'opus' | 'sonnet' | 'haiku';
   readonly effort: 'low' | 'medium' | 'high';
   readonly reason: string;
 }
@@ -72,6 +75,17 @@ export interface PrepareDelegationResult {
 const SCAFFOLDING_KEYWORDS = ['stub', 'boilerplate', 'type def', 'interface', 'scaffold'];
 
 /**
+ * Resolves the recommended model for a given agent type from the agent config.
+ * Falls back to `defaultModel` when no per-agent override exists.
+ */
+function resolveModel(
+  agent: 'scaffolder' | 'implementer',
+  agentConfig: ResolvedProjectConfig['agents'],
+): 'opus' | 'sonnet' | 'haiku' {
+  return agentConfig.models[agent] ?? agentConfig.defaultModel;
+}
+
+/**
  * Deterministic heuristic classification for a single task.
  * Advisory — agents can override these recommendations.
  *
@@ -82,23 +96,30 @@ const SCAFFOLDING_KEYWORDS = ['stub', 'boilerplate', 'type def', 'interface', 's
  *   3. files length >= 3 → high/implementer
  *   4. Default → medium/implementer
  */
-export function classifyTask(task: TaskInput): TaskClassification {
+export function classifyTask(
+  task: TaskInput,
+  agentConfig: ResolvedProjectConfig['agents'] = DEFAULTS.agents,
+): TaskClassification {
   // Check testLayer first (highest priority)
   if (task.testLayer === 'acceptance') {
+    const recommendedAgent = 'implementer' as const;
     return {
       taskId: task.id,
       complexity: 'high',
-      recommendedAgent: 'implementer',
+      recommendedAgent,
+      recommendedModel: resolveModel(recommendedAgent, agentConfig),
       effort: 'high',
       reason: 'Acceptance test task — requires understanding feature intent holistically',
     };
   }
 
   if (task.testLayer === 'integration') {
+    const recommendedAgent = 'implementer' as const;
     return {
       taskId: task.id,
       complexity: 'medium',
-      recommendedAgent: 'implementer',
+      recommendedAgent,
+      recommendedModel: resolveModel(recommendedAgent, agentConfig),
       effort: 'medium',
       reason: 'Integration layer task — preserve implementer lane',
     };
@@ -109,10 +130,12 @@ export function classifyTask(task: TaskInput): TaskClassification {
   // Check scaffolding keywords
   const matchedKeyword = SCAFFOLDING_KEYWORDS.find(kw => titleLower.includes(kw));
   if (matchedKeyword) {
+    const recommendedAgent = 'scaffolder' as const;
     return {
       taskId: task.id,
       complexity: 'low',
-      recommendedAgent: 'scaffolder',
+      recommendedAgent,
+      recommendedModel: resolveModel(recommendedAgent, agentConfig),
       effort: 'low',
       reason: `Title contains scaffolding keyword "${matchedKeyword}"`,
     };
@@ -120,30 +143,36 @@ export function classifyTask(task: TaskInput): TaskClassification {
 
   // Check high-complexity signals
   if (task.blockedBy && task.blockedBy.length >= 2) {
+    const recommendedAgent = 'implementer' as const;
     return {
       taskId: task.id,
       complexity: 'high',
-      recommendedAgent: 'implementer',
+      recommendedAgent,
+      recommendedModel: resolveModel(recommendedAgent, agentConfig),
       effort: 'high',
       reason: `Task has ${task.blockedBy.length} dependencies (>= 2 threshold)`,
     };
   }
 
   if (task.files && task.files.length >= 3) {
+    const recommendedAgent = 'implementer' as const;
     return {
       taskId: task.id,
       complexity: 'high',
-      recommendedAgent: 'implementer',
+      recommendedAgent,
+      recommendedModel: resolveModel(recommendedAgent, agentConfig),
       effort: 'high',
       reason: `Task touches ${task.files.length} files (>= 3 threshold)`,
     };
   }
 
   // Default: medium complexity
+  const recommendedAgent = 'implementer' as const;
   return {
     taskId: task.id,
     complexity: 'medium',
-    recommendedAgent: 'implementer',
+    recommendedAgent,
+    recommendedModel: resolveModel(recommendedAgent, agentConfig),
     effort: 'medium',
     reason: 'Standard task — no scaffolding keywords or high-complexity signals',
   };
@@ -285,8 +314,9 @@ export async function handlePrepareDelegation(
     } catch { /* fire-and-forget */ }
 
     // Compute task classifications when tasks are provided (advisory)
+    const agentConfig = DEFAULTS.agents;
     const taskClassifications = args.tasks
-      ? args.tasks.map(classifyTask)
+      ? args.tasks.map(t => classifyTask(t, agentConfig))
       : undefined;
 
     const result: PrepareDelegationResult = {

--- a/skills-src/delegation/SKILL.md
+++ b/skills-src/delegation/SKILL.md
@@ -43,7 +43,7 @@ Rationalization patterns that violate this principle are catalogued in `referenc
 
 **Auto-detection:** tmux + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` present means `agent-team`. Otherwise `subagent`. Override with `{{COMMAND_PREFIX}}delegate --mode subagent|agent-team`.
 
-**CRITICAL:** Always specify `model: "opus"` for coding tasks (when not using native agent definitions).
+Use the `recommendedModel` from `prepare_delegation` task classifications when available. If no classification exists (e.g., fixer dispatch), omit `model` to inherit the session default.
 
 ### Pre-Dispatch Schema Discovery
 

--- a/skills-src/delegation/references/agent-teams-saga.md
+++ b/skills-src/delegation/references/agent-teams-saga.md
@@ -103,7 +103,6 @@ exarchos_event append:
     teammateName: {name}
     worktreePath: {path}
     assignedTaskIds: [{taskIds}]
-    model: "opus"
 
 # Execute side effect
 # Note: teammates inherit the lead's permission mode (per Claude Code docs).
@@ -112,7 +111,6 @@ Task:
   subagent_type: "general-purpose"
   team_name: {featureId}
   name: {teammateName}
-  model: "opus"
   prompt: {spawnPrompt}  # See implementer-prompt.md template
 ```
 
@@ -199,7 +197,7 @@ If a compensating action itself fails after 3 retries, mark the workflow with `_
 | **Permissions inherit from lead** | Do NOT set `mode` at spawn -- not respected. All teammates inherit the lead's permission mode. |
 | **Teammates load MCP automatically** | Exarchos MCP tools are available without explicit instruction. The spawn prompt guides WHICH tools to use, not HOW to access them. |
 
-**CRITICAL:** Ensure your session is using the opus model for coding tasks. All teammates inherit the session model -- use Task tool dispatch if you need per-task model selection.
+**Model selection:** Teammates inherit the session model. Model is configured via `.exarchos.yml` and resolved by `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Event Payload Conventions
 

--- a/skills-src/delegation/references/fixer-prompt.md
+++ b/skills-src/delegation/references/fixer-prompt.md
@@ -109,7 +109,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix: SQL injection vulnerability",
   prompt: `
 # Fix Task: SQL Injection in User Query

--- a/skills-src/delegation/references/implementer-prompt.md
+++ b/skills-src/delegation/references/implementer-prompt.md
@@ -280,7 +280,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Implement user validation",
   prompt: `
 # Task: Implement User Email Validation

--- a/skills-src/delegation/references/parallel-strategy.md
+++ b/skills-src/delegation/references/parallel-strategy.md
@@ -21,8 +21,8 @@ Group B (depends on Group A):
 
 ```typescript
 // CORRECT: Single message, parallel execution
-Task({ model: "opus", description: "Task 001", prompt: "..." })
-Task({ model: "opus", description: "Task 002", prompt: "..." })
+Task({ description: "Task 001", prompt: "..." })
+Task({ description: "Task 002", prompt: "..." })
 
 // WRONG: Separate messages = sequential
 ```
@@ -59,7 +59,7 @@ Agent Teams supports one team per session. If you need more parallel groups than
 | Parallel dispatch | Multiple `Task()` in one message | Named teammates in agent team |
 | Waiting | `TaskOutput({ block: true })` | `TeammateIdle` hook (fires when teammate idle) |
 | Visibility | None (background) | tmux split panes |
-| Model control | `model: "opus"` per task | Session model for all |
+| Model control | `recommendedModel` from config | Session model for all |
 | Max parallelism | Unlimited | One team, N teammates |
 | Resume on crash | Task results preserved | Teammates lost (worktrees survive) |
 
@@ -73,14 +73,9 @@ TaskOutput({ task_id: "task-002-id" })
 
 ## Model Selection Guide
 
-| Task Type | Model | Reason |
-|-----------|-------|--------|
-| Code implementation | `opus` | Best quality for coding |
-| Code review | `opus` | Thorough analysis |
-| File search/exploration | (default) | Speed over quality |
-| Simple queries | `haiku` | Fast, low cost |
+Model selection is config-driven via `.exarchos.yml`. The `prepare_delegation` action returns a `recommendedModel` in each task classification based on the config cascade: per-agent override, then default-model, then fallback. Override per-task via the Task tool's `model` parameter when needed.
 
-**Note:** When using Agent Teams, all teammates inherit the session's model. Use Task tool dispatch if you need per-task model selection (e.g., `haiku` for simple queries, `opus` for implementation).
+**Note:** When using Agent Teams, all teammates inherit the session's model. Model is resolved from `.exarchos.yml` config via `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Agent Teams Dispatch Pattern
 
@@ -106,7 +101,7 @@ Each teammate receives the full implementer prompt including TDD requirements, f
 | Cross-task deps | Orchestrator manages phases | Shared task list + unblocked task detection |
 | Monitoring | `TaskOutput` polling | tmux panes + `TeammateIdle` hook |
 | State updates | Orchestrator updates state | Hook auto-updates via state bridge |
-| Model per task | Yes (`model: "opus"` per Task) | No (session model for all) |
+| Model per task | Yes (`recommendedModel` per Task) | No (session model for all) |
 | Quality gates | Manual via `post_delegation_check` action | Automatic via `TeammateIdle` hook |
 | Recovery | Task results preserved | Worktrees survive, teammates lost |
 

--- a/skills-src/delegation/references/pr-fixes-mode.md
+++ b/skills-src/delegation/references/pr-fixes-mode.md
@@ -99,7 +99,6 @@ Use TodoWrite to track all fix tasks with priority labels.
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix [P{priority} {severity}]: {issue summary}",
   prompt: `
 # Task: Fix PR Feedback - {issue summary}

--- a/skills-src/delegation/references/worked-example.md
+++ b/skills-src/delegation/references/worked-example.md
@@ -41,13 +41,13 @@ Build two self-contained prompts from `implementer-prompt.md` and dispatch in a 
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-001: Email format validator",
   prompt: `# Task: Email Format Validator\n\n## Working Directory\n/project/.worktrees/task-001\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
 
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-002: Domain MX check",
   prompt: `# Task: Domain MX Check\n\n## Working Directory\n/project/.worktrees/task-002\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
@@ -86,7 +86,7 @@ Re-dispatch with fixer prompt in the same worktree:
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus",
+  subagent_type: "general-purpose",
   description: "Fix task-002: DNS mock missing",
   prompt: `# Fix Task: DNS Mock Missing\n\n## Adversarial Verification Posture\nIndependently verify the failure...\n\n## Working Directory\n/project/.worktrees/task-002\n\n## Issue to Fix\n**File:** src/validators/domain.test.ts\n**Problem:** Missing vi.mock('dns') — test makes real network calls\n**Fix:** Add vi.mock('dns') with MX record stub\n\n## Verification\nRun: npm run test:run\nAll tests must pass without network access.`
 })

--- a/skills-src/delegation/references/workflow-steps.md
+++ b/skills-src/delegation/references/workflow-steps.md
@@ -40,7 +40,6 @@ TodoWrite({
 // Launch multiple in single message for parallel execution
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 001",
   prompt: "[Full implementer prompt]"
@@ -48,7 +47,6 @@ Task({
 
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 002",
   prompt: "[Full implementer prompt]"

--- a/skills-src/delegation/references/worktree-enforcement.md
+++ b/skills-src/delegation/references/worktree-enforcement.md
@@ -64,7 +64,7 @@ When using native isolation:
 | Don't | Do Instead |
 |-------|------------|
 | Make subagents read plan files | Provide full task text in prompt |
-| Use default model for coding | Specify `model: "opus"` |
+| Use default model for coding | Use configured model from `prepare_delegation` |
 | Send sequential Task calls | Batch parallel tasks in one message |
 | Skip worktree for parallel work | Create isolated worktrees |
 | Forget to track in TodoWrite | Update status for every task |

--- a/skills/claude/delegation/SKILL.md
+++ b/skills/claude/delegation/SKILL.md
@@ -43,7 +43,7 @@ Rationalization patterns that violate this principle are catalogued in `referenc
 
 **Auto-detection:** tmux + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` present means `agent-team`. Otherwise `subagent`. Override with `/exarchos:delegate --mode subagent|agent-team`.
 
-**CRITICAL:** Always specify `model: "opus"` for coding tasks (when not using native agent definitions).
+Use the `recommendedModel` from `prepare_delegation` task classifications when available. If no classification exists (e.g., fixer dispatch), omit `model` to inherit the session default.
 
 ### Pre-Dispatch Schema Discovery
 

--- a/skills/claude/delegation/references/agent-teams-saga.md
+++ b/skills/claude/delegation/references/agent-teams-saga.md
@@ -103,7 +103,6 @@ exarchos_event append:
     teammateName: {name}
     worktreePath: {path}
     assignedTaskIds: [{taskIds}]
-    model: "opus"
 
 # Execute side effect
 # Note: teammates inherit the lead's permission mode (per Claude Code docs).
@@ -112,7 +111,6 @@ Task:
   subagent_type: "general-purpose"
   team_name: {featureId}
   name: {teammateName}
-  model: "opus"
   prompt: {spawnPrompt}  # See implementer-prompt.md template
 ```
 
@@ -199,7 +197,7 @@ If a compensating action itself fails after 3 retries, mark the workflow with `_
 | **Permissions inherit from lead** | Do NOT set `mode` at spawn -- not respected. All teammates inherit the lead's permission mode. |
 | **Teammates load MCP automatically** | Exarchos MCP tools are available without explicit instruction. The spawn prompt guides WHICH tools to use, not HOW to access them. |
 
-**CRITICAL:** Ensure your session is using the opus model for coding tasks. All teammates inherit the session model -- use Task tool dispatch if you need per-task model selection.
+**Model selection:** Teammates inherit the session model. Model is configured via `.exarchos.yml` and resolved by `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Event Payload Conventions
 

--- a/skills/claude/delegation/references/fixer-prompt.md
+++ b/skills/claude/delegation/references/fixer-prompt.md
@@ -109,7 +109,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix: SQL injection vulnerability",
   prompt: `
 # Fix Task: SQL Injection in User Query

--- a/skills/claude/delegation/references/implementer-prompt.md
+++ b/skills/claude/delegation/references/implementer-prompt.md
@@ -280,7 +280,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Implement user validation",
   prompt: `
 # Task: Implement User Email Validation

--- a/skills/claude/delegation/references/parallel-strategy.md
+++ b/skills/claude/delegation/references/parallel-strategy.md
@@ -21,8 +21,8 @@ Group B (depends on Group A):
 
 ```typescript
 // CORRECT: Single message, parallel execution
-Task({ model: "opus", description: "Task 001", prompt: "..." })
-Task({ model: "opus", description: "Task 002", prompt: "..." })
+Task({ description: "Task 001", prompt: "..." })
+Task({ description: "Task 002", prompt: "..." })
 
 // WRONG: Separate messages = sequential
 ```
@@ -59,7 +59,7 @@ Agent Teams supports one team per session. If you need more parallel groups than
 | Parallel dispatch | Multiple `Task()` in one message | Named teammates in agent team |
 | Waiting | `TaskOutput({ block: true })` | `TeammateIdle` hook (fires when teammate idle) |
 | Visibility | None (background) | tmux split panes |
-| Model control | `model: "opus"` per task | Session model for all |
+| Model control | `recommendedModel` from config | Session model for all |
 | Max parallelism | Unlimited | One team, N teammates |
 | Resume on crash | Task results preserved | Teammates lost (worktrees survive) |
 
@@ -73,14 +73,9 @@ TaskOutput({ task_id: "task-002-id" })
 
 ## Model Selection Guide
 
-| Task Type | Model | Reason |
-|-----------|-------|--------|
-| Code implementation | `opus` | Best quality for coding |
-| Code review | `opus` | Thorough analysis |
-| File search/exploration | (default) | Speed over quality |
-| Simple queries | `haiku` | Fast, low cost |
+Model selection is config-driven via `.exarchos.yml`. The `prepare_delegation` action returns a `recommendedModel` in each task classification based on the config cascade: per-agent override, then default-model, then fallback. Override per-task via the Task tool's `model` parameter when needed.
 
-**Note:** When using Agent Teams, all teammates inherit the session's model. Use Task tool dispatch if you need per-task model selection (e.g., `haiku` for simple queries, `opus` for implementation).
+**Note:** When using Agent Teams, all teammates inherit the session's model. Model is resolved from `.exarchos.yml` config via `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Agent Teams Dispatch Pattern
 
@@ -106,7 +101,7 @@ Each teammate receives the full implementer prompt including TDD requirements, f
 | Cross-task deps | Orchestrator manages phases | Shared task list + unblocked task detection |
 | Monitoring | `TaskOutput` polling | tmux panes + `TeammateIdle` hook |
 | State updates | Orchestrator updates state | Hook auto-updates via state bridge |
-| Model per task | Yes (`model: "opus"` per Task) | No (session model for all) |
+| Model per task | Yes (`recommendedModel` per Task) | No (session model for all) |
 | Quality gates | Manual via `post_delegation_check` action | Automatic via `TeammateIdle` hook |
 | Recovery | Task results preserved | Worktrees survive, teammates lost |
 

--- a/skills/claude/delegation/references/pr-fixes-mode.md
+++ b/skills/claude/delegation/references/pr-fixes-mode.md
@@ -99,7 +99,6 @@ Use TodoWrite to track all fix tasks with priority labels.
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix [P{priority} {severity}]: {issue summary}",
   prompt: `
 # Task: Fix PR Feedback - {issue summary}

--- a/skills/claude/delegation/references/worked-example.md
+++ b/skills/claude/delegation/references/worked-example.md
@@ -41,13 +41,13 @@ Build two self-contained prompts from `implementer-prompt.md` and dispatch in a 
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-001: Email format validator",
   prompt: `# Task: Email Format Validator\n\n## Working Directory\n/project/.worktrees/task-001\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
 
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-002: Domain MX check",
   prompt: `# Task: Domain MX Check\n\n## Working Directory\n/project/.worktrees/task-002\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
@@ -86,7 +86,7 @@ Re-dispatch with fixer prompt in the same worktree:
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus",
+  subagent_type: "general-purpose",
   description: "Fix task-002: DNS mock missing",
   prompt: `# Fix Task: DNS Mock Missing\n\n## Adversarial Verification Posture\nIndependently verify the failure...\n\n## Working Directory\n/project/.worktrees/task-002\n\n## Issue to Fix\n**File:** src/validators/domain.test.ts\n**Problem:** Missing vi.mock('dns') — test makes real network calls\n**Fix:** Add vi.mock('dns') with MX record stub\n\n## Verification\nRun: npm run test:run\nAll tests must pass without network access.`
 })

--- a/skills/claude/delegation/references/workflow-steps.md
+++ b/skills/claude/delegation/references/workflow-steps.md
@@ -40,7 +40,6 @@ TodoWrite({
 // Launch multiple in single message for parallel execution
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 001",
   prompt: "[Full implementer prompt]"
@@ -48,7 +47,6 @@ Task({
 
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 002",
   prompt: "[Full implementer prompt]"

--- a/skills/claude/delegation/references/worktree-enforcement.md
+++ b/skills/claude/delegation/references/worktree-enforcement.md
@@ -64,7 +64,7 @@ When using native isolation:
 | Don't | Do Instead |
 |-------|------------|
 | Make subagents read plan files | Provide full task text in prompt |
-| Use default model for coding | Specify `model: "opus"` |
+| Use default model for coding | Use configured model from `prepare_delegation` |
 | Send sequential Task calls | Batch parallel tasks in one message |
 | Skip worktree for parallel work | Create isolated worktrees |
 | Forget to track in TodoWrite | Update status for every task |

--- a/skills/codex/delegation/SKILL.md
+++ b/skills/codex/delegation/SKILL.md
@@ -43,7 +43,7 @@ Rationalization patterns that violate this principle are catalogued in `referenc
 
 **Auto-detection:** tmux + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` present means `agent-team`. Otherwise `subagent`. Override with `delegate --mode subagent|agent-team`.
 
-**CRITICAL:** Always specify `model: "opus"` for coding tasks (when not using native agent definitions).
+Use the `recommendedModel` from `prepare_delegation` task classifications when available. If no classification exists (e.g., fixer dispatch), omit `model` to inherit the session default.
 
 ### Pre-Dispatch Schema Discovery
 

--- a/skills/codex/delegation/references/agent-teams-saga.md
+++ b/skills/codex/delegation/references/agent-teams-saga.md
@@ -103,7 +103,6 @@ exarchos_event append:
     teammateName: {name}
     worktreePath: {path}
     assignedTaskIds: [{taskIds}]
-    model: "opus"
 
 # Execute side effect
 # Note: teammates inherit the lead's permission mode (per Claude Code docs).
@@ -112,7 +111,6 @@ Task:
   subagent_type: "general-purpose"
   team_name: {featureId}
   name: {teammateName}
-  model: "opus"
   prompt: {spawnPrompt}  # See implementer-prompt.md template
 ```
 
@@ -199,7 +197,7 @@ If a compensating action itself fails after 3 retries, mark the workflow with `_
 | **Permissions inherit from lead** | Do NOT set `mode` at spawn -- not respected. All teammates inherit the lead's permission mode. |
 | **Teammates load MCP automatically** | Exarchos MCP tools are available without explicit instruction. The spawn prompt guides WHICH tools to use, not HOW to access them. |
 
-**CRITICAL:** Ensure your session is using the opus model for coding tasks. All teammates inherit the session model -- use Task tool dispatch if you need per-task model selection.
+**Model selection:** Teammates inherit the session model. Model is configured via `.exarchos.yml` and resolved by `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Event Payload Conventions
 

--- a/skills/codex/delegation/references/fixer-prompt.md
+++ b/skills/codex/delegation/references/fixer-prompt.md
@@ -109,7 +109,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix: SQL injection vulnerability",
   prompt: `
 # Fix Task: SQL Injection in User Query

--- a/skills/codex/delegation/references/implementer-prompt.md
+++ b/skills/codex/delegation/references/implementer-prompt.md
@@ -280,7 +280,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Implement user validation",
   prompt: `
 # Task: Implement User Email Validation

--- a/skills/codex/delegation/references/parallel-strategy.md
+++ b/skills/codex/delegation/references/parallel-strategy.md
@@ -21,8 +21,8 @@ Group B (depends on Group A):
 
 ```typescript
 // CORRECT: Single message, parallel execution
-Task({ model: "opus", description: "Task 001", prompt: "..." })
-Task({ model: "opus", description: "Task 002", prompt: "..." })
+Task({ description: "Task 001", prompt: "..." })
+Task({ description: "Task 002", prompt: "..." })
 
 // WRONG: Separate messages = sequential
 ```
@@ -59,7 +59,7 @@ Agent Teams supports one team per session. If you need more parallel groups than
 | Parallel dispatch | Multiple `Task()` in one message | Named teammates in agent team |
 | Waiting | `TaskOutput({ block: true })` | `TeammateIdle` hook (fires when teammate idle) |
 | Visibility | None (background) | tmux split panes |
-| Model control | `model: "opus"` per task | Session model for all |
+| Model control | `recommendedModel` from config | Session model for all |
 | Max parallelism | Unlimited | One team, N teammates |
 | Resume on crash | Task results preserved | Teammates lost (worktrees survive) |
 
@@ -73,14 +73,9 @@ TaskOutput({ task_id: "task-002-id" })
 
 ## Model Selection Guide
 
-| Task Type | Model | Reason |
-|-----------|-------|--------|
-| Code implementation | `opus` | Best quality for coding |
-| Code review | `opus` | Thorough analysis |
-| File search/exploration | (default) | Speed over quality |
-| Simple queries | `haiku` | Fast, low cost |
+Model selection is config-driven via `.exarchos.yml`. The `prepare_delegation` action returns a `recommendedModel` in each task classification based on the config cascade: per-agent override, then default-model, then fallback. Override per-task via the Task tool's `model` parameter when needed.
 
-**Note:** When using Agent Teams, all teammates inherit the session's model. Use Task tool dispatch if you need per-task model selection (e.g., `haiku` for simple queries, `opus` for implementation).
+**Note:** When using Agent Teams, all teammates inherit the session's model. Model is resolved from `.exarchos.yml` config via `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Agent Teams Dispatch Pattern
 
@@ -106,7 +101,7 @@ Each teammate receives the full implementer prompt including TDD requirements, f
 | Cross-task deps | Orchestrator manages phases | Shared task list + unblocked task detection |
 | Monitoring | `TaskOutput` polling | tmux panes + `TeammateIdle` hook |
 | State updates | Orchestrator updates state | Hook auto-updates via state bridge |
-| Model per task | Yes (`model: "opus"` per Task) | No (session model for all) |
+| Model per task | Yes (`recommendedModel` per Task) | No (session model for all) |
 | Quality gates | Manual via `post_delegation_check` action | Automatic via `TeammateIdle` hook |
 | Recovery | Task results preserved | Worktrees survive, teammates lost |
 

--- a/skills/codex/delegation/references/pr-fixes-mode.md
+++ b/skills/codex/delegation/references/pr-fixes-mode.md
@@ -99,7 +99,6 @@ Use TodoWrite to track all fix tasks with priority labels.
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix [P{priority} {severity}]: {issue summary}",
   prompt: `
 # Task: Fix PR Feedback - {issue summary}

--- a/skills/codex/delegation/references/worked-example.md
+++ b/skills/codex/delegation/references/worked-example.md
@@ -41,13 +41,13 @@ Build two self-contained prompts from `implementer-prompt.md` and dispatch in a 
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-001: Email format validator",
   prompt: `# Task: Email Format Validator\n\n## Working Directory\n/project/.worktrees/task-001\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
 
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-002: Domain MX check",
   prompt: `# Task: Domain MX Check\n\n## Working Directory\n/project/.worktrees/task-002\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
@@ -86,7 +86,7 @@ Re-dispatch with fixer prompt in the same worktree:
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus",
+  subagent_type: "general-purpose",
   description: "Fix task-002: DNS mock missing",
   prompt: `# Fix Task: DNS Mock Missing\n\n## Adversarial Verification Posture\nIndependently verify the failure...\n\n## Working Directory\n/project/.worktrees/task-002\n\n## Issue to Fix\n**File:** src/validators/domain.test.ts\n**Problem:** Missing vi.mock('dns') — test makes real network calls\n**Fix:** Add vi.mock('dns') with MX record stub\n\n## Verification\nRun: npm run test:run\nAll tests must pass without network access.`
 })

--- a/skills/codex/delegation/references/workflow-steps.md
+++ b/skills/codex/delegation/references/workflow-steps.md
@@ -40,7 +40,6 @@ TodoWrite({
 // Launch multiple in single message for parallel execution
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 001",
   prompt: "[Full implementer prompt]"
@@ -48,7 +47,6 @@ Task({
 
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 002",
   prompt: "[Full implementer prompt]"

--- a/skills/codex/delegation/references/worktree-enforcement.md
+++ b/skills/codex/delegation/references/worktree-enforcement.md
@@ -64,7 +64,7 @@ When using native isolation:
 | Don't | Do Instead |
 |-------|------------|
 | Make subagents read plan files | Provide full task text in prompt |
-| Use default model for coding | Specify `model: "opus"` |
+| Use default model for coding | Use configured model from `prepare_delegation` |
 | Send sequential Task calls | Batch parallel tasks in one message |
 | Skip worktree for parallel work | Create isolated worktrees |
 | Forget to track in TodoWrite | Update status for every task |

--- a/skills/copilot/delegation/SKILL.md
+++ b/skills/copilot/delegation/SKILL.md
@@ -43,7 +43,7 @@ Rationalization patterns that violate this principle are catalogued in `referenc
 
 **Auto-detection:** tmux + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` present means `agent-team`. Otherwise `subagent`. Override with `/delegate --mode subagent|agent-team`.
 
-**CRITICAL:** Always specify `model: "opus"` for coding tasks (when not using native agent definitions).
+Use the `recommendedModel` from `prepare_delegation` task classifications when available. If no classification exists (e.g., fixer dispatch), omit `model` to inherit the session default.
 
 ### Pre-Dispatch Schema Discovery
 

--- a/skills/copilot/delegation/references/agent-teams-saga.md
+++ b/skills/copilot/delegation/references/agent-teams-saga.md
@@ -103,7 +103,6 @@ exarchos_event append:
     teammateName: {name}
     worktreePath: {path}
     assignedTaskIds: [{taskIds}]
-    model: "opus"
 
 # Execute side effect
 # Note: teammates inherit the lead's permission mode (per Claude Code docs).
@@ -112,7 +111,6 @@ Task:
   subagent_type: "general-purpose"
   team_name: {featureId}
   name: {teammateName}
-  model: "opus"
   prompt: {spawnPrompt}  # See implementer-prompt.md template
 ```
 
@@ -199,7 +197,7 @@ If a compensating action itself fails after 3 retries, mark the workflow with `_
 | **Permissions inherit from lead** | Do NOT set `mode` at spawn -- not respected. All teammates inherit the lead's permission mode. |
 | **Teammates load MCP automatically** | Exarchos MCP tools are available without explicit instruction. The spawn prompt guides WHICH tools to use, not HOW to access them. |
 
-**CRITICAL:** Ensure your session is using the opus model for coding tasks. All teammates inherit the session model -- use Task tool dispatch if you need per-task model selection.
+**Model selection:** Teammates inherit the session model. Model is configured via `.exarchos.yml` and resolved by `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Event Payload Conventions
 

--- a/skills/copilot/delegation/references/fixer-prompt.md
+++ b/skills/copilot/delegation/references/fixer-prompt.md
@@ -109,7 +109,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix: SQL injection vulnerability",
   prompt: `
 # Fix Task: SQL Injection in User Query

--- a/skills/copilot/delegation/references/implementer-prompt.md
+++ b/skills/copilot/delegation/references/implementer-prompt.md
@@ -280,7 +280,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Implement user validation",
   prompt: `
 # Task: Implement User Email Validation

--- a/skills/copilot/delegation/references/parallel-strategy.md
+++ b/skills/copilot/delegation/references/parallel-strategy.md
@@ -21,8 +21,8 @@ Group B (depends on Group A):
 
 ```typescript
 // CORRECT: Single message, parallel execution
-Task({ model: "opus", description: "Task 001", prompt: "..." })
-Task({ model: "opus", description: "Task 002", prompt: "..." })
+Task({ description: "Task 001", prompt: "..." })
+Task({ description: "Task 002", prompt: "..." })
 
 // WRONG: Separate messages = sequential
 ```
@@ -59,7 +59,7 @@ Agent Teams supports one team per session. If you need more parallel groups than
 | Parallel dispatch | Multiple `Task()` in one message | Named teammates in agent team |
 | Waiting | `TaskOutput({ block: true })` | `TeammateIdle` hook (fires when teammate idle) |
 | Visibility | None (background) | tmux split panes |
-| Model control | `model: "opus"` per task | Session model for all |
+| Model control | `recommendedModel` from config | Session model for all |
 | Max parallelism | Unlimited | One team, N teammates |
 | Resume on crash | Task results preserved | Teammates lost (worktrees survive) |
 
@@ -73,14 +73,9 @@ TaskOutput({ task_id: "task-002-id" })
 
 ## Model Selection Guide
 
-| Task Type | Model | Reason |
-|-----------|-------|--------|
-| Code implementation | `opus` | Best quality for coding |
-| Code review | `opus` | Thorough analysis |
-| File search/exploration | (default) | Speed over quality |
-| Simple queries | `haiku` | Fast, low cost |
+Model selection is config-driven via `.exarchos.yml`. The `prepare_delegation` action returns a `recommendedModel` in each task classification based on the config cascade: per-agent override, then default-model, then fallback. Override per-task via the Task tool's `model` parameter when needed.
 
-**Note:** When using Agent Teams, all teammates inherit the session's model. Use Task tool dispatch if you need per-task model selection (e.g., `haiku` for simple queries, `opus` for implementation).
+**Note:** When using Agent Teams, all teammates inherit the session's model. Model is resolved from `.exarchos.yml` config via `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Agent Teams Dispatch Pattern
 
@@ -106,7 +101,7 @@ Each teammate receives the full implementer prompt including TDD requirements, f
 | Cross-task deps | Orchestrator manages phases | Shared task list + unblocked task detection |
 | Monitoring | `TaskOutput` polling | tmux panes + `TeammateIdle` hook |
 | State updates | Orchestrator updates state | Hook auto-updates via state bridge |
-| Model per task | Yes (`model: "opus"` per Task) | No (session model for all) |
+| Model per task | Yes (`recommendedModel` per Task) | No (session model for all) |
 | Quality gates | Manual via `post_delegation_check` action | Automatic via `TeammateIdle` hook |
 | Recovery | Task results preserved | Worktrees survive, teammates lost |
 

--- a/skills/copilot/delegation/references/pr-fixes-mode.md
+++ b/skills/copilot/delegation/references/pr-fixes-mode.md
@@ -99,7 +99,6 @@ Use TodoWrite to track all fix tasks with priority labels.
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix [P{priority} {severity}]: {issue summary}",
   prompt: `
 # Task: Fix PR Feedback - {issue summary}

--- a/skills/copilot/delegation/references/worked-example.md
+++ b/skills/copilot/delegation/references/worked-example.md
@@ -41,13 +41,13 @@ Build two self-contained prompts from `implementer-prompt.md` and dispatch in a 
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-001: Email format validator",
   prompt: `# Task: Email Format Validator\n\n## Working Directory\n/project/.worktrees/task-001\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
 
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-002: Domain MX check",
   prompt: `# Task: Domain MX Check\n\n## Working Directory\n/project/.worktrees/task-002\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
@@ -86,7 +86,7 @@ Re-dispatch with fixer prompt in the same worktree:
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus",
+  subagent_type: "general-purpose",
   description: "Fix task-002: DNS mock missing",
   prompt: `# Fix Task: DNS Mock Missing\n\n## Adversarial Verification Posture\nIndependently verify the failure...\n\n## Working Directory\n/project/.worktrees/task-002\n\n## Issue to Fix\n**File:** src/validators/domain.test.ts\n**Problem:** Missing vi.mock('dns') — test makes real network calls\n**Fix:** Add vi.mock('dns') with MX record stub\n\n## Verification\nRun: npm run test:run\nAll tests must pass without network access.`
 })

--- a/skills/copilot/delegation/references/workflow-steps.md
+++ b/skills/copilot/delegation/references/workflow-steps.md
@@ -40,7 +40,6 @@ TodoWrite({
 // Launch multiple in single message for parallel execution
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 001",
   prompt: "[Full implementer prompt]"
@@ -48,7 +47,6 @@ Task({
 
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 002",
   prompt: "[Full implementer prompt]"

--- a/skills/copilot/delegation/references/worktree-enforcement.md
+++ b/skills/copilot/delegation/references/worktree-enforcement.md
@@ -64,7 +64,7 @@ When using native isolation:
 | Don't | Do Instead |
 |-------|------------|
 | Make subagents read plan files | Provide full task text in prompt |
-| Use default model for coding | Specify `model: "opus"` |
+| Use default model for coding | Use configured model from `prepare_delegation` |
 | Send sequential Task calls | Batch parallel tasks in one message |
 | Skip worktree for parallel work | Create isolated worktrees |
 | Forget to track in TodoWrite | Update status for every task |

--- a/skills/cursor/delegation/SKILL.md
+++ b/skills/cursor/delegation/SKILL.md
@@ -43,7 +43,7 @@ Rationalization patterns that violate this principle are catalogued in `referenc
 
 **Auto-detection:** tmux + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` present means `agent-team`. Otherwise `subagent`. Override with `delegate --mode subagent|agent-team`.
 
-**CRITICAL:** Always specify `model: "opus"` for coding tasks (when not using native agent definitions).
+Use the `recommendedModel` from `prepare_delegation` task classifications when available. If no classification exists (e.g., fixer dispatch), omit `model` to inherit the session default.
 
 ### Pre-Dispatch Schema Discovery
 

--- a/skills/cursor/delegation/references/agent-teams-saga.md
+++ b/skills/cursor/delegation/references/agent-teams-saga.md
@@ -103,7 +103,6 @@ exarchos_event append:
     teammateName: {name}
     worktreePath: {path}
     assignedTaskIds: [{taskIds}]
-    model: "opus"
 
 # Execute side effect
 # Note: teammates inherit the lead's permission mode (per Claude Code docs).
@@ -112,7 +111,6 @@ Task:
   subagent_type: "general-purpose"
   team_name: {featureId}
   name: {teammateName}
-  model: "opus"
   prompt: {spawnPrompt}  # See implementer-prompt.md template
 ```
 
@@ -199,7 +197,7 @@ If a compensating action itself fails after 3 retries, mark the workflow with `_
 | **Permissions inherit from lead** | Do NOT set `mode` at spawn -- not respected. All teammates inherit the lead's permission mode. |
 | **Teammates load MCP automatically** | Exarchos MCP tools are available without explicit instruction. The spawn prompt guides WHICH tools to use, not HOW to access them. |
 
-**CRITICAL:** Ensure your session is using the opus model for coding tasks. All teammates inherit the session model -- use Task tool dispatch if you need per-task model selection.
+**Model selection:** Teammates inherit the session model. Model is configured via `.exarchos.yml` and resolved by `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Event Payload Conventions
 

--- a/skills/cursor/delegation/references/fixer-prompt.md
+++ b/skills/cursor/delegation/references/fixer-prompt.md
@@ -109,7 +109,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix: SQL injection vulnerability",
   prompt: `
 # Fix Task: SQL Injection in User Query

--- a/skills/cursor/delegation/references/implementer-prompt.md
+++ b/skills/cursor/delegation/references/implementer-prompt.md
@@ -280,7 +280,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Implement user validation",
   prompt: `
 # Task: Implement User Email Validation

--- a/skills/cursor/delegation/references/parallel-strategy.md
+++ b/skills/cursor/delegation/references/parallel-strategy.md
@@ -21,8 +21,8 @@ Group B (depends on Group A):
 
 ```typescript
 // CORRECT: Single message, parallel execution
-Task({ model: "opus", description: "Task 001", prompt: "..." })
-Task({ model: "opus", description: "Task 002", prompt: "..." })
+Task({ description: "Task 001", prompt: "..." })
+Task({ description: "Task 002", prompt: "..." })
 
 // WRONG: Separate messages = sequential
 ```
@@ -59,7 +59,7 @@ Agent Teams supports one team per session. If you need more parallel groups than
 | Parallel dispatch | Multiple `Task()` in one message | Named teammates in agent team |
 | Waiting | `TaskOutput({ block: true })` | `TeammateIdle` hook (fires when teammate idle) |
 | Visibility | None (background) | tmux split panes |
-| Model control | `model: "opus"` per task | Session model for all |
+| Model control | `recommendedModel` from config | Session model for all |
 | Max parallelism | Unlimited | One team, N teammates |
 | Resume on crash | Task results preserved | Teammates lost (worktrees survive) |
 
@@ -73,14 +73,9 @@ TaskOutput({ task_id: "task-002-id" })
 
 ## Model Selection Guide
 
-| Task Type | Model | Reason |
-|-----------|-------|--------|
-| Code implementation | `opus` | Best quality for coding |
-| Code review | `opus` | Thorough analysis |
-| File search/exploration | (default) | Speed over quality |
-| Simple queries | `haiku` | Fast, low cost |
+Model selection is config-driven via `.exarchos.yml`. The `prepare_delegation` action returns a `recommendedModel` in each task classification based on the config cascade: per-agent override, then default-model, then fallback. Override per-task via the Task tool's `model` parameter when needed.
 
-**Note:** When using Agent Teams, all teammates inherit the session's model. Use Task tool dispatch if you need per-task model selection (e.g., `haiku` for simple queries, `opus` for implementation).
+**Note:** When using Agent Teams, all teammates inherit the session's model. Model is resolved from `.exarchos.yml` config via `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Agent Teams Dispatch Pattern
 
@@ -106,7 +101,7 @@ Each teammate receives the full implementer prompt including TDD requirements, f
 | Cross-task deps | Orchestrator manages phases | Shared task list + unblocked task detection |
 | Monitoring | `TaskOutput` polling | tmux panes + `TeammateIdle` hook |
 | State updates | Orchestrator updates state | Hook auto-updates via state bridge |
-| Model per task | Yes (`model: "opus"` per Task) | No (session model for all) |
+| Model per task | Yes (`recommendedModel` per Task) | No (session model for all) |
 | Quality gates | Manual via `post_delegation_check` action | Automatic via `TeammateIdle` hook |
 | Recovery | Task results preserved | Worktrees survive, teammates lost |
 

--- a/skills/cursor/delegation/references/pr-fixes-mode.md
+++ b/skills/cursor/delegation/references/pr-fixes-mode.md
@@ -99,7 +99,6 @@ Use TodoWrite to track all fix tasks with priority labels.
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix [P{priority} {severity}]: {issue summary}",
   prompt: `
 # Task: Fix PR Feedback - {issue summary}

--- a/skills/cursor/delegation/references/worked-example.md
+++ b/skills/cursor/delegation/references/worked-example.md
@@ -41,13 +41,13 @@ Build two self-contained prompts from `implementer-prompt.md` and dispatch in a 
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-001: Email format validator",
   prompt: `# Task: Email Format Validator\n\n## Working Directory\n/project/.worktrees/task-001\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
 
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-002: Domain MX check",
   prompt: `# Task: Domain MX Check\n\n## Working Directory\n/project/.worktrees/task-002\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
@@ -86,7 +86,7 @@ Re-dispatch with fixer prompt in the same worktree:
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus",
+  subagent_type: "general-purpose",
   description: "Fix task-002: DNS mock missing",
   prompt: `# Fix Task: DNS Mock Missing\n\n## Adversarial Verification Posture\nIndependently verify the failure...\n\n## Working Directory\n/project/.worktrees/task-002\n\n## Issue to Fix\n**File:** src/validators/domain.test.ts\n**Problem:** Missing vi.mock('dns') — test makes real network calls\n**Fix:** Add vi.mock('dns') with MX record stub\n\n## Verification\nRun: npm run test:run\nAll tests must pass without network access.`
 })

--- a/skills/cursor/delegation/references/workflow-steps.md
+++ b/skills/cursor/delegation/references/workflow-steps.md
@@ -40,7 +40,6 @@ TodoWrite({
 // Launch multiple in single message for parallel execution
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 001",
   prompt: "[Full implementer prompt]"
@@ -48,7 +47,6 @@ Task({
 
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 002",
   prompt: "[Full implementer prompt]"

--- a/skills/cursor/delegation/references/worktree-enforcement.md
+++ b/skills/cursor/delegation/references/worktree-enforcement.md
@@ -64,7 +64,7 @@ When using native isolation:
 | Don't | Do Instead |
 |-------|------------|
 | Make subagents read plan files | Provide full task text in prompt |
-| Use default model for coding | Specify `model: "opus"` |
+| Use default model for coding | Use configured model from `prepare_delegation` |
 | Send sequential Task calls | Batch parallel tasks in one message |
 | Skip worktree for parallel work | Create isolated worktrees |
 | Forget to track in TodoWrite | Update status for every task |

--- a/skills/generic/delegation/SKILL.md
+++ b/skills/generic/delegation/SKILL.md
@@ -43,7 +43,7 @@ Rationalization patterns that violate this principle are catalogued in `referenc
 
 **Auto-detection:** tmux + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` present means `agent-team`. Otherwise `subagent`. Override with `delegate --mode subagent|agent-team`.
 
-**CRITICAL:** Always specify `model: "opus"` for coding tasks (when not using native agent definitions).
+Use the `recommendedModel` from `prepare_delegation` task classifications when available. If no classification exists (e.g., fixer dispatch), omit `model` to inherit the session default.
 
 ### Pre-Dispatch Schema Discovery
 

--- a/skills/generic/delegation/references/agent-teams-saga.md
+++ b/skills/generic/delegation/references/agent-teams-saga.md
@@ -103,7 +103,6 @@ exarchos_event append:
     teammateName: {name}
     worktreePath: {path}
     assignedTaskIds: [{taskIds}]
-    model: "opus"
 
 # Execute side effect
 # Note: teammates inherit the lead's permission mode (per Claude Code docs).
@@ -112,7 +111,6 @@ Task:
   subagent_type: "general-purpose"
   team_name: {featureId}
   name: {teammateName}
-  model: "opus"
   prompt: {spawnPrompt}  # See implementer-prompt.md template
 ```
 
@@ -199,7 +197,7 @@ If a compensating action itself fails after 3 retries, mark the workflow with `_
 | **Permissions inherit from lead** | Do NOT set `mode` at spawn -- not respected. All teammates inherit the lead's permission mode. |
 | **Teammates load MCP automatically** | Exarchos MCP tools are available without explicit instruction. The spawn prompt guides WHICH tools to use, not HOW to access them. |
 
-**CRITICAL:** Ensure your session is using the opus model for coding tasks. All teammates inherit the session model -- use Task tool dispatch if you need per-task model selection.
+**Model selection:** Teammates inherit the session model. Model is configured via `.exarchos.yml` and resolved by `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Event Payload Conventions
 

--- a/skills/generic/delegation/references/fixer-prompt.md
+++ b/skills/generic/delegation/references/fixer-prompt.md
@@ -109,7 +109,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix: SQL injection vulnerability",
   prompt: `
 # Fix Task: SQL Injection in User Query

--- a/skills/generic/delegation/references/implementer-prompt.md
+++ b/skills/generic/delegation/references/implementer-prompt.md
@@ -280,7 +280,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Implement user validation",
   prompt: `
 # Task: Implement User Email Validation

--- a/skills/generic/delegation/references/parallel-strategy.md
+++ b/skills/generic/delegation/references/parallel-strategy.md
@@ -21,8 +21,8 @@ Group B (depends on Group A):
 
 ```typescript
 // CORRECT: Single message, parallel execution
-Task({ model: "opus", description: "Task 001", prompt: "..." })
-Task({ model: "opus", description: "Task 002", prompt: "..." })
+Task({ description: "Task 001", prompt: "..." })
+Task({ description: "Task 002", prompt: "..." })
 
 // WRONG: Separate messages = sequential
 ```
@@ -59,7 +59,7 @@ Agent Teams supports one team per session. If you need more parallel groups than
 | Parallel dispatch | Multiple `Task()` in one message | Named teammates in agent team |
 | Waiting | `TaskOutput({ block: true })` | `TeammateIdle` hook (fires when teammate idle) |
 | Visibility | None (background) | tmux split panes |
-| Model control | `model: "opus"` per task | Session model for all |
+| Model control | `recommendedModel` from config | Session model for all |
 | Max parallelism | Unlimited | One team, N teammates |
 | Resume on crash | Task results preserved | Teammates lost (worktrees survive) |
 
@@ -73,14 +73,9 @@ TaskOutput({ task_id: "task-002-id" })
 
 ## Model Selection Guide
 
-| Task Type | Model | Reason |
-|-----------|-------|--------|
-| Code implementation | `opus` | Best quality for coding |
-| Code review | `opus` | Thorough analysis |
-| File search/exploration | (default) | Speed over quality |
-| Simple queries | `haiku` | Fast, low cost |
+Model selection is config-driven via `.exarchos.yml`. The `prepare_delegation` action returns a `recommendedModel` in each task classification based on the config cascade: per-agent override, then default-model, then fallback. Override per-task via the Task tool's `model` parameter when needed.
 
-**Note:** When using Agent Teams, all teammates inherit the session's model. Use Task tool dispatch if you need per-task model selection (e.g., `haiku` for simple queries, `opus` for implementation).
+**Note:** When using Agent Teams, all teammates inherit the session's model. Model is resolved from `.exarchos.yml` config via `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Agent Teams Dispatch Pattern
 
@@ -106,7 +101,7 @@ Each teammate receives the full implementer prompt including TDD requirements, f
 | Cross-task deps | Orchestrator manages phases | Shared task list + unblocked task detection |
 | Monitoring | `TaskOutput` polling | tmux panes + `TeammateIdle` hook |
 | State updates | Orchestrator updates state | Hook auto-updates via state bridge |
-| Model per task | Yes (`model: "opus"` per Task) | No (session model for all) |
+| Model per task | Yes (`recommendedModel` per Task) | No (session model for all) |
 | Quality gates | Manual via `post_delegation_check` action | Automatic via `TeammateIdle` hook |
 | Recovery | Task results preserved | Worktrees survive, teammates lost |
 

--- a/skills/generic/delegation/references/pr-fixes-mode.md
+++ b/skills/generic/delegation/references/pr-fixes-mode.md
@@ -99,7 +99,6 @@ Use TodoWrite to track all fix tasks with priority labels.
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix [P{priority} {severity}]: {issue summary}",
   prompt: `
 # Task: Fix PR Feedback - {issue summary}

--- a/skills/generic/delegation/references/worked-example.md
+++ b/skills/generic/delegation/references/worked-example.md
@@ -41,13 +41,13 @@ Build two self-contained prompts from `implementer-prompt.md` and dispatch in a 
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-001: Email format validator",
   prompt: `# Task: Email Format Validator\n\n## Working Directory\n/project/.worktrees/task-001\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
 
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-002: Domain MX check",
   prompt: `# Task: Domain MX Check\n\n## Working Directory\n/project/.worktrees/task-002\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
@@ -86,7 +86,7 @@ Re-dispatch with fixer prompt in the same worktree:
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus",
+  subagent_type: "general-purpose",
   description: "Fix task-002: DNS mock missing",
   prompt: `# Fix Task: DNS Mock Missing\n\n## Adversarial Verification Posture\nIndependently verify the failure...\n\n## Working Directory\n/project/.worktrees/task-002\n\n## Issue to Fix\n**File:** src/validators/domain.test.ts\n**Problem:** Missing vi.mock('dns') — test makes real network calls\n**Fix:** Add vi.mock('dns') with MX record stub\n\n## Verification\nRun: npm run test:run\nAll tests must pass without network access.`
 })

--- a/skills/generic/delegation/references/workflow-steps.md
+++ b/skills/generic/delegation/references/workflow-steps.md
@@ -40,7 +40,6 @@ TodoWrite({
 // Launch multiple in single message for parallel execution
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 001",
   prompt: "[Full implementer prompt]"
@@ -48,7 +47,6 @@ Task({
 
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 002",
   prompt: "[Full implementer prompt]"

--- a/skills/generic/delegation/references/worktree-enforcement.md
+++ b/skills/generic/delegation/references/worktree-enforcement.md
@@ -64,7 +64,7 @@ When using native isolation:
 | Don't | Do Instead |
 |-------|------------|
 | Make subagents read plan files | Provide full task text in prompt |
-| Use default model for coding | Specify `model: "opus"` |
+| Use default model for coding | Use configured model from `prepare_delegation` |
 | Send sequential Task calls | Batch parallel tasks in one message |
 | Skip worktree for parallel work | Create isolated worktrees |
 | Forget to track in TodoWrite | Update status for every task |

--- a/skills/opencode/delegation/SKILL.md
+++ b/skills/opencode/delegation/SKILL.md
@@ -43,7 +43,7 @@ Rationalization patterns that violate this principle are catalogued in `referenc
 
 **Auto-detection:** tmux + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` present means `agent-team`. Otherwise `subagent`. Override with `/delegate --mode subagent|agent-team`.
 
-**CRITICAL:** Always specify `model: "opus"` for coding tasks (when not using native agent definitions).
+Use the `recommendedModel` from `prepare_delegation` task classifications when available. If no classification exists (e.g., fixer dispatch), omit `model` to inherit the session default.
 
 ### Pre-Dispatch Schema Discovery
 

--- a/skills/opencode/delegation/references/agent-teams-saga.md
+++ b/skills/opencode/delegation/references/agent-teams-saga.md
@@ -103,7 +103,6 @@ exarchos_event append:
     teammateName: {name}
     worktreePath: {path}
     assignedTaskIds: [{taskIds}]
-    model: "opus"
 
 # Execute side effect
 # Note: teammates inherit the lead's permission mode (per Claude Code docs).
@@ -112,7 +111,6 @@ Task:
   subagent_type: "general-purpose"
   team_name: {featureId}
   name: {teammateName}
-  model: "opus"
   prompt: {spawnPrompt}  # See implementer-prompt.md template
 ```
 
@@ -199,7 +197,7 @@ If a compensating action itself fails after 3 retries, mark the workflow with `_
 | **Permissions inherit from lead** | Do NOT set `mode` at spawn -- not respected. All teammates inherit the lead's permission mode. |
 | **Teammates load MCP automatically** | Exarchos MCP tools are available without explicit instruction. The spawn prompt guides WHICH tools to use, not HOW to access them. |
 
-**CRITICAL:** Ensure your session is using the opus model for coding tasks. All teammates inherit the session model -- use Task tool dispatch if you need per-task model selection.
+**Model selection:** Teammates inherit the session model. Model is configured via `.exarchos.yml` and resolved by `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Event Payload Conventions
 

--- a/skills/opencode/delegation/references/fixer-prompt.md
+++ b/skills/opencode/delegation/references/fixer-prompt.md
@@ -109,7 +109,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix: SQL injection vulnerability",
   prompt: `
 # Fix Task: SQL Injection in User Query

--- a/skills/opencode/delegation/references/implementer-prompt.md
+++ b/skills/opencode/delegation/references/implementer-prompt.md
@@ -280,7 +280,6 @@ When done, report:
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Implement user validation",
   prompt: `
 # Task: Implement User Email Validation

--- a/skills/opencode/delegation/references/parallel-strategy.md
+++ b/skills/opencode/delegation/references/parallel-strategy.md
@@ -21,8 +21,8 @@ Group B (depends on Group A):
 
 ```typescript
 // CORRECT: Single message, parallel execution
-Task({ model: "opus", description: "Task 001", prompt: "..." })
-Task({ model: "opus", description: "Task 002", prompt: "..." })
+Task({ description: "Task 001", prompt: "..." })
+Task({ description: "Task 002", prompt: "..." })
 
 // WRONG: Separate messages = sequential
 ```
@@ -59,7 +59,7 @@ Agent Teams supports one team per session. If you need more parallel groups than
 | Parallel dispatch | Multiple `Task()` in one message | Named teammates in agent team |
 | Waiting | `TaskOutput({ block: true })` | `TeammateIdle` hook (fires when teammate idle) |
 | Visibility | None (background) | tmux split panes |
-| Model control | `model: "opus"` per task | Session model for all |
+| Model control | `recommendedModel` from config | Session model for all |
 | Max parallelism | Unlimited | One team, N teammates |
 | Resume on crash | Task results preserved | Teammates lost (worktrees survive) |
 
@@ -73,14 +73,9 @@ TaskOutput({ task_id: "task-002-id" })
 
 ## Model Selection Guide
 
-| Task Type | Model | Reason |
-|-----------|-------|--------|
-| Code implementation | `opus` | Best quality for coding |
-| Code review | `opus` | Thorough analysis |
-| File search/exploration | (default) | Speed over quality |
-| Simple queries | `haiku` | Fast, low cost |
+Model selection is config-driven via `.exarchos.yml`. The `prepare_delegation` action returns a `recommendedModel` in each task classification based on the config cascade: per-agent override, then default-model, then fallback. Override per-task via the Task tool's `model` parameter when needed.
 
-**Note:** When using Agent Teams, all teammates inherit the session's model. Use Task tool dispatch if you need per-task model selection (e.g., `haiku` for simple queries, `opus` for implementation).
+**Note:** When using Agent Teams, all teammates inherit the session's model. Model is resolved from `.exarchos.yml` config via `prepare_delegation`. Use Task tool dispatch if you need per-task model override.
 
 ## Agent Teams Dispatch Pattern
 
@@ -106,7 +101,7 @@ Each teammate receives the full implementer prompt including TDD requirements, f
 | Cross-task deps | Orchestrator manages phases | Shared task list + unblocked task detection |
 | Monitoring | `TaskOutput` polling | tmux panes + `TeammateIdle` hook |
 | State updates | Orchestrator updates state | Hook auto-updates via state bridge |
-| Model per task | Yes (`model: "opus"` per Task) | No (session model for all) |
+| Model per task | Yes (`recommendedModel` per Task) | No (session model for all) |
 | Quality gates | Manual via `post_delegation_check` action | Automatic via `TeammateIdle` hook |
 | Recovery | Task results preserved | Worktrees survive, teammates lost |
 

--- a/skills/opencode/delegation/references/pr-fixes-mode.md
+++ b/skills/opencode/delegation/references/pr-fixes-mode.md
@@ -99,7 +99,6 @@ Use TodoWrite to track all fix tasks with priority labels.
 ```typescript
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   description: "Fix [P{priority} {severity}]: {issue summary}",
   prompt: `
 # Task: Fix PR Feedback - {issue summary}

--- a/skills/opencode/delegation/references/worked-example.md
+++ b/skills/opencode/delegation/references/worked-example.md
@@ -41,13 +41,13 @@ Build two self-contained prompts from `implementer-prompt.md` and dispatch in a 
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-001: Email format validator",
   prompt: `# Task: Email Format Validator\n\n## Working Directory\n/project/.worktrees/task-001\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
 
 Task({
-  subagent_type: "general-purpose", model: "opus", run_in_background: true,
+  subagent_type: "general-purpose", run_in_background: true,
   description: "Implement task-002: Domain MX check",
   prompt: `# Task: Domain MX Check\n\n## Working Directory\n/project/.worktrees/task-002\n\n[Full implementer prompt with TDD, file paths, acceptance criteria...]`
 })
@@ -86,7 +86,7 @@ Re-dispatch with fixer prompt in the same worktree:
 
 ```typescript
 Task({
-  subagent_type: "general-purpose", model: "opus",
+  subagent_type: "general-purpose",
   description: "Fix task-002: DNS mock missing",
   prompt: `# Fix Task: DNS Mock Missing\n\n## Adversarial Verification Posture\nIndependently verify the failure...\n\n## Working Directory\n/project/.worktrees/task-002\n\n## Issue to Fix\n**File:** src/validators/domain.test.ts\n**Problem:** Missing vi.mock('dns') — test makes real network calls\n**Fix:** Add vi.mock('dns') with MX record stub\n\n## Verification\nRun: npm run test:run\nAll tests must pass without network access.`
 })

--- a/skills/opencode/delegation/references/workflow-steps.md
+++ b/skills/opencode/delegation/references/workflow-steps.md
@@ -40,7 +40,6 @@ TodoWrite({
 // Launch multiple in single message for parallel execution
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 001",
   prompt: "[Full implementer prompt]"
@@ -48,7 +47,6 @@ Task({
 
 Task({
   subagent_type: "general-purpose",
-  model: "opus",
   run_in_background: true,
   description: "Implement task 002",
   prompt: "[Full implementer prompt]"

--- a/skills/opencode/delegation/references/worktree-enforcement.md
+++ b/skills/opencode/delegation/references/worktree-enforcement.md
@@ -64,7 +64,7 @@ When using native isolation:
 | Don't | Do Instead |
 |-------|------------|
 | Make subagents read plan files | Provide full task text in prompt |
-| Use default model for coding | Specify `model: "opus"` |
+| Use default model for coding | Use configured model from `prepare_delegation` |
 | Send sequential Task calls | Batch parallel tasks in one message |
 | Skip worktree for parallel work | Create isolated worktrees |
 | Forget to track in TodoWrite | Update status for every task |


### PR DESCRIPTION
## Summary

- Add `agents` config section to `.exarchos.yml` for project-level model policy
- Wire model resolution into `prepare_delegation` task classification via `recommendedModel` field
- Remove all 18 hardcoded `model: "opus"` sites from delegation skill docs
- Regenerate agent markdown with correct model values (`inherit` for implementer/fixer/reviewer)
- Add scaffolder agent to plugin manifest
- Ship opinionated default `.exarchos.yml`

## Changes

### Config layer
- `yaml-schema.ts`: `AgentsConfig` with `AgentModelValue` enum (`opus | sonnet | haiku`) and `AgentSpecIdKey` enum
- `resolve.ts`: `agents` section in `ResolvedProjectConfig` with defaults (`scaffolder: haiku`, `reviewer: sonnet`)
- `yaml-loader.ts`: `agents` added to `SECTION_KEYS` for fallback parsing

### Orchestrate layer
- `prepare-delegation.ts`: `recommendedModel` field on `TaskClassification`, `resolveModel()` helper with cascade (per-agent config → defaultModel → opus), `classifyTask` accepts agent config
- `composite.ts`: `adaptWithCtx` adapter threads `DispatchContext` into `prepare_delegation`

### Agent markdown
- `agents/{implementer,fixer,reviewer}.md`: `model: opus` → `model: inherit` (matches `definitions.ts`)
- `agents/scaffolder.md`: newly generated with `model: sonnet`
- `plugin.json`: scaffolder added to agents array

### Skill docs (9 source files, 63 total with rendered variants)
- Replaced "CRITICAL: Always specify `model: "opus"`" with `recommendedModel` guidance
- All `model: "opus"` removed from examples across 8 reference files

### Default config
- `.exarchos.yml`: opinionated defaults for agents, review dimensions, VCS, workflow, tools, plugins

## Test Plan

- [x] 6 new yaml-schema tests (valid, partial, invalid model, invalid key, omitted, unknown keys)
- [x] 5 new resolve tests (defaults, override, per-agent, partial merge, frozen)
- [x] 6 new classifyTask model resolution tests (config variants, defaults, cascade)
- [x] 3 new handler threading tests (ctx config, no ctx defaults, field presence)
- [x] 2 new agent markdown tests (model matches definition)
- [x] 1 new default config parse test
- [x] All 5402 existing tests pass
- [x] Typecheck clean
- [x] Skills guard in sync

Closes #1113

🤖 Generated with [Claude Code](https://claude.com/claude-code)