### PR TITLE
fix(commands): restore exarchos: namespace on discover/reload/tdd (#1131)

### DIFF
--- a/commands/discover.md
+++ b/commands/discover.md
@@ -1,5 +1,4 @@
 ---
-name: discover
 description: Start a discovery workflow for research and document deliverables
 ---
 

--- a/commands/reload.md
+++ b/commands/reload.md
@@ -1,5 +1,4 @@
 ---
-name: reload
 description: "Manually trigger context reload to recover from context degradation."
 ---
 

--- a/commands/tdd.md
+++ b/commands/tdd.md
@@ -1,5 +1,4 @@
 ---
-name: tdd
 description: "Plan implementation following strict TDD (Red-Green-Refactor)."
 ---
 

--- a/src/namespacing-validation.test.ts
+++ b/src/namespacing-validation.test.ts
@@ -39,14 +39,16 @@ function findUnNamespacedSkillCalls(dir: string): string[] {
 // Explicit `name:` frontmatter in a command file bypasses the plugin
 // namespace — surfaces the command as bare `/X` instead of `/exarchos:X`.
 // Let the plugin loader derive the name from the filename instead.
-const EXPLICIT_NAME_FRONTMATTER = /^---\r?\n(?:[^\n]*\n)*?name:\s*\S+/;
+const FRONTMATTER_BLOCK = /^---\r?\n([\s\S]*?)\r?\n---/m;
+const NAME_KEY = /^name:\s*\S+/m;
 
 function findExplicitNameFrontmatter(dir: string): string[] {
   const files = collectMdFiles(dir);
   const violations: string[] = [];
   for (const file of files) {
     const content = readFileSync(file, 'utf-8');
-    if (EXPLICIT_NAME_FRONTMATTER.test(content)) {
+    const match = FRONTMATTER_BLOCK.exec(content);
+    if (match && NAME_KEY.test(match[1])) {
       violations.push(relative(repoRoot, file));
     }
   }

--- a/src/namespacing-validation.test.ts
+++ b/src/namespacing-validation.test.ts
@@ -36,6 +36,23 @@ function findUnNamespacedSkillCalls(dir: string): string[] {
   return violations;
 }
 
+// Explicit `name:` frontmatter in a command file bypasses the plugin
+// namespace — surfaces the command as bare `/X` instead of `/exarchos:X`.
+// Let the plugin loader derive the name from the filename instead.
+const EXPLICIT_NAME_FRONTMATTER = /^---\r?\n(?:[^\n]*\n)*?name:\s*\S+/;
+
+function findExplicitNameFrontmatter(dir: string): string[] {
+  const files = collectMdFiles(dir);
+  const violations: string[] = [];
+  for (const file of files) {
+    const content = readFileSync(file, 'utf-8');
+    if (EXPLICIT_NAME_FRONTMATTER.test(content)) {
+      violations.push(relative(repoRoot, file));
+    }
+  }
+  return violations;
+}
+
 describe('Command namespacing', () => {
   it('scanCommandFiles_UnNamespacedSkillInvocations_ReportsViolations', () => {
     const violations = findUnNamespacedSkillCalls(join(repoRoot, 'commands'));
@@ -45,5 +62,13 @@ describe('Command namespacing', () => {
   it('scanSkillFiles_UnNamespacedSkillInvocations_ReportsViolations', () => {
     const violations = findUnNamespacedSkillCalls(join(repoRoot, 'skills'));
     expect(violations, `Un-namespaced Skill() calls in skills:\n${violations.join('\n')}`).toHaveLength(0);
+  });
+
+  it('scanCommandFiles_ExplicitNameFrontmatter_ReportsViolations', () => {
+    const violations = findExplicitNameFrontmatter(join(repoRoot, 'commands'));
+    expect(
+      violations,
+      `Command files with explicit \`name:\` frontmatter (breaks plugin namespacing — remove the field so the loader derives it from the filename):\n${violations.join('\n')}`,
+    ).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- Remove explicit `name:` frontmatter from `commands/discover.md`, `commands/reload.md`, `commands/tdd.md` — the field was bypassing the plugin namespace, surfacing the commands as bare `/discover` etc. instead of `/exarchos:discover`
- Add a lint test (`namespacing-validation.test.ts`) that fails if any command file regresses this

## Changes

- `commands/discover.md` — drop `name: discover` line
- `commands/reload.md` — drop `name: reload` line
- `commands/tdd.md` — drop `name: tdd` line
- `src/namespacing-validation.test.ts` — new test `scanCommandFiles_ExplicitNameFrontmatter_ReportsViolations`

## Test Plan

- [x] New test fails RED on the 3 violations, passes GREEN after the frontmatter removal
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 605 pass, 4 skipped, 0 fail

Closes #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)