### PR TITLE
fix(mcp): surface prune/checkpoint/agents/plugins in describe config (#1130)

### DIFF
--- a/servers/exarchos-mcp/src/workflow/describe-config.test.ts
+++ b/servers/exarchos-mcp/src/workflow/describe-config.test.ts
@@ -22,15 +22,10 @@ describe('buildConfigDescription', () => {
 
   it('DescribeConfig_AllSectionsPresent', () => {
     const result = buildConfigDescription(DEFAULTS);
-    expect(result).toHaveProperty('review');
-    expect(result).toHaveProperty('vcs');
-    expect(result).toHaveProperty('workflow');
-    expect(result).toHaveProperty('tools');
-    expect(result).toHaveProperty('hooks');
-    expect(result).toHaveProperty('prune');
-    expect(result).toHaveProperty('checkpoint');
-    expect(result).toHaveProperty('agents');
-    expect(result).toHaveProperty('plugins');
+    // Parity check — any top-level section added to DEFAULTS must appear
+    // in the description output (and vice versa), so future sections can't
+    // silently regress.
+    expect(Object.keys(result).sort()).toEqual(Object.keys(DEFAULTS).sort());
   });
 
   it('DescribeConfig_GateOverride_ShowsGateAndDimension', () => {

--- a/servers/exarchos-mcp/src/workflow/describe-config.test.ts
+++ b/servers/exarchos-mcp/src/workflow/describe-config.test.ts
@@ -27,6 +27,10 @@ describe('buildConfigDescription', () => {
     expect(result).toHaveProperty('workflow');
     expect(result).toHaveProperty('tools');
     expect(result).toHaveProperty('hooks');
+    expect(result).toHaveProperty('prune');
+    expect(result).toHaveProperty('checkpoint');
+    expect(result).toHaveProperty('agents');
+    expect(result).toHaveProperty('plugins');
   });
 
   it('DescribeConfig_GateOverride_ShowsGateAndDimension', () => {
@@ -96,5 +100,73 @@ describe('buildConfigDescription', () => {
     const result = buildConfigDescription(config);
 
     expect(result.hooks.on.source).toBe('.exarchos.yml');
+  });
+
+  it('DescribeConfig_PruneDefaults_AllDefault', () => {
+    const result = buildConfigDescription(DEFAULTS);
+    expect(result.prune.staleAfterDays.value).toBe(14);
+    expect(result.prune.staleAfterDays.source).toBe('default');
+    expect(result.prune.maxBatchSize.value).toBe(25);
+    expect(result.prune.requireDryRun.value).toBe(true);
+    expect(result.prune.malformedHandling.value).toBe('report');
+    expect(result.prune.phaseExclusions.value).toEqual(['delegate', 'review', 'synthesize']);
+  });
+
+  it('DescribeConfig_PruneOverride_ShowsSource', () => {
+    const config = resolveConfig({ prune: { 'stale-after-days': 7 } });
+    const result = buildConfigDescription(config);
+
+    expect(result.prune.staleAfterDays.value).toBe(7);
+    expect(result.prune.staleAfterDays.source).toBe('.exarchos.yml');
+    expect(result.prune.maxBatchSize.source).toBe('default');
+  });
+
+  it('DescribeConfig_CheckpointDefaults_AllDefault', () => {
+    const result = buildConfigDescription(DEFAULTS);
+    expect(result.checkpoint.operationThreshold.value).toBe(20);
+    expect(result.checkpoint.operationThreshold.source).toBe('default');
+    expect(result.checkpoint.enforceOnPhaseTransition.value).toBe(true);
+    expect(result.checkpoint.enforceOnWaveDispatch.value).toBe(true);
+  });
+
+  it('DescribeConfig_CheckpointOverride_ShowsSource', () => {
+    const config = resolveConfig({ checkpoint: { 'operation-threshold': 10 } });
+    const result = buildConfigDescription(config);
+
+    expect(result.checkpoint.operationThreshold.value).toBe(10);
+    expect(result.checkpoint.operationThreshold.source).toBe('.exarchos.yml');
+  });
+
+  it('DescribeConfig_AgentsDefaults_AllDefault', () => {
+    const result = buildConfigDescription(DEFAULTS);
+    expect(result.agents.defaultModel.value).toBe('opus');
+    expect(result.agents.defaultModel.source).toBe('default');
+    expect(result.agents.models.source).toBe('default');
+  });
+
+  it('DescribeConfig_AgentsOverride_ShowsSource', () => {
+    const config = resolveConfig({
+      agents: { 'default-model': 'sonnet', models: { implementer: 'opus' } },
+    });
+    const result = buildConfigDescription(config);
+
+    expect(result.agents.defaultModel.value).toBe('sonnet');
+    expect(result.agents.defaultModel.source).toBe('.exarchos.yml');
+    expect(result.agents.models.source).toBe('.exarchos.yml');
+  });
+
+  it('DescribeConfig_PluginsDefaults_AllDefault', () => {
+    const result = buildConfigDescription(DEFAULTS);
+    expect(result.plugins.axiom.enabled.value).toBe(true);
+    expect(result.plugins.axiom.enabled.source).toBe('default');
+    expect(result.plugins.impeccable.enabled.value).toBe(true);
+  });
+
+  it('DescribeConfig_PluginsOverride_ShowsSource', () => {
+    const config = resolveConfig({ plugins: { axiom: { enabled: false } } });
+    const result = buildConfigDescription(config);
+
+    expect(result.plugins.axiom.enabled.value).toBe(false);
+    expect(result.plugins.axiom.enabled.source).toBe('.exarchos.yml');
   });
 });

--- a/servers/exarchos-mcp/src/workflow/describe-config.ts
+++ b/servers/exarchos-mcp/src/workflow/describe-config.ts
@@ -76,5 +76,38 @@ export function buildConfigDescription(config: ResolvedProjectConfig) {
     hooks: {
       on: annotate(config.hooks.on, DEFAULTS.hooks.on),
     },
+    prune: {
+      staleAfterDays: annotate(config.prune.staleAfterDays, DEFAULTS.prune.staleAfterDays),
+      maxBatchSize: annotate(config.prune.maxBatchSize, DEFAULTS.prune.maxBatchSize),
+      phaseExclusions: annotate(config.prune.phaseExclusions, DEFAULTS.prune.phaseExclusions),
+      malformedHandling: annotate(config.prune.malformedHandling, DEFAULTS.prune.malformedHandling),
+      requireDryRun: annotate(config.prune.requireDryRun, DEFAULTS.prune.requireDryRun),
+    },
+    checkpoint: {
+      operationThreshold: annotate(
+        config.checkpoint.operationThreshold,
+        DEFAULTS.checkpoint.operationThreshold,
+      ),
+      enforceOnPhaseTransition: annotate(
+        config.checkpoint.enforceOnPhaseTransition,
+        DEFAULTS.checkpoint.enforceOnPhaseTransition,
+      ),
+      enforceOnWaveDispatch: annotate(
+        config.checkpoint.enforceOnWaveDispatch,
+        DEFAULTS.checkpoint.enforceOnWaveDispatch,
+      ),
+    },
+    agents: {
+      defaultModel: annotate(config.agents.defaultModel, DEFAULTS.agents.defaultModel),
+      models: annotate(config.agents.models, DEFAULTS.agents.models),
+    },
+    plugins: {
+      axiom: {
+        enabled: annotate(config.plugins.axiom.enabled, DEFAULTS.plugins.axiom.enabled),
+      },
+      impeccable: {
+        enabled: annotate(config.plugins.impeccable.enabled, DEFAULTS.plugins.impeccable.enabled),
+      },
+    },
   };
 }


### PR DESCRIPTION
## Summary

- Extend `buildConfigDescription` to emit `prune`, `checkpoint`, `agents`, and `plugins` sections — all four were present in `ResolvedProjectConfig` but silently dropped from the describe response
- Discovered scope: filed #1130 for 3 sections; fix also covers `plugins` (same shape of bug)
- Each field annotated with `source` (default vs `.exarchos.yml`) per existing pattern

## Changes

- `servers/exarchos-mcp/src/workflow/describe-config.ts` — 33 lines added, mirrors the existing section-by-section annotate pattern
- `servers/exarchos-mcp/src/workflow/describe-config.test.ts` — 9 new tests (section presence + default/override pairs per section)

## Test Plan

- [x] 9 new tests fail RED before the fix; all pass GREEN after
- [x] Full mcp suite: 5499 pass, 0 fail, 21 skipped (368 test files)
- [x] Typecheck clean

Closes #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)