### PR TITLE
fix(doctor): detect plugin-installed exarchos MCP (#1128)

### DIFF
--- a/servers/exarchos-mcp/src/runtime/agent-environment-detector.test.ts
+++ b/servers/exarchos-mcp/src/runtime/agent-environment-detector.test.ts
@@ -114,6 +114,98 @@ describe('detectAgentEnvironments — claude-code', () => {
     expect(claude.mcpRegistered).toBe(false);
   });
 
+  it('DetectAgentEnvironments_ExarchosPluginInstalledAndManifestWiresMcp_ReturnsMcpRegisteredTrue', async () => {
+    // Regression: #1128. Plugin-marketplace install is exarchos's primary
+    // distribution path — the claude-code MCP is wired via the plugin
+    // manifest, not the top-level `~/.claude.json`. The detector must
+    // consult `installed_plugins.json` + the per-plugin manifest.
+    const home = '/tmp/home-plugin-installed';
+    const claudeJson = `${home}/.claude.json`;
+    const installedPluginsJson = `${home}/.claude/plugins/installed_plugins.json`;
+    const pluginInstallPath = `${home}/.claude/plugins/cache/lvlup-sw/exarchos/2.8.0`;
+    const pluginManifest = `${pluginInstallPath}/.claude-plugin/plugin.json`;
+
+    const claudeJsonBody = JSON.stringify({ mcpServers: {} });
+    const installedPluginsBody = JSON.stringify({
+      version: 2,
+      plugins: {
+        'exarchos@lvlup-sw': [
+          { scope: 'user', installPath: pluginInstallPath, version: '2.8.0' },
+        ],
+      },
+    });
+    const manifestBody = JSON.stringify({
+      name: 'exarchos',
+      version: '2.8.0',
+      mcpServers: { exarchos: { command: 'node' } },
+    });
+
+    const result = await detectAgentEnvironments({
+      fs: mapFs({
+        [claudeJson]: claudeJsonBody,
+        [installedPluginsJson]: installedPluginsBody,
+        [pluginManifest]: manifestBody,
+      }),
+      home: () => home,
+      cwd: () => '/tmp/proj',
+    });
+
+    const claude = result.find((r) => r.name === 'claude-code')!;
+    expect(claude.configPresent).toBe(true);
+    expect(claude.configValid).toBe(true);
+    expect(claude.mcpRegistered).toBe(true);
+  });
+
+  it('DetectAgentEnvironments_ExarchosPluginInstalledButManifestMissingMcp_ReturnsMcpRegisteredFalse', async () => {
+    const home = '/tmp/home-plugin-no-mcp';
+    const claudeJson = `${home}/.claude.json`;
+    const installedPluginsJson = `${home}/.claude/plugins/installed_plugins.json`;
+    const pluginInstallPath = `${home}/.claude/plugins/cache/lvlup-sw/exarchos/2.8.0`;
+    const pluginManifest = `${pluginInstallPath}/.claude-plugin/plugin.json`;
+
+    const installedPluginsBody = JSON.stringify({
+      version: 2,
+      plugins: {
+        'exarchos@lvlup-sw': [
+          { scope: 'user', installPath: pluginInstallPath, version: '2.8.0' },
+        ],
+      },
+    });
+    const manifestBody = JSON.stringify({ name: 'exarchos', version: '2.8.0' });
+
+    const result = await detectAgentEnvironments({
+      fs: mapFs({
+        [claudeJson]: JSON.stringify({ mcpServers: {} }),
+        [installedPluginsJson]: installedPluginsBody,
+        [pluginManifest]: manifestBody,
+      }),
+      home: () => home,
+      cwd: () => '/tmp/proj',
+    });
+
+    const claude = result.find((r) => r.name === 'claude-code')!;
+    expect(claude.mcpRegistered).toBe(false);
+  });
+
+  it('DetectAgentEnvironments_InstalledPluginsJsonMalformed_DoesNotThrowAndMcpStaysFalse', async () => {
+    const home = '/tmp/home-plugin-bad-json';
+    const claudeJson = `${home}/.claude.json`;
+    const installedPluginsJson = `${home}/.claude/plugins/installed_plugins.json`;
+
+    const result = await detectAgentEnvironments({
+      fs: mapFs({
+        [claudeJson]: JSON.stringify({ mcpServers: {} }),
+        [installedPluginsJson]: '{not-json',
+      }),
+      home: () => home,
+      cwd: () => '/tmp/proj',
+    });
+
+    const claude = result.find((r) => r.name === 'claude-code')!;
+    expect(claude.configPresent).toBe(true);
+    expect(claude.mcpRegistered).toBe(false);
+  });
+
   it('DetectAgentEnvironments_ClaudeJsonMalformed_ReturnsConfigValidFalse', async () => {
     const home = '/tmp/home-claude-bad';
     const claudeJson = `${home}/.claude.json`;

--- a/servers/exarchos-mcp/src/runtime/agent-environment-detector.ts
+++ b/servers/exarchos-mcp/src/runtime/agent-environment-detector.ts
@@ -109,7 +109,16 @@ async function probeRuntime(
 
   if (name === 'claude-code') {
     const probed = await probeJsonMcpConfig(fs, configPath);
-    return { name, configPath, ...probed, skillsDir: path.join(home, '.claude', 'skills') };
+    const mcpRegistered =
+      probed.mcpRegistered || (await probeExarchosPluginInstall(fs, home));
+    return {
+      name,
+      configPath,
+      configPresent: probed.configPresent,
+      configValid: probed.configValid,
+      mcpRegistered,
+      skillsDir: path.join(home, '.claude', 'skills'),
+    };
   }
   if (name === 'cursor' || name === 'opencode') {
     const probed = await probeJsonMcpConfig(fs, configPath);
@@ -163,6 +172,66 @@ async function probeJsonMcpConfig(
     return { configPresent: true, configValid: true, mcpRegistered };
   } catch {
     return { configPresent: true, configValid: false, mcpRegistered: false };
+  }
+}
+
+/**
+ * Plugin-marketplace install is exarchos's primary distribution path for
+ * claude-code. When installed via marketplace, the MCP server is wired
+ * through the plugin manifest (`<installPath>/.claude-plugin/plugin.json`
+ * → `mcpServers.exarchos`), never through the top-level `~/.claude.json`.
+ * This probe inspects `installed_plugins.json` + the per-plugin manifest
+ * so `exarchos doctor` doesn't false-negative the common install path.
+ *
+ * Returns `true` iff at least one installed plugin named `exarchos@*` has
+ * a manifest declaring `mcpServers.exarchos`. Returns `false` on any
+ * failure (missing file, malformed JSON, etc.) — absence is never a
+ * runtime error.
+ */
+async function probeExarchosPluginInstall(fs: DetectorFs, home: string): Promise<boolean> {
+  const installedPluginsPath = path.join(home, '.claude', 'plugins', 'installed_plugins.json');
+  const raw = await readOrNull(fs, installedPluginsPath);
+  if (raw === null) return false;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return false;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return false;
+
+  const plugins = (parsed as { plugins?: unknown }).plugins;
+  if (typeof plugins !== 'object' || plugins === null) return false;
+
+  for (const [key, value] of Object.entries(plugins as Record<string, unknown>)) {
+    if (!key.startsWith('exarchos@')) continue;
+    if (!Array.isArray(value)) continue;
+    for (const entry of value) {
+      if (typeof entry !== 'object' || entry === null) continue;
+      const installPath = (entry as { installPath?: unknown }).installPath;
+      if (typeof installPath !== 'string') continue;
+      const manifestPath = path.join(installPath, '.claude-plugin', 'plugin.json');
+      if (await manifestWiresExarchosMcp(fs, manifestPath)) return true;
+    }
+  }
+  return false;
+}
+
+async function manifestWiresExarchosMcp(fs: DetectorFs, manifestPath: string): Promise<boolean> {
+  const raw = await readOrNull(fs, manifestPath);
+  if (raw === null) return false;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== 'object' || parsed === null) return false;
+    const mcpServers = (parsed as { mcpServers?: unknown }).mcpServers;
+    return (
+      typeof mcpServers === 'object' &&
+      mcpServers !== null &&
+      'exarchos' in (mcpServers as Record<string, unknown>)
+    );
+  } catch {
+    return false;
   }
 }
 

--- a/servers/exarchos-mcp/src/runtime/agent-environment-detector.ts
+++ b/servers/exarchos-mcp/src/runtime/agent-environment-detector.ts
@@ -190,7 +190,12 @@ async function probeJsonMcpConfig(
  */
 async function probeExarchosPluginInstall(fs: DetectorFs, home: string): Promise<boolean> {
   const installedPluginsPath = path.join(home, '.claude', 'plugins', 'installed_plugins.json');
-  const raw = await readOrNull(fs, installedPluginsPath);
+  let raw: string | null;
+  try {
+    raw = await readOrNull(fs, installedPluginsPath);
+  } catch {
+    return false;
+  }
   if (raw === null) return false;
 
   let parsed: unknown;
@@ -219,7 +224,12 @@ async function probeExarchosPluginInstall(fs: DetectorFs, home: string): Promise
 }
 
 async function manifestWiresExarchosMcp(fs: DetectorFs, manifestPath: string): Promise<boolean> {
-  const raw = await readOrNull(fs, manifestPath);
+  let raw: string | null;
+  try {
+    raw = await readOrNull(fs, manifestPath);
+  } catch {
+    return false;
+  }
   if (raw === null) return false;
   try {
     const parsed = JSON.parse(raw) as unknown;


### PR DESCRIPTION
## Summary

- `agent-environment-detector` now recognizes exarchos as MCP-registered when installed via the Claude Code plugin marketplace (primary distribution path per CLAUDE.md)
- Previously the detector inspected only `~/.claude.json` top-level `mcpServers`, producing a false-negative "exarchos not registered" warning for everyone who installed via the documented path
- The probe reads `~/.claude/plugins/installed_plugins.json`, locates any `exarchos@*` entry, and verifies the per-plugin manifest (`<installPath>/.claude-plugin/plugin.json`) declares `mcpServers.exarchos`

## Changes

- `servers/exarchos-mcp/src/runtime/agent-environment-detector.ts` — claude-code branch ORs the existing top-level check with `probeExarchosPluginInstall()`. Pure with respect to the injected `DetectorFs`; no new module globals. Any failure (missing file, malformed JSON, absent manifest) collapses to `false` — absence is never a runtime error.
- `servers/exarchos-mcp/src/runtime/agent-environment-detector.test.ts` — 3 new tests: positive path, manifest-without-mcpServers negative, malformed-`installed_plugins.json` graceful degradation.

## Live verification

```
before: { "status": "Warning", "message": "exarchos not registered in claude-code (/home/reedsalus/.claude.json)" }
after:  { "status": "Pass",    "message": "exarchos registered in 1 agent runtime(s): claude-code" }
```

## Test Plan

- [x] 3 new tests RED → GREEN
- [x] `src/orchestrate/doctor/**` — 45 tests pass (downstream check suite)
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 5494 pass, 21 skipped, 0 fail
- [x] Live repro via `node dist/exarchos.js doctor --format json` on a real plugin-marketplace install

Closes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)