### PR TITLE
fix(mcp): dispatch guards — preflight events + current-branch check + safer fallback (#1129)

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -406,12 +406,12 @@ describe('StackEnqueuedData', () => {
 
 describe('EventTypes', () => {
   it('EventTypes_CountMatchesRegisteredTypes', () => {
-    // Locked to the current registered-type count. Bumped to 69 with
-    // the addition of checkpoint enforcement events
-    // (checkpoint.enforced, checkpoint.state_missing).
+    // Locked to the current registered-type count. Bumped to 71 with
+    // the addition of preflight events (preflight.executed,
+    // preflight.blocked) — the dispatch-guard emission fix from #1129.
     // When new event types are added, bump this number alongside
     // their registration in `event-store/schemas.ts`.
-    expect(EventTypes).toHaveLength(69);
+    expect(EventTypes).toHaveLength(71);
   });
 
   it('should include workflow-level types', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -460,7 +460,7 @@ describe('EventTypes', () => {
   });
 
   it('EventTypes_HasExpectedCount', () => {
-    expect(EventTypes).toHaveLength(69);
+    expect(EventTypes).toHaveLength(71);
   });
 
   it('EventTypes_IncludesSessionTagged', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -95,6 +95,17 @@ describe('EVENT_EMISSION_REGISTRY', () => {
       expect(EVENT_EMISSION_REGISTRY[eventType]).toBe('auto');
     }
   });
+
+  it('EventTypes_PreflightEventsRegistered_BothNamesPresent', () => {
+    // Regression: #1129. `prepare_delegation` emits preflight.executed and
+    // preflight.blocked, but without registration the event store rejects
+    // the append — and fire-and-forget `.catch(()=>{})` silently swallows
+    // the rejection. Every preflight event ends up in the bit bucket.
+    expect(EventTypes).toContain('preflight.executed');
+    expect(EventTypes).toContain('preflight.blocked');
+    expect(EVENT_EMISSION_REGISTRY['preflight.executed']).toBe('auto');
+    expect(EVENT_EMISSION_REGISTRY['preflight.blocked']).toBe('auto');
+  });
 });
 
 // ─── T2: EVENT_DATA_SCHEMAS map ─────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -74,6 +74,8 @@ export const EventTypes = [
   'init.executed',
   'checkpoint.enforced',
   'checkpoint.state_missing',
+  'preflight.executed',
+  'preflight.blocked',
 ] as const;
 
 export type EventType = typeof EventTypes[number];
@@ -242,6 +244,8 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   // auto — emitted by checkpoint enforcement gate
   'checkpoint.enforced': 'auto',
   'checkpoint.state_missing': 'auto',
+  'preflight.executed': 'auto',
+  'preflight.blocked': 'auto',
 
   // planned — schema exists, not yet emitted in production
   'eval.run.started': 'planned',

--- a/servers/exarchos-mcp/src/orchestrate/dispatch-guard.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/dispatch-guard.test.ts
@@ -4,6 +4,8 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   validateBranchAncestry,
   assertMainWorktree,
+  assertCurrentBranchNotProtected,
+  getCurrentBranch,
 } from './dispatch-guard.js';
 import type { AncestryResult, WorktreeAssertionResult } from './dispatch-guard.js';
 
@@ -129,5 +131,59 @@ describe('assertMainWorktree', () => {
     // Assert
     expect(result.isMain).toBe(true);
     expect(result.actual).toBe(customPath);
+  });
+});
+
+// ─── getCurrentBranch ────────────────────────────────────────────────────────
+
+describe('getCurrentBranch', () => {
+  it('getCurrentBranch_OnFeatureBranch_ReturnsBranchName', () => {
+    const gitExec = vi.fn().mockReturnValue('feature/my-branch\n');
+    expect(getCurrentBranch(gitExec)).toBe('feature/my-branch');
+    expect(gitExec).toHaveBeenCalledWith(['rev-parse', '--abbrev-ref', 'HEAD']);
+  });
+
+  it('getCurrentBranch_GitCommandFails_ReturnsNull', () => {
+    const gitExec = vi.fn().mockImplementation(() => {
+      throw new Error('fatal: not a git repository');
+    });
+    expect(getCurrentBranch(gitExec)).toBeNull();
+  });
+
+  it('getCurrentBranch_DetachedHead_ReturnsHead', () => {
+    // `git rev-parse --abbrev-ref HEAD` returns 'HEAD' on detached HEAD —
+    // callers treat this the same as any non-protected branch name.
+    const gitExec = vi.fn().mockReturnValue('HEAD\n');
+    expect(getCurrentBranch(gitExec)).toBe('HEAD');
+  });
+});
+
+// ─── assertCurrentBranchNotProtected ─────────────────────────────────────────
+
+describe('assertCurrentBranchNotProtected', () => {
+  it('assertCurrentBranchNotProtected_OnMain_ReturnsBlocked', () => {
+    const result = assertCurrentBranchNotProtected('main');
+    expect(result.blocked).toBe(true);
+    expect(result.reason).toBe('current-branch-protected');
+    expect(result.currentBranch).toBe('main');
+  });
+
+  it('assertCurrentBranchNotProtected_OnMaster_ReturnsBlocked', () => {
+    const result = assertCurrentBranchNotProtected('master');
+    expect(result.blocked).toBe(true);
+    expect(result.reason).toBe('current-branch-protected');
+  });
+
+  it('assertCurrentBranchNotProtected_OnFeatureBranch_ReturnsNotBlocked', () => {
+    const result = assertCurrentBranchNotProtected('feature/dispatch-guards');
+    expect(result.blocked).toBe(false);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('assertCurrentBranchNotProtected_OnNullBranch_ReturnsNotBlocked', () => {
+    // Null means we couldn't determine current branch — absence of signal
+    // shouldn't be upgraded to a block. Other guards (ancestry) still run.
+    const result = assertCurrentBranchNotProtected(null);
+    expect(result.blocked).toBe(false);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/dispatch-guard.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/dispatch-guard.test.ts
@@ -150,11 +150,19 @@ describe('getCurrentBranch', () => {
     expect(getCurrentBranch(gitExec)).toBeNull();
   });
 
-  it('getCurrentBranch_DetachedHead_ReturnsHead', () => {
-    // `git rev-parse --abbrev-ref HEAD` returns 'HEAD' on detached HEAD —
-    // callers treat this the same as any non-protected branch name.
+  it('getCurrentBranch_DetachedHead_ReturnsNull', () => {
+    // `git rev-parse --abbrev-ref HEAD` returns the literal string 'HEAD'
+    // when HEAD is detached. Collapse to null so downstream guards treat
+    // it as "no current branch" rather than a branch literally named
+    // "HEAD" — otherwise protected-branch checks and fallback logic get
+    // a meaningless string instead of the absence signal they expect.
     const gitExec = vi.fn().mockReturnValue('HEAD\n');
-    expect(getCurrentBranch(gitExec)).toBe('HEAD');
+    expect(getCurrentBranch(gitExec)).toBeNull();
+  });
+
+  it('getCurrentBranch_EmptyOutput_ReturnsNull', () => {
+    const gitExec = vi.fn().mockReturnValue('\n');
+    expect(getCurrentBranch(gitExec)).toBeNull();
   });
 });
 

--- a/servers/exarchos-mcp/src/orchestrate/dispatch-guard.ts
+++ b/servers/exarchos-mcp/src/orchestrate/dispatch-guard.ts
@@ -97,10 +97,17 @@ export async function validateBranchAncestry(
  * Resolve the current checked-out branch via `git rev-parse --abbrev-ref
  * HEAD`. Returns `null` on any git failure — callers treat absence as a
  * non-signal, not as a block.
+ *
+ * On detached HEAD, `git rev-parse --abbrev-ref HEAD` returns the literal
+ * string "HEAD". Collapse that to `null` so downstream guards (protected-
+ * branch refusal, prepare-delegation fallback) treat it as "no current
+ * branch" rather than a branch literally named "HEAD".
  */
 export function getCurrentBranch(gitExec: GitExec): string | null {
   try {
-    return gitExec(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
+    const branch = gitExec(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
+    if (branch === '' || branch === 'HEAD') return null;
+    return branch;
   } catch {
     return null;
   }

--- a/servers/exarchos-mcp/src/orchestrate/dispatch-guard.ts
+++ b/servers/exarchos-mcp/src/orchestrate/dispatch-guard.ts
@@ -21,6 +21,21 @@ export interface WorktreeAssertionResult {
   readonly expected: string;
 }
 
+export interface CurrentBranchProtectionResult {
+  readonly blocked: boolean;
+  readonly reason?: 'current-branch-protected';
+  readonly currentBranch?: string;
+}
+
+export type GitExec = (args: readonly string[]) => string;
+
+/**
+ * Branches that dispatch must never run *from*. The guard refuses
+ * `prepare_delegation` when HEAD points at any of these — you must
+ * check out a feature branch first.
+ */
+const PROTECTED_CURRENT_BRANCHES: ReadonlySet<string> = new Set(['main', 'master']);
+
 // ─── Branch Ancestry Validation ─────────────────────────────────────────────
 
 /**
@@ -74,6 +89,44 @@ export async function validateBranchAncestry(
   }
 
   return { passed: true, checks: ['ancestry'] };
+}
+
+// ─── Current Branch ─────────────────────────────────────────────────────────
+
+/**
+ * Resolve the current checked-out branch via `git rev-parse --abbrev-ref
+ * HEAD`. Returns `null` on any git failure — callers treat absence as a
+ * non-signal, not as a block.
+ */
+export function getCurrentBranch(gitExec: GitExec): string | null {
+  try {
+    return gitExec(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Refuse dispatch when HEAD is on a protected base branch (main / master).
+ * Distinct from the ancestry check: ancestry tests "does integrationBranch
+ * descend from main?" which trivially passes when integrationBranch IS
+ * main. The stated "never dispatch from main" rule needs to inspect
+ * current HEAD, not workflow-state metadata.
+ *
+ * Accepts `null` (current branch unknown) and returns "not blocked" — the
+ * absence of a signal is not grounds to escalate to a refusal.
+ */
+export function assertCurrentBranchNotProtected(
+  currentBranch: string | null,
+): CurrentBranchProtectionResult {
+  if (currentBranch !== null && PROTECTED_CURRENT_BRANCHES.has(currentBranch)) {
+    return {
+      blocked: true,
+      reason: 'current-branch-protected',
+      currentBranch,
+    };
+  }
+  return { blocked: false };
 }
 
 // ─── Worktree Assertion ─────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -30,6 +30,8 @@ vi.mock('../telemetry/telemetry-queries.js', () => ({
 vi.mock('./dispatch-guard.js', () => ({
   validateBranchAncestry: vi.fn().mockResolvedValue({ passed: true, checks: ['ancestry'] }),
   assertMainWorktree: vi.fn().mockReturnValue({ isMain: true, actual: '/repo', expected: 'main worktree (no .claude/worktrees/ in path)' }),
+  getCurrentBranch: vi.fn().mockReturnValue('feature/test-branch'),
+  assertCurrentBranchNotProtected: vi.fn().mockReturnValue({ blocked: false }),
 }));
 
 vi.mock('../workflow/checkpoint.js', () => ({
@@ -46,7 +48,12 @@ import { generateQualityHints } from '../quality/hints.js';
 import { emitGateEvent } from './gate-utils.js';
 import { handlePrepareDelegation, classifyTask } from './prepare-delegation.js';
 import type { TaskClassification } from './prepare-delegation.js';
-import { validateBranchAncestry, assertMainWorktree } from './dispatch-guard.js';
+import {
+  validateBranchAncestry,
+  assertMainWorktree,
+  getCurrentBranch,
+  assertCurrentBranchNotProtected,
+} from './dispatch-guard.js';
 import { shouldEnforceCheckpoint } from '../workflow/checkpoint.js';
 import { DEFAULTS } from '../config/resolve.js';
 
@@ -729,6 +736,71 @@ describe('handlePrepareDelegation', () => {
     expect(data.reason).toBe('worktree-location');
     expect(data.actual).toBe('/repo/.claude/worktrees/agent-abc123');
     expect(data.expected).toBeDefined();
+  });
+
+  // ─── #1129 C: Current-Branch Protection ────────────────────────────────
+  it('handlePrepareDelegation_OnProtectedBranch_ReturnsBlockedAndEmitsPreflightBlocked', async () => {
+    // Arrange: current branch is main (protected)
+    const state = readyWorkflowState();
+    const { mockStore } = setupMaterializer(state);
+    vi.mocked(getCurrentBranch).mockReturnValueOnce('main');
+    vi.mocked(assertCurrentBranchNotProtected).mockReturnValueOnce({
+      blocked: true,
+      reason: 'current-branch-protected',
+      currentBranch: 'main',
+    });
+    const args = { featureId: 'test-feature' };
+
+    // Act
+    const result = await handlePrepareDelegation(args, STATE_DIR);
+
+    // Assert: blocked with the dedicated reason — ancestry never even runs
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      blocked: boolean;
+      reason: string;
+      currentBranch: string;
+    };
+    expect(data.blocked).toBe(true);
+    expect(data.reason).toBe('current-branch-protected');
+    expect(data.currentBranch).toBe('main');
+    expect(vi.mocked(validateBranchAncestry)).not.toHaveBeenCalled();
+
+    const preflightEvent = mockStore.append.mock.calls.find(
+      (call: unknown[]) => (call[1] as { type: string }).type === 'preflight.blocked',
+    );
+    expect(preflightEvent).toBeDefined();
+    const eventData = (preflightEvent![1] as { type: string; data: Record<string, unknown> }).data;
+    expect(eventData.reason).toBe('current-branch-protected');
+  });
+
+  // ─── #1129 D: integrationBranch fallback safety ─────────────────────────
+  it('handlePrepareDelegation_IntegrationBranchUnset_UsesCurrentBranchNotFeatureId', async () => {
+    // Arrange: synthesis.integrationBranch unset; current branch known
+    const state = readyWorkflowState() as ReturnType<typeof readyWorkflowState> & {
+      synthesis?: { integrationBranch?: string };
+    };
+    delete state.synthesis;
+    setupMaterializer(state);
+    vi.mocked(getCurrentBranch).mockReturnValueOnce('feature/real-branch');
+    vi.mocked(validateBranchAncestry).mockResolvedValue({
+      passed: true,
+      checks: ['ancestry'],
+    });
+    vi.mocked(generateQualityHints).mockReturnValue([]);
+    const args = {
+      featureId: 'dogfood-v280',  // not a real branch name
+      tasks: [{ id: 'task-1', title: 'x' }],
+    };
+
+    // Act
+    await handlePrepareDelegation(args, STATE_DIR);
+
+    // Assert: ancestry ran against current branch, never against featureId
+    const call = vi.mocked(validateBranchAncestry).mock.calls[0];
+    expect(call).toBeDefined();
+    expect(call![0]).toBe('feature/real-branch');
+    expect(call![0]).not.toBe('dogfood-v280');
   });
 
   it('handlePrepareDelegation_InMainWorktree_ProceedsNormally', async () => {

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -16,7 +16,12 @@ import {
   getOrCreateEventStore,
   queryDeltaEvents,
 } from '../views/tools.js';
-import { validateBranchAncestry, assertMainWorktree } from './dispatch-guard.js';
+import {
+  validateBranchAncestry,
+  assertMainWorktree,
+  getCurrentBranch,
+  assertCurrentBranchNotProtected,
+} from './dispatch-guard.js';
 import type { AncestryResult } from './dispatch-guard.js';
 import {
   WORKFLOW_STATE_VIEW,
@@ -260,8 +265,40 @@ export async function handlePrepareDelegation(
       wsEvents,
     );
 
-    const integrationBranch = workflowState.synthesis?.integrationBranch ?? args.featureId;
     const gitExec = createGitExec();
+    const currentBranch = getCurrentBranch(gitExec);
+
+    // #1129 C: refuse dispatch from a protected base branch (main/master).
+    // Runs before ancestry because 'integrationBranch descends from main'
+    // trivially passes when HEAD is on main — that case must be caught
+    // at HEAD inspection, not ancestry.
+    const protectionResult = assertCurrentBranchNotProtected(currentBranch);
+    if (protectionResult.blocked) {
+      store.append(streamId, {
+        type: 'preflight.blocked',
+        data: {
+          reason: protectionResult.reason,
+          details: {
+            currentBranch: protectionResult.currentBranch,
+          },
+        },
+      }).catch(() => { /* fire-and-forget */ });
+
+      return {
+        success: true,
+        data: {
+          blocked: true,
+          reason: protectionResult.reason,
+          currentBranch: protectionResult.currentBranch,
+        },
+      };
+    }
+
+    // #1129 D: derive integration branch from workflow state, falling
+    // back to the current checked-out branch — never to featureId, which
+    // is a different namespace and produces misleading git-errors.
+    const integrationBranch =
+      workflowState.synthesis?.integrationBranch ?? currentBranch ?? args.featureId;
     const ancestryResult = await validateBranchAncestry(
       integrationBranch,
       ['main'],


### PR DESCRIPTION
## Summary

Three co-located regressions in the PR #1124 dispatch guards, fixed in TDD order.

- **A — preflight events silently dropped**: `preflight.executed` and `preflight.blocked` were not in `EventTypes`, so the store rejected every append; fire-and-forget `.catch(()=>{})` hid the rejection. The guards emitted zero observable signal in production, even though mock-based tests claimed otherwise.
- **C — "dispatch from main" undetectable**: the ancestry guard checks "main is ancestor of integrationBranch" — trivially true when integrationBranch IS main. A new guard inspects current HEAD via `git rev-parse --abbrev-ref HEAD` and refuses dispatch from `main` / `master` before ancestry even runs.
- **D — featureId-as-branch fallback**: when `synthesis.integrationBranch` was unset, the code coerced `featureId` into a branch name, producing misleading `fatal: Not a valid object name <featureId>` errors. The fallback now resolves to the current checked-out branch; featureId is the last-resort only when HEAD can't be determined.

All four TDD cycles (A registration, B helper, C integration, D fallback) are co-located here rather than split into 4 PRs — they share a single hotspot (`dispatch-guard.ts` + `prepare-delegation.ts`) and reviewing them independently would be harder than as a unit.

## Changes

- `servers/exarchos-mcp/src/event-store/schemas.ts` — register `preflight.executed` + `preflight.blocked` in `EventTypes` and `EVENT_EMISSION_REGISTRY`
- `servers/exarchos-mcp/src/orchestrate/dispatch-guard.ts` — new `getCurrentBranch(gitExec)` and `assertCurrentBranchNotProtected(currentBranch)` pure helpers. Protected set: `{main, master}`
- `servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts` — current-branch protection check runs before ancestry; `integrationBranch` fallback chain is now `synthesis.integrationBranch → currentBranch → featureId`
- Tests: 11 new tests across 3 files (4 guard-unit + 5 handler-integration + 2 schema registration)

## Test plan

- [x] `npm run test:run` — 5500+ pass, 0 fail across the full mcp suite
- [x] `npm run typecheck` — clean
- [x] All RED tests written first, confirmed failing for the documented reason, then passed after the GREEN commits
- [x] `npm run build` — dist rebuilt; behavior confirmed correct via tests (live MCP session runs pre-rebuild code until restart)

## Out of scope

- Broader hardening of the `.catch(() => { /* fire-and-forget */ })` pattern across the codebase. The immediate bug (unregistered event types) is fixed; a follow-up should add stderr logging so future silent-drop classes surface.
- The "tests mock the boundary they're supposed to exercise" meta-bug from the v2.8.0 dogfood. Warrants a separate design issue (MCP integration harness).

Closes #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)