### PR TITLE
fix: rename agent_spec.format → outputFormat + guard registration collisions (#1127)

### DIFF
--- a/documentation/reference/tools/orchestrate.md
+++ b/documentation/reference/tools/orchestrate.md
@@ -360,7 +360,7 @@ Retrieve an agent specification for subagent dispatch. Returns the agent's syste
 {
   "action": "agent_spec",
   "agent": "implementer",
-  "format": "full"
+  "outputFormat": "full"
 }
 ```
 
@@ -368,7 +368,7 @@ Retrieve an agent specification for subagent dispatch. Returns the agent's syste
 |-----------|----------|------|-------------|
 | `agent` | yes | string (enum) | Agent identifier from the registered spec list |
 | `context` | no | object | Key-value pairs for template variable interpolation in prompts |
-| `format` | no | `"full"` \| `"prompt-only"` (default: `"full"`) | `full` returns the complete spec; `prompt-only` returns just the system prompt |
+| `outputFormat` | no | `"full"` \| `"prompt-only"` (default: `"full"`) | `full` returns the complete spec; `prompt-only` returns just the system prompt. Renamed from `format` in #1127 to avoid a registration collision with the `format: "table" \| "json"` parameter on `doctor` and `init`. |
 
 Phases: all. Role: `any`.
 

--- a/servers/exarchos-mcp/src/agents/handler.test.ts
+++ b/servers/exarchos-mcp/src/agents/handler.test.ts
@@ -6,7 +6,7 @@ import { handleAgentSpec, agentSpecSchema } from './handler.js';
 describe('handleAgentSpec', () => {
   it('AgentSpec_ValidAgent_ReturnsFullSpec', async () => {
     // Arrange
-    const args = { agent: 'implementer' as const, format: 'full' as const };
+    const args = { agent: 'implementer' as const, outputFormat: 'full' as const };
 
     // Act
     const result = await handleAgentSpec(args);
@@ -62,7 +62,7 @@ describe('handleAgentSpec', () => {
         requirements: 'Must validate email format',
         filePaths: 'src/login.ts, src/login.test.ts',
       },
-      format: 'full' as const,
+      outputFormat: 'full' as const,
     };
 
     // Act
@@ -87,7 +87,7 @@ describe('handleAgentSpec', () => {
       context: {
         taskDescription: 'Build it',
       },
-      format: 'full' as const,
+      outputFormat: 'full' as const,
     };
 
     // Act
@@ -112,7 +112,7 @@ describe('handleAgentSpec', () => {
         reviewScope: 'PR #42',
         designRequirements: 'DR-1: Must have tests',
       },
-      format: 'prompt-only' as const,
+      outputFormat: 'prompt-only' as const,
     };
 
     // Act
@@ -137,29 +137,29 @@ describe('handleAgentSpec', () => {
 });
 
 describe('agentSpecSchema', () => {
-  it('should accept valid full format', () => {
+  it('should accept valid full outputFormat', () => {
     const result = agentSpecSchema.safeParse({
       agent: 'implementer',
-      format: 'full',
+      outputFormat: 'full',
     });
     expect(result.success).toBe(true);
   });
 
-  it('should accept valid prompt-only format', () => {
+  it('should accept valid prompt-only outputFormat', () => {
     const result = agentSpecSchema.safeParse({
       agent: 'reviewer',
-      format: 'prompt-only',
+      outputFormat: 'prompt-only',
     });
     expect(result.success).toBe(true);
   });
 
-  it('should default format to full', () => {
+  it('should default outputFormat to full', () => {
     const result = agentSpecSchema.safeParse({
       agent: 'fixer',
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.format).toBe('full');
+      expect(result.data.outputFormat).toBe('full');
     }
   });
 

--- a/servers/exarchos-mcp/src/agents/handler.ts
+++ b/servers/exarchos-mcp/src/agents/handler.ts
@@ -16,7 +16,7 @@ const AGENT_IDS = ALL_AGENT_SPECS.map(s => s.id) as [string, ...string[]];
 export const agentSpecSchema = z.object({
   agent: z.enum(AGENT_IDS),
   context: z.record(z.string(), z.string()).optional(),
-  format: z.enum(['full', 'prompt-only']).default('full'),
+  outputFormat: z.enum(['full', 'prompt-only']).default('full'),
 });
 
 type AgentSpecArgs = z.infer<typeof agentSpecSchema>;
@@ -52,7 +52,7 @@ function interpolatePrompt(
 // ─── Handler ────────────────────────────────────────────────────────────────
 
 export async function handleAgentSpec(args: AgentSpecArgs): Promise<ToolResult> {
-  const { agent, context = {}, format = 'full' } = args;
+  const { agent, context = {}, outputFormat = 'full' } = args;
 
   // Find spec by agent ID
   const spec: AgentSpec | undefined = ALL_AGENT_SPECS.find(s => s.id === agent);
@@ -72,7 +72,7 @@ export async function handleAgentSpec(args: AgentSpecArgs): Promise<ToolResult> 
   const { systemPrompt, unresolvedVars } = interpolatePrompt(spec.systemPrompt, context);
 
   // Format: prompt-only
-  if (format === 'prompt-only') {
+  if (outputFormat === 'prompt-only') {
     return {
       success: true,
       data: {

--- a/servers/exarchos-mcp/src/orchestrate/composite.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.test.ts
@@ -419,7 +419,7 @@ describe('handleOrchestrate', () => {
       const args = {
         action: 'agent_spec',
         agent: 'implementer',
-        format: 'full',
+        outputFormat: 'full',
       };
 
       // Act
@@ -428,7 +428,7 @@ describe('handleOrchestrate', () => {
       // Assert
       expect(result).toBe(expected);
       expect(handleAgentSpec).toHaveBeenCalledWith(
-        { agent: 'implementer', format: 'full' },
+        { agent: 'implementer', outputFormat: 'full' },
         STATE_DIR,
       );
     });

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -159,6 +159,83 @@ describe('buildRegistrationSchema', () => {
     expect(() => buildRegistrationSchema(colliding)).toThrow(/collides/);
   });
 
+  it('should throw when two actions share a field whose defaults differ', () => {
+    // Guards the "defaults diverge" arm of describeContractConflict: same
+    // base type (string), no enum, but mismatched defaults would otherwise
+    // let the first declaration silently shadow the second at the
+    // registration boundary.
+    const colliding: readonly ToolAction[] = [
+      {
+        name: 'first',
+        description: 'First action',
+        schema: z.object({ mode: z.string().default('full') }),
+        phases: new Set(['ideate']),
+        roles: new Set(['any']),
+      },
+      {
+        name: 'second',
+        description: 'Second action',
+        schema: z.object({ mode: z.string().default('json') }),
+        phases: new Set(['ideate']),
+        roles: new Set(['any']),
+      },
+    ];
+
+    expect(() => buildRegistrationSchema(colliding)).toThrow(/collides/);
+    expect(() => buildRegistrationSchema(colliding)).toThrow(/Default values differ/);
+  });
+
+  it('should throw when two actions share a literal-valued field with different values', () => {
+    // Regression: before this fix, z.literal was classified as 'other' and
+    // defaults=none on both sides silently passed — two actions could bind
+    // the same field to incompatible literal values without detection.
+    const colliding: readonly ToolAction[] = [
+      {
+        name: 'first',
+        description: 'First',
+        schema: z.object({ tag: z.literal('alpha') }),
+        phases: new Set(['ideate']),
+        roles: new Set(['any']),
+      },
+      {
+        name: 'second',
+        description: 'Second',
+        schema: z.object({ tag: z.literal('beta') }),
+        phases: new Set(['ideate']),
+        roles: new Set(['any']),
+      },
+    ];
+
+    expect(() => buildRegistrationSchema(colliding)).toThrow(/collides/);
+  });
+
+  it('should throw when a union-of-literals field diverges across actions', () => {
+    // Union-of-literals is the hand-rolled form of z.enum(). Same contract
+    // semantics must apply: mismatched value sets must collide.
+    const colliding: readonly ToolAction[] = [
+      {
+        name: 'first',
+        description: 'First',
+        schema: z.object({
+          mode: z.union([z.literal('a'), z.literal('b')]),
+        }),
+        phases: new Set(['ideate']),
+        roles: new Set(['any']),
+      },
+      {
+        name: 'second',
+        description: 'Second',
+        schema: z.object({
+          mode: z.union([z.literal('a'), z.literal('c')]),
+        }),
+        phases: new Set(['ideate']),
+        roles: new Set(['any']),
+      },
+    ];
+
+    expect(() => buildRegistrationSchema(colliding)).toThrow(/collides/);
+  });
+
   it('should allow two actions to share a field when their schemas are structurally identical', () => {
     const compatible: readonly ToolAction[] = [
       {

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -113,6 +113,111 @@ describe('buildRegistrationSchema', () => {
     const schema = buildRegistrationSchema(testActions);
     expect(schema).toBeInstanceOf(z.ZodObject);
   });
+
+  // ─── Collision-detection guard (regression for #1127) ─────────────────────
+
+  it('should throw when two actions declare the same field with incompatible enums', () => {
+    const colliding: readonly ToolAction[] = [
+      {
+        name: 'first',
+        description: 'First action',
+        schema: z.object({ format: z.enum(['full', 'prompt-only']).default('full') }),
+        phases: new Set(['ideate']),
+        roles: new Set(['any']),
+      },
+      {
+        name: 'second',
+        description: 'Second action',
+        schema: z.object({ format: z.enum(['table', 'json']).optional() }),
+        phases: new Set(['ideate']),
+        roles: new Set(['any']),
+      },
+    ];
+
+    expect(() => buildRegistrationSchema(colliding)).toThrow(/collides/);
+    expect(() => buildRegistrationSchema(colliding)).toThrow(/first|second/);
+  });
+
+  it('should throw when two actions declare the same field with incompatible base types', () => {
+    const colliding: readonly ToolAction[] = [
+      {
+        name: 'a',
+        description: 'A',
+        schema: z.object({ limit: z.number().int() }),
+        phases: new Set(['ideate']),
+        roles: new Set(['any']),
+      },
+      {
+        name: 'b',
+        description: 'B',
+        schema: z.object({ limit: z.string() }),
+        phases: new Set(['ideate']),
+        roles: new Set(['any']),
+      },
+    ];
+
+    expect(() => buildRegistrationSchema(colliding)).toThrow(/collides/);
+  });
+
+  it('should allow two actions to share a field when their schemas are structurally identical', () => {
+    const compatible: readonly ToolAction[] = [
+      {
+        name: 'create_pr',
+        description: 'Create',
+        schema: z.object({ prId: z.string().min(1) }),
+        phases: new Set(['ideate']),
+        roles: new Set(['any']),
+      },
+      {
+        name: 'merge_pr',
+        description: 'Merge',
+        schema: z.object({ prId: z.string().min(1) }),
+        phases: new Set(['ideate']),
+        roles: new Set(['any']),
+      },
+    ];
+
+    expect(() => buildRegistrationSchema(compatible)).not.toThrow();
+  });
+
+  it('should not collide on format across the real orchestrate registry (#1127 regression)', () => {
+    const orchestrate = TOOL_REGISTRY.find((t) => t.name === 'exarchos_orchestrate')!;
+    expect(() => buildRegistrationSchema(orchestrate.actions)).not.toThrow();
+  });
+
+  it('should accept doctor format values against the real orchestrate registration schema', () => {
+    const orchestrate = TOOL_REGISTRY.find((t) => t.name === 'exarchos_orchestrate')!;
+    const schema = buildRegistrationSchema(orchestrate.actions);
+
+    // Regression for #1127: before the fix, agent_spec.format (full|prompt-only)
+    // shadowed doctor/init.format (table|json), making these payloads fail
+    // validation at the registered-tool boundary.
+    expect(schema.safeParse({ action: 'doctor' }).success).toBe(true);
+    expect(schema.safeParse({ action: 'doctor', format: 'json' }).success).toBe(true);
+    expect(schema.safeParse({ action: 'doctor', format: 'table' }).success).toBe(true);
+    expect(schema.safeParse({ action: 'init', nonInteractive: true }).success).toBe(true);
+    expect(schema.safeParse({ action: 'init', format: 'json' }).success).toBe(true);
+  });
+
+  it('should expose agent_spec outputFormat on the real orchestrate registration schema', () => {
+    const orchestrate = TOOL_REGISTRY.find((t) => t.name === 'exarchos_orchestrate')!;
+    const schema = buildRegistrationSchema(orchestrate.actions);
+
+    expect(
+      schema.safeParse({
+        action: 'agent_spec',
+        agent: 'implementer',
+        outputFormat: 'full',
+      }).success,
+    ).toBe(true);
+    expect(
+      schema.safeParse({
+        action: 'agent_spec',
+        agent: 'implementer',
+        outputFormat: 'prompt-only',
+      }).success,
+    ).toBe(true);
+  });
 });
 
 // ─── Type Coercion Tests ─────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -138,20 +138,123 @@ export function buildRegistrationSchema(
   const shape: z.ZodRawShape = {
     action: z.enum(actionNames),
   };
+  // Track the first action to declare each field. A later action declaring the
+  // same field with an incompatible enum value set or differing default is a
+  // #1127-class collision — the composite's "first wins" merge silently
+  // shadowed the later declaration at the MCP-registration boundary.
+  // Constraint drift (min/max, pattern, optionality) is allowed: handler-level
+  // schemas re-validate via dispatch(), so "first wins" is harmless there.
+  const provenance = new Map<string, { action: string; contract: FieldContract }>();
 
   for (const action of actions) {
     const fields = action.schema.shape;
     for (const [key, zodType] of Object.entries(fields)) {
-      if (key in shape) continue; // already added from an earlier action
-      // Make all per-action fields optional at the composite level;
-      // individual handlers enforce required fields via their own schemas.
-      // Unwrap preprocess effects for clean JSON Schema generation.
       const field = unwrapPreprocess(zodType as z.ZodTypeAny);
+      const contract = fieldContract(field);
+
+      const prior = provenance.get(key);
+      if (prior) {
+        const conflict = describeContractConflict(prior.contract, contract);
+        if (conflict) {
+          throw new Error(
+            `buildRegistrationSchema: field '${key}' declared by action '${action.name}' collides with the declaration from action '${prior.action}'. ${conflict} ` +
+            `Rename the field in one action (see agent_spec.outputFormat, #1127) or align the declarations.`,
+          );
+        }
+        continue; // compatible — first wins preserved
+      }
+
       shape[key] = field.isOptional() ? field : field.optional();
+      provenance.set(key, { action: action.name, contract });
     }
   }
 
   return z.object(shape).strict();
+}
+
+/**
+ * Contract-level view of a Zod field, capturing only the properties whose
+ * divergence across actions causes MCP-registration-time hazards: the enum
+ * value set and the default value. Base type is tracked solely to distinguish
+ * enum-vs-non-enum collisions. Refinements and optionality are ignored.
+ */
+interface FieldContract {
+  readonly kind: 'enum' | 'string' | 'number' | 'boolean' | 'array' | 'object' | 'other';
+  readonly enumValues: readonly string[] | null; // present iff kind === 'enum'
+  readonly defaultValue: string | null; // JSON-stringified default, null if none
+}
+
+function fieldContract(zodType: z.ZodTypeAny): FieldContract {
+  const inner = unwrapOptional(zodType);
+  const enumValues = extractEnumValues(inner);
+  const defaultValue = extractDefault(inner);
+  return {
+    kind: enumValues ? 'enum' : baseKind(inner),
+    enumValues,
+    defaultValue: defaultValue === undefined ? null : JSON.stringify(defaultValue),
+  };
+}
+
+function baseKind(schema: z.ZodTypeAny): FieldContract['kind'] {
+  let current = schema;
+  if (current instanceof z.ZodDefault) current = current._def.innerType;
+  if (current instanceof z.ZodOptional) current = current._def.innerType;
+  if (current instanceof z.ZodString) return 'string';
+  // Number covers z.number() and z.number().int() — JSON Schema distinguishes
+  // them as number vs integer, but the per-handler schema re-validates
+  // refinements, so at the composite boundary they're the same contract.
+  if (current instanceof z.ZodNumber) return 'number';
+  if (current instanceof z.ZodBoolean) return 'boolean';
+  if (current instanceof z.ZodArray) return 'array';
+  if (current instanceof z.ZodObject || current instanceof z.ZodRecord) return 'object';
+  return 'other';
+}
+
+function unwrapOptional(schema: z.ZodTypeAny): z.ZodTypeAny {
+  let current = schema;
+  // Peel Optional and Nullable wrappers. Keep Default wrappers — the default
+  // is a contract-level attribute we explicitly want to inspect.
+  while (current instanceof z.ZodOptional || current instanceof z.ZodNullable) {
+    current = current._def.innerType;
+  }
+  return current;
+}
+
+function extractEnumValues(schema: z.ZodTypeAny): readonly string[] | null {
+  let current = schema;
+  if (current instanceof z.ZodDefault) current = current._def.innerType;
+  if (current instanceof z.ZodOptional) current = current._def.innerType;
+  if (current instanceof z.ZodEnum) {
+    return [...(current._def.values as readonly string[])].sort();
+  }
+  return null;
+}
+
+function extractDefault(schema: z.ZodTypeAny): unknown {
+  if (schema instanceof z.ZodDefault) {
+    return schema._def.defaultValue();
+  }
+  return undefined;
+}
+
+function describeContractConflict(a: FieldContract, b: FieldContract): string | null {
+  if (a.kind !== b.kind) {
+    return `Base types differ: ${a.kind} vs ${b.kind}.`;
+  }
+  if (a.kind === 'enum') {
+    if (
+      !a.enumValues ||
+      !b.enumValues ||
+      a.enumValues.length !== b.enumValues.length ||
+      a.enumValues.some((v, i) => v !== b.enumValues![i])
+    ) {
+      return `Enum value sets differ: [${a.enumValues?.join(', ')}] vs [${b.enumValues?.join(', ')}].`;
+    }
+  }
+  if (a.defaultValue !== b.defaultValue) {
+    return `Default values differ: ${a.defaultValue ?? '(none)'} vs ${b.defaultValue ?? '(none)'}.`;
+  }
+  return null;
 }
 
 /**

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -221,13 +221,54 @@ function unwrapOptional(schema: z.ZodTypeAny): z.ZodTypeAny {
 }
 
 function extractEnumValues(schema: z.ZodTypeAny): readonly string[] | null {
-  let current = schema;
-  if (current instanceof z.ZodDefault) current = current._def.innerType;
-  if (current instanceof z.ZodOptional) current = current._def.innerType;
+  const current = peelEnumWrappers(schema);
   if (current instanceof z.ZodEnum) {
     return [...(current._def.values as readonly string[])].sort();
   }
+  if (current instanceof z.ZodLiteral) {
+    // Treat a literal as a 1-member enum so two actions declaring the same
+    // field with different literal values collide instead of silently
+    // shadowing each other (#1127-class hazard).
+    return [JSON.stringify(current._def.value as unknown)];
+  }
+  if (current instanceof z.ZodNativeEnum) {
+    // TS `enum` objects round-trip both member names and values for numeric
+    // enums (reverse mapping). Stringify-dedupe the values so string and
+    // numeric native enums produce a stable, comparable set.
+    const raw = Object.values(current._def.values as Record<string, unknown>);
+    return [...new Set(raw.map((v) => JSON.stringify(v)))].sort();
+  }
+  if (current instanceof z.ZodUnion) {
+    // Union-of-literals is the hand-rolled form of z.enum(). Collect the
+    // literal values; fall back to null if any branch isn't a literal so
+    // heterogeneous unions (e.g. string | string[]) still classify via
+    // baseKind instead of being falsely flagged as enum-compatible.
+    const options = current._def.options as readonly z.ZodTypeAny[];
+    const literalValues: string[] = [];
+    for (const opt of options) {
+      const peeled = peelEnumWrappers(opt);
+      if (!(peeled instanceof z.ZodLiteral)) return null;
+      literalValues.push(JSON.stringify(peeled._def.value as unknown));
+    }
+    return [...new Set(literalValues)].sort();
+  }
   return null;
+}
+
+/** Peel ZodDefault / ZodOptional / ZodNullable wrappers so the caller can
+ *  match on the underlying enum-ish kind. Kept narrow on purpose: we don't
+ *  peel ZodEffects or ZodBranded because those change the wire-level
+ *  contract and deserve to be classified distinctly. */
+function peelEnumWrappers(schema: z.ZodTypeAny): z.ZodTypeAny {
+  let current = schema;
+  while (
+    current instanceof z.ZodDefault ||
+    current instanceof z.ZodOptional ||
+    current instanceof z.ZodNullable
+  ) {
+    current = current._def.innerType;
+  }
+  return current;
 }
 
 function extractDefault(schema: z.ZodTypeAny): unknown {


### PR DESCRIPTION
## Summary

Fixes #1127 — `doctor` and `init` actions were unreachable via MCP because `agent_spec.format` (enum `full|prompt-only`, default `full`) shadowed `doctor.format` and `init.format` (enum `table|json`) in `buildRegistrationSchema`'s silent first-wins field merge. The SDK-level schema injected the wrong default into every `exarchos_orchestrate` call and rejected documented-valid payloads at the MCP boundary.

## Changes

### Fix (renames the colliding field)
- `servers/exarchos-mcp/src/agents/handler.ts` — `agent_spec.format` → `agent_spec.outputFormat`
- `servers/exarchos-mcp/src/agents/handler.test.ts`, `servers/exarchos-mcp/src/orchestrate/composite.test.ts` — test call-sites updated
- `documentation/reference/tools/orchestrate.md` — docs updated with cross-reference to #1127

### Guard (prevents the class of bug)
- `servers/exarchos-mcp/src/registry.ts` — `buildRegistrationSchema` now throws at registration time when two actions declare the same field with:
  - incompatible **base types** (e.g., `string` vs `number`)
  - different **enum value sets**
  - different **defaults**

  Constraint drift (min/max/optionality) remains first-wins because handler-level schemas re-validate via `dispatch()`. Guard is scoped narrowly on purpose — it catches #1127-class hazards without flagging latent constraint-drift as errors. (The guard surfaced pre-existing drift on `stateFile`, `designPath`, and `prNumbers` across several actions; those are not reachability bugs and are left for a separate hygiene pass.)

### Regression coverage
- `servers/exarchos-mcp/src/registry.test.ts` — 6 new tests, including ones that exercise the real `exarchos_orchestrate` registry through the registration schema (not `dispatch()`), closing the DIM-4 test-fidelity gap identified in #1127.

## Test Plan

- [x] `npm run test:run` (root) — 604/604 ✓
- [x] `servers/exarchos-mcp && npm run test:run` — 5497/5497 ✓
- [x] `npm run typecheck` — ✓
- [x] New regression tests assert:
  - `exarchos_orchestrate({action:'doctor'})` parses
  - `exarchos_orchestrate({action:'doctor', format:'json'})` parses
  - `exarchos_orchestrate({action:'init', nonInteractive:true})` parses
  - `exarchos_orchestrate({action:'agent_spec', agent:'implementer', outputFormat:'full'|'prompt-only'})` parses
  - `buildRegistrationSchema` throws on synthetic enum/base-type collisions
  - `buildRegistrationSchema` accepts structurally-identical shared fields

Closes #1127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)