### PR TITLE
fix(mcp): await audit event emission to restore read-your-writes (#1145)

### DIFF
--- a/docs/audits/2026-04-18-v2.8.0-dogfood.md
+++ b/docs/audits/2026-04-18-v2.8.0-dogfood.md
@@ -1,8 +1,8 @@
 # v2.8.0 Dogfood Audit — Remaining Items
 
 **Date**: 2026-04-18
-**Release**: [v2.8.0](https://github.com/lvlup-sw/exarchos/releases/tag/v2.8.0)
-**Status**: 3 of 7 features verified, **5 bugs filed + fixed (shipping as v2.8.1)**, 1 new bug filed during shepherd dogfood (PR rollup rot), 4 features still pending. Item #5 (shepherd) was exercised live in the follow-up session — see below.
+**Release**: [v2.8.0](https://github.com/lvlup-sw/exarchos/releases/tag/v2.8.0) → **[v2.8.1](https://github.com/lvlup-sw/exarchos/releases/tag/v2.8.1)** (5 dogfood-audit fixes shipped)
+**Status**: 3 of 7 features verified; **5 bugs filed + fixed (v2.8.1)**; 1 new bug filed during shepherd dogfood (PR rollup rot); 4 features still pending; **post-merge re-verification complete — 4/5 fixes hold, #1129 has a partial regression** (see re-verify results at the bottom). Item #5 (shepherd) was exercised live in the follow-up session.
 
 ## What's done
 
@@ -149,3 +149,53 @@ Shepherded fixes for all 5 filed bugs through to `main`, shipping as **v2.8.1**:
 | #1129 | PR #1135 | `prepare_delegation` from main → must refuse; `exarchos_event query type:preflight.*` → events must persist. |
 | #1130 | PR #1133 | `exarchos_orchestrate describe config:true` → `prune`/`checkpoint`/`agents`/`plugins` all present. |
 | #1131 | PR #1132 | `claude slash-commands` — `discover`/`reload`/`tdd` render as `exarchos:<name>`. |
+
+---
+
+## Post-merge re-verification — 2026-04-18
+
+Exercised every fix against the live v2.8.1 plugin install (`~/.claude/plugins/cache/lvlup-sw/exarchos/2.8.1/`), verified via the running MCP server. Installed plugin version confirmed by `exarchos_orchestrate doctor`: `plugin-version-match: Plugin v2.8.1 matches installed version`.
+
+### Summary
+
+| Bug | Fix PR | Re-verify result | Evidence |
+|---|---|---|---|
+| #1127 | #1144 | ✅ HOLDS | `agent_spec` accepts `outputFormat: "prompt-only"` → returns `systemPrompt` + `unresolvedVars`. `doctor` and `init --dry-run` both reachable via MCP, no registration collision. |
+| #1128 | #1134 | ✅ HOLDS | `doctor` returns 9 Pass / 0 Warn / 0 Fail / 1 Skipped (remote-mcp, expected). Plugin-install detectors (`plugin-version-match`, `plugin-skill-hash-sync`, `agent-mcp-registered`) all Pass. |
+| #1129 | #1135 | ⚠️ **PARTIAL REGRESSION — events still dropped** | See below. |
+| #1130 | #1133 | ✅ HOLDS | `exarchos_workflow describe config:true` surfaces `prune`, `checkpoint`, `agents`, `plugins` with per-key `{value, source}` attribution (`default` vs `.exarchos.yml`). *(Protocol note: audit originally said `exarchos_orchestrate describe`, but the config surface lives on `exarchos_workflow.describe`. Minor doc drift, not a bug.)* |
+| #1131 | #1132 | ✅ HOLDS | `commands/discover.md`, `commands/reload.md`, `commands/tdd.md` all present and rendering as `exarchos:<name>` in the live slash-command list (confirmed via in-session skill roster). |
+
+### #1129 partial regression — dispatch guards still dropping preflight events
+
+**What the fix was supposed to do**: emit `preflight.blocked` (or `preflight.executed`) whenever `prepare_delegation` runs, so the stream carries audit trail of dispatch safety decisions. Event types were registered in `EventTypes` + `EVENT_EMISSION_REGISTRY` (`event-store/schemas.ts:77-78, 247-248`) — the registration half of the fix landed correctly.
+
+**What still works** ✅:
+- `prepare_delegation` from `main` returns `{blocked: true, reason: "current-branch-protected", currentBranch: "main"}` — the branch-protection refusal is correct.
+- Both `preflight.blocked` and `preflight.executed` are queryable built-in event types (`exarchos_event describe eventTypes:[...]` returns `{source: "auto", isBuiltIn: true}` for each).
+- Direct append via `exarchos_event.append` with `type: "preflight.blocked"` lands and reads back via `exarchos_event.query` — sequence 1 on a fresh stream, timestamp persists.
+
+**What is broken** ❌:
+- The fire-and-forget append inside `prepare_delegation` (at `servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts:276-285` — the current-branch-protected emit) **does not land**.
+- **Repro**: Called `exarchos_orchestrate prepare_delegation featureId:<id>` twice against two different streams (one empty, one with an existing workflow history). Both returned `blocked: true`. Both streams show ZERO new `preflight.blocked` events after the call. The manually-appended event from `exarchos_event.append` on the same stream DOES persist — proving the store is reachable, the event type is accepted, and the schema is correct.
+- Fire-and-forget pattern on line 285: `store.append(...).catch(() => { /* fire-and-forget */ })` — the `.catch` is swallowing whatever is going wrong, making the failure invisible.
+
+**Likely root cause (unverified — needs separate investigation)**:
+- The orchestrate handler obtains its store via `getOrCreateEventStore(stateDir)` (`views/tools.ts:139-146`), which returns a cached `EventStore` singleton keyed by `stateDir`.
+- The `exarchos_event.append` MCP path uses `ctx.eventStore` — injected via DispatchContext from MCP bootstrap.
+- These two references may resolve to the same `stateDir` but different `EventStore` instances — a DI drift bug where the factory cache and the injected context hold separate SQLite handles or in-memory write buffers. My direct `exarchos_event.append` wrote via the injected instance (visible to `query`); the handler's `getOrCreateEventStore` write appears to go to a distinct sink that neither `query` nor subsequent calls read.
+- Equally plausible: the fire-and-forget promise never settles before the MCP server discards the handler frame, and there's no flush/await before response serialization.
+
+**Test gap** (this is the #1129 original meta-finding playing out again):
+- `orchestrate/prepare-delegation.test.ts` lines 770/852/880/909 assert `mockStore.append` was *called* with the right event — it's the mock's call recorder, not the real store. The test does not write through an integration harness with a real SQLite-backed `EventStore`, so it cannot observe the drop.
+- `event-store/schemas.test.ts:100-107` asserts the event type is registered — which is necessary but not sufficient.
+- No test in the repo currently binds `prepare_delegation`'s handler to a real `EventStore`, invokes it, then queries the store — which is exactly the check that would have caught this.
+
+**Suggested follow-up**:
+1. **File a new issue** targeting v2.8.2: "Dispatch guards emit preflight events but they never persist — fire-and-forget append silently dropped (regression of #1129)." Severity: High — dispatch safety audit trail is still missing, even though the surface-level branch refusal works.
+2. **Integration test** (the exact pattern the audit meta-section called out): a test that constructs a real `EventStore(tmpDir)`, injects it into the prepare-delegation handler context, invokes with `featureId` on main, then queries the store for `preflight.blocked`. If this passes, the bug is in the DI wiring between factory cache and injected ctx; if it fails, the bug is in the fire-and-forget async lifecycle and needs an explicit await-or-track.
+3. **Short-term workaround**: change the three `store.append(...).catch(() => {})` call sites in `prepare-delegation.ts` (lines 277, 310, 338) to `await store.append(...)` with a try/catch that at minimum logs the failure via the existing telemetry sink. Fire-and-forget has no place in a safety-audit emission path.
+
+### Remaining items (unchanged)
+
+Items **#2 (discovery workflow)**, **#6 (checkpoint enforcement)**, and **#7 (multi-runtime init)** remain un-exercised. The #1129 regression finding above adds a priority signal to #6: checkpoint enforcement relies on event persistence via the same event-store surface, so it is non-trivially likely to share a persistence-drop defect. Recommend prioritizing **#6 next** rather than the original 2 → 6 → 7 ordering — if checkpoint events are also being dropped, the finding is structurally identical to the #1129 regression and can be bundled into the same v2.8.2 fix.

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.integration.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.integration.test.ts
@@ -1,0 +1,165 @@
+// Regression harness for #1145: verifies preflight.* events actually
+// persist to a real EventStore, not just that a mock's .append was called.
+//
+// The v2.8.1 fix for #1129 added store.append() call sites for preflight
+// events. The existing unit tests assert on mockStore.append.mock.calls,
+// which only proves the handler *invoked* the append. Live MCP testing
+// revealed events are being silently dropped — this harness exercises the
+// real store through the production code path and queries it after the
+// handler returns.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { handlePrepareDelegation } from './prepare-delegation.js';
+import { handleOrchestrate } from './composite.js';
+import {
+  getOrCreateEventStore,
+  resetMaterializerCache,
+} from '../views/tools.js';
+import { EventStore } from '../event-store/store.js';
+import type { DispatchContext } from '../core/dispatch.js';
+
+vi.mock('./dispatch-guard.js', () => ({
+  validateBranchAncestry: vi.fn().mockResolvedValue({ passed: true, checks: ['ancestry'] }),
+  assertMainWorktree: vi.fn().mockReturnValue({
+    isMain: true,
+    actual: '/fake/repo',
+    expected: 'main worktree (no .claude/worktrees/ in path)',
+  }),
+  getCurrentBranch: vi.fn().mockReturnValue('main'),
+  assertCurrentBranchNotProtected: vi.fn().mockReturnValue({
+    blocked: true,
+    reason: 'current-branch-protected',
+    currentBranch: 'main',
+  }),
+}));
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prep-deleg-integ-'));
+  resetMaterializerCache();
+});
+
+afterEach(async () => {
+  resetMaterializerCache();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function flushAsyncQueue(ms = 50): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await new Promise(queueMicrotask);
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('handlePrepareDelegation — event persistence (integration)', () => {
+  it('persists preflight.blocked to the real store when branch is protected', async () => {
+    const args = { featureId: 'test-integration-stream' };
+
+    const result = await handlePrepareDelegation(args, tmpDir);
+    await flushAsyncQueue();
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      blocked: boolean;
+      reason: string;
+      currentBranch: string;
+    };
+    expect(data.blocked).toBe(true);
+    expect(data.reason).toBe('current-branch-protected');
+    expect(data.currentBranch).toBe('main');
+
+    const store = getOrCreateEventStore(tmpDir);
+    const events = await store.query('test-integration-stream', {
+      type: 'preflight.blocked',
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe('preflight.blocked');
+    const eventData = events[0]?.data as {
+      reason: string;
+      details: { currentBranch: string };
+    };
+    expect(eventData.reason).toBe('current-branch-protected');
+    expect(eventData.details.currentBranch).toBe('main');
+  });
+
+  // Reproduces the production MCP topology: the handler writes via the
+  // factory-cached EventStore (`getOrCreateEventStore`), while MCP callers
+  // query via `ctx.eventStore` — a distinct instance at the same stateDir.
+  it('event persists across distinct EventStore instances pointing at the same stateDir', async () => {
+    const args = { featureId: 'test-cross-instance' };
+
+    await handlePrepareDelegation(args, tmpDir);
+    await flushAsyncQueue(200);
+
+    const freshReader = new EventStore(tmpDir);
+    const events = await freshReader.query('test-cross-instance', {
+      type: 'preflight.blocked',
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe('preflight.blocked');
+  });
+
+  // Reproduces the EXACT production MCP call path: handleOrchestrate
+  // dispatched with a DispatchContext whose ctx.eventStore is a distinct
+  // instance from the factory-cached store the handler uses internally.
+  // This is the drift that caused #1129's partial regression to escape.
+  it('preflight.blocked persists when dispatched via handleOrchestrate with DispatchContext', async () => {
+    const ctxStore = new EventStore(tmpDir);
+    const ctx: DispatchContext = {
+      stateDir: tmpDir,
+      eventStore: ctxStore,
+      enableTelemetry: false,
+    };
+
+    const result = await handleOrchestrate(
+      { action: 'prepare_delegation', featureId: 'test-composite-stream' },
+      ctx,
+    );
+    await flushAsyncQueue(200);
+
+    expect(result.success).toBe(true);
+    const data = result.data as { blocked: boolean; reason: string };
+    expect(data.blocked).toBe(true);
+    expect(data.reason).toBe('current-branch-protected');
+
+    const events = await ctxStore.query('test-composite-stream', {
+      type: 'preflight.blocked',
+    });
+    expect(events).toHaveLength(1);
+  });
+
+  // Race reproduction: a caller that queries IMMEDIATELY after the dispatch
+  // response returns (no flush, no sleep) — exactly what a downstream MCP
+  // client does. The event must be visible the moment the dispatch returns,
+  // not "eventually." This is the failure mode that surfaced in the v2.8.1
+  // dogfood re-verify: the handler returned blocked, the caller queried,
+  // the stream was empty. Fire-and-forget appends are not synchronous with
+  // the dispatch response, so any "read your writes" MCP caller races.
+  it('preflight.blocked is visible the moment handleOrchestrate returns (no flush)', async () => {
+    const ctxStore = new EventStore(tmpDir);
+    const ctx: DispatchContext = {
+      stateDir: tmpDir,
+      eventStore: ctxStore,
+      enableTelemetry: false,
+    };
+
+    await handleOrchestrate(
+      { action: 'prepare_delegation', featureId: 'test-race-stream' },
+      ctx,
+    );
+
+    // Intentionally no flush — mirrors a subsequent MCP call from the
+    // same client reading its own writes.
+    const events = await ctxStore.query('test-race-stream', {
+      type: 'preflight.blocked',
+    });
+    expect(events).toHaveLength(1);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -10,6 +10,8 @@ import { execFileSync } from 'node:child_process';
 import type { ToolResult } from '../format.js';
 import type { ResolvedProjectConfig } from '../config/resolve.js';
 import { DEFAULTS } from '../config/resolve.js';
+import type { EventStore } from '../event-store/store.js';
+import { orchestrateLogger } from '../logger.js';
 import type { DispatchContext } from '../core/dispatch.js';
 import {
   getOrCreateMaterializer,
@@ -225,6 +227,29 @@ function assembleQualityHints(
   }));
 }
 
+// Audit-trail events must persist before the handler returns so callers
+// that query the stream immediately after dispatch observe them
+// (read-your-writes). Failures are logged, never propagated — emission is
+// best-effort; the dispatch response itself is what the caller acts on.
+async function emitAuditEvent(
+  store: EventStore,
+  streamId: string,
+  event: Parameters<EventStore['append']>[1],
+): Promise<void> {
+  try {
+    await store.append(streamId, event);
+  } catch (err) {
+    orchestrateLogger.warn(
+      {
+        streamId,
+        eventType: event.type,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      'audit event emission failed',
+    );
+  }
+}
+
 // ─── Git Exec Helper ───────────────────────────────────────────────────────
 
 function createGitExec(): (args: readonly string[]) => string {
@@ -274,7 +299,7 @@ export async function handlePrepareDelegation(
     // at HEAD inspection, not ancestry.
     const protectionResult = assertCurrentBranchNotProtected(currentBranch);
     if (protectionResult.blocked) {
-      store.append(streamId, {
+      await emitAuditEvent(store, streamId, {
         type: 'preflight.blocked',
         data: {
           reason: protectionResult.reason,
@@ -282,7 +307,7 @@ export async function handlePrepareDelegation(
             currentBranch: protectionResult.currentBranch,
           },
         },
-      }).catch(() => { /* fire-and-forget */ });
+      });
 
       return {
         success: true,
@@ -306,8 +331,7 @@ export async function handlePrepareDelegation(
     );
 
     if (ancestryResult.blocked) {
-      // Fire-and-forget: emit preflight.blocked event for ancestry failure
-      store.append(streamId, {
+      await emitAuditEvent(store, streamId, {
         type: 'preflight.blocked',
         data: {
           reason: ancestryResult.reason,
@@ -316,7 +340,7 @@ export async function handlePrepareDelegation(
             ...(ancestryResult.error ? { error: ancestryResult.error } : {}),
           },
         },
-      }).catch(() => { /* fire-and-forget */ });
+      });
 
       return {
         success: true,
@@ -334,8 +358,7 @@ export async function handlePrepareDelegation(
     if (!args.nativeIsolation) {
       const worktreeResult = assertMainWorktree();
       if (!worktreeResult.isMain) {
-        // Fire-and-forget: emit preflight.blocked event for worktree violation
-        store.append(streamId, {
+        await emitAuditEvent(store, streamId, {
           type: 'preflight.blocked',
           data: {
             reason: 'worktree-location',
@@ -344,7 +367,7 @@ export async function handlePrepareDelegation(
               expected: worktreeResult.expected,
             },
           },
-        }).catch(() => { /* fire-and-forget */ });
+        });
 
         return {
           success: true,
@@ -359,14 +382,14 @@ export async function handlePrepareDelegation(
     }
 
     const checksRun = args.nativeIsolation ? ['ancestry'] : ['ancestry', 'worktree'];
-    store.append(streamId, {
+    await emitAuditEvent(store, streamId, {
       type: 'preflight.executed',
       data: {
         checks: checksRun,
         passed: true,
         integrationBranch,
       },
-    }).catch(() => { /* fire-and-forget */ });
+    });
 
     // ─── DR-5: Checkpoint Gate ──────────────────────────────────────────
     const checkpointConfig: CheckpointEnforcementConfig = ctx?.projectConfig?.checkpoint ?? {
@@ -384,15 +407,14 @@ export async function handlePrepareDelegation(
     const checkpointWarnings: string[] = [];
 
     if (gateResult.gated) {
-      // Emit checkpoint.enforced event (best-effort)
-      store.append(streamId, {
+      await emitAuditEvent(store, streamId, {
         type: 'checkpoint.enforced',
         data: {
           operationsSince: gateResult.operationsSince,
           threshold: gateResult.threshold,
           blockedAction: 'wave-dispatch',
         },
-      }).catch(() => { /* fire-and-forget */ });
+      });
 
       return {
         success: true,

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -484,14 +484,20 @@ export async function handleSet(
         'phase-transition',
       );
 
-      // DR-10: emit checkpoint.state_missing event on graceful degradation
+      // DR-10: emit checkpoint.state_missing event on graceful degradation.
+      // Awaited so callers that query the stream immediately after this
+      // handler returns observe the event (read-your-writes consistency).
       if (gateResult.warning === 'checkpoint-state-missing' && eventStore) {
-        eventStore.append(input.featureId, {
-          type: 'checkpoint.state_missing' as import('../event-store/schemas.js').EventType,
-          correlationId: input.featureId,
-          source: 'workflow',
-          data: { action: 'set' },
-        }).catch(() => { /* fire-and-forget */ });
+        try {
+          await eventStore.append(input.featureId, {
+            type: 'checkpoint.state_missing' as import('../event-store/schemas.js').EventType,
+            correlationId: input.featureId,
+            source: 'workflow',
+            data: { action: 'set' },
+          });
+        } catch {
+          // Best-effort event emission — don't block the set() response
+        }
       }
 
       if (gateResult.gated) {


### PR DESCRIPTION
## Summary

- Closes the #1129 partial regression surfaced during post-v2.8.1 dogfood re-verification: `prepare_delegation` returned `blocked: true` correctly, but callers querying the stream immediately after observed empty results. The preflight events eventually landed (minutes later in production) but the dispatch response returned before the fire-and-forget append settled — breaking read-your-writes consistency.
- Root cause is the `store.append(...).catch(() => { /* fire-and-forget */ })` pattern, not DI drift or absolute persistence failure. Fix is to `await` the emission with `try/catch` + logger.warn (not silent swallow), so the event is durable before the handler returns.
- Parent: **#1145** (umbrella epic on the `v2.8.5` milestone — "E2E boundary coverage: integration harness for event-store + PR-queue flows"). This PR lands Task 1 of that epic: the event-store integration harness, plus the fix the harness discriminated.

## Changes

- **`servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts`** — add `emitAuditEvent()` helper; replace 5 fire-and-forget sites (`preflight.blocked` ×3 branches, `preflight.executed`, `checkpoint.enforced`) with awaited calls.
- **`servers/exarchos-mcp/src/workflow/tools.ts`** — replace sibling `checkpoint.state_missing` fire-and-forget with the same awaited try/catch pattern already used on lines 500-513 of that file for `checkpoint.enforced`.
- **`servers/exarchos-mcp/src/orchestrate/prepare-delegation.integration.test.ts` (new)** — four tests exercising a real `EventStore` through `handleOrchestrate` + `DispatchContext`. One test (`preflight.blocked is visible the moment handleOrchestrate returns (no flush)`) specifically queries without flushing the async queue, reproducing the production race. RED on `main`, GREEN here.
- **`docs/audits/2026-04-18-v2.8.0-dogfood.md`** — post-merge re-verification section: 4/5 v2.8.1 fixes confirmed holding, #1129 flagged as partial regression with full repro evidence.

## Why this test design

The meta-finding from the 2026-04-18 dogfood audit was: **tests mock the boundary they are supposed to exercise.** The existing `prepare-delegation.test.ts` suite asserts on `mockStore.append.mock.calls` — it proves the handler *invoked* `.append()` but not that the event *landed*. That is why #1135 passed review: its unit tests were satisfied without ever touching a real `EventStore`.

The new integration test binds the real handler to a real file-backed `EventStore` via a real `DispatchContext`, invokes through the composite (`handleOrchestrate`), then queries the store *without* flushing async microtasks. This is the same read-your-writes pattern a downstream MCP caller follows — and the failure mode it surfaces is exactly the fire-and-forget lifecycle bug.

## Test plan

- [x] RED-first: added the no-flush race test against `main`, confirmed it fails with `expected [] to have a length of 1 but got +0`.
- [x] GREEN: applied the awaited-emission fix, confirmed the race test passes.
- [x] Existing `prepare-delegation.test.ts` (51 tests) still passes — no regression in mocked unit coverage.
- [x] Full MCP server suite: **5526 passed**, 0 regressions (4 pre-existing skipped benchmarks unchanged).
- [x] `npm run typecheck` — clean.
- [ ] Post-merge live re-verification: call `prepare_delegation` from `main` via MCP, query the stream immediately — event must be visible with no wait.

## Not in this PR

- The parallel `auto-update-prs.yml` bug noted in #1145 (CI check-runs do not attach to PR `statusCheckRollup` after `GITHUB_TOKEN` push + `workflow_dispatch`). Different surface (GHA YAML), different repro methodology, different fix axes (PAT vs `repository_dispatch` vs ruleset). Will be addressed in a follow-up PR under the same #1145 umbrella.
- Task 3 of #1145 (repo-wide scan for other fire-and-forget emission sites) — found one more in `workflow/tools.ts` during this work and fixed it; deeper scan deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)