### PR TITLE
fix(ci): use GitHub App token for auto-update-prs (#1145)

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -8,7 +8,11 @@
 # sibling PR in a multi-PR queue after the first merge (see #1145).
 #
 # Required secrets (configure at org or repo level):
-#   - PR_AUTOUPDATE_APP_ID        — numeric ID of the installed GitHub App
+#   - PR_AUTOUPDATE_CLIENT_ID     — Client ID of the installed GitHub App
+#                                    (visible on the App's settings page;
+#                                    GitHub has moved to Client ID as the
+#                                    canonical identifier — App ID is still
+#                                    accepted by the action for backcompat)
 #   - PR_AUTOUPDATE_APP_KEY       — PEM-encoded private key for the App
 #
 # The App needs these permissions on this repository:
@@ -35,7 +39,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.PR_AUTOUPDATE_APP_ID }}
+          # The action's `app-id` input accepts either the numeric App ID
+          # or the Client ID (Iv23li...). We use Client ID because GitHub
+          # has made it the canonical App identifier going forward.
+          app-id: ${{ secrets.PR_AUTOUPDATE_CLIENT_ID }}
           private-key: ${{ secrets.PR_AUTOUPDATE_APP_KEY }}
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -53,13 +53,17 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            const pulls = await github.rest.pulls.list({
+            // github.paginate walks all pages — `pulls.list` would
+            // cap at 30 by default, silently skipping later PRs if the
+            // open-PR count ever grows past one page.
+            const pulls = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              base: 'main'
+              base: 'main',
+              per_page: 100
             });
-            for (const pr of pulls.data) {
+            for (const pr of pulls) {
               try {
                 // Authenticated as the GitHub App installation, so the
                 // resulting push fires pull_request.synchronize and CI

--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -1,23 +1,50 @@
+# Auto Update PR Branches
+#
+# Keeps open PRs current with `main` after each merge so auto-merge queues
+# drain cleanly. Uses a GitHub App installation token (not GITHUB_TOKEN)
+# so the resulting push fires `pull_request.synchronize` natively —
+# GitHub intentionally suppresses PR events for GITHUB_TOKEN pushes to
+# avoid recursive workflow loops, which is what silently BLOCKed every
+# sibling PR in a multi-PR queue after the first merge (see #1145).
+#
+# Required secrets (configure at org or repo level):
+#   - PR_AUTOUPDATE_APP_ID        — numeric ID of the installed GitHub App
+#   - PR_AUTOUPDATE_APP_KEY       — PEM-encoded private key for the App
+#
+# The App needs these permissions on this repository:
+#   - Contents:      Write   (to push the merge commit to PR branches)
+#   - Pull requests: Write   (to call updateBranch on each open PR)
+#
+# Once configured, the explicit `workflow_dispatch` fallback is no longer
+# needed — the App-token push triggers `ci.yml` via `pull_request.synchronize`
+# and check-runs attach to `statusCheckRollup` normally.
 name: Auto Update PR Branches
 on:
   push:
     branches: [main]
 
 permissions:
-  actions: write
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   update-prs:
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     runs-on: self-hosted
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PR_AUTOUPDATE_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOUPDATE_APP_KEY }}
+
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+
       - uses: actions/github-script@v8
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const pulls = await github.rest.pulls.list({
               owner: context.repo.owner,
@@ -25,39 +52,19 @@ jobs:
               state: 'open',
               base: 'main'
             });
-            const updated = [];
             for (const pr of pulls.data) {
               try {
+                // Authenticated as the GitHub App installation, so the
+                // resulting push fires pull_request.synchronize and CI
+                // re-runs via the PR event path — check-runs attach to
+                // the rollup automatically, no workflow_dispatch needed.
                 await github.rest.pulls.updateBranch({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   pull_number: pr.number
                 });
                 console.log(`Updated PR #${pr.number}`);
-                updated.push(pr);
               } catch (e) {
                 console.log(`Skipped PR #${pr.number} update: ${e.message}`);
-              }
-            }
-
-            // Wait for merge commits to propagate before dispatching CI
-            if (updated.length > 0) {
-              console.log(`Waiting 5s for ${updated.length} merge commit(s) to propagate...`);
-              await new Promise(r => setTimeout(r, 5000));
-            }
-
-            // Dispatch CI on updated branches — needed because pushes
-            // from GITHUB_TOKEN don't trigger pull_request workflows
-            for (const pr of updated) {
-              try {
-                await github.rest.actions.createWorkflowDispatch({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  workflow_id: 'ci.yml',
-                  ref: pr.head.ref
-                });
-                console.log(`Dispatched CI for PR #${pr.number} on ${pr.head.ref}`);
-              } catch (e) {
-                console.error(`Failed to dispatch CI for PR #${pr.number}: ${e.message}`);
               }
             }


### PR DESCRIPTION
## Summary

- Closes the second of two bugs tracked under #1145. First bug (#1129 preflight event persistence) is fixed in #1146; this PR targets the multi-PR auto-merge queue rot that silently BLOCKed #1133 / #1134 / #1135 during the v2.8.1 rollout.
- Root cause: `pulls.updateBranch` authored by `GITHUB_TOKEN` does not trigger `pull_request.synchronize` — GitHub intentionally suppresses that to avoid recursive workflow loops. The explicit `workflow_dispatch` fallback at `auto-update-prs.yml:53-58` ran CI, but those check-runs are not part of the PR's `statusCheckRollup`, so branch protection saw the required context as missing and flipped `mergeStateStatus` to `BLOCKED` with no actionable signal.
- Fix: mint a GitHub App installation token and pass it to `github-script`, so the `updateBranch` push is authored by the App (not `GITHUB_TOKEN`) and fires `pull_request.synchronize` natively. CI re-runs via the PR event path, check-runs attach to the rollup, auto-merge proceeds. The `workflow_dispatch` gymnastics (and 5-second propagation wait) are deleted.

## ⚠️ Pre-merge user action required

This PR **cannot merge cleanly until the App credential is in place.** Once merged without the secrets configured, the next push to `main` will fail the `auto-update-prs` workflow with an obvious token-minting error — non-fatal to the repo (the workflow is best-effort), but the queue rot won't be fixed either.

**What you need to do before merging:**
1. Create a GitHub App (on the `lvlup-sw` org, or install on this repo specifically). Minimal repository permissions:
   - `Contents: Write`
   - `Pull requests: Write`
2. Install the App on the `exarchos` repository.
3. Capture the App's **Client ID** (visible on the App settings page, e.g. `Iv23li...`) and generate a private key (PEM).
4. Add two repo secrets:
   - `PR_AUTOUPDATE_CLIENT_ID` — the Client ID from step 3 (GitHub has moved to Client ID as the canonical App identifier; App ID still works for backcompat)
   - `PR_AUTOUPDATE_APP_KEY` — the full PEM contents (including `-----BEGIN PRIVATE KEY-----` / `-----END PRIVATE KEY-----` lines)

The header comment in `auto-update-prs.yml` documents these requirements inline for future maintainers.

## Changes

- **`.github/workflows/auto-update-prs.yml`** — replace `GITHUB_TOKEN`-authored calls with an App installation token minted via `actions/create-github-app-token@v1`. Delete the `workflow_dispatch` fallback (15 lines gone). Tighten workflow permissions from `actions: write` + `contents: write` + `pull-requests: write` to `contents: read` + `pull-requests: read` — the App token handles all writes, the workflow's default token no longer needs to.

## Test plan

Cannot be validated in CI — the failure mode requires two concurrent auto-merge PRs against `main`, which is a post-merge observation:

- [ ] Configure `PR_AUTOUPDATE_CLIENT_ID` and `PR_AUTOUPDATE_APP_KEY` secrets.
- [ ] Merge this PR.
- [ ] Next time there are ≥ 2 open PRs against `main` with auto-merge armed, merge one. Observe the sibling PRs:
  - The `Auto Update PR Branches` workflow run should show "Mint GitHub App installation token" step succeeding.
  - Each sibling PR's branch should update, and `ci.yml` should re-run as a `pull_request.synchronize`-triggered run (not `workflow_dispatch`).
  - `statusCheckRollup` on each sibling should include the new CI run; `mergeStateStatus` should remain `CLEAN`; auto-merge should proceed.
- [ ] If the App is misconfigured, the `create-github-app-token` step fails early with a clear error — recoverable by updating the secret, no corruption of PR state.

## Rollback plan

If the App setup hits a blocker, revert this PR. The pre-existing workflow with `GITHUB_TOKEN` + `workflow_dispatch` still "works" in the reduced sense that single-PR auto-merge succeeds; it only fails the multi-PR case. The manual workaround (`gh pr close && gh pr reopen` per stuck PR) remains available in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)