### PR TITLE
fix(cli): resolve argv[1] symlink in isDirectExecution (#1158)

### DIFF
--- a/servers/exarchos-mcp/src/index.test.ts
+++ b/servers/exarchos-mcp/src/index.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { InMemoryBackend } from './storage/memory-backend.js';
 import type { StorageBackend } from './storage/backend.js';
 import { isMcpServerInvocation, isDirectExecution } from './index.js';
@@ -296,5 +300,51 @@ describe('isDirectExecution (#1085)', () => {
         'C:\\Users\\John Doe\\repo\\dist\\exarchos.js',
       ),
     ).toBe(true);
+  });
+
+  // Regression for #1158: `npm link` installs argv[1] as a symlink, but Node
+  // resolves symlinks for ESM modules so import.meta.url points at the real
+  // file. Without realpath normalization, the guard misses and main() never
+  // runs — the CLI silently no-ops.
+  describe('symlink resolution (#1158)', () => {
+    let scratch: string;
+
+    beforeEach(() => {
+      scratch = mkdtempSync(join(tmpdir(), 'exarchos-symlink-test-'));
+    });
+
+    afterEach(() => {
+      rmSync(scratch, { recursive: true, force: true });
+    });
+
+    it('matches when argv[1] is a symlink to the real module', () => {
+      const realDir = join(scratch, 'dist');
+      mkdirSync(realDir, { recursive: true });
+      const realScript = join(realDir, 'exarchos.js');
+      writeFileSync(realScript, '// fixture\n');
+
+      const binDir = join(scratch, 'bin');
+      mkdirSync(binDir, { recursive: true });
+      const linkPath = join(binDir, 'exarchos');
+      symlinkSync(realScript, linkPath);
+
+      // Node's ESM loader resolves symlinks, so import.meta.url points at the
+      // real file even when invoked through the symlink.
+      const metaUrl = pathToFileURL(realScript).href;
+
+      expect(isDirectExecution(metaUrl, linkPath)).toBe(true);
+    });
+
+    it('falls back to raw argv[1] when realpath fails (path does not exist)', () => {
+      // The fallback preserves prior shape-only behavior for environments
+      // where argv[1] is synthetic (e.g. unit tests) or the file has been
+      // removed between invocation and guard evaluation.
+      expect(
+        isDirectExecution(
+          'file:///Users/foo/.npm/bin/exarchos.js',
+          '/Users/foo/.npm/bin/exarchos.js',
+        ),
+      ).toBe(true);
+    });
   });
 });

--- a/servers/exarchos-mcp/src/index.ts
+++ b/servers/exarchos-mcp/src/index.ts
@@ -3,6 +3,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
+import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 import { logger } from './logger.js';
@@ -347,16 +348,28 @@ async function main() {
  * Without these, Windows users hit a silent CLI no-op — `main()` never ran
  * because `endsWith` never matched. See #1085.
  *
+ * On Linux, `npm link` installs a symlink (e.g. `~/.local/bin/exarchos` →
+ * `.../dist/exarchos.js`). `argv[1]` is the symlink path, but Node resolves
+ * symlinks for ESM modules so `import.meta.url` points at the real file. The
+ * `endsWith` check then misses and the CLI silently no-ops. Resolving
+ * `argv[1]` through `realpathSync` before comparing closes that gap. See #1158.
+ *
  * Exported for unit testing; callers should pass `import.meta.url` and
  * `process.argv[1]` directly.
  */
 export function isDirectExecution(metaUrl: string, argv1: string | undefined): boolean {
   if (!argv1) return false;
   const modulePath = fileURLToPath(metaUrl).replace(/\\/g, '/');
-  const normalizedArgv = argv1.replace(/\\/g, '/');
+  const resolvedArgv = (() => {
+    try {
+      return realpathSync(argv1).replace(/\\/g, '/');
+    } catch {
+      return argv1.replace(/\\/g, '/');
+    }
+  })();
   return (
-    modulePath.endsWith(normalizedArgv) ||
-    modulePath.endsWith(normalizedArgv.replace(/\.ts$/, '.js'))
+    modulePath.endsWith(resolvedArgv) ||
+    modulePath.endsWith(resolvedArgv.replace(/\.ts$/, '.js'))
   );
 }
 


### PR DESCRIPTION
## Summary

On Linux, installing the CLI via `npm link` produced a working-looking `exarchos` command that silently exited 0 with no output — the standard dev workflow was blocked. Root cause is the same class as #1085: `isDirectExecution` compared `argv[1]` (a symlink path) against `import.meta.url` (which Node resolves to the real file for ESM modules), the `endsWith` missed, and `main()` never ran.

## Changes

- **`servers/exarchos-mcp/src/index.ts`** — Normalize `argv[1]` through `realpathSync` before the suffix match, with a raw-string fallback on failure (preserves behavior when the file doesn't exist, e.g. synthetic test inputs). Kept `endsWith` semantics so the existing Windows `/C:/...` vs `C:/...` prefix tolerance still holds.
- **`servers/exarchos-mcp/src/index.test.ts`** — Regression tests: real symlink on tmpfs proves the fix, plus a non-existent-path case proves the fallback.

## Test Plan

Added two `#1158` regression tests to the existing `isDirectExecution` suite. All 20 tests pass. Full MCP-server suite green (5528/5528). End-to-end: built `dist/exarchos.js`, confirmed `exarchos --help` via the existing `~/.local/bin/exarchos` symlink now prints usage and exits 0 (pre-fix: empty stdout, exit 0).

---

**Results:** Tests 5528 ✓ · Build 0 errors
**Related:** Closes #1158, same class as #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)