### PR TITLE
feat(review): platform-agnostic fixer-dispatch pipeline (#1159)

### DIFF
--- a/docs/designs/2026-04-19-fixer-token-efficiency.md
+++ b/docs/designs/2026-04-19-fixer-token-efficiency.md
@@ -1,0 +1,177 @@
+# Fixer Token Efficiency — Design
+
+**Tracking issue:** [#1159](https://github.com/lvlup-sw/exarchos/issues/1159)
+**Discovery report:** [`docs/research/fixer-token-efficiency.md`](../research/fixer-token-efficiency.md)
+**Workflow:** `feat-fixer-token-efficiency`
+**Date:** 2026-04-19
+**Scope:** Phases 1 + 2 (canonical types + provider adapters + classifier). Phase 3 (file-batched dispatch with context prefetch) deferred to a follow-up issue.
+
+## 1. Context
+
+The discovery report ranked four optimizations from #1159 (P1–P4) against the current code. The ideate session corrected two assumptions in that ranking:
+
+1. **The pipeline is platform-agnostic.** Exarchos's CLI is reviewer-agnostic and must remain so. Any severity-routing or batching logic has to work for CodeRabbit, Sentry, GitHub-Copilot, human reviewers, and future providers.
+2. **The actual fixer-dispatch path is shepherd, not `extract_fix_tasks`.** The shepherd skill polls PR comments via `assess_stack`, then chooses direct-fix or delegated-fix per item using a prose heuristic in `references/fix-strategies.md`. The basileus #159 cost numbers measure the `/exarchos:delegate --fixes` path invoked by shepherd's "cross-cutting" branch.
+
+An axiom backend-quality review of the corrected proposals surfaced one HIGH-severity constraint (provider adapter registry must be a single source of truth, constructor-injected) and one HIGH-severity contract constraint (changes to `actionItem` shape must be additive). Both are folded into the design below.
+
+## 2. Out of scope (for this design)
+
+- Per-fix sub-event observability for batched dispatch (folded into Phase 3).
+- Modifying the `agents/fixer.md` template, `{{contextSnippet}}` prefetch, file-grouped dispatch construction.
+- AC #4 benchmark from #1159 (≥40% token reduction). Phase 3 territory.
+- The `extract_fix_tasks` / `state.reviews[].findings[]` internal-review pipeline. Stays as-is; Phase 1+2 work alongside it, not replacing it.
+
+## 3. Pre-work: canonical domain types
+
+Before any handler is touched, land the canonical types in a new file `servers/exarchos-mcp/src/review/types.ts`:
+
+```typescript
+export type Severity = 'HIGH' | 'MEDIUM' | 'LOW';
+export type ReviewerKind = 'coderabbit' | 'sentry' | 'human' | 'github-copilot' | 'unknown';
+
+export interface ActionItem {
+  readonly id: string;                  // stable per-comment ID from the source
+  readonly reviewer: ReviewerKind;      // which adapter produced this
+  readonly file?: string;               // optional: not all comments are file-bound
+  readonly line?: number;
+  readonly severity?: Severity;         // optional in Phase 1; required after soak
+  readonly title: string;               // short, human-readable
+  readonly body: string;                // full comment body
+  readonly threadId?: string;           // for reply tracking
+  readonly raw: unknown;                // provider-original payload, for debugging
+}
+
+export interface ProviderAdapter {
+  readonly kind: ReviewerKind;
+  parse(rawComment: unknown): ActionItem | null;
+}
+
+export interface ReviewAdapterRegistry {
+  forReviewer(kind: ReviewerKind): ProviderAdapter | undefined;
+  list(): readonly ProviderAdapter[];
+}
+```
+
+The `ActionItem` shape is **additive** to whatever `assess_stack` returns today: existing consumers that read `actionItem.context` keep working; new fields populate where adapters can fill them. Severity stays optional in Phase 1 and is promoted to required at the start of Phase 2 (one minor version of soak).
+
+The registry interface enforces the DIM-1 constraint: there is one factory (`createReviewAdapterRegistry()`), one place adapters are instantiated, and consumers receive the registry via constructor injection. No lazy fallback; missing registry is a startup error.
+
+## 4. Phase 1: Provider adapters + `assess_stack` wiring
+
+### 4.1 Adapter implementations
+
+Create `servers/exarchos-mcp/src/review/providers/` containing one file per reviewer:
+
+- `coderabbit.ts` — parses CodeRabbit comment bodies. Extracts severity from the tier markers documented in `fix-strategies.md:178-194`: `Critical → HIGH`, `Major → HIGH`, `Minor → LOW`. Refactor-suggestion or nitpick blocks → `LOW`. Bug/security blocks → `HIGH`.
+- `sentry.ts` — extracts the `CRITICAL`/`MEDIUM`/etc. tags Sentry attaches; maps `CRITICAL → HIGH`, `MEDIUM → MEDIUM`, anything else → `LOW`.
+- `github-copilot.ts` — Copilot review comments don't carry severity; default `MEDIUM`.
+- `human.ts` — fallback adapter. No severity tag; defaults to `MEDIUM`. (We don't try to infer severity from prose — too unreliable.)
+- `unknown.ts` — catch-all for unrecognized authors. Emits the comment as `severity: 'MEDIUM'` and emits a `provider.unknown_tier` event with the literal author string seen, satisfying the DIM-7 resilience constraint.
+
+Each adapter's `parse()` is pure — given a raw comment from the GitHub API, return an `ActionItem` or `null` (informational comments like `github-actions[bot]` gate summaries return `null`).
+
+### 4.2 Registry
+
+`createReviewAdapterRegistry()` in `servers/exarchos-mcp/src/review/registry.ts` returns a frozen registry containing the five adapters. The registry exposes `forReviewer(kind)` and `list()`. No mutation; no late-binding.
+
+### 4.3 `assess_stack` wiring
+
+Modify `assess_stack` to accept a `ReviewAdapterRegistry` via constructor injection (or a factory parameter — the existing handler shape will dictate). For each fetched PR comment, route by author to the appropriate adapter, call `adapter.parse(comment)`, and attach the resulting `ActionItem` fields to the existing `actionItem.context` payload. Existing fields stay; new fields populate where adapters succeed.
+
+### 4.4 Observability
+
+Emit one new event per adapter dispatch decision:
+
+- `provider.unknown_tier` — when an adapter encounters a tier string it doesn't recognize. Data: `{reviewer, rawTier, commentId}`. Tells us when reviewers ship new tiers we need to handle.
+
+No other new events in Phase 1; existing `gate.executed` and `ci.status` events continue as today.
+
+### 4.5 Hygiene obligation
+
+After Phase 1 ships, prose blocks at `skills-src/shepherd/references/fix-strategies.md:159-194` (Sentry, CodeRabbit, Human reviewer guidance) become redundant — the adapters now own that logic. Either delete the duplicated content or convert each block to a one-line pointer ("see `review/providers/coderabbit.ts`"). DIM-5 enforces single source of truth.
+
+## 5. Phase 2: `classify_action_items` action
+
+### 5.1 New action surface
+
+Add `classify_action_items` to `exarchos_orchestrate`. Input: `{actionItems: ActionItem[]}`. Output:
+
+```typescript
+{
+  groups: Array<{
+    file: string | null;             // null = file-less group (e.g. PR-level comments)
+    items: ActionItem[];
+    severity: Severity;              // max severity in the group
+    recommendation: 'direct' | 'delegate-fixer' | 'delegate-scaffolder';
+    rationale: string;               // human-readable, for logging/debugging
+  }>;
+  summary: { totalItems: number; directCount: number; delegateCount: number };
+}
+```
+
+The handler groups action items by `file` (items without `file` go in a single "global" group). Per-group recommendation:
+
+- All items `severity: 'LOW'` AND title matches doc-nit keywords (`<remarks>`, `sealed`, `OrderBy`, `format`) → `delegate-scaffolder`. Mirrors the existing `SCAFFOLDING_KEYWORDS` heuristic in `prepare-delegation.ts:91`.
+- Group has 1 item AND `severity !== 'HIGH'` AND fits the existing direct-fix heuristic (≤20 lines, single file) → `direct`. Mirrors `fix-strategies.md:9-14`.
+- Otherwise → `delegate-fixer`.
+
+The recommendation is advisory; shepherd reads it and acts. We do not yet *execute* the dispatch from this action — that's Phase 3.
+
+### 5.2 Promoting `actionItem.severity` to required
+
+At the start of Phase 2, promote `severity` from optional to required in `ActionItem`. Adapters already populate it; the soak window in Phase 1 confirms no consumer relied on its absence. This is a contract tightening, not a breaking change for anyone who watched the optional field.
+
+### 5.3 Observability
+
+Emit one new event per classification call:
+
+- `dispatch.classified` — emitted once per `classify_action_items` invocation. Data: `{groupCount, directCount, delegateCount, severityDistribution: {high, medium, low}}`. Lets us measure (a) how often the heuristic recommends delegate vs direct and (b) the severity distribution of real PR comments — which is the data we need to validate Phase 3's design and to check the discovery's DIM-3 finding empirically.
+
+### 5.4 Shepherd integration
+
+Update `skills-src/shepherd/SKILL.md` Step 2 to call `classify_action_items` on the `actionItems` returned by `assess_stack`, then route per group's `recommendation`. Replace the prose heuristic at `fix-strategies.md:9-14` with a one-line pointer. DIM-5 cleanup obligation.
+
+### 5.5 Hygiene obligation
+
+After Phase 2 ships, the direct-vs-delegate table in `fix-strategies.md:9-14` is owned by `classify_action_items`. Delete the table or convert to "see `classify_action_items` runbook".
+
+## 6. Test strategy
+
+| Phase | Layer | Test approach |
+|---|---|---|
+| Pre-work | `ActionItem` / `ProviderAdapter` types | Type-only — compile-time validation |
+| 1 | Per-provider adapter | Unit tests against fixture comments. Capture 5–10 real comments per provider from basileus #159 (CodeRabbit, Sentry) and exarchos PRs (human, GitHub-Copilot). Each adapter test asserts the parsed `ActionItem` shape. |
+| 1 | Registry | Unit test: registry construction is deterministic; missing reviewer returns undefined; no mutation possible. |
+| 1 | `assess_stack` integration | Existing tests must continue to pass. Add one new test that asserts `actionItem.severity` is populated when adapters succeed. |
+| 2 | `classify_action_items` | Unit tests for each branch of the recommendation logic. Property-based test: given any `ActionItem[]`, output `groups` partition the input (no item lost, no item duplicated). |
+| 2 | Shepherd integration | One smoke test that runs the loop against a mocked PR with mixed-severity comments and asserts the recommendations match expectation. |
+
+## 7. Phased rollout
+
+| Phase | Ships | Token impact | Phase entry condition |
+|---|---|---|---|
+| Pre-work | Canonical types, no handlers | 0% | (none) |
+| 1 | Adapters + registry + `assess_stack` wiring + Phase 1 hygiene cleanup | 0% — foundation only | Pre-work merged |
+| 2 | `classify_action_items` + shepherd integration + Phase 2 hygiene cleanup + severity promoted to required | ~10% routing win + ~30% wall-clock parallelism (per #1159 P3) | Phase 1 has soaked through one minor version |
+| 3 (separate ideate) | File-batched dispatch + context prefetch + AC #4 benchmark | ~40-55% per #1159 P1+P2 estimates | Phase 2 measurements in hand |
+
+## 8. Open questions for plan
+
+These are intentionally left for `/exarchos:plan` to resolve, since they're implementation-detail decisions:
+
+- **Q-P1: How many fixture comments per provider?** Phase 1 tests need real comments. 5–10 per provider is a guess. Plan should pick a number and source.
+- **Q-P2: Where do GitHub-Copilot review comments come from in the API response?** They appear under specific bot author names; need to confirm the exact name(s) so the adapter dispatcher routes correctly.
+- **Q-P3: Soak window length.** "One minor version of soak" before promoting severity to required — pick concrete: one release? one week? Tie to a clear gate.
+- **Q-P4: Backwards compatibility for existing `actionItem.context` consumers.** Phase 1 keeps `context` intact and adds new fields alongside. Plan should grep for `actionItem.context` consumers and confirm none break.
+- **Q-P5: Scaffolder routing test.** The Phase 2 doc-nit heuristic mirrors `SCAFFOLDING_KEYWORDS` in `prepare-delegation.ts:91`. Should the keyword list be shared between the two heuristics, or duplicated for now? (DRY pull versus coupling tradeoff.)
+
+## 9. Why this scope and not more
+
+Phase 3 is where the bulk of #1159's claimed token savings live. We're explicitly *not* shipping it in this ideate because:
+
+- Phase 3's design needs a partial-failure observability decision (the discovery's DIM-2 HIGH) that benefits from seeing real classifier output first.
+- Phase 3 changes the `agents/fixer.md` template, which has wider blast radius than handler additions.
+- Phase 3's AC #4 benchmark is meaningful only after Phases 1+2 normalize the data — measuring against today's pre-adapter state would confound provider-shape variance with optimization wins.
+
+Splitting at the Phase 2/3 boundary lets Phase 3 ship a smaller, sharper change with a measurable benchmark, against a known classifier baseline.

--- a/docs/designs/2026-04-19-process-fidelity-harness.md
+++ b/docs/designs/2026-04-19-process-fidelity-harness.md
@@ -1,0 +1,344 @@
+# Design: Process-Fidelity Test Harness
+
+**Status:** Design (ideate phase). Implementation plan will follow.
+**Workflow:** `process-fidelity-harness`
+**Date:** 2026-04-19
+**Source research:** `docs/research/2026-04-19-e2e-testing-strategy.md` (Tier 1)
+
+## 1. Summary
+
+Exarchos ships a CLI binary and an MCP server binary, but today's 420 tests drive only the in-process module graph. This design specifies the **shared fixture library** that makes process-fidelity tests feasible: a small set of procedural helpers for hermetic environment setup, MCP-server process spawning, CLI invocation, and response normalization.
+
+This is the foundation for Tier 1 of the e2e testing strategy. It lands as one PR. Four follow-up PRs consume it: F2 MCP smoke tests, F2 CLI smoke tests, F3 `@modelcontextprotocol/conformance` integration, and a Windows CI matrix extension.
+
+The design closes the axiom DIM-4 (Test Fidelity) gap at the process boundary: tests will spawn the real binaries, speak real JSON-RPC over real stdio, and assert on real responses, using wiring that mirrors production step-for-step.
+
+## 2. Problem
+
+Per the research doc, today's test suite covers approximately one tuple of the 54-cell (OS × harness × invocation-surface) ship surface. No test crosses the process boundary between Exarchos's shipped binary and its consumer. This means:
+
+- A server that fails to start because of a missing runtime flag passes every in-process handler test.
+- A regression in the `bin` wrapper passes every CLI function test.
+- A Zod-schema change that breaks JSON-RPC tool-call parsing passes every unit test.
+- A Windows-specific `path.resolve` bug ships undetected, because CI is Linux-only.
+- The "MCP parity" contract in [#1109](https://github.com/lvlup-sw/exarchos/issues/1109) has no operational definition, because no test compares CLI output to MCP output.
+
+The shared fixture library is the prerequisite for fixing all of the above. It is not itself a test suite; it is the foundation that makes the follow-up test suites cheap to write.
+
+## 3. Scope
+
+### 3.1 In scope for this design (PR 1)
+
+- `withHermeticEnv(callback)` — single-mode hermetic environment wrapper.
+- `spawnMcpClient(opts)` — spawns the built MCP server binary and returns a connected `Client`.
+- `runCli(opts)` — invokes a CLI binary in the hermetic env, returns `{ stdout, stderr, exitCode }`.
+- `normalize(value)` — canonicalizes timestamps, event sequences, IDs, and paths for equivalence assertions.
+- `expectNoLeakedProcesses()` — global `afterEach` hook asserting all spawned children have terminated.
+- Vitest `projects` split defining `unit`, `integration`, and `process` projects.
+- `test/fixtures/` directory layout.
+
+### 3.2 In scope for follow-up PRs (not this design)
+
+| PR | Owner issue | Scope |
+|----|-------------|-------|
+| PR 2 | `exarchos#<F2-mcp>` | First F2 MCP smoke test: `exarchos_workflow` init/get round-trip over stdio. |
+| PR 3 | `exarchos#<F2-cli>` | First F2 CLI smoke test: `exarchos install` against tmp `$HOME`, assert filesystem result. |
+| PR 4 | `exarchos#<F3-conformance>` | Integrate `@modelcontextprotocol/conformance` as a `conformance` vitest project. |
+| PR 5 | `exarchos#<win-ci>` | Extend GitHub Actions matrix to include `windows-latest` for the `unit` project. |
+
+Each follow-up PR gets its own ideate and design. This design only commits to: **the fixture library exposes the right primitives for PRs 2–5 to consume.**
+
+### 3.3 Out of scope entirely
+
+- Per-action parity contract schema (belongs in PR 4's design).
+- macOS CI runner (Tier 2).
+- F4 platform probes, F5 per-runtime install fixtures, F6 lifecycle tests (Tiers 2 and 3).
+- Harness-internal behavior tests.
+- LLM-driven conversation tests (`mcpjam` territory).
+
+## 4. Architecture
+
+### 4.1 Library shape: procedural functional
+
+Four top-level exports, each a direct mirror of a production wiring step. No abstractions on top. No context objects, no vitest plugins, no custom matchers.
+
+Rationale vs. alternatives (context-object pattern; vitest fixture injection) is documented in the ideate transcript. Axiom grounding:
+
+- **DIM-4:** call sites mirror production wiring; tests read as small programs doing what the harness does.
+- **DIM-6:** tight single-responsibility per function.
+- **DIM-5:** minimal surface; no config paths; no optional facades.
+- **DIM-1:** every resource's lifecycle is visible at the call site.
+
+### 4.2 Binary invocation targets
+
+**F2 MCP:** `(b)` `npm link`-resolved binary on `PATH`. `spawnMcpClient` resolves `exarchos-mcp` from `PATH` at call time. This exercises the `bin` entry in `package.json` and the shebang wrapper. Setup step in CI: `npm link` once before the `process` project runs.
+
+**F2 CLI:** target-agnostic. `runCli(opts)` takes `{ command, args, env, cwd }` and runs it. For the initial PR 3, tests pass `command: 'exarchos-install'` (the `npm link`-resolved binary). When [#1115](https://github.com/lvlup-sw/exarchos/issues/1115)'s `get-exarchos.sh` bootstrap ships, a second test file wires `command` to the downloaded binary with zero harness changes. Target `(c)` (`create-exarchos`-scaffolded install) is **not supported** — `create-exarchos` is on the deprecation path per [#1043](https://github.com/lvlup-sw/exarchos/issues/1043), and investing fixtures in it is sunk cost.
+
+A comment on [#1115](https://github.com/lvlup-sw/exarchos/issues/1115) ([comment-4277752096](https://github.com/lvlup-sw/exarchos/issues/1115#issuecomment-4277752096)) cross-links the F2 CLI requirements so the bootstrap-script work can wire in the second target without re-deriving the design.
+
+### 4.3 Hermeticity model
+
+Single-mode. `withHermeticEnv(callback)`:
+
+1. Creates `tmp/<test-id>/{home,state,cwd,git}/`.
+2. Sets `HOME`, `EXARCHOS_STATE_DIR`, `process.chdir(tmpCwd)`, and runs `git init` in `tmpGit` if needed.
+3. Runs the callback.
+4. Unconditionally cleans up in `finally`: restores env, restores CWD, removes tmp tree.
+
+**No mode flag.** The axiom reasoning from the ideate stands: because F2 tests spawn the real binary as a fresh subprocess, the server's module graph is fully isolated by construction. The test driver is thin; env + CWD + FS reset is sufficient. A multi-mode helper would violate DIM-1 (conditional ambient state), DIM-5 (unused config paths), and DIM-6 (fuzzy responsibility).
+
+### 4.4 Normalizer
+
+`normalize(value: unknown): NormalizedShape` walks the input and canonicalizes non-deterministic fields.
+
+**PR 1 minimum set:**
+
+| Field pattern | Replacement |
+|---------------|-------------|
+| ISO-8601 timestamps | `<TIMESTAMP>` |
+| `_eventSequence`, `sequence` | `<SEQ>` |
+| Absolute paths under `tmp/` | `<WORKTREE>/<RELATIVE>` |
+| UUIDs | `<UUID>` |
+| MCP request IDs | `<REQ_ID>` |
+
+**Function signature is fixed.** The per-action parity schema (what tolerance is applied to which fields for which action) lives in PR 4's design. PR 4 extends `normalize` as needed; PR 1 ships only these five rules.
+
+### 4.5 Vitest project split
+
+`vitest.config.ts` grows a `projects` array:
+
+```typescript
+projects: [
+  { name: 'unit',        include: ['src/**/*.test.ts', 'servers/exarchos-mcp/src/**/*.test.ts'] },
+  { name: 'integration', include: ['servers/exarchos-mcp/src/__tests__/**/*.test.ts'] },
+  { name: 'process',     include: ['test/process/**/*.test.ts'],      testTimeout: 15000 },
+]
+```
+
+Future projects (`conformance`, `e2e`) added by follow-up PRs.
+
+`package.json` scripts:
+
+```
+test:unit         — vitest --project unit --project integration
+test:process      — vitest --project process
+test:all          — vitest (all projects)
+```
+
+The existing `test:run` is aliased to `test:unit` to preserve current CI behavior.
+
+### 4.6 File layout
+
+```
+test/
+├── fixtures/
+│   ├── hermetic.ts              — withHermeticEnv
+│   ├── mcp-client.ts            — spawnMcpClient
+│   ├── cli-runner.ts            — runCli
+│   ├── normalizers.ts           — normalize
+│   ├── process-tracker.ts       — expectNoLeakedProcesses
+│   └── index.ts                 — barrel export
+├── process/
+│   └── .gitkeep                 — PR 2 adds first test here
+└── setup/
+    └── global.ts                — afterEach(expectNoLeakedProcesses) hook
+```
+
+## 5. Public API
+
+### 5.1 `withHermeticEnv`
+
+```typescript
+export async function withHermeticEnv<T>(
+  callback: (env: HermeticEnv) => Promise<T>
+): Promise<T>;
+
+export interface HermeticEnv {
+  homeDir: string;      // tmp/<id>/home
+  stateDir: string;     // tmp/<id>/state
+  cwdDir: string;       // tmp/<id>/cwd (process.cwd during callback)
+  gitDir: string;       // tmp/<id>/git (git init'd)
+  testId: string;       // stable ID for this invocation
+}
+```
+
+**Guarantees:**
+- `process.env.HOME`, `process.env.EXARCHOS_STATE_DIR`, and `process.cwd()` are set for the duration of the callback.
+- Cleanup runs unconditionally, even if the callback throws.
+- Concurrent callers get non-overlapping `tmp/<id>/` directories.
+
+### 5.2 `spawnMcpClient`
+
+```typescript
+export async function spawnMcpClient(opts?: SpawnMcpClientOpts): Promise<SpawnedMcpClient>;
+
+export interface SpawnMcpClientOpts {
+  command?: string;              // default: 'exarchos-mcp' (npm-link resolved)
+  args?: string[];
+  env?: Record<string, string>;  // merged with current env
+  stateDir?: string;             // sets EXARCHOS_STATE_DIR
+  timeout?: number;              // default: 10000ms for initialize
+}
+
+export interface SpawnedMcpClient {
+  client: Client;                // @modelcontextprotocol/sdk Client
+  server: ChildProcess;          // handle to the spawned process
+  terminate(): Promise<void>;    // closes client, waits for process exit
+  stderr: string[];              // captured stderr lines
+}
+```
+
+**Guarantees:**
+- Returns only after `client.connect(transport)` completes.
+- `terminate()` is idempotent.
+- If the process exits before initialize completes, `spawnMcpClient` rejects with captured stderr.
+
+### 5.3 `runCli`
+
+```typescript
+export async function runCli(opts: RunCliOpts): Promise<CliResult>;
+
+export interface RunCliOpts {
+  command: string;               // e.g. 'exarchos-install'
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;                  // default: process.cwd()
+  stdin?: string;
+  timeout?: number;              // default: 30000ms
+}
+
+export interface CliResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  durationMs: number;
+}
+```
+
+**Guarantees:**
+- Rejects on timeout; always returns a structured result otherwise (including non-zero exit codes).
+- Does not throw on non-zero exit; caller asserts on `exitCode`.
+
+### 5.4 `normalize`
+
+```typescript
+export function normalize<T>(value: T): Normalized<T>;
+```
+
+Recursively walks the input, replacing matched fields with the canonical placeholders listed in §4.4. Deterministic, pure, no I/O. The `Normalized<T>` type is structurally identical to `T` with replaced fields as strings.
+
+### 5.5 `expectNoLeakedProcesses`
+
+```typescript
+export function expectNoLeakedProcesses(): void;
+```
+
+Inspects the process tracker (populated by `spawnMcpClient` and `runCli`). If any spawned child is still alive, fails the test and force-kills the leaked children. Wired globally via `test/setup/global.ts` registered in the `process` project's `setupFiles`.
+
+## 6. PR sequencing
+
+Per Option B from the ideate: shared fixtures land first, then independent follow-ups.
+
+```
+PR 1 (this design)           PR 2: F2 MCP smoke
+┌──────────────────────┐     ┌──────────────────────┐
+│ Shared fixtures      │────▶│ spawnMcpClient +     │
+│ + vitest projects    │     │ exarchos_workflow    │
+│ + CI wiring          │     │ round-trip test      │
+└──────────────────────┘     └──────────────────────┘
+         │
+         ├───────────────────▶ PR 3: F2 CLI smoke
+         │                    ┌──────────────────────┐
+         │                    │ runCli + exarchos-   │
+         │                    │ install filesystem   │
+         │                    │ assertions           │
+         │                    └──────────────────────┘
+         │
+         ├───────────────────▶ PR 4: F3 conformance
+         │                    ┌──────────────────────┐
+         │                    │ @modelcontextprotocol│
+         │                    │ /conformance wrapped │
+         │                    │ as vitest project    │
+         │                    └──────────────────────┘
+         │
+         └───────────────────▶ PR 5: Windows CI
+                              ┌──────────────────────┐
+                              │ matrix: windows-     │
+                              │ latest on unit       │
+                              │ project only         │
+                              └──────────────────────┘
+```
+
+PRs 2–5 are all independent of each other after PR 1 merges. They can land in any order.
+
+## 7. Follow-up issues
+
+One issue per follow-up PR, each referencing this design and folded into the appropriate v3.0 milestone:
+
+| Issue title | Epic / milestone fold-in |
+|-------------|--------------------------|
+| `test(e2e): F2 MCP process-fidelity smoke — exarchos_workflow round-trip` | [#1109](https://github.com/lvlup-sw/exarchos/issues/1109) (MCP parity cross-cutting) |
+| `test(e2e): F2 CLI process-fidelity smoke — exarchos install against tmp $HOME` | [#1087](https://github.com/lvlup-sw/exarchos/issues/1087) (v3.0 P1: CLI ergonomic) |
+| `test(e2e): integrate @modelcontextprotocol/conformance as vitest project` | [#1109](https://github.com/lvlup-sw/exarchos/issues/1109) |
+| `ci: add windows-latest to unit project matrix` | [#1118](https://github.com/lvlup-sw/exarchos/issues/1118) (platform-agnosticity) |
+
+Issue bodies template: summary, fixture consumption list, acceptance criteria, axiom dimensions closed, blocking/blocked-by references.
+
+## 8. Testing strategy
+
+The fixture library itself needs tests. These live in `test/fixtures/*.test.ts` and run in the `unit` project (they don't need process fidelity; they *are* the process-fidelity infrastructure).
+
+**Required coverage:**
+
+- `withHermeticEnv`: env/CWD restored on throw; concurrent callers get non-overlapping tmp dirs; cleanup runs when callback succeeds and when it throws.
+- `spawnMcpClient`: process-exit-before-initialize rejects with stderr; `terminate()` is idempotent; timeout path rejects cleanly.
+- `runCli`: non-zero exit returned as structured result; timeout rejection; stdin piping.
+- `normalize`: each canonical-field rule in isolation; idempotence (normalizing twice is a no-op); deep nested structures.
+- `expectNoLeakedProcesses`: fails test when a live child remains; force-kills leaked children.
+
+**Not tested here:** the actual contract of the MCP server or CLI. Those are PR 2's and PR 3's responsibility.
+
+## 9. Risks and mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| `npm link` is non-deterministic across OSes | Document the link step in CI config; fail fast if `exarchos-mcp` not on `PATH` when `process` project runs. |
+| Process spawn latency (~300ms per test) balloons CI time | Keep the `process` project to ≤20 tests through Tier 1; run it on Linux PR-gate only; defer matrix expansion to Tier 2. |
+| Tmp-dir cleanup races on Windows under file locks | Use `fs.rm({ force: true, retryable: true })`; tolerate cleanup failure in `finally` with a logged warning, not a test failure. |
+| Flaky process termination detection on slow CI runners | `terminate()` uses SIGTERM then SIGKILL after 3s; `expectNoLeakedProcesses` uses the same timeout. |
+| Fixture library grows beyond its charter | Rule: if a helper is consumed by only one test file, it lives in that test file, not in `test/fixtures/`. |
+
+## 10. Open questions (deferred to follow-up ideates)
+
+These are flagged here so follow-up PRs can pick them up with context:
+
+- **PR 2:** which Zod input schema validation errors should the smoke test cover, if any?
+- **PR 3:** how do we assert on the installed state tree — deep-equal against a fixture, or selective path existence checks?
+- **PR 4:** which spec version of `@modelcontextprotocol/conformance` do we pin, and how do we track spec-version upgrades?
+- **PR 5:** do we cache `node_modules` on Windows runners, or rebuild fresh each job?
+- **Post-Tier-1:** when [#1115](https://github.com/lvlup-sw/exarchos/issues/1115) lands, does the F2 CLI test run against a downloaded binary each run, or a locally-built binary served via `file://`? See [#1115 comment](https://github.com/lvlup-sw/exarchos/issues/1115#issuecomment-4277752096).
+
+## 11. References
+
+**Internal:**
+- `docs/research/2026-04-19-e2e-testing-strategy.md` (Tier 1 framing)
+- `skills/backend-quality/references/dimensions.md` (axiom dimensions DIM-1, DIM-4, DIM-5, DIM-6, DIM-7)
+- `skills/verify/references/test-antipatterns.md`
+- `CLAUDE.md` (architecture overview)
+
+**External:**
+- [`@modelcontextprotocol/sdk` client docs](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/client.md) — `StdioClientTransport`, `Client.callTool`, `Client.listTools`
+- [`@modelcontextprotocol/conformance`](https://www.npmjs.com/package/@modelcontextprotocol/conformance) — official spec conformance suite
+- [`@scalvert/bin-tester`](https://github.com/scalvert/bin-tester) — CLI-in-tmpdir pattern reference
+- [Vitest projects configuration](https://vitest.dev/guide/projects.html)
+
+**Related issues:**
+- [#1085](https://github.com/lvlup-sw/exarchos/issues/1085) — Windows MCP server bug (target of PR 5)
+- [#1087](https://github.com/lvlup-sw/exarchos/issues/1087) — v3.0 CLI Ergonomic Infrastructure (PR 3 consumer)
+- [#1088](https://github.com/lvlup-sw/exarchos/issues/1088) — HATEOAS + NDJSON output contract (F3 consumer)
+- [#1098](https://github.com/lvlup-sw/exarchos/issues/1098) — Uniform HATEOAS envelope (F3 consumer)
+- [#1109](https://github.com/lvlup-sw/exarchos/issues/1109) — MCP parity cross-cutting (PR 2 + PR 4)
+- [#1115](https://github.com/lvlup-sw/exarchos/issues/1115) — Universal bootstrap script (downstream of PR 3's target-agnostic design)
+- [#1118](https://github.com/lvlup-sw/exarchos/issues/1118) — Codify platform-agnosticity (PR 5 rationale)
+- [#1139](https://github.com/lvlup-sw/exarchos/issues/1139) — Capability resolver (future F3 work)

--- a/docs/plans/2026-04-19-fixer-token-efficiency.md
+++ b/docs/plans/2026-04-19-fixer-token-efficiency.md
@@ -258,19 +258,19 @@ Two facts surfaced when reading the existing code that the design didn't anticip
 
 ---
 
-### Task 13: Emit `provider.unknown_tier` events from adapters
+### Task 13: Emit `provider.unknown-tier` events from adapters
 
 **Phase:** RED → GREEN
 
 1. [RED] Write test: `CoderabbitAdapter_UnrecognizedTier_EmitsUnknownTierEvent`
    - File: `servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts` (event emission integration; adapter unit test would couple too tightly to event-store)
-   - Mock event store. Mock CodeRabbit comment with body `"_:rocket: Brand new tier_ ..."`. Run `assess_stack`. Assert one event of type `provider.unknown_tier` was emitted with data `{reviewer: 'coderabbit', rawTier: ':rocket: Brand new tier', commentId: <id>}`.
+   - Mock event store. Mock CodeRabbit comment with body `"_:rocket: Brand new tier_ ..."`. Run `assess_stack`. Assert one event of type `provider.unknown-tier` was emitted with data `{reviewer: 'coderabbit', rawTier: ':rocket: Brand new tier', commentId: <id>}`.
    - Expected failure: adapter doesn't surface unknown tiers and assess_stack doesn't emit the event.
 
 2. [GREEN]
    - Adapter: when tier doesn't match any known pattern, return `ActionItem` with `normalizedSeverity: 'MEDIUM'` AND attach `unknownTier?: string` field to the result.
    - Add `unknownTier?: string` field to `ActionItem` (or to a sibling result type — pick least-coupling option).
-   - In `assess_stack`, after dispatching the adapter, emit `provider.unknown_tier` if the result carries an `unknownTier`.
+   - In `assess_stack`, after dispatching the adapter, emit `provider.unknown-tier` if the result carries an `unknownTier`.
    - Register the new event type in `servers/exarchos-mcp/src/event-store/event-types.ts` (or wherever event types live — confirm during implementation).
 
 **Dependencies:** Task 11

--- a/docs/plans/2026-04-19-fixer-token-efficiency.md
+++ b/docs/plans/2026-04-19-fixer-token-efficiency.md
@@ -1,0 +1,530 @@
+# Fixer Token Efficiency — Implementation Plan
+
+**Design:** [`docs/designs/2026-04-19-fixer-token-efficiency.md`](../designs/2026-04-19-fixer-token-efficiency.md)
+**Workflow:** `feat-fixer-token-efficiency`
+**Date:** 2026-04-19
+**Iron Law:** No production code without a failing test first.
+
+## Implementation deltas from design
+
+Two facts surfaced when reading the existing code that the design didn't anticipate:
+
+1. **`ActionItem` already exists** in `servers/exarchos-mcp/src/orchestrate/assess-stack.ts:44-49` with `severity: 'critical' | 'major' | 'minor'` (lowercase, fixed taxonomy) and no `file`/`line`/`reviewer`/`raw` fields. Per the design's DIM-3 additive constraint, we **extend the existing `ActionItem`** with new optional fields rather than introducing a parallel type. Severity stays as today during Phase 1; adapters populate a new `normalizedSeverity: 'HIGH' | 'MEDIUM' | 'LOW'` field. Phase 2 promotes `normalizedSeverity` to required.
+
+2. **Comment bodies are truncated to 200 chars** at `assess-stack.ts:68-73` (`COMMENT_BODY_LIMIT`) before they reach any consumer. Adapters need the full body to parse tier markers (CodeRabbit's "Critical" header may live below the truncation point). Phase 1 retains full bodies for adapter input; truncation moves to display-only.
+
+3. **Existing `classifyActionItems` function** at `assess-stack.ts:158-198` is coarse-grained (every comment → "major"). Phase 2's `classify_review_items` action wraps + replaces it.
+
+## Task summary
+
+- **Pre-work (4 tasks):** Domain types, comment-truncation refactor.
+- **Phase 1 (12 tasks):** 5 provider adapters, registry, `assess_stack` wiring, event emission, hygiene cleanup.
+- **Phase 2 (9 tasks):** Classifier types, file-grouping, recommendation logic, action registration, event emission, shepherd integration, hygiene cleanup, severity promotion.
+
+**Total: 25 tasks.**
+
+---
+
+## Pre-work
+
+### Task 1: Extend `ActionItem` with optional reviewer-context fields
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write test: `ActionItem_WithReviewerFields_TypeChecks`
+   - File: `servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts`
+   - Test constructs an `ActionItem` literal that sets `file`, `line`, `reviewer`, `threadId`, `raw`, `normalizedSeverity`. Compile-time check (assertion via type predicate / `satisfies`).
+   - Expected failure: TS error — fields don't exist on `ActionItem`.
+
+2. [GREEN] Add optional fields to `ActionItem` interface:
+   - File: `servers/exarchos-mcp/src/orchestrate/assess-stack.ts:44-49`
+   - Append: `readonly file?: string; readonly line?: number; readonly reviewer?: ReviewerKind; readonly threadId?: string; readonly raw?: unknown; readonly normalizedSeverity?: Severity;`
+
+3. [REFACTOR] Move `ActionItem` and its supporting types (`Severity`, `ReviewerKind`) to a new file `servers/exarchos-mcp/src/review/types.ts` and re-export from `assess-stack.ts` for backwards compatibility. Keeps the canonical-type-in-one-place invariant from DIM-6.
+
+**Dependencies:** None
+**Parallelizable:** No (foundational)
+
+---
+
+### Task 2: Define `ProviderAdapter` interface
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `ProviderAdapter_Interface_RejectsMissingMembers`
+   - File: `servers/exarchos-mcp/src/review/types.test.ts`
+   - Test asserts the type via `satisfies ProviderAdapter` for a stub object missing `kind` or `parse`.
+   - Expected failure: file doesn't exist.
+
+2. [GREEN] Add to `servers/exarchos-mcp/src/review/types.ts`:
+   ```typescript
+   export interface ProviderAdapter {
+     readonly kind: ReviewerKind;
+     parse(rawComment: VcsPrComment): ActionItem | null;
+   }
+   ```
+
+**Dependencies:** Task 1
+**Parallelizable:** Yes (with Task 3)
+
+---
+
+### Task 3: Define `ReviewAdapterRegistry` interface
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `ReviewAdapterRegistry_Interface_HasForReviewerAndList`
+   - File: `servers/exarchos-mcp/src/review/types.test.ts`
+   - `satisfies ReviewAdapterRegistry` test against stub.
+   - Expected failure: interface doesn't exist.
+
+2. [GREEN] Add to `servers/exarchos-mcp/src/review/types.ts`:
+   ```typescript
+   export interface ReviewAdapterRegistry {
+     forReviewer(kind: ReviewerKind): ProviderAdapter | undefined;
+     list(): readonly ProviderAdapter[];
+   }
+   ```
+
+**Dependencies:** Task 1
+**Parallelizable:** Yes (with Task 2)
+
+---
+
+### Task 4: Retain full comment bodies through `queryPrComments`
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write test: `QueryPrComments_LongCommentBody_RetainsFullBody`
+   - File: `servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts`
+   - Mock `provider.getPrComments()` to return a comment whose body is 500 chars. Assert the returned `PrComment.body` is 500 chars (not 200+`...`).
+   - Expected failure: `truncateBody` truncates at 200.
+
+2. [GREEN] Modify `PrComment` in `assess-stack.ts:39-42` to add `fullBody: string` field. `queryPrComments` populates `fullBody` with the original; `body` continues to be truncated for display.
+   - File: `servers/exarchos-mcp/src/orchestrate/assess-stack.ts:39-42, 118-132`
+
+3. [REFACTOR] If `body` is no longer read by anyone after later tasks, delete it. (Track for Phase 2 cleanup; do not delete in Pre-work.)
+
+**Dependencies:** None
+**Parallelizable:** Yes (with Tasks 2, 3)
+
+---
+
+## Phase 1: Provider adapters + `assess_stack` wiring
+
+### Task 5: CodeRabbit adapter
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write tests in `servers/exarchos-mcp/src/review/providers/coderabbit.test.ts`:
+   - `CoderabbitAdapter_CriticalTier_NormalizesToHigh`
+   - `CoderabbitAdapter_MajorTier_NormalizesToHigh`
+   - `CoderabbitAdapter_MinorTier_NormalizesToLow`
+   - `CoderabbitAdapter_NitpickBlock_NormalizesToLow`
+   - `CoderabbitAdapter_UnrecognizedTier_DefaultsToMedium`
+   - `CoderabbitAdapter_NonCoderabbitAuthor_ReturnsNull`
+   - Each test calls `coderabbitAdapter.parse(fixture)` and asserts the resulting `ActionItem.normalizedSeverity` and `ActionItem.reviewer`.
+   - Expected failure: file doesn't exist.
+
+2. [GREEN] Create `servers/exarchos-mcp/src/review/providers/coderabbit.ts`. Author check: `comment.author === 'coderabbitai[bot]'` (verify exact string in fixture). Tier extraction: regex on body for `_:warning: Potential issue_`, `_:hammer_and_wrench: Refactor suggestion_`, `_:bulb: Verification agent_`, "Nitpick" block headers. Map: `Potential issue|Critical|Major → HIGH`; `Refactor suggestion → MEDIUM`; `Nitpick|Verification|Minor → LOW`.
+
+3. [REFACTOR] Extract the tier map to a constant in the adapter file.
+
+**Dependencies:** Task 2
+**Parallelizable:** Yes (with Tasks 6, 7, 8, 9)
+
+---
+
+### Task 6: Sentry adapter
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `servers/exarchos-mcp/src/review/providers/sentry.test.ts`:
+   - `SentryAdapter_CriticalTag_NormalizesToHigh`
+   - `SentryAdapter_MediumTag_NormalizesToMedium`
+   - `SentryAdapter_NoSeverityTag_DefaultsToLow`
+   - `SentryAdapter_NonSentryAuthor_ReturnsNull`
+   - Expected failure: file doesn't exist.
+
+2. [GREEN] Create `servers/exarchos-mcp/src/review/providers/sentry.ts`. Author check: `comment.author === 'sentry-io[bot]'` (verify in fixture). Tag extraction: regex for `CRITICAL`, `HIGH`, `MEDIUM`, `LOW` in body. Map: `CRITICAL|HIGH → HIGH`; `MEDIUM → MEDIUM`; default `LOW`.
+
+**Dependencies:** Task 2
+**Parallelizable:** Yes (with Tasks 5, 7, 8, 9)
+
+---
+
+### Task 7: GitHub-Copilot adapter
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `servers/exarchos-mcp/src/review/providers/github-copilot.test.ts`:
+   - `GithubCopilotAdapter_AnyComment_DefaultsToMedium`
+   - `GithubCopilotAdapter_NonCopilotAuthor_ReturnsNull`
+   - Expected failure: file doesn't exist.
+
+2. [GREEN] Create `servers/exarchos-mcp/src/review/providers/github-copilot.ts`. Author check: `comment.author === 'github-copilot[bot]'` or `Copilot`. Always returns `normalizedSeverity: 'MEDIUM'`.
+
+**Dependencies:** Task 2
+**Parallelizable:** Yes (with Tasks 5, 6, 8, 9)
+
+---
+
+### Task 8: Human adapter
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `servers/exarchos-mcp/src/review/providers/human.test.ts`:
+   - `HumanAdapter_AnyComment_DefaultsToMedium`
+   - `HumanAdapter_BotAuthor_ReturnsNull`
+   - Expected failure: file doesn't exist.
+
+2. [GREEN] Create `servers/exarchos-mcp/src/review/providers/human.ts`. Author check: `!comment.author.endsWith('[bot]') && comment.author !== 'Copilot'`. Always returns `normalizedSeverity: 'MEDIUM'`. Reviewer kind: `'human'`.
+
+**Dependencies:** Task 2
+**Parallelizable:** Yes (with Tasks 5, 6, 7, 9)
+
+---
+
+### Task 9: Unknown adapter (fallback)
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `servers/exarchos-mcp/src/review/providers/unknown.test.ts`:
+   - `UnknownAdapter_AnyAuthor_AlwaysParses`
+   - `UnknownAdapter_DefaultsToMedium`
+   - Expected failure: file doesn't exist.
+
+2. [GREEN] Create `servers/exarchos-mcp/src/review/providers/unknown.ts`. Always returns an `ActionItem` with `reviewer: 'unknown'`, `normalizedSeverity: 'MEDIUM'`. Adapter is the catch-all when no other adapter claims the author.
+
+**Dependencies:** Task 2
+**Parallelizable:** Yes (with Tasks 5, 6, 7, 8)
+
+---
+
+### Task 10: Registry factory
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write tests in `servers/exarchos-mcp/src/review/registry.test.ts`:
+   - `CreateReviewAdapterRegistry_ReturnsAllFiveAdapters`
+   - `CreateReviewAdapterRegistry_ForReviewerCoderabbit_ReturnsCoderabbitAdapter`
+   - `CreateReviewAdapterRegistry_ForReviewerUnknownKind_ReturnsUndefined`
+   - `CreateReviewAdapterRegistry_ListIsImmutable` — assert returned array is frozen / mutation throws.
+   - Expected failure: file doesn't exist.
+
+2. [GREEN] Create `servers/exarchos-mcp/src/review/registry.ts`. Export `createReviewAdapterRegistry(): ReviewAdapterRegistry` returning a frozen registry with all five adapters.
+
+3. [REFACTOR] If duplication appears between this factory and `assess_stack`'s adapter usage, extract a `dispatchAdapter(comment, registry)` helper.
+
+**Dependencies:** Tasks 5, 6, 7, 8, 9, 3
+**Parallelizable:** No (gates Task 11)
+
+---
+
+### Task 11: Wire registry into `assess_stack` — adapter dispatch per comment
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write test: `QueryPrStatus_CoderabbitComment_PopulatesNormalizedSeverity`
+   - File: `servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts`
+   - Mock provider returns a CodeRabbit comment with a "Potential issue" body. Assert the resulting `PrStatus.unresolvedComments[0]` (or whichever shape carries it after refactor) has the parsed `ActionItem` attached with `normalizedSeverity: 'HIGH'`, `reviewer: 'coderabbit'`, `file: <fixture>`, `line: <fixture>`.
+   - Expected failure: `assess_stack` doesn't dispatch through adapters.
+
+2. [GREEN] Modify `assess-stack.ts`:
+   - Add a `registry: ReviewAdapterRegistry` parameter to the handler (constructor-injected). Default to `createReviewAdapterRegistry()` only at the top-level handler entry — never lazy-construct inside.
+   - In `queryPrComments`, for each `VcsPrComment`, route to `registry.forReviewer(detectKind(comment.author))?.parse(comment) ?? unknownAdapter.parse(comment)`.
+   - Attach the parsed `ActionItem` (or its fields) to whatever shape `queryPrStatus` returns. Likely add `actionItem?: ActionItem` to `PrComment`.
+
+3. [REFACTOR] Extract `detectKind(author: string): ReviewerKind` to `registry.ts`.
+
+**Dependencies:** Task 10, Task 4
+**Parallelizable:** No
+
+---
+
+### Task 12: Modify `classifyActionItems` to use adapter output for severity
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `ClassifyActionItems_HighSeverityComment_RetainsHighSeverity`
+   - File: `servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts`
+   - Construct a `PrStatus` whose `unresolvedComments[0]` has an attached `ActionItem` with `normalizedSeverity: 'HIGH'`. Assert the resulting `ActionItem` from `classifyActionItems` carries `normalizedSeverity: 'HIGH'` (not the existing default `severity: 'major'`).
+   - Expected failure: `classifyActionItems` ignores adapter output.
+
+2. [GREEN] Modify `classifyActionItems` (assess-stack.ts:158-198): for `comment-reply` items, populate `normalizedSeverity` from the comment's attached `ActionItem.normalizedSeverity` if present, else leave undefined. Existing `severity: 'major'` default unchanged for backward compat.
+
+**Dependencies:** Task 11
+**Parallelizable:** Yes (with Task 13)
+
+---
+
+### Task 13: Emit `provider.unknown_tier` events from adapters
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `CoderabbitAdapter_UnrecognizedTier_EmitsUnknownTierEvent`
+   - File: `servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts` (event emission integration; adapter unit test would couple too tightly to event-store)
+   - Mock event store. Mock CodeRabbit comment with body `"_:rocket: Brand new tier_ ..."`. Run `assess_stack`. Assert one event of type `provider.unknown_tier` was emitted with data `{reviewer: 'coderabbit', rawTier: ':rocket: Brand new tier', commentId: <id>}`.
+   - Expected failure: adapter doesn't surface unknown tiers and assess_stack doesn't emit the event.
+
+2. [GREEN]
+   - Adapter: when tier doesn't match any known pattern, return `ActionItem` with `normalizedSeverity: 'MEDIUM'` AND attach `unknownTier?: string` field to the result.
+   - Add `unknownTier?: string` field to `ActionItem` (or to a sibling result type — pick least-coupling option).
+   - In `assess_stack`, after dispatching the adapter, emit `provider.unknown_tier` if the result carries an `unknownTier`.
+   - Register the new event type in `servers/exarchos-mcp/src/event-store/event-types.ts` (or wherever event types live — confirm during implementation).
+
+**Dependencies:** Task 11
+**Parallelizable:** Yes (with Task 12)
+
+---
+
+### Task 14: Hygiene — prune redundant prose from `fix-strategies.md`
+
+**Phase:** REFACTOR-only (no test required; documentation change)
+
+1. Delete or convert the Sentry guidance block at `skills-src/shepherd/references/fix-strategies.md:157-176` to a one-liner pointer.
+2. Delete or convert the CodeRabbit guidance block at `skills-src/shepherd/references/fix-strategies.md:178-194` to a one-liner pointer.
+3. Delete or convert the Human Reviewer guidance block at `skills-src/shepherd/references/fix-strategies.md:196-202` to a one-liner pointer.
+4. Run `npm run build:skills` and commit regenerated `skills/` per CLAUDE.md convention.
+5. **Verify:** No production code references the deleted blocks. Skill rendering still works (no broken `@references/` includes).
+
+**Dependencies:** Tasks 5, 6, 8 (adapters that own the moved logic must exist first)
+**Parallelizable:** Yes (with Tasks 11, 12, 13 — different file)
+
+---
+
+## Phase 2: `classify_review_items` action + shepherd integration
+
+### Task 15: Define `ClassificationGroup` output type
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `ClassificationGroup_Type_HasFileItemsSeverityRecommendation`
+   - File: `servers/exarchos-mcp/src/review/classifier.test.ts`
+   - `satisfies ClassificationGroup` test against stub.
+   - Expected failure: file doesn't exist.
+
+2. [GREEN] Add to `servers/exarchos-mcp/src/review/types.ts`:
+   ```typescript
+   export type DispatchRecommendation = 'direct' | 'delegate-fixer' | 'delegate-scaffolder';
+   export interface ClassificationGroup {
+     readonly file: string | null;
+     readonly items: readonly ActionItem[];
+     readonly severity: Severity;            // max severity in group
+     readonly recommendation: DispatchRecommendation;
+     readonly rationale: string;
+   }
+   export interface ClassificationResult {
+     readonly groups: readonly ClassificationGroup[];
+     readonly summary: { totalItems: number; directCount: number; delegateCount: number };
+   }
+   ```
+
+**Dependencies:** Task 1, Task 11 (so `ActionItem.normalizedSeverity` is in place)
+**Parallelizable:** Yes (with Task 16)
+
+---
+
+### Task 16: File-grouping function
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `servers/exarchos-mcp/src/review/classifier.test.ts`:
+   - `GroupItemsByFile_TwoItemsSameFile_ReturnsOneGroup`
+   - `GroupItemsByFile_ItemsAcrossFiles_ReturnsOneGroupPerFile`
+   - `GroupItemsByFile_ItemsWithoutFile_GroupedUnderNullFile`
+   - Expected failure: function doesn't exist.
+
+2. [GREEN] Create `servers/exarchos-mcp/src/review/classifier.ts` with `groupItemsByFile(items: readonly ActionItem[]): Map<string | null, ActionItem[]>`.
+
+**Dependencies:** Task 1
+**Parallelizable:** Yes (with Task 15)
+
+---
+
+### Task 17: Recommendation logic — direct vs delegate-fixer
+
+**Phase:** RED → GREEN
+
+1. [RED] Write tests in `servers/exarchos-mcp/src/review/classifier.test.ts`:
+   - `RecommendForGroup_SingleItemNonHighSeverity_RecommendsDirect`
+   - `RecommendForGroup_MultipleItemsSameFile_RecommendsDelegateFixer`
+   - `RecommendForGroup_AnyHighSeverity_RecommendsDelegateFixer`
+   - `RecommendForGroup_PopulatesRationale`
+   - Expected failure: function doesn't exist.
+
+2. [GREEN] Add `recommendForGroup(items: readonly ActionItem[]): {recommendation: DispatchRecommendation; rationale: string; severity: Severity}` to `classifier.ts`.
+
+**Dependencies:** Tasks 15, 16
+**Parallelizable:** Yes (with Task 18)
+
+---
+
+### Task 18: Doc-nit routing to scaffolder
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write tests in `servers/exarchos-mcp/src/review/classifier.test.ts`:
+   - `RecommendForGroup_AllLowSeverityWithDocNitKeyword_RecommendsScaffolder`
+   - `RecommendForGroup_LowSeverityNoKeyword_RecommendsDirect`
+   - Expected failure: scaffolder branch doesn't exist.
+
+2. [GREEN] Extend `recommendForGroup`: if all items have `normalizedSeverity: 'LOW'` AND any item title matches `DOC_NIT_KEYWORDS = ['<remarks>', 'sealed', 'OrderBy', 'format', 'XML doc']`, recommend `delegate-scaffolder`.
+
+3. [REFACTOR] If `DOC_NIT_KEYWORDS` overlaps `SCAFFOLDING_KEYWORDS` from `prepare-delegation.ts:91`, extract a shared constant in a new `servers/exarchos-mcp/src/orchestrate/scaffolding-keywords.ts` and re-export from both consumers. Resolves design Q-P5.
+
+**Dependencies:** Task 17
+**Parallelizable:** No
+
+---
+
+### Task 19: Top-level `classifyReviewItems()` entry point
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `ClassifyReviewItems_MixedItems_ProducesGroupsAndSummary`
+   - File: `servers/exarchos-mcp/src/review/classifier.test.ts`
+   - Property-style test: given a randomly generated `ActionItem[]`, all items appear in exactly one group's `items` (partition invariant from design test strategy).
+   - Plus a concrete fixture test that constructs 5 items across 3 files with mixed severities and asserts the full `ClassificationResult` shape.
+   - Expected failure: function doesn't exist.
+
+2. [GREEN] Add `classifyReviewItems(items: readonly ActionItem[]): ClassificationResult` to `classifier.ts`. Composes `groupItemsByFile` + `recommendForGroup` per group + summary aggregation.
+
+**Dependencies:** Tasks 16, 17, 18
+**Parallelizable:** No (gates Task 20)
+
+---
+
+### Task 20: Register `classify_review_items` orchestrate action
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `OrchestrateClassifyReviewItems_GivenItems_ReturnsClassificationResult`
+   - File: `servers/exarchos-mcp/src/orchestrate/classify-review-items.test.ts`
+   - Calls the handler with sample input; asserts result shape.
+   - Expected failure: handler + registry entry don't exist.
+
+2. [GREEN]
+   - Create `servers/exarchos-mcp/src/orchestrate/classify-review-items.ts` exporting `handleClassifyReviewItems(args: {actionItems: ActionItem[]}): ToolResult` that wraps `classifyReviewItems()`.
+   - Add registry entry in `servers/exarchos-mcp/src/registry.ts`: name `classify_review_items`, schema `z.object({ actionItems: z.array(...) })`, phases `REVIEW_PHASES`, roles `ROLE_LEAD`.
+   - Wire dispatch in the orchestrate handler dispatcher.
+
+**Dependencies:** Task 19
+**Parallelizable:** No
+
+---
+
+### Task 21: Emit `dispatch.classified` event
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `OrchestrateClassifyReviewItems_OnInvocation_EmitsDispatchClassifiedEvent`
+   - File: `servers/exarchos-mcp/src/orchestrate/classify-review-items.test.ts`
+   - Mock event store. Run handler with 4 items (1 HIGH/1 MEDIUM/2 LOW across 2 files). Assert one `dispatch.classified` event was emitted with data `{groupCount: 2, directCount, delegateCount, severityDistribution: {high: 1, medium: 1, low: 2}}`.
+   - Expected failure: handler doesn't emit.
+
+2. [GREEN]
+   - Register event type `dispatch.classified` in event types module.
+   - Emit from `handleClassifyReviewItems` after computing the result.
+
+**Dependencies:** Task 20
+**Parallelizable:** Yes (with Task 22)
+
+---
+
+### Task 22: Promote `normalizedSeverity` to required in `ActionItem`
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write test: `ActionItem_WithoutNormalizedSeverity_TypeError`
+   - File: `servers/exarchos-mcp/src/review/types.test.ts`
+   - `// @ts-expect-error` test that a literal missing `normalizedSeverity` fails to type-check.
+   - Expected failure: field is currently optional.
+
+2. [GREEN] Change `normalizedSeverity?: Severity` to `normalizedSeverity: Severity` in `types.ts`. Run `npm run typecheck`. Fix every callsite that constructs `ActionItem` without populating it. Adapters already populate it (Phase 1). Existing `classifyActionItems` populates it from comment adapter output; unattached items (CI-fix, review-address) need an explicit default — set to `'HIGH'` for `ci-fix`, `'HIGH'` for `review-address` to mirror existing `severity: 'critical'`/`'major'` mappings.
+
+3. [REFACTOR] If the existing lowercase `severity` field becomes redundant (every consumer reads `normalizedSeverity`), mark it deprecated with a JSDoc `@deprecated` comment. Do not delete in this task; deletion is out of scope.
+
+**Dependencies:** Task 11 (adapters in place), Task 12 (severity threading complete)
+**Parallelizable:** Yes (with Task 21)
+
+---
+
+### Task 23: Update shepherd skill to call `classify_review_items`
+
+**Phase:** REFACTOR-only (skill prose change)
+
+1. Update `skills-src/shepherd/SKILL.md` Step 2 (lines 94-138):
+   - Insert a step before the action-item iteration: "Call `exarchos_orchestrate({action: 'classify_review_items', actionItems: <from assess_stack>})` and route per group's `recommendation`."
+   - Update the action-item types table to reference `recommendation` instead of `type`.
+2. Run `npm run build:skills`; commit regenerated `skills/`.
+3. **Verify:** Existing event emission protocol (`remediation.attempted` / `remediation.succeeded`) still wraps each fix attempt.
+
+**Dependencies:** Task 20
+**Parallelizable:** Yes (with Tasks 21, 22, 24)
+
+---
+
+### Task 24: Hygiene — delete `fix-strategies.md` direct-vs-delegate table
+
+**Phase:** REFACTOR-only
+
+1. Delete the table at `skills-src/shepherd/references/fix-strategies.md:9-14` and the surrounding "Decision: Fix Directly vs. Delegate" section.
+2. Replace with: "See `classify_review_items` orchestrate action — it owns this decision."
+3. Run `npm run build:skills`; commit regenerated `skills/`.
+4. **Verify:** No skill prose still references the deleted heuristic.
+
+**Dependencies:** Task 23 (shepherd skill updated to use classifier first)
+**Parallelizable:** Yes (with Tasks 21, 22)
+
+---
+
+### Task 25: Smoke test — shepherd integration with classifier
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `ShepherdIteration_MixedSeverityComments_RoutesPerClassifier`
+   - File: `servers/exarchos-mcp/src/__tests__/shepherd-classifier-integration.test.ts`
+   - Mock VCS provider returning a PR with a CodeRabbit Critical comment, a Sentry Medium comment, and a human nit. Run `assess_stack` → `classify_review_items`. Assert the classifier output contains 3 groups with expected recommendations (`delegate-fixer` / `direct` / `direct`).
+   - Expected failure: integration not wired.
+
+2. [GREEN] Confirm wiring works end-to-end. May require fixture work, not new code if Tasks 11+20 are correct.
+
+**Dependencies:** Tasks 20, 11
+**Parallelizable:** No (final integration check)
+
+---
+
+## Parallelization plan
+
+```text
+Pre-work
+├── Task 1 (foundational) ─┬─→ Task 2 ─┐
+                           ├─→ Task 3 ─┤
+                           └─→ Task 4 ─┴─→ Phase 1
+
+Phase 1
+├── Tasks 5, 6, 7, 8, 9 (5 adapters in parallel) ──→ Task 10 ──→ Task 11 ──┬─→ Task 12
+                                                                          └─→ Task 13
+└── Task 14 (hygiene, parallel with 11/12/13)
+
+Phase 2
+├── Tasks 15, 16 (parallel) ──→ Task 17 ──→ Task 18 ──→ Task 19 ──→ Task 20 ──┬─→ Task 21
+                                                                              ├─→ Task 22
+                                                                              ├─→ Task 23 ──→ Task 24
+                                                                              └─→ Task 25 (final)
+```
+
+**Worktree sizing recommendation:** 5 worktrees for the adapter wave (Tasks 5–9). Otherwise sequential — most later tasks are gated.
+
+## Open questions resolved during planning
+
+- **Q-P1 (fixture count):** Plan says 4–6 representative comments per provider, sourced from basileus #159 thread + recent exarchos PRs. Implementer can adjust during Task 5–9 RED phase.
+- **Q-P2 (Copilot author name):** Plan defers to implementer to confirm the exact author string in fixture data during Task 7.
+- **Q-P3 (soak window):** Plan promotes severity to required as Task 22, executed within the same PR sequence — no version-soak gate. The "soak" was a design hedge; in practice all callsites are in this same change-set and can be updated together.
+- **Q-P4 (back-compat for existing `actionItem.context`):** Pre-work Task 1 keeps existing fields untouched; new fields are additive. No grep needed because we're adding, not replacing, in Phase 1.
+- **Q-P5 (shared keyword constant):** Resolved in Task 18 REFACTOR — extract `SCAFFOLDING_KEYWORDS` to a shared module.
+
+## Open questions for plan-review
+
+None expected — all design Q-P# items are resolved above.

--- a/docs/plans/2026-04-19-fixer-token-efficiency.md
+++ b/docs/plans/2026-04-19-fixer-token-efficiency.md
@@ -142,11 +142,11 @@ Two facts surfaced when reading the existing code that the design didn't anticip
 1. [RED] Write tests in `servers/exarchos-mcp/src/review/providers/sentry.test.ts`:
    - `SentryAdapter_CriticalTag_NormalizesToHigh`
    - `SentryAdapter_MediumTag_NormalizesToMedium`
-   - `SentryAdapter_NoSeverityTag_DefaultsToLow`
+   - `SentryAdapter_NoSeverityTag_DefaultsToMedium`
    - `SentryAdapter_NonSentryAuthor_ReturnsNull`
    - Expected failure: file doesn't exist.
 
-2. [GREEN] Create `servers/exarchos-mcp/src/review/providers/sentry.ts`. Author check: `comment.author === 'sentry-io[bot]'` (verify in fixture). Tag extraction: regex for `CRITICAL`, `HIGH`, `MEDIUM`, `LOW` in body. Map: `CRITICAL|HIGH → HIGH`; `MEDIUM → MEDIUM`; default `LOW`.
+2. [GREEN] Create `servers/exarchos-mcp/src/review/providers/sentry.ts`. Author check: `comment.author === 'sentry-io[bot]'` (verify in fixture). Tag extraction: regex for `CRITICAL`, `HIGH`, `MEDIUM`, `LOW` in body. Map: `CRITICAL|HIGH → HIGH`; `MEDIUM → MEDIUM`; `LOW → LOW`; default `MEDIUM` (comments without a tier marker still get a reply task but at a non-blocking severity).
 
 **Dependencies:** Task 2
 **Parallelizable:** Yes (with Tasks 5, 7, 8, 9)

--- a/docs/plans/2026-04-19-fixer-token-efficiency.md
+++ b/docs/plans/2026-04-19-fixer-token-efficiency.md
@@ -97,8 +97,8 @@ Two facts surfaced when reading the existing code that the design didn't anticip
 
 1. [RED] Write test: `QueryPrComments_LongCommentBody_RetainsFullBody`
    - File: `servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts`
-   - Mock `provider.getPrComments()` to return a comment whose body is 500 chars. Assert the returned `PrComment.body` is 500 chars (not 200+`...`).
-   - Expected failure: `truncateBody` truncates at 200.
+   - Mock `provider.getPrComments()` to return a comment whose body is 500 chars. Assert `PrComment.fullBody` is 500 chars (original, untruncated) and `PrComment.body` remains display-truncated at 200 chars.
+   - Expected failure: `fullBody` does not yet exist on `PrComment`.
 
 2. [GREEN] Modify `PrComment` in `assess-stack.ts:39-42` to add `fullBody: string` field. `queryPrComments` populates `fullBody` with the original; `body` continues to be truncated for display.
    - File: `servers/exarchos-mcp/src/orchestrate/assess-stack.ts:39-42, 118-132`

--- a/docs/research/2026-04-19-azd-aspire-integration.md
+++ b/docs/research/2026-04-19-azd-aspire-integration.md
@@ -1,0 +1,146 @@
+# Exarchos × azd × Aspire: Integration Research
+
+**Status:** Research (discovery phase). Not an implementation plan.
+**Workflow:** `azd-aspire-integration`
+**Date:** 2026-04-19
+
+**Related internal:**
+- `CLAUDE.md` — "agent-first CLI patterns (Aspire-inspired)" is already a stated design principle
+- `docs/designs/2026-03-05-ga-extensibility.md` — Exarchos already exposes `registerCustomTool`, `registerCustomWorkflows`, `registerCustomView`
+- `project_v3_roadmap.md` (memory) — v3.0 pillars #1087–#1091, cross-cutting #1109
+- Azure DevOps VCS provider: `servers/exarchos-mcp/src/vcs/azure-devops.ts`
+- Microsoft Learn companion MCP: `packages/create-exarchos/src/companions.ts:72–79`
+
+**External references:**
+- azd extension framework: [Azure/azure-dev/cli/azd/docs/extension-framework.md](https://github.com/Azure/azure-dev/blob/main/cli/azd/docs/extension-framework.md)
+- Aspire MCP server: [aspire.dev/reference/cli/commands/aspire-agent-mcp](https://github.com/microsoft/aspire.dev/blob/main/src/frontend/src/content/docs/reference/cli/commands/aspire-agent-mcp.mdx), shipped in Aspire 13.2
+- Local `aspire` skill at `~/.claude/skills/aspire/` (already installed via Claude Code)
+
+---
+
+## 1. Executive summary
+
+Three CLIs, three different problems, one shared premise: **agent-first, composable command surfaces with structured output**. Exarchos orchestrates SDLC workflows. `aspire` operates the local AppHost and Azure-bound deploys. `azd` provisions and deploys Azure infra from a project model. They do not overlap — they **stack**.
+
+There are three integration vectors, ranked by leverage:
+
+1. **Exarchos as an azd extension** (`azd x` → `azd exarchos <action>`). azd's Go/gRPC extension framework is the closest analogue to Exarchos's own custom-tool registry, and it would put Exarchos's workflow primitives directly into the Azure developer loop without requiring Claude Code. Medium cost (Go shim + gRPC client), high reach.
+2. **Aspire MCP federation** (mount `aspire agent mcp` alongside `exarchos mcp`). Aspire 13.2 already ships a Claude Code-compatible MCP server and an `aspire agent init` scaffolder. Exarchos skills can call `aspire_*` tools for live resource state during `/exarchos:debug` or `/exarchos:shepherd` without any code in Exarchos. Near-zero cost, narrow but high-signal reach.
+3. **Three-CLI unified SDLC trace**. An Exarchos workflow spans review → `aspire publish` → `azd up` → PR merge, with each step emitting into the Exarchos event stream and each CLI remaining the authority over its own domain. High cost, strategic payoff — it is the v3.0 cross-cutting story (#1109) made concrete for .NET/Azure users.
+
+Vector 2 is zero-lift and should be the first thing we validate. Vector 1 is the real question this report tries to answer. Vector 3 is aspirational and depends on both.
+
+## 2. Surface inventory
+
+### 2.1 Exarchos today
+
+- **Distribution:** standalone CLI (`exarchos install | mcp | install-skills`), Claude Code plugin, marketplace-registered (`@lvlup-sw/exarchos`). Node 20+, ESM, TypeScript. `src/install.ts:26, package.json:7`.
+- **MCP surface:** 4 public composite tools (`exarchos_workflow`, `exarchos_event`, `exarchos_orchestrate`, `exarchos_view`) + `exarchos_sync` hidden.
+- **Extension surface:** `registerCustomTool`, `registerCustomWorkflows`, `registerCustomView`, all resolved from `.exarchos.yml` at MCP startup (`servers/exarchos-mcp/src/config/register.ts:1–149`). External code can register composite-tool actions today.
+- **Runtime independence:** skill rendering to 6 runtimes (`claude`, `codex`, `copilot`, `cursor`, `opencode`, `generic`) — Exarchos already treats "non-Claude users" as a first-class axis (`src/runtimes/load.ts:29–36`).
+- **Azure footprint today:** Azure DevOps as a VCS provider; Microsoft Learn companion MCP. **No Aspire or azd touchpoint.**
+
+### 2.2 azd extension framework
+
+- **Scaffold + lifecycle:** `azd x init | build | watch | pack | release | publish`. Registry lives at `~/.azd/registry`; extensions are distributed via GitHub releases and a `registry.json` manifest.
+- **Manifest:** YAML with `id`, `namespace`, `capabilities: [custom-commands, lifecycle-events]`, `examples`. Any subcommand you register under your namespace becomes `azd <namespace> <command>`.
+- **gRPC contract (proto):** extensions run out-of-process and talk to azd core over gRPC. Services exposed: `Project`, `Environment`, `Prompt`, `Event`, `Workflow`, `Deployment`, `Compose`, `UserConfig`. The `Prompt` service is "UX as a service" — extensions get consistent interactive UX without re-implementing it.
+- **Reference implementation:** `microsoft.azd.demo` is Go; the gRPC framing means any language works, but the SDK path is Go-first.
+- **AI/MCP status:** no azd MCP server today. The demo extension integrates Azure AI resource catalogs (model deployment, quotas) — that is AI-as-*resource*, not agent-tooling. The SDK-side Azure MCP server (`eng/common/mcp/azure-sdk-mcp.ps1`) is unrelated infra for Azure SDK development.
+
+### 2.3 Aspire CLI
+
+- **App lifecycle:** `aspire new | init | start | stop | ps | describe | wait | add | update | restore | doctor`.
+- **Observability:** `aspire logs | otel logs | otel traces | export`.
+- **Deploy:** `aspire publish | deploy | do <step>`. Azure Container Apps via `azd up` remains the default deploy backend, but Aspire 9.3+ made publisher selection internal (resource-annotation driven).
+- **Docs for agents:** `aspire docs search | get`, `aspire docs api search | get` — a first-class way to pull authoritative Aspire API/workflow docs without WebFetch.
+- **MCP server (13.2):** `aspire agent mcp` serves an MCP stdio endpoint exposing resource management, logs/traces, resource commands, integration info. `aspire agent init` **auto-detects Claude Code and writes `.mcp.json`** — this is the exact path Exarchos uses today.
+
+## 3. The fit: why these three stack cleanly
+
+| Axis | Exarchos | azd | Aspire |
+|---|---|---|---|
+| Owns | SDLC workflow state, agent orchestration | Azure infra provisioning + env lifecycle | Local AppHost + distributed-app telemetry |
+| State store | JSON event streams (per-workflow) | Azure subscription + local env folder | AppHost process + OTel pipeline |
+| Extension point | custom-tool / workflow / view registry | gRPC extensions under `azd <namespace>` | custom resources + `WithCommand`; MCP tools |
+| Agent exposure | MCP server (stdio) | none today | MCP server (stdio, 13.2+) |
+| Azure coupling | none | total | strong but optional |
+
+**The non-overlap is the point.** Exarchos never wants to own "how to provision a Container App" or "how to start a PostgreSQL sidecar locally". azd and Aspire already own those. Conversely, neither azd nor Aspire wants to own "workflow phase transitions with saga compensation" or "review-classifier triage" — that is Exarchos.
+
+What is missing is a **shared trace**: when an Exarchos workflow kicks off a deploy, the azd/Aspire side of the story disappears into stderr. A shared trace is the integration thesis.
+
+## 4. Integration vectors
+
+### Vector 1 — Exarchos as an azd extension
+
+**Shape.** An extension with manifest `id: lvlup.exarchos`, `namespace: exarchos`, `capabilities: [custom-commands, lifecycle-events]`. It registers `azd exarchos workflow init|get|set`, `azd exarchos event append|query`, and a curated subset of orchestrate actions. Under the hood, the extension is a thin client that spawns `exarchos mcp` as a subprocess and proxies calls, or (cleaner) wraps the handler library directly via a Node child process with NDJSON over stdio.
+
+**Why this specifically.** Three properties make this vector qualitatively better than the alternatives:
+
+1. **Reaches Azure devs where they already are.** Every `azd init` user is a candidate; they never have to know about Claude Code, MCP, or the plugin marketplace.
+2. **Gives Exarchos event-stream access to azd's own lifecycle events.** The azd `Event` gRPC service lets extensions subscribe to project/service events (pre-deploy, post-deploy, env-up, env-down). Exarchos can append these as `deploy.*` events into the workflow stream without any polling.
+3. **`Prompt` gRPC service = free UX parity.** Exarchos CLI prompts today are inconsistent with the azd experience. Delegating to azd's prompt service inside an azd-hosted extension means a deploy-triggered workflow gets the same subscription-picker and env-selector the rest of azd uses.
+
+**Cost.** Moderate. The azd extension SDK is Go-first; a Go shim that shells to `node dist/exarchos.js mcp` is small (~500 LOC) but adds a Go build artifact to the repo. Alternative: write the extension in TypeScript, handle gRPC manually via `@grpc/grpc-js`. Both work; Go is less friction for distribution.
+
+**Risks.**
+- **Violates "standalone CLI" principle** if it becomes the primary install path. The `.claude-plugin` surface must remain first-class; azd extension is a *second* distribution, not a replacement.
+- **Registry story.** azd extensions publish to a GitHub-hosted registry; Exarchos would need a versioned release pipeline for the shim binaries across OS × arch. Doable, non-trivial.
+- **Scope bleed.** It is tempting to expose all 50+ orchestrate actions. Don't. Pick the 6–8 that make sense inside an azd project (workflow init, event append/query, pipeline view, a read-only status surface). The extension should feel like "azd-native Exarchos", not "Exarchos-but-run-via-azd".
+
+### Vector 2 — Aspire MCP federation
+
+**Shape.** Zero Exarchos code. In projects with an Aspire AppHost, the user runs `aspire agent init` once. This writes `.mcp.json` listing `aspire` alongside `exarchos`. Both MCP servers are now visible to Claude Code (or any MCP client) in the same session.
+
+**Exarchos side.** Update relevant skills (`/exarchos:debug`, `/exarchos:shepherd`, `/exarchos:oneshot`) to **detect** an adjacent Aspire AppHost and, when found, prefer `aspire_*` tools for runtime state over shelling out to `dotnet` or reading logs directly. This is a documentation change, not a code change.
+
+**Why this works now.** The Aspire MCP server is already Claude Code-compatible. The `.mcp.json` it writes is the same schema Exarchos uses. No bridge code is needed; MCP is the bridge.
+
+**Cost.** Near zero. A skill update in `skills-src/debug/references/` and `skills-src/shepherd/references/` adding an "if Aspire AppHost, prefer `aspire` MCP for live state" paragraph. One PR.
+
+**Risks.**
+- **Runtime drift.** We would be recommending an external tool whose behavior Exarchos does not control. If Aspire's MCP tool names change between 13.2 and 13.3, our skills go stale. Mitigation: treat the guidance as examples, not hard dispatch.
+- **Not all MCP clients.** Only clients where the user has installed both servers see the federation. The skill language must be conditional.
+
+### Vector 3 — Unified SDLC trace across all three
+
+**Shape.** An Exarchos workflow type `cloud-ship` that bakes in three phases:
+1. `review` (existing Exarchos) — design + plan + TDD task dispatch
+2. `publish` — call `aspire publish` (via MCP tool or shell), emit `publish.artifacts_generated` into the workflow stream with the Bicep/Compose output paths
+3. `deploy` — call `azd up` (via the azd extension from Vector 1, or shell), emit `deploy.started` / `deploy.resource_provisioned` / `deploy.completed` by subscribing to azd's `Event` gRPC service
+
+**Why this is the strategic bet.** It turns Exarchos into the *system of record* for a deploy's entire narrative. Today when a deploy fails in CI, a reviewer has to stitch together the Exarchos PR thread, the Aspire AppHost logs, and the azd deploy output from three terminals. A `cloud-ship` workflow collapses all three into one event stream that `exarchos_view` can render.
+
+**Cost.** High. Depends on Vector 1 (extension needed for live azd event subscription) and Vector 2 (skill guidance for Aspire live state). A new workflow type, a new phase topology, synthesis hooks, shepherd hooks. Not v3.0 — more like v3.1 or v4.0.
+
+**Risks.**
+- **Defining "success" across three tools.** Exarchos's gate model (D1–D5 dimensions) does not natively map to "did the Container App health probe go green". A cloud-ship workflow has to define post-deploy gates that are Azure-specific, and that pushes Azure concepts into Exarchos's core.
+- **Over-indexing on Azure.** If `cloud-ship` becomes a first-class workflow type, it tilts Exarchos toward Azure in a way the VCS-provider abstraction has so far avoided.
+
+## 5. What Exarchos should borrow, not integrate
+
+Independent of the vectors above, two patterns from these CLIs are worth copying into Exarchos itself:
+
+**From Aspire: `WithCommand` on resources.** Aspire lets an AppHost author attach named commands to a resource (e.g., `myservice.WithCommand("seed-data", ...)`), surfaced both in the dashboard and via MCP. The Exarchos analogue would be **per-task custom actions**: an implementer task could declare `withCommand("rerun-failing-tests", ...)` and the shepherd/reviewer could invoke it without having to know the task's internal shape. Low cost, high UX win.
+
+**From azd: `Prompt` as a service.** azd's insight that "interactive UX is a shared service, not per-extension code" is exactly the problem Exarchos has today — every custom tool re-invents its own prompting. A `PromptService`-style gRPC-or-MCP surface where Exarchos extensions delegate prompting back to the host would make the custom-tool story much more consistent.
+
+Both are independent of the integration vectors and could ship inside v3.0 extensibility (#1087).
+
+## 6. Recommendation
+
+**Do Vector 2 now.** A single PR updating `debug`, `shepherd`, and `oneshot` skills to reference `aspire agent mcp` when an Aspire AppHost is detected. This is the cheapest signal that the three-CLI thesis has users.
+
+**Plan Vector 1 for v3.1.** The azd extension is the real integration. It should be designed against the v3.0 extensibility surface (#1087) — if the Exarchos custom-tool API is well-shaped, the extension is thin. If it is not, the extension work will drive the API harder than Claude Code alone ever would. That pressure is valuable.
+
+**Defer Vector 3 until after Basileus.** A `cloud-ship` workflow type belongs in the world where Basileus handles the remote agent surface and Exarchos stays local-authoritative for workflow state. Revisit after the Basileus posture (see `project_basileus_mcp_posture.md`) firms up.
+
+**Adopt the `WithCommand` and `PromptService` patterns inside v3.0.** Both are independently justified; the integration framing is a bonus.
+
+## 7. Open questions
+
+1. Does the azd extension framework support non-Go extensions in practice, or is the Go SDK path a de facto requirement? (Answer by prototyping a TypeScript extension against the gRPC protos.)
+2. What is the Aspire MCP tool surface exactly — names, args, return shapes? Needed before the skill update in Vector 2 can be specific about which `aspire_*` tools replace which Exarchos shell-outs.
+3. Does Aspire 13.2's `aspire agent init` conflict with Exarchos's `.mcp.json` when both scaffold to the same file? (Test: run `aspire agent init` in an Exarchos-plugin-enabled repo.)
+4. If Exarchos ships as an azd extension, what is the signed-release / supply-chain story? azd extensions trust GitHub releases; Exarchos today ships via npm + Claude Code marketplace.

--- a/docs/research/2026-04-19-e2e-testing-strategy.md
+++ b/docs/research/2026-04-19-e2e-testing-strategy.md
@@ -1,0 +1,406 @@
+# E2E Testing Strategy: Fidelity Across the Ship Surface
+
+**Status:** Research (discovery phase). Not an implementation plan.
+**Workflow:** `e2e-testing-coverage`
+**Date:** 2026-04-19
+
+**Related internal:**
+- `docs/plans/2026-02-06-testing-gaps.md` (boundary + integration work, complete)
+- `docs/plans/2026-02-08-test-coverage.md` (module coverage 88% → 95%+, in flight)
+- `docs/audits/2026-02-06-testing-gaps.md` (what escaped, and why)
+- axiom dimensions: `skills/backend-quality/references/dimensions.md`
+
+**Related issues:**
+- [#1118](https://github.com/lvlup-sw/exarchos/issues/1118) codify platform-agnosticity principle
+- [#1109](https://github.com/lvlup-sw/exarchos/issues/1109) v3.0 cross-cutting: event-sourcing + MCP parity + basileus-forward
+- [#1088](https://github.com/lvlup-sw/exarchos/issues/1088) Agent Output Contract (HATEOAS + NDJSON)
+- [#1115](https://github.com/lvlup-sw/exarchos/issues/1115) universal bootstrap script
+
+---
+
+## 1. Executive summary
+
+Exarchos has 420 tests and 95%+ line coverage inside the MCP server. It has zero tests against the binaries it ships, the installer run against a real `$HOME`, or the six agent harnesses it promises to support. Under the axiom **DIM-4 (Test Fidelity)** lens — *the degree to which tests exercise actual production behavior* — the question is not "do we need more test layers". It is "where does our test wiring diverge from the wiring every user actually runs". The answer is: nearly everywhere outside the module graph.
+
+The ship surface is a 3 × 6 × 3 cross-product: 3 operating systems, 6 agent harnesses, 3 invocation surfaces (CLI, MCP stdio, installed content files). That is 54 production wirings. Today's tests cover approximately one tuple — Linux × no-harness × in-process handler — and the `install.test.ts` suite touches a partial second (Linux installer with real symlinks, documented as fragile under git worktrees).
+
+This document proposes six fidelity classes (F1–F6) that replace the test-pyramid framing with a cross-product coverage model. It maps each class to the axiom dimensions it closes, to the minimum viable test shape, and to the v3.0 issues that require it before they can ship. Two classes (F2 process fidelity and F3 protocol fidelity) can be bought in a few weeks and should gate all v3.0 CLI work. Three more (F4 platform, F5 harness, F6 lifecycle) scale the investment to match the platform-agnosticity claim in [#1118](https://github.com/lvlup-sw/exarchos/issues/1118).
+
+## 2. Why "layers" is the wrong frame
+
+The test pyramid assumes a single production configuration and asks how much verification sits at each depth. It answers "does this module work" and "do these modules work together".
+
+Exarchos does not ship a single configuration. It ships a CLI binary, an MCP server binary, and rendered content (skills, commands, rules) that each harness discovers from a harness-specific path. Every OS × harness combination is a distinct wiring. A test pyramid on the Linux × in-process configuration says nothing about whether the macOS × Claude Code tuple works. The two share source code, not wiring.
+
+Axiom **DIM-4** names this directly. Its invariants: test setup matches production wiring, mocks are used only at true infrastructure boundaries, critical paths have integration tests with the same composition root as production. Its canonical failure mode is "4,192 tests pass, system is broken" — tests exercise a topology that does not exist in production.
+
+The platform-agnosticity principle being codified in [#1118](https://github.com/lvlup-sw/exarchos/issues/1118) hardens this reframe into a product invariant. If platform-agnosticity is a principle, every test that exercises only one platform under-fulfills it. The metric we care about is: *what fraction of the ship surface does the test suite actually exercise?*
+
+## 3. The ship surface, formally
+
+### 3.1 The cross-product
+
+| Axis | Values | Count |
+|------|--------|-------|
+| OS | Linux, macOS, Windows | 3 |
+| Harness | Claude Code, Codex, Copilot, Cursor, OpenCode, generic | 6 |
+| Invocation surface | CLI (user shell), MCP stdio (harness-spawned subprocess), installed content files | 3 |
+| **Production wirings** | | **54** |
+
+Each cell has a distinct set of failure modes:
+
+- **OS axis** — path separators, symlink semantics (Linux `getcwd` canonicalizes; macOS `process.cwd` preserves; Windows uses junction points), case sensitivity, line endings, executable format, shell quoting, `$HOME` resolution. The [opencode#16661](https://github.com/anomalyco/opencode/issues/16661) macOS symlink regression from 2026-03 is a recent, in-ecosystem example of what falls through when CI covers two of three OSes.
+- **Harness axis** — each harness reads installed content from its own path. Claude Code reads `~/.claude/`. Codex, Copilot, Cursor, OpenCode each have their own conventions, and `build-skills` renders a per-runtime variant at `skills/<runtime>/<name>/SKILL.md`. Frontmatter dialects differ. Skill activation triggers differ.
+- **Surface axis** — the CLI and the MCP facade are both first-class entry points. The v3.0 Agent Output Contract ([#1088](https://github.com/lvlup-sw/exarchos/issues/1088), [#1098](https://github.com/lvlup-sw/exarchos/issues/1098)) makes them contractually equivalent under the HATEOAS-envelope proposal. Installed content is a third surface: the skill files on disk are the contract the harness consumes.
+
+### 3.2 Today's coverage
+
+| Cell | Covered? | Evidence |
+|------|----------|----------|
+| Linux × none × in-process handler | Yes (420 tests) | `servers/exarchos-mcp/src/**/*.test.ts` |
+| Linux × none × CLI | Partial | `src/install.test.ts` (39 tests; one fragile against git worktrees) |
+| Linux × none × MCP stdio | **No** | No test spawns the built MCP binary |
+| Linux × Claude Code × any surface | **No** | No test verifies Claude Code loads installed content |
+| macOS × any × any | **No** | No macOS CI runner |
+| Windows × any × any | **No** | No Windows CI runner; Windows bug [#1085](https://github.com/lvlup-sw/exarchos/issues/1085) shipped undetected |
+| All other 49 cells | **No** | — |
+
+The `boundary.test.ts` work closed a DIM-1 and DIM-3 gap (cross-module round-trips), and `2026-02-08-test-coverage.md` raises module coverage from 88% to 95%+. Both stay inside the Linux × in-process tuple. Neither addresses the other 53 cells.
+
+## 4. Current state under an axiom lens
+
+Mapping existing work to the eight axiom dimensions:
+
+| Dimension | Status | Load-bearing evidence |
+|-----------|--------|----------------------|
+| DIM-1 Topology | Strong inside module graph via `boundary.test.ts`. Weak across process boundary — no test verifies `exarchos install` produces a state tree the running MCP server actually reads. |
+| DIM-2 Observability | Unit-tested for error paths. No test observes server stderr during crashes or stdio deadlocks. |
+| DIM-3 Contracts | **Major gap.** No test validates Zod tool-input schemas against the JSON-RPC wire. No test validates tool-output shape against an external contract. No CLI↔MCP parity test — and "MCP parity" is exactly what [#1109](https://github.com/lvlup-sw/exarchos/issues/1109) asks for. |
+| DIM-4 Test Fidelity | **Major gap.** One of 54 ship tuples covered. Test-only wiring (in-process handler, tmp state dir, no actual MCP client) diverges from production wiring at every published surface. |
+| DIM-5 Hygiene | Good inside module graph, per the audit pass in `2026-02-06-testing-gaps.md` and the active cleanup in [#1097](https://github.com/lvlup-sw/exarchos/issues/1097). |
+| DIM-6 Architecture | Per-module review in `2026-02-06-testing-gaps.md`. No architectural test at the process boundary. |
+| DIM-7 Resilience | Gap. No subprocess-lifecycle tests (hang, crash, stdout-buffer-full, stdin-closed), no timeout tests, no concurrent-client tests. |
+| DIM-8 Prose Quality | Out of scope for this document. |
+
+The tightest failure-to-dimension mapping: every undetected bug in the opencode#16661 class (macOS-only, Windows-only, or harness-only regressions) is a **DIM-4** (test-production divergence) finding on the OS or harness axis.
+
+## 5. External canon
+
+Exarchos is not the first project to solve any of this. The landscape offers drop-in components:
+
+- **`@modelcontextprotocol/conformance`** (Anthropic, 0.1.16 as of 2026-03-30) is the official MCP protocol conformance suite. It runs spec scenarios against a server implementation: initialize handshake, tool discovery, error codes, capability declaration. Adopting it closes the DIM-3 wire-conformance gap without writing custom JSON-RPC tests.
+- **`@modelcontextprotocol/sdk` `StdioClientTransport`** is the canonical pattern for writing a test that spawns and drives an MCP server. A test sets `command: 'node', args: ['dist/servers/exarchos-mcp/index.js']`, connects a `Client`, calls `listTools()` and `callTool(...)`, and asserts on the real wire response. This is F2 process fidelity with no custom plumbing.
+- **`@scalvert/bin-tester`** (v3.0.0) provides a CLI-in-tmpdir harness. For `exarchos install` verification the test creates a disposable `$HOME`, runs the built CLI, and asserts on the resulting filesystem.
+- **`cli-testing-library`** offers a user-simulation API (`findByText`, `userEvent`) for interactive CLI flows like the wizard-fallback pattern in [#1093](https://github.com/lvlup-sw/exarchos/issues/1093).
+- **`microsoft/tui-test`** handles terminal-rendering e2e for any TUI surface we eventually ship.
+- **`mcpjam`** runs MCP servers against real LLMs (Claude, GPT, Ollama). A superset of what Exarchos needs; useful for benchmarks, out of scope here.
+
+The near-analog regression is [opencode#16661](https://github.com/anomalyco/opencode/issues/16661) (2026-03-09): a macOS-only symlink behavior difference shipped because the CI matrix was Linux + Windows only. The author calls out `getcwd()` semantics as the divergence source. Exarchos's own `install.test.ts:356` hardcodes a `/exarchos$/` regex and fails under git worktrees — memory `feedback_worktree_install_fragility.md` notes this is "pre-existing, not a regression", which is exactly the signal that the same class of bug can ship here.
+
+## 6. Six fidelity classes
+
+Each class is independently adoptable. Each closes a specific set of axiom dimensions for a specific subset of the 54-tuple ship surface.
+
+### F1 — Module fidelity
+
+**What it tests:** single-module behavior; cross-module round-trips inside one process.
+**Cells covered:** Linux × none × in-process (one tuple).
+**Dimensions closed:** DIM-1, DIM-2, DIM-5, DIM-6, locally.
+**Status:** Strong. 420 tests. `2026-02-06-testing-gaps.md` complete; `2026-02-08-test-coverage.md` in flight.
+**Proposed action:** keep executing the existing plans. No new work from this document.
+
+### F2 — Process fidelity
+
+**What it tests:** the shipped binary, invoked exactly as the harness invokes it.
+**Cells covered:** Linux × none × {CLI, MCP stdio}. Matrix expansion to macOS/Windows is F4.
+**Dimensions closed:** DIM-1 across the process boundary (lazy-fallback constructors become visible); DIM-4 at the surface axis; DIM-7 (resource leak on process teardown).
+
+**Minimum viable MCP test:**
+
+```typescript
+const transport = new StdioClientTransport({
+  command: 'node',
+  args: ['dist/servers/exarchos-mcp/index.js'],
+  env: { ...process.env, EXARCHOS_STATE_DIR: tmpStateDir },
+});
+const client = new Client({ name: 'e2e', version: '0.0.0' });
+await client.connect(transport);
+const { tools } = await client.listTools();
+expect(tools.map(t => t.name)).toContain('exarchos_workflow');
+const result = await client.callTool({
+  name: 'exarchos_workflow',
+  arguments: { action: 'init', featureId: 'e2e-smoke', workflowType: 'discovery' },
+});
+expect(result.isError).toBeFalsy();
+await client.close();
+```
+
+**Minimum viable CLI test:** `bin-tester` invokes the built `exarchos install` against `$HOME = tmp/home-<id>/`, then asserts `~/.claude/` symlinks exist and `~/.claude.json` contains the MCP registration.
+**Cost:** ~1 week once hermetic fixtures exist.
+**Determinism risks:** process spawn adds ~300ms per test. Run F2 in its own vitest project. Use a per-test `EXARCHOS_STATE_DIR` to prevent cross-test state bleed.
+
+### F3 — Protocol fidelity
+
+**What it tests:** the MCP wire format, the CLI output format, and the CLI↔MCP response-equivalence contract.
+**Cells covered:** cross-cutting on the invocation-surface axis. Any failure here is a 54-tuple failure.
+**Dimensions closed:** DIM-3 at every published boundary.
+
+Three sub-components:
+
+1. **MCP conformance.** Integrate `@modelcontextprotocol/conformance` as a CI gate. The suite ships scenarios for initialize, tools/list, tools/call, error codes, capability declaration.
+2. **CLI↔MCP parity.** For each action exposed on both surfaces, run it via both and assert the HATEOAS envelope is structurally identical after normalizing timestamps and IDs. This is what operationally satisfies the "MCP parity" goal in [#1109](https://github.com/lvlup-sw/exarchos/issues/1109) and what validates the envelope spec in [#1088](https://github.com/lvlup-sw/exarchos/issues/1088) / [#1098](https://github.com/lvlup-sw/exarchos/issues/1098).
+3. **Capability handshake.** Once [#1139](https://github.com/lvlup-sw/exarchos/issues/1139) ships, tests must verify the yaml ⊕ handshake merge resolves to the expected effective capability record on each runtime. An F3 concern that transitively becomes F5.
+
+**Cost:** conformance integration ~2 days; parity harness ~1 week (normalizer design dominates); handshake resolver tests scale with [#1139](https://github.com/lvlup-sw/exarchos/issues/1139) delivery.
+**Determinism risks:** timestamps, stream IDs, and event sequences must be canonicalized before equivalence. The `_eventSequence` and `updatedAt` fields in workflow state are known non-deterministic; normalize to `<TIMESTAMP>` and `<SEQ>` placeholders.
+
+### F4 — Platform fidelity
+
+**What it tests:** OS-specific behavior differences. Symlink semantics, path separators, line endings, executable format, case sensitivity, shell quoting.
+**Cells covered:** multiplies F1–F3 coverage by OS.
+**Dimensions closed:** DIM-4 at the OS axis.
+
+**Action:** extend GitHub Actions to `runs-on: ${{ matrix.os }}` with `[ubuntu-latest, macos-latest, windows-latest]`. Start with the F1 suite on all three to catch cheap regressions (the opencode#16661 class). Scale to F2 + F3 as those come online.
+
+**Known probes to add:** symlink-vs-junction install on Windows (matches [#1085](https://github.com/lvlup-sw/exarchos/issues/1085)), case-insensitive path collisions on APFS, CRLF vs LF in rendered skill files.
+
+**Cost:** CI matrix change is an afternoon. Probe tests land incrementally.
+**Determinism risks:** macOS and Windows runners are slower and pricier. Gate F2/F3 on Linux per-PR; run macOS/Windows nightly, with a labeled opt-in for PRs touching installer or path handling.
+
+### F5 — Harness fidelity
+
+**What it tests:** that rendered skills, commands, and rules land at each harness's expected path and parse in that harness's format.
+**Cells covered:** multiplies F1–F4 coverage by harness.
+**Dimensions closed:** DIM-4 at the harness axis; DIM-3 at the frontmatter-contract boundary.
+
+**Scope:** path-and-format parsing only. Actual harness loading stays manual QA in a tracked matrix. Automating the load step is a follow-on discovery (§13).
+
+**Test shape:** for each runtime in `runtimes/<name>.yaml`, after `exarchos install`, assert:
+1. Files exist at the runtime's expected paths.
+2. Each `SKILL.md` has valid frontmatter matching the runtime's declared dialect.
+3. `{{CALL}}` and other macros have been substituted (no unresolved placeholders).
+4. File encoding and line endings match runtime requirements.
+
+**Cost:** one `runtime-install.test.ts` per runtime (6 files). Initial harness-expectation fixture table ~1 week — the hard part is reading each harness's docs and writing down what it expects.
+**Determinism risks:** harness path conventions change; record each runtime's spec version in the fixture.
+**Non-Claude runtimes:** the daemon in [#1137](https://github.com/lvlup-sw/exarchos/issues/1137) is only useful if each non-Claude runtime actually works. F5 is how we know.
+
+### F6 — Lifecycle fidelity
+
+**What it tests:** a full workflow runs `init → plan → plan-review → delegate → integrate → synthesize → cleanup` against a real MCP server, real git worktree, real event stream, with compensation exercised on a forced failure.
+**Cells covered:** Linux × Claude Code × all three surfaces in a single test.
+**Dimensions closed:** DIM-1 across the full composition root; DIM-4 at scale; DIM-7 under realistic pressure.
+
+**Test shape:** one long-running test initializes a tmp git repo, spawns the MCP server, drives it through a scripted workflow via `StdioClientTransport`, asserts event sequences at phase transitions, injects a compensation-triggering failure, asserts cleanup. Event-stream assertions use the F3 normalizers.
+
+**Cost:** ~2–3 weeks. High value, high maintenance.
+**Determinism risks:** the flakiest class. Budget ≤2% flake rate. Pin vitest timeout at 120s. Run nightly only.
+**Explicit defer:** multi-agent delegation with real subagent spawning — out of scope until agent spawning has its own mocked-subagent harness. The `prune_stale_workflows` bug in [#1117](https://github.com/lvlup-sw/exarchos/issues/1117) is the kind of issue F6 would catch if it were extended to cover long-running state.
+
+## 7. Cross-cutting concerns
+
+**Hermeticity.** Every F2+ test needs an isolated `$HOME`, an isolated state dir, and (for F6) an isolated git repo. Centralize in `test/fixtures/hermetic.ts` — one `withHermeticEnv(callback)` helper that creates `tmp/{home,state,repo}/<test-id>/`, sets `HOME`, `EXARCHOS_STATE_DIR`, `GIT_DIR`, runs the callback, then unconditionally cleans up.
+
+**Determinism.** Maintain one `test/fixtures/normalizers.ts` with canonicalizers for timestamps (`<TIMESTAMP>`), event sequences (`<SEQ>`), worktree paths (`<WORKTREE>`), PR URLs (`<PR_URL>`), and random IDs (`<ID>`). Every F3 equivalence assertion runs through it. Every F6 event-stream assertion runs through it.
+
+**Flakiness budget.** Target: F1 and F2 at 0% flake on PR gate. F3 conformance at 0%. F4 matrix ≤1%. F6 lifecycle ≤2%, nightly only. Any F1/F2/F3 flake is a P0 — fix before merging any non-related change.
+
+**CI cost envelope.** Current CI is ~3 min (Linux, one job). Adding F2 adds ~2 min. Adding F3 conformance adds ~1 min. Matrix expansion to macOS+Windows multiplies by 3 at peak. Keep per-PR CI under 10 min by deferring F4 full matrix and F6 lifecycle to nightly.
+
+**Test-double ratio.** Per DIM-4 guidance in `skills/verify/references/test-antipatterns.md`, F2+ tests use mocks only at true infrastructure boundaries (network, external APIs we don't ship). Everything in-process runs real code. No `vi.mock` inside F2–F6.
+
+**v3.0 alignment.**
+- [#1088](https://github.com/lvlup-sw/exarchos/issues/1088) (HATEOAS + NDJSON) — F3 parity harness is the test infrastructure this contract lives or dies by.
+- [#1100](https://github.com/lvlup-sw/exarchos/issues/1100) (NDJSON streaming for `--follow`) — F2 CLI test spawns the process, reads line-delimited stdout, asserts each line parses as a typed NDJSON event.
+- [#1115](https://github.com/lvlup-sw/exarchos/issues/1115) (universal bootstrap script) — replaces the npm installer with a shell script that downloads a binary. Cannot ship without F4 matrix coverage; the value proposition *is* cross-platform.
+- [#1139](https://github.com/lvlup-sw/exarchos/issues/1139) (capability resolver) — handshake + envelope conformance belongs in F3.
+- [#1142](https://github.com/lvlup-sw/exarchos/issues/1142) (tier-gated bootstrap-pull) — F5 per-runtime render verification, parameterized on tier.
+
+## 8. Recommended architecture
+
+### 8.1 Vitest project split
+
+```
+vitest.config.ts
+└── projects:
+    ├── unit          — F1 (default test:run)
+    ├── integration   — F1 cross-module (boundary.test.ts)
+    ├── process       — F2 (StdioClientTransport + bin-tester)
+    ├── conformance   — F3 (@modelcontextprotocol/conformance + parity)
+    └── e2e           — F4 matrix probes + F5 install fixtures + F6 lifecycle
+```
+
+Each project has its own timeout, its own setupFiles, and its own CI gate.
+
+### 8.2 Test layout
+
+```
+test/
+├── fixtures/
+│   ├── hermetic.ts           — tmp-$HOME / tmp-state / tmp-git harness
+│   ├── normalizers.ts        — deterministic replacements
+│   ├── runtimes/<name>.json  — per-runtime expected install layout
+│   └── stdio-client.ts       — StdioClientTransport factory
+├── process/
+│   ├── mcp-stdio.test.ts     — F2 MCP smoke
+│   └── cli-install.test.ts   — F2 CLI smoke
+├── conformance/
+│   ├── mcp-conformance.test.ts     — @modelcontextprotocol/conformance wrapper
+│   ├── cli-mcp-parity.test.ts      — per-action parity
+│   └── capability-handshake.test.ts — effective capability resolver
+└── e2e/
+    ├── platform-probes.test.ts     — F4 symlink/path/case probes
+    ├── runtime-install.test.ts     — F5 per-harness install
+    └── workflow-lifecycle.test.ts  — F6 full saga
+```
+
+### 8.3 Package.json scripts
+
+```
+"test:unit"          — existing test:run against unit + integration projects
+"test:process"       — F2 (requires build)
+"test:conformance"   — F3 (requires build)
+"test:e2e"           — F4 + F5 + F6 (requires build + matrix env)
+"test:all"           — all above, sequential
+```
+
+## 9. CI integration
+
+### 9.1 PR gate (per commit)
+
+- Unit + integration on Linux (~3 min).
+- F2 process fidelity on Linux (~2 min).
+- F3 MCP conformance on Linux (~1 min).
+- Unit project on macOS and Windows (matrix, no extra infra — runs F1 against the other OSes for opencode#16661-class detection). Parallel wall-time ~4 min.
+
+Total: ~10 min. Covers DIM-1, DIM-3, DIM-4 on all three OSes at the module level plus F2 + F3 on Linux.
+
+### 9.2 Nightly
+
+- F4 platform probes on all three OSes.
+- F5 runtime-install tests on Linux (path assertions are OS-independent; platform interaction is F4's concern).
+- F6 workflow-lifecycle on Linux.
+
+### 9.3 Opt-in per-PR
+
+Label `ci:full-matrix` triggers F4 + F5 + F6 on a PR when installer, path handling, or HSM code changes.
+
+## 10. Prioritization
+
+### Tier 1 — ships before any v3.0 CLI work (~2 engineer-weeks)
+
+| Item | Effort | Unblocks |
+|------|--------|----------|
+| F2 MCP StdioClientTransport harness + one smoke test | 3 days | [#1088](https://github.com/lvlup-sw/exarchos/issues/1088), [#1098](https://github.com/lvlup-sw/exarchos/issues/1098), [#1109](https://github.com/lvlup-sw/exarchos/issues/1109), [#1139](https://github.com/lvlup-sw/exarchos/issues/1139), [#1140](https://github.com/lvlup-sw/exarchos/issues/1140) |
+| F2 CLI bin-tester harness + installer smoke test | 2 days | [#1087](https://github.com/lvlup-sw/exarchos/issues/1087), [#1093](https://github.com/lvlup-sw/exarchos/issues/1093), [#1115](https://github.com/lvlup-sw/exarchos/issues/1115) |
+| F3 `@modelcontextprotocol/conformance` integration | 2 days | Spec-compliance claim for all future MCP work |
+| Windows runner on GitHub Actions matrix for unit suite | 1 day | Closes [#1085](https://github.com/lvlup-sw/exarchos/issues/1085)-class regressions |
+| Hermetic + normalizer fixtures | 3 days | Prerequisite for Tier 2 + 3 |
+
+Tier 1 closes DIM-3 at the wire and DIM-4 at the process boundary. After Tier 1, every subsequent v3.0 CLI/MCP change can be verified before merge.
+
+### Tier 2 — validates platform-agnosticity ([#1118](https://github.com/lvlup-sw/exarchos/issues/1118)) (~4 engineer-weeks)
+
+| Item | Effort |
+|------|--------|
+| macOS runner on CI matrix | 1 day |
+| F4 platform probes (symlink, path, case, line endings) | 1 week |
+| F5 per-runtime install fixtures (6 harnesses × path assertions) | 2 weeks |
+| Manual harness-loading QA matrix (documented) | 2 days |
+
+Tier 2 is the empirical check on the platform-agnosticity principle. Without it, [#1118](https://github.com/lvlup-sw/exarchos/issues/1118) is aspirational.
+
+### Tier 3 — v3.0 polish (~6 engineer-weeks)
+
+| Item | Effort |
+|------|--------|
+| F6 full workflow lifecycle | 3 weeks |
+| F3 CLI↔MCP parity harness | 2 weeks |
+| F3 capability-handshake resolver tests (follows [#1139](https://github.com/lvlup-sw/exarchos/issues/1139)) | Scales with #1139 |
+| Compensation-on-failure lifecycle test | 1 week |
+
+Tier 3 is worthwhile only after Tier 1 + Tier 2 provide the foundation. The lifecycle test is the most expensive and most valuable single test in the proposal; it catches the regression class that unit tests structurally cannot.
+
+## 11. Issue-to-fidelity mapping
+
+| Issue | Title | Fidelity class |
+|-------|-------|---------------|
+| [#1085](https://github.com/lvlup-sw/exarchos/issues/1085) | Windows MCP server bug | F4 (OS axis) |
+| [#1087](https://github.com/lvlup-sw/exarchos/issues/1087) | v3.0 P1: CLI Ergonomic Infrastructure | F2 CLI |
+| [#1088](https://github.com/lvlup-sw/exarchos/issues/1088) | v3.0 P2: Agent Output Contract | F3 parity |
+| [#1092](https://github.com/lvlup-sw/exarchos/issues/1092) | Pluggable IInteractionService | F2 CLI |
+| [#1093](https://github.com/lvlup-sw/exarchos/issues/1093) | TTY detection + wizard-fallback | F2 CLI (cli-testing-library) |
+| [#1095](https://github.com/lvlup-sw/exarchos/issues/1095) | OptionWithLegacy for flag renames | F3 contracts |
+| [#1096](https://github.com/lvlup-sw/exarchos/issues/1096) | Rich exit codes | F2 CLI |
+| [#1098](https://github.com/lvlup-sw/exarchos/issues/1098) | Uniform HATEOAS envelope | F3 parity |
+| [#1100](https://github.com/lvlup-sw/exarchos/issues/1100) | NDJSON streaming protocol | F2 CLI + F3 format |
+| [#1101](https://github.com/lvlup-sw/exarchos/issues/1101) | Self-documenting root | F2 CLI |
+| [#1109](https://github.com/lvlup-sw/exarchos/issues/1109) | Event-sourcing + MCP parity | F3 parity |
+| [#1115](https://github.com/lvlup-sw/exarchos/issues/1115) | Universal bootstrap script | F2 CLI + F4 matrix |
+| [#1117](https://github.com/lvlup-sw/exarchos/issues/1117) | Pruner stale-workflow bug | F6 lifecycle |
+| [#1118](https://github.com/lvlup-sw/exarchos/issues/1118) | Codify platform-agnosticity | **F4 + F5 together** |
+| [#1137](https://github.com/lvlup-sw/exarchos/issues/1137) | exarchos watch sideband daemon | F2 + F5 non-Claude harnesses |
+| [#1139](https://github.com/lvlup-sw/exarchos/issues/1139) | Capability resolver yaml ⊕ handshake | F3 handshake |
+| [#1140](https://github.com/lvlup-sw/exarchos/issues/1140) | PiggybackSink + _notifications envelope | F3 envelope |
+| [#1142](https://github.com/lvlup-sw/exarchos/issues/1142) | Skill bootstrap-pull tier-guarded | F5 per-runtime render |
+
+## 12. Non-goals
+
+- **Harness-internal behavior.** We test that our content lands at the right path in the right format. Whether Claude Code, Codex, etc. then behave correctly with that content is the harness's responsibility.
+- **Full LLM-driven conversation E2E.** `mcpjam` exists for this. Useful for benchmarks, not for regression gating.
+- **Basileus contract tests.** Basileus is a separate product; its interaction surface with Exarchos is tested via `exarchos_sync` fabric actions in [#1143](https://github.com/lvlup-sw/exarchos/issues/1143) when those land.
+- **Property-based test expansion.** Scoped in `2026-02-08-test-coverage.md`.
+- **Performance or load testing.** Mentioned in external references (k6); out of scope here.
+- **Security testing.** Appropriate as a separate workflow under `/security-review`.
+
+## 13. Escalation
+
+Each tier corresponds to a `/exarchos:ideate` candidate:
+
+1. **Tier 1 ideate:** *"Process-fidelity test harness: MCP stdio + CLI bin-tester + MCP conformance suite, with hermetic fixtures and Windows runner"*. Design deliverables: fixture-library API, vitest project split, CI config diff, per-action parity contract schema.
+2. **Tier 2 ideate:** *"Platform-agnosticity verification: OS matrix, per-runtime install fixtures, harness-expectation table"*. Design deliverables: runtime fixture schema, macOS CI config, manual-QA matrix template.
+3. **Tier 3 ideate:** *"Workflow-lifecycle e2e: full-saga test, compensation verification, HATEOAS-parity harness"*. Design deliverables: saga test DSL, event-stream normalizer, parity assertion library.
+
+Separately, a follow-on discovery: *"automated harness-loading verification"* — whether it is feasible to spawn each supported harness in CI and observe it loading Exarchos content. The F5 upgrade path from path-parsing to load-verification.
+
+## 14. Appendix
+
+### 14.1 Glossary
+
+- **Fidelity class (F1–F6)** — a category of test distinguished by which cells of the ship-surface cross-product it covers.
+- **Ship surface** — the set of production wirings Exarchos supports: (OS × harness × invocation-surface).
+- **Process fidelity** — tests that drive the shipped binary rather than the in-process module graph.
+- **Protocol fidelity** — tests that verify the wire-format contract at every published boundary.
+- **Harness** — an agent runtime that loads Exarchos content (Claude Code, Codex, Copilot, Cursor, OpenCode, generic).
+- **Tuple** — one cell of the 54-cell cross-product.
+- **HATEOAS envelope** — the v3.0 uniform response wrapper proposed in [#1098](https://github.com/lvlup-sw/exarchos/issues/1098).
+
+### 14.2 References
+
+**Internal:**
+- `docs/plans/2026-02-06-testing-gaps.md`
+- `docs/plans/2026-02-08-test-coverage.md`
+- `docs/audits/2026-02-06-testing-gaps.md`
+- `docs/bugs/2026-02-06-workflow-state-testing-gaps.md`
+- `CLAUDE.md` (architecture overview)
+- `skills-src/discovery/SKILL.md`
+- axiom dimensions: `skills/backend-quality/references/dimensions.md`
+- axiom test antipatterns: `skills/verify/references/test-antipatterns.md`
+- axiom contract testing: `skills/verify/references/contract-testing.md`
+
+**External:**
+- `@modelcontextprotocol/conformance` — https://www.npmjs.com/package/@modelcontextprotocol/conformance
+- `@modelcontextprotocol/sdk` TypeScript — https://github.com/modelcontextprotocol/typescript-sdk
+- `@scalvert/bin-tester` — https://github.com/scalvert/bin-tester
+- `cli-testing-library` — https://github.com/crutchcorn/cli-testing-library
+- `microsoft/tui-test` — https://github.com/microsoft/tui-test
+- Agnost AI testing guide — https://agnost.ai/blog/testing-mcp-servers-complete-guide
+- opencode macOS matrix regression — https://github.com/anomalyco/opencode/issues/16661
+
+### 14.3 Cross-references to existing plans
+
+This document **does not** duplicate:
+- `docs/plans/2026-02-06-testing-gaps.md` — F1 boundary tests inside the MCP server (complete).
+- `docs/plans/2026-02-08-test-coverage.md` — F1 module-level line/function coverage (in flight).
+
+This document **does** propose net-new work in F2, F3, F4, F5, F6. The F1 plans remain authoritative for module-level testing.

--- a/docs/research/fixer-token-efficiency.md
+++ b/docs/research/fixer-token-efficiency.md
@@ -1,0 +1,103 @@
+# Fixer Subagent Token Efficiency — Research Report
+
+**Tracking issue:** [#1159](https://github.com/lvlup-sw/exarchos/issues/1159)
+**Date:** 2026-04-19
+**Workflow:** `discover-fixer-token-efficiency`
+**Status:** Discovery output. Implementation belongs in a follow-up `/exarchos:ideate` workflow.
+
+## 1. Problem (validated)
+
+The `exarchos-fixer` subagent, when dispatched against batches of code-review comments, costs ~12–15k tokens and 6–8 tool calls per item. On a busy PR (~50 comments) this projects to ~600k tokens and ~45 minutes per remediation round.
+
+The per-round metrics in #1159 (rounds 1–3 on basileus PR [#159](https://github.com/lvlup-sw/basileus/pull/159) — 110/61/137 tool calls; 214k/131k/234k tokens) were observed externally via Claude Code session metadata, not via exarchos's own telemetry. **`exarchos_view team_performance` and `exarchos_view delegation_timeline` returned empty for this session**, so the baseline numbers cannot be reproduced from event-store data today. This is a data-availability gap — see Open Question Q1.
+
+### Causes from the issue, in order
+
+1. **Read amplification per file** (~30–40% of cost). When N comments touch the same file, the fixer Reads it N times.
+2. **Investigation cost** (~30–50k tokens on the high-investigation rounds). Some fixes legitimately require cross-repo reading (round 3 inspected `Strategos.Npgsql.Internal.ExpressionTranslator` to confirm predicate-pushdown was infeasible).
+3. **One-size-fits-all subagent type.** Doc/style nits go through the same heavyweight pipeline as architectural fixes.
+4. **Per-cluster build+test overhead** (~6 min wall-clock on round 3). This is a safety rail; the issue marks it explicitly as **not** an optimization target.
+
+## 2. Current architecture
+
+### Fixer dispatch surface
+
+| Concern | Where | Current behavior |
+|---|---|---|
+| Fixer agent template | [`agents/fixer.md`](../../agents/fixer.md) | Accepts `{{failureContext}}`, `{{taskDescription}}`, `{{filePaths}}` only — no source-code placeholder |
+| Scaffolder agent template | [`agents/scaffolder.md`](../../agents/scaffolder.md) | Defined and dispatchable today |
+| Template interpolation | [`servers/exarchos-mcp/src/agents/handler.ts:28-50`](../../servers/exarchos-mcp/src/agents/handler.ts) | String replacement only; no dynamic file Reads |
+| Hook wiring | [`servers/exarchos-mcp/src/agents/generate-cc-agents.ts:15-51`](../../servers/exarchos-mcp/src/agents/generate-cc-agents.ts) | `TRIGGER_MAP` supports `pre-write`, `pre-edit`, `post-test`. **No `pre-dispatch` trigger.** |
+| Review-comment ingest | [`servers/exarchos-mcp/src/orchestrate/check-pr-comments.ts:1-117`](../../servers/exarchos-mcp/src/orchestrate/check-pr-comments.ts) | Flat list per comment; no severity, no thread reply detection |
+| Finding → task extraction | [`servers/exarchos-mcp/src/orchestrate/extract-fix-tasks.ts:163-171`](../../servers/exarchos-mcp/src/orchestrate/extract-fix-tasks.ts) | 1:1 mapping, no file grouping. Severity threaded through (`severity: finding.severity ?? 'MEDIUM'`) but unused downstream |
+| Task classification | [`servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts:91,115-195`](../../servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts) | `classifyTask()` already routes scaffolding-keyword titles → `scaffolder` + `sonnet`. Does **not** read severity. |
+| Severity catalog | [`servers/exarchos-mcp/src/review/check-catalog.ts:9,14`](../../servers/exarchos-mcp/src/review/check-catalog.ts) | `CheckSeverity = 'HIGH' \| 'MEDIUM' \| 'LOW'` exists |
+| Shepherd loop | [`skills-src/shepherd/SKILL.md:20-150`](../../skills-src/shepherd/SKILL.md) | `assess → fix → resubmit` iteration ≤5x; no per-iteration batching |
+
+### What's missing today
+
+- File grouping anywhere in the dispatch path
+- Source-code prefetch / inlining
+- Severity → agent-class routing
+- A `prepare_review_fixes` action on `exarchos_orchestrate`
+- Per-subagent token telemetry inside exarchos's event store
+
+## 3. Optimizations mapped to implementation surfaces
+
+### P1 — Batch by file (highest leverage)
+
+**Issue estimate:** ~30% token savings.
+**Implementation surface:** new orchestrate action `prepare_review_fixes` (or a new step inside `extract-fix-tasks.ts`) that groups findings by `file` before emitting tasks. Each grouped task lists multiple `(line, description)` items for one file; the fixer Reads that file once.
+
+**Effort:** Small (~1 handler + schema + 1 task-shape change). Existing `findings[]` already carry `file` and `line`.
+**Risk:** Low. Only changes task granularity; doesn't change agent behavior.
+**Cross-cutting:** `extract_fix_tasks` consumers — must accept multi-finding tasks. Verify `prepare_delegation` path still works.
+
+### P2 — Pre-fetch ±40 lines of context (medium leverage, low effort)
+
+**Issue estimate:** ~15–25% token savings (saves 50–80k of fixer Reads at cost of ~5k inlined tokens per dispatch).
+**Implementation surface:** extend the fixer template (`agents/fixer.md`) with a `{{contextSnippet}}` placeholder, then add Read calls inside `prepare_review_fixes` (or `prepare_delegation` for review-derived tasks) that materialize `±N` lines around each `(file, line)` and concatenate them into the prompt.
+**Effort:** Small–Medium. Need a per-task source loader; need to bound payload (cap at e.g. 20 snippets × 80 lines per task).
+**Risk:** Medium. Inlining stale source if a prior fix in the same batch already mutated the file. Needs sequencing — see Open Question Q2.
+
+### P3 — Severity-tier routing to scaffolder vs fixer
+
+**Issue estimate:** ~10% token savings, ~30% wall-clock from parallelism.
+**Implementation surface:** extend `classifyTask()` in `prepare-delegation.ts` to read the existing `severity` field. Add cases:
+- `severity === 'LOW'` AND title matches doc-nit keywords (`<remarks>`, `sealed`, `sort`, `format`) → `scaffolder` + `haiku`
+- `severity === 'HIGH'` → `fixer` + `opus` (current default)
+- substantive non-LOW → `fixer` + `sonnet`
+
+**Effort:** Trivial. Severity is already in the data shape (`extract-fix-tasks.ts:170`); all that's missing is consumption.
+**Risk:** Low if the heuristic is conservative (i.e. only routes obvious nits to scaffolder). Mis-routing a substantive fix to scaffolder is recoverable via the existing fixer fallback path.
+
+### P4 — Pre-resolve cross-repo investigation in the orchestrator
+
+**Issue estimate:** 20–40k tokens per investigation-heavy item.
+**Implementation surface:** there is **no existing pattern for this** (see Open Question Q3). Two candidate shapes:
+- (a) An optional `directives` field on each fix task (string array) that the orchestrator populates when it has done upfront investigation. The fixer prompt template would surface `{{directives}}` as "Use approach X. Do NOT explore Y because <reason>."
+- (b) A `pre_investigate` action that takes a finding and returns a directive string, invoked selectively when `severity === 'HIGH'` and the finding mentions cross-repo paths.
+
+**Effort:** Medium–Large. (a) is a small data-shape change but only useful if a human/orchestrator actually fills it. (b) requires actually running investigation logic — hard to implement without an LLM call, in which case the savings vs. the fixer doing it itself are unclear.
+**Risk:** High that (b) just relocates the cost. P4 is the weakest of the four.
+
+## 4. Ranked recommendation
+
+| Rank | Optimization | Leverage | Effort | Risk | Verdict |
+|---|---|---|---|---|---|
+| 1 | **P3** — severity routing | ~10% tokens, ~30% wall-clock | Trivial (~50 lines, classification only) | Low | **Ship first.** Severity already plumbed; only consumption is missing. Highest ratio of impact-per-line-changed. |
+| 2 | **P1** — batch by file | ~30% tokens | Small (one orchestrate action + task-shape change) | Low | **Ship second.** Largest token win. Independent of P2/P3. |
+| 3 | **P2** — context prefetch | ~15–25% tokens | Small–Medium | Medium (stale-source risk after intra-batch edits) | **Ship third, after P1.** Needs sequencing rules to avoid stale snippets — see Q2. |
+| 4 | **P4** — pre-resolve investigation | 20–40k per item, but only on a small fraction of items | Medium–Large; design unclear | High | **Defer.** Likely just relocates the cost. Re-evaluate after P1/P2/P3 are measured. |
+
+## 5. Open questions for ideate
+
+- **Q1: Telemetry baseline.** Acceptance criterion #4 in #1159 demands a "≥40% token reduction" benchmark. Today we cannot measure this from event-store data — `team_performance` and `delegation_timeline` views are empty during this session. **Decide:** instrument the dispatcher to emit `subagent.tokens_used` events (and back-fill the views), or rely on manual measurement against a single representative batch (e.g. replay basileus #159 round 3 contents).
+- **Q2: Stale-snippet risk for P2.** When a single batched task has 5 fixes for one file, the prefetched snippets reflect the file *before* fix 1 lands. If fix 1 shifts line numbers, fixes 2–5 see incorrect snippets. **Decide:** prefetch on each iteration, prefetch by symbol-name instead of line-range, or warn the fixer to re-Read after each Edit.
+- **Q3: P4 design.** Should the orchestrator do its own investigation (LLM-backed → cost relocation) or just expose a `directives` slot for humans / future logic? **Decide:** start with the data-shape (a) and let the slot stay empty until a real use case appears.
+- **Q4: `prepare_review_fixes` vs. extending `extract_fix_tasks`.** Both are viable. New action is more discoverable; extending the existing handler keeps the surface smaller. **Decide:** new action, gated on a `groupByFile: boolean` arg defaulting to `true`.
+- **Q5: Build+test cadence under batching.** If P1 collapses 5 single-file tasks into 1 multi-fix task, the per-cluster build+test now covers 5x the changes per run. Failure attribution gets harder. **Decide:** keep one build per task (cheap because tasks are larger but fewer) or add a per-fix re-test inside the fixer. The issue explicitly opts to leave build+test alone, so default to "one build per task."
+
+## 6. Recommended next step
+
+Open `/exarchos:ideate` referencing this report as design input. Scope: P3 + P1 + P2 (deferring P4). Acceptance gate from #1159 remains valid; resolve Q1 first so the benchmark is measurable.

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -406,12 +406,12 @@ describe('StackEnqueuedData', () => {
 
 describe('EventTypes', () => {
   it('EventTypes_CountMatchesRegisteredTypes', () => {
-    // Locked to the current registered-type count. Bumped to 71 with
-    // the addition of preflight events (preflight.executed,
-    // preflight.blocked) — the dispatch-guard emission fix from #1129.
+    // Locked to the current registered-type count. Bumped to 72 with
+    // the addition of provider.unknown-tier (#1159) — review provider
+    // adapters emit it when an upstream tier vocabulary changes.
     // When new event types are added, bump this number alongside
     // their registration in `event-store/schemas.ts`.
-    expect(EventTypes).toHaveLength(71);
+    expect(EventTypes).toHaveLength(72);
   });
 
   it('should include workflow-level types', () => {

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -406,12 +406,12 @@ describe('StackEnqueuedData', () => {
 
 describe('EventTypes', () => {
   it('EventTypes_CountMatchesRegisteredTypes', () => {
-    // Locked to the current registered-type count. Bumped to 72 with
-    // the addition of provider.unknown-tier (#1159) — review provider
-    // adapters emit it when an upstream tier vocabulary changes.
+    // Locked to the current registered-type count. Bumped to 73 with
+    // the addition of dispatch.classified (#1159) — emitted by the
+    // classify_review_items orchestrate action.
     // When new event types are added, bump this number alongside
     // their registration in `event-store/schemas.ts`.
-    expect(EventTypes).toHaveLength(72);
+    expect(EventTypes).toHaveLength(73);
   });
 
   it('should include workflow-level types', () => {

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -406,12 +406,12 @@ describe('StackEnqueuedData', () => {
 
 describe('EventTypes', () => {
   it('EventTypes_CountMatchesRegisteredTypes', () => {
-    // Locked to the current registered-type count. Bumped to 73 with
-    // the addition of dispatch.classified (#1159) — emitted by the
-    // classify_review_items orchestrate action.
+    // Locked to the current registered-type count. Bumped to 74 with
+    // the addition of provider.parse-error (#1161) — emitted by
+    // assess_stack when a review adapter throws mid-batch.
     // When new event types are added, bump this number alongside
     // their registration in `event-store/schemas.ts`.
-    expect(EventTypes).toHaveLength(73);
+    expect(EventTypes).toHaveLength(74);
   });
 
   it('should include workflow-level types', () => {

--- a/servers/exarchos-mcp/src/__tests__/integration/shepherd-classifier.integration.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/integration/shepherd-classifier.integration.test.ts
@@ -1,0 +1,119 @@
+// ─── Shepherd → Classifier Integration Smoke Test (Issue #1159 T25) ─────────
+//
+// End-to-end: a mocked PR with comments from CodeRabbit (Critical),
+// Sentry (Medium), and a human (nit) flows through assess_stack →
+// the adapter registry → classify_review_items, and the classifier's
+// per-group recommendations match the per-reviewer severity routing.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, vi } from 'vitest';
+import type { VcsProvider, CiStatus, ReviewStatus, PrComment } from '../../vcs/provider.js';
+import { handleAssessStack } from '../../orchestrate/assess-stack.js';
+import { handleClassifyReviewItems } from '../../orchestrate/classify-review-items.js';
+import type { ActionItem } from '../../review/types.js';
+
+const mockAppend = vi.fn();
+const mockQuery = vi.fn().mockResolvedValue([]);
+
+vi.mock('../../event-store/store.js', () => ({
+  EventStore: vi.fn().mockImplementation(() => ({
+    append: mockAppend,
+    query: mockQuery,
+  })),
+}));
+
+const STATE_DIR = '/tmp/test-shepherd-classifier-integration';
+
+function mockProvider(comments: PrComment[]): VcsProvider {
+  const ci: CiStatus = {
+    status: 'pass',
+    checks: [{ name: 'ci/build', status: 'pass' }],
+  };
+  const review: ReviewStatus = { state: 'pending', reviewers: [] };
+  return {
+    name: 'github',
+    createPr: vi.fn(),
+    checkCi: vi.fn().mockResolvedValue(ci),
+    mergePr: vi.fn(),
+    addComment: vi.fn(),
+    getReviewStatus: vi.fn().mockResolvedValue(review),
+    listPrs: vi.fn().mockResolvedValue([]),
+    getPrComments: vi.fn().mockResolvedValue(comments),
+    getRepository: vi.fn(),
+    getPrChecks: vi.fn(),
+    setAutoMerge: vi.fn(),
+  } as unknown as VcsProvider;
+}
+
+describe('shepherd → classifier integration (#1159)', () => {
+  it('ShepherdIteration_MixedSeverityComments_RoutesPerClassifier', async () => {
+    const comments: PrComment[] = [
+      // CodeRabbit Critical → HIGH → delegate-fixer
+      {
+        id: 1,
+        author: 'coderabbitai[bot]',
+        body: '_:warning: Potential issue_\n\nNull dereference risk in auth path.',
+        createdAt: '2026-01-01T00:00:00Z',
+        path: 'src/auth.ts',
+        line: 42,
+      },
+      // Sentry Medium → MEDIUM → direct
+      {
+        id: 2,
+        author: 'sentry-io[bot]',
+        body: 'Severity: MEDIUM\n\nProbable type coercion in handler.',
+        createdAt: '2026-01-01T00:00:00Z',
+        path: 'src/handler.ts',
+        line: 17,
+      },
+      // Human nit → MEDIUM → direct
+      {
+        id: 3,
+        author: 'alice',
+        body: 'Could you rename this variable for clarity?',
+        createdAt: '2026-01-01T00:00:00Z',
+        path: 'src/util.ts',
+        line: 5,
+      },
+    ];
+
+    const assessResult = await handleAssessStack(
+      { featureId: 'feat-integration', prNumbers: [42] },
+      STATE_DIR,
+      mockProvider(comments),
+    );
+
+    expect(assessResult.success).toBe(true);
+    const assessData = assessResult.data as { actionItems: ActionItem[] };
+    const commentReplyItems = assessData.actionItems.filter((i) => i.type === 'comment-reply');
+    expect(commentReplyItems).toHaveLength(3);
+
+    const classifyResult = await handleClassifyReviewItems({
+      featureId: 'feat-integration',
+      actionItems: commentReplyItems,
+    });
+
+    expect(classifyResult.success).toBe(true);
+    const result = classifyResult.data as {
+      groups: Array<{ file: string | null; recommendation: string; severity: string }>;
+      summary: { totalItems: number; directCount: number; delegateCount: number };
+    };
+
+    expect(result.summary.totalItems).toBe(3);
+    expect(result.groups).toHaveLength(3);
+
+    const byFile = new Map(result.groups.map((g) => [g.file, g]));
+
+    const authGroup = byFile.get('src/auth.ts');
+    expect(authGroup?.severity).toBe('HIGH');
+    expect(authGroup?.recommendation).toBe('delegate-fixer');
+
+    const handlerGroup = byFile.get('src/handler.ts');
+    expect(handlerGroup?.severity).toBe('MEDIUM');
+    expect(handlerGroup?.recommendation).toBe('direct');
+
+    const utilGroup = byFile.get('src/util.ts');
+    expect(utilGroup?.severity).toBe('MEDIUM');
+    expect(utilGroup?.recommendation).toBe('direct');
+  });
+});

--- a/servers/exarchos-mcp/src/cli-commands/subagent-context.test.ts
+++ b/servers/exarchos-mcp/src/cli-commands/subagent-context.test.ts
@@ -109,10 +109,11 @@ describe('subagent-context', () => {
       expect(deniedOrchestrate!.actions).toContain('prepare_synthesis');
       expect(deniedOrchestrate!.actions).toContain('assess_stack');
       // 4 original + 13 check_ actions + 20 new handler actions + 3 oneshot/prune actions
-      // (prune_stale_workflows, request_synthesize, finalize_oneshot) = 40.
+      // (prune_stale_workflows, request_synthesize, finalize_oneshot) + 1 classify_review_items
+      // (#1159) = 41.
       // Doctor now has ALL_PHASES so it's allowed, not denied.
       // Bump this number when new lead-only actions are registered.
-      expect(deniedOrchestrate!.actions).toHaveLength(40);
+      expect(deniedOrchestrate!.actions).toHaveLength(41);
     });
 
     it('should include event actions for delegate phase with teammate role', () => {
@@ -168,7 +169,8 @@ describe('subagent-context', () => {
         (c) => c.name === 'exarchos_orchestrate',
       );
       expect(deniedOrchestrate).toBeDefined();
-      expect(deniedOrchestrate!.actions.length).toBe(45);
+      // Bumped to 46 with the addition of classify_review_items (#1159).
+      expect(deniedOrchestrate!.actions.length).toBe(46);
     });
 
     it('should deny workflow init and cancel for teammate role', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -460,7 +460,7 @@ describe('EventTypes', () => {
   });
 
   it('EventTypes_HasExpectedCount', () => {
-    expect(EventTypes).toHaveLength(71);
+    expect(EventTypes).toHaveLength(72);
   });
 
   it('EventTypes_IncludesSessionTagged', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -460,7 +460,7 @@ describe('EventTypes', () => {
   });
 
   it('EventTypes_HasExpectedCount', () => {
-    expect(EventTypes).toHaveLength(72);
+    expect(EventTypes).toHaveLength(73);
   });
 
   it('EventTypes_IncludesSessionTagged', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -460,7 +460,7 @@ describe('EventTypes', () => {
   });
 
   it('EventTypes_HasExpectedCount', () => {
-    expect(EventTypes).toHaveLength(73);
+    expect(EventTypes).toHaveLength(74);
   });
 
   it('EventTypes_IncludesSessionTagged', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -77,6 +77,7 @@ export const EventTypes = [
   'preflight.executed',
   'preflight.blocked',
   'provider.unknown-tier',
+  'provider.parse-error',
   'dispatch.classified',
 ] as const;
 
@@ -252,6 +253,11 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   // auto — emitted by assess_stack when a review provider adapter
   // encounters an unrecognised severity tier (#1159).
   'provider.unknown-tier': 'auto',
+
+  // auto — emitted by assess_stack when adapter.parse throws; the batch
+  // continues, but we record the failure so observability catches
+  // adapter regressions instead of them being silently swallowed (#1161).
+  'provider.parse-error': 'auto',
 
   // auto — emitted by classify_review_items per invocation, capturing
   // the per-group dispatch decisions for downstream observability (#1159).
@@ -918,6 +924,14 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
     reviewer: z.string().min(1),
     rawTier: z.string().optional(),
     commentId: z.number().int(),
+  }),
+
+  // Review provider adapter parse-error (#1161) — batch continues; this
+  // event records the single-comment failure for observability.
+  'provider.parse-error': z.object({
+    reviewer: z.string().min(1),
+    commentId: z.number().int(),
+    errorMessage: z.string().min(1),
   }),
 
   // classify_review_items per-invocation observability (#1159)

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -76,6 +76,7 @@ export const EventTypes = [
   'checkpoint.state_missing',
   'preflight.executed',
   'preflight.blocked',
+  'provider.unknown-tier',
 ] as const;
 
 export type EventType = typeof EventTypes[number];
@@ -246,6 +247,10 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   'checkpoint.state_missing': 'auto',
   'preflight.executed': 'auto',
   'preflight.blocked': 'auto',
+
+  // auto — emitted by assess_stack when a review provider adapter
+  // encounters an unrecognised severity tier (#1159).
+  'provider.unknown-tier': 'auto',
 
   // planned — schema exists, not yet emitted in production
   'eval.run.started': 'planned',
@@ -902,6 +907,13 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
 
   // Init (exarchos init)
   'init.executed': InitExecutedDataSchema,
+
+  // Review provider adapter unknown-tier (#1159)
+  'provider.unknown-tier': z.object({
+    reviewer: z.string().min(1),
+    rawTier: z.string().optional(),
+    commentId: z.number().int(),
+  }),
 };
 
 // ─── TypeScript Types ───────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -77,6 +77,7 @@ export const EventTypes = [
   'preflight.executed',
   'preflight.blocked',
   'provider.unknown-tier',
+  'dispatch.classified',
 ] as const;
 
 export type EventType = typeof EventTypes[number];
@@ -251,6 +252,10 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   // auto — emitted by assess_stack when a review provider adapter
   // encounters an unrecognised severity tier (#1159).
   'provider.unknown-tier': 'auto',
+
+  // auto — emitted by classify_review_items per invocation, capturing
+  // the per-group dispatch decisions for downstream observability (#1159).
+  'dispatch.classified': 'auto',
 
   // planned — schema exists, not yet emitted in production
   'eval.run.started': 'planned',
@@ -913,6 +918,18 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
     reviewer: z.string().min(1),
     rawTier: z.string().optional(),
     commentId: z.number().int(),
+  }),
+
+  // classify_review_items per-invocation observability (#1159)
+  'dispatch.classified': z.object({
+    groupCount: z.number().int().nonnegative(),
+    directCount: z.number().int().nonnegative(),
+    delegateCount: z.number().int().nonnegative(),
+    severityDistribution: z.object({
+      high: z.number().int().nonnegative(),
+      medium: z.number().int().nonnegative(),
+      low: z.number().int().nonnegative(),
+    }),
   }),
 };
 

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
@@ -639,4 +639,55 @@ describe('handleAssessStack', () => {
       expect(secondGate.passed).toBe(false);
     });
   });
+
+  describe('comment body retention', () => {
+    it('QueryPrComments_LongCommentBody_RetainsFullBody', async () => {
+      const longBody = 'A'.repeat(500);
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          { id: 1, author: 'reviewer', body: longBody, createdAt: '2026-01-01T00:00:00Z' },
+        ],
+      });
+
+      const result = await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        provider,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        status: { prs: Array<{ unresolvedComments: Array<{ body: string; fullBody: string }> }> };
+      };
+      const comment = data.status.prs[0].unresolvedComments[0];
+      expect(comment.fullBody).toBe(longBody);
+      expect(comment.fullBody.length).toBe(500);
+      expect(comment.body.length).toBeLessThanOrEqual(204);
+    });
+  });
+
+  describe('ActionItem with reviewer-context fields', () => {
+    it('ActionItem_WithReviewerFields_TypeChecks', async () => {
+      const { ActionItem: _ActionItem } = await import('./assess-stack.js') as unknown as {
+        ActionItem: never;
+      };
+      void _ActionItem;
+      const item = {
+        type: 'comment-reply' as const,
+        pr: 42,
+        description: 'CodeRabbit critical finding',
+        severity: 'critical' as const,
+        file: 'src/foo.ts',
+        line: 10,
+        reviewer: 'coderabbit' as const,
+        threadId: 'thread-123',
+        raw: { id: 999 },
+        normalizedSeverity: 'HIGH' as const,
+      } satisfies import('./assess-stack.js').ActionItem;
+      expect(item.file).toBe('src/foo.ts');
+      expect(item.normalizedSeverity).toBe('HIGH');
+      expect(item.reviewer).toBe('coderabbit');
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
@@ -19,6 +19,7 @@ vi.mock('../event-store/store.js', () => ({
 }));
 
 import { handleAssessStack } from './assess-stack.js';
+import type { ReviewAdapterRegistry, ProviderAdapter, ReviewerKind } from '../review/types.js';
 
 const STATE_DIR = '/tmp/test-assess-stack';
 
@@ -895,6 +896,95 @@ describe('handleAssessStack', () => {
       expect(item.file).toBe('src/foo.ts');
       expect(item.normalizedSeverity).toBe('HIGH');
       expect(item.reviewer).toBe('coderabbit');
+    });
+  });
+
+  // ─── Adapter Parse Error Handling (#1161) ─────────────────────────────────
+
+  describe('adapter parse-error batch safety', () => {
+    function makeRegistry(opts: {
+      throwingAuthor: string;
+      throwMessage: string;
+    }): ReviewAdapterRegistry {
+      const throwingAdapter: ProviderAdapter = {
+        kind: 'coderabbit',
+        parse: () => {
+          throw new Error(opts.throwMessage);
+        },
+      };
+      const passthroughAdapter: ProviderAdapter = {
+        kind: 'unknown',
+        parse: (c) => ({
+          type: 'comment-reply',
+          pr: 0,
+          description: c.body.slice(0, 100),
+          severity: 'major',
+          reviewer: 'unknown',
+          threadId: String(c.id),
+          raw: c,
+          normalizedSeverity: 'MEDIUM',
+        }),
+      };
+      const byKind = new Map<ReviewerKind, ProviderAdapter>([
+        ['coderabbit', throwingAdapter],
+        ['unknown', passthroughAdapter],
+      ]);
+      return {
+        forReviewer: (k) => byKind.get(k),
+        list: () => [throwingAdapter, passthroughAdapter],
+      };
+    }
+
+    it('AssessStack_AdapterThrows_EmitsProviderParseError', async () => {
+      const registry = makeRegistry({ throwingAuthor: 'coderabbitai[bot]', throwMessage: 'bad body' });
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          { id: 99, author: 'coderabbitai[bot]', body: 'explodes', createdAt: '2026-01-01T00:00:00Z' },
+        ],
+      });
+
+      await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        provider,
+        registry,
+      );
+
+      const parseErrCalls = mockAppend.mock.calls.filter(
+        (call: unknown[]) => (call[1] as { type: string }).type === 'provider.parse-error',
+      );
+      expect(parseErrCalls.length).toBe(1);
+      const data = (parseErrCalls[0][1] as { data: Record<string, unknown> }).data;
+      expect(data.reviewer).toBe('coderabbit');
+      expect(data.commentId).toBe(99);
+      expect(data.errorMessage).toContain('bad body');
+      const idemKey = (parseErrCalls[0][2] as { idempotencyKey: string })?.idempotencyKey;
+      expect(idemKey).toBe('test-feature:provider.parse-error:42:99');
+    });
+
+    it('AssessStack_AdapterThrowsOnOne_BatchContinuesForOthers', async () => {
+      const registry = makeRegistry({ throwingAuthor: 'coderabbitai[bot]', throwMessage: 'boom' });
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          { id: 1, author: 'coderabbitai[bot]', body: 'explodes', createdAt: '2026-01-01T00:00:00Z' },
+          { id: 2, author: 'mystery-reviewer', body: 'survives', createdAt: '2026-01-01T00:00:00Z' },
+        ],
+      });
+
+      const result = await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        provider,
+        registry,
+      );
+
+      expect(result.success).toBe(true);
+      const status = (result.data as { status: { prs: Array<{ unresolvedComments: Array<{ body: string }> }> } }).status;
+      const bodies = status.prs[0].unresolvedComments.map((c) => c.body);
+      expect(bodies).toContain('survives');
+      expect(bodies).toContain('explodes');
     });
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
@@ -640,6 +640,96 @@ describe('handleAssessStack', () => {
     });
   });
 
+  describe('provider.unknown-tier event emission', () => {
+    it('AssessStack_CoderabbitUnknownTier_EmitsUnknownTierEvent', async () => {
+      mockAppend.mockClear();
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          {
+            id: 777,
+            author: 'coderabbitai[bot]',
+            body: '_:rocket: Brand new tier_\n\nLooks like something CodeRabbit ships in a future version.',
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        provider,
+      );
+
+      const unknownTierCalls = mockAppend.mock.calls.filter(
+        (call: unknown[]) => (call[1] as { type: string }).type === 'provider.unknown-tier',
+      );
+      expect(unknownTierCalls.length).toBe(1);
+      const data = (unknownTierCalls[0][1] as { data: { reviewer: string; commentId: number } }).data;
+      expect(data.reviewer).toBe('coderabbit');
+      expect(data.commentId).toBe(777);
+    });
+
+    it('AssessStack_RecognizedTier_DoesNotEmitUnknownTierEvent', async () => {
+      mockAppend.mockClear();
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          {
+            id: 1,
+            author: 'coderabbitai[bot]',
+            body: '_:warning: Potential issue_\n\nThis is a recognized tier.',
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        provider,
+      );
+
+      const unknownTierCalls = mockAppend.mock.calls.filter(
+        (call: unknown[]) => (call[1] as { type: string }).type === 'provider.unknown-tier',
+      );
+      expect(unknownTierCalls.length).toBe(0);
+    });
+  });
+
+  describe('classifyActionItems severity threading', () => {
+    it('ClassifyActionItems_HighSeverityComment_RetainsHighNormalizedSeverity', async () => {
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          {
+            id: 1,
+            author: 'coderabbitai[bot]',
+            body: '_:warning: Potential issue_\n\nNull pointer.',
+            createdAt: '2026-01-01T00:00:00Z',
+            path: 'src/x.ts',
+            line: 5,
+          },
+        ],
+      });
+
+      const result = await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        provider,
+      );
+
+      const data = result.data as {
+        actionItems: Array<{ type: string; normalizedSeverity?: string; reviewer?: string; file?: string }>;
+      };
+      const commentReply = data.actionItems.find((i) => i.type === 'comment-reply');
+      expect(commentReply).toBeDefined();
+      expect(commentReply?.normalizedSeverity).toBe('HIGH');
+      expect(commentReply?.reviewer).toBe('coderabbit');
+      expect(commentReply?.file).toBe('src/x.ts');
+    });
+  });
+
   describe('adapter dispatch via registry', () => {
     it('QueryPrComments_CoderabbitComment_PopulatesNormalizedSeverity', async () => {
       const provider = createMockProvider({

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
@@ -640,6 +640,95 @@ describe('handleAssessStack', () => {
     });
   });
 
+  describe('adapter dispatch via registry', () => {
+    it('QueryPrComments_CoderabbitComment_PopulatesNormalizedSeverity', async () => {
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          {
+            id: 999,
+            author: 'coderabbitai[bot]',
+            body: '_:warning: Potential issue_\n\nMissing null check on line 42.',
+            createdAt: '2026-01-01T00:00:00Z',
+            path: 'src/auth.ts',
+            line: 42,
+          },
+        ],
+      });
+
+      const result = await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        provider,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        status: { prs: Array<{ unresolvedComments: Array<{ actionItem?: Record<string, unknown> }> }> };
+      };
+      const comment = data.status.prs[0].unresolvedComments[0];
+      expect(comment.actionItem).toBeDefined();
+      expect(comment.actionItem?.reviewer).toBe('coderabbit');
+      expect(comment.actionItem?.normalizedSeverity).toBe('HIGH');
+      expect(comment.actionItem?.file).toBe('src/auth.ts');
+      expect(comment.actionItem?.line).toBe(42);
+    });
+
+    it('QueryPrComments_HumanComment_PopulatesNormalizedMedium', async () => {
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          {
+            id: 1,
+            author: 'alice',
+            body: 'Could you rename this variable?',
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      const result = await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        provider,
+      );
+
+      const data = result.data as {
+        status: { prs: Array<{ unresolvedComments: Array<{ actionItem?: Record<string, unknown> }> }> };
+      };
+      const comment = data.status.prs[0].unresolvedComments[0];
+      expect(comment.actionItem?.reviewer).toBe('human');
+      expect(comment.actionItem?.normalizedSeverity).toBe('MEDIUM');
+    });
+
+    it('QueryPrComments_UnknownBot_RoutesToUnknownAdapter', async () => {
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          {
+            id: 7,
+            author: 'mystery-scanner[bot]',
+            body: 'something happened',
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      const result = await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        provider,
+      );
+
+      const data = result.data as {
+        status: { prs: Array<{ unresolvedComments: Array<{ actionItem?: Record<string, unknown> }> }> };
+      };
+      const comment = data.status.prs[0].unresolvedComments[0];
+      expect(comment.actionItem?.reviewer).toBe('unknown');
+      expect(comment.actionItem?.normalizedSeverity).toBe('MEDIUM');
+    });
+  });
+
   describe('comment body retention', () => {
     it('QueryPrComments_LongCommentBody_RetainsFullBody', async () => {
       const longBody = 'A'.repeat(500);

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.test.ts
@@ -670,6 +670,34 @@ describe('handleAssessStack', () => {
       expect(data.commentId).toBe(777);
     });
 
+    it('AssessStack_CoderabbitUnknownTier_EventCarriesRawTier', async () => {
+      mockAppend.mockClear();
+      const provider = createMockProvider({
+        checkCi: { status: 'pass', checks: [{ name: 'ci/build', status: 'pass' }] },
+        prComments: [
+          {
+            id: 778,
+            author: 'coderabbitai[bot]',
+            body: '_:rocket: Brand new tier_\n\nUnrecognised marker.',
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      await handleAssessStack(
+        { featureId: 'test-feature', prNumbers: [42] },
+        STATE_DIR,
+        provider,
+      );
+
+      const unknownTierCalls = mockAppend.mock.calls.filter(
+        (call: unknown[]) => (call[1] as { type: string }).type === 'provider.unknown-tier',
+      );
+      expect(unknownTierCalls.length).toBe(1);
+      const data = (unknownTierCalls[0][1] as { data: { reviewer: string; commentId: number; rawTier?: string } }).data;
+      expect(data.rawTier).toBe('_:rocket: Brand new tier_');
+    });
+
     it('AssessStack_RecognizedTier_DoesNotEmitUnknownTierEvent', async () => {
       mockAppend.mockClear();
       const provider = createMockProvider({

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
@@ -138,6 +138,7 @@ async function queryPrComments(
           data: {
             reviewer: actionItem.reviewer ?? kind,
             commentId: c.id,
+            ...(actionItem.rawTier ? { rawTier: actionItem.rawTier } : {}),
           },
         }, {
           idempotencyKey: `${featureId}:provider.unknown-tier:${prNumber}:${c.id}`,

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
@@ -40,9 +40,11 @@ interface PrComment {
   readonly body: string;       // truncated for display
   readonly fullBody: string;   // untruncated; consumed by review provider adapters (#1159)
   readonly isResolved: boolean;
+  readonly actionItem?: ActionItem;  // populated by provider adapter dispatch (#1159)
 }
 
-import type { Severity, ReviewerKind, ActionItem } from '../review/types.js';
+import type { Severity, ReviewerKind, ActionItem, ReviewAdapterRegistry } from '../review/types.js';
+import { createReviewAdapterRegistry, detectKind } from '../review/registry.js';
 export type { Severity, ReviewerKind, ActionItem };
 
 export interface ShepherdStatusState {
@@ -112,16 +114,28 @@ async function queryPrReviews(provider: VcsProvider, prNumber: number): Promise<
   }
 }
 
-async function queryPrComments(provider: VcsProvider, prNumber: number): Promise<PrComment[]> {
+async function queryPrComments(
+  provider: VcsProvider,
+  prNumber: number,
+  registry: ReviewAdapterRegistry,
+): Promise<PrComment[]> {
   try {
     const comments: VcsPrComment[] = await provider.getPrComments(String(prNumber));
     // All comments from VcsProvider are treated as unresolved
     // (GitHub API doesn't provide isResolved for review comments)
-    return comments.map(c => ({
-      body: truncateBody(c.body),
-      fullBody: c.body,
-      isResolved: false,
-    }));
+    return comments.map(c => {
+      const kind = detectKind(c.author);
+      const adapter = registry.forReviewer(kind);
+      const parsed = adapter?.parse(c) ?? undefined;
+      // Stamp the PR number onto the parsed item (adapters return pr=0 by convention)
+      const actionItem = parsed ? { ...parsed, pr: prNumber } : undefined;
+      return {
+        body: truncateBody(c.body),
+        fullBody: c.body,
+        isResolved: false,
+        actionItem,
+      };
+    });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     orchestrateLogger.warn({ prNumber, err: message }, 'Failed to query comments');
@@ -136,10 +150,14 @@ function computeOverallCi(checks: readonly CiCheck[]): 'pass' | 'fail' | 'pendin
   return 'pass';
 }
 
-async function queryPrStatus(provider: VcsProvider, prNumber: number): Promise<PrStatus> {
+async function queryPrStatus(
+  provider: VcsProvider,
+  prNumber: number,
+  registry: ReviewAdapterRegistry,
+): Promise<PrStatus> {
   const checks = await queryPrChecks(provider, prNumber);
   const reviews = await queryPrReviews(provider, prNumber);
-  const allComments = await queryPrComments(provider, prNumber);
+  const allComments = await queryPrComments(provider, prNumber, registry);
   const unresolvedComments = allComments.filter(c => !c.isResolved);
 
   return {
@@ -362,6 +380,7 @@ export async function handleAssessStack(
   args: { featureId: string; prNumbers: number[] },
   stateDir: string,
   provider?: VcsProvider,
+  registry: ReviewAdapterRegistry = createReviewAdapterRegistry(),
 ): Promise<ToolResult> {
   const vcsGuard = requiresGitHub(provider, 'assess_stack');
   if (vcsGuard) return vcsGuard;
@@ -405,7 +424,7 @@ export async function handleAssessStack(
 
   // Query status for each PR
   const prStatuses = await Promise.all(
-    args.prNumbers.map(pr => queryPrStatus(vcs, pr)),
+    args.prNumbers.map(pr => queryPrStatus(vcs, pr, registry)),
   );
 
   // Emit dual events

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
@@ -118,24 +118,39 @@ async function queryPrComments(
   provider: VcsProvider,
   prNumber: number,
   registry: ReviewAdapterRegistry,
+  eventStore: EventStore,
+  featureId: string,
 ): Promise<PrComment[]> {
   try {
     const comments: VcsPrComment[] = await provider.getPrComments(String(prNumber));
     // All comments from VcsProvider are treated as unresolved
     // (GitHub API doesn't provide isResolved for review comments)
-    return comments.map(c => {
+    const results: PrComment[] = [];
+    for (const c of comments) {
       const kind = detectKind(c.author);
       const adapter = registry.forReviewer(kind);
       const parsed = adapter?.parse(c) ?? undefined;
       // Stamp the PR number onto the parsed item (adapters return pr=0 by convention)
       const actionItem = parsed ? { ...parsed, pr: prNumber } : undefined;
-      return {
+      if (actionItem?.unknownTier) {
+        await eventStore.append(featureId, {
+          type: 'provider.unknown-tier' as const,
+          data: {
+            reviewer: actionItem.reviewer ?? kind,
+            commentId: c.id,
+          },
+        }, {
+          idempotencyKey: `${featureId}:provider.unknown-tier:${prNumber}:${c.id}`,
+        });
+      }
+      results.push({
         body: truncateBody(c.body),
         fullBody: c.body,
         isResolved: false,
         actionItem,
-      };
-    });
+      });
+    }
+    return results;
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     orchestrateLogger.warn({ prNumber, err: message }, 'Failed to query comments');
@@ -154,10 +169,12 @@ async function queryPrStatus(
   provider: VcsProvider,
   prNumber: number,
   registry: ReviewAdapterRegistry,
+  eventStore: EventStore,
+  featureId: string,
 ): Promise<PrStatus> {
   const checks = await queryPrChecks(provider, prNumber);
   const reviews = await queryPrReviews(provider, prNumber);
-  const allComments = await queryPrComments(provider, prNumber, registry);
+  const allComments = await queryPrComments(provider, prNumber, registry, eventStore, featureId);
   const unresolvedComments = allComments.filter(c => !c.isResolved);
 
   return {
@@ -189,11 +206,21 @@ export function classifyActionItems(prStatuses: readonly PrStatus[]): ActionItem
 
     // Unresolved comments -> comment-reply items
     for (const comment of prStatus.unresolvedComments) {
+      // Thread the adapter-parsed fields when present (#1159);
+      // fall back to the legacy shape when no adapter ran.
+      const adapterItem = comment.actionItem;
       items.push({
         type: 'comment-reply',
         pr: prStatus.pr,
-        description: `Unresolved comment: ${comment.body.slice(0, 100)}`,
+        description: adapterItem?.description
+          ?? `Unresolved comment: ${comment.body.slice(0, 100)}`,
         severity: 'major',
+        ...(adapterItem?.reviewer ? { reviewer: adapterItem.reviewer } : {}),
+        ...(adapterItem?.file ? { file: adapterItem.file } : {}),
+        ...(adapterItem?.line !== undefined ? { line: adapterItem.line } : {}),
+        ...(adapterItem?.threadId ? { threadId: adapterItem.threadId } : {}),
+        ...(adapterItem?.normalizedSeverity ? { normalizedSeverity: adapterItem.normalizedSeverity } : {}),
+        ...(adapterItem?.raw !== undefined ? { raw: adapterItem.raw } : {}),
       });
     }
 
@@ -424,7 +451,7 @@ export async function handleAssessStack(
 
   // Query status for each PR
   const prStatuses = await Promise.all(
-    args.prNumbers.map(pr => queryPrStatus(vcs, pr, registry)),
+    args.prNumbers.map(pr => queryPrStatus(vcs, pr, registry, eventStore, args.featureId)),
   );
 
   // Emit dual events

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
@@ -37,16 +37,13 @@ interface PrReview {
 }
 
 interface PrComment {
-  readonly body: string;
+  readonly body: string;       // truncated for display
+  readonly fullBody: string;   // untruncated; consumed by review provider adapters (#1159)
   readonly isResolved: boolean;
 }
 
-export interface ActionItem {
-  readonly type: 'ci-fix' | 'comment-reply' | 'review-address' | 'stack-fix';
-  readonly pr: number;
-  readonly description: string;
-  readonly severity: 'critical' | 'major' | 'minor';
-}
+import type { Severity, ReviewerKind, ActionItem } from '../review/types.js';
+export type { Severity, ReviewerKind, ActionItem };
 
 export interface ShepherdStatusState {
   readonly prs: readonly PrStatus[];
@@ -122,6 +119,7 @@ async function queryPrComments(provider: VcsProvider, prNumber: number): Promise
     // (GitHub API doesn't provide isResolved for review comments)
     return comments.map(c => ({
       body: truncateBody(c.body),
+      fullBody: c.body,
       isResolved: false,
     }));
   } catch (err: unknown) {

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
@@ -129,9 +129,31 @@ async function queryPrComments(
     for (const c of comments) {
       const kind = detectKind(c.author);
       const adapter = registry.forReviewer(kind);
-      const parsed = adapter?.parse(c) ?? undefined;
-      // Stamp the PR number onto the parsed item (adapters return pr=0 by convention)
-      const actionItem = parsed ? { ...parsed, pr: prNumber } : undefined;
+      // Outer defensive wrap: even though adapters self-guard in their own
+      // try/catch, a malformed comment or a bug in an adapter must not kill
+      // the entire batch. On throw we record `provider.parse-error` for
+      // observability and continue with actionItem=undefined (#1161).
+      let actionItem: ActionItem | undefined;
+      try {
+        const parsed = adapter?.parse(c) ?? undefined;
+        actionItem = parsed ? { ...parsed, pr: prNumber } : undefined;
+      } catch (err: unknown) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        orchestrateLogger.warn(
+          { prNumber, commentId: c.id, reviewer: kind, err: errorMessage },
+          'Review adapter threw while parsing comment; skipping item',
+        );
+        await eventStore.append(featureId, {
+          type: 'provider.parse-error' as const,
+          data: {
+            reviewer: kind,
+            commentId: c.id,
+            errorMessage,
+          },
+        }, {
+          idempotencyKey: `${featureId}:provider.parse-error:${prNumber}:${c.id}`,
+        });
+      }
       if (actionItem?.unknownTier) {
         await eventStore.append(featureId, {
           type: 'provider.unknown-tier' as const,

--- a/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
+++ b/servers/exarchos-mcp/src/orchestrate/assess-stack.ts
@@ -200,6 +200,7 @@ export function classifyActionItems(prStatuses: readonly PrStatus[]): ActionItem
           pr: prStatus.pr,
           description: `CI check '${check.name}' is failing`,
           severity: 'critical',
+          normalizedSeverity: 'HIGH',
         });
       }
     }
@@ -207,7 +208,7 @@ export function classifyActionItems(prStatuses: readonly PrStatus[]): ActionItem
     // Unresolved comments -> comment-reply items
     for (const comment of prStatus.unresolvedComments) {
       // Thread the adapter-parsed fields when present (#1159);
-      // fall back to the legacy shape when no adapter ran.
+      // fall back to MEDIUM when no adapter ran (registry omitted, edge case).
       const adapterItem = comment.actionItem;
       items.push({
         type: 'comment-reply',
@@ -215,11 +216,11 @@ export function classifyActionItems(prStatuses: readonly PrStatus[]): ActionItem
         description: adapterItem?.description
           ?? `Unresolved comment: ${comment.body.slice(0, 100)}`,
         severity: 'major',
+        normalizedSeverity: adapterItem?.normalizedSeverity ?? 'MEDIUM',
         ...(adapterItem?.reviewer ? { reviewer: adapterItem.reviewer } : {}),
         ...(adapterItem?.file ? { file: adapterItem.file } : {}),
         ...(adapterItem?.line !== undefined ? { line: adapterItem.line } : {}),
         ...(adapterItem?.threadId ? { threadId: adapterItem.threadId } : {}),
-        ...(adapterItem?.normalizedSeverity ? { normalizedSeverity: adapterItem.normalizedSeverity } : {}),
         ...(adapterItem?.raw !== undefined ? { raw: adapterItem.raw } : {}),
       });
     }
@@ -232,6 +233,7 @@ export function classifyActionItems(prStatuses: readonly PrStatus[]): ActionItem
           pr: prStatus.pr,
           description: `Changes requested by ${review.author}`,
           severity: 'major',
+          normalizedSeverity: 'HIGH',
         });
       }
     }

--- a/servers/exarchos-mcp/src/orchestrate/classify-review-items.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/classify-review-items.test.ts
@@ -113,4 +113,79 @@ describe('handleClassifyReviewItems', () => {
     const key2 = (eventStore2.append as ReturnType<typeof vi.fn>).mock.calls[0][2].idempotencyKey;
     expect(key1).toBe(key2);
   });
+
+  // ─── Idempotency Signature Robustness (#1161) ─────────────────────────────
+
+  it('OrchestrateClassifyReviewItems_ReorderedItems_ProducesSameIdempotencyKey', async () => {
+    const eventStoreA = makeEventStore();
+    const eventStoreB = makeEventStore();
+    const a = makeItem({ threadId: 't-1', file: 'src/a.ts', line: 10, reviewer: 'coderabbit', normalizedSeverity: 'HIGH' });
+    const b = makeItem({ threadId: 't-2', file: 'src/b.ts', line: 20, reviewer: 'sentry', normalizedSeverity: 'MEDIUM' });
+    await handleClassifyReviewItems({ featureId: 'feat-x', actionItems: [a, b], eventStore: eventStoreA });
+    await handleClassifyReviewItems({ featureId: 'feat-x', actionItems: [b, a], eventStore: eventStoreB });
+
+    const keyA = (eventStoreA.append as ReturnType<typeof vi.fn>).mock.calls[0][2].idempotencyKey;
+    const keyB = (eventStoreB.append as ReturnType<typeof vi.fn>).mock.calls[0][2].idempotencyKey;
+    expect(keyA).toBe(keyB);
+  });
+
+  it('OrchestrateClassifyReviewItems_DifferentSeverity_ProducesDifferentIdempotencyKey', async () => {
+    const eventStoreA = makeEventStore();
+    const eventStoreB = makeEventStore();
+    const base = { threadId: 't-1', file: 'src/a.ts', line: 10, reviewer: 'coderabbit' as const };
+    await handleClassifyReviewItems({
+      featureId: 'feat-x',
+      actionItems: [makeItem({ ...base, normalizedSeverity: 'HIGH' })],
+      eventStore: eventStoreA,
+    });
+    await handleClassifyReviewItems({
+      featureId: 'feat-x',
+      actionItems: [makeItem({ ...base, normalizedSeverity: 'LOW' })],
+      eventStore: eventStoreB,
+    });
+
+    const keyA = (eventStoreA.append as ReturnType<typeof vi.fn>).mock.calls[0][2].idempotencyKey;
+    const keyB = (eventStoreB.append as ReturnType<typeof vi.fn>).mock.calls[0][2].idempotencyKey;
+    expect(keyA).not.toBe(keyB);
+  });
+
+  it('OrchestrateClassifyReviewItems_DifferentReviewer_ProducesDifferentIdempotencyKey', async () => {
+    const eventStoreA = makeEventStore();
+    const eventStoreB = makeEventStore();
+    const base = { threadId: 't-1', file: 'src/a.ts', line: 10, normalizedSeverity: 'HIGH' as const };
+    await handleClassifyReviewItems({
+      featureId: 'feat-x',
+      actionItems: [makeItem({ ...base, reviewer: 'coderabbit' })],
+      eventStore: eventStoreA,
+    });
+    await handleClassifyReviewItems({
+      featureId: 'feat-x',
+      actionItems: [makeItem({ ...base, reviewer: 'sentry' })],
+      eventStore: eventStoreB,
+    });
+
+    const keyA = (eventStoreA.append as ReturnType<typeof vi.fn>).mock.calls[0][2].idempotencyKey;
+    const keyB = (eventStoreB.append as ReturnType<typeof vi.fn>).mock.calls[0][2].idempotencyKey;
+    expect(keyA).not.toBe(keyB);
+  });
+
+  // ─── Telemetry Failure is Non-Fatal (#1161) ───────────────────────────────
+
+  it('OrchestrateClassifyReviewItems_EventStoreThrows_StillReturnsResult', async () => {
+    const eventStore = {
+      append: vi.fn().mockRejectedValue(new Error('event store down')),
+      query: vi.fn().mockResolvedValue([]),
+      batchAppend: vi.fn().mockResolvedValue(undefined),
+    } as unknown as EventStore;
+
+    const result = await handleClassifyReviewItems({
+      featureId: 'feat-x',
+      actionItems: [makeItem({ file: 'src/a.ts' })],
+      eventStore,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { groups: unknown[] };
+    expect(Array.isArray(data.groups)).toBe(true);
+  });
 });

--- a/servers/exarchos-mcp/src/orchestrate/classify-review-items.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/classify-review-items.test.ts
@@ -83,4 +83,34 @@ describe('handleClassifyReviewItems', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('OrchestrateClassifyReviewItems_DispatchClassifiedEvent_UsesIdempotencyKey', async () => {
+    const eventStore = makeEventStore();
+    const items: ActionItem[] = [makeItem({ threadId: 'thread-1' })];
+    await handleClassifyReviewItems({
+      featureId: 'feat-x',
+      actionItems: items,
+      eventStore,
+    });
+
+    const opts = (eventStore.append as ReturnType<typeof vi.fn>).mock.calls[0][2];
+    expect(opts).toBeDefined();
+    expect(opts.idempotencyKey).toBeDefined();
+    expect(opts.idempotencyKey).toMatch(/^feat-x:dispatch\.classified:[0-9a-f]{16}$/);
+  });
+
+  it('OrchestrateClassifyReviewItems_SameInputs_ProducesSameIdempotencyKey', async () => {
+    const eventStore1 = makeEventStore();
+    const eventStore2 = makeEventStore();
+    const items: ActionItem[] = [
+      makeItem({ threadId: 'thread-1', file: 'src/a.ts' }),
+      makeItem({ threadId: 'thread-2', file: 'src/b.ts' }),
+    ];
+    await handleClassifyReviewItems({ featureId: 'feat-x', actionItems: items, eventStore: eventStore1 });
+    await handleClassifyReviewItems({ featureId: 'feat-x', actionItems: items, eventStore: eventStore2 });
+
+    const key1 = (eventStore1.append as ReturnType<typeof vi.fn>).mock.calls[0][2].idempotencyKey;
+    const key2 = (eventStore2.append as ReturnType<typeof vi.fn>).mock.calls[0][2].idempotencyKey;
+    expect(key1).toBe(key2);
+  });
 });

--- a/servers/exarchos-mcp/src/orchestrate/classify-review-items.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/classify-review-items.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleClassifyReviewItems } from './classify-review-items.js';
+import type { ActionItem } from '../review/types.js';
+import type { EventStore } from '../event-store/store.js';
+
+function makeItem(overrides: Partial<ActionItem> = {}): ActionItem {
+  return {
+    type: 'comment-reply',
+    pr: 1,
+    description: 'sample',
+    severity: 'major',
+    normalizedSeverity: 'MEDIUM',
+    ...overrides,
+  };
+}
+
+function makeEventStore(): EventStore {
+  return {
+    append: vi.fn().mockResolvedValue(undefined),
+    query: vi.fn().mockResolvedValue([]),
+    batchAppend: vi.fn().mockResolvedValue(undefined),
+  } as unknown as EventStore;
+}
+
+describe('handleClassifyReviewItems', () => {
+  it('OrchestrateClassifyReviewItems_GivenItems_ReturnsClassificationResult', async () => {
+    const items: ActionItem[] = [
+      makeItem({ file: 'src/a.ts', normalizedSeverity: 'HIGH' }),
+      makeItem({ file: 'src/a.ts', normalizedSeverity: 'MEDIUM' }),
+      makeItem({ file: 'src/b.ts', normalizedSeverity: 'LOW' }),
+    ];
+
+    const result = await handleClassifyReviewItems({
+      featureId: 'test-feature',
+      actionItems: items,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      groups: Array<{ file: string | null; recommendation: string }>;
+      summary: { totalItems: number; directCount: number; delegateCount: number };
+    };
+    expect(data.groups.length).toBe(2);
+    expect(data.summary.totalItems).toBe(3);
+  });
+
+  it('OrchestrateClassifyReviewItems_OnInvocation_EmitsDispatchClassifiedEvent', async () => {
+    const eventStore = makeEventStore();
+    const items: ActionItem[] = [
+      makeItem({ file: 'src/a.ts', normalizedSeverity: 'HIGH' }),
+      makeItem({ file: 'src/b.ts', normalizedSeverity: 'MEDIUM' }),
+      makeItem({ file: 'src/c.ts', normalizedSeverity: 'LOW' }),
+      makeItem({ file: 'src/c.ts', normalizedSeverity: 'LOW' }),
+    ];
+
+    await handleClassifyReviewItems({
+      featureId: 'test-feature',
+      actionItems: items,
+      eventStore,
+    });
+
+    expect(eventStore.append).toHaveBeenCalledTimes(1);
+    const [streamId, event] = (eventStore.append as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(streamId).toBe('test-feature');
+    expect(event.type).toBe('dispatch.classified');
+    expect(event.data.severityDistribution).toEqual({ high: 1, medium: 1, low: 2 });
+    expect(event.data.groupCount).toBe(3);
+  });
+
+  it('OrchestrateClassifyReviewItems_MissingFeatureId_ReturnsInvalidInput', async () => {
+    const result = await handleClassifyReviewItems({
+      featureId: '',
+      actionItems: [],
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('OrchestrateClassifyReviewItems_NoEventStore_StillReturnsResult', async () => {
+    const result = await handleClassifyReviewItems({
+      featureId: 'test-feature',
+      actionItems: [makeItem()],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/classify-review-items.ts
+++ b/servers/exarchos-mcp/src/orchestrate/classify-review-items.ts
@@ -1,0 +1,73 @@
+// ─── Classify Review Items Orchestrate Action ───────────────────────────────
+//
+// Wraps review/classifier.ts as an orchestrate action. Consumers
+// (typically the shepherd skill) pass an array of normalized ActionItems
+// returned by assess_stack and receive a ClassificationResult containing
+// per-file groups, each annotated with a dispatch recommendation.
+//
+// Emits one `dispatch.classified` event per invocation so we can later
+// measure classifier accuracy and the realized severity distribution
+// across PR comments. The handler is provider-agnostic — it operates on
+// already-normalized ActionItems regardless of which adapter produced them.
+// ────────────────────────────────────────────────────────────────────────────
+
+import type { ToolResult } from '../format.js';
+import type { EventStore } from '../event-store/store.js';
+import type { ActionItem, Severity } from '../review/types.js';
+import { classifyReviewItems } from '../review/classifier.js';
+
+export interface ClassifyReviewItemsArgs {
+  readonly featureId: string;
+  readonly actionItems: readonly ActionItem[];
+  readonly eventStore?: EventStore;
+}
+
+function severityDistribution(items: readonly ActionItem[]): {
+  high: number;
+  medium: number;
+  low: number;
+} {
+  let high = 0;
+  let medium = 0;
+  let low = 0;
+  for (const item of items) {
+    const s: Severity = item.normalizedSeverity ?? 'MEDIUM';
+    if (s === 'HIGH') high += 1;
+    else if (s === 'MEDIUM') medium += 1;
+    else low += 1;
+  }
+  return { high, medium, low };
+}
+
+export async function handleClassifyReviewItems(
+  args: ClassifyReviewItemsArgs,
+): Promise<ToolResult> {
+  if (!args.featureId) {
+    return {
+      success: false,
+      error: { code: 'INVALID_INPUT', message: 'featureId is required' },
+    };
+  }
+  if (!Array.isArray(args.actionItems)) {
+    return {
+      success: false,
+      error: { code: 'INVALID_INPUT', message: 'actionItems must be an array' },
+    };
+  }
+
+  const result = classifyReviewItems(args.actionItems);
+
+  if (args.eventStore) {
+    await args.eventStore.append(args.featureId, {
+      type: 'dispatch.classified' as const,
+      data: {
+        groupCount: result.groups.length,
+        directCount: result.summary.directCount,
+        delegateCount: result.summary.delegateCount,
+        severityDistribution: severityDistribution(args.actionItems),
+      },
+    });
+  }
+
+  return { success: true, data: result };
+}

--- a/servers/exarchos-mcp/src/orchestrate/classify-review-items.ts
+++ b/servers/exarchos-mcp/src/orchestrate/classify-review-items.ts
@@ -16,6 +16,32 @@ import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import type { ActionItem, Severity } from '../review/types.js';
 import { classifyReviewItems } from '../review/classifier.js';
+import { orchestrateLogger } from '../logger.js';
+
+// Canonical per-item fingerprint for idempotency. Including all identifying
+// fields (not just threadId) makes the signature stable across equivalent
+// inputs and distinct across genuinely different batches; sorting on the
+// composite key renders order-insensitivity (#1161 PR feedback).
+function canonicalSignature(items: readonly ActionItem[]): string {
+  const canonical = items
+    .map((i) => ({
+      threadId: i.threadId ?? null,
+      file: i.file ?? null,
+      line: i.line ?? null,
+      reviewer: i.reviewer ?? null,
+      severity: i.normalizedSeverity ?? null,
+      description: i.description ?? null,
+    }))
+    .sort((a, b) => {
+      const ka = `${a.threadId ?? ''}|${a.file ?? ''}|${a.line ?? ''}|${a.reviewer ?? ''}|${a.severity ?? ''}|${a.description ?? ''}`;
+      const kb = `${b.threadId ?? ''}|${b.file ?? ''}|${b.line ?? ''}|${b.reviewer ?? ''}|${b.severity ?? ''}|${b.description ?? ''}`;
+      return ka.localeCompare(kb);
+    });
+  return createHash('sha1')
+    .update(JSON.stringify(canonical))
+    .digest('hex')
+    .slice(0, 16);
+}
 
 export interface ClassifyReviewItemsArgs {
   readonly featureId: string;
@@ -60,22 +86,29 @@ export async function handleClassifyReviewItems(
 
   if (args.eventStore) {
     // Idempotency: same featureId + same input ActionItems → same key,
-    // so retries don't accumulate duplicate events on the stream.
-    const signature = createHash('sha1')
-      .update(JSON.stringify(args.actionItems.map((i) => i.threadId ?? i.file ?? i.description)))
-      .digest('hex')
-      .slice(0, 16);
-    await args.eventStore.append(args.featureId, {
-      type: 'dispatch.classified' as const,
-      data: {
-        groupCount: result.groups.length,
-        directCount: result.summary.directCount,
-        delegateCount: result.summary.delegateCount,
-        severityDistribution: severityDistribution(args.actionItems),
-      },
-    }, {
-      idempotencyKey: `${args.featureId}:dispatch.classified:${signature}`,
-    });
+    // so retries don't accumulate duplicate events on the stream. Telemetry
+    // is best-effort — a failing event store must not abort classification,
+    // which is the shepherd-visible result (#1161).
+    const signature = canonicalSignature(args.actionItems);
+    try {
+      await args.eventStore.append(args.featureId, {
+        type: 'dispatch.classified' as const,
+        data: {
+          groupCount: result.groups.length,
+          directCount: result.summary.directCount,
+          delegateCount: result.summary.delegateCount,
+          severityDistribution: severityDistribution(args.actionItems),
+        },
+      }, {
+        idempotencyKey: `${args.featureId}:dispatch.classified:${signature}`,
+      });
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      orchestrateLogger.warn(
+        { featureId: args.featureId, err: errorMessage },
+        'Failed to append dispatch.classified event; classification result still returned',
+      );
+    }
   }
 
   return { success: true, data: result };

--- a/servers/exarchos-mcp/src/orchestrate/classify-review-items.ts
+++ b/servers/exarchos-mcp/src/orchestrate/classify-review-items.ts
@@ -11,6 +11,7 @@
 // already-normalized ActionItems regardless of which adapter produced them.
 // ────────────────────────────────────────────────────────────────────────────
 
+import { createHash } from 'node:crypto';
 import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import type { ActionItem, Severity } from '../review/types.js';
@@ -58,6 +59,12 @@ export async function handleClassifyReviewItems(
   const result = classifyReviewItems(args.actionItems);
 
   if (args.eventStore) {
+    // Idempotency: same featureId + same input ActionItems → same key,
+    // so retries don't accumulate duplicate events on the stream.
+    const signature = createHash('sha1')
+      .update(JSON.stringify(args.actionItems.map((i) => i.threadId ?? i.file ?? i.description)))
+      .digest('hex')
+      .slice(0, 16);
     await args.eventStore.append(args.featureId, {
       type: 'dispatch.classified' as const,
       data: {
@@ -66,6 +73,8 @@ export async function handleClassifyReviewItems(
         delegateCount: result.summary.delegateCount,
         severityDistribution: severityDistribution(args.actionItems),
       },
+    }, {
+      idempotencyKey: `${args.featureId}:dispatch.classified:${signature}`,
     });
   }
 

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -50,6 +50,7 @@ import { handleValidatePrBody } from './validate-pr-body.js';
 import { handleValidatePrStack } from './validate-pr-stack.js';
 import { handleDebugReviewGate } from './debug-review-gate.js';
 import { handleExtractFixTasks } from './extract-fix-tasks.js';
+import { handleClassifyReviewItems } from './classify-review-items.js';
 import { handleGenerateTraceability } from './generate-traceability.js';
 import { handleSpecCoverageCheck } from './spec-coverage-check.js';
 import { handleVerifyWorktreeBaseline } from './verify-worktree-baseline.js';
@@ -170,6 +171,7 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   validate_pr_stack: adaptArgs(handleValidatePrStack),
   debug_review_gate: adaptArgs(handleDebugReviewGate),
   extract_fix_tasks: adaptArgs(handleExtractFixTasks),
+  classify_review_items: adaptArgsWithEventStore(handleClassifyReviewItems),
   generate_traceability: adaptArgs(handleGenerateTraceability),
   spec_coverage_check: adaptArgs(handleSpecCoverageCheck),
   verify_worktree_baseline: adapt(handleVerifyWorktreeBaseline),

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -87,7 +87,7 @@ export interface PrepareDelegationResult {
 
 // ─── Task Classification ────────────────────────────────────────────────────
 
-import { SCAFFOLDING_KEYWORDS } from './scaffolding-keywords.js';
+import { TASK_SCAFFOLDING_KEYWORDS as SCAFFOLDING_KEYWORDS } from './scaffolding-keywords.js';
 
 /**
  * Resolves the recommended model for a given agent type from the agent config.

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -87,8 +87,7 @@ export interface PrepareDelegationResult {
 
 // ─── Task Classification ────────────────────────────────────────────────────
 
-/** Keywords in task titles that indicate low-complexity scaffolding work. */
-const SCAFFOLDING_KEYWORDS = ['stub', 'boilerplate', 'type def', 'interface', 'scaffold'];
+import { SCAFFOLDING_KEYWORDS } from './scaffolding-keywords.js';
 
 /**
  * Resolves the recommended model for a given agent type from the agent config.

--- a/servers/exarchos-mcp/src/orchestrate/scaffolding-keywords.ts
+++ b/servers/exarchos-mcp/src/orchestrate/scaffolding-keywords.ts
@@ -1,25 +1,31 @@
-// ─── Scaffolding Keywords ───────────────────────────────────────────────────
+// ─── Scaffolding Keyword Sets ───────────────────────────────────────────────
 //
-// Shared keyword set used by two routers:
-//   - prepare-delegation.ts classifies plan tasks as scaffolding work
-//   - review/classifier.ts routes all-LOW review-comment groups to the
-//     scaffolder agent when at least one item description matches a keyword
+// Two distinct keyword sets, used by two different routers (PR #1161 split):
 //
-// Original five keywords ('stub', 'boilerplate', 'type def', 'interface',
-// 'scaffold') target plan-task titles. The doc-nit additions ('<remarks>',
-// 'sealed', 'orderby', 'format', 'xml doc') target review comments authored
-// by automated reviewers (CodeRabbit, Sentry) that flag style/doc issues
-// suitable for the scaffolder's faster, cheaper context (#1159 design Q-P5).
+//   TASK_SCAFFOLDING_KEYWORDS — matches plan-task TITLES. Used by
+//     prepare-delegation.ts to recommend the scaffolder agent for cheap
+//     setup work. Tokens here must be specific to scaffolding tasks; broad
+//     tokens like 'format' would mis-classify substantive tasks (e.g.,
+//     "format and lint output for telemetry view") as scaffolding work.
+//
+//   REVIEW_DOC_NIT_KEYWORDS — matches review-comment DESCRIPTIONS. Used by
+//     review/classifier.ts to recommend the scaffolder agent when an
+//     all-LOW-severity review group looks like a doc nit. Tokens here can
+//     be broad because they're applied only to LOW-severity items already.
+//
+// Keep the sets disjoint to avoid one consumer accidentally borrowing the
+// other's tokens.
 // ────────────────────────────────────────────────────────────────────────────
 
-export const SCAFFOLDING_KEYWORDS: readonly string[] = [
-  // Plan-task scaffolding
+export const TASK_SCAFFOLDING_KEYWORDS: readonly string[] = [
   'stub',
   'boilerplate',
   'type def',
   'interface',
   'scaffold',
-  // Review-comment doc nits (#1159)
+];
+
+export const REVIEW_DOC_NIT_KEYWORDS: readonly string[] = [
   '<remarks>',
   'sealed',
   'orderby',

--- a/servers/exarchos-mcp/src/orchestrate/scaffolding-keywords.ts
+++ b/servers/exarchos-mcp/src/orchestrate/scaffolding-keywords.ts
@@ -1,0 +1,28 @@
+// ─── Scaffolding Keywords ───────────────────────────────────────────────────
+//
+// Shared keyword set used by two routers:
+//   - prepare-delegation.ts classifies plan tasks as scaffolding work
+//   - review/classifier.ts routes all-LOW review-comment groups to the
+//     scaffolder agent when at least one item description matches a keyword
+//
+// Original five keywords ('stub', 'boilerplate', 'type def', 'interface',
+// 'scaffold') target plan-task titles. The doc-nit additions ('<remarks>',
+// 'sealed', 'orderby', 'format', 'xml doc') target review comments authored
+// by automated reviewers (CodeRabbit, Sentry) that flag style/doc issues
+// suitable for the scaffolder's faster, cheaper context (#1159 design Q-P5).
+// ────────────────────────────────────────────────────────────────────────────
+
+export const SCAFFOLDING_KEYWORDS: readonly string[] = [
+  // Plan-task scaffolding
+  'stub',
+  'boilerplate',
+  'type def',
+  'interface',
+  'scaffold',
+  // Review-comment doc nits (#1159)
+  '<remarks>',
+  'sealed',
+  'orderby',
+  'format',
+  'xml doc',
+];

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -499,10 +499,10 @@ describe('TOOL_REGISTRY', () => {
   });
 
   describe('exarchos_orchestrate', () => {
-    it('should have 63 actions for task management, review triage, gate checks, validation handlers, runbooks, agent spec, oneshot/pruning, doctor, init, VCS, and composite actions', () => {
+    it('should have 64 actions for task management, review triage, gate checks, validation handlers, runbooks, agent spec, oneshot/pruning, doctor, init, VCS, classify_review_items (#1159), and composite actions', () => {
       const composite = findComposite('exarchos_orchestrate');
       expect(composite).toBeDefined();
-      expect(composite!.actions).toHaveLength(63);
+      expect(composite!.actions).toHaveLength(64);
 
       const actionNames = composite!.actions.map((a) => a.name);
       expect(actionNames).toEqual(

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -1328,6 +1328,18 @@ describe('Plugin Integration Registry Wiring', () => {
     expect(prepareReview!.roles.has('lead')).toBe(true);
   });
 
+  it('RegistryActions_ClassifyReviewItems_IncludesSynthesizePhase', () => {
+    // Regression: shepherd invokes classify_review_items during synthesize.
+    // If this action is restricted to REVIEW_PHASES only, the runtime
+    // phase-guard rejects the call and breaks the shepherd loop (#1161).
+    const action = findAction('exarchos_orchestrate', 'classify_review_items');
+    expect(action).toBeDefined();
+    expect(action!.phases.has('synthesize')).toBe(true);
+    expect(action!.phases.has('review')).toBe(true);
+    expect(action!.phases.has('overhaul-review')).toBe(true);
+    expect(action!.phases.has('debug-review')).toBe(true);
+  });
+
   it('RegistryActions_CheckReviewVerdict_HasPluginFindingsInSchema', () => {
     const action = findAction('exarchos_orchestrate', 'check_review_verdict');
     expect(action).toBeDefined();

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -1086,6 +1086,16 @@ const orchestrateActions: readonly ToolAction[] = [
     roles: ROLE_LEAD,
   },
   {
+    name: 'classify_review_items',
+    description: 'Group ActionItems by file and recommend dispatch strategy (direct/delegate-fixer/delegate-scaffolder) per group (#1159)',
+    schema: z.object({
+      featureId: z.string().min(1),
+      actionItems: z.array(z.record(z.string(), z.unknown())),
+    }),
+    phases: REVIEW_PHASES,
+    roles: ROLE_LEAD,
+  },
+  {
     name: 'generate_traceability',
     description: 'Generate a traceability matrix mapping design sections to plan tasks',
     schema: z.object({

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -1092,7 +1092,10 @@ const orchestrateActions: readonly ToolAction[] = [
       featureId: z.string().min(1),
       actionItems: z.array(z.record(z.string(), z.unknown())),
     }),
-    phases: REVIEW_PHASES,
+    // Shepherd operates within `synthesize` and invokes classify_review_items
+    // after assess_stack; restricting to REVIEW_PHASES would trip phase-guard
+    // at runtime (#1161 / Sentry bug prediction).
+    phases: SYNTHESIS_REVIEW_PHASES,
     roles: ROLE_LEAD,
   },
   {

--- a/servers/exarchos-mcp/src/review/classifier.test.ts
+++ b/servers/exarchos-mcp/src/review/classifier.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import {
+  classifyReviewItems,
+  groupItemsByFile,
+  recommendForGroup,
+} from './classifier.js';
+import type { ActionItem } from './types.js';
+
+function makeItem(overrides: Partial<ActionItem> = {}): ActionItem {
+  return {
+    type: 'comment-reply',
+    pr: 1,
+    description: overrides.description ?? 'sample',
+    severity: 'major',
+    normalizedSeverity: 'MEDIUM',
+    ...overrides,
+  };
+}
+
+describe('groupItemsByFile', () => {
+  it('GroupItemsByFile_TwoItemsSameFile_ReturnsOneGroup', () => {
+    const groups = groupItemsByFile([
+      makeItem({ file: 'src/a.ts', line: 10 }),
+      makeItem({ file: 'src/a.ts', line: 20 }),
+    ]);
+    expect(groups.size).toBe(1);
+    expect(groups.get('src/a.ts')).toHaveLength(2);
+  });
+
+  it('GroupItemsByFile_ItemsAcrossFiles_ReturnsOneGroupPerFile', () => {
+    const groups = groupItemsByFile([
+      makeItem({ file: 'src/a.ts' }),
+      makeItem({ file: 'src/b.ts' }),
+      makeItem({ file: 'src/a.ts' }),
+    ]);
+    expect(groups.size).toBe(2);
+    expect(groups.get('src/a.ts')).toHaveLength(2);
+    expect(groups.get('src/b.ts')).toHaveLength(1);
+  });
+
+  it('GroupItemsByFile_ItemsWithoutFile_GroupedUnderNullKey', () => {
+    const groups = groupItemsByFile([
+      makeItem({ file: undefined }),
+      makeItem({ file: undefined }),
+    ]);
+    expect(groups.has(null as unknown as string)).toBe(true);
+    expect(groups.get(null as unknown as string)).toHaveLength(2);
+  });
+});
+
+describe('recommendForGroup', () => {
+  it('RecommendForGroup_SingleNonHighItem_RecommendsDirect', () => {
+    const r = recommendForGroup([makeItem({ normalizedSeverity: 'MEDIUM' })]);
+    expect(r.recommendation).toBe('direct');
+    expect(r.severity).toBe('MEDIUM');
+    expect(r.rationale).toMatch(/single|direct/i);
+  });
+
+  it('RecommendForGroup_MultipleItemsSameFile_RecommendsDelegateFixer', () => {
+    const r = recommendForGroup([
+      makeItem({ file: 'src/a.ts', normalizedSeverity: 'MEDIUM' }),
+      makeItem({ file: 'src/a.ts', normalizedSeverity: 'MEDIUM' }),
+    ]);
+    expect(r.recommendation).toBe('delegate-fixer');
+  });
+
+  it('RecommendForGroup_AnyHighSeverity_RecommendsDelegateFixer', () => {
+    const r = recommendForGroup([makeItem({ normalizedSeverity: 'HIGH' })]);
+    expect(r.recommendation).toBe('delegate-fixer');
+    expect(r.severity).toBe('HIGH');
+  });
+
+  it('RecommendForGroup_AllLowWithDocNitKeyword_RecommendsScaffolder', () => {
+    const r = recommendForGroup([
+      makeItem({
+        normalizedSeverity: 'LOW',
+        description: 'Add <remarks> XML doc on PublicMethod',
+      }),
+    ]);
+    expect(r.recommendation).toBe('delegate-scaffolder');
+  });
+
+  it('RecommendForGroup_LowSeverityNoDocNitKeyword_RecommendsDirect', () => {
+    const r = recommendForGroup([
+      makeItem({
+        normalizedSeverity: 'LOW',
+        description: 'Consider renaming the variable for clarity',
+      }),
+    ]);
+    expect(r.recommendation).toBe('direct');
+  });
+
+  it('RecommendForGroup_PopulatesRationale', () => {
+    const r = recommendForGroup([makeItem({ normalizedSeverity: 'HIGH' })]);
+    expect(r.rationale.length).toBeGreaterThan(0);
+  });
+
+  it('RecommendForGroup_MaxSeverityIsHighWhenMixed', () => {
+    const r = recommendForGroup([
+      makeItem({ normalizedSeverity: 'LOW' }),
+      makeItem({ normalizedSeverity: 'HIGH' }),
+      makeItem({ normalizedSeverity: 'MEDIUM' }),
+    ]);
+    expect(r.severity).toBe('HIGH');
+  });
+});
+
+describe('classifyReviewItems', () => {
+  it('ClassifyReviewItems_MixedItems_ProducesGroupsAndSummary', () => {
+    const result = classifyReviewItems([
+      makeItem({ file: 'src/a.ts', normalizedSeverity: 'HIGH' }),
+      makeItem({ file: 'src/a.ts', normalizedSeverity: 'MEDIUM' }),
+      makeItem({ file: 'src/b.ts', normalizedSeverity: 'LOW', description: 'nit' }),
+      makeItem({ file: undefined, normalizedSeverity: 'MEDIUM' }),
+    ]);
+    expect(result.groups.length).toBe(3);
+    expect(result.summary.totalItems).toBe(4);
+    expect(result.summary.directCount + result.summary.delegateCount).toBe(3);
+  });
+
+  it('ClassifyReviewItems_PartitionInvariant', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            file: fc.option(fc.string({ minLength: 1, maxLength: 30 })),
+            severity: fc.constantFrom('HIGH', 'MEDIUM', 'LOW') as fc.Arbitrary<
+              'HIGH' | 'MEDIUM' | 'LOW'
+            >,
+          }),
+          { maxLength: 50 },
+        ),
+        (raw) => {
+          const items: ActionItem[] = raw.map((r) =>
+            makeItem({
+              file: r.file ?? undefined,
+              normalizedSeverity: r.severity,
+            }),
+          );
+          const result = classifyReviewItems(items);
+          const itemsInGroups = result.groups.flatMap((g) => g.items as ActionItem[]);
+          // Partition: every item appears in exactly one group, no losses, no duplicates.
+          expect(itemsInGroups.length).toBe(items.length);
+          expect(result.summary.totalItems).toBe(items.length);
+        },
+      ),
+    );
+  });
+});

--- a/servers/exarchos-mcp/src/review/classifier.ts
+++ b/servers/exarchos-mcp/src/review/classifier.ts
@@ -22,7 +22,7 @@ import type {
   DispatchRecommendation,
   Severity,
 } from './types.js';
-import { SCAFFOLDING_KEYWORDS } from '../orchestrate/scaffolding-keywords.js';
+import { REVIEW_DOC_NIT_KEYWORDS } from '../orchestrate/scaffolding-keywords.js';
 
 const SEVERITY_RANK: Record<Severity, number> = { LOW: 0, MEDIUM: 1, HIGH: 2 };
 
@@ -63,7 +63,7 @@ function maxSeverity(items: readonly ActionItem[]): Severity {
 
 function isDocNit(item: ActionItem): boolean {
   const haystack = (item.description ?? '').toLowerCase();
-  return SCAFFOLDING_KEYWORDS.some((kw) => haystack.includes(kw.toLowerCase()));
+  return REVIEW_DOC_NIT_KEYWORDS.some((kw) => haystack.includes(kw.toLowerCase()));
 }
 
 export function recommendForGroup(items: readonly ActionItem[]): {

--- a/servers/exarchos-mcp/src/review/classifier.ts
+++ b/servers/exarchos-mcp/src/review/classifier.ts
@@ -1,0 +1,142 @@
+// ─── Review Classification (Issue #1159 Phase 2) ────────────────────────────
+//
+// Promotes the prose direct-vs-delegate heuristic from
+// skills-src/shepherd/references/fix-strategies.md into a structured
+// orchestrate action. Consumers pass a list of ActionItems (typically the
+// `actionItems` returned by assess_stack) and receive a list of file-keyed
+// groups, each with a recommended dispatch strategy:
+//
+//   direct              — small enough to fix in the running shepherd loop
+//   delegate-fixer      — multi-item or HIGH severity → spawn fixer subagent
+//   delegate-scaffolder — pure doc-nit cluster → cheap scaffolder dispatch
+//
+// The shared SCAFFOLDING_KEYWORDS constant is also used by
+// orchestrate/prepare-delegation.ts (#1159 design Q-P5 resolution).
+// ────────────────────────────────────────────────────────────────────────────
+
+import type {
+  ActionItem,
+  ClassificationGroup,
+  ClassificationResult,
+  ClassificationSummary,
+  DispatchRecommendation,
+  Severity,
+} from './types.js';
+import { SCAFFOLDING_KEYWORDS } from '../orchestrate/scaffolding-keywords.js';
+
+const SEVERITY_RANK: Record<Severity, number> = { LOW: 0, MEDIUM: 1, HIGH: 2 };
+
+const DIRECT_FIX_MAX_ITEMS = 1;
+
+const NULL_FILE_KEY = null as unknown as string;
+
+// ─── Grouping ──────────────────────────────────────────────────────────────
+
+export function groupItemsByFile(
+  items: readonly ActionItem[],
+): Map<string | null, ActionItem[]> {
+  const groups = new Map<string | null, ActionItem[]>();
+  for (const item of items) {
+    const key = item.file ?? NULL_FILE_KEY;
+    const bucket = groups.get(key);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      groups.set(key, [item]);
+    }
+  }
+  return groups;
+}
+
+// ─── Per-Group Recommendation ──────────────────────────────────────────────
+
+function maxSeverity(items: readonly ActionItem[]): Severity {
+  let highest: Severity = 'LOW';
+  for (const item of items) {
+    const s = item.normalizedSeverity ?? 'MEDIUM';
+    if (SEVERITY_RANK[s] > SEVERITY_RANK[highest]) {
+      highest = s;
+    }
+  }
+  return highest;
+}
+
+function isDocNit(item: ActionItem): boolean {
+  const haystack = (item.description ?? '').toLowerCase();
+  return SCAFFOLDING_KEYWORDS.some((kw) => haystack.includes(kw.toLowerCase()));
+}
+
+export function recommendForGroup(items: readonly ActionItem[]): {
+  recommendation: DispatchRecommendation;
+  rationale: string;
+  severity: Severity;
+} {
+  const severity = maxSeverity(items);
+
+  // All-LOW + at least one doc-nit keyword → cheap scaffolder dispatch.
+  if (severity === 'LOW' && items.some(isDocNit)) {
+    return {
+      recommendation: 'delegate-scaffolder',
+      rationale: 'All items are LOW severity and at least one matches a doc-nit keyword (scaffolding work)',
+      severity,
+    };
+  }
+
+  // Any HIGH severity → delegate to fixer subagent regardless of count.
+  if (severity === 'HIGH') {
+    return {
+      recommendation: 'delegate-fixer',
+      rationale: 'Group contains HIGH severity item(s); delegate to fixer subagent',
+      severity,
+    };
+  }
+
+  // Multi-item groups (same file, multiple comments) → delegate to amortise
+  // file-read overhead per #1159 P1.
+  if (items.length > DIRECT_FIX_MAX_ITEMS) {
+    return {
+      recommendation: 'delegate-fixer',
+      rationale: `Group has ${items.length} items on the same file; batched fixer dispatch amortises file-read cost`,
+      severity,
+    };
+  }
+
+  return {
+    recommendation: 'direct',
+    rationale: 'Single item, non-HIGH severity; cheap to address inline in the shepherd loop',
+    severity,
+  };
+}
+
+// ─── Top-Level Entry Point ─────────────────────────────────────────────────
+
+export function classifyReviewItems(items: readonly ActionItem[]): ClassificationResult {
+  const grouped = groupItemsByFile(items);
+  const groups: ClassificationGroup[] = [];
+  let directCount = 0;
+  let delegateCount = 0;
+
+  for (const [file, groupItems] of grouped.entries()) {
+    const { recommendation, rationale, severity } = recommendForGroup(groupItems);
+    groups.push({
+      file,
+      items: groupItems,
+      severity,
+      recommendation,
+      rationale,
+    });
+    if (recommendation === 'direct') {
+      directCount += 1;
+    } else {
+      delegateCount += 1;
+    }
+  }
+
+  const summary: ClassificationSummary = {
+    totalItems: items.length,
+    directCount,
+    delegateCount,
+  };
+
+  return { groups, summary };
+}

--- a/servers/exarchos-mcp/src/review/providers/coderabbit.test.ts
+++ b/servers/exarchos-mcp/src/review/providers/coderabbit.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { coderabbitAdapter } from './coderabbit.js';
+import type { PrComment as VcsPrComment } from '../../vcs/provider.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeComment(overrides: Partial<VcsPrComment> = {}): VcsPrComment {
+  return {
+    id: 1,
+    author: 'coderabbitai[bot]',
+    body: '',
+    createdAt: '2026-04-19T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('coderabbitAdapter', () => {
+  it('CoderabbitAdapter_PotentialIssueTier_NormalizesToHigh', () => {
+    const comment = makeComment({
+      body: '_:warning: Potential issue_\n\nThis check can throw at runtime.',
+    });
+
+    const result = coderabbitAdapter.parse(comment);
+
+    expect(result).not.toBeNull();
+    expect(result?.normalizedSeverity).toBe('HIGH');
+    expect(result?.reviewer).toBe('coderabbit');
+    expect(result?.type).toBe('comment-reply');
+  });
+
+  it('CoderabbitAdapter_RefactorSuggestionTier_NormalizesToMedium', () => {
+    const comment = makeComment({
+      body: '_:hammer_and_wrench: Refactor suggestion_\n\nConsider extracting this helper.',
+    });
+
+    const result = coderabbitAdapter.parse(comment);
+
+    expect(result).not.toBeNull();
+    expect(result?.normalizedSeverity).toBe('MEDIUM');
+  });
+
+  it('CoderabbitAdapter_VerificationAgentTier_NormalizesToLow', () => {
+    const comment = makeComment({
+      body: '_:bulb: Verification agent_\n\nLet us verify this hypothesis.',
+    });
+
+    const result = coderabbitAdapter.parse(comment);
+
+    expect(result).not.toBeNull();
+    expect(result?.normalizedSeverity).toBe('LOW');
+  });
+
+  it('CoderabbitAdapter_NitpickHeader_NormalizesToLow', () => {
+    const comment = makeComment({
+      body: '**Nitpick**: prefer `const` over `let` here.',
+    });
+
+    const result = coderabbitAdapter.parse(comment);
+
+    expect(result).not.toBeNull();
+    expect(result?.normalizedSeverity).toBe('LOW');
+  });
+
+  it('CoderabbitAdapter_UnrecognizedTier_DefaultsToMedium', () => {
+    const comment = makeComment({
+      body: 'Some prose with no tier marker whatsoever.',
+    });
+
+    const result = coderabbitAdapter.parse(comment);
+
+    expect(result).not.toBeNull();
+    expect(result?.normalizedSeverity).toBe('MEDIUM');
+    // Sibling indicator that the tier was not recognized; the spec leaves the
+    // exact field name to the implementer. We assert that the returned object
+    // contains some marker keyed on "unknownTier" so callers can distinguish
+    // explicit MEDIUM from default-MEDIUM.
+    const withMarker = result as unknown as Record<string, unknown>;
+    expect(withMarker.unknownTier).toBe(true);
+  });
+
+  it('CoderabbitAdapter_NonCoderabbitAuthor_ReturnsNull', () => {
+    const comment = makeComment({
+      author: 'github-actions[bot]',
+      body: '_:warning: Potential issue_',
+    });
+
+    const result = coderabbitAdapter.parse(comment);
+
+    expect(result).toBeNull();
+  });
+
+  it('CoderabbitAdapter_PopulatesFileAndLine', () => {
+    const comment = makeComment({
+      body: '_:warning: Potential issue_\n\nGuard against null.',
+      path: 'src/foo.ts',
+      line: 42,
+    });
+
+    const result = coderabbitAdapter.parse(comment);
+
+    expect(result).not.toBeNull();
+    expect(result?.file).toBe('src/foo.ts');
+    expect(result?.line).toBe(42);
+  });
+});

--- a/servers/exarchos-mcp/src/review/providers/coderabbit.test.ts
+++ b/servers/exarchos-mcp/src/review/providers/coderabbit.test.ts
@@ -137,6 +137,28 @@ describe('coderabbitAdapter', () => {
     expect(result?.rawTier).toBe('_:rocket: Brand new tier_');
   });
 
+  it('CoderabbitAdapter_MidSentenceMinor_DoesNotMatchLow', () => {
+    // Regression for #1161 review feedback: "minor"/"nitpick" used mid-sentence
+    // must NOT classify the comment as LOW. Heading-position anchor required.
+    const comment = makeComment({
+      body: 'This is a minor concern, but it could surface a real bug under load.',
+    });
+
+    const result = coderabbitAdapter.parse(comment);
+
+    expect(result?.normalizedSeverity).not.toBe('LOW');
+  });
+
+  it('CoderabbitAdapter_NitpickHeading_StillMatchesLow', () => {
+    const comment = makeComment({
+      body: '## Nitpick\n\nName this variable more descriptively.',
+    });
+
+    const result = coderabbitAdapter.parse(comment);
+
+    expect(result?.normalizedSeverity).toBe('LOW');
+  });
+
   it('CoderabbitAdapter_MalformedInput_DoesNotThrow', () => {
     // Defensive check: a comment with a body that breaks string ops
     // (e.g., body coerced from a non-string upstream) must return null

--- a/servers/exarchos-mcp/src/review/providers/coderabbit.test.ts
+++ b/servers/exarchos-mcp/src/review/providers/coderabbit.test.ts
@@ -104,4 +104,48 @@ describe('coderabbitAdapter', () => {
     expect(result?.file).toBe('src/foo.ts');
     expect(result?.line).toBe(42);
   });
+
+  it('CoderabbitAdapter_CriticalHeading_NormalizesToHigh', () => {
+    const comment = makeComment({
+      body: '## Critical\n\nThis blocks the release.',
+    });
+
+    const result = coderabbitAdapter.parse(comment);
+
+    expect(result?.normalizedSeverity).toBe('HIGH');
+    expect(result?.unknownTier).toBeUndefined();
+  });
+
+  it('CoderabbitAdapter_MajorBoldHeading_NormalizesToHigh', () => {
+    const comment = makeComment({
+      body: '**Major**\n\nNeeds attention before merge.',
+    });
+
+    const result = coderabbitAdapter.parse(comment);
+
+    expect(result?.normalizedSeverity).toBe('HIGH');
+  });
+
+  it('CoderabbitAdapter_UnknownTier_PopulatesRawTier', () => {
+    const comment = makeComment({
+      body: '_:rocket: Brand new tier_\n\nUnrecognised marker.',
+    });
+
+    const result = coderabbitAdapter.parse(comment);
+
+    expect(result?.unknownTier).toBe(true);
+    expect(result?.rawTier).toBe('_:rocket: Brand new tier_');
+  });
+
+  it('CoderabbitAdapter_MalformedInput_DoesNotThrow', () => {
+    // Defensive check: a comment with a body that breaks string ops
+    // (e.g., body coerced from a non-string upstream) must return null
+    // rather than throwing into queryPrComments and killing the batch.
+    const malformed = {
+      ...makeComment(),
+      body: null as unknown as string,
+    };
+    expect(() => coderabbitAdapter.parse(malformed)).not.toThrow();
+    expect(coderabbitAdapter.parse(malformed)).toBeNull();
+  });
 });

--- a/servers/exarchos-mcp/src/review/providers/coderabbit.ts
+++ b/servers/exarchos-mcp/src/review/providers/coderabbit.ts
@@ -45,9 +45,12 @@ const MEDIUM_TIER_PATTERNS: readonly RegExp[] = [
   /_:hammer_and_wrench: Refactor suggestion_/,
 ];
 
+// Heading-position anchor for Nitpick/Minor mirrors the Critical/Major rule
+// above. Without it, prose like "this is a minor concern" mid-sentence would
+// classify the whole comment as LOW (PR #1161 review feedback).
 const LOW_TIER_PATTERNS: readonly RegExp[] = [
   /_:bulb: Verification agent_/,
-  /\b(Nitpick|Minor)\b/i,
+  /(^|\n)[ \t]*[#*]*\s*(Nitpick|Minor)\b/i,
 ];
 
 function classifyTier(body: string): Severity | null {
@@ -76,11 +79,13 @@ export const coderabbitAdapter: ProviderAdapter = {
   kind: 'coderabbit',
 
   parse(comment: VcsPrComment): ActionItem | null {
-    if (comment.author !== CODERABBIT_AUTHOR) {
-      return null;
-    }
-
     try {
+      if (typeof comment.author !== 'string' || comment.author !== CODERABBIT_AUTHOR) {
+        return null;
+      }
+      if (typeof comment.body !== 'string') {
+        return null;
+      }
       const tier = classifyTier(comment.body);
       const normalizedSeverity: Severity = tier ?? 'MEDIUM';
       const unknownTier = tier === null;

--- a/servers/exarchos-mcp/src/review/providers/coderabbit.ts
+++ b/servers/exarchos-mcp/src/review/providers/coderabbit.ts
@@ -65,19 +65,10 @@ function classifyTier(body: string): Severity | null {
 
 // ─── Adapter ────────────────────────────────────────────────────────────────
 
-/**
- * ActionItem variant returned by the CodeRabbit adapter. Adds an optional
- * `unknownTier` marker (set when the body did not match any recognized tier
- * pattern) so callers can distinguish an explicit MEDIUM from a fallback.
- */
-export interface CoderabbitActionItem extends ActionItem {
-  readonly unknownTier?: boolean;
-}
-
 export const coderabbitAdapter: ProviderAdapter = {
   kind: 'coderabbit',
 
-  parse(comment: VcsPrComment): CoderabbitActionItem | null {
+  parse(comment: VcsPrComment): ActionItem | null {
     if (comment.author !== CODERABBIT_AUTHOR) {
       return null;
     }
@@ -86,7 +77,7 @@ export const coderabbitAdapter: ProviderAdapter = {
     const normalizedSeverity: Severity = tier ?? 'MEDIUM';
     const unknownTier = tier === null;
 
-    const item: CoderabbitActionItem = {
+    return {
       type: 'comment-reply',
       pr: 0,
       description: comment.body.slice(0, 100),
@@ -99,7 +90,5 @@ export const coderabbitAdapter: ProviderAdapter = {
       normalizedSeverity,
       ...(unknownTier ? { unknownTier: true } : {}),
     };
-
-    return item;
   },
 };

--- a/servers/exarchos-mcp/src/review/providers/coderabbit.ts
+++ b/servers/exarchos-mcp/src/review/providers/coderabbit.ts
@@ -27,11 +27,18 @@ const CODERABBIT_AUTHOR = 'coderabbitai[bot]';
 // CodeRabbit uses in summary/walkthrough sections.
 
 // "Critical"/"Major" must be in heading position: at the start of the body
-// or at the start of a line, optionally wrapped in markdown emphasis. The
-// case-insensitive flag matches CodeRabbit's varying capitalization.
+// or at the start of a line, optionally preceded by markdown heading or
+// emphasis markers (`#`, `*`). Case-insensitive to match CodeRabbit's
+// varying capitalization. Mid-sentence occurrences must NOT match — the
+// leading anchor + bounded prefix character class enforces that.
+//
+// Note: `_` is intentionally omitted from the trailing word-boundary side
+// because `_` is a JS word character; `_Critical_` has no \b after the
+// word, which would block the match. CodeRabbit emits headings as `##
+// Critical` or `**Critical**`, not as `_Critical_`, so this is fine.
 const HIGH_TIER_PATTERNS: readonly RegExp[] = [
   /_:warning: Potential issue_/,
-  /(^|\n)[ \t]*[#*_]*\s*(Critical|Major)\b/i,
+  /(^|\n)[ \t]*[#*]*\s*(Critical|Major)\b/i,
 ];
 
 const MEDIUM_TIER_PATTERNS: readonly RegExp[] = [

--- a/servers/exarchos-mcp/src/review/providers/coderabbit.ts
+++ b/servers/exarchos-mcp/src/review/providers/coderabbit.ts
@@ -1,0 +1,98 @@
+// ─── CodeRabbit Provider Adapter ────────────────────────────────────────────
+//
+// Parses raw CodeRabbit (`coderabbitai[bot]`) PR comments into ActionItem
+// values. Tier markers in the comment body are mapped to normalizedSeverity:
+//
+//   _:warning: Potential issue_           → HIGH
+//   "Critical" / "Major" heading          → HIGH
+//   _:hammer_and_wrench: Refactor         → MEDIUM
+//   _:bulb: Verification agent_           → LOW
+//   "Nitpick" / "Minor"                   → LOW
+//   (none of the above)                   → MEDIUM (with unknownTier marker)
+//
+// Comments authored by anyone other than `coderabbitai[bot]` return null so a
+// future registry can dispatch them to a different adapter.
+// ────────────────────────────────────────────────────────────────────────────
+
+import type { ActionItem, ProviderAdapter, Severity } from '../types.js';
+import type { PrComment as VcsPrComment } from '../../vcs/provider.js';
+
+const CODERABBIT_AUTHOR = 'coderabbitai[bot]';
+
+// ─── Tier Markers ───────────────────────────────────────────────────────────
+//
+// Markers must appear as italic underscored phrases that CodeRabbit emits at
+// the top of each finding section. We also recognize plain heading words for
+// the heading-position aliases ("Critical"/"Major"/"Nitpick"/"Minor") which
+// CodeRabbit uses in summary/walkthrough sections.
+
+// "Critical"/"Major" must be in heading position: at the start of the body
+// or at the start of a line, optionally wrapped in markdown emphasis. The
+// case-insensitive flag matches CodeRabbit's varying capitalization.
+const HIGH_TIER_PATTERNS: readonly RegExp[] = [
+  /_:warning: Potential issue_/,
+  /(^|\n)[ \t]*[#*_]*\s*(Critical|Major)\b/i,
+];
+
+const MEDIUM_TIER_PATTERNS: readonly RegExp[] = [
+  /_:hammer_and_wrench: Refactor suggestion_/,
+];
+
+const LOW_TIER_PATTERNS: readonly RegExp[] = [
+  /_:bulb: Verification agent_/,
+  /\b(Nitpick|Minor)\b/i,
+];
+
+function classifyTier(body: string): Severity | null {
+  for (const re of HIGH_TIER_PATTERNS) {
+    if (re.test(body)) return 'HIGH';
+  }
+  for (const re of MEDIUM_TIER_PATTERNS) {
+    if (re.test(body)) return 'MEDIUM';
+  }
+  for (const re of LOW_TIER_PATTERNS) {
+    if (re.test(body)) return 'LOW';
+  }
+  return null;
+}
+
+// ─── Adapter ────────────────────────────────────────────────────────────────
+
+/**
+ * ActionItem variant returned by the CodeRabbit adapter. Adds an optional
+ * `unknownTier` marker (set when the body did not match any recognized tier
+ * pattern) so callers can distinguish an explicit MEDIUM from a fallback.
+ */
+export interface CoderabbitActionItem extends ActionItem {
+  readonly unknownTier?: boolean;
+}
+
+export const coderabbitAdapter: ProviderAdapter = {
+  kind: 'coderabbit',
+
+  parse(comment: VcsPrComment): CoderabbitActionItem | null {
+    if (comment.author !== CODERABBIT_AUTHOR) {
+      return null;
+    }
+
+    const tier = classifyTier(comment.body);
+    const normalizedSeverity: Severity = tier ?? 'MEDIUM';
+    const unknownTier = tier === null;
+
+    const item: CoderabbitActionItem = {
+      type: 'comment-reply',
+      pr: 0,
+      description: comment.body.slice(0, 100),
+      severity: 'major',
+      reviewer: 'coderabbit',
+      threadId: String(comment.id),
+      raw: comment,
+      file: comment.path,
+      line: comment.line,
+      normalizedSeverity,
+      ...(unknownTier ? { unknownTier: true } : {}),
+    };
+
+    return item;
+  },
+};

--- a/servers/exarchos-mcp/src/review/providers/coderabbit.ts
+++ b/servers/exarchos-mcp/src/review/providers/coderabbit.ts
@@ -65,6 +65,13 @@ function classifyTier(body: string): Severity | null {
 
 // ─── Adapter ────────────────────────────────────────────────────────────────
 
+function rawTierMarker(body: string): string {
+  // First non-empty line, capped — gives a humans the unrecognised marker
+  // text without dragging the entire comment into the event payload.
+  const firstLine = body.split('\n').find((l) => l.trim().length > 0) ?? '';
+  return firstLine.slice(0, 80);
+}
+
 export const coderabbitAdapter: ProviderAdapter = {
   kind: 'coderabbit',
 
@@ -73,22 +80,30 @@ export const coderabbitAdapter: ProviderAdapter = {
       return null;
     }
 
-    const tier = classifyTier(comment.body);
-    const normalizedSeverity: Severity = tier ?? 'MEDIUM';
-    const unknownTier = tier === null;
+    try {
+      const tier = classifyTier(comment.body);
+      const normalizedSeverity: Severity = tier ?? 'MEDIUM';
+      const unknownTier = tier === null;
 
-    return {
-      type: 'comment-reply',
-      pr: 0,
-      description: comment.body.slice(0, 100),
-      severity: 'major',
-      reviewer: 'coderabbit',
-      threadId: String(comment.id),
-      raw: comment,
-      file: comment.path,
-      line: comment.line,
-      normalizedSeverity,
-      ...(unknownTier ? { unknownTier: true } : {}),
-    };
+      return {
+        type: 'comment-reply',
+        pr: 0,
+        description: comment.body.slice(0, 100),
+        severity: 'major',
+        reviewer: 'coderabbit',
+        threadId: String(comment.id),
+        raw: comment,
+        file: comment.path,
+        line: comment.line,
+        normalizedSeverity,
+        ...(unknownTier ? { unknownTier: true, rawTier: rawTierMarker(comment.body) } : {}),
+      };
+    } catch {
+      // Defensive: a malformed body that trips one of our regexes must not
+      // kill the whole batch in queryPrComments. Returning null lets
+      // classifyActionItems still emit a comment-reply ActionItem at the
+      // default MEDIUM severity rather than losing the comment entirely.
+      return null;
+    }
   },
 };

--- a/servers/exarchos-mcp/src/review/providers/github-copilot.test.ts
+++ b/servers/exarchos-mcp/src/review/providers/github-copilot.test.ts
@@ -87,4 +87,10 @@ describe('githubCopilotAdapter', () => {
     expect(item?.file).toBeUndefined();
     expect(item?.line).toBeUndefined();
   });
+
+  it('GithubCopilotAdapter_MalformedInput_DoesNotThrow', () => {
+    const malformed = makeComment({ body: null as unknown as string });
+    expect(() => githubCopilotAdapter.parse(malformed)).not.toThrow();
+    expect(githubCopilotAdapter.parse(malformed)).toBeNull();
+  });
 });

--- a/servers/exarchos-mcp/src/review/providers/github-copilot.test.ts
+++ b/servers/exarchos-mcp/src/review/providers/github-copilot.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { githubCopilotAdapter } from './github-copilot.js';
+import type { PrComment as VcsPrComment } from '../../vcs/provider.js';
+
+// ─── Test Fixtures ──────────────────────────────────────────────────────────
+
+const COPILOT_AUTHORS = [
+  'github-copilot[bot]',
+  'Copilot',
+  'copilot[bot]',
+] as const;
+
+function makeComment(overrides: Partial<VcsPrComment> = {}): VcsPrComment {
+  return {
+    id: 42,
+    author: 'github-copilot[bot]',
+    body: 'Consider extracting this into a helper function for clarity.',
+    createdAt: '2026-04-19T00:00:00Z',
+    path: 'src/foo.ts',
+    line: 17,
+    ...overrides,
+  };
+}
+
+describe('githubCopilotAdapter', () => {
+  it('GithubCopilotAdapter_KindIsGithubCopilot', () => {
+    expect(githubCopilotAdapter.kind).toBe('github-copilot');
+  });
+
+  describe('GithubCopilotAdapter_KnownCopilotAuthor_ReturnsActionItem', () => {
+    for (const author of COPILOT_AUTHORS) {
+      it(`recognizes author "${author}"`, () => {
+        const comment = makeComment({ author });
+        const item = githubCopilotAdapter.parse(comment);
+        expect(item).not.toBeNull();
+        expect(item?.reviewer).toBe('github-copilot');
+        expect(item?.type).toBe('comment-reply');
+        expect(item?.threadId).toBe(String(comment.id));
+        expect(item?.raw).toBe(comment);
+      });
+    }
+  });
+
+  it('GithubCopilotAdapter_AnyComment_DefaultsToMedium', () => {
+    // Copilot comments don't carry a severity tier — adapter normalizes to MEDIUM.
+    const item = githubCopilotAdapter.parse(makeComment());
+    expect(item).not.toBeNull();
+    expect(item?.normalizedSeverity).toBe('MEDIUM');
+    // Legacy severity field must remain 'major' for backwards compatibility.
+    expect(item?.severity).toBe('major');
+  });
+
+  it('GithubCopilotAdapter_NonCopilotAuthor_ReturnsNull', () => {
+    const item = githubCopilotAdapter.parse(makeComment({ author: 'someone-else' }));
+    expect(item).toBeNull();
+  });
+
+  it('GithubCopilotAdapter_PopulatesFileAndLine', () => {
+    const item = githubCopilotAdapter.parse(makeComment({ path: 'lib/bar.ts', line: 99 }));
+    expect(item?.file).toBe('lib/bar.ts');
+    expect(item?.line).toBe(99);
+  });
+
+  it('GithubCopilotAdapter_LongBody_TruncatesDescriptionTo100Chars', () => {
+    const longBody = 'x'.repeat(250);
+    const item = githubCopilotAdapter.parse(makeComment({ body: longBody }));
+    expect(item?.description).toHaveLength(100);
+    expect(item?.description).toBe('x'.repeat(100));
+  });
+
+  it('GithubCopilotAdapter_ShortBody_DescriptionUntruncated', () => {
+    const body = 'short note';
+    const item = githubCopilotAdapter.parse(makeComment({ body }));
+    expect(item?.description).toBe(body);
+  });
+
+  it('GithubCopilotAdapter_PrIsZero', () => {
+    // Adapter does not know the PR number; caller is expected to fill it.
+    const item = githubCopilotAdapter.parse(makeComment());
+    expect(item?.pr).toBe(0);
+  });
+
+  it('GithubCopilotAdapter_MissingFileAndLine_ReturnsUndefined', () => {
+    const item = githubCopilotAdapter.parse(
+      makeComment({ path: undefined, line: undefined }),
+    );
+    expect(item?.file).toBeUndefined();
+    expect(item?.line).toBeUndefined();
+  });
+});

--- a/servers/exarchos-mcp/src/review/providers/github-copilot.ts
+++ b/servers/exarchos-mcp/src/review/providers/github-copilot.ts
@@ -46,17 +46,22 @@ export const githubCopilotAdapter: ProviderAdapter = {
       return null;
     }
 
-    return {
-      type: 'comment-reply',
-      pr: 0,
-      description: truncate(comment.body, DESCRIPTION_MAX_LENGTH),
-      severity: 'major',
-      reviewer: 'github-copilot',
-      threadId: String(comment.id),
-      raw: comment,
-      file: comment.path,
-      line: comment.line,
-      normalizedSeverity: 'MEDIUM',
-    };
+    try {
+      return {
+        type: 'comment-reply',
+        pr: 0,
+        description: truncate(comment.body, DESCRIPTION_MAX_LENGTH),
+        severity: 'major',
+        reviewer: 'github-copilot',
+        threadId: String(comment.id),
+        raw: comment,
+        file: comment.path,
+        line: comment.line,
+        normalizedSeverity: 'MEDIUM',
+      };
+    } catch {
+      // Defensive: bad body must not kill the whole batch (#1159).
+      return null;
+    }
   },
 };

--- a/servers/exarchos-mcp/src/review/providers/github-copilot.ts
+++ b/servers/exarchos-mcp/src/review/providers/github-copilot.ts
@@ -1,0 +1,62 @@
+// ─── GitHub Copilot Provider Adapter ────────────────────────────────────────
+//
+// Parses GitHub Copilot review comments into ActionItem values for the
+// fixer-dispatch pipeline (issue #1159).
+//
+// Copilot review comments do not carry an explicit severity tier — they are
+// advisory suggestions. This adapter normalizes everything from Copilot to
+// MEDIUM and uses the legacy `severity: 'major'` value for backwards
+// compatibility with the existing assess-stack pipeline.
+//
+// Author recognition
+// ──────────────────
+// Copilot can post under a few different login forms depending on the
+// repository's GitHub App / integration configuration. The most common
+// observed variants are:
+//   - 'github-copilot[bot]'  (full bot login as it appears on GitHub PRs)
+//   - 'copilot[bot]'         (shorter bot login seen on some installations)
+//   - 'Copilot'              (display name; appears in some API surfaces)
+// We accept all three. If new Copilot author strings surface in the wild,
+// add them to COPILOT_AUTHORS below and extend the test parameterization.
+// ────────────────────────────────────────────────────────────────────────────
+
+import type { ProviderAdapter, ActionItem } from '../types.js';
+import type { PrComment as VcsPrComment } from '../../vcs/provider.js';
+
+const COPILOT_AUTHORS: ReadonlySet<string> = new Set([
+  'github-copilot[bot]',
+  'Copilot',
+  'copilot[bot]',
+]);
+
+const DESCRIPTION_MAX_LENGTH = 100;
+
+function isCopilotAuthor(author: string): boolean {
+  return COPILOT_AUTHORS.has(author);
+}
+
+function truncate(body: string, max: number): string {
+  return body.length > max ? body.slice(0, max) : body;
+}
+
+export const githubCopilotAdapter: ProviderAdapter = {
+  kind: 'github-copilot',
+  parse(comment: VcsPrComment): ActionItem | null {
+    if (!isCopilotAuthor(comment.author)) {
+      return null;
+    }
+
+    return {
+      type: 'comment-reply',
+      pr: 0,
+      description: truncate(comment.body, DESCRIPTION_MAX_LENGTH),
+      severity: 'major',
+      reviewer: 'github-copilot',
+      threadId: String(comment.id),
+      raw: comment,
+      file: comment.path,
+      line: comment.line,
+      normalizedSeverity: 'MEDIUM',
+    };
+  },
+};

--- a/servers/exarchos-mcp/src/review/providers/github-copilot.ts
+++ b/servers/exarchos-mcp/src/review/providers/github-copilot.ts
@@ -42,11 +42,13 @@ function truncate(body: string, max: number): string {
 export const githubCopilotAdapter: ProviderAdapter = {
   kind: 'github-copilot',
   parse(comment: VcsPrComment): ActionItem | null {
-    if (!isCopilotAuthor(comment.author)) {
-      return null;
-    }
-
     try {
+      if (typeof comment.author !== 'string' || !isCopilotAuthor(comment.author)) {
+        return null;
+      }
+      if (typeof comment.body !== 'string') {
+        return null;
+      }
       return {
         type: 'comment-reply',
         pr: 0,

--- a/servers/exarchos-mcp/src/review/providers/human.test.ts
+++ b/servers/exarchos-mcp/src/review/providers/human.test.ts
@@ -89,4 +89,10 @@ describe('humanAdapter', () => {
   it('HumanAdapter_KindIsHuman', () => {
     expect(humanAdapter.kind).toBe('human');
   });
+
+  it('HumanAdapter_MalformedInput_DoesNotThrow', () => {
+    const malformed = makeComment({ body: null as unknown as string });
+    expect(() => humanAdapter.parse(malformed)).not.toThrow();
+    expect(humanAdapter.parse(malformed)).toBeNull();
+  });
 });

--- a/servers/exarchos-mcp/src/review/providers/human.test.ts
+++ b/servers/exarchos-mcp/src/review/providers/human.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { humanAdapter } from './human.js';
+import type { PrComment as VcsPrComment } from '../../vcs/provider.js';
+
+function makeComment(overrides: Partial<VcsPrComment> = {}): VcsPrComment {
+  return {
+    id: 42,
+    author: 'alice',
+    body: 'Please consider extracting this helper into its own module.',
+    createdAt: '2026-04-19T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('humanAdapter', () => {
+  it('HumanAdapter_HumanAuthor_ReturnsActionItem', () => {
+    const comment = makeComment({
+      id: 7,
+      author: 'reed',
+      body: 'Suggest renaming `foo` to `parsedFoo` for clarity.',
+    });
+
+    const item = humanAdapter.parse(comment);
+
+    expect(item).not.toBeNull();
+    expect(item?.type).toBe('comment-reply');
+    expect(item?.pr).toBe(0);
+    expect(item?.reviewer).toBe('human');
+    expect(item?.threadId).toBe('7');
+    expect(item?.severity).toBe('major');
+    expect(item?.raw).toBe(comment);
+    expect(item?.description).toBe(
+      'Suggest renaming `foo` to `parsedFoo` for clarity.',
+    );
+  });
+
+  it('HumanAdapter_AnyComment_DefaultsToMedium', () => {
+    // Even with prose suggesting urgency ("CRITICAL", "must fix immediately"),
+    // the human adapter does not infer severity — always MEDIUM.
+    const urgent = humanAdapter.parse(
+      makeComment({ body: 'CRITICAL: this must be fixed immediately!' }),
+    );
+    const calm = humanAdapter.parse(
+      makeComment({ body: 'Tiny nit, feel free to ignore.' }),
+    );
+
+    expect(urgent?.normalizedSeverity).toBe('MEDIUM');
+    expect(calm?.normalizedSeverity).toBe('MEDIUM');
+  });
+
+  it('HumanAdapter_BotAuthor_ReturnsNull', () => {
+    const botAuthors = [
+      'coderabbitai[bot]',
+      'sentry-io[bot]',
+      'github-actions[bot]',
+    ];
+
+    for (const author of botAuthors) {
+      const item = humanAdapter.parse(makeComment({ author }));
+      expect(item, `bot author ${author} should be rejected`).toBeNull();
+    }
+  });
+
+  it('HumanAdapter_CopilotAuthor_ReturnsNull', () => {
+    const item = humanAdapter.parse(makeComment({ author: 'Copilot' }));
+    expect(item).toBeNull();
+  });
+
+  it('HumanAdapter_PopulatesFileAndLine', () => {
+    const item = humanAdapter.parse(
+      makeComment({
+        path: 'src/foo.ts',
+        line: 123,
+      }),
+    );
+
+    expect(item?.file).toBe('src/foo.ts');
+    expect(item?.line).toBe(123);
+  });
+
+  it('HumanAdapter_TruncatesLongBodyTo100Chars', () => {
+    const longBody = 'a'.repeat(250);
+    const item = humanAdapter.parse(makeComment({ body: longBody }));
+
+    expect(item?.description.length).toBe(100);
+    expect(item?.description).toBe('a'.repeat(100));
+  });
+
+  it('HumanAdapter_KindIsHuman', () => {
+    expect(humanAdapter.kind).toBe('human');
+  });
+});

--- a/servers/exarchos-mcp/src/review/providers/human.ts
+++ b/servers/exarchos-mcp/src/review/providers/human.ts
@@ -18,11 +18,16 @@ const DESCRIPTION_MAX_LENGTH = 100;
 export const humanAdapter: ProviderAdapter = {
   kind: 'human',
   parse(comment: VcsPrComment): ActionItem | null {
-    if (isBotAuthor(comment.author)) {
-      return null;
-    }
-
     try {
+      if (typeof comment.author !== 'string') {
+        return null;
+      }
+      if (isBotAuthor(comment.author)) {
+        return null;
+      }
+      if (typeof comment.body !== 'string') {
+        return null;
+      }
       return {
         type: 'comment-reply',
         pr: 0,

--- a/servers/exarchos-mcp/src/review/providers/human.ts
+++ b/servers/exarchos-mcp/src/review/providers/human.ts
@@ -22,18 +22,23 @@ export const humanAdapter: ProviderAdapter = {
       return null;
     }
 
-    return {
-      type: 'comment-reply',
-      pr: 0,
-      description: comment.body.slice(0, DESCRIPTION_MAX_LENGTH),
-      severity: 'major',
-      reviewer: 'human',
-      threadId: String(comment.id),
-      raw: comment,
-      file: comment.path,
-      line: comment.line,
-      normalizedSeverity: 'MEDIUM',
-    };
+    try {
+      return {
+        type: 'comment-reply',
+        pr: 0,
+        description: comment.body.slice(0, DESCRIPTION_MAX_LENGTH),
+        severity: 'major',
+        reviewer: 'human',
+        threadId: String(comment.id),
+        raw: comment,
+        file: comment.path,
+        line: comment.line,
+        normalizedSeverity: 'MEDIUM',
+      };
+    } catch {
+      // Defensive: bad body must not kill the whole batch (#1159).
+      return null;
+    }
   },
 };
 

--- a/servers/exarchos-mcp/src/review/providers/human.ts
+++ b/servers/exarchos-mcp/src/review/providers/human.ts
@@ -1,0 +1,42 @@
+import type { ActionItem, ProviderAdapter } from '../types.js';
+import type { PrComment as VcsPrComment } from '../../vcs/provider.js';
+
+const DESCRIPTION_MAX_LENGTH = 100;
+
+/**
+ * Catch-all adapter for non-bot reviewers.
+ *
+ * The human adapter intentionally does NOT infer severity from prose — natural
+ * language signals like "CRITICAL" or "nit" are too unreliable to drive fixer
+ * dispatch. Every accepted comment defaults to {@link Severity} `MEDIUM`.
+ *
+ * Bot authors are rejected (returns `null`) so dedicated adapters can claim
+ * them. This includes:
+ *   - any author whose login ends with `[bot]` (GitHub bot convention)
+ *   - the literal `Copilot` (GitHub Copilot reviews surface without a [bot] suffix)
+ */
+export const humanAdapter: ProviderAdapter = {
+  kind: 'human',
+  parse(comment: VcsPrComment): ActionItem | null {
+    if (isBotAuthor(comment.author)) {
+      return null;
+    }
+
+    return {
+      type: 'comment-reply',
+      pr: 0,
+      description: comment.body.slice(0, DESCRIPTION_MAX_LENGTH),
+      severity: 'major',
+      reviewer: 'human',
+      threadId: String(comment.id),
+      raw: comment,
+      file: comment.path,
+      line: comment.line,
+      normalizedSeverity: 'MEDIUM',
+    };
+  },
+};
+
+function isBotAuthor(author: string): boolean {
+  return author.endsWith('[bot]') || author === 'Copilot';
+}

--- a/servers/exarchos-mcp/src/review/providers/sentry.test.ts
+++ b/servers/exarchos-mcp/src/review/providers/sentry.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { sentryAdapter } from './sentry.js';
+import type { PrComment as VcsPrComment } from '../../vcs/provider.js';
+
+// ─── Test Helpers ────────────────────────────────────────────────────────────
+
+function makeComment(overrides: Partial<VcsPrComment> = {}): VcsPrComment {
+  return {
+    id: 12345,
+    author: 'sentry-io[bot]',
+    body: '',
+    createdAt: '2026-04-19T12:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('sentryAdapter', () => {
+  it('SentryAdapter_CriticalTag_NormalizesToHigh', () => {
+    const comment = makeComment({
+      body: '## CRITICAL\n\nNullPointerException in handler.ts',
+    });
+    const result = sentryAdapter.parse(comment);
+    expect(result).not.toBeNull();
+    expect(result?.normalizedSeverity).toBe('HIGH');
+  });
+
+  it('SentryAdapter_HighTag_NormalizesToHigh', () => {
+    const comment = makeComment({
+      body: '## HIGH severity issue detected\n\nMemory leak.',
+    });
+    const result = sentryAdapter.parse(comment);
+    expect(result).not.toBeNull();
+    expect(result?.normalizedSeverity).toBe('HIGH');
+  });
+
+  it('SentryAdapter_MediumTag_NormalizesToMedium', () => {
+    const comment = makeComment({
+      body: '## MEDIUM\n\nSlow query detected.',
+    });
+    const result = sentryAdapter.parse(comment);
+    expect(result).not.toBeNull();
+    expect(result?.normalizedSeverity).toBe('MEDIUM');
+  });
+
+  it('SentryAdapter_LowTag_NormalizesToLow', () => {
+    const comment = makeComment({
+      body: '## LOW\n\nMinor warning.',
+    });
+    const result = sentryAdapter.parse(comment);
+    expect(result).not.toBeNull();
+    expect(result?.normalizedSeverity).toBe('LOW');
+  });
+
+  it('SentryAdapter_NoSeverityTag_DefaultsToMedium', () => {
+    const comment = makeComment({
+      body: 'Sentry detected something but no severity tag is present.',
+    });
+    const result = sentryAdapter.parse(comment);
+    expect(result).not.toBeNull();
+    expect(result?.normalizedSeverity).toBe('MEDIUM');
+  });
+
+  it('SentryAdapter_NonSentryAuthor_ReturnsNull', () => {
+    const comment = makeComment({
+      author: 'coderabbitai[bot]',
+      body: '## CRITICAL bug',
+    });
+    const result = sentryAdapter.parse(comment);
+    expect(result).toBeNull();
+  });
+
+  it('SentryAdapter_PopulatesFileAndLine', () => {
+    const comment = makeComment({
+      id: 999,
+      body: '## HIGH\n\nUnhandled exception in fetch().',
+      path: 'src/handler.ts',
+      line: 42,
+    });
+    const result = sentryAdapter.parse(comment);
+    expect(result).not.toBeNull();
+    expect(result?.file).toBe('src/handler.ts');
+    expect(result?.line).toBe(42);
+    expect(result?.type).toBe('comment-reply');
+    expect(result?.reviewer).toBe('sentry');
+    expect(result?.threadId).toBe('999');
+    expect(result?.severity).toBe('major');
+    expect(result?.pr).toBe(0);
+    expect(result?.raw).toBe(comment);
+    expect(result?.description.length).toBeLessThanOrEqual(100);
+  });
+});

--- a/servers/exarchos-mcp/src/review/providers/sentry.test.ts
+++ b/servers/exarchos-mcp/src/review/providers/sentry.test.ts
@@ -100,14 +100,19 @@ describe('sentryAdapter', () => {
     expect(sentryAdapter.parse(malformed)).toBeNull();
   });
 
-  it('SentryAdapter_NoTier_PopulatesRawTier', () => {
+  it('SentryAdapter_NoTier_DoesNotSetUnknownTier', () => {
+    // Sentry comments often arrive without a tier marker — that's normal,
+    // not drift. The adapter must NOT flag those as unknownTier or it
+    // floods the provider.unknown-tier event stream with false positives
+    // (PR #1161 review feedback).
     const result = sentryAdapter.parse({
       id: 5,
       author: 'sentry-io[bot]',
       body: 'Notice: something happened\n\nSee details below.',
       createdAt: '2026-04-19T00:00:00Z',
     });
-    expect(result?.unknownTier).toBe(true);
-    expect(result?.rawTier).toBe('Notice: something happened');
+    expect(result?.unknownTier).toBeUndefined();
+    expect(result?.rawTier).toBeUndefined();
+    expect(result?.normalizedSeverity).toBe('MEDIUM');
   });
 });

--- a/servers/exarchos-mcp/src/review/providers/sentry.test.ts
+++ b/servers/exarchos-mcp/src/review/providers/sentry.test.ts
@@ -88,4 +88,26 @@ describe('sentryAdapter', () => {
     expect(result?.raw).toBe(comment);
     expect(result?.description.length).toBeLessThanOrEqual(100);
   });
+
+  it('SentryAdapter_MalformedInput_DoesNotThrow', () => {
+    const malformed = {
+      id: 1,
+      author: 'sentry-io[bot]',
+      body: null as unknown as string,
+      createdAt: '2026-04-19T00:00:00Z',
+    };
+    expect(() => sentryAdapter.parse(malformed)).not.toThrow();
+    expect(sentryAdapter.parse(malformed)).toBeNull();
+  });
+
+  it('SentryAdapter_NoTier_PopulatesRawTier', () => {
+    const result = sentryAdapter.parse({
+      id: 5,
+      author: 'sentry-io[bot]',
+      body: 'Notice: something happened\n\nSee details below.',
+      createdAt: '2026-04-19T00:00:00Z',
+    });
+    expect(result?.unknownTier).toBe(true);
+    expect(result?.rawTier).toBe('Notice: something happened');
+  });
 });

--- a/servers/exarchos-mcp/src/review/providers/sentry.ts
+++ b/servers/exarchos-mcp/src/review/providers/sentry.ts
@@ -28,32 +28,36 @@ const SEVERITY_PATTERNS: ReadonlyArray<{ tag: string; severity: Severity }> = [
   { tag: 'LOW', severity: 'LOW' },
 ];
 
-function detectSeverity(body: string): { severity: Severity; matched: boolean } {
+function detectSeverity(body: string): { severity: Severity } {
   for (const { tag, severity } of SEVERITY_PATTERNS) {
     const re = new RegExp(`\\b${tag}\\b`);
     if (re.test(body)) {
-      return { severity, matched: true };
+      return { severity };
     }
   }
-  return { severity: 'MEDIUM', matched: false };
-}
-
-function rawTierMarker(body: string): string {
-  const firstLine = body.split('\n').find((l) => l.trim().length > 0) ?? '';
-  return firstLine.slice(0, 80);
+  return { severity: 'MEDIUM' };
 }
 
 export const sentryAdapter: ProviderAdapter = {
   kind: 'sentry',
   parse(comment: VcsPrComment): ActionItem | null {
-    if (comment.author !== SENTRY_AUTHOR) {
-      return null;
-    }
-
     try {
-      const { severity: normalizedSeverity, matched } = detectSeverity(comment.body);
+      if (typeof comment.author !== 'string' || comment.author !== SENTRY_AUTHOR) {
+        return null;
+      }
+      if (typeof comment.body !== 'string') {
+        return null;
+      }
+      const { severity: normalizedSeverity } = detectSeverity(comment.body);
       const description = comment.body.slice(0, 100);
 
+      // Note: we intentionally do NOT set `unknownTier` when no tier matched.
+      // Unlike CodeRabbit, Sentry does not use a strict tier convention on
+      // every comment — many bug-prediction comments arrive with no tier
+      // marker at all. Treating "no tier" as "unknown tier" would flood the
+      // provider.unknown-tier event stream with false positives. The signal
+      // is reserved for adapters whose providers DO use a structured tier
+      // vocabulary that we want to detect drift in (#1159 PR feedback).
       return {
         type: 'comment-reply',
         pr: 0,
@@ -65,7 +69,6 @@ export const sentryAdapter: ProviderAdapter = {
         file: comment.path,
         line: comment.line,
         normalizedSeverity,
-        ...(matched ? {} : { unknownTier: true, rawTier: rawTierMarker(comment.body) }),
       };
     } catch {
       // Defensive: bad body must not kill the whole batch (#1159).

--- a/servers/exarchos-mcp/src/review/providers/sentry.ts
+++ b/servers/exarchos-mcp/src/review/providers/sentry.ts
@@ -28,14 +28,14 @@ const SEVERITY_PATTERNS: ReadonlyArray<{ tag: string; severity: Severity }> = [
   { tag: 'LOW', severity: 'LOW' },
 ];
 
-function detectSeverity(body: string): Severity {
+function detectSeverity(body: string): { severity: Severity; matched: boolean } {
   for (const { tag, severity } of SEVERITY_PATTERNS) {
     const re = new RegExp(`\\b${tag}\\b`);
     if (re.test(body)) {
-      return severity;
+      return { severity, matched: true };
     }
   }
-  return 'MEDIUM';
+  return { severity: 'MEDIUM', matched: false };
 }
 
 export const sentryAdapter: ProviderAdapter = {
@@ -45,10 +45,10 @@ export const sentryAdapter: ProviderAdapter = {
       return null;
     }
 
-    const normalizedSeverity = detectSeverity(comment.body);
+    const { severity: normalizedSeverity, matched } = detectSeverity(comment.body);
     const description = comment.body.slice(0, 100);
 
-    const item: ActionItem = {
+    return {
       type: 'comment-reply',
       pr: 0,
       description,
@@ -59,7 +59,7 @@ export const sentryAdapter: ProviderAdapter = {
       file: comment.path,
       line: comment.line,
       normalizedSeverity,
+      ...(matched ? {} : { unknownTier: true }),
     };
-    return item;
   },
 };

--- a/servers/exarchos-mcp/src/review/providers/sentry.ts
+++ b/servers/exarchos-mcp/src/review/providers/sentry.ts
@@ -1,0 +1,65 @@
+// ─── Sentry Provider Adapter ─────────────────────────────────────────────────
+//
+// Parses comments authored by the `sentry-io[bot]` GitHub App into ActionItem
+// values consumed by the fixer-dispatch pipeline. Sentry surfaces issue
+// severity via tag headers (CRITICAL/HIGH/MEDIUM/LOW) embedded in comment
+// bodies; this adapter scans for those tokens and normalizes them onto the
+// shared Severity type so downstream routing can be reviewer-agnostic.
+//
+// CRITICAL and HIGH both map to HIGH (Sentry treats CRITICAL as the most
+// severe band but HIGH is also actionable; collapsing them avoids a fourth
+// tier that the rest of the pipeline does not understand). When no tag is
+// found, the adapter defaults to MEDIUM rather than dropping the comment, so
+// agents still receive a reply task but at a non-blocking severity.
+
+import type { ActionItem, ProviderAdapter, Severity } from '../types.js';
+import type { PrComment as VcsPrComment } from '../../vcs/provider.js';
+
+const SENTRY_AUTHOR = 'sentry-io[bot]';
+
+// Standalone-token match: severity tags only count when they appear as a
+// whole word (markdown headers like `## HIGH`, prose like `Severity: HIGH`).
+// Anchored with \b on both sides so substrings like `HIGHLIGHT` or
+// `MEDIUMLY` cannot accidentally trigger a match.
+const SEVERITY_PATTERNS: ReadonlyArray<{ tag: string; severity: Severity }> = [
+  { tag: 'CRITICAL', severity: 'HIGH' },
+  { tag: 'HIGH', severity: 'HIGH' },
+  { tag: 'MEDIUM', severity: 'MEDIUM' },
+  { tag: 'LOW', severity: 'LOW' },
+];
+
+function detectSeverity(body: string): Severity {
+  for (const { tag, severity } of SEVERITY_PATTERNS) {
+    const re = new RegExp(`\\b${tag}\\b`);
+    if (re.test(body)) {
+      return severity;
+    }
+  }
+  return 'MEDIUM';
+}
+
+export const sentryAdapter: ProviderAdapter = {
+  kind: 'sentry',
+  parse(comment: VcsPrComment): ActionItem | null {
+    if (comment.author !== SENTRY_AUTHOR) {
+      return null;
+    }
+
+    const normalizedSeverity = detectSeverity(comment.body);
+    const description = comment.body.slice(0, 100);
+
+    const item: ActionItem = {
+      type: 'comment-reply',
+      pr: 0,
+      description,
+      severity: 'major',
+      reviewer: 'sentry',
+      threadId: String(comment.id),
+      raw: comment,
+      file: comment.path,
+      line: comment.line,
+      normalizedSeverity,
+    };
+    return item;
+  },
+};

--- a/servers/exarchos-mcp/src/review/providers/sentry.ts
+++ b/servers/exarchos-mcp/src/review/providers/sentry.ts
@@ -38,6 +38,11 @@ function detectSeverity(body: string): { severity: Severity; matched: boolean } 
   return { severity: 'MEDIUM', matched: false };
 }
 
+function rawTierMarker(body: string): string {
+  const firstLine = body.split('\n').find((l) => l.trim().length > 0) ?? '';
+  return firstLine.slice(0, 80);
+}
+
 export const sentryAdapter: ProviderAdapter = {
   kind: 'sentry',
   parse(comment: VcsPrComment): ActionItem | null {
@@ -45,21 +50,26 @@ export const sentryAdapter: ProviderAdapter = {
       return null;
     }
 
-    const { severity: normalizedSeverity, matched } = detectSeverity(comment.body);
-    const description = comment.body.slice(0, 100);
+    try {
+      const { severity: normalizedSeverity, matched } = detectSeverity(comment.body);
+      const description = comment.body.slice(0, 100);
 
-    return {
-      type: 'comment-reply',
-      pr: 0,
-      description,
-      severity: 'major',
-      reviewer: 'sentry',
-      threadId: String(comment.id),
-      raw: comment,
-      file: comment.path,
-      line: comment.line,
-      normalizedSeverity,
-      ...(matched ? {} : { unknownTier: true }),
-    };
+      return {
+        type: 'comment-reply',
+        pr: 0,
+        description,
+        severity: 'major',
+        reviewer: 'sentry',
+        threadId: String(comment.id),
+        raw: comment,
+        file: comment.path,
+        line: comment.line,
+        normalizedSeverity,
+        ...(matched ? {} : { unknownTier: true, rawTier: rawTierMarker(comment.body) }),
+      };
+    } catch {
+      // Defensive: bad body must not kill the whole batch (#1159).
+      return null;
+    }
   },
 };

--- a/servers/exarchos-mcp/src/review/providers/unknown.test.ts
+++ b/servers/exarchos-mcp/src/review/providers/unknown.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { unknownAdapter } from './unknown.js';
+import type { PrComment as VcsPrComment } from '../../vcs/provider.js';
+
+function makeComment(overrides: Partial<VcsPrComment> = {}): VcsPrComment {
+  return {
+    id: 1,
+    author: 'mystery-bot[bot]',
+    body: 'arbitrary content',
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('unknownAdapter', () => {
+  it('UnknownAdapter_AnyAuthor_AlwaysParses', () => {
+    const item = unknownAdapter.parse(makeComment({ author: 'never-seen-bot[bot]' }));
+    expect(item).not.toBeNull();
+    expect(item?.reviewer).toBe('unknown');
+  });
+
+  it('UnknownAdapter_AnyComment_DefaultsToMedium', () => {
+    const item = unknownAdapter.parse(makeComment({ body: 'CRITICAL!! HIGH!! Major!!' }));
+    expect(item?.normalizedSeverity).toBe('MEDIUM');
+  });
+
+  it('UnknownAdapter_PopulatesFileAndLine', () => {
+    const item = unknownAdapter.parse(makeComment({ path: 'src/a.ts', line: 42 }));
+    expect(item?.file).toBe('src/a.ts');
+    expect(item?.line).toBe(42);
+  });
+
+  it('UnknownAdapter_PopulatesThreadIdAndRaw', () => {
+    const comment = makeComment({ id: 999 });
+    const item = unknownAdapter.parse(comment);
+    expect(item?.threadId).toBe('999');
+    expect(item?.raw).toBe(comment);
+  });
+});

--- a/servers/exarchos-mcp/src/review/providers/unknown.test.ts
+++ b/servers/exarchos-mcp/src/review/providers/unknown.test.ts
@@ -36,4 +36,10 @@ describe('unknownAdapter', () => {
     expect(item?.threadId).toBe('999');
     expect(item?.raw).toBe(comment);
   });
+
+  it('UnknownAdapter_MalformedInput_DoesNotThrow', () => {
+    const malformed = makeComment({ body: null as unknown as string });
+    expect(() => unknownAdapter.parse(malformed)).not.toThrow();
+    expect(unknownAdapter.parse(malformed)).toBeNull();
+  });
 });

--- a/servers/exarchos-mcp/src/review/providers/unknown.ts
+++ b/servers/exarchos-mcp/src/review/providers/unknown.ts
@@ -21,17 +21,22 @@ function summarize(body: string): string {
 export const unknownAdapter: ProviderAdapter = {
   kind: 'unknown',
   parse(comment: VcsPrComment): ActionItem | null {
-    return {
-      type: 'comment-reply',
-      pr: 0,
-      description: summarize(comment.body),
-      severity: 'major',
-      file: comment.path,
-      line: comment.line,
-      reviewer: 'unknown',
-      threadId: String(comment.id),
-      raw: comment,
-      normalizedSeverity: 'MEDIUM',
-    };
+    try {
+      return {
+        type: 'comment-reply',
+        pr: 0,
+        description: summarize(comment.body),
+        severity: 'major',
+        file: comment.path,
+        line: comment.line,
+        reviewer: 'unknown',
+        threadId: String(comment.id),
+        raw: comment,
+        normalizedSeverity: 'MEDIUM',
+      };
+    } catch {
+      // Defensive: bad body must not kill the whole batch (#1159).
+      return null;
+    }
   },
 };

--- a/servers/exarchos-mcp/src/review/providers/unknown.ts
+++ b/servers/exarchos-mcp/src/review/providers/unknown.ts
@@ -1,0 +1,37 @@
+// ─── Unknown Reviewer Adapter ───────────────────────────────────────────────
+//
+// Catch-all fallback adapter for PR comments whose author isn't claimed by
+// any of the typed adapters (CodeRabbit, Sentry, GitHub-Copilot, Human).
+// Always returns an ActionItem with reviewer='unknown' and
+// normalizedSeverity='MEDIUM'. The registry consults the unknown adapter
+// last; an upstream caller should emit a `provider.unknown_tier` style
+// event when this adapter handles a comment, surfacing the unfamiliar
+// author so it can be classified later.
+// ────────────────────────────────────────────────────────────────────────────
+
+import type { ProviderAdapter, ActionItem } from '../types.js';
+import type { PrComment as VcsPrComment } from '../../vcs/provider.js';
+
+const DESCRIPTION_MAX_LENGTH = 100;
+
+function summarize(body: string): string {
+  return body.slice(0, DESCRIPTION_MAX_LENGTH);
+}
+
+export const unknownAdapter: ProviderAdapter = {
+  kind: 'unknown',
+  parse(comment: VcsPrComment): ActionItem | null {
+    return {
+      type: 'comment-reply',
+      pr: 0,
+      description: summarize(comment.body),
+      severity: 'major',
+      file: comment.path,
+      line: comment.line,
+      reviewer: 'unknown',
+      threadId: String(comment.id),
+      raw: comment,
+      normalizedSeverity: 'MEDIUM',
+    };
+  },
+};

--- a/servers/exarchos-mcp/src/review/providers/unknown.ts
+++ b/servers/exarchos-mcp/src/review/providers/unknown.ts
@@ -22,6 +22,9 @@ export const unknownAdapter: ProviderAdapter = {
   kind: 'unknown',
   parse(comment: VcsPrComment): ActionItem | null {
     try {
+      if (typeof comment.body !== 'string') {
+        return null;
+      }
       return {
         type: 'comment-reply',
         pr: 0,

--- a/servers/exarchos-mcp/src/review/registry.test.ts
+++ b/servers/exarchos-mcp/src/review/registry.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { createReviewAdapterRegistry, detectKind } from './registry.js';
+
+describe('createReviewAdapterRegistry', () => {
+  it('CreateReviewAdapterRegistry_ReturnsAllFiveAdapters', () => {
+    const registry = createReviewAdapterRegistry();
+    const adapters = registry.list();
+    expect(adapters).toHaveLength(5);
+    const kinds = adapters.map((a) => a.kind).sort();
+    expect(kinds).toEqual(['coderabbit', 'github-copilot', 'human', 'sentry', 'unknown']);
+  });
+
+  it('CreateReviewAdapterRegistry_ForReviewerCoderabbit_ReturnsCoderabbitAdapter', () => {
+    const registry = createReviewAdapterRegistry();
+    const adapter = registry.forReviewer('coderabbit');
+    expect(adapter?.kind).toBe('coderabbit');
+  });
+
+  it('CreateReviewAdapterRegistry_ForReviewerSentry_ReturnsSentryAdapter', () => {
+    const registry = createReviewAdapterRegistry();
+    const adapter = registry.forReviewer('sentry');
+    expect(adapter?.kind).toBe('sentry');
+  });
+
+  it('CreateReviewAdapterRegistry_ForReviewerHuman_ReturnsHumanAdapter', () => {
+    const registry = createReviewAdapterRegistry();
+    expect(registry.forReviewer('human')?.kind).toBe('human');
+  });
+
+  it('CreateReviewAdapterRegistry_ForReviewerGithubCopilot_ReturnsCopilotAdapter', () => {
+    const registry = createReviewAdapterRegistry();
+    expect(registry.forReviewer('github-copilot')?.kind).toBe('github-copilot');
+  });
+
+  it('CreateReviewAdapterRegistry_ForReviewerUnknown_ReturnsUnknownAdapter', () => {
+    const registry = createReviewAdapterRegistry();
+    expect(registry.forReviewer('unknown')?.kind).toBe('unknown');
+  });
+
+  it('CreateReviewAdapterRegistry_ListIsImmutable', () => {
+    const registry = createReviewAdapterRegistry();
+    const adapters = registry.list();
+    expect(() => {
+      (adapters as unknown as { push: (x: unknown) => void }).push({});
+    }).toThrow();
+  });
+});
+
+describe('detectKind', () => {
+  it('DetectKind_CoderabbitAuthor_ReturnsCoderabbit', () => {
+    expect(detectKind('coderabbitai[bot]')).toBe('coderabbit');
+  });
+
+  it('DetectKind_SentryAuthor_ReturnsSentry', () => {
+    expect(detectKind('sentry-io[bot]')).toBe('sentry');
+  });
+
+  it('DetectKind_GithubCopilotBotAuthor_ReturnsGithubCopilot', () => {
+    expect(detectKind('github-copilot[bot]')).toBe('github-copilot');
+  });
+
+  it('DetectKind_CopilotShortBotAuthor_ReturnsGithubCopilot', () => {
+    expect(detectKind('copilot[bot]')).toBe('github-copilot');
+  });
+
+  it('DetectKind_CopilotDisplayName_ReturnsGithubCopilot', () => {
+    expect(detectKind('Copilot')).toBe('github-copilot');
+  });
+
+  it('DetectKind_HumanAuthor_ReturnsHuman', () => {
+    expect(detectKind('alice')).toBe('human');
+    expect(detectKind('reed-salus')).toBe('human');
+  });
+
+  it('DetectKind_UnknownBot_ReturnsUnknown', () => {
+    expect(detectKind('mystery-bot[bot]')).toBe('unknown');
+    expect(detectKind('github-actions[bot]')).toBe('unknown');
+  });
+});

--- a/servers/exarchos-mcp/src/review/registry.ts
+++ b/servers/exarchos-mcp/src/review/registry.ts
@@ -1,0 +1,68 @@
+// ─── Review Adapter Registry (Issue #1159) ──────────────────────────────────
+//
+// Single source of truth for the set of provider adapters that interpret
+// PR review comments. The registry is constructed once via the
+// createReviewAdapterRegistry() factory and injected into every consumer
+// (assess_stack, classify_review_items, etc). There is no lazy fallback or
+// late-binding mutation — absence of an adapter is a deterministic
+// undefined return from forReviewer(), and the unknown adapter is always
+// available as the final fallback.
+//
+// detectKind() inspects a comment's author string and routes it to the
+// appropriate ReviewerKind. It is the sole place author-string conventions
+// are encoded; adapters themselves do not branch on author beyond their
+// own self-check.
+// ────────────────────────────────────────────────────────────────────────────
+
+import type {
+  ProviderAdapter,
+  ReviewAdapterRegistry,
+  ReviewerKind,
+} from './types.js';
+import { coderabbitAdapter } from './providers/coderabbit.js';
+import { sentryAdapter } from './providers/sentry.js';
+import { githubCopilotAdapter } from './providers/github-copilot.js';
+import { humanAdapter } from './providers/human.js';
+import { unknownAdapter } from './providers/unknown.js';
+
+const COPILOT_AUTHORS: ReadonlySet<string> = new Set([
+  'github-copilot[bot]',
+  'copilot[bot]',
+  'Copilot',
+]);
+
+const KNOWN_BOT_KINDS: ReadonlyMap<string, ReviewerKind> = new Map([
+  ['coderabbitai[bot]', 'coderabbit'],
+  ['sentry-io[bot]', 'sentry'],
+]);
+
+export function detectKind(author: string): ReviewerKind {
+  const known = KNOWN_BOT_KINDS.get(author);
+  if (known) return known;
+  if (COPILOT_AUTHORS.has(author)) return 'github-copilot';
+  if (author.endsWith('[bot]')) return 'unknown';
+  return 'human';
+}
+
+export function createReviewAdapterRegistry(): ReviewAdapterRegistry {
+  const adapters: readonly ProviderAdapter[] = Object.freeze([
+    coderabbitAdapter,
+    sentryAdapter,
+    githubCopilotAdapter,
+    humanAdapter,
+    unknownAdapter,
+  ]);
+
+  const byKind = new Map<ReviewerKind, ProviderAdapter>(
+    adapters.map((a) => [a.kind, a]),
+  );
+
+  return Object.freeze({
+    forReviewer(kind: ReviewerKind): ProviderAdapter | undefined {
+      return byKind.get(kind);
+    },
+    list(): readonly ProviderAdapter[] {
+      return adapters;
+    },
+  });
+}

--- a/servers/exarchos-mcp/src/review/types.test.ts
+++ b/servers/exarchos-mcp/src/review/types.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  ProviderAdapter,
+  ReviewAdapterRegistry,
+  ActionItem,
+} from './types.js';
+import type { PrComment as VcsPrComment } from '../vcs/provider.js';
+
+describe('review types', () => {
+  it('ProviderAdapter_StubImplementation_SatisfiesInterface', () => {
+    const stub: ProviderAdapter = {
+      kind: 'human',
+      parse(_raw: VcsPrComment): ActionItem | null {
+        return null;
+      },
+    };
+    expect(stub.kind).toBe('human');
+    expect(stub.parse({
+      id: 1,
+      author: 'someone',
+      body: '',
+      createdAt: '2026-01-01',
+    })).toBeNull();
+  });
+
+  it('ReviewAdapterRegistry_StubImplementation_SatisfiesInterface', () => {
+    const stubAdapter: ProviderAdapter = {
+      kind: 'human',
+      parse(): ActionItem | null {
+        return null;
+      },
+    };
+    const registry: ReviewAdapterRegistry = {
+      forReviewer(kind) {
+        return kind === 'human' ? stubAdapter : undefined;
+      },
+      list() {
+        return [stubAdapter];
+      },
+    };
+    expect(registry.forReviewer('human')).toBe(stubAdapter);
+    expect(registry.forReviewer('coderabbit')).toBeUndefined();
+    expect(registry.list()).toHaveLength(1);
+  });
+});

--- a/servers/exarchos-mcp/src/review/types.ts
+++ b/servers/exarchos-mcp/src/review/types.ts
@@ -63,6 +63,13 @@ export interface ActionItem {
   readonly threadId?: string;
   readonly raw?: unknown;
   readonly normalizedSeverity?: Severity;
+  /**
+   * True when the adapter could not match any recognised severity tier
+   * in the comment body. Surfaced via the `provider.unknown-tier` event
+   * by assess_stack so that drift in upstream tier vocabulary is visible
+   * (#1159).
+   */
+  readonly unknownTier?: boolean;
 }
 
 export interface ProviderAdapter {

--- a/servers/exarchos-mcp/src/review/types.ts
+++ b/servers/exarchos-mcp/src/review/types.ts
@@ -35,3 +35,42 @@ export interface ReviewDispatch {
   velocity: VelocityTier;
   reason: string;
 }
+
+// ─── Review Action Items (Issue #1159) ──────────────────────────────────────
+// Canonical types for the multi-reviewer fixer-dispatch pipeline.
+// Adapters in src/review/providers/ produce ActionItem values from raw
+// VcsPrComment input. assess-stack.ts re-exports these for backwards compat.
+
+import type { PrComment as VcsPrComment } from '../vcs/provider.js';
+
+export type Severity = 'HIGH' | 'MEDIUM' | 'LOW';
+
+export type ReviewerKind =
+  | 'coderabbit'
+  | 'sentry'
+  | 'human'
+  | 'github-copilot'
+  | 'unknown';
+
+export interface ActionItem {
+  readonly type: 'ci-fix' | 'comment-reply' | 'review-address' | 'stack-fix';
+  readonly pr: number;
+  readonly description: string;
+  readonly severity: 'critical' | 'major' | 'minor';
+  readonly file?: string;
+  readonly line?: number;
+  readonly reviewer?: ReviewerKind;
+  readonly threadId?: string;
+  readonly raw?: unknown;
+  readonly normalizedSeverity?: Severity;
+}
+
+export interface ProviderAdapter {
+  readonly kind: ReviewerKind;
+  parse(rawComment: VcsPrComment): ActionItem | null;
+}
+
+export interface ReviewAdapterRegistry {
+  forReviewer(kind: ReviewerKind): ProviderAdapter | undefined;
+  list(): readonly ProviderAdapter[];
+}

--- a/servers/exarchos-mcp/src/review/types.ts
+++ b/servers/exarchos-mcp/src/review/types.ts
@@ -81,3 +81,29 @@ export interface ReviewAdapterRegistry {
   forReviewer(kind: ReviewerKind): ProviderAdapter | undefined;
   list(): readonly ProviderAdapter[];
 }
+
+// ─── Review Classification (Issue #1159 Phase 2) ────────────────────────────
+// classify_review_items groups parsed ActionItems by file and recommends a
+// dispatch strategy per group. Replaces the prose direct-vs-delegate
+// heuristic in skills-src/shepherd/references/fix-strategies.md.
+
+export type DispatchRecommendation = 'direct' | 'delegate-fixer' | 'delegate-scaffolder';
+
+export interface ClassificationGroup {
+  readonly file: string | null;        // null = file-less group (e.g. PR-level comments)
+  readonly items: readonly ActionItem[];
+  readonly severity: Severity;          // max severity in the group
+  readonly recommendation: DispatchRecommendation;
+  readonly rationale: string;
+}
+
+export interface ClassificationSummary {
+  readonly totalItems: number;
+  readonly directCount: number;
+  readonly delegateCount: number;
+}
+
+export interface ClassificationResult {
+  readonly groups: readonly ClassificationGroup[];
+  readonly summary: ClassificationSummary;
+}

--- a/servers/exarchos-mcp/src/review/types.ts
+++ b/servers/exarchos-mcp/src/review/types.ts
@@ -70,6 +70,13 @@ export interface ActionItem {
    * (#1159).
    */
   readonly unknownTier?: boolean;
+  /**
+   * When `unknownTier` is true, the first line / leading marker chunk of
+   * the comment body that the adapter failed to classify. Forwarded to
+   * the `provider.unknown-tier` event as `rawTier` so a human can see
+   * which upstream marker tripped (#1159).
+   */
+  readonly rawTier?: string;
 }
 
 export interface ProviderAdapter {

--- a/servers/exarchos-mcp/src/review/types.ts
+++ b/servers/exarchos-mcp/src/review/types.ts
@@ -62,7 +62,7 @@ export interface ActionItem {
   readonly reviewer?: ReviewerKind;
   readonly threadId?: string;
   readonly raw?: unknown;
-  readonly normalizedSeverity?: Severity;
+  readonly normalizedSeverity: Severity;
   /**
    * True when the adapter could not match any recognised severity tier
    * in the comment body. Surfaced via the `provider.unknown-tier` event

--- a/skills-src/shepherd/SKILL.md
+++ b/skills-src/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Read context from `actionItem.context`, compose response, post via GitHub MCP |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills-src/shepherd/SKILL.md
+++ b/skills-src/shepherd/SKILL.md
@@ -93,7 +93,26 @@ Review the returned `actionItems` and `recommendation`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult `references/fix-strategies.md` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call `classify_review_items` on
+the assessment's `actionItems` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+```typescript
+{{MCP_PREFIX}}exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+```
+
+The result returns `groups: ClassificationGroup[]` with a `recommendation`
+per group: `direct` (handle inline), `delegate-fixer` (spawn the fixer
+subagent for batched/HIGH-severity work), or `delegate-scaffolder`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult `references/fix-strategies.md` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 

--- a/skills-src/shepherd/SKILL.md
+++ b/skills-src/shepherd/SKILL.md
@@ -149,7 +149,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic `add_pr_comment` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. `mcp__plugin_github_github__add_reply_to_pull_request_comment` for GitHub) until `VcsProvider` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills-src/shepherd/SKILL.md
+++ b/skills-src/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills-src/shepherd/references/fix-strategies.md
+++ b/skills-src/shepherd/references/fix-strategies.md
@@ -4,14 +4,16 @@ How to address common issues found during shepherd assessment.
 
 ## Decision: Fix Directly vs. Delegate
 
-| Condition | Approach |
-|-----------|----------|
-| Single file, < 20 lines changed | Fix directly in the stack branch |
-| Multiple files, contained concern | Fix directly if < 5 files |
-| Cross-cutting or architectural | Route to `/exarchos:delegate --fixes` for subagent dispatch |
-| Test changes needed | Fix directly (keep TDD cycle tight) |
+The `classify_review_items` orchestrate action owns this decision (#1159).
+Pass it the `actionItems` from `assess_stack` and consume the
+`recommendation` field on each returned group:
 
-**Default to fixing directly** — delegation adds overhead. Only delegate when the fix scope warrants it.
+- `direct` — handle inline in the shepherd loop
+- `delegate-fixer` — spawn the fixer subagent (batched / HIGH severity)
+- `delegate-scaffolder` — cheap scaffolder dispatch for doc nits
+
+Test changes still warrant inline handling regardless of recommendation —
+keep the TDD cycle tight rather than delegating test edits.
 
 ## Remediation Event Emission
 

--- a/skills-src/shepherd/references/fix-strategies.md
+++ b/skills-src/shepherd/references/fix-strategies.md
@@ -154,52 +154,19 @@ For each comment, determine the appropriate response:
 | Already fixed (outdated) | Reply confirming | "Fixed in [commit/PR description] — [brief explanation]." |
 | False positive | Reply explaining | "[Explanation of why this doesn't apply in this context]." |
 
-### Sentry Comments
+### Per-reviewer parsing (Sentry, CodeRabbit, Human, GitHub-Copilot)
 
-Sentry's `[bot]` leaves **bug predictions** — AI-generated analysis of potential runtime issues. These appear as inline review comments with severity tags (CRITICAL, MEDIUM, etc.).
+Severity normalization and per-reviewer comment parsing live in the
+provider adapters under `servers/exarchos-mcp/src/review/providers/` (#1159).
+`assess_stack` dispatches each PR comment through the adapter registry
+and attaches a normalized `ActionItem` (with `normalizedSeverity` and
+`reviewer` fields) to each unresolved comment. Use that signal when
+deciding response strategy below; you do not need to re-parse tier
+markers in the shepherd loop.
 
-**Sentry comments deserve careful attention because they often identify real bugs** (field name mismatches, type coercion issues, null reference risks).
-
-How to handle:
-1. Read the full comment body — Sentry includes a "Suggested Fix" section
-2. Evaluate whether the bug is real:
-   - Check if the code path is actually reachable
-   - Check if the field names/types match what the data actually provides
-   - Check existing tests — does any test exercise this path?
-3. If real: fix the bug, add a test, reply confirming
-4. If false positive: reply explaining why (e.g., "This path is guarded by X" or "The field is validated at Y before reaching this code")
-
-**Common Sentry findings:**
-- Field name mismatches between producers and consumers
-- Missing null checks on optional fields
-- Type mismatches (string vs. enum, array vs. object)
-- Unreachable error paths due to upstream validation
-
-### CodeRabbit Comments
-
-CodeRabbit leaves detailed code review suggestions with severity indicators. It re-reviews automatically on push, so code fixes may auto-resolve threads.
-
-How to handle:
-1. Read all CodeRabbit comments, noting severity (Critical, Major, Minor)
-2. Critical/Major: Must address — fix or provide strong rationale for not fixing
-3. Minor: Fix if low-effort, otherwise acknowledge
-4. CodeRabbit marks threads as "Addressed in commits" when it detects the code changed — but always verify with a reply
-
-**Common CodeRabbit findings:**
-- Error handling gaps (missing try/catch, bare catches)
-- Code duplication (DRY violations)
-- Style/naming suggestions
-- Performance optimizations
-- Security concerns
-
-### Human Reviewer Comments
-
-Human comments require the most careful handling:
-1. Read comments carefully — understand the full context
-2. For required changes: fix the code, reply confirming
-3. For questions: answer directly on the PR
-4. For suggestions: discuss or implement, reply with decision
-5. For approval with minor nits: fix nits, note the approval
+If you encounter a reviewer the adapters do not recognise, the
+`provider.unknown-tier` event surfaces it for follow-up. Treat the
+comment as MEDIUM in the meantime.
 
 ### GitHub Actions Bot Comments
 

--- a/skills-src/shepherd/references/fix-strategies.md
+++ b/skills-src/shepherd/references/fix-strategies.md
@@ -166,9 +166,13 @@ and attaches a normalized `ActionItem` (with `normalizedSeverity` and
 deciding response strategy below; you do not need to re-parse tier
 markers in the shepherd loop.
 
-If you encounter a reviewer the adapters do not recognise, the
-`provider.unknown-tier` event surfaces it for follow-up. Treat the
-comment as MEDIUM in the meantime.
+If a *recognised* reviewer (e.g. CodeRabbit) ships a new severity tier
+that the adapter does not match, the `provider.unknown-tier` event
+surfaces the unrecognised tier marker for follow-up — the comment is
+processed as MEDIUM in the meantime. Unknown *reviewers* (authors that
+don't match any typed adapter) are routed silently to the `unknown`
+adapter and never trigger this event; their comments are also processed
+as MEDIUM by default.
 
 ### GitHub Actions Bot Comments
 

--- a/skills/claude/shepherd/SKILL.md
+++ b/skills/claude/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Read context from `actionItem.context`, compose response, post via GitHub MCP |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/claude/shepherd/SKILL.md
+++ b/skills/claude/shepherd/SKILL.md
@@ -149,7 +149,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic `add_pr_comment` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. `mcp__plugin_github_github__add_reply_to_pull_request_comment` for GitHub) until `VcsProvider` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/claude/shepherd/SKILL.md
+++ b/skills/claude/shepherd/SKILL.md
@@ -93,7 +93,26 @@ Review the returned `actionItems` and `recommendation`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult `references/fix-strategies.md` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call `classify_review_items` on
+the assessment's `actionItems` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+```typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+```
+
+The result returns `groups: ClassificationGroup[]` with a `recommendation`
+per group: `direct` (handle inline), `delegate-fixer` (spawn the fixer
+subagent for batched/HIGH-severity work), or `delegate-scaffolder`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult `references/fix-strategies.md` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 

--- a/skills/claude/shepherd/SKILL.md
+++ b/skills/claude/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/claude/shepherd/references/fix-strategies.md
+++ b/skills/claude/shepherd/references/fix-strategies.md
@@ -4,14 +4,16 @@ How to address common issues found during shepherd assessment.
 
 ## Decision: Fix Directly vs. Delegate
 
-| Condition | Approach |
-|-----------|----------|
-| Single file, < 20 lines changed | Fix directly in the stack branch |
-| Multiple files, contained concern | Fix directly if < 5 files |
-| Cross-cutting or architectural | Route to `/exarchos:delegate --fixes` for subagent dispatch |
-| Test changes needed | Fix directly (keep TDD cycle tight) |
+The `classify_review_items` orchestrate action owns this decision (#1159).
+Pass it the `actionItems` from `assess_stack` and consume the
+`recommendation` field on each returned group:
 
-**Default to fixing directly** — delegation adds overhead. Only delegate when the fix scope warrants it.
+- `direct` — handle inline in the shepherd loop
+- `delegate-fixer` — spawn the fixer subagent (batched / HIGH severity)
+- `delegate-scaffolder` — cheap scaffolder dispatch for doc nits
+
+Test changes still warrant inline handling regardless of recommendation —
+keep the TDD cycle tight rather than delegating test edits.
 
 ## Remediation Event Emission
 

--- a/skills/claude/shepherd/references/fix-strategies.md
+++ b/skills/claude/shepherd/references/fix-strategies.md
@@ -154,52 +154,19 @@ For each comment, determine the appropriate response:
 | Already fixed (outdated) | Reply confirming | "Fixed in [commit/PR description] — [brief explanation]." |
 | False positive | Reply explaining | "[Explanation of why this doesn't apply in this context]." |
 
-### Sentry Comments
+### Per-reviewer parsing (Sentry, CodeRabbit, Human, GitHub-Copilot)
 
-Sentry's `[bot]` leaves **bug predictions** — AI-generated analysis of potential runtime issues. These appear as inline review comments with severity tags (CRITICAL, MEDIUM, etc.).
+Severity normalization and per-reviewer comment parsing live in the
+provider adapters under `servers/exarchos-mcp/src/review/providers/` (#1159).
+`assess_stack` dispatches each PR comment through the adapter registry
+and attaches a normalized `ActionItem` (with `normalizedSeverity` and
+`reviewer` fields) to each unresolved comment. Use that signal when
+deciding response strategy below; you do not need to re-parse tier
+markers in the shepherd loop.
 
-**Sentry comments deserve careful attention because they often identify real bugs** (field name mismatches, type coercion issues, null reference risks).
-
-How to handle:
-1. Read the full comment body — Sentry includes a "Suggested Fix" section
-2. Evaluate whether the bug is real:
-   - Check if the code path is actually reachable
-   - Check if the field names/types match what the data actually provides
-   - Check existing tests — does any test exercise this path?
-3. If real: fix the bug, add a test, reply confirming
-4. If false positive: reply explaining why (e.g., "This path is guarded by X" or "The field is validated at Y before reaching this code")
-
-**Common Sentry findings:**
-- Field name mismatches between producers and consumers
-- Missing null checks on optional fields
-- Type mismatches (string vs. enum, array vs. object)
-- Unreachable error paths due to upstream validation
-
-### CodeRabbit Comments
-
-CodeRabbit leaves detailed code review suggestions with severity indicators. It re-reviews automatically on push, so code fixes may auto-resolve threads.
-
-How to handle:
-1. Read all CodeRabbit comments, noting severity (Critical, Major, Minor)
-2. Critical/Major: Must address — fix or provide strong rationale for not fixing
-3. Minor: Fix if low-effort, otherwise acknowledge
-4. CodeRabbit marks threads as "Addressed in commits" when it detects the code changed — but always verify with a reply
-
-**Common CodeRabbit findings:**
-- Error handling gaps (missing try/catch, bare catches)
-- Code duplication (DRY violations)
-- Style/naming suggestions
-- Performance optimizations
-- Security concerns
-
-### Human Reviewer Comments
-
-Human comments require the most careful handling:
-1. Read comments carefully — understand the full context
-2. For required changes: fix the code, reply confirming
-3. For questions: answer directly on the PR
-4. For suggestions: discuss or implement, reply with decision
-5. For approval with minor nits: fix nits, note the approval
+If you encounter a reviewer the adapters do not recognise, the
+`provider.unknown-tier` event surfaces it for follow-up. Treat the
+comment as MEDIUM in the meantime.
 
 ### GitHub Actions Bot Comments
 

--- a/skills/claude/shepherd/references/fix-strategies.md
+++ b/skills/claude/shepherd/references/fix-strategies.md
@@ -166,9 +166,13 @@ and attaches a normalized `ActionItem` (with `normalizedSeverity` and
 deciding response strategy below; you do not need to re-parse tier
 markers in the shepherd loop.
 
-If you encounter a reviewer the adapters do not recognise, the
-`provider.unknown-tier` event surfaces it for follow-up. Treat the
-comment as MEDIUM in the meantime.
+If a *recognised* reviewer (e.g. CodeRabbit) ships a new severity tier
+that the adapter does not match, the `provider.unknown-tier` event
+surfaces the unrecognised tier marker for follow-up — the comment is
+processed as MEDIUM in the meantime. Unknown *reviewers* (authors that
+don't match any typed adapter) are routed silently to the `unknown`
+adapter and never trigger this event; their comments are also processed
+as MEDIUM by default.
 
 ### GitHub Actions Bot Comments
 

--- a/skills/codex/shepherd/SKILL.md
+++ b/skills/codex/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Read context from `actionItem.context`, compose response, post via GitHub MCP |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/codex/shepherd/SKILL.md
+++ b/skills/codex/shepherd/SKILL.md
@@ -149,7 +149,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic `add_pr_comment` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. `mcp__plugin_github_github__add_reply_to_pull_request_comment` for GitHub) until `VcsProvider` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/codex/shepherd/SKILL.md
+++ b/skills/codex/shepherd/SKILL.md
@@ -93,7 +93,26 @@ Review the returned `actionItems` and `recommendation`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult `references/fix-strategies.md` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call `classify_review_items` on
+the assessment's `actionItems` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+```
+
+The result returns `groups: ClassificationGroup[]` with a `recommendation`
+per group: `direct` (handle inline), `delegate-fixer` (spawn the fixer
+subagent for batched/HIGH-severity work), or `delegate-scaffolder`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult `references/fix-strategies.md` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 

--- a/skills/codex/shepherd/SKILL.md
+++ b/skills/codex/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/codex/shepherd/references/fix-strategies.md
+++ b/skills/codex/shepherd/references/fix-strategies.md
@@ -4,14 +4,16 @@ How to address common issues found during shepherd assessment.
 
 ## Decision: Fix Directly vs. Delegate
 
-| Condition | Approach |
-|-----------|----------|
-| Single file, < 20 lines changed | Fix directly in the stack branch |
-| Multiple files, contained concern | Fix directly if < 5 files |
-| Cross-cutting or architectural | Route to `/exarchos:delegate --fixes` for subagent dispatch |
-| Test changes needed | Fix directly (keep TDD cycle tight) |
+The `classify_review_items` orchestrate action owns this decision (#1159).
+Pass it the `actionItems` from `assess_stack` and consume the
+`recommendation` field on each returned group:
 
-**Default to fixing directly** — delegation adds overhead. Only delegate when the fix scope warrants it.
+- `direct` — handle inline in the shepherd loop
+- `delegate-fixer` — spawn the fixer subagent (batched / HIGH severity)
+- `delegate-scaffolder` — cheap scaffolder dispatch for doc nits
+
+Test changes still warrant inline handling regardless of recommendation —
+keep the TDD cycle tight rather than delegating test edits.
 
 ## Remediation Event Emission
 

--- a/skills/codex/shepherd/references/fix-strategies.md
+++ b/skills/codex/shepherd/references/fix-strategies.md
@@ -154,52 +154,19 @@ For each comment, determine the appropriate response:
 | Already fixed (outdated) | Reply confirming | "Fixed in [commit/PR description] — [brief explanation]." |
 | False positive | Reply explaining | "[Explanation of why this doesn't apply in this context]." |
 
-### Sentry Comments
+### Per-reviewer parsing (Sentry, CodeRabbit, Human, GitHub-Copilot)
 
-Sentry's `[bot]` leaves **bug predictions** — AI-generated analysis of potential runtime issues. These appear as inline review comments with severity tags (CRITICAL, MEDIUM, etc.).
+Severity normalization and per-reviewer comment parsing live in the
+provider adapters under `servers/exarchos-mcp/src/review/providers/` (#1159).
+`assess_stack` dispatches each PR comment through the adapter registry
+and attaches a normalized `ActionItem` (with `normalizedSeverity` and
+`reviewer` fields) to each unresolved comment. Use that signal when
+deciding response strategy below; you do not need to re-parse tier
+markers in the shepherd loop.
 
-**Sentry comments deserve careful attention because they often identify real bugs** (field name mismatches, type coercion issues, null reference risks).
-
-How to handle:
-1. Read the full comment body — Sentry includes a "Suggested Fix" section
-2. Evaluate whether the bug is real:
-   - Check if the code path is actually reachable
-   - Check if the field names/types match what the data actually provides
-   - Check existing tests — does any test exercise this path?
-3. If real: fix the bug, add a test, reply confirming
-4. If false positive: reply explaining why (e.g., "This path is guarded by X" or "The field is validated at Y before reaching this code")
-
-**Common Sentry findings:**
-- Field name mismatches between producers and consumers
-- Missing null checks on optional fields
-- Type mismatches (string vs. enum, array vs. object)
-- Unreachable error paths due to upstream validation
-
-### CodeRabbit Comments
-
-CodeRabbit leaves detailed code review suggestions with severity indicators. It re-reviews automatically on push, so code fixes may auto-resolve threads.
-
-How to handle:
-1. Read all CodeRabbit comments, noting severity (Critical, Major, Minor)
-2. Critical/Major: Must address — fix or provide strong rationale for not fixing
-3. Minor: Fix if low-effort, otherwise acknowledge
-4. CodeRabbit marks threads as "Addressed in commits" when it detects the code changed — but always verify with a reply
-
-**Common CodeRabbit findings:**
-- Error handling gaps (missing try/catch, bare catches)
-- Code duplication (DRY violations)
-- Style/naming suggestions
-- Performance optimizations
-- Security concerns
-
-### Human Reviewer Comments
-
-Human comments require the most careful handling:
-1. Read comments carefully — understand the full context
-2. For required changes: fix the code, reply confirming
-3. For questions: answer directly on the PR
-4. For suggestions: discuss or implement, reply with decision
-5. For approval with minor nits: fix nits, note the approval
+If you encounter a reviewer the adapters do not recognise, the
+`provider.unknown-tier` event surfaces it for follow-up. Treat the
+comment as MEDIUM in the meantime.
 
 ### GitHub Actions Bot Comments
 

--- a/skills/codex/shepherd/references/fix-strategies.md
+++ b/skills/codex/shepherd/references/fix-strategies.md
@@ -166,9 +166,13 @@ and attaches a normalized `ActionItem` (with `normalizedSeverity` and
 deciding response strategy below; you do not need to re-parse tier
 markers in the shepherd loop.
 
-If you encounter a reviewer the adapters do not recognise, the
-`provider.unknown-tier` event surfaces it for follow-up. Treat the
-comment as MEDIUM in the meantime.
+If a *recognised* reviewer (e.g. CodeRabbit) ships a new severity tier
+that the adapter does not match, the `provider.unknown-tier` event
+surfaces the unrecognised tier marker for follow-up — the comment is
+processed as MEDIUM in the meantime. Unknown *reviewers* (authors that
+don't match any typed adapter) are routed silently to the `unknown`
+adapter and never trigger this event; their comments are also processed
+as MEDIUM by default.
 
 ### GitHub Actions Bot Comments
 

--- a/skills/copilot/shepherd/SKILL.md
+++ b/skills/copilot/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Read context from `actionItem.context`, compose response, post via GitHub MCP |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/copilot/shepherd/SKILL.md
+++ b/skills/copilot/shepherd/SKILL.md
@@ -149,7 +149,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic `add_pr_comment` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. `mcp__plugin_github_github__add_reply_to_pull_request_comment` for GitHub) until `VcsProvider` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/copilot/shepherd/SKILL.md
+++ b/skills/copilot/shepherd/SKILL.md
@@ -93,7 +93,26 @@ Review the returned `actionItems` and `recommendation`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult `references/fix-strategies.md` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call `classify_review_items` on
+the assessment's `actionItems` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+```
+
+The result returns `groups: ClassificationGroup[]` with a `recommendation`
+per group: `direct` (handle inline), `delegate-fixer` (spawn the fixer
+subagent for batched/HIGH-severity work), or `delegate-scaffolder`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult `references/fix-strategies.md` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 

--- a/skills/copilot/shepherd/SKILL.md
+++ b/skills/copilot/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/copilot/shepherd/references/fix-strategies.md
+++ b/skills/copilot/shepherd/references/fix-strategies.md
@@ -4,14 +4,16 @@ How to address common issues found during shepherd assessment.
 
 ## Decision: Fix Directly vs. Delegate
 
-| Condition | Approach |
-|-----------|----------|
-| Single file, < 20 lines changed | Fix directly in the stack branch |
-| Multiple files, contained concern | Fix directly if < 5 files |
-| Cross-cutting or architectural | Route to `/exarchos:delegate --fixes` for subagent dispatch |
-| Test changes needed | Fix directly (keep TDD cycle tight) |
+The `classify_review_items` orchestrate action owns this decision (#1159).
+Pass it the `actionItems` from `assess_stack` and consume the
+`recommendation` field on each returned group:
 
-**Default to fixing directly** — delegation adds overhead. Only delegate when the fix scope warrants it.
+- `direct` — handle inline in the shepherd loop
+- `delegate-fixer` — spawn the fixer subagent (batched / HIGH severity)
+- `delegate-scaffolder` — cheap scaffolder dispatch for doc nits
+
+Test changes still warrant inline handling regardless of recommendation —
+keep the TDD cycle tight rather than delegating test edits.
 
 ## Remediation Event Emission
 

--- a/skills/copilot/shepherd/references/fix-strategies.md
+++ b/skills/copilot/shepherd/references/fix-strategies.md
@@ -154,52 +154,19 @@ For each comment, determine the appropriate response:
 | Already fixed (outdated) | Reply confirming | "Fixed in [commit/PR description] — [brief explanation]." |
 | False positive | Reply explaining | "[Explanation of why this doesn't apply in this context]." |
 
-### Sentry Comments
+### Per-reviewer parsing (Sentry, CodeRabbit, Human, GitHub-Copilot)
 
-Sentry's `[bot]` leaves **bug predictions** — AI-generated analysis of potential runtime issues. These appear as inline review comments with severity tags (CRITICAL, MEDIUM, etc.).
+Severity normalization and per-reviewer comment parsing live in the
+provider adapters under `servers/exarchos-mcp/src/review/providers/` (#1159).
+`assess_stack` dispatches each PR comment through the adapter registry
+and attaches a normalized `ActionItem` (with `normalizedSeverity` and
+`reviewer` fields) to each unresolved comment. Use that signal when
+deciding response strategy below; you do not need to re-parse tier
+markers in the shepherd loop.
 
-**Sentry comments deserve careful attention because they often identify real bugs** (field name mismatches, type coercion issues, null reference risks).
-
-How to handle:
-1. Read the full comment body — Sentry includes a "Suggested Fix" section
-2. Evaluate whether the bug is real:
-   - Check if the code path is actually reachable
-   - Check if the field names/types match what the data actually provides
-   - Check existing tests — does any test exercise this path?
-3. If real: fix the bug, add a test, reply confirming
-4. If false positive: reply explaining why (e.g., "This path is guarded by X" or "The field is validated at Y before reaching this code")
-
-**Common Sentry findings:**
-- Field name mismatches between producers and consumers
-- Missing null checks on optional fields
-- Type mismatches (string vs. enum, array vs. object)
-- Unreachable error paths due to upstream validation
-
-### CodeRabbit Comments
-
-CodeRabbit leaves detailed code review suggestions with severity indicators. It re-reviews automatically on push, so code fixes may auto-resolve threads.
-
-How to handle:
-1. Read all CodeRabbit comments, noting severity (Critical, Major, Minor)
-2. Critical/Major: Must address — fix or provide strong rationale for not fixing
-3. Minor: Fix if low-effort, otherwise acknowledge
-4. CodeRabbit marks threads as "Addressed in commits" when it detects the code changed — but always verify with a reply
-
-**Common CodeRabbit findings:**
-- Error handling gaps (missing try/catch, bare catches)
-- Code duplication (DRY violations)
-- Style/naming suggestions
-- Performance optimizations
-- Security concerns
-
-### Human Reviewer Comments
-
-Human comments require the most careful handling:
-1. Read comments carefully — understand the full context
-2. For required changes: fix the code, reply confirming
-3. For questions: answer directly on the PR
-4. For suggestions: discuss or implement, reply with decision
-5. For approval with minor nits: fix nits, note the approval
+If you encounter a reviewer the adapters do not recognise, the
+`provider.unknown-tier` event surfaces it for follow-up. Treat the
+comment as MEDIUM in the meantime.
 
 ### GitHub Actions Bot Comments
 

--- a/skills/copilot/shepherd/references/fix-strategies.md
+++ b/skills/copilot/shepherd/references/fix-strategies.md
@@ -166,9 +166,13 @@ and attaches a normalized `ActionItem` (with `normalizedSeverity` and
 deciding response strategy below; you do not need to re-parse tier
 markers in the shepherd loop.
 
-If you encounter a reviewer the adapters do not recognise, the
-`provider.unknown-tier` event surfaces it for follow-up. Treat the
-comment as MEDIUM in the meantime.
+If a *recognised* reviewer (e.g. CodeRabbit) ships a new severity tier
+that the adapter does not match, the `provider.unknown-tier` event
+surfaces the unrecognised tier marker for follow-up — the comment is
+processed as MEDIUM in the meantime. Unknown *reviewers* (authors that
+don't match any typed adapter) are routed silently to the `unknown`
+adapter and never trigger this event; their comments are also processed
+as MEDIUM by default.
 
 ### GitHub Actions Bot Comments
 

--- a/skills/cursor/shepherd/SKILL.md
+++ b/skills/cursor/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Read context from `actionItem.context`, compose response, post via GitHub MCP |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/cursor/shepherd/SKILL.md
+++ b/skills/cursor/shepherd/SKILL.md
@@ -149,7 +149,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic `add_pr_comment` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. `mcp__plugin_github_github__add_reply_to_pull_request_comment` for GitHub) until `VcsProvider` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/cursor/shepherd/SKILL.md
+++ b/skills/cursor/shepherd/SKILL.md
@@ -93,7 +93,26 @@ Review the returned `actionItems` and `recommendation`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult `references/fix-strategies.md` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call `classify_review_items` on
+the assessment's `actionItems` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+```
+
+The result returns `groups: ClassificationGroup[]` with a `recommendation`
+per group: `direct` (handle inline), `delegate-fixer` (spawn the fixer
+subagent for batched/HIGH-severity work), or `delegate-scaffolder`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult `references/fix-strategies.md` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 

--- a/skills/cursor/shepherd/SKILL.md
+++ b/skills/cursor/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/cursor/shepherd/references/fix-strategies.md
+++ b/skills/cursor/shepherd/references/fix-strategies.md
@@ -4,14 +4,16 @@ How to address common issues found during shepherd assessment.
 
 ## Decision: Fix Directly vs. Delegate
 
-| Condition | Approach |
-|-----------|----------|
-| Single file, < 20 lines changed | Fix directly in the stack branch |
-| Multiple files, contained concern | Fix directly if < 5 files |
-| Cross-cutting or architectural | Route to `/exarchos:delegate --fixes` for subagent dispatch |
-| Test changes needed | Fix directly (keep TDD cycle tight) |
+The `classify_review_items` orchestrate action owns this decision (#1159).
+Pass it the `actionItems` from `assess_stack` and consume the
+`recommendation` field on each returned group:
 
-**Default to fixing directly** — delegation adds overhead. Only delegate when the fix scope warrants it.
+- `direct` — handle inline in the shepherd loop
+- `delegate-fixer` — spawn the fixer subagent (batched / HIGH severity)
+- `delegate-scaffolder` — cheap scaffolder dispatch for doc nits
+
+Test changes still warrant inline handling regardless of recommendation —
+keep the TDD cycle tight rather than delegating test edits.
 
 ## Remediation Event Emission
 

--- a/skills/cursor/shepherd/references/fix-strategies.md
+++ b/skills/cursor/shepherd/references/fix-strategies.md
@@ -154,52 +154,19 @@ For each comment, determine the appropriate response:
 | Already fixed (outdated) | Reply confirming | "Fixed in [commit/PR description] — [brief explanation]." |
 | False positive | Reply explaining | "[Explanation of why this doesn't apply in this context]." |
 
-### Sentry Comments
+### Per-reviewer parsing (Sentry, CodeRabbit, Human, GitHub-Copilot)
 
-Sentry's `[bot]` leaves **bug predictions** — AI-generated analysis of potential runtime issues. These appear as inline review comments with severity tags (CRITICAL, MEDIUM, etc.).
+Severity normalization and per-reviewer comment parsing live in the
+provider adapters under `servers/exarchos-mcp/src/review/providers/` (#1159).
+`assess_stack` dispatches each PR comment through the adapter registry
+and attaches a normalized `ActionItem` (with `normalizedSeverity` and
+`reviewer` fields) to each unresolved comment. Use that signal when
+deciding response strategy below; you do not need to re-parse tier
+markers in the shepherd loop.
 
-**Sentry comments deserve careful attention because they often identify real bugs** (field name mismatches, type coercion issues, null reference risks).
-
-How to handle:
-1. Read the full comment body — Sentry includes a "Suggested Fix" section
-2. Evaluate whether the bug is real:
-   - Check if the code path is actually reachable
-   - Check if the field names/types match what the data actually provides
-   - Check existing tests — does any test exercise this path?
-3. If real: fix the bug, add a test, reply confirming
-4. If false positive: reply explaining why (e.g., "This path is guarded by X" or "The field is validated at Y before reaching this code")
-
-**Common Sentry findings:**
-- Field name mismatches between producers and consumers
-- Missing null checks on optional fields
-- Type mismatches (string vs. enum, array vs. object)
-- Unreachable error paths due to upstream validation
-
-### CodeRabbit Comments
-
-CodeRabbit leaves detailed code review suggestions with severity indicators. It re-reviews automatically on push, so code fixes may auto-resolve threads.
-
-How to handle:
-1. Read all CodeRabbit comments, noting severity (Critical, Major, Minor)
-2. Critical/Major: Must address — fix or provide strong rationale for not fixing
-3. Minor: Fix if low-effort, otherwise acknowledge
-4. CodeRabbit marks threads as "Addressed in commits" when it detects the code changed — but always verify with a reply
-
-**Common CodeRabbit findings:**
-- Error handling gaps (missing try/catch, bare catches)
-- Code duplication (DRY violations)
-- Style/naming suggestions
-- Performance optimizations
-- Security concerns
-
-### Human Reviewer Comments
-
-Human comments require the most careful handling:
-1. Read comments carefully — understand the full context
-2. For required changes: fix the code, reply confirming
-3. For questions: answer directly on the PR
-4. For suggestions: discuss or implement, reply with decision
-5. For approval with minor nits: fix nits, note the approval
+If you encounter a reviewer the adapters do not recognise, the
+`provider.unknown-tier` event surfaces it for follow-up. Treat the
+comment as MEDIUM in the meantime.
 
 ### GitHub Actions Bot Comments
 

--- a/skills/cursor/shepherd/references/fix-strategies.md
+++ b/skills/cursor/shepherd/references/fix-strategies.md
@@ -166,9 +166,13 @@ and attaches a normalized `ActionItem` (with `normalizedSeverity` and
 deciding response strategy below; you do not need to re-parse tier
 markers in the shepherd loop.
 
-If you encounter a reviewer the adapters do not recognise, the
-`provider.unknown-tier` event surfaces it for follow-up. Treat the
-comment as MEDIUM in the meantime.
+If a *recognised* reviewer (e.g. CodeRabbit) ships a new severity tier
+that the adapter does not match, the `provider.unknown-tier` event
+surfaces the unrecognised tier marker for follow-up — the comment is
+processed as MEDIUM in the meantime. Unknown *reviewers* (authors that
+don't match any typed adapter) are routed silently to the `unknown`
+adapter and never trigger this event; their comments are also processed
+as MEDIUM by default.
 
 ### GitHub Actions Bot Comments
 

--- a/skills/generic/shepherd/SKILL.md
+++ b/skills/generic/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Read context from `actionItem.context`, compose response, post via GitHub MCP |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/generic/shepherd/SKILL.md
+++ b/skills/generic/shepherd/SKILL.md
@@ -149,7 +149,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic `add_pr_comment` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. `mcp__plugin_github_github__add_reply_to_pull_request_comment` for GitHub) until `VcsProvider` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/generic/shepherd/SKILL.md
+++ b/skills/generic/shepherd/SKILL.md
@@ -93,7 +93,26 @@ Review the returned `actionItems` and `recommendation`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult `references/fix-strategies.md` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call `classify_review_items` on
+the assessment's `actionItems` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+```
+
+The result returns `groups: ClassificationGroup[]` with a `recommendation`
+per group: `direct` (handle inline), `delegate-fixer` (spawn the fixer
+subagent for batched/HIGH-severity work), or `delegate-scaffolder`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult `references/fix-strategies.md` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 

--- a/skills/generic/shepherd/SKILL.md
+++ b/skills/generic/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/generic/shepherd/references/fix-strategies.md
+++ b/skills/generic/shepherd/references/fix-strategies.md
@@ -4,14 +4,16 @@ How to address common issues found during shepherd assessment.
 
 ## Decision: Fix Directly vs. Delegate
 
-| Condition | Approach |
-|-----------|----------|
-| Single file, < 20 lines changed | Fix directly in the stack branch |
-| Multiple files, contained concern | Fix directly if < 5 files |
-| Cross-cutting or architectural | Route to `/exarchos:delegate --fixes` for subagent dispatch |
-| Test changes needed | Fix directly (keep TDD cycle tight) |
+The `classify_review_items` orchestrate action owns this decision (#1159).
+Pass it the `actionItems` from `assess_stack` and consume the
+`recommendation` field on each returned group:
 
-**Default to fixing directly** — delegation adds overhead. Only delegate when the fix scope warrants it.
+- `direct` — handle inline in the shepherd loop
+- `delegate-fixer` — spawn the fixer subagent (batched / HIGH severity)
+- `delegate-scaffolder` — cheap scaffolder dispatch for doc nits
+
+Test changes still warrant inline handling regardless of recommendation —
+keep the TDD cycle tight rather than delegating test edits.
 
 ## Remediation Event Emission
 

--- a/skills/generic/shepherd/references/fix-strategies.md
+++ b/skills/generic/shepherd/references/fix-strategies.md
@@ -154,52 +154,19 @@ For each comment, determine the appropriate response:
 | Already fixed (outdated) | Reply confirming | "Fixed in [commit/PR description] — [brief explanation]." |
 | False positive | Reply explaining | "[Explanation of why this doesn't apply in this context]." |
 
-### Sentry Comments
+### Per-reviewer parsing (Sentry, CodeRabbit, Human, GitHub-Copilot)
 
-Sentry's `[bot]` leaves **bug predictions** — AI-generated analysis of potential runtime issues. These appear as inline review comments with severity tags (CRITICAL, MEDIUM, etc.).
+Severity normalization and per-reviewer comment parsing live in the
+provider adapters under `servers/exarchos-mcp/src/review/providers/` (#1159).
+`assess_stack` dispatches each PR comment through the adapter registry
+and attaches a normalized `ActionItem` (with `normalizedSeverity` and
+`reviewer` fields) to each unresolved comment. Use that signal when
+deciding response strategy below; you do not need to re-parse tier
+markers in the shepherd loop.
 
-**Sentry comments deserve careful attention because they often identify real bugs** (field name mismatches, type coercion issues, null reference risks).
-
-How to handle:
-1. Read the full comment body — Sentry includes a "Suggested Fix" section
-2. Evaluate whether the bug is real:
-   - Check if the code path is actually reachable
-   - Check if the field names/types match what the data actually provides
-   - Check existing tests — does any test exercise this path?
-3. If real: fix the bug, add a test, reply confirming
-4. If false positive: reply explaining why (e.g., "This path is guarded by X" or "The field is validated at Y before reaching this code")
-
-**Common Sentry findings:**
-- Field name mismatches between producers and consumers
-- Missing null checks on optional fields
-- Type mismatches (string vs. enum, array vs. object)
-- Unreachable error paths due to upstream validation
-
-### CodeRabbit Comments
-
-CodeRabbit leaves detailed code review suggestions with severity indicators. It re-reviews automatically on push, so code fixes may auto-resolve threads.
-
-How to handle:
-1. Read all CodeRabbit comments, noting severity (Critical, Major, Minor)
-2. Critical/Major: Must address — fix or provide strong rationale for not fixing
-3. Minor: Fix if low-effort, otherwise acknowledge
-4. CodeRabbit marks threads as "Addressed in commits" when it detects the code changed — but always verify with a reply
-
-**Common CodeRabbit findings:**
-- Error handling gaps (missing try/catch, bare catches)
-- Code duplication (DRY violations)
-- Style/naming suggestions
-- Performance optimizations
-- Security concerns
-
-### Human Reviewer Comments
-
-Human comments require the most careful handling:
-1. Read comments carefully — understand the full context
-2. For required changes: fix the code, reply confirming
-3. For questions: answer directly on the PR
-4. For suggestions: discuss or implement, reply with decision
-5. For approval with minor nits: fix nits, note the approval
+If you encounter a reviewer the adapters do not recognise, the
+`provider.unknown-tier` event surfaces it for follow-up. Treat the
+comment as MEDIUM in the meantime.
 
 ### GitHub Actions Bot Comments
 

--- a/skills/generic/shepherd/references/fix-strategies.md
+++ b/skills/generic/shepherd/references/fix-strategies.md
@@ -166,9 +166,13 @@ and attaches a normalized `ActionItem` (with `normalizedSeverity` and
 deciding response strategy below; you do not need to re-parse tier
 markers in the shepherd loop.
 
-If you encounter a reviewer the adapters do not recognise, the
-`provider.unknown-tier` event surfaces it for follow-up. Treat the
-comment as MEDIUM in the meantime.
+If a *recognised* reviewer (e.g. CodeRabbit) ships a new severity tier
+that the adapter does not match, the `provider.unknown-tier` event
+surfaces the unrecognised tier marker for follow-up — the comment is
+processed as MEDIUM in the meantime. Unknown *reviewers* (authors that
+don't match any typed adapter) are routed silently to the `unknown`
+adapter and never trigger this event; their comments are also processed
+as MEDIUM by default.
 
 ### GitHub Actions Bot Comments
 

--- a/skills/opencode/shepherd/SKILL.md
+++ b/skills/opencode/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Read context from `actionItem.context`, compose response, post via GitHub MCP |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/opencode/shepherd/SKILL.md
+++ b/skills/opencode/shepherd/SKILL.md
@@ -149,7 +149,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic `add_pr_comment` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. `mcp__plugin_github_github__add_reply_to_pull_request_comment` for GitHub) until `VcsProvider` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/opencode/shepherd/SKILL.md
+++ b/skills/opencode/shepherd/SKILL.md
@@ -93,7 +93,26 @@ Review the returned `actionItems` and `recommendation`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult `references/fix-strategies.md` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call `classify_review_items` on
+the assessment's `actionItems` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+```typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+```
+
+The result returns `groups: ClassificationGroup[]` with a `recommendation`
+per group: `direct` (handle inline), `delegate-fixer` (spawn the fixer
+subagent for batched/HIGH-severity work), or `delegate-scaffolder`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult `references/fix-strategies.md` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 

--- a/skills/opencode/shepherd/SKILL.md
+++ b/skills/opencode/shepherd/SKILL.md
@@ -130,7 +130,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via GitHub MCP. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate these fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/skills/opencode/shepherd/references/fix-strategies.md
+++ b/skills/opencode/shepherd/references/fix-strategies.md
@@ -4,14 +4,16 @@ How to address common issues found during shepherd assessment.
 
 ## Decision: Fix Directly vs. Delegate
 
-| Condition | Approach |
-|-----------|----------|
-| Single file, < 20 lines changed | Fix directly in the stack branch |
-| Multiple files, contained concern | Fix directly if < 5 files |
-| Cross-cutting or architectural | Route to `/exarchos:delegate --fixes` for subagent dispatch |
-| Test changes needed | Fix directly (keep TDD cycle tight) |
+The `classify_review_items` orchestrate action owns this decision (#1159).
+Pass it the `actionItems` from `assess_stack` and consume the
+`recommendation` field on each returned group:
 
-**Default to fixing directly** — delegation adds overhead. Only delegate when the fix scope warrants it.
+- `direct` — handle inline in the shepherd loop
+- `delegate-fixer` — spawn the fixer subagent (batched / HIGH severity)
+- `delegate-scaffolder` — cheap scaffolder dispatch for doc nits
+
+Test changes still warrant inline handling regardless of recommendation —
+keep the TDD cycle tight rather than delegating test edits.
 
 ## Remediation Event Emission
 

--- a/skills/opencode/shepherd/references/fix-strategies.md
+++ b/skills/opencode/shepherd/references/fix-strategies.md
@@ -154,52 +154,19 @@ For each comment, determine the appropriate response:
 | Already fixed (outdated) | Reply confirming | "Fixed in [commit/PR description] — [brief explanation]." |
 | False positive | Reply explaining | "[Explanation of why this doesn't apply in this context]." |
 
-### Sentry Comments
+### Per-reviewer parsing (Sentry, CodeRabbit, Human, GitHub-Copilot)
 
-Sentry's `[bot]` leaves **bug predictions** — AI-generated analysis of potential runtime issues. These appear as inline review comments with severity tags (CRITICAL, MEDIUM, etc.).
+Severity normalization and per-reviewer comment parsing live in the
+provider adapters under `servers/exarchos-mcp/src/review/providers/` (#1159).
+`assess_stack` dispatches each PR comment through the adapter registry
+and attaches a normalized `ActionItem` (with `normalizedSeverity` and
+`reviewer` fields) to each unresolved comment. Use that signal when
+deciding response strategy below; you do not need to re-parse tier
+markers in the shepherd loop.
 
-**Sentry comments deserve careful attention because they often identify real bugs** (field name mismatches, type coercion issues, null reference risks).
-
-How to handle:
-1. Read the full comment body — Sentry includes a "Suggested Fix" section
-2. Evaluate whether the bug is real:
-   - Check if the code path is actually reachable
-   - Check if the field names/types match what the data actually provides
-   - Check existing tests — does any test exercise this path?
-3. If real: fix the bug, add a test, reply confirming
-4. If false positive: reply explaining why (e.g., "This path is guarded by X" or "The field is validated at Y before reaching this code")
-
-**Common Sentry findings:**
-- Field name mismatches between producers and consumers
-- Missing null checks on optional fields
-- Type mismatches (string vs. enum, array vs. object)
-- Unreachable error paths due to upstream validation
-
-### CodeRabbit Comments
-
-CodeRabbit leaves detailed code review suggestions with severity indicators. It re-reviews automatically on push, so code fixes may auto-resolve threads.
-
-How to handle:
-1. Read all CodeRabbit comments, noting severity (Critical, Major, Minor)
-2. Critical/Major: Must address — fix or provide strong rationale for not fixing
-3. Minor: Fix if low-effort, otherwise acknowledge
-4. CodeRabbit marks threads as "Addressed in commits" when it detects the code changed — but always verify with a reply
-
-**Common CodeRabbit findings:**
-- Error handling gaps (missing try/catch, bare catches)
-- Code duplication (DRY violations)
-- Style/naming suggestions
-- Performance optimizations
-- Security concerns
-
-### Human Reviewer Comments
-
-Human comments require the most careful handling:
-1. Read comments carefully — understand the full context
-2. For required changes: fix the code, reply confirming
-3. For questions: answer directly on the PR
-4. For suggestions: discuss or implement, reply with decision
-5. For approval with minor nits: fix nits, note the approval
+If you encounter a reviewer the adapters do not recognise, the
+`provider.unknown-tier` event surfaces it for follow-up. Treat the
+comment as MEDIUM in the meantime.
 
 ### GitHub Actions Bot Comments
 

--- a/skills/opencode/shepherd/references/fix-strategies.md
+++ b/skills/opencode/shepherd/references/fix-strategies.md
@@ -166,9 +166,13 @@ and attaches a normalized `ActionItem` (with `normalizedSeverity` and
 deciding response strategy below; you do not need to re-parse tier
 markers in the shepherd loop.
 
-If you encounter a reviewer the adapters do not recognise, the
-`provider.unknown-tier` event surfaces it for follow-up. Treat the
-comment as MEDIUM in the meantime.
+If a *recognised* reviewer (e.g. CodeRabbit) ships a new severity tier
+that the adapter does not match, the `provider.unknown-tier` event
+surfaces the unrecognised tier marker for follow-up — the comment is
+processed as MEDIUM in the meantime. Unknown *reviewers* (authors that
+don't match any typed adapter) are routed silently to the `unknown`
+adapter and never trigger this event; their comments are also processed
+as MEDIUM by default.
 
 ### GitHub Actions Bot Comments
 

--- a/test/migration/__fixtures__/batch-baselines/shepherd.md
+++ b/test/migration/__fixtures__/batch-baselines/shepherd.md
@@ -149,7 +149,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response. Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic `add_pr_comment` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. `mcp__plugin_github_github__add_reply_to_pull_request_comment` for GitHub) until `VcsProvider` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/test/migration/__fixtures__/batch-baselines/shepherd.md
+++ b/test/migration/__fixtures__/batch-baselines/shepherd.md
@@ -93,7 +93,26 @@ Review the returned `actionItems` and `recommendation`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult `references/fix-strategies.md` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call `classify_review_items` on
+the assessment's `actionItems` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+```typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+```
+
+The result returns `groups: ClassificationGroup[]` with a `recommendation`
+per group: `direct` (handle inline), `delegate-fixer` (spawn the fixer
+subagent for batched/HIGH-severity work), or `delegate-scaffolder`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult `references/fix-strategies.md` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 
@@ -130,7 +149,7 @@ These events feed `selfCorrectionRate` and `avgRemediationAttempts` metrics in C
 | Type | Strategy |
 |------|----------|
 | `ci-fix` | Read logs, reproduce locally, fix, commit to stack branch |
-| `comment-reply` | Read context from `actionItem.context`, compose response, post via GitHub MCP |
+| `comment-reply` | Use `actionItem.reviewer`, `normalizedSeverity`, `file`, `line`, and `raw` (full original comment) to compose a response; post via the `add_pr_comment` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under `servers/exarchos-mcp/src/review/providers/` populate the input fields per #1159 — no manual tier parsing needed. |
 | `review-address` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | `restack` | Run `git rebase origin/<base>`, verify with `exarchos_orchestrate({ action: "list_prs" })` |
 | `escalate` | Consult `references/escalation-criteria.md` |

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -3317,7 +3317,7 @@ These events feed \`selfCorrectionRate\` and \`avgRemediationAttempts\` metrics 
 | Type | Strategy |
 |------|----------|
 | \`ci-fix\` | Read logs, reproduce locally, fix, commit to stack branch |
-| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response; post via the \`add_pr_comment\` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. |
+| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response. Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic \`add_pr_comment\` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. \`mcp__plugin_github_github__add_reply_to_pull_request_comment\` for GitHub) until \`VcsProvider\` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | \`review-address\` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | \`restack\` | Run \`git rebase origin/<base>\`, verify with \`exarchos_orchestrate({ action: "list_prs" })\` |
 | \`escalate\` | Consult \`references/escalation-criteria.md\` |
@@ -7557,7 +7557,7 @@ These events feed \`selfCorrectionRate\` and \`avgRemediationAttempts\` metrics 
 | Type | Strategy |
 |------|----------|
 | \`ci-fix\` | Read logs, reproduce locally, fix, commit to stack branch |
-| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response; post via the \`add_pr_comment\` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. |
+| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response. Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic \`add_pr_comment\` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. \`mcp__plugin_github_github__add_reply_to_pull_request_comment\` for GitHub) until \`VcsProvider\` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | \`review-address\` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | \`restack\` | Run \`git rebase origin/<base>\`, verify with \`exarchos_orchestrate({ action: "list_prs" })\` |
 | \`escalate\` | Consult \`references/escalation-criteria.md\` |
@@ -11789,7 +11789,7 @@ These events feed \`selfCorrectionRate\` and \`avgRemediationAttempts\` metrics 
 | Type | Strategy |
 |------|----------|
 | \`ci-fix\` | Read logs, reproduce locally, fix, commit to stack branch |
-| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response; post via the \`add_pr_comment\` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. |
+| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response. Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic \`add_pr_comment\` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. \`mcp__plugin_github_github__add_reply_to_pull_request_comment\` for GitHub) until \`VcsProvider\` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | \`review-address\` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | \`restack\` | Run \`git rebase origin/<base>\`, verify with \`exarchos_orchestrate({ action: "list_prs" })\` |
 | \`escalate\` | Consult \`references/escalation-criteria.md\` |
@@ -16027,7 +16027,7 @@ These events feed \`selfCorrectionRate\` and \`avgRemediationAttempts\` metrics 
 | Type | Strategy |
 |------|----------|
 | \`ci-fix\` | Read logs, reproduce locally, fix, commit to stack branch |
-| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response; post via the \`add_pr_comment\` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. |
+| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response. Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic \`add_pr_comment\` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. \`mcp__plugin_github_github__add_reply_to_pull_request_comment\` for GitHub) until \`VcsProvider\` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | \`review-address\` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | \`restack\` | Run \`git rebase origin/<base>\`, verify with \`exarchos_orchestrate({ action: "list_prs" })\` |
 | \`escalate\` | Consult \`references/escalation-criteria.md\` |
@@ -20259,7 +20259,7 @@ These events feed \`selfCorrectionRate\` and \`avgRemediationAttempts\` metrics 
 | Type | Strategy |
 |------|----------|
 | \`ci-fix\` | Read logs, reproduce locally, fix, commit to stack branch |
-| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response; post via the \`add_pr_comment\` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. |
+| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response. Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic \`add_pr_comment\` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. \`mcp__plugin_github_github__add_reply_to_pull_request_comment\` for GitHub) until \`VcsProvider\` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | \`review-address\` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | \`restack\` | Run \`git rebase origin/<base>\`, verify with \`exarchos_orchestrate({ action: "list_prs" })\` |
 | \`escalate\` | Consult \`references/escalation-criteria.md\` |
@@ -24499,7 +24499,7 @@ These events feed \`selfCorrectionRate\` and \`avgRemediationAttempts\` metrics 
 | Type | Strategy |
 |------|----------|
 | \`ci-fix\` | Read logs, reproduce locally, fix, commit to stack branch |
-| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response; post via the \`add_pr_comment\` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. |
+| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response. Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. **Posting:** PR-level summary comments use the provider-agnostic \`add_pr_comment\` orchestrate action; per-thread inline replies currently require the platform-specific MCP (e.g. \`mcp__plugin_github_github__add_reply_to_pull_request_comment\` for GitHub) until \`VcsProvider\` gains a thread-reply primitive — see [#1165](https://github.com/lvlup-sw/exarchos/issues/1165) for tracking. |
 | \`review-address\` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | \`restack\` | Run \`git rebase origin/<base>\`, verify with \`exarchos_orchestrate({ action: "list_prs" })\` |
 | \`escalate\` | Consult \`references/escalation-criteria.md\` |

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -3261,7 +3261,26 @@ Review the returned \`actionItems\` and \`recommendation\`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult \`references/fix-strategies.md\` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call \`classify_review_items\` on
+the assessment's \`actionItems\` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+\`\`\`typescript
+mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+\`\`\`
+
+The result returns \`groups: ClassificationGroup[]\` with a \`recommendation\`
+per group: \`direct\` (handle inline), \`delegate-fixer\` (spawn the fixer
+subagent for batched/HIGH-severity work), or \`delegate-scaffolder\`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult \`references/fix-strategies.md\` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 
@@ -3298,7 +3317,7 @@ These events feed \`selfCorrectionRate\` and \`avgRemediationAttempts\` metrics 
 | Type | Strategy |
 |------|----------|
 | \`ci-fix\` | Read logs, reproduce locally, fix, commit to stack branch |
-| \`comment-reply\` | Read context from \`actionItem.context\`, compose response, post via GitHub MCP |
+| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response; post via the \`add_pr_comment\` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. |
 | \`review-address\` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | \`restack\` | Run \`git rebase origin/<base>\`, verify with \`exarchos_orchestrate({ action: "list_prs" })\` |
 | \`escalate\` | Consult \`references/escalation-criteria.md\` |
@@ -7482,7 +7501,26 @@ Review the returned \`actionItems\` and \`recommendation\`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult \`references/fix-strategies.md\` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call \`classify_review_items\` on
+the assessment's \`actionItems\` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+\`\`\`
+
+The result returns \`groups: ClassificationGroup[]\` with a \`recommendation\`
+per group: \`direct\` (handle inline), \`delegate-fixer\` (spawn the fixer
+subagent for batched/HIGH-severity work), or \`delegate-scaffolder\`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult \`references/fix-strategies.md\` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 
@@ -7519,7 +7557,7 @@ These events feed \`selfCorrectionRate\` and \`avgRemediationAttempts\` metrics 
 | Type | Strategy |
 |------|----------|
 | \`ci-fix\` | Read logs, reproduce locally, fix, commit to stack branch |
-| \`comment-reply\` | Read context from \`actionItem.context\`, compose response, post via GitHub MCP |
+| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response; post via the \`add_pr_comment\` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. |
 | \`review-address\` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | \`restack\` | Run \`git rebase origin/<base>\`, verify with \`exarchos_orchestrate({ action: "list_prs" })\` |
 | \`escalate\` | Consult \`references/escalation-criteria.md\` |
@@ -11695,7 +11733,26 @@ Review the returned \`actionItems\` and \`recommendation\`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult \`references/fix-strategies.md\` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call \`classify_review_items\` on
+the assessment's \`actionItems\` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+\`\`\`
+
+The result returns \`groups: ClassificationGroup[]\` with a \`recommendation\`
+per group: \`direct\` (handle inline), \`delegate-fixer\` (spawn the fixer
+subagent for batched/HIGH-severity work), or \`delegate-scaffolder\`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult \`references/fix-strategies.md\` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 
@@ -11732,7 +11789,7 @@ These events feed \`selfCorrectionRate\` and \`avgRemediationAttempts\` metrics 
 | Type | Strategy |
 |------|----------|
 | \`ci-fix\` | Read logs, reproduce locally, fix, commit to stack branch |
-| \`comment-reply\` | Read context from \`actionItem.context\`, compose response, post via GitHub MCP |
+| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response; post via the \`add_pr_comment\` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. |
 | \`review-address\` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | \`restack\` | Run \`git rebase origin/<base>\`, verify with \`exarchos_orchestrate({ action: "list_prs" })\` |
 | \`escalate\` | Consult \`references/escalation-criteria.md\` |
@@ -15914,7 +15971,26 @@ Review the returned \`actionItems\` and \`recommendation\`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult \`references/fix-strategies.md\` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call \`classify_review_items\` on
+the assessment's \`actionItems\` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+\`\`\`
+
+The result returns \`groups: ClassificationGroup[]\` with a \`recommendation\`
+per group: \`direct\` (handle inline), \`delegate-fixer\` (spawn the fixer
+subagent for batched/HIGH-severity work), or \`delegate-scaffolder\`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult \`references/fix-strategies.md\` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 
@@ -15951,7 +16027,7 @@ These events feed \`selfCorrectionRate\` and \`avgRemediationAttempts\` metrics 
 | Type | Strategy |
 |------|----------|
 | \`ci-fix\` | Read logs, reproduce locally, fix, commit to stack branch |
-| \`comment-reply\` | Read context from \`actionItem.context\`, compose response, post via GitHub MCP |
+| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response; post via the \`add_pr_comment\` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. |
 | \`review-address\` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | \`restack\` | Run \`git rebase origin/<base>\`, verify with \`exarchos_orchestrate({ action: "list_prs" })\` |
 | \`escalate\` | Consult \`references/escalation-criteria.md\` |
@@ -20127,7 +20203,26 @@ Review the returned \`actionItems\` and \`recommendation\`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult \`references/fix-strategies.md\` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call \`classify_review_items\` on
+the assessment's \`actionItems\` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+\`\`\`
+
+The result returns \`groups: ClassificationGroup[]\` with a \`recommendation\`
+per group: \`direct\` (handle inline), \`delegate-fixer\` (spawn the fixer
+subagent for batched/HIGH-severity work), or \`delegate-scaffolder\`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult \`references/fix-strategies.md\` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 
@@ -20164,7 +20259,7 @@ These events feed \`selfCorrectionRate\` and \`avgRemediationAttempts\` metrics 
 | Type | Strategy |
 |------|----------|
 | \`ci-fix\` | Read logs, reproduce locally, fix, commit to stack branch |
-| \`comment-reply\` | Read context from \`actionItem.context\`, compose response, post via GitHub MCP |
+| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response; post via the \`add_pr_comment\` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. |
 | \`review-address\` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | \`restack\` | Run \`git rebase origin/<base>\`, verify with \`exarchos_orchestrate({ action: "list_prs" })\` |
 | \`escalate\` | Consult \`references/escalation-criteria.md\` |
@@ -24348,7 +24443,26 @@ Review the returned \`actionItems\` and \`recommendation\`:
 
 ### Step 2 — Fix
 
-Address each blocking action item from the assessment. Consult \`references/fix-strategies.md\` for detailed strategies per issue type.
+Before iterating over individual action items, classify them so the loop
+knows which to fix inline vs. delegate. Call \`classify_review_items\` on
+the assessment's \`actionItems\` (the comment-reply subset is what the
+classifier groups by file; CI-fix and review-address items are passed
+through unchanged):
+
+\`\`\`typescript
+mcp__exarchos__exarchos_orchestrate({
+  action: "classify_review_items",
+  featureId: "<id>",
+  actionItems: <actionItems from assess_stack>
+})
+\`\`\`
+
+The result returns \`groups: ClassificationGroup[]\` with a \`recommendation\`
+per group: \`direct\` (handle inline), \`delegate-fixer\` (spawn the fixer
+subagent for batched/HIGH-severity work), or \`delegate-scaffolder\`
+(cheap subagent for doc nits). Iterate the groups in order, applying
+per-group strategy, then consult \`references/fix-strategies.md\` for
+detailed per-issue-type instructions.
 
 **Remediation event protocol (FLYWHEEL):**
 
@@ -24385,7 +24499,7 @@ These events feed \`selfCorrectionRate\` and \`avgRemediationAttempts\` metrics 
 | Type | Strategy |
 |------|----------|
 | \`ci-fix\` | Read logs, reproduce locally, fix, commit to stack branch |
-| \`comment-reply\` | Read context from \`actionItem.context\`, compose response, post via GitHub MCP |
+| \`comment-reply\` | Use \`actionItem.reviewer\`, \`normalizedSeverity\`, \`file\`, \`line\`, and \`raw\` (full original comment) to compose a response; post via the \`add_pr_comment\` orchestrate action (provider-agnostic — VcsProvider routes to GitHub, GitLab, or Azure DevOps). Provider adapters under \`servers/exarchos-mcp/src/review/providers/\` populate the input fields per #1159 — no manual tier parsing needed. |
 | \`review-address\` | Fix code for CHANGES_REQUESTED, reply to each thread |
 | \`restack\` | Run \`git rebase origin/<base>\`, verify with \`exarchos_orchestrate({ action: "list_prs" })\` |
 | \`escalate\` | Consult \`references/escalation-criteria.md\` |


### PR DESCRIPTION
## Summary

Closes #1159. Promotes the prose direct-vs-delegate heuristic for fixer-subagent dispatch into a structured, platform-agnostic pipeline. Each PR-comment provider (CodeRabbit, Sentry, GitHub-Copilot, human, unknown) gets a normalized adapter under `servers/exarchos-mcp/src/review/providers/`; `assess_stack` routes comments through a single registry; a new `classify_review_items` orchestrate action groups the resulting `ActionItem`s by file and recommends per-group dispatch (`direct` / `delegate-fixer` / `delegate-scaffolder`). Severity is normalized to `HIGH`/`MEDIUM`/`LOW` regardless of source.

## Changes

- **5 provider adapters** under `servers/exarchos-mcp/src/review/providers/` with per-tier severity normalization. CodeRabbit and Sentry parse upstream tier markers; unknown markers surface a `provider.unknown-tier` event with the raw marker.
- **`createReviewAdapterRegistry`** — frozen single-source-of-truth, constructor-injected into `assess_stack`.
- **`classify_review_items`** orchestrate action — file-grouping + severity-aware routing; emits `dispatch.classified` events with deterministic idempotency keys.
- **`ActionItem`** extended with `file`, `line`, `reviewer`, `threadId`, `raw`, `normalizedSeverity` (required), `unknownTier`, `rawTier`. `assess_stack` retains full comment bodies via a new `fullBody` field so adapters can parse without truncation.
- **Shepherd skill update** — Step 2 now opens with `classify_review_items`; per-reviewer prose in `fix-strategies.md` replaced with adapter pointers; `add_pr_comment` orchestrate action used instead of GitHub-MCP-specific calls.
- **Two new event types** registered: `provider.unknown-tier`, `dispatch.classified`.
- **Adapter `parse()` defensive try/catch** so a single bad comment can't kill an entire PR's batch.

Incidental commits: `2c7c8bad` (e2e-testing-strategy research doc) and `8158596b` (azd-aspire-integration research doc) landed on this branch from parallel workflows. Doc-only, no code overlap with #1159.

## Test Plan

- [x] 5617/5617 repo tests pass (12 new tests for the review fixes alone)
- [x] `npx tsc --noEmit` clean from `servers/exarchos-mcp/`
- [x] `npm run skills:guard` passes (skills regenerated for shepherd updates)
- [x] Spec-review (subagent): PASS — all 25 plan tasks landed
- [x] Quality-review (axiom 8-dimension audit): NEEDS_FIXES → APPROVED after addressing 1 HIGH + 1 MEDIUM + 2 SHOULDs
- [x] End-to-end smoke test: CodeRabbit Critical + Sentry Medium + human nit → 3 groups with correct recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)