### PR TITLE
fix(mcp): v2.9.0-rc.1 orchestrate/views/tasks cluster (#1187, #1188, #1189, #1190)

### DIFF
--- a/docs/rca/2026-04-27-v29-rc1-orchestrate-cluster.md
+++ b/docs/rca/2026-04-27-v29-rc1-orchestrate-cluster.md
@@ -1,0 +1,228 @@
+# RCA: v2.9.0-rc.1 Orchestrate/Views/Tasks Cluster (#1187, #1188, #1189, #1190)
+
+**Date:** 2026-04-27
+**Anchor issue:** #1188 (parent-tool default-key leak — the cascade trigger)
+**Cluster:** #1187, #1189, #1190
+**Workflow:** `debug-v29-rc1-orchestrate-cluster`
+**Reproduction context:** `refactor-projection-state-patched-fold` workflow, 2026-04-26 (same session that produced PR #1185)
+
+## Summary
+
+Four bugs filed against v2.9.0-rc.1 share a common dimension: **schema/contract integrity at the boundary** (DIM-3 in axiom backend-quality taxonomy). Each defect is a different surface of the same underlying issue — payload shapes drift between producer and consumer, and the existing safety nets (Zod `.strict()`, runtime preconditions, projection event types) reject or silently drop the misshapen data without telling the caller what shape was expected.
+
+| # | Surface | Producer | Consumer | What drifts |
+|---|---------|----------|----------|-------------|
+| #1187 | View output | `discoverStreams()` | `handleViewPipeline` | Stream-id taxonomy: feature vs infra |
+| #1188 | Per-action validation | MCP SDK auto-defaults | `dispatch()` per-action `safeParse` | Sibling-action keys leak across discriminated union |
+| #1189 | Gate consultation | Manually-emitted `gate.executed` | `hasPassingGate` | `data.taskId` shape: top-level vs `data.details.taskId` |
+| #1190 | Skill instruction | `prepare_delegation` precondition check | Operator (skill reader) | `task.assigned` event is required but undocumented |
+
+These are post-PR-1185 follow-ups. The event-store and projection cluster (#1179, #1180, #1182, #1184) hardened the *event* contract; this cluster hardens the *dispatch and view* contracts.
+
+## Defect 1: Pipeline View Phantom Rows (#1187)
+
+### Symptom
+
+`exarchos view ls` (CLI) and `exarchos_view pipeline` (MCP) return rows where `featureId`, `workflowType`, and `phase` are empty strings, even when `workflow_state` is empty. The phantoms come from infrastructure event streams (`exarchos-init`, `exarchos-doctor`, `telemetry`).
+
+### Root Cause
+
+`servers/exarchos-mcp/src/views/tools.ts:399-443` (`handleViewPipeline`) materializes every stream returned by `discoverStreams()`. The `PIPELINE_VIEW` projection's initial state has empty strings for `featureId`/`workflowType`/`phase`. Infrastructure streams never emit `workflow.started`, so their materialized state remains in the initial-empty shape — but the loop at line 412 pushes them onto `allWorkflows` regardless.
+
+Three stream IDs are reserved for non-feature use across three modules:
+
+- `INIT_STREAM_ID = 'exarchos-init'` — `orchestrate/init/index.ts:42`
+- `DOCTOR_STREAM_ID = 'exarchos-doctor'` — `orchestrate/doctor/index.ts:116`
+- `TELEMETRY_STREAM = 'telemetry'` — `telemetry/constants.ts:1`
+
+No shared module enumerates them. The view layer has no way to distinguish "feature stream" from "infra stream" without hard-coding the names.
+
+### Fix
+
+Introduce `servers/exarchos-mcp/src/core/infra-streams.ts` re-exporting the three constants as a `INFRA_STREAM_IDS: ReadonlySet<string>` and a `isFeatureStream(streamId): boolean` predicate. Filter `discoverStreams()` output through `isFeatureStream` in `handleViewPipeline` before materialization.
+
+This is the **Specification pattern** (predicate as a first-class value) plus **DRY** (single source of truth — the existing per-module constants are imported, not duplicated).
+
+## Defect 2: Orchestrate Parent-Tool Default-Key Leak (#1188)
+
+### Symptom
+
+Every call to `exarchos_orchestrate({ action: "check_tdd_compliance", ... })` rejects with:
+
+```
+INVALID_INPUT: (root): Unrecognized key(s) in object: 'nativeIsolation', 'outputFormat'
+```
+
+The keys are not in the caller's payload. They are defaults from sibling action schemas (`nativeIsolation` from `prepare_delegation`, `outputFormat` from `agent_spec`).
+
+Cascade impact: `task_complete` requires `tdd-compliance` to have passed. Because `check_tdd_compliance` is unreachable, every `task_complete` call in the delegate phase returns `GATE_NOT_PASSED`.
+
+### Root Cause
+
+`servers/exarchos-mcp/src/registry.ts:134-173` (`buildRegistrationSchema`) flattens every per-action schema into one parent `z.object().strict()` discriminated by `action`. At line 167:
+
+```typescript
+shape[key] = field.isOptional() ? field : field.optional();
+```
+
+Fields keep their `.default()` wrappers from the originating per-action schema. When the MCP SDK validates the caller's payload against this parent schema, Zod applies the defaults: every payload, regardless of action, gets `nativeIsolation: false` and `outputFormat: 'full'` injected.
+
+`servers/exarchos-mcp/src/core/dispatch.ts:311-319` then re-validates against the matching action's per-action schema:
+
+```typescript
+const { action: _action, ...rest } = args;
+const parsed = matchingAction.schema.safeParse(rest);
+```
+
+If that schema is `.strict()` (like `check_tdd_compliance` at `registry.ts:926-934`), `rest` contains the leaked defaults that the per-action schema does not declare → rejection.
+
+Per-action `.strict()` is the right safety choice (catches caller typos). The problem is the parent schema injecting cross-action keys before the per-action validator sees the payload.
+
+### Fix
+
+In `core/dispatch.ts`, before per-action `safeParse`, filter `rest` to keys present in the matching action's schema shape:
+
+```typescript
+const actionShapeKeys = new Set(Object.keys(matchingAction.schema.shape));
+const cleaned = Object.fromEntries(
+  Object.entries(rest).filter(([k]) => actionShapeKeys.has(k))
+);
+const parsed = matchingAction.schema.safeParse(cleaned);
+```
+
+Pure function, single boundary, preserves `.strict()` typo-detection on caller-supplied keys (because the only stripped keys are ones that came from the parent-default mechanism, not the caller).
+
+This is **Tolerant Dispatch** — the boundary tolerates upstream's well-meaning over-supply while the per-action schema retains its strict contract for caller-originated keys. Analogous to Microsoft's [forward-compatible data contracts](https://learn.microsoft.com/dotnet/framework/wcf/feature-details/forward-compatible-data-contracts) (extra fields ignored at deserialization).
+
+## Defect 3: task_complete Gate Consultation (#1189)
+
+### Symptom
+
+`task_complete` enforces a `tdd-compliance` gate precondition. When a `gate.executed` event with `passed: true` is manually emitted to the event store and then `task_complete` is called, the handler returns `GATE_NOT_PASSED` — it does not see the manually-emitted gate.
+
+The only override is `evidence.type === 'manual'` (added by #940 closed 2026-03-01). Any other `evidence.type` (`test`, `build`, `typecheck`) does not bypass — even with `evidence.passed === true`.
+
+### Root Cause
+
+`servers/exarchos-mcp/src/tasks/tools.ts:206-233` has two compounding issues:
+
+**(a) Schema-shape mismatch in `hasPassingGate`** (lines 212-219):
+
+```typescript
+const hasPassingGate = (gateName: string): boolean =>
+  gateEvents.some((e) => {
+    const d = e.data as Record<string, unknown> | undefined;
+    if (!d) return false;
+    const details = d.details as Record<string, unknown> | undefined;
+    return d.gateName === gateName && d.passed === true &&
+      (details != null && (!details.taskId || details.taskId === args.taskId));
+  });
+```
+
+The check requires `details != null` and reads `details.taskId`. Manually-emitted events that put `taskId` at `data.taskId` (the natural place for an operator following the gate-event schema as documented) match `data.gateName` and `data.passed` but fail `details != null`. Result: every operator-supplied gate event is silently dropped.
+
+**(b) Narrow `manualBypass` (line 207):**
+
+```typescript
+const manualBypass = args.evidence?.type === 'manual' && args.evidence.passed === true;
+```
+
+Conflates two orthogonal concerns: *what kind of proof* (`evidence.type`) and *whether to skip prerequisites* (`bypass`). The intent of `evidence.passed === true` is "I have evidence the work succeeded" — independent of the proof type.
+
+### Fix
+
+Two complementary changes — both Tolerant Reader (Postel's Law) applied at the same boundary:
+
+1. **Broaden `hasPassingGate`** to accept `taskId` at either `data.taskId` (top level) or `data.details.taskId` (nested), preserving back-compat with handler-emitted events while accepting operator-emitted events.
+2. **Broaden `manualBypass`** to accept any `evidence?.passed === true` (regardless of `evidence.type`). This separates evidence-type-tag from override-mechanism per **SRP**.
+
+The two changes are independent — either alone would unblock the issue's repro. Both together close the loop.
+
+This is the **Tolerant Reader pattern** (Fowler) / forward-compatible deserialization (Microsoft data-contract guidance): accept extra/alternative shapes at read time without requiring the producer to know the canonical layout.
+
+## Defect 4: prepare_delegation Undocumented Precondition (#1190)
+
+### Symptom
+
+The delegation skill (`skills-src/delegation/SKILL.md`) instructs Step 1 = call `prepare_delegation`. The action returns `{ ready: false, blockers: ["no task.assigned events found — emit task.assigned events for each task via exarchos_event before calling prepare_delegation"] }` even though `task.assigned` is *not* listed in the skill's event-contract table (line 142-156). Operators discover the requirement only by attempting the call.
+
+Same UX defect class as #1029 (closed 2026-03-14), which fixed the `quality.queried` version of the same gap. The fix was incomplete — `task.assigned` was missed.
+
+### Root Cause
+
+Two factors:
+
+1. **DelegationReadinessView** (`servers/exarchos-mcp/src/views/delegation-readiness-view.ts:138-156`) counts `task.assigned` events to determine `taskCount`. The skill's event-contract table lists `team.task.planned` (team-scoped, agent-teams mode) but not `task.assigned` (feature-scoped, canonical task initialization). The codebase doesn't explain why both events exist.
+
+2. **Adjacent UX nit:** `prepare_delegation` returns `{ blocked: true, reason: "current-branch-protected", currentBranch: "main" }` (`prepare-delegation.ts:301-321`) with no remediation hint. Resolution requires reading `CLAUDE.md`'s Workflow Dispatch Conventions section.
+
+### Fix
+
+**Option C (hybrid)** from the issue body — lowest UX friction, minimal code surface:
+
+1. **Skill update** (`skills-src/delegation/SKILL.md`):
+   - Add `task.assigned` row to event-contract table with "When: before `prepare_delegation`"
+   - Reframe Step 1: "validates readiness; canonical preconditions live in `exarchos_orchestrate describe(['prepare_delegation'])`" — making `describe` the authoritative spec (mirrors the #1029 pattern of "when in doubt, query the runtime")
+
+2. **Handler hint** (`prepare-delegation.ts`):
+   - Add `hint: "checkout the feature/phase branch before dispatching delegation"` to the `current-branch-protected` blocker payload
+
+**Rejecting Option B (drop precondition server-side):** would require migrating readiness-counting from `task.assigned` (feature-scope, mode-agnostic) to `team.task.planned` (team-scope, agent-teams-mode only). Different semantics. Higher risk than the docs+hint approach.
+
+## Cross-Cutting (#1109) Verification
+
+| Constraint | Each fix |
+|------------|----------|
+| **Event-sourcing integrity** | No new events emitted; #1189's `hasPassingGate` becomes more tolerant in *reading* `gate.executed` events; output of every projection remains reconstructable from the event log alone. |
+| **MCP parity** | Every code-side fix is in shared core (`views/tools.ts`, `core/dispatch.ts`, `tasks/tools.ts`, `orchestrate/prepare-delegation.ts`) — both CLI and MCP facades dispatch through the same handlers, so behavior is uniform by construction. |
+| **Basileus-forward** | No fix introduces a local-only assumption. The `infra-streams.ts` predicate is transport-agnostic; dispatch tolerance is transport-agnostic. |
+| **Capability resolution** | None of the fixes touch capability/handshake state — no yaml-vs-handshake reads added or modified. |
+
+## Backend-Quality Dimension Mapping
+
+| Defect | Primary | Secondary |
+|--------|---------|-----------|
+| #1187 | DIM-3 (Contracts: stream-id taxonomy) | DIM-2 (Observability: phantom-row noise) |
+| #1188 | DIM-1 (Topology: cross-action ambient state) | DIM-3 (Contracts: schema-dispatch invariant) |
+| #1189 | DIM-3 (Contracts: gate-event shape) | DIM-7 (Resilience: silent drop of valid evidence) |
+| #1190 | DIM-3 (Contracts: undocumented preconditions) | DIM-2 (Observability: runtime-only blocker discovery) |
+
+## Contributing Factors
+
+- [x] Missing test coverage — none of the four bugs had a regression test before this RCA
+- [x] Edge case not considered — each defect is a "happy-path tested, degenerate-input untested" pattern
+- [x] Inadequate cross-module discoverability — infra-stream constants live in three modules; gate-event shape is implicit; preconditions are runtime-only
+- [ ] Race condition / timing issue (n/a)
+- [ ] External dependency failure (n/a)
+
+## Prevention
+
+### Immediate (this PR)
+
+- [x] Centralize `INFRA_STREAM_IDS` in shared `core/infra-streams.ts` (one fact, one place)
+- [x] Add Tolerant Dispatch helper in `core/dispatch.ts` (boundary normalization)
+- [x] Apply Tolerant Reader to `hasPassingGate` (accept canonical and operator shapes)
+- [x] Add regression tests for all four defects (the missing dimension above)
+- [x] Reframe delegation Step 1 around `describe()` (runtime is the spec)
+
+### Longer-term
+
+- [ ] Audit other discriminated-union schemas in `registry.ts` for cross-action default leakage (this could affect any per-action schema with `.strict()`)
+- [ ] Audit other gate handlers in `tasks/tools.ts` for the same `data.taskId` vs `data.details.taskId` shape ambiguity
+- [ ] Consider a generic "describe-driven preconditions" generator so skills cannot drift from runtime checks (would have prevented #1029 and #1190)
+
+## Timeline
+
+| Event | Date | Notes |
+|-------|------|-------|
+| Reported | 2026-04-26 | Issues #1187, #1188, #1189, #1190 filed during `refactor-projection-state-patched-fold` workflow |
+| Investigated | 2026-04-27 | Five parallel Explore agents; ~30 min total |
+| Fixed | 2026-04-27 | This PR |
+| Verified | TBD | Pending merge + post-merge eval-capture run |
+
+## Related
+
+- Parent cluster: `docs/rca/2026-04-26-v29-event-projection-cluster.md` (PR #1185, the *event/projection* half of v2.9.0-rc.1 hardening)
+- Issues: #1187, #1188, #1189, #1190
+- Closed sibling: #940 (manual-evidence bypass — too narrow, broadened here), #1029 (delegation precondition gap — incomplete fix, completed here), #971 (PID-lock for cross-process EventStore — orthogonal but referenced by #1188 cascade context), #1184 (4 of 5 sub-bugs in PR #1185; sub-bug 5 confirmed already-fixed during this RCA's investigation, issue closed 2026-04-27)
+- Cross-cutting: #1109 (event-sourcing + MCP parity + Basileus-forward invariants)

--- a/docs/rca/2026-04-27-v29-rc1-orchestrate-cluster.md
+++ b/docs/rca/2026-04-27-v29-rc1-orchestrate-cluster.md
@@ -80,17 +80,29 @@ Per-action `.strict()` is the right safety choice (catches caller typos). The pr
 
 ### Fix
 
-In `core/dispatch.ts`, before per-action `safeParse`, filter `rest` to keys present in the matching action's schema shape:
+In `core/dispatch.ts`, before per-action `safeParse`, drop only keys declared on a *sibling* action's schema. Keys declared on the matching action's schema, and keys not declared on any action, both pass through. The leaked sibling defaults disappear; caller typos still hit `.strict()` and are reported with a clear unrecognized-key error.
 
 ```typescript
-const actionShapeKeys = new Set(Object.keys(matchingAction.schema.shape));
+const actionShape = (matchingAction.schema as { shape?: Record<string, unknown> }).shape;
+const siblingKeys = new Set<string>();
+for (const a of registeredTool.actions) {
+  if (a === matchingAction) continue;
+  const shape = (a.schema as { shape?: Record<string, unknown> }).shape;
+  if (shape && typeof shape === 'object') {
+    for (const k of Object.keys(shape)) siblingKeys.add(k);
+  }
+}
 const cleaned = Object.fromEntries(
-  Object.entries(rest).filter(([k]) => actionShapeKeys.has(k))
+  Object.entries(rest).filter(([k]) => {
+    const inAction = !!actionShape && Object.prototype.hasOwnProperty.call(actionShape, k);
+    if (inAction) return true;
+    return !siblingKeys.has(k); // keep unknown caller keys; drop only leaked sibling defaults
+  })
 );
 const parsed = matchingAction.schema.safeParse(cleaned);
 ```
 
-Pure function, single boundary, preserves `.strict()` typo-detection on caller-supplied keys (because the only stripped keys are ones that came from the parent-default mechanism, not the caller).
+Pure function, single boundary, preserves `.strict()` typo-detection on caller-supplied keys (the only stripped keys are ones that belong to a sibling action's schema, which is exactly the parent-default leak surface).
 
 This is **Tolerant Dispatch** — the boundary tolerates upstream's well-meaning over-supply while the per-action schema retains its strict contract for caller-originated keys. Analogous to Microsoft's [forward-compatible data contracts](https://learn.microsoft.com/dotnet/framework/wcf/feature-details/forward-compatible-data-contracts) (extra fields ignored at deserialization).
 
@@ -134,7 +146,7 @@ Conflates two orthogonal concerns: *what kind of proof* (`evidence.type`) and *w
 Two complementary changes — both Tolerant Reader (Postel's Law) applied at the same boundary:
 
 1. **Broaden `hasPassingGate`** to accept `taskId` at either `data.taskId` (top level) or `data.details.taskId` (nested), preserving back-compat with handler-emitted events while accepting operator-emitted events.
-2. **Broaden `manualBypass`** to accept any `evidence?.passed === true` (regardless of `evidence.type`). This separates evidence-type-tag from override-mechanism per **SRP**.
+2. **Broaden the evidence bypass** to accept any `evidence?.passed === true` *and* a non-empty `evidence.output` (after trimming whitespace), regardless of `evidence.type`. The non-empty-output guard is a sanity check — it preserves the "substantive proof" intent of the original `manual` bypass while removing the type-tag conflation. This separates evidence-type-tag from override-mechanism per **SRP**.
 
 The two changes are independent — either alone would unblock the issue's repro. Both together close the loop.
 

--- a/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/tasks/tools.test.ts
@@ -356,12 +356,33 @@ describe('handleTaskComplete manual evidence bypass', () => {
     expect(result.error?.code).toBe('GATE_NOT_PASSED');
   });
 
-  it('handleTaskComplete_NonManualEvidence_StillRequiresGates', async () => {
+  it('handleTaskComplete_NonManualEvidenceWithPassedAndOutput_BypassesGates', async () => {
+    // Updated for #1189: the bypass is orthogonal to evidence.type
+    // (SRP — separate "what kind of proof" from "whether to skip
+    // prerequisites"). Any evidence with `passed === true` AND a
+    // non-empty `output` asserts work succeeded, regardless of type.
+    // The narrow `type === 'manual'` interpretation predated #1189.
     const result = await handleTaskComplete(
       {
         taskId: 't-test-type',
         evidence: { type: 'test', output: 'all passed', passed: true },
         streamId: 'wf-test-type',
+      },
+      tempDir,
+      store,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it('handleTaskComplete_NonManualEvidenceWithEmptyOutput_StillRequiresGates', async () => {
+    // Empty output is the sanity guard — passed===true alone is not
+    // enough to bypass; substantive proof is required (#1189).
+    const result = await handleTaskComplete(
+      {
+        taskId: 't-test-empty',
+        evidence: { type: 'test', output: '', passed: true },
+        streamId: 'wf-test-empty',
       },
       tempDir,
       store,

--- a/servers/exarchos-mcp/src/core/dispatch.test.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.test.ts
@@ -357,6 +357,71 @@ describe('dispatch', () => {
     });
   });
 
+  describe('parent-tool default-key leak (#1188)', () => {
+    it('Dispatch_LeakedSiblingDefaults_DoesNotRejectStrictPerActionSchema', async () => {
+      // Reproduces #1188: the MCP SDK applies defaults from the flattened
+      // parent schema (via buildRegistrationSchema) to every payload
+      // before dispatch sees it. Sibling-action defaults like
+      // `nativeIsolation` (from prepare_delegation) and `outputFormat`
+      // (from agent_spec) end up on payloads for actions whose schema is
+      // .strict() — like `check_tdd_compliance` — causing
+      // "Unrecognized key(s) in object" rejections.
+      //
+      // Dispatch must strip parent-tool defaults that are not declared
+      // in the matching action's schema before per-action validation
+      // (Tolerant Dispatch). The per-action .strict() guard is
+      // preserved for caller-supplied keys.
+      const { dispatch } = await import('./dispatch.js');
+
+      const result = await dispatch(
+        'exarchos_orchestrate',
+        {
+          action: 'check_tdd_compliance',
+          featureId: 'leak-test',
+          taskId: 'T1',
+          branch: 'feat/leak-test',
+          // Leaked defaults from sibling actions — caller never supplies these:
+          nativeIsolation: false, // from prepare_delegation
+          outputFormat: 'full', // from agent_spec
+        },
+        { stateDir: tmpDir, eventStore, enableTelemetry: false },
+      );
+
+      // The handler may still fail (no real git/test fixtures), but it
+      // must NOT fail with INVALID_INPUT mentioning the leaked keys.
+      if (!result.success) {
+        const message = result.error?.message ?? '';
+        expect(message).not.toMatch(/Unrecognized key\(s\)/);
+        expect(message).not.toMatch(/nativeIsolation/);
+        expect(message).not.toMatch(/outputFormat/);
+      }
+    });
+
+    it('Dispatch_CallerTypo_StillRejected', async () => {
+      // Tolerant Dispatch must NOT swallow caller typos — keys not
+      // declared on any action's schema are caller errors and should
+      // surface clearly via the per-action .strict() rejection.
+      const { dispatch } = await import('./dispatch.js');
+
+      const result = await dispatch(
+        'exarchos_orchestrate',
+        {
+          action: 'check_tdd_compliance',
+          featureId: 'typo-test',
+          taskId: 'T1',
+          branch: 'feat/typo-test',
+          // Caller-supplied typo — not declared on any orchestrate action.
+          totallyMadeUpKey: 'this is a typo',
+        },
+        { stateDir: tmpDir, eventStore, enableTelemetry: false },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('INVALID_INPUT');
+      expect(result.error?.message).toMatch(/totallyMadeUpKey/);
+    });
+  });
+
   describe('doctor action wiring', () => {
     it('Dispatch_ExarchosOrchestrateDoctor_RoutesToOrchestrateCompositeAndReturnsValidDoctorOutput', async () => {
       // Arrange

--- a/servers/exarchos-mcp/src/core/dispatch.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.ts
@@ -309,7 +309,42 @@ export async function dispatch(
     }
 
     const { action: _action, ...rest } = args;
-    const parsed = matchingAction.schema.safeParse(rest);
+    // Tolerant Dispatch (#1188): the MCP SDK validates against the flattened
+    // parent schema (buildRegistrationSchema) and applies sibling-action
+    // defaults (e.g. `nativeIsolation` from prepare_delegation, `outputFormat`
+    // from agent_spec) to every payload. Per-action schemas use .strict()
+    // to catch caller typos, so those leaked defaults would be rejected as
+    // unrecognized keys.
+    //
+    // Strip only sibling-action keys: a key declared on some other action's
+    // schema but not on the matching action's. Keys that aren't declared
+    // anywhere (caller typos) pass through so .strict() still rejects
+    // them — preserving the typo-detection guard.
+    const actionShape = (matchingAction.schema as { shape?: Record<string, unknown> }).shape;
+    const cleanedRest =
+      actionShape && typeof actionShape === 'object'
+        ? (() => {
+            const siblingKeys = new Set<string>();
+            for (const a of registeredTool.actions) {
+              if (a === matchingAction) continue;
+              const shape = (a.schema as { shape?: Record<string, unknown> }).shape;
+              if (shape && typeof shape === 'object') {
+                for (const k of Object.keys(shape)) siblingKeys.add(k);
+              }
+            }
+            return Object.fromEntries(
+              Object.entries(rest).filter(([k]) => {
+                const inAction = Object.prototype.hasOwnProperty.call(actionShape, k);
+                if (inAction) return true;
+                // Drop sibling-action keys (leaked parent defaults). Keep
+                // unknown keys so the per-action .strict() guard rejects
+                // caller typos with a clear error.
+                return !siblingKeys.has(k);
+              }),
+            );
+          })()
+        : rest;
+    const parsed = matchingAction.schema.safeParse(cleanedRest);
     if (!parsed.success) {
       const context = `${tool}/${actionName}`;
       return {

--- a/servers/exarchos-mcp/src/core/infra-streams.ts
+++ b/servers/exarchos-mcp/src/core/infra-streams.ts
@@ -1,0 +1,23 @@
+// Reserved stream identifiers for non-feature event streams.
+//
+// Centralized here so view/listing handlers can distinguish feature workflows
+// from infrastructure streams without duplicating string literals across
+// modules (DIM-1 — single source of truth).
+//
+// The owning modules (`orchestrate/init`, `orchestrate/doctor`,
+// `telemetry/constants`) re-export from this file to preserve existing
+// import paths.
+
+export const INIT_STREAM_ID = 'exarchos-init';
+export const DOCTOR_STREAM_ID = 'exarchos-doctor';
+export const TELEMETRY_STREAM = 'telemetry';
+
+export const INFRA_STREAM_IDS: ReadonlySet<string> = new Set([
+  INIT_STREAM_ID,
+  DOCTOR_STREAM_ID,
+  TELEMETRY_STREAM,
+]);
+
+export function isFeatureStream(streamId: string): boolean {
+  return !INFRA_STREAM_IDS.has(streamId);
+}

--- a/servers/exarchos-mcp/src/orchestrate/dispatch-guard.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/dispatch-guard.test.ts
@@ -194,4 +194,14 @@ describe('assertCurrentBranchNotProtected', () => {
     const result = assertCurrentBranchNotProtected(null);
     expect(result.blocked).toBe(false);
   });
+
+  it('assertCurrentBranchNotProtected_OnMain_IncludesRemediationHint', () => {
+    // #1190 UX nit: blocker payloads must include actionable remediation,
+    // not just a reason code. Operators should not need to grep CLAUDE.md
+    // to recover from a blocked dispatch.
+    const result = assertCurrentBranchNotProtected('main');
+    expect(result.blocked).toBe(true);
+    expect(result.hint).toBeDefined();
+    expect(result.hint).toMatch(/checkout|feature/i);
+  });
 });

--- a/servers/exarchos-mcp/src/orchestrate/dispatch-guard.ts
+++ b/servers/exarchos-mcp/src/orchestrate/dispatch-guard.ts
@@ -25,6 +25,12 @@ export interface CurrentBranchProtectionResult {
   readonly blocked: boolean;
   readonly reason?: 'current-branch-protected';
   readonly currentBranch?: string;
+  /**
+   * Operator-facing remediation hint (#1190). Present when `blocked: true`
+   * so callers don't need to consult external docs to recover. Omitted
+   * when `blocked: false` (no remediation needed).
+   */
+  readonly hint?: string;
 }
 
 export type GitExec = (args: readonly string[]) => string;
@@ -131,6 +137,7 @@ export function assertCurrentBranchNotProtected(
       blocked: true,
       reason: 'current-branch-protected',
       currentBranch,
+      hint: `checkout the feature/phase branch before dispatching delegation (HEAD is on ${currentBranch})`,
     };
   }
   return { blocked: false };

--- a/servers/exarchos-mcp/src/orchestrate/doctor/index.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/index.ts
@@ -113,7 +113,8 @@ export type BuildProbesFn = (ctx: DispatchContext) => DoctorProbes;
  * not tied to any workflow, so a dedicated stream keeps diagnostic
  * history separate from workflow streams.
  */
-export const DOCTOR_STREAM_ID = 'exarchos-doctor';
+import { DOCTOR_STREAM_ID } from '../../core/infra-streams.js';
+export { DOCTOR_STREAM_ID };
 
 /**
  * Testable seam — accepts an explicit `checks` list and `buildProbes`

--- a/servers/exarchos-mcp/src/orchestrate/init/index.ts
+++ b/servers/exarchos-mcp/src/orchestrate/init/index.ts
@@ -39,7 +39,8 @@ import { OpenCodeWriter } from './writers/opencode.js';
 
 // ─── Constants ────────────────────────────────────────────────────────────
 
-export const INIT_STREAM_ID = 'exarchos-init';
+import { INIT_STREAM_ID } from '../../core/infra-streams.js';
+export { INIT_STREAM_ID };
 
 // ─── Types ────────────────────────────────────────────────────────────────
 

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -316,6 +316,7 @@ export async function handlePrepareDelegation(
           blocked: true,
           reason: protectionResult.reason,
           currentBranch: protectionResult.currentBranch,
+          ...(protectionResult.hint ? { hint: protectionResult.hint } : {}),
         },
       };
     }

--- a/servers/exarchos-mcp/src/tasks/tools.test.ts
+++ b/servers/exarchos-mcp/src/tasks/tools.test.ts
@@ -892,6 +892,133 @@ describe('handleTaskComplete gate enforcement', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('GATE_NOT_PASSED');
   });
+
+  // ─── #1189: Tolerant Reader for gate.executed shape ────────────────────────
+  describe('#1189 — gate consultation tolerates alt shapes', () => {
+    it('HandleTaskComplete_GateWithTopLevelTaskId_RecognizedAsPassing', async () => {
+      // GIVEN: operator-emitted gate.executed events with taskId at the
+      // top level of `data` (alongside gateName/layer/passed) — the
+      // shape an operator naturally writes when manually satisfying a
+      // gate. The canonical handler-emitted shape places taskId inside
+      // data.details.taskId; both should be honored (Tolerant Reader,
+      // Postel's Law).
+      const store = new EventStore(tempDir);
+      await store.append('wf-gate-tlid', {
+        type: 'task.assigned',
+        data: { taskId: 'T-01', title: 'Top-level taskId test', assignee: 'agent-1' },
+      });
+      await store.append('wf-gate-tlid', {
+        type: 'gate.executed',
+        data: { gateName: 'tdd-compliance', layer: 'delegate', passed: true, taskId: 'T-01' },
+      });
+      await store.append('wf-gate-tlid', {
+        type: 'gate.executed',
+        data: { gateName: 'static-analysis', layer: 'quality', passed: true, taskId: 'T-01' },
+      });
+
+      const result = await handleTaskComplete(
+        { taskId: 'T-01', streamId: 'wf-gate-tlid' },
+        tempDir,
+        store,
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('HandleTaskComplete_GateWithTopLevelTaskIdMismatch_RejectsCompletion', async () => {
+      // GIVEN: a gate event with top-level taskId that does NOT match
+      // the task being completed. The Tolerant Reader must still
+      // enforce the taskId equality contract.
+      const store = new EventStore(tempDir);
+      await store.append('wf-gate-tlid-mm', {
+        type: 'task.assigned',
+        data: { taskId: 'T-01', title: 'Mismatch test', assignee: 'agent-1' },
+      });
+      await store.append('wf-gate-tlid-mm', {
+        type: 'gate.executed',
+        data: { gateName: 'tdd-compliance', layer: 'delegate', passed: true, taskId: 'T-99' },
+      });
+
+      const result = await handleTaskComplete(
+        { taskId: 'T-01', streamId: 'wf-gate-tlid-mm' },
+        tempDir,
+        store,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('GATE_NOT_PASSED');
+    });
+
+    it('HandleTaskComplete_NonManualEvidenceWithPassedTrue_BypassesGate', async () => {
+      // GIVEN: a task with no gate.executed events but operator-supplied
+      // `evidence.passed === true` and a non-empty output. The bypass
+      // mechanism is orthogonal to evidence.type (SRP — separate
+      // "what kind of proof" from "whether to skip prerequisites").
+      const store = new EventStore(tempDir);
+      await store.append('wf-evbypass', {
+        type: 'task.assigned',
+        data: { taskId: 'T-01', title: 'Evidence bypass', assignee: 'agent-1' },
+      });
+
+      const result = await handleTaskComplete(
+        {
+          taskId: 'T-01',
+          streamId: 'wf-evbypass',
+          evidence: { type: 'test', output: '5727 tests passed', passed: true },
+        },
+        tempDir,
+        store,
+      );
+
+      expect(result.success).toBe(true);
+    });
+
+    it('HandleTaskComplete_EvidenceWithEmptyOutput_DoesNotBypass', async () => {
+      // GIVEN: passed===true but no actual proof. Empty output is a
+      // sanity guard — bypass requires substantive evidence, not just
+      // an assertion.
+      const store = new EventStore(tempDir);
+      await store.append('wf-evempty', {
+        type: 'task.assigned',
+        data: { taskId: 'T-01', title: 'Empty evidence', assignee: 'agent-1' },
+      });
+
+      const result = await handleTaskComplete(
+        {
+          taskId: 'T-01',
+          streamId: 'wf-evempty',
+          evidence: { type: 'test', output: '', passed: true },
+        },
+        tempDir,
+        store,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('GATE_NOT_PASSED');
+    });
+
+    it('HandleTaskComplete_ManualEvidenceBypass_StillWorks', async () => {
+      // Backward compatibility: the original `evidence.type === 'manual'`
+      // bypass (per #940) must still work after the broadening.
+      const store = new EventStore(tempDir);
+      await store.append('wf-manual', {
+        type: 'task.assigned',
+        data: { taskId: 'T-01', title: 'Manual evidence', assignee: 'agent-1' },
+      });
+
+      const result = await handleTaskComplete(
+        {
+          taskId: 'T-01',
+          streamId: 'wf-manual',
+          evidence: { type: 'manual', output: 'docs-only task — no gates run', passed: true },
+        },
+        tempDir,
+        store,
+      );
+
+      expect(result.success).toBe(true);
+    });
+  });
 });
 
 // ─── Batch Gate Failures (DR-2) ──────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/tasks/tools.test.ts
+++ b/servers/exarchos-mcp/src/tasks/tools.test.ts
@@ -997,6 +997,30 @@ describe('handleTaskComplete gate enforcement', () => {
       expect(result.error?.code).toBe('GATE_NOT_PASSED');
     });
 
+    it('HandleTaskComplete_EvidenceWithWhitespaceOnlyOutput_DoesNotBypass', async () => {
+      // GIVEN: passed===true with whitespace-only output. The substantive-
+      // proof guard must trim before the length check — otherwise "   "
+      // (or "\t\n") would trivially bypass while contributing no evidence.
+      const store = new EventStore(tempDir);
+      await store.append('wf-evws', {
+        type: 'task.assigned',
+        data: { taskId: 'T-01', title: 'Whitespace evidence', assignee: 'agent-1' },
+      });
+
+      const result = await handleTaskComplete(
+        {
+          taskId: 'T-01',
+          streamId: 'wf-evws',
+          evidence: { type: 'test', output: '   \t\n  ', passed: true },
+        },
+        tempDir,
+        store,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('GATE_NOT_PASSED');
+    });
+
     it('HandleTaskComplete_ManualEvidenceBypass_StillWorks', async () => {
       // Backward compatibility: the original `evidence.type === 'manual'`
       // bypass (per #940) must still work after the broadening.

--- a/servers/exarchos-mcp/src/tasks/tools.ts
+++ b/servers/exarchos-mcp/src/tasks/tools.ts
@@ -203,24 +203,41 @@ export async function handleTaskComplete(
 
   const store = eventStore;
 
-  // Manual evidence bypass: docs-only or non-code tasks can skip gate checks
-  const manualBypass = args.evidence?.type === 'manual' && args.evidence.passed === true;
+  // Evidence-based bypass (#1189): orthogonal to evidence.type (SRP —
+  // separate "what kind of proof" from "whether to skip prerequisites").
+  // Any evidence with passed===true AND substantive (non-empty) output
+  // asserts work succeeded; the type tag is metadata about the proof,
+  // not the override mechanism. Preserves the original `type === 'manual'`
+  // behavior (#940) since manual evidence will satisfy passed===true plus
+  // a non-empty output.
+  const evidenceBypass =
+    args.evidence?.passed === true && (args.evidence.output ?? '').length > 0;
 
   // Gate enforcement: verify D1 (TDD compliance) and D2 (static analysis) gates passed for this task
   const gateEvents = await store.query(args.streamId, { type: 'gate.executed' });
 
+  // Tolerant Reader (#1189): taskId may live at `data.details.taskId`
+  // (canonical handler-emitted shape) or at `data.taskId` (operator-emitted
+  // shape, e.g. when satisfying a gate manually via exarchos_event append).
+  // Both shapes are valid per the GateExecutedData schema (which is not
+  // .strict()). If a top-level taskId is present, it is authoritative;
+  // otherwise fall back to the canonical details.taskId, with a missing
+  // taskId on the canonical path indicating a project-wide gate.
   const hasPassingGate = (gateName: string): boolean =>
     gateEvents.some((e) => {
       const d = e.data as Record<string, unknown> | undefined;
       if (!d) return false;
+      if (d.gateName !== gateName || d.passed !== true) return false;
+      if (typeof d.taskId === 'string') {
+        return d.taskId === args.taskId;
+      }
       const details = d.details as Record<string, unknown> | undefined;
-      return d.gateName === gateName && d.passed === true &&
-        (details != null && (!details.taskId || details.taskId === args.taskId));
+      return details != null && (!details.taskId || details.taskId === args.taskId);
     });
 
   const unmetGates: string[] = [];
-  if (!manualBypass && !hasPassingGate('tdd-compliance')) unmetGates.push('tdd-compliance');
-  if (!manualBypass && !hasPassingGate('static-analysis')) unmetGates.push('static-analysis');
+  if (!evidenceBypass && !hasPassingGate('tdd-compliance')) unmetGates.push('tdd-compliance');
+  if (!evidenceBypass && !hasPassingGate('static-analysis')) unmetGates.push('static-analysis');
   if (unmetGates.length > 0) {
     return {
       success: false,

--- a/servers/exarchos-mcp/src/tasks/tools.ts
+++ b/servers/exarchos-mcp/src/tasks/tools.ts
@@ -205,13 +205,14 @@ export async function handleTaskComplete(
 
   // Evidence-based bypass (#1189): orthogonal to evidence.type (SRP —
   // separate "what kind of proof" from "whether to skip prerequisites").
-  // Any evidence with passed===true AND substantive (non-empty) output
+  // Any evidence with passed===true AND substantive (non-whitespace) output
   // asserts work succeeded; the type tag is metadata about the proof,
   // not the override mechanism. Preserves the original `type === 'manual'`
   // behavior (#940) since manual evidence will satisfy passed===true plus
-  // a non-empty output.
+  // a non-empty output. Trim before length-check so whitespace-only output
+  // (e.g. "   ") cannot trivially bypass the gate.
   const evidenceBypass =
-    args.evidence?.passed === true && (args.evidence.output ?? '').length > 0;
+    args.evidence?.passed === true && (args.evidence.output ?? '').trim().length > 0;
 
   // Gate enforcement: verify D1 (TDD compliance) and D2 (static analysis) gates passed for this task
   const gateEvents = await store.query(args.streamId, { type: 'gate.executed' });

--- a/servers/exarchos-mcp/src/telemetry/constants.ts
+++ b/servers/exarchos-mcp/src/telemetry/constants.ts
@@ -1,4 +1,5 @@
-export const TELEMETRY_STREAM = 'telemetry';
+import { TELEMETRY_STREAM } from '../core/infra-streams.js';
+export { TELEMETRY_STREAM };
 
 // ─── Threshold Constants ─────────────────────────────────────────────────────
 

--- a/servers/exarchos-mcp/src/views/tools.test.ts
+++ b/servers/exarchos-mcp/src/views/tools.test.ts
@@ -1256,4 +1256,41 @@ describe('Backend Integration (Task 12)', () => {
 
     querySpy.mockRestore();
   });
+
+  // ─── #1187: pipeline view filters infra streams ───────────────────────────
+  describe('handleViewPipeline infra-stream filter (#1187)', () => {
+    it('Pipeline_WithInfraStreams_ExcludesPhantomRows', async () => {
+      // GIVEN: one real feature workflow stream alongside the three reserved
+      // infrastructure streams (exarchos-init, exarchos-doctor, telemetry)
+      await store.append('feat-real', {
+        type: 'workflow.started',
+        data: { featureId: 'real-feature', workflowType: 'feature' },
+      });
+      await store.append('exarchos-init', {
+        type: 'init.executed',
+        data: { runtime: 'claude' },
+      });
+      await store.append('exarchos-doctor', {
+        type: 'diagnostic.executed',
+        data: { check: 'mcp-handshake' },
+      });
+      await store.append('telemetry', {
+        type: 'tool.invoked',
+        data: { tool: 'exarchos_view', argsBytes: 12 },
+      });
+
+      // WHEN: pipeline view materializes all discovered streams
+      const result = await handleViewPipeline({}, tmpDir, store);
+
+      // THEN: only the feature workflow appears — infra streams are filtered
+      // out before materialization, so no phantom rows with empty featureId
+      // leak into the response.
+      expect(result.success).toBe(true);
+      const data = result.data as { workflows: Array<{ featureId: string }>; total: number };
+      expect(data.total).toBe(1);
+      expect(data.workflows).toHaveLength(1);
+      expect(data.workflows[0]?.featureId).toBe('real-feature');
+      expect(data.workflows.every((w) => w.featureId !== '')).toBe(true);
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/views/tools.ts
+++ b/servers/exarchos-mcp/src/views/tools.ts
@@ -8,6 +8,7 @@ import type { WorkflowEvent } from '../event-store/schemas.js';
 import { formatResult, pickFields, type ToolResult } from '../format.js';
 import { logger } from '../logger.js';
 import { TERMINAL_PHASES } from '../workflow/terminal-phases.js';
+import { isFeatureStream } from '../core/infra-streams.js';
 import { ViewMaterializer } from './materializer.js';
 import { SnapshotStore } from './snapshot-store.js';
 import {
@@ -405,8 +406,11 @@ export async function handleViewPipeline(
     const store = eventStore;
     const materializer = getOrCreateMaterializer(stateDir);
 
-    // Materialize all streams to get phase info for filtering
-    const streamIds = await discoverStreams(stateDir, store);
+    // Materialize all streams to get phase info for filtering. Infrastructure
+    // streams (exarchos-init, exarchos-doctor, telemetry) are excluded — they
+    // never emit workflow.started so they would surface as phantom rows with
+    // empty featureId/workflowType/phase (#1187).
+    const streamIds = (await discoverStreams(stateDir, store)).filter(isFeatureStream);
     const allWorkflows: PipelineViewState[] = [];
 
     for (const streamId of streamIds) {

--- a/skills-src/delegation/SKILL.md
+++ b/skills-src/delegation/SKILL.md
@@ -58,6 +58,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the `prepare_delegation` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for `prepare_delegation` lives in the runtime — query it with `exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })` if anything in this skill drifts from observed behavior. Treat the runtime `describe` output as the source of truth.
+
+### Step 0 — Pre-emit (required before `prepare_delegation`)
+
+Before calling `prepare_delegation`, the workflow stream must contain a `task.assigned` event for each task. The readiness view counts these events to populate `taskCount`; without them, `prepare_delegation` returns `{ ready: false, blockers: ["no task.assigned events found ..."] }`.
+
+```typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+```
+
+### Step 1 — Prepare (readiness check)
+
 ```typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -72,6 +91,8 @@ The composite action performs:
 3. **Quality signal assembly** — queries `code_quality` view; if `gatePassRate < 0.80`, returns quality hints to embed in prompts. Emits `gate.executed('plan-coverage')` on success (no pre-query needed)
 4. **Benchmark detection** — sets `verification.hasBenchmarks` if any task has benchmark criteria
 5. **Readiness verdict** — returns `{ ready: true, worktrees: [...], qualityHints: [...] }` or `{ ready: false, reason: "..." }`
+
+**If `blocked: true` with `reason: "current-branch-protected"`:** the response includes a `hint` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
 
 **If `ready: false`:** Stop. Report the reason to the user. Do not proceed.
 
@@ -145,6 +166,7 @@ The delegate phase requires these events (checked by `check-event-emissions`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| `task.assigned` | Before `prepare_delegation` (one per task; see Step 0) | Orchestrator |
 | `team.spawned` | After team creation, before dispatch | Orchestrator |
 | `team.task.planned` | For each task in the plan (use `batch_append`) | Orchestrator |
 | `team.teammate.dispatched` | After each subagent is spawned | Orchestrator |

--- a/skills/claude/delegation/SKILL.md
+++ b/skills/claude/delegation/SKILL.md
@@ -58,6 +58,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the `prepare_delegation` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for `prepare_delegation` lives in the runtime — query it with `exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })` if anything in this skill drifts from observed behavior. Treat the runtime `describe` output as the source of truth.
+
+### Step 0 — Pre-emit (required before `prepare_delegation`)
+
+Before calling `prepare_delegation`, the workflow stream must contain a `task.assigned` event for each task. The readiness view counts these events to populate `taskCount`; without them, `prepare_delegation` returns `{ ready: false, blockers: ["no task.assigned events found ..."] }`.
+
+```typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+```
+
+### Step 1 — Prepare (readiness check)
+
 ```typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -72,6 +91,8 @@ The composite action performs:
 3. **Quality signal assembly** — queries `code_quality` view; if `gatePassRate < 0.80`, returns quality hints to embed in prompts. Emits `gate.executed('plan-coverage')` on success (no pre-query needed)
 4. **Benchmark detection** — sets `verification.hasBenchmarks` if any task has benchmark criteria
 5. **Readiness verdict** — returns `{ ready: true, worktrees: [...], qualityHints: [...] }` or `{ ready: false, reason: "..." }`
+
+**If `blocked: true` with `reason: "current-branch-protected"`:** the response includes a `hint` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
 
 **If `ready: false`:** Stop. Report the reason to the user. Do not proceed.
 
@@ -151,6 +172,7 @@ The delegate phase requires these events (checked by `check-event-emissions`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| `task.assigned` | Before `prepare_delegation` (one per task; see Step 0) | Orchestrator |
 | `team.spawned` | After team creation, before dispatch | Orchestrator |
 | `team.task.planned` | For each task in the plan (use `batch_append`) | Orchestrator |
 | `team.teammate.dispatched` | After each subagent is spawned | Orchestrator |

--- a/skills/codex/delegation/SKILL.md
+++ b/skills/codex/delegation/SKILL.md
@@ -58,6 +58,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the `prepare_delegation` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for `prepare_delegation` lives in the runtime — query it with `exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })` if anything in this skill drifts from observed behavior. Treat the runtime `describe` output as the source of truth.
+
+### Step 0 — Pre-emit (required before `prepare_delegation`)
+
+Before calling `prepare_delegation`, the workflow stream must contain a `task.assigned` event for each task. The readiness view counts these events to populate `taskCount`; without them, `prepare_delegation` returns `{ ready: false, blockers: ["no task.assigned events found ..."] }`.
+
+```typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+```
+
+### Step 1 — Prepare (readiness check)
+
 ```typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -72,6 +91,8 @@ The composite action performs:
 3. **Quality signal assembly** — queries `code_quality` view; if `gatePassRate < 0.80`, returns quality hints to embed in prompts. Emits `gate.executed('plan-coverage')` on success (no pre-query needed)
 4. **Benchmark detection** — sets `verification.hasBenchmarks` if any task has benchmark criteria
 5. **Readiness verdict** — returns `{ ready: true, worktrees: [...], qualityHints: [...] }` or `{ ready: false, reason: "..." }`
+
+**If `blocked: true` with `reason: "current-branch-protected"`:** the response includes a `hint` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
 
 **If `ready: false`:** Stop. Report the reason to the user. Do not proceed.
 
@@ -149,6 +170,7 @@ The delegate phase requires these events (checked by `check-event-emissions`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| `task.assigned` | Before `prepare_delegation` (one per task; see Step 0) | Orchestrator |
 | `team.spawned` | After team creation, before dispatch | Orchestrator |
 | `team.task.planned` | For each task in the plan (use `batch_append`) | Orchestrator |
 | `team.teammate.dispatched` | After each subagent is spawned | Orchestrator |

--- a/skills/copilot/delegation/SKILL.md
+++ b/skills/copilot/delegation/SKILL.md
@@ -58,6 +58,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the `prepare_delegation` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for `prepare_delegation` lives in the runtime — query it with `exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })` if anything in this skill drifts from observed behavior. Treat the runtime `describe` output as the source of truth.
+
+### Step 0 — Pre-emit (required before `prepare_delegation`)
+
+Before calling `prepare_delegation`, the workflow stream must contain a `task.assigned` event for each task. The readiness view counts these events to populate `taskCount`; without them, `prepare_delegation` returns `{ ready: false, blockers: ["no task.assigned events found ..."] }`.
+
+```typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+```
+
+### Step 1 — Prepare (readiness check)
+
 ```typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -72,6 +91,8 @@ The composite action performs:
 3. **Quality signal assembly** — queries `code_quality` view; if `gatePassRate < 0.80`, returns quality hints to embed in prompts. Emits `gate.executed('plan-coverage')` on success (no pre-query needed)
 4. **Benchmark detection** — sets `verification.hasBenchmarks` if any task has benchmark criteria
 5. **Readiness verdict** — returns `{ ready: true, worktrees: [...], qualityHints: [...] }` or `{ ready: false, reason: "..." }`
+
+**If `blocked: true` with `reason: "current-branch-protected"`:** the response includes a `hint` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
 
 **If `ready: false`:** Stop. Report the reason to the user. Do not proceed.
 
@@ -145,6 +166,7 @@ The delegate phase requires these events (checked by `check-event-emissions`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| `task.assigned` | Before `prepare_delegation` (one per task; see Step 0) | Orchestrator |
 | `team.spawned` | After team creation, before dispatch | Orchestrator |
 | `team.task.planned` | For each task in the plan (use `batch_append`) | Orchestrator |
 | `team.teammate.dispatched` | After each subagent is spawned | Orchestrator |

--- a/skills/cursor/delegation/SKILL.md
+++ b/skills/cursor/delegation/SKILL.md
@@ -58,6 +58,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the `prepare_delegation` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for `prepare_delegation` lives in the runtime — query it with `exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })` if anything in this skill drifts from observed behavior. Treat the runtime `describe` output as the source of truth.
+
+### Step 0 — Pre-emit (required before `prepare_delegation`)
+
+Before calling `prepare_delegation`, the workflow stream must contain a `task.assigned` event for each task. The readiness view counts these events to populate `taskCount`; without them, `prepare_delegation` returns `{ ready: false, blockers: ["no task.assigned events found ..."] }`.
+
+```typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+```
+
+### Step 1 — Prepare (readiness check)
+
 ```typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -72,6 +91,8 @@ The composite action performs:
 3. **Quality signal assembly** — queries `code_quality` view; if `gatePassRate < 0.80`, returns quality hints to embed in prompts. Emits `gate.executed('plan-coverage')` on success (no pre-query needed)
 4. **Benchmark detection** — sets `verification.hasBenchmarks` if any task has benchmark criteria
 5. **Readiness verdict** — returns `{ ready: true, worktrees: [...], qualityHints: [...] }` or `{ ready: false, reason: "..." }`
+
+**If `blocked: true` with `reason: "current-branch-protected"`:** the response includes a `hint` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
 
 **If `ready: false`:** Stop. Report the reason to the user. Do not proceed.
 
@@ -148,6 +169,7 @@ The delegate phase requires these events (checked by `check-event-emissions`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| `task.assigned` | Before `prepare_delegation` (one per task; see Step 0) | Orchestrator |
 | `team.spawned` | After team creation, before dispatch | Orchestrator |
 | `team.task.planned` | For each task in the plan (use `batch_append`) | Orchestrator |
 | `team.teammate.dispatched` | After each subagent is spawned | Orchestrator |

--- a/skills/generic/delegation/SKILL.md
+++ b/skills/generic/delegation/SKILL.md
@@ -58,6 +58,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the `prepare_delegation` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for `prepare_delegation` lives in the runtime — query it with `exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })` if anything in this skill drifts from observed behavior. Treat the runtime `describe` output as the source of truth.
+
+### Step 0 — Pre-emit (required before `prepare_delegation`)
+
+Before calling `prepare_delegation`, the workflow stream must contain a `task.assigned` event for each task. The readiness view counts these events to populate `taskCount`; without them, `prepare_delegation` returns `{ ready: false, blockers: ["no task.assigned events found ..."] }`.
+
+```typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+```
+
+### Step 1 — Prepare (readiness check)
+
 ```typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -72,6 +91,8 @@ The composite action performs:
 3. **Quality signal assembly** — queries `code_quality` view; if `gatePassRate < 0.80`, returns quality hints to embed in prompts. Emits `gate.executed('plan-coverage')` on success (no pre-query needed)
 4. **Benchmark detection** — sets `verification.hasBenchmarks` if any task has benchmark criteria
 5. **Readiness verdict** — returns `{ ready: true, worktrees: [...], qualityHints: [...] }` or `{ ready: false, reason: "..." }`
+
+**If `blocked: true` with `reason: "current-branch-protected"`:** the response includes a `hint` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
 
 **If `ready: false`:** Stop. Report the reason to the user. Do not proceed.
 
@@ -145,6 +166,7 @@ The delegate phase requires these events (checked by `check-event-emissions`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| `task.assigned` | Before `prepare_delegation` (one per task; see Step 0) | Orchestrator |
 | `team.spawned` | After team creation, before dispatch | Orchestrator |
 | `team.task.planned` | For each task in the plan (use `batch_append`) | Orchestrator |
 | `team.teammate.dispatched` | After each subagent is spawned | Orchestrator |

--- a/skills/opencode/delegation/SKILL.md
+++ b/skills/opencode/delegation/SKILL.md
@@ -58,6 +58,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the `prepare_delegation` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for `prepare_delegation` lives in the runtime — query it with `exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })` if anything in this skill drifts from observed behavior. Treat the runtime `describe` output as the source of truth.
+
+### Step 0 — Pre-emit (required before `prepare_delegation`)
+
+Before calling `prepare_delegation`, the workflow stream must contain a `task.assigned` event for each task. The readiness view counts these events to populate `taskCount`; without them, `prepare_delegation` returns `{ ready: false, blockers: ["no task.assigned events found ..."] }`.
+
+```typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+```
+
+### Step 1 — Prepare (readiness check)
+
 ```typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -72,6 +91,8 @@ The composite action performs:
 3. **Quality signal assembly** — queries `code_quality` view; if `gatePassRate < 0.80`, returns quality hints to embed in prompts. Emits `gate.executed('plan-coverage')` on success (no pre-query needed)
 4. **Benchmark detection** — sets `verification.hasBenchmarks` if any task has benchmark criteria
 5. **Readiness verdict** — returns `{ ready: true, worktrees: [...], qualityHints: [...] }` or `{ ready: false, reason: "..." }`
+
+**If `blocked: true` with `reason: "current-branch-protected"`:** the response includes a `hint` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
 
 **If `ready: false`:** Stop. Report the reason to the user. Do not proceed.
 
@@ -149,6 +170,7 @@ The delegate phase requires these events (checked by `check-event-emissions`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| `task.assigned` | Before `prepare_delegation` (one per task; see Step 0) | Orchestrator |
 | `team.spawned` | After team creation, before dispatch | Orchestrator |
 | `team.task.planned` | For each task in the plan (use `batch_append`) | Orchestrator |
 | `team.teammate.dispatched` | After each subagent is spawned | Orchestrator |

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -677,6 +677,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the \`prepare_delegation\` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for \`prepare_delegation\` lives in the runtime — query it with \`exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })\` if anything in this skill drifts from observed behavior. Treat the runtime \`describe\` output as the source of truth.
+
+### Step 0 — Pre-emit (required before \`prepare_delegation\`)
+
+Before calling \`prepare_delegation\`, the workflow stream must contain a \`task.assigned\` event for each task. The readiness view counts these events to populate \`taskCount\`; without them, \`prepare_delegation\` returns \`{ ready: false, blockers: ["no task.assigned events found ..."] }\`.
+
+\`\`\`typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+\`\`\`
+
+### Step 1 — Prepare (readiness check)
+
 \`\`\`typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -691,6 +710,8 @@ The composite action performs:
 3. **Quality signal assembly** — queries \`code_quality\` view; if \`gatePassRate < 0.80\`, returns quality hints to embed in prompts. Emits \`gate.executed('plan-coverage')\` on success (no pre-query needed)
 4. **Benchmark detection** — sets \`verification.hasBenchmarks\` if any task has benchmark criteria
 5. **Readiness verdict** — returns \`{ ready: true, worktrees: [...], qualityHints: [...] }\` or \`{ ready: false, reason: "..." }\`
+
+**If \`blocked: true\` with \`reason: "current-branch-protected"\`:** the response includes a \`hint\` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
 
 **If \`ready: false\`:** Stop. Report the reason to the user. Do not proceed.
 
@@ -770,6 +791,7 @@ The delegate phase requires these events (checked by \`check-event-emissions\`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| \`task.assigned\` | Before \`prepare_delegation\` (one per task; see Step 0) | Orchestrator |
 | \`team.spawned\` | After team creation, before dispatch | Orchestrator |
 | \`team.task.planned\` | For each task in the plan (use \`batch_append\`) | Orchestrator |
 | \`team.teammate.dispatched\` | After each subagent is spawned | Orchestrator |
@@ -4921,6 +4943,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the \`prepare_delegation\` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for \`prepare_delegation\` lives in the runtime — query it with \`exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })\` if anything in this skill drifts from observed behavior. Treat the runtime \`describe\` output as the source of truth.
+
+### Step 0 — Pre-emit (required before \`prepare_delegation\`)
+
+Before calling \`prepare_delegation\`, the workflow stream must contain a \`task.assigned\` event for each task. The readiness view counts these events to populate \`taskCount\`; without them, \`prepare_delegation\` returns \`{ ready: false, blockers: ["no task.assigned events found ..."] }\`.
+
+\`\`\`typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+\`\`\`
+
+### Step 1 — Prepare (readiness check)
+
 \`\`\`typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -4935,6 +4976,8 @@ The composite action performs:
 3. **Quality signal assembly** — queries \`code_quality\` view; if \`gatePassRate < 0.80\`, returns quality hints to embed in prompts. Emits \`gate.executed('plan-coverage')\` on success (no pre-query needed)
 4. **Benchmark detection** — sets \`verification.hasBenchmarks\` if any task has benchmark criteria
 5. **Readiness verdict** — returns \`{ ready: true, worktrees: [...], qualityHints: [...] }\` or \`{ ready: false, reason: "..." }\`
+
+**If \`blocked: true\` with \`reason: "current-branch-protected"\`:** the response includes a \`hint\` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
 
 **If \`ready: false\`:** Stop. Report the reason to the user. Do not proceed.
 
@@ -5012,6 +5055,7 @@ The delegate phase requires these events (checked by \`check-event-emissions\`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| \`task.assigned\` | Before \`prepare_delegation\` (one per task; see Step 0) | Orchestrator |
 | \`team.spawned\` | After team creation, before dispatch | Orchestrator |
 | \`team.task.planned\` | For each task in the plan (use \`batch_append\`) | Orchestrator |
 | \`team.teammate.dispatched\` | After each subagent is spawned | Orchestrator |
@@ -9161,6 +9205,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the \`prepare_delegation\` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for \`prepare_delegation\` lives in the runtime — query it with \`exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })\` if anything in this skill drifts from observed behavior. Treat the runtime \`describe\` output as the source of truth.
+
+### Step 0 — Pre-emit (required before \`prepare_delegation\`)
+
+Before calling \`prepare_delegation\`, the workflow stream must contain a \`task.assigned\` event for each task. The readiness view counts these events to populate \`taskCount\`; without them, \`prepare_delegation\` returns \`{ ready: false, blockers: ["no task.assigned events found ..."] }\`.
+
+\`\`\`typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+\`\`\`
+
+### Step 1 — Prepare (readiness check)
+
 \`\`\`typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -9175,6 +9238,8 @@ The composite action performs:
 3. **Quality signal assembly** — queries \`code_quality\` view; if \`gatePassRate < 0.80\`, returns quality hints to embed in prompts. Emits \`gate.executed('plan-coverage')\` on success (no pre-query needed)
 4. **Benchmark detection** — sets \`verification.hasBenchmarks\` if any task has benchmark criteria
 5. **Readiness verdict** — returns \`{ ready: true, worktrees: [...], qualityHints: [...] }\` or \`{ ready: false, reason: "..." }\`
+
+**If \`blocked: true\` with \`reason: "current-branch-protected"\`:** the response includes a \`hint\` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
 
 **If \`ready: false\`:** Stop. Report the reason to the user. Do not proceed.
 
@@ -9248,6 +9313,7 @@ The delegate phase requires these events (checked by \`check-event-emissions\`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| \`task.assigned\` | Before \`prepare_delegation\` (one per task; see Step 0) | Orchestrator |
 | \`team.spawned\` | After team creation, before dispatch | Orchestrator |
 | \`team.task.planned\` | For each task in the plan (use \`batch_append\`) | Orchestrator |
 | \`team.teammate.dispatched\` | After each subagent is spawned | Orchestrator |
@@ -13393,6 +13459,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the \`prepare_delegation\` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for \`prepare_delegation\` lives in the runtime — query it with \`exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })\` if anything in this skill drifts from observed behavior. Treat the runtime \`describe\` output as the source of truth.
+
+### Step 0 — Pre-emit (required before \`prepare_delegation\`)
+
+Before calling \`prepare_delegation\`, the workflow stream must contain a \`task.assigned\` event for each task. The readiness view counts these events to populate \`taskCount\`; without them, \`prepare_delegation\` returns \`{ ready: false, blockers: ["no task.assigned events found ..."] }\`.
+
+\`\`\`typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+\`\`\`
+
+### Step 1 — Prepare (readiness check)
+
 \`\`\`typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -13407,6 +13492,8 @@ The composite action performs:
 3. **Quality signal assembly** — queries \`code_quality\` view; if \`gatePassRate < 0.80\`, returns quality hints to embed in prompts. Emits \`gate.executed('plan-coverage')\` on success (no pre-query needed)
 4. **Benchmark detection** — sets \`verification.hasBenchmarks\` if any task has benchmark criteria
 5. **Readiness verdict** — returns \`{ ready: true, worktrees: [...], qualityHints: [...] }\` or \`{ ready: false, reason: "..." }\`
+
+**If \`blocked: true\` with \`reason: "current-branch-protected"\`:** the response includes a \`hint\` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
 
 **If \`ready: false\`:** Stop. Report the reason to the user. Do not proceed.
 
@@ -13483,6 +13570,7 @@ The delegate phase requires these events (checked by \`check-event-emissions\`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| \`task.assigned\` | Before \`prepare_delegation\` (one per task; see Step 0) | Orchestrator |
 | \`team.spawned\` | After team creation, before dispatch | Orchestrator |
 | \`team.task.planned\` | For each task in the plan (use \`batch_append\`) | Orchestrator |
 | \`team.teammate.dispatched\` | After each subagent is spawned | Orchestrator |
@@ -17631,6 +17719,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the \`prepare_delegation\` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for \`prepare_delegation\` lives in the runtime — query it with \`exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })\` if anything in this skill drifts from observed behavior. Treat the runtime \`describe\` output as the source of truth.
+
+### Step 0 — Pre-emit (required before \`prepare_delegation\`)
+
+Before calling \`prepare_delegation\`, the workflow stream must contain a \`task.assigned\` event for each task. The readiness view counts these events to populate \`taskCount\`; without them, \`prepare_delegation\` returns \`{ ready: false, blockers: ["no task.assigned events found ..."] }\`.
+
+\`\`\`typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+\`\`\`
+
+### Step 1 — Prepare (readiness check)
+
 \`\`\`typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -17645,6 +17752,8 @@ The composite action performs:
 3. **Quality signal assembly** — queries \`code_quality\` view; if \`gatePassRate < 0.80\`, returns quality hints to embed in prompts. Emits \`gate.executed('plan-coverage')\` on success (no pre-query needed)
 4. **Benchmark detection** — sets \`verification.hasBenchmarks\` if any task has benchmark criteria
 5. **Readiness verdict** — returns \`{ ready: true, worktrees: [...], qualityHints: [...] }\` or \`{ ready: false, reason: "..." }\`
+
+**If \`blocked: true\` with \`reason: "current-branch-protected"\`:** the response includes a \`hint\` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
 
 **If \`ready: false\`:** Stop. Report the reason to the user. Do not proceed.
 
@@ -17718,6 +17827,7 @@ The delegate phase requires these events (checked by \`check-event-emissions\`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| \`task.assigned\` | Before \`prepare_delegation\` (one per task; see Step 0) | Orchestrator |
 | \`team.spawned\` | After team creation, before dispatch | Orchestrator |
 | \`team.task.planned\` | For each task in the plan (use \`batch_append\`) | Orchestrator |
 | \`team.teammate.dispatched\` | After each subagent is spawned | Orchestrator |
@@ -21863,6 +21973,25 @@ Before dispatching, query decision runbooks to classify the work and select the 
 
 Use the \`prepare_delegation\` composite action to validate readiness in a single call. This replaces manual script invocations and individual checks.
 
+> **Authoritative spec:** the canonical list of preconditions, blockers, and arguments for \`prepare_delegation\` lives in the runtime — query it with \`exarchos_orchestrate({ action: "describe", actions: ["prepare_delegation"] })\` if anything in this skill drifts from observed behavior. Treat the runtime \`describe\` output as the source of truth.
+
+### Step 0 — Pre-emit (required before \`prepare_delegation\`)
+
+Before calling \`prepare_delegation\`, the workflow stream must contain a \`task.assigned\` event for each task. The readiness view counts these events to populate \`taskCount\`; without them, \`prepare_delegation\` returns \`{ ready: false, blockers: ["no task.assigned events found ..."] }\`.
+
+\`\`\`typescript
+exarchos_event({
+  action: "batch_append",
+  stream: "<featureId>",
+  events: tasks.map((t) => ({
+    type: "task.assigned",
+    data: { taskId: t.id, title: t.title, branch: t.branch },
+  })),
+})
+\`\`\`
+
+### Step 1 — Prepare (readiness check)
+
 \`\`\`typescript
 exarchos_orchestrate({
   action: "prepare_delegation",
@@ -21877,6 +22006,8 @@ The composite action performs:
 3. **Quality signal assembly** — queries \`code_quality\` view; if \`gatePassRate < 0.80\`, returns quality hints to embed in prompts. Emits \`gate.executed('plan-coverage')\` on success (no pre-query needed)
 4. **Benchmark detection** — sets \`verification.hasBenchmarks\` if any task has benchmark criteria
 5. **Readiness verdict** — returns \`{ ready: true, worktrees: [...], qualityHints: [...] }\` or \`{ ready: false, reason: "..." }\`
+
+**If \`blocked: true\` with \`reason: "current-branch-protected"\`:** the response includes a \`hint\` field (e.g. "checkout the feature/phase branch before dispatching delegation"). Apply the hint, then re-call.
 
 **If \`ready: false\`:** Stop. Report the reason to the user. Do not proceed.
 
@@ -21954,6 +22085,7 @@ The delegate phase requires these events (checked by \`check-event-emissions\`):
 
 | Event | When | Emitted By |
 |-------|------|------------|
+| \`task.assigned\` | Before \`prepare_delegation\` (one per task; see Step 0) | Orchestrator |
 | \`team.spawned\` | After team creation, before dispatch | Orchestrator |
 | \`team.task.planned\` | For each task in the plan (use \`batch_append\`) | Orchestrator |
 | \`team.teammate.dispatched\` | After each subagent is spawned | Orchestrator |


### PR DESCRIPTION
## Summary

Resolves the post-PR-#1185 follow-up cluster: four v2.9.0-rc.1 defects sharing a DIM-3 (Contracts) theme — payload-shape drift between producer and consumer that the existing safety nets reject without telling the caller what shape was expected.

Closes #1187, #1188, #1189, #1190.

Full root cause analysis: [`docs/rca/2026-04-27-v29-rc1-orchestrate-cluster.md`](docs/rca/2026-04-27-v29-rc1-orchestrate-cluster.md).

| # | Surface | Pattern applied |
|---|---------|-----------------|
| #1187 | Pipeline view phantom rows | **Specification** + DRY (centralize infra-stream IDs) |
| #1188 | Orchestrate parent-default key leak | **Tolerant Dispatch** (boundary normalization) |
| #1189 | task_complete gate consultation | **Tolerant Reader** / Postel's Law + **SRP** (separate evidence-tag from override-mechanism) |
| #1190 | prepare_delegation undocumented preconditions | **Authoritative Spec** (runtime describe as canonical contract) |

## Changes

### Fix 1: Pipeline view filters infra streams (#1187)

`handleViewPipeline` materialized every stream returned by `discoverStreams()`, so `exarchos-init` / `exarchos-doctor` / `telemetry` surfaced as phantom rows with empty `featureId`/`workflowType`/`phase`.

- New `servers/exarchos-mcp/src/core/infra-streams.ts` — single source of truth for the three reserved IDs + `INFRA_STREAM_IDS: ReadonlySet<string>` + `isFeatureStream(id)` predicate.
- `orchestrate/init/index.ts`, `orchestrate/doctor/index.ts`, `telemetry/constants.ts` — re-export from core (existing import paths preserved).
- `views/tools.ts` — apply predicate to `discoverStreams()` output before materialization.
- Regression test: `Pipeline_WithInfraStreams_ExcludesPhantomRows`.

### Fix 2: Strip sibling-action defaults in dispatch (#1188)

`buildRegistrationSchema` flattens every action schema into one `.strict()` parent for MCP registration. Fields keep their `.default()` wrappers, so the MCP SDK applies sibling defaults (`nativeIsolation` from `prepare_delegation`, `outputFormat` from `agent_spec`) to every payload regardless of action — and the per-action `.strict()` then rejects them.

- `core/dispatch.ts` — before per-action `safeParse`, drop keys declared on a sibling action's schema but not on the matching action's. Caller typos (declared nowhere) still pass through and get rejected by `.strict()` — preserving the typo-detection guard that motivated `.strict()` in the first place.
- Regression tests: `Dispatch_LeakedSiblingDefaults_DoesNotRejectStrictPerActionSchema` (the bug) + `Dispatch_CallerTypo_StillRejected` (the typo-detection guard).

Cascade impact resolved: `task_complete` requires `tdd-compliance` to have passed, and `check_tdd_compliance` was unreachable, so every `task_complete` call in the delegate phase returned `GATE_NOT_PASSED`. With this fix, both flow.

### Fix 3: Tolerant gate-event reading + broaden evidence bypass (#1189)

Two compounding issues at the gate-precondition check:

1. **Schema mismatch**: `hasPassingGate` only matched events with `data.details.taskId` (canonical handler-emitted shape). Operators emitting `gate.executed` events naturally place `taskId` at `data.taskId` (top-level) — both shapes parse, but the consumer was the strict half.
2. **Narrow bypass**: `manualBypass = evidence.type === 'manual' && passed === true` — conflated evidence-tag (proof type) with override-mechanism (skip prerequisites).

- `tasks/tools.ts` — `hasPassingGate` now accepts `taskId` at either `data.taskId` or `data.details.taskId` (Tolerant Reader). Top-level wins when present. Missing-taskId on the canonical path still signals project-wide gate (preserves existing contract).
- `manualBypass` becomes `evidenceBypass = evidence?.passed === true && (evidence.output ?? '').length > 0` — orthogonal to `evidence.type` per SRP. Empty-output sanity guard prevents trivially-true assertions from bypassing.
- Regression tests in `tasks/tools.test.ts` (`#1189 — gate consultation tolerates alt shapes`):
  - top-level taskId match → accepted
  - top-level taskId mismatch → still rejected
  - non-manual + passed + non-empty output → bypasses
  - empty output → does NOT bypass
  - manual evidence still works → backward compat
- Updated obsolete `__tests__/tasks/tools.test.ts:NonManualEvidence_StillRequiresGates` (locked in old narrow contract) — replaced with two tests reflecting the new contract.

### Fix 4: Document task.assigned + remediation hint (#1190)

`prepare_delegation` enforces a `task.assigned`-event-per-task precondition (via `DelegationReadinessView`'s task counter) that was not documented in the delegation skill. Same UX defect class as closed #1029.

- `skills-src/delegation/SKILL.md`:
  - New "Step 0 — Pre-emit" subsection documents the `task.assigned` `batch_append`
  - Step 1 reframed around `exarchos_orchestrate describe(...)` as authoritative spec — runtime is canonical when text drifts (mirrors #1029)
  - Event-contract table gains `task.assigned` row with timing constraint
- `dispatch-guard.ts`: `CurrentBranchProtectionResult` gains optional `hint` field; `assertCurrentBranchNotProtected` sets it on the blocked path.
- `prepare-delegation.ts`: thread the hint into the blocker payload.
- All 6 runtime variants regenerated (`claude`, `codex`, `copilot`, `cursor`, `generic`, `opencode`); `npm run skills:guard` passes.
- Regression test: `assertCurrentBranchNotProtected_OnMain_IncludesRemediationHint`.

## Cross-Cutting (#1109) Verification

- [x] **Event-sourcing integrity:** No new event types emitted. #1189's `hasPassingGate` becomes more tolerant in *reading* `gate.executed` events; output of every projection remains reconstructable from the event log alone. Replayability preserved.
- [x] **MCP parity:** Every code-side fix lives in shared core (`views/tools.ts`, `core/dispatch.ts`, `tasks/tools.ts`, `orchestrate/prepare-delegation.ts`) — both CLI and MCP facades dispatch through the same handlers, so behavior is uniform by construction.
- [x] **Basileus-forward:** No fix introduces a local-only assumption. The `infra-streams.ts` predicate, dispatch tolerance, and `hint` text are transport-agnostic.
- [x] **Capability resolution:** No fix touches yaml capability fields or handshake state.

## Backend-Quality Dimension Mapping

| Defect | Primary | Secondary |
|--------|---------|-----------|
| #1187 | DIM-3 (Contracts: stream-id taxonomy) | DIM-2 (Observability: phantom-row noise) |
| #1188 | DIM-1 (Topology: cross-action ambient state) | DIM-3 (Contracts: schema-dispatch invariant) |
| #1189 | DIM-3 (Contracts: gate-event shape) | DIM-7 (Resilience: silent drop of valid evidence) |
| #1190 | DIM-3 (Contracts: undocumented preconditions) | DIM-2 (Observability: runtime-only blocker discovery) |

## Test Plan

- [x] `npx tsc --noEmit` clean (root + MCP server)
- [x] `cd servers/exarchos-mcp && npm run test:run`: 5744 pass / 2 pre-existing macOS path-canonicalization flakes (`yaml-loader.test.ts`, `index.test.ts`) — same flakes called out in PR #1185's test plan
- [x] `node scripts/check-event-store-composition-root.mjs`: exit 0
- [x] `npm run build:skills` + `npm run skills:guard`: clean (96 variants across 8 runtimes)
- [x] `npm run build`: full bundle compiles for darwin/linux/windows
- [ ] Manual: dispatch `prepare_delegation` after pre-emitting `task.assigned` events; verify the readiness view recognizes them and Step 0 of the regenerated skill text matches behavior (Fix 4)
- [ ] Manual: invoke `exarchos_orchestrate({ action: "check_tdd_compliance", ... })` from MCP and verify it succeeds (Fix 2)
- [ ] Manual: emit a `gate.executed` event with `data.taskId` (top-level), then call `task_complete` — verify it accepts (Fix 3)
- [ ] Manual: `exarchos view ls` against an empty workflow_state with infra streams populated — verify zero phantom rows (Fix 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
