### PR TITLE
refactor(#1192): reviewer hardening — readonly capability tier + adapter cleanups

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -34,6 +34,11 @@ reviews:
       instructions: "Prioritize security: auth, input validation, error handling."
     - path: "docs/**"
       instructions: "Check for accuracy and completeness. Light review only."
+    - path: "skills-src/*/references/**/*.md"
+      instructions: |
+        Reference files are includes, not standalone skill entry points.
+        Do NOT require YAML frontmatter on these files.
+        See CLAUDE.md "Reference-file frontmatter" rule.
 
   coding_guidelines:
     - title: TypeScript SOLID Principles

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -39,6 +39,11 @@ reviews:
         Reference files are includes, not standalone skill entry points.
         Do NOT require YAML frontmatter on these files.
         See CLAUDE.md "Reference-file frontmatter" rule.
+    - path: "skills/*/references/**/*.md"
+      instructions: |
+        Reference files are includes, not standalone skill entry points.
+        Do NOT require YAML frontmatter on these files.
+        See CLAUDE.md "Reference-file frontmatter" rule.
 
   coding_guidelines:
     - title: TypeScript SOLID Principles

--- a/.codex/agents/fixer.toml
+++ b/.codex/agents/fixer.toml
@@ -43,4 +43,5 @@ When done, output a JSON completion report:
 - shell:exec
 - mcp:exarchos
 """
+sandbox_mode = "workspace-write"
 mcp_servers = ["exarchos"]

--- a/.codex/agents/implementer.toml
+++ b/.codex/agents/implementer.toml
@@ -91,4 +91,5 @@ When done, output a JSON completion report:
 - isolation:worktree
 - session:resume
 """
+sandbox_mode = "workspace-write"
 mcp_servers = ["exarchos"]

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -22,24 +22,6 @@ Rules:
 - Be specific in findings — include file paths and line references
 - Categorize findings: critical, warning, suggestion
 
-## Forbidden MCP Actions (read-only review boundary)
-
-You MAY call only these strictly read-only Exarchos MCP actions:
-- `exarchos_view` — `pipeline`, `tasks`, `workflow_status`, `stack_status`, `telemetry`, `team_performance`, `delegation_timeline`, `delegation_readiness`, `synthesis_readiness`, `shepherd_status`, `convergence`, `quality_hints`, `describe` (NOT `code_quality` — emits `quality.regression` events; NOT `stack_place` — mutates)
-- `exarchos_workflow` — `get`, `describe` only
-- `exarchos_event` — `query`, `describe` only
-- `exarchos_orchestrate` — `describe` only
-
-You MUST NOT call any other MCP action — they all mutate state, emit events, or call external services. Forbidden examples include but are not limited to:
-- `exarchos_workflow set/init/cancel/cleanup/checkpoint/reconcile/rehydrate` (`reconcile` writes state, `rehydrate` emits `workflow.rehydrated`)
-- `exarchos_event append/batch_append`
-- `exarchos_orchestrate check_*` (each emits a `gate.executed` event)
-- `exarchos_orchestrate task_claim/task_complete/task_fail`
-- `exarchos_orchestrate create_pr/merge_pr/add_pr_comment/create_issue/...`
-- `exarchos_view code_quality/stack_place`
-
-Workflow mutation, event emission, and gate execution belong to the orchestrator. If a finding requires state changes, gate runs, or fresh quality checks, surface it as a recommendation in the review verdict — the orchestrator will dispatch.
-
 ## Completion Report
 When done, output a JSON completion report:
 ```json
@@ -53,6 +35,7 @@ When done, output a JSON completion report:
 
 ## Declared capabilities
 - fs:read
-- mcp:exarchos
+- mcp:exarchos:readonly
 """
+sandbox_mode = "read-only"
 mcp_servers = ["exarchos"]

--- a/.codex/agents/scaffolder.toml
+++ b/.codex/agents/scaffolder.toml
@@ -43,4 +43,5 @@ When done, output a JSON completion report:
 - mcp:exarchos
 - isolation:worktree
 """
+sandbox_mode = "workspace-write"
 mcp_servers = ["exarchos"]

--- a/.cursor/agents/fixer.md
+++ b/.cursor/agents/fixer.md
@@ -25,6 +25,8 @@ description: >-
 model: inherit
 readonly: false
 is_background: false
+mcp:
+  exarchos: true
 ---
 You are a fixer agent. Your job is to diagnose and repair failures.
 

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -25,57 +25,10 @@ description: >-
 model: inherit
 readonly: false
 is_background: false
+mcp:
+  exarchos: true
 ---
 You are a TDD implementer agent working in an isolated worktree.
-
-## Worktree Verification
-Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
-3. If NOT in worktree: STOP and report error
-
-## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
-
-The startup check above only verifies you booted in the right place. Shell
-`cd` and script runners can leave you in another worktree mid-task. Once
-that happens, subsequent `git` commands execute against whatever worktree
-your shell is sitting in — and commits land on the wrong branch. Recent
-sessions have seen this corrupt the orchestrator's main worktree HEAD.
-
-Rules:
-
-1. **All `git` commands must use `git -C <my-worktree-path>`.** Never rely
-   on the shell's working directory for git. Capture your worktree path at
-   startup (from `pwd`) and use it explicitly for every `git add`,
-   `git commit`, `git status`, `git log`, etc.
-2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
-   explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
-3. **If a command must run from a specific directory, restore the
-   worktree cwd immediately after.** If you need one-off output from
-   `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`
-   before the next git operation.
-4. **Never `git reset --hard` outside your worktree.** If you believe
-   you've accidentally committed to a branch in another worktree, STOP
-   and report it — do not try to self-heal with a reset in the parent
-   repo.
-
-Concrete example — **wrong vs right** for running typecheck in the
-completion gate:
-
-```bash
-# WRONG — cds into main worktree, then subsequent git ops contaminate it
-cd /home/user/repo && npm run typecheck
-git status     # now runs in /home/user/repo, not the worktree
-
-# RIGHT — uses --prefix, shell cwd never leaves the worktree
-npm --prefix "$WORKTREE" run typecheck
-git -C "$WORKTREE" status
-```
-
-Where `$WORKTREE` is the absolute path captured at startup (the `pwd`
-output from the Worktree Verification step above).
 
 ## Task
 {{taskDescription}}

--- a/.cursor/agents/reviewer.md
+++ b/.cursor/agents/reviewer.md
@@ -24,6 +24,8 @@ description: >-
 model: inherit
 readonly: true
 is_background: false
+mcp:
+  exarchos: true
 ---
 You are a code reviewer agent. You analyze code for quality, correctness, and design compliance.
 
@@ -45,24 +47,6 @@ Rules:
 - Use Read/Grep/Glob to inspect code. If a finding requires running tests or a typecheck to confirm, surface it as a recommendation in the review verdict — the orchestrator will dispatch a separate run
 - Be specific in findings — include file paths and line references
 - Categorize findings: critical, warning, suggestion
-
-## Forbidden MCP Actions (read-only review boundary)
-
-You MAY call only these strictly read-only Exarchos MCP actions:
-- `exarchos_view` — `pipeline`, `tasks`, `workflow_status`, `stack_status`, `telemetry`, `team_performance`, `delegation_timeline`, `delegation_readiness`, `synthesis_readiness`, `shepherd_status`, `convergence`, `quality_hints`, `describe` (NOT `code_quality` — emits `quality.regression` events; NOT `stack_place` — mutates)
-- `exarchos_workflow` — `get`, `describe` only
-- `exarchos_event` — `query`, `describe` only
-- `exarchos_orchestrate` — `describe` only
-
-You MUST NOT call any other MCP action — they all mutate state, emit events, or call external services. Forbidden examples include but are not limited to:
-- `exarchos_workflow set/init/cancel/cleanup/checkpoint/reconcile/rehydrate` (`reconcile` writes state, `rehydrate` emits `workflow.rehydrated`)
-- `exarchos_event append/batch_append`
-- `exarchos_orchestrate check_*` (each emits a `gate.executed` event)
-- `exarchos_orchestrate task_claim/task_complete/task_fail`
-- `exarchos_orchestrate create_pr/merge_pr/add_pr_comment/create_issue/...`
-- `exarchos_view code_quality/stack_place`
-
-Workflow mutation, event emission, and gate execution belong to the orchestrator. If a finding requires state changes, gate runs, or fresh quality checks, surface it as a recommendation in the review verdict — the orchestrator will dispatch.
 
 ## Completion Report
 When done, output a JSON completion report:

--- a/.cursor/agents/scaffolder.md
+++ b/.cursor/agents/scaffolder.md
@@ -25,14 +25,10 @@ description: >-
 model: inherit
 readonly: false
 is_background: false
+mcp:
+  exarchos: true
 ---
 You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.
-
-## Worktree Verification
-Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
-3. If NOT in worktree: STOP and report error
 
 ## Task
 {{taskDescription}}

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -46,24 +46,6 @@ Rules:
 - Be specific in findings — include file paths and line references
 - Categorize findings: critical, warning, suggestion
 
-## Forbidden MCP Actions (read-only review boundary)
-
-You MAY call only these strictly read-only Exarchos MCP actions:
-- `exarchos_view` — `pipeline`, `tasks`, `workflow_status`, `stack_status`, `telemetry`, `team_performance`, `delegation_timeline`, `delegation_readiness`, `synthesis_readiness`, `shepherd_status`, `convergence`, `quality_hints`, `describe` (NOT `code_quality` — emits `quality.regression` events; NOT `stack_place` — mutates)
-- `exarchos_workflow` — `get`, `describe` only
-- `exarchos_event` — `query`, `describe` only
-- `exarchos_orchestrate` — `describe` only
-
-You MUST NOT call any other MCP action — they all mutate state, emit events, or call external services. Forbidden examples include but are not limited to:
-- `exarchos_workflow set/init/cancel/cleanup/checkpoint/reconcile/rehydrate` (`reconcile` writes state, `rehydrate` emits `workflow.rehydrated`)
-- `exarchos_event append/batch_append`
-- `exarchos_orchestrate check_*` (each emits a `gate.executed` event)
-- `exarchos_orchestrate task_claim/task_complete/task_fail`
-- `exarchos_orchestrate create_pr/merge_pr/add_pr_comment/create_issue/...`
-- `exarchos_view code_quality/stack_place`
-
-Workflow mutation, event emission, and gate execution belong to the orchestrator. If a finding requires state changes, gate runs, or fresh quality checks, surface it as a recommendation in the review verdict — the orchestrator will dispatch.
-
 ## Completion Report
 When done, output a JSON completion report:
 ```json

--- a/.opencode/agents/reviewer.md
+++ b/.opencode/agents/reviewer.md
@@ -64,24 +64,6 @@ Rules:
 - Be specific in findings — include file paths and line references
 - Categorize findings: critical, warning, suggestion
 
-## Forbidden MCP Actions (read-only review boundary)
-
-You MAY call only these strictly read-only Exarchos MCP actions:
-- `exarchos_view` — `pipeline`, `tasks`, `workflow_status`, `stack_status`, `telemetry`, `team_performance`, `delegation_timeline`, `delegation_readiness`, `synthesis_readiness`, `shepherd_status`, `convergence`, `quality_hints`, `describe` (NOT `code_quality` — emits `quality.regression` events; NOT `stack_place` — mutates)
-- `exarchos_workflow` — `get`, `describe` only
-- `exarchos_event` — `query`, `describe` only
-- `exarchos_orchestrate` — `describe` only
-
-You MUST NOT call any other MCP action — they all mutate state, emit events, or call external services. Forbidden examples include but are not limited to:
-- `exarchos_workflow set/init/cancel/cleanup/checkpoint/reconcile/rehydrate` (`reconcile` writes state, `rehydrate` emits `workflow.rehydrated`)
-- `exarchos_event append/batch_append`
-- `exarchos_orchestrate check_*` (each emits a `gate.executed` event)
-- `exarchos_orchestrate task_claim/task_complete/task_fail`
-- `exarchos_orchestrate create_pr/merge_pr/add_pr_comment/create_issue/...`
-- `exarchos_view code_quality/stack_place`
-
-Workflow mutation, event emission, and gate execution belong to the orchestrator. If a finding requires state changes, gate runs, or fresh quality checks, surface it as a recommendation in the review verdict — the orchestrator will dispatch.
-
 ## Completion Report
 When done, output a JSON completion report:
 ```json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ cd servers/exarchos-mcp && npm run test:run
 - **Skill frontmatter** — `name` (kebab-case), `description` (<=1,024 chars), `metadata`
 - **Skill metadata** — Skills invoking Exarchos MCP tools MUST include `metadata.mcp-server: exarchos` in frontmatter. Utility/standards skills without MCP dependency are exempt.
 - **Skills source-of-truth** — Edit `skills-src/<name>/SKILL.md`, then run `npm run build:skills` and commit both the source and the regenerated `skills/` tree. Direct edits to `skills/<runtime>/**` will fail the `skills:guard` CI check.
+- **Reference-file frontmatter** — Files under `skills-src/<skill>/references/*.md` MUST NOT have YAML frontmatter. Frontmatter is reserved for skill entry points (`SKILL.md`, `commands/*.md`, `rules/*.md`). Reference files are includes; frontmatter is metadata noise that triggers spurious validator complaints.
 
 ## Workflow Dispatch Conventions
 

--- a/agents/fixer.md
+++ b/agents/fixer.md
@@ -1,8 +1,8 @@
 ---
 name: exarchos-fixer
-description: |
+description: |-
   Use this agent when a task has failed and needs diagnosis and repair with adversarial verification.
-  
+
   <example>
   Context: A delegated task failed its quality gates or tests
   user: "Task-005 failed TDD compliance — fix it"
@@ -11,19 +11,27 @@ description: |
   Failed task requiring root cause analysis and targeted fix triggers the fixer agent.
   </commentary>
   </example>
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
 model: inherit
 color: red
-disallowedTools: ["Agent"]
-mcpServers: ["exarchos"]
+disallowedTools:
+  - Agent
+mcpServers:
+  - exarchos
 skills:
   - tdd-patterns
 hooks:
   PostToolUse:
-    - matcher: "Bash"
+    - matcher: Bash
       hooks:
         - type: command
-          command: "npm run test:run"
+          command: npm --prefix "$(git rev-parse --show-toplevel)" run test:run
 ---
 
 You are a fixer agent. Your job is to diagnose and repair failures.

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -1,8 +1,8 @@
 ---
 name: exarchos-implementer
-description: |
+description: |-
   Use this agent when dispatching TDD implementation tasks to a subagent in an isolated worktree.
-  
+
   <example>
   Context: Orchestrator is dispatching a task from an implementation plan
   user: "Implement the agent spec handler (task-003)"
@@ -11,22 +11,30 @@ description: |
   Implementation task requiring test-first development triggers the implementer agent.
   </commentary>
   </example>
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
 model: inherit
 color: blue
-disallowedTools: ["Agent"]
+disallowedTools:
+  - Agent
 isolation: worktree
 memory: project
-mcpServers: ["exarchos"]
+mcpServers:
+  - exarchos
 skills:
   - tdd-patterns
   - testing-patterns
 hooks:
   PostToolUse:
-    - matcher: "Bash"
+    - matcher: Bash
       hooks:
         - type: command
-          command: "npm run test:run"
+          command: npm --prefix "$(git rev-parse --show-toplevel)" run test:run
 ---
 
 You are a TDD implementer agent working in an isolated worktree.

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -1,8 +1,8 @@
 ---
 name: exarchos-reviewer
-description: |
+description: |-
   Use this agent when performing read-only code review for quality, design compliance, and test coverage.
-  
+
   <example>
   Context: Feature implementation is complete and needs review
   user: "Review the agent spec handler for code quality"
@@ -11,11 +11,19 @@ description: |
   Code review request triggers the reviewer agent for read-only analysis.
   </commentary>
   </example>
-tools: ["Read", "Grep", "Glob"]
+tools:
+  - Read
+  - Grep
+  - Glob
 model: inherit
 color: green
-disallowedTools: ["Write", "Edit", "Agent", "Bash"]
-mcpServers: ["exarchos"]
+disallowedTools:
+  - Write
+  - Edit
+  - Agent
+  - Bash
+mcpServers:
+  - exarchos
 ---
 
 You are a code reviewer agent. You analyze code for quality, correctness, and design compliance.
@@ -38,24 +46,6 @@ Rules:
 - Use Read/Grep/Glob to inspect code. If a finding requires running tests or a typecheck to confirm, surface it as a recommendation in the review verdict — the orchestrator will dispatch a separate run
 - Be specific in findings — include file paths and line references
 - Categorize findings: critical, warning, suggestion
-
-## Forbidden MCP Actions (read-only review boundary)
-
-You MAY call only these strictly read-only Exarchos MCP actions:
-- `exarchos_view` — `pipeline`, `tasks`, `workflow_status`, `stack_status`, `telemetry`, `team_performance`, `delegation_timeline`, `delegation_readiness`, `synthesis_readiness`, `shepherd_status`, `convergence`, `quality_hints`, `describe` (NOT `code_quality` — emits `quality.regression` events; NOT `stack_place` — mutates)
-- `exarchos_workflow` — `get`, `describe` only
-- `exarchos_event` — `query`, `describe` only
-- `exarchos_orchestrate` — `describe` only
-
-You MUST NOT call any other MCP action — they all mutate state, emit events, or call external services. Forbidden examples include but are not limited to:
-- `exarchos_workflow set/init/cancel/cleanup/checkpoint/reconcile/rehydrate` (`reconcile` writes state, `rehydrate` emits `workflow.rehydrated`)
-- `exarchos_event append/batch_append`
-- `exarchos_orchestrate check_*` (each emits a `gate.executed` event)
-- `exarchos_orchestrate task_claim/task_complete/task_fail`
-- `exarchos_orchestrate create_pr/merge_pr/add_pr_comment/create_issue/...`
-- `exarchos_view code_quality/stack_place`
-
-Workflow mutation, event emission, and gate execution belong to the orchestrator. If a finding requires state changes, gate runs, or fresh quality checks, surface it as a recommendation in the review verdict — the orchestrator will dispatch.
 
 ## Completion Report
 When done, output a JSON completion report:

--- a/agents/scaffolder.md
+++ b/agents/scaffolder.md
@@ -1,8 +1,8 @@
 ---
 name: exarchos-scaffolder
-description: |
+description: |-
   Use this agent for low-complexity scaffolding tasks — file creation, boilerplate generation, and structural setup.
-  
+
   <example>
   Context: Orchestrator needs new files or boilerplate created
   user: "Create the directory structure and stub files for the new feature"
@@ -11,12 +11,20 @@ description: |
   Simple file creation and boilerplate generation triggers the scaffolder agent with concise output.
   </commentary>
   </example>
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
 model: sonnet
 color: cyan
-disallowedTools: ["Agent"]
+disallowedTools:
+  - Agent
 isolation: worktree
-mcpServers: ["exarchos"]
+mcpServers:
+  - exarchos
 ---
 
 You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.

--- a/docs/designs/2026-04-25-delegation-runtime-parity.md
+++ b/docs/designs/2026-04-25-delegation-runtime-parity.md
@@ -57,7 +57,7 @@ The new domain type is a typed enum of capabilities declared by an agent spec. C
 | `team:agent-teams` | Tmux-based parallel UI | `--mode agent-team` | — | — | — | — |
 | `session:resume` | Resume by `agentId` | native | — | — | — | — |
 
-Capabilities are encoded in `servers/exarchos-mcp/src/agents/capabilities.ts` as a Zod discriminated union. Agent specs in `definitions.ts` declare `capabilities: Capability[]`. The Claude tool array (`Read`, `Write`, etc.) disappears from the registry; it reappears only inside `adapters/claude.ts` during lowering. This is the dependency-direction inversion required by Hexagonal Architecture and the semantic-translation discipline required by ACL.
+Capabilities are encoded in `servers/exarchos-mcp/src/agents/capabilities.ts` as a Zod `z.enum([...])` of string-key capability identifiers. Agent specs in `definitions.ts` declare `capabilities: Capability[]`. The Claude tool array (`Read`, `Write`, etc.) disappears from the registry; it reappears only inside `adapters/claude.ts` during lowering. This is the dependency-direction inversion required by Hexagonal Architecture and the semantic-translation discipline required by ACL.
 
 Each runtime declares `supportedCapabilities: Capability[]` in `runtimes/<name>.yaml`. A spec requiring `team:agent-teams` against a runtime that doesn't declare it produces a build-time error from the renderer, not a silent omission.
 

--- a/runtimes/claude.yaml
+++ b/runtimes/claude.yaml
@@ -45,6 +45,7 @@ supportedCapabilities:
   subagent:completion-signal: native
   subagent:start-signal: native
   mcp:exarchos: native
+  mcp:exarchos:readonly: native
   isolation:worktree: native
   team:agent-teams: native
   session:resume: native

--- a/runtimes/codex.yaml
+++ b/runtimes/codex.yaml
@@ -72,6 +72,7 @@ supportedCapabilities:
   shell:exec: native
   subagent:spawn: native
   mcp:exarchos: native
+  mcp:exarchos:readonly: native
   isolation:worktree: advisory
   session:resume: advisory
   # Omitted (unsupported on Codex):

--- a/runtimes/copilot.yaml
+++ b/runtimes/copilot.yaml
@@ -59,6 +59,7 @@ supportedCapabilities:
   shell:exec: native
   subagent:spawn: native
   mcp:exarchos: native
+  mcp:exarchos:readonly: native
   isolation:worktree: advisory
   session:resume: advisory
 skillsInstallPath: "~/.copilot/skills"

--- a/runtimes/cursor.yaml
+++ b/runtimes/cursor.yaml
@@ -43,6 +43,7 @@ supportedCapabilities:
   shell:exec: native
   subagent:spawn: native
   mcp:exarchos: native
+  mcp:exarchos:readonly: native
   isolation:worktree: advisory
   session:resume: advisory
 skillsInstallPath: "~/.cursor/skills"

--- a/runtimes/opencode.yaml
+++ b/runtimes/opencode.yaml
@@ -41,6 +41,7 @@ supportedCapabilities:
   shell:exec: native
   subagent:spawn: native
   mcp:exarchos: native
+  mcp:exarchos:readonly: native
   isolation:worktree: advisory
   session:resume: advisory
 skillsInstallPath: "~/.config/opencode/skills"

--- a/servers/exarchos-mcp/src/adapters/mcp.test.ts
+++ b/servers/exarchos-mcp/src/adapters/mcp.test.ts
@@ -5,6 +5,8 @@ import * as os from 'node:os';
 import { EventStore } from '../event-store/store.js';
 import { TOOL_REGISTRY, buildToolDescription } from '../registry.js';
 import type { DispatchContext } from '../core/dispatch.js';
+import { dispatch, READ_ONLY_ACTIONS } from '../core/dispatch.js';
+import { createInMemoryResolver } from '../capabilities/resolver.js';
 
 // Mock the state-store module
 vi.mock('../workflow/state-store.js', async (importOriginal) => {
@@ -81,6 +83,181 @@ describe('createMcpServer', () => {
     // Assert — server.server should be accessible and have a notification method
     expect(server.server).toBeDefined();
     expect(typeof server.server.notification).toBe('function');
+  });
+
+  // ─── T04: server-side readonly action allowlist (Issue #1192) ─────────────
+  //
+  // When the effective capability set is `{mcp:exarchos:readonly}` (i.e. the
+  // caller does NOT also hold `mcp:exarchos`), dispatch must reject mutating
+  // composite-tool actions with a structured CAPABILITY_DENIED error. Read-only
+  // actions still succeed (they may return a domain error like missing state,
+  // but never CAPABILITY_DENIED). A spec that holds BOTH tiers keeps full
+  // access — the readonly gate fires only when the readonly tier is the only
+  // mcp:exarchos capability present.
+
+  it('MCPDispatch_AllowsReadAction_UnderReadonly', async () => {
+    // Arrange — capability resolver reports only the readonly tier.
+    const readonlyCtx: DispatchContext = {
+      ...ctx,
+      capabilityResolver: createInMemoryResolver(['mcp:exarchos:readonly']),
+    };
+
+    // Act — `get` is on the read-only allowlist for exarchos_workflow.
+    const result = await dispatch(
+      'exarchos_workflow',
+      { action: 'get', featureId: 'foo' },
+      readonlyCtx,
+    );
+
+    // Assert — must not be the readonly gate's structured rejection. The
+    // call may still fail for other reasons (missing state file), but never
+    // with CAPABILITY_DENIED.
+    expect(result.error?.code).not.toBe('CAPABILITY_DENIED');
+  });
+
+  it('MCPDispatch_RejectsMutatingAction_UnderReadonly', async () => {
+    // Arrange
+    const readonlyCtx: DispatchContext = {
+      ...ctx,
+      capabilityResolver: createInMemoryResolver(['mcp:exarchos:readonly']),
+    };
+
+    // Act — `set` is a mutating workflow action (auto-emits state.patched).
+    const result = await dispatch(
+      'exarchos_workflow',
+      { action: 'set', featureId: 'foo', updates: {} },
+      readonlyCtx,
+    );
+
+    // Assert — structured error identifying the gated tool/action so the
+    // caller can correlate the rejection back to a specific dispatch.
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('CAPABILITY_DENIED');
+    expect(result.error?.tool).toBe('exarchos_workflow');
+    expect(result.error?.action).toBe('set');
+  });
+
+  it('MCPDispatch_RejectsAppend_UnderReadonly', async () => {
+    // Arrange
+    const readonlyCtx: DispatchContext = {
+      ...ctx,
+      capabilityResolver: createInMemoryResolver(['mcp:exarchos:readonly']),
+    };
+
+    // Act — `append` writes to the event store; must be denied.
+    const result = await dispatch(
+      'exarchos_event',
+      {
+        action: 'append',
+        stream: 'foo',
+        event: { type: 'test.event', data: {} },
+      },
+      readonlyCtx,
+    );
+
+    // Assert
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('CAPABILITY_DENIED');
+    expect(result.error?.tool).toBe('exarchos_event');
+    expect(result.error?.action).toBe('append');
+  });
+
+  it('MCPDispatch_RejectsTaskComplete_UnderReadonly', async () => {
+    // Arrange
+    const readonlyCtx: DispatchContext = {
+      ...ctx,
+      capabilityResolver: createInMemoryResolver(['mcp:exarchos:readonly']),
+    };
+
+    // Act — task_complete auto-emits task.completed; mutating.
+    const result = await dispatch(
+      'exarchos_orchestrate',
+      {
+        action: 'task_complete',
+        taskId: 't1',
+        streamId: 'foo',
+      },
+      readonlyCtx,
+    );
+
+    // Assert
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('CAPABILITY_DENIED');
+    expect(result.error?.tool).toBe('exarchos_orchestrate');
+    expect(result.error?.action).toBe('task_complete');
+  });
+
+  it('MCPDispatch_AllowsView_UnderReadonly', async () => {
+    // Arrange — exarchos_view is wholesale read-only (`'*'` allowlist).
+    const readonlyCtx: DispatchContext = {
+      ...ctx,
+      capabilityResolver: createInMemoryResolver(['mcp:exarchos:readonly']),
+    };
+
+    // Act
+    const result = await dispatch(
+      'exarchos_view',
+      { action: 'pipeline' },
+      readonlyCtx,
+    );
+
+    // Assert — never blocked by the readonly gate, regardless of action.
+    expect(result.error?.code).not.toBe('CAPABILITY_DENIED');
+  });
+
+  it('MCPDispatch_BothCaps_KeepsFullAccess', async () => {
+    // Arrange — when the spec carries BOTH `mcp:exarchos` and the readonly
+    // tier, the less-restrictive tier wins (mirrors the resolver's tier
+    // merge logic that T05 will land). The readonly gate must NOT fire.
+    const fullCtx: DispatchContext = {
+      ...ctx,
+      capabilityResolver: createInMemoryResolver([
+        'mcp:exarchos',
+        'mcp:exarchos:readonly',
+      ]),
+    };
+
+    // Act
+    const result = await dispatch(
+      'exarchos_workflow',
+      { action: 'set', featureId: 'foo', updates: {} },
+      fullCtx,
+    );
+
+    // Assert — may fail for other reasons but never CAPABILITY_DENIED.
+    expect(result.error?.code).not.toBe('CAPABILITY_DENIED');
+  });
+
+  it('READ_ONLY_ACTIONS_ExposesAllowlistShape', () => {
+    // Sanity check the constant shape so T05 / T06-T10 can rely on it.
+    expect(READ_ONLY_ACTIONS.exarchos_workflow).toEqual(
+      expect.arrayContaining(['get', 'describe', 'reconcile', 'rehydrate']),
+    );
+    expect(READ_ONLY_ACTIONS.exarchos_event).toEqual(
+      expect.arrayContaining(['query', 'describe']),
+    );
+    // The view tool is wholesale read-only.
+    expect(READ_ONLY_ACTIONS.exarchos_view).toBe('*');
+    // Orchestrate read-only set must include the deterministic-info actions
+    // and exclude every mutator we explicitly check for in other tests.
+    const orch = READ_ONLY_ACTIONS.exarchos_orchestrate as readonly string[];
+    expect(orch).toEqual(
+      expect.arrayContaining([
+        'describe',
+        'runbook',
+        'agent_spec',
+        'doctor',
+        'list_prs',
+        'get_pr_comments',
+        'check_ci',
+      ]),
+    );
+    expect(orch).not.toContain('task_complete');
+    expect(orch).not.toContain('task_fail');
+    expect(orch).not.toContain('add_pr_comment');
+    expect(orch).not.toContain('merge_pr');
+    expect(orch).not.toContain('create_pr');
+    expect(orch).not.toContain('merge_orchestrate');
   });
 
   it('CreateMcpServer_SlimRegistration_UsesSlimDescriptions', async () => {

--- a/servers/exarchos-mcp/src/adapters/mcp.test.ts
+++ b/servers/exarchos-mcp/src/adapters/mcp.test.ts
@@ -231,7 +231,16 @@ describe('createMcpServer', () => {
   it('READ_ONLY_ACTIONS_ExposesAllowlistShape', () => {
     // Sanity check the constant shape so T05 / T06-T10 can rely on it.
     expect(READ_ONLY_ACTIONS.exarchos_workflow).toEqual(
-      expect.arrayContaining(['get', 'describe', 'reconcile', 'rehydrate']),
+      expect.arrayContaining(['get', 'describe']),
+    );
+    // `reconcile` and `rehydrate` are mutating (event-emitting + state
+    // rewrite) and must NOT appear in the workflow allowlist — see the
+    // dispatch.ts comment block.
+    expect(READ_ONLY_ACTIONS.exarchos_workflow).not.toEqual(
+      expect.arrayContaining(['reconcile']),
+    );
+    expect(READ_ONLY_ACTIONS.exarchos_workflow).not.toEqual(
+      expect.arrayContaining(['rehydrate']),
     );
     expect(READ_ONLY_ACTIONS.exarchos_event).toEqual(
       expect.arrayContaining(['query', 'describe']),

--- a/servers/exarchos-mcp/src/agents/__fixtures__/plugin-manifest.fixture.json
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/plugin-manifest.fixture.json
@@ -1,0 +1,40 @@
+{
+  "name": "exarchos",
+  "description": "A local-first SDLC workflow harness — structured, durable state for coding agents, with convergence gates, agent teams, and full audit trail.",
+  "version": "2.9.0-rc.1",
+  "author": {
+    "name": "LevelUp Software"
+  },
+  "homepage": "https://github.com/lvlup-sw/exarchos",
+  "repository": "https://github.com/lvlup-sw/exarchos",
+  "license": "Apache-2.0",
+  "keywords": [
+    "workflow",
+    "sdlc",
+    "event-sourcing"
+  ],
+  "agents": [
+    "./agents/implementer.md",
+    "./agents/fixer.md",
+    "./agents/reviewer.md",
+    "./agents/scaffolder.md"
+  ],
+  "commands": "./commands/",
+  "skills": "./skills/",
+  "mcpServers": {
+    "exarchos": {
+      "type": "stdio",
+      "command": "exarchos",
+      "args": ["mcp"],
+      "env": {
+        "WORKFLOW_STATE_DIR": "~/.claude/workflow-state",
+        "EXARCHOS_PLUGIN_ROOT": "${CLAUDE_PLUGIN_ROOT}"
+      }
+    }
+  },
+  "metadata": {
+    "compat": {
+      "minBinaryVersion": "2.9.0-rc.1"
+    }
+  }
+}

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
@@ -31,7 +31,7 @@ hooks:
     - matcher: Bash
       hooks:
         - type: command
-          command: npm run test:run
+          command: npm --prefix "$(git rev-parse --show-toplevel)" run test:run
 ---
 
 You are a fixer agent. Your job is to diagnose and repair failures.

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
@@ -1,8 +1,8 @@
 ---
 name: exarchos-fixer
-description: |
+description: |-
   Use this agent when a task has failed and needs diagnosis and repair with adversarial verification.
-  
+
   <example>
   Context: A delegated task failed its quality gates or tests
   user: "Task-005 failed TDD compliance — fix it"
@@ -11,19 +11,27 @@ description: |
   Failed task requiring root cause analysis and targeted fix triggers the fixer agent.
   </commentary>
   </example>
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
 model: inherit
 color: red
-disallowedTools: ["Agent"]
-mcpServers: ["exarchos"]
+disallowedTools:
+  - Agent
+mcpServers:
+  - exarchos
 skills:
   - tdd-patterns
 hooks:
   PostToolUse:
-    - matcher: "Bash"
+    - matcher: Bash
       hooks:
         - type: command
-          command: "npm run test:run"
+          command: npm run test:run
 ---
 
 You are a fixer agent. Your job is to diagnose and repair failures.

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
@@ -1,8 +1,8 @@
 ---
 name: exarchos-implementer
-description: |
+description: |-
   Use this agent when dispatching TDD implementation tasks to a subagent in an isolated worktree.
-  
+
   <example>
   Context: Orchestrator is dispatching a task from an implementation plan
   user: "Implement the agent spec handler (task-003)"
@@ -11,22 +11,30 @@ description: |
   Implementation task requiring test-first development triggers the implementer agent.
   </commentary>
   </example>
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
 model: inherit
 color: blue
-disallowedTools: ["Agent"]
+disallowedTools:
+  - Agent
 isolation: worktree
 memory: project
-mcpServers: ["exarchos"]
+mcpServers:
+  - exarchos
 skills:
   - tdd-patterns
   - testing-patterns
 hooks:
   PostToolUse:
-    - matcher: "Bash"
+    - matcher: Bash
       hooks:
         - type: command
-          command: "npm run test:run"
+          command: npm run test:run
 ---
 
 You are a TDD implementer agent working in an isolated worktree.

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
@@ -34,7 +34,7 @@ hooks:
     - matcher: Bash
       hooks:
         - type: command
-          command: npm run test:run
+          command: npm --prefix "$(git rev-parse --show-toplevel)" run test:run
 ---
 
 You are a TDD implementer agent working in an isolated worktree.

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/reviewer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/reviewer.md
@@ -1,8 +1,8 @@
 ---
 name: exarchos-reviewer
-description: |
+description: |-
   Use this agent when performing read-only code review for quality, design compliance, and test coverage.
-  
+
   <example>
   Context: Feature implementation is complete and needs review
   user: "Review the agent spec handler for code quality"
@@ -11,11 +11,19 @@ description: |
   Code review request triggers the reviewer agent for read-only analysis.
   </commentary>
   </example>
-tools: ["Read", "Grep", "Glob"]
+tools:
+  - Read
+  - Grep
+  - Glob
 model: inherit
 color: green
-disallowedTools: ["Write", "Edit", "Agent", "Bash"]
-mcpServers: ["exarchos"]
+disallowedTools:
+  - Write
+  - Edit
+  - Agent
+  - Bash
+mcpServers:
+  - exarchos
 ---
 
 You are a code reviewer agent. You analyze code for quality, correctness, and design compliance.

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/reviewer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/reviewer.md
@@ -47,24 +47,6 @@ Rules:
 - Be specific in findings — include file paths and line references
 - Categorize findings: critical, warning, suggestion
 
-## Forbidden MCP Actions (read-only review boundary)
-
-You MAY call only these strictly read-only Exarchos MCP actions:
-- `exarchos_view` — `pipeline`, `tasks`, `workflow_status`, `stack_status`, `telemetry`, `team_performance`, `delegation_timeline`, `delegation_readiness`, `synthesis_readiness`, `shepherd_status`, `convergence`, `quality_hints`, `describe` (NOT `code_quality` — emits `quality.regression` events; NOT `stack_place` — mutates)
-- `exarchos_workflow` — `get`, `describe` only
-- `exarchos_event` — `query`, `describe` only
-- `exarchos_orchestrate` — `describe` only
-
-You MUST NOT call any other MCP action — they all mutate state, emit events, or call external services. Forbidden examples include but are not limited to:
-- `exarchos_workflow set/init/cancel/cleanup/checkpoint/reconcile/rehydrate` (`reconcile` writes state, `rehydrate` emits `workflow.rehydrated`)
-- `exarchos_event append/batch_append`
-- `exarchos_orchestrate check_*` (each emits a `gate.executed` event)
-- `exarchos_orchestrate task_claim/task_complete/task_fail`
-- `exarchos_orchestrate create_pr/merge_pr/add_pr_comment/create_issue/...`
-- `exarchos_view code_quality/stack_place`
-
-Workflow mutation, event emission, and gate execution belong to the orchestrator. If a finding requires state changes, gate runs, or fresh quality checks, surface it as a recommendation in the review verdict — the orchestrator will dispatch.
-
 ## Completion Report
 When done, output a JSON completion report:
 ```json

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
@@ -1,8 +1,8 @@
 ---
 name: exarchos-scaffolder
-description: |
+description: |-
   Use this agent for low-complexity scaffolding tasks — file creation, boilerplate generation, and structural setup.
-  
+
   <example>
   Context: Orchestrator needs new files or boilerplate created
   user: "Create the directory structure and stub files for the new feature"
@@ -11,12 +11,20 @@ description: |
   Simple file creation and boilerplate generation triggers the scaffolder agent with concise output.
   </commentary>
   </example>
-tools: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
 model: sonnet
 color: cyan
-disallowedTools: ["Agent"]
+disallowedTools:
+  - Agent
 isolation: worktree
-mcpServers: ["exarchos"]
+mcpServers:
+  - exarchos
 ---
 
 You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.

--- a/servers/exarchos-mcp/src/agents/adapters/claude.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/claude.test.ts
@@ -9,13 +9,25 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 import { describe, it, expect } from 'vitest';
-import { claudeAdapter } from './claude.js';
+import { parse as parseYaml } from 'yaml';
+import { claudeAdapter, generateClaudeAgentMarkdown } from './claude.js';
+import type { AgentSpec } from '../types.js';
 import {
   IMPLEMENTER,
   FIXER,
   REVIEWER,
   SCAFFOLDER,
 } from '../definitions.js';
+
+// Extracts the `---\n…\n---` YAML frontmatter block (without the
+// surrounding fences) from a generated Claude agent file. Returns the
+// raw YAML text so callers can `parseYaml` it and assert round-trip
+// fidelity against the input spec.
+function extractFrontmatter(contents: string): string {
+  const match = contents.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!match) throw new Error('No YAML frontmatter delimiters found');
+  return match[1];
+}
 
 describe('Claude adapter', () => {
   it('ClaudeAdapter_RuntimeIdentifier_IsClaude', () => {
@@ -32,8 +44,13 @@ describe('Claude adapter', () => {
     const out = claudeAdapter.lowerSpec(IMPLEMENTER);
     expect(out.contents.length).toBeGreaterThan(0);
     expect(out.contents.startsWith('---\n')).toBe(true);
-    expect(out.contents).toContain('name: exarchos-implementer');
-    expect(out.contents).toMatch(/tools:\s*\[/);
+    // Parse the frontmatter rather than asserting on raw bytes — the
+    // YAML library may render scalars unquoted/quoted/plain depending
+    // on content. The contract is the parsed value, not the byte form.
+    const fm = parseYaml(extractFrontmatter(out.contents)) as Record<string, unknown>;
+    expect(fm.name).toBe('exarchos-implementer');
+    expect(Array.isArray(fm.tools)).toBe(true);
+    expect((fm.tools as string[]).length).toBeGreaterThan(0);
     // Body should include some implementer description text.
     expect(out.contents).toContain('TDD');
   });
@@ -51,5 +68,89 @@ describe('Claude adapter', () => {
     for (const spec of [IMPLEMENTER, FIXER, REVIEWER, SCAFFOLDER]) {
       expect(claudeAdapter.validateSupport(spec)).toEqual({ ok: true });
     }
+  });
+});
+
+// ─── Adversarial YAML field tests ──────────────────────────────────────────
+//
+// The Claude adapter renders agent files as Markdown with YAML frontmatter.
+// A safe renderer must escape any character that would otherwise change
+// YAML semantics (embedded quotes, leading colons, leading whitespace,
+// shell `$(…)` substitutions inside hook commands, etc).
+//
+// These tests construct synthetic AgentSpecs with YAML-hostile field
+// values, render them, parse the resulting frontmatter back through a
+// real YAML parser, and assert that the parsed value matches the
+// original input. This is a round-trip contract: render → parse must be
+// the identity for the field under test.
+//
+// Item 4 of #1192 (worktree-anchored hooks) introduces hook command
+// strings containing `$(git rev-parse --show-toplevel)` and embedded
+// double quotes — exactly the inputs the current concat renderer
+// mangles. These tests pin the contract that must hold before that work
+// can land.
+describe('ClaudeAdapter_GenerateMarkdown_HandlesYamlSpecialChars', () => {
+  function withOverrides(spec: AgentSpec, overrides: Partial<AgentSpec>): AgentSpec {
+    return { ...spec, ...overrides };
+  }
+
+  it('Description_WithEmbeddedDoubleQuotes_RoundTripsThroughYamlParse', () => {
+    const description = 'Use "X" pattern when refactoring legacy modules';
+    const spec = withOverrides(IMPLEMENTER, { description });
+    const md = generateClaudeAgentMarkdown(spec);
+    const parsed = parseYaml(extractFrontmatter(md)) as Record<string, unknown>;
+    expect(parsed.description).toBe(description);
+  });
+
+  it('Description_WithEmbeddedColon_RoundTripsThroughYamlParse', () => {
+    const description = 'Use for: thing handling and related concerns';
+    const spec = withOverrides(IMPLEMENTER, { description });
+    const md = generateClaudeAgentMarkdown(spec);
+    const parsed = parseYaml(extractFrontmatter(md)) as Record<string, unknown>;
+    expect(parsed.description).toBe(description);
+  });
+
+  it('Description_WithLeadingWhitespaceMultiline_RoundTripsThroughYamlParse', () => {
+    // Multi-line description where one line begins with whitespace —
+    // exposes naive `description: |` block-scalar renderers that
+    // strip indentation.
+    const description = 'First line of the description.\n  Indented continuation line.\nFinal line.';
+    const spec = withOverrides(IMPLEMENTER, { description });
+    const md = generateClaudeAgentMarkdown(spec);
+    const parsed = parseYaml(extractFrontmatter(md)) as Record<string, unknown>;
+    expect(parsed.description).toBe(description);
+  });
+
+  it('HookCommand_WithSubshellAndQuotes_RoundTripsThroughYamlParse', () => {
+    // The exact failure mode Item 4 will trigger: a hook command that
+    // contains both `$(...)` and embedded double quotes.
+    const command = 'cd "$(git rev-parse --show-toplevel)" && npm run test:run';
+    const spec = withOverrides(IMPLEMENTER, {
+      validationRules: [
+        { trigger: 'post-test', rule: 'run tests', command },
+      ],
+    });
+    const md = generateClaudeAgentMarkdown(spec);
+    const parsed = parseYaml(extractFrontmatter(md)) as Record<string, unknown>;
+    const hooks = parsed.hooks as Record<string, Array<{
+      matcher: string;
+      hooks: Array<{ type: string; command: string }>;
+    }>>;
+    expect(hooks).toBeDefined();
+    expect(hooks.PostToolUse).toBeDefined();
+    expect(hooks.PostToolUse[0].hooks[0].command).toBe(command);
+  });
+
+  it('DisallowedTool_WithEmbeddedColon_RoundTripsThroughYamlParse', () => {
+    // Synthetic case: a tool name with a colon. Not a realistic Claude
+    // tool name, but it proves the renderer escapes scalar list entries
+    // rather than emitting them raw — the same primitive Item 4's hook
+    // commands rely on.
+    const spec = withOverrides(IMPLEMENTER, {
+      disallowedTools: ['Agent', 'Server:Restart'],
+    });
+    const md = generateClaudeAgentMarkdown(spec);
+    const parsed = parseYaml(extractFrontmatter(md)) as Record<string, unknown>;
+    expect(parsed.disallowedTools).toEqual(['Agent', 'Server:Restart']);
   });
 });

--- a/servers/exarchos-mcp/src/agents/adapters/claude.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/claude.test.ts
@@ -141,6 +141,38 @@ describe('ClaudeAdapter_GenerateMarkdown_HandlesYamlSpecialChars', () => {
     expect(hooks.PostToolUse[0].hooks[0].command).toBe(command);
   });
 
+  it('ClaudeAdapter_HookCommand_WithSubshell_RendersValidYaml', () => {
+    // #1192 Item 4, T24 — regression guard for the exact hook-command
+    // shape T25 will introduce: `npm --prefix "$(git rev-parse
+    // --show-toplevel)" run test:run`. This combines a `$(...)` shell
+    // substitution with embedded double quotes inside a YAML scalar —
+    // the precise input the pre-T02 string-concat renderer mangled.
+    //
+    // T25 anchors hook commands to the git toplevel so they survive
+    // sub-agent worktree `cd`s (see CLAUDE.md "Worktree Hygiene"). That
+    // anchoring is only safe if this rendered scalar parses back to the
+    // identity. Locking the property here lets T25 land without needing
+    // to re-prove YAML safety in the same change.
+    const command = 'npm --prefix "$(git rev-parse --show-toplevel)" run test:run';
+    const spec = withOverrides(IMPLEMENTER, {
+      validationRules: [
+        { trigger: 'post-test', rule: 'All tests must pass', command },
+      ],
+    });
+    const md = generateClaudeAgentMarkdown(spec);
+    // 1. The frontmatter must parse without throwing.
+    const parsed = parseYaml(extractFrontmatter(md)) as Record<string, unknown>;
+    // 2. The hook command must round-trip byte-for-byte.
+    const hooks = parsed.hooks as Record<string, Array<{
+      matcher: string;
+      hooks: Array<{ type: string; command: string }>;
+    }>>;
+    expect(hooks).toBeDefined();
+    expect(hooks.PostToolUse).toBeDefined();
+    expect(hooks.PostToolUse).toHaveLength(1);
+    expect(hooks.PostToolUse[0].hooks[0].command).toBe(command);
+  });
+
   it('DisallowedTool_WithEmbeddedColon_RoundTripsThroughYamlParse', () => {
     // Synthetic case: a tool name with a colon. Not a realistic Claude
     // tool name, but it proves the renderer escapes scalar list entries

--- a/servers/exarchos-mcp/src/agents/adapters/claude.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/claude.test.ts
@@ -154,3 +154,68 @@ describe('ClaudeAdapter_GenerateMarkdown_HandlesYamlSpecialChars', () => {
     expect(parsed.disallowedTools).toEqual(['Agent', 'Server:Restart']);
   });
 });
+
+// ─── mcp:exarchos:readonly capability wiring (#1192 Item 1, T06) ──────────
+//
+// The readonly capability tier is enforced server-side at dispatch time
+// (see `READ_ONLY_ACTIONS` + `enforceReadonlyGate` in core/dispatch.ts,
+// task T04). Claude Code's frontmatter only grants/denies MCP servers at
+// the whole-server granularity (`mcpServers: ["exarchos"]`) — there is no
+// per-action allowlist surface in the agent file format. Therefore an
+// agent whose ONLY mcp tier is `mcp:exarchos:readonly` must still receive
+// the `mcpServers: ["exarchos"]` grant in frontmatter; the dispatch-layer
+// gate handles per-action enforcement at runtime.
+//
+// Without this wiring, a spec carrying only `mcp:exarchos:readonly` would
+// render frontmatter that omits the exarchos server entirely, leaving the
+// agent unable to invoke even the read-only action subset.
+describe('ClaudeAdapter_LowerSpec_McpReadonlyTier', () => {
+  function withOverrides(spec: AgentSpec, overrides: Partial<AgentSpec>): AgentSpec {
+    return { ...spec, ...overrides };
+  }
+
+  it('ClaudeAdapter_LowerSpec_ReadonlyMaps_To_ExarchosMcpServerGrant', () => {
+    // Spec holds `mcp:exarchos:readonly` (and NOT `mcp:exarchos`).
+    // Expect the adapter to still emit the `exarchos` server entry so
+    // the agent can reach the dispatch-layer readonly gate at all.
+    const spec = withOverrides(IMPLEMENTER, {
+      capabilities: ['fs:read', 'mcp:exarchos:readonly'],
+    });
+    const md = generateClaudeAgentMarkdown(spec);
+    const fm = parseYaml(extractFrontmatter(md)) as Record<string, unknown>;
+    expect(fm.mcpServers).toEqual(['exarchos']);
+  });
+
+  it('ClaudeAdapter_LowerSpec_FullMcpCap_StillEmitsExarchosServerGrant', () => {
+    // Sanity: pre-existing behavior unchanged for `mcp:exarchos`.
+    const spec = withOverrides(IMPLEMENTER, {
+      capabilities: ['fs:read', 'mcp:exarchos'],
+    });
+    const md = generateClaudeAgentMarkdown(spec);
+    const fm = parseYaml(extractFrontmatter(md)) as Record<string, unknown>;
+    expect(fm.mcpServers).toEqual(['exarchos']);
+  });
+
+  it('ClaudeAdapter_LowerSpec_NoMcpCap_OmitsMcpServersField', () => {
+    // Sanity: when neither tier is present, `mcpServers` is not emitted
+    // at all (so the readonly wiring is provably gated on capability,
+    // not unconditional).
+    const spec = withOverrides(IMPLEMENTER, {
+      capabilities: ['fs:read'],
+    });
+    const md = generateClaudeAgentMarkdown(spec);
+    const fm = parseYaml(extractFrontmatter(md)) as Record<string, unknown>;
+    expect(fm.mcpServers).toBeUndefined();
+  });
+
+  it('ClaudeAdapter_ValidateSupport_ReadonlyTier_IsNative', () => {
+    // Claude is the reference runtime — every capability is `native`.
+    // The readonly tier was added to the Capability enum in T03; if the
+    // claude support map weren't refreshed, validateSupport would reject
+    // a spec that uses it.
+    const spec = withOverrides(IMPLEMENTER, {
+      capabilities: ['fs:read', 'mcp:exarchos:readonly'],
+    });
+    expect(claudeAdapter.validateSupport(spec)).toEqual({ ok: true });
+  });
+});

--- a/servers/exarchos-mcp/src/agents/adapters/claude.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/claude.ts
@@ -11,6 +11,7 @@
 // See docs/designs/2026-04-25-delegation-runtime-parity.md §4.
 // ────────────────────────────────────────────────────────────────────────────
 
+import { stringify as stringifyYaml } from 'yaml';
 import type { AgentSpec, AgentValidationRule } from '../types.js';
 import type { RuntimeAdapter, ValidationResult } from './types.js';
 import { buildSupportMap } from './support-levels.js';
@@ -52,14 +53,19 @@ const TRIGGER_MAP: Record<string, { hookType: string; matcher: string }> = {
 
 // ─── Build Hooks from Rules ─────────────────────────────────────────────────
 
+interface ClaudeHookEntry {
+  matcher: string;
+  hooks: Array<{ type: string; command: string }>;
+}
+
 /**
  * Maps validation rules to the Claude hook format.
  * Rules without a `command` property are skipped.
  */
 function buildHooksFromRules(
   rules: readonly AgentValidationRule[],
-): Record<string, Array<{ matcher: string; hooks: Array<{ type: string; command: string }> }>> {
-  const hooks: Record<string, Array<{ matcher: string; hooks: Array<{ type: string; command: string }> }>> = {};
+): Record<string, ClaudeHookEntry[]> {
+  const hooks: Record<string, ClaudeHookEntry[]> = {};
 
   for (const rule of rules) {
     if (!rule.command) continue;
@@ -82,30 +88,6 @@ function buildHooksFromRules(
   return hooks;
 }
 
-// ─── YAML Serialization Helpers ─────────────────────────────────────────────
-
-function serializeHooksYaml(
-  hooks: Record<string, Array<{ matcher: string; hooks: Array<{ type: string; command: string }> }>>,
-  indent: number,
-): string {
-  const pad = ' '.repeat(indent);
-  let yaml = '';
-
-  for (const [hookType, hookList] of Object.entries(hooks)) {
-    yaml += `${pad}${hookType}:\n`;
-    for (const hookEntry of hookList) {
-      yaml += `${pad}  - matcher: "${hookEntry.matcher}"\n`;
-      yaml += `${pad}    hooks:\n`;
-      for (const h of hookEntry.hooks) {
-        yaml += `${pad}      - type: ${h.type}\n`;
-        yaml += `${pad}        command: "${h.command}"\n`;
-      }
-    }
-  }
-
-  return yaml;
-}
-
 // ─── Generate Agent Markdown ────────────────────────────────────────────────
 
 /**
@@ -113,39 +95,36 @@ function serializeHooksYaml(
  * (Markdown with YAML frontmatter + system prompt body). Output is
  * byte-pinned by `generate-agents.test.ts`'s snapshot regression suite.
  *
+ * Frontmatter is built as a plain JS object and serialized with
+ * `yaml.stringify` (yaml@^2.8.2). This eliminates the previous
+ * string-concat path and the `serializeHooksYaml` helper, both of which
+ * mishandled embedded quotes, colons, leading whitespace, and shell
+ * `$(...)` substitutions in user-supplied scalar values. See #1192
+ * Item 2 (and Item 4, which adds quote-bearing hook commands).
+ *
  * Exported so `generated-drift.test.ts` can assert per-spec markdown
  * generation in isolation. Production callers should go through the
  * `claudeAdapter.lowerSpec` entry point below.
  */
 export function generateClaudeAgentMarkdown(spec: AgentSpec): string {
-  let frontmatter = '---\n';
+  // Build the frontmatter as a plain JS object so the YAML library
+  // owns scalar escaping. Field ordering is preserved to minimise the
+  // snapshot diff against the committed fixtures.
+  const frontmatter: Record<string, unknown> = {};
 
-  // Required fields
-  frontmatter += `name: exarchos-${spec.id}\n`;
-
-  // Description: multi-line uses YAML block scalar, single-line uses quoted string
-  if (spec.description.includes('\n')) {
-    frontmatter += 'description: |\n';
-    for (const line of spec.description.split('\n')) {
-      frontmatter += `  ${line}\n`;
-    }
-  } else {
-    frontmatter += `description: "${spec.description}"\n`;
-  }
+  frontmatter.name = `exarchos-${spec.id}`;
+  frontmatter.description = spec.description;
 
   // Lower capabilities to Claude's flat `tools` array.
-  const derivedTools = deriveClaudeToolsFromCapabilities(spec);
-  frontmatter += `tools: [${derivedTools.map(t => `"${t}"`).join(', ')}]\n`;
-  frontmatter += `model: ${spec.model}\n`;
+  frontmatter.tools = [...deriveClaudeToolsFromCapabilities(spec)];
+  frontmatter.model = spec.model;
 
-  // Optional: color
   if (spec.color) {
-    frontmatter += `color: ${spec.color}\n`;
+    frontmatter.color = spec.color;
   }
 
-  // Optional: disallowedTools
   if (spec.disallowedTools && spec.disallowedTools.length > 0) {
-    frontmatter += `disallowedTools: [${spec.disallowedTools.map(t => `"${t}"`).join(', ')}]\n`;
+    frontmatter.disallowedTools = [...spec.disallowedTools];
   }
 
   // Isolation: derive from capabilities so the spec has a single source
@@ -154,17 +133,15 @@ export function generateClaudeAgentMarkdown(spec: AgentSpec): string {
   // avoid the support-validation/render split that produced two
   // disagreeing answers.
   if (spec.capabilities.includes('isolation:worktree')) {
-    frontmatter += `isolation: worktree\n`;
+    frontmatter.isolation = 'worktree';
   }
 
-  // Optional: memory (mapped from memoryScope)
   if (spec.memoryScope) {
-    frontmatter += `memory: ${spec.memoryScope}\n`;
+    frontmatter.memory = spec.memoryScope;
   }
 
-  // Optional: maxTurns
   if (spec.maxTurns !== undefined) {
-    frontmatter += `maxTurns: ${spec.maxTurns}\n`;
+    frontmatter.maxTurns = spec.maxTurns;
   }
 
   // mcpServers: derive from `mcp:exarchos` capability for the same
@@ -172,27 +149,35 @@ export function generateClaudeAgentMarkdown(spec: AgentSpec): string {
   // is wired today; if/when additional MCP servers become first-class
   // capabilities, extend this list with parallel checks.
   if (spec.capabilities.includes('mcp:exarchos')) {
-    frontmatter += `mcpServers: ["exarchos"]\n`;
+    frontmatter.mcpServers = ['exarchos'];
   }
 
-  // Optional: skills (array format)
   if (spec.skills.length > 0) {
-    frontmatter += 'skills:\n';
-    for (const skill of spec.skills) {
-      frontmatter += `  - ${skill.name}\n`;
-    }
+    frontmatter.skills = spec.skills.map((s) => s.name);
   }
 
-  // Optional: hooks (from validation rules)
   const hooks = buildHooksFromRules(spec.validationRules);
   if (Object.keys(hooks).length > 0) {
-    frontmatter += 'hooks:\n';
-    frontmatter += serializeHooksYaml(hooks, 2);
+    frontmatter.hooks = hooks;
   }
 
-  frontmatter += '---\n';
+  // `lineWidth: 0` disables auto-wrapping so long descriptions don't
+  // get folded into multi-line block scalars on every render (the
+  // snapshot suite would then drift on any cosmetic length change).
+  //
+  // `defaultStringType: 'PLAIN'` lets the YAML library decide per-scalar:
+  // safe values render unquoted (matches the prior renderer's intent
+  // for things like `name: exarchos-implementer`), values containing
+  // YAML-significant characters get auto-quoted, and multi-line strings
+  // become block scalars. This is the safest default and produces the
+  // smallest semantic diff against the previous hand-rolled output.
+  const yamlText = stringifyYaml(frontmatter, {
+    lineWidth: 0,
+    defaultStringType: 'PLAIN',
+    defaultKeyType: 'PLAIN',
+  });
 
-  return `${frontmatter}\n${spec.systemPrompt}\n`;
+  return `---\n${yamlText}---\n\n${spec.systemPrompt}\n`;
 }
 
 // ─── Adapter ────────────────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/agents/adapters/claude.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/claude.ts
@@ -144,11 +144,25 @@ export function generateClaudeAgentMarkdown(spec: AgentSpec): string {
     frontmatter.maxTurns = spec.maxTurns;
   }
 
-  // mcpServers: derive from `mcp:exarchos` capability for the same
+  // mcpServers: derive from `mcp:exarchos*` capabilities for the same
   // single-source-of-truth reason as isolation above. Only `exarchos`
   // is wired today; if/when additional MCP servers become first-class
   // capabilities, extend this list with parallel checks.
-  if (spec.capabilities.includes('mcp:exarchos')) {
+  //
+  // Both `mcp:exarchos` (full) and `mcp:exarchos:readonly` (restricted
+  // tier — #1192 Item 1, T03) map to the same `mcpServers` grant.
+  // Claude Code's frontmatter only exposes whole-server allow/deny;
+  // there is no per-action allowlist surface in the agent file format,
+  // so per-action enforcement for the readonly tier happens server-side
+  // at dispatch time via `READ_ONLY_ACTIONS` / `enforceReadonlyGate`
+  // in `core/dispatch.ts` (T04). Granting the server here is the
+  // necessary precondition for that gate to fire — without the grant,
+  // a readonly-only spec would be unable to invoke even the read-only
+  // action subset.
+  if (
+    spec.capabilities.includes('mcp:exarchos') ||
+    spec.capabilities.includes('mcp:exarchos:readonly')
+  ) {
     frontmatter.mcpServers = ['exarchos'];
   }
 

--- a/servers/exarchos-mcp/src/agents/adapters/codex.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/codex.test.ts
@@ -83,6 +83,56 @@ describe('CodexAdapter', () => {
   it('CodexAdapter_FallbackFlag_DefaultsToFalse', () => {
     expect(codexAdapter.customAgentResolutionWorks).toBe(false);
   });
+
+  it('CodexAdapter_LowerSpec_Readonly_GrantsExarchosTool', () => {
+    // T03 added `mcp:exarchos:readonly` to the Capability enum and T04 wired
+    // a server-side action allowlist. The Codex adapter must lower the
+    // readonly capability to the same `mcp_servers = ["exarchos"]` entry as
+    // the broad `mcp:exarchos` capability — runtime gating happens at the
+    // dispatch layer, not in the per-runtime tool name. Without this entry,
+    // any spec listing the readonly cap (without the broad cap) would silently
+    // emit no `mcp_servers` line at all and the agent could not invoke even
+    // readonly tools.
+    const readonlySpec: AgentSpec = {
+      ...baseSpec,
+      mcpServers: undefined,
+      capabilities: [
+        'fs:read',
+        'mcp:exarchos:readonly',
+        'isolation:worktree',
+      ] as readonly Capability[],
+    };
+    const { contents } = codexAdapter.lowerSpec(readonlySpec);
+
+    // Top-level mcp_servers = ["exarchos"] line must be present.
+    expect(contents).toMatch(/^mcp_servers\s*=\s*\["exarchos"\]\s*$/m);
+    // And the broad capability must NOT be in the spec — the readonly cap
+    // alone must produce the mcp_servers entry.
+    expect(readonlySpec.capabilities).not.toContain('mcp:exarchos');
+  });
+
+  it('CodexAdapter_LowerSpec_FullCap_BehaviorUnchanged', () => {
+    // Snapshot regression: the broad `mcp:exarchos` capability still emits
+    // the same `mcp_servers = ["exarchos"]` line. Adding readonly support
+    // must not perturb the existing path.
+    const fullSpec: AgentSpec = {
+      ...baseSpec,
+      mcpServers: undefined,
+    };
+    const { contents } = codexAdapter.lowerSpec(fullSpec);
+    expect(contents).toMatch(/^mcp_servers\s*=\s*\["exarchos"\]\s*$/m);
+  });
+
+  it('CodexAdapter_ValidateSupport_AcceptsReadonlyCapability', () => {
+    // The readonly cap must be classified as `native` (not `unsupported`)
+    // so specs declaring it pass validation.
+    const readonlySpec: AgentSpec = {
+      ...baseSpec,
+      capabilities: ['fs:read', 'mcp:exarchos:readonly'] as readonly Capability[],
+    };
+    const result = codexAdapter.validateSupport(readonlySpec);
+    expect(result.ok).toBe(true);
+  });
 });
 
 describe('tomlBasicString', () => {

--- a/servers/exarchos-mcp/src/agents/adapters/codex.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/codex.test.ts
@@ -9,6 +9,9 @@
 // docs/research/2026-04-25-delegation-platform-agnosticity.md §3.
 // ────────────────────────────────────────────────────────────────────────────
 
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import type { AgentSpec } from '../types.js';
 import type { Capability } from '../capabilities.js';
@@ -177,6 +180,40 @@ describe('CodexAdapter', () => {
     expect(reviewerSandbox?.[1]).toBe('read-only');
     expect(implementerSandbox?.[1]).toBe('workspace-write');
     expect(r.contents).not.toEqual(i.contents);
+  });
+
+  // ─── On-disk artifact divergence (Issue #1192 Item 6, T28) ────────────────
+  //
+  // T27 above asserts `lowerSpec` produces divergent surfaces for REVIEWER vs
+  // IMPLEMENTER. T28 catches the orthogonal failure mode: drift between the
+  // adapter's *output* and the committed `.codex/agents/*.toml` artifacts.
+  // Without this guard, an adapter change that's never re-rendered (or a hand
+  // edit to a TOML file) could silently restore byte-identical surfaces in
+  // the artifacts shipped to consumers, even while T27 keeps passing.
+  // ──────────────────────────────────────────────────────────────────────────
+  it('CodexArtifact_OnDisk_REVIEWER_AND_IMPLEMENTER_HaveDistinctToolSurfaces', () => {
+    // Resolve repo root from this test file's location:
+    //   servers/exarchos-mcp/src/agents/adapters/codex.test.ts
+    //     → ../../../../..  = repo root
+    const here = dirname(fileURLToPath(import.meta.url));
+    const repoRoot = resolve(here, '../../../../..');
+    const reviewerToml = readFileSync(
+      resolve(repoRoot, '.codex/agents/reviewer.toml'),
+      'utf8',
+    );
+    const implementerToml = readFileSync(
+      resolve(repoRoot, '.codex/agents/implementer.toml'),
+      'utf8',
+    );
+
+    // Each artifact must declare the sandbox_mode that matches its spec's
+    // capabilities — read-only for REVIEWER, workspace-write for IMPLEMENTER.
+    expect(reviewerToml).toMatch(/^sandbox_mode\s*=\s*"read-only"\s*$/m);
+    expect(implementerToml).toMatch(
+      /^sandbox_mode\s*=\s*"workspace-write"\s*$/m,
+    );
+    // And the artifacts as a whole must not be byte-identical.
+    expect(reviewerToml).not.toBe(implementerToml);
   });
 });
 

--- a/servers/exarchos-mcp/src/agents/adapters/codex.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/codex.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect } from 'vitest';
 import type { AgentSpec } from '../types.js';
 import type { Capability } from '../capabilities.js';
-import { codexAdapter } from './codex.js';
+import { codexAdapter, tomlBasicString } from './codex.js';
 
 const baseSpec: AgentSpec = {
   id: 'implementer',
@@ -82,5 +82,22 @@ describe('CodexAdapter', () => {
 
   it('CodexAdapter_FallbackFlag_DefaultsToFalse', () => {
     expect(codexAdapter.customAgentResolutionWorks).toBe(false);
+  });
+});
+
+describe('tomlBasicString', () => {
+  it('TomlBasicString_EscapesBackspace', () => {
+    expect(tomlBasicString('a\bb')).toBe('"a\\bb"');
+  });
+
+  it('TomlBasicString_EscapesFormfeed', () => {
+    expect(tomlBasicString('a\fb')).toBe('"a\\fb"');
+  });
+
+  it('TomlBasicString_EscapesAllControlChars_InOrder', () => {
+    // Asserts no double-escaping bugs and stable order with a cocktail input.
+    const input = 'q"\\\b\f\n\r\tx';
+    const got = tomlBasicString(input);
+    expect(got).toBe('"q\\"\\\\\\b\\f\\n\\r\\tx"');
   });
 });

--- a/servers/exarchos-mcp/src/agents/adapters/codex.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/codex.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect } from 'vitest';
 import type { AgentSpec } from '../types.js';
 import type { Capability } from '../capabilities.js';
 import { codexAdapter, tomlBasicString } from './codex.js';
+import { REVIEWER, IMPLEMENTER } from '../definitions.js';
 
 const baseSpec: AgentSpec = {
   id: 'implementer',
@@ -132,6 +133,50 @@ describe('CodexAdapter', () => {
     };
     const result = codexAdapter.validateSupport(readonlySpec);
     expect(result.ok).toBe(true);
+  });
+
+  // ─── Negative-capability enforcement (Issue #1192 Item 6, T27) ────────────
+  //
+  // Codex's TOML format exposes a structural `sandbox_mode` primitive that
+  // controls fs/shell access. Prior to T27, `lowerSpec` emitted no
+  // `sandbox_mode` line at all — so REVIEWER (no fs:write, no shell:exec)
+  // and IMPLEMENTER (both) produced byte-identical tool surfaces. The
+  // negative-capability guarantee in REVIEWER's spec (read-only) was
+  // therefore prose-only, not structural.
+  //
+  // Mapping (matches Claude's deriveClaudeToolsFromCapabilities pattern):
+  //   - no fs:write AND no shell:exec  → sandbox_mode = "read-only"
+  //   - has fs:write OR  has shell:exec → sandbox_mode = "workspace-write"
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('CodexAdapter_LowerSpec_OmitsWriteAccess_WhenSpecLacksFsWrite', () => {
+    const { contents } = codexAdapter.lowerSpec(REVIEWER);
+    // REVIEWER declares neither fs:write nor shell:exec; sandbox_mode
+    // must lock the artifact to read-only at the runtime layer.
+    expect(contents).toMatch(/^sandbox_mode\s*=\s*"read-only"\s*$/m);
+    // And it MUST NOT promote to workspace-write.
+    expect(contents).not.toMatch(/^sandbox_mode\s*=\s*"workspace-write"\s*$/m);
+  });
+
+  it('CodexAdapter_LowerSpec_IncludesWriteAccess_WhenSpecHasFsWrite', () => {
+    const { contents } = codexAdapter.lowerSpec(IMPLEMENTER);
+    // IMPLEMENTER declares fs:write + shell:exec; sandbox_mode must grant
+    // workspace-write so the runtime allows file writes and shell exec.
+    expect(contents).toMatch(/^sandbox_mode\s*=\s*"workspace-write"\s*$/m);
+    expect(contents).not.toMatch(/^sandbox_mode\s*=\s*"read-only"\s*$/m);
+  });
+
+  it('CodexAdapter_LowerSpec_REVIEWER_AND_IMPLEMENTER_HaveDistinctToolSurfaces', () => {
+    const r = codexAdapter.lowerSpec(REVIEWER);
+    const i = codexAdapter.lowerSpec(IMPLEMENTER);
+    // Beyond the trivial id/description differences, the rendered
+    // sandbox_mode line must differ — REVIEWER's read-only contract is
+    // structurally enforced at the adapter layer, not just by prompt prose.
+    const reviewerSandbox = r.contents.match(/^sandbox_mode\s*=\s*"([^"]+)"\s*$/m);
+    const implementerSandbox = i.contents.match(/^sandbox_mode\s*=\s*"([^"]+)"\s*$/m);
+    expect(reviewerSandbox?.[1]).toBe('read-only');
+    expect(implementerSandbox?.[1]).toBe('workspace-write');
+    expect(r.contents).not.toEqual(i.contents);
   });
 });
 

--- a/servers/exarchos-mcp/src/agents/adapters/codex.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/codex.ts
@@ -40,8 +40,15 @@ const CODEX_SUPPORT_LEVELS = buildSupportMap('native', {
 });
 
 /** Escape characters disallowed inside a TOML basic string. */
-function tomlBasicString(value: string): string {
-  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t')}"`;
+export function tomlBasicString(value: string): string {
+  return `"${value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\x08/g, '\\b')
+    .replace(/\f/g, '\\f')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t')}"`;
 }
 
 /**

--- a/servers/exarchos-mcp/src/agents/adapters/codex.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/codex.ts
@@ -68,6 +68,38 @@ function tomlStringArray(values: readonly string[]): string {
 }
 
 /**
+ * Derive Codex's `sandbox_mode` from the spec's declared capabilities.
+ *
+ * Codex's TOML format has no per-tool allowlist primitive (cf. Claude's
+ * `tools` array or OpenCode's `tools` boolean map). The single structural
+ * gate the runtime exposes is `sandbox_mode`, with three documented
+ * values:
+ *
+ *   - `read-only`        — process is barred from filesystem writes and
+ *                          shell execution outside its session bounds.
+ *   - `workspace-write`  — process may write within the workspace and
+ *                          spawn shell commands from it.
+ *   - `danger-full-access` — no sandbox; not used here.
+ *
+ * Mapping (parallels `deriveClaudeToolsFromCapabilities` in claude.ts):
+ *
+ *   - capabilities lack BOTH `fs:write` and `shell:exec` → `read-only`
+ *   - capabilities include EITHER `fs:write` or `shell:exec` → `workspace-write`
+ *
+ * Without this derivation, REVIEWER (read-only) and IMPLEMENTER (write +
+ * shell) would lower to byte-identical sandbox configurations — the
+ * negative-capability guarantee in REVIEWER's spec would be prose-only.
+ * Issue #1192 Item 6, T27.
+ */
+function deriveCodexSandboxMode(spec: AgentSpec): 'read-only' | 'workspace-write' {
+  const caps = new Set<string>(spec.capabilities);
+  if (caps.has('fs:write') || caps.has('shell:exec')) {
+    return 'workspace-write';
+  }
+  return 'read-only';
+}
+
+/**
  * Compose the `developer_instructions` body: the agent's system prompt
  * followed by a brief enumeration of declared capabilities so the
  * underlying model knows which platform affordances to expect.
@@ -91,6 +123,12 @@ function lowerSpec(spec: AgentSpec): { path: string; contents: string } {
   lines.push(
     `developer_instructions = ${tomlMultilineString(renderDeveloperInstructions(spec))}`,
   );
+
+  // Negative-capability enforcement (#1192 Item 6, T27): emit a
+  // capability-derived `sandbox_mode` so the runtime structurally honors
+  // the spec's fs/shell declarations rather than falling back to a
+  // session default that may grant more access than the spec authorized.
+  lines.push(`sandbox_mode = ${tomlBasicString(deriveCodexSandboxMode(spec))}`);
 
   if (spec.mcpServers && spec.mcpServers.length > 0) {
     lines.push(`mcp_servers = ${tomlStringArray([...spec.mcpServers])}`);

--- a/servers/exarchos-mcp/src/agents/adapters/codex.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/codex.ts
@@ -94,7 +94,14 @@ function lowerSpec(spec: AgentSpec): { path: string; contents: string } {
 
   if (spec.mcpServers && spec.mcpServers.length > 0) {
     lines.push(`mcp_servers = ${tomlStringArray([...spec.mcpServers])}`);
-  } else if (spec.capabilities.includes('mcp:exarchos')) {
+  } else if (
+    spec.capabilities.includes('mcp:exarchos') ||
+    spec.capabilities.includes('mcp:exarchos:readonly')
+  ) {
+    // Both the broad and readonly capabilities grant the same Codex
+    // mcp_servers entry — Codex's TOML format has no per-action sub-grant
+    // primitive. The server-side action allowlist (T04 dispatch gate) is
+    // what enforces the readonly tier; this adapter just opens the channel.
     lines.push(`mcp_servers = ${tomlStringArray(['exarchos'])}`);
   }
 

--- a/servers/exarchos-mcp/src/agents/adapters/copilot.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/copilot.test.ts
@@ -108,6 +108,29 @@ describe('CopilotAdapter', () => {
     expect(data.tools).toContain('mcp__exarchos');
   });
 
+  it('CopilotAdapter_LowerSpec_Readonly_GrantsExarchosTool', () => {
+    // T03 added `mcp:exarchos:readonly` to the Capability enum and T04 wired
+    // a server-side action allowlist. The adapter must lower the readonly
+    // capability to the same `mcp__exarchos` tool entry as the broad
+    // `mcp:exarchos` capability — runtime gating happens at the dispatch
+    // layer, not in the per-runtime tool name. Without this entry, the
+    // `CAPABILITY_TO_TOOL` Record fails the exhaustive `Record<Capability, …>`
+    // typecheck and any spec listing the readonly cap silently emits no
+    // tool entry at all.
+    const readonlySpec: AgentSpec = {
+      ...IMPLEMENTER_FIXTURE,
+      capabilities: ['fs:read', 'mcp:exarchos:readonly'],
+    };
+    const { contents } = adapter.lowerSpec(readonlySpec);
+    const { data } = parseFrontmatter(contents);
+
+    expect(Array.isArray(data.tools)).toBe(true);
+    expect(data.tools).toContain('mcp__exarchos');
+    // And the broad capability is NOT in the spec — the readonly cap alone
+    // must produce the tool entry.
+    expect(readonlySpec.capabilities).not.toContain('mcp:exarchos');
+  });
+
   it('CopilotAdapter_ValidateSupport_RejectsClaudeOnlyHooks', () => {
     const specWithStartHook: AgentSpec = {
       ...IMPLEMENTER_FIXTURE,

--- a/servers/exarchos-mcp/src/agents/adapters/copilot.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/copilot.ts
@@ -26,6 +26,11 @@
 //   shell:exec                  → `shell`
 //   subagent:spawn              → `task`
 //   mcp:exarchos                → `mcp__exarchos` tool entry only
+//   mcp:exarchos:readonly       → `mcp__exarchos` (same tool name; the
+//                                 server-side dispatch gate from T04 is
+//                                 what enforces the readonly action
+//                                 allowlist — Copilot's tool array has
+//                                 no per-action sub-grant primitive)
 //   isolation:worktree          → advisory; emits no tool entry
 //   subagent:start-signal       → unsupported (Copilot has no equivalent hook)
 //   subagent:completion-signal  → unsupported
@@ -63,6 +68,7 @@ const CAPABILITY_TO_TOOL: Record<Capability, string | null> = {
   'shell:exec': 'shell',
   'subagent:spawn': 'task',
   'mcp:exarchos': 'mcp__exarchos',
+  'mcp:exarchos:readonly': 'mcp__exarchos',
   'isolation:worktree': null,
   'subagent:start-signal': null,
   'subagent:completion-signal': null,

--- a/servers/exarchos-mcp/src/agents/adapters/cursor.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/cursor.test.ts
@@ -70,4 +70,55 @@ describe('CursorAdapter', () => {
     // from IMPLEMENTER.systemPrompt is present.
     expect(body).toContain('TDD implementer agent');
   });
+
+  // ─── Item 1, T09: mcp:exarchos:readonly capability wiring ──────────────
+  //
+  // A spec that grants only `mcp:exarchos:readonly` (no `mcp:exarchos`)
+  // must still appear as MCP-enabled in the cursor agent definition so
+  // that the Cursor runtime knows to enable the exarchos MCP server for
+  // this agent. The mutating-action gate is enforced server-side
+  // (see core/dispatch.ts), not at the cursor adapter layer — the
+  // adapter's job is just to grant the tool.
+  //
+  // Mirrors T08 (Copilot) per the PR-#1192 Item 1 plan.
+  // ────────────────────────────────────────────────────────────────────────
+  it('CursorAdapter_LowerSpec_Readonly_GrantsExarchosTool', () => {
+    const spec: AgentSpec = {
+      ...IMPLEMENTER,
+      capabilities: ['fs:read', 'mcp:exarchos:readonly'],
+    };
+    const { contents } = CursorAdapter.lowerSpec(spec);
+    const { data } = splitFrontmatter(contents);
+    // Exarchos MCP server must be granted in the cursor frontmatter so the
+    // runtime enables the server for this agent. The shape mirrors
+    // OpenCode's `mcp: { exarchos: true }` (see opencode.ts buildFrontmatter).
+    expect(data.mcp).toBeDefined();
+    expect((data.mcp as Record<string, unknown>).exarchos).toBe(true);
+  });
+
+  it('CursorAdapter_LowerSpec_Full_GrantsExarchosTool', () => {
+    // The full `mcp:exarchos` capability also grants the exarchos MCP
+    // server (the readonly tier is the more-restrictive sibling).
+    const spec: AgentSpec = {
+      ...IMPLEMENTER,
+      capabilities: ['fs:read', 'mcp:exarchos'],
+    };
+    const { contents } = CursorAdapter.lowerSpec(spec);
+    const { data } = splitFrontmatter(contents);
+    expect(data.mcp).toBeDefined();
+    expect((data.mcp as Record<string, unknown>).exarchos).toBe(true);
+  });
+
+  it('CursorAdapter_LowerSpec_NoMcpCapability_OmitsMcpField', () => {
+    // Specs that declare neither MCP capability must NOT emit an `mcp`
+    // grant in the cursor frontmatter — leaking the grant would broaden
+    // the trust boundary for fs/shell-only agents.
+    const spec: AgentSpec = {
+      ...IMPLEMENTER,
+      capabilities: ['fs:read', 'fs:write'],
+    };
+    const { contents } = CursorAdapter.lowerSpec(spec);
+    const { data } = splitFrontmatter(contents);
+    expect(data.mcp).toBeUndefined();
+  });
 });

--- a/servers/exarchos-mcp/src/agents/adapters/cursor.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/cursor.test.ts
@@ -9,7 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import { parse as parseYaml } from 'yaml';
 import { CursorAdapter } from './cursor.js';
-import { IMPLEMENTER, REVIEWER } from '../definitions.js';
+import { IMPLEMENTER, REVIEWER, SCAFFOLDER } from '../definitions.js';
 import type { AgentSpec } from '../types.js';
 
 /** Split a Markdown-with-YAML-frontmatter document into frontmatter + body. */
@@ -69,5 +69,76 @@ describe('CursorAdapter', () => {
     // The body should be the spec's systemPrompt body — assert a substring
     // from IMPLEMENTER.systemPrompt is present.
     expect(body).toContain('TDD implementer agent');
+  });
+
+  // ─── Advisory worktree-isolation strip ───────────────────────────────────
+  //
+  // Cursor declares `isolation:worktree` as `advisory` (see
+  // CURSOR_SUPPORT_LEVELS in cursor.ts). The IMPLEMENTER and SCAFFOLDER
+  // specs include hard "STOP if pwd doesn't contain `.worktrees/`" startup
+  // guards which assume the runtime enforces worktree isolation. Cursor
+  // doesn't, so the rendered Cursor agent must not carry the hard guard
+  // (it would always trip in normal use). The strip is conservative: it
+  // pattern-matches the known guard subsections and silently no-ops if
+  // the prose is absent.
+
+  it('CursorAdapter_LowerSpec_StripsHardWorktreeGuard_ForAdvisoryIsolation', () => {
+    // IMPLEMENTER.systemPrompt source contains the guard.
+    expect(IMPLEMENTER.systemPrompt).toMatch(/## Worktree Verification/);
+    expect(IMPLEMENTER.systemPrompt).toMatch(/STOP and report error/);
+
+    const { contents } = CursorAdapter.lowerSpec(IMPLEMENTER);
+    const { body } = splitFrontmatter(contents);
+
+    // The hard "STOP" + ".worktrees/" guard region must be gone.
+    expect(body).not.toMatch(/## Worktree Verification/);
+    expect(body).not.toMatch(/## Worktree Hygiene/);
+    expect(body).not.toMatch(/STOP and report error/);
+
+    // Other systemPrompt content must be preserved.
+    expect(body).toContain('TDD implementer agent');
+    expect(body).toContain('## Task');
+    expect(body).toContain('## TDD Protocol');
+    expect(body).toContain('## Completion Report');
+  });
+
+  it('CursorAdapter_LowerSpec_StripsHardWorktreeGuard_FromScaffolder', () => {
+    // SCAFFOLDER also has the guard.
+    expect(SCAFFOLDER.systemPrompt).toMatch(/## Worktree Verification/);
+    expect(SCAFFOLDER.systemPrompt).toMatch(/STOP and report error/);
+
+    const { contents } = CursorAdapter.lowerSpec(SCAFFOLDER);
+    const { body } = splitFrontmatter(contents);
+
+    expect(body).not.toMatch(/## Worktree Verification/);
+    expect(body).not.toMatch(/STOP and report error/);
+
+    // Other content preserved.
+    expect(body).toContain('scaffolder agent');
+    expect(body).toContain('## Task');
+    expect(body).toContain('## Protocol');
+    expect(body).toContain('## Completion Report');
+  });
+
+  it('CursorAdapter_LowerSpec_GuardStrip_IsConservativeNoOp_WhenProseAbsent', () => {
+    // Synthetic spec whose systemPrompt has no "## Worktree Verification"
+    // / "## Worktree Hygiene" headings: the strip must leave the body
+    // untouched (silent no-op).
+    const synthetic: AgentSpec = {
+      ...IMPLEMENTER,
+      systemPrompt: 'Just a plain prompt with no worktree guard sections.\n',
+    };
+    const { contents } = CursorAdapter.lowerSpec(synthetic);
+    const { body } = splitFrontmatter(contents);
+    expect(body).toContain('Just a plain prompt with no worktree guard sections.');
+  });
+
+  it('CursorAdapter_LowerSpec_DoesNotMutateSourceSpec', () => {
+    // The strip happens at the adapter layer; the source spec
+    // (used by other runtimes) must be unchanged.
+    const before = IMPLEMENTER.systemPrompt;
+    CursorAdapter.lowerSpec(IMPLEMENTER);
+    expect(IMPLEMENTER.systemPrompt).toBe(before);
+    expect(IMPLEMENTER.systemPrompt).toMatch(/## Worktree Verification/);
   });
 });

--- a/servers/exarchos-mcp/src/agents/adapters/cursor.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/cursor.ts
@@ -47,6 +47,41 @@ function agentFilePath(agentName: string): string {
   return `.cursor/agents/${agentName}.md`;
 }
 
+/**
+ * Strip the hard "STOP if pwd doesn't contain `.worktrees/`" worktree
+ * guard from a systemPrompt when the target runtime treats
+ * `isolation:worktree` as advisory rather than native (Cursor's case
+ * today — see CURSOR_SUPPORT_LEVELS).
+ *
+ * The guard lives in two known H2 subsections in the canonical specs
+ * (`definitions.ts`):
+ *   - `## Worktree Verification` — the startup STOP block
+ *   - `## Worktree Hygiene (MANDATORY ...)` — the extended per-command rules
+ *
+ * Both are predicated on the runtime actually placing the agent inside
+ * a `.worktrees/` path; under advisory isolation that assumption fails
+ * and the guards would always trip.
+ *
+ * The match is conservative: we anchor on the exact H2 headings and
+ * stop at the next H2 (or end of string). If a future spec drops these
+ * sections or renames the headings, this is a silent no-op rather than
+ * an over-eager strip that clobbers unrelated content.
+ *
+ * Note: this strip is intentionally implemented at the adapter layer.
+ * The source `definitions.ts` IMPLEMENTER/SCAFFOLDER specs keep the
+ * guards verbatim (Claude and other native-isolation runtimes still
+ * need them).
+ */
+function stripAdvisoryWorktreeGuard(systemPrompt: string): string {
+  // Match `## Worktree Verification` or `## Worktree Hygiene <anything to EOL>`
+  // and everything up to (but not including) the next H2 or EOF. Anchored
+  // at start-of-line to avoid matching the heading inside a code fence or
+  // inline reference. Includes the trailing blank line so we don't leave
+  // double newlines behind.
+  const pattern = /(?:^|\n)## Worktree (?:Verification|Hygiene)[^\n]*\n[\s\S]*?(?=\n## |\n?$)/g;
+  return systemPrompt.replace(pattern, '');
+}
+
 function lowerSpec(spec: AgentSpec): { path: string; contents: string } {
   const readonly = !spec.capabilities.includes('fs:write');
 
@@ -58,8 +93,17 @@ function lowerSpec(spec: AgentSpec): { path: string; contents: string } {
     is_background: false,
   };
 
+  // Cursor treats `isolation:worktree` as advisory (see
+  // CURSOR_SUPPORT_LEVELS). Strip the hard guard so the rendered
+  // agent doesn't trip on a runtime that doesn't enforce worktree
+  // placement.
+  const renderedPrompt =
+    CURSOR_SUPPORT_LEVELS['isolation:worktree'] === 'advisory'
+      ? stripAdvisoryWorktreeGuard(spec.systemPrompt)
+      : spec.systemPrompt;
+
   const yaml = stringifyYaml(frontmatter).trimEnd();
-  const contents = `---\n${yaml}\n---\n${spec.systemPrompt}`;
+  const contents = `---\n${yaml}\n---\n${renderedPrompt}`;
 
   return { path: agentFilePath(spec.id), contents };
 }

--- a/servers/exarchos-mcp/src/agents/adapters/cursor.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/cursor.ts
@@ -47,16 +47,44 @@ function agentFilePath(agentName: string): string {
   return `.cursor/agents/${agentName}.md`;
 }
 
+/**
+ * Frontmatter shape emitted into `.cursor/agents/<id>.md`. The optional
+ * `mcp` field gates per-agent MCP server enablement; mirrors the shape
+ * used by the OpenCode adapter.
+ */
+interface CursorFrontmatter {
+  name: string;
+  description: string;
+  model: 'inherit';
+  readonly: boolean;
+  is_background: boolean;
+  mcp?: Record<string, true>;
+}
+
 function lowerSpec(spec: AgentSpec): { path: string; contents: string } {
   const readonly = !spec.capabilities.includes('fs:write');
 
-  const frontmatter = {
+  const frontmatter: CursorFrontmatter = {
     name: spec.id,
     description: spec.description,
-    model: 'inherit' as const,
+    model: 'inherit',
     readonly,
     is_background: false,
   };
+
+  // Item 1, T09: grant the exarchos MCP server when either capability tier
+  // is present. Both tiers map to the same server entry — the readonly
+  // distinction is enforced server-side via the action allowlist gate
+  // (see core/dispatch.ts), not at the cursor adapter layer. The
+  // less-restrictive sibling (`mcp:exarchos`) wins on merge per the
+  // handshake-authoritative resolver, but at the YAML level both tiers
+  // result in the same `mcp.exarchos = true` grant.
+  if (
+    spec.capabilities.includes('mcp:exarchos') ||
+    spec.capabilities.includes('mcp:exarchos:readonly')
+  ) {
+    frontmatter.mcp = { exarchos: true };
+  }
 
   const yaml = stringifyYaml(frontmatter).trimEnd();
   const contents = `---\n${yaml}\n---\n${spec.systemPrompt}`;

--- a/servers/exarchos-mcp/src/agents/adapters/opencode.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/opencode.test.ts
@@ -77,11 +77,16 @@ describe('OpenCodeAdapter', () => {
     }
   });
 
-  it('OpenCodeAdapter_LowerSpec_BodyContainsSpecDescription', () => {
+  it('OpenCodeAdapter_LowerSpec_BodyContainsSpecDescriptionAndSystemPromptSentinels', () => {
     const { contents } = OpenCodeAdapter.lowerSpec(IMPLEMENTER);
     const { body } = splitFrontmatter(contents);
     // The lowered markdown body must include the spec's systemPrompt content
     // (or, at minimum, the spec's description so dispatch context is preserved).
     expect(body).toContain(IMPLEMENTER.description);
+    // Sentinels from IMPLEMENTER.systemPrompt — structural anchors unlikely to
+    // be edited. Without these, a regression dropping most of systemPrompt
+    // would still pass the description-only assertion. See #1192 Item 10.
+    expect(body).toContain('## Task');
+    expect(body).toContain('{{taskDescription}}');
   });
 });

--- a/servers/exarchos-mcp/src/agents/adapters/opencode.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/opencode.test.ts
@@ -77,6 +77,23 @@ describe('OpenCodeAdapter', () => {
     }
   });
 
+  it('OpenCodeAdapter_LowerSpec_Readonly_GrantsExarchosTool', () => {
+    // Item 1, T10 (#1192): the readonly tier of mcp:exarchos must still
+    // surface the exarchos MCP server in OpenCode's `mcp` map. The server-
+    // side allowlist (T04) is what enforces read-only action filtering;
+    // the adapter just needs to grant the tool so the agent can dial it.
+    const spec: AgentSpec = {
+      ...IMPLEMENTER,
+      capabilities: ['fs:read', 'mcp:exarchos:readonly'],
+    };
+    const { contents } = OpenCodeAdapter.lowerSpec(spec);
+    const { data } = splitFrontmatter(contents);
+
+    const mcp = data.mcp as Record<string, true> | undefined;
+    expect(mcp).toBeDefined();
+    expect(mcp?.exarchos).toBe(true);
+  });
+
   it('OpenCodeAdapter_LowerSpec_BodyContainsSpecDescriptionAndSystemPromptSentinels', () => {
     const { contents } = OpenCodeAdapter.lowerSpec(IMPLEMENTER);
     const { body } = splitFrontmatter(contents);

--- a/servers/exarchos-mcp/src/agents/adapters/opencode.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/opencode.ts
@@ -93,7 +93,13 @@ function buildFrontmatter(spec: AgentSpec): OpenCodeFrontmatter {
     description: spec.description,
     tools: capabilitiesToTools(spec.capabilities),
   };
-  if (spec.capabilities.includes('mcp:exarchos')) {
+  // Both `mcp:exarchos` and `mcp:exarchos:readonly` grant the same MCP
+  // tool entry — the read-only tier is enforced server-side by the
+  // dispatch action allowlist (T04), not by withholding the tool.
+  if (
+    spec.capabilities.includes('mcp:exarchos') ||
+    spec.capabilities.includes('mcp:exarchos:readonly')
+  ) {
     fm.mcp = { exarchos: true };
   }
   // `inherit` means "use the host session's current model" — OpenCode

--- a/servers/exarchos-mcp/src/agents/adapters/support-levels.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/support-levels.test.ts
@@ -56,6 +56,7 @@ const NON_CLAUDE_EXPECTED: Readonly<Record<Capability, SupportLevel>> = {
   'shell:exec': 'native',
   'subagent:spawn': 'native',
   'mcp:exarchos': 'native',
+  'mcp:exarchos:readonly': 'native',
   'isolation:worktree': 'advisory',
   'session:resume': 'advisory',
   'subagent:completion-signal': 'unsupported',

--- a/servers/exarchos-mcp/src/agents/agents.test.ts
+++ b/servers/exarchos-mcp/src/agents/agents.test.ts
@@ -183,16 +183,13 @@ describe('Agent Spec Definitions', () => {
     // Per #1109 Constraint 3 (Basileus-forward), MCP remains first-class
     // for the reviewer so it can consult read-only views (exarchos_view's
     // pure-read actions, workflow.get/describe, event.query/describe,
-    // orchestrate.describe). Mutating MCP actions — including every
-    // orchestrate.check_* (each emits a gate.executed event), workflow
-    // .reconcile/rehydrate, view.code_quality (emits regressions), and
-    // all explicit writes — are forbidden at the prompt layer
-    // (see Forbidden MCP Actions section in systemPrompt) — capability-
-    // level filtering of mutating composite-tool actions requires a
-    // separate `mcp:exarchos:readonly` capability negotiated via the
-    // handshake-authoritative resolver (#1109 §2.8) and is tracked as
-    // follow-up work.
-    expect(REVIEWER.capabilities).toContain('mcp:exarchos');
+    // orchestrate.describe). T11: the trust boundary is now enforced
+    // structurally by the `mcp:exarchos:readonly` capability tier (T03)
+    // combined with the dispatch-layer action allowlist (T04) — not by
+    // prose-layer prohibitions. The previous "Forbidden MCP Actions"
+    // systemPrompt block is therefore removed.
+    expect(REVIEWER.capabilities).toContain('mcp:exarchos:readonly');
+    expect(REVIEWER.capabilities).not.toContain('mcp:exarchos');
     expect(REVIEWER.capabilities).not.toContain('shell:exec');
     expect(REVIEWER.capabilities).not.toContain('fs:write');
     expect(REVIEWER.disallowedTools).toContain('Write');
@@ -201,9 +198,9 @@ describe('Agent Spec Definitions', () => {
     expect(REVIEWER.disallowedTools).toContain('Bash');
     expect(REVIEWER.systemPrompt).toContain('{{reviewScope}}');
     expect(REVIEWER.systemPrompt).toContain('{{designRequirements}}');
-    // Defense-in-depth: prompt-layer guard explicitly forbids mutating
-    // MCP actions until capability-level enforcement lands.
-    expect(REVIEWER.systemPrompt).toContain('Forbidden MCP Actions');
+    // The prose "Forbidden MCP Actions" guard is gone — capability-tier
+    // + dispatch-layer enforcement supersedes it.
+    expect(REVIEWER.systemPrompt).not.toContain('Forbidden MCP Actions');
     expect(REVIEWER.mcpServers).toEqual(['exarchos']);
   });
 
@@ -249,7 +246,8 @@ describe('Agent Spec Definitions', () => {
     const KNOWN_CAPS = new Set([
       'fs:read', 'fs:write', 'shell:exec',
       'subagent:spawn', 'subagent:completion-signal', 'subagent:start-signal',
-      'mcp:exarchos', 'isolation:worktree', 'team:agent-teams', 'session:resume',
+      'mcp:exarchos', 'mcp:exarchos:readonly',
+      'isolation:worktree', 'team:agent-teams', 'session:resume',
     ]);
     const KNOWN_DISALLOWED = new Set(['Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob', 'Agent', 'WebFetch', 'WebSearch']);
     for (const spec of ALL_AGENT_SPECS) {

--- a/servers/exarchos-mcp/src/agents/capabilities.test.ts
+++ b/servers/exarchos-mcp/src/agents/capabilities.test.ts
@@ -6,6 +6,10 @@ describe('Capability vocabulary', () => {
     expect(() => Capability.parse('bogus')).toThrow();
   });
 
+  it('Capability_Parses_MCPExarchosReadonly', () => {
+    expect(Capability.parse('mcp:exarchos:readonly')).toBe('mcp:exarchos:readonly');
+  });
+
   it('Capability_AllVocabularyMembersValid_AllParse', () => {
     const vocabulary = [
       'fs:read',

--- a/servers/exarchos-mcp/src/agents/capabilities.test.ts
+++ b/servers/exarchos-mcp/src/agents/capabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { Capability } from './capabilities.js';
+import { Capability, CAPABILITY_KEYS } from './capabilities.js';
 
 describe('Capability vocabulary', () => {
   it('Capability_RejectsUnknownVerb_ZodFails', () => {
@@ -26,5 +26,14 @@ describe('Capability vocabulary', () => {
     for (const member of vocabulary) {
       expect(() => Capability.parse(member)).not.toThrow();
     }
+  });
+
+  it('CapabilityKeys_MatchesEnumValues', () => {
+    expect(CAPABILITY_KEYS).toEqual(new Set(Capability.options));
+    expect(CAPABILITY_KEYS.size).toBe(Capability.options.length);
+  });
+
+  it('CapabilityKeys_IsReadonly', () => {
+    expect(Object.isFrozen(CAPABILITY_KEYS)).toBe(true);
   });
 });

--- a/servers/exarchos-mcp/src/agents/capabilities.test.ts
+++ b/servers/exarchos-mcp/src/agents/capabilities.test.ts
@@ -35,5 +35,14 @@ describe('Capability vocabulary', () => {
 
   it('CapabilityKeys_IsReadonly', () => {
     expect(Object.isFrozen(CAPABILITY_KEYS)).toBe(true);
+    // `Object.freeze` alone does not protect Set internals — verify that
+    // mutators actually throw (the freezeCapabilityKeys helper replaces
+    // .add/.delete/.clear with throwing stubs).
+    const mutable = CAPABILITY_KEYS as unknown as Set<string>;
+    const sizeBefore = CAPABILITY_KEYS.size;
+    expect(() => mutable.add('not-a-real-capability')).toThrow(TypeError);
+    expect(() => mutable.delete('fs:read')).toThrow(TypeError);
+    expect(() => mutable.clear()).toThrow(TypeError);
+    expect(CAPABILITY_KEYS.size).toBe(sizeBefore);
   });
 });

--- a/servers/exarchos-mcp/src/agents/capabilities.ts
+++ b/servers/exarchos-mcp/src/agents/capabilities.ts
@@ -15,3 +15,11 @@ export const Capability = z.enum([
 ]);
 
 export type Capability = z.infer<typeof Capability>;
+
+/**
+ * Canonical source for tests and adapters that need to enumerate or validate
+ * against the full capability vocabulary. Frozen to prevent runtime mutation.
+ */
+export const CAPABILITY_KEYS: ReadonlySet<Capability> = Object.freeze(
+  new Set(Capability.options),
+);

--- a/servers/exarchos-mcp/src/agents/capabilities.ts
+++ b/servers/exarchos-mcp/src/agents/capabilities.ts
@@ -8,6 +8,7 @@ export const Capability = z.enum([
   'subagent:completion-signal',
   'subagent:start-signal',
   'mcp:exarchos',
+  'mcp:exarchos:readonly',
   'isolation:worktree',
   'team:agent-teams',
   'session:resume',

--- a/servers/exarchos-mcp/src/agents/capabilities.ts
+++ b/servers/exarchos-mcp/src/agents/capabilities.ts
@@ -18,8 +18,21 @@ export type Capability = z.infer<typeof Capability>;
 
 /**
  * Canonical source for tests and adapters that need to enumerate or validate
- * against the full capability vocabulary. Frozen to prevent runtime mutation.
+ * against the full capability vocabulary. Mutators are replaced with
+ * throwing stubs so runtime widening of the trust boundary is impossible —
+ * `Object.freeze(set)` alone is insufficient because Set internal slots
+ * ignore the frozen flag and `.add()` still mutates.
  */
-export const CAPABILITY_KEYS: ReadonlySet<Capability> = Object.freeze(
+function freezeCapabilityKeys(set: Set<Capability>): ReadonlySet<Capability> {
+  const throwImmutable = (): never => {
+    throw new TypeError('CAPABILITY_KEYS is immutable; mutation is forbidden');
+  };
+  Object.defineProperty(set, 'add', { value: throwImmutable, writable: false, configurable: false });
+  Object.defineProperty(set, 'delete', { value: throwImmutable, writable: false, configurable: false });
+  Object.defineProperty(set, 'clear', { value: throwImmutable, writable: false, configurable: false });
+  return Object.freeze(set);
+}
+
+export const CAPABILITY_KEYS: ReadonlySet<Capability> = freezeCapabilityKeys(
   new Set(Capability.options),
 );

--- a/servers/exarchos-mcp/src/agents/definitions.test.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.test.ts
@@ -108,4 +108,22 @@ describe('AgentSpec capability declarations', () => {
     };
     expect(bad).toBeDefined();
   });
+
+  // Issue #1192 Item 4 (T26): every spec with a post-test validationRule must
+  // anchor its command to the git toplevel. Bare `npm run test:run` would
+  // execute against whatever shell cwd the agent has drifted to — anchoring
+  // via $(git rev-parse --show-toplevel) ensures the worktree is what's tested.
+  it('Hooks_PostTestCommand_IsGitToplevelAnchored', () => {
+    const all = [IMPLEMENTER, FIXER, REVIEWER, SCAFFOLDER];
+    for (const spec of all) {
+      const postTestRules = (spec.validationRules ?? []).filter(
+        (r) => r.trigger === 'post-test' && typeof r.command === 'string',
+      );
+      for (const rule of postTestRules) {
+        expect(rule.command, `${spec.id} post-test command must anchor to git toplevel`).toContain(
+          '$(git rev-parse --show-toplevel)',
+        );
+      }
+    }
+  });
 });

--- a/servers/exarchos-mcp/src/agents/definitions.test.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.test.ts
@@ -47,13 +47,40 @@ describe('AgentSpec capability declarations', () => {
 
   it('AgentSpec_ReviewerCapabilities_ReadOnly', () => {
     expect(REVIEWER.capabilities).toEqual(
-      expect.arrayContaining(['fs:read', 'mcp:exarchos']),
+      expect.arrayContaining(['fs:read', 'mcp:exarchos:readonly']),
     );
-    // Reviewer is read-only: must not declare write capability. MCP
-    // remains declared (per #1109 Constraint 3) so the reviewer can call
-    // read-only views; mutating MCP actions are forbidden at the prompt
-    // layer (see Forbidden MCP Actions in REVIEWER.systemPrompt).
+    // Reviewer is read-only: must not declare write capability. The
+    // mutating-MCP trust boundary is now capability-enforced via the
+    // `mcp:exarchos:readonly` tier (T03/T04) rather than prompt-enforced.
     expect(REVIEWER.capabilities).not.toContain('fs:write');
+  });
+
+  it('REVIEWER_Capabilities_UsesReadonlyMCP', () => {
+    // T11: REVIEWER migrates from `mcp:exarchos` to `mcp:exarchos:readonly`.
+    // The dispatch-layer gate (T04) only fires when the readonly tier is
+    // present AND the full tier is NOT — so we must drop `mcp:exarchos`.
+    expect(REVIEWER.capabilities).toContain('mcp:exarchos:readonly');
+    expect(REVIEWER.capabilities).not.toContain('mcp:exarchos');
+  });
+
+  it('REVIEWER_SystemPrompt_LacksForbiddenActionsBlock', () => {
+    // T11: with the dispatch-layer gate enforcing the trust boundary
+    // structurally, the prose-layer "Forbidden MCP Actions" block is
+    // redundant and removed.
+    expect(REVIEWER.systemPrompt).not.toContain('Forbidden MCP Actions');
+    expect(REVIEWER.systemPrompt).not.toContain('You MUST NOT call any other MCP action');
+    expect(REVIEWER.systemPrompt).not.toContain('exarchos_event append/batch_append');
+  });
+
+  it('REVIEWER_SystemPrompt_PreservesNonForbiddenSections', () => {
+    // The deletion must be scoped — other systemPrompt sections survive.
+    expect(REVIEWER.systemPrompt).toContain('## Review Scope');
+    expect(REVIEWER.systemPrompt).toContain('## Design Requirements');
+    expect(REVIEWER.systemPrompt).toContain('## Review Protocol');
+    expect(REVIEWER.systemPrompt).toContain('## Completion Report');
+    expect(REVIEWER.systemPrompt).toContain('{{reviewScope}}');
+    expect(REVIEWER.systemPrompt).toContain('{{designRequirements}}');
+    expect(REVIEWER.systemPrompt).toContain('READ-ONLY access');
   });
 
   it('AgentSpec_ScaffolderCapabilities', () => {

--- a/servers/exarchos-mcp/src/agents/definitions.test.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.test.ts
@@ -114,8 +114,7 @@ describe('AgentSpec capability declarations', () => {
   // execute against whatever shell cwd the agent has drifted to — anchoring
   // via $(git rev-parse --show-toplevel) ensures the worktree is what's tested.
   it('Hooks_PostTestCommand_IsGitToplevelAnchored', () => {
-    const all = [IMPLEMENTER, FIXER, REVIEWER, SCAFFOLDER];
-    for (const spec of all) {
+    for (const spec of ALL_AGENT_SPECS) {
       const postTestRules = (spec.validationRules ?? []).filter(
         (r) => r.trigger === 'post-test' && typeof r.command === 'string',
       );

--- a/servers/exarchos-mcp/src/agents/definitions.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.ts
@@ -232,24 +232,6 @@ Rules:
 - Be specific in findings — include file paths and line references
 - Categorize findings: critical, warning, suggestion
 
-## Forbidden MCP Actions (read-only review boundary)
-
-You MAY call only these strictly read-only Exarchos MCP actions:
-- \`exarchos_view\` — \`pipeline\`, \`tasks\`, \`workflow_status\`, \`stack_status\`, \`telemetry\`, \`team_performance\`, \`delegation_timeline\`, \`delegation_readiness\`, \`synthesis_readiness\`, \`shepherd_status\`, \`convergence\`, \`quality_hints\`, \`describe\` (NOT \`code_quality\` — emits \`quality.regression\` events; NOT \`stack_place\` — mutates)
-- \`exarchos_workflow\` — \`get\`, \`describe\` only
-- \`exarchos_event\` — \`query\`, \`describe\` only
-- \`exarchos_orchestrate\` — \`describe\` only
-
-You MUST NOT call any other MCP action — they all mutate state, emit events, or call external services. Forbidden examples include but are not limited to:
-- \`exarchos_workflow set/init/cancel/cleanup/checkpoint/reconcile/rehydrate\` (\`reconcile\` writes state, \`rehydrate\` emits \`workflow.rehydrated\`)
-- \`exarchos_event append/batch_append\`
-- \`exarchos_orchestrate check_*\` (each emits a \`gate.executed\` event)
-- \`exarchos_orchestrate task_claim/task_complete/task_fail\`
-- \`exarchos_orchestrate create_pr/merge_pr/add_pr_comment/create_issue/...\`
-- \`exarchos_view code_quality/stack_place\`
-
-Workflow mutation, event emission, and gate execution belong to the orchestrator. If a finding requires state changes, gate runs, or fresh quality checks, surface it as a recommendation in the review verdict — the orchestrator will dispatch.
-
 ## Completion Report
 When done, output a JSON completion report:
 \`\`\`json
@@ -265,29 +247,24 @@ When done, output a JSON completion report:
   // OpenCode's `tools.bash`. Test runs / typecheck / git inspection
   // belong to the orchestrator, not the reviewer agent.
   //
-  // `mcp:exarchos` is retained so the reviewer can consult read-only MCP
-  // surfaces (`exarchos_view`, `exarchos_workflow get`, `exarchos_event
-  // query`, `exarchos_orchestrate describe`) for code-quality data
-  // during review. Per #1109 Constraint 3 (Basileus-forward), MCP must
-  // remain first-class; demoting MCP entirely would violate that.
+  // `mcp:exarchos:readonly` is declared (NOT the full `mcp:exarchos`)
+  // so the reviewer can consult read-only MCP surfaces (`exarchos_view`
+  // pure-read actions, `exarchos_workflow get/describe`, `exarchos_event
+  // query/describe`, `exarchos_orchestrate describe`) while mutating
+  // composite-tool actions are blocked at the dispatch layer (T04).
+  // Per #1109 Constraint 3 (Basileus-forward), MCP remains first-class;
+  // the readonly tier preserves that without exposing write actions.
   //
   // Trust-boundary state — defense in depth (DIM-2 + DIM-7):
   //   1. shell:exec absent + Bash in disallowedTools → no shell escape
   //   2. fs:write absent + Write/Edit in disallowedTools → no FS mutation
-  //   3. mcp:exarchos PRESENT but mutating actions are prompt-forbidden
-  //      (see systemPrompt "Forbidden MCP actions" section). The composite
-  //      tools expose write actions (workflow.set, event.append,
-  //      orchestrate.task_complete, etc.) under shared composite names
-  //      that cannot be filtered at the runtime tool-allowlist level.
-  //
-  // The capability-level enforcement of read-only MCP requires either a
-  // new `mcp:exarchos:readonly` capability negotiated via the
-  // handshake-authoritative resolution path (#1109 §2.8 / ADR §2.8) or a
-  // server-side read-only tool partition. Tracked in #1192 — not in
-  // scope for this PR.
+  //   3. mcp:exarchos:readonly (without mcp:exarchos) → dispatch-layer
+  //      gate rejects mutating composite actions (workflow.set,
+  //      event.append, orchestrate.task_complete, etc.) structurally,
+  //      not via prose. See `core/dispatch.ts` readonly action allowlist.
   capabilities: [
     'fs:read',
-    'mcp:exarchos',
+    'mcp:exarchos:readonly',
   ],
   disallowedTools: ['Write', 'Edit', 'Agent', 'Bash'],
   model: 'inherit',

--- a/servers/exarchos-mcp/src/agents/definitions.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.ts
@@ -121,7 +121,7 @@ When done, output a JSON completion report:
   ],
   validationRules: [
     { trigger: 'pre-write', rule: 'Test file must exist before implementation file is written' },
-    { trigger: 'post-test', rule: 'All tests must pass', command: 'npm run test:run' },
+    { trigger: 'post-test', rule: 'All tests must pass', command: 'npm --prefix "$(git rev-parse --show-toplevel)" run test:run' },
   ],
   resumable: true,
   memoryScope: 'project',
@@ -190,7 +190,7 @@ When done, output a JSON completion report:
     { name: 'tdd-patterns', content: '' },
   ],
   validationRules: [
-    { trigger: 'post-test', rule: 'All tests must pass after fix', command: 'npm run test:run' },
+    { trigger: 'post-test', rule: 'All tests must pass after fix', command: 'npm --prefix "$(git rev-parse --show-toplevel)" run test:run' },
   ],
   resumable: false,
   mcpServers: ['exarchos'],

--- a/servers/exarchos-mcp/src/agents/drift.test.ts
+++ b/servers/exarchos-mcp/src/agents/drift.test.ts
@@ -7,17 +7,13 @@
 
 import { describe, it, expect } from 'vitest';
 import { ALL_AGENT_SPECS } from './definitions.js';
+import { CAPABILITY_KEYS } from './capabilities.js';
+import { deriveClaudeToolsFromCapabilities } from './adapters/claude.js';
 
 // ─── Known Names ───────────────────────────────────────────────────────────
 
 const KNOWN_DISALLOWED_TOOLS: ReadonlySet<string> = new Set([
   'Read', 'Write', 'Edit', 'Bash', 'Grep', 'Glob', 'Agent', 'WebFetch', 'WebSearch',
-]);
-
-const KNOWN_CAPABILITIES: ReadonlySet<string> = new Set([
-  'fs:read', 'fs:write', 'shell:exec',
-  'subagent:spawn', 'subagent:completion-signal', 'subagent:start-signal',
-  'mcp:exarchos', 'isolation:worktree', 'team:agent-teams', 'session:resume',
 ]);
 
 // ─── Template Var Pattern ──────────────────────────────────────────────────
@@ -33,8 +29,8 @@ describe('Agent Spec Drift Prevention', () => {
     for (const spec of ALL_AGENT_SPECS) {
       for (const cap of spec.capabilities) {
         expect(
-          KNOWN_CAPABILITIES.has(cap),
-          `${spec.id}: capability '${cap}' is not in the known set: ${[...KNOWN_CAPABILITIES].join(', ')}`,
+          CAPABILITY_KEYS.has(cap),
+          `${spec.id}: capability '${cap}' is not in the known set: ${[...CAPABILITY_KEYS].join(', ')}`,
         ).toBe(true);
       }
       if (spec.disallowedTools) {
@@ -73,23 +69,12 @@ describe('Agent Spec Drift Prevention', () => {
   });
 
   it('AllAgentSpecs_DisallowedToolsNotInDerivedTools_NoOverlap', () => {
-    // After Task 4a/14 this drift check moves into the Claude adapter snapshot.
-    // Until then, we sanity-check against the derivation shim.
+    // Use the canonical Claude derivation helper so this check stays in lock-step
+    // with what `agents/*.md` actually grants. Cross-adapter coverage lives in
+    // each adapter's own snapshot test (see runtimes/*.test.ts).
     for (const spec of ALL_AGENT_SPECS) {
       if (!spec.disallowedTools) continue;
-      // Reproduce the same derivation shape used by the temporary shim so the
-      // assertion still describes "what Claude sees". Direct fs:write/shell:exec
-      // mapping is sufficient to detect overlap with disallowedTools.
-      const derived = new Set<string>();
-      if (spec.capabilities.includes('fs:read')) {
-        derived.add('Read'); derived.add('Grep'); derived.add('Glob');
-      }
-      if (spec.capabilities.includes('fs:write')) {
-        derived.add('Write'); derived.add('Edit');
-      }
-      if (spec.capabilities.includes('shell:exec')) {
-        derived.add('Bash');
-      }
+      const derived = new Set<string>(deriveClaudeToolsFromCapabilities(spec));
       for (const disallowed of spec.disallowedTools) {
         expect(
           derived.has(disallowed),

--- a/servers/exarchos-mcp/src/agents/generate-agents.test.ts
+++ b/servers/exarchos-mcp/src/agents/generate-agents.test.ts
@@ -13,12 +13,31 @@
 // 5 in docs/plans/2026-04-25-delegation-runtime-parity.md.
 // ────────────────────────────────────────────────────────────────────────────
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import matter from 'gray-matter';
 import { parse as parseToml } from '@iarna/toml';
+
+// ─── Test-controlled writePluginManifest ──────────────────────────────────
+//
+// Most tests want the real implementation; the rollback tests below need to
+// inject a synthetic write failure. We hoist a `vi.fn` and route the module
+// through a partial mock that delegates to the real implementation by
+// default, so behaviour is transparent unless an individual test installs
+// `mockImplementationOnce(...)`.
+const writePluginManifestMock = vi.hoisted(() => vi.fn());
+vi.mock('./plugin-manifest.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('./plugin-manifest.js')>();
+  writePluginManifestMock.mockImplementation(actual.writePluginManifest);
+  return {
+    ...actual,
+    writePluginManifest: writePluginManifestMock,
+  };
+});
+
 import {
   generateAgents,
   GenerateAgentsError,
@@ -557,4 +576,144 @@ describe('Per-runtime smoke validation', () => {
       });
     }
   }
+});
+
+// ─── Manifest-write rollback (T17) ─────────────────────────────────────────
+//
+// If `writePluginManifest` throws after per-runtime artifact files have
+// been written, `generateAgents` must unlink every artifact it CREATED
+// during the failed run (best-effort), so the on-disk state matches the
+// pre-run state for newly-created paths. Pre-existing files are left
+// untouched: rollback is scoped to "things this run produced", not "things
+// that happened to share a target path".
+//
+// Refs #1192 (Items 3+5+17), T17.
+describe('generateAgents — manifest write failure rollback', () => {
+  let tmp: string;
+  let pluginJsonPath: string;
+
+  beforeEach(() => {
+    tmp = makeTempDir();
+    pluginJsonPath = makeTempPluginJson(tmp);
+  });
+
+  afterEach(() => {
+    rmrf(tmp);
+    // Re-bind to the real implementation so subsequent test files /
+    // re-runs see the genuine writePluginManifest behaviour.
+    writePluginManifestMock.mockReset();
+  });
+
+  it('GenerateAgents_RollsBackArtifacts_OnManifestWriteFailure', async () => {
+    // Snapshot the pre-run state of every per-runtime directory under tmp.
+    // Anything not in this set is "newly created by this run" and must be
+    // unlinked when the manifest write fails.
+    const pluginManifest = await import('./plugin-manifest.js');
+    writePluginManifestMock.mockImplementation(() => {
+      throw new Error('simulated manifest write failure');
+    });
+
+    const expectedArtifacts: string[] = [];
+    for (const adapter of ALL_ADAPTERS) {
+      for (const spec of CANONICAL_SPECS) {
+        expectedArtifacts.push(
+          path.join(tmp, adapter.agentFilePath(spec.id)),
+        );
+      }
+    }
+
+    // None of these exist before the run.
+    for (const p of expectedArtifacts) {
+      expect(fs.existsSync(p), `expected ${p} not to exist pre-run`).toBe(
+        false,
+      );
+    }
+
+    let caught: unknown;
+    try {
+      generateAgents({
+        outputRoot: tmp,
+        specs: CANONICAL_SPECS,
+        adapters: ALL_ADAPTERS,
+        pluginJsonPath,
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    // Sanity: writePluginManifest was actually called (so we exercised the
+    // rollback path) and the original failure surfaced.
+    expect(writePluginManifestMock).toHaveBeenCalled();
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(
+      /simulated manifest write failure/,
+    );
+
+    // Every newly-created artifact must have been unlinked.
+    for (const p of expectedArtifacts) {
+      expect(
+        fs.existsSync(p),
+        `expected ${p} to be rolled back (unlinked) after manifest failure`,
+      ).toBe(false);
+    }
+
+    // The plugin manifest itself was NOT created by this run, and must
+    // still exist (preflight passed; we just blocked the rewrite).
+    expect(fs.existsSync(pluginJsonPath)).toBe(true);
+    // Touch reference so vitest doesn't flag the import as unused — we
+    // want the dynamic import to confirm the mock-bound module resolves.
+    expect(typeof pluginManifest.writePluginManifest).toBe('function');
+  });
+
+  it('GenerateAgents_PreservesPreExistingFiles_OnManifestWriteFailure', () => {
+    writePluginManifestMock.mockImplementation(() => {
+      throw new Error('simulated manifest write failure');
+    });
+
+    // Pre-create a file at one of the per-runtime artifact paths with
+    // sentinel contents. Rollback must NOT unlink it — the run did not
+    // create it.
+    const preexistingPath = path.join(
+      tmp,
+      claudeAdapter.agentFilePath(IMPLEMENTER.id),
+    );
+    fs.mkdirSync(path.dirname(preexistingPath), { recursive: true });
+    const sentinel = 'PRE-EXISTING-SENTINEL\n';
+    fs.writeFileSync(preexistingPath, sentinel, 'utf-8');
+
+    // Also pre-create a non-artifact file in the same directory to
+    // confirm rollback never touches files outside its tracked set.
+    const bystander = path.join(
+      path.dirname(preexistingPath),
+      'bystander.md',
+    );
+    fs.writeFileSync(bystander, 'BYSTANDER\n', 'utf-8');
+
+    let caught: unknown;
+    try {
+      generateAgents({
+        outputRoot: tmp,
+        specs: CANONICAL_SPECS,
+        adapters: ALL_ADAPTERS,
+        pluginJsonPath,
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+
+    // Pre-existing artifact-path file still present. Note: the run will
+    // have OVERWRITTEN it with the lowered contents before the manifest
+    // failure, but the file itself must remain on disk — rollback only
+    // unlinks paths that did NOT exist pre-run.
+    expect(
+      fs.existsSync(preexistingPath),
+      'pre-existing artifact file must NOT be unlinked by rollback',
+    ).toBe(true);
+
+    // Bystander file untouched (was never an artifact target).
+    expect(fs.existsSync(bystander)).toBe(true);
+    expect(fs.readFileSync(bystander, 'utf-8')).toBe('BYSTANDER\n');
+  });
 });

--- a/servers/exarchos-mcp/src/agents/generate-agents.test.ts
+++ b/servers/exarchos-mcp/src/agents/generate-agents.test.ts
@@ -35,6 +35,7 @@ import { codexAdapter } from './adapters/codex.js';
 import { OpenCodeAdapter } from './adapters/opencode.js';
 import { CursorAdapter } from './adapters/cursor.js';
 import { CopilotAdapter } from './adapters/copilot.js';
+import { RUNTIMES } from './adapters/types.js';
 import type { RuntimeAdapter, Runtime } from './adapters/types.js';
 
 // ─── Test utilities ────────────────────────────────────────────────────────
@@ -413,7 +414,6 @@ describe('generateAgents', () => {
 //     `name`, `description`, `developer_instructions`. Codex does not
 //     emit `model` from `lowerSpec`.
 
-const RUNTIMES = ['claude', 'codex', 'opencode', 'cursor', 'copilot'] as const;
 const SPECS = ['implementer', 'fixer', 'reviewer', 'scaffolder'] as const;
 
 const SMOKE_ADAPTERS: Record<Runtime, RuntimeAdapter> = {

--- a/servers/exarchos-mcp/src/agents/generate-agents.ts
+++ b/servers/exarchos-mcp/src/agents/generate-agents.ts
@@ -43,6 +43,7 @@ import {
   type Runtime,
   type RuntimeAdapter,
 } from './adapters/types.js';
+import { readPluginManifest, writePluginManifest } from './plugin-manifest.js';
 
 // ─── Default registry ──────────────────────────────────────────────────────
 
@@ -224,6 +225,10 @@ function validateAllPairs(
  * a partially regenerated tree.
  */
 function preflightPluginJson(pluginJsonPath: string): void {
+  // Preserve the structured GenerateAgentsError on missing-file so callers
+  // (and tests) keep the same operator-facing failure shape; everything
+  // else (JSON syntax, schema violations) is delegated to
+  // readPluginManifest which throws a descriptive plain Error.
   if (!fs.existsSync(pluginJsonPath)) {
     throw new GenerateAgentsError([
       {
@@ -236,31 +241,7 @@ function preflightPluginJson(pluginJsonPath: string): void {
       },
     ]);
   }
-  let raw: string;
-  try {
-    raw = fs.readFileSync(pluginJsonPath, 'utf-8');
-  } catch (err) {
-    throw new Error(
-      `generateAgents: failed to read plugin manifest at ${pluginJsonPath}: ${
-        (err as Error).message
-      }`,
-    );
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (err) {
-    throw new Error(
-      `generateAgents: plugin manifest at ${pluginJsonPath} is not valid JSON: ${
-        (err as Error).message
-      }`,
-    );
-  }
-  if (typeof parsed !== 'object' || parsed === null) {
-    throw new Error(
-      `generateAgents: plugin manifest at ${pluginJsonPath} must be a JSON object`,
-    );
-  }
+  readPluginManifest(pluginJsonPath);
 }
 
 /**
@@ -277,34 +258,13 @@ function updatePluginJson(
   pluginJsonPath: string,
   specs: readonly AgentSpec[],
 ): void {
-  let raw: string;
-  try {
-    raw = fs.readFileSync(pluginJsonPath, 'utf-8');
-  } catch (err) {
-    throw new Error(
-      `generateAgents: failed to read plugin manifest at ${pluginJsonPath}: ${
-        (err as Error).message
-      }`,
-    );
-  }
-  // Already preflighted; re-parse defensively in case the manifest
-  // changed between preflight and write (rare but possible during
-  // concurrent runs).
-  const manifest = JSON.parse(raw) as { agents?: unknown; [k: string]: unknown };
+  // Re-read defensively in case the manifest changed between preflight
+  // and write (rare but possible during concurrent runs). The write goes
+  // through atomicWriteFile (temp + fsync + rename) via writePluginManifest
+  // so concurrent readers never observe a partial write.
+  const manifest = readPluginManifest(pluginJsonPath);
   manifest.agents = specs.map((s) => `./agents/${s.id}.md`);
-  try {
-    fs.writeFileSync(
-      pluginJsonPath,
-      JSON.stringify(manifest, null, 2) + '\n',
-      'utf-8',
-    );
-  } catch (err) {
-    throw new Error(
-      `generateAgents: failed to write plugin manifest at ${pluginJsonPath}: ${
-        (err as Error).message
-      }`,
-    );
-  }
+  writePluginManifest(pluginJsonPath, manifest);
 }
 
 // ─── Entry point ───────────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/agents/generate-agents.ts
+++ b/servers/exarchos-mcp/src/agents/generate-agents.ts
@@ -323,8 +323,15 @@ export function generateAgents(
   // stays inside the root. A malicious or buggy adapter that returns
   // `../../../etc/passwd` or an absolute path must be rejected before
   // any directory creation or file write touches the filesystem.
+  //
+  // Rollback bookkeeping (T17): track every artifact path this run
+  // CREATES (vs. overwrites). If the manifest write below throws, those
+  // newly-created files are unlinked so the on-disk state matches the
+  // pre-run state. Files that already existed before the run are left
+  // intact — rollback is scoped to "things this run produced".
   const resolvedRoot = path.resolve(outputRoot);
   const filesWritten: string[] = [];
+  const newlyCreatedArtifacts: string[] = [];
   for (const adapter of adapters) {
     for (const spec of specs) {
       const lowered = adapter.lowerSpec(spec);
@@ -345,6 +352,12 @@ export function generateAgents(
           }' spec '${spec.id}': ${(err as Error).message}`,
         );
       }
+      // Capture pre-existence BEFORE the write so rollback never unlinks
+      // a file the user had on disk before this run started. `fs.statSync`
+      // with `throwIfNoEntry: false` returns `undefined` for missing
+      // paths and avoids the deprecated-for-some-uses `fs.existsSync`.
+      const preExisted =
+        fs.statSync(absPath, { throwIfNoEntry: false }) !== undefined;
       try {
         fs.writeFileSync(absPath, lowered.contents, 'utf-8');
       } catch (err) {
@@ -355,17 +368,52 @@ export function generateAgents(
         );
       }
       filesWritten.push(absPath);
+      if (!preExisted) {
+        newlyCreatedArtifacts.push(absPath);
+      }
     }
   }
 
   // 3. Plugin.json update. Only Claude has a manifest today; the other
   //    runtimes load agents via filesystem convention.
-  updatePluginJson(pluginJsonPath, specs);
+  //
+  // Rollback contract (T17): on manifest write failure, unlink every
+  // path in `newlyCreatedArtifacts` (best-effort — individual unlink
+  // errors must NOT mask the original manifest error) and re-throw a
+  // wrapped error that names the original cause and the rollback
+  // count. This closes the partial-state gap where a manifest failure
+  // would otherwise leave 20 fresh files on disk while plugin.json
+  // still pointed at the prior generation.
+  try {
+    updatePluginJson(pluginJsonPath, specs);
+  } catch (e) {
+    rollbackArtifacts(newlyCreatedArtifacts);
+    throw new Error(
+      `generate-agents: manifest write failed; rolled back ${newlyCreatedArtifacts.length} new artifacts. Original error: ${
+        (e as Error).message
+      }`,
+    );
+  }
 
   return {
     filesWritten,
     pluginJsonUpdated: true,
   };
+}
+
+/**
+ * Best-effort cleanup helper for T17 rollback. Unlinks every path in
+ * `paths`, swallowing per-file errors so a partial cleanup never masks
+ * the original failure that triggered the rollback.
+ */
+function rollbackArtifacts(paths: readonly string[]): void {
+  for (const p of paths) {
+    try {
+      fs.unlinkSync(p);
+    } catch {
+      /* best-effort cleanup — surface the original error, not this one */
+    }
+  }
 }
 
 // ─── Re-exports for convenience ────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/agents/generated-drift.test.ts
+++ b/servers/exarchos-mcp/src/agents/generated-drift.test.ts
@@ -10,24 +10,21 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { parse as parseYaml } from 'yaml';
 import { claudeAdapter, deriveClaudeToolsFromCapabilities } from './adapters/claude.js';
 import { ALL_AGENT_SPECS } from './definitions.js';
 
 // ─── Helper: Parse YAML Frontmatter ─────────────────────────────────────────
-
-function parseFrontmatter(content: string): Record<string, string> {
-  const parts = content.split('---');
-  if (parts.length < 3) return {};
-  const yaml = parts[1].trim();
-  const result: Record<string, string> = {};
-  for (const line of yaml.split('\n')) {
-    // Only match top-level key: value pairs (no leading whitespace)
-    const match = line.match(/^(\w+):\s*(.+)$/);
-    if (match) {
-      result[match[1]] = match[2].replace(/^"(.*)"$/, '$1');
-    }
-  }
-  return result;
+//
+// Use a real YAML parser. The previous regex-based parser only matched
+// flow-style scalars (`tools: ["a", "b"]` on one line) which was an
+// artefact of the hand-rolled string-concat renderer; the YAML library
+// emits structured values (block lists, block scalars, etc) and the
+// drift contract is on the *parsed* value, not the byte form.
+function parseFrontmatter(content: string): Record<string, unknown> {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  return (parseYaml(match[1]) ?? {}) as Record<string, unknown>;
 }
 
 // ─── Shared Setup ───────────────────────────────────────────────────────────
@@ -110,13 +107,14 @@ describe('Generated Agent File Drift', () => {
       const content = fs.readFileSync(filePath, 'utf-8');
       const fm = parseFrontmatter(content);
 
-      // Use the derivation shim (TEMPORARY — replaced by Task 4a snapshot test).
-      const derivedTools = deriveClaudeToolsFromCapabilities(spec);
-      const expectedTools = `[${derivedTools.map(t => `"${t}"`).join(', ')}]`;
+      // Compare parsed arrays — the YAML renderer may emit either
+      // block-style or flow-style sequences; the drift contract is
+      // semantic equality with the derivation shim, not byte form.
+      const derivedTools = [...deriveClaudeToolsFromCapabilities(spec)];
       expect(
         fm.tools,
         `Frontmatter tools mismatch for spec '${spec.id}'`,
-      ).toBe(expectedTools);
+      ).toEqual(derivedTools);
     }
   });
 

--- a/servers/exarchos-mcp/src/agents/plugin-manifest.test.ts
+++ b/servers/exarchos-mcp/src/agents/plugin-manifest.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { PluginManifestSchema } from './plugin-manifest.js';
+import {
+  PluginManifestSchema,
+  writePluginManifest,
+  type PluginManifest,
+} from './plugin-manifest.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -55,5 +60,109 @@ describe('PluginManifestSchema', () => {
     const livePath = path.join(repoRoot, '.claude-plugin/plugin.json');
     const live = JSON.parse(fs.readFileSync(livePath, 'utf8')) as unknown;
     expect(() => PluginManifestSchema.parse(live)).not.toThrow();
+  });
+});
+
+describe('writePluginManifest', () => {
+  const createdDirs: string[] = [];
+
+  function makeTmpDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-plugin-manifest-'));
+    createdDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    while (createdDirs.length > 0) {
+      const dir = createdDirs.pop();
+      if (dir !== undefined) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  const validManifest: PluginManifest = {
+    name: 'exarchos',
+    description: 'Test description',
+    version: '0.0.0',
+    author: { name: 'Test Author' },
+    agents: ['./agents/implementer.md', './agents/reviewer.md'],
+    commands: './commands/',
+    skills: './skills/',
+    metadata: { compat: { minBinaryVersion: '2.9.0-rc.1' } },
+  };
+
+  it('WritePluginManifest_AtomicReplace_RoundTrips', () => {
+    const dir = makeTmpDir();
+    const target = path.join(dir, 'plugin.json');
+
+    writePluginManifest(target, validManifest);
+
+    // Round-trip: parse the file back through the same schema and assert
+    // deep-equal. Mirrors what readPluginManifest (T14) will do.
+    const raw = fs.readFileSync(target, 'utf8');
+    const parsed = PluginManifestSchema.parse(JSON.parse(raw));
+    expect(parsed).toEqual(validManifest);
+  });
+
+  it('WritePluginManifest_RejectsInvalidShape', () => {
+    const dir = makeTmpDir();
+    const target = path.join(dir, 'plugin.json');
+
+    const invalid = {
+      name: 'exarchos',
+      // Violates AgentPathSchema — must match `./agents/<kebab>.md`.
+      agents: ['not-a-valid-path'],
+    } as unknown as PluginManifest;
+
+    expect(() => writePluginManifest(target, invalid)).toThrow();
+
+    // The schema must reject BEFORE any disk I/O — neither the target
+    // nor a temp sibling should exist.
+    expect(fs.existsSync(target)).toBe(false);
+    const entries = fs.readdirSync(dir);
+    expect(entries.filter((e) => e.includes('.tmp'))).toEqual([]);
+  });
+
+  it('WritePluginManifest_PreservesOriginalOnRenameError', () => {
+    const dir = makeTmpDir();
+    // Use a DIRECTORY at the target path — `fs.renameSync(file, existingDir)`
+    // fails predictably (EISDIR on Linux, ENOTDIR on macOS) and the failure
+    // happens AFTER the temp file is staged. That's the exact error path we
+    // want to exercise: temp written, rename throws, original (the dir) is
+    // untouched, and the temp must be cleaned up.
+    //
+    // Mocking `fs.renameSync` directly is not viable here — vitest cannot
+    // spy on ESM namespace exports (`Cannot redefine property: renameSync`),
+    // and `vi.mock('node:fs', …)` would clobber every other fs call in the
+    // module. A real failure path is both more portable and a stronger
+    // assertion.
+    const target = path.join(dir, 'plugin.json');
+    fs.mkdirSync(target);
+    const dirInodeBefore = fs.statSync(target).ino;
+    const dirIsDirBefore = fs.statSync(target).isDirectory();
+
+    expect(() => writePluginManifest(target, validManifest)).toThrow();
+
+    // Original (the directory) is untouched: still a directory, same inode.
+    const statAfter = fs.statSync(target);
+    expect(statAfter.isDirectory()).toBe(dirIsDirBefore);
+    expect(statAfter.ino).toBe(dirInodeBefore);
+
+    // No temp leftover next to the target.
+    const entries = fs.readdirSync(dir);
+    expect(entries.filter((e) => e.includes('.tmp'))).toEqual([]);
+  });
+
+  it('WritePluginManifest_TempFileCreatedAndRemoved_OnSuccess', () => {
+    const dir = makeTmpDir();
+    const target = path.join(dir, 'plugin.json');
+
+    writePluginManifest(target, validManifest);
+
+    // Only the target file should remain — no `*.tmp.*` siblings.
+    const entries = fs.readdirSync(dir);
+    expect(entries).toEqual(['plugin.json']);
   });
 });

--- a/servers/exarchos-mcp/src/agents/plugin-manifest.test.ts
+++ b/servers/exarchos-mcp/src/agents/plugin-manifest.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { PluginManifestSchema } from './plugin-manifest.js';
+import { PluginManifestSchema, readPluginManifest } from './plugin-manifest.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -55,5 +56,74 @@ describe('PluginManifestSchema', () => {
     const livePath = path.join(repoRoot, '.claude-plugin/plugin.json');
     const live = JSON.parse(fs.readFileSync(livePath, 'utf8')) as unknown;
     expect(() => PluginManifestSchema.parse(live)).not.toThrow();
+  });
+});
+
+describe('readPluginManifest', () => {
+  const tmpDirs: string[] = [];
+
+  function makeTmpFile(contents: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-manifest-test-'));
+    tmpDirs.push(dir);
+    const file = path.join(dir, 'plugin.json');
+    fs.writeFileSync(file, contents, 'utf8');
+    return file;
+  }
+
+  afterEach(() => {
+    while (tmpDirs.length > 0) {
+      const dir = tmpDirs.pop();
+      if (dir !== undefined) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('ReadPluginManifest_ParsesValidFile', () => {
+    const valid = {
+      name: 'exarchos',
+      description: 'Test',
+      version: '0.0.0',
+      agents: ['./agents/implementer.md', './agents/reviewer.md'],
+      metadata: { compat: { minBinaryVersion: '2.9.0-rc.1' } },
+    };
+    const file = makeTmpFile(JSON.stringify(valid));
+    const result = readPluginManifest(file);
+    expect(result.name).toBe('exarchos');
+    expect(result.agents).toEqual(['./agents/implementer.md', './agents/reviewer.md']);
+    expect(result.version).toBe('0.0.0');
+  });
+
+  it('ReadPluginManifest_ThrowsDescriptive_OnMissingFile', () => {
+    const missing = path.join(os.tmpdir(), 'definitely-does-not-exist-xyz', 'plugin.json');
+    expect(() => readPluginManifest(missing)).toThrow(missing);
+  });
+
+  it('ReadPluginManifest_ThrowsDescriptive_OnInvalidJson', () => {
+    const file = makeTmpFile('{not json}');
+    let caught: Error | undefined;
+    try {
+      readPluginManifest(file);
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught!.message).toContain(file);
+    // Parse-position info from JSON.parse (e.g., "position N" or "line/column")
+    expect(caught!.message).toMatch(/position|line|column|JSON/i);
+  });
+
+  it('ReadPluginManifest_ThrowsDescriptive_OnSchemaViolation', () => {
+    const file = makeTmpFile(JSON.stringify({ name: 'x' })); // missing `agents`
+    let caught: Error | undefined;
+    try {
+      readPluginManifest(file);
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught!.message).toContain(file);
+    expect(caught!.message).toContain('schema violation');
+    expect(caught!.message).toContain('agents');
   });
 });

--- a/servers/exarchos-mcp/src/agents/plugin-manifest.test.ts
+++ b/servers/exarchos-mcp/src/agents/plugin-manifest.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PluginManifestSchema } from './plugin-manifest.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('PluginManifestSchema', () => {
+  it('PluginManifestSchema_AcceptsCanonicalShape', () => {
+    const valid = {
+      name: 'exarchos',
+      description: 'Test description',
+      version: '0.0.0',
+      author: { name: 'Test Author' },
+      homepage: 'https://example.com',
+      repository: 'https://example.com/repo',
+      license: 'Apache-2.0',
+      keywords: ['workflow'],
+      agents: ['./agents/implementer.md', './agents/reviewer.md'],
+      commands: './commands/',
+      skills: './skills/',
+      mcpServers: {
+        exarchos: {
+          type: 'stdio',
+          command: 'exarchos',
+          args: ['mcp'],
+          env: { FOO: 'bar' },
+        },
+      },
+      metadata: { compat: { minBinaryVersion: '2.9.0-rc.1' } },
+    };
+    expect(() => PluginManifestSchema.parse(valid)).not.toThrow();
+  });
+
+  it('PluginManifestSchema_RejectsMissingAgents', () => {
+    expect(() => PluginManifestSchema.parse({})).toThrow();
+  });
+
+  it('PluginManifestSchema_RejectsAgentEntryWithBadShape', () => {
+    expect(() =>
+      PluginManifestSchema.parse({
+        name: 'exarchos',
+        agents: ['not-a-relative-md-path'],
+      }),
+    ).toThrow();
+  });
+
+  it('PluginManifestSchema_AcceptsActualLivePluginJson', () => {
+    // Read the actual .claude-plugin/plugin.json and assert it parses.
+    // Regression guard against schema drift.
+    // __dirname = servers/exarchos-mcp/src/agents → repoRoot is 4 levels up.
+    const repoRoot = path.resolve(__dirname, '../../../..');
+    const livePath = path.join(repoRoot, '.claude-plugin/plugin.json');
+    const live = JSON.parse(fs.readFileSync(livePath, 'utf8')) as unknown;
+    expect(() => PluginManifestSchema.parse(live)).not.toThrow();
+  });
+});

--- a/servers/exarchos-mcp/src/agents/plugin-manifest.test.ts
+++ b/servers/exarchos-mcp/src/agents/plugin-manifest.test.ts
@@ -53,11 +53,14 @@ describe('PluginManifestSchema', () => {
     ).toThrow();
   });
 
-  it('PluginManifestSchema_AcceptsActualLivePluginJson', () => {
-    const repoRoot = path.resolve(__dirname, '../../../..');
-    const livePath = path.join(repoRoot, '.claude-plugin/plugin.json');
-    const live = JSON.parse(fs.readFileSync(livePath, 'utf8')) as unknown;
-    expect(() => PluginManifestSchema.parse(live)).not.toThrow();
+  it('PluginManifestSchema_AcceptsRepresentativeManifest', () => {
+    // Self-contained fixture mirrors the live `.claude-plugin/plugin.json`
+    // shape (agents, commands, skills, mcpServers, metadata) without
+    // coupling the test to whatever the repo root currently holds — keeps
+    // the test deterministic and runnable from a packaged tarball.
+    const fixturePath = path.join(__dirname, '__fixtures__/plugin-manifest.fixture.json');
+    const fixture = JSON.parse(fs.readFileSync(fixturePath, 'utf8')) as unknown;
+    expect(() => PluginManifestSchema.parse(fixture)).not.toThrow();
   });
 });
 

--- a/servers/exarchos-mcp/src/agents/plugin-manifest.ts
+++ b/servers/exarchos-mcp/src/agents/plugin-manifest.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { atomicWriteFile } from '../utils/atomic-write.js';
+
 /**
  * Zod schema for `.claude-plugin/plugin.json`.
  *
@@ -57,3 +59,27 @@ export const PluginManifestSchema = z
   .passthrough();
 
 export type PluginManifest = z.infer<typeof PluginManifestSchema>;
+
+/**
+ * Atomically write a plugin manifest to disk.
+ *
+ * Validates `manifest` via {@link PluginManifestSchema} BEFORE any disk I/O
+ * — if the manifest is malformed, no temp file is staged and the target is
+ * not touched. On valid input the JSON is staged to a sibling temp file
+ * (via {@link atomicWriteFile}: temp + fsync + rename), so concurrent
+ * readers either see the prior contents or the new contents — never a
+ * partial write. On rename failure the temp is best-effort cleaned up and
+ * the original error is rethrown.
+ *
+ * Output formatting: `JSON.stringify(manifest, null, 2)` + trailing
+ * newline. Matches the conventional shape of `.claude-plugin/plugin.json`.
+ *
+ * Used by T16 to rewire `updatePluginJson` in `generate-agents.ts` so the
+ * plugin manifest write path goes through the same validated atomic-write
+ * surface as the projection sidecar.
+ */
+export function writePluginManifest(filePath: string, manifest: PluginManifest): void {
+  const validated = PluginManifestSchema.parse(manifest);
+  const json = JSON.stringify(validated, null, 2) + '\n';
+  atomicWriteFile(filePath, json);
+}

--- a/servers/exarchos-mcp/src/agents/plugin-manifest.ts
+++ b/servers/exarchos-mcp/src/agents/plugin-manifest.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+/**
+ * Zod schema for `.claude-plugin/plugin.json`.
+ *
+ * Source of truth for plugin manifest validation across the MCP server.
+ * Mirrors the live shape of the manifest. `.passthrough()` is applied so
+ * forward-compat fields the generator does not manage are preserved when
+ * we round-trip the file (T15 will write through this schema).
+ *
+ * Required fields are tightly typed; the rest are optional/passthrough so
+ * we tolerate evolving Claude Code plugin manifests without churning the
+ * schema.
+ *
+ * Consumers:
+ *   - T14: `readPluginManifest` (typed read helper)
+ *   - T15: `writePluginManifest` (atomic write helper)
+ *   - T16: `generate-agents.ts` rewires preflight + update via these helpers
+ */
+
+/** Canonical agent path: `./agents/<kebab-id>.md`. */
+const AgentPathSchema = z.string().regex(/^\.\/agents\/[a-z0-9-]+\.md$/);
+
+const AuthorSchema = z
+  .object({
+    name: z.string().min(1),
+    email: z.string().optional(),
+    url: z.string().optional(),
+  })
+  .passthrough();
+
+const McpServerSchema = z
+  .object({
+    type: z.string().optional(),
+    command: z.string().optional(),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+  })
+  .passthrough();
+
+export const PluginManifestSchema = z
+  .object({
+    name: z.string().min(1),
+    description: z.string().optional(),
+    version: z.string().optional(),
+    author: AuthorSchema.optional(),
+    homepage: z.string().optional(),
+    repository: z.string().optional(),
+    license: z.string().optional(),
+    keywords: z.array(z.string()).optional(),
+    agents: z.array(AgentPathSchema),
+    commands: z.string().optional(),
+    skills: z.string().optional(),
+    mcpServers: z.record(z.string(), McpServerSchema).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+export type PluginManifest = z.infer<typeof PluginManifestSchema>;

--- a/servers/exarchos-mcp/src/agents/plugin-manifest.ts
+++ b/servers/exarchos-mcp/src/agents/plugin-manifest.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import { z } from 'zod';
 
 /**
@@ -57,3 +58,41 @@ export const PluginManifestSchema = z
   .passthrough();
 
 export type PluginManifest = z.infer<typeof PluginManifestSchema>;
+
+/**
+ * Reads `.claude-plugin/plugin.json` (or any file matching the schema)
+ * from disk, parses JSON, and validates against {@link PluginManifestSchema}.
+ *
+ * Throws a descriptive `Error` (always including the file path) for:
+ *   - read failures (missing file, permissions, etc.)
+ *   - JSON syntax errors (preserves parse-position info from `JSON.parse`)
+ *   - schema violations (full Zod issue list, JSON-formatted)
+ *
+ * Single-shot synchronous read by design — manifest is small, callers
+ * are CLI/preflight paths, and sync I/O keeps error semantics simple.
+ */
+export function readPluginManifest(path: string): PluginManifest {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(path, 'utf8');
+  } catch (e) {
+    throw new Error(
+      `readPluginManifest: failed to read ${path}: ${(e as Error).message}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(
+      `readPluginManifest: invalid JSON in ${path}: ${(e as Error).message}`,
+    );
+  }
+  const result = PluginManifestSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `readPluginManifest: schema violation in ${path}:\n${JSON.stringify(result.error.issues, null, 2)}`,
+    );
+  }
+  return result.data;
+}

--- a/servers/exarchos-mcp/src/capabilities/resolver.test.ts
+++ b/servers/exarchos-mcp/src/capabilities/resolver.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
   createInMemoryResolver,
+  resolveEffectiveCapabilities,
   ANTHROPIC_NATIVE_CACHING,
 } from './resolver.js';
+import type { Capability } from '../agents/capabilities.js';
 
 describe('CapabilityResolver (T017, DR-14)', () => {
   it('CapabilityResolver_AnthropicNative_ReturnsTrue', () => {
@@ -13,5 +15,75 @@ describe('CapabilityResolver (T017, DR-14)', () => {
   it('CapabilityResolver_Unknown_ReturnsFalse', () => {
     const resolver = createInMemoryResolver([ANTHROPIC_NATIVE_CACHING]);
     expect(resolver.has('bogus_flag')).toBe(false);
+  });
+});
+
+describe('resolveEffectiveCapabilities (handshake-authoritative, ADR §2.8)', () => {
+  it('Resolver_HandshakeReadonly_OverridesYamlFull', () => {
+    const yaml: Capability[] = ['mcp:exarchos'];
+    const handshake: Capability[] = ['mcp:exarchos:readonly'];
+    const effective = resolveEffectiveCapabilities(yaml, handshake);
+    expect(effective.has('mcp:exarchos:readonly')).toBe(true);
+    expect(effective.has('mcp:exarchos')).toBe(false);
+  });
+
+  it('Resolver_HandshakeFull_OverridesYamlReadonly', () => {
+    const yaml: Capability[] = ['mcp:exarchos:readonly'];
+    const handshake: Capability[] = ['mcp:exarchos'];
+    const effective = resolveEffectiveCapabilities(yaml, handshake);
+    expect(effective.has('mcp:exarchos')).toBe(true);
+    expect(effective.has('mcp:exarchos:readonly')).toBe(false);
+  });
+
+  it('Resolver_HandshakeSilent_FallsBackToYaml', () => {
+    const yaml: Capability[] = ['mcp:exarchos:readonly'];
+    const handshake: Capability[] = [];
+    const effective = resolveEffectiveCapabilities(yaml, handshake);
+    expect(effective.has('mcp:exarchos:readonly')).toBe(true);
+    expect(effective.has('mcp:exarchos')).toBe(false);
+  });
+
+  it('Resolver_HandshakeSilent_FallsBackToYamlFull', () => {
+    const yaml: Capability[] = ['mcp:exarchos'];
+    const handshake: Capability[] = [];
+    const effective = resolveEffectiveCapabilities(yaml, handshake);
+    expect(effective.has('mcp:exarchos')).toBe(true);
+    expect(effective.has('mcp:exarchos:readonly')).toBe(false);
+  });
+
+  it('Resolver_NeitherDeclaresMcp_NoMcpInEffective', () => {
+    const yaml: Capability[] = ['fs:read'];
+    const handshake: Capability[] = ['fs:write'];
+    const effective = resolveEffectiveCapabilities(yaml, handshake);
+    expect(effective.has('mcp:exarchos')).toBe(false);
+    expect(effective.has('mcp:exarchos:readonly')).toBe(false);
+  });
+
+  it('Resolver_NonMcpFamily_UnionsWithHandshakePrecedence', () => {
+    const yaml: Capability[] = ['fs:read'];
+    const handshake: Capability[] = ['fs:write'];
+    const effective = resolveEffectiveCapabilities(yaml, handshake);
+    expect(effective.has('fs:read')).toBe(true);
+    expect(effective.has('fs:write')).toBe(true);
+  });
+
+  it('Resolver_NonMcpFamily_UnionsAcrossManyCaps', () => {
+    const yaml: Capability[] = ['fs:read', 'isolation:worktree'];
+    const handshake: Capability[] = ['fs:write', 'shell:exec'];
+    const effective = resolveEffectiveCapabilities(yaml, handshake);
+    expect(effective.has('fs:read')).toBe(true);
+    expect(effective.has('fs:write')).toBe(true);
+    expect(effective.has('shell:exec')).toBe(true);
+    expect(effective.has('isolation:worktree')).toBe(true);
+  });
+
+  it('Resolver_EffectiveRecord_IsImmutable', () => {
+    const yaml: Capability[] = ['fs:read'];
+    const handshake: Capability[] = ['mcp:exarchos:readonly'];
+    const effective = resolveEffectiveCapabilities(yaml, handshake);
+    expect(Object.isFrozen(effective)).toBe(true);
+    expect(() => {
+      (effective as Set<Capability>).add('shell:exec');
+    }).toThrow();
   });
 });

--- a/servers/exarchos-mcp/src/capabilities/resolver.ts
+++ b/servers/exarchos-mcp/src/capabilities/resolver.ts
@@ -47,6 +47,14 @@ function isMcpExarchosFamily(cap: Capability): boolean {
   return MCP_EXARCHOS_FAMILY.has(cap);
 }
 
+function uniqueMcpTiers(caps: readonly Capability[]): Capability[] {
+  const seen = new Set<Capability>();
+  for (const c of caps) {
+    if (isMcpExarchosFamily(c)) seen.add(c);
+  }
+  return [...seen];
+}
+
 /**
  * Per ADR ontological-data-fabric §2.8: capability resolution is
  * handshake-authoritative. For the `mcp:exarchos` family, the handshake
@@ -80,12 +88,28 @@ export function resolveEffectiveCapabilities(
 
   // mcp:exarchos family: handshake authoritative — pick the handshake's
   // declared tier if present; otherwise fall back to yaml's declared tier.
-  const handshakeMcp = handshakeCaps.find(isMcpExarchosFamily);
-  if (handshakeMcp !== undefined) {
-    effective.add(handshakeMcp);
-  } else {
-    const yamlMcp = yamlCaps.find(isMcpExarchosFamily);
-    if (yamlMcp !== undefined) effective.add(yamlMcp);
+  //
+  // Fail closed when a single source declares more than one distinct tier
+  // (e.g., both `mcp:exarchos` and `mcp:exarchos:readonly`). Silently
+  // picking by array order would let a misconfigured spec hand out broader
+  // privileges than intended. Reject the session instead so the operator
+  // sees the contradiction.
+  const handshakeMcpTiers = uniqueMcpTiers(handshakeCaps);
+  if (handshakeMcpTiers.length > 1) {
+    throw new Error(
+      `Capability resolution failed: handshake declares conflicting mcp:exarchos tiers (${handshakeMcpTiers.join(', ')}). Pick exactly one.`,
+    );
+  }
+  const yamlMcpTiers = uniqueMcpTiers(yamlCaps);
+  if (yamlMcpTiers.length > 1) {
+    throw new Error(
+      `Capability resolution failed: runtime YAML declares conflicting mcp:exarchos tiers (${yamlMcpTiers.join(', ')}). Pick exactly one.`,
+    );
+  }
+  if (handshakeMcpTiers.length === 1) {
+    effective.add(handshakeMcpTiers[0]);
+  } else if (yamlMcpTiers.length === 1) {
+    effective.add(yamlMcpTiers[0]);
   }
 
   return freezeSet(effective);

--- a/servers/exarchos-mcp/src/capabilities/resolver.ts
+++ b/servers/exarchos-mcp/src/capabilities/resolver.ts
@@ -9,6 +9,8 @@
  * handshake-based implementation later.
  */
 
+import type { Capability } from '../agents/capabilities.js';
+
 export interface CapabilityResolver {
   has(capability: string): boolean;
   list(): readonly string[];
@@ -29,3 +31,81 @@ export function createInMemoryResolver(
 }
 
 export const ANTHROPIC_NATIVE_CACHING = 'anthropic_native_caching' as const;
+
+/**
+ * Capabilities in the `mcp:exarchos` family. The resolver treats this family
+ * as a tiered set: a single tier wins (handshake authoritative) rather than
+ * being unioned, so an agent never simultaneously holds the full and readonly
+ * tiers.
+ */
+const MCP_EXARCHOS_FAMILY: ReadonlySet<Capability> = new Set<Capability>([
+  'mcp:exarchos',
+  'mcp:exarchos:readonly',
+]);
+
+function isMcpExarchosFamily(cap: Capability): boolean {
+  return MCP_EXARCHOS_FAMILY.has(cap);
+}
+
+/**
+ * Per ADR ontological-data-fabric §2.8: capability resolution is
+ * handshake-authoritative. For the `mcp:exarchos` family, the handshake
+ * tier wins over yaml even when narrower. This prevents runtime widening
+ * of trust boundaries via stale yaml defaults — if the handshake declares
+ * `mcp:exarchos:readonly` while yaml declares `mcp:exarchos` (full), the
+ * effective record is `mcp:exarchos:readonly`. Conversely, if the handshake
+ * declares the full tier while yaml is narrower, the handshake still wins
+ * (the runtime is the source of truth for what is actually mounted).
+ *
+ * Other capability families (fs:read, fs:write, shell:exec, isolation:*,
+ * etc.) merge by union — handshake additions widen the set; yaml-declared
+ * caps are preserved.
+ *
+ * The returned set is frozen to prevent downstream mutation of the trust
+ * boundary after resolution.
+ */
+export function resolveEffectiveCapabilities(
+  yamlCaps: readonly Capability[],
+  handshakeCaps: readonly Capability[],
+): ReadonlySet<Capability> {
+  const effective = new Set<Capability>();
+
+  // Non-mcp:exarchos: union (handshake additions widen).
+  for (const c of yamlCaps) {
+    if (!isMcpExarchosFamily(c)) effective.add(c);
+  }
+  for (const c of handshakeCaps) {
+    if (!isMcpExarchosFamily(c)) effective.add(c);
+  }
+
+  // mcp:exarchos family: handshake authoritative — pick the handshake's
+  // declared tier if present; otherwise fall back to yaml's declared tier.
+  const handshakeMcp = handshakeCaps.find(isMcpExarchosFamily);
+  if (handshakeMcp !== undefined) {
+    effective.add(handshakeMcp);
+  } else {
+    const yamlMcp = yamlCaps.find(isMcpExarchosFamily);
+    if (yamlMcp !== undefined) effective.add(yamlMcp);
+  }
+
+  return freezeSet(effective);
+}
+
+/**
+ * Return a frozen Set whose mutators throw. `Object.freeze(set)` alone is
+ * insufficient because Set's internal slots ignore the frozen flag — `.add`
+ * still mutates. We replace mutators with throwing stubs and freeze the
+ * object identity so downstream code cannot widen the trust boundary after
+ * resolution.
+ */
+function freezeSet<T>(set: Set<T>): ReadonlySet<T> {
+  const throwImmutable = (): never => {
+    throw new TypeError(
+      'resolveEffectiveCapabilities returned an immutable set; mutation is forbidden',
+    );
+  };
+  Object.defineProperty(set, 'add', { value: throwImmutable, writable: false, configurable: false });
+  Object.defineProperty(set, 'delete', { value: throwImmutable, writable: false, configurable: false });
+  Object.defineProperty(set, 'clear', { value: throwImmutable, writable: false, configurable: false });
+  return Object.freeze(set);
+}

--- a/servers/exarchos-mcp/src/core/dispatch.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.ts
@@ -74,7 +74,13 @@ export interface DispatchContext {
 // action surface returns deterministic data without auto-emitting events
 // or mutating workflow / event store state.
 export const READ_ONLY_ACTIONS = {
-  exarchos_workflow: ['get', 'describe', 'reconcile', 'rehydrate'],
+  // Excluded as mutating: `reconcile` reapplies events to overwrite the
+  // on-disk state file; `rehydrate` emits a `workflow.rehydrated` event
+  // (per its tool contract) and may persist a fresh snapshot. Both touch
+  // the event/state stores and are not safe under the readonly tier — a
+  // read-only viewer should consume the latest known state via `get` (or
+  // `exarchos_view`) instead.
+  exarchos_workflow: ['get', 'describe'],
   exarchos_event: ['query', 'describe'],
   // Orchestrate read-only set: descriptive actions (`describe`, `runbook`,
   // `agent_spec`, `doctor`), pure-analysis gate checks (`check_*`),

--- a/servers/exarchos-mcp/src/core/dispatch.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.ts
@@ -54,6 +54,130 @@ export interface DispatchContext {
   readonly capabilityResolver?: CapabilityResolver;
 }
 
+// ─── T04: Server-side Read-only Action Allowlist (Issue #1192) ─────────────
+//
+// Composite-tool actions that are safe to invoke under the
+// `mcp:exarchos:readonly` capability tier. Anything NOT listed here (for a
+// given tool) is treated as mutating and rejected with CAPABILITY_DENIED
+// when the effective capability set contains `mcp:exarchos:readonly` but
+// NOT `mcp:exarchos`.
+//
+// The tier merge rule: a spec that holds BOTH `mcp:exarchos` and
+// `mcp:exarchos:readonly` keeps full access (less-restrictive wins). The
+// gate fires only when the readonly tier is the only `mcp:exarchos*` cap
+// the resolver reports — see `enforceReadonlyGate` below.
+//
+// Exported so T05 (resolver tier merge) and T06-T10 (per-runtime adapters)
+// can reference the same allowlist instead of duplicating action lists.
+//
+// `'*'` for `exarchos_view` means the entire tool is read-only — every
+// action surface returns deterministic data without auto-emitting events
+// or mutating workflow / event store state.
+export const READ_ONLY_ACTIONS = {
+  exarchos_workflow: ['get', 'describe', 'reconcile', 'rehydrate'],
+  exarchos_event: ['query', 'describe'],
+  // Orchestrate read-only set: descriptive actions (`describe`, `runbook`,
+  // `agent_spec`, `doctor`), pure-analysis gate checks (`check_*`),
+  // information extractors (`extract_task`, `review_diff`,
+  // `verify_worktree`, `select_debug_track`, `investigation_timer`,
+  // `assess_refactor_scope`), validators (`validate_pr_body`,
+  // `validate_pr_stack`, `verify_doc_links`, `verify_review_triage`,
+  // `verify_worktree_baseline`, `verify_delegation_saga`,
+  // `spec_coverage_check`, `needs_schema_sync`, `generate_traceability`,
+  // `classify_review_items`), readiness queries (`prepare_review`), and
+  // the read-only VCS surfaces (`check_ci`, `list_prs`,
+  // `get_pr_comments`).
+  //
+  // Excluded as mutating: `task_claim`, `task_complete`, `task_fail`
+  // (event-emitting), `prepare_delegation`, `prepare_synthesis`,
+  // `assess_stack` (event-emitting / `shepherd.*`), `setup_worktree`,
+  // `merge_orchestrate`, `merge_pr`, `create_pr`, `create_issue`,
+  // `add_pr_comment`, `init`, `new_project`, `prune_stale_workflows`,
+  // `request_synthesize`, `finalize_oneshot`, `reconcile_state`,
+  // `extract_fix_tasks`, `pre_synthesis_check`, `post_delegation_check`,
+  // `debug_review_gate`, `check_pr_comments` (queries gh state but is
+  // grouped with synthesis review actions and may emit), and the
+  // `review_triage` orchestrator.
+  exarchos_orchestrate: [
+    'describe',
+    'runbook',
+    'agent_spec',
+    'doctor',
+    'check_static_analysis',
+    'check_security_scan',
+    'check_context_economy',
+    'check_operational_resilience',
+    'check_workflow_determinism',
+    'check_review_verdict',
+    'check_convergence',
+    'check_provenance_chain',
+    'check_design_completeness',
+    'check_plan_coverage',
+    'check_tdd_compliance',
+    'check_post_merge',
+    'check_task_decomposition',
+    'check_event_emissions',
+    'check_coderabbit',
+    'check_polish_scope',
+    'check_coverage_thresholds',
+    'check_ci',
+    'extract_task',
+    'review_diff',
+    'verify_worktree',
+    'verify_worktree_baseline',
+    'verify_delegation_saga',
+    'verify_doc_links',
+    'verify_review_triage',
+    'select_debug_track',
+    'investigation_timer',
+    'assess_refactor_scope',
+    'validate_pr_body',
+    'validate_pr_stack',
+    'spec_coverage_check',
+    'needs_schema_sync',
+    'generate_traceability',
+    'classify_review_items',
+    'prepare_review',
+    'list_prs',
+    'get_pr_comments',
+  ],
+  exarchos_view: '*',
+} as const;
+
+export type ReadOnlyActionsMap = typeof READ_ONLY_ACTIONS;
+
+/**
+ * Apply the readonly capability gate. Returns a structured CAPABILITY_DENIED
+ * ToolResult when the effective capability set forbids `action` on `tool`,
+ * or `null` when the call is allowed to proceed.
+ *
+ * Gate rule: fires only when `mcp:exarchos:readonly` is present AND
+ * `mcp:exarchos` is NOT present (less-restrictive tier wins on merge).
+ */
+export function enforceReadonlyGate(
+  tool: string,
+  action: string,
+  resolver: CapabilityResolver | undefined,
+): ToolResult | null {
+  if (!resolver) return null;
+  if (!resolver.has('mcp:exarchos:readonly')) return null;
+  if (resolver.has('mcp:exarchos')) return null;
+
+  const allowed = (READ_ONLY_ACTIONS as Record<string, readonly string[] | '*'>)[tool];
+  if (allowed === '*') return null;
+  if (allowed && allowed.includes(action)) return null;
+
+  return {
+    success: false,
+    error: {
+      code: 'CAPABILITY_DENIED',
+      message: `Action "${action}" on tool "${tool}" requires the mcp:exarchos capability; only mcp:exarchos:readonly is granted.`,
+      tool,
+      action,
+    },
+  };
+}
+
 // ─── Composite Handler Map ──────────────────────────────────────────────────
 
 /**
@@ -356,6 +480,14 @@ export async function dispatch(
     // Thread the validated args forward so downstream handlers get the
     // coerced shape (z.preprocess effects, defaults, etc.).
     args = { action: actionName, ...parsed.data } as Record<string, unknown>;
+
+    // T04 (Issue #1192): apply the readonly capability gate AFTER schema
+    // validation so callers still get INVALID_INPUT for malformed payloads
+    // that happen to target a denied action — the readonly gate is for
+    // capability shaping, not input validation. Gate is built-in only;
+    // custom tools manage their own capability surface.
+    const denied = enforceReadonlyGate(tool, actionName, ctx.capabilityResolver);
+    if (denied) return denied;
   }
 
   const coreHandler = builtInHandler

--- a/servers/exarchos-mcp/src/format.ts
+++ b/servers/exarchos-mcp/src/format.ts
@@ -39,6 +39,11 @@ export interface ToolResult {
     gate?: string;
     operationsSince?: number;
     threshold?: number;
+    // T04 (Issue #1192): the readonly capability gate uses these fields to
+    // identify which composite tool / action was rejected so callers can
+    // correlate a CAPABILITY_DENIED rejection back to a specific dispatch.
+    tool?: string;
+    action?: string;
   };
   readonly warnings?: readonly string[];
   readonly _meta?: unknown;

--- a/servers/exarchos-mcp/src/parity/readonly-cap-parity.test.ts
+++ b/servers/exarchos-mcp/src/parity/readonly-cap-parity.test.ts
@@ -1,0 +1,184 @@
+// ─── CLI/MCP Parity Under mcp:exarchos:readonly (Issue #1192, T12) ─────────
+//
+// Closes the #1109 Constraint 2 (MCP Parity) verification step for the
+// capability ISP work landed in T03–T11. The capability gate
+// (`enforceReadonlyGate`, src/core/dispatch.ts) lives in the shared
+// transport-agnostic dispatch entry, so both the CLI adapter
+// (src/adapters/cli.ts) and the MCP adapter (src/adapters/mcp.ts) consult
+// the same `ctx.capabilityResolver` and short-circuit identically when
+// the effective capability set is `{mcp:exarchos:readonly}`.
+//
+// This suite locks that contract in by exercising both arms with the same
+// readonly resolver and asserting:
+//
+//   1. ALLOWED action (read-only): both facades return byte-equal payloads
+//      after normalization, and neither surfaces CAPABILITY_DENIED.
+//   2. DENIED action (mutating): both facades return a structurally
+//      identical CAPABILITY_DENIED envelope (`error.code`, `error.tool`,
+//      `error.action` all match).
+//
+// If a future refactor splits the gate into per-facade copies and one
+// drifts, this test fails — which is the whole point of the parity check.
+//
+// Strategy notes:
+//   - Pipeline view (`exarchos_view pipeline`, CLI alias `vw ls`) is the
+//     positive-case action: `exarchos_view` is wholesale read-only
+//     (READ_ONLY_ACTIONS.exarchos_view === '*'), so the gate is a pure
+//     no-op and any divergence has to come from facade-specific shaping.
+//   - `workflow set` is the negative-case action: it is the canonical
+//     mutating workflow operation (auto-emits state.patched in normal use)
+//     and is explicitly outside READ_ONLY_ACTIONS.exarchos_workflow.
+//   - The stateDir is shared between the two arms so any deterministic
+//     read returns identical materialized output regardless of which
+//     facade is queried first.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { CLI_EXIT_CODES } from '../adapters/cli.js';
+import { type DispatchContext } from '../core/dispatch.js';
+import { EventStore } from '../event-store/store.js';
+import { createInMemoryResolver } from '../capabilities/resolver.js';
+import { resetMaterializerCache } from '../views/tools.js';
+import {
+  callCli as harnessCallCli,
+  callMcp as harnessCallMcp,
+  normalize as harnessNormalize,
+  UUID_ANY_RE,
+} from '../__tests__/parity-harness.js';
+
+// ─── Fixture ──────────────────────────────────────────────────────────────
+
+interface ReadonlyFixture {
+  readonly tmpDir: string;
+  readonly ctx: DispatchContext;
+}
+
+async function setupFixture(): Promise<ReadonlyFixture> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'readonly-parity-'));
+  const eventStore = new EventStore(tmpDir);
+  await eventStore.initialize();
+  const ctx: DispatchContext = {
+    stateDir: tmpDir,
+    eventStore,
+    enableTelemetry: false,
+    // The whole point of the suite: both facades share this resolver, so
+    // both observe `{mcp:exarchos:readonly}` and only `mcp:exarchos:readonly`.
+    capabilityResolver: createInMemoryResolver(['mcp:exarchos:readonly']),
+  };
+  return { tmpDir, ctx };
+}
+
+async function teardownFixture(f: ReadonlyFixture): Promise<void> {
+  await fs.rm(f.tmpDir, { recursive: true, force: true });
+}
+
+// ─── Normalization ────────────────────────────────────────────────────────
+
+/**
+ * Mirrors the views parity normalizer (timestamps → `<ISO>`, UUIDs → `<UUID>`,
+ * `_perf` dropped) so transient wall-clock / measurement-path drift doesn't
+ * register as a parity violation.
+ */
+function normalize(value: unknown): unknown {
+  return harnessNormalize(value, {
+    timestampPlaceholder: '<ISO>',
+    uuidPlaceholder: '<UUID>',
+    uuidRegex: UUID_ANY_RE,
+    dropKeys: new Set(['_perf']),
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('CLI/MCP parity under mcp:exarchos:readonly (Issue #1192, T12)', () => {
+  let fixture: ReadonlyFixture;
+
+  beforeEach(async () => {
+    // The materializer caches projection state across test runs; clear it
+    // so each tmpDir starts from a clean slate.
+    resetMaterializerCache();
+    fixture = await setupFixture();
+  });
+
+  afterEach(async () => {
+    resetMaterializerCache();
+    await teardownFixture(fixture);
+  });
+
+  it('Readonly_AllowedReadAction_CLI_AndMCP_ReturnEqualPayload', async () => {
+    // Arrange — `pipeline` is on the wholesale-readonly view tool; the
+    // gate must pass through both facades identically.
+    const args = { limit: 10, offset: 0 };
+
+    // Act — invoke the same action through each facade against the shared
+    // ctx (same stateDir, same resolver).
+    const mcpResult = await harnessCallMcp(fixture.ctx, 'exarchos_view', {
+      action: 'pipeline',
+      ...args,
+    });
+    // CLI alias for exarchos_view is `vw`; for the `pipeline` action the
+    // registry exposes alias `ls` — see registry.ts line ~1530.
+    const { result: cliResult, exitCode } = await harnessCallCli(
+      fixture.ctx,
+      'vw',
+      'ls',
+      args,
+    );
+
+    // Assert — both succeed, both return equal payloads after normalizing
+    // transient fields, and neither path surfaces CAPABILITY_DENIED.
+    expect(exitCode).toBe(CLI_EXIT_CODES.SUCCESS);
+    expect(mcpResult.success).toBe(true);
+    expect(cliResult.success).toBe(true);
+    expect(mcpResult.error?.code).not.toBe('CAPABILITY_DENIED');
+    expect(cliResult.error?.code).not.toBe('CAPABILITY_DENIED');
+    expect(normalize(cliResult)).toEqual(normalize(mcpResult));
+  });
+
+  it('Readonly_MutatingAction_RejectsIdentically_From_CLI_AndMCP', async () => {
+    // Arrange — `workflow set` is the canonical mutating action; it is
+    // explicitly NOT on READ_ONLY_ACTIONS.exarchos_workflow.
+    const args = {
+      featureId: 'parity-readonly-feature',
+      updates: { phase: 'ideate' },
+    };
+
+    // Act — both facades against the same ctx.
+    const mcpResult = await harnessCallMcp(fixture.ctx, 'exarchos_workflow', {
+      action: 'set',
+      ...args,
+    });
+    const { result: cliResult, exitCode } = await harnessCallCli(
+      fixture.ctx,
+      'wf',
+      'set',
+      args,
+    );
+
+    // Assert — both reject with structurally identical CAPABILITY_DENIED.
+    expect(mcpResult.success).toBe(false);
+    expect(cliResult.success).toBe(false);
+    // CLI maps a failed dispatch ToolResult to HANDLER_ERROR (2).
+    expect(exitCode).toBe(CLI_EXIT_CODES.HANDLER_ERROR);
+
+    // Error envelope must be byte-equal across the two facades for the
+    // identifying triple (code, tool, action). Message strings are part
+    // of the gate's contract too — they're built from those three fields
+    // by `enforceReadonlyGate` so any divergence in message text would
+    // imply two different gate code paths, defeating the parity check.
+    expect(mcpResult.error?.code).toBe('CAPABILITY_DENIED');
+    expect(cliResult.error?.code).toBe('CAPABILITY_DENIED');
+    expect(mcpResult.error?.tool).toBe('exarchos_workflow');
+    expect(cliResult.error?.tool).toBe('exarchos_workflow');
+    expect(mcpResult.error?.action).toBe('set');
+    expect(cliResult.error?.action).toBe('set');
+
+    // Strongest assertion: the entire normalized error envelope matches.
+    // If a future change adds a facade-specific field (e.g. CLI tacks on
+    // `argv` while MCP omits it), this catches it.
+    expect(normalize(cliResult)).toEqual(normalize(mcpResult));
+  });
+});

--- a/servers/exarchos-mcp/src/projections/store.ts
+++ b/servers/exarchos-mcp/src/projections/store.ts
@@ -20,11 +20,11 @@
  * concurrency is out of scope.
  */
 
-import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { storeLogger } from '../logger.js';
+import { atomicWriteFile } from '../utils/atomic-write.js';
 import { SnapshotRecord } from './snapshot-schema.js';
 
 /** Default sidecar size cap when `SNAPSHOT_MAX_RECORDS` is unset or invalid. */
@@ -217,28 +217,6 @@ function applySizeCap(
   const prunedCount = dataLines.length - maxRecords;
   const retained = dataLines.slice(prunedCount);
   return { content: retained.join('\n') + '\n', prunedCount };
-}
-
-function atomicWriteFile(target: string, content: string): void {
-  const tmp = `${target}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
-  const fd = fs.openSync(tmp, 'w');
-  try {
-    fs.writeSync(fd, content);
-    fs.fsyncSync(fd);
-  } finally {
-    fs.closeSync(fd);
-  }
-
-  try {
-    fs.renameSync(tmp, target);
-  } catch (err: unknown) {
-    try {
-      fs.unlinkSync(tmp);
-    } catch {
-      /* best-effort cleanup — don't mask the original error */
-    }
-    throw err;
-  }
 }
 
 function readIfExists(target: string): string {

--- a/servers/exarchos-mcp/src/runtimes/claude.test.ts
+++ b/servers/exarchos-mcp/src/runtimes/claude.test.ts
@@ -38,6 +38,7 @@ const REQUIRED_CAPABILITY_KEYS = [
   'subagent:completion-signal',
   'subagent:start-signal',
   'mcp:exarchos',
+  'mcp:exarchos:readonly',
   'isolation:worktree',
   'team:agent-teams',
   'session:resume',
@@ -57,7 +58,7 @@ function loadClaudeYaml(): Record<string, unknown> {
 }
 
 describe('runtimes/claude.yaml supportedCapabilities', () => {
-  it('ClaudeYaml_SupportedCapabilities_AllTenAreNative', () => {
+  it('ClaudeYaml_SupportedCapabilities_AllElevenAreNative', () => {
     const data = loadClaudeYaml();
     const supported = data.supportedCapabilities;
 
@@ -76,7 +77,7 @@ describe('runtimes/claude.yaml supportedCapabilities', () => {
       expect(map[key], `capability '${key}' should be 'native'`).toBe('native');
     }
 
-    // No additional keys beyond the canonical ten.
+    // No additional keys beyond the canonical eleven.
     expect(Object.keys(map).sort()).toEqual([...REQUIRED_CAPABILITY_KEYS].sort());
   });
 

--- a/servers/exarchos-mcp/src/runtimes/codex.test.ts
+++ b/servers/exarchos-mcp/src/runtimes/codex.test.ts
@@ -54,26 +54,27 @@ function loadCodexYaml(): CodexYamlShape {
 }
 
 describe('runtimes/codex.yaml supportedCapabilities (Task 7b)', () => {
-  it('CodexYaml_SupportedCapabilities_FiveNativeTwoAdvisory', () => {
+  it('CodexYaml_SupportedCapabilities_SixNativeTwoAdvisory', () => {
     const yaml = loadCodexYaml();
 
     expect(yaml.supportedCapabilities).toBeDefined();
     const map = yaml.supportedCapabilities ?? {};
 
-    // Native (5): the runtime has a first-class primitive for each.
+    // Native (6): the runtime has a first-class primitive for each.
     expect(map['fs:read']).toBe('native');
     expect(map['fs:write']).toBe('native');
     expect(map['shell:exec']).toBe('native');
     expect(map['subagent:spawn']).toBe('native');
     expect(map['mcp:exarchos']).toBe('native');
+    expect(map['mcp:exarchos:readonly']).toBe('native');
 
     // Advisory (2): the spec may declare these but Codex has no primitive
     // to enforce them — orchestrator-managed.
     expect(map['isolation:worktree']).toBe('advisory');
     expect(map['session:resume']).toBe('advisory');
 
-    // Exactly 7 keys total (5 native + 2 advisory).
-    expect(Object.keys(map)).toHaveLength(7);
+    // Exactly 8 keys total (6 native + 2 advisory).
+    expect(Object.keys(map)).toHaveLength(8);
   });
 
   it('CodexYaml_SupportedCapabilities_ExcludesClaudeOnlyCapabilities', () => {

--- a/servers/exarchos-mcp/src/runtimes/copilot.test.ts
+++ b/servers/exarchos-mcp/src/runtimes/copilot.test.ts
@@ -113,7 +113,7 @@ describe('runtimes/copilot.yaml — local task --agent primitive', () => {
     expect(referencesBareName).toBe(true);
   });
 
-  it('CopilotYaml_SupportedCapabilities_FiveNativeTwoAdvisory', () => {
+  it('CopilotYaml_SupportedCapabilities_SixNativeTwoAdvisory', () => {
     const data = loadCopilotYaml();
     const supported = data.supportedCapabilities;
 
@@ -127,8 +127,9 @@ describe('runtimes/copilot.yaml — local task --agent primitive', () => {
 
     const map = supported as Record<string, unknown>;
 
-    // Per Task 4f's COPILOT_SUPPORT_LEVELS:
-    //   native (5):    fs:read, fs:write, shell:exec, subagent:spawn, mcp:exarchos
+    // Per COPILOT_SUPPORT_LEVELS (Task 4f + #1192 T08 readonly tier):
+    //   native (6):    fs:read, fs:write, shell:exec, subagent:spawn,
+    //                  mcp:exarchos, mcp:exarchos:readonly
     //   advisory (2):  isolation:worktree, session:resume
     //   unsupported (3, omitted): subagent:completion-signal,
     //                             subagent:start-signal, team:agent-teams
@@ -138,6 +139,7 @@ describe('runtimes/copilot.yaml — local task --agent primitive', () => {
       'shell:exec',
       'subagent:spawn',
       'mcp:exarchos',
+      'mcp:exarchos:readonly',
     ];
     const expectedAdvisory = ['isolation:worktree', 'session:resume'];
 

--- a/servers/exarchos-mcp/src/runtimes/opencode.test.ts
+++ b/servers/exarchos-mcp/src/runtimes/opencode.test.ts
@@ -52,6 +52,7 @@ const EXPECTED_NATIVE = [
   'shell:exec',
   'subagent:spawn',
   'mcp:exarchos',
+  'mcp:exarchos:readonly',
 ] as const;
 
 const EXPECTED_ADVISORY = [
@@ -79,7 +80,7 @@ function loadOpencodeYaml(): Record<string, unknown> {
 }
 
 describe('runtimes/opencode.yaml supportedCapabilities', () => {
-  it('OpencodeYaml_SupportedCapabilities_FiveNativeTwoAdvisory', () => {
+  it('OpencodeYaml_SupportedCapabilities_SixNativeTwoAdvisory', () => {
     const data = loadOpencodeYaml();
     const supported = data.supportedCapabilities;
 

--- a/servers/exarchos-mcp/src/utils/atomic-write.ts
+++ b/servers/exarchos-mcp/src/utils/atomic-write.ts
@@ -35,9 +35,22 @@ export function atomicWriteFile(target: string, content: string | Buffer): void 
       fs.writeSync(fd, content);
     }
     fs.fsyncSync(fd);
-  } finally {
-    fs.closeSync(fd);
+  } catch (err: unknown) {
+    // Write or fsync failed — close fd and unlink the tmp before rethrowing
+    // so a stale `*.tmp` doesn't accumulate alongside `target`.
+    try {
+      fs.closeSync(fd);
+    } catch {
+      /* best-effort */
+    }
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* best-effort cleanup — don't mask the original error */
+    }
+    throw err;
   }
+  fs.closeSync(fd);
 
   try {
     fs.renameSync(tmp, target);

--- a/servers/exarchos-mcp/src/utils/atomic-write.ts
+++ b/servers/exarchos-mcp/src/utils/atomic-write.ts
@@ -1,0 +1,52 @@
+/**
+ * Atomic file writer — temp + fsync + rename.
+ *
+ * Stages `content` to `<target>.<pid>.<random>.tmp`, fsyncs the tmp file,
+ * then `fs.renameSync`s it over `target`. Rename is atomic on POSIX
+ * filesystems and on Windows when source and target are on the same volume,
+ * so concurrent readers either see the prior contents or the new contents
+ * — never a partial write.
+ *
+ * On rename failure the tmp file is best-effort unlinked; the original
+ * error is rethrown unwrapped so callers can inspect `code` (e.g.,
+ * `EXDEV`, `EACCES`).
+ *
+ * Originally inlined in `projections/store.ts`. Extracted here in T15
+ * (#1192 Items 3+5+17) so `agents/plugin-manifest.ts` and the projection
+ * store share one implementation.
+ *
+ * Concurrency caveat: intended for single-writer processes. Cross-process
+ * concurrency is out of scope — multiple processes racing the same
+ * `target` may each succeed in renaming, and the last winner clobbers the
+ * earlier one (which is fine for the projection sidecar and plugin.json
+ * use cases since both have a single owning writer).
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+
+export function atomicWriteFile(target: string, content: string | Buffer): void {
+  const tmp = `${target}.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`;
+  const fd = fs.openSync(tmp, 'w');
+  try {
+    if (typeof content === 'string') {
+      fs.writeSync(fd, content);
+    } else {
+      fs.writeSync(fd, content);
+    }
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+
+  try {
+    fs.renameSync(tmp, target);
+  } catch (err: unknown) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* best-effort cleanup — don't mask the original error */
+    }
+    throw err;
+  }
+}

--- a/skills-src/_shared/references/coding-standards.md
+++ b/skills-src/_shared/references/coding-standards.md
@@ -1,7 +1,3 @@
----
-paths: "**/*.ts", "**/*.tsx", "**/*.cs"
----
-
 # Coding Standards
 
 Apply these standards when reviewing or writing TypeScript or C# code.

--- a/skills-src/_shared/references/mcp-tool-guidance.md
+++ b/skills-src/_shared/references/mcp-tool-guidance.md
@@ -1,8 +1,3 @@
----
-name: mcp-tool-guidance
-description: "Prefer specialized MCP tools over generic CLI approaches."
----
-
 # MCP Tool Guidance
 
 Use specialized MCP tools over generic approaches:

--- a/skills-src/_shared/references/skill-path-resolution.md
+++ b/skills-src/_shared/references/skill-path-resolution.md
@@ -1,8 +1,3 @@
----
-name: skill-path-resolution
-description: "Resolve @skills/<name>/SKILL.md paths to ~/.claude/skills/<name>/SKILL.md."
----
-
 # Skill Path Resolution
 
 `@skills/<name>/SKILL.md` resolves to `~/.claude/skills/<name>/SKILL.md`.

--- a/skills-src/_shared/references/tdd.md
+++ b/skills-src/_shared/references/tdd.md
@@ -1,7 +1,3 @@
----
-paths: "**/*.ts", "**/*.tsx", "**/*.cs"
----
-
 # TDD Rules
 
 Enforce strict TDD when modifying TypeScript or C# files.

--- a/skills-src/_shared/references/telemetry-awareness.md
+++ b/skills-src/_shared/references/telemetry-awareness.md
@@ -1,8 +1,3 @@
----
-name: telemetry-awareness
-description: "Apply telemetryHints from session-start output to subsequent MCP tool calls."
----
-
 # Telemetry Awareness
 
 When `telemetryHints` appear in session-start output, apply the suggested

--- a/skills-src/brainstorming/references/worked-example.md
+++ b/skills-src/brainstorming/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: brainstorming-worked-example
-description: "Complete trace of the brainstorming skill in action, showing happy path and pivot recovery."
----
-
 # Worked Example: Brainstorming — Event Deduplication
 
 ## Context

--- a/skills-src/cleanup/references/merge-verification.md
+++ b/skills-src/cleanup/references/merge-verification.md
@@ -1,7 +1,3 @@
----
-name: merge-verification
----
-
 # Merge Verification Guide
 
 ## Why Verify?

--- a/skills-src/debug/references/hotfix-track.md
+++ b/skills-src/debug/references/hotfix-track.md
@@ -1,7 +1,3 @@
----
-name: hotfix-track
----
-
 # Hotfix Track
 
 ## Purpose

--- a/skills-src/debug/references/thorough-track.md
+++ b/skills-src/debug/references/thorough-track.md
@@ -1,7 +1,3 @@
----
-name: thorough-track
----
-
 # Thorough Track
 
 ## Purpose

--- a/skills-src/debug/references/troubleshooting.md
+++ b/skills-src/debug/references/troubleshooting.md
@@ -1,7 +1,3 @@
----
-name: troubleshooting
----
-
 # Troubleshooting
 
 ## MCP Tool Call Failed

--- a/skills-src/delegation/references/fix-mode.md
+++ b/skills-src/delegation/references/fix-mode.md
@@ -1,7 +1,3 @@
----
-name: fix-mode
----
-
 # Fix Mode (--fixes)
 
 When invoked with `--fixes`, delegation handles review failures instead of initial implementation.

--- a/skills-src/delegation/references/implementer-prompt.md
+++ b/skills-src/delegation/references/implementer-prompt.md
@@ -1,8 +1,3 @@
----
-name: implementer-prompt
-description: Canonical implementer prompt template — embedded in agent definitions on runtimes with native agent support, dispatched inline on others.
----
-
 # Implementer Prompt Template
 
 **Note:** On runtimes with native agent definitions (e.g. Claude Code), this template is compiled into `servers/exarchos-mcp/src/agents/definitions.ts` (IMPLEMENTER spec) and the rendered agent file (e.g. `agents/exarchos-implementer.md`) is generated from the registry at build time. This reference document is the canonical prompt evolution record and is used directly by runtime clients without native agent support (Cursor, Copilot CLI, etc.).

--- a/skills-src/delegation/references/parallel-strategy.md
+++ b/skills-src/delegation/references/parallel-strategy.md
@@ -15,6 +15,7 @@ Group B (depends on Group A):
 - Task 004: API handlers
 ```
 
+<!-- requires:subagent:spawn -->
 ## Dispatching Parallel Tasks
 
 **Critical:** Use a single message with multiple subagent invocations — the runtime's spawn primitive renders the parallel dispatch:
@@ -26,6 +27,7 @@ Group B (depends on Group A):
 
 // WRONG: Separate messages = sequential
 ```
+<!-- /requires -->
 
 <!-- requires:team:agent-teams -->
 ## Agent Teams Dispatch
@@ -54,13 +56,14 @@ Teammates use Claude Code's native shared task list for claim/complete tracking.
 Agent Teams supports one team per session. If you need more parallel groups than teammates, assign multiple tasks per teammate (sequential within the group).
 <!-- /requires -->
 
+<!-- requires:subagent:spawn -->
 ## Dispatch Properties
 
-Subagent dispatch is the universal parallelism mode (available in every
-runtime). On runtimes with the `agent-teams` capability, a second canonical
-table follows that places Subagent and Agent Teams modes side-by-side across
-every dispatch property — use it when choosing between modes or comparing
-their semantics.
+Subagent dispatch is the universal parallelism mode on runtimes that
+support `subagent:spawn`. On runtimes with the `agent-teams` capability, a
+second canonical table follows that places Subagent and Agent Teams modes
+side-by-side across every dispatch property — use it when choosing between
+modes or comparing their semantics.
 
 | Property | Subagent Mode |
 |----------|------------------------------------------------------------------------|
@@ -73,6 +76,7 @@ their semantics.
 | Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) |
 | Max parallelism | Unlimited |
 | Resume on crash | Task results preserved |
+<!-- /requires -->
 
 <!-- requires:team:agent-teams -->
 ### Canonical Comparison: Subagent vs Agent Teams
@@ -90,6 +94,7 @@ their semantics.
 | Resume on crash | Task results preserved | Worktrees survive; teammates lost |
 <!-- /requires -->
 
+<!-- requires:subagent:spawn -->
 ## Waiting for Parallel Completion
 
 ```text
@@ -97,6 +102,7 @@ their semantics.
 {{SUBAGENT_RESULT_API}}
 // (poll/await per task_id on poll-based runtimes; inline on runtimes that return replies in the dispatching turn)
 ```
+<!-- /requires -->
 
 ## Model Selection Guide
 

--- a/skills-src/delegation/references/parallel-strategy.md
+++ b/skills-src/delegation/references/parallel-strategy.md
@@ -1,8 +1,3 @@
----
-name: parallel-strategy
-description: Parallel dispatch and result-collection strategy for subagent teammates.
----
-
 # Parallel Execution Strategy
 
 ## Identifying Parallel Groups

--- a/skills-src/delegation/references/parallel-strategy.md
+++ b/skills-src/delegation/references/parallel-strategy.md
@@ -67,7 +67,7 @@ modes or comparing their semantics.
 
 | Property | Subagent Mode |
 |----------|------------------------------------------------------------------------|
-| Parallel dispatch | Multiple `{{TASK_TOOL}}` invocations in one message |
+| Parallel dispatch | Multiple subagent invocations in one message (see example above) |
 | Waiting / monitoring | `{{SUBAGENT_RESULT_API}}` (no live visibility) |
 | Visibility | None (background) |
 | Cross-task deps | Orchestrator manages phases |
@@ -83,7 +83,7 @@ modes or comparing their semantics.
 
 | Property | Subagent Mode | Agent Teams Mode |
 |----------|---------------------------------------------------------------|---------------------------------------------------------|
-| Parallel dispatch | Multiple `{{TASK_TOOL}}` invocations in one message | Named teammates in one agent team |
+| Parallel dispatch | Multiple subagent invocations in one message | Named teammates in one agent team |
 | Waiting / monitoring | `{{SUBAGENT_RESULT_API}}` (no live visibility) | `TeammateIdle` hook + tmux split panes |
 | Visibility | None (background) | tmux split panes |
 | Cross-task deps | Orchestrator manages phases | Shared task list + unblocked-task detection |

--- a/skills-src/delegation/references/parallel-strategy.md
+++ b/skills-src/delegation/references/parallel-strategy.md
@@ -59,28 +59,40 @@ Teammates use Claude Code's native shared task list for claim/complete tracking.
 Agent Teams supports one team per session. If you need more parallel groups than teammates, assign multiple tasks per teammate (sequential within the group).
 <!-- /requires -->
 
-## Subagent Dispatch Properties
+## Dispatch Properties
 
-| Aspect | Subagent dispatch |
-|--------|---------------------|
+Subagent dispatch is the universal parallelism mode (available in every
+runtime). On runtimes with the `agent-teams` capability, a second canonical
+table follows that places Subagent and Agent Teams modes side-by-side across
+every dispatch property — use it when choosing between modes or comparing
+their semantics.
+
+| Property | Subagent Mode |
+|----------|------------------------------------------------------------------------|
 | Parallel dispatch | Multiple `{{TASK_TOOL}}` invocations in one message |
-| Waiting | `{{SUBAGENT_RESULT_API}}` |
+| Waiting / monitoring | `{{SUBAGENT_RESULT_API}}` (no live visibility) |
 | Visibility | None (background) |
-| Model control | `recommendedModel` from `prepare_delegation` (computed from the config cascade) |
+| Cross-task deps | Orchestrator manages phases |
+| State updates | Orchestrator updates state |
+| Quality gates | Manual via `post_delegation_check` action |
+| Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) |
 | Max parallelism | Unlimited |
 | Resume on crash | Task results preserved |
 
 <!-- requires:team:agent-teams -->
-## Agent Teams Dispatch Properties (Claude only)
+### Canonical Comparison: Subagent vs Agent Teams
 
-| Aspect | Agent Teams |
-|--------|---------------------|
-| Parallel dispatch | Named teammates in agent team |
-| Waiting | `TeammateIdle hook` |
-| Visibility | tmux split panes |
-| Model control | Session model for all |
-| Max parallelism | One team, N teammates |
-| Resume on crash | Teammates lost (worktrees survive) |
+| Property | Subagent Mode | Agent Teams Mode |
+|----------|---------------------------------------------------------------|---------------------------------------------------------|
+| Parallel dispatch | Multiple `{{TASK_TOOL}}` invocations in one message | Named teammates in one agent team |
+| Waiting / monitoring | `{{SUBAGENT_RESULT_API}}` (no live visibility) | `TeammateIdle` hook + tmux split panes |
+| Visibility | None (background) | tmux split panes |
+| Cross-task deps | Orchestrator manages phases | Shared task list + unblocked-task detection |
+| State updates | Orchestrator updates state | `TeammateIdle` hook auto-updates via state bridge |
+| Quality gates | Manual via `post_delegation_check` action | Automatic via `TeammateIdle` hook |
+| Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) | Session model shared by all teammates |
+| Max parallelism | Unlimited | One team, N teammates |
+| Resume on crash | Task results preserved | Worktrees survive; teammates lost |
 <!-- /requires -->
 
 ## Waiting for Parallel Completion
@@ -114,17 +126,7 @@ When using `--mode agent-team`, the orchestrator creates named teammates and del
 
 Each teammate receives the full implementer prompt including TDD requirements, file paths, and commit strategy.
 
-### Subagent vs Agent Teams Parallelism
-
-| Aspect | Task Tool (Subagent) | Agent Teams (Teammate) |
-|--------|---------------------|----------------------|
-| Parallelism | Multiple `Task()` calls in one message | Named teammates in one team |
-| Cross-task deps | Orchestrator manages phases | Shared task list + unblocked task detection |
-| Monitoring | `TaskOutput` polling | tmux panes + `TeammateIdle` hook |
-| State updates | Orchestrator updates state | Hook auto-updates via state bridge |
-| Model per task | Yes (`recommendedModel` per Task) | No (session model for all) |
-| Quality gates | Manual via `post_delegation_check` action | Automatic via `TeammateIdle` hook |
-| Recovery | Task results preserved | Worktrees survive, teammates lost |
+For a side-by-side comparison of dispatch, monitoring, state, model, and recovery semantics across both modes, see the canonical [Dispatch Properties](#dispatch-properties) table above.
 
 ### Shared Task List Coordination
 

--- a/skills-src/delegation/references/state-management.md
+++ b/skills-src/delegation/references/state-management.md
@@ -59,19 +59,19 @@ Workflow task state includes additional fields for resume-aware fixer flow on ru
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `agentId` | string | Runtime agent ID for resume. Canonical source: runtime stop-hook payload (e.g. `SubagentStop` on Claude Code). |
+| `agentId` | string | Runtime agent ID for resume. Canonical source: the runtime's stop-event hook payload (e.g., `SubagentStop` on Claude Code; equivalent on Codex/Copilot). |
 | `agentResumed` | boolean | Whether this agent was resumed (vs. fresh dispatch). |
-| `lastExitReason` | string | Completion status (e.g., `"success"`, `"failure"`, `"timeout"`). Canonical source: `SubagentStop` hook payload. |
+| `lastExitReason` | string | Completion status (e.g., `"success"`, `"failure"`, `"timeout"`). Canonical source: the runtime's stop-event hook payload. |
 
-The `SubagentStop` hook (`hooks/hooks.json`) is the **canonical source** for `agentId` and `lastExitReason`. When the hook fires for `exarchos-implementer` or `exarchos-fixer` agents, the orchestrator persists the hook payload fields into `tasks[id=taskId]`. This enables the resume-first strategy in the fixer flow: when a task fails, the orchestrator can resume the original agent with failure context rather than dispatching a fresh fixer.
+The runtime's stop-event hook (registered via the runtime's hook configuration) is the **canonical source** for `agentId` and `lastExitReason`. When the hook fires for `exarchos-implementer` or `exarchos-fixer` agents, the orchestrator persists the hook payload fields into `tasks[id=taskId]`. This enables the resume-first strategy in the fixer flow: when a task fails, the orchestrator can resume the original agent with failure context rather than dispatching a fresh fixer.
 
-**State update on SubagentStop hook:**
+**State update on agent stop-event hook:**
 ```text
 action: "set", featureId: "<id>", updates: {
   "tasks[id=<taskId>]": {
-    "agentId": "<from SubagentStop hook payload: agent_id>",
+    "agentId": "<from stop-event hook payload: agent_id>",
     "agentResumed": false,
-    "lastExitReason": "<from SubagentStop hook payload: exit_reason>"
+    "lastExitReason": "<from stop-event hook payload: exit_reason>"
   }
 }
 ```

--- a/skills-src/delegation/references/state-management.md
+++ b/skills-src/delegation/references/state-management.md
@@ -59,7 +59,7 @@ Workflow task state includes additional fields for resume-aware fixer flow on ru
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `agentId` | string | Runtime agent ID for resume. Canonical source: the runtime's stop-event hook payload (e.g., `SubagentStop` on Claude Code; equivalent on Codex/Copilot). |
+| `agentId` | string | Runtime agent ID for resume. Canonical source: the runtime's stop-event hook payload. |
 | `agentResumed` | boolean | Whether this agent was resumed (vs. fresh dispatch). |
 | `lastExitReason` | string | Completion status (e.g., `"success"`, `"failure"`, `"timeout"`). Canonical source: the runtime's stop-event hook payload. |
 

--- a/skills-src/delegation/references/workflow-steps.md
+++ b/skills-src/delegation/references/workflow-steps.md
@@ -1,7 +1,3 @@
----
-name: workflow-steps
----
-
 # Delegation Workflow Steps
 
 ## Step 1: Prepare Environment

--- a/skills-src/delegation/references/worktree-enforcement.md
+++ b/skills-src/delegation/references/worktree-enforcement.md
@@ -1,7 +1,3 @@
----
-name: worktree-enforcement
----
-
 # Worktree Enforcement (MANDATORY)
 
 All implementation tasks MUST run in isolated worktrees, not the main project root.

--- a/skills-src/implementation-planning/references/worked-example.md
+++ b/skills-src/implementation-planning/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: implementation-planning-worked-example
-description: "Complete trace of the implementation planning skill in action, showing happy path and re-planning after gap detection."
----
-
 # Worked Example: Implementation Planning — Event Stream Compaction
 
 ## Context

--- a/skills-src/oneshot-workflow/references/choice-state.md
+++ b/skills-src/oneshot-workflow/references/choice-state.md
@@ -1,7 +1,3 @@
----
-name: oneshot-choice-state
----
-
 # Oneshot Choice State: `implementing → ?`
 
 The oneshot workflow has a UML *choice state* at the end of `implementing`.

--- a/skills-src/prune-workflows/references/safeguards.md
+++ b/skills-src/prune-workflows/references/safeguards.md
@@ -1,7 +1,3 @@
----
-name: prune-safeguards
----
-
 # Prune Safeguards
 
 The `prune_stale_workflows` orchestrate action runs two safeguards on each

--- a/skills-src/refactor/references/explore-checklist.md
+++ b/skills-src/refactor/references/explore-checklist.md
@@ -1,7 +1,3 @@
----
-name: explore-checklist
----
-
 # Refactor Exploration Checklist
 
 ## Scope Assessment

--- a/skills-src/refactor/references/polish-track.md
+++ b/skills-src/refactor/references/polish-track.md
@@ -1,7 +1,3 @@
----
-name: polish-track
----
-
 # Polish Track — Detailed Phase Guide
 
 ## Purpose

--- a/skills-src/spec-review/references/review-checklist.md
+++ b/skills-src/spec-review/references/review-checklist.md
@@ -1,8 +1,3 @@
----
-name: spec-review-checklist
-description: "Validation script invocations and report template for spec compliance verification."
----
-
 # Spec Review Checklist
 
 ## Adversarial Review Posture

--- a/skills-src/spec-review/references/worked-example.md
+++ b/skills-src/spec-review/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: spec-review-worked-example
-description: "Complete trace of the spec review skill in action, showing happy path and false-positive correction."
----
-
 # Worked Example: Spec Review — Workflow Transition Validation
 
 ## Context

--- a/skills-src/synthesis/references/github-native-stacking.md
+++ b/skills-src/synthesis/references/github-native-stacking.md
@@ -1,7 +1,3 @@
----
-name: github-native-stacking
----
-
 # GitHub-Native PR Stacking
 
 PR stacking creates a chain of dependent pull requests that merge bottom-up into `main`. Each PR targets the previous PR's branch as its base, forming a reviewable sequence of incremental changes.

--- a/skills-src/synthesis/references/synthesis-steps.md
+++ b/skills-src/synthesis/references/synthesis-steps.md
@@ -1,7 +1,3 @@
----
-name: synthesis-steps
----
-
 # Synthesis Process
 
 ## Step 1: Verify Readiness

--- a/skills/claude/brainstorming/references/worked-example.md
+++ b/skills/claude/brainstorming/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: brainstorming-worked-example
-description: "Complete trace of the brainstorming skill in action, showing happy path and pivot recovery."
----
-
 # Worked Example: Brainstorming — Event Deduplication
 
 ## Context

--- a/skills/claude/cleanup/references/merge-verification.md
+++ b/skills/claude/cleanup/references/merge-verification.md
@@ -1,7 +1,3 @@
----
-name: merge-verification
----
-
 # Merge Verification Guide
 
 ## Why Verify?

--- a/skills/claude/debug/references/hotfix-track.md
+++ b/skills/claude/debug/references/hotfix-track.md
@@ -1,7 +1,3 @@
----
-name: hotfix-track
----
-
 # Hotfix Track
 
 ## Purpose

--- a/skills/claude/debug/references/thorough-track.md
+++ b/skills/claude/debug/references/thorough-track.md
@@ -1,7 +1,3 @@
----
-name: thorough-track
----
-
 # Thorough Track
 
 ## Purpose

--- a/skills/claude/debug/references/troubleshooting.md
+++ b/skills/claude/debug/references/troubleshooting.md
@@ -1,7 +1,3 @@
----
-name: troubleshooting
----
-
 # Troubleshooting
 
 ## MCP Tool Call Failed

--- a/skills/claude/delegation/references/fix-mode.md
+++ b/skills/claude/delegation/references/fix-mode.md
@@ -1,7 +1,3 @@
----
-name: fix-mode
----
-
 # Fix Mode (--fixes)
 
 When invoked with `--fixes`, delegation handles review failures instead of initial implementation.

--- a/skills/claude/delegation/references/implementer-prompt.md
+++ b/skills/claude/delegation/references/implementer-prompt.md
@@ -1,8 +1,3 @@
----
-name: implementer-prompt
-description: Canonical implementer prompt template — embedded in agent definitions on runtimes with native agent support, dispatched inline on others.
----
-
 # Implementer Prompt Template
 
 **Note:** On runtimes with native agent definitions (e.g. Claude Code), this template is compiled into `servers/exarchos-mcp/src/agents/definitions.ts` (IMPLEMENTER spec) and the rendered agent file (e.g. `agents/exarchos-implementer.md`) is generated from the registry at build time. This reference document is the canonical prompt evolution record and is used directly by runtime clients without native agent support (Cursor, Copilot CLI, etc.).

--- a/skills/claude/delegation/references/parallel-strategy.md
+++ b/skills/claude/delegation/references/parallel-strategy.md
@@ -15,6 +15,7 @@ Group B (depends on Group A):
 - Task 004: API handlers
 ```
 
+
 ## Dispatching Parallel Tasks
 
 **Critical:** Use a single message with multiple subagent invocations — the runtime's spawn primitive renders the parallel dispatch:
@@ -65,13 +66,14 @@ Teammates use Claude Code's native shared task list for claim/complete tracking.
 
 Agent Teams supports one team per session. If you need more parallel groups than teammates, assign multiple tasks per teammate (sequential within the group).
 
+
 ## Dispatch Properties
 
-Subagent dispatch is the universal parallelism mode (available in every
-runtime). On runtimes with the `agent-teams` capability, a second canonical
-table follows that places Subagent and Agent Teams modes side-by-side across
-every dispatch property — use it when choosing between modes or comparing
-their semantics.
+Subagent dispatch is the universal parallelism mode on runtimes that
+support `subagent:spawn`. On runtimes with the `agent-teams` capability, a
+second canonical table follows that places Subagent and Agent Teams modes
+side-by-side across every dispatch property — use it when choosing between
+modes or comparing their semantics.
 
 | Property | Subagent Mode |
 |----------|------------------------------------------------------------------------|
@@ -99,6 +101,7 @@ their semantics.
 | Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) | Session model shared by all teammates |
 | Max parallelism | Unlimited | One team, N teammates |
 | Resume on crash | Task results preserved | Worktrees survive; teammates lost |
+
 
 ## Waiting for Parallel Completion
 

--- a/skills/claude/delegation/references/parallel-strategy.md
+++ b/skills/claude/delegation/references/parallel-strategy.md
@@ -1,8 +1,3 @@
----
-name: parallel-strategy
-description: Parallel dispatch and result-collection strategy for subagent teammates.
----
-
 # Parallel Execution Strategy
 
 ## Identifying Parallel Groups

--- a/skills/claude/delegation/references/parallel-strategy.md
+++ b/skills/claude/delegation/references/parallel-strategy.md
@@ -70,28 +70,40 @@ Teammates use Claude Code's native shared task list for claim/complete tracking.
 
 Agent Teams supports one team per session. If you need more parallel groups than teammates, assign multiple tasks per teammate (sequential within the group).
 
-## Subagent Dispatch Properties
+## Dispatch Properties
 
-| Aspect | Subagent dispatch |
-|--------|---------------------|
+Subagent dispatch is the universal parallelism mode (available in every
+runtime). On runtimes with the `agent-teams` capability, a second canonical
+table follows that places Subagent and Agent Teams modes side-by-side across
+every dispatch property — use it when choosing between modes or comparing
+their semantics.
+
+| Property | Subagent Mode |
+|----------|------------------------------------------------------------------------|
 | Parallel dispatch | Multiple `Task` invocations in one message |
-| Waiting | `TaskOutput({ task_id, block: true })` |
+| Waiting / monitoring | `TaskOutput({ task_id, block: true })` (no live visibility) |
 | Visibility | None (background) |
-| Model control | `recommendedModel` from `prepare_delegation` (computed from the config cascade) |
+| Cross-task deps | Orchestrator manages phases |
+| State updates | Orchestrator updates state |
+| Quality gates | Manual via `post_delegation_check` action |
+| Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) |
 | Max parallelism | Unlimited |
 | Resume on crash | Task results preserved |
 
 
-## Agent Teams Dispatch Properties (Claude only)
+### Canonical Comparison: Subagent vs Agent Teams
 
-| Aspect | Agent Teams |
-|--------|---------------------|
-| Parallel dispatch | Named teammates in agent team |
-| Waiting | `TeammateIdle hook` |
-| Visibility | tmux split panes |
-| Model control | Session model for all |
-| Max parallelism | One team, N teammates |
-| Resume on crash | Teammates lost (worktrees survive) |
+| Property | Subagent Mode | Agent Teams Mode |
+|----------|---------------------------------------------------------------|---------------------------------------------------------|
+| Parallel dispatch | Multiple `Task` invocations in one message | Named teammates in one agent team |
+| Waiting / monitoring | `TaskOutput({ task_id, block: true })` (no live visibility) | `TeammateIdle` hook + tmux split panes |
+| Visibility | None (background) | tmux split panes |
+| Cross-task deps | Orchestrator manages phases | Shared task list + unblocked-task detection |
+| State updates | Orchestrator updates state | `TeammateIdle` hook auto-updates via state bridge |
+| Quality gates | Manual via `post_delegation_check` action | Automatic via `TeammateIdle` hook |
+| Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) | Session model shared by all teammates |
+| Max parallelism | Unlimited | One team, N teammates |
+| Resume on crash | Task results preserved | Worktrees survive; teammates lost |
 
 ## Waiting for Parallel Completion
 
@@ -124,17 +136,7 @@ When using `--mode agent-team`, the orchestrator creates named teammates and del
 
 Each teammate receives the full implementer prompt including TDD requirements, file paths, and commit strategy.
 
-### Subagent vs Agent Teams Parallelism
-
-| Aspect | Task Tool (Subagent) | Agent Teams (Teammate) |
-|--------|---------------------|----------------------|
-| Parallelism | Multiple `Task()` calls in one message | Named teammates in one team |
-| Cross-task deps | Orchestrator manages phases | Shared task list + unblocked task detection |
-| Monitoring | `TaskOutput` polling | tmux panes + `TeammateIdle` hook |
-| State updates | Orchestrator updates state | Hook auto-updates via state bridge |
-| Model per task | Yes (`recommendedModel` per Task) | No (session model for all) |
-| Quality gates | Manual via `post_delegation_check` action | Automatic via `TeammateIdle` hook |
-| Recovery | Task results preserved | Worktrees survive, teammates lost |
+For a side-by-side comparison of dispatch, monitoring, state, model, and recovery semantics across both modes, see the canonical [Dispatch Properties](#dispatch-properties) table above.
 
 ### Shared Task List Coordination
 

--- a/skills/claude/delegation/references/parallel-strategy.md
+++ b/skills/claude/delegation/references/parallel-strategy.md
@@ -77,7 +77,7 @@ modes or comparing their semantics.
 
 | Property | Subagent Mode |
 |----------|------------------------------------------------------------------------|
-| Parallel dispatch | Multiple `Task` invocations in one message |
+| Parallel dispatch | Multiple subagent invocations in one message (see example above) |
 | Waiting / monitoring | `TaskOutput({ task_id, block: true })` (no live visibility) |
 | Visibility | None (background) |
 | Cross-task deps | Orchestrator manages phases |
@@ -92,7 +92,7 @@ modes or comparing their semantics.
 
 | Property | Subagent Mode | Agent Teams Mode |
 |----------|---------------------------------------------------------------|---------------------------------------------------------|
-| Parallel dispatch | Multiple `Task` invocations in one message | Named teammates in one agent team |
+| Parallel dispatch | Multiple subagent invocations in one message | Named teammates in one agent team |
 | Waiting / monitoring | `TaskOutput({ task_id, block: true })` (no live visibility) | `TeammateIdle` hook + tmux split panes |
 | Visibility | None (background) | tmux split panes |
 | Cross-task deps | Orchestrator manages phases | Shared task list + unblocked-task detection |

--- a/skills/claude/delegation/references/state-management.md
+++ b/skills/claude/delegation/references/state-management.md
@@ -58,7 +58,7 @@ Workflow task state includes additional fields for resume-aware fixer flow on ru
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `agentId` | string | Runtime agent ID for resume. Canonical source: the runtime's stop-event hook payload (e.g., `SubagentStop` on Claude Code; equivalent on Codex/Copilot). |
+| `agentId` | string | Runtime agent ID for resume. Canonical source: the runtime's stop-event hook payload. |
 | `agentResumed` | boolean | Whether this agent was resumed (vs. fresh dispatch). |
 | `lastExitReason` | string | Completion status (e.g., `"success"`, `"failure"`, `"timeout"`). Canonical source: the runtime's stop-event hook payload. |
 

--- a/skills/claude/delegation/references/state-management.md
+++ b/skills/claude/delegation/references/state-management.md
@@ -58,19 +58,19 @@ Workflow task state includes additional fields for resume-aware fixer flow on ru
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `agentId` | string | Runtime agent ID for resume. Canonical source: runtime stop-hook payload (e.g. `SubagentStop` on Claude Code). |
+| `agentId` | string | Runtime agent ID for resume. Canonical source: the runtime's stop-event hook payload (e.g., `SubagentStop` on Claude Code; equivalent on Codex/Copilot). |
 | `agentResumed` | boolean | Whether this agent was resumed (vs. fresh dispatch). |
-| `lastExitReason` | string | Completion status (e.g., `"success"`, `"failure"`, `"timeout"`). Canonical source: `SubagentStop` hook payload. |
+| `lastExitReason` | string | Completion status (e.g., `"success"`, `"failure"`, `"timeout"`). Canonical source: the runtime's stop-event hook payload. |
 
-The `SubagentStop` hook (`hooks/hooks.json`) is the **canonical source** for `agentId` and `lastExitReason`. When the hook fires for `exarchos-implementer` or `exarchos-fixer` agents, the orchestrator persists the hook payload fields into `tasks[id=taskId]`. This enables the resume-first strategy in the fixer flow: when a task fails, the orchestrator can resume the original agent with failure context rather than dispatching a fresh fixer.
+The runtime's stop-event hook (registered via the runtime's hook configuration) is the **canonical source** for `agentId` and `lastExitReason`. When the hook fires for `exarchos-implementer` or `exarchos-fixer` agents, the orchestrator persists the hook payload fields into `tasks[id=taskId]`. This enables the resume-first strategy in the fixer flow: when a task fails, the orchestrator can resume the original agent with failure context rather than dispatching a fresh fixer.
 
-**State update on SubagentStop hook:**
+**State update on agent stop-event hook:**
 ```text
 action: "set", featureId: "<id>", updates: {
   "tasks[id=<taskId>]": {
-    "agentId": "<from SubagentStop hook payload: agent_id>",
+    "agentId": "<from stop-event hook payload: agent_id>",
     "agentResumed": false,
-    "lastExitReason": "<from SubagentStop hook payload: exit_reason>"
+    "lastExitReason": "<from stop-event hook payload: exit_reason>"
   }
 }
 ```

--- a/skills/claude/delegation/references/workflow-steps.md
+++ b/skills/claude/delegation/references/workflow-steps.md
@@ -1,7 +1,3 @@
----
-name: workflow-steps
----
-
 # Delegation Workflow Steps
 
 ## Step 1: Prepare Environment

--- a/skills/claude/delegation/references/worktree-enforcement.md
+++ b/skills/claude/delegation/references/worktree-enforcement.md
@@ -1,7 +1,3 @@
----
-name: worktree-enforcement
----
-
 # Worktree Enforcement (MANDATORY)
 
 All implementation tasks MUST run in isolated worktrees, not the main project root.

--- a/skills/claude/implementation-planning/references/worked-example.md
+++ b/skills/claude/implementation-planning/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: implementation-planning-worked-example
-description: "Complete trace of the implementation planning skill in action, showing happy path and re-planning after gap detection."
----
-
 # Worked Example: Implementation Planning — Event Stream Compaction
 
 ## Context

--- a/skills/claude/refactor/references/explore-checklist.md
+++ b/skills/claude/refactor/references/explore-checklist.md
@@ -1,7 +1,3 @@
----
-name: explore-checklist
----
-
 # Refactor Exploration Checklist
 
 ## Scope Assessment

--- a/skills/claude/refactor/references/polish-track.md
+++ b/skills/claude/refactor/references/polish-track.md
@@ -1,7 +1,3 @@
----
-name: polish-track
----
-
 # Polish Track — Detailed Phase Guide
 
 ## Purpose

--- a/skills/claude/spec-review/references/review-checklist.md
+++ b/skills/claude/spec-review/references/review-checklist.md
@@ -1,8 +1,3 @@
----
-name: spec-review-checklist
-description: "Validation script invocations and report template for spec compliance verification."
----
-
 # Spec Review Checklist
 
 ## Adversarial Review Posture

--- a/skills/claude/spec-review/references/worked-example.md
+++ b/skills/claude/spec-review/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: spec-review-worked-example
-description: "Complete trace of the spec review skill in action, showing happy path and false-positive correction."
----
-
 # Worked Example: Spec Review — Workflow Transition Validation
 
 ## Context

--- a/skills/claude/synthesis/references/synthesis-steps.md
+++ b/skills/claude/synthesis/references/synthesis-steps.md
@@ -1,7 +1,3 @@
----
-name: synthesis-steps
----
-
 # Synthesis Process
 
 ## Step 1: Verify Readiness

--- a/skills/codex/brainstorming/references/worked-example.md
+++ b/skills/codex/brainstorming/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: brainstorming-worked-example
-description: "Complete trace of the brainstorming skill in action, showing happy path and pivot recovery."
----
-
 # Worked Example: Brainstorming — Event Deduplication
 
 ## Context

--- a/skills/codex/cleanup/references/merge-verification.md
+++ b/skills/codex/cleanup/references/merge-verification.md
@@ -1,7 +1,3 @@
----
-name: merge-verification
----
-
 # Merge Verification Guide
 
 ## Why Verify?

--- a/skills/codex/debug/references/hotfix-track.md
+++ b/skills/codex/debug/references/hotfix-track.md
@@ -1,7 +1,3 @@
----
-name: hotfix-track
----
-
 # Hotfix Track
 
 ## Purpose

--- a/skills/codex/debug/references/thorough-track.md
+++ b/skills/codex/debug/references/thorough-track.md
@@ -1,7 +1,3 @@
----
-name: thorough-track
----
-
 # Thorough Track
 
 ## Purpose

--- a/skills/codex/debug/references/troubleshooting.md
+++ b/skills/codex/debug/references/troubleshooting.md
@@ -1,7 +1,3 @@
----
-name: troubleshooting
----
-
 # Troubleshooting
 
 ## MCP Tool Call Failed

--- a/skills/codex/delegation/references/fix-mode.md
+++ b/skills/codex/delegation/references/fix-mode.md
@@ -1,7 +1,3 @@
----
-name: fix-mode
----
-
 # Fix Mode (--fixes)
 
 When invoked with `--fixes`, delegation handles review failures instead of initial implementation.

--- a/skills/codex/delegation/references/implementer-prompt.md
+++ b/skills/codex/delegation/references/implementer-prompt.md
@@ -1,8 +1,3 @@
----
-name: implementer-prompt
-description: Canonical implementer prompt template — embedded in agent definitions on runtimes with native agent support, dispatched inline on others.
----
-
 # Implementer Prompt Template
 
 **Note:** On runtimes with native agent definitions (e.g. Claude Code), this template is compiled into `servers/exarchos-mcp/src/agents/definitions.ts` (IMPLEMENTER spec) and the rendered agent file (e.g. `agents/exarchos-implementer.md`) is generated from the registry at build time. This reference document is the canonical prompt evolution record and is used directly by runtime clients without native agent support (Cursor, Copilot CLI, etc.).

--- a/skills/codex/delegation/references/parallel-strategy.md
+++ b/skills/codex/delegation/references/parallel-strategy.md
@@ -48,7 +48,7 @@ modes or comparing their semantics.
 
 | Property | Subagent Mode |
 |----------|------------------------------------------------------------------------|
-| Parallel dispatch | Multiple `spawn_agent` invocations in one message |
+| Parallel dispatch | Multiple subagent invocations in one message (see example above) |
 | Waiting / monitoring | `wait_agent({ task_id })` (no live visibility) |
 | Visibility | None (background) |
 | Cross-task deps | Orchestrator manages phases |

--- a/skills/codex/delegation/references/parallel-strategy.md
+++ b/skills/codex/delegation/references/parallel-strategy.md
@@ -15,6 +15,7 @@ Group B (depends on Group A):
 - Task 004: API handlers
 ```
 
+
 ## Dispatching Parallel Tasks
 
 **Critical:** Use a single message with multiple subagent invocations — the runtime's spawn primitive renders the parallel dispatch:
@@ -36,13 +37,14 @@ spawn_agent({
 ```
 
 
+
 ## Dispatch Properties
 
-Subagent dispatch is the universal parallelism mode (available in every
-runtime). On runtimes with the `agent-teams` capability, a second canonical
-table follows that places Subagent and Agent Teams modes side-by-side across
-every dispatch property — use it when choosing between modes or comparing
-their semantics.
+Subagent dispatch is the universal parallelism mode on runtimes that
+support `subagent:spawn`. On runtimes with the `agent-teams` capability, a
+second canonical table follows that places Subagent and Agent Teams modes
+side-by-side across every dispatch property — use it when choosing between
+modes or comparing their semantics.
 
 | Property | Subagent Mode |
 |----------|------------------------------------------------------------------------|
@@ -55,6 +57,7 @@ their semantics.
 | Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) |
 | Max parallelism | Unlimited |
 | Resume on crash | Task results preserved |
+
 
 
 ## Waiting for Parallel Completion

--- a/skills/codex/delegation/references/parallel-strategy.md
+++ b/skills/codex/delegation/references/parallel-strategy.md
@@ -1,8 +1,3 @@
----
-name: parallel-strategy
-description: Parallel dispatch and result-collection strategy for subagent teammates.
----
-
 # Parallel Execution Strategy
 
 ## Identifying Parallel Groups

--- a/skills/codex/delegation/references/parallel-strategy.md
+++ b/skills/codex/delegation/references/parallel-strategy.md
@@ -41,14 +41,23 @@ spawn_agent({
 ```
 
 
-## Subagent Dispatch Properties
+## Dispatch Properties
 
-| Aspect | Subagent dispatch |
-|--------|---------------------|
+Subagent dispatch is the universal parallelism mode (available in every
+runtime). On runtimes with the `agent-teams` capability, a second canonical
+table follows that places Subagent and Agent Teams modes side-by-side across
+every dispatch property — use it when choosing between modes or comparing
+their semantics.
+
+| Property | Subagent Mode |
+|----------|------------------------------------------------------------------------|
 | Parallel dispatch | Multiple `spawn_agent` invocations in one message |
-| Waiting | `wait_agent({ task_id })` |
+| Waiting / monitoring | `wait_agent({ task_id })` (no live visibility) |
 | Visibility | None (background) |
-| Model control | `recommendedModel` from `prepare_delegation` (computed from the config cascade) |
+| Cross-task deps | Orchestrator manages phases |
+| State updates | Orchestrator updates state |
+| Quality gates | Manual via `post_delegation_check` action |
+| Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) |
 | Max parallelism | Unlimited |
 | Resume on crash | Task results preserved |
 

--- a/skills/codex/delegation/references/workflow-steps.md
+++ b/skills/codex/delegation/references/workflow-steps.md
@@ -1,7 +1,3 @@
----
-name: workflow-steps
----
-
 # Delegation Workflow Steps
 
 ## Step 1: Prepare Environment

--- a/skills/codex/delegation/references/worktree-enforcement.md
+++ b/skills/codex/delegation/references/worktree-enforcement.md
@@ -1,7 +1,3 @@
----
-name: worktree-enforcement
----
-
 # Worktree Enforcement (MANDATORY)
 
 All implementation tasks MUST run in isolated worktrees, not the main project root.

--- a/skills/codex/implementation-planning/references/worked-example.md
+++ b/skills/codex/implementation-planning/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: implementation-planning-worked-example
-description: "Complete trace of the implementation planning skill in action, showing happy path and re-planning after gap detection."
----
-
 # Worked Example: Implementation Planning — Event Stream Compaction
 
 ## Context

--- a/skills/codex/refactor/references/explore-checklist.md
+++ b/skills/codex/refactor/references/explore-checklist.md
@@ -1,7 +1,3 @@
----
-name: explore-checklist
----
-
 # Refactor Exploration Checklist
 
 ## Scope Assessment

--- a/skills/codex/refactor/references/polish-track.md
+++ b/skills/codex/refactor/references/polish-track.md
@@ -1,7 +1,3 @@
----
-name: polish-track
----
-
 # Polish Track — Detailed Phase Guide
 
 ## Purpose

--- a/skills/codex/spec-review/references/review-checklist.md
+++ b/skills/codex/spec-review/references/review-checklist.md
@@ -1,8 +1,3 @@
----
-name: spec-review-checklist
-description: "Validation script invocations and report template for spec compliance verification."
----
-
 # Spec Review Checklist
 
 ## Adversarial Review Posture

--- a/skills/codex/spec-review/references/worked-example.md
+++ b/skills/codex/spec-review/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: spec-review-worked-example
-description: "Complete trace of the spec review skill in action, showing happy path and false-positive correction."
----
-
 # Worked Example: Spec Review — Workflow Transition Validation
 
 ## Context

--- a/skills/codex/synthesis/references/synthesis-steps.md
+++ b/skills/codex/synthesis/references/synthesis-steps.md
@@ -1,7 +1,3 @@
----
-name: synthesis-steps
----
-
 # Synthesis Process
 
 ## Step 1: Verify Readiness

--- a/skills/copilot/brainstorming/references/worked-example.md
+++ b/skills/copilot/brainstorming/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: brainstorming-worked-example
-description: "Complete trace of the brainstorming skill in action, showing happy path and pivot recovery."
----
-
 # Worked Example: Brainstorming — Event Deduplication
 
 ## Context

--- a/skills/copilot/cleanup/references/merge-verification.md
+++ b/skills/copilot/cleanup/references/merge-verification.md
@@ -1,7 +1,3 @@
----
-name: merge-verification
----
-
 # Merge Verification Guide
 
 ## Why Verify?

--- a/skills/copilot/debug/references/hotfix-track.md
+++ b/skills/copilot/debug/references/hotfix-track.md
@@ -1,7 +1,3 @@
----
-name: hotfix-track
----
-
 # Hotfix Track
 
 ## Purpose

--- a/skills/copilot/debug/references/thorough-track.md
+++ b/skills/copilot/debug/references/thorough-track.md
@@ -1,7 +1,3 @@
----
-name: thorough-track
----
-
 # Thorough Track
 
 ## Purpose

--- a/skills/copilot/debug/references/troubleshooting.md
+++ b/skills/copilot/debug/references/troubleshooting.md
@@ -1,7 +1,3 @@
----
-name: troubleshooting
----
-
 # Troubleshooting
 
 ## MCP Tool Call Failed

--- a/skills/copilot/delegation/references/fix-mode.md
+++ b/skills/copilot/delegation/references/fix-mode.md
@@ -1,7 +1,3 @@
----
-name: fix-mode
----
-
 # Fix Mode (--fixes)
 
 When invoked with `--fixes`, delegation handles review failures instead of initial implementation.

--- a/skills/copilot/delegation/references/implementer-prompt.md
+++ b/skills/copilot/delegation/references/implementer-prompt.md
@@ -1,8 +1,3 @@
----
-name: implementer-prompt
-description: Canonical implementer prompt template — embedded in agent definitions on runtimes with native agent support, dispatched inline on others.
----
-
 # Implementer Prompt Template
 
 **Note:** On runtimes with native agent definitions (e.g. Claude Code), this template is compiled into `servers/exarchos-mcp/src/agents/definitions.ts` (IMPLEMENTER spec) and the rendered agent file (e.g. `agents/exarchos-implementer.md`) is generated from the registry at build time. This reference document is the canonical prompt evolution record and is used directly by runtime clients without native agent support (Cursor, Copilot CLI, etc.).

--- a/skills/copilot/delegation/references/parallel-strategy.md
+++ b/skills/copilot/delegation/references/parallel-strategy.md
@@ -33,14 +33,23 @@ task --agent implementer 'Task 002: <full context for Task 002>'
 ```
 
 
-## Subagent Dispatch Properties
+## Dispatch Properties
 
-| Aspect | Subagent dispatch |
-|--------|---------------------|
+Subagent dispatch is the universal parallelism mode (available in every
+runtime). On runtimes with the `agent-teams` capability, a second canonical
+table follows that places Subagent and Agent Teams modes side-by-side across
+every dispatch property — use it when choosing between modes or comparing
+their semantics.
+
+| Property | Subagent Mode |
+|----------|------------------------------------------------------------------------|
 | Parallel dispatch | Multiple `task` invocations in one message |
-| Waiting | `inline reply from task --agent (no separate collection API)` |
+| Waiting / monitoring | `inline reply from task --agent (no separate collection API)` (no live visibility) |
 | Visibility | None (background) |
-| Model control | `recommendedModel` from `prepare_delegation` (computed from the config cascade) |
+| Cross-task deps | Orchestrator manages phases |
+| State updates | Orchestrator updates state |
+| Quality gates | Manual via `post_delegation_check` action |
+| Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) |
 | Max parallelism | Unlimited |
 | Resume on crash | Task results preserved |
 

--- a/skills/copilot/delegation/references/parallel-strategy.md
+++ b/skills/copilot/delegation/references/parallel-strategy.md
@@ -40,7 +40,7 @@ modes or comparing their semantics.
 
 | Property | Subagent Mode |
 |----------|------------------------------------------------------------------------|
-| Parallel dispatch | Multiple `task` invocations in one message |
+| Parallel dispatch | Multiple subagent invocations in one message (see example above) |
 | Waiting / monitoring | `inline reply from task --agent (no separate collection API)` (no live visibility) |
 | Visibility | None (background) |
 | Cross-task deps | Orchestrator manages phases |

--- a/skills/copilot/delegation/references/parallel-strategy.md
+++ b/skills/copilot/delegation/references/parallel-strategy.md
@@ -1,8 +1,3 @@
----
-name: parallel-strategy
-description: Parallel dispatch and result-collection strategy for subagent teammates.
----
-
 # Parallel Execution Strategy
 
 ## Identifying Parallel Groups

--- a/skills/copilot/delegation/references/parallel-strategy.md
+++ b/skills/copilot/delegation/references/parallel-strategy.md
@@ -15,6 +15,7 @@ Group B (depends on Group A):
 - Task 004: API handlers
 ```
 
+
 ## Dispatching Parallel Tasks
 
 **Critical:** Use a single message with multiple subagent invocations — the runtime's spawn primitive renders the parallel dispatch:
@@ -28,13 +29,14 @@ task --agent implementer 'Task 002: <full context for Task 002>'
 ```
 
 
+
 ## Dispatch Properties
 
-Subagent dispatch is the universal parallelism mode (available in every
-runtime). On runtimes with the `agent-teams` capability, a second canonical
-table follows that places Subagent and Agent Teams modes side-by-side across
-every dispatch property — use it when choosing between modes or comparing
-their semantics.
+Subagent dispatch is the universal parallelism mode on runtimes that
+support `subagent:spawn`. On runtimes with the `agent-teams` capability, a
+second canonical table follows that places Subagent and Agent Teams modes
+side-by-side across every dispatch property — use it when choosing between
+modes or comparing their semantics.
 
 | Property | Subagent Mode |
 |----------|------------------------------------------------------------------------|
@@ -47,6 +49,7 @@ their semantics.
 | Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) |
 | Max parallelism | Unlimited |
 | Resume on crash | Task results preserved |
+
 
 
 ## Waiting for Parallel Completion

--- a/skills/copilot/delegation/references/workflow-steps.md
+++ b/skills/copilot/delegation/references/workflow-steps.md
@@ -1,7 +1,3 @@
----
-name: workflow-steps
----
-
 # Delegation Workflow Steps
 
 ## Step 1: Prepare Environment

--- a/skills/copilot/delegation/references/worktree-enforcement.md
+++ b/skills/copilot/delegation/references/worktree-enforcement.md
@@ -1,7 +1,3 @@
----
-name: worktree-enforcement
----
-
 # Worktree Enforcement (MANDATORY)
 
 All implementation tasks MUST run in isolated worktrees, not the main project root.

--- a/skills/copilot/implementation-planning/references/worked-example.md
+++ b/skills/copilot/implementation-planning/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: implementation-planning-worked-example
-description: "Complete trace of the implementation planning skill in action, showing happy path and re-planning after gap detection."
----
-
 # Worked Example: Implementation Planning — Event Stream Compaction
 
 ## Context

--- a/skills/copilot/refactor/references/explore-checklist.md
+++ b/skills/copilot/refactor/references/explore-checklist.md
@@ -1,7 +1,3 @@
----
-name: explore-checklist
----
-
 # Refactor Exploration Checklist
 
 ## Scope Assessment

--- a/skills/copilot/refactor/references/polish-track.md
+++ b/skills/copilot/refactor/references/polish-track.md
@@ -1,7 +1,3 @@
----
-name: polish-track
----
-
 # Polish Track — Detailed Phase Guide
 
 ## Purpose

--- a/skills/copilot/spec-review/references/review-checklist.md
+++ b/skills/copilot/spec-review/references/review-checklist.md
@@ -1,8 +1,3 @@
----
-name: spec-review-checklist
-description: "Validation script invocations and report template for spec compliance verification."
----
-
 # Spec Review Checklist
 
 ## Adversarial Review Posture

--- a/skills/copilot/spec-review/references/worked-example.md
+++ b/skills/copilot/spec-review/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: spec-review-worked-example
-description: "Complete trace of the spec review skill in action, showing happy path and false-positive correction."
----
-
 # Worked Example: Spec Review — Workflow Transition Validation
 
 ## Context

--- a/skills/copilot/synthesis/references/synthesis-steps.md
+++ b/skills/copilot/synthesis/references/synthesis-steps.md
@@ -1,7 +1,3 @@
----
-name: synthesis-steps
----
-
 # Synthesis Process
 
 ## Step 1: Verify Readiness

--- a/skills/cursor/brainstorming/references/worked-example.md
+++ b/skills/cursor/brainstorming/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: brainstorming-worked-example
-description: "Complete trace of the brainstorming skill in action, showing happy path and pivot recovery."
----
-
 # Worked Example: Brainstorming — Event Deduplication
 
 ## Context

--- a/skills/cursor/cleanup/references/merge-verification.md
+++ b/skills/cursor/cleanup/references/merge-verification.md
@@ -1,7 +1,3 @@
----
-name: merge-verification
----
-
 # Merge Verification Guide
 
 ## Why Verify?

--- a/skills/cursor/debug/references/hotfix-track.md
+++ b/skills/cursor/debug/references/hotfix-track.md
@@ -1,7 +1,3 @@
----
-name: hotfix-track
----
-
 # Hotfix Track
 
 ## Purpose

--- a/skills/cursor/debug/references/thorough-track.md
+++ b/skills/cursor/debug/references/thorough-track.md
@@ -1,7 +1,3 @@
----
-name: thorough-track
----
-
 # Thorough Track
 
 ## Purpose

--- a/skills/cursor/debug/references/troubleshooting.md
+++ b/skills/cursor/debug/references/troubleshooting.md
@@ -1,7 +1,3 @@
----
-name: troubleshooting
----
-
 # Troubleshooting
 
 ## MCP Tool Call Failed

--- a/skills/cursor/delegation/references/fix-mode.md
+++ b/skills/cursor/delegation/references/fix-mode.md
@@ -1,7 +1,3 @@
----
-name: fix-mode
----
-
 # Fix Mode (--fixes)
 
 When invoked with `--fixes`, delegation handles review failures instead of initial implementation.

--- a/skills/cursor/delegation/references/implementer-prompt.md
+++ b/skills/cursor/delegation/references/implementer-prompt.md
@@ -1,8 +1,3 @@
----
-name: implementer-prompt
-description: Canonical implementer prompt template — embedded in agent definitions on runtimes with native agent support, dispatched inline on others.
----
-
 # Implementer Prompt Template
 
 **Note:** On runtimes with native agent definitions (e.g. Claude Code), this template is compiled into `servers/exarchos-mcp/src/agents/definitions.ts` (IMPLEMENTER spec) and the rendered agent file (e.g. `agents/exarchos-implementer.md`) is generated from the registry at build time. This reference document is the canonical prompt evolution record and is used directly by runtime clients without native agent support (Cursor, Copilot CLI, etc.).

--- a/skills/cursor/delegation/references/parallel-strategy.md
+++ b/skills/cursor/delegation/references/parallel-strategy.md
@@ -1,8 +1,3 @@
----
-name: parallel-strategy
-description: Parallel dispatch and result-collection strategy for subagent teammates.
----
-
 # Parallel Execution Strategy
 
 ## Identifying Parallel Groups

--- a/skills/cursor/delegation/references/parallel-strategy.md
+++ b/skills/cursor/delegation/references/parallel-strategy.md
@@ -15,6 +15,7 @@ Group B (depends on Group A):
 - Task 004: API handlers
 ```
 
+
 ## Dispatching Parallel Tasks
 
 **Critical:** Use a single message with multiple subagent invocations — the runtime's spawn primitive renders the parallel dispatch:
@@ -38,13 +39,14 @@ Task({
 ```
 
 
+
 ## Dispatch Properties
 
-Subagent dispatch is the universal parallelism mode (available in every
-runtime). On runtimes with the `agent-teams` capability, a second canonical
-table follows that places Subagent and Agent Teams modes side-by-side across
-every dispatch property — use it when choosing between modes or comparing
-their semantics.
+Subagent dispatch is the universal parallelism mode on runtimes that
+support `subagent:spawn`. On runtimes with the `agent-teams` capability, a
+second canonical table follows that places Subagent and Agent Teams modes
+side-by-side across every dispatch property — use it when choosing between
+modes or comparing their semantics.
 
 | Property | Subagent Mode |
 |----------|------------------------------------------------------------------------|
@@ -57,6 +59,7 @@ their semantics.
 | Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) |
 | Max parallelism | Unlimited |
 | Resume on crash | Task results preserved |
+
 
 
 ## Waiting for Parallel Completion

--- a/skills/cursor/delegation/references/parallel-strategy.md
+++ b/skills/cursor/delegation/references/parallel-strategy.md
@@ -43,14 +43,23 @@ Task({
 ```
 
 
-## Subagent Dispatch Properties
+## Dispatch Properties
 
-| Aspect | Subagent dispatch |
-|--------|---------------------|
+Subagent dispatch is the universal parallelism mode (available in every
+runtime). On runtimes with the `agent-teams` capability, a second canonical
+table follows that places Subagent and Agent Teams modes side-by-side across
+every dispatch property — use it when choosing between modes or comparing
+their semantics.
+
+| Property | Subagent Mode |
+|----------|------------------------------------------------------------------------|
 | Parallel dispatch | Multiple `Task` invocations in one message |
-| Waiting | `Task() reply (inline)` |
+| Waiting / monitoring | `Task() reply (inline)` (no live visibility) |
 | Visibility | None (background) |
-| Model control | `recommendedModel` from `prepare_delegation` (computed from the config cascade) |
+| Cross-task deps | Orchestrator manages phases |
+| State updates | Orchestrator updates state |
+| Quality gates | Manual via `post_delegation_check` action |
+| Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) |
 | Max parallelism | Unlimited |
 | Resume on crash | Task results preserved |
 

--- a/skills/cursor/delegation/references/parallel-strategy.md
+++ b/skills/cursor/delegation/references/parallel-strategy.md
@@ -50,7 +50,7 @@ modes or comparing their semantics.
 
 | Property | Subagent Mode |
 |----------|------------------------------------------------------------------------|
-| Parallel dispatch | Multiple `Task` invocations in one message |
+| Parallel dispatch | Multiple subagent invocations in one message (see example above) |
 | Waiting / monitoring | `Task() reply (inline)` (no live visibility) |
 | Visibility | None (background) |
 | Cross-task deps | Orchestrator manages phases |

--- a/skills/cursor/delegation/references/workflow-steps.md
+++ b/skills/cursor/delegation/references/workflow-steps.md
@@ -1,7 +1,3 @@
----
-name: workflow-steps
----
-
 # Delegation Workflow Steps
 
 ## Step 1: Prepare Environment

--- a/skills/cursor/delegation/references/worktree-enforcement.md
+++ b/skills/cursor/delegation/references/worktree-enforcement.md
@@ -1,7 +1,3 @@
----
-name: worktree-enforcement
----
-
 # Worktree Enforcement (MANDATORY)
 
 All implementation tasks MUST run in isolated worktrees, not the main project root.

--- a/skills/cursor/implementation-planning/references/worked-example.md
+++ b/skills/cursor/implementation-planning/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: implementation-planning-worked-example
-description: "Complete trace of the implementation planning skill in action, showing happy path and re-planning after gap detection."
----
-
 # Worked Example: Implementation Planning — Event Stream Compaction
 
 ## Context

--- a/skills/cursor/refactor/references/explore-checklist.md
+++ b/skills/cursor/refactor/references/explore-checklist.md
@@ -1,7 +1,3 @@
----
-name: explore-checklist
----
-
 # Refactor Exploration Checklist
 
 ## Scope Assessment

--- a/skills/cursor/refactor/references/polish-track.md
+++ b/skills/cursor/refactor/references/polish-track.md
@@ -1,7 +1,3 @@
----
-name: polish-track
----
-
 # Polish Track — Detailed Phase Guide
 
 ## Purpose

--- a/skills/cursor/spec-review/references/review-checklist.md
+++ b/skills/cursor/spec-review/references/review-checklist.md
@@ -1,8 +1,3 @@
----
-name: spec-review-checklist
-description: "Validation script invocations and report template for spec compliance verification."
----
-
 # Spec Review Checklist
 
 ## Adversarial Review Posture

--- a/skills/cursor/spec-review/references/worked-example.md
+++ b/skills/cursor/spec-review/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: spec-review-worked-example
-description: "Complete trace of the spec review skill in action, showing happy path and false-positive correction."
----
-
 # Worked Example: Spec Review — Workflow Transition Validation
 
 ## Context

--- a/skills/cursor/synthesis/references/synthesis-steps.md
+++ b/skills/cursor/synthesis/references/synthesis-steps.md
@@ -1,7 +1,3 @@
----
-name: synthesis-steps
----
-
 # Synthesis Process
 
 ## Step 1: Verify Readiness

--- a/skills/generic/brainstorming/references/worked-example.md
+++ b/skills/generic/brainstorming/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: brainstorming-worked-example
-description: "Complete trace of the brainstorming skill in action, showing happy path and pivot recovery."
----
-
 # Worked Example: Brainstorming — Event Deduplication
 
 ## Context

--- a/skills/generic/cleanup/references/merge-verification.md
+++ b/skills/generic/cleanup/references/merge-verification.md
@@ -1,7 +1,3 @@
----
-name: merge-verification
----
-
 # Merge Verification Guide
 
 ## Why Verify?

--- a/skills/generic/debug/references/hotfix-track.md
+++ b/skills/generic/debug/references/hotfix-track.md
@@ -1,7 +1,3 @@
----
-name: hotfix-track
----
-
 # Hotfix Track
 
 ## Purpose

--- a/skills/generic/debug/references/thorough-track.md
+++ b/skills/generic/debug/references/thorough-track.md
@@ -1,7 +1,3 @@
----
-name: thorough-track
----
-
 # Thorough Track
 
 ## Purpose

--- a/skills/generic/debug/references/troubleshooting.md
+++ b/skills/generic/debug/references/troubleshooting.md
@@ -1,7 +1,3 @@
----
-name: troubleshooting
----
-
 # Troubleshooting
 
 ## MCP Tool Call Failed

--- a/skills/generic/delegation/references/fix-mode.md
+++ b/skills/generic/delegation/references/fix-mode.md
@@ -1,7 +1,3 @@
----
-name: fix-mode
----
-
 # Fix Mode (--fixes)
 
 When invoked with `--fixes`, delegation handles review failures instead of initial implementation.

--- a/skills/generic/delegation/references/implementer-prompt.md
+++ b/skills/generic/delegation/references/implementer-prompt.md
@@ -1,8 +1,3 @@
----
-name: implementer-prompt
-description: Canonical implementer prompt template — embedded in agent definitions on runtimes with native agent support, dispatched inline on others.
----
-
 # Implementer Prompt Template
 
 **Note:** On runtimes with native agent definitions (e.g. Claude Code), this template is compiled into `servers/exarchos-mcp/src/agents/definitions.ts` (IMPLEMENTER spec) and the rendered agent file (e.g. `agents/exarchos-implementer.md`) is generated from the registry at build time. This reference document is the canonical prompt evolution record and is used directly by runtime clients without native agent support (Cursor, Copilot CLI, etc.).

--- a/skills/generic/delegation/references/parallel-strategy.md
+++ b/skills/generic/delegation/references/parallel-strategy.md
@@ -33,14 +33,23 @@ Execute each task sequentially in the current session, one at a time, against th
 ```
 
 
-## Subagent Dispatch Properties
+## Dispatch Properties
 
-| Aspect | Subagent dispatch |
-|--------|---------------------|
+Subagent dispatch is the universal parallelism mode (available in every
+runtime). On runtimes with the `agent-teams` capability, a second canonical
+table follows that places Subagent and Agent Teams modes side-by-side across
+every dispatch property — use it when choosing between modes or comparing
+their semantics.
+
+| Property | Subagent Mode |
+|----------|------------------------------------------------------------------------|
 | Parallel dispatch | Multiple `[sequential execution]` invocations in one message |
-| Waiting | `[task output is the assistant's next message]` |
+| Waiting / monitoring | `[task output is the assistant's next message]` (no live visibility) |
 | Visibility | None (background) |
-| Model control | `recommendedModel` from `prepare_delegation` (computed from the config cascade) |
+| Cross-task deps | Orchestrator manages phases |
+| State updates | Orchestrator updates state |
+| Quality gates | Manual via `post_delegation_check` action |
+| Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) |
 | Max parallelism | Unlimited |
 | Resume on crash | Task results preserved |
 

--- a/skills/generic/delegation/references/parallel-strategy.md
+++ b/skills/generic/delegation/references/parallel-strategy.md
@@ -1,8 +1,3 @@
----
-name: parallel-strategy
-description: Parallel dispatch and result-collection strategy for subagent teammates.
----
-
 # Parallel Execution Strategy
 
 ## Identifying Parallel Groups

--- a/skills/generic/delegation/references/parallel-strategy.md
+++ b/skills/generic/delegation/references/parallel-strategy.md
@@ -15,47 +15,10 @@ Group B (depends on Group A):
 - Task 004: API handlers
 ```
 
-## Dispatching Parallel Tasks
-
-**Critical:** Use a single message with multiple subagent invocations — the runtime's spawn primitive renders the parallel dispatch:
-
-```typescript
-// CORRECT: Single message, parallel execution
-Execute each task sequentially in the current session, one at a time, against the prepared worktrees.
-Execute each task sequentially in the current session, one at a time, against the prepared worktrees.
-
-// WRONG: Separate messages = sequential
-```
 
 
-## Dispatch Properties
-
-Subagent dispatch is the universal parallelism mode (available in every
-runtime). On runtimes with the `agent-teams` capability, a second canonical
-table follows that places Subagent and Agent Teams modes side-by-side across
-every dispatch property — use it when choosing between modes or comparing
-their semantics.
-
-| Property | Subagent Mode |
-|----------|------------------------------------------------------------------------|
-| Parallel dispatch | Multiple `[sequential execution]` invocations in one message |
-| Waiting / monitoring | `[task output is the assistant's next message]` (no live visibility) |
-| Visibility | None (background) |
-| Cross-task deps | Orchestrator manages phases |
-| State updates | Orchestrator updates state |
-| Quality gates | Manual via `post_delegation_check` action |
-| Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) |
-| Max parallelism | Unlimited |
-| Resume on crash | Task results preserved |
 
 
-## Waiting for Parallel Completion
-
-```text
-// Wait for all background tasks via the runtime's result-collection primitive
-[task output is the assistant's next message]
-// (poll/await per task_id on poll-based runtimes; inline on runtimes that return replies in the dispatching turn)
-```
 
 ## Model Selection Guide
 

--- a/skills/generic/delegation/references/workflow-steps.md
+++ b/skills/generic/delegation/references/workflow-steps.md
@@ -1,7 +1,3 @@
----
-name: workflow-steps
----
-
 # Delegation Workflow Steps
 
 ## Step 1: Prepare Environment

--- a/skills/generic/delegation/references/worktree-enforcement.md
+++ b/skills/generic/delegation/references/worktree-enforcement.md
@@ -1,7 +1,3 @@
----
-name: worktree-enforcement
----
-
 # Worktree Enforcement (MANDATORY)
 
 All implementation tasks MUST run in isolated worktrees, not the main project root.

--- a/skills/generic/implementation-planning/references/worked-example.md
+++ b/skills/generic/implementation-planning/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: implementation-planning-worked-example
-description: "Complete trace of the implementation planning skill in action, showing happy path and re-planning after gap detection."
----
-
 # Worked Example: Implementation Planning — Event Stream Compaction
 
 ## Context

--- a/skills/generic/refactor/references/explore-checklist.md
+++ b/skills/generic/refactor/references/explore-checklist.md
@@ -1,7 +1,3 @@
----
-name: explore-checklist
----
-
 # Refactor Exploration Checklist
 
 ## Scope Assessment

--- a/skills/generic/refactor/references/polish-track.md
+++ b/skills/generic/refactor/references/polish-track.md
@@ -1,7 +1,3 @@
----
-name: polish-track
----
-
 # Polish Track — Detailed Phase Guide
 
 ## Purpose

--- a/skills/generic/spec-review/references/review-checklist.md
+++ b/skills/generic/spec-review/references/review-checklist.md
@@ -1,8 +1,3 @@
----
-name: spec-review-checklist
-description: "Validation script invocations and report template for spec compliance verification."
----
-
 # Spec Review Checklist
 
 ## Adversarial Review Posture

--- a/skills/generic/spec-review/references/worked-example.md
+++ b/skills/generic/spec-review/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: spec-review-worked-example
-description: "Complete trace of the spec review skill in action, showing happy path and false-positive correction."
----
-
 # Worked Example: Spec Review — Workflow Transition Validation
 
 ## Context

--- a/skills/generic/synthesis/references/synthesis-steps.md
+++ b/skills/generic/synthesis/references/synthesis-steps.md
@@ -1,7 +1,3 @@
----
-name: synthesis-steps
----
-
 # Synthesis Process
 
 ## Step 1: Verify Readiness

--- a/skills/opencode/brainstorming/references/worked-example.md
+++ b/skills/opencode/brainstorming/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: brainstorming-worked-example
-description: "Complete trace of the brainstorming skill in action, showing happy path and pivot recovery."
----
-
 # Worked Example: Brainstorming — Event Deduplication
 
 ## Context

--- a/skills/opencode/cleanup/references/merge-verification.md
+++ b/skills/opencode/cleanup/references/merge-verification.md
@@ -1,7 +1,3 @@
----
-name: merge-verification
----
-
 # Merge Verification Guide
 
 ## Why Verify?

--- a/skills/opencode/debug/references/hotfix-track.md
+++ b/skills/opencode/debug/references/hotfix-track.md
@@ -1,7 +1,3 @@
----
-name: hotfix-track
----
-
 # Hotfix Track
 
 ## Purpose

--- a/skills/opencode/debug/references/thorough-track.md
+++ b/skills/opencode/debug/references/thorough-track.md
@@ -1,7 +1,3 @@
----
-name: thorough-track
----
-
 # Thorough Track
 
 ## Purpose

--- a/skills/opencode/debug/references/troubleshooting.md
+++ b/skills/opencode/debug/references/troubleshooting.md
@@ -1,7 +1,3 @@
----
-name: troubleshooting
----
-
 # Troubleshooting
 
 ## MCP Tool Call Failed

--- a/skills/opencode/delegation/references/fix-mode.md
+++ b/skills/opencode/delegation/references/fix-mode.md
@@ -1,7 +1,3 @@
----
-name: fix-mode
----
-
 # Fix Mode (--fixes)
 
 When invoked with `--fixes`, delegation handles review failures instead of initial implementation.

--- a/skills/opencode/delegation/references/implementer-prompt.md
+++ b/skills/opencode/delegation/references/implementer-prompt.md
@@ -1,8 +1,3 @@
----
-name: implementer-prompt
-description: Canonical implementer prompt template — embedded in agent definitions on runtimes with native agent support, dispatched inline on others.
----
-
 # Implementer Prompt Template
 
 **Note:** On runtimes with native agent definitions (e.g. Claude Code), this template is compiled into `servers/exarchos-mcp/src/agents/definitions.ts` (IMPLEMENTER spec) and the rendered agent file (e.g. `agents/exarchos-implementer.md`) is generated from the registry at build time. This reference document is the canonical prompt evolution record and is used directly by runtime clients without native agent support (Cursor, Copilot CLI, etc.).

--- a/skills/opencode/delegation/references/parallel-strategy.md
+++ b/skills/opencode/delegation/references/parallel-strategy.md
@@ -15,6 +15,7 @@ Group B (depends on Group A):
 - Task 004: API handlers
 ```
 
+
 ## Dispatching Parallel Tasks
 
 **Critical:** Use a single message with multiple subagent invocations — the runtime's spawn primitive renders the parallel dispatch:
@@ -36,13 +37,14 @@ Task({
 ```
 
 
+
 ## Dispatch Properties
 
-Subagent dispatch is the universal parallelism mode (available in every
-runtime). On runtimes with the `agent-teams` capability, a second canonical
-table follows that places Subagent and Agent Teams modes side-by-side across
-every dispatch property — use it when choosing between modes or comparing
-their semantics.
+Subagent dispatch is the universal parallelism mode on runtimes that
+support `subagent:spawn`. On runtimes with the `agent-teams` capability, a
+second canonical table follows that places Subagent and Agent Teams modes
+side-by-side across every dispatch property — use it when choosing between
+modes or comparing their semantics.
 
 | Property | Subagent Mode |
 |----------|------------------------------------------------------------------------|
@@ -55,6 +57,7 @@ their semantics.
 | Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) |
 | Max parallelism | Unlimited |
 | Resume on crash | Task results preserved |
+
 
 
 ## Waiting for Parallel Completion

--- a/skills/opencode/delegation/references/parallel-strategy.md
+++ b/skills/opencode/delegation/references/parallel-strategy.md
@@ -41,14 +41,23 @@ Task({
 ```
 
 
-## Subagent Dispatch Properties
+## Dispatch Properties
 
-| Aspect | Subagent dispatch |
-|--------|---------------------|
+Subagent dispatch is the universal parallelism mode (available in every
+runtime). On runtimes with the `agent-teams` capability, a second canonical
+table follows that places Subagent and Agent Teams modes side-by-side across
+every dispatch property — use it when choosing between modes or comparing
+their semantics.
+
+| Property | Subagent Mode |
+|----------|------------------------------------------------------------------------|
 | Parallel dispatch | Multiple `Task` invocations in one message |
-| Waiting | `Task() reply (inline, no poll)` |
+| Waiting / monitoring | `Task() reply (inline, no poll)` (no live visibility) |
 | Visibility | None (background) |
-| Model control | `recommendedModel` from `prepare_delegation` (computed from the config cascade) |
+| Cross-task deps | Orchestrator manages phases |
+| State updates | Orchestrator updates state |
+| Quality gates | Manual via `post_delegation_check` action |
+| Model control | `recommendedModel` per task from `prepare_delegation` (config cascade) |
 | Max parallelism | Unlimited |
 | Resume on crash | Task results preserved |
 

--- a/skills/opencode/delegation/references/parallel-strategy.md
+++ b/skills/opencode/delegation/references/parallel-strategy.md
@@ -1,8 +1,3 @@
----
-name: parallel-strategy
-description: Parallel dispatch and result-collection strategy for subagent teammates.
----
-
 # Parallel Execution Strategy
 
 ## Identifying Parallel Groups

--- a/skills/opencode/delegation/references/parallel-strategy.md
+++ b/skills/opencode/delegation/references/parallel-strategy.md
@@ -48,7 +48,7 @@ modes or comparing their semantics.
 
 | Property | Subagent Mode |
 |----------|------------------------------------------------------------------------|
-| Parallel dispatch | Multiple `Task` invocations in one message |
+| Parallel dispatch | Multiple subagent invocations in one message (see example above) |
 | Waiting / monitoring | `Task() reply (inline, no poll)` (no live visibility) |
 | Visibility | None (background) |
 | Cross-task deps | Orchestrator manages phases |

--- a/skills/opencode/delegation/references/workflow-steps.md
+++ b/skills/opencode/delegation/references/workflow-steps.md
@@ -1,7 +1,3 @@
----
-name: workflow-steps
----
-
 # Delegation Workflow Steps
 
 ## Step 1: Prepare Environment

--- a/skills/opencode/delegation/references/worktree-enforcement.md
+++ b/skills/opencode/delegation/references/worktree-enforcement.md
@@ -1,7 +1,3 @@
----
-name: worktree-enforcement
----
-
 # Worktree Enforcement (MANDATORY)
 
 All implementation tasks MUST run in isolated worktrees, not the main project root.

--- a/skills/opencode/implementation-planning/references/worked-example.md
+++ b/skills/opencode/implementation-planning/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: implementation-planning-worked-example
-description: "Complete trace of the implementation planning skill in action, showing happy path and re-planning after gap detection."
----
-
 # Worked Example: Implementation Planning — Event Stream Compaction
 
 ## Context

--- a/skills/opencode/refactor/references/explore-checklist.md
+++ b/skills/opencode/refactor/references/explore-checklist.md
@@ -1,7 +1,3 @@
----
-name: explore-checklist
----
-
 # Refactor Exploration Checklist
 
 ## Scope Assessment

--- a/skills/opencode/refactor/references/polish-track.md
+++ b/skills/opencode/refactor/references/polish-track.md
@@ -1,7 +1,3 @@
----
-name: polish-track
----
-
 # Polish Track — Detailed Phase Guide
 
 ## Purpose

--- a/skills/opencode/spec-review/references/review-checklist.md
+++ b/skills/opencode/spec-review/references/review-checklist.md
@@ -1,8 +1,3 @@
----
-name: spec-review-checklist
-description: "Validation script invocations and report template for spec compliance verification."
----
-
 # Spec Review Checklist
 
 ## Adversarial Review Posture

--- a/skills/opencode/spec-review/references/worked-example.md
+++ b/skills/opencode/spec-review/references/worked-example.md
@@ -1,8 +1,3 @@
----
-name: spec-review-worked-example
-description: "Complete trace of the spec review skill in action, showing happy path and false-positive correction."
----
-
 # Worked Example: Spec Review — Workflow Transition Validation
 
 ## Context

--- a/skills/opencode/synthesis/references/synthesis-steps.md
+++ b/skills/opencode/synthesis/references/synthesis-steps.md
@@ -1,7 +1,3 @@
----
-name: synthesis-steps
----
-
 # Synthesis Process
 
 ## Step 1: Verify Readiness

--- a/src/runtimes/presence-cursor.test.ts
+++ b/src/runtimes/presence-cursor.test.ts
@@ -83,7 +83,7 @@ describe('runtimes/cursor.yaml presence', () => {
     expect(spawn.replaceAll('{{agent}}', agentName)).toContain(agentName);
   });
 
-  it('CursorYaml_SupportedCapabilities_FiveNativeTwoAdvisory', () => {
+  it('CursorYaml_SupportedCapabilities_SixNativeTwoAdvisory', () => {
     const raw = loadCursorYamlRaw();
     const sc = raw.supportedCapabilities;
     expect(sc).toBeDefined();
@@ -96,14 +96,22 @@ describe('runtimes/cursor.yaml presence', () => {
     const advisory = Object.entries(map).filter(([, v]) => v === 'advisory');
     const unsupported = Object.entries(map).filter(([, v]) => v === 'unsupported');
 
-    // Per discovery §3 + Task 4f: 5 native + 2 advisory + 0 unsupported (omitted).
-    expect(native).toHaveLength(5);
+    // Per discovery §3 + Task 4f + #1192 T09 readonly tier:
+    // 6 native + 2 advisory + 0 unsupported (omitted).
+    expect(native).toHaveLength(6);
     expect(advisory).toHaveLength(2);
     expect(unsupported).toHaveLength(0);
 
     const nativeKeys = native.map(([k]) => k).sort();
     expect(nativeKeys).toEqual(
-      ['fs:read', 'fs:write', 'mcp:exarchos', 'shell:exec', 'subagent:spawn'].sort(),
+      [
+        'fs:read',
+        'fs:write',
+        'mcp:exarchos',
+        'mcp:exarchos:readonly',
+        'shell:exec',
+        'subagent:spawn',
+      ].sort(),
     );
 
     const advisoryKeys = advisory.map(([k]) => k).sort();

--- a/src/runtimes/types.ts
+++ b/src/runtimes/types.ts
@@ -64,6 +64,7 @@ export const SupportedCapabilityKey = z.enum([
   'subagent:completion-signal',
   'subagent:start-signal',
   'mcp:exarchos',
+  'mcp:exarchos:readonly',
   'isolation:worktree',
   'team:agent-teams',
   'session:resume',


### PR DESCRIPTION
## Summary

Closes #1192 — resolves 15 of the 20 deferred CodeRabbit findings from PR #1181 (5 dropped/non-actionable per verification matrix). Core change: REVIEWER's read-only trust boundary moves from prompt-enforced to **capability-enforced** via a new `mcp:exarchos:readonly` capability tier, with server-side action allowlisting and parity across all 5 runtime adapters.

## Changes

### Wave 0 (foundations)
- **T01** — Reference-file frontmatter contract (CLAUDE.md + .coderabbit.yaml)
- **T02** — Replace string-concat YAML in claude.ts with `yaml@^2.8.2`

### Wave 1 (capability tier + manifest + test infra)
- **T03–T12** — `mcp:exarchos:readonly` capability + server-side allowlist + handshake-tier resolver + 5 adapter wirings + REVIEWER migration (deletes Forbidden MCP Actions prompt block) + CLI/MCP parity test
- **T13–T17** — `PluginManifestSchema` (Zod) + atomic `read/writePluginManifest` + rollback on failure
- **T18–T19** — Re-export `CAPABILITY_KEYS`, drift.test imports canonical helpers
- **T20–T21** — Codex `tomlBasicString` `\b`/`\f` escapes; canonical RUNTIMES import
- **T23** — OpenCode body-contract sentinels

### Wave 2 (hooks + adapter hardening)
- **T24–T26** — Hook YAML render-time test + git-toplevel anchoring + lint enforcement
- **T27–T28** — Codex `validateSupport` rejects specs needing absent capabilities; divergence test
- **T29** — Cursor `lowerSpec` strips hard worktree guard when `isolation:worktree` is advisory

### Wave 3 (docs)
- **T31–T34** — Consolidate parallelism tables, reconcile design doc to z.enum, neutralize state-management.md, apply frontmatter-strip rule to 24 reference files

## Tests

- `npm run typecheck`: pass
- `npm run test:run`: 444/444 in agents + parity + capabilities + adapters
- `npm run skills:guard`: pass (zero diff against committed `skills/` tree)

## Deferrals (tracked)

- **T22** — Extending MCP-server tsconfig to typecheck test files surfaced 280 latent type errors. Tracked in #1196 for phased `tsconfig.strict.json` rollout.
- **T30** — Worktree-hygiene fences in shared `systemPrompts`. T29's regex strip handles the case sufficiently; refactor remains low-priority follow-up.

## Out of scope (per verification matrix)

Items 13, 17, 19 dropped (refuted, subsumed, or no-op); items 6/9/12/15/17 partially verified and folded where actionable.

## Test plan

- [ ] CI green on this PR
- [ ] No `skills/` drift after merge
- [ ] REVIEWER subagent rejects mutating MCP actions at the dispatch layer (not prompt-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)