### PR TITLE
v2.9.0 dogfood bundle: 8 DR fixes from #1109

### DIFF
--- a/.codex/agents/implementer.toml
+++ b/.codex/agents/implementer.toml
@@ -3,6 +3,23 @@ description = "Use this agent when dispatching TDD implementation tasks to a sub
 developer_instructions = """
 You are a TDD implementer agent working in an isolated worktree.
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
 ## Worktree Verification
 Before making ANY file changes:
 1. Run: `pwd`

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -47,6 +47,12 @@ Set-Location "<absolute worktree path>"   # PowerShell
 Where `<absolute worktree path>` is the path you were dispatched to.
 After that, the verification block below confirms you landed correctly.
 
+## Worktree Verification
+Before making ANY file changes:
+1. Run: `pwd`
+2. Verify the path contains `.worktrees/`
+3. If NOT in worktree: STOP and report error
+
 ## Task
 {{taskDescription}}
 

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -30,6 +30,23 @@ mcp:
 ---
 You are a TDD implementer agent working in an isolated worktree.
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
 ## Task
 {{taskDescription}}
 

--- a/.cursor/agents/scaffolder.md
+++ b/.cursor/agents/scaffolder.md
@@ -30,6 +30,12 @@ mcp:
 ---
 You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.
 
+## Worktree Verification
+Before making ANY file changes:
+1. Run: `pwd`
+2. Verify the path contains `.worktrees/`
+3. If NOT in worktree: STOP and report error
+
 ## Task
 {{taskDescription}}
 

--- a/.github/agents/implementer.agent.md
+++ b/.github/agents/implementer.agent.md
@@ -30,6 +30,23 @@ tools:
 
 You are a TDD implementer agent working in an isolated worktree.
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
 ## Worktree Verification
 Before making ANY file changes:
 1. Run: `pwd`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,15 @@ jobs:
       # be on PATH or the spawn fails with `exit null`.
       - uses: oven-sh/setup-bun@v2
 
+      # CodeRabbit/CI #1213: install root deps so `bun build --compile`
+      # (invoked from compiled-binary-mcp.test.ts) can resolve
+      # `js-yaml` (src/runtimes/load.ts) and `@inquirer/prompts`
+      # (src/install-skills.ts) — both declared in the root
+      # package.json but otherwise absent on the runner.
+      - name: Install root dependencies
+        working-directory: .
+        run: npm ci
+
       - run: npm ci
       - run: npx tsc --noEmit
       - run: npm run test:run
@@ -150,6 +159,17 @@ jobs:
           node-version: '24'
           cache: npm
           cache-dependency-path: servers/exarchos-mcp/package-lock.json
+
+      # CodeRabbit/CI #1213: install root deps so `bun build --compile`
+      # can resolve modules imported via the cross-tree bridge — e.g.
+      # `js-yaml` (from `src/runtimes/load.ts`) and `@inquirer/prompts`
+      # (from `src/install-skills.ts`) which the MCP entry point reaches
+      # transitively. Both are declared in root `package.json` but were
+      # absent on the runner because only `servers/exarchos-mcp` had a
+      # `npm ci`. The bundler then errored with "Could not resolve
+      # 'js-yaml'" / "Could not resolve '@inquirer/prompts'".
+      - name: Install root dependencies
+        run: npm ci
 
       # Install MCP-server runtime deps so `bun build --compile` can
       # resolve `pino`, `commander`, `@modelcontextprotocol/sdk`,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,14 @@ jobs:
       # produced by the earlier `npm ci` (`prepare` → `tsc`).
       - run: npm run skills:guard
 
+      # runtimes:guard — re-run `scripts/codegen-runtimes.ts` and fail
+      # if `git diff src/runtimes/embedded.ts` is non-empty. The
+      # embedded module is what the compiled binary uses to resolve
+      # runtimes (#1213 review-item #4 reversal, #1214); CI must catch
+      # any drift between `runtimes/*.yaml` and the checked-in
+      # generated module before it leaks into a release.
+      - run: npm run runtimes:guard
+
   test-mcp:
     name: Exarchos MCP Server
     needs: changes

--- a/.opencode/agents/implementer.md
+++ b/.opencode/agents/implementer.md
@@ -46,6 +46,23 @@ Implementation task requiring test-first development triggers the implementer ag
 
 You are a TDD implementer agent working in an isolated worktree.
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
 ## Worktree Verification
 Before making ANY file changes:
 1. Run: `pwd`

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -39,6 +39,23 @@ hooks:
 
 You are a TDD implementer agent working in an isolated worktree.
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
 ## Worktree Verification
 Before making ANY file changes:
 1. Run: `pwd`

--- a/docs/designs/2026-05-04-v290-dogfood-bundle.md
+++ b/docs/designs/2026-05-04-v290-dogfood-bundle.md
@@ -1,0 +1,217 @@
+# v2.9.0 Windows Dogfood Bundle — Topology Cleanup + Targeted Fixes
+
+**Target version:** v2.9.0 — Cross-platform & Install
+**Cross-cutting reference:** [#1109](https://github.com/lvlup-sw/exarchos/issues/1109) (event-sourcing integrity, MCP parity, basileus-forward)
+**Closes:** #1201, #1203, #1204, #1205, #1206, #1207 (partial), #1208 (verify), #1209, #1210, #1211, #1212
+**Defers:** #1207 auto-rebase → #1119 (v2.11.0)
+**Related housekeeping (separate):** #1119 scope update post #1193 merge
+**Source reports:** `exarchos-issues-2026-04-30-agency-csl-auto-pr-wave1.md`, `exarchos-issue-check_task_decomposition-parser-false-positives.md`
+
+## Overview
+
+The 2026-04-30 Windows dogfood of `agency-csl-auto-pr` (33-task plan, GitHub Copilot CLI) surfaced 11 issues spanning the delegation surface, the dispatch handlers, the implementer prompt template, and the CLI install pipeline. Filing them as 10 separate issues exposed a shared root cause: **readiness state is computed twice, in two places, against two slightly different inputs** — `prepare_delegation` (handler) does its own plan-artifact check while `delegation_readiness` (view) does another, and the worktree count comes from a global `task.assigned` counter that ignores wave scoping. Both surfaces report different blockers for the same conceptual readiness state.
+
+This design treats the bundle as one topology fix plus a set of targeted cleanups, all framed through the axiom backend-quality dimensions and the #1109 invariants.
+
+### Lens
+
+| Dimension / Constraint | Where it bites |
+|---|---|
+| **DIM-1 Topology** + #1109 Constraint 1 | Single source of truth for readiness state; output reconstructible from events |
+| **DIM-2 Observability** | PASS reports must reflect action actually taken (`#1203`, `#1210`) |
+| **DIM-3 Contracts** | Same fact across CLI/MCP must come from the same projection (`#1205`, `#1206`); template-runtime preconditions explicit (`#1204`); parser regexes match real planning output (`#1211`) |
+| **DIM-4 Test Fidelity** | Tests exercise real production fixtures, not stripped-down synthetic ones (`#1211`) |
+| **DIM-5 Hygiene** | Documented surfaces are wired (`#1201`); no duplicate readiness logic (`#1205`) |
+| **DIM-7 Resilience** | Recovery paths exist where realistic operating conditions need them (`#1207` runbook for v2.9.0; full auto-rebase deferred to #1119) |
+| **#1109 Constraint 2 (MCP parity)** | CLI and MCP facades return identical envelopes — not separately validated |
+| **#1109 Constraint 3 (basileus-forward)** | Templates work across all runtimes (`#1204`) without hidden cwd assumptions |
+
+## Verification of #1208 (likely already fixed)
+
+PR #1193 (merged 2026-04-28) shipped the `merge-pending` HSM substate, the `mergePendingEntry` guard checking `data.worktree` / `data.worktreePath` on the latest `task.completed`, and the `merge_orchestrate` next_action verb emission (`hsm-definitions.ts:71-101`, `next-actions-computer.ts:100-124`). The dogfood ran on an installed v2.8.x build that pre-dated this code.
+
+**Plan:** as the first verification step, run a workflow with `task.completed` carrying `data.worktreePath` against current HEAD and confirm `next_actions` surfaces `merge_orchestrate`. If confirmed, close #1208 as fixed-in-#1193 with a comment citing the build the dogfood ran against. If a residual bug is found (e.g., projection ordering, edge case the guard misses), patch it in this PR and document the residual in the issue.
+
+This verification gates the inclusion of any code change for #1208 — we're not patching code that's already correct.
+
+## DR-T: Topology Fix — readiness projection consolidation (#1205, #1206, #1212-state-desync)
+
+The core change. Today, the `delegation-readiness-view.ts` projection tracks plan approval, task count (incremented per `task.assigned`), worktree expected/ready counts, and worktree failures. The `prepare_delegation` handler then *also* checks `Boolean(workflowState.artifacts?.plan)` as a side-blocker not present in the view, and computes its own `taskCount` from `args.tasks?.length ?? readiness.plan.taskCount`. Two surfaces, two contracts.
+
+### DR-T-1: Plan-artifact check moves into the projection (#1205)
+
+The projection folds `state.patched` events whose patch sets `artifacts.plan` (or the dot-path equivalent), and tracks `plan.artifactPresent: boolean` alongside `plan.approved` and `plan.taskCount`. The `computeBlockers` helper emits a `Plan artifact is missing` blocker when `plan.artifactPresent === false`. `prepare-delegation.ts:444-449` deletes the local supplementary check entirely.
+
+Result: both `exarchos_orchestrate prepare_delegation` and `exarchos_view delegation_readiness` return the identical blocker for the identical workflow state. Single source of truth. DIM-1 ✓, DIM-3 ✓, Constraint 2 ✓.
+
+### DR-T-2: Wave scoping via projection-side task ID set (#1206)
+
+The projection currently tracks `worktrees.expected` as a monotonic counter. It will instead track `assignedTaskIds: Set<string>` and `readyTaskIds: Set<string>`. When `prepare_delegation` is called with a `tasks` arg, the handler computes:
+
+```ts
+const expected = args.tasks
+  ? args.tasks.filter(t => state.assignedTaskIds.has(t.id)).length
+  : state.assignedTaskIds.size;
+const ready = args.tasks
+  ? args.tasks.filter(t => state.readyTaskIds.has(t.id)).length
+  : state.readyTaskIds.size;
+const pendingWorktrees = expected - ready;
+```
+
+The blocker `${pendingWorktrees} worktrees pending` is then accurate to the wave being prepared. When `tasks` is omitted, behavior matches today (all tasks).
+
+The view continues to expose the per-task ID sets (not just counts) so downstream consumers can do their own wave scoping. `delegation_readiness` view output gains `assignedTaskIds` and `readyTaskIds` arrays (alongside the legacy `worktrees.expected`/`worktrees.ready` counts kept for back-compat).
+
+No event schema change. "Wave" remains an orchestrator-time grouping, not a domain event. The projection answers "is the subset ready?" rather than mutating its accumulator semantics.
+
+### DR-T-3: State-vs-plan desync diagnostic (#1212-state-desync)
+
+The projection compares `plan.taskCount` (incremented by `task.assigned` events) against the workflow state's `tasks.length`. When they diverge after a plan revision, `computeBlockers` adds:
+
+> `state-vs-plan desync: workflow.tasks has N entries but plan.taskCount is M (likely stale state after plan-review revision)`
+
+The blocker fires when `state.tasks.length !== plan.taskCount && plan.taskCount > 0`. Doesn't gate readiness on its own (`ready` stays computed off worktree state), but surfaces the drift loudly so an operator notices before delegating against stale state. DIM-2 ✓.
+
+### Files changed by DR-T
+
+- `servers/exarchos-mcp/src/views/delegation-readiness-view.ts` — projection state, event handlers, blocker computation
+- `servers/exarchos-mcp/src/views/delegation-readiness-view.test.ts` — projection tests for new state, wave scoping, desync diagnostic
+- `servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts` — delete the supplementary plan-artifact check; thread `tasks` arg into projection-driven scoping
+- `servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts` — wave-scoping integration tests
+- `skills-src/delegation/SKILL.md` — document the projection contract once, point both `prepare_delegation` and `delegation_readiness` at it
+
+## Targeted fixes — one DR each
+
+### DR-1: setup_worktree gitignore PASS reflects action actually taken (#1203)
+
+`servers/exarchos-mcp/src/orchestrate/setup-worktree.ts:85-115` (`ensureGitignored`) replaces `git check-ignore` with a direct read of the repo's `.gitignore`. The function:
+
+1. Reads `<repoRoot>/.gitignore` if it exists; checks for a line matching `^.worktrees/?$`.
+2. If found, returns `{ status: 'pass', detail: 'already present' }`.
+3. If not found, appends `.worktrees/\n` and returns `{ status: 'pass', detail: 'added' }`.
+4. If `.gitignore` doesn't exist, creates it with `.worktrees/\n` and returns `{ status: 'pass', detail: 'created with entry' }`.
+5. On any I/O error, returns `{ status: 'fail', detail: <error> }`.
+
+The PASS message always reflects the path taken. `git check-ignore` is never called — the contract is "the repo's `.gitignore` lists `.worktrees/`," not "any ignore source matches `.worktrees/`." DIM-2 ✓, DIM-3 ✓.
+
+### DR-2: implementer-prompt template includes explicit cd-into-worktree (#1204)
+
+`skills-src/delegation/references/implementer-prompt.md:19-33` and the compiled IMPLEMENTER spec in `servers/exarchos-mcp/src/agents/definitions.ts` add a recovery step before verification:
+
+```markdown
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime. Your FIRST command must be:
+
+  cd "<absolute worktree path>"             # bash / zsh / sh
+  Set-Location "<absolute worktree path>"   # PowerShell
+
+After that, the verification block below confirms you landed correctly.
+```
+
+The existing verification block (`pwd | grep -q "\.worktrees" || abort`) becomes a safety check rather than the entry point. Native-isolation runtimes (Claude Code) are unaffected because `cd` to an already-current directory is a no-op. Non-native runtimes (Copilot CLI, Cursor at the time of writing) get a working entry path. DIM-3 ✓, Constraint 3 ✓.
+
+After editing the source, `npm run build:skills` regenerates `skills/<runtime>/delegation/references/implementer-prompt.md` for every runtime variant.
+
+### DR-3: setup_worktree honors planned branch name (#1209)
+
+`servers/exarchos-mcp/src/orchestrate/setup-worktree.ts:275-277` reads from workflow state when present:
+
+```ts
+// Pseudocode
+const plannedBranch = workflowState?.tasks?.find(t => t.id === args.taskId)?.branch;
+const branchName = args.branch ?? plannedBranch ?? `feature/${args.taskId}-${args.taskName}`;
+```
+
+`SetupWorktreeArgs` gains an optional `branch?: string` field. When neither the arg nor workflow state supplies a branch, the legacy default applies. Reading workflow state requires threading `stateDir` (or the materialized state) into the handler — a small DI extension that mirrors how `prepare-delegation.ts` already takes `stateDir` + `ctx`. DIM-1 ✓.
+
+### DR-4: check_static_analysis SKIP for unsupported toolchains (#1210)
+
+`servers/exarchos-mcp/src/orchestrate/pure/static-analysis.ts:308-330` returns `status: 'skip'` (new variant in the discriminated union) when `detectProjectType` returns `undefined`. The `StaticAnalysisResult.status` enum extends from `'pass' | 'fail' | 'error'` to `'pass' | 'fail' | 'error' | 'skip'`. The handler at `static-analysis.ts:62-134` maps `skip` to a `gate.executed` event with `passed: false, skipped: true, skipReason: 'no-toolchain'`.
+
+The convergence view (`view convergence`) treats skipped gates as inconclusive — explicitly rendered as `SKIP` rather than green. D2 dimension reports "skipped (no toolchain)" instead of falsely reporting pass. DIM-2 ✓, DIM-4 ✓.
+
+### DR-5: check_task_decomposition parser fixes + characterization fixtures (#1211)
+
+Three regex-level fixes in `servers/exarchos-mcp/src/orchestrate/task-decomposition.ts`:
+
+1. **Description detection** (lines 132-160): replace literal `**Description:**` matching with "everything between the task heading and the next field-header (`**...**:`) or section header (`### `)". Drops the `inDesc` state machine; counts words in the captured block.
+2. **Dependency parser** (lines 331-349): match both `T-\d+` and `T\d+` formats (case-insensitive, leading word boundary, trailing non-letter boundary). Remove the greedy `/[0-9]+/g` fallback entirely — if the dep line has no `T<id>` or `T-<id>` references, return `[]` rather than scraping every digit-run.
+3. **File-conflict detector** (lines 366-376): require a known file extension (regex anchored at end: `\.(ts|tsx|js|jsx|json|md|yml|yaml|sh|ps1|sql|kql|bicep|cs|csproj)$`). Tighten the character class to exclude PascalCase / camelCase identifier patterns. Optionally: prefer files listed under an explicit `**Files:**` section when present (don't infer from narrative when the section exists).
+
+**Test fidelity (DIM-4):** add `task-decomposition.fixtures.test.ts` that runs the full parser against a real plan generated by `@skills/implementation-planning` (committed under `servers/exarchos-mcp/src/orchestrate/fixtures/plans/agency-csl-auto-pr.md` — captured from the dogfood report). Assertions:
+
+- `wellDecomposed === totalTasks` (no false rework finding)
+- `dagValid === true` (no false cycle)
+- `parallelSafe === true` (no false conflict on `imageProvenance.isFirstParty` etc.)
+- Dependency extraction returns the canonical T-IDs the plan declares, and nothing else.
+
+The fixture is the test-production parity fix the issue body asks for.
+
+### DR-6: merge_orchestrate ancestry error message links runbook (#1207, partial)
+
+`servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts` (and/or where `validateBranchAncestry`'s blocker text is composed in `merge-orchestrate.ts`) extends the failure message to include a remediation hint:
+
+> `ancestry missing: <integrationBranch>. The integration branch advanced past this source branch's branchpoint. Run \`git fetch && git rebase ${integrationBranch} && git push --force-with-lease\` from the worktree, or see <runbook URL> for the full procedure.`
+
+The runbook URL points at a new section in `skills-src/delegation/SKILL.md` § "When integration advances mid-wave" that documents the manual rebase procedure plus rollback advice. No auto-rebase code in this PR; that work is reserved for #1119 (v2.11.0). DIM-2 ✓ (better failure context), DIM-7 partial (manual recovery documented).
+
+### DR-7: CLI install-skills wired (#1201, separate commit)
+
+`servers/exarchos-mcp/src/adapters/cli.ts` (or wherever the CLI subcommand registry lives) wires the `install-skills` verb that's already documented. Implementation calls into the existing skills-installation logic (whatever `install-rewrite` from #1176 left in place); the CLI subcommand is a thin presentation wrapper.
+
+**MCP parity is intentionally not added.** `install-skills` writes to the local filesystem; remote MCP wouldn't be a meaningful surface (the remote server isn't where the user wants their skills installed). Document the CLI-only nature in the subcommand help text and in a `cli-only` annotation in the dispatch registry.
+
+This lands as a single isolated commit — easy to revert if it grows beyond expected scope. Standalone from the topology cleanup.
+
+### DR-8: Small docs/hint fixes (#1212)
+
+Three sub-fixes, mostly content edits:
+
+- **(a) install SKIP message link** — extend `resolved.remediation` in `servers/exarchos-mcp/src/config/test-runtime-resolver.ts` to include a one-line example and a doc-section anchor.
+- **(b) `task.assigned` event hint includes `branch`** — update the event-emission catalog (wherever `requiredFields` for `task.assigned` is declared, `event-store/schemas.ts` or the emission-guide source) to list `branch` as an optional field. Keeps two sources of truth aligned: workflow state and event payload.
+- **(c) `exarchos_workflow set updates` array-insertion syntax documented** — `skills-src/workflow-state/SKILL.md` gains a worked example for adding new entries to `tasks[]` (the supported syntax — verify against the parser before documenting, then assert with a unit test).
+
+The state-vs-plan desync diagnostic (originally bundled here) folds into DR-T-3 above.
+
+## Test plan
+
+- [ ] **#1208 verification first.** Run a feature workflow against current HEAD with `task.completed` carrying `data.worktreePath`. Confirm `next_actions` surfaces `merge_orchestrate`. Document the result; if green, post the verification trace as a comment on #1208 and close as fixed-in-#1193.
+- [ ] `cd servers/exarchos-mcp && npm run test:run` — full MCP suite passes.
+- [ ] `npm run typecheck` — clean.
+- [ ] `npm run build` — root build clean (rendered skills regenerated for every runtime).
+- [ ] `npm run skills:guard` — no drift between `skills-src/` and rendered `skills/`.
+- [ ] DR-T tests: projection unit tests cover plan-artifact fold, wave scoping, desync diagnostic.
+- [ ] DR-T parity test: the same workflow state produces identical blockers from `prepare_delegation` (handler) and `delegation_readiness` (view).
+- [ ] DR-1 tests: gitignore round-trip — empty `.gitignore`, missing `.gitignore`, already-present, parent-glob (must NOT lie about action), non-readable file → fail.
+- [ ] DR-2 manual: dispatch an implementer agent on a non-Claude-Code runtime equivalent (test harness if available; else document manual repro on Copilot CLI).
+- [ ] DR-3 tests: branch resolution priority — arg > planned > default.
+- [ ] DR-4 tests: SKIP path emits gate event with `skipped: true`; convergence view renders SKIP not PASS.
+- [ ] DR-5 fixture test: parser passes on the agency-csl-auto-pr fixture (`wellDecomposed === totalTasks`, no cycle, no false conflicts).
+- [ ] DR-5 unit tests: the three regex fixes (description span, T<id>/T-<id> dependency match, file-extension filter).
+- [ ] DR-6: failed merge_orchestrate emits the new ancestry error text including the runbook link; ancestry happy path unchanged.
+- [ ] DR-7: `exarchos install-skills` runs end-to-end from a local checkout against a temp `$HOME`. Help text says "CLI only."
+- [ ] DR-8: docs-only verification (manual) plus a unit test for the documented array-insertion syntax in `workflow_set`.
+
+## Out of scope (and where they live)
+
+| Concern | Why deferred | Tracking |
+|---|---|---|
+| Auto-rebase / autonomous ancestry recovery | Touches subagent worktree branches; needs independent risk analysis. Already on the v2.11.0 roadmap. | #1119 (scope update needed; see housekeeping below) |
+| Vitest-on-bun migration / drop `better-sqlite3` shim | Orthogonal CI surface, separate risk profile (vitest-on-bun edge cases on Windows runners). DR-5's parser fixtures don't hit storage so #1198 is not a blocker for this PR. | #1198 |
+| Convergence view UX rendering for SKIP gates | DR-4 emits the right event data; the rendering polish (e.g., yellow vs green) can land in a follow-up if reviewer feedback requests it. | n/a (in-PR adjustable) |
+
+## Housekeeping (separate from this PR)
+
+After this PR merges (or in parallel), post a comment on #1119 noting that PR #1193 has shipped the merge-orchestrator skeleton (state machine, preflight composer, executor, rollback, `next_actions` verb). #1119's remaining scope shrinks to the **autonomous** parts: auto-rebase, conflict resolution, drift self-recovery. The body's "Builds on #1181, #1185" note should be updated to reference #1193 explicitly. This is a 5-minute issue-housekeeping action; not part of this PR.
+
+## #1109 verification
+
+- [x] **Event-sourcing**: DR-T projection reads `state.patched` (plan-artifact), `task.assigned` (assignedTaskIds), `worktree.created` (readyTaskIds), `gate.executed` (existing). No new events emitted by DR-T. DR-4 modifies an existing event payload (`gate.executed` for static-analysis). No projection-only state.
+- [x] **MCP parity**: DR-T explicitly produces identical blockers across `prepare_delegation` (handler/MCP) and `delegation_readiness` (view/MCP & CLI). The new parity test (`servers/exarchos-mcp/src/orchestrate/prepare-delegation.parity.test.ts` if not already present) asserts byte-equivalence at the relevant fields.
+- [x] **Basileus-forward**: DR-2 explicitly removes a hidden cwd assumption that broke non-Claude-Code runtimes. DR-7's CLI-only annotation is documented, not assumed.
+- [x] **Capability resolution**: no reads of yaml capability fields at runtime in any DR; runtime resolution stays through the existing resolver chain.
+
+## Auto-chain note
+
+After plan approval, this design auto-continues into `/exarchos:plan` to produce the TDD task plan. The plan will decompose the DRs into testable tasks (likely ~12-15 tasks given the topology cleanup is the largest piece).

--- a/docs/plans/2026-05-04-v290-dogfood-bundle.md
+++ b/docs/plans/2026-05-04-v290-dogfood-bundle.md
@@ -1,0 +1,546 @@
+# v2.9.0 Dogfood Bundle — TDD Implementation Plan
+
+**Design:** [`docs/designs/2026-05-04-v290-dogfood-bundle.md`](../designs/2026-05-04-v290-dogfood-bundle.md)
+**Workflow:** `v290-dogfood-bundle`
+**Total tasks:** 17 (one verification gate + 16 implementation tasks)
+**Cross-cutting:** [#1109](https://github.com/lvlup-sw/exarchos/issues/1109)
+
+## Iron Law
+
+> NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
+
+Every task has explicit RED → GREEN → REFACTOR phases. Tests use `Method_Scenario_Outcome` naming.
+
+## Dependency graph
+
+```
+T-01 (verify #1208)  ──┐
+                       ├──► T-02 → T-03   (DR-T-1: plan-artifact)
+                       ├──► T-04 → T-05 → T-06   (DR-T-2 + DR-T-3: wave scoping + desync)
+                       ├──► T-07   (DR-1: gitignore)        ┐
+                       ├──► T-08   (DR-2: prompt template)  │
+                       ├──► T-09   (DR-3: branch override)  │ all independent,
+                       ├──► T-10   (DR-4: static-analysis)  │ parallel-safe
+                       ├──► T-11 → T-12 → T-13 → T-14   (DR-5: parser fixes via fixture-driven RED)
+                       ├──► T-15   (DR-6: ancestry message) │
+                       ├──► T-16   (DR-7: CLI install)      │ ← SEPARATE COMMIT
+                       └──► T-17   (DR-8: docs/hints)       ┘
+```
+
+T-01 gates everything (it may collapse #1208 work entirely). After T-01 the implementation tasks split into 8 independent tracks with internal sequential chains.
+
+---
+
+### Task T-01: Verify #1208 against current HEAD
+
+**Goal:** Run a feature workflow against current HEAD with `task.completed` carrying `data.worktreePath` and confirm `next_actions` surfaces the `merge_orchestrate` verb. PR #1193 shipped the HSM detour and the next_action verb (`hsm-definitions.ts:71-101`, `next-actions-computer.ts:100-124`); the dogfood ran on a v2.8.x build that pre-dated this. Either close as fixed-in-#1193 or document the residual bug for inclusion in this PR.
+
+**Files:**
+- (read-only) `servers/exarchos-mcp/src/workflow/hsm-definitions.ts`
+- (read-only) `servers/exarchos-mcp/src/next-actions-computer.ts`
+- (read-only) `servers/exarchos-mcp/src/views/next-action-projection.ts` (or wherever the projection lives)
+
+1. [RED] Write test: `mergePendingDetour_TaskCompletedWithWorktreePath_SurfacesMergeOrchestrateVerb`
+   - File: `servers/exarchos-mcp/src/next-actions-computer.test.ts` (new test in existing file)
+   - Set up workflow state in `delegate` phase, append a `task.completed` event with `data: { worktreePath: '...' }`, materialize next-action projection, assert verb is `merge_orchestrate`.
+   - Expected: PASS at HEAD (verifying existing PR #1193 wiring). If FAIL, document the failure mode.
+
+2. [GREEN] Only if RED revealed a bug — patch it. Otherwise no production code change.
+
+3. [REFACTOR] N/A.
+
+**Acceptance criteria:**
+- New characterization test passes against current HEAD.
+- Comment posted on #1208 with the test reference and verdict (fixed-in-#1193 or residual bug).
+- If residual: a follow-up task added to this plan; otherwise close #1208.
+
+**Dependencies:** None
+**Parallelizable:** No (gates all subsequent work — outcome decides whether #1208 needs implementation work)
+
+---
+
+### Task T-02: Plan-artifact field in delegation-readiness projection
+
+**Goal:** Fold `state.patched` events whose patch sets `artifacts.plan` (nested or dot-path form) into a new projection field `plan.artifactPresent: boolean`. Emit `Plan artifact is missing` blocker when false.
+
+**Files:**
+- `servers/exarchos-mcp/src/views/delegation-readiness-view.ts`
+- `servers/exarchos-mcp/src/views/delegation-readiness-view.test.ts`
+
+1. [RED] Write test: `delegationReadiness_StatePatchedWithArtifactsPlan_FlipsArtifactPresent`
+   - Apply `state.patched` event with `data.patch.artifacts.plan = "docs/plans/foo.md"`; assert `plan.artifactPresent === true`.
+   - Apply with dot-path form `data.patch["artifacts.plan"] = "..."`; same assertion.
+   - Init state asserts `plan.artifactPresent === false` and blocker `Plan artifact is missing` present.
+
+2. [GREEN] Extend `DelegationReadinessState.plan` with `artifactPresent: boolean`. Extend `handleStatePatched` to resolve `artifacts.plan` (nested + dot-path), mirroring the existing `planReview.approved` resolution. Extend `computeBlockers` to push the blocker when `!plan.artifactPresent`.
+
+3. [REFACTOR] If the nested/dot-path resolution duplicates `handleStatePatched`'s existing pattern, extract a `resolvePatchPath<T>(patch, path)` helper.
+
+**Acceptance criteria:**
+- Three new projection tests pass.
+- Existing tests still pass.
+- `init()` blocker list now contains `Plan artifact is missing` alongside the existing two.
+
+**Dependencies:** T-01
+**Parallelizable:** No (T-03 follows directly)
+
+---
+
+### Task T-03: Remove handler-side plan-artifact check + parity guard
+
+**Goal:** Delete the supplementary `Boolean(workflowState.artifacts?.plan)` check from `prepare-delegation.ts`. Add a regression test asserting `prepare_delegation` and `delegation_readiness` view produce the **identical** blocker list for the same workflow state.
+
+**Files:**
+- `servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts`
+- `servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts`
+
+1. [RED] Write test: `prepareDelegation_BlockerList_MatchesDelegationReadinessView`
+   - Construct workflow state with no plan artifact set; call `handlePrepareDelegation` and `delegationReadinessProjection.materialize()` against the same event stream; assert blockers arrays are equal.
+   - Repeat with plan artifact set: both surfaces omit the blocker.
+
+2. [GREEN] Delete `prepare-delegation.ts:444-449` (the `hasPlanArtifact` block and the `additionalBlockers` merge). Use `readiness.blockers` directly.
+
+3. [REFACTOR] If `additionalBlockers` is now empty everywhere, remove the variable.
+
+**Acceptance criteria:**
+- Parity test passes.
+- No surface-specific blocker emission for plan-artifact in the handler.
+- Existing prepare-delegation tests pass.
+
+**Dependencies:** T-02
+**Parallelizable:** No
+
+---
+
+### Task T-04: Projection tracks task ID sets, not counters
+
+**Goal:** Replace `worktrees.expected: number` and `worktrees.ready: number` with `assignedTaskIds: ReadonlySet<string>` and `readyTaskIds: ReadonlySet<string>`. Keep the count fields exposed at the view boundary for back-compat, derived from the sets.
+
+**Files:**
+- `servers/exarchos-mcp/src/views/delegation-readiness-view.ts`
+- `servers/exarchos-mcp/src/views/delegation-readiness-view.test.ts`
+
+1. [RED] Write tests:
+   - `delegationReadiness_TaskAssignedTwice_AccumulatesAssignedTaskIds` — two events with `taskId: "001"` and `"002"` produce `assignedTaskIds = Set(["001", "002"])`.
+   - `delegationReadiness_DuplicateTaskAssigned_DeduplicatesByTaskId` — two events with same `taskId: "001"` produce a Set of size 1.
+   - `delegationReadiness_WorktreeCreatedWithTaskId_AddsToReadyTaskIds` — `worktree.created` event with `data.taskId: "001"` adds "001" to `readyTaskIds`. (Confirm event payload format from the emission catalog before writing.)
+   - `delegationReadiness_LegacyExpectedCount_DerivedFromSet` — view exposes `worktrees.expected === assignedTaskIds.size` for back-compat.
+
+2. [GREEN] Update `DelegationReadinessState` shape. `handleTaskAssigned` adds to set. `handleWorktreeCreated` adds to ready set (requires the event to carry `taskId` — verify and document if the projection has to fall back to a non-keyed counter when `taskId` is absent). Derive `worktrees.expected`/`worktrees.ready` from `.size` for back-compat consumers.
+
+3. [REFACTOR] Extract a `withTaskAdded(state, taskId, key)` helper if `handleTaskAssigned` and `handleWorktreeCreated` end up with parallel structure.
+
+**Acceptance criteria:**
+- New set-based projection tests pass.
+- Existing tests still pass (back-compat counts derived correctly).
+- View output shape includes `assignedTaskIds`/`readyTaskIds` arrays alongside legacy counts.
+
+**Dependencies:** T-03
+**Parallelizable:** No (T-05 follows)
+
+---
+
+### Task T-05: Wave-scoped worktree readiness in prepare_delegation
+
+**Goal:** When `prepare_delegation` is called with a `tasks` arg, scope the worktree-pending blocker to the named subset using the per-task ID sets from T-04. When `tasks` is omitted, behavior matches today.
+
+**Files:**
+- `servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts`
+- `servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts`
+
+1. [RED] Write tests:
+   - `prepareDelegation_TasksArgSubsetReady_NoBlocker` — projection has 33 assignedTaskIds and 3 readyTaskIds; `tasks` arg lists the same 3 IDs as ready; blockers do not include `worktrees pending`.
+   - `prepareDelegation_TasksArgSubsetPending_ExactPendingCountInBlocker` — same as above but `tasks` arg lists 3 unready IDs; blocker says `3 worktrees pending` (not 30).
+   - `prepareDelegation_NoTasksArg_AllAssignedConsidered` — without `tasks` arg, blocker reports global pending count.
+
+2. [GREEN] In `handlePrepareDelegation`, when `args.tasks` is present, compute scoped expected/ready by intersecting against the projection's sets. Replace the readiness `blockers` re-computation accordingly. Keep `nativeIsolation` short-circuit semantics intact.
+
+3. [REFACTOR] Pull the wave-scoping computation into a pure helper `computeScopedWorktrees(readiness, tasksFilter)` that returns `{expected, ready, pending}` — easier to unit test.
+
+**Acceptance criteria:**
+- All three wave-scoping tests pass.
+- `nativeIsolation` test still passes.
+- The `33 worktrees pending` regression that #1206 reports is the explicit RED for the second test; it goes green after this task.
+
+**Dependencies:** T-04
+**Parallelizable:** No (T-06 follows)
+
+---
+
+### Task T-06: State-vs-plan desync diagnostic blocker
+
+**Goal:** When `plan.taskCount` (incremented by `task.assigned` events) diverges from `workflow.tasks.length`, emit a diagnostic blocker. Doesn't gate `ready` on its own — surfaces the drift loudly.
+
+**Files:**
+- `servers/exarchos-mcp/src/views/delegation-readiness-view.ts`
+- `servers/exarchos-mcp/src/views/delegation-readiness-view.test.ts`
+- `servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts` (thread workflowState.tasks.length into the readiness assembly so the projection can compare)
+
+1. [RED] Write test: `delegationReadiness_PlanTaskCountDiffersFromStateTasks_AddsDesyncBlocker`
+   - Set up state with `plan.taskCount === 33` (33 task.assigned events) and `workflow.tasks.length === 31`; expect blocker text matching the design pattern.
+   - Test reverse direction: `state.tasks.length > plan.taskCount`.
+   - Test no-desync case: equal counts produce no blocker.
+
+2. [GREEN] Either (a) thread `state.tasks.length` into `computeBlockers` via the handler (projection stays pure), or (b) extend the projection to fold `workflow.transition`/`state.patched` events that mutate `tasks`. Prefer (a) — keeps the projection focused on stream events.
+
+3. [REFACTOR] If (a), document the cross-cutting input on the projection's `materialize` signature.
+
+**Acceptance criteria:**
+- Three desync tests pass.
+- Blocker fires when counts diverge and `plan.taskCount > 0` (no false-positive at init).
+
+**Dependencies:** T-05
+**Parallelizable:** No
+
+---
+
+### Task T-07: setup_worktree gitignore — direct read, honest PASS
+
+**Goal:** Replace `git check-ignore` with direct read of repo `.gitignore`. PASS message reflects exactly which path was taken (`already present`, `added`, or `created with entry`).
+
+**Files:**
+- `servers/exarchos-mcp/src/orchestrate/setup-worktree.ts`
+- `servers/exarchos-mcp/src/orchestrate/setup-worktree.test.ts`
+
+1. [RED] Write tests:
+   - `ensureGitignored_AlreadyPresent_ReportsAlreadyPresent` — `.gitignore` containing `.worktrees/` returns PASS with detail `'already present'`.
+   - `ensureGitignored_NotPresent_AppendsAndReportsAdded` — `.gitignore` lacks the entry; function appends and returns PASS with detail `'added'`.
+   - `ensureGitignored_FileMissing_CreatesWithEntry` — no `.gitignore`; function creates it and returns PASS with detail `'created with entry'`.
+   - `ensureGitignored_GlobalIgnoreOnlyMatch_StillReportsHonestState` — match comes from `.git/info/exclude` not repo `.gitignore`; function still appends to repo `.gitignore`.
+   - `ensureGitignored_ReadFails_ReturnsFail` — simulate I/O error; returns FAIL with detail.
+
+2. [GREEN] Rewrite `ensureGitignored`. Read file with `readFileSync`, scan for `^.worktrees/?$`, branch on outcome, append/create as needed. Remove `execFileSync('git', ['check-ignore', ...])` calls entirely.
+
+3. [REFACTOR] Extract `readGitignoreLines(repoRoot)` helper if useful.
+
+**Acceptance criteria:**
+- All five tests pass.
+- No `check-ignore` invocation remaining in the function.
+- Behavior is platform-agnostic (no Windows path-separator surprises).
+
+**Dependencies:** T-01
+**Parallelizable:** Yes
+
+---
+
+### Task T-08: implementer-prompt template adds explicit cd-into-worktree
+
+**Goal:** Add a "Working Directory Setup (MANDATORY)" section before the verification block in the source template. Render via `npm run build:skills`. Update the compiled IMPLEMENTER spec in `agents/definitions.ts`.
+
+**Files:**
+- `skills-src/delegation/references/implementer-prompt.md`
+- `servers/exarchos-mcp/src/agents/definitions.ts`
+- `servers/exarchos-mcp/src/agents/definitions.test.ts`
+- `skills/<runtime>/delegation/references/implementer-prompt.md` (regenerated by build)
+
+1. [RED] Write test: `implementerSpec_PromptBody_IncludesCdIntoWorktreeBeforeVerification`
+   - Asserts the rendered/compiled prompt contains a section header matching `## Working Directory Setup` AND that this section appears before the `## CRITICAL: Worktree Verification` block.
+   - Asserts both bash (`cd "..."`) and PowerShell (`Set-Location "..."`) examples are present.
+
+2. [GREEN] Edit `skills-src/delegation/references/implementer-prompt.md` to insert the new section. Update `agents/definitions.ts` IMPLEMENTER spec to include the same instruction in the embedded prompt body. Run `npm run build:skills`.
+
+3. [REFACTOR] If the cd snippet is duplicated between `definitions.ts` and the markdown, document where the canonical text lives.
+
+**Acceptance criteria:**
+- Rendering test passes against both source markdown and compiled spec.
+- `npm run skills:guard` passes (no drift between `skills-src/` and `skills/`).
+- Visual review: the new section is the first action the agent is told to take.
+
+**Dependencies:** T-01
+**Parallelizable:** Yes
+
+---
+
+### Task T-09: setup_worktree honors planned branch from workflow state
+
+**Goal:** `SetupWorktreeArgs` gains optional `branch?: string`. When neither arg nor workflow state supplies a branch, fall back to the legacy `feature/<id>-<name>` default. Resolution priority: `args.branch > workflow.tasks[id=<taskId>].branch > default`.
+
+**Files:**
+- `servers/exarchos-mcp/src/orchestrate/setup-worktree.ts`
+- `servers/exarchos-mcp/src/orchestrate/setup-worktree.test.ts`
+
+1. [RED] Write tests:
+   - `setupWorktree_WorkflowTasksHasBranch_UsesItOverDefault` — workflow state has `tasks[id="001"].branch = "feature/foo/t001"`; result branch matches.
+   - `setupWorktree_ArgBranchOverridesWorkflowState` — both arg and state set; arg wins.
+   - `setupWorktree_NoBranchAnywhere_UsesLegacyDefault` — current behavior preserved.
+
+2. [GREEN] Extend `SetupWorktreeArgs` schema. Thread `stateDir` (or pre-loaded workflow state) into `handleSetupWorktree` — mirror how `prepare-delegation.ts` already consumes `stateDir + ctx`. Resolve branch in the documented priority.
+
+3. [REFACTOR] Extract `resolveBranchName(args, workflowState)` pure helper.
+
+**Acceptance criteria:**
+- Three tests pass.
+- Existing setup-worktree tests pass with unchanged default behavior.
+- The `Branch created` check report includes which source the branch came from (e.g., `from workflow state`, `from arg`, `default`).
+
+**Dependencies:** T-01
+**Parallelizable:** Yes
+
+---
+
+### Task T-10: check_static_analysis SKIP for unsupported toolchains
+
+**Goal:** Extend `StaticAnalysisResult.status` from `'pass' | 'fail' | 'error'` to include `'skip'`. The "no toolchain detected" path returns `'skip'`. Handler emits `gate.executed` event with `passed: false, skipped: true, skipReason: 'no-toolchain'`. Convergence view treats skip as inconclusive.
+
+**Files:**
+- `servers/exarchos-mcp/src/orchestrate/pure/static-analysis.ts`
+- `servers/exarchos-mcp/src/orchestrate/pure/static-analysis.test.ts`
+- `servers/exarchos-mcp/src/orchestrate/static-analysis.ts`
+- `servers/exarchos-mcp/src/orchestrate/static-analysis.test.ts`
+- `servers/exarchos-mcp/src/views/convergence-view.ts` (or wherever D2 rendering lives)
+- `servers/exarchos-mcp/src/views/convergence-view.test.ts`
+
+1. [RED] Write tests:
+   - `runStaticAnalysis_NoToolchainDetected_ReturnsSkipStatus` — pure function returns `status: 'skip'`.
+   - `handleStaticAnalysis_SkipStatus_EmitsEventWithSkippedTrue` — handler emits `gate.executed` with `passed: false, skipped: true, skipReason: 'no-toolchain'`.
+   - `convergenceView_D2GateSkipped_RendersAsSkipNotPass` — D2 dimension reports SKIP / inconclusive.
+
+2. [GREEN] Update `StaticAnalysisResult` discriminated union. Update the no-toolchain branch to return `'skip'`. Update the handler to map `'skip'` to the augmented event payload. Update the convergence view to render skipped gates distinctly from passed ones.
+
+3. [REFACTOR] If `'skip'` semantics propagate to other gates later, document the convention.
+
+**Acceptance criteria:**
+- Three tests pass.
+- Existing static-analysis tests pass (pass / fail / error paths unchanged).
+- D2 dimension in convergence view no longer falsely greens for repos without a recognized toolchain.
+
+**Dependencies:** T-01
+**Parallelizable:** Yes
+
+---
+
+### Task T-11: Capture agency-csl-auto-pr fixture + characterization RED gate
+
+**Goal:** Commit a real plan generated by `@skills/implementation-planning` as a test fixture. Write the integration test that runs `check_task_decomposition` against it and asserts the parser DOES NOT produce false positives. This test fails on current code (RED) and goes green incrementally as T-12, T-13, T-14 fix each parser bug.
+
+**Files:**
+- `servers/exarchos-mcp/src/orchestrate/fixtures/plans/agency-csl-auto-pr.md` (new)
+- `servers/exarchos-mcp/src/orchestrate/task-decomposition.fixtures.test.ts` (new)
+
+1. [RED] Capture and commit the fixture. Write tests:
+   - `taskDecomposition_AgencyCslAutoPr_AllTasksWellDecomposed` — `wellDecomposed === totalTasks`.
+   - `taskDecomposition_AgencyCslAutoPr_NoCycleDetected` — `dagValid === true`, no `Unresolved dependency: ... unknown 24` style errors.
+   - `taskDecomposition_AgencyCslAutoPr_NoFalseFileConflicts` — `parallelSafe === true`, no conflicts on dotted-identifier tokens.
+
+2. [GREEN] None — this task is the failing-test capture. The three sub-bug fixes (T-12, T-13, T-14) make it pass incrementally.
+
+3. [REFACTOR] N/A.
+
+**Acceptance criteria:**
+- Fixture committed (capture from the dogfood report; trim to a representative subset if the full 33-task plan is too large).
+- All three fixture tests fail on current code, with failure modes matching the dogfood report (Description = 0 words, dependency-on-unknown-24, file-conflict on `imageProvenance.isFirstParty`).
+- Document the failures in the test file's leading comment.
+
+**Dependencies:** T-01
+**Parallelizable:** No (T-12, T-13, T-14 follow)
+
+---
+
+### Task T-12: Fix Description span parsing
+
+**Goal:** Replace literal `**Description:**` matching with "everything between the task heading and the next field-header (`**...**:`) or section header (`### `)". Description word count reflects the actual prose under the task heading.
+
+**Files:**
+- `servers/exarchos-mcp/src/orchestrate/task-decomposition.ts`
+- `servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts`
+
+1. [RED] Write tests:
+   - `validateTaskStructure_TaskWithGoalSection_CountsGoalProseAsDescription` — block with `**Goal:**` followed by 50 words of prose; `descriptionWordCount > 10`, `hasDescription === true`.
+   - `validateTaskStructure_TaskWithMultipleSections_DescriptionStopsAtNextFieldHeader` — block with `Goal: ...\n\n**Acceptance criteria:**`; description includes Goal text only.
+   - `validateTaskStructure_NoFieldHeaders_FullBodyCounted` — block with naked prose under task heading; full body counts.
+   - One additional fixture-level assertion in `task-decomposition.fixtures.test.ts` should now go green (or partially green).
+
+2. [GREEN] Replace the description-extraction block in `validateTaskStructure` (`task-decomposition.ts:132-160`). New algorithm: skip the heading line; capture lines until `^### ` or `^\*\*\w+:\*\*` (exclusive). Count words.
+
+3. [REFACTOR] Extract `extractDescriptionSpan(lines)` pure helper.
+
+**Acceptance criteria:**
+- Three new tests pass.
+- The fixture test for `wellDecomposed === totalTasks` passes after this task lands (assuming the other parser bugs don't independently fail tasks — which they don't, since description failure is sufficient on its own to fail the task structure check).
+- Existing description-related tests still pass; if any test was specifically for the literal `**Description:**` form, update it to match the new contract or remove if unreachable.
+
+**Dependencies:** T-11
+**Parallelizable:** No (T-13 follows)
+
+---
+
+### Task T-13: Fix T-id dependency parser
+
+**Goal:** Match both `T-XX` and `TXX` formats. Anchor strictly to the `**Dependencies:**` line. Remove the greedy `/[0-9]+/g` fallback — if no `T<id>`/`T-<id>` present, return `[]`.
+
+**Files:**
+- `servers/exarchos-mcp/src/orchestrate/task-decomposition.ts`
+- `servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts`
+
+1. [RED] Write tests:
+   - `extractDependencies_ThyphenIdFormat_ReturnsTIds` — line `**Dependencies:** T-001, T-002` → `["T-001", "T-002"]`.
+   - `extractDependencies_NoHyphenIdFormat_ReturnsTIds` — line `**Dependencies:** T001, T002` → `["T001", "T002"]` (or normalized to T-001/T-002 — pick one and document).
+   - `extractDependencies_NarrativeContainsRollup24h_DoesNotExtract24` — line `**Dependencies:** T002 (\`GetCslSloRollup24h\` exposes ...)` → `["T002"]`, NOT `["T002", "24"]`.
+   - `extractDependencies_NoTIdsAtAll_ReturnsEmptyArray` — line `**Dependencies:** none` → `[]`.
+   - `extractDependencies_DigitsInOtherLines_NotExtracted` — `**Dependencies:**` line absent or empty; never falls back to digit-scraping the whole block.
+
+2. [GREEN] Rewrite `extractDependencies` (`task-decomposition.ts:331-349`). Single regex matching `\b(T-?\d+)\b` (with leading word boundary, trailing non-word boundary). No fallback to plain digits.
+
+3. [REFACTOR] If T-XX vs TXX normalization is decided, document it (comment or test). Otherwise leave both forms as-is.
+
+**Acceptance criteria:**
+- Five new tests pass.
+- The fixture-level "no false cycle" assertion (`taskDecomposition_AgencyCslAutoPr_NoCycleDetected`) goes green.
+- Existing dependency-extraction tests pass; update any whose expectations relied on the greedy fallback.
+
+**Dependencies:** T-12
+**Parallelizable:** No (T-14 follows)
+
+---
+
+### Task T-14: Fix file-conflict detection extension filter
+
+**Goal:** Tighten file-path regex to require a known file extension. Tokens like `imageProvenance.isFirstParty` no longer match. Optionally prefer files declared under an explicit `**Files:**` section when present.
+
+**Files:**
+- `servers/exarchos-mcp/src/orchestrate/task-decomposition.ts`
+- `servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts`
+
+1. [RED] Write tests:
+   - `extractFiles_DottedIdentifierLikeFieldName_NotMatched` — `\`imageProvenance.isFirstParty\`` → not in extracted files.
+   - `extractFiles_KnownExtension_Matched` — `\`src/foo.ts\``, `\`config.json\``, `\`README.md\`` → all matched.
+   - `extractFiles_UnknownExtension_NotMatched` — `\`some.unknownext\`` → not matched (or document the allowed-list behavior).
+   - `checkParallelSafety_AgencyCslLikeNarrative_NoFalseConflicts` — two parallel tasks with overlapping field-name references but no overlapping file paths → `safe === true`.
+
+2. [GREEN] Tighten `filePattern` in both `extractFiles` and the inline pattern in `validateTaskStructure`. Allowed extensions: `ts | tsx | js | jsx | mjs | cjs | json | md | yml | yaml | sh | ps1 | sql | kql | bicep | cs | csproj | sln | go | rs | toml`. (Confirm the list against the project's actual file inventory before locking.) Optional: if a `**Files:**` section is present in the task block, prefer those over inferred files.
+
+3. [REFACTOR] Centralize the extension allowlist as a module-level constant `FILE_EXTENSION_ALLOWLIST` shared by `extractFiles` and `validateTaskStructure`.
+
+**Acceptance criteria:**
+- Four new tests pass.
+- Fixture-level "no false file conflicts" assertion goes green.
+- Genuine file conflicts in synthetic tests still detected (regression guard).
+
+**Dependencies:** T-13
+**Parallelizable:** No
+
+---
+
+### Task T-15: merge_orchestrate ancestry error message links runbook
+
+**Goal:** Failed ancestry preflight emits a message that includes the manual remediation command and a link to the runbook section. Add the runbook section to `skills-src/delegation/SKILL.md`.
+
+**Files:**
+- `servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts` (or wherever the ancestry blocker text composes)
+- `servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.test.ts`
+- `skills-src/delegation/SKILL.md`
+
+1. [RED] Write test: `mergePreflight_AncestryFails_MessageIncludesRebaseInstructionAndRunbookLink`
+   - Run preflight with a non-descendant source branch; assert the failure result includes `git rebase` instruction and a link to `skills-src/delegation/SKILL.md#when-integration-advances-mid-wave` (or the deployed equivalent).
+
+2. [GREEN] Extend the failure message composition. Add the runbook section to `SKILL.md` with the manual rebase + rollback procedure. Run `npm run build:skills`.
+
+3. [REFACTOR] If multiple preflight failures use similar pattern, extract a `formatRemediation(failure)` helper.
+
+**Acceptance criteria:**
+- Test passes.
+- `npm run skills:guard` passes (rendered SKILL files match source).
+- The runbook section is discoverable from the failure message and reads as a complete procedure.
+- No auto-rebase code introduced (deferred to #1119).
+
+**Dependencies:** T-01
+**Parallelizable:** Yes
+
+---
+
+### Task T-16: CLI install-skills wired (#1201) — separate commit
+
+**Goal:** Wire the documented `install-skills` subcommand into the CLI. CLI-only (no MCP parity — install writes to local filesystem). Help text annotated `cli-only`.
+
+**Files:**
+- `servers/exarchos-mcp/src/adapters/cli.ts`
+- `servers/exarchos-mcp/src/adapters/cli.test.ts`
+- (consumes existing skills-installation logic from #1176 install-rewrite)
+
+1. [RED] Write tests:
+   - `cli_InstallSkillsSubcommand_RegisteredInRegistry` — `exarchos install-skills --help` exits 0 and the help text mentions skills.
+   - `cli_InstallSkills_HelpTextSaysCliOnly` — help text contains `cli-only` annotation explicitly.
+   - Integration smoke (if feasible): `exarchos install-skills` against a tempdir `$HOME` writes the expected skill files.
+
+2. [GREEN] Add the subcommand definition. Wire it to call into the existing skills-installation function. Add the `cli-only` annotation. If a subcommand registry exists with a `mcpVisible` flag (or similar), set it to false.
+
+3. [REFACTOR] If the install logic from #1176 lives in a function that can be reused without duplication, prefer reuse. Otherwise document why a new wrapper is needed.
+
+**Acceptance criteria:**
+- Three tests pass.
+- Lands as a single isolated commit titled `feat(cli)(#1201): wire install-skills subcommand`. Easy to revert if it grows beyond expected scope.
+- `exarchos install-skills` runs end-to-end from a local checkout against a temp `$HOME`.
+
+**Dependencies:** T-01
+**Parallelizable:** Yes
+
+---
+
+### Task T-17: Small docs/hint fixes (#1212)
+
+**Goal:** Three sub-edits — install SKIP message link, `task.assigned` event hint includes `branch`, `workflow_set` array-insertion syntax documented.
+
+**Files:**
+- `servers/exarchos-mcp/src/config/test-runtime-resolver.ts`
+- `servers/exarchos-mcp/src/config/test-runtime-resolver.test.ts`
+- `servers/exarchos-mcp/src/event-store/schemas.ts` (or the emission-guide source for `task.assigned` hint)
+- `servers/exarchos-mcp/src/event-store/schemas.test.ts`
+- `servers/exarchos-mcp/src/workflow/state-store.ts` (or the workflow_set parser)
+- `servers/exarchos-mcp/src/workflow/state-store.test.ts`
+- `skills-src/workflow-state/SKILL.md`
+
+1. [RED] Write tests:
+   - `testRuntimeResolver_RemediationMessage_IncludesDocLinkOrExample` — resolver remediation contains either a doc URL or an inline example fragment.
+   - `eventEmissionCatalog_TaskAssigned_OptionalBranchField` — `task.assigned` schema/hint includes `branch` as an optional field.
+   - `workflowSetParser_ArrayInsertionSyntax_AppendsNewEntry` — verify the supported array-insert syntax (e.g., `tasks[append]: {entry}` or `tasks[id=NEW]: {entry}` — confirm against the parser's actual implementation before writing the test).
+
+2. [GREEN] Each sub-edit:
+   - Extend `resolved.remediation` with link/example.
+   - Add `branch?: string` to the `task.assigned` event hint catalog. Document in the emission guide source.
+   - Either confirm the parser already supports an insertion syntax (then document it in `skills-src/workflow-state/SKILL.md` with worked example), or implement minimal support if missing.
+
+3. [REFACTOR] N/A.
+
+**Acceptance criteria:**
+- Three tests pass.
+- `skills-src/workflow-state/SKILL.md` gains a worked example for adding new tasks array entries.
+- `npm run skills:guard` passes.
+
+**Dependencies:** T-01
+**Parallelizable:** Yes
+
+---
+
+## Parallelization summary
+
+After T-01 verification gates the rest:
+
+- **Sequential chain A** (DR-T topology): T-02 → T-03 → T-04 → T-05 → T-06 (one worktree, ~5 sequential cycles)
+- **Sequential chain B** (DR-5 parser): T-11 → T-12 → T-13 → T-14 (one worktree, ~4 sequential cycles)
+- **Independent tasks** (each in its own worktree, all parallel): T-07, T-08, T-09, T-10, T-15, T-16, T-17
+
+**Recommended dispatch waves:**
+
+- Wave 0: T-01 (verification, blocking)
+- Wave 1 (parallel): T-02, T-07, T-08, T-09, T-10, T-11, T-15, T-16, T-17 — 9 worktrees
+- Wave 2 (sequential within chains): T-03 (after T-02), T-12 (after T-11)
+- Wave 3: T-04 (after T-03), T-13 (after T-12)
+- Wave 4: T-05 (after T-04), T-14 (after T-13)
+- Wave 5: T-06 (after T-05) — terminal in chain A
+
+Or, simpler: Wave 0 = T-01; Wave 1 = all chain-heads + all independents in parallel; Wave 2-N = chain successors as predecessors complete.
+
+---
+
+## Out of scope (per design)
+
+- #1207 auto-rebase recovery (deferred to #1119)
+- #1198 vitest-on-bun migration (orthogonal; separate PR)
+- Convergence view UX polish for SKIP rendering (in-PR adjustable based on review)
+
+## #1109 invariant verification (in PR description)
+
+- [ ] Event-sourcing: events read/written documented per DR
+- [ ] MCP parity: T-03 parity test asserts byte-equivalent blockers across surfaces
+- [ ] Basileus-forward: T-08 explicitly removes a hidden cwd assumption
+- [ ] Capability resolution: no yaml capability fields read at runtime

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "!**/trigger-tests"
   ],
   "scripts": {
-    "build": "tsc && npm run build:binary && npm run build:skills",
+    "build": "npm run codegen:runtimes && tsc && npm run build:binary && npm run build:skills",
     "build:binary": "bun run scripts/build-binary.ts --all",
+    "codegen:runtimes": "bun run scripts/codegen-runtimes.ts",
+    "runtimes:guard": "npm run codegen:runtimes && git diff --exit-code -- src/runtimes/embedded.ts || (echo 'src/runtimes/embedded.ts is out of sync with runtimes/*.yaml — run npm run codegen:runtimes' && exit 1)",
     "generate:agents": "tsx servers/exarchos-mcp/src/agents/generate-agents.ts",
     "build:skills": "npm run generate:agents && node dist/build-skills.js",
     "skills:guard": "node dist/skills-guard.js",

--- a/scripts/build-binary.ts
+++ b/scripts/build-binary.ts
@@ -42,7 +42,10 @@
  */
 import { $ } from 'bun';
 import { mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { TARGETS, type Target } from './build-binary-targets.js';
+import { generateEmbeddedRuntimesModule } from './codegen-runtimes.js';
 
 // Re-export so existing importers of `./build-binary.js` keep working.
 export { TARGETS };
@@ -77,7 +80,32 @@ function getHostTarget(): Target {
   return match;
 }
 
+/**
+ * Codegen `src/runtimes/embedded.ts` BEFORE every `bun build --compile`
+ * call so the bundled artifact always embeds an up-to-date runtimes
+ * module. The compiled binary is the primary install path for
+ * `install-skills` (#1213, #1214) — the YAML files don't ship inside
+ * the bundle, so the bridge MUST resolve runtimes from the embedded
+ * import. Re-running codegen here makes the binary self-consistent
+ * even when a developer skipped `npm run codegen:runtimes` before
+ * hitting `npm run build:binary`. CI's `runtimes:guard` separately
+ * enforces drift on the checked-in copy.
+ */
+function codegenEmbeddedRuntimes(): void {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const root = resolve(here, '..');
+  generateEmbeddedRuntimesModule({
+    runtimesDir: resolve(root, 'runtimes'),
+    outFile: resolve(root, 'src/runtimes/embedded.ts'),
+  });
+}
+
 async function buildOne(target: Target): Promise<void> {
+  // Regenerate the embedded runtimes module before bundling so that
+  // the produced binary cannot ship a stale embedded array. See the
+  // helper's docstring for the full rationale.
+  codegenEmbeddedRuntimes();
+
   const ext = target.os === 'windows' ? '.exe' : '';
   const outfile = `dist/bin/exarchos-${target.os}-${target.arch}${ext}`;
   mkdirSync('dist/bin', { recursive: true });

--- a/scripts/codegen-runtimes.test.ts
+++ b/scripts/codegen-runtimes.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for `scripts/codegen-runtimes.ts` (#1213, #1214).
+ *
+ * These exercise three invariants the embedded-runtimes codegen MUST
+ * uphold so that:
+ *
+ *   1. The compiled binary always has every required runtime present
+ *      (otherwise `install-skills --agent <name>` would fail at
+ *      user-runtime, defeating the point of inlining).
+ *   2. The emitted file is byte-identical across invocations on the
+ *      same input — otherwise `runtimes:guard` (CI) would oscillate.
+ *   3. Every embedded entry round-trips through `RuntimeMapSchema`
+ *      cleanly, so we cannot smuggle malformed data into the binary.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, copyFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  renderEmbeddedRuntimesModule,
+  generateEmbeddedRuntimesModule,
+  sortRuntimes,
+} from './codegen-runtimes.js';
+import { loadAllRuntimes, REQUIRED_RUNTIME_NAMES } from '../src/runtimes/load.js';
+import { RuntimeMapSchema } from '../src/runtimes/types.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const RUNTIMES_DIR = join(REPO_ROOT, 'runtimes');
+
+/** Copy the real `runtimes/*.yaml` into a fresh tmp dir so the codegen
+ *  has a stable input independent of any concurrent test mutating the
+ *  workspace.
+ */
+function makeRuntimesFixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'codegen-runtimes-'));
+  for (const file of readdirSync(RUNTIMES_DIR)) {
+    if (file.endsWith('.yaml') || file.endsWith('.yml')) {
+      copyFileSync(join(RUNTIMES_DIR, file), join(dir, file));
+    }
+  }
+  return dir;
+}
+
+describe('codegen-runtimes', () => {
+  it('EmbeddedRuntimes_AllRequiredNames_Present', () => {
+    const fixture = makeRuntimesFixture();
+    const outFile = join(mkdtempSync(join(tmpdir(), 'codegen-out-')), 'embedded.ts');
+    generateEmbeddedRuntimesModule({ runtimesDir: fixture, outFile });
+
+    const source = readFileSync(outFile, 'utf8');
+    // Coarse-grained presence check: the canonical names appear in the
+    // emitted source. Stricter parse-back happens in the schema test below.
+    for (const name of REQUIRED_RUNTIME_NAMES) {
+      expect(source).toContain(`"name": "${name}"`);
+    }
+  });
+
+  it('EmbeddedRuntimes_OutputDeterministic_TwoRunsByteIdentical', () => {
+    const fixture = makeRuntimesFixture();
+    const outA = join(mkdtempSync(join(tmpdir(), 'codegen-out-a-')), 'embedded.ts');
+    const outB = join(mkdtempSync(join(tmpdir(), 'codegen-out-b-')), 'embedded.ts');
+
+    generateEmbeddedRuntimesModule({ runtimesDir: fixture, outFile: outA });
+    generateEmbeddedRuntimesModule({ runtimesDir: fixture, outFile: outB });
+
+    expect(readFileSync(outA, 'utf8')).toEqual(readFileSync(outB, 'utf8'));
+  });
+
+  it('EmbeddedRuntimes_ParsesViaRuntimeMapSchema_NoFailures', () => {
+    // The render step takes the already-validated array (loadAllRuntimes
+    // ran Zod), but the contract is "every emitted entry round-trips"
+    // — so we re-parse each entry to lock the contract in place against
+    // any future codegen mutation that might strip fields.
+    const runtimes = loadAllRuntimes(RUNTIMES_DIR);
+    expect(runtimes.length).toBeGreaterThan(0);
+
+    const sorted = sortRuntimes(runtimes);
+    for (const rt of sorted) {
+      const parsed = RuntimeMapSchema.safeParse(rt);
+      expect(parsed.success, `runtime ${rt.name} failed schema parse`).toBe(true);
+    }
+  });
+
+  it('EmbeddedRuntimes_SortOrder_RequiredFirstThenExtras', () => {
+    // Synthesize an "extras" runtime to exercise the sort branch even
+    // though the production runtimes/ tree has no extras today.
+    const real = loadAllRuntimes(RUNTIMES_DIR);
+    const extra = { ...real[0]!, name: 'aardvark-extra' };
+    const sorted = sortRuntimes([...real, extra]);
+
+    // First N entries must follow REQUIRED_RUNTIME_NAMES ordering.
+    for (let i = 0; i < REQUIRED_RUNTIME_NAMES.length; i++) {
+      expect(sorted[i]?.name).toBe(REQUIRED_RUNTIME_NAMES[i]);
+    }
+    // The extras tail must be alphabetical, with our synthetic entry
+    // first since it sorts before any other plausible extra.
+    expect(sorted[REQUIRED_RUNTIME_NAMES.length]?.name).toBe('aardvark-extra');
+  });
+
+  it('renderEmbeddedRuntimesModule_EmitsHeaderAndExports', () => {
+    const runtimes = loadAllRuntimes(RUNTIMES_DIR);
+    const source = renderEmbeddedRuntimesModule(runtimes);
+    expect(source).toContain('GENERATED FILE');
+    expect(source).toContain('export const EMBEDDED_RUNTIMES');
+    expect(source).toContain('export function getEmbeddedRuntime');
+  });
+});

--- a/scripts/codegen-runtimes.ts
+++ b/scripts/codegen-runtimes.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env bun
+/**
+ * Codegen for the embedded runtimes module (#1213, #1214).
+ *
+ * Reads `runtimes/*.yaml` at build time, validates every entry against
+ * `RuntimeMapSchema`, and emits a typed TS module
+ * `src/runtimes/embedded.ts` that exports a frozen `EMBEDDED_RUNTIMES`
+ * array. The emitted module is the runtime-side source of truth used by
+ * the install-skills bridge from inside the compiled binary, where the
+ * `runtimes/` directory is not on disk (the YAML files are not part of
+ * the bundled artifact graph).
+ *
+ * ── Why a codegen step instead of a `Bun.embeddedFiles`-style trick ─────
+ * The runtime YAML directory must remain the SINGLE source of truth so
+ * authors edit one file. Embedding YAML *strings* into the binary would
+ * still require a parse + Zod validation at user-runtime — including
+ * `js-yaml` and `zod` in the hot path of every `install-skills`
+ * invocation. Codegen sidesteps both: validation runs at build time and
+ * the emitted module is plain JSON-shaped TypeScript, deeply frozen.
+ *
+ * ── Determinism contract ──────────────────────────────────────────────
+ * The emitted file MUST be a pure function of `runtimes/*.yaml` so
+ * `runtimes:guard` (CI) can re-run codegen and `git diff --exit-code`
+ * the result. We enforce determinism by:
+ *
+ *   1. Sorting runtimes in canonical order: `REQUIRED_RUNTIME_NAMES`
+ *      first (in declaration order), then any extras alphabetically.
+ *   2. Using `JSON.stringify(value, null, 2)` for the inlined object
+ *      literal, which preserves insertion order of string keys per the
+ *      ECMAScript spec — the same invariant that backs the skills:guard
+ *      determinism contract.
+ *
+ * Implements: PR #1213 review-item #4 (CodeRabbit), #1109 §2 (MCP parity).
+ */
+
+import { writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadAllRuntimes, REQUIRED_RUNTIME_NAMES } from '../src/runtimes/load.js';
+import type { RuntimeMap } from '../src/runtimes/types.js';
+
+/**
+ * Sort the loaded runtimes deterministically. `REQUIRED_RUNTIME_NAMES`
+ * provides the canonical ordering for the well-known runtimes; any
+ * extras (loaded with a warning by `loadAllRuntimes`) trail in
+ * alphabetical order so the codegen output is total-ordered without
+ * ever depending on filesystem iteration order.
+ */
+export function sortRuntimes(runtimes: readonly RuntimeMap[]): RuntimeMap[] {
+  const requiredOrder = new Map<string, number>();
+  REQUIRED_RUNTIME_NAMES.forEach((name, idx) => requiredOrder.set(name, idx));
+
+  const required: RuntimeMap[] = [];
+  const extras: RuntimeMap[] = [];
+  for (const rt of runtimes) {
+    if (requiredOrder.has(rt.name)) {
+      required.push(rt);
+    } else {
+      extras.push(rt);
+    }
+  }
+  required.sort((a, b) => {
+    const ai = requiredOrder.get(a.name) ?? 0;
+    const bi = requiredOrder.get(b.name) ?? 0;
+    return ai - bi;
+  });
+  extras.sort((a, b) => a.name.localeCompare(b.name));
+  return [...required, ...extras];
+}
+
+/**
+ * Render the emitted `embedded.ts` source as a single string. Pulled
+ * out so the unit test can compare two invocations for byte-for-byte
+ * determinism without touching disk.
+ */
+export function renderEmbeddedRuntimesModule(runtimes: readonly RuntimeMap[]): string {
+  const sorted = sortRuntimes(runtimes);
+  const inlined = JSON.stringify(sorted, null, 2);
+
+  return `// GENERATED FILE — DO NOT EDIT. Regenerate via \`npm run codegen:runtimes\`.
+// Source: runtimes/*.yaml (validated against RuntimeMapSchema).
+// Drift is enforced by \`npm run runtimes:guard\` (CI).
+import type { RuntimeMap } from './types.js';
+
+const RAW_RUNTIMES = ${inlined} as const;
+
+/**
+ * Deep-freeze a runtime map and any nested objects so the consumer
+ * cannot mutate the embedded copy. \`Object.freeze\` is shallow, but the
+ * shape is JSON-flat (objects + arrays + primitives), so a recursive
+ * walk is sufficient.
+ */
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    deepFreeze((value as Record<string, unknown>)[key]);
+  }
+  return Object.freeze(value);
+}
+
+/**
+ * Frozen array of validated \`RuntimeMap\` entries embedded into the
+ * compiled binary. The bridge in
+ * \`servers/exarchos-mcp/src/cli-commands/install-skills-bridge.js\`
+ * prefers this array over reading \`runtimes/*.yaml\` from disk so
+ * \`install-skills\` works inside the single-file binary, where the
+ * YAML directory does not ship.
+ *
+ * Sorted by canonical \`REQUIRED_RUNTIME_NAMES\` order, then any extras
+ * alphabetically — see \`scripts/codegen-runtimes.ts\` for the contract.
+ */
+export const EMBEDDED_RUNTIMES: readonly RuntimeMap[] = Object.freeze(
+  RAW_RUNTIMES.map((r) => deepFreeze(r as unknown as RuntimeMap)),
+) as readonly RuntimeMap[];
+
+/**
+ * Convenience lookup for a single embedded runtime by name. Returns
+ * \`undefined\` when no embedded runtime matches — callers decide
+ * whether to throw or fall back. Mirrors the \`findRuntime()\` helper
+ * in \`src/install-skills.ts\` so call-site behavior is identical
+ * regardless of whether the runtimes came from FS or the embedded
+ * module.
+ */
+export function getEmbeddedRuntime(name: string): RuntimeMap | undefined {
+  return EMBEDDED_RUNTIMES.find((r) => r.name === name);
+}
+`;
+}
+
+/**
+ * Resolve the repo root from this file's location. The codegen script
+ * lives at `scripts/codegen-runtimes.ts`, so the repo root is one
+ * directory above. We use `import.meta.url` rather than `process.cwd()`
+ * so the script is robust against being invoked from a sibling
+ * directory.
+ */
+function repoRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..');
+}
+
+/**
+ * Load every runtime YAML in `runtimesDir`, render the embedded module,
+ * and write it to `outFile`. Exported so tests can drive the same code
+ * path against a temp directory.
+ */
+export function generateEmbeddedRuntimesModule(opts: {
+  runtimesDir: string;
+  outFile: string;
+}): void {
+  const runtimes = loadAllRuntimes(opts.runtimesDir);
+  const source = renderEmbeddedRuntimesModule(runtimes);
+  writeFileSync(opts.outFile, source, 'utf8');
+}
+
+// Self-invocation guard: only run the side-effecting codegen when this
+// file is the entry point. Importing it from a test must NOT regenerate
+// `src/runtimes/embedded.ts` against the real repo.
+if (import.meta.main) {
+  const root = repoRoot();
+  generateEmbeddedRuntimesModule({
+    runtimesDir: resolve(root, 'runtimes'),
+    outFile: resolve(root, 'src/runtimes/embedded.ts'),
+  });
+  console.log(`Wrote src/runtimes/embedded.ts`);
+}

--- a/servers/exarchos-mcp/package-lock.json
+++ b/servers/exarchos-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lvlup-sw/exarchos-mcp",
-  "version": "2.9.0-rc.1",
+  "version": "2.9.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lvlup-sw/exarchos-mcp",
-      "version": "2.9.0-rc.1",
+      "version": "2.9.0-rc.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "commander": "^14.0.3",

--- a/servers/exarchos-mcp/src/adapters/cli.test.ts
+++ b/servers/exarchos-mcp/src/adapters/cli.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { fileURLToPath } from 'node:url';
 import type { ToolResult } from '../format.js';
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
@@ -673,9 +674,11 @@ function findHostBinary(): string | null {
   if (!platform) return null;
   const ext = platform === 'windows' ? '.exe' : '';
   // cli.test.ts lives at servers/exarchos-mcp/src/adapters/, so the repo
-  // root is four directories up.
+  // root is four directories up. CodeRabbit #3 (#1213): use fileURLToPath
+  // not URL().pathname — on Windows the latter yields `/C:/...` (leading
+  // slash) which breaks path.resolve.
   const repoRoot = path.resolve(
-    path.dirname(new URL(import.meta.url).pathname),
+    path.dirname(fileURLToPath(import.meta.url)),
     '..',
     '..',
     '..',

--- a/servers/exarchos-mcp/src/adapters/cli.test.ts
+++ b/servers/exarchos-mcp/src/adapters/cli.test.ts
@@ -566,3 +566,162 @@ describe('commanderErrorToResult mapping table (F-024-CMDR)', () => {
     expect(exitCode).toBe(CLI_EXIT_CODES.UNCAUGHT_EXCEPTION);
   });
 });
+
+// ─── T-16 / DR-7: install-skills CLI subcommand ──────────────────────────────
+//
+// `exarchos install-skills [--agent <name>]` is documented in README.md and
+// `documentation/guide/installation.md` but was never wired into the
+// Commander program in v2.9. T-16 ships the wiring as a single isolated
+// commit so it's easy to revert if the surface needs to grow.
+//
+// This subcommand is intentionally CLI-only — `installSkills()` writes to
+// the local filesystem (e.g. `~/.claude/skills/`) and shells out to
+// `npx skills add`, neither of which makes sense over an MCP transport.
+// The help text carries an explicit `cli-only` annotation so an agent
+// reading the schema/help output knows not to attempt the equivalent over
+// the MCP surface.
+
+vi.mock('../cli-commands/install-skills-bridge.js', () => ({
+  runInstallSkills: vi.fn(async () => {}),
+}));
+
+describe('install-skills subcommand (T-16, DR-7)', () => {
+  let ctx: DispatchContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = createTestContext();
+  });
+
+  it('cli_InstallSkillsSubcommand_RegisteredInRegistry', () => {
+    // The subcommand must be present on the Commander program so that
+    // `exarchos install-skills` resolves to a real action handler instead
+    // of producing `error: unknown command 'install-skills'`. We assert
+    // both the registration and the documented `--agent` flag — the two
+    // pieces a user (or agent) sees from `--help`.
+    const program = buildCli(ctx);
+    const installSkillsCmd = program.commands.find(
+      (c) => c.name() === 'install-skills',
+    );
+    expect(installSkillsCmd).toBeDefined();
+    const optionFlags = installSkillsCmd?.options.map((o) => o.flags) ?? [];
+    expect(optionFlags.some((f) => f.includes('--agent'))).toBe(true);
+  });
+
+  it('cli_InstallSkills_HelpTextSaysCliOnly', () => {
+    // Surface annotation: the `cli-only` marker tells agent callers that
+    // this subcommand has no MCP equivalent. Putting it in the description
+    // (not just a code comment) means it shows up in `--help` output and
+    // any future schema introspection.
+    const program = buildCli(ctx);
+    const installSkillsCmd = program.commands.find(
+      (c) => c.name() === 'install-skills',
+    );
+    expect(installSkillsCmd).toBeDefined();
+    const helpText = installSkillsCmd?.description() ?? '';
+    expect(helpText.toLowerCase()).toContain('cli-only');
+  });
+
+  it('cli_InstallSkillsSubcommand_DispatchesToBridge', async () => {
+    // Smoke check on the wiring: parsing the subcommand should reach the
+    // bridge module (which encapsulates the cross-package import of the
+    // root `installSkills()` implementation). The bridge is mocked above
+    // so no real spawn / IO happens during this test.
+    const program = buildCli(ctx);
+    await program.parseAsync([
+      'node',
+      'exarchos',
+      'install-skills',
+      '--agent',
+      'claude',
+    ]);
+
+    const { runInstallSkills } = await import(
+      '../cli-commands/install-skills-bridge.js'
+    );
+    expect(runInstallSkills).toHaveBeenCalledTimes(1);
+    expect(runInstallSkills).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: 'claude' }),
+    );
+  });
+});
+
+// ─── T-16 / DR-7: install-skills binary smoke (conditional) ──────────────────
+//
+// Cheap end-to-end probe against the compiled binary at
+// `dist/bin/exarchos-<os>-<arch>`. Skipped when the binary is absent so
+// developers without a local build don't see a phantom failure; CI runs
+// `npm run build` before tests, so the binary IS present there.
+//
+// We assert only on `install-skills --help` (not a full invocation) because
+// the underlying `npx skills add` is interactive and cannot run to
+// completion under vitest spawn without TTY allocation. Reaching `--help`
+// proves Commander registered the subcommand inside the bundled binary
+// and that the `cli-only` annotation survives through `bun build --compile`.
+// The pre-T-16 binary failed this with `error: unknown command 'install-skills'`.
+
+function findHostBinary(): string | null {
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  const platform =
+    process.platform === 'darwin'
+      ? 'darwin'
+      : process.platform === 'linux'
+        ? 'linux'
+        : process.platform === 'win32'
+          ? 'windows'
+          : null;
+  if (!platform) return null;
+  const ext = platform === 'windows' ? '.exe' : '';
+  // cli.test.ts lives at servers/exarchos-mcp/src/adapters/, so the repo
+  // root is four directories up.
+  const repoRoot = path.resolve(
+    path.dirname(new URL(import.meta.url).pathname),
+    '..',
+    '..',
+    '..',
+    '..',
+  );
+  const candidate = path.join(repoRoot, 'dist', 'bin', `exarchos-${platform}-${arch}${ext}`);
+  return fs.existsSync(candidate) ? candidate : null;
+}
+
+const SMOKE_BINARY = findHostBinary();
+
+describe.skipIf(!SMOKE_BINARY)(
+  'install-skills binary smoke (T-16, DR-7)',
+  () => {
+    let homeTmp: string;
+    let stateTmp: string;
+
+    beforeEach(() => {
+      homeTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-T16-home-'));
+      stateTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-T16-state-'));
+    });
+
+    afterEach(() => {
+      // Best-effort cleanup. Errors are swallowed because the smoke test's
+      // value is in the spawn assertion, not in tempdir hygiene; CI will
+      // GC the runner anyway.
+      try {
+        fs.rmSync(homeTmp, { recursive: true, force: true });
+        fs.rmSync(stateTmp, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    });
+
+    it('cli_InstallSkillsBinary_HelpAgainstTempHome_ExitsZero', async () => {
+      if (!SMOKE_BINARY) throw new Error('binary check should have skipped');
+      const { spawnSync } = await import('node:child_process');
+      const result = spawnSync(SMOKE_BINARY, ['install-skills', '--help'], {
+        encoding: 'utf-8',
+        timeout: 30_000,
+        env: { ...process.env, HOME: homeTmp, WORKFLOW_STATE_DIR: stateTmp },
+      });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('install-skills');
+      expect(result.stdout).toContain('--agent');
+      expect(result.stdout.toLowerCase()).toContain('cli-only');
+    });
+  },
+);

--- a/servers/exarchos-mcp/src/adapters/cli.ts
+++ b/servers/exarchos-mcp/src/adapters/cli.ts
@@ -623,6 +623,64 @@ export function buildCli(ctx: DispatchContext): Command {
     }
   });
 
+  // ─── Top-level `exarchos install-skills` command (T-16, DR-7, #1201) ────
+  //
+  // Bridges the documented `exarchos install-skills [--agent <name>]`
+  // surface (README.md "Install Skills" section, `documentation/guide/
+  // installation.md`) to the `installSkills()` implementation in the
+  // root `src/install-skills.ts` module.
+  //
+  // CLI-only by design: the underlying installer writes to the local
+  // filesystem (e.g. `~/.claude/skills/`) and shells out to
+  // `npx skills add`, neither of which makes sense over an MCP stdio
+  // transport. The `cli-only` annotation in the description is part
+  // of the surface contract — agent callers reading `--help` (or any
+  // future schema-introspection output) see immediately that there is
+  // no MCP equivalent.
+  //
+  // The bridge module (`cli-commands/install-skills-bridge.js`) owns
+  // the cross-package import of `installSkills()` because the MCP
+  // server's tsc `rootDir: "./src"` would otherwise reject the path
+  // with TS6059. Authored as JS (tsc `allowJs: false`) so the static
+  // imports survive type-checking; bun's `--compile` bundler still
+  // follows them at build time.
+  //
+  // Exit-code mapping (DR-3 contract):
+  //   - Success                      → SUCCESS (exit 0)
+  //   - `npx skills add` non-zero    → forwarded child code (`exitCode`
+  //                                    on the thrown InstallSkillsError)
+  //   - Any other thrown error       → UNCAUGHT_EXCEPTION (exit 3)
+  program
+    .command('install-skills')
+    .description(
+      'Install the Exarchos skills bundle for a target agent runtime (cli-only — no MCP equivalent)',
+    )
+    .option(
+      '--agent <name>',
+      'Target agent runtime (claude, codex, opencode, copilot, cursor, generic). Auto-detected when omitted.',
+    )
+    .action(async (opts: { agent?: string }) => {
+      try {
+        const { runInstallSkills } = await import(
+          '../cli-commands/install-skills-bridge.js'
+        );
+        await runInstallSkills({ agent: opts.agent });
+        process.exitCode = CLI_EXIT_CODES.SUCCESS;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const candidateExitCode =
+          typeof err === 'object' && err !== null && 'exitCode' in err
+            ? (err as { exitCode?: unknown }).exitCode
+            : undefined;
+        const exitCode =
+          typeof candidateExitCode === 'number'
+            ? candidateExitCode
+            : CLI_EXIT_CODES.UNCAUGHT_EXCEPTION;
+        printError({ code: 'INSTALL_SKILLS_FAILED', message });
+        process.exitCode = exitCode;
+      }
+    });
+
   return program;
 }
 

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
@@ -39,6 +39,23 @@ hooks:
 
 You are a TDD implementer agent working in an isolated worktree.
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
 ## Worktree Verification
 Before making ANY file changes:
 1. Run: `pwd`

--- a/servers/exarchos-mcp/src/agents/adapters/cursor.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/cursor.test.ts
@@ -120,16 +120,24 @@ describe('CursorAdapter', () => {
   // the prose is absent.
   // ────────────────────────────────────────────────────────────────────────
 
-  it('CursorAdapter_LowerSpec_StripsHardWorktreeGuard_ForAdvisoryIsolation', () => {
+  it('CursorAdapter_LowerSpec_StripsHygieneButRetainsVerification_ForAdvisoryIsolation', () => {
+    // CodeRabbit #1213/#2: the lighter `## Worktree Verification` startup
+    // STOP block is retained for cursor (advisory isolation still benefits
+    // from a sanity check), while the heavier `## Worktree Hygiene`
+    // per-command rule block IS stripped (its rules are unworkable when
+    // the runtime doesn't actually place the agent inside `.worktrees/`).
     expect(IMPLEMENTER.systemPrompt).toMatch(/## Worktree Verification/);
+    expect(IMPLEMENTER.systemPrompt).toMatch(/## Worktree Hygiene/);
     expect(IMPLEMENTER.systemPrompt).toMatch(/STOP and report error/);
 
     const { contents } = CursorAdapter.lowerSpec(IMPLEMENTER);
     const { body } = splitFrontmatter(contents);
 
-    expect(body).not.toMatch(/## Worktree Verification/);
+    // Verification block is RETAINED.
+    expect(body).toMatch(/## Worktree Verification/);
+    expect(body).toMatch(/STOP and report error/);
+    // Hygiene block is STRIPPED.
     expect(body).not.toMatch(/## Worktree Hygiene/);
-    expect(body).not.toMatch(/STOP and report error/);
 
     expect(body).toContain('TDD implementer agent');
     expect(body).toContain('## Task');
@@ -137,15 +145,18 @@ describe('CursorAdapter', () => {
     expect(body).toContain('## Completion Report');
   });
 
-  it('CursorAdapter_LowerSpec_StripsHardWorktreeGuard_FromScaffolder', () => {
+  it('CursorAdapter_LowerSpec_RetainsVerificationBlock_FromScaffolder', () => {
+    // Same retention contract for SCAFFOLDER: verification stays, hygiene
+    // (if any) goes.
     expect(SCAFFOLDER.systemPrompt).toMatch(/## Worktree Verification/);
     expect(SCAFFOLDER.systemPrompt).toMatch(/STOP and report error/);
 
     const { contents } = CursorAdapter.lowerSpec(SCAFFOLDER);
     const { body } = splitFrontmatter(contents);
 
-    expect(body).not.toMatch(/## Worktree Verification/);
-    expect(body).not.toMatch(/STOP and report error/);
+    expect(body).toMatch(/## Worktree Verification/);
+    expect(body).toMatch(/STOP and report error/);
+    expect(body).not.toMatch(/## Worktree Hygiene/);
 
     expect(body).toContain('scaffolder agent');
     expect(body).toContain('## Task');

--- a/servers/exarchos-mcp/src/agents/adapters/cursor.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/cursor.ts
@@ -63,31 +63,37 @@ interface CursorFrontmatter {
 }
 
 /**
- * Strip the hard "STOP if pwd doesn't contain `.worktrees/`" worktree
- * guard from a systemPrompt when the target runtime treats
- * `isolation:worktree` as advisory rather than native (Cursor's case
- * today — see CURSOR_SUPPORT_LEVELS).
+ * Strip the heavy `## Worktree Hygiene` per-command rule block from a
+ * systemPrompt when the target runtime treats `isolation:worktree` as
+ * advisory rather than native (Cursor's case today — see
+ * CURSOR_SUPPORT_LEVELS).
  *
- * The guard lives in two known H2 subsections in the canonical specs
- * (`definitions.ts`):
- *   - `## Worktree Verification` — the startup STOP block
- *   - `## Worktree Hygiene (MANDATORY ...)` — the extended per-command rules
+ * CodeRabbit #1213/#2: the lighter `## Worktree Verification` startup
+ * STOP block IS retained for cursor. Operators on advisory-isolation
+ * runtimes still need an explicit "verify your cwd before editing"
+ * checkpoint — without it, a subagent that boots in the parent repo
+ * silently writes to the wrong directory. The cursor adapter previously
+ * stripped both blocks for symmetry, but the verification block has
+ * value even under advisory isolation (it's a sanity check, not a hard
+ * runtime invariant).
  *
- * Both are predicated on the runtime actually placing the agent inside
- * a `.worktrees/` path; under advisory isolation that assumption fails
- * and the guards would always trip.
+ * The hygiene block (per-command `git -C` + `npm --prefix` rules) IS
+ * still stripped — it depends on the runtime actually placing the
+ * agent inside `.worktrees/`, and on advisory isolation that
+ * assumption fails and the rules would force an unworkable command
+ * style.
  *
- * The match is conservative: anchored on the exact H2 headings and
- * stops at the next H2 (or end of string). If a future spec drops these
- * sections or renames the headings, this is a silent no-op rather than
+ * The match is conservative: anchored on the exact H2 heading and
+ * stops at the next H2 (or end of string). If a future spec drops the
+ * section or renames the heading, this is a silent no-op rather than
  * an over-eager strip that clobbers unrelated content.
  *
  * The source `definitions.ts` IMPLEMENTER/SCAFFOLDER specs keep the
- * guards verbatim (Claude and other native-isolation runtimes still
- * need them).
+ * full guard verbatim (Claude and other native-isolation runtimes
+ * still need both blocks).
  */
 function stripAdvisoryWorktreeGuard(systemPrompt: string): string {
-  const pattern = /(?:^|\n)## Worktree (?:Verification|Hygiene)[^\n]*\n[\s\S]*?(?=\n## |\n?$)/g;
+  const pattern = /(?:^|\n)## Worktree Hygiene[^\n]*\n[\s\S]*?(?=\n## |\n?$)/g;
   return systemPrompt.replace(pattern, '');
 }
 

--- a/servers/exarchos-mcp/src/agents/definitions.test.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.test.ts
@@ -109,6 +109,31 @@ describe('AgentSpec capability declarations', () => {
     expect(bad).toBeDefined();
   });
 
+  // DR-2 (T-08, #1204): IMPLEMENTER prompt must include an explicit
+  // "Working Directory Setup" recovery step BEFORE the verification block.
+  // Some runtimes (Copilot CLI, generic MCP) spawn subagents in the parent
+  // repo cwd. Without an explicit `cd <worktree>` first, the verification
+  // `pwd | grep .worktrees` fails on turn 0 and the agent aborts before
+  // doing any work. The recovery step makes the prompt robust across all
+  // runtime environments — basileus-forward (#1109 Constraint 3).
+  it('ImplementerSpec_PromptBody_IncludesCdIntoWorktreeBeforeVerification', () => {
+    const prompt = IMPLEMENTER.systemPrompt;
+
+    // The new section header must be present.
+    const wdSetupIndex = prompt.indexOf('## Working Directory Setup');
+    expect(wdSetupIndex, 'IMPLEMENTER systemPrompt must include "## Working Directory Setup"').toBeGreaterThan(-1);
+
+    // It must come BEFORE the verification block, not after.
+    const verificationIndex = prompt.indexOf('## Worktree Verification');
+    expect(verificationIndex).toBeGreaterThan(-1);
+    expect(wdSetupIndex).toBeLessThan(verificationIndex);
+
+    // Both bash and PowerShell entry forms must be available.
+    const setupSection = prompt.slice(wdSetupIndex, verificationIndex);
+    expect(setupSection).toMatch(/\bcd\b/);
+    expect(setupSection).toMatch(/Set-Location/);
+  });
+
   // Issue #1192 Item 4 (T26): every spec with a post-test validationRule must
   // anchor its command to the git toplevel. Bare `npm run test:run` would
   // execute against whatever shell cwd the agent has drifted to — anchoring

--- a/servers/exarchos-mcp/src/agents/definitions.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.ts
@@ -25,6 +25,23 @@ Implementation task requiring test-first development triggers the implementer ag
   color: 'blue',
   systemPrompt: `You are a TDD implementer agent working in an isolated worktree.
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's \`isolation: "worktree"\`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+\`\`\`bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+\`\`\`
+\`\`\`powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+\`\`\`
+
+Where \`<absolute worktree path>\` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
 ## Worktree Verification
 Before making ANY file changes:
 1. Run: \`pwd\`

--- a/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.d.ts
+++ b/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.d.ts
@@ -8,7 +8,42 @@
  * gives `cli.ts` a typed surface for the dynamic import in the
  * `install-skills` action handler.
  *
- * Implements: DR-7 (install-skills CLI surface), T-16 (#1201).
+ * To preserve the rootDir invariant we DO NOT use `import type` here
+ * to reach outside `servers/exarchos-mcp/src/`. The `RuntimeMap` and
+ * `InstallSkillsOpts` shapes used in the test-injection points are
+ * declared locally with the loosest accurate signatures (`unknown`
+ * arrays, `unknown` opts), which is sufficient for the call-site
+ * `cli.ts` and lets the bridge tests pass typed mocks via
+ * `as unknown as <type>` casts.
+ *
+ * Implements: DR-7 (install-skills CLI surface), T-16 (#1201),
+ *             #1213 review-item #4 reversal, #1214.
  */
 
-export function runInstallSkills(opts: { agent?: string }): Promise<void>;
+/**
+ * Optional injection points for tests. Production code calls
+ * `runInstallSkills(opts)` without the second argument.
+ */
+export interface RunInstallSkillsDeps {
+  env?: NodeJS.ProcessEnv;
+  loadFromDisk?: (dir: string) => readonly unknown[];
+  embedded?: readonly unknown[];
+  installer?: (opts: unknown) => Promise<void>;
+}
+
+/**
+ * `EXARCHOS_RUNTIMES_FROM_DISK=1` toggle predicate. Exported so the
+ * bridge tests can assert on the same predicate the production path
+ * uses without re-checking the literal env var name in two places.
+ */
+export function shouldLoadFromDisk(env?: NodeJS.ProcessEnv): boolean;
+
+/**
+ * Run the `install-skills` CLI subcommand. Resolves the runtime map
+ * array from `EMBEDDED_RUNTIMES` by default; reads `runtimes/*.yaml`
+ * from disk when `EXARCHOS_RUNTIMES_FROM_DISK=1`.
+ */
+export function runInstallSkills(
+  opts: { agent?: string },
+  deps?: RunInstallSkillsDeps,
+): Promise<void>;

--- a/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.d.ts
+++ b/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Type declarations for the JavaScript bridge module
+ * `install-skills-bridge.js`.
+ *
+ * The bridge is authored in JS so it can do cross-package static
+ * imports without tripping tsc's `rootDir: "./src"` constraint
+ * (see the bridge file's header for the full rationale). This `.d.ts`
+ * gives `cli.ts` a typed surface for the dynamic import in the
+ * `install-skills` action handler.
+ *
+ * Implements: DR-7 (install-skills CLI surface), T-16 (#1201).
+ */
+
+export function runInstallSkills(opts: { agent?: string }): Promise<void>;

--- a/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.js
+++ b/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.js
@@ -1,18 +1,19 @@
 /**
  * Bridge module for the `install-skills` CLI subcommand (T-16, #1201).
  *
- * Imports `installSkills()` and `loadAllRuntimes()` from the workspace-root
- * `src/` tree, which lives outside the MCP server's tsc `rootDir: "./src"`.
- * Authored as plain JavaScript (not TypeScript) so tsc — which has
- * `allowJs: false` — never resolves these specifiers and therefore never
- * emits TS6059 ("file is not under rootDir"). Bun's `--compile` bundler
- * ignores tsc settings and follows the static imports normally, so the
- * installer code (and its `@inquirer/prompts` lazy import) end up inside
- * the single-file binary.
+ * Imports `installSkills()`, `loadAllRuntimes()`, and the codegen-emitted
+ * `EMBEDDED_RUNTIMES` from the workspace-root `src/` tree, which lives
+ * outside the MCP server's tsc `rootDir: "./src"`. Authored as plain
+ * JavaScript (not TypeScript) so tsc — which has `allowJs: false` —
+ * never resolves these specifiers and therefore never emits TS6059
+ * ("file is not under rootDir"). Bun's `--compile` bundler ignores tsc
+ * settings and follows the static imports normally, so the installer
+ * code (and its `@inquirer/prompts` lazy import) end up inside the
+ * single-file binary.
  *
  * Why a JS bridge instead of a runtime dynamic import in `cli.ts`:
- *   - A `string`-typed dynamic import would hide the specifier from bun's
- *     static analysis and break the compiled binary at user-runtime
+ *   - A `string`-typed dynamic import would hide the specifier from
+ *     bun's static analysis and break the compiled binary at user-runtime
  *     ("Cannot find module"). bun must see the import statically to
  *     bundle it.
  *   - Promoting the bridge to `.ts` would require enabling Project
@@ -20,26 +21,43 @@
  *     larger refactor. T-16 deliberately ships in a single isolated
  *     commit; the bridge can move to `.ts` later.
  *
- * Runtimes-directory resolution: `loadAllRuntimes` reads YAML from a
- * directory path. For a local-checkout invocation we resolve the path
- * relative to this bridge's location (walk up to the workspace root).
- * For the compiled binary, a future commit can swap to an embedded
- * codegen module — `installSkills()` already accepts the `runtimes`
- * array via injection, so the swap is local to this file.
+ * ── Runtimes resolution policy (#1213, #1214) ─────────────────────────
+ * Compiled binary is the PRIMARY install path. The `runtimes/` directory
+ * does not ship inside `bun build --compile` output (YAML files aren't
+ * part of the static module graph), so reading them from disk at
+ * user-runtime fails with "Runtimes directory not found". Per #1109 §2
+ * (MCP parity) and the axiom backend-quality "no runtime FS dependency
+ * on the primary path" principle, we inject the runtime map array via
+ * a build-time codegen step (`scripts/codegen-runtimes.ts`) that emits
+ * `src/runtimes/embedded.ts`. Bun statically follows that import and
+ * bakes the validated, frozen `EMBEDDED_RUNTIMES` array into the binary.
  *
- * Implements: DR-7 (install-skills CLI surface), T-16 (#1201).
+ * Resolution order:
+ *   - Default (production, including the compiled binary): use
+ *     `EMBEDDED_RUNTIMES` directly. Zero filesystem dependency.
+ *   - Override (`EXARCHOS_RUNTIMES_FROM_DISK=1`): load from
+ *     `runtimes/*.yaml` relative to this bridge's location. Used only
+ *     for dev hot-reload — when an author edits a YAML file and wants
+ *     to skip the codegen step. CI's `runtimes:guard` enforces drift.
+ *
+ * Implements: DR-7 (install-skills CLI surface), T-16 (#1201),
+ *             #1213 review-item #4 reversal, #1214.
  */
 
 import { installSkills } from '../../../../src/install-skills.js';
 import { loadAllRuntimes } from '../../../../src/runtimes/load.js';
+import { EMBEDDED_RUNTIMES } from '../../../../src/runtimes/embedded.js';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 /**
  * Walk from this bridge up to the workspace root. Bridge lives at
- * `servers/exarchos-mcp/src/cli-commands/` so the workspace root is four
- * directories above. The runtimes YAML directory sits directly under
- * the workspace root.
+ * `servers/exarchos-mcp/src/cli-commands/` so the workspace root is
+ * four directories above. The runtimes YAML directory sits directly
+ * under the workspace root.
+ *
+ * Only used when `EXARCHOS_RUNTIMES_FROM_DISK=1` selects the FS path
+ * (dev hot-reload). The compiled binary never reaches this function.
  *
  * @returns {string}
  */
@@ -49,10 +67,44 @@ function resolveRuntimesDir() {
 }
 
 /**
+ * Decide whether to read runtimes from disk. Pulled into a named
+ * helper so the bridge tests can spy on the env var without
+ * duplicating the string literal across call sites.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {boolean}
+ */
+export function shouldLoadFromDisk(env = process.env) {
+  return env.EXARCHOS_RUNTIMES_FROM_DISK === '1';
+}
+
+/**
+ * @typedef {Object} RunInstallSkillsDeps
+ * @property {NodeJS.ProcessEnv} [env]
+ *   Process env override (test injection).
+ * @property {(dir: string) => import('../../../../src/runtimes/types.js').RuntimeMap[]} [loadFromDisk]
+ *   FS loader override (test injection). Defaults to `loadAllRuntimes`.
+ * @property {readonly import('../../../../src/runtimes/types.js').RuntimeMap[]} [embedded]
+ *   Embedded array override (test injection). Defaults to
+ *   `EMBEDDED_RUNTIMES` from the codegen-emitted module.
+ * @property {(opts: import('../../../../src/install-skills.js').InstallSkillsOpts) => Promise<void>} [installer]
+ *   Installer override (test injection). Defaults to `installSkills`.
+ */
+
+/**
  * @param {{ agent?: string }} opts
+ * @param {RunInstallSkillsDeps} [deps]
  * @returns {Promise<void>}
  */
-export async function runInstallSkills(opts) {
-  const runtimes = loadAllRuntimes(resolveRuntimesDir());
-  await installSkills({ agent: opts.agent, runtimes });
+export async function runInstallSkills(opts, deps = {}) {
+  const env = deps.env ?? process.env;
+  const loadFromDisk = deps.loadFromDisk ?? loadAllRuntimes;
+  const embedded = deps.embedded ?? EMBEDDED_RUNTIMES;
+  const installer = deps.installer ?? installSkills;
+
+  const runtimes = shouldLoadFromDisk(env)
+    ? loadFromDisk(resolveRuntimesDir())
+    : embedded;
+
+  await installer({ agent: opts.agent, runtimes });
 }

--- a/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.js
+++ b/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.js
@@ -1,0 +1,58 @@
+/**
+ * Bridge module for the `install-skills` CLI subcommand (T-16, #1201).
+ *
+ * Imports `installSkills()` and `loadAllRuntimes()` from the workspace-root
+ * `src/` tree, which lives outside the MCP server's tsc `rootDir: "./src"`.
+ * Authored as plain JavaScript (not TypeScript) so tsc — which has
+ * `allowJs: false` — never resolves these specifiers and therefore never
+ * emits TS6059 ("file is not under rootDir"). Bun's `--compile` bundler
+ * ignores tsc settings and follows the static imports normally, so the
+ * installer code (and its `@inquirer/prompts` lazy import) end up inside
+ * the single-file binary.
+ *
+ * Why a JS bridge instead of a runtime dynamic import in `cli.ts`:
+ *   - A `string`-typed dynamic import would hide the specifier from bun's
+ *     static analysis and break the compiled binary at user-runtime
+ *     ("Cannot find module"). bun must see the import statically to
+ *     bundle it.
+ *   - Promoting the bridge to `.ts` would require enabling Project
+ *     References across the root and server tsconfigs, which is a
+ *     larger refactor. T-16 deliberately ships in a single isolated
+ *     commit; the bridge can move to `.ts` later.
+ *
+ * Runtimes-directory resolution: `loadAllRuntimes` reads YAML from a
+ * directory path. For a local-checkout invocation we resolve the path
+ * relative to this bridge's location (walk up to the workspace root).
+ * For the compiled binary, a future commit can swap to an embedded
+ * codegen module — `installSkills()` already accepts the `runtimes`
+ * array via injection, so the swap is local to this file.
+ *
+ * Implements: DR-7 (install-skills CLI surface), T-16 (#1201).
+ */
+
+import { installSkills } from '../../../../src/install-skills.js';
+import { loadAllRuntimes } from '../../../../src/runtimes/load.js';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+/**
+ * Walk from this bridge up to the workspace root. Bridge lives at
+ * `servers/exarchos-mcp/src/cli-commands/` so the workspace root is four
+ * directories above. The runtimes YAML directory sits directly under
+ * the workspace root.
+ *
+ * @returns {string}
+ */
+function resolveRuntimesDir() {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', '..', 'runtimes');
+}
+
+/**
+ * @param {{ agent?: string }} opts
+ * @returns {Promise<void>}
+ */
+export async function runInstallSkills(opts) {
+  const runtimes = loadAllRuntimes(resolveRuntimesDir());
+  await installSkills({ agent: opts.agent, runtimes });
+}

--- a/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.test.ts
+++ b/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for `install-skills-bridge.js` runtimes resolution policy
+ * (#1213 review-item #4 reversal, #1214).
+ *
+ * The bridge MUST prefer `EMBEDDED_RUNTIMES` by default — otherwise
+ * the compiled binary fails at user-runtime with "Runtimes directory
+ * not found" because the YAML files are not part of the bundled
+ * artifact graph. The `EXARCHOS_RUNTIMES_FROM_DISK=1` override exists
+ * solely for dev hot-reload; CI's `runtimes:guard` enforces drift.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { runInstallSkills, shouldLoadFromDisk } from './install-skills-bridge.js';
+import { EMBEDDED_RUNTIMES } from '../../../../src/runtimes/embedded.js';
+import { loadAllRuntimes } from '../../../../src/runtimes/load.js';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Walk up from servers/exarchos-mcp/src/cli-commands → repo root.
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const RUNTIMES_DIR = resolve(REPO_ROOT, 'runtimes');
+
+describe('install-skills-bridge', () => {
+  it('Bridge_Default_UsesEmbeddedRuntimes', async () => {
+    const installer = vi.fn(async () => {});
+    await runInstallSkills(
+      { agent: 'generic' },
+      {
+        env: {},
+        installer,
+        loadFromDisk: vi.fn(() => {
+          throw new Error('FS path must not run when env var is unset');
+        }),
+      },
+    );
+    expect(installer).toHaveBeenCalledTimes(1);
+    const callArg = installer.mock.calls[0]?.[0];
+    expect(callArg?.runtimes).toBe(EMBEDDED_RUNTIMES);
+  });
+
+  it('Bridge_DiskFlagSet_LoadsFromFilesystem', async () => {
+    const installer = vi.fn(async () => {});
+    const fakeRuntimes = [{ name: 'fake' } as never];
+    const loadFromDisk = vi.fn(() => fakeRuntimes);
+    await runInstallSkills(
+      { agent: 'fake' },
+      {
+        env: { EXARCHOS_RUNTIMES_FROM_DISK: '1' } as NodeJS.ProcessEnv,
+        installer,
+        loadFromDisk,
+      },
+    );
+    expect(loadFromDisk).toHaveBeenCalledTimes(1);
+    expect(installer).toHaveBeenCalledTimes(1);
+    const callArg = installer.mock.calls[0]?.[0];
+    expect(callArg?.runtimes).toBe(fakeRuntimes);
+  });
+
+  it('Bridge_EmbeddedAndDisk_ProduceIdenticalRuntimes', () => {
+    const fromDisk = loadAllRuntimes(RUNTIMES_DIR);
+    const fromEmbedded = [...EMBEDDED_RUNTIMES];
+
+    // Order may differ (FS yields alphabetical via readdirSync().sort();
+    // codegen yields REQUIRED_RUNTIME_NAMES order). Compare by name set
+    // and by per-name field equality.
+    const diskByName = new Map(fromDisk.map((r) => [r.name, r] as const));
+    const embeddedByName = new Map(fromEmbedded.map((r) => [r.name, r] as const));
+
+    expect(new Set(diskByName.keys())).toEqual(new Set(embeddedByName.keys()));
+
+    for (const [name, diskRt] of diskByName) {
+      const embeddedRt = embeddedByName.get(name);
+      expect(embeddedRt, `embedded missing ${name}`).toBeDefined();
+      // Deep-equal across the entire validated shape — the codegen
+      // round-trip must not drop or transform any field.
+      expect(embeddedRt).toEqual(diskRt);
+    }
+  });
+
+  it('shouldLoadFromDisk_OnlyTrueWhenEnvVarIsExactlyOne', () => {
+    expect(shouldLoadFromDisk({})).toBe(false);
+    expect(shouldLoadFromDisk({ EXARCHOS_RUNTIMES_FROM_DISK: '0' } as NodeJS.ProcessEnv)).toBe(false);
+    expect(shouldLoadFromDisk({ EXARCHOS_RUNTIMES_FROM_DISK: 'true' } as NodeJS.ProcessEnv)).toBe(false);
+    expect(shouldLoadFromDisk({ EXARCHOS_RUNTIMES_FROM_DISK: '1' } as NodeJS.ProcessEnv)).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/config/test-runtime-resolver.test.ts
+++ b/servers/exarchos-mcp/src/config/test-runtime-resolver.test.ts
@@ -809,4 +809,29 @@ describe('resolveTestRuntime', () => {
       expect(call[0]).toBe('my-feat-stream');
     }
   });
+
+  // ─── T-17 (DR-8a): remediation copy must teach next step ───────────────
+  // Empty repos and missing-script repos surface `source: 'unresolved'`
+  // with a `remediation` string. That string is the *only* breadcrumb a
+  // dispatched agent gets — it must include either an inline example
+  // showing what to write or a link to the user-facing docs explaining
+  // .exarchos.yml. A bare "configure your project" message is not enough.
+  it('testRuntimeResolver_RemediationMessage_IncludesDocLinkOrExample', () => {
+    const dir = makeTmpDir();
+
+    const result = resolveTestRuntime(dir);
+
+    expect(result.source).toBe('unresolved');
+    expect(result.remediation).toBeDefined();
+    const message = result.remediation!;
+    // A concrete, actionable hint: either a YAML snippet a caller could
+    // paste, or a doc anchor the caller can follow. We accept either form
+    // so future docs reorganization doesn't constrain the message.
+    const hasInlineYamlExample = /test:\s/.test(message);
+    const hasDocLink = /https?:\/\/|skills-src\/|docs\//.test(message);
+    expect(
+      hasInlineYamlExample || hasDocLink,
+      `remediation must include an inline YAML example (a "test:" key) or a doc link, got: ${message}`,
+    ).toBe(true);
+  });
 });

--- a/servers/exarchos-mcp/src/config/test-runtime-resolver.ts
+++ b/servers/exarchos-mcp/src/config/test-runtime-resolver.ts
@@ -68,8 +68,16 @@ export interface ResolveOptions {
  */
 const SAFE_COMMAND_PATTERN = /^[a-zA-Z0-9_\- :.=\/+,@"'\\]+$/;
 
+// Remediation copy for the "no project markers detected" branch. Includes a
+// minimal `.exarchos.yml` example so a dispatched agent has something
+// concrete to paste, plus a pointer to the workflow-state skill where the
+// configuration story is documented end-to-end. Format chosen to render
+// readably in both Markdown contexts and plain-text logs.
 const UNRESOLVED_REMEDIATION =
-  'No project markers detected. Add a .exarchos.yml with test/typecheck/install commands or pass an override.';
+  'No project markers detected. Add a .exarchos.yml at the repo root, ' +
+  'for example: `test: pytest`, `typecheck: pyright`, `install: pip install -e .`. ' +
+  'See skills-src/workflow-state/SKILL.md for the full configuration reference, ' +
+  'or pass an override (test/typecheck/install) to this resolver.';
 
 function assertSafe(label: string, value: string): void {
   const trimmed = value.trim();

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -6,6 +6,7 @@ import {
   AGENT_EVENT_TYPES,
   EventTypes,
   WorkflowEventBase,
+  TaskAssignedData,
   TeamSpawnedData,
   TeamTaskAssignedData,
   TeamTaskCompletedData,
@@ -2561,5 +2562,47 @@ describe('CommandResolvedEventSchema', () => {
       source: 'config',
     });
     expect(result.success).toBe(false);
+  });
+});
+
+// ─── T-17 (DR-8b): task.assigned hint catalog includes optional `branch` ────
+//
+// Orchestrators discover the `task.assigned` event shape via the published
+// schema (rendered as JSON-schema by `handleEventTypeDescribe` /
+// `serializeEventCatalog`'s `hasSchema` flag). The dogfood report flagged
+// that callers couldn't tell whether `branch` was supported on
+// `task.assigned`; this test pins the contract so the catalog stays aligned
+// with `setup_worktree`'s branch-resolution priority (T-09) and with
+// `skills-src/delegation/SKILL.md`'s pre-emit example.
+describe('TaskAssignedData hint catalog', () => {
+  it('eventEmissionCatalog_TaskAssigned_OptionalBranchField', () => {
+    // Schema must accept a payload that includes branch...
+    const withBranch = TaskAssignedData.safeParse({
+      taskId: 'T-001',
+      title: 'Wire setup_worktree branch resolution',
+      branch: 'feature/v290/T-001-branch-resolution',
+    });
+    expect(withBranch.success).toBe(true);
+
+    // ...and a payload that omits it (branch must be optional, not required).
+    const withoutBranch = TaskAssignedData.safeParse({
+      taskId: 'T-002',
+      title: 'No branch yet',
+    });
+    expect(withoutBranch.success).toBe(true);
+
+    // Catalog rendering: the JSON-schema view that callers consume via
+    // `event.describe({ eventTypes: ['task.assigned'] })` must list `branch`
+    // as a property and must NOT mark it required.
+    const json = zodToJsonSchema(TaskAssignedData) as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+    expect(json.properties).toBeDefined();
+    expect(json.properties).toHaveProperty('branch');
+    // `branch` must be present and optional (i.e., not in the required[]
+    // array — required[] may be absent entirely if no fields are required).
+    const required = json.required ?? [];
+    expect(required).not.toContain('branch');
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -337,7 +337,13 @@ export const WorkflowStartedData = z.object({
 export const TaskAssignedData = z.object({
   taskId: z.string().describe('Unique identifier for the task'),
   title: z.string().describe('Human-readable task title'),
-  branch: z.string().optional().describe('Git branch for this task'),
+  // Optional. When present, downstream tools (e.g., setup_worktree) may
+  // honor this as the planned branch for the task — see the resolution
+  // priority documented on SetupWorktreeArgs (`args.branch >
+  // workflow.tasks[id].branch > default`). Aligns the event hint with the
+  // workflow-state shape so orchestrators can pre-emit the same branch
+  // they later set on the workflow.
+  branch: z.string().optional().describe('Git branch for this task (planned). Optional.'),
   worktree: z.string().optional().describe('Path to the git worktree for isolation'),
   assignee: z.string().optional().describe('Agent or user assigned to this task'),
 });

--- a/servers/exarchos-mcp/src/next-actions-computer.test.ts
+++ b/servers/exarchos-mcp/src/next-actions-computer.test.ts
@@ -168,14 +168,16 @@ describe('computeNextActions (T040, DR-8)', () => {
     // reported as missing. Should succeed at HEAD.
     const transition = executeTransition(hsm, initial, 'merge-pending');
     expect(transition.success).toBe(true);
+    expect(transition.newPhase).toBe('merge-pending');
 
-    // The transitioned state is what callers project against
-    // computeNextActions to compute the rehydration envelope's
-    // `next_actions` field.
+    // CodeRabbit #16 (#1213): drive computeNextActions with the phase the
+    // HSM actually emitted instead of a manually-rebuilt literal. If
+    // executeTransition is ever modified to land on a different phase,
+    // this test will fail loudly instead of silently passing on a
+    // hardcoded 'merge-pending'.
     const transitioned = {
-      phase: 'merge-pending',
-      workflowType: 'feature',
-      featureId: 'feat-x',
+      ...initial,
+      phase: transition.newPhase!,
       // mergeOrchestrator is set by handleMergeOrchestrate; absent at this
       // step, which the surfacing filter treats as "not yet terminated".
     };

--- a/servers/exarchos-mcp/src/next-actions-computer.test.ts
+++ b/servers/exarchos-mcp/src/next-actions-computer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { computeNextActions } from './next-actions-computer.js';
 import { NextAction } from './next-action.js';
-import { getHSMDefinition } from './workflow/state-machine.js';
+import { getHSMDefinition, executeTransition } from './workflow/state-machine.js';
 
 describe('computeNextActions (T040, DR-8)', () => {
   it('NextActions_Given_PlanPhase_Then_IncludesDelegateTransition', () => {
@@ -130,5 +130,64 @@ describe('computeNextActions (T040, DR-8)', () => {
 
     const merge = actions.find((a) => a.verb === 'merge_orchestrate');
     expect(merge).toBeUndefined();
+  });
+
+  // fix-001 (review #1213, T-01): verifies #1208's fix at HEAD.
+  //
+  // Scenario from the dogfood report: a workflow parked in `delegate` emits
+  // `task.completed` with `data.worktreePath`. PR #1193 wired the
+  // `delegate → merge-pending` transition (guarded by the
+  // `merge-pending-entry` predicate that inspects the latest task.completed
+  // for a worktree association) and the `merge_orchestrate` next-action
+  // verb. This test stitches both ends together: starting from the
+  // `delegate` phase, the HSM transition succeeds and `computeNextActions`
+  // surfaces the `merge_orchestrate` verb. If either end regresses (the
+  // guard stops recognizing `worktreePath`, or the next-action computer
+  // stops surfacing `merge_orchestrate` in `merge-pending`), this test
+  // fails — closing the original #1208 reproduction.
+  it('mergePendingDetour_TaskCompletedWithWorktreePath_SurfacesMergeOrchestrateVerb', () => {
+    const hsm = getHSMDefinition('feature');
+
+    // Workflow parked in `delegate` with a recently-completed task that
+    // carries a worktree path. Mirror the event-store stub used elsewhere
+    // in this suite (`state._events` is the canonical shape for HSM guards).
+    const initial = {
+      phase: 'delegate',
+      workflowType: 'feature',
+      featureId: 'feat-x',
+      _events: [
+        {
+          type: 'task.completed',
+          data: { taskId: 'T11', worktreePath: '/tmp/.worktrees/feat-x-T11' },
+        },
+      ],
+    };
+
+    // Drive the HSM transition the same way prepare_synthesis / merge
+    // orchestration would: this is the "detour" that #1208 originally
+    // reported as missing. Should succeed at HEAD.
+    const transition = executeTransition(hsm, initial, 'merge-pending');
+    expect(transition.success).toBe(true);
+
+    // The transitioned state is what callers project against
+    // computeNextActions to compute the rehydration envelope's
+    // `next_actions` field.
+    const transitioned = {
+      phase: 'merge-pending',
+      workflowType: 'feature',
+      featureId: 'feat-x',
+      // mergeOrchestrator is set by handleMergeOrchestrate; absent at this
+      // step, which the surfacing filter treats as "not yet terminated".
+    };
+
+    const actions = computeNextActions(transitioned, hsm);
+    const merge = actions.find((a) => a.verb === 'merge_orchestrate');
+
+    // PASS = #1208 fixed-in-#1193 confirmed at HEAD. FAIL would surface a
+    // residual regression in either the HSM detour or the next-action
+    // surfacing.
+    expect(merge).toBeDefined();
+    expect(merge?.validTargets).toEqual(['merge_orchestrate']);
+    expect(merge?.reason).toBe('Pending subagent worktree merge');
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -160,6 +160,51 @@ function adaptArgsWithStateDirAndEventStore<T>(
   };
 }
 
+/**
+ * DR-3 (T-09, #1204): adapter for `setup_worktree` that pre-loads workflow
+ * state when `featureId` and `ctx.eventStore` are both supplied. The handler
+ * itself stays synchronous and source-of-truth for the resolution priority
+ * (args.branch > workflowState.tasks[id].branch > legacy default); this
+ * adapter just feeds it the materialized `tasks` list so it can look up the
+ * planned branch. Falls back to no workflow state when either prerequisite
+ * is missing — preserves the legacy default behavior.
+ */
+function adaptSetupWorktree(): ActionHandler {
+  return async (args, stateDir, ctx) => {
+    const featureId = (args as { featureId?: string }).featureId;
+    let workflowState: { tasks?: Array<{ id: string; branch?: string }> } | undefined;
+
+    if (featureId && ctx?.eventStore) {
+      try {
+        const { getOrCreateMaterializer, queryDeltaEvents } = await import('../views/tools.js');
+        const { WORKFLOW_STATE_VIEW } = await import('../views/workflow-state-projection.js');
+        const materializer = getOrCreateMaterializer(stateDir);
+        const events = await queryDeltaEvents(
+          ctx.eventStore,
+          materializer,
+          featureId,
+          WORKFLOW_STATE_VIEW,
+        );
+        const view = materializer.materialize<{ tasks: Array<{ id: string; branch?: string }> }>(
+          featureId,
+          WORKFLOW_STATE_VIEW,
+          events,
+        );
+        workflowState = { tasks: view.tasks };
+      } catch {
+        // Best-effort: missing/unreadable state is not a setup_worktree
+        // failure — handler falls back to legacy default branch.
+        workflowState = undefined;
+      }
+    }
+
+    return handleSetupWorktree(
+      args as unknown as Parameters<typeof handleSetupWorktree>[0],
+      workflowState,
+    );
+  };
+}
+
 const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   task_claim: adaptWithEventStore(handleTaskClaim),
   task_complete: adaptWithEventStore(handleTaskComplete),
@@ -199,7 +244,7 @@ const ACTION_HANDLERS: Readonly<Record<string, ActionHandler>> = {
   generate_traceability: adaptArgs(handleGenerateTraceability),
   spec_coverage_check: adaptArgs(handleSpecCoverageCheck),
   verify_worktree_baseline: adapt(handleVerifyWorktreeBaseline),
-  setup_worktree: adaptArgs(handleSetupWorktree),
+  setup_worktree: adaptSetupWorktree(),
   verify_delegation_saga: adaptArgs(handleVerifyDelegationSaga),
   post_delegation_check: adaptArgsWithEventStore(handlePostDelegationCheck),
   reconcile_state: adaptArgsWithEventStore(handleReconcileState),

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -56,7 +56,7 @@ import { handleClassifyReviewItems } from './classify-review-items.js';
 import { handleGenerateTraceability } from './generate-traceability.js';
 import { handleSpecCoverageCheck } from './spec-coverage-check.js';
 import { handleVerifyWorktreeBaseline } from './verify-worktree-baseline.js';
-import { handleSetupWorktree } from './setup-worktree.js';
+import { handleSetupWorktree, type SetupWorktreeArgs } from './setup-worktree.js';
 import { handleVerifyDelegationSaga } from './verify-delegation-saga.js';
 import { handlePostDelegationCheck } from './post-delegation-check.js';
 import { handleReconcileState } from './reconcile-state.js';
@@ -198,10 +198,13 @@ function adaptSetupWorktree(): ActionHandler {
       }
     }
 
-    return handleSetupWorktree(
-      args as unknown as Parameters<typeof handleSetupWorktree>[0],
-      workflowState,
-    );
+    // fix-005 (review #1213): the previous double-cast
+    // (`args as unknown as Parameters<typeof handleSetupWorktree>[0]`)
+    // defeated the type system. Cast directly to the exported
+    // SetupWorktreeArgs — the registry hands `args` as a generic record,
+    // and handleSetupWorktree validates required fields at runtime, so a
+    // single cast at this adapter boundary is the narrowest sound option.
+    return handleSetupWorktree(args as unknown as SetupWorktreeArgs, workflowState);
   };
 }
 

--- a/servers/exarchos-mcp/src/orchestrate/dispatch-guard.ts
+++ b/servers/exarchos-mcp/src/orchestrate/dispatch-guard.ts
@@ -13,6 +13,14 @@ export interface AncestryResult {
   readonly reason?: 'ancestry' | 'git-error';
   readonly missing?: string[];
   readonly error?: string;
+  /**
+   * Operator-facing remediation hint (#1212 / DR-6). Populated by callers
+   * that have enough context to spell out the recovery command (e.g.,
+   * `mergePreflight` knows the source/target branch pair and links to the
+   * merge-orchestrator runbook). `validateBranchAncestry` itself does not
+   * set this — it has no remediation context for the various callers.
+   */
+  readonly hint?: string;
 }
 
 export interface WorktreeAssertionResult {

--- a/servers/exarchos-mcp/src/orchestrate/fixtures/plans/agency-csl-auto-pr.md
+++ b/servers/exarchos-mcp/src/orchestrate/fixtures/plans/agency-csl-auto-pr.md
@@ -1,0 +1,127 @@
+# agency-csl-auto-pr — fixture plan (representative subset)
+
+This fixture is a minimal subset of the real `docs/plans/2026-04-29-agency-csl-auto-pr.md`
+plan (33 tasks total) captured to reproduce the three parser false-positive failure
+modes documented in
+[`exarchos-issue-check_task_decomposition-parser-false-positives.md`](../../../../../../../exarchos-issue-check_task_decomposition-parser-false-positives.md).
+
+The plan structure is the standard `@skills/implementation-planning` shape: each
+task has a `**Goal:**` paragraph (not `**Description:**`), TDD step lists with
+`[RED]`/`[GREEN]`/`[REFACTOR]` markers, an `**Acceptance criteria:**` section,
+and explicit `**Dependencies:**` / `**Parallelizable:**` lines.
+
+Three tasks are sufficient to reproduce all three bugs:
+
+- **Task 003** and **Task 004** both reference the dotted record fields
+  `imageProvenance.isFirstParty` and `mutatingTool.detected` in narrative prose
+  (Bug 3 — file-conflict on dotted identifiers).
+- **Task 033**'s `**Dependencies:**` line references `T002` and includes the
+  Kusto function name `GetCslSloRollup24h` in narrative parens (Bug 2 — greedy
+  digit fallback extracts `24`).
+- All three tasks use `**Goal:**` instead of `**Description:**` so the parser
+  reports `descriptionWordCount === 0` despite hundreds of words of substantive
+  prose (Bug 1).
+
+## Tasks
+
+### Task 002: Author the Kusto schema for CSL telemetry rollups
+
+**Goal:** Define the Kusto query module that exposes per-SLO sample-size rollups
+over a rolling 24-hour window. The schema must declare both the input event
+shape (drawn from the `agencyEvents` Kusto table) and the projected rollup row
+shape consumed by downstream alerting and dashboards. Validate against a frozen
+sample of last week's `agencyEvents` rows so future schema drift is caught at
+build time rather than at runtime when the dashboard renders empty.
+
+**Files:**
+- `kusto/queries/csl-slo-rollup-24h.kql`
+- `kusto/queries/csl-slo-rollup-24h.test.ts`
+- `kusto/schemas/agency-events.ts`
+
+**Tests:**
+- [RED] `GetCslSloRollup24h_FrozenSample_ProducesExpectedRollupRows` — assert
+  the query against the frozen `agencyEvents` sample produces the expected
+  per-SLO sample-size counts.
+- [RED] `GetCslSloRollup24h_EmptyWindow_ReturnsZeroRowsNotError` — assert
+  empty-window behavior is graceful (zero rows, not a Kusto error).
+
+**Dependencies:** None
+**Parallelizable:** Yes
+
+### Task 003: First-party image provenance check
+
+**Goal:** Implement the provenance check that flags any image whose
+`imageProvenance.isFirstParty` field is `false` for downstream review. The check
+runs as part of the agency-csl pipeline's pre-commit gate and must record the
+review verdict back onto the record. When `imageProvenance.isFirstParty` is
+absent (legacy records), the check defaults to `false` and the record is
+flagged. Edge case: a record may carry both a first-party flag and a
+`mutatingTool.detected` signal — when both are set, the mutating-tool signal
+wins (more conservative).
+
+**Files:**
+- `src/checks/image-provenance.ts`
+- `src/checks/image-provenance.test.ts`
+
+**Tests:**
+- [RED] `ImageProvenanceCheck_FirstPartyTrue_DoesNotFlag` — verify a record
+  with `imageProvenance.isFirstParty = true` and no mutating-tool signal is
+  not flagged.
+- [RED] `ImageProvenanceCheck_FirstPartyFalse_FlagsForReview` — verify the
+  flag fires when `imageProvenance.isFirstParty` is `false`.
+- [RED] `ImageProvenanceCheck_LegacyRecordMissingField_DefaultsToFlagged` —
+  verify legacy records without the field default to flagged.
+
+**Dependencies:** None
+**Parallelizable:** Yes
+
+### Task 004: Mutating-tool detection check
+
+**Goal:** Implement the detection check that flags any image whose
+`mutatingTool.detected` field is `true` for downstream review. This check is
+adjacent to the first-party provenance check (T003) but operates on a separate
+field of the same record. Where the two checks overlap is in the narrative
+discussion of which signal wins when both fire — `mutatingTool.detected` is
+more conservative and takes precedence over `imageProvenance.isFirstParty` in
+the pipeline's combined verdict logic (which lives in a separate file owned by
+T005, not T003 or T004).
+
+**Files:**
+- `src/checks/mutating-tool.ts`
+- `src/checks/mutating-tool.test.ts`
+
+**Tests:**
+- [RED] `MutatingToolCheck_DetectedTrue_FlagsForReview` — verify the flag
+  fires when `mutatingTool.detected` is `true`.
+- [RED] `MutatingToolCheck_DetectedFalse_DoesNotFlag` — verify no flag when
+  `mutatingTool.detected` is `false`.
+- [RED] `MutatingToolCheck_FieldAbsent_DefaultsToNotDetected` — verify
+  records without the field default to "not detected" (the field's absence
+  is informational, not a flag).
+
+**Dependencies:** None
+**Parallelizable:** Yes
+
+### Task 033: SLO sample-size dashboard panel
+
+**Goal:** Render the per-SLO sample-size panel in the agency-csl Grafana
+dashboard, sourced from the rollup query authored in T002. The panel shows
+24-hour rolling sample sizes per SLO bucket, with a threshold line at the
+minimum-sample-size policy boundary. Supports drill-down into the underlying
+event stream when the on-call engineer clicks a panel cell. The dashboard
+provisioning JSON declares the panel's query reference, axes, and the
+threshold annotation.
+
+**Files:**
+- `dashboards/agency-csl/slo-sample-size-panel.json`
+- `dashboards/agency-csl/slo-sample-size-panel.test.ts`
+
+**Tests:**
+- [RED] `SloSampleSizePanel_QueryReference_ResolvesToRollupQuery` — assert
+  the panel JSON's query reference resolves to the T002 rollup query module.
+- [RED] `SloSampleSizePanel_ThresholdAnnotation_MatchesPolicyBoundary` —
+  assert the threshold annotation value equals the documented
+  minimum-sample-size policy.
+
+**Dependencies:** T002 (`GetCslSloRollup24h` exposes sample size per SLO)
+**Parallelizable:** Yes

--- a/servers/exarchos-mcp/src/orchestrate/fixtures/plans/agency-csl-auto-pr.md
+++ b/servers/exarchos-mcp/src/orchestrate/fixtures/plans/agency-csl-auto-pr.md
@@ -3,7 +3,7 @@
 This fixture is a minimal subset of the real `docs/plans/2026-04-29-agency-csl-auto-pr.md`
 plan (33 tasks total) captured to reproduce the three parser false-positive failure
 modes documented in
-[`exarchos-issue-check_task_decomposition-parser-false-positives.md`](../../../../../../../exarchos-issue-check_task_decomposition-parser-false-positives.md).
+[`exarchos-issue-check_task_decomposition-parser-false-positives.md`](../../../../../../exarchos-issue-check_task_decomposition-parser-false-positives.md).
 
 The plan structure is the standard `@skills/implementation-planning` shape: each
 task has a `**Goal:**` paragraph (not `**Description:**`), TDD step lists with

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -44,7 +44,11 @@ import {
 } from '../views/tools.js';
 import { generateQualityHints } from '../quality/hints.js';
 import { emitGateEvent } from './gate-utils.js';
-import { handlePrepareDelegation, classifyTask } from './prepare-delegation.js';
+import {
+  handlePrepareDelegation,
+  classifyTask,
+  computeScopedWorktrees,
+} from './prepare-delegation.js';
 import type { TaskClassification } from './prepare-delegation.js';
 import { delegationReadinessProjection } from '../views/delegation-readiness-view.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
@@ -1657,5 +1661,81 @@ describe('handlePrepareDelegation', () => {
       const result = classifyTask({ id: '006', title: 'Implement handler' }, DEFAULTS.agents);
       expect(result.recommendedModel).toBe('opus');
     });
+  });
+});
+
+// ─── F19 (#1213): computeScopedWorktrees task-ID canonicalisation ──────────
+//
+// Callers may pass `T-001`/`T001`/`001` interchangeably; the projection's
+// `readyTaskIds` preserves the form recorded by upstream emitters. Strict
+// string-equality comparisons mis-fire on this drift and produce false
+// "<N> worktrees pending" blockers. The helper now canonicalises both
+// sides via `canonicaliseTaskId` (collapses `T-NNN`/`TNNN`/`NNN` to a
+// shared `<digits>` form) before comparing.
+
+describe('computeScopedWorktrees', () => {
+  function readiness(
+    readyTaskIds: readonly string[],
+    expected: number,
+    blockers: readonly string[] = [],
+  ): DelegationReadinessState {
+    return {
+      ready: readyTaskIds.length === expected,
+      blockers,
+      plan: { approved: true, taskCount: expected, artifactPresent: true },
+      quality: { queried: true, gatePassRate: null, regressions: [] },
+      worktrees: {
+        expected,
+        ready: readyTaskIds.length,
+        failed: [],
+        assignedTaskIds: [],
+        readyTaskIds: [...readyTaskIds],
+      },
+    };
+  }
+
+  it('ComputeScopedWorktrees_HyphenedVsUnhyphenedIds_TreatedEqual', () => {
+    // Wave addresses tasks with the hyphenated form `T-001`/`T-002`; the
+    // projection holds the unhyphenated form `T001`/`T002` (e.g. because
+    // an upstream task.assigned event normalised them differently). Both
+    // tasks ARE worktree-ready, so the wave-scoped count must report
+    // 2/2 ready and zero pending — not "2 worktrees pending".
+    const state = readiness(['T001', 'T002'], 2, ['2 worktrees pending']);
+    const result = computeScopedWorktrees(state, [
+      { id: 'T-001' },
+      { id: 'T-002' },
+    ]);
+    expect(result.expected).toBe(2);
+    expect(result.ready).toBe(2);
+    expect(result.pending).toBe(0);
+    // The "2 worktrees pending" blocker must drop because the wave is
+    // fully ready under canonical comparison.
+    expect(result.blockers).not.toContain('2 worktrees pending');
+  });
+
+  it('ComputeScopedWorktrees_PlainNumericInArgs_MatchesTPrefixedReady', () => {
+    // Wave passes plain-numeric IDs (`001`, `002`); projection records
+    // the `T-`-prefixed form. Canonical comparison still matches.
+    const state = readiness(['T-001', 'T-002'], 2);
+    const result = computeScopedWorktrees(state, [{ id: '001' }, { id: '002' }]);
+    expect(result.expected).toBe(2);
+    expect(result.ready).toBe(2);
+    expect(result.pending).toBe(0);
+  });
+
+  it('ComputeScopedWorktrees_MismatchedIds_StillReportsPending', () => {
+    // Sanity: when a wave member is genuinely missing from
+    // readyTaskIds (regardless of form), pending is non-zero.
+    const state = readiness(['T-001'], 2, ['1 worktrees pending']);
+    const result = computeScopedWorktrees(state, [
+      { id: 'T-001' }, // ready
+      { id: 'T-099' }, // not ready
+    ]);
+    expect(result.expected).toBe(2);
+    expect(result.ready).toBe(1);
+    expect(result.pending).toBe(1);
+    // Blocker rewritten to wave-scoped count (matches existing scoping
+    // contract; canonical comparison only changes the match logic).
+    expect(result.blockers).toContain('1 worktrees pending');
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -1738,4 +1738,57 @@ describe('computeScopedWorktrees', () => {
     // contract; canonical comparison only changes the match logic).
     expect(result.blockers).toContain('1 worktrees pending');
   });
+
+  // F-iter3 (#1213, sentry HIGH r3186305844): the global readiness can be
+  // empty of "N worktrees pending" blockers (because globally everything is
+  // ready) while a wave subset still has unready members. Without an
+  // explicit synthesise step the caller saw `blockers === []` and dispatched
+  // prematurely. The next three tests pin the synthesise / no-synthesise /
+  // existing-rewrite behaviours.
+  it('ComputeScopedWorktrees_GlobalReadyButWavePending_SynthesisesBlocker', () => {
+    // Globally only T-001 is ready and the projection has no
+    // "N worktrees pending" blocker (e.g. global expected==1 / ready==1
+    // because the global expected count was scoped to the ready set, OR a
+    // mix of legacy/modern worktree.created events). The wave addresses
+    // T-002 — which is not ready. Without synthesis the caller would see
+    // blockers===[] and dispatch.
+    const state = readiness(['T-001'], 1, []);
+    const result = computeScopedWorktrees(state, [{ id: 'T-002' }]);
+    expect(result.expected).toBe(1);
+    expect(result.ready).toBe(0);
+    expect(result.pending).toBe(1);
+    expect(result.blockers).toContain('1 worktrees pending');
+  });
+
+  it('ComputeScopedWorktrees_GlobalAndWaveReady_NoBlockerSynthesised', () => {
+    // Globally and wave-locally the only task is ready. No blocker should
+    // be synthesised; result.blockers must remain empty.
+    const state = readiness(['T-001'], 1, []);
+    const result = computeScopedWorktrees(state, [{ id: 'T-001' }]);
+    expect(result.expected).toBe(1);
+    expect(result.ready).toBe(1);
+    expect(result.pending).toBe(0);
+    expect(result.blockers).toEqual([]);
+  });
+
+  it('ComputeScopedWorktrees_GlobalHasPendingBlocker_RewrittenToWaveCount', () => {
+    // Existing transformation contract: the global "5 worktrees pending"
+    // blocker must be rewritten to the wave-scoped count, not duplicated
+    // or left at the global value.
+    const state = readiness(['T-001'], 5, ['5 worktrees pending']);
+    const result = computeScopedWorktrees(state, [
+      { id: 'T-001' }, // ready
+      { id: 'T-002' }, // not ready
+    ]);
+    expect(result.expected).toBe(2);
+    expect(result.ready).toBe(1);
+    expect(result.pending).toBe(1);
+    expect(result.blockers).toContain('1 worktrees pending');
+    expect(result.blockers).not.toContain('5 worktrees pending');
+    // Synthesise step must not produce a duplicate "1 worktrees pending".
+    const matches = result.blockers.filter(b =>
+      /^\d+ worktrees pending$/.test(b),
+    );
+    expect(matches).toHaveLength(1);
+  });
 });

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -117,7 +117,13 @@ function readyDelegationReadiness(): DelegationReadinessState {
     blockers: [],
     plan: { approved: true, taskCount: 2, artifactPresent: true },
     quality: { queried: true, gatePassRate: null, regressions: [] },
-    worktrees: { expected: 2, ready: 2, failed: [] },
+    worktrees: {
+      expected: 2,
+      ready: 2,
+      failed: [],
+      assignedTaskIds: ['task-1', 'task-2'],
+      readyTaskIds: ['task-1', 'task-2'],
+    },
   };
 }
 
@@ -127,7 +133,13 @@ function notReadyDelegationReadiness(): DelegationReadinessState {
     blockers: ['plan not approved', 'no task.assigned events found — emit task.assigned events for each task via exarchos_event before calling prepare_delegation'],
     plan: { approved: false, taskCount: 0, artifactPresent: false },
     quality: { queried: false, gatePassRate: null, regressions: [] },
-    worktrees: { expected: 0, ready: 0, failed: [] },
+    worktrees: {
+      expected: 0,
+      ready: 0,
+      failed: [],
+      assignedTaskIds: [],
+      readyTaskIds: [],
+    },
   };
 }
 
@@ -438,7 +450,7 @@ describe('handlePrepareDelegation', () => {
       blockers: ['Plan artifact is missing'],
       plan: { approved: true, taskCount: 2, artifactPresent: false },
       quality: { queried: true, gatePassRate: null, regressions: [] },
-      worktrees: { expected: 2, ready: 2, failed: [] },
+      worktrees: { expected: 2, ready: 2, failed: [], assignedTaskIds: [], readyTaskIds: [] },
     };
     setupMaterializer(state, undefined, drState);
     const args = { featureId: 'test-feature' };
@@ -465,7 +477,7 @@ describe('handlePrepareDelegation', () => {
       blockers: [],
       plan: { approved: true, taskCount: 2, artifactPresent: true },
       quality: { queried: true, gatePassRate: null, regressions: [] },
-      worktrees: { expected: 2, ready: 2, failed: [] },
+      worktrees: { expected: 2, ready: 2, failed: [], assignedTaskIds: [], readyTaskIds: [] },
     };
     setupMaterializer(state, undefined, drState);
     vi.mocked(generateQualityHints).mockReturnValue([]);
@@ -479,6 +491,100 @@ describe('handlePrepareDelegation', () => {
     expect(data.readiness.blockers).toEqual([]);
   });
 
+  // ─── DR-T-2 (T-05): wave-scoped worktree readiness ─────────────────────
+
+  it('PrepareDelegation_TasksArgSubsetReady_NoBlocker', async () => {
+    // Projection has 5 assigned, 3 ready (subset). tasks arg names the
+    // 3 ready ones — wave is complete, no worktree blocker should fire.
+    const state = readyWorkflowState();
+    const drState: DelegationReadinessState = {
+      ready: false,
+      blockers: ['2 worktrees pending'], // global view: 2 of 5 still pending
+      plan: { approved: true, taskCount: 5, artifactPresent: true },
+      quality: { queried: true, gatePassRate: null, regressions: [] },
+      worktrees: {
+        expected: 5, ready: 3, failed: [],
+        assignedTaskIds: ['t1', 't2', 't3', 't4', 't5'],
+        readyTaskIds: ['t1', 't2', 't3'],
+      },
+    };
+    setupMaterializer(state, undefined, drState);
+    vi.mocked(generateQualityHints).mockReturnValue([]);
+    const args = {
+      featureId: 'test-feature',
+      tasks: [
+        { id: 't1', title: 'A' },
+        { id: 't2', title: 'B' },
+        { id: 't3', title: 'C' },
+      ],
+    };
+
+    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+    expect(result.success).toBe(true);
+    const data = result.data as { ready: boolean; readiness: DelegationReadinessState };
+    expect(data.ready).toBe(true);
+    expect(data.readiness.blockers).not.toContain(expect.stringContaining('worktrees pending'));
+  });
+
+  it('PrepareDelegation_TasksArgSubsetPending_ExactPendingCountInBlocker', async () => {
+    // Projection has 33 assigned, 0 ready. tasks arg names 3 pending.
+    // Blocker should report 3 worktrees pending, not 33.
+    const state = readyWorkflowState();
+    const drState: DelegationReadinessState = {
+      ready: false,
+      blockers: ['33 worktrees pending'],
+      plan: { approved: true, taskCount: 33, artifactPresent: true },
+      quality: { queried: true, gatePassRate: null, regressions: [] },
+      worktrees: {
+        expected: 33, ready: 0, failed: [],
+        assignedTaskIds: Array.from({ length: 33 }, (_, i) => `T-${String(i + 1).padStart(3, '0')}`),
+        readyTaskIds: [],
+      },
+    };
+    setupMaterializer(state, undefined, drState);
+    const args = {
+      featureId: 'test-feature',
+      tasks: [
+        { id: 'T-001', title: 'A' },
+        { id: 'T-002', title: 'B' },
+        { id: 'T-003', title: 'C' },
+      ],
+    };
+
+    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+    expect(result.success).toBe(true);
+    const data = result.data as { ready: boolean; readiness: DelegationReadinessState; blockers: string[] };
+    expect(data.ready).toBe(false);
+    expect(data.readiness.blockers).toContain('3 worktrees pending');
+    expect(data.readiness.blockers).not.toContain('33 worktrees pending');
+  });
+
+  it('PrepareDelegation_NoTasksArg_AllAssignedConsidered', async () => {
+    // Without tasks arg, the global blocker passes through unchanged.
+    const state = readyWorkflowState();
+    const drState: DelegationReadinessState = {
+      ready: false,
+      blockers: ['10 worktrees pending'],
+      plan: { approved: true, taskCount: 10, artifactPresent: true },
+      quality: { queried: true, gatePassRate: null, regressions: [] },
+      worktrees: {
+        expected: 10, ready: 0, failed: [],
+        assignedTaskIds: Array.from({ length: 10 }, (_, i) => `t-${i}`),
+        readyTaskIds: [],
+      },
+    };
+    setupMaterializer(state, undefined, drState);
+    const args = { featureId: 'test-feature' }; // no tasks arg
+
+    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+    expect(result.success).toBe(true);
+    const data = result.data as { ready: boolean; readiness: DelegationReadinessState };
+    expect(data.readiness.blockers).toContain('10 worktrees pending');
+  });
+
   // ─── DR-5: nativeIsolation readiness.blockers consistency ─────────────────
 
   it('handlePrepareDelegation_NativeIsolation_ExcludesWorktreeBlockers', async () => {
@@ -489,7 +595,7 @@ describe('handlePrepareDelegation', () => {
       blockers: ['worktrees pending', 'no worktrees expected'],
       plan: { approved: true, taskCount: 2, artifactPresent: true },
       quality: { queried: true, gatePassRate: null, regressions: [] },
-      worktrees: { expected: 2, ready: 0, failed: [] },
+      worktrees: { expected: 2, ready: 0, failed: [], assignedTaskIds: [], readyTaskIds: [] },
     };
     setupMaterializer(state, undefined, drState);
     vi.mocked(generateQualityHints).mockReturnValue([]);
@@ -517,7 +623,7 @@ describe('handlePrepareDelegation', () => {
       blockers: ['plan not approved', 'worktrees pending'],
       plan: { approved: false, taskCount: 0, artifactPresent: false },
       quality: { queried: false, gatePassRate: null, regressions: [] },
-      worktrees: { expected: 2, ready: 0, failed: [] },
+      worktrees: { expected: 2, ready: 0, failed: [], assignedTaskIds: [], readyTaskIds: [] },
     };
     setupMaterializer(state, undefined, drState);
     const args = { featureId: 'test-feature', nativeIsolation: true };
@@ -548,7 +654,7 @@ describe('handlePrepareDelegation', () => {
       blockers: ['plan not approved', 'worktrees pending'],
       plan: { approved: false, taskCount: 0, artifactPresent: false },
       quality: { queried: true, gatePassRate: null, regressions: [] },
-      worktrees: { expected: 2, ready: 0, failed: [] },
+      worktrees: { expected: 2, ready: 0, failed: [], assignedTaskIds: [], readyTaskIds: [] },
     };
     setupMaterializer(state, undefined, drState);
     const args = { featureId: 'test-feature' };
@@ -581,7 +687,7 @@ describe('handlePrepareDelegation', () => {
       blockers: ['no worktrees expected'],
       plan: { approved: true, taskCount: 2, artifactPresent: true },
       quality: { queried: true, gatePassRate: null, regressions: [] },
-      worktrees: { expected: 0, ready: 0, failed: [] },
+      worktrees: { expected: 0, ready: 0, failed: [], assignedTaskIds: [], readyTaskIds: [] },
     };
     setupMaterializer(state, undefined, drState);
     vi.mocked(generateQualityHints).mockReturnValue([]);
@@ -605,7 +711,7 @@ describe('handlePrepareDelegation', () => {
       blockers: ['no worktrees expected'],
       plan: { approved: true, taskCount: 2, artifactPresent: true },
       quality: { queried: true, gatePassRate: null, regressions: [] },
-      worktrees: { expected: 0, ready: 0, failed: [] },
+      worktrees: { expected: 0, ready: 0, failed: [], assignedTaskIds: [], readyTaskIds: [] },
     };
     setupMaterializer(state, undefined, drState);
     const args = { featureId: 'test-feature' };
@@ -629,7 +735,7 @@ describe('handlePrepareDelegation', () => {
       blockers: ['plan not approved', 'no worktrees expected'],
       plan: { approved: false, taskCount: 0, artifactPresent: false },
       quality: { queried: true, gatePassRate: null, regressions: [] },
-      worktrees: { expected: 0, ready: 0, failed: [] },
+      worktrees: { expected: 0, ready: 0, failed: [], assignedTaskIds: [], readyTaskIds: [] },
     };
     setupMaterializer(state, undefined, drState);
     const args = { featureId: 'test-feature', nativeIsolation: true };
@@ -677,7 +783,7 @@ describe('handlePrepareDelegation', () => {
     const state = readyWorkflowState();
     const drState: DelegationReadinessState = {
       ...readyDelegationReadiness(),
-      worktrees: { expected: 3, ready: 3, failed: [] },
+      worktrees: { expected: 3, ready: 3, failed: [], assignedTaskIds: [], readyTaskIds: [] },
     };
     setupMaterializer(state, undefined, drState);
     vi.mocked(generateQualityHints).mockReturnValue([]);

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -115,7 +115,7 @@ function readyDelegationReadiness(): DelegationReadinessState {
   return {
     ready: true,
     blockers: [],
-    plan: { approved: true, taskCount: 2 },
+    plan: { approved: true, taskCount: 2, artifactPresent: true },
     quality: { queried: true, gatePassRate: null, regressions: [] },
     worktrees: { expected: 2, ready: 2, failed: [] },
   };
@@ -125,7 +125,7 @@ function notReadyDelegationReadiness(): DelegationReadinessState {
   return {
     ready: false,
     blockers: ['plan not approved', 'no task.assigned events found — emit task.assigned events for each task via exarchos_event before calling prepare_delegation'],
-    plan: { approved: false, taskCount: 0 },
+    plan: { approved: false, taskCount: 0, artifactPresent: false },
     quality: { queried: false, gatePassRate: null, regressions: [] },
     worktrees: { expected: 0, ready: 0, failed: [] },
   };
@@ -421,27 +421,62 @@ describe('handlePrepareDelegation', () => {
     expect(data.readiness.ready).toBe(false);
   });
 
-  it('HandlePrepareDelegation_ViewReadyButPlanArtifactMissing_ReturnsBlocker', async () => {
-    // Arrange: view says ready, but workflow state has no plan artifact
+  // DR-T-1 (T-03): plan-artifact blocker comes ONLY from the projection.
+  // This replaces a previous test that asserted a handler-side supplementary
+  // check fired when artifacts.plan was missing in workflow state. After T-03
+  // the handler trusts the projection — single source of truth (#1205).
+  it('HandlePrepareDelegation_BlockerList_MatchesDelegationReadinessView', async () => {
+    // Arrange: projection reports the plan-artifact blocker; handler should
+    // surface it verbatim with no extra emission. workflow state's
+    // artifacts.plan is irrelevant here — the projection is authoritative.
     const state = {
       ...readyWorkflowState(),
       artifacts: { design: 'design.md', plan: null, pr: null },
     };
-    const drState = readyDelegationReadiness();
+    const drState: DelegationReadinessState = {
+      ready: false,
+      blockers: ['Plan artifact is missing'],
+      plan: { approved: true, taskCount: 2, artifactPresent: false },
+      quality: { queried: true, gatePassRate: null, regressions: [] },
+      worktrees: { expected: 2, ready: 2, failed: [] },
+    };
     setupMaterializer(state, undefined, drState);
     const args = { featureId: 'test-feature' };
 
-    // Act
     const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
 
-    // Assert
     expect(result.success).toBe(true);
-    const data = result.data as {
-      ready: boolean;
-      blockers: string[];
-    };
+    const data = result.data as { ready: boolean; blockers: string[] };
     expect(data.ready).toBe(false);
-    expect(data.blockers).toContain('Plan artifact is missing');
+    // Blocker should appear EXACTLY ONCE — handler trusts projection, no
+    // duplicate emission from a supplementary check.
+    expect(data.blockers).toEqual(['Plan artifact is missing']);
+  });
+
+  it('HandlePrepareDelegation_ViewReady_NoSupplementaryPlanArtifactCheck', async () => {
+    // Arrange: projection says ready (artifactPresent: true) but workflow
+    // state lacks artifacts.plan. Handler must NOT add a side blocker.
+    const state = {
+      ...readyWorkflowState(),
+      artifacts: { design: 'design.md', plan: null, pr: null },
+    };
+    const drState: DelegationReadinessState = {
+      ready: true,
+      blockers: [],
+      plan: { approved: true, taskCount: 2, artifactPresent: true },
+      quality: { queried: true, gatePassRate: null, regressions: [] },
+      worktrees: { expected: 2, ready: 2, failed: [] },
+    };
+    setupMaterializer(state, undefined, drState);
+    vi.mocked(generateQualityHints).mockReturnValue([]);
+    const args = { featureId: 'test-feature' };
+
+    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+    expect(result.success).toBe(true);
+    const data = result.data as { ready: boolean; readiness: DelegationReadinessState };
+    expect(data.ready).toBe(true);
+    expect(data.readiness.blockers).toEqual([]);
   });
 
   // ─── DR-5: nativeIsolation readiness.blockers consistency ─────────────────
@@ -452,7 +487,7 @@ describe('handlePrepareDelegation', () => {
     const drState: DelegationReadinessState = {
       ready: false,
       blockers: ['worktrees pending', 'no worktrees expected'],
-      plan: { approved: true, taskCount: 2 },
+      plan: { approved: true, taskCount: 2, artifactPresent: true },
       quality: { queried: true, gatePassRate: null, regressions: [] },
       worktrees: { expected: 2, ready: 0, failed: [] },
     };
@@ -480,7 +515,7 @@ describe('handlePrepareDelegation', () => {
     const drState: DelegationReadinessState = {
       ready: false,
       blockers: ['plan not approved', 'worktrees pending'],
-      plan: { approved: false, taskCount: 0 },
+      plan: { approved: false, taskCount: 0, artifactPresent: false },
       quality: { queried: false, gatePassRate: null, regressions: [] },
       worktrees: { expected: 2, ready: 0, failed: [] },
     };
@@ -511,7 +546,7 @@ describe('handlePrepareDelegation', () => {
     const drState: DelegationReadinessState = {
       ready: false,
       blockers: ['plan not approved', 'worktrees pending'],
-      plan: { approved: false, taskCount: 0 },
+      plan: { approved: false, taskCount: 0, artifactPresent: false },
       quality: { queried: true, gatePassRate: null, regressions: [] },
       worktrees: { expected: 2, ready: 0, failed: [] },
     };
@@ -531,8 +566,9 @@ describe('handlePrepareDelegation', () => {
     expect(data.ready).toBe(false);
     expect(data.readiness.blockers).toContain('plan not approved');
     expect(data.readiness.blockers).toContain('worktrees pending');
-    // Plan artifact missing is added as supplementary check
-    expect(data.readiness.blockers).toContain('Plan artifact is missing');
+    // Plan artifact missing now comes from the projection itself (T-02);
+    // the handler does not emit a supplementary copy (T-03).
+    // (This fixture's drState.blockers does not include it, so it should NOT appear here.)
   });
 
   // ─── T-15: nativeIsolation parameter ──────────────────────────────────────
@@ -543,7 +579,7 @@ describe('handlePrepareDelegation', () => {
     const drState: DelegationReadinessState = {
       ready: false,
       blockers: ['no worktrees expected'],
-      plan: { approved: true, taskCount: 2 },
+      plan: { approved: true, taskCount: 2, artifactPresent: true },
       quality: { queried: true, gatePassRate: null, regressions: [] },
       worktrees: { expected: 0, ready: 0, failed: [] },
     };
@@ -567,7 +603,7 @@ describe('handlePrepareDelegation', () => {
     const drState: DelegationReadinessState = {
       ready: false,
       blockers: ['no worktrees expected'],
-      plan: { approved: true, taskCount: 2 },
+      plan: { approved: true, taskCount: 2, artifactPresent: true },
       quality: { queried: true, gatePassRate: null, regressions: [] },
       worktrees: { expected: 0, ready: 0, failed: [] },
     };
@@ -591,7 +627,7 @@ describe('handlePrepareDelegation', () => {
     const drState: DelegationReadinessState = {
       ready: false,
       blockers: ['plan not approved', 'no worktrees expected'],
-      plan: { approved: false, taskCount: 0 },
+      plan: { approved: false, taskCount: 0, artifactPresent: false },
       quality: { queried: true, gatePassRate: null, regressions: [] },
       worktrees: { expected: 0, ready: 0, failed: [] },
     };

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -491,6 +491,104 @@ describe('handlePrepareDelegation', () => {
     expect(data.readiness.blockers).toEqual([]);
   });
 
+  // ─── DR-T-3 (T-06): state-vs-plan desync diagnostic ────────────────────
+
+  it('PrepareDelegation_TaskCountExceedsStateTasks_AddsDesyncBlocker', async () => {
+    // Projection has 33 task.assigned events (plan.taskCount = 33), but
+    // workflow state has only 31 entries in tasks[]. Plan revision likely
+    // added two without re-syncing state — surface the drift.
+    const state = {
+      ...readyWorkflowState(),
+      tasks: Array.from({ length: 31 }, (_, i) => ({
+        id: `T-${String(i + 1).padStart(3, '0')}`,
+        title: `Task ${i + 1}`,
+        status: 'pending',
+      })),
+    };
+    const drState: DelegationReadinessState = {
+      ready: false,
+      blockers: [],
+      plan: { approved: true, taskCount: 33, artifactPresent: true },
+      quality: { queried: true, gatePassRate: null, regressions: [] },
+      worktrees: {
+        expected: 33, ready: 0, failed: [],
+        assignedTaskIds: Array.from({ length: 33 }, (_, i) => `T-${String(i + 1).padStart(3, '0')}`),
+        readyTaskIds: [],
+      },
+    };
+    setupMaterializer(state, undefined, drState);
+    const args = { featureId: 'test-feature' };
+
+    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+    expect(result.success).toBe(true);
+    const data = result.data as { readiness: DelegationReadinessState };
+    const desync = data.readiness.blockers.find(b => /state-vs-plan desync/.test(b));
+    expect(desync).toBeDefined();
+    expect(desync).toContain('31');
+    expect(desync).toContain('33');
+  });
+
+  it('PrepareDelegation_StateTasksExceedPlanCount_AddsDesyncBlocker', async () => {
+    // Reverse: state has more entries than plan.taskCount. Either drift
+    // direction triggers the diagnostic.
+    const state = {
+      ...readyWorkflowState(),
+      tasks: Array.from({ length: 5 }, (_, i) => ({
+        id: `t-${i}`,
+        title: `T ${i}`,
+        status: 'pending',
+      })),
+    };
+    const drState: DelegationReadinessState = {
+      ready: false,
+      blockers: [],
+      plan: { approved: true, taskCount: 3, artifactPresent: true },
+      quality: { queried: true, gatePassRate: null, regressions: [] },
+      worktrees: {
+        expected: 3, ready: 0, failed: [],
+        assignedTaskIds: ['t-0', 't-1', 't-2'],
+        readyTaskIds: [],
+      },
+    };
+    setupMaterializer(state, undefined, drState);
+    const args = { featureId: 'test-feature' };
+
+    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+    expect(result.success).toBe(true);
+    const data = result.data as { readiness: DelegationReadinessState };
+    expect(data.readiness.blockers.find(b => /state-vs-plan desync/.test(b))).toBeDefined();
+  });
+
+  it('PrepareDelegation_TaskCountMatchesStateTasks_NoDesyncBlocker', async () => {
+    // Counts match — no drift, no diagnostic.
+    const state = readyWorkflowState();
+    setupMaterializer(state); // uses readyDelegationReadiness()
+    vi.mocked(generateQualityHints).mockReturnValue([]);
+    const args = { featureId: 'test-feature' };
+
+    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+    expect(result.success).toBe(true);
+    const data = result.data as { readiness: DelegationReadinessState };
+    expect(data.readiness.blockers.find(b => /state-vs-plan desync/.test(b))).toBeUndefined();
+  });
+
+  it('PrepareDelegation_PlanTaskCountZero_NoDesyncBlockerEvenIfStateEmpty', async () => {
+    // Initial state — no tasks anywhere yet. Diagnostic should not fire
+    // at the empty-state baseline (blocker would be noise).
+    const state = notReadyWorkflowState();
+    setupMaterializer(state); // uses notReadyDelegationReadiness()
+    const args = { featureId: 'test-feature' };
+
+    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+    expect(result.success).toBe(true);
+    const data = result.data as { readiness: DelegationReadinessState };
+    expect(data.readiness.blockers.find(b => /state-vs-plan desync/.test(b))).toBeUndefined();
+  });
+
   // ─── DR-T-2 (T-05): wave-scoped worktree readiness ─────────────────────
 
   it('PrepareDelegation_TasksArgSubsetReady_NoBlocker', async () => {

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -46,6 +46,8 @@ import { generateQualityHints } from '../quality/hints.js';
 import { emitGateEvent } from './gate-utils.js';
 import { handlePrepareDelegation, classifyTask } from './prepare-delegation.js';
 import type { TaskClassification } from './prepare-delegation.js';
+import { delegationReadinessProjection } from '../views/delegation-readiness-view.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
 import {
   validateBranchAncestry,
   assertMainWorktree,
@@ -438,31 +440,64 @@ describe('handlePrepareDelegation', () => {
   // check fired when artifacts.plan was missing in workflow state. After T-03
   // the handler trusts the projection — single source of truth (#1205).
   it('HandlePrepareDelegation_BlockerList_MatchesDelegationReadinessView', async () => {
-    // Arrange: projection reports the plan-artifact blocker; handler should
-    // surface it verbatim with no extra emission. workflow state's
-    // artifacts.plan is irrelevant here — the projection is authoritative.
+    // fix-003 (review #1213, T-03): true parity test — replay the SAME
+    // event stream through both the handler (via the mocked materializer)
+    // and `delegationReadinessProjection.apply` directly, then deep-equal
+    // the resulting blockers arrays. Earlier revisions of this test only
+    // asserted the handler did not append a supplementary blocker; they
+    // never invoked the projection itself, so a divergence in the
+    // projection's blocker generation could pass undetected.
+
+    // ── Step 1: build a minimal event stream that exercises the
+    // plan-artifact branch.
+    // - workflow.transition → plan-review flips planReview.approved to true.
+    // - state.patched without artifacts.plan keeps artifactPresent at false.
+    // - task.assigned x2 + worktree.created x2 satisfy the worktree gate.
+    const events: WorkflowEvent[] = [
+      { type: 'workflow.transition', data: { to: 'plan-review' } } as unknown as WorkflowEvent,
+      { type: 'task.assigned', data: { taskId: 'task-1' } } as unknown as WorkflowEvent,
+      { type: 'task.assigned', data: { taskId: 'task-2' } } as unknown as WorkflowEvent,
+      { type: 'worktree.created', data: { taskId: 'task-1', worktreePath: '/w/1' } } as unknown as WorkflowEvent,
+      { type: 'worktree.created', data: { taskId: 'task-2', worktreePath: '/w/2' } } as unknown as WorkflowEvent,
+    ];
+
+    // ── Step 2: replay events through the projection — this is the
+    // delegation_readiness view as a caller would observe it.
+    let projectedView = delegationReadinessProjection.init();
+    for (const ev of events) {
+      projectedView = delegationReadinessProjection.apply(projectedView, ev);
+    }
+
+    // Sanity-check the projection: plan-artifact blocker must be present
+    // (because no state.patched flipped artifactPresent), AND no worktree
+    // pending (both created). If this ever stops being true the test
+    // fixture needs updating.
+    expect(projectedView.blockers).toContain('Plan artifact is missing');
+    expect(projectedView.blockers.find(b => /worktrees pending/.test(b))).toBeUndefined();
+
+    // ── Step 3: feed the SAME projection result into the handler. Workflow
+    // state's `artifacts.plan` is irrelevant — the projection is authoritative.
     const state = {
       ...readyWorkflowState(),
+      // Match projection's view of tasks: 2 entries, no plan artifact.
       artifacts: { design: 'design.md', plan: null, pr: null },
     };
-    const drState: DelegationReadinessState = {
-      ready: false,
-      blockers: ['Plan artifact is missing'],
-      plan: { approved: true, taskCount: 2, artifactPresent: false },
-      quality: { queried: true, gatePassRate: null, regressions: [] },
-      worktrees: { expected: 2, ready: 2, failed: [], assignedTaskIds: [], readyTaskIds: [] },
-    };
-    setupMaterializer(state, undefined, drState);
+    setupMaterializer(state, undefined, projectedView);
     const args = { featureId: 'test-feature' };
 
     const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
 
+    // ── Step 4: deep-equal the blocker arrays. The handler must not
+    // mutate or supplement what the projection produced (no `tasks` arg
+    // here, so the wave-scoping helper is a passthrough).
     expect(result.success).toBe(true);
-    const data = result.data as { ready: boolean; blockers: string[] };
-    expect(data.ready).toBe(false);
-    // Blocker should appear EXACTLY ONCE — handler trusts projection, no
-    // duplicate emission from a supplementary check.
-    expect(data.blockers).toEqual(['Plan artifact is missing']);
+    const data = result.data as {
+      ready: boolean;
+      readiness: DelegationReadinessState;
+      blockers: string[];
+    };
+    expect(data.readiness.blockers).toEqual(projectedView.blockers);
+    expect(data.blockers).toEqual([...projectedView.blockers]);
   });
 
   it('HandlePrepareDelegation_ViewReady_NoSupplementaryPlanArtifactCheck', async () => {

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -622,7 +622,10 @@ describe('handlePrepareDelegation', () => {
     expect(result.success).toBe(true);
     const data = result.data as { ready: boolean; readiness: DelegationReadinessState };
     expect(data.ready).toBe(true);
-    expect(data.readiness.blockers).not.toContain(expect.stringContaining('worktrees pending'));
+    // fix-006 (review #1213): explicit predicate avoids the
+    // `not.toContain(expect.stringContaining(...))` asymmetric-matcher
+    // construction whose semantics vary across vitest versions.
+    expect(data.readiness.blockers.find(b => /worktrees pending/.test(b))).toBeUndefined();
   });
 
   it('PrepareDelegation_TasksArgSubsetPending_ExactPendingCountInBlocker', async () => {
@@ -681,6 +684,51 @@ describe('handlePrepareDelegation', () => {
     expect(result.success).toBe(true);
     const data = result.data as { ready: boolean; readiness: DelegationReadinessState };
     expect(data.readiness.blockers).toContain('10 worktrees pending');
+  });
+
+  // fix-005 (review #1213): wave-scoping must update both blockers AND the
+  // numeric worktrees.expected/ready surfaces, not just the blocker strings.
+  // Plan T-05 specified a pure helper computeScopedWorktrees(readiness,
+  // tasksFilter) returning { expected, ready, pending } so all three counts
+  // stay in lockstep. This test asserts effectiveReadiness.worktrees mirrors
+  // the wave subset rather than the global stream-wide count.
+  it('PrepareDelegation_TasksArgSubset_EffectiveReadinessReportsScopedWorktreeCounts', async () => {
+    // Projection has 5 assigned, 2 ready (global). The wave names 3 of those
+    // 5 — 2 ready, 1 pending. Effective readiness must report
+    // worktrees.expected === 3 and worktrees.ready === 2 (NOT 5/2).
+    const state = readyWorkflowState();
+    const drState: DelegationReadinessState = {
+      ready: false,
+      blockers: ['3 worktrees pending'], // global view: 3 of 5 still pending
+      plan: { approved: true, taskCount: 5, artifactPresent: true },
+      quality: { queried: true, gatePassRate: null, regressions: [] },
+      worktrees: {
+        expected: 5, ready: 2, failed: [],
+        assignedTaskIds: ['t1', 't2', 't3', 't4', 't5'],
+        readyTaskIds: ['t1', 't2'],
+      },
+    };
+    setupMaterializer(state, undefined, drState);
+    const args = {
+      featureId: 'test-feature',
+      tasks: [
+        { id: 't1', title: 'A' }, // ready
+        { id: 't2', title: 'B' }, // ready
+        { id: 't3', title: 'C' }, // pending
+      ],
+    };
+
+    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+    expect(result.success).toBe(true);
+    const data = result.data as { ready: boolean; readiness: DelegationReadinessState };
+    // Wave size is 3 (not 5). One pending in the wave (t3).
+    expect(data.readiness.worktrees.expected).toBe(args.tasks.length);
+    expect(data.readiness.worktrees.expected).toBe(3);
+    expect(data.readiness.worktrees.ready).toBe(2);
+    // Blocker reports the wave-scoped pending count.
+    expect(data.readiness.blockers).toContain('1 worktrees pending');
+    expect(data.readiness.blockers).not.toContain('3 worktrees pending');
   });
 
   // ─── DR-5: nativeIsolation readiness.blockers consistency ─────────────────

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -441,21 +441,18 @@ export async function handlePrepareDelegation(
       drEvents,
     );
 
-    // Supplementary check: plan artifact existence (not tracked by the readiness view)
-    const hasPlanArtifact = Boolean(workflowState.artifacts?.plan);
-    const additionalBlockers: string[] = [];
-    if (!hasPlanArtifact) {
-      additionalBlockers.push('Plan artifact is missing');
-    }
-
-    // Merge readiness from view with supplementary checks
-    const allBlockers = [...readiness.blockers, ...additionalBlockers];
-
+    // DR-T-1 (#1205, T-03): plan-artifact presence is tracked by the
+    // delegation-readiness projection itself (T-02). The handler trusts
+    // the view as the single source of truth and does not run a parallel
+    // filesystem/state check. This eliminates the prior divergence where
+    // `prepare_delegation` and `delegation_readiness` reported different
+    // blocker lists for identical workflow state (axiom DIM-1, #1109 §2).
+    //
     // When nativeIsolation is true, filter out worktree-related blockers
-    // (Claude Code handles worktree isolation natively via `isolation: "worktree"`)
+    // (Claude Code handles worktree isolation natively via `isolation: "worktree"`).
     const effectiveBlockers = args.nativeIsolation
-      ? allBlockers.filter(b => !isWorktreeBlocker(b))
-      : allBlockers;
+      ? readiness.blockers.filter(b => !isWorktreeBlocker(b))
+      : readiness.blockers;
 
     const effectiveReady = effectiveBlockers.length === 0;
 

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -204,6 +204,45 @@ function isWorktreeBlocker(blocker: string): boolean {
   return WORKTREE_BLOCKER_PATTERNS.some(p => blocker.includes(p));
 }
 
+/**
+ * DR-T-2 (#1206, T-05): when a `tasks` filter is provided, replace the
+ * global "N worktrees pending" blocker with one scoped to the wave.
+ *
+ * Behavior:
+ * - No `tasks` arg → blockers pass through unchanged.
+ * - `tasks` arg present and the wave subset is fully ready → drop the
+ *   "worktrees pending" blocker entirely.
+ * - `tasks` arg present with M of the wave still pending → replace the
+ *   global "N worktrees pending" with "M worktrees pending".
+ *
+ * Other worktree blockers (e.g., baseline failures, "no worktrees
+ * expected") pass through — they're stream-global signals, not wave-scoped.
+ */
+function scopeWorktreeBlocker(
+  readiness: DelegationReadinessState,
+  tasksFilter: readonly { id: string }[] | undefined,
+): readonly string[] {
+  if (!tasksFilter || tasksFilter.length === 0) {
+    return readiness.blockers;
+  }
+
+  const taskIds = tasksFilter.map(t => t.id);
+  const readyInWave = taskIds.filter(id => readiness.worktrees.readyTaskIds.includes(id)).length;
+  const pendingInWave = taskIds.length - readyInWave;
+
+  return readiness.blockers.flatMap(blocker => {
+    // Only touch the canonical "<N> worktrees pending" message; pass
+    // through other worktree-class blockers (failed, no-worktrees-expected).
+    if (!/^\d+ worktrees pending$/.test(blocker)) {
+      return [blocker];
+    }
+    if (pendingInWave === 0) {
+      return []; // wave is complete — drop the blocker
+    }
+    return [`${pendingInWave} worktrees pending`];
+  });
+}
+
 // ─── Quality Hint Assembly ──────────────────────────────────────────────────
 
 function assembleQualityHints(
@@ -448,11 +487,18 @@ export async function handlePrepareDelegation(
     // `prepare_delegation` and `delegation_readiness` reported different
     // blocker lists for identical workflow state (axiom DIM-1, #1109 §2).
     //
+    // DR-T-2 (#1206, T-05): when a `tasks` arg is provided, scope the
+    // worktrees-pending blocker to that subset using assignedTaskIds and
+    // readyTaskIds from the projection. Prevents the documented "wave-by-
+    // wave dispatch" pattern from being blocked by the global per-stream
+    // count when only a subset is being prepared.
+    const scopedBlockers = scopeWorktreeBlocker(readiness, args.tasks);
+
     // When nativeIsolation is true, filter out worktree-related blockers
     // (Claude Code handles worktree isolation natively via `isolation: "worktree"`).
     const effectiveBlockers = args.nativeIsolation
-      ? readiness.blockers.filter(b => !isWorktreeBlocker(b))
-      : readiness.blockers;
+      ? scopedBlockers.filter(b => !isWorktreeBlocker(b))
+      : scopedBlockers;
 
     const effectiveReady = effectiveBlockers.length === 0;
 

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -285,7 +285,7 @@ export function computeScopedWorktrees(
   const expected = taskIds.length;
   const pending = expected - readyInWave;
 
-  const blockers = readiness.blockers.flatMap(blocker => {
+  let blockers = readiness.blockers.flatMap(blocker => {
     // Only touch the canonical "<N> worktrees pending" message; pass
     // through other worktree-class blockers (failed, no-worktrees-expected).
     if (!/^\d+ worktrees pending$/.test(blocker)) {
@@ -296,6 +296,19 @@ export function computeScopedWorktrees(
     }
     return [`${pending} worktrees pending`];
   });
+
+  // F-iter3 (#1213, sentry HIGH r3186305844): if the global readiness has no
+  // "N worktrees pending" blocker (because the global state was ready) but
+  // the wave subset still has pending worktrees, synthesise one. Without
+  // this the caller sees an empty blockers array and dispatches prematurely
+  // (e.g. mixed legacy/modern `worktree.created` events leave the global
+  // view consistent but the wave-projection is not).
+  if (
+    pending > 0 &&
+    !blockers.some(b => /^\d+ worktrees pending$/.test(b))
+  ) {
+    blockers = [...blockers, `${pending} worktrees pending`];
+  }
 
   return { expected, ready: readyInWave, pending, blockers };
 }

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -39,6 +39,7 @@ import type { DelegationReadinessState } from '../views/delegation-readiness-vie
 import { generateQualityHints } from '../quality/hints.js';
 import type { QualityHint } from '../quality/hints.js';
 import { emitGateEvent } from './gate-utils.js';
+import { canonicaliseTaskId } from './task-decomposition.js';
 import { queryTelemetryState } from '../telemetry/telemetry-queries.js';
 import type { TelemetryViewState } from '../telemetry/telemetry-projection.js';
 import {
@@ -269,9 +270,17 @@ export function computeScopedWorktrees(
     };
   }
 
+  // F19 (#1213): canonicalise IDs before comparing. Callers may pass
+  // `T-001`/`T001`/`001` interchangeably; the projection's `readyTaskIds`
+  // preserves the form recorded by upstream emitters. Without
+  // canonicalisation a wave addressed as `T-001` reports "1 worktrees
+  // pending" even when the projection holds `T001` as ready.
+  const canonicalReady = new Set(
+    readiness.worktrees.readyTaskIds.map(canonicaliseTaskId),
+  );
   const taskIds = tasksFilter.map(t => t.id);
   const readyInWave = taskIds.filter(id =>
-    readiness.worktrees.readyTaskIds.includes(id),
+    canonicalReady.has(canonicaliseTaskId(id)),
   ).length;
   const expected = taskIds.length;
   const pending = expected - readyInWave;

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -232,42 +232,63 @@ function computeDesyncBlockers(
 }
 
 /**
- * DR-T-2 (#1206, T-05): when a `tasks` filter is provided, replace the
- * global "N worktrees pending" blocker with one scoped to the wave.
+ * DR-T-2 (#1206, T-05) / fix-005 (#1213): pure helper that recomputes
+ * worktree counts and blockers against a wave subset.
  *
- * Behavior:
- * - No `tasks` arg → blockers pass through unchanged.
- * - `tasks` arg present and the wave subset is fully ready → drop the
- *   "worktrees pending" blocker entirely.
- * - `tasks` arg present with M of the wave still pending → replace the
- *   global "N worktrees pending" with "M worktrees pending".
+ * Returns:
+ * - `expected` — the size of the wave (or the projection's expected when
+ *   no filter is provided).
+ * - `ready` — count of wave members whose worktree is in `readyTaskIds`
+ *   (or the projection's global `ready` when no filter is provided).
+ * - `pending` — `expected - ready`.
+ * - `blockers` — `readiness.blockers` with the canonical
+ *   `"<N> worktrees pending"` message rewritten to the wave-scoped count
+ *   (dropped entirely when the wave is fully ready). Other worktree-class
+ *   blockers (e.g., "no worktrees expected", baseline failures) pass
+ *   through unchanged — they're stream-global signals, not wave-scoped.
  *
- * Other worktree blockers (e.g., baseline failures, "no worktrees
- * expected") pass through — they're stream-global signals, not wave-scoped.
+ * Pure: no I/O, no shared state. Exported for unit testing.
  */
-function scopeWorktreeBlocker(
+export interface ScopedWorktreesResult {
+  readonly expected: number;
+  readonly ready: number;
+  readonly pending: number;
+  readonly blockers: readonly string[];
+}
+
+export function computeScopedWorktrees(
   readiness: DelegationReadinessState,
   tasksFilter: readonly { id: string }[] | undefined,
-): readonly string[] {
+): ScopedWorktreesResult {
   if (!tasksFilter || tasksFilter.length === 0) {
-    return readiness.blockers;
+    return {
+      expected: readiness.worktrees.expected,
+      ready: readiness.worktrees.ready,
+      pending: Math.max(0, readiness.worktrees.expected - readiness.worktrees.ready),
+      blockers: readiness.blockers,
+    };
   }
 
   const taskIds = tasksFilter.map(t => t.id);
-  const readyInWave = taskIds.filter(id => readiness.worktrees.readyTaskIds.includes(id)).length;
-  const pendingInWave = taskIds.length - readyInWave;
+  const readyInWave = taskIds.filter(id =>
+    readiness.worktrees.readyTaskIds.includes(id),
+  ).length;
+  const expected = taskIds.length;
+  const pending = expected - readyInWave;
 
-  return readiness.blockers.flatMap(blocker => {
+  const blockers = readiness.blockers.flatMap(blocker => {
     // Only touch the canonical "<N> worktrees pending" message; pass
     // through other worktree-class blockers (failed, no-worktrees-expected).
     if (!/^\d+ worktrees pending$/.test(blocker)) {
       return [blocker];
     }
-    if (pendingInWave === 0) {
+    if (pending === 0) {
       return []; // wave is complete — drop the blocker
     }
-    return [`${pendingInWave} worktrees pending`];
+    return [`${pending} worktrees pending`];
   });
+
+  return { expected, ready: readyInWave, pending, blockers };
 }
 
 // ─── Quality Hint Assembly ──────────────────────────────────────────────────
@@ -514,18 +535,21 @@ export async function handlePrepareDelegation(
     // `prepare_delegation` and `delegation_readiness` reported different
     // blocker lists for identical workflow state (axiom DIM-1, #1109 §2).
     //
-    // DR-T-2 (#1206, T-05): when a `tasks` arg is provided, scope the
-    // worktrees-pending blocker to that subset using assignedTaskIds and
-    // readyTaskIds from the projection. Prevents the documented "wave-by-
-    // wave dispatch" pattern from being blocked by the global per-stream
-    // count when only a subset is being prepared.
-    const scopedBlockers = scopeWorktreeBlocker(readiness, args.tasks);
+    // DR-T-2 (#1206, T-05) / fix-005 (#1213): when a `tasks` arg is
+    // provided, scope the worktrees-pending blocker AND the numeric
+    // expected/ready counts to that subset. Prevents the documented
+    // "wave-by-wave dispatch" pattern from being blocked by the global
+    // per-stream count when only a subset is being prepared, and keeps
+    // the visible numeric surfaces in lockstep with the (possibly
+    // rewritten) blocker string so callers don't see "expected: 5 /
+    // ready: 2" alongside a "1 worktrees pending" blocker.
+    const scoped = computeScopedWorktrees(readiness, args.tasks);
 
     // When nativeIsolation is true, filter out worktree-related blockers
     // (Claude Code handles worktree isolation natively via `isolation: "worktree"`).
     const baseBlockers = args.nativeIsolation
-      ? scopedBlockers.filter(b => !isWorktreeBlocker(b))
-      : scopedBlockers;
+      ? scoped.blockers.filter(b => !isWorktreeBlocker(b))
+      : scoped.blockers;
 
     // ready is computed off the wave-scoped + native-filtered blockers,
     // BEFORE appending the desync diagnostic — drift is informational, it
@@ -545,6 +569,11 @@ export async function handlePrepareDelegation(
       ...readiness,
       ready: effectiveReady,
       blockers: effectiveBlockers,
+      worktrees: {
+        ...readiness.worktrees,
+        expected: scoped.expected,
+        ready: scoped.ready,
+      },
     };
 
     // Build result

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -205,6 +205,33 @@ function isWorktreeBlocker(blocker: string): boolean {
 }
 
 /**
+ * DR-T-3 (#1212, T-06): produce a state-vs-plan desync diagnostic when
+ * the projection's plan.taskCount diverges from workflowState.tasks.length.
+ *
+ * Diagnostic-only: does NOT gate readiness on its own. The blocker is
+ * appended to the visible list so an operator notices, but the ready
+ * gate is computed without it.
+ *
+ * Suppressed at empty baseline (plan.taskCount === 0) to avoid noise on
+ * fresh workflows where the projection hasn't seen task.assigned events
+ * yet.
+ */
+function computeDesyncBlockers(
+  workflowState: WorkflowStateView,
+  readiness: DelegationReadinessState,
+): readonly string[] {
+  const stateTasks = Array.isArray(workflowState.tasks) ? workflowState.tasks.length : 0;
+  const planCount = readiness.plan.taskCount;
+
+  if (planCount === 0) return []; // baseline — no diagnostic
+  if (stateTasks === planCount) return [];
+
+  return [
+    `state-vs-plan desync: workflow.tasks has ${stateTasks} entries but plan.taskCount is ${planCount} (likely stale state after plan-review revision)`,
+  ];
+}
+
+/**
  * DR-T-2 (#1206, T-05): when a `tasks` filter is provided, replace the
  * global "N worktrees pending" blocker with one scoped to the wave.
  *
@@ -496,11 +523,23 @@ export async function handlePrepareDelegation(
 
     // When nativeIsolation is true, filter out worktree-related blockers
     // (Claude Code handles worktree isolation natively via `isolation: "worktree"`).
-    const effectiveBlockers = args.nativeIsolation
+    const baseBlockers = args.nativeIsolation
       ? scopedBlockers.filter(b => !isWorktreeBlocker(b))
       : scopedBlockers;
 
-    const effectiveReady = effectiveBlockers.length === 0;
+    // ready is computed off the wave-scoped + native-filtered blockers,
+    // BEFORE appending the desync diagnostic — drift is informational, it
+    // does not gate dispatch on its own (per #1212 design).
+    const effectiveReady = baseBlockers.length === 0;
+
+    // DR-T-3 (#1212, T-06): state-vs-plan desync diagnostic. Compares the
+    // projection's plan.taskCount (incremented by task.assigned events)
+    // against workflowState.tasks.length. When the two diverge after a
+    // plan-review revision, the operator should notice before dispatching
+    // against stale state.
+    const desyncBlockers = computeDesyncBlockers(workflowState, readiness);
+
+    const effectiveBlockers = [...baseBlockers, ...desyncBlockers];
 
     const effectiveReadiness: DelegationReadinessState = {
       ...readiness,

--- a/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.test.ts
@@ -309,6 +309,61 @@ describe('mergePreflight — failure paths (T07)', () => {
     expect(result.worktree.actual).toBe(subagentCwd);
   });
 
+  it('mergePreflight_AncestryFails_MessageIncludesRebaseInstructionAndRunbookLink', async () => {
+    // T-15 / DR-6: when ancestry fails (source branch is not a descendant of
+    // target), the preflight must surface a remediation hint that
+    // (a) instructs the operator to run `git rebase`, and
+    // (b) links to the runbook section
+    //     `skills-src/delegation/SKILL.md#when-integration-advances-mid-wave`
+    //     so the operator can find the manual rebase + rollback procedure
+    //     without consulting external docs.
+    //
+    // Auto-rebase is explicitly deferred to #1119; this test asserts the
+    // human-facing message only.
+    const gitExec = makeGitExec([
+      {
+        args: ['merge-base', '--is-ancestor', 'main', 'feat/x'],
+        stdout: '',
+        exitCode: 1,
+      },
+      {
+        args: ['rev-parse', '--abbrev-ref', 'HEAD'],
+        stdout: 'feat/x\n',
+        exitCode: 0,
+      },
+      { args: ['status', '--porcelain'], stdout: '', exitCode: 0 },
+      { args: ['diff', '--cached', '--quiet'], stdout: '', exitCode: 0 },
+    ]);
+
+    const result = await mergePreflight({
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      gitExec,
+      cwd: '/tmp/repo',
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.ancestry.passed).toBe(false);
+    expect(result.ancestry.reason).toBe('ancestry');
+
+    // Remediation hint MUST be populated on ancestry failures.
+    expect(result.ancestry.hint).toBeDefined();
+    const hint = result.ancestry.hint!;
+
+    // (a) Manual remediation command must be discoverable verbatim.
+    expect(hint).toContain('git rebase');
+    // The hint should name the actual target branch so the operator can
+    // copy-paste without resolving placeholders.
+    expect(hint).toContain('main');
+
+    // (b) Link to the runbook section. The anchor must match the heading
+    // added to skills-src/delegation/SKILL.md (## When integration advances
+    // mid-wave → #when-integration-advances-mid-wave).
+    expect(hint).toContain(
+      'skills-src/delegation/SKILL.md#when-integration-advances-mid-wave',
+    );
+  });
+
   it('mergePreflight_DirtyTree_PassedFalseAndDriftFieldPopulated', async () => {
     // Drive drift to fail: `git status --porcelain` reports dirty files.
     const gitExec = makeGitExec([

--- a/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts
@@ -177,9 +177,16 @@ function formatAncestryRemediation(
   sourceBranch: string,
   targetBranch: string,
 ): string {
+  // CodeRabbit #1213/#6: omit the source-branch arg from the rebase hint.
+  // `git rebase <target> <source>` checks `<source>` out, which fails when
+  // the same branch is checked out in another worktree (the common case
+  // here — operator runs from the feature worktree). The two-arg form
+  // also forces a hard branch checkout instead of using the operator's
+  // current HEAD, which is rarely what they want. Run from the feature
+  // worktree with `git rebase <target>`.
   return (
     `source branch ${sourceBranch} is not a descendant of ${targetBranch}. ` +
-    `Rebase manually with: git rebase ${targetBranch} ${sourceBranch}. ` +
+    `Rebase manually with: git rebase ${targetBranch} (run from the ${sourceBranch} worktree). ` +
     `Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave`
   );
 }

--- a/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts
@@ -159,13 +159,41 @@ function adaptToDispatchGuardExec(
 }
 
 /**
+ * Build the operator-facing remediation hint for an ancestry-failed merge
+ * preflight (T-15 / DR-6, #1212). The hint must be self-contained so the
+ * operator can recover without consulting external docs:
+ *
+ *   1. The exact `git rebase` command, with both branch names interpolated
+ *      so it is copy-pasteable.
+ *   2. A link to the runbook section in the delegation skill that
+ *      documents the manual rebase + rollback procedure. The anchor
+ *      `#when-integration-advances-mid-wave` is the slugified heading
+ *      added in `skills-src/delegation/SKILL.md` under task T-15.
+ *
+ * No auto-rebase is invoked here; per the plan, automation is deferred
+ * to issue #1119.
+ */
+function formatAncestryRemediation(
+  sourceBranch: string,
+  targetBranch: string,
+): string {
+  return (
+    `source branch ${sourceBranch} is not a descendant of ${targetBranch}. ` +
+    `Rebase manually with: git rebase ${targetBranch} ${sourceBranch}. ` +
+    `Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave`
+  );
+}
+
+/**
  * Compose all four preflight guards into a single result. DR-MO-1
  * (topology preflight) requires that ancestry, current-branch
  * protection, main-worktree assertion, and working-tree drift all
  * pass before a merge is attempted.
  *
- * T06 covers only the happy path; T07 will exercise each failure
- * branch independently.
+ * T06 covers only the happy path; T07 exercises each failure
+ * branch independently. T-15 (#1212, DR-6) added the ancestry-failure
+ * remediation hint so operators can recover without consulting
+ * external docs.
  */
 export async function mergePreflight(
   args: MergePreflightArgs,
@@ -180,11 +208,29 @@ export async function mergePreflight(
   // `[targetBranch]` as the required upstream. The synthesis-flow caller
   // uses the opposite direction (target=main, upstream=feature-branches)
   // because there the assertion is "all features have landed in main."
-  const ancestry = await validateBranchAncestry(
+  const ancestryRaw = await validateBranchAncestry(
     args.sourceBranch,
     [args.targetBranch],
     adapter,
   );
+
+  // T-15: when ancestry fails because the source has diverged from the
+  // target (`reason: 'ancestry'`), enrich the result with a remediation
+  // hint that names the manual rebase command and links to the runbook.
+  // We do this here rather than inside `validateBranchAncestry` because
+  // only the merge-preflight caller knows the appropriate runbook target —
+  // other callers (synthesis-flow) need different remediation copy.
+  const ancestry: AncestryResult =
+    ancestryRaw.reason === 'ancestry'
+      ? {
+          ...ancestryRaw,
+          hint: formatAncestryRemediation(
+            args.sourceBranch,
+            args.targetBranch,
+          ),
+        }
+      : ancestryRaw;
+
   const currentBranch = getCurrentBranch(adapter);
   const currentBranchProtection = assertCurrentBranchNotProtected(currentBranch);
   const worktree = assertMainWorktree(repoRoot);

--- a/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.test.ts
@@ -307,7 +307,11 @@ describe('runStaticAnalysis', () => {
   // ============================================================
 
   describe('usage errors', () => {
-    it('empty directory with no project files returns pass (no applicable toolchain)', () => {
+    it('empty directory with no project files returns skip (no applicable toolchain)', () => {
+      // T-10: no-toolchain repos produce a 'skip' (inconclusive) result so
+      // the static-analysis gate cannot falsely-green a project that has
+      // no recognized toolchain. See DR-4 in
+      // docs/plans/2026-05-04-v290-dogfood-bundle.md.
       const emptyDir = path.join(tmpDir, 'empty');
       fs.mkdirSync(emptyDir, { recursive: true });
 
@@ -316,7 +320,8 @@ describe('runStaticAnalysis', () => {
         runCommand: successRunner(),
       });
 
-      expect(result.status).toBe('pass');
+      expect(result.status).toBe('skip');
+      expect(result.skipReason).toBe('no-toolchain');
       expect(result.projectType).toBeUndefined();
       expect(result.output).toContain('No recognized project type');
     });
@@ -483,10 +488,36 @@ describe('runStaticAnalysis', () => {
         runCommand: successRunner(),
       });
 
-      expect(result.status).toBe('pass');
+      // T-10: no-toolchain now resolves to 'skip' instead of 'pass' so the
+      // gate is honestly inconclusive rather than falsely-green.
+      expect(result.status).toBe('skip');
       expect(result.projectType).toBeUndefined();
       expect(result.passCount).toBe(0);
       expect(result.failCount).toBe(0);
+    });
+
+    // ─── T-10: SKIP status for unsupported toolchains ──────────────────────
+
+    it('runStaticAnalysis_NoToolchainDetected_ReturnsSkipStatus', () => {
+      // A directory with no recognized project file (no package.json,
+      // no *.csproj/*.sln, no go.mod, no Cargo.toml) should yield a
+      // 'skip' status with skipReason='no-toolchain' rather than a
+      // false-green 'pass'.
+      const repoRoot = createProjectDir({ 'README.md': '# Empty repo' });
+
+      const result = runStaticAnalysis({
+        repoRoot,
+        runCommand: successRunner(),
+      });
+
+      expect(result.status).toBe('skip');
+      expect(result.skipReason).toBe('no-toolchain');
+      expect(result.projectType).toBeUndefined();
+      expect(result.passCount).toBe(0);
+      expect(result.failCount).toBe(0);
+      // Output should announce SKIP, not PASS, in the result line.
+      expect(result.output).toContain('Result: SKIP');
+      expect(result.output).not.toContain('Result: PASS');
     });
 
     it('.NET project reports failure when dotnet build fails', () => {

--- a/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/static-analysis.ts
@@ -11,6 +11,12 @@
  * Exit code semantics (mapped to status field):
  *   'pass'  = all checks pass (warnings OK)
  *   'fail'  = errors found in one or more tools
+ *   'skip'  = no applicable toolchain detected (inconclusive — distinct from
+ *             'pass' so the gate cannot falsely-green repos with no
+ *             recognized toolchain). When this status is returned, the
+ *             `skipReason` field carries the reason code (currently only
+ *             'no-toolchain'). See DR-4 in
+ *             docs/plans/2026-05-04-v290-dogfood-bundle.md.
  *   'error' = usage error (missing repo root, no package.json)
  */
 
@@ -51,13 +57,32 @@ export interface StaticAnalysisInput {
   readonly runCommand: RunCommandFn;
 }
 
+/**
+ * Reason code for a 'skip' status. Currently only 'no-toolchain' is emitted
+ * (no recognized project files in repoRoot). The union is open for future
+ * skip reasons (e.g. 'all-checks-skipped-by-flag') without a breaking change.
+ */
+export type StaticAnalysisSkipReason = 'no-toolchain';
+
 export interface StaticAnalysisResult {
-  /** Overall status: pass, fail, or error. */
-  readonly status: 'pass' | 'fail' | 'error';
+  /**
+   * Overall status.
+   *
+   * - 'pass'  — all applicable checks passed
+   * - 'fail'  — one or more checks failed
+   * - 'skip'  — no applicable toolchain detected (inconclusive); see
+   *             `skipReason` for the reason code. Distinct from 'pass' so
+   *             the gate does not falsely-green a repo with no recognized
+   *             toolchain. See DR-4 in v2.9 dogfood plan.
+   * - 'error' — usage error (missing/invalid repo root, etc.)
+   */
+  readonly status: 'pass' | 'fail' | 'skip' | 'error';
   /** Structured markdown report. */
   readonly output: string;
   /** Error message when status is 'error'. */
   readonly error?: string;
+  /** Reason code when status is 'skip'. */
+  readonly skipReason?: StaticAnalysisSkipReason;
   /** Number of checks that passed. */
   readonly passCount: number;
   /** Number of checks that failed. */
@@ -308,6 +333,10 @@ export function runStaticAnalysis(input: StaticAnalysisInput): StaticAnalysisRes
   const projectType = detectProjectType(repoRoot);
 
   if (!projectType) {
+    // T-10 / DR-4: no recognized toolchain returns 'skip' (inconclusive),
+    // NOT 'pass'. A pass would falsely-green any repo missing a toolchain
+    // marker. Callers (handler + convergence view) translate this into a
+    // skipped/inconclusive gate result rather than a passing one.
     const output = [
       '## Static Analysis Report',
       '',
@@ -317,12 +346,13 @@ export function runStaticAnalysis(input: StaticAnalysisInput): StaticAnalysisRes
       '',
       '---',
       '',
-      '**Result: PASS** (0/0 checks — no applicable toolchain detected)',
+      '**Result: SKIP** (no applicable toolchain detected)',
     ].join('\n');
 
     return {
-      status: 'pass',
+      status: 'skip',
       output,
+      skipReason: 'no-toolchain',
       passCount: 0,
       failCount: 0,
       projectType: undefined,

--- a/servers/exarchos-mcp/src/orchestrate/setup-worktree.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/setup-worktree.test.ts
@@ -822,4 +822,165 @@ describe('handleSetupWorktree', () => {
     const pnpmCalls = vi.mocked(execFileSync).mock.calls.filter((c) => c[0] === 'pnpm');
     expect(pnpmCalls).toHaveLength(0);
   });
+
+  // ─── DR-1 (T-07, #1203): direct-read .gitignore, honest PASS message ──
+
+  describe('ensureGitignored direct-read behavior', () => {
+    function setupBaseExecMocks() {
+      // Generic happy-path mocks for show-ref / rev-parse / install / test.
+      vi.mocked(execFileSync).mockImplementation((cmd: unknown, args: unknown) => {
+        const cmdStr = String(cmd);
+        const argsArr = args as string[];
+        if (cmdStr === 'git' && argsArr.includes('show-ref')) return '';
+        if (cmdStr === 'git' && argsArr.includes('rev-parse')) return '.git';
+        if (cmdStr === 'npm') return '';
+        if (cmdStr === 'pnpm') return '';
+        if (cmdStr === 'yarn') return '';
+        if (cmdStr === 'bun') return '';
+        return '';
+      });
+    }
+
+    it('ensureGitignored_AlreadyPresent_ReportsAlreadyPresent', () => {
+      setupBaseExecMocks();
+      vi.mocked(existsSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return true;
+        if (path === '/repo/.worktrees/T-001-x') return true;
+        if (path === '/repo/.worktrees/T-001-x/package.json') return true;
+        return false;
+      });
+      vi.mocked(readFileSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return 'node_modules/\n.worktrees/\n';
+        if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
+        return '';
+      });
+
+      const result = handleSetupWorktree({
+        repoRoot: '/repo', taskId: 'T-001', taskName: 'x',
+      });
+
+      expect(result.success).toBe(true);
+      const data = result.data as { passed: boolean; report: string };
+      expect(data.report).toMatch(/PASS.*\.worktrees is gitignored.*already present/i);
+      expect(appendFileSync).not.toHaveBeenCalledWith('/repo/.gitignore', expect.anything());
+    });
+
+    it('ensureGitignored_NotPresent_AppendsAndReportsAdded', () => {
+      setupBaseExecMocks();
+      vi.mocked(existsSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return true;
+        if (path === '/repo/.worktrees/T-002-y') return true;
+        if (path === '/repo/.worktrees/T-002-y/package.json') return true;
+        return false;
+      });
+      vi.mocked(readFileSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return 'node_modules/\n';
+        if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
+        return '';
+      });
+
+      const result = handleSetupWorktree({
+        repoRoot: '/repo', taskId: 'T-002', taskName: 'y',
+      });
+
+      expect(result.success).toBe(true);
+      const data = result.data as { report: string };
+      expect(data.report).toMatch(/PASS.*\.worktrees is gitignored.*added/i);
+      expect(appendFileSync).toHaveBeenCalledWith('/repo/.gitignore', '.worktrees/\n');
+    });
+
+    it('ensureGitignored_FileMissing_CreatesWithEntry', () => {
+      setupBaseExecMocks();
+      vi.mocked(existsSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return false;
+        if (path === '/repo/.worktrees/T-003-z') return true;
+        if (path === '/repo/.worktrees/T-003-z/package.json') return true;
+        return false;
+      });
+      vi.mocked(readFileSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
+        return '';
+      });
+
+      const result = handleSetupWorktree({
+        repoRoot: '/repo', taskId: 'T-003', taskName: 'z',
+      });
+
+      expect(result.success).toBe(true);
+      const data = result.data as { report: string };
+      expect(data.report).toMatch(/PASS.*\.worktrees is gitignored.*created/i);
+      expect(appendFileSync).toHaveBeenCalledWith('/repo/.gitignore', '.worktrees/\n');
+    });
+
+    it('ensureGitignored_GlobalIgnoreOnlyMatch_StillReportsHonestlyAndUpdatesRepoGitignore', () => {
+      // Critical regression coverage for #1203: a non-repo source (e.g.,
+      // global gitignore, .git/info/exclude) might tell `git check-ignore`
+      // the path is ignored. Repo `.gitignore` itself is empty of this entry
+      // and `git status` from a fresh clone would show .worktrees/ as
+      // untracked. The new contract: PASS message reflects the repo file
+      // state truthfully, and we always update the repo file when needed.
+      setupBaseExecMocks();
+      vi.mocked(existsSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return true;
+        if (path === '/repo/.worktrees/T-004-a') return true;
+        if (path === '/repo/.worktrees/T-004-a/package.json') return true;
+        return false;
+      });
+      vi.mocked(readFileSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return 'node_modules/\n'; // .worktrees absent
+        if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
+        return '';
+      });
+
+      const result = handleSetupWorktree({
+        repoRoot: '/repo', taskId: 'T-004', taskName: 'a',
+      });
+
+      expect(result.success).toBe(true);
+      const data = result.data as { report: string };
+      // Even if a global ignore would have matched, the repo file is
+      // missing — function must add and report 'added' truthfully.
+      expect(data.report).toMatch(/added/i);
+      expect(appendFileSync).toHaveBeenCalledWith('/repo/.gitignore', '.worktrees/\n');
+      // No git check-ignore call — function works directly off the repo file.
+      const checkIgnoreCalls = vi.mocked(execFileSync).mock.calls.filter(
+        (c) => Array.isArray(c[1]) && (c[1] as string[]).includes('check-ignore'),
+      );
+      expect(checkIgnoreCalls).toHaveLength(0);
+    });
+
+    it('ensureGitignored_AppendThrows_ReportsFail', () => {
+      setupBaseExecMocks();
+      vi.mocked(existsSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return true;
+        return false;
+      });
+      vi.mocked(readFileSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return 'node_modules/\n';
+        return '';
+      });
+      vi.mocked(appendFileSync).mockImplementation(() => {
+        throw new Error('EACCES: permission denied');
+      });
+
+      const result = handleSetupWorktree({
+        repoRoot: '/repo', taskId: 'T-005', taskName: 'b',
+      });
+
+      expect(result.success).toBe(true); // overall flow succeeds at I/O level
+      const data = result.data as { passed: boolean; report: string };
+      expect(data.report).toMatch(/FAIL.*\.worktrees is gitignored.*EACCES/i);
+      expect(data.passed).toBe(false);
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/orchestrate/setup-worktree.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/setup-worktree.test.ts
@@ -983,4 +983,114 @@ describe('handleSetupWorktree', () => {
       expect(data.passed).toBe(false);
     });
   });
+
+  // ─── DR-3 (T-09, #1204): branch-override resolution ───────────────────────
+  //
+  // Resolution priority: args.branch > workflow.tasks[id=<taskId>].branch >
+  // legacy `feature/<id>-<name>` default. The "Branch created" check report
+  // includes a source-attribution suffix indicating which path was taken
+  // (`from arg`, `from workflow state`, or `default`).
+
+  describe('branch-override resolution (DR-3)', () => {
+    function setupHappyPathMocks() {
+      vi.mocked(execFileSync).mockImplementation((cmd: unknown, args: unknown) => {
+        const cmdStr = String(cmd);
+        const argsArr = args as string[];
+        if (cmdStr === 'git' && argsArr.includes('show-ref')) {
+          // Branch does not exist — handler proceeds to create it.
+          const error = new Error('not found') as Error & { status: number };
+          error.status = 1;
+          throw error;
+        }
+        if (cmdStr === 'git' && argsArr.includes('branch')) return '';
+        if (cmdStr === 'git' && argsArr.includes('worktree')) return '';
+        if (cmdStr === 'git' && argsArr.includes('rev-parse')) return '.git';
+        if (cmdStr === 'npm' || cmdStr === 'pnpm' || cmdStr === 'yarn' || cmdStr === 'bun') return '';
+        return '';
+      });
+      vi.mocked(existsSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return true;
+        // Worktree dir does NOT exist initially — `git worktree add` is invoked.
+        if (path.endsWith('/package.json')) return true;
+        return false;
+      });
+      vi.mocked(readFileSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return '.worktrees/\n';
+        if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
+        return '';
+      });
+    }
+
+    it('setupWorktree_WorkflowTasksHasBranch_UsesItOverDefault', () => {
+      setupHappyPathMocks();
+      const workflowState = {
+        tasks: [
+          { id: 'T-001', title: 't', status: 'pending', branch: 'feature/foo/t001' },
+        ],
+      };
+
+      const result = handleSetupWorktree(
+        {
+          repoRoot: '/repo',
+          taskId: 'T-001',
+          taskName: 'user-model',
+          skipTests: true,
+        },
+        workflowState,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as { branchName: string; report: string };
+      expect(data.branchName).toBe('feature/foo/t001');
+      expect(data.report).toMatch(/Branch created.*from workflow state/i);
+      // Verify `git branch` was called with the planned name, not the legacy default.
+      const branchCalls = vi.mocked(execFileSync).mock.calls.filter(
+        (c) => c[0] === 'git' && Array.isArray(c[1]) && (c[1] as string[]).includes('branch') && (c[1] as string[]).includes('feature/foo/t001'),
+      );
+      expect(branchCalls.length).toBeGreaterThan(0);
+    });
+
+    it('setupWorktree_ArgBranchOverridesWorkflowState', () => {
+      setupHappyPathMocks();
+      const workflowState = {
+        tasks: [
+          { id: 'T-002', title: 't', status: 'pending', branch: 'feature/state/branch' },
+        ],
+      };
+
+      const result = handleSetupWorktree(
+        {
+          repoRoot: '/repo',
+          taskId: 'T-002',
+          taskName: 'auth',
+          skipTests: true,
+          branch: 'feature/arg/branch',
+        },
+        workflowState,
+      );
+
+      expect(result.success).toBe(true);
+      const data = result.data as { branchName: string; report: string };
+      expect(data.branchName).toBe('feature/arg/branch');
+      expect(data.report).toMatch(/Branch created.*from arg/i);
+    });
+
+    it('setupWorktree_NoBranchAnywhere_UsesLegacyDefault', () => {
+      setupHappyPathMocks();
+
+      const result = handleSetupWorktree({
+        repoRoot: '/repo',
+        taskId: 'T-003',
+        taskName: 'db',
+        skipTests: true,
+      });
+
+      expect(result.success).toBe(true);
+      const data = result.data as { branchName: string; report: string };
+      expect(data.branchName).toBe('feature/T-003-db');
+      expect(data.report).toMatch(/Branch created.*default/i);
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/orchestrate/setup-worktree.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/setup-worktree.test.ts
@@ -226,6 +226,52 @@ describe('handleSetupWorktree', () => {
     );
   });
 
+  // ── #1213 / CodeRabbit #7: gitignore append must preserve line boundary ─
+
+  it('WorktreesNotGitignored_ExistingGitignoreNoTrailingNewline_PrependsNewline', () => {
+    // Existing .gitignore lacks trailing newline (ends with "dist", no \n).
+    // A bare append would produce "dist.worktrees/\n" — a single
+    // concatenated line that no longer ignores either path. The fix
+    // prepends a newline so the final contents are "dist\n.worktrees/\n".
+    vi.mocked(execFileSync).mockImplementation((cmd: unknown, args: unknown) => {
+      const cmdStr = String(cmd);
+      const argsArr = args as string[];
+      if (cmdStr === 'git' && argsArr.includes('show-ref')) return '';
+      if (cmdStr === 'git' && argsArr.includes('rev-parse')) return '.git';
+      if (cmdStr === 'npm' && argsArr.includes('install')) return '';
+      if (cmdStr === 'npm' && argsArr.includes('test:run')) return '';
+      return '';
+    });
+    vi.mocked(existsSync).mockImplementation((p: unknown) => {
+      const path = String(p);
+      if (path === '/repo/.gitignore') return true;
+      if (path === '/repo/.worktrees/task-004b-newline') return true;
+      if (path === '/repo/.worktrees/task-004b-newline/package.json') return true;
+      return false;
+    });
+    vi.mocked(readFileSync).mockImplementation((p: unknown) => {
+      const path = String(p);
+      // Crucially: NO trailing newline here.
+      if (path === '/repo/.gitignore') return 'dist';
+      if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
+      return '';
+    });
+
+    const result = handleSetupWorktree({
+      repoRoot: '/repo',
+      taskId: 'task-004b',
+      taskName: 'newline',
+    });
+
+    expect(result.success).toBe(true);
+    // The append payload MUST start with \n so the final content is
+    // "dist\n.worktrees/\n", not "dist.worktrees/\n".
+    expect(appendFileSync).toHaveBeenCalledWith(
+      '/repo/.gitignore',
+      '\n.worktrees/\n',
+    );
+  });
+
   // ── Test 5: install fails ───────────────────────────────────────────────
 
   it('NpmInstallFails_Step4Fails', () => {

--- a/servers/exarchos-mcp/src/orchestrate/setup-worktree.ts
+++ b/servers/exarchos-mcp/src/orchestrate/setup-worktree.ts
@@ -13,7 +13,7 @@ import { splitCommand } from '../config/tokenize-command.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
-interface SetupWorktreeArgs {
+export interface SetupWorktreeArgs {
   readonly repoRoot: string;
   readonly taskId: string;
   readonly taskName: string;

--- a/servers/exarchos-mcp/src/orchestrate/setup-worktree.ts
+++ b/servers/exarchos-mcp/src/orchestrate/setup-worktree.ts
@@ -114,6 +114,10 @@ function formatReport(
 // New contract: PASS means "the repo's `.gitignore` lists `.worktrees/`."
 // The detail string reflects exactly which path the function took
 // (already present / added / created with entry).
+//
+// fix-007 (review #1213): orchestration-only — read/format helpers
+// extracted below so each concern (read vs error formatting vs control
+// flow) sits in its own function and stays easy to read in isolation.
 function ensureGitignored(repoRoot: string): CheckResult {
   const gitignorePath = join(repoRoot, '.gitignore');
 
@@ -121,18 +125,12 @@ function ensureGitignored(repoRoot: string): CheckResult {
   let needsAppend: boolean;
 
   if (existsSync(gitignorePath)) {
-    let contents: string;
-    try {
-      contents = readFileSync(gitignorePath, 'utf-8');
-    } catch (err) {
-      return {
-        name: '.worktrees is gitignored',
-        status: 'fail',
-        detail: `Failed to read ${gitignorePath}: ${err instanceof Error ? err.message : String(err)}`,
-      };
+    const readResult = readGitignoreLines(gitignorePath);
+    if (readResult.kind === 'error') {
+      return formatGitignoreError(`Failed to read ${gitignorePath}`, readResult.err);
     }
 
-    if (containsWorktreesEntry(contents)) {
+    if (containsWorktreesEntry(readResult.contents)) {
       return { name: '.worktrees is gitignored', status: 'pass', detail: 'already present' };
     }
 
@@ -147,15 +145,43 @@ function ensureGitignored(repoRoot: string): CheckResult {
     try {
       appendFileSync(gitignorePath, '.worktrees/\n');
     } catch (err) {
-      return {
-        name: '.worktrees is gitignored',
-        status: 'fail',
-        detail: `Failed to ${detail === 'created with entry' ? 'create' : 'append to'} ${gitignorePath}: ${err instanceof Error ? err.message : String(err)}`,
-      };
+      const verb = detail === 'created with entry' ? 'create' : 'append to';
+      return formatGitignoreError(`Failed to ${verb} ${gitignorePath}`, err);
     }
   }
 
   return { name: '.worktrees is gitignored', status: 'pass', detail };
+}
+
+/**
+ * fix-007 (#1213): I/O wrapper that returns either the file contents or a
+ * structured error. Centralizes the readFileSync try/catch so the
+ * orchestrator can stay flat.
+ */
+type ReadGitignoreResult =
+  | { kind: 'ok'; contents: string }
+  | { kind: 'error'; err: unknown };
+
+function readGitignoreLines(gitignorePath: string): ReadGitignoreResult {
+  try {
+    return { kind: 'ok', contents: readFileSync(gitignorePath, 'utf-8') };
+  } catch (err) {
+    return { kind: 'error', err };
+  }
+}
+
+/**
+ * fix-007 (#1213): single-source formatter for the gitignore-step CheckResult
+ * `fail` shape. Keeps the `${prefix}: ${message}` convention in one place so
+ * any future adjustment to the detail string lives in one function.
+ */
+function formatGitignoreError(prefix: string, err: unknown): CheckResult {
+  const message = err instanceof Error ? err.message : String(err);
+  return {
+    name: '.worktrees is gitignored',
+    status: 'fail',
+    detail: `${prefix}: ${message}`,
+  };
 }
 
 /**

--- a/servers/exarchos-mcp/src/orchestrate/setup-worktree.ts
+++ b/servers/exarchos-mcp/src/orchestrate/setup-worktree.ts
@@ -19,6 +19,28 @@ interface SetupWorktreeArgs {
   readonly taskName: string;
   readonly baseBranch?: string;
   readonly skipTests?: boolean;
+  /**
+   * DR-3 (T-09, #1204): explicit branch override. When supplied, takes
+   * precedence over workflow-state and the legacy default. Lets callers
+   * override the planned branch without mutating workflow state.
+   */
+  readonly branch?: string;
+  /**
+   * DR-3 (T-09, #1204): used by the composite adapter for `featureId`
+   * routing in the registry schema. Not consumed by the handler directly —
+   * the adapter pre-loads workflow state from this and threads it via the
+   * second positional argument.
+   */
+  readonly featureId?: string;
+}
+
+/**
+ * Minimal shape of the workflow state needed by the handler. The composite
+ * adapter materializes the full WorkflowStateView and projects this subset;
+ * tests can pass a literal without instantiating a projection.
+ */
+interface SetupWorktreeWorkflowState {
+  readonly tasks?: ReadonlyArray<{ id: string; branch?: string }>;
 }
 
 type CheckStatus = 'pass' | 'fail' | 'skip';
@@ -150,20 +172,68 @@ function containsWorktreesEntry(contents: string): boolean {
   return false;
 }
 
-function createBranch(repoRoot: string, branchName: string, baseBranch: string): CheckResult {
+// ─── DR-3 (T-09, #1204): branch-name resolution ─────────────────────────────
+//
+// Resolution priority:
+//   1. args.branch                              — explicit caller override
+//   2. workflow.tasks[id=<taskId>].branch       — planned branch from state
+//   3. `feature/<taskId>-<taskName>`            — legacy default
+//
+// Returns the resolved name plus a `source` tag used to annotate the
+// "Branch created" check detail. Pure: no I/O, easy to unit-test.
+
+type BranchSource = 'arg' | 'workflow state' | 'default';
+
+interface ResolvedBranch {
+  readonly name: string;
+  readonly source: BranchSource;
+}
+
+function resolveBranchName(
+  args: SetupWorktreeArgs,
+  workflowState?: SetupWorktreeWorkflowState,
+): ResolvedBranch {
+  if (args.branch && args.branch.length > 0) {
+    return { name: args.branch, source: 'arg' };
+  }
+  const planned = workflowState?.tasks?.find((t) => t.id === args.taskId)?.branch;
+  if (planned && planned.length > 0) {
+    return { name: planned, source: 'workflow state' };
+  }
+  return { name: `feature/${args.taskId}-${args.taskName}`, source: 'default' };
+}
+
+function createBranch(
+  repoRoot: string,
+  branchName: string,
+  baseBranch: string,
+  source: BranchSource,
+): CheckResult {
   // Check if branch already exists
   try {
     gitExec(repoRoot, ['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`]);
-    return { name: `Branch created`, status: 'pass', detail: `${branchName} already exists` };
+    return {
+      name: `Branch created`,
+      status: 'pass',
+      detail: `${branchName} already exists (from ${source})`,
+    };
   } catch {
     // Branch does not exist — create it
   }
 
   try {
     gitExec(repoRoot, ['branch', branchName, baseBranch]);
-    return { name: `Branch created`, status: 'pass', detail: `${branchName} from ${baseBranch}` };
+    return {
+      name: `Branch created`,
+      status: 'pass',
+      detail: `${branchName} from ${baseBranch} (from ${source})`,
+    };
   } catch {
-    return { name: `Branch created`, status: 'fail', detail: `Failed to create ${branchName} from ${baseBranch}` };
+    return {
+      name: `Branch created`,
+      status: 'fail',
+      detail: `Failed to create ${branchName} from ${baseBranch} (from ${source})`,
+    };
   }
 }
 
@@ -283,7 +353,10 @@ function runBaselineTests(worktreePath: string, skipTests: boolean): CheckResult
 
 // ─── Handler ────────────────────────────────────────────────────────────────
 
-export function handleSetupWorktree(args: SetupWorktreeArgs): ToolResult {
+export function handleSetupWorktree(
+  args: SetupWorktreeArgs,
+  workflowState?: SetupWorktreeWorkflowState,
+): ToolResult {
   // Validate required args
   if (!args.repoRoot) {
     return {
@@ -307,9 +380,12 @@ export function handleSetupWorktree(args: SetupWorktreeArgs): ToolResult {
   const baseBranch = args.baseBranch ?? 'main';
   const skipTests = args.skipTests ?? false;
 
-  // Derive paths
+  // DR-3 (T-09, #1204): resolve branch with priority args > state > default.
+  // Worktree directory still uses the legacy `<taskId>-<taskName>` layout —
+  // the override only changes the git-branch ref, not the on-disk path.
+  const resolvedBranch = resolveBranchName(args, workflowState);
+  const branchName = resolvedBranch.name;
   const worktreeName = `${args.taskId}-${args.taskName}`;
-  const branchName = `feature/${worktreeName}`;
   const worktreePath = join(args.repoRoot, '.worktrees', worktreeName);
 
   const checks: CheckResult[] = [];
@@ -318,7 +394,7 @@ export function handleSetupWorktree(args: SetupWorktreeArgs): ToolResult {
   checks.push(ensureGitignored(args.repoRoot));
 
   // Step 2: Create feature branch
-  checks.push(createBranch(args.repoRoot, branchName, baseBranch));
+  checks.push(createBranch(args.repoRoot, branchName, baseBranch, resolvedBranch.source));
 
   // Step 3: Create worktree
   checks.push(createWorktree(args.repoRoot, worktreePath, branchName));

--- a/servers/exarchos-mcp/src/orchestrate/setup-worktree.ts
+++ b/servers/exarchos-mcp/src/orchestrate/setup-worktree.ts
@@ -123,6 +123,11 @@ function ensureGitignored(repoRoot: string): CheckResult {
 
   let detail: 'already present' | 'added' | 'created with entry';
   let needsAppend: boolean;
+  // CodeRabbit #7: when the existing .gitignore lacks a trailing newline,
+  // a bare append produces `dist.worktrees/\n` (single concatenated line)
+  // instead of two distinct entries. Prepend a newline if needed so the
+  // boundary is preserved.
+  let prependNewline = false;
 
   if (existsSync(gitignorePath)) {
     const readResult = readGitignoreLines(gitignorePath);
@@ -136,6 +141,8 @@ function ensureGitignored(repoRoot: string): CheckResult {
 
     detail = 'added';
     needsAppend = true;
+    prependNewline =
+      readResult.contents.length > 0 && !readResult.contents.endsWith('\n');
   } else {
     detail = 'created with entry';
     needsAppend = true;
@@ -143,7 +150,8 @@ function ensureGitignored(repoRoot: string): CheckResult {
 
   if (needsAppend) {
     try {
-      appendFileSync(gitignorePath, '.worktrees/\n');
+      const payload = (prependNewline ? '\n' : '') + '.worktrees/\n';
+      appendFileSync(gitignorePath, payload);
     } catch (err) {
       const verb = detail === 'created with entry' ? 'create' : 'append to';
       return formatGitignoreError(`Failed to ${verb} ${gitignorePath}`, err);

--- a/servers/exarchos-mcp/src/orchestrate/setup-worktree.ts
+++ b/servers/exarchos-mcp/src/orchestrate/setup-worktree.ts
@@ -4,7 +4,7 @@
 // validation steps: gitignore, branch, worktree, npm install, baseline tests.
 // ────────────────────────────────────────────────────────────────────────────
 
-import { existsSync, appendFileSync } from 'node:fs';
+import { existsSync, appendFileSync, readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import type { ToolResult } from '../format.js';
@@ -82,36 +82,72 @@ function formatReport(
 
 // ─── Step Functions ─────────────────────────────────────────────────────────
 
+// DR-1 (T-07, #1203): direct-read the repo's `.gitignore`. The previous
+// implementation used `git check-ignore -q .worktrees/`, which honors any
+// ignore source (global excludes, .git/info/exclude, parent globs). When
+// a non-repo source matched, the function reported PASS without writing
+// to the repo file — a fresh clone or CI run then saw `.worktrees/` as
+// untracked, breaking subsequent `merge_orchestrate` preflights.
+//
+// New contract: PASS means "the repo's `.gitignore` lists `.worktrees/`."
+// The detail string reflects exactly which path the function took
+// (already present / added / created with entry).
 function ensureGitignored(repoRoot: string): CheckResult {
-  // Check if .worktrees/ is already gitignored
-  try {
-    execFileSync('git', ['-C', repoRoot, 'check-ignore', '-q', '.worktrees/'], {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return { name: '.worktrees is gitignored', status: 'pass' };
-  } catch {
-    // Not ignored — add to .gitignore
-  }
-
   const gitignorePath = join(repoRoot, '.gitignore');
+
+  let detail: 'already present' | 'added' | 'created with entry';
+  let needsAppend: boolean;
+
   if (existsSync(gitignorePath)) {
-    appendFileSync(gitignorePath, '.worktrees/\n');
+    let contents: string;
+    try {
+      contents = readFileSync(gitignorePath, 'utf-8');
+    } catch (err) {
+      return {
+        name: '.worktrees is gitignored',
+        status: 'fail',
+        detail: `Failed to read ${gitignorePath}: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    if (containsWorktreesEntry(contents)) {
+      return { name: '.worktrees is gitignored', status: 'pass', detail: 'already present' };
+    }
+
+    detail = 'added';
+    needsAppend = true;
   } else {
-    // Create new .gitignore with the entry
-    appendFileSync(gitignorePath, '.worktrees/\n');
+    detail = 'created with entry';
+    needsAppend = true;
   }
 
-  // Verify it worked
-  try {
-    execFileSync('git', ['-C', repoRoot, 'check-ignore', '-q', '.worktrees/'], {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return { name: '.worktrees is gitignored', status: 'pass', detail: 'added to .gitignore' };
-  } catch {
-    return { name: '.worktrees is gitignored', status: 'fail', detail: 'Failed to add to .gitignore' };
+  if (needsAppend) {
+    try {
+      appendFileSync(gitignorePath, '.worktrees/\n');
+    } catch (err) {
+      return {
+        name: '.worktrees is gitignored',
+        status: 'fail',
+        detail: `Failed to ${detail === 'created with entry' ? 'create' : 'append to'} ${gitignorePath}: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
   }
+
+  return { name: '.worktrees is gitignored', status: 'pass', detail };
+}
+
+/**
+ * Returns true if `contents` has a non-comment, non-negated line matching
+ * `.worktrees` or `.worktrees/`. Comments (#) and negations (!) don't
+ * count — those would not actually ignore the directory.
+ */
+function containsWorktreesEntry(contents: string): boolean {
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === '' || line.startsWith('#') || line.startsWith('!')) continue;
+    if (line === '.worktrees' || line === '.worktrees/') return true;
+  }
+  return false;
 }
 
 function createBranch(repoRoot: string, branchName: string, baseBranch: string): CheckResult {

--- a/servers/exarchos-mcp/src/orchestrate/static-analysis.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/static-analysis.test.ts
@@ -79,6 +79,26 @@ function makeErrorResult() {
   };
 }
 
+function makeSkipResult() {
+  return {
+    status: 'skip' as const,
+    output: [
+      '## Static Analysis Report',
+      '',
+      '**Repository:** `/home/user/empty-repo`',
+      '',
+      '- **SKIP**: No recognized project type (no package.json, *.csproj, go.mod, or Cargo.toml)',
+      '',
+      '---',
+      '',
+      '**Result: SKIP** (no applicable toolchain detected)',
+    ].join('\n'),
+    skipReason: 'no-toolchain' as const,
+    passCount: 0,
+    failCount: 0,
+  };
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('handleStaticAnalysis', () => {
@@ -239,6 +259,58 @@ describe('handleStaticAnalysis', () => {
       expect(result.success).toBe(false);
       expect(result.error?.code).toBe('SCRIPT_ERROR');
       expect(result.error?.message).toContain('No package.json found');
+    });
+  });
+
+  // ─── Skip Status (T-10: no-toolchain inconclusive) ───────────────────
+
+  describe('skip status from analysis', () => {
+    it('handleStaticAnalysis_SkipStatus_EmitsEventWithSkippedTrue', async () => {
+      // Arrange: pure function reports skip / no-toolchain.
+      mockRunStaticAnalysis.mockReturnValue(makeSkipResult());
+
+      const args = { featureId: 'feat-1', repoRoot: '/home/user/empty-repo' };
+
+      // Act
+      const result = await handleStaticAnalysis(args, STATE_DIR, mockStore as unknown as EventStore);
+
+      // Assert: handler returns success with passed=false + skipped=true.
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        passed: boolean;
+        skipped: boolean;
+        skipReason?: string;
+        passCount: number;
+        failCount: number;
+        report: string;
+      };
+      expect(data.passed).toBe(false);
+      expect(data.skipped).toBe(true);
+      expect(data.skipReason).toBe('no-toolchain');
+      expect(data.passCount).toBe(0);
+      expect(data.failCount).toBe(0);
+      expect(data.report).toContain('Result: SKIP');
+
+      // Assert: gate.executed event reflects skip in details payload.
+      expect(mockStore.append).toHaveBeenCalledTimes(1);
+      const appendCall = mockStore.append.mock.calls[0];
+      expect(appendCall[0]).toBe('feat-1');
+      const event = appendCall[1] as {
+        type: string;
+        data: {
+          gateName: string;
+          layer: string;
+          passed: boolean;
+          details: Record<string, unknown>;
+        };
+      };
+      expect(event.type).toBe('gate.executed');
+      expect(event.data.gateName).toBe('static-analysis');
+      expect(event.data.layer).toBe('quality');
+      expect(event.data.passed).toBe(false);
+      expect(event.data.details.dimension).toBe('D2');
+      expect(event.data.details.skipped).toBe(true);
+      expect(event.data.details.skipReason).toBe('no-toolchain');
     });
   });
 

--- a/servers/exarchos-mcp/src/orchestrate/static-analysis.ts
+++ b/servers/exarchos-mcp/src/orchestrate/static-analysis.ts
@@ -27,6 +27,15 @@ interface StaticAnalysisResult {
   readonly passCount: number;
   readonly failCount: number;
   readonly report: string;
+  /**
+   * True when the gate could not actually run (no recognized toolchain).
+   * Distinct from `passed:false` (which means a real failure) — callers
+   * should treat skipped gates as inconclusive, not green. See DR-4 in
+   * docs/plans/2026-05-04-v290-dogfood-bundle.md.
+   */
+  readonly skipped?: boolean;
+  /** Reason code when `skipped` is true (e.g. 'no-toolchain'). */
+  readonly skipReason?: string;
 }
 
 // ─── Command Runner Adapter ─────────────────────────────────────────────────
@@ -107,6 +116,12 @@ export async function handleStaticAnalysis(
     };
   }
 
+  // T-10 / DR-4: 'skip' status means no recognized toolchain — gate is
+  // inconclusive, not green. Map to passed=false + skipped=true so
+  // convergence-view can surface it as skipped, and emit the gate event
+  // with details.skipped + details.skipReason so projections can render
+  // SKIP distinctly from PASS / FAIL.
+  const skipped = analysisResult.status === 'skip';
   const passed = analysisResult.status === 'pass';
   const { passCount, failCount, output } = analysisResult;
 
@@ -118,6 +133,7 @@ export async function handleStaticAnalysis(
       phase: 'delegate',
       passCount,
       failCount,
+      ...(skipped ? { skipped: true, skipReason: analysisResult.skipReason ?? 'no-toolchain' } : {}),
       ...(args.taskId ? { taskId: args.taskId } : {}),
     });
   } catch { /* fire-and-forget */ }
@@ -128,6 +144,7 @@ export async function handleStaticAnalysis(
     passCount,
     failCount,
     report: output,
+    ...(skipped ? { skipped: true, skipReason: analysisResult.skipReason ?? 'no-toolchain' } : {}),
   };
 
   return { success: true, data: result };

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.fixtures.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.fixtures.test.ts
@@ -1,7 +1,7 @@
-// ─── check_task_decomposition: parser false-positive fixture (RED gate) ─────
+// ─── check_task_decomposition: parser false-positive fixture (regression) ───
 //
-// This test file is the characterization RED gate for the three parser
-// false-positives documented in
+// This test file is the characterization regression suite for the three
+// parser false-positives documented in
 // `exarchos-issue-check_task_decomposition-parser-false-positives.md`. It runs
 // `handleTaskDecomposition` against a real-shape plan fixture captured from the
 // `agency-csl-auto-pr` dogfood and asserts the parser does NOT produce false
@@ -9,8 +9,9 @@
 // shape (Goal / TDD steps / Acceptance criteria / Dependencies / Parallelizable)
 // rather than a literal `**Description:**` field.
 //
-// **All three tests in this file are expected to FAIL on current code.** They
-// go green incrementally as downstream parser fixes land:
+// **All three tests in this file are regression tests — these should now
+// pass.** Previously failing on the v2.9.0 RED baseline, they went green
+// incrementally as the downstream parser fixes landed:
 //
 //   - `taskDecomposition_AgencyCslAutoPr_AllTasksWellDecomposed`
 //       Targets Bug 1 (Description span parsing). Current parser only counts
@@ -41,7 +42,9 @@
 //       declared under an explicit `**Files:**` section).
 //
 // Per the v2.9.0 dogfood-bundle plan T-11, this file does NOT modify production
-// parser code. The single commit captures the failing baseline.
+// parser code. It is a regression test suite (previously the failing
+// baseline) that exists to detect any future re-introduction of the three
+// false positives.
 // ────────────────────────────────────────────────────────────────────────────
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.fixtures.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.fixtures.test.ts
@@ -1,0 +1,162 @@
+// ─── check_task_decomposition: parser false-positive fixture (RED gate) ─────
+//
+// This test file is the characterization RED gate for the three parser
+// false-positives documented in
+// `exarchos-issue-check_task_decomposition-parser-false-positives.md`. It runs
+// `handleTaskDecomposition` against a real-shape plan fixture captured from the
+// `agency-csl-auto-pr` dogfood and asserts the parser does NOT produce false
+// positives. The fixture follows the standard `@skills/implementation-planning`
+// shape (Goal / TDD steps / Acceptance criteria / Dependencies / Parallelizable)
+// rather than a literal `**Description:**` field.
+//
+// **All three tests in this file are expected to FAIL on current code.** They
+// go green incrementally as downstream parser fixes land:
+//
+//   - `taskDecomposition_AgencyCslAutoPr_AllTasksWellDecomposed`
+//       Targets Bug 1 (Description span parsing). Current parser only counts
+//       words inside a literal `**Description:**` field; the fixture uses
+//       `**Goal:**` so every task reports `descriptionWordCount === 0` and
+//       fails `wellDecomposed === totalTasks`. Fixed by **T-12** — replace
+//       literal `**Description:**` matching with "everything between the task
+//       heading and the next field-header (`**...**:`) or section header
+//       (`### `)".
+//
+//   - `taskDecomposition_AgencyCslAutoPr_NoCycleDetected`
+//       Targets Bug 2 (Greedy digit fallback in `extractDependencies`). When
+//       the deps line is `**Dependencies:** T002 (\`GetCslSloRollup24h\` ...)`,
+//       the `T-XX` regex misses (no hyphen), the parser falls back to a plain
+//       `/[0-9]+/g` scan, and the `24` from `Rollup24h` is treated as a
+//       dependency on a non-existent task. Fixed by **T-13** — match both
+//       `T-XX` and `TXX` formats, anchor strictly to the deps line, and remove
+//       the greedy digit fallback.
+//
+//   - `taskDecomposition_AgencyCslAutoPr_NoFalseFileConflicts`
+//       Targets Bug 3 (Dotted-identifier file-path detection). The current
+//       file-path regex `/^[a-zA-Z0-9_./-]+\.[a-zA-Z]+$/` (inside backticks)
+//       matches dotted record-field tokens like
+//       `\`imageProvenance.isFirstParty\``. When two parallel tasks both
+//       reference the same dotted identifier in narrative prose, the parser
+//       reports a false file conflict. Fixed by **T-14** — restrict file-path
+//       matching to a known-extension allowlist (and optionally prefer files
+//       declared under an explicit `**Files:**` section).
+//
+// Per the v2.9.0 dogfood-bundle plan T-11, this file does NOT modify production
+// parser code. The single commit captures the failing baseline.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock gate-utils.emitGateEvent so the handler's fire-and-forget event
+// emission is observable but inert (no real EventStore needed). We do NOT
+// mock `node:fs/promises` here — the test reads the real fixture file from
+// disk so the integration is end-to-end.
+vi.mock('./gate-utils.js', () => ({
+  emitGateEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import type { EventStore } from '../event-store/store.js';
+import { handleTaskDecomposition } from './task-decomposition.js';
+
+// Resolve the fixture path relative to this test file so the test runs from
+// any cwd (vitest, scoped runs, watch mode).
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const FIXTURE_PATH = resolve(__dirname, 'fixtures/plans/agency-csl-auto-pr.md');
+
+const STATE_DIR = '/tmp/test-state-task-decomposition-fixtures';
+
+const mockStore = {
+  append: vi.fn().mockResolvedValue(undefined),
+};
+
+interface DecompositionData {
+  readonly passed: boolean;
+  readonly wellDecomposed: number;
+  readonly needsRework: number;
+  readonly totalTasks: number;
+  readonly dagValid: boolean;
+  readonly parallelSafe: boolean;
+  readonly report: string;
+}
+
+describe('check_task_decomposition / agency-csl-auto-pr fixture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('taskDecomposition_AgencyCslAutoPr_AllTasksWellDecomposed', async () => {
+    // Bug 1 — Description span parsing. Every fixture task uses **Goal:**
+    // (the standard implementation-planning shape) and has substantive prose.
+    // The parser must count those words as the description; otherwise every
+    // task reports descriptionWordCount === 0 and fails the structure check.
+    // Fixed by T-12.
+    const result = await handleTaskDecomposition(
+      { featureId: 'fixture-agency-csl', planPath: FIXTURE_PATH },
+      STATE_DIR,
+      mockStore as unknown as EventStore,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as DecompositionData;
+
+    expect(data.totalTasks).toBeGreaterThan(0);
+    // The headline assertion: every task in the fixture is well-decomposed.
+    // On current code, this fails with `wellDecomposed: 0`, `needsRework: 4`
+    // because the description-span parser cannot find a literal
+    // `**Description:**` field in any task block.
+    expect(data.wellDecomposed).toBe(data.totalTasks);
+    expect(data.needsRework).toBe(0);
+  });
+
+  it('taskDecomposition_AgencyCslAutoPr_NoCycleDetected', async () => {
+    // Bug 2 — Greedy digit fallback in extractDependencies. Task 033's deps
+    // line is `**Dependencies:** T002 (\`GetCslSloRollup24h\` exposes ...)`.
+    // The current parser falls back to scraping all digits when the T-XX
+    // regex misses (no hyphen), pulling `24` out of `Rollup24h` and treating
+    // it as an unknown dependency. Fixed by T-13.
+    const result = await handleTaskDecomposition(
+      { featureId: 'fixture-agency-csl', planPath: FIXTURE_PATH },
+      STATE_DIR,
+      mockStore as unknown as EventStore,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as DecompositionData;
+
+    // The headline assertion: the dependency graph is a valid DAG. On current
+    // code, this fails with a CYCLE DETECTED entry of the form
+    // `Unresolved dependency: 033 depends on unknown 24`.
+    expect(data.dagValid).toBe(true);
+    // Belt-and-suspenders: if the report drifts to a different cycle text,
+    // we still want to flag the specific known false-positive.
+    expect(data.report).not.toContain('unknown 24');
+    expect(data.report).not.toContain('depends on unknown 24');
+  });
+
+  it('taskDecomposition_AgencyCslAutoPr_NoFalseFileConflicts', async () => {
+    // Bug 3 — Dotted-identifier file-path detection. Tasks 003 and 004 both
+    // reference `\`imageProvenance.isFirstParty\`` and `\`mutatingTool.detected\``
+    // in narrative prose (TypeScript record field names, not file paths).
+    // The current file-path regex matches anything backtick-quoted with a
+    // dot and an alphabetic suffix, so the parser reports a false file
+    // conflict between the two tasks. Fixed by T-14.
+    const result = await handleTaskDecomposition(
+      { featureId: 'fixture-agency-csl', planPath: FIXTURE_PATH },
+      STATE_DIR,
+      mockStore as unknown as EventStore,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as DecompositionData;
+
+    // The headline assertion: no parallel-safety conflicts. On current code,
+    // this fails with conflicts on `imageProvenance.isFirstParty` and
+    // `mutatingTool.detected`.
+    expect(data.parallelSafe).toBe(true);
+    // Specific dotted-identifier tokens must not appear as conflicting files.
+    expect(data.report).not.toContain('imageProvenance.isFirstParty');
+    expect(data.report).not.toContain('mutatingTool.detected');
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts
@@ -307,6 +307,58 @@ table so the workflow surface can invoke it directly without bash detour.
     expect(result.descriptionWordCount).toBeLessThan(30);
   });
 
+  // F20 (#1213): only `**Goal:**` / `**Description:**` headers introduce
+  // the description span. Tasks that open with `**Files:**` /
+  // `**Dependencies:**` / `**Tests:**` etc. used to mis-count the inline
+  // tail of those headers as description prose, which silently satisfied
+  // the 10-word threshold and masked legitimate missing-description
+  // failures.
+  it('ExtractDescription_TaskBeginsWithFilesHeader_DoesNotCountFilesAsDescription', () => {
+    // The first field header after the title is `**Files:**`, with multiple
+    // backtick-quoted paths inline. The whole block carries NO narrative
+    // prose: no naked sentence, no `**Goal:**`, no `**Description:**`.
+    // The validator must therefore report a missing description.
+    const block = `### Task T-99: terse files-only task
+
+**Files:** \`src/foo.ts\`, \`src/bar.ts\`, \`src/baz.ts\`, \`src/quux.ts\`, \`src/zap.ts\`, \`src/widget.ts\`
+
+**Tests:**
+- [RED] \`Foo_Bar_Baz\`
+
+**Dependencies:** None
+**Parallelizable:** No`;
+
+    const result = validateTaskStructure(block);
+
+    // The 6 paths inline on the **Files:** header would, under the old
+    // first-field-wins rule, contribute several words and could push past
+    // the 10-word threshold. With the F20 fix that header terminates the
+    // description scan instead of introducing it, so the count is zero
+    // and `hasDescription` is false.
+    expect(result.hasDescription).toBe(false);
+    expect(result.descriptionWordCount).toBeLessThanOrEqual(10);
+  });
+
+  it('ExtractDescription_TaskBeginsWithDependenciesHeader_DoesNotCountDepsAsDescription', () => {
+    // Same shape, different leading non-description header. Same rule.
+    const block = `### Task T-77: deps-first task
+
+**Dependencies:** T001, T002, T003, T004, T005, T006, T007, T008, T009, T010, T011
+
+**Files:**
+- \`src/foo.ts\`
+
+**Tests:**
+- [RED] \`Foo_Bar_Baz\`
+
+**Parallelizable:** No`;
+
+    const result = validateTaskStructure(block);
+
+    expect(result.hasDescription).toBe(false);
+    expect(result.descriptionWordCount).toBeLessThanOrEqual(10);
+  });
+
   it('validateTaskStructure_NoFieldHeaders_FullBodyCounted', () => {
     // Block has naked prose under the task heading with no field-headers at
     // all. The new contract counts the entire body as the description.

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts
@@ -28,6 +28,7 @@ import {
   validateDependencyDAG,
   checkParallelSafety,
   handleTaskDecomposition,
+  extractDependencies,
 } from './task-decomposition.js';
 
 const mockedEmitGateEvent = vi.mocked(emitGateEvent);
@@ -349,6 +350,91 @@ describe('validateDependencyDAG', () => {
     // The cycle path should mention both T-01 and T-02
     expect(result.cyclePath).toContain('T-01');
     expect(result.cyclePath).toContain('T-02');
+  });
+});
+
+// ─── T-13 dependency-parser contract (DR-5 step 2/3) ────────────────────
+//
+// `extractDependencies` MUST anchor strictly to the `**Dependencies:**` line
+// and MUST match both `T-XX` and `TXX` formats via a single regex
+// `\b(T-?\d+)\b`. There is NO greedy `[0-9]+` fallback — if the deps line
+// contains no `T<id>`/`T-<id>` token, the helper returns `[]`.
+//
+// Normalization decision (documented for posterity): the helper returns
+// matches **verbatim** — `T-001` stays `T-001`, `T002` stays `T002`. The
+// equivalence between `T-NNN`, `TNNN`, and `NNN` is handled at comparison
+// time inside `validateDependencyDAG` (canonical form: strip leading
+// `T-?` and leading zeros). Doing it here would conflate task-ID forms
+// emitted by `parseTaskBlocks`, which preserves the form as written.
+
+describe('extractDependencies', () => {
+  it('extractDependencies_ThyphenIdFormat_ReturnsTIds', () => {
+    const block = `### Task T-XX: example
+
+**Description:** sample task body that should be ignored by the dependency
+parser entirely. Numbers like 24 in prose must not leak.
+
+**Dependencies:** T-001, T-002
+**Parallelizable:** No`;
+
+    expect(extractDependencies(block)).toEqual(['T-001', 'T-002']);
+  });
+
+  it('extractDependencies_NoHyphenIdFormat_ReturnsTIds', () => {
+    const block = `### Task TXX: example
+
+**Description:** sample task body.
+
+**Dependencies:** T001, T002
+**Parallelizable:** No`;
+
+    // Verbatim — see header comment for normalization decision.
+    expect(extractDependencies(block)).toEqual(['T001', 'T002']);
+  });
+
+  it('extractDependencies_NarrativeContainsRollup24h_DoesNotExtract24', () => {
+    // Regression for the agency-csl-auto-pr fixture (T-13). Task 033's deps
+    // line embeds prose that contains `Rollup24h`. The greedy `[0-9]+`
+    // fallback used to scrape `24` out of `Rollup24h` and treat it as an
+    // unknown dependency. The new parser must return only the T-id.
+    const block = `### Task 033: SLO sample-size dashboard panel
+
+**Description:** add a Grafana panel.
+
+**Dependencies:** T002 (\`GetCslSloRollup24h\` exposes sample size per SLO)
+**Parallelizable:** No`;
+
+    const deps = extractDependencies(block);
+    expect(deps).toEqual(['T002']);
+    expect(deps).not.toContain('24');
+  });
+
+  it('extractDependencies_NoTIdsAtAll_ReturnsEmptyArray', () => {
+    const block = `### Task T-01: example
+
+**Description:** sample.
+
+**Dependencies:** none
+**Parallelizable:** No`;
+
+    expect(extractDependencies(block)).toEqual([]);
+  });
+
+  it('extractDependencies_DigitsInOtherLines_NotExtracted', () => {
+    // Deps line is empty — must not fall back to digit-scraping the wider
+    // block (which contains `2024` in prose, file paths with version-like
+    // numbers, etc.).
+    const block = `### Task T-01: build the 2024 rollup pipeline
+
+**Description:** Process 1000 records per second from the 24-hour buffer.
+
+**Files:**
+- \`src/v1/api-2024.ts\`
+
+**Dependencies:**
+**Parallelizable:** No`;
+
+    expect(extractDependencies(block)).toEqual([]);
   });
 });
 

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts
@@ -604,6 +604,60 @@ the validator should treat as a target.
     expect(files).toContain('config.json');
   });
 
+  // ─── F21 (#1213): explicit Files section is authoritative even if empty
+  it('ExtractFiles_ExplicitFilesNone_ReturnsEmptyAndSkipsFallback', () => {
+    // The author declared the Files section explicitly and put `none`
+    // there (no allowlisted paths). Other parts of the task body
+    // contain unrelated backtick-quoted paths (e.g. a snippet showing
+    // a *prior* file the task replaces, or an example reference). The
+    // explicit Files section is authoritative — fallback inference
+    // MUST NOT scrape those unrelated backticks and pollute the file
+    // count, which would produce false parallel-conflict reports.
+    const block = `### Task T-99: pure prose / docs task
+
+**Goal:** Update the narrative description in the README so it reflects
+the renamed module \`unrelated.ts\` mentioned in the prior commit. Also
+clarify the snippet about \`example.json\` from earlier docs.
+
+**Files:** none
+
+**Tests:**
+- [RED] \`Doc_Update_NoFiles\`
+
+**Dependencies:** None
+**Parallelizable:** Yes`;
+
+    const files = extractFiles(block);
+    // The unrelated `unrelated.ts` and `example.json` backticks elsewhere
+    // in the task body MUST NOT be returned. The explicit Files section
+    // declared zero paths, and that's the answer.
+    expect(files).not.toContain('unrelated.ts');
+    expect(files).not.toContain('example.json');
+    expect(files).toEqual([]);
+  });
+
+  it('ExtractFiles_NoFilesSection_FallsBackToWholeBlockInference', () => {
+    // No explicit **Files:** header anywhere in the block — preserve
+    // existing behavior of scraping the whole block for backtick paths
+    // with allowlisted extensions. (Regression-guard for the legacy
+    // shape; without this assertion the F21 fix would silently break
+    // tasks that omit the Files header entirely.)
+    const block = `### Task T-50: legacy shape, no Files header
+
+**Goal:** Edit \`src/legacy.ts\` and \`src/legacy.test.ts\` to reflect
+the new contract.
+
+**Tests:**
+- [RED] \`Legacy_Contract_Honored\`
+
+**Dependencies:** None
+**Parallelizable:** No`;
+
+    const files = extractFiles(block);
+    expect(files).toContain('src/legacy.ts');
+    expect(files).toContain('src/legacy.test.ts');
+  });
+
   it('checkParallelSafety_AgencyCslLikeNarrative_NoFalseConflicts', () => {
     // End-to-end regression on the agency-csl shape: two parallel tasks
     // that share dotted-identifier *field-name* references in prose but

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts
@@ -515,6 +515,43 @@ the validator should treat as a target.
     expect(files).not.toContain('some.unknownext');
   });
 
+  // ─── #1213 / CodeRabbit #17: inline **Files:** header parsing ─────────
+  it('extractFiles_InlineFilesHeader_CapturesPathOnSameLine', () => {
+    // Regression: when the **Files:** header carries paths inline on the
+    // same line (instead of a multi-line list), the parser dropped them
+    // because it `continue`-d past the header without inspecting the tail.
+    // Now the inline tail is captured before falling through to the next
+    // line.
+    const block = `### Task T-01: example
+
+**Goal:** Inline files header.
+
+**Files:** \`src/inline-only.ts\`
+
+**Dependencies:** None
+**Parallelizable:** No`;
+
+    const files = extractFiles(block);
+    expect(files).toContain('src/inline-only.ts');
+  });
+
+  it('extractFiles_InlineFilesHeader_MultiplePaths_AllCaptured', () => {
+    // Multiple comma-separated inline paths on the **Files:** header line.
+    const block = `### Task T-02: example
+
+**Goal:** Multiple inline paths.
+
+**Files:** \`src/a.ts\`, \`src/b.ts\`, \`config.json\`
+
+**Dependencies:** None
+**Parallelizable:** No`;
+
+    const files = extractFiles(block);
+    expect(files).toContain('src/a.ts');
+    expect(files).toContain('src/b.ts');
+    expect(files).toContain('config.json');
+  });
+
   it('checkParallelSafety_AgencyCslLikeNarrative_NoFalseConflicts', () => {
     // End-to-end regression on the agency-csl shape: two parallel tasks
     // that share dotted-identifier *field-name* references in prose but

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts
@@ -237,6 +237,89 @@ Test names:
     expect(result.hasTests).toBe(true);
     expect(result.testCount).toBeGreaterThanOrEqual(2);
   });
+
+  // ─── T-12 description-span contract (DR-5 step 1/3) ──────────────────────
+  //
+  // The description span is "everything between the task heading and the next
+  // field-header (`**...**:`) or section header (`### `)". The first
+  // field-header encountered (e.g. `**Goal:**` or `**Description:**`) is
+  // *included* as the description introducer; the SECOND field-header (e.g.
+  // `**Files:**`, `**Acceptance criteria:**`) terminates the span. This lets
+  // plans authored to the standard `@skills/implementation-planning` shape
+  // (which uses `**Goal:**`, not `**Description:**`) score correctly.
+
+  it('validateTaskStructure_TaskWithGoalSection_CountsGoalProseAsDescription', () => {
+    // Block uses `**Goal:**` (not `**Description:**`) followed by ~50 words of
+    // substantive prose. The new contract counts that prose as the
+    // description; the legacy `**Description:**`-literal parser reports 0.
+    const block = `### Task T-01: Author the schema module
+
+**Goal:** Define the schema module that exposes per-record validation rules
+across the ingestion pipeline, declaring both the input row shape and the
+projected normalized shape consumed by the downstream alerting layer. The
+module must carry a frozen sample-set so future schema drift is caught at
+build time rather than at runtime when the dashboard renders empty results.
+
+**Files:**
+- \`src/schema/module.ts\`
+- \`src/schema/module.test.ts\`
+
+**Tests:**
+- [RED] \`Schema_Validate_RejectsMalformedRow\`
+
+**Dependencies:** None
+**Parallelizable:** Yes`;
+
+    const result = validateTaskStructure(block);
+
+    expect(result.hasDescription).toBe(true);
+    expect(result.descriptionWordCount).toBeGreaterThan(10);
+  });
+
+  it('validateTaskStructure_TaskWithMultipleSections_DescriptionStopsAtNextFieldHeader', () => {
+    // Block carries `**Goal:**` content followed by `**Acceptance criteria:**`.
+    // The description span includes the Goal prose only; words after the
+    // Acceptance criteria field-header MUST NOT be folded into the
+    // description count.
+    const block = `### Task T-02: Wire the gate handler
+
+**Goal:** Wire the freshly authored gate handler into the orchestrate dispatch
+table so the workflow surface can invoke it directly without bash detour.
+
+**Acceptance criteria:**
+- The gate handler appears in the dispatch table alongside its peers and the
+  acceptance suite covers every documented status code with a dedicated
+  characterization assertion that exercises the surrounding event emission.
+
+**Files:**
+- \`src/orchestrate/gate-handler.ts\``;
+
+    const result = validateTaskStructure(block);
+
+    // "Wire the freshly authored gate handler into the orchestrate dispatch
+    // table so the workflow surface can invoke it directly without bash detour."
+    // ~22 words. Acceptance criteria adds ~30 words; if those leak in the
+    // count would jump well past 30.
+    expect(result.hasDescription).toBe(true);
+    expect(result.descriptionWordCount).toBeGreaterThan(10);
+    expect(result.descriptionWordCount).toBeLessThan(30);
+  });
+
+  it('validateTaskStructure_NoFieldHeaders_FullBodyCounted', () => {
+    // Block has naked prose under the task heading with no field-headers at
+    // all. The new contract counts the entire body as the description.
+    const block = `### Task T-03: Naked prose task
+
+This task has no field headers whatsoever. The author wrote a brief paragraph
+of substantive narrative prose describing the work to be done, and trusted
+that the structural validator would still recognize the description as
+present without requiring a literal Description field-header marker.`;
+
+    const result = validateTaskStructure(block);
+
+    expect(result.hasDescription).toBe(true);
+    expect(result.descriptionWordCount).toBeGreaterThan(20);
+  });
 });
 
 describe('validateDependencyDAG', () => {

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.test.ts
@@ -29,6 +29,7 @@ import {
   checkParallelSafety,
   handleTaskDecomposition,
   extractDependencies,
+  extractFiles,
 } from './task-decomposition.js';
 
 const mockedEmitGateEvent = vi.mocked(emitGateEvent);
@@ -435,6 +436,121 @@ parser entirely. Numbers like 24 in prose must not leak.
 **Parallelizable:** No`;
 
     expect(extractDependencies(block)).toEqual([]);
+  });
+});
+
+// ─── T-14 file-conflict extension-filter contract (DR-5 step 3/3) ────────
+//
+// `extractFiles` MUST require a known file extension before treating a
+// backtick-quoted token as a file path. Tokens like `imageProvenance.isFirstParty`
+// (TypeScript record-field references in narrative prose) MUST NOT match.
+// This closes the final fixture-level `parallelSafe === true` assertion in
+// `task-decomposition.fixtures.test.ts`.
+//
+// Allowed extensions:
+//   ts | tsx | js | jsx | mjs | cjs | json | md | yml | yaml | sh | ps1
+//   sql | kql | bicep | cs | csproj | sln | go | rs | toml
+//
+// The same extension allowlist must apply to both `extractFiles` and the
+// inline file-path pattern inside `validateTaskStructure`. After T-14
+// REFACTOR they share a module-level `FILE_EXTENSION_ALLOWLIST` constant.
+
+describe('extractFiles', () => {
+  it('extractFiles_DottedIdentifierLikeFieldName_NotMatched', () => {
+    // Regression for the agency-csl-auto-pr fixture. TypeScript record-field
+    // references in narrative prose used to be scraped as file paths because
+    // the prior regex required only `.<alphabetic>` after a backtick token.
+    // The tightened regex limits matches to a known-extension allowlist.
+    const block = `### Task T-01: example
+
+**Goal:** When the upstream signal flips, propagate \`imageProvenance.isFirstParty\`
+through the projection so downstream consumers see the change without polling.
+
+**Files:**
+- \`src/projection/provenance.ts\`
+
+**Dependencies:** None
+**Parallelizable:** Yes`;
+
+    const files = extractFiles(block);
+    expect(files).not.toContain('imageProvenance.isFirstParty');
+  });
+
+  it('extractFiles_KnownExtension_Matched', () => {
+    // Sanity: the allowlist MUST cover the canonical project extensions
+    // used in real plans (TypeScript source, JSON config, Markdown docs).
+    const block = `### Task T-01: example
+
+**Goal:** Author the module, the config, and the readme entry.
+
+**Files:**
+- \`src/foo.ts\`
+- \`config.json\`
+- \`README.md\`
+
+**Dependencies:** None
+**Parallelizable:** No`;
+
+    const files = extractFiles(block);
+    expect(files).toContain('src/foo.ts');
+    expect(files).toContain('config.json');
+    expect(files).toContain('README.md');
+  });
+
+  it('extractFiles_UnknownExtension_NotMatched', () => {
+    // The allowlist is closed. A backtick-quoted token whose suffix is not
+    // on the list (e.g. `.unknownext`) MUST NOT match, even if its shape
+    // otherwise resembles a path.
+    const block = `### Task T-01: example
+
+**Goal:** Reference an unknown-suffix token.
+
+The token \`some.unknownext\` appears in prose but is not a real file path
+the validator should treat as a target.
+
+**Dependencies:** None
+**Parallelizable:** No`;
+
+    const files = extractFiles(block);
+    expect(files).not.toContain('some.unknownext');
+  });
+
+  it('checkParallelSafety_AgencyCslLikeNarrative_NoFalseConflicts', () => {
+    // End-to-end regression on the agency-csl shape: two parallel tasks
+    // that share dotted-identifier *field-name* references in prose but
+    // have disjoint *file* targets must NOT be flagged as conflicting.
+    const blockA = `### Task T-001: producer side
+
+**Goal:** Emit the \`imageProvenance.isFirstParty\` signal and the
+\`mutatingTool.detected\` flag from the upstream extractor.
+
+**Files:**
+- \`src/extractor/producer.ts\`
+- \`src/extractor/producer.test.ts\`
+
+**Dependencies:** None
+**Parallelizable:** Yes`;
+
+    const blockB = `### Task T-002: consumer side
+
+**Goal:** React to \`imageProvenance.isFirstParty\` and \`mutatingTool.detected\`
+on the projection side without coupling to the producer module.
+
+**Files:**
+- \`src/projection/consumer.ts\`
+- \`src/projection/consumer.test.ts\`
+
+**Dependencies:** None
+**Parallelizable:** Yes`;
+
+    const tasks = [
+      { id: 'T-001', isParallel: true, files: extractFiles(blockA) },
+      { id: 'T-002', isParallel: true, files: extractFiles(blockB) },
+    ];
+
+    const result = checkParallelSafety(tasks);
+    expect(result.safe).toBe(true);
+    expect(result.conflicts).toHaveLength(0);
   });
 });
 

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -564,6 +564,14 @@ export function extractFiles(block: string): string[] {
   for (const line of lines) {
     if (/^\*\*Files:\*\*/i.test(line)) {
       inFilesSection = true;
+      // CodeRabbit #17 (#1213): if the **Files:** header line itself
+      // contains paths after the colon (inline form, e.g.
+      // `**Files:** \`a.ts\`, \`b.ts\``), capture them. Without this,
+      // single-line Files headers were silently dropped.
+      const inlineTail = line.replace(/^\*\*Files:\*\*\s*/i, '');
+      if (inlineTail.length > 0) {
+        filesSectionLines.push(inlineTail);
+      }
       continue;
     }
     if (inFilesSection) {

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -240,37 +240,49 @@ export function validateTaskStructure(block: string): TaskStructureResult {
  * A cycle is detected when we encounter a node that is in-progress.
  */
 export function validateDependencyDAG(tasks: readonly DagTask[]): DagValidationResult {
+  // Cycle/unresolved comparisons run on the canonical ID (`canonicaliseTaskId`)
+  // so that `T-002`, `T002`, and `002` are treated as the same task. We keep
+  // a parallel map to recover the original ID for error messages.
   const visitState = new Map<string, number>();
-  const taskIds = new Set<string>();
+  const canonicalToOriginal = new Map<string, string>();
 
   for (const task of tasks) {
-    // Reject duplicate task IDs
-    if (taskIds.has(task.id)) {
+    const canonical = canonicaliseTaskId(task.id);
+    if (canonicalToOriginal.has(canonical)) {
       return { valid: false, cyclePath: `Duplicate task ID: ${task.id}` };
     }
-    visitState.set(task.id, 0);
-    taskIds.add(task.id);
+    visitState.set(canonical, 0);
+    canonicalToOriginal.set(canonical, task.id);
   }
 
-  // Build adjacency map (task -> deps), reject unresolved references
+  // Build adjacency map (canonical task -> canonical deps), reject
+  // unresolved references against the canonical key set.
   const depsMap = new Map<string, readonly string[]>();
   for (const task of tasks) {
+    const canonicalSelf = canonicaliseTaskId(task.id);
+    const canonicalDeps: string[] = [];
     for (const dep of task.deps) {
-      if (!taskIds.has(dep)) {
-        return { valid: false, cyclePath: `Unresolved dependency: ${task.id} depends on unknown ${dep}` };
+      const canonicalDep = canonicaliseTaskId(dep);
+      if (!canonicalToOriginal.has(canonicalDep)) {
+        return {
+          valid: false,
+          cyclePath: `Unresolved dependency: ${task.id} depends on unknown ${dep}`,
+        };
       }
+      canonicalDeps.push(canonicalDep);
     }
-    depsMap.set(task.id, task.deps);
+    depsMap.set(canonicalSelf, canonicalDeps);
   }
 
-  // Iterative DFS
+  // Iterative DFS over canonical IDs.
   for (const task of tasks) {
-    if (visitState.get(task.id) !== 0) {
+    const canonicalRoot = canonicaliseTaskId(task.id);
+    if (visitState.get(canonicalRoot) !== 0) {
       continue;
     }
 
-    // Stack entries: [node, phase] where phase is 'enter' or 'exit'
-    const stack: Array<[string, 'enter' | 'exit']> = [[task.id, 'enter']];
+    // Stack entries: [canonicalNode, phase] where phase is 'enter' or 'exit'
+    const stack: Array<[string, 'enter' | 'exit']> = [[canonicalRoot, 'enter']];
 
     while (stack.length > 0) {
       const [node, phase] = stack.pop()!;
@@ -289,7 +301,7 @@ export function validateDependencyDAG(tasks: readonly DagTask[]): DagValidationR
 
       // Cycle: node is in-progress (already on the DFS stack)
       if (state === 1) {
-        return { valid: false, cyclePath: node };
+        return { valid: false, cyclePath: canonicalToOriginal.get(node) ?? node };
       }
 
       // Mark in-progress
@@ -301,8 +313,10 @@ export function validateDependencyDAG(tasks: readonly DagTask[]): DagValidationR
       for (const dep of deps) {
         const depState = visitState.get(dep);
         if (depState === 1) {
-          // Cycle found
-          return { valid: false, cyclePath: `${node} \u2192 ${dep}` };
+          // Cycle found \u2014 report using original IDs.
+          const nodeOriginal = canonicalToOriginal.get(node) ?? node;
+          const depOriginal = canonicalToOriginal.get(dep) ?? dep;
+          return { valid: false, cyclePath: `${nodeOriginal} \u2192 ${depOriginal}` };
         }
         if (depState === 0) {
           stack.push([dep, 'enter']);
@@ -353,6 +367,22 @@ export function checkParallelSafety(tasks: readonly ParallelTask[]): ParallelSaf
 
 /**
  * Extract dependency task IDs from a task block's **Dependencies:** field.
+ *
+ * Anchors strictly to the `**Dependencies:**` line — never falls back to
+ * digit-scraping the wider block, which used to pull tokens like `24` out
+ * of narrative prose ("`GetCslSloRollup24h`") and report them as unknown
+ * dependencies.
+ *
+ * Matches both `T-NNN` and `TNNN` formats via a single word-boundary regex
+ * (`\b(T-?\d+)\b`). The returned matches are verbatim — `T-001` stays
+ * `T-001`, `T002` stays `T002`. The equivalence between `T-NNN`, `TNNN`,
+ * and `NNN` (bare numeric IDs emitted by `parseTaskBlocks` for `### Task
+ * 002:` headings) is handled at comparison time inside
+ * `validateDependencyDAG`, not here, so this helper does not silently
+ * mutate caller-visible IDs.
+ *
+ * Returns `[]` if no `T<id>`/`T-<id>` token is present (e.g. `none`,
+ * empty, or "Task 1, Task 2"-style narrative without a recognised id).
  */
 export function extractDependencies(block: string): string[] {
   const lines = block.split('\n');
@@ -362,17 +392,29 @@ export function extractDependencies(block: string): string[] {
       if (!depsLine || /^none$/i.test(depsLine)) {
         return [];
       }
-      // Try T-XX format first
-      const tRefs = depsLine.match(/T-[0-9]+/g);
-      if (tRefs && tRefs.length > 0) {
-        return tRefs;
-      }
-      // Fall back to plain numeric (e.g., "Task 1, Task 2" or "1, 2")
-      const numRefs = depsLine.match(/[0-9]+/g);
-      return numRefs ?? [];
+      const tRefs = depsLine.match(/\bT-?\d+\b/g);
+      return tRefs ?? [];
     }
   }
   return [];
+}
+
+/**
+ * Canonicalise a task ID for cycle/unresolved-dependency comparison.
+ *
+ * Three forms are treated as equivalent: `T-002`, `T002`, and `002`. The
+ * canonical form strips an optional leading `T-?` and then strips leading
+ * zeros (so `T-01`, `T01`, `01`, and `1` all collapse to `1`).
+ *
+ * This bridges `parseTaskBlocks` (which preserves the form as written —
+ * `T-XX` or bare numeric) and `extractDependencies` (which preserves
+ * verbatim `T-NNN`/`TNNN` tokens from the deps line). Without this
+ * normalisation, plans that mix forms — e.g. a fixture with bare-numeric
+ * task IDs and `T<id>`-prefixed dependency references — would report
+ * spurious unresolved-dependency errors.
+ */
+function canonicaliseTaskId(id: string): string {
+  return id.replace(/^T-?/i, '').replace(/^0+/, '') || '0';
 }
 
 /**

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -115,36 +115,30 @@ export function parseTaskBlocks(content: string): TaskBlock[] {
 // ─── Validate Task Structure ────────────────────────────────────────────
 
 /**
- * Validate a task block for description quality, file targets, and test
- * expectations.
+ * Extract the description span from a task block's lines.
  *
- * Description parsing (DR-5 step 1):
- * - The description span is "everything between the task heading and the
- *   next field-header (`**Word:**`) or section header (`### `)".
- * - The FIRST field-header encountered (e.g. `**Goal:**` or
- *   `**Description:**`) is treated as a description introducer and is
- *   *included* in the span — its inline tail and the prose that follows
- *   count as description. The SECOND field-header terminates the span.
- * - This matches the standard `@skills/implementation-planning` shape
- *   (`**Goal:**` + paragraph) without relying on a literal `**Description:**`
- *   field-header.
- * - When the block has no field-headers at all, the entire body counts.
+ * The description span is "everything between the task heading and the next
+ * field-header (`**Word:**`) or section header (`### `)" — with the caveat
+ * that the FIRST field-header encountered is treated as a description
+ * introducer and is *included* in the span (its inline tail is captured;
+ * the prose after it is also captured). The SECOND field-header terminates
+ * the span.
  *
- * File detection: backtick-quoted paths like `path/to/file.ext`
+ * This handles the three canonical block shapes:
+ * - Standard implementation-planning shape (`**Goal:**` + paragraph followed
+ *   by `**Files:**`, `**Tests:**`, etc.) — Goal prose counts as description.
+ * - Legacy explicit `**Description:**` shape — Description prose counts.
+ * - Naked-prose shape (no field-headers at all) — full body counts.
  *
- * Test detection: `[RED]` markers or `Method_Scenario_Outcome` patterns
- * (PascalCase segments joined by underscores).
+ * Returned as the array of captured raw lines (not yet word-counted) so
+ * callers can decide how to render or score them.
  */
-export function validateTaskStructure(block: string): TaskStructureResult {
-  const lines = block.split('\n');
-
-  // --- Description (span from heading to next structural header) ---
-  // Skip the heading line itself; capture lines until either a `### ` section
-  // header or the SECOND `**Field:**` line. The first field-header acts as a
-  // description introducer (its trailing inline text is captured).
+export function extractDescriptionSpan(lines: readonly string[]): string[] {
   const descLines: string[] = [];
   let firstFieldSeen = false;
-  // Skip the leading heading line if present.
+
+  // Skip the leading task-heading line if present so its title text doesn't
+  // pollute the description count.
   const start = lines.length > 0 && /^###\s+Task\s+/.test(lines[0]) ? 1 : 0;
 
   for (let i = start; i < lines.length; i++) {
@@ -166,7 +160,25 @@ export function validateTaskStructure(block: string): TaskStructureResult {
     descLines.push(line);
   }
 
-  const descText = descLines.join(' ');
+  return descLines;
+}
+
+/**
+ * Validate a task block for description quality, file targets, and test
+ * expectations.
+ *
+ * Description parsing (DR-5 step 1): see `extractDescriptionSpan` above.
+ *
+ * File detection: backtick-quoted paths like `path/to/file.ext`
+ *
+ * Test detection: `[RED]` markers or `Method_Scenario_Outcome` patterns
+ * (PascalCase segments joined by underscores).
+ */
+export function validateTaskStructure(block: string): TaskStructureResult {
+  const lines = block.split('\n');
+
+  // --- Description (span from heading to next structural header) ---
+  const descText = extractDescriptionSpan(lines).join(' ');
   const descWords = descText
     .trim()
     .split(/\s+/)

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -118,11 +118,17 @@ export function parseTaskBlocks(content: string): TaskBlock[] {
  * Validate a task block for description quality, file targets, and test
  * expectations.
  *
- * Description parsing:
- * - Scans for `**Description:**` inline text
- * - Continues collecting text across blank lines
- * - Stops at next field header (`**Field:**`) or section header (`###`)
- * - Counts all words in collected description text
+ * Description parsing (DR-5 step 1):
+ * - The description span is "everything between the task heading and the
+ *   next field-header (`**Word:**`) or section header (`### `)".
+ * - The FIRST field-header encountered (e.g. `**Goal:**` or
+ *   `**Description:**`) is treated as a description introducer and is
+ *   *included* in the span — its inline tail and the prose that follows
+ *   count as description. The SECOND field-header terminates the span.
+ * - This matches the standard `@skills/implementation-planning` shape
+ *   (`**Goal:**` + paragraph) without relying on a literal `**Description:**`
+ *   field-header.
+ * - When the block has no field-headers at all, the entire body counts.
  *
  * File detection: backtick-quoted paths like `path/to/file.ext`
  *
@@ -132,27 +138,35 @@ export function parseTaskBlocks(content: string): TaskBlock[] {
 export function validateTaskStructure(block: string): TaskStructureResult {
   const lines = block.split('\n');
 
-  // --- Description ---
-  let descText = '';
-  let inDesc = false;
+  // --- Description (span from heading to next structural header) ---
+  // Skip the heading line itself; capture lines until either a `### ` section
+  // header or the SECOND `**Field:**` line. The first field-header acts as a
+  // description introducer (its trailing inline text is captured).
+  const descLines: string[] = [];
+  let firstFieldSeen = false;
+  // Skip the leading heading line if present.
+  const start = lines.length > 0 && /^###\s+Task\s+/.test(lines[0]) ? 1 : 0;
 
-  for (const line of lines) {
-    if (/^\*\*Description:\*\*/.test(line)) {
-      // Extract inline text after **Description:**
-      const inline = line.replace(/^\*\*Description:\*\*\s*/, '');
-      descText = inline;
-      inDesc = true;
-      continue;
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^###\s/.test(line)) {
+      break;
     }
-    if (inDesc) {
-      // Stop at next field header or section header
-      if (/^\*\*/.test(line) || /^###/.test(line)) {
+    const fieldMatch = /^\*\*\w[\w\s]*:\*\*\s?(.*)$/.exec(line);
+    if (fieldMatch) {
+      if (firstFieldSeen) {
+        // Second field-header — terminate the description span.
         break;
       }
-      descText += ' ' + line;
+      // First field-header — drop the `**Field:**` label, keep inline tail.
+      firstFieldSeen = true;
+      descLines.push(fieldMatch[1] ?? '');
+      continue;
     }
+    descLines.push(line);
   }
 
+  const descText = descLines.join(' ');
   const descWords = descText
     .trim()
     .split(/\s+/)

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -523,8 +523,12 @@ export function extractDependencies(block: string): string[] {
  * normalisation, plans that mix forms — e.g. a fixture with bare-numeric
  * task IDs and `T<id>`-prefixed dependency references — would report
  * spurious unresolved-dependency errors.
+ *
+ * Exported so cross-module comparators (e.g. `computeScopedWorktrees`,
+ * which compares caller-supplied task IDs against projection-held
+ * `readyTaskIds`) collapse mixed forms identically.
  */
-function canonicaliseTaskId(id: string): string {
+export function canonicaliseTaskId(id: string): string {
   return id.replace(/^T-?/i, '').replace(/^0+/, '') || '0';
 }
 

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -591,9 +591,18 @@ export function extractFiles(block: string): string[] {
   const lines = block.split('\n');
   const filesSectionLines: string[] = [];
   let inFilesSection = false;
+  // F21 (#1213): track whether the block contained an explicit **Files:**
+  // header at all. If so, the section is AUTHORITATIVE — even when it
+  // declares zero allowlisted paths (e.g. `**Files:** none`, an empty
+  // section, or paths with non-allowlisted extensions only). Without
+  // this flag, an empty Files section silently fell through to
+  // whole-block inference and scraped unrelated backticks elsewhere in
+  // the body, producing false-positive parallel-conflict reports.
+  let sawFilesSection = false;
   for (const line of lines) {
     if (/^\*\*Files:\*\*/i.test(line)) {
       inFilesSection = true;
+      sawFilesSection = true;
       // CodeRabbit #17 (#1213): if the **Files:** header line itself
       // contains paths after the colon (inline form, e.g.
       // `**Files:** \`a.ts\`, \`b.ts\``), capture them. Without this,
@@ -606,13 +615,19 @@ export function extractFiles(block: string): string[] {
     }
     if (inFilesSection) {
       if (/^###\s/.test(line) || /^\*\*\w[\w\s]*:\*\*/.test(line)) {
-        break;
+        inFilesSection = false;
+        continue;
       }
       filesSectionLines.push(line);
     }
   }
 
-  if (filesSectionLines.length > 0) {
+  if (sawFilesSection) {
+    // Authoritative path: an explicit **Files:** section was present.
+    // Return whatever IT declares (possibly empty); do NOT fall through
+    // to whole-block inference. This prevents `**Files:** none` (or an
+    // empty section) from being silently overridden by unrelated
+    // backticks elsewhere in the task body.
     const filesSection = filesSectionLines.join('\n');
     const declared: string[] = [];
     const sectionPattern = new RegExp(FILE_PATH_PATTERN_SOURCE, 'g');
@@ -620,13 +635,11 @@ export function extractFiles(block: string): string[] {
     while ((m = sectionPattern.exec(filesSection)) !== null) {
       declared.push(m[1]);
     }
-    if (declared.length > 0) {
-      return declared;
-    }
+    return declared;
   }
 
-  // Fallback: scan the whole block for backtick-quoted paths with an
-  // allowlisted extension.
+  // Fallback: no explicit **Files:** section appeared at all. Scan the
+  // whole block for backtick-quoted paths with an allowlisted extension.
   const blockPattern = new RegExp(FILE_PATH_PATTERN_SOURCE, 'g');
   const files: string[] = [];
   let match: RegExpExecArray | null;

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -74,6 +74,50 @@ interface TaskDecompositionResult {
   readonly report: string;
 }
 
+// ─── Constants ──────────────────────────────────────────────────────────
+
+/**
+ * Closed-set allowlist of file extensions accepted as real file paths by
+ * `extractFiles` and `validateTaskStructure`. Tokens whose suffix is not
+ * on this list (e.g. `imageProvenance.isFirstParty` — a TypeScript
+ * record-field reference in narrative prose) are intentionally rejected
+ * to avoid false parallel-safety conflicts on dotted-identifier tokens.
+ *
+ * Extensions are mirrored across both call sites; centralising here keeps
+ * the two regexes in lockstep (T-14 REFACTOR).
+ */
+export const FILE_EXTENSION_ALLOWLIST: readonly string[] = [
+  'ts',
+  'tsx',
+  'js',
+  'jsx',
+  'mjs',
+  'cjs',
+  'json',
+  'md',
+  'yml',
+  'yaml',
+  'sh',
+  'ps1',
+  'sql',
+  'kql',
+  'bicep',
+  'cs',
+  'csproj',
+  'sln',
+  'go',
+  'rs',
+  'toml',
+];
+
+/**
+ * Regex source fragment matching a backtick-quoted file path whose suffix
+ * is on `FILE_EXTENSION_ALLOWLIST`. The capture group brackets the path so
+ * the same source compiles for both `match` (line-level scanning) and
+ * `exec` (capture-group extraction) call sites.
+ */
+const FILE_PATH_PATTERN_SOURCE = `\`([a-zA-Z0-9_./-]+\\.(?:${FILE_EXTENSION_ALLOWLIST.join('|')}))\``;
+
 // ─── Parse Task Blocks ──────────────────────────────────────────────────
 
 /**
@@ -187,13 +231,11 @@ export function validateTaskStructure(block: string): TaskStructureResult {
   const hasDescription = descriptionWordCount > 10;
 
   // --- File targets ---
-  // Match backtick-quoted paths whose suffix is on the closed extension
-  // allowlist. Without the allowlist, dotted-identifier tokens like
+  // Match backtick-quoted paths whose suffix is on `FILE_EXTENSION_ALLOWLIST`.
+  // Without the allowlist, dotted-identifier tokens like
   // `imageProvenance.isFirstParty` (record-field references in prose) used
-  // to match and pollute the file count / parallel-safety check. The
-  // allowlist intentionally mirrors `extractFiles` below — see T-14 REFACTOR
-  // for the centralised constant.
-  const filePattern = /`[a-zA-Z0-9_./-]+\.(?:ts|tsx|js|jsx|mjs|cjs|json|md|yml|yaml|sh|ps1|sql|kql|bicep|cs|csproj|sln|go|rs|toml)`/g;
+  // to match and pollute the file count / parallel-safety check.
+  const filePattern = new RegExp(FILE_PATH_PATTERN_SOURCE, 'g');
   let fileCount = 0;
   for (const line of lines) {
     const matches = line.match(filePattern);
@@ -450,8 +492,6 @@ function isParallelizable(block: string): boolean {
  * in the block — explicit declarations are the source of truth.
  */
 export function extractFiles(block: string): string[] {
-  const filePattern = /`([a-zA-Z0-9_./-]+\.(?:ts|tsx|js|jsx|mjs|cjs|json|md|yml|yaml|sh|ps1|sql|kql|bicep|cs|csproj|sln|go|rs|toml))`/g;
-
   // Prefer files declared under an explicit `**Files:**` section when
   // present. Capture lines from the `**Files:**` header until the next
   // field-header (`**Word:**`) or section header (`### `).
@@ -474,8 +514,8 @@ export function extractFiles(block: string): string[] {
   if (filesSectionLines.length > 0) {
     const filesSection = filesSectionLines.join('\n');
     const declared: string[] = [];
+    const sectionPattern = new RegExp(FILE_PATH_PATTERN_SOURCE, 'g');
     let m: RegExpExecArray | null;
-    const sectionPattern = new RegExp(filePattern.source, 'g');
     while ((m = sectionPattern.exec(filesSection)) !== null) {
       declared.push(m[1]);
     }
@@ -486,9 +526,9 @@ export function extractFiles(block: string): string[] {
 
   // Fallback: scan the whole block for backtick-quoted paths with an
   // allowlisted extension.
+  const blockPattern = new RegExp(FILE_PATH_PATTERN_SOURCE, 'g');
   const files: string[] = [];
   let match: RegExpExecArray | null;
-  const blockPattern = new RegExp(filePattern.source, 'g');
   while ((match = blockPattern.exec(block)) !== null) {
     files.push(match[1]);
   }

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -433,7 +433,7 @@ function isParallelizable(block: string): boolean {
 /**
  * Extract backtick-quoted file paths from a task block.
  */
-function extractFiles(block: string): string[] {
+export function extractFiles(block: string): string[] {
   const filePattern = /`([a-zA-Z0-9_./-]+\.[a-zA-Z]+)`/g;
   const files: string[] = [];
   let match: RegExpExecArray | null;

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -190,15 +190,41 @@ export function extractDescriptionSpan(lines: readonly string[]): string[] {
     if (/^###\s/.test(line)) {
       break;
     }
-    const fieldMatch = /^\*\*\w[\w\s]*:\*\*\s?(.*)$/.exec(line);
+    // F20 (#1213): capture the LABEL inside `**...:**` separately so we
+    // can distinguish description introducers (`**Goal:**`,
+    // `**Description:**`) from non-description structural headers
+    // (`**Files:**`, `**Tests:**`, `**Dependencies:**`,
+    // `**Parallelizable:**`, `**Acceptance criteria:**`, …).
+    //
+    // Previously the FIRST `**Field:**` line was treated as the
+    // description introducer regardless of label. Tasks that opened with
+    // `**Files:** \`a.ts\`, \`b.ts\`, \`c.ts\``, etc. inadvertently had
+    // their inline file list counted as description prose, satisfying
+    // the 10-word threshold and masking missing-description failures.
+    //
+    // Now: only `Goal` / `Description` (case-insensitive) introduce the
+    // span. Any other label terminates the scan immediately, leaving
+    // any preceding naked-prose lines as the description (handles the
+    // legacy "no field-headers at all" shape via the `else` branch
+    // below).
+    const fieldMatch = /^\*\*(\w[\w\s]*?):\*\*\s?(.*)$/.exec(line);
     if (fieldMatch) {
+      const label = (fieldMatch[1] ?? '').trim();
+      const isDescriptionIntroducer = /^(goal|description)$/i.test(label);
       if (firstFieldSeen) {
         // Second field-header — terminate the description span.
         break;
       }
-      // First field-header — drop the `**Field:**` label, keep inline tail.
+      if (!isDescriptionIntroducer) {
+        // Non-description header reached before any introducer —
+        // terminate the scan WITHOUT swallowing this line. Any naked
+        // prose preceding it (already pushed to `descLines`) remains
+        // the description.
+        break;
+      }
+      // First description-introducer — drop the label, keep inline tail.
       firstFieldSeen = true;
-      descLines.push(fieldMatch[1] ?? '');
+      descLines.push(fieldMatch[2] ?? '');
       continue;
     }
     descLines.push(line);

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -187,7 +187,13 @@ export function validateTaskStructure(block: string): TaskStructureResult {
   const hasDescription = descriptionWordCount > 10;
 
   // --- File targets ---
-  const filePattern = /`[a-zA-Z0-9_./-]+\.[a-zA-Z]+`/g;
+  // Match backtick-quoted paths whose suffix is on the closed extension
+  // allowlist. Without the allowlist, dotted-identifier tokens like
+  // `imageProvenance.isFirstParty` (record-field references in prose) used
+  // to match and pollute the file count / parallel-safety check. The
+  // allowlist intentionally mirrors `extractFiles` below — see T-14 REFACTOR
+  // for the centralised constant.
+  const filePattern = /`[a-zA-Z0-9_./-]+\.(?:ts|tsx|js|jsx|mjs|cjs|json|md|yml|yaml|sh|ps1|sql|kql|bicep|cs|csproj|sln|go|rs|toml)`/g;
   let fileCount = 0;
   for (const line of lines) {
     const matches = line.match(filePattern);
@@ -432,12 +438,58 @@ function isParallelizable(block: string): boolean {
 
 /**
  * Extract backtick-quoted file paths from a task block.
+ *
+ * The path's suffix MUST be on a closed extension allowlist; tokens whose
+ * suffix is anything else (e.g. `imageProvenance.isFirstParty` —
+ * a TypeScript record-field reference in narrative prose) are not treated
+ * as file paths. Without this filter the parallel-safety check produces
+ * false conflicts on dotted-identifier tokens shared between tasks.
+ *
+ * If the block contains an explicit `**Files:**` section, paths declared
+ * under that section take precedence over inferred matches found elsewhere
+ * in the block — explicit declarations are the source of truth.
  */
 export function extractFiles(block: string): string[] {
-  const filePattern = /`([a-zA-Z0-9_./-]+\.[a-zA-Z]+)`/g;
+  const filePattern = /`([a-zA-Z0-9_./-]+\.(?:ts|tsx|js|jsx|mjs|cjs|json|md|yml|yaml|sh|ps1|sql|kql|bicep|cs|csproj|sln|go|rs|toml))`/g;
+
+  // Prefer files declared under an explicit `**Files:**` section when
+  // present. Capture lines from the `**Files:**` header until the next
+  // field-header (`**Word:**`) or section header (`### `).
+  const lines = block.split('\n');
+  const filesSectionLines: string[] = [];
+  let inFilesSection = false;
+  for (const line of lines) {
+    if (/^\*\*Files:\*\*/i.test(line)) {
+      inFilesSection = true;
+      continue;
+    }
+    if (inFilesSection) {
+      if (/^###\s/.test(line) || /^\*\*\w[\w\s]*:\*\*/.test(line)) {
+        break;
+      }
+      filesSectionLines.push(line);
+    }
+  }
+
+  if (filesSectionLines.length > 0) {
+    const filesSection = filesSectionLines.join('\n');
+    const declared: string[] = [];
+    let m: RegExpExecArray | null;
+    const sectionPattern = new RegExp(filePattern.source, 'g');
+    while ((m = sectionPattern.exec(filesSection)) !== null) {
+      declared.push(m[1]);
+    }
+    if (declared.length > 0) {
+      return declared;
+    }
+  }
+
+  // Fallback: scan the whole block for backtick-quoted paths with an
+  // allowlisted extension.
   const files: string[] = [];
   let match: RegExpExecArray | null;
-  while ((match = filePattern.exec(block)) !== null) {
+  const blockPattern = new RegExp(filePattern.source, 'g');
+  while ((match = blockPattern.exec(block)) !== null) {
     files.push(match[1]);
   }
   return files;

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -278,33 +278,45 @@ export function validateTaskStructure(block: string): TaskStructureResult {
 // ─── Dependency DAG Validation ──────────────────────────────────────────
 
 /**
- * Validate that the dependency graph among tasks is a DAG (no cycles).
+ * fix-008 (review #1213): build the canonical-ID lookup tables in one place.
  *
- * Uses iterative DFS with explicit stack tracking. Each node has three states:
- * - 0 = unvisited
- * - 1 = in-progress (on the DFS stack)
- * - 2 = done (fully explored)
- *
- * A cycle is detected when we encounter a node that is in-progress.
+ * Returns the `visitState` (canonical \u2192 0/1/2 cycle marker), the
+ * `canonicalToOriginal` map (used to surface error messages with the
+ * caller's original ID spelling), and the `depsMap` (canonical \u2192
+ * canonical[] adjacency). May short-circuit with an `error` describing a
+ * duplicate ID or unresolved dependency \u2014 both halt validation up front
+ * before any DFS work runs.
  */
-export function validateDependencyDAG(tasks: readonly DagTask[]): DagValidationResult {
-  // Cycle/unresolved comparisons run on the canonical ID (`canonicaliseTaskId`)
-  // so that `T-002`, `T002`, and `002` are treated as the same task. We keep
-  // a parallel map to recover the original ID for error messages.
+type CanonicalMaps = {
+  readonly kind: 'ok';
+  readonly visitState: Map<string, number>;
+  readonly canonicalToOriginal: Map<string, string>;
+  readonly depsMap: Map<string, readonly string[]>;
+};
+
+type CanonicalMapsError = {
+  readonly kind: 'error';
+  readonly result: DagValidationResult;
+};
+
+function buildCanonicalMaps(
+  tasks: readonly DagTask[],
+): CanonicalMaps | CanonicalMapsError {
   const visitState = new Map<string, number>();
   const canonicalToOriginal = new Map<string, string>();
 
   for (const task of tasks) {
     const canonical = canonicaliseTaskId(task.id);
     if (canonicalToOriginal.has(canonical)) {
-      return { valid: false, cyclePath: `Duplicate task ID: ${task.id}` };
+      return {
+        kind: 'error',
+        result: { valid: false, cyclePath: `Duplicate task ID: ${task.id}` },
+      };
     }
     visitState.set(canonical, 0);
     canonicalToOriginal.set(canonical, task.id);
   }
 
-  // Build adjacency map (canonical task -> canonical deps), reject
-  // unresolved references against the canonical key set.
   const depsMap = new Map<string, readonly string[]>();
   for (const task of tasks) {
     const canonicalSelf = canonicaliseTaskId(task.id);
@@ -313,8 +325,11 @@ export function validateDependencyDAG(tasks: readonly DagTask[]): DagValidationR
       const canonicalDep = canonicaliseTaskId(dep);
       if (!canonicalToOriginal.has(canonicalDep)) {
         return {
-          valid: false,
-          cyclePath: `Unresolved dependency: ${task.id} depends on unknown ${dep}`,
+          kind: 'error',
+          result: {
+            valid: false,
+            cyclePath: `Unresolved dependency: ${task.id} depends on unknown ${dep}`,
+          },
         };
       }
       canonicalDeps.push(canonicalDep);
@@ -322,55 +337,103 @@ export function validateDependencyDAG(tasks: readonly DagTask[]): DagValidationR
     depsMap.set(canonicalSelf, canonicalDeps);
   }
 
-  // Iterative DFS over canonical IDs.
-  for (const task of tasks) {
-    const canonicalRoot = canonicaliseTaskId(task.id);
-    if (visitState.get(canonicalRoot) !== 0) {
+  return { kind: 'ok', visitState, canonicalToOriginal, depsMap };
+}
+
+/**
+ * fix-008 (review #1213): iterative DFS over the canonical adjacency.
+ *
+ * `visit` is mutated in place (caller-owned). On detecting a cycle the
+ * function returns a `DagValidationResult` carrying the offending edge
+ * (in original-ID spelling); on a clean traversal it returns `null` so
+ * the outer loop can advance to the next root.
+ *
+ * Stack entries are `[canonicalNode, phase]` where phase is `'enter'` for
+ * descent and `'exit'` for the post-order mark; this lets the iterative
+ * DFS mirror the recursive shape (pre-order discover, post-order finish)
+ * without recursion overhead or stack-depth limits on large plans.
+ */
+function dfsCycleCheck(
+  root: string,
+  adj: ReadonlyMap<string, readonly string[]>,
+  visit: Map<string, number>,
+  canonicalToOriginal: ReadonlyMap<string, string>,
+): DagValidationResult | null {
+  const stack: Array<[string, 'enter' | 'exit']> = [[root, 'enter']];
+
+  while (stack.length > 0) {
+    const [node, phase] = stack.pop()!;
+
+    if (phase === 'exit') {
+      visit.set(node, 2);
       continue;
     }
 
-    // Stack entries: [canonicalNode, phase] where phase is 'enter' or 'exit'
-    const stack: Array<[string, 'enter' | 'exit']> = [[canonicalRoot, 'enter']];
+    const state = visit.get(node);
 
-    while (stack.length > 0) {
-      const [node, phase] = stack.pop()!;
+    // Already fully explored
+    if (state === 2) {
+      continue;
+    }
 
-      if (phase === 'exit') {
-        visitState.set(node, 2);
-        continue;
+    // Cycle: node is in-progress (already on the DFS stack)
+    if (state === 1) {
+      return { valid: false, cyclePath: canonicalToOriginal.get(node) ?? node };
+    }
+
+    visit.set(node, 1);
+    stack.push([node, 'exit']);
+
+    const deps = adj.get(node) ?? [];
+    for (const dep of deps) {
+      const depState = visit.get(dep);
+      if (depState === 1) {
+        // Cycle found \u2014 report using original IDs.
+        const nodeOriginal = canonicalToOriginal.get(node) ?? node;
+        const depOriginal = canonicalToOriginal.get(dep) ?? dep;
+        return { valid: false, cyclePath: `${nodeOriginal} \u2192 ${depOriginal}` };
       }
-
-      const state = visitState.get(node);
-
-      // Already fully explored
-      if (state === 2) {
-        continue;
-      }
-
-      // Cycle: node is in-progress (already on the DFS stack)
-      if (state === 1) {
-        return { valid: false, cyclePath: canonicalToOriginal.get(node) ?? node };
-      }
-
-      // Mark in-progress
-      visitState.set(node, 1);
-      stack.push([node, 'exit']);
-
-      // Push dependencies
-      const deps = depsMap.get(node) ?? [];
-      for (const dep of deps) {
-        const depState = visitState.get(dep);
-        if (depState === 1) {
-          // Cycle found \u2014 report using original IDs.
-          const nodeOriginal = canonicalToOriginal.get(node) ?? node;
-          const depOriginal = canonicalToOriginal.get(dep) ?? dep;
-          return { valid: false, cyclePath: `${nodeOriginal} \u2192 ${depOriginal}` };
-        }
-        if (depState === 0) {
-          stack.push([dep, 'enter']);
-        }
+      if (depState === 0) {
+        stack.push([dep, 'enter']);
       }
     }
+  }
+
+  return null;
+}
+
+/**
+ * Validate that the dependency graph among tasks is a DAG (no cycles).
+ *
+ * Uses iterative DFS with explicit stack tracking. Each node has three states:
+ * - 0 = unvisited
+ * - 1 = in-progress (on the DFS stack)
+ * - 2 = done (fully explored)
+ *
+ * A cycle is detected when we encounter a node that is in-progress. Map-
+ * construction and the DFS itself are extracted to `buildCanonicalMaps`
+ * and `dfsCycleCheck` so this function reads as orchestration only.
+ */
+export function validateDependencyDAG(tasks: readonly DagTask[]): DagValidationResult {
+  // Cycle/unresolved comparisons run on the canonical ID
+  // (`canonicaliseTaskId`) so that `T-002`, `T002`, and `002` are treated
+  // as the same task. We keep a parallel map to recover the original ID
+  // for error messages.
+  const maps = buildCanonicalMaps(tasks);
+  if (maps.kind === 'error') return maps.result;
+
+  for (const task of tasks) {
+    const canonicalRoot = canonicaliseTaskId(task.id);
+    if (maps.visitState.get(canonicalRoot) !== 0) {
+      continue;
+    }
+    const cycle = dfsCycleCheck(
+      canonicalRoot,
+      maps.depsMap,
+      maps.visitState,
+      maps.canonicalToOriginal,
+    );
+    if (cycle !== null) return cycle;
   }
 
   return { valid: true };

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -354,7 +354,7 @@ export function checkParallelSafety(tasks: readonly ParallelTask[]): ParallelSaf
 /**
  * Extract dependency task IDs from a task block's **Dependencies:** field.
  */
-function extractDependencies(block: string): string[] {
+export function extractDependencies(block: string): string[] {
   const lines = block.split('\n');
   for (const line of lines) {
     if (/^\*\*Dependencies:\*\*/.test(line)) {

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -1193,6 +1193,12 @@ const orchestrateActions: readonly ToolAction[] = [
       taskName: z.string().min(1),
       baseBranch: z.string().optional(),
       skipTests: z.boolean().optional(),
+      // DR-3 (T-09, #1204): resolution priority is
+      //   `branch` > `workflow.tasks[id=taskId].branch` > legacy default.
+      // Provide `featureId` to let the composite adapter look up the planned
+      // branch from workflow state when `branch` is not supplied.
+      branch: z.string().min(1).optional(),
+      featureId: z.string().min(1).optional(),
     }),
     phases: DELEGATE_PHASES,
     roles: ROLE_LEAD,

--- a/servers/exarchos-mcp/src/views/convergence-view.test.ts
+++ b/servers/exarchos-mcp/src/views/convergence-view.test.ts
@@ -203,4 +203,49 @@ describe('ConvergenceView', () => {
       expect(next).toBe(state);
     });
   });
+
+  // ─── T-10: Skipped gates render as SKIP, not PASS ──────────────────────
+
+  describe('apply - skipped gate (T-10)', () => {
+    it('convergenceView_D2GateSkipped_RendersAsSkipNotPass', () => {
+      // A static-analysis gate that ran in a no-toolchain repo emits
+      // gate.executed with passed=false, details.skipped=true,
+      // details.skipReason='no-toolchain'. The convergence view must
+      // expose this as a skipped/inconclusive result, NOT mark D2 as
+      // converged (passed). See DR-4 in the v2.9 dogfood plan.
+      const state = convergenceProjection.init();
+      const event = makeEvent('gate.executed', {
+        gateName: 'static-analysis',
+        layer: 'quality',
+        passed: false,
+        details: {
+          dimension: 'D2',
+          phase: 'delegate',
+          skipped: true,
+          skipReason: 'no-toolchain',
+          passCount: 0,
+          failCount: 0,
+        },
+      });
+
+      const next = convergenceProjection.apply(state, event);
+
+      // D2 must be present (the event was applied) but NOT converged —
+      // skip is inconclusive, not green.
+      expect(next.dimensions['D2']).toBeDefined();
+      expect(next.dimensions['D2'].converged).toBe(false);
+
+      // The single gate result must surface the skipped flag so
+      // downstream rendering can distinguish skip from fail.
+      expect(next.dimensions['D2'].gateResults).toHaveLength(1);
+      const gateResult = next.dimensions['D2'].gateResults[0];
+      expect(gateResult.gateName).toBe('static-analysis');
+      expect(gateResult.passed).toBe(false);
+      expect(gateResult.skipped).toBe(true);
+      expect(gateResult.skipReason).toBe('no-toolchain');
+
+      // Overall convergence cannot be true when D2 is skipped.
+      expect(next.overallConverged).toBe(false);
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/views/convergence-view.ts
+++ b/servers/exarchos-mcp/src/views/convergence-view.ts
@@ -19,12 +19,31 @@ const DIMENSION_LABELS: Record<string, string> = {
 
 // ─── View State Interface ─────────────────────────────────────────────────
 
+/**
+ * A single gate result captured under a convergence dimension.
+ *
+ * `skipped` and `skipReason` are populated when the underlying gate could not
+ * actually run (e.g. static-analysis on a repo with no recognized toolchain).
+ * A skipped gate has `passed: false` AND `skipped: true` — this is distinct
+ * from a real failure (passed: false, skipped undefined/false). The dimension
+ * is treated as not-converged in either case so a skip never falsely-greens
+ * convergence. See DR-4 in docs/plans/2026-05-04-v290-dogfood-bundle.md.
+ */
+export interface ConvergenceGateResult {
+  readonly gateName: string;
+  readonly passed: boolean;
+  readonly timestamp: string;
+  readonly phase?: string;
+  readonly skipped?: boolean;
+  readonly skipReason?: string;
+}
+
 export interface ConvergenceViewState {
   readonly featureId: string;
   readonly dimensions: Record<string, {
     readonly dimension: string;       // 'D1' | 'D2' | 'D3' | 'D4' | 'D5'
     readonly label: string;           // Human-readable name
-    readonly gateResults: Array<{ gateName: string; passed: boolean; timestamp: string; phase?: string }>;
+    readonly gateResults: ConvergenceGateResult[];
     readonly converged: boolean;      // All gates for this dimension passed
     readonly lastChecked: string | null;
   }>;
@@ -35,16 +54,18 @@ export interface ConvergenceViewState {
 // ─── Convergence Predicates ────────────────────────────────────────────────
 
 function isDimensionConverged(
-  gateResults: Array<{ gateName: string; passed: boolean; timestamp: string; phase?: string }>,
+  gateResults: ConvergenceGateResult[],
 ): boolean {
   if (gateResults.length === 0) return false;
 
-  // Check only the latest result per unique gate name so retries can recover
-  const latestByGate = new Map<string, boolean>();
+  // Check only the latest result per unique gate name so retries can recover.
+  // A gate is only "green" when passed AND not skipped — a skipped gate is
+  // inconclusive, never converged (T-10 / DR-4).
+  const latestByGate = new Map<string, { passed: boolean; skipped: boolean }>();
   for (const r of gateResults) {
-    latestByGate.set(r.gateName, r.passed);
+    latestByGate.set(r.gateName, { passed: r.passed, skipped: r.skipped === true });
   }
-  return [...latestByGate.values()].every((passed) => passed);
+  return [...latestByGate.values()].every((v) => v.passed && !v.skipped);
 }
 
 function computeUncheckedDimensions(
@@ -86,13 +107,22 @@ function handleGateExecuted(
 
   const passed = data.passed ?? false;
   const phase = data.details?.phase as string | undefined;
+  // T-10 / DR-4: surface skipped/skipReason from the event details so
+  // downstream rendering can distinguish a skipped (inconclusive) gate
+  // from a true pass or fail. A skipped gate is never converged.
+  const skipped = data.details?.skipped === true ? true : undefined;
+  const skipReason = typeof data.details?.skipReason === 'string'
+    ? (data.details.skipReason as string)
+    : undefined;
   const existing = state.dimensions[dimension];
 
-  const newGateResult = {
+  const newGateResult: ConvergenceGateResult = {
     gateName: data.gateName,
     passed,
     timestamp: event.timestamp,
     ...(phase !== undefined && { phase }),
+    ...(skipped !== undefined && { skipped }),
+    ...(skipReason !== undefined && { skipReason }),
   };
 
   const updatedGateResults = existing

--- a/servers/exarchos-mcp/src/views/delegation-readiness-view.test.ts
+++ b/servers/exarchos-mcp/src/views/delegation-readiness-view.test.ts
@@ -40,6 +40,8 @@ describe('DelegationReadinessView', () => {
         expected: 0,
         ready: 0,
         failed: [],
+        assignedTaskIds: [],
+        readyTaskIds: [],
       });
     });
 
@@ -175,6 +177,48 @@ describe('DelegationReadinessView', () => {
       expect(state.plan.taskCount).toBe(2);
       expect(state.worktrees.expected).toBe(2);
     });
+
+    // ─── DR-T-2 (T-04): per-task ID tracking ──────────────────────────────
+
+    it('Apply_TaskAssigned_AccumulatesAssignedTaskIds', () => {
+      let state = delegationReadinessProjection.init();
+      state = delegationReadinessProjection.apply(state, makeEvent('task.assigned', {
+        taskId: 'task-1', title: 'A',
+      }, 1));
+      state = delegationReadinessProjection.apply(state, makeEvent('task.assigned', {
+        taskId: 'task-2', title: 'B',
+      }, 2));
+
+      expect(state.worktrees.assignedTaskIds).toEqual(['task-1', 'task-2']);
+    });
+
+    it('Apply_DuplicateTaskAssigned_DeduplicatesByTaskId', () => {
+      let state = delegationReadinessProjection.init();
+      state = delegationReadinessProjection.apply(state, makeEvent('task.assigned', {
+        taskId: 'task-1', title: 'A',
+      }, 1));
+      state = delegationReadinessProjection.apply(state, makeEvent('task.assigned', {
+        taskId: 'task-1', title: 'A again',
+      }, 2));
+
+      // Same taskId — assignedTaskIds and counts both deduplicated.
+      expect(state.worktrees.assignedTaskIds).toEqual(['task-1']);
+      expect(state.worktrees.expected).toBe(1);
+      expect(state.plan.taskCount).toBe(1);
+    });
+
+    it('Apply_LegacyExpectedCount_DerivedFromAssignedTaskIds', () => {
+      let state = delegationReadinessProjection.init();
+      state = delegationReadinessProjection.apply(state, makeEvent('task.assigned', {
+        taskId: 'task-1', title: 'A',
+      }, 1));
+      state = delegationReadinessProjection.apply(state, makeEvent('task.assigned', {
+        taskId: 'task-2', title: 'B',
+      }, 2));
+
+      // expected count is now derived from assignedTaskIds.length
+      expect(state.worktrees.expected).toBe(state.worktrees.assignedTaskIds.length);
+    });
   });
 
   // ─── T5: worktree.created ─────────────────────────────────────────────────
@@ -190,6 +234,48 @@ describe('DelegationReadinessView', () => {
       const next = delegationReadinessProjection.apply(state, event);
 
       expect(next.worktrees.ready).toBe(1);
+    });
+
+    // DR-T-2 (T-04): track readyTaskIds keyed by taskId in event data.
+    it('Apply_WorktreeCreatedWithTaskId_AddsToReadyTaskIds', () => {
+      const state = delegationReadinessProjection.init();
+      const event = makeEvent('worktree.created', {
+        worktreePath: '/tmp/wt-1',
+        taskId: 'task-1',
+      });
+
+      const next = delegationReadinessProjection.apply(state, event);
+
+      expect(next.worktrees.readyTaskIds).toEqual(['task-1']);
+      expect(next.worktrees.ready).toBe(1);
+    });
+
+    it('Apply_DuplicateWorktreeCreated_DeduplicatesByTaskId', () => {
+      let state = delegationReadinessProjection.init();
+      state = delegationReadinessProjection.apply(state, makeEvent('worktree.created', {
+        worktreePath: '/tmp/wt-1', taskId: 'task-1',
+      }, 1));
+      state = delegationReadinessProjection.apply(state, makeEvent('worktree.created', {
+        worktreePath: '/tmp/wt-1', taskId: 'task-1',
+      }, 2));
+
+      expect(state.worktrees.readyTaskIds).toEqual(['task-1']);
+      expect(state.worktrees.ready).toBe(1);
+    });
+
+    it('Apply_WorktreeCreatedWithoutTaskId_StillIncrementsReadyCount', () => {
+      // Back-compat: legacy worktree.created events without taskId still
+      // bump the count (using path as a fallback identity) but do not
+      // contribute to per-task scoping.
+      const state = delegationReadinessProjection.init();
+      const event = makeEvent('worktree.created', {
+        worktreePath: '/tmp/wt-1',
+        // taskId omitted
+      });
+
+      const next = delegationReadinessProjection.apply(state, event);
+
+      expect(next.worktrees.ready).toBeGreaterThanOrEqual(1);
     });
   });
 

--- a/servers/exarchos-mcp/src/views/delegation-readiness-view.test.ts
+++ b/servers/exarchos-mcp/src/views/delegation-readiness-view.test.ts
@@ -571,6 +571,42 @@ describe('DelegationReadinessView', () => {
       expect(state.ready).toBe(false);
       expect(state.blockers).toContain('plan not approved');
     });
+
+    // ─── #1213 / Sentry #1: isReady consistency with computeBlockers ──────
+    it('Apply_PlanArtifactMissing_OtherGatesPass_SetsReadyFalse', () => {
+      // Regression: isReady() previously omitted plan.artifactPresent, so a
+      // workflow with approved plan + assigned task + worktree created could
+      // report ready=true while computeBlockers() still listed
+      // "Plan artifact is missing". This test asserts ready is gated on
+      // plan.artifactPresent matching the blocker logic.
+      let state = delegationReadinessProjection.init();
+
+      // Approve plan
+      state = delegationReadinessProjection.apply(state, makeEvent('workflow.transition', {
+        from: 'planning',
+        to: 'plan-review',
+        trigger: 'PLAN_COMPLETE',
+        featureId: 'feat-1',
+      }, 1));
+
+      // Assign a task
+      state = delegationReadinessProjection.apply(state, makeEvent('task.assigned', {
+        taskId: 'task-1',
+        title: 'Task 1',
+        worktree: '/tmp/wt-1',
+      }, 2));
+
+      // Worktree created
+      state = delegationReadinessProjection.apply(state, makeEvent('worktree.created', {
+        worktreePath: '/tmp/wt-1',
+        taskId: 'task-1',
+      }, 3));
+
+      // Plan artifact never captured → still missing
+      expect(state.plan.artifactPresent).toBe(false);
+      expect(state.blockers).toContain('Plan artifact is missing');
+      expect(state.ready).toBe(false);
+    });
   });
 
   // ─── DR-3: Blocker message references events ──────────────────────────────

--- a/servers/exarchos-mcp/src/views/delegation-readiness-view.test.ts
+++ b/servers/exarchos-mcp/src/views/delegation-readiness-view.test.ts
@@ -30,7 +30,7 @@ describe('DelegationReadinessView', () => {
       expect(state.blockers).toContain('plan not approved');
       expect(state.blockers).toContain('no task.assigned events found — emit task.assigned events for each task via exarchos_event before calling prepare_delegation');
       expect(state.blockers).not.toContain('quality signals not queried');
-      expect(state.plan).toEqual({ approved: false, taskCount: 0 });
+      expect(state.plan).toEqual({ approved: false, taskCount: 0, artifactPresent: false });
       expect(state.quality).toEqual({
         queried: false,
         gatePassRate: null,
@@ -41,6 +41,14 @@ describe('DelegationReadinessView', () => {
         ready: 0,
         failed: [],
       });
+    });
+
+    it('Init_PlanArtifactMissing_BlockerPresent', () => {
+      // T-02: plan-artifact presence is now tracked in the projection (DR-T-1).
+      const state = delegationReadinessProjection.init();
+
+      expect(state.plan.artifactPresent).toBe(false);
+      expect(state.blockers).toContain('Plan artifact is missing');
     });
   });
 
@@ -313,6 +321,50 @@ describe('DelegationReadinessView', () => {
 
       expect(next).toBe(state);
     });
+
+    // ─── DR-T-1 (T-02): plan-artifact projection fold ──────────────────────
+
+    it('Apply_StatePatched_NestedArtifactsPlan_FlipsArtifactPresent', () => {
+      const state = delegationReadinessProjection.init();
+      const event = makeEvent('state.patched', {
+        featureId: 'feat-1',
+        fields: ['artifacts'],
+        patch: { artifacts: { plan: 'docs/plans/foo.md' } },
+      });
+
+      const next = delegationReadinessProjection.apply(state, event);
+
+      expect(next.plan.artifactPresent).toBe(true);
+      expect(next.blockers).not.toContain('Plan artifact is missing');
+    });
+
+    it('Apply_StatePatched_DotPathArtifactsPlan_FlipsArtifactPresent', () => {
+      const state = delegationReadinessProjection.init();
+      const event = makeEvent('state.patched', {
+        featureId: 'feat-1',
+        fields: ['artifacts.plan'],
+        patch: { 'artifacts.plan': 'docs/plans/foo.md' },
+      });
+
+      const next = delegationReadinessProjection.apply(state, event);
+
+      expect(next.plan.artifactPresent).toBe(true);
+      expect(next.blockers).not.toContain('Plan artifact is missing');
+    });
+
+    it('Apply_StatePatched_ArtifactsPlanEmpty_DoesNotFlipArtifactPresent', () => {
+      const state = delegationReadinessProjection.init();
+      const event = makeEvent('state.patched', {
+        featureId: 'feat-1',
+        fields: ['artifacts.plan'],
+        patch: { 'artifacts.plan': '' },
+      });
+
+      const next = delegationReadinessProjection.apply(state, event);
+
+      expect(next.plan.artifactPresent).toBe(false);
+      expect(next.blockers).toContain('Plan artifact is missing');
+    });
   });
 
   // ─── T8: All conditions met → ready ───────────────────────────────────────
@@ -329,18 +381,25 @@ describe('DelegationReadinessView', () => {
         featureId: 'feat-1',
       }, 1));
 
+      // DR-T-1: capture plan artifact (now required for full readiness)
+      state = delegationReadinessProjection.apply(state, makeEvent('state.patched', {
+        featureId: 'feat-1',
+        fields: ['artifacts.plan'],
+        patch: { 'artifacts.plan': 'docs/plans/feat-1.md' },
+      }, 2));
+
       // Assign a task
       state = delegationReadinessProjection.apply(state, makeEvent('task.assigned', {
         taskId: 'task-1',
         title: 'Implement feature A',
         worktree: '/tmp/wt-1',
-      }, 2));
+      }, 3));
 
       // Worktree created
       state = delegationReadinessProjection.apply(state, makeEvent('worktree.created', {
         worktreePath: '/tmp/wt-1',
         taskId: 'task-1',
-      }, 3));
+      }, 4));
 
       expect(state.ready).toBe(true);
       expect(state.blockers).toEqual([]);
@@ -356,18 +415,25 @@ describe('DelegationReadinessView', () => {
         patch: { planReview: { approved: true } },
       }, 1));
 
+      // DR-T-1: capture plan artifact
+      state = delegationReadinessProjection.apply(state, makeEvent('state.patched', {
+        featureId: 'feat-1',
+        fields: ['artifacts.plan'],
+        patch: { 'artifacts.plan': 'docs/plans/feat-1.md' },
+      }, 2));
+
       // Assign a task
       state = delegationReadinessProjection.apply(state, makeEvent('task.assigned', {
         taskId: 'task-1',
         title: 'Implement feature A',
         worktree: '/tmp/wt-1',
-      }, 2));
+      }, 3));
 
       // Worktree created
       state = delegationReadinessProjection.apply(state, makeEvent('worktree.created', {
         worktreePath: '/tmp/wt-1',
         taskId: 'task-1',
-      }, 3));
+      }, 4));
 
       expect(state.ready).toBe(true);
       expect(state.blockers).toEqual([]);

--- a/servers/exarchos-mcp/src/views/delegation-readiness-view.ts
+++ b/servers/exarchos-mcp/src/views/delegation-readiness-view.ts
@@ -24,6 +24,19 @@ export interface DelegationReadinessState {
     readonly expected: number;
     readonly ready: number;
     readonly failed: readonly string[];
+    /**
+     * DR-T-2 (#1206): per-task ID tracking for wave scoping. Populated by
+     * `task.assigned` events; deduplicated. `expected` is derived from
+     * `assignedTaskIds.length` and kept for back-compat consumers.
+     */
+    readonly assignedTaskIds: readonly string[];
+    /**
+     * DR-T-2 (#1206): per-task ID tracking for wave scoping. Populated by
+     * `worktree.created` events that carry `data.taskId`; deduplicated.
+     * `ready` is derived from `readyTaskIds.length` plus a fallback
+     * counter for legacy events without taskId. See handleWorktreeCreated.
+     */
+    readonly readyTaskIds: readonly string[];
   };
 }
 
@@ -147,6 +160,14 @@ function handleTaskAssigned(
   const data = event.data as { taskId?: string } | undefined;
   if (!data?.taskId) return state;
 
+  // DR-T-2 (#1206): dedup by taskId. Multiple `task.assigned` events with
+  // the same taskId (e.g. from rehydration replay) must not double-count.
+  if (state.worktrees.assignedTaskIds.includes(data.taskId)) {
+    return state;
+  }
+
+  const assignedTaskIds = [...state.worktrees.assignedTaskIds, data.taskId];
+
   return withReadiness({
     plan: {
       ...state.plan,
@@ -155,15 +176,39 @@ function handleTaskAssigned(
     quality: state.quality,
     worktrees: {
       ...state.worktrees,
-      expected: state.worktrees.expected + 1,
+      expected: assignedTaskIds.length, // derived
+      assignedTaskIds,
     },
   });
 }
 
 function handleWorktreeCreated(
   state: DelegationReadinessState,
-  _event: WorkflowEvent,
+  event: WorkflowEvent,
 ): DelegationReadinessState {
+  const data = event.data as { taskId?: string; worktreePath?: string } | undefined;
+  const taskId = data?.taskId;
+
+  // DR-T-2 (#1206): when the event carries a taskId, dedupe and add to
+  // readyTaskIds. When it doesn't (legacy), bump the count via fallback
+  // delta so totals stay sensible but per-task scoping skips it.
+  if (taskId) {
+    if (state.worktrees.readyTaskIds.includes(taskId)) {
+      return state;
+    }
+    const readyTaskIds = [...state.worktrees.readyTaskIds, taskId];
+    return withReadiness({
+      plan: state.plan,
+      quality: state.quality,
+      worktrees: {
+        ...state.worktrees,
+        ready: state.worktrees.ready + 1,
+        readyTaskIds,
+      },
+    });
+  }
+
+  // Legacy: no taskId on event. Bump count only.
   return withReadiness({
     plan: state.plan,
     quality: state.quality,
@@ -258,7 +303,13 @@ export const delegationReadinessProjection: ViewProjection<DelegationReadinessSt
     ],
     plan: { approved: false, taskCount: 0, artifactPresent: false },
     quality: { queried: false, gatePassRate: null, regressions: [] },
-    worktrees: { expected: 0, ready: 0, failed: [] },
+    worktrees: {
+      expected: 0,
+      ready: 0,
+      failed: [],
+      assignedTaskIds: [],
+      readyTaskIds: [],
+    },
   }),
 
   apply: (view: DelegationReadinessState, event: WorkflowEvent): DelegationReadinessState => {

--- a/servers/exarchos-mcp/src/views/delegation-readiness-view.ts
+++ b/servers/exarchos-mcp/src/views/delegation-readiness-view.ts
@@ -13,6 +13,7 @@ export interface DelegationReadinessState {
   readonly plan: {
     readonly approved: boolean;
     readonly taskCount: number;
+    readonly artifactPresent: boolean;
   };
   readonly quality: {
     readonly queried: boolean;
@@ -33,6 +34,10 @@ function computeBlockers(state: Omit<DelegationReadinessState, 'ready' | 'blocke
 
   if (!state.plan.approved) {
     blockers.push('plan not approved');
+  }
+
+  if (!state.plan.artifactPresent) {
+    blockers.push('Plan artifact is missing');
   }
 
   if (state.plan.taskCount === 0) {
@@ -211,9 +216,28 @@ function handleStatePatched(
       ? planReview.approved
       : undefined;
 
-  if (approved !== undefined && approved !== state.plan.approved) {
+  // DR-T-1 (#1205): Resolve artifacts.plan presence from nested or dot-path form.
+  // Truthy non-empty string = present; empty string = absent.
+  const artifacts = data.patch.artifacts as { plan?: unknown } | undefined;
+  const artifactsPlanDotPath = data.patch['artifacts.plan'];
+  const artifactsPlanRaw = artifactsPlanDotPath !== undefined
+    ? artifactsPlanDotPath
+    : artifacts?.plan;
+  const artifactPresent = artifactsPlanRaw === undefined
+    ? undefined
+    : typeof artifactsPlanRaw === 'string' && artifactsPlanRaw.length > 0;
+
+  const planChanged =
+    (approved !== undefined && approved !== state.plan.approved) ||
+    (artifactPresent !== undefined && artifactPresent !== state.plan.artifactPresent);
+
+  if (planChanged) {
     return withReadiness({
-      plan: { ...state.plan, approved },
+      plan: {
+        ...state.plan,
+        ...(approved !== undefined ? { approved } : {}),
+        ...(artifactPresent !== undefined ? { artifactPresent } : {}),
+      },
       quality: state.quality,
       worktrees: state.worktrees,
     });
@@ -227,8 +251,12 @@ function handleStatePatched(
 export const delegationReadinessProjection: ViewProjection<DelegationReadinessState> = {
   init: (): DelegationReadinessState => ({
     ready: false,
-    blockers: ['plan not approved', 'no task.assigned events found — emit task.assigned events for each task via exarchos_event before calling prepare_delegation'],
-    plan: { approved: false, taskCount: 0 },
+    blockers: [
+      'plan not approved',
+      'Plan artifact is missing',
+      'no task.assigned events found — emit task.assigned events for each task via exarchos_event before calling prepare_delegation',
+    ],
+    plan: { approved: false, taskCount: 0, artifactPresent: false },
     quality: { queried: false, gatePassRate: null, regressions: [] },
     worktrees: { expected: 0, ready: 0, failed: [] },
   }),

--- a/servers/exarchos-mcp/src/views/delegation-readiness-view.ts
+++ b/servers/exarchos-mcp/src/views/delegation-readiness-view.ts
@@ -76,6 +76,7 @@ function computeBlockers(state: Omit<DelegationReadinessState, 'ready' | 'blocke
 function isReady(state: Omit<DelegationReadinessState, 'ready' | 'blockers'>): boolean {
   return (
     state.plan.approved &&
+    state.plan.artifactPresent &&
     state.worktrees.ready >= state.worktrees.expected &&
     state.worktrees.expected > 0 &&
     state.worktrees.failed.length === 0

--- a/servers/exarchos-mcp/src/workflow/guards.test.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.test.ts
@@ -1004,6 +1004,39 @@ describe('oneshotPlanSet', () => {
     const result = guards.oneshotPlanSet.evaluate(state);
     expect(result).not.toBe(true);
   });
+
+  // F23 (#1213): align guard with the `delegationReadinessProjection`
+  // contract — `artifacts.plan` MUST be a non-empty string (plan
+  // contents or path). Non-string truthy values (true, objects,
+  // numbers) used to satisfy the guard, which diverged from the
+  // projection's `artifactPresent = typeof === 'string' && .length > 0`
+  // narrowing. Now both surfaces enforce the same shape.
+  it('oneshotPlanSet_rejectsNonStringTruthyValues', () => {
+    // Patches that wrote `artifacts.plan = true` or `= 1` or `= {}`
+    // previously silently advanced the workflow. None of these are
+    // valid plan artifacts; all must fail the guard.
+    const cases: ReadonlyArray<{ label: string; plan: unknown }> = [
+      { label: 'boolean true', plan: true },
+      { label: 'number 1', plan: 1 },
+      { label: 'plain object', plan: {} },
+      { label: 'object with path field', plan: { path: 'plan.md' } },
+      { label: 'array', plan: ['plan.md'] },
+    ];
+    for (const { label, plan } of cases) {
+      const state: Record<string, unknown> = {
+        featureId: 'test-feature',
+        artifacts: { plan },
+      };
+      const result = guards.oneshotPlanSet.evaluate(state);
+      expect(
+        result,
+        `expected non-string plan (${label}) to fail the guard`,
+      ).not.toBe(true);
+      const failure = result as GuardFailure;
+      expect(failure.passed).toBe(false);
+      expect(failure.reason).toContain('artifacts.plan');
+    }
+  });
 });
 
 // ─── Discovery Workflow Guard Tests (#1080) ────────────────────────────────

--- a/servers/exarchos-mcp/src/workflow/guards.ts
+++ b/servers/exarchos-mcp/src/workflow/guards.ts
@@ -743,7 +743,7 @@ export const guards = {
   oneshotPlanSet: {
     id: 'oneshot-plan-set',
     description:
-      'Oneshot workflow plan artifact is captured in state.artifacts.plan. `oneshot.planSummary` is a pipeline-view hint, not a plan, and is not sufficient alone to transition plan → implementing.',
+      'Oneshot workflow plan artifact is captured in state.artifacts.plan as a non-empty string (plan contents or path). `oneshot.planSummary` is a pipeline-view hint, not a plan, and is not sufficient alone to transition plan → implementing.',
     evaluate: (state: Record<string, unknown>): GuardResult => {
       // Tightened: require `artifacts.plan` as the primary (and only
       // sufficient) condition. Previously either `oneshot.planSummary`
@@ -753,6 +753,17 @@ export const guards = {
       // with no persisted plan artifact at all. `planSummary` is still
       // recommended as a human-readable label, but it is not the artifact
       // the guard enforces.
+      //
+      // F23 (#1213): tightened further to require a STRING. Previously
+      // any non-string truthy value (e.g. `true`, an object, a number)
+      // also satisfied the guard, which diverged from the
+      // `delegationReadinessProjection`'s `artifactPresent` projection
+      // (which already required `typeof === 'string' && .length > 0`).
+      // Aligning the two surfaces on "non-empty string" is the most
+      // defensible contract — `artifacts.plan` is a plan path or plan
+      // contents, both of which are strings. Patches that set
+      // `artifacts.plan = true` or `= {}` no longer silently advance
+      // the workflow.
       const artifacts = state.artifacts as Record<string, unknown> | undefined;
       const plan = artifacts?.plan;
       // Whitespace-only plan strings are not a real plan artifact — they
@@ -760,12 +771,11 @@ export const guards = {
       // oneshot transition `plan → implementing` with a blank document.
       // Require at least one non-whitespace character.
       if (typeof plan === 'string' && plan.trim().length > 0) return true;
-      if (plan != null && typeof plan !== 'string') return true;
       const featureId = typeof state.featureId === 'string' ? state.featureId : '<featureId>';
       return {
         passed: false,
         reason:
-          'oneshot-plan-set not satisfied: state.artifacts.plan is required (a non-empty plan artifact) before transitioning plan → implementing. `oneshot.planSummary` alone does not satisfy this guard.',
+          'oneshot-plan-set not satisfied: state.artifacts.plan is required (a non-empty string of plan contents or a plan path) before transitioning plan → implementing. `oneshot.planSummary` alone does not satisfy this guard, and non-string values (true, objects, numbers) are not accepted.',
         expectedShape: { artifacts: { plan: '<one-page plan contents or path>' } },
         suggestedFix: {
           tool: 'exarchos_workflow',

--- a/servers/exarchos-mcp/src/workflow/state-store.test.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.test.ts
@@ -944,4 +944,38 @@ describe('applyDotPath array append syntax (T-17)', () => {
     applyDotPath(obj, 'tasks[0].status', 'complete');
     expect(tasks[0].status).toBe('complete');
   });
+
+  // ─── #1213 / CodeRabbit #18: malformed/compound bracket forms ─────────
+  it('parsePath_CompoundBrackets_TasksZeroOne_ThrowsMalformedError', () => {
+    // `tasks[0][1]` is a compound double-index form the parser does not
+    // recognize. Without an explicit guard it would fall through and be
+    // pushed as a literal property name — same silent-success bug
+    // fix-004 closed for keyed access. Now rejected loudly.
+    const obj: Record<string, unknown> = { tasks: [['a', 'b']] };
+
+    expect(() => applyDotPath(obj, 'tasks[0][1]', 'updated')).toThrow(
+      /malformed array access/i,
+    );
+  });
+
+  it('parsePath_UnterminatedBracket_TasksKeyedNoClose_ThrowsMalformedError', () => {
+    // `tasks[id=T-001` (no closing bracket) is not a valid bracket form.
+    // The non-numeric guard requires `[...]`, so this falls past it. The
+    // new compound/malformed guard catches it.
+    const obj: Record<string, unknown> = { tasks: [{ id: 'T-001' }] };
+
+    expect(() =>
+      applyDotPath(obj, 'tasks[id=T-001.status', 'complete'),
+    ).toThrow(/malformed array access/i);
+  });
+
+  it('parsePath_MismatchedCloseBracket_TasksClose_ThrowsMalformedError', () => {
+    // `tasks]` has only a closing bracket. None of the bracket patterns
+    // match, but the bare `]` should still be rejected as malformed.
+    const obj: Record<string, unknown> = { tasks: [] };
+
+    expect(() => applyDotPath(obj, 'tasks].status', 'complete')).toThrow(
+      /malformed array access/i,
+    );
+  });
 });

--- a/servers/exarchos-mcp/src/workflow/state-store.test.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.test.ts
@@ -875,3 +875,73 @@ describe('applyDotPath array replacement (#1003)', () => {
     expect(tasks.some(t => t.id === '001')).toBe(false);
   });
 });
+
+// ─── T-17 (DR-8c): documented array-insertion syntax in workflow_set ─────────
+//
+// `skills-src/workflow-state/SKILL.md` previously documented `tasks[id=001]`
+// as the pattern for editing a single task in place. The parser does NOT
+// support keyed array access — `parsePath` only recognizes numeric brackets
+// (`[\d+]`). The supported insertion patterns are:
+//   1. Replace the entire array: `updates: { tasks: [...] }`
+//   2. Replace one element by index: `updates: { 'tasks[0].status': '...' }`
+//   3. Append by next index: `updates: { 'tasks[<length>]': { id, title } }`
+//      — `assertArrayBounds` allows `index <= arr.length + MAX_ARRAY_GAP` so
+//      writing at the current `arr.length` slot performs a real append.
+//
+// This test pins option (3) so the SKILL.md worked example can rely on it.
+describe('applyDotPath array append syntax (T-17)', () => {
+  it('workflowSetParser_ArrayInsertionSyntax_AppendsNewEntry', () => {
+    // Arrange — start with a 2-element task array, mimicking a workflow that
+    // already received its first plan and now wants to add a follow-up task
+    // without rewriting the whole list.
+    const obj: Record<string, unknown> = {
+      tasks: [
+        { id: 'T-001', title: 'Existing 1', status: 'complete' },
+        { id: 'T-002', title: 'Existing 2', status: 'in_progress' },
+      ],
+    };
+
+    // Act — append by writing at index === current array length.
+    // This is the syntax `skills-src/workflow-state/SKILL.md` documents.
+    applyDotPath(obj, 'tasks[2]', {
+      id: 'T-003',
+      title: 'New follow-up',
+      status: 'pending',
+    });
+
+    // Assert — array grew by exactly one entry; existing entries unchanged.
+    const tasks = obj.tasks as Array<Record<string, unknown>>;
+    expect(tasks).toHaveLength(3);
+    expect(tasks[0]).toEqual({ id: 'T-001', title: 'Existing 1', status: 'complete' });
+    expect(tasks[1]).toEqual({ id: 'T-002', title: 'Existing 2', status: 'in_progress' });
+    expect(tasks[2]).toEqual({ id: 'T-003', title: 'New follow-up', status: 'pending' });
+  });
+
+  it('workflowSetParser_ArrayInsertionSyntax_KeyedAccessFormIsNotSupported', () => {
+    // The SKILL.md guidance previously hinted at `tasks[id=001]` — confirm
+    // the parser does NOT honor that form. `parsePath` only recognizes
+    // numeric brackets (`tasks[0]`); `tasks[id=T-001]` falls through as a
+    // literal property name and silently writes to a bogus top-level key.
+    // This test pins that behavior so a future parser change that adds
+    // keyed support is forced to update both this test and the SKILL.md
+    // worked example simultaneously.
+    const obj: Record<string, unknown> = {
+      tasks: [{ id: 'T-001', status: 'pending' }],
+    };
+
+    applyDotPath(obj, 'tasks[id=T-001].status', 'complete');
+
+    // The legitimate task entry was NOT updated.
+    const tasks = obj.tasks as Array<Record<string, unknown>>;
+    expect(tasks[0].status).toBe('pending');
+
+    // Instead, a bogus top-level key was created (silent misapplication).
+    // Documenting this here so callers know they need the by-index form.
+    expect(obj['tasks[id=T-001]']).toBeDefined();
+
+    // The legitimate by-index form continues to work and is the only
+    // supported way to update one task in place.
+    applyDotPath(obj, 'tasks[0].status', 'complete');
+    expect(tasks[0].status).toBe('complete');
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/state-store.test.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.test.ts
@@ -917,27 +917,27 @@ describe('applyDotPath array append syntax (T-17)', () => {
     expect(tasks[2]).toEqual({ id: 'T-003', title: 'New follow-up', status: 'pending' });
   });
 
-  it('workflowSetParser_ArrayInsertionSyntax_KeyedAccessFormIsNotSupported', () => {
-    // The SKILL.md guidance previously hinted at `tasks[id=001]` — confirm
-    // the parser does NOT honor that form. `parsePath` only recognizes
-    // numeric brackets (`tasks[0]`); `tasks[id=T-001]` falls through as a
-    // literal property name and silently writes to a bogus top-level key.
-    // This test pins that behavior so a future parser change that adds
-    // keyed support is forced to update both this test and the SKILL.md
-    // worked example simultaneously.
+  it('workflowSetParser_ArrayInsertionSyntax_KeyedAccessFormThrowsClearError', () => {
+    // fix-004 (review #1213, T-17c): the keyed-access form `tasks[id=T-001]`
+    // used to be silently misapplied (parser fell through to a literal
+    // property name and created a bogus top-level key). That was the worst
+    // possible failure mode — caller saw `success: true` while the actual
+    // task was untouched. The parser now throws a clear error so callers
+    // get loud feedback and can switch to the by-index form documented in
+    // skills-src/workflow-state/SKILL.md.
     const obj: Record<string, unknown> = {
       tasks: [{ id: 'T-001', status: 'pending' }],
     };
 
-    applyDotPath(obj, 'tasks[id=T-001].status', 'complete');
+    expect(() => applyDotPath(obj, 'tasks[id=T-001].status', 'complete')).toThrow(
+      /keyed array access.*not supported/i,
+    );
 
-    // The legitimate task entry was NOT updated.
+    // The legitimate task entry remains untouched (no silent
+    // misapplication side-effect either).
     const tasks = obj.tasks as Array<Record<string, unknown>>;
     expect(tasks[0].status).toBe('pending');
-
-    // Instead, a bogus top-level key was created (silent misapplication).
-    // Documenting this here so callers know they need the by-index form.
-    expect(obj['tasks[id=T-001]']).toBeDefined();
+    expect(obj['tasks[id=T-001]']).toBeUndefined();
 
     // The legitimate by-index form continues to work and is the only
     // supported way to update one task in place.

--- a/servers/exarchos-mcp/src/workflow/state-store.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.ts
@@ -505,6 +505,22 @@ function parsePath(dotPath: string): Array<string | number> {
       );
     }
 
+    // CodeRabbit #18 (#1213): catch malformed and compound bracket forms
+    // that the patterns above don't recognize but which still contain
+    // bracket characters. Examples: `tasks[0][1]` (compound double
+    // index), `tasks[id=T-001` (unterminated), `tasks]` (mismatched
+    // close), `[]` (empty body). Falling through here would push the
+    // whole literal as a property name — same silent-success bug
+    // fix-004 closed for keyed access. Reject loudly with the same
+    // remediation guidance.
+    if (part.includes('[') || part.includes(']')) {
+      throw new StateStoreError(
+        ErrorCode.INVALID_INPUT,
+        `Malformed array access in dot-path segment "${part}" (from "${dotPath}"). ` +
+          `Use numeric brackets only, e.g. "tasks[0].status".`,
+      );
+    }
+
     segments.push(part);
   }
 

--- a/servers/exarchos-mcp/src/workflow/state-store.ts
+++ b/servers/exarchos-mcp/src/workflow/state-store.ts
@@ -461,6 +461,14 @@ export function deepMerge(
 /**
  * Parse a dot-path string into segments, handling array bracket notation.
  * Example: "tasks[0].status" -> ["tasks", 0, "status"]
+ *
+ * fix-004 (#1213, T-17c): keyed-access bracket forms such as
+ * `tasks[id=T-001]` are explicitly rejected. Earlier behavior fell
+ * through to treat the whole `tasks[id=T-001]` chunk as a literal property
+ * name and silently wrote to a bogus top-level key, returning success
+ * while the actual task was untouched. The parser now throws so callers
+ * get loud feedback and reach for the supported by-index form documented
+ * in `skills-src/workflow-state/SKILL.md`.
  */
 function parsePath(dotPath: string): Array<string | number> {
   const segments: Array<string | number> = [];
@@ -472,15 +480,32 @@ function parsePath(dotPath: string): Array<string | number> {
     if (bracketMatch) {
       segments.push(bracketMatch[1]);
       segments.push(parseInt(bracketMatch[2], 10));
-    } else {
-      // Check for standalone bracket: "[0]"
-      const standaloneBracket = part.match(/^\[(\d+)\]$/);
-      if (standaloneBracket) {
-        segments.push(parseInt(standaloneBracket[1], 10));
-      } else {
-        segments.push(part);
-      }
+      continue;
     }
+
+    // Check for standalone bracket: "[0]"
+    const standaloneBracket = part.match(/^\[(\d+)\]$/);
+    if (standaloneBracket) {
+      segments.push(parseInt(standaloneBracket[1], 10));
+      continue;
+    }
+
+    // fix-004: detect non-numeric bracket content and reject loudly. Match
+    // any `[...]` whose body is NOT pure digits — covers `tasks[id=001]`,
+    // `tasks[id=T-001]`, `tasks[name=foo]`, `tasks[*]`, etc.
+    const nonNumericBracket = part.match(/^([^[]*)\[([^\]]*)\]$/);
+    if (nonNumericBracket && !/^\d+$/.test(nonNumericBracket[2])) {
+      throw new StateStoreError(
+        ErrorCode.INVALID_INPUT,
+        `keyed array access is not supported in dot-paths (got "${part}" in "${dotPath}"). ` +
+          `The parser only recognizes numeric brackets, e.g. "tasks[0].status". ` +
+          `To edit one task, first read tasks (action: "get", query: "tasks"), ` +
+          `then write to its array index. To append, write to "tasks[<length>]". ` +
+          `See skills-src/workflow-state/SKILL.md for the supported patterns.`,
+      );
+    }
+
+    segments.push(part);
   }
 
   return segments;

--- a/skills-src/delegation/SKILL.md
+++ b/skills-src/delegation/SKILL.md
@@ -362,6 +362,113 @@ for phase transitions, guards, and playbook guidance. Use
 `exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })`
 for orchestrate action schemas.
 
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by `merge_orchestrate` ancestry preflight: the
+failure message links here verbatim and includes the manual `git rebase`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+```
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+```
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+Each subagent worktree is created at the integration branch's tip at
+dispatch time. When the orchestrator merges sibling worktrees serially,
+each merge moves the integration branch forward. A worktree that was
+dispatched against an older integration tip will fail the ancestry
+preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that `git status` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   ```bash
+   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   ```
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
+   feature branch restores the pre-rebase state.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   ```bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   ```
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass `--strategy-option=theirs` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   ```typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   ```
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   ```bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   ```
+
+2. **Mark the task `failed`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a `merge.aborted` event with
+   `reason: "ancestry-rebase-conflict"` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
+
 ## Transition
 
 After all tasks complete, **auto-continue immediately** (no user confirmation):

--- a/skills-src/delegation/SKILL.md
+++ b/skills-src/delegation/SKILL.md
@@ -376,9 +376,9 @@ must drive recovery by hand.
 
 The merge-orchestrator reports an ancestry failure of the form:
 
-```
+```text
 source branch <feature-branch> is not a descendant of <integration-branch>.
-Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
 Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
 ```
 
@@ -406,12 +406,14 @@ subagent worktree) and that `git status` is clean.
 1. **Capture the rollback SHA** before doing anything destructive:
 
    ```bash
-   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   git rev-parse <feature-branch> > /tmp/rollback.sha
    ```
 
    Keep this until the merge has been verified. If anything goes wrong,
-   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
-   feature branch restores the pre-rebase state.
+   `git reset --hard "$(cat /tmp/rollback.sha)"` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like `feature/dr-6`
+   don't break the path with embedded `/` characters.
 
 2. **Rebase the feature branch onto the current integration tip:**
 
@@ -448,7 +450,7 @@ still fails after rebase:
    ```bash
    cd <feature-worktree-path>
    git rebase --abort   # if mid-rebase
-   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   git reset --hard "$(cat /tmp/rollback.sha)"
    ```
 
 2. **Mark the task `failed`** in workflow state and dispatch a fixer (see

--- a/skills-src/delegation/references/implementer-prompt.md
+++ b/skills-src/delegation/references/implementer-prompt.md
@@ -16,6 +16,24 @@ Before dispatch, query `exarchos_view` with `action: 'quality_hints'` and `skill
 ## Working Directory
 [Absolute path to worktree or project root]
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path from the **Working Directory**
+section above. After that, the verification block below confirms you landed
+correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills-src/delegation/references/implementer-prompt.md
+++ b/skills-src/delegation/references/implementer-prompt.md
@@ -311,6 +311,22 @@ The prompt body itself is what makes the dispatch self-contained. A worked examp
 ## Working Directory
 /home/user/project/.worktrees/task-003
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "/home/user/project/.worktrees/task-003"             # bash / zsh / sh
+```
+```powershell
+Set-Location "/home/user/project/.worktrees/task-003"   # PowerShell
+```
+
+After that, the verification block below confirms you landed correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills-src/workflow-state/SKILL.md
+++ b/skills-src/workflow-state/SKILL.md
@@ -93,11 +93,48 @@ Use `{{MCP_PREFIX}}exarchos_workflow` with `action: "set"` with `featureId` and 
 
 - **Update phase**: `phase: "delegate"`
 - **Set artifact path**: `updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }`
-- **Mark task complete**: `updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }`
+- **Mark task complete (by index)**: `updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }`
 - **Add worktree**: `updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }`
 - **Phase + updates together**: `phase: "delegate"`, `updates: { "artifacts.plan": "docs/plans/plan.md" }`
 
 Worktree status values: `'active' | 'merged' | 'removed'`
+
+#### Editing the `tasks` array
+
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   ```
+
+2. **Edit one task by its array index**:
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   ```
+   First read `tasks` (`action: "get", query: "tasks"`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length `N`, write to `tasks[N]`:
+   ```typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   ```
+   The parser allows writing one slot past the current length (`MAX_ARRAY_GAP = 1`); writing further out (`tasks[5]` against a length-2 array) throws `INVALID_INPUT`. Read the current `tasks` length before appending.
 
 ### Get Summary
 

--- a/skills-src/workflow-state/SKILL.md
+++ b/skills-src/workflow-state/SKILL.md
@@ -101,7 +101,7 @@ Worktree status values: `'active' | 'merged' | 'removed'`
 
 #### Editing the `tasks` array
 
-The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported and now throw an `INVALID_INPUT` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning `success: true` while the actual task was untouched. Three patterns are supported:
 
 1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
    ```typescript

--- a/skills/claude/delegation/SKILL.md
+++ b/skills/claude/delegation/SKILL.md
@@ -368,6 +368,113 @@ for phase transitions, guards, and playbook guidance. Use
 `exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })`
 for orchestrate action schemas.
 
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by `merge_orchestrate` ancestry preflight: the
+failure message links here verbatim and includes the manual `git rebase`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+```
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+```
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+Each subagent worktree is created at the integration branch's tip at
+dispatch time. When the orchestrator merges sibling worktrees serially,
+each merge moves the integration branch forward. A worktree that was
+dispatched against an older integration tip will fail the ancestry
+preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that `git status` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   ```bash
+   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   ```
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
+   feature branch restores the pre-rebase state.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   ```bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   ```
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass `--strategy-option=theirs` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   ```typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   ```
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   ```bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   ```
+
+2. **Mark the task `failed`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a `merge.aborted` event with
+   `reason: "ancestry-rebase-conflict"` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
+
 ## Transition
 
 After all tasks complete, **auto-continue immediately** (no user confirmation):

--- a/skills/claude/delegation/SKILL.md
+++ b/skills/claude/delegation/SKILL.md
@@ -382,9 +382,9 @@ must drive recovery by hand.
 
 The merge-orchestrator reports an ancestry failure of the form:
 
-```
+```text
 source branch <feature-branch> is not a descendant of <integration-branch>.
-Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
 Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
 ```
 
@@ -412,12 +412,14 @@ subagent worktree) and that `git status` is clean.
 1. **Capture the rollback SHA** before doing anything destructive:
 
    ```bash
-   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   git rev-parse <feature-branch> > /tmp/rollback.sha
    ```
 
    Keep this until the merge has been verified. If anything goes wrong,
-   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
-   feature branch restores the pre-rebase state.
+   `git reset --hard "$(cat /tmp/rollback.sha)"` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like `feature/dr-6`
+   don't break the path with embedded `/` characters.
 
 2. **Rebase the feature branch onto the current integration tip:**
 
@@ -454,7 +456,7 @@ still fails after rebase:
    ```bash
    cd <feature-worktree-path>
    git rebase --abort   # if mid-rebase
-   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   git reset --hard "$(cat /tmp/rollback.sha)"
    ```
 
 2. **Mark the task `failed`** in workflow state and dispatch a fixer (see

--- a/skills/claude/delegation/references/implementer-prompt.md
+++ b/skills/claude/delegation/references/implementer-prompt.md
@@ -16,6 +16,24 @@ Before dispatch, query `exarchos_view` with `action: 'quality_hints'` and `skill
 ## Working Directory
 [Absolute path to worktree or project root]
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path from the **Working Directory**
+section above. After that, the verification block below confirms you landed
+correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills/claude/delegation/references/implementer-prompt.md
+++ b/skills/claude/delegation/references/implementer-prompt.md
@@ -316,6 +316,22 @@ The prompt body itself is what makes the dispatch self-contained. A worked examp
 ## Working Directory
 /home/user/project/.worktrees/task-003
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "/home/user/project/.worktrees/task-003"             # bash / zsh / sh
+```
+```powershell
+Set-Location "/home/user/project/.worktrees/task-003"   # PowerShell
+```
+
+After that, the verification block below confirms you landed correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills/claude/workflow-state/SKILL.md
+++ b/skills/claude/workflow-state/SKILL.md
@@ -101,7 +101,7 @@ Worktree status values: `'active' | 'merged' | 'removed'`
 
 #### Editing the `tasks` array
 
-The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported and now throw an `INVALID_INPUT` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning `success: true` while the actual task was untouched. Three patterns are supported:
 
 1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
    ```typescript

--- a/skills/claude/workflow-state/SKILL.md
+++ b/skills/claude/workflow-state/SKILL.md
@@ -93,11 +93,48 @@ Use `mcp__plugin_exarchos_exarchos__exarchos_workflow` with `action: "set"` with
 
 - **Update phase**: `phase: "delegate"`
 - **Set artifact path**: `updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }`
-- **Mark task complete**: `updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }`
+- **Mark task complete (by index)**: `updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }`
 - **Add worktree**: `updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }`
 - **Phase + updates together**: `phase: "delegate"`, `updates: { "artifacts.plan": "docs/plans/plan.md" }`
 
 Worktree status values: `'active' | 'merged' | 'removed'`
+
+#### Editing the `tasks` array
+
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   ```
+
+2. **Edit one task by its array index**:
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   ```
+   First read `tasks` (`action: "get", query: "tasks"`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length `N`, write to `tasks[N]`:
+   ```typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   ```
+   The parser allows writing one slot past the current length (`MAX_ARRAY_GAP = 1`); writing further out (`tasks[5]` against a length-2 array) throws `INVALID_INPUT`. Read the current `tasks` length before appending.
 
 ### Get Summary
 

--- a/skills/codex/delegation/SKILL.md
+++ b/skills/codex/delegation/SKILL.md
@@ -323,6 +323,113 @@ for phase transitions, guards, and playbook guidance. Use
 `exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })`
 for orchestrate action schemas.
 
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by `merge_orchestrate` ancestry preflight: the
+failure message links here verbatim and includes the manual `git rebase`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+```
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+```
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+Each subagent worktree is created at the integration branch's tip at
+dispatch time. When the orchestrator merges sibling worktrees serially,
+each merge moves the integration branch forward. A worktree that was
+dispatched against an older integration tip will fail the ancestry
+preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that `git status` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   ```bash
+   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   ```
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
+   feature branch restores the pre-rebase state.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   ```bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   ```
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass `--strategy-option=theirs` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   ```typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   ```
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   ```bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   ```
+
+2. **Mark the task `failed`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a `merge.aborted` event with
+   `reason: "ancestry-rebase-conflict"` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
+
 ## Transition
 
 After all tasks complete, **auto-continue immediately** (no user confirmation):

--- a/skills/codex/delegation/SKILL.md
+++ b/skills/codex/delegation/SKILL.md
@@ -337,9 +337,9 @@ must drive recovery by hand.
 
 The merge-orchestrator reports an ancestry failure of the form:
 
-```
+```text
 source branch <feature-branch> is not a descendant of <integration-branch>.
-Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
 Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
 ```
 
@@ -367,12 +367,14 @@ subagent worktree) and that `git status` is clean.
 1. **Capture the rollback SHA** before doing anything destructive:
 
    ```bash
-   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   git rev-parse <feature-branch> > /tmp/rollback.sha
    ```
 
    Keep this until the merge has been verified. If anything goes wrong,
-   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
-   feature branch restores the pre-rebase state.
+   `git reset --hard "$(cat /tmp/rollback.sha)"` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like `feature/dr-6`
+   don't break the path with embedded `/` characters.
 
 2. **Rebase the feature branch onto the current integration tip:**
 
@@ -409,7 +411,7 @@ still fails after rebase:
    ```bash
    cd <feature-worktree-path>
    git rebase --abort   # if mid-rebase
-   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   git reset --hard "$(cat /tmp/rollback.sha)"
    ```
 
 2. **Mark the task `failed`** in workflow state and dispatch a fixer (see

--- a/skills/codex/delegation/references/implementer-prompt.md
+++ b/skills/codex/delegation/references/implementer-prompt.md
@@ -16,6 +16,24 @@ Before dispatch, query `exarchos_view` with `action: 'quality_hints'` and `skill
 ## Working Directory
 [Absolute path to worktree or project root]
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path from the **Working Directory**
+section above. After that, the verification block below confirms you landed
+correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills/codex/delegation/references/implementer-prompt.md
+++ b/skills/codex/delegation/references/implementer-prompt.md
@@ -288,6 +288,22 @@ The prompt body itself is what makes the dispatch self-contained. A worked examp
 ## Working Directory
 /home/user/project/.worktrees/task-003
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "/home/user/project/.worktrees/task-003"             # bash / zsh / sh
+```
+```powershell
+Set-Location "/home/user/project/.worktrees/task-003"   # PowerShell
+```
+
+After that, the verification block below confirms you landed correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills/codex/workflow-state/SKILL.md
+++ b/skills/codex/workflow-state/SKILL.md
@@ -101,7 +101,7 @@ Worktree status values: `'active' | 'merged' | 'removed'`
 
 #### Editing the `tasks` array
 
-The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported and now throw an `INVALID_INPUT` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning `success: true` while the actual task was untouched. Three patterns are supported:
 
 1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
    ```typescript

--- a/skills/codex/workflow-state/SKILL.md
+++ b/skills/codex/workflow-state/SKILL.md
@@ -93,11 +93,48 @@ Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with `featureId` and
 
 - **Update phase**: `phase: "delegate"`
 - **Set artifact path**: `updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }`
-- **Mark task complete**: `updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }`
+- **Mark task complete (by index)**: `updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }`
 - **Add worktree**: `updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }`
 - **Phase + updates together**: `phase: "delegate"`, `updates: { "artifacts.plan": "docs/plans/plan.md" }`
 
 Worktree status values: `'active' | 'merged' | 'removed'`
+
+#### Editing the `tasks` array
+
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   ```
+
+2. **Edit one task by its array index**:
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   ```
+   First read `tasks` (`action: "get", query: "tasks"`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length `N`, write to `tasks[N]`:
+   ```typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   ```
+   The parser allows writing one slot past the current length (`MAX_ARRAY_GAP = 1`); writing further out (`tasks[5]` against a length-2 array) throws `INVALID_INPUT`. Read the current `tasks` length before appending.
 
 ### Get Summary
 

--- a/skills/copilot/delegation/SKILL.md
+++ b/skills/copilot/delegation/SKILL.md
@@ -329,9 +329,9 @@ must drive recovery by hand.
 
 The merge-orchestrator reports an ancestry failure of the form:
 
-```
+```text
 source branch <feature-branch> is not a descendant of <integration-branch>.
-Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
 Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
 ```
 
@@ -359,12 +359,14 @@ subagent worktree) and that `git status` is clean.
 1. **Capture the rollback SHA** before doing anything destructive:
 
    ```bash
-   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   git rev-parse <feature-branch> > /tmp/rollback.sha
    ```
 
    Keep this until the merge has been verified. If anything goes wrong,
-   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
-   feature branch restores the pre-rebase state.
+   `git reset --hard "$(cat /tmp/rollback.sha)"` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like `feature/dr-6`
+   don't break the path with embedded `/` characters.
 
 2. **Rebase the feature branch onto the current integration tip:**
 
@@ -401,7 +403,7 @@ still fails after rebase:
    ```bash
    cd <feature-worktree-path>
    git rebase --abort   # if mid-rebase
-   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   git reset --hard "$(cat /tmp/rollback.sha)"
    ```
 
 2. **Mark the task `failed`** in workflow state and dispatch a fixer (see

--- a/skills/copilot/delegation/SKILL.md
+++ b/skills/copilot/delegation/SKILL.md
@@ -315,6 +315,113 @@ for phase transitions, guards, and playbook guidance. Use
 `exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })`
 for orchestrate action schemas.
 
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by `merge_orchestrate` ancestry preflight: the
+failure message links here verbatim and includes the manual `git rebase`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+```
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+```
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+Each subagent worktree is created at the integration branch's tip at
+dispatch time. When the orchestrator merges sibling worktrees serially,
+each merge moves the integration branch forward. A worktree that was
+dispatched against an older integration tip will fail the ancestry
+preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that `git status` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   ```bash
+   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   ```
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
+   feature branch restores the pre-rebase state.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   ```bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   ```
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass `--strategy-option=theirs` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   ```typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   ```
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   ```bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   ```
+
+2. **Mark the task `failed`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a `merge.aborted` event with
+   `reason: "ancestry-rebase-conflict"` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
+
 ## Transition
 
 After all tasks complete, **auto-continue immediately** (no user confirmation):

--- a/skills/copilot/delegation/references/implementer-prompt.md
+++ b/skills/copilot/delegation/references/implementer-prompt.md
@@ -16,6 +16,24 @@ Before dispatch, query `exarchos_view` with `action: 'quality_hints'` and `skill
 ## Working Directory
 [Absolute path to worktree or project root]
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path from the **Working Directory**
+section above. After that, the verification block below confirms you landed
+correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills/copilot/delegation/references/implementer-prompt.md
+++ b/skills/copilot/delegation/references/implementer-prompt.md
@@ -284,6 +284,22 @@ The prompt body itself is what makes the dispatch self-contained. A worked examp
 ## Working Directory
 /home/user/project/.worktrees/task-003
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "/home/user/project/.worktrees/task-003"             # bash / zsh / sh
+```
+```powershell
+Set-Location "/home/user/project/.worktrees/task-003"   # PowerShell
+```
+
+After that, the verification block below confirms you landed correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills/copilot/workflow-state/SKILL.md
+++ b/skills/copilot/workflow-state/SKILL.md
@@ -101,7 +101,7 @@ Worktree status values: `'active' | 'merged' | 'removed'`
 
 #### Editing the `tasks` array
 
-The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported and now throw an `INVALID_INPUT` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning `success: true` while the actual task was untouched. Three patterns are supported:
 
 1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
    ```typescript

--- a/skills/copilot/workflow-state/SKILL.md
+++ b/skills/copilot/workflow-state/SKILL.md
@@ -93,11 +93,48 @@ Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with `featureId` and
 
 - **Update phase**: `phase: "delegate"`
 - **Set artifact path**: `updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }`
-- **Mark task complete**: `updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }`
+- **Mark task complete (by index)**: `updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }`
 - **Add worktree**: `updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }`
 - **Phase + updates together**: `phase: "delegate"`, `updates: { "artifacts.plan": "docs/plans/plan.md" }`
 
 Worktree status values: `'active' | 'merged' | 'removed'`
+
+#### Editing the `tasks` array
+
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   ```
+
+2. **Edit one task by its array index**:
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   ```
+   First read `tasks` (`action: "get", query: "tasks"`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length `N`, write to `tasks[N]`:
+   ```typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   ```
+   The parser allows writing one slot past the current length (`MAX_ARRAY_GAP = 1`); writing further out (`tasks[5]` against a length-2 array) throws `INVALID_INPUT`. Read the current `tasks` length before appending.
 
 ### Get Summary
 

--- a/skills/cursor/delegation/SKILL.md
+++ b/skills/cursor/delegation/SKILL.md
@@ -339,9 +339,9 @@ must drive recovery by hand.
 
 The merge-orchestrator reports an ancestry failure of the form:
 
-```
+```text
 source branch <feature-branch> is not a descendant of <integration-branch>.
-Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
 Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
 ```
 
@@ -369,12 +369,14 @@ subagent worktree) and that `git status` is clean.
 1. **Capture the rollback SHA** before doing anything destructive:
 
    ```bash
-   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   git rev-parse <feature-branch> > /tmp/rollback.sha
    ```
 
    Keep this until the merge has been verified. If anything goes wrong,
-   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
-   feature branch restores the pre-rebase state.
+   `git reset --hard "$(cat /tmp/rollback.sha)"` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like `feature/dr-6`
+   don't break the path with embedded `/` characters.
 
 2. **Rebase the feature branch onto the current integration tip:**
 
@@ -411,7 +413,7 @@ still fails after rebase:
    ```bash
    cd <feature-worktree-path>
    git rebase --abort   # if mid-rebase
-   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   git reset --hard "$(cat /tmp/rollback.sha)"
    ```
 
 2. **Mark the task `failed`** in workflow state and dispatch a fixer (see

--- a/skills/cursor/delegation/SKILL.md
+++ b/skills/cursor/delegation/SKILL.md
@@ -325,6 +325,113 @@ for phase transitions, guards, and playbook guidance. Use
 `exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })`
 for orchestrate action schemas.
 
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by `merge_orchestrate` ancestry preflight: the
+failure message links here verbatim and includes the manual `git rebase`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+```
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+```
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+Each subagent worktree is created at the integration branch's tip at
+dispatch time. When the orchestrator merges sibling worktrees serially,
+each merge moves the integration branch forward. A worktree that was
+dispatched against an older integration tip will fail the ancestry
+preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that `git status` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   ```bash
+   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   ```
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
+   feature branch restores the pre-rebase state.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   ```bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   ```
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass `--strategy-option=theirs` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   ```typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   ```
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   ```bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   ```
+
+2. **Mark the task `failed`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a `merge.aborted` event with
+   `reason: "ancestry-rebase-conflict"` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
+
 ## Transition
 
 After all tasks complete, **auto-continue immediately** (no user confirmation):

--- a/skills/cursor/delegation/references/implementer-prompt.md
+++ b/skills/cursor/delegation/references/implementer-prompt.md
@@ -16,6 +16,24 @@ Before dispatch, query `exarchos_view` with `action: 'quality_hints'` and `skill
 ## Working Directory
 [Absolute path to worktree or project root]
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path from the **Working Directory**
+section above. After that, the verification block below confirms you landed
+correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills/cursor/delegation/references/implementer-prompt.md
+++ b/skills/cursor/delegation/references/implementer-prompt.md
@@ -289,6 +289,22 @@ The prompt body itself is what makes the dispatch self-contained. A worked examp
 ## Working Directory
 /home/user/project/.worktrees/task-003
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "/home/user/project/.worktrees/task-003"             # bash / zsh / sh
+```
+```powershell
+Set-Location "/home/user/project/.worktrees/task-003"   # PowerShell
+```
+
+After that, the verification block below confirms you landed correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills/cursor/workflow-state/SKILL.md
+++ b/skills/cursor/workflow-state/SKILL.md
@@ -101,7 +101,7 @@ Worktree status values: `'active' | 'merged' | 'removed'`
 
 #### Editing the `tasks` array
 
-The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported and now throw an `INVALID_INPUT` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning `success: true` while the actual task was untouched. Three patterns are supported:
 
 1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
    ```typescript

--- a/skills/cursor/workflow-state/SKILL.md
+++ b/skills/cursor/workflow-state/SKILL.md
@@ -93,11 +93,48 @@ Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with `featureId` and
 
 - **Update phase**: `phase: "delegate"`
 - **Set artifact path**: `updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }`
-- **Mark task complete**: `updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }`
+- **Mark task complete (by index)**: `updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }`
 - **Add worktree**: `updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }`
 - **Phase + updates together**: `phase: "delegate"`, `updates: { "artifacts.plan": "docs/plans/plan.md" }`
 
 Worktree status values: `'active' | 'merged' | 'removed'`
+
+#### Editing the `tasks` array
+
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   ```
+
+2. **Edit one task by its array index**:
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   ```
+   First read `tasks` (`action: "get", query: "tasks"`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length `N`, write to `tasks[N]`:
+   ```typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   ```
+   The parser allows writing one slot past the current length (`MAX_ARRAY_GAP = 1`); writing further out (`tasks[5]` against a length-2 array) throws `INVALID_INPUT`. Read the current `tasks` length before appending.
 
 ### Get Summary
 

--- a/skills/generic/delegation/SKILL.md
+++ b/skills/generic/delegation/SKILL.md
@@ -296,6 +296,113 @@ for phase transitions, guards, and playbook guidance. Use
 `exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })`
 for orchestrate action schemas.
 
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by `merge_orchestrate` ancestry preflight: the
+failure message links here verbatim and includes the manual `git rebase`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+```
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+```
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+Each subagent worktree is created at the integration branch's tip at
+dispatch time. When the orchestrator merges sibling worktrees serially,
+each merge moves the integration branch forward. A worktree that was
+dispatched against an older integration tip will fail the ancestry
+preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that `git status` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   ```bash
+   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   ```
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
+   feature branch restores the pre-rebase state.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   ```bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   ```
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass `--strategy-option=theirs` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   ```typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   ```
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   ```bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   ```
+
+2. **Mark the task `failed`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a `merge.aborted` event with
+   `reason: "ancestry-rebase-conflict"` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
+
 ## Transition
 
 After all tasks complete, **auto-continue immediately** (no user confirmation):

--- a/skills/generic/delegation/SKILL.md
+++ b/skills/generic/delegation/SKILL.md
@@ -310,9 +310,9 @@ must drive recovery by hand.
 
 The merge-orchestrator reports an ancestry failure of the form:
 
-```
+```text
 source branch <feature-branch> is not a descendant of <integration-branch>.
-Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
 Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
 ```
 
@@ -340,12 +340,14 @@ subagent worktree) and that `git status` is clean.
 1. **Capture the rollback SHA** before doing anything destructive:
 
    ```bash
-   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   git rev-parse <feature-branch> > /tmp/rollback.sha
    ```
 
    Keep this until the merge has been verified. If anything goes wrong,
-   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
-   feature branch restores the pre-rebase state.
+   `git reset --hard "$(cat /tmp/rollback.sha)"` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like `feature/dr-6`
+   don't break the path with embedded `/` characters.
 
 2. **Rebase the feature branch onto the current integration tip:**
 
@@ -382,7 +384,7 @@ still fails after rebase:
    ```bash
    cd <feature-worktree-path>
    git rebase --abort   # if mid-rebase
-   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   git reset --hard "$(cat /tmp/rollback.sha)"
    ```
 
 2. **Mark the task `failed`** in workflow state and dispatch a fixer (see

--- a/skills/generic/delegation/references/implementer-prompt.md
+++ b/skills/generic/delegation/references/implementer-prompt.md
@@ -16,6 +16,24 @@ Before dispatch, query `exarchos_view` with `action: 'quality_hints'` and `skill
 ## Working Directory
 [Absolute path to worktree or project root]
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path from the **Working Directory**
+section above. After that, the verification block below confirms you landed
+correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills/generic/delegation/references/implementer-prompt.md
+++ b/skills/generic/delegation/references/implementer-prompt.md
@@ -284,6 +284,22 @@ The prompt body itself is what makes the dispatch self-contained. A worked examp
 ## Working Directory
 /home/user/project/.worktrees/task-003
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "/home/user/project/.worktrees/task-003"             # bash / zsh / sh
+```
+```powershell
+Set-Location "/home/user/project/.worktrees/task-003"   # PowerShell
+```
+
+After that, the verification block below confirms you landed correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills/generic/workflow-state/SKILL.md
+++ b/skills/generic/workflow-state/SKILL.md
@@ -101,7 +101,7 @@ Worktree status values: `'active' | 'merged' | 'removed'`
 
 #### Editing the `tasks` array
 
-The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported and now throw an `INVALID_INPUT` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning `success: true` while the actual task was untouched. Three patterns are supported:
 
 1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
    ```typescript

--- a/skills/generic/workflow-state/SKILL.md
+++ b/skills/generic/workflow-state/SKILL.md
@@ -93,11 +93,48 @@ Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with `featureId` and
 
 - **Update phase**: `phase: "delegate"`
 - **Set artifact path**: `updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }`
-- **Mark task complete**: `updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }`
+- **Mark task complete (by index)**: `updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }`
 - **Add worktree**: `updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }`
 - **Phase + updates together**: `phase: "delegate"`, `updates: { "artifacts.plan": "docs/plans/plan.md" }`
 
 Worktree status values: `'active' | 'merged' | 'removed'`
+
+#### Editing the `tasks` array
+
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   ```
+
+2. **Edit one task by its array index**:
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   ```
+   First read `tasks` (`action: "get", query: "tasks"`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length `N`, write to `tasks[N]`:
+   ```typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   ```
+   The parser allows writing one slot past the current length (`MAX_ARRAY_GAP = 1`); writing further out (`tasks[5]` against a length-2 array) throws `INVALID_INPUT`. Read the current `tasks` length before appending.
 
 ### Get Summary
 

--- a/skills/opencode/delegation/SKILL.md
+++ b/skills/opencode/delegation/SKILL.md
@@ -323,6 +323,113 @@ for phase transitions, guards, and playbook guidance. Use
 `exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })`
 for orchestrate action schemas.
 
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by `merge_orchestrate` ancestry preflight: the
+failure message links here verbatim and includes the manual `git rebase`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+```
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+```
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+Each subagent worktree is created at the integration branch's tip at
+dispatch time. When the orchestrator merges sibling worktrees serially,
+each merge moves the integration branch forward. A worktree that was
+dispatched against an older integration tip will fail the ancestry
+preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that `git status` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   ```bash
+   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   ```
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
+   feature branch restores the pre-rebase state.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   ```bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   ```
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass `--strategy-option=theirs` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   ```typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   ```
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   ```bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   ```
+
+2. **Mark the task `failed`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a `merge.aborted` event with
+   `reason: "ancestry-rebase-conflict"` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
+
 ## Transition
 
 After all tasks complete, **auto-continue immediately** (no user confirmation):

--- a/skills/opencode/delegation/SKILL.md
+++ b/skills/opencode/delegation/SKILL.md
@@ -337,9 +337,9 @@ must drive recovery by hand.
 
 The merge-orchestrator reports an ancestry failure of the form:
 
-```
+```text
 source branch <feature-branch> is not a descendant of <integration-branch>.
-Rebase manually with: git rebase <integration-branch> <feature-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
 Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
 ```
 
@@ -367,12 +367,14 @@ subagent worktree) and that `git status` is clean.
 1. **Capture the rollback SHA** before doing anything destructive:
 
    ```bash
-   git rev-parse <feature-branch> > /tmp/rollback-<feature-branch>.sha
+   git rev-parse <feature-branch> > /tmp/rollback.sha
    ```
 
    Keep this until the merge has been verified. If anything goes wrong,
-   `git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)` on the
-   feature branch restores the pre-rebase state.
+   `git reset --hard "$(cat /tmp/rollback.sha)"` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like `feature/dr-6`
+   don't break the path with embedded `/` characters.
 
 2. **Rebase the feature branch onto the current integration tip:**
 
@@ -409,7 +411,7 @@ still fails after rebase:
    ```bash
    cd <feature-worktree-path>
    git rebase --abort   # if mid-rebase
-   git reset --hard $(cat /tmp/rollback-<feature-branch>.sha)
+   git reset --hard "$(cat /tmp/rollback.sha)"
    ```
 
 2. **Mark the task `failed`** in workflow state and dispatch a fixer (see

--- a/skills/opencode/delegation/references/implementer-prompt.md
+++ b/skills/opencode/delegation/references/implementer-prompt.md
@@ -16,6 +16,24 @@ Before dispatch, query `exarchos_view` with `action: 'quality_hints'` and `skill
 ## Working Directory
 [Absolute path to worktree or project root]
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path from the **Working Directory**
+section above. After that, the verification block below confirms you landed
+correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills/opencode/delegation/references/implementer-prompt.md
+++ b/skills/opencode/delegation/references/implementer-prompt.md
@@ -288,6 +288,22 @@ The prompt body itself is what makes the dispatch self-contained. A worked examp
 ## Working Directory
 /home/user/project/.worktrees/task-003
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "/home/user/project/.worktrees/task-003"             # bash / zsh / sh
+```
+```powershell
+Set-Location "/home/user/project/.worktrees/task-003"   # PowerShell
+```
+
+After that, the verification block below confirms you landed correctly.
+
 ## CRITICAL: Worktree Verification (MANDATORY)
 
 Before making ANY file changes, you MUST verify you are in a worktree:

--- a/skills/opencode/workflow-state/SKILL.md
+++ b/skills/opencode/workflow-state/SKILL.md
@@ -101,7 +101,7 @@ Worktree status values: `'active' | 'merged' | 'removed'`
 
 #### Editing the `tasks` array
 
-The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported and now throw an `INVALID_INPUT` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning `success: true` while the actual task was untouched. Three patterns are supported:
 
 1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
    ```typescript

--- a/skills/opencode/workflow-state/SKILL.md
+++ b/skills/opencode/workflow-state/SKILL.md
@@ -93,11 +93,48 @@ Use `mcp__exarchos__exarchos_workflow` with `action: "set"` with `featureId` and
 
 - **Update phase**: `phase: "delegate"`
 - **Set artifact path**: `updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }`
-- **Mark task complete**: `updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }`
+- **Mark task complete (by index)**: `updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }`
 - **Add worktree**: `updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }`
 - **Phase + updates together**: `phase: "delegate"`, `updates: { "artifacts.plan": "docs/plans/plan.md" }`
 
 Worktree status values: `'active' | 'merged' | 'removed'`
+
+#### Editing the `tasks` array
+
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported — they are silently treated as a literal property name and write to a bogus top-level key. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   ```
+
+2. **Edit one task by its array index**:
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   ```
+   First read `tasks` (`action: "get", query: "tasks"`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length `N`, write to `tasks[N]`:
+   ```typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   ```
+   The parser allows writing one slot past the current length (`MAX_ARRAY_GAP = 1`); writing further out (`tasks[5]` against a length-2 array) throws `INVALID_INPUT`. Read the current `tasks` length before appending.
 
 ### Get Summary
 

--- a/src/runtimes/embedded.ts
+++ b/src/runtimes/embedded.ts
@@ -1,0 +1,265 @@
+// GENERATED FILE — DO NOT EDIT. Regenerate via `npm run codegen:runtimes`.
+// Source: runtimes/*.yaml (validated against RuntimeMapSchema).
+// Drift is enforced by `npm run runtimes:guard` (CI).
+import type { RuntimeMap } from './types.js';
+
+const RAW_RUNTIMES = [
+  {
+    "name": "generic",
+    "capabilities": {
+      "hasSubagents": false,
+      "hasSlashCommands": false,
+      "hasHooks": false,
+      "hasSkillChaining": false,
+      "mcpPrefix": "mcp__exarchos__"
+    },
+    "preferredFacade": "cli",
+    "skillsInstallPath": "~/.agents/skills",
+    "detection": {
+      "binaries": [],
+      "envVars": []
+    },
+    "placeholders": {
+      "MCP_PREFIX": "mcp__exarchos__",
+      "COMMAND_PREFIX": "",
+      "TASK_TOOL": "[sequential execution]",
+      "CHAIN": "[Invoke the exarchos:{{next}} skill with args: {{args}}]",
+      "SPAWN_AGENT_CALL": "Execute each task sequentially in the current session, one at a time, against the prepared worktrees.",
+      "SUBAGENT_COMPLETION_HOOK": "in-session checkpoint (no subagent channel)",
+      "SUBAGENT_RESULT_API": "[task output is the assistant's next message]"
+    }
+  },
+  {
+    "name": "claude",
+    "capabilities": {
+      "hasSubagents": true,
+      "hasSlashCommands": true,
+      "hasHooks": true,
+      "hasSkillChaining": true,
+      "mcpPrefix": "mcp__plugin_exarchos_exarchos__"
+    },
+    "preferredFacade": "mcp",
+    "skillsInstallPath": "~/.claude/skills",
+    "detection": {
+      "binaries": [
+        "claude"
+      ],
+      "envVars": [
+        "CLAUDECODE",
+        "CLAUDE_CODE_ENTRYPOINT"
+      ]
+    },
+    "placeholders": {
+      "MCP_PREFIX": "mcp__plugin_exarchos_exarchos__",
+      "COMMAND_PREFIX": "/exarchos:",
+      "TASK_TOOL": "Task",
+      "CHAIN": "Skill({ skill: \"exarchos:{{next}}\", args: \"{{args}}\" })",
+      "SPAWN_AGENT_CALL": "Task({\n  subagent_type: \"exarchos-{{agent}}\",\n  run_in_background: true,\n  description: \"{{description}}\",\n  prompt: \"{{prompt}}\"\n})\n",
+      "SUBAGENT_COMPLETION_HOOK": "TeammateIdle hook",
+      "SUBAGENT_RESULT_API": "TaskOutput({ task_id, block: true })"
+    },
+    "supportedCapabilities": {
+      "fs:read": "native",
+      "fs:write": "native",
+      "shell:exec": "native",
+      "subagent:spawn": "native",
+      "subagent:completion-signal": "native",
+      "subagent:start-signal": "native",
+      "mcp:exarchos": "native",
+      "mcp:exarchos:readonly": "native",
+      "isolation:worktree": "native",
+      "team:agent-teams": "native",
+      "session:resume": "native"
+    }
+  },
+  {
+    "name": "codex",
+    "capabilities": {
+      "hasSubagents": true,
+      "hasSlashCommands": true,
+      "hasHooks": false,
+      "hasSkillChaining": false,
+      "mcpPrefix": "mcp__exarchos__"
+    },
+    "preferredFacade": "mcp",
+    "skillsInstallPath": "$HOME/.agents/skills",
+    "detection": {
+      "binaries": [
+        "codex"
+      ],
+      "envVars": []
+    },
+    "placeholders": {
+      "MCP_PREFIX": "mcp__exarchos__",
+      "COMMAND_PREFIX": "",
+      "TASK_TOOL": "spawn_agent",
+      "CHAIN": "[Invoke the exarchos:{{next}} skill with args: {{args}}]",
+      "SPAWN_AGENT_CALL": "spawn_agent({\n  agent_type: \"default\",\n  message: \"{{description}}\\n\\n{{prompt}}\"\n})\n",
+      "SUBAGENT_COMPLETION_HOOK": "subagent completion signal (poll-based)",
+      "SUBAGENT_RESULT_API": "wait_agent({ task_id })"
+    },
+    "supportedCapabilities": {
+      "fs:read": "native",
+      "fs:write": "native",
+      "shell:exec": "native",
+      "subagent:spawn": "native",
+      "mcp:exarchos": "native",
+      "mcp:exarchos:readonly": "native",
+      "isolation:worktree": "advisory",
+      "session:resume": "advisory"
+    }
+  },
+  {
+    "name": "opencode",
+    "capabilities": {
+      "hasSubagents": true,
+      "hasSlashCommands": true,
+      "hasHooks": false,
+      "hasSkillChaining": false,
+      "mcpPrefix": "mcp__exarchos__"
+    },
+    "preferredFacade": "cli",
+    "skillsInstallPath": "~/.config/opencode/skills",
+    "detection": {
+      "binaries": [
+        "opencode"
+      ],
+      "envVars": []
+    },
+    "placeholders": {
+      "MCP_PREFIX": "mcp__exarchos__",
+      "COMMAND_PREFIX": "/",
+      "TASK_TOOL": "Task",
+      "CHAIN": "[Invoke the exarchos:{{next}} skill with args: {{args}}]",
+      "SPAWN_AGENT_CALL": "Task({\n  subagent_type: \"{{agent}}\",\n  prompt: \"{{prompt}}\"\n})\n",
+      "SUBAGENT_COMPLETION_HOOK": "inline (no completion hook — Task() reply returns synchronously)",
+      "SUBAGENT_RESULT_API": "Task() reply (inline, no poll)"
+    },
+    "supportedCapabilities": {
+      "fs:read": "native",
+      "fs:write": "native",
+      "shell:exec": "native",
+      "subagent:spawn": "native",
+      "mcp:exarchos": "native",
+      "mcp:exarchos:readonly": "native",
+      "isolation:worktree": "advisory",
+      "session:resume": "advisory"
+    }
+  },
+  {
+    "name": "copilot",
+    "capabilities": {
+      "hasSubagents": true,
+      "hasSlashCommands": true,
+      "hasHooks": false,
+      "hasSkillChaining": false,
+      "mcpPrefix": "mcp__exarchos__"
+    },
+    "preferredFacade": "cli",
+    "skillsInstallPath": "~/.copilot/skills",
+    "detection": {
+      "binaries": [
+        "copilot"
+      ],
+      "envVars": []
+    },
+    "placeholders": {
+      "MCP_PREFIX": "mcp__exarchos__",
+      "COMMAND_PREFIX": "/",
+      "TASK_TOOL": "task",
+      "CHAIN": "[Invoke the exarchos:{{next}} skill with args: {{args}}]",
+      "SPAWN_AGENT_CALL": "task --agent {{agent}} '{{description}}: {{prompt}}'",
+      "SUBAGENT_COMPLETION_HOOK": "subagent completion signal (poll-based)",
+      "SUBAGENT_RESULT_API": "inline reply from task --agent (no separate collection API)"
+    },
+    "supportedCapabilities": {
+      "fs:read": "native",
+      "fs:write": "native",
+      "shell:exec": "native",
+      "subagent:spawn": "native",
+      "mcp:exarchos": "native",
+      "mcp:exarchos:readonly": "native",
+      "isolation:worktree": "advisory",
+      "session:resume": "advisory"
+    }
+  },
+  {
+    "name": "cursor",
+    "capabilities": {
+      "hasSubagents": true,
+      "hasSlashCommands": false,
+      "hasHooks": false,
+      "hasSkillChaining": false,
+      "mcpPrefix": "mcp__exarchos__"
+    },
+    "preferredFacade": "mcp",
+    "skillsInstallPath": "~/.cursor/skills",
+    "detection": {
+      "binaries": [
+        "cursor-agent",
+        "cursor"
+      ],
+      "envVars": []
+    },
+    "placeholders": {
+      "MCP_PREFIX": "mcp__exarchos__",
+      "COMMAND_PREFIX": "",
+      "TASK_TOOL": "Task",
+      "CHAIN": "[Invoke the exarchos:{{next}} skill with args: {{args}}]",
+      "SPAWN_AGENT_CALL": "Task({\n  subagent_type: \"{{agent}}\",\n  description: \"{{description}}\",\n  prompt: \"{{prompt}}\"\n})\n",
+      "SUBAGENT_COMPLETION_HOOK": "subagent completion signal (poll-based)",
+      "SUBAGENT_RESULT_API": "Task() reply (inline)"
+    },
+    "supportedCapabilities": {
+      "fs:read": "native",
+      "fs:write": "native",
+      "shell:exec": "native",
+      "subagent:spawn": "native",
+      "mcp:exarchos": "native",
+      "mcp:exarchos:readonly": "native",
+      "isolation:worktree": "advisory",
+      "session:resume": "advisory"
+    }
+  }
+] as const;
+
+/**
+ * Deep-freeze a runtime map and any nested objects so the consumer
+ * cannot mutate the embedded copy. `Object.freeze` is shallow, but the
+ * shape is JSON-flat (objects + arrays + primitives), so a recursive
+ * walk is sufficient.
+ */
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    deepFreeze((value as Record<string, unknown>)[key]);
+  }
+  return Object.freeze(value);
+}
+
+/**
+ * Frozen array of validated `RuntimeMap` entries embedded into the
+ * compiled binary. The bridge in
+ * `servers/exarchos-mcp/src/cli-commands/install-skills-bridge.js`
+ * prefers this array over reading `runtimes/*.yaml` from disk so
+ * `install-skills` works inside the single-file binary, where the
+ * YAML directory does not ship.
+ *
+ * Sorted by canonical `REQUIRED_RUNTIME_NAMES` order, then any extras
+ * alphabetically — see `scripts/codegen-runtimes.ts` for the contract.
+ */
+export const EMBEDDED_RUNTIMES: readonly RuntimeMap[] = Object.freeze(
+  RAW_RUNTIMES.map((r) => deepFreeze(r as unknown as RuntimeMap)),
+) as readonly RuntimeMap[];
+
+/**
+ * Convenience lookup for a single embedded runtime by name. Returns
+ * `undefined` when no embedded runtime matches — callers decide
+ * whether to throw or fall back. Mirrors the `findRuntime()` helper
+ * in `src/install-skills.ts` so call-site behavior is identical
+ * regardless of whether the runtimes came from FS or the embedded
+ * module.
+ */
+export function getEmbeddedRuntime(name: string): RuntimeMap | undefined {
+  return EMBEDDED_RUNTIMES.find((r) => r.name === name);
+}

--- a/test/migration/__fixtures__/batch-baselines/workflow-state.md
+++ b/test/migration/__fixtures__/batch-baselines/workflow-state.md
@@ -93,11 +93,48 @@ Use `mcp__plugin_exarchos_exarchos__exarchos_workflow` with `action: "set"` with
 
 - **Update phase**: `phase: "delegate"`
 - **Set artifact path**: `updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }`
-- **Mark task complete**: `updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }`
+- **Mark task complete (by index)**: `updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }`
 - **Add worktree**: `updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }`
 - **Phase + updates together**: `phase: "delegate"`, `updates: { "artifacts.plan": "docs/plans/plan.md" }`
 
 Worktree status values: `'active' | 'merged' | 'removed'`
+
+#### Editing the `tasks` array
+
+The dot-path parser used by `set updates` recognizes only **numeric** array brackets (`tasks[0]`, `tasks[1]`, …). Keyed forms like `tasks[id=T-001]` are NOT supported and now throw an `INVALID_INPUT` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning `success: true` while the actual task was untouched. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   ```
+
+2. **Edit one task by its array index**:
+   ```typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   ```
+   First read `tasks` (`action: "get", query: "tasks"`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length `N`, write to `tasks[N]`:
+   ```typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   ```
+   The parser allows writing one slot past the current length (`MAX_ARRAY_GAP = 1`); writing further out (`tasks[5]` against a length-2 array) throws `INVALID_INPUT`. Read the current `tasks` length before appending.
 
 ### Get Summary
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -987,6 +987,115 @@ for phase transitions, guards, and playbook guidance. Use
 \`exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })\`
 for orchestrate action schemas.
 
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by \`merge_orchestrate\` ancestry preflight: the
+failure message links here verbatim and includes the manual \`git rebase\`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+\`\`\`text
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+\`\`\`
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+Each subagent worktree is created at the integration branch's tip at
+dispatch time. When the orchestrator merges sibling worktrees serially,
+each merge moves the integration branch forward. A worktree that was
+dispatched against an older integration tip will fail the ancestry
+preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that \`git status\` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   \`\`\`bash
+   git rev-parse <feature-branch> > /tmp/rollback.sha
+   \`\`\`
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   \`git reset --hard "$(cat /tmp/rollback.sha)"\` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like \`feature/dr-6\`
+   don't break the path with embedded \`/\` characters.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   \`\`\`bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   \`\`\`
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass \`--strategy-option=theirs\` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   \`\`\`typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   \`\`\`
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   \`\`\`bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard "$(cat /tmp/rollback.sha)"
+   \`\`\`
+
+2. **Mark the task \`failed\`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a \`merge.aborted\` event with
+   \`reason: "ancestry-rebase-conflict"\` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
+
 ## Transition
 
 After all tasks complete, **auto-continue immediately** (no user confirmation):
@@ -4315,11 +4424,48 @@ Use \`mcp__plugin_exarchos_exarchos__exarchos_workflow\` with \`action: "set"\` 
 
 - **Update phase**: \`phase: "delegate"\`
 - **Set artifact path**: \`updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }\`
-- **Mark task complete**: \`updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }\`
+- **Mark task complete (by index)**: \`updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }\`
 - **Add worktree**: \`updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }\`
 - **Phase + updates together**: \`phase: "delegate"\`, \`updates: { "artifacts.plan": "docs/plans/plan.md" }\`
 
 Worktree status values: \`'active' | 'merged' | 'removed'\`
+
+#### Editing the \`tasks\` array
+
+The dot-path parser used by \`set updates\` recognizes only **numeric** array brackets (\`tasks[0]\`, \`tasks[1]\`, …). Keyed forms like \`tasks[id=T-001]\` are NOT supported and now throw an \`INVALID_INPUT\` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning \`success: true\` while the actual task was untouched. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   \`\`\`typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   \`\`\`
+
+2. **Edit one task by its array index**:
+   \`\`\`typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   \`\`\`
+   First read \`tasks\` (\`action: "get", query: "tasks"\`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length \`N\`, write to \`tasks[N]\`:
+   \`\`\`typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   \`\`\`
+   The parser allows writing one slot past the current length (\`MAX_ARRAY_GAP = 1\`); writing further out (\`tasks[5]\` against a length-2 array) throws \`INVALID_INPUT\`. Read the current \`tasks\` length before appending.
 
 ### Get Summary
 
@@ -5418,6 +5564,115 @@ parameter schemas and \`exarchos_workflow({ action: "describe", playbook: "featu
 for phase transitions, guards, and playbook guidance. Use
 \`exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })\`
 for orchestrate action schemas.
+
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by \`merge_orchestrate\` ancestry preflight: the
+failure message links here verbatim and includes the manual \`git rebase\`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+\`\`\`text
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+\`\`\`
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+Each subagent worktree is created at the integration branch's tip at
+dispatch time. When the orchestrator merges sibling worktrees serially,
+each merge moves the integration branch forward. A worktree that was
+dispatched against an older integration tip will fail the ancestry
+preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that \`git status\` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   \`\`\`bash
+   git rev-parse <feature-branch> > /tmp/rollback.sha
+   \`\`\`
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   \`git reset --hard "$(cat /tmp/rollback.sha)"\` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like \`feature/dr-6\`
+   don't break the path with embedded \`/\` characters.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   \`\`\`bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   \`\`\`
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass \`--strategy-option=theirs\` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   \`\`\`typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   \`\`\`
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   \`\`\`bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard "$(cat /tmp/rollback.sha)"
+   \`\`\`
+
+2. **Mark the task \`failed\`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a \`merge.aborted\` event with
+   \`reason: "ancestry-rebase-conflict"\` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
 
 ## Transition
 
@@ -8745,11 +9000,48 @@ Use \`mcp__exarchos__exarchos_workflow\` with \`action: "set"\` with \`featureId
 
 - **Update phase**: \`phase: "delegate"\`
 - **Set artifact path**: \`updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }\`
-- **Mark task complete**: \`updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }\`
+- **Mark task complete (by index)**: \`updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }\`
 - **Add worktree**: \`updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }\`
 - **Phase + updates together**: \`phase: "delegate"\`, \`updates: { "artifacts.plan": "docs/plans/plan.md" }\`
 
 Worktree status values: \`'active' | 'merged' | 'removed'\`
+
+#### Editing the \`tasks\` array
+
+The dot-path parser used by \`set updates\` recognizes only **numeric** array brackets (\`tasks[0]\`, \`tasks[1]\`, …). Keyed forms like \`tasks[id=T-001]\` are NOT supported and now throw an \`INVALID_INPUT\` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning \`success: true\` while the actual task was untouched. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   \`\`\`typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   \`\`\`
+
+2. **Edit one task by its array index**:
+   \`\`\`typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   \`\`\`
+   First read \`tasks\` (\`action: "get", query: "tasks"\`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length \`N\`, write to \`tasks[N]\`:
+   \`\`\`typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   \`\`\`
+   The parser allows writing one slot past the current length (\`MAX_ARRAY_GAP = 1\`); writing further out (\`tasks[5]\` against a length-2 array) throws \`INVALID_INPUT\`. Read the current \`tasks\` length before appending.
 
 ### Get Summary
 
@@ -9840,6 +10132,115 @@ parameter schemas and \`exarchos_workflow({ action: "describe", playbook: "featu
 for phase transitions, guards, and playbook guidance. Use
 \`exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })\`
 for orchestrate action schemas.
+
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by \`merge_orchestrate\` ancestry preflight: the
+failure message links here verbatim and includes the manual \`git rebase\`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+\`\`\`text
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+\`\`\`
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+Each subagent worktree is created at the integration branch's tip at
+dispatch time. When the orchestrator merges sibling worktrees serially,
+each merge moves the integration branch forward. A worktree that was
+dispatched against an older integration tip will fail the ancestry
+preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that \`git status\` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   \`\`\`bash
+   git rev-parse <feature-branch> > /tmp/rollback.sha
+   \`\`\`
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   \`git reset --hard "$(cat /tmp/rollback.sha)"\` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like \`feature/dr-6\`
+   don't break the path with embedded \`/\` characters.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   \`\`\`bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   \`\`\`
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass \`--strategy-option=theirs\` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   \`\`\`typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   \`\`\`
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   \`\`\`bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard "$(cat /tmp/rollback.sha)"
+   \`\`\`
+
+2. **Mark the task \`failed\`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a \`merge.aborted\` event with
+   \`reason: "ancestry-rebase-conflict"\` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
 
 ## Transition
 
@@ -13167,11 +13568,48 @@ Use \`mcp__exarchos__exarchos_workflow\` with \`action: "set"\` with \`featureId
 
 - **Update phase**: \`phase: "delegate"\`
 - **Set artifact path**: \`updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }\`
-- **Mark task complete**: \`updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }\`
+- **Mark task complete (by index)**: \`updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }\`
 - **Add worktree**: \`updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }\`
 - **Phase + updates together**: \`phase: "delegate"\`, \`updates: { "artifacts.plan": "docs/plans/plan.md" }\`
 
 Worktree status values: \`'active' | 'merged' | 'removed'\`
+
+#### Editing the \`tasks\` array
+
+The dot-path parser used by \`set updates\` recognizes only **numeric** array brackets (\`tasks[0]\`, \`tasks[1]\`, …). Keyed forms like \`tasks[id=T-001]\` are NOT supported and now throw an \`INVALID_INPUT\` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning \`success: true\` while the actual task was untouched. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   \`\`\`typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   \`\`\`
+
+2. **Edit one task by its array index**:
+   \`\`\`typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   \`\`\`
+   First read \`tasks\` (\`action: "get", query: "tasks"\`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length \`N\`, write to \`tasks[N]\`:
+   \`\`\`typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   \`\`\`
+   The parser allows writing one slot past the current length (\`MAX_ARRAY_GAP = 1\`); writing further out (\`tasks[5]\` against a length-2 array) throws \`INVALID_INPUT\`. Read the current \`tasks\` length before appending.
 
 ### Get Summary
 
@@ -14272,6 +14710,115 @@ parameter schemas and \`exarchos_workflow({ action: "describe", playbook: "featu
 for phase transitions, guards, and playbook guidance. Use
 \`exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })\`
 for orchestrate action schemas.
+
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by \`merge_orchestrate\` ancestry preflight: the
+failure message links here verbatim and includes the manual \`git rebase\`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+\`\`\`text
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+\`\`\`
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+Each subagent worktree is created at the integration branch's tip at
+dispatch time. When the orchestrator merges sibling worktrees serially,
+each merge moves the integration branch forward. A worktree that was
+dispatched against an older integration tip will fail the ancestry
+preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that \`git status\` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   \`\`\`bash
+   git rev-parse <feature-branch> > /tmp/rollback.sha
+   \`\`\`
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   \`git reset --hard "$(cat /tmp/rollback.sha)"\` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like \`feature/dr-6\`
+   don't break the path with embedded \`/\` characters.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   \`\`\`bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   \`\`\`
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass \`--strategy-option=theirs\` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   \`\`\`typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   \`\`\`
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   \`\`\`bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard "$(cat /tmp/rollback.sha)"
+   \`\`\`
+
+2. **Mark the task \`failed\`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a \`merge.aborted\` event with
+   \`reason: "ancestry-rebase-conflict"\` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
 
 ## Transition
 
@@ -17599,11 +18146,48 @@ Use \`mcp__exarchos__exarchos_workflow\` with \`action: "set"\` with \`featureId
 
 - **Update phase**: \`phase: "delegate"\`
 - **Set artifact path**: \`updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }\`
-- **Mark task complete**: \`updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }\`
+- **Mark task complete (by index)**: \`updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }\`
 - **Add worktree**: \`updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }\`
 - **Phase + updates together**: \`phase: "delegate"\`, \`updates: { "artifacts.plan": "docs/plans/plan.md" }\`
 
 Worktree status values: \`'active' | 'merged' | 'removed'\`
+
+#### Editing the \`tasks\` array
+
+The dot-path parser used by \`set updates\` recognizes only **numeric** array brackets (\`tasks[0]\`, \`tasks[1]\`, …). Keyed forms like \`tasks[id=T-001]\` are NOT supported and now throw an \`INVALID_INPUT\` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning \`success: true\` while the actual task was untouched. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   \`\`\`typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   \`\`\`
+
+2. **Edit one task by its array index**:
+   \`\`\`typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   \`\`\`
+   First read \`tasks\` (\`action: "get", query: "tasks"\`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length \`N\`, write to \`tasks[N]\`:
+   \`\`\`typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   \`\`\`
+   The parser allows writing one slot past the current length (\`MAX_ARRAY_GAP = 1\`); writing further out (\`tasks[5]\` against a length-2 array) throws \`INVALID_INPUT\`. Read the current \`tasks\` length before appending.
 
 ### Get Summary
 
@@ -18675,6 +19259,115 @@ parameter schemas and \`exarchos_workflow({ action: "describe", playbook: "featu
 for phase transitions, guards, and playbook guidance. Use
 \`exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })\`
 for orchestrate action schemas.
+
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by \`merge_orchestrate\` ancestry preflight: the
+failure message links here verbatim and includes the manual \`git rebase\`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+\`\`\`text
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+\`\`\`
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+Each subagent worktree is created at the integration branch's tip at
+dispatch time. When the orchestrator merges sibling worktrees serially,
+each merge moves the integration branch forward. A worktree that was
+dispatched against an older integration tip will fail the ancestry
+preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that \`git status\` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   \`\`\`bash
+   git rev-parse <feature-branch> > /tmp/rollback.sha
+   \`\`\`
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   \`git reset --hard "$(cat /tmp/rollback.sha)"\` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like \`feature/dr-6\`
+   don't break the path with embedded \`/\` characters.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   \`\`\`bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   \`\`\`
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass \`--strategy-option=theirs\` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   \`\`\`typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   \`\`\`
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   \`\`\`bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard "$(cat /tmp/rollback.sha)"
+   \`\`\`
+
+2. **Mark the task \`failed\`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a \`merge.aborted\` event with
+   \`reason: "ancestry-rebase-conflict"\` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
 
 ## Transition
 
@@ -22002,11 +22695,48 @@ Use \`mcp__exarchos__exarchos_workflow\` with \`action: "set"\` with \`featureId
 
 - **Update phase**: \`phase: "delegate"\`
 - **Set artifact path**: \`updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }\`
-- **Mark task complete**: \`updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }\`
+- **Mark task complete (by index)**: \`updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }\`
 - **Add worktree**: \`updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }\`
 - **Phase + updates together**: \`phase: "delegate"\`, \`updates: { "artifacts.plan": "docs/plans/plan.md" }\`
 
 Worktree status values: \`'active' | 'merged' | 'removed'\`
+
+#### Editing the \`tasks\` array
+
+The dot-path parser used by \`set updates\` recognizes only **numeric** array brackets (\`tasks[0]\`, \`tasks[1]\`, …). Keyed forms like \`tasks[id=T-001]\` are NOT supported and now throw an \`INVALID_INPUT\` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning \`success: true\` while the actual task was untouched. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   \`\`\`typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   \`\`\`
+
+2. **Edit one task by its array index**:
+   \`\`\`typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   \`\`\`
+   First read \`tasks\` (\`action: "get", query: "tasks"\`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length \`N\`, write to \`tasks[N]\`:
+   \`\`\`typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   \`\`\`
+   The parser allows writing one slot past the current length (\`MAX_ARRAY_GAP = 1\`); writing further out (\`tasks[5]\` against a length-2 array) throws \`INVALID_INPUT\`. Read the current \`tasks\` length before appending.
 
 ### Get Summary
 
@@ -23105,6 +23835,115 @@ parameter schemas and \`exarchos_workflow({ action: "describe", playbook: "featu
 for phase transitions, guards, and playbook guidance. Use
 \`exarchos_orchestrate({ action: "describe", actions: ["check_tdd_compliance", "task_complete"] })\`
 for orchestrate action schemas.
+
+---
+
+## When integration advances mid-wave
+
+Runbook for recovering when a subagent worktree's branch has diverged from the
+integration branch. Triggered by \`merge_orchestrate\` ancestry preflight: the
+failure message links here verbatim and includes the manual \`git rebase\`
+command. Auto-rebase is **not** wired today (tracked in #1119) — operators
+must drive recovery by hand.
+
+### Symptom
+
+The merge-orchestrator reports an ancestry failure of the form:
+
+\`\`\`text
+source branch <feature-branch> is not a descendant of <integration-branch>.
+Rebase manually with: git rebase <integration-branch> (run from the <feature-branch> worktree).
+Runbook: skills-src/delegation/SKILL.md#when-integration-advances-mid-wave
+\`\`\`
+
+This means the integration branch advanced (typically because an earlier
+worktree merge landed) while the failing worktree was still in flight.
+Fast-forward merge is no longer safe — the working branch must catch up
+first.
+
+### Why this happens
+
+Each subagent worktree is created at the integration branch's tip at
+dispatch time. When the orchestrator merges sibling worktrees serially,
+each merge moves the integration branch forward. A worktree that was
+dispatched against an older integration tip will fail the ancestry
+preflight when its turn comes.
+
+This is expected behavior under the current single-writer merge contract —
+preflight is fail-only on purpose so the operator stays in control.
+
+### Recovery procedure
+
+Before each step, verify you are in the **main worktree** (not the failing
+subagent worktree) and that \`git status\` is clean.
+
+1. **Capture the rollback SHA** before doing anything destructive:
+
+   \`\`\`bash
+   git rev-parse <feature-branch> > /tmp/rollback.sha
+   \`\`\`
+
+   Keep this until the merge has been verified. If anything goes wrong,
+   \`git reset --hard "$(cat /tmp/rollback.sha)"\` on the feature branch
+   restores the pre-rebase state. The filename is intentionally
+   branch-name-free so slash-delimited branches like \`feature/dr-6\`
+   don't break the path with embedded \`/\` characters.
+
+2. **Rebase the feature branch onto the current integration tip:**
+
+   \`\`\`bash
+   cd <feature-worktree-path>
+   git fetch origin
+   git rebase <integration-branch>
+   \`\`\`
+
+   Resolve any conflicts that surface. The conflicts are real — they reflect
+   genuine drift between the two branches, not preflight noise. Do **not**
+   pass \`--strategy-option=theirs\` blindly; that drops the subagent's work.
+
+3. **Re-run ancestry preflight from the main worktree:**
+
+   \`\`\`typescript
+   exarchos_orchestrate({
+     action: "merge_orchestrate",
+     featureId: "<featureId>",
+     taskId: "<taskId>",
+   })
+   \`\`\`
+
+   The preflight should now pass. Proceed with the orchestrator's normal
+   merge flow.
+
+### Rollback procedure
+
+If the rebase produces conflicts you cannot resolve safely, or the merge
+still fails after rebase:
+
+1. **Reset the feature branch** to the captured rollback SHA:
+
+   \`\`\`bash
+   cd <feature-worktree-path>
+   git rebase --abort   # if mid-rebase
+   git reset --hard "$(cat /tmp/rollback.sha)"
+   \`\`\`
+
+2. **Mark the task \`failed\`** in workflow state and dispatch a fixer (see
+   the Failure Recovery section above). Do **not** delete the worktree —
+   the fixer needs the original branch state to diagnose the conflict.
+
+3. **Record the incident** by emitting a \`merge.aborted\` event with
+   \`reason: "ancestry-rebase-conflict"\` and the failing branch's pre-rebase
+   SHA so the convergence view captures the rollback.
+
+### Why no auto-rebase yet
+
+Auto-rebase is deferred to issue #1119. Today the orchestrator stops at
+the ancestry preflight on purpose: a botched auto-rebase across diverged
+worktrees risks silently dropping subagent work, and the recovery path
+above is short enough that operator-driven rebase is preferable to
+clever-but-fragile automation.
+
+---
 
 ## Transition
 
@@ -26432,11 +27271,48 @@ Use \`mcp__exarchos__exarchos_workflow\` with \`action: "set"\` with \`featureId
 
 - **Update phase**: \`phase: "delegate"\`
 - **Set artifact path**: \`updates: { "artifacts.design": "docs/designs/2026-01-05-feature.md" }\`
-- **Mark task complete**: \`updates: { "tasks[id=001].status": "complete", "tasks[id=001].completedAt": "<timestamp>" }\`
+- **Mark task complete (by index)**: \`updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<timestamp>" }\`
 - **Add worktree**: \`updates: { "worktrees.wt-001": { "branch": "feature/001-types", "taskId": "001", "status": "active" } }\`
 - **Phase + updates together**: \`phase: "delegate"\`, \`updates: { "artifacts.plan": "docs/plans/plan.md" }\`
 
 Worktree status values: \`'active' | 'merged' | 'removed'\`
+
+#### Editing the \`tasks\` array
+
+The dot-path parser used by \`set updates\` recognizes only **numeric** array brackets (\`tasks[0]\`, \`tasks[1]\`, …). Keyed forms like \`tasks[id=T-001]\` are NOT supported and now throw an \`INVALID_INPUT\` error with a clear message — earlier versions silently wrote to a bogus top-level key, returning \`success: true\` while the actual task was untouched. Three patterns are supported:
+
+1. **Replace the whole array** (use this when the plan is being revised wholesale; matches the issue #1003 contract):
+   \`\`\`typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { tasks: [
+       { id: "T-001", title: "...", status: "pending" },
+       { id: "T-002", title: "...", status: "pending" },
+     ]},
+   })
+   \`\`\`
+
+2. **Edit one task by its array index**:
+   \`\`\`typescript
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[0].status": "complete", "tasks[0].completedAt": "<ts>" },
+   })
+   \`\`\`
+   First read \`tasks\` (\`action: "get", query: "tasks"\`) to find the index of the task you want to edit, then set by that index.
+
+3. **Append a new task** by writing to the next-free index. If the array currently has length \`N\`, write to \`tasks[N]\`:
+   \`\`\`typescript
+   // Suppose tasks already contains T-001 and T-002 (length 2). To append:
+   exarchos_workflow({
+     action: "set",
+     featureId: "<id>",
+     updates: { "tasks[2]": { id: "T-003", title: "Follow-up", status: "pending" } },
+   })
+   \`\`\`
+   The parser allows writing one slot past the current length (\`MAX_ARRAY_GAP = 1\`); writing further out (\`tasks[5]\` against a length-2 array) throws \`INVALID_INPUT\`. Read the current \`tasks\` length before appending.
 
 ### Get Summary
 


### PR DESCRIPTION
## Summary

Bundled fix for 8 distinct issues surfaced by the v2.9 dogfood report (#1109), shipping as **17 TDD tasks across 30 commits** on `feature/v290-dogfood-bundle`. Each DR is independent and revertable; the bundle is a delivery convenience, not coupling.

| DR | Tasks | Issue | Effect |
|---|---|---|---|
| DR-T-1 | T-02, T-03 | #1205 | `delegation_readiness` projection tracks `plan.artifactPresent` + parity with `prepare_delegation` |
| DR-T-2 | T-04, T-05 | #1206 | per-task ID sets in projection; `prepare_delegation tasks=` arg scopes worktree-pending blocker to wave |
| DR-T-3 | T-06 | #1212 | state-vs-plan desync diagnostic blocker |
| DR-1 | T-07 | #1203 | `setup_worktree` direct-reads `.gitignore` (no more `git check-ignore`); honest PASS detail |
| DR-2 | T-08 | #1204 | IMPLEMENTER prompt explicit cd-into-worktree (Working Directory Setup MANDATORY) |
| DR-3 | T-09 | #1204 | `setup_worktree` honors `branch?` arg + `workflow.tasks[id].branch` |
| DR-4 | T-10 | #1204 | `check_static_analysis` returns `'skip'` for no-toolchain repos; convergence view treats skip as inconclusive |
| DR-5 | T-11→T-14 | #1204 | parser fixture (`agency-csl-auto-pr.md`) + 3 false-positive fixes: description span, T-id dependency anchor, file-conflict extension filter |
| DR-6 | T-15 | #1212 | merge ancestry preflight failure links runbook section in `skills-src/delegation/SKILL.md` |
| DR-7 | T-16 | #1201 | CLI `install-skills` subcommand (cli-only) |
| DR-8 | T-17 | #1212 | three docs/hint fixes: resolver remediation example, `task.assigned.branch` documented, `workflow_set` array-append syntax |

T-01 verification gate confirmed #1208 was fixed-in-#1193; closed.

## Changes

### Projections & view
- `delegation-readiness-view.ts` — `plan.artifactPresent`, per-task `assignedTaskIds` / `readyTaskIds` sets, state-vs-plan desync blocker
- `convergence-view.ts` — D2 SKIP rendering distinct from PASS

### Orchestrate handlers
- `prepare-delegation.ts` — wave-scoped worktree-pending; removed handler-side plan-artifact check (parity with view)
- `setup-worktree.ts` — direct gitignore read; `branch?` arg + workflow-state lookup with priority `arg > state > default`; source attribution in PASS report
- `static-analysis.ts` — `'skip'` status with `skipReason` and augmented `gate.executed` payload
- `pure/merge-preflight.ts` — ancestry failure includes `git rebase` instruction + runbook link

### Parser
- `task-decomposition.ts` — description span (heading→next field-header), `extractDependencies` strict to `**Dependencies:**` line (no greedy digit fallback), `FILE_EXTENSION_ALLOWLIST` for file-conflict filter; helpers `extractDescriptionSpan`, `canonicaliseTaskId`, `resolveBranchName` extracted
- New fixture: `servers/exarchos-mcp/src/orchestrate/fixtures/plans/agency-csl-auto-pr.md` (681 words, 4 tasks, 127 lines)

### Skills + agents
- `agents/definitions.ts` — IMPLEMENTER systemPrompt gains "Working Directory Setup (MANDATORY)" before existing verification block; bash + PowerShell variants
- `skills-src/delegation/references/implementer-prompt.md` — same section in canonical template
- `skills-src/delegation/SKILL.md` — new `## When integration advances mid-wave` runbook section
- `skills-src/workflow-state/SKILL.md` — worked example for `workflow_set` array-append syntax
- `skills/<runtime>/...` — regenerated across 6 runtimes (claude, codex, copilot, cursor, generic, opencode); `skills:guard` clean
- `__fixtures__/snapshots/claude/implementer.md` — updated to track new agent output

### CLI
- `adapters/cli.ts` — `install-skills [--agent <name>]` subcommand wired with `cli-only` annotation; `cli-commands/install-skills-bridge.{js,d.ts}` for cross-package import

### Misc
- `event-store/schemas.ts` — `task.assigned.branch` field documented (was already optional)
- `config/test-runtime-resolver.ts` — remediation message includes example
- `workflow/state-store.test.ts` — array-insertion contract pinned
- `orchestrate/dispatch-guard.ts` — small guard adjustment for T-15

## Test Plan

- [x] `npx vitest run src/orchestrate/task-decomposition.{test,fixtures.test}.ts src/orchestrate/setup-worktree.test.ts src/orchestrate/static-analysis.test.ts src/orchestrate/pure/static-analysis.test.ts src/orchestrate/pure/merge-preflight.test.ts src/views/convergence-view.test.ts src/views/delegation-readiness-view.test.ts src/orchestrate/prepare-delegation.test.ts src/agents/generate-agents.test.ts src/adapters/cli.test.ts src/config/test-runtime-resolver.test.ts src/event-store/schemas.test.ts src/workflow/state-store.test.ts` — **579/579 pass**
- [x] `npm run skills:guard` — clean (skills/ and agents/ in sync with sources)
- [x] `npm run build:skills` — 102 variants across 8 runtimes
- [x] `npm run typecheck` (root) and `npx tsc --noEmit` (servers/exarchos-mcp) — clean
- [ ] CI on this PR

### Known pre-existing failures (NOT regressions, present on main)
- `gates.test.ts` 5 failures in `Quality Gate Commands > handleTaskGate` — `mockExecSync` not called with expected args, predates this branch
- `install.test.ts:356` worktree fragility (`/exarchos$/` regex hardcoded) — flagged in CLAUDE.md memory

## #1109 Invariant Verification

- [x] **Event-sourcing** — `state.patched.artifacts.plan` (DR-T-1), `worktree.created.taskId` (DR-T-2), `gate.executed.skipped` (DR-4), `team.task.planned.blockedBy` chain documented per DR
- [x] **MCP parity** — T-03 parity test asserts `prepare_delegation` and `delegation_readiness` view produce byte-equivalent blocker lists for the same workflow state
- [x] **Basileus-forward** — T-08 explicitly removes a hidden cwd assumption from the IMPLEMENTER prompt for non-native-isolation runtimes
- [x] **Capability resolution** — no yaml `capabilities` field is read at runtime by anything in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)