### PR TITLE
fix(schema): document intentional CLI/MCP hidden-tool asymmetry (closes #1218)

### DIFF
--- a/servers/exarchos-mcp/src/adapters/cli.test.ts
+++ b/servers/exarchos-mcp/src/adapters/cli.test.ts
@@ -28,10 +28,16 @@ vi.mock('./schema-introspection.js', () => ({
   listSchemas: vi.fn(() => [
     {
       tool: 'exarchos_workflow',
+      hidden: false,
       actions: [
         { name: 'init', description: 'Initialize a new workflow' },
         { name: 'get', description: 'Read workflow state' },
       ],
+    },
+    {
+      tool: 'exarchos_sync',
+      hidden: true,
+      actions: [{ name: 'now', description: 'Trigger immediate sync' }],
     },
   ]),
   resolveSchemaRef: vi.fn(() => ({
@@ -204,6 +210,26 @@ describe('schema command', () => {
     const output = stdoutSpy.mock.calls.map(([s]) => s).join('');
     expect(output).toContain('exarchos_workflow');
     expect(output).toContain('init');
+
+    stdoutSpy.mockRestore();
+  });
+
+  // Bug #1218: hidden tools (e.g. exarchos_sync) MUST stay in the CLI
+  // schema listing — the asymmetry with MCP `tools/list` is intentional —
+  // but they should be marked `(hidden)` so the operator can see they are
+  // not part of the model-facing contract.
+  it('SchemaCommand_NoArgs_MarksHiddenTools', async () => {
+    // Arrange
+    const program = buildCli(ctx);
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    // Act
+    await program.parseAsync(['node', 'exarchos', 'schema']);
+
+    // Assert
+    const output = stdoutSpy.mock.calls.map(([s]) => s).join('');
+    expect(output).toMatch(/^exarchos_workflow:$/m);
+    expect(output).toMatch(/^exarchos_sync \(hidden\):$/m);
 
     stdoutSpy.mockRestore();
   });

--- a/servers/exarchos-mcp/src/adapters/cli.ts
+++ b/servers/exarchos-mcp/src/adapters/cli.ts
@@ -406,9 +406,17 @@ export function buildCli(ctx: DispatchContext): Command {
     .action(async (ref?: string) => {
       const { listSchemas, resolveSchemaRef } = await import('./schema-introspection.js');
       if (!ref) {
+        // The CLI surface intentionally lists the FULL registry — including
+        // tools that the MCP adapter hides from `tools/list` (e.g.
+        // `exarchos_sync`). We append `(hidden)` so users can see at a
+        // glance which entries are operator-only and not part of the
+        // model-facing contract. See bug #1218 and
+        // `schema-introspection.ts:listSchemas` for the tier-model
+        // rationale.
         const schemas = listSchemas();
         for (const tool of schemas) {
-          process.stdout.write(`\n${tool.tool}:\n`);
+          const marker = tool.hidden ? ' (hidden)' : '';
+          process.stdout.write(`\n${tool.tool}${marker}:\n`);
           for (const action of tool.actions) {
             process.stdout.write(`  ${action.name} — ${action.description}\n`);
           }

--- a/servers/exarchos-mcp/src/adapters/mcp.ts
+++ b/servers/exarchos-mcp/src/adapters/mcp.ts
@@ -37,6 +37,21 @@ export function createMcpServer(ctx: DispatchContext): McpServer {
   );
 
   for (const tool of getFullRegistry()) {
+    // Tier model — INTENTIONAL asymmetry between MCP and CLI surfaces.
+    //
+    // `hidden: true` means the tool is excluded from MCP `tools/list` (so it
+    // is not advertised to model-side agents and does not consume their
+    // context budget) but remains reachable via the CLI for operators,
+    // scripts, and introspection (`exarchos schema`, `exarchos sy ...`).
+    //
+    // The companion CLI introspection path (`listSchemas()` in
+    // `./schema-introspection.ts`) deliberately returns the FULL registry
+    // and tags hidden tools so users can see they exist while understanding
+    // they are internal / not part of the model-facing contract.
+    //
+    // See bug #1218 for the triage that fixed this asymmetry as
+    // intentional, and registry.ts:`CompositeTool.hidden` for the field
+    // contract.
     if (tool.hidden) continue;
     const inputSchema = buildRegistrationSchema(tool.actions);
     const description = buildToolDescription(tool, ctx.slimRegistration ?? false);

--- a/servers/exarchos-mcp/src/adapters/schema-introspection.test.ts
+++ b/servers/exarchos-mcp/src/adapters/schema-introspection.test.ts
@@ -76,6 +76,30 @@ describe('listSchemas', () => {
       }
     }
   });
+
+  // Bug #1218: the CLI introspection surface lists the FULL registry
+  // (including tools that MCP `tools/list` filters out). To keep that
+  // asymmetry visible — without breaking anything — every entry now carries
+  // a `hidden` flag so renderers can mark hidden tools as operator-only.
+  it('ListSchemas_TagsHiddenTools_PreservingTierModel', () => {
+    const schemas = listSchemas();
+
+    const sync = schemas.find((s) => s.tool === 'exarchos_sync');
+    expect(sync, 'exarchos_sync must remain in the CLI introspection surface').toBeDefined();
+    expect(sync!.hidden).toBe(true);
+
+    // All currently visible composite tools must report hidden === false.
+    for (const visibleName of [
+      'exarchos_workflow',
+      'exarchos_event',
+      'exarchos_orchestrate',
+      'exarchos_view',
+    ]) {
+      const tool = schemas.find((s) => s.tool === visibleName);
+      expect(tool, `${visibleName} must be present in CLI listSchemas()`).toBeDefined();
+      expect(tool!.hidden).toBe(false);
+    }
+  });
 });
 
 describe('resolveTopologyRef', () => {

--- a/servers/exarchos-mcp/src/adapters/schema-introspection.ts
+++ b/servers/exarchos-mcp/src/adapters/schema-introspection.ts
@@ -52,14 +52,31 @@ export function resolveSchemaRef(ref: string): Record<string, unknown> {
 
 /**
  * Lists all tools and their actions from the registry.
- * Returns a summary with tool name and action name/description pairs.
+ *
+ * Tier model — INTENTIONAL asymmetry with the MCP `tools/list` surface.
+ * `listSchemas()` returns the FULL registry, including `hidden: true` tools
+ * (e.g. `exarchos_sync`). The MCP adapter (`./mcp.ts`) skips hidden tools
+ * during `registerTool()` so they stay off the model-facing surface. The
+ * CLI introspection path keeps them visible because the CLI is the operator
+ * / script / debugging surface, where seeing the complete registry is the
+ * desired behavior.
+ *
+ * Each returned entry carries a `hidden` boolean so callers (CLI renderers,
+ * docs generators, parity tests) can mark or filter hidden tools without
+ * having to re-walk the registry.
+ *
+ * See bug #1218 for the triage that locked this asymmetry in as
+ * intentional, and `registry.ts:CompositeTool.hidden` for the field
+ * contract.
  */
 export function listSchemas(): Array<{
   tool: string;
+  hidden: boolean;
   actions: Array<{ name: string; description: string }>;
 }> {
   return getFullRegistry().map((tool) => ({
     tool: tool.name,
+    hidden: tool.hidden === true,
     actions: tool.actions.map((action) => ({
       name: action.name,
       description: action.description,


### PR DESCRIPTION
## Summary

Triages bug #1218 — the surface asymmetry where `exarchos schema` (CLI) lists the full tool registry while MCP `tools/list` filters `hidden: true` tools (`exarchos_sync`).

**Triage outcome: option (a) — intentional asymmetry.** The fix documents the tier model at both call sites and adds an additive `(hidden)` visual marker so operators can see which entries are not part of the model-facing contract.

## Evidence the asymmetry is intentional

- `registry.ts:59` — the `CompositeTool.hidden` field is documented as *"When true, the tool is excluded from MCP registration (not exposed to agents). CLI access is preserved."*
- v2.4.4 commit `f3ae2e1a` (`docs: refactor README ... hide sync tool`) explicitly states *"Hide exarchos_sync from MCP registration (planned, saves agent context)"* — the rationale is model-context economy, not deprecation.
- The e2e test `test/process/cli/schema.test.ts` (in the v2.9-revisited series) already documents the asymmetry: *"the CLI command exposes the FULL registry — including `hidden: true` tools like `exarchos_sync` — for introspection convenience. The MCP adapter (mcp.ts §`if (tool.hidden) continue`) filters hidden tools out of `tools/list` so model-side surface stays curated."*

The two surfaces serve different audiences: MCP is the curated model-facing surface; CLI introspection is the operator/scripting surface.

## Changes

- `servers/exarchos-mcp/src/adapters/mcp.ts` — add a comment block at the `if (tool.hidden) continue` filter explaining the tier model and pointing at the CLI counterpart.
- `servers/exarchos-mcp/src/adapters/schema-introspection.ts` — add a parallel comment block on `listSchemas()`; extend the return shape with a `hidden: boolean` flag so renderers can mark hidden entries without re-walking the registry.
- `servers/exarchos-mcp/src/adapters/cli.ts` — append `" (hidden)"` to the rendered tool header for hidden tools.
- `servers/exarchos-mcp/src/adapters/schema-introspection.test.ts` — assert `listSchemas()` tags `exarchos_sync` with `hidden=true` and visible tools with `hidden=false`.
- `servers/exarchos-mcp/src/adapters/cli.test.ts` — extend the `listSchemas` mock with a hidden entry; add `SchemaCommand_NoArgs_MarksHiddenTools` covering the rendered marker.

Behavior preserved: MCP `tools/list` still excludes hidden tools, CLI `schema` still lists them. The only on-the-wire change is the additive `(hidden)` suffix on hidden tool headers in CLI text output.

## Test Plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run servers/exarchos-mcp/src/adapters/` — 159/159 passing
- [x] `SchemaCommand_NoArgs_MarksHiddenTools` (new) asserts the `(hidden)` marker is rendered for `exarchos_sync` and not for visible tools
- [x] `ListSchemas_TagsHiddenTools_PreservingTierModel` (new) asserts the registry tier model holds at the introspection layer
- [x] Existing `ListSchemas_ReturnsAllToolsAndActions` continues to pass — hidden tools remain in the listing (asymmetry preserved)
- [x] Existing parity test `schema_toolsCoverMcpToolsList_complete` (CLI ⊇ MCP) is unaffected by the additive marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)