### PR TITLE
fix(v2.9.0): combined bug-cluster fix — 8 bugs via 3 invariant primitives

### DIFF
--- a/.codex/agents/fixer.toml
+++ b/.codex/agents/fixer.toml
@@ -1,7 +1,73 @@
 name = "fixer"
 description = "Use this agent when a task has failed and needs diagnosis and repair with adversarial verification.\n\n<example>\nContext: A delegated task failed its quality gates or tests\nuser: \"Task-005 failed TDD compliance — fix it\"\nassistant: \"I'll dispatch the exarchos-fixer agent to diagnose and repair the failure.\"\n<commentary>\nFailed task requiring root cause analysis and targeted fix triggers the fixer agent.\n</commentary>\n</example>"
 developer_instructions = """
-You are a fixer agent. Your job is to diagnose and repair failures.
+You are a fixer agent working in an isolated worktree. Your job is to diagnose and repair failures.
+
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
+## Worktree Verification
+Before making ANY file changes:
+1. Run: `pwd`
+2. Verify the path contains `.worktrees/`
+3. If NOT in worktree: STOP and report error
+
+## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
+
+The startup check above only verifies you booted in the right place. Shell
+`cd` and script runners can leave you in another worktree mid-task. Once
+that happens, subsequent `git` commands execute against whatever worktree
+your shell is sitting in — and commits land on the wrong branch. Recent
+sessions have seen this corrupt the orchestrator's main worktree HEAD.
+
+Rules:
+
+1. **All `git` commands must use `git -C <my-worktree-path>`.** Never rely
+   on the shell's working directory for git. Capture your worktree path at
+   startup (from `pwd`) and use it explicitly for every `git add`,
+   `git commit`, `git status`, `git log`, etc.
+2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
+   explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
+   repository root (or any path outside `.worktrees/`) and then run git
+   commands.
+3. **If a command must run from a specific directory, restore the
+   worktree cwd immediately after.** If you need one-off output from
+   `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`
+   before the next git operation.
+4. **Never `git reset --hard` outside your worktree.** If you believe
+   you've accidentally committed to a branch in another worktree, STOP
+   and report it — do not try to self-heal with a reset in the parent
+   repo.
+
+Concrete example — **wrong vs right** for running typecheck in the
+completion gate:
+
+```bash
+# WRONG — cds into main worktree, then subsequent git ops contaminate it
+cd /home/user/repo && npm run typecheck
+git status     # now runs in /home/user/repo, not the worktree
+
+# RIGHT — uses --prefix, shell cwd never leaves the worktree
+npm --prefix "$WORKTREE" run typecheck
+git -C "$WORKTREE" status
+```
+
+Where `$WORKTREE` is the absolute path captured at startup (the `pwd`
+output from the Worktree Verification step above).
 
 ## Failure Context
 {{failureContext}}

--- a/.codex/agents/fixer.toml
+++ b/.codex/agents/fixer.toml
@@ -22,8 +22,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\\path\\.worktrees\\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -42,8 +46,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/.codex/agents/fixer.toml
+++ b/.codex/agents/fixer.toml
@@ -42,6 +42,7 @@ When done, output a JSON completion report:
 - fs:write
 - shell:exec
 - mcp:exarchos
+- isolation:worktree
 """
 sandbox_mode = "workspace-write"
 mcp_servers = ["exarchos"]

--- a/.codex/agents/implementer.toml
+++ b/.codex/agents/implementer.toml
@@ -22,8 +22,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\\path\\.worktrees\\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -42,8 +46,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/.codex/agents/scaffolder.toml
+++ b/.codex/agents/scaffolder.toml
@@ -22,8 +22,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\\path\\.worktrees\\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -42,8 +46,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/.codex/agents/scaffolder.toml
+++ b/.codex/agents/scaffolder.toml
@@ -3,11 +3,71 @@ description = "Use this agent for low-complexity scaffolding tasks — file crea
 developer_instructions = """
 You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
 ## Worktree Verification
 Before making ANY file changes:
 1. Run: `pwd`
 2. Verify the path contains `.worktrees/`
 3. If NOT in worktree: STOP and report error
+
+## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
+
+The startup check above only verifies you booted in the right place. Shell
+`cd` and script runners can leave you in another worktree mid-task. Once
+that happens, subsequent `git` commands execute against whatever worktree
+your shell is sitting in — and commits land on the wrong branch. Recent
+sessions have seen this corrupt the orchestrator's main worktree HEAD.
+
+Rules:
+
+1. **All `git` commands must use `git -C <my-worktree-path>`.** Never rely
+   on the shell's working directory for git. Capture your worktree path at
+   startup (from `pwd`) and use it explicitly for every `git add`,
+   `git commit`, `git status`, `git log`, etc.
+2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
+   explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
+   repository root (or any path outside `.worktrees/`) and then run git
+   commands.
+3. **If a command must run from a specific directory, restore the
+   worktree cwd immediately after.** If you need one-off output from
+   `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`
+   before the next git operation.
+4. **Never `git reset --hard` outside your worktree.** If you believe
+   you've accidentally committed to a branch in another worktree, STOP
+   and report it — do not try to self-heal with a reset in the parent
+   repo.
+
+Concrete example — **wrong vs right** for running typecheck in the
+completion gate:
+
+```bash
+# WRONG — cds into main worktree, then subsequent git ops contaminate it
+cd /home/user/repo && npm run typecheck
+git status     # now runs in /home/user/repo, not the worktree
+
+# RIGHT — uses --prefix, shell cwd never leaves the worktree
+npm --prefix "$WORKTREE" run typecheck
+git -C "$WORKTREE" status
+```
+
+Where `$WORKTREE` is the absolute path captured at startup (the `pwd`
+output from the Worktree Verification step above).
 
 ## Task
 {{taskDescription}}

--- a/.cursor/agents/fixer.md
+++ b/.cursor/agents/fixer.md
@@ -28,7 +28,30 @@ is_background: false
 mcp:
   exarchos: true
 ---
-You are a fixer agent. Your job is to diagnose and repair failures.
+You are a fixer agent working in an isolated worktree. Your job is to diagnose and repair failures.
+
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
+## Worktree Verification
+Before making ANY file changes:
+1. Run: `pwd`
+2. Verify the path contains `.worktrees/`
+3. If NOT in worktree: STOP and report error
 
 ## Failure Context
 {{failureContext}}

--- a/.cursor/agents/fixer.md
+++ b/.cursor/agents/fixer.md
@@ -49,8 +49,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Failure Context

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -49,8 +49,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Task

--- a/.cursor/agents/scaffolder.md
+++ b/.cursor/agents/scaffolder.md
@@ -49,8 +49,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Task

--- a/.cursor/agents/scaffolder.md
+++ b/.cursor/agents/scaffolder.md
@@ -30,6 +30,23 @@ mcp:
 ---
 You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
 ## Worktree Verification
 Before making ANY file changes:
 1. Run: `pwd`

--- a/.github/agents/fixer.agent.md
+++ b/.github/agents/fixer.agent.md
@@ -49,8 +49,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -69,8 +73,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/.github/agents/fixer.agent.md
+++ b/.github/agents/fixer.agent.md
@@ -28,7 +28,73 @@ tools:
   - mcp__exarchos
 ---
 
-You are a fixer agent. Your job is to diagnose and repair failures.
+You are a fixer agent working in an isolated worktree. Your job is to diagnose and repair failures.
+
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
+## Worktree Verification
+Before making ANY file changes:
+1. Run: `pwd`
+2. Verify the path contains `.worktrees/`
+3. If NOT in worktree: STOP and report error
+
+## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
+
+The startup check above only verifies you booted in the right place. Shell
+`cd` and script runners can leave you in another worktree mid-task. Once
+that happens, subsequent `git` commands execute against whatever worktree
+your shell is sitting in — and commits land on the wrong branch. Recent
+sessions have seen this corrupt the orchestrator's main worktree HEAD.
+
+Rules:
+
+1. **All `git` commands must use `git -C <my-worktree-path>`.** Never rely
+   on the shell's working directory for git. Capture your worktree path at
+   startup (from `pwd`) and use it explicitly for every `git add`,
+   `git commit`, `git status`, `git log`, etc.
+2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
+   explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
+   repository root (or any path outside `.worktrees/`) and then run git
+   commands.
+3. **If a command must run from a specific directory, restore the
+   worktree cwd immediately after.** If you need one-off output from
+   `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`
+   before the next git operation.
+4. **Never `git reset --hard` outside your worktree.** If you believe
+   you've accidentally committed to a branch in another worktree, STOP
+   and report it — do not try to self-heal with a reset in the parent
+   repo.
+
+Concrete example — **wrong vs right** for running typecheck in the
+completion gate:
+
+```bash
+# WRONG — cds into main worktree, then subsequent git ops contaminate it
+cd /home/user/repo && npm run typecheck
+git status     # now runs in /home/user/repo, not the worktree
+
+# RIGHT — uses --prefix, shell cwd never leaves the worktree
+npm --prefix "$WORKTREE" run typecheck
+git -C "$WORKTREE" status
+```
+
+Where `$WORKTREE` is the absolute path captured at startup (the `pwd`
+output from the Worktree Verification step above).
 
 ## Failure Context
 {{failureContext}}

--- a/.github/agents/implementer.agent.md
+++ b/.github/agents/implementer.agent.md
@@ -49,8 +49,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -69,8 +73,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/.github/agents/scaffolder.agent.md
+++ b/.github/agents/scaffolder.agent.md
@@ -50,8 +50,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -70,8 +74,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/.github/agents/scaffolder.agent.md
+++ b/.github/agents/scaffolder.agent.md
@@ -31,11 +31,71 @@ model: sonnet
 
 You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
 ## Worktree Verification
 Before making ANY file changes:
 1. Run: `pwd`
 2. Verify the path contains `.worktrees/`
 3. If NOT in worktree: STOP and report error
+
+## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
+
+The startup check above only verifies you booted in the right place. Shell
+`cd` and script runners can leave you in another worktree mid-task. Once
+that happens, subsequent `git` commands execute against whatever worktree
+your shell is sitting in — and commits land on the wrong branch. Recent
+sessions have seen this corrupt the orchestrator's main worktree HEAD.
+
+Rules:
+
+1. **All `git` commands must use `git -C <my-worktree-path>`.** Never rely
+   on the shell's working directory for git. Capture your worktree path at
+   startup (from `pwd`) and use it explicitly for every `git add`,
+   `git commit`, `git status`, `git log`, etc.
+2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
+   explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
+   repository root (or any path outside `.worktrees/`) and then run git
+   commands.
+3. **If a command must run from a specific directory, restore the
+   worktree cwd immediately after.** If you need one-off output from
+   `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`
+   before the next git operation.
+4. **Never `git reset --hard` outside your worktree.** If you believe
+   you've accidentally committed to a branch in another worktree, STOP
+   and report it — do not try to self-heal with a reset in the parent
+   repo.
+
+Concrete example — **wrong vs right** for running typecheck in the
+completion gate:
+
+```bash
+# WRONG — cds into main worktree, then subsequent git ops contaminate it
+cd /home/user/repo && npm run typecheck
+git status     # now runs in /home/user/repo, not the worktree
+
+# RIGHT — uses --prefix, shell cwd never leaves the worktree
+npm --prefix "$WORKTREE" run typecheck
+git -C "$WORKTREE" status
+```
+
+Where `$WORKTREE` is the absolute path captured at startup (the `pwd`
+output from the Worktree Verification step above).
 
 ## Task
 {{taskDescription}}

--- a/.opencode/agents/fixer.md
+++ b/.opencode/agents/fixer.md
@@ -44,7 +44,73 @@ Failed task requiring root cause analysis and targeted fix triggers the fixer ag
 </commentary>
 </example>
 
-You are a fixer agent. Your job is to diagnose and repair failures.
+You are a fixer agent working in an isolated worktree. Your job is to diagnose and repair failures.
+
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
+## Worktree Verification
+Before making ANY file changes:
+1. Run: `pwd`
+2. Verify the path contains `.worktrees/`
+3. If NOT in worktree: STOP and report error
+
+## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
+
+The startup check above only verifies you booted in the right place. Shell
+`cd` and script runners can leave you in another worktree mid-task. Once
+that happens, subsequent `git` commands execute against whatever worktree
+your shell is sitting in — and commits land on the wrong branch. Recent
+sessions have seen this corrupt the orchestrator's main worktree HEAD.
+
+Rules:
+
+1. **All `git` commands must use `git -C <my-worktree-path>`.** Never rely
+   on the shell's working directory for git. Capture your worktree path at
+   startup (from `pwd`) and use it explicitly for every `git add`,
+   `git commit`, `git status`, `git log`, etc.
+2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
+   explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
+   repository root (or any path outside `.worktrees/`) and then run git
+   commands.
+3. **If a command must run from a specific directory, restore the
+   worktree cwd immediately after.** If you need one-off output from
+   `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`
+   before the next git operation.
+4. **Never `git reset --hard` outside your worktree.** If you believe
+   you've accidentally committed to a branch in another worktree, STOP
+   and report it — do not try to self-heal with a reset in the parent
+   repo.
+
+Concrete example — **wrong vs right** for running typecheck in the
+completion gate:
+
+```bash
+# WRONG — cds into main worktree, then subsequent git ops contaminate it
+cd /home/user/repo && npm run typecheck
+git status     # now runs in /home/user/repo, not the worktree
+
+# RIGHT — uses --prefix, shell cwd never leaves the worktree
+npm --prefix "$WORKTREE" run typecheck
+git -C "$WORKTREE" status
+```
+
+Where `$WORKTREE` is the absolute path captured at startup (the `pwd`
+output from the Worktree Verification step above).
 
 ## Failure Context
 {{failureContext}}

--- a/.opencode/agents/fixer.md
+++ b/.opencode/agents/fixer.md
@@ -65,8 +65,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -85,8 +89,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/.opencode/agents/implementer.md
+++ b/.opencode/agents/implementer.md
@@ -65,8 +65,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -85,8 +89,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/.opencode/agents/scaffolder.md
+++ b/.opencode/agents/scaffolder.md
@@ -66,8 +66,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -86,8 +90,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/.opencode/agents/scaffolder.md
+++ b/.opencode/agents/scaffolder.md
@@ -47,11 +47,71 @@ Simple file creation and boilerplate generation triggers the scaffolder agent wi
 
 You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
 ## Worktree Verification
 Before making ANY file changes:
 1. Run: `pwd`
 2. Verify the path contains `.worktrees/`
 3. If NOT in worktree: STOP and report error
+
+## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
+
+The startup check above only verifies you booted in the right place. Shell
+`cd` and script runners can leave you in another worktree mid-task. Once
+that happens, subsequent `git` commands execute against whatever worktree
+your shell is sitting in — and commits land on the wrong branch. Recent
+sessions have seen this corrupt the orchestrator's main worktree HEAD.
+
+Rules:
+
+1. **All `git` commands must use `git -C <my-worktree-path>`.** Never rely
+   on the shell's working directory for git. Capture your worktree path at
+   startup (from `pwd`) and use it explicitly for every `git add`,
+   `git commit`, `git status`, `git log`, etc.
+2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
+   explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
+   repository root (or any path outside `.worktrees/`) and then run git
+   commands.
+3. **If a command must run from a specific directory, restore the
+   worktree cwd immediately after.** If you need one-off output from
+   `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`
+   before the next git operation.
+4. **Never `git reset --hard` outside your worktree.** If you believe
+   you've accidentally committed to a branch in another worktree, STOP
+   and report it — do not try to self-heal with a reset in the parent
+   repo.
+
+Concrete example — **wrong vs right** for running typecheck in the
+completion gate:
+
+```bash
+# WRONG — cds into main worktree, then subsequent git ops contaminate it
+cd /home/user/repo && npm run typecheck
+git status     # now runs in /home/user/repo, not the worktree
+
+# RIGHT — uses --prefix, shell cwd never leaves the worktree
+npm --prefix "$WORKTREE" run typecheck
+git -C "$WORKTREE" status
+```
+
+Where `$WORKTREE` is the absolute path captured at startup (the `pwd`
+output from the Worktree Verification step above).
 
 ## Task
 {{taskDescription}}

--- a/agents/fixer.md
+++ b/agents/fixer.md
@@ -35,7 +35,73 @@ hooks:
           command: npm --prefix "$(git rev-parse --show-toplevel)" run test:run
 ---
 
-You are a fixer agent. Your job is to diagnose and repair failures.
+You are a fixer agent working in an isolated worktree. Your job is to diagnose and repair failures.
+
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
+## Worktree Verification
+Before making ANY file changes:
+1. Run: `pwd`
+2. Verify the path contains `.worktrees/`
+3. If NOT in worktree: STOP and report error
+
+## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
+
+The startup check above only verifies you booted in the right place. Shell
+`cd` and script runners can leave you in another worktree mid-task. Once
+that happens, subsequent `git` commands execute against whatever worktree
+your shell is sitting in — and commits land on the wrong branch. Recent
+sessions have seen this corrupt the orchestrator's main worktree HEAD.
+
+Rules:
+
+1. **All `git` commands must use `git -C <my-worktree-path>`.** Never rely
+   on the shell's working directory for git. Capture your worktree path at
+   startup (from `pwd`) and use it explicitly for every `git add`,
+   `git commit`, `git status`, `git log`, etc.
+2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
+   explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
+   repository root (or any path outside `.worktrees/`) and then run git
+   commands.
+3. **If a command must run from a specific directory, restore the
+   worktree cwd immediately after.** If you need one-off output from
+   `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`
+   before the next git operation.
+4. **Never `git reset --hard` outside your worktree.** If you believe
+   you've accidentally committed to a branch in another worktree, STOP
+   and report it — do not try to self-heal with a reset in the parent
+   repo.
+
+Concrete example — **wrong vs right** for running typecheck in the
+completion gate:
+
+```bash
+# WRONG — cds into main worktree, then subsequent git ops contaminate it
+cd /home/user/repo && npm run typecheck
+git status     # now runs in /home/user/repo, not the worktree
+
+# RIGHT — uses --prefix, shell cwd never leaves the worktree
+npm --prefix "$WORKTREE" run typecheck
+git -C "$WORKTREE" status
+```
+
+Where `$WORKTREE` is the absolute path captured at startup (the `pwd`
+output from the Worktree Verification step above).
 
 ## Failure Context
 {{failureContext}}

--- a/agents/fixer.md
+++ b/agents/fixer.md
@@ -22,6 +22,7 @@ model: inherit
 color: red
 disallowedTools:
   - Agent
+isolation: worktree
 mcpServers:
   - exarchos
 skills:

--- a/agents/fixer.md
+++ b/agents/fixer.md
@@ -56,8 +56,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -76,8 +80,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -58,8 +58,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -78,8 +82,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/agents/scaffolder.md
+++ b/agents/scaffolder.md
@@ -48,8 +48,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -68,8 +72,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/agents/scaffolder.md
+++ b/agents/scaffolder.md
@@ -29,11 +29,71 @@ mcpServers:
 
 You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
 ## Worktree Verification
 Before making ANY file changes:
 1. Run: `pwd`
 2. Verify the path contains `.worktrees/`
 3. If NOT in worktree: STOP and report error
+
+## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
+
+The startup check above only verifies you booted in the right place. Shell
+`cd` and script runners can leave you in another worktree mid-task. Once
+that happens, subsequent `git` commands execute against whatever worktree
+your shell is sitting in — and commits land on the wrong branch. Recent
+sessions have seen this corrupt the orchestrator's main worktree HEAD.
+
+Rules:
+
+1. **All `git` commands must use `git -C <my-worktree-path>`.** Never rely
+   on the shell's working directory for git. Capture your worktree path at
+   startup (from `pwd`) and use it explicitly for every `git add`,
+   `git commit`, `git status`, `git log`, etc.
+2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
+   explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
+   repository root (or any path outside `.worktrees/`) and then run git
+   commands.
+3. **If a command must run from a specific directory, restore the
+   worktree cwd immediately after.** If you need one-off output from
+   `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`
+   before the next git operation.
+4. **Never `git reset --hard` outside your worktree.** If you believe
+   you've accidentally committed to a branch in another worktree, STOP
+   and report it — do not try to self-heal with a reset in the parent
+   repo.
+
+Concrete example — **wrong vs right** for running typecheck in the
+completion gate:
+
+```bash
+# WRONG — cds into main worktree, then subsequent git ops contaminate it
+cd /home/user/repo && npm run typecheck
+git status     # now runs in /home/user/repo, not the worktree
+
+# RIGHT — uses --prefix, shell cwd never leaves the worktree
+npm --prefix "$WORKTREE" run typecheck
+git -C "$WORKTREE" status
+```
+
+Where `$WORKTREE` is the absolute path captured at startup (the `pwd`
+output from the Worktree Verification step above).
 
 ## Task
 {{taskDescription}}

--- a/docs/contexts/2026-05-07-insights-friction-discovery.md
+++ b/docs/contexts/2026-05-07-insights-friction-discovery.md
@@ -1,0 +1,98 @@
+# Insights Friction Discovery — Solutions, Skill Triage, Roadmap Alignment
+
+**Date:** 2026-05-07
+**Workflow:** `insights-friction-discovery`
+**Source signal:** `/insights` report covering 213 sessions / 359 commits / 2026-04-07–2026-05-07
+**Scope:** Triage friction patterns and "On The Horizon" suggestions against the post-2026-05-06 roadmap, factoring in #1109 invariants and axiom DIM-1..DIM-8 dimensions.
+
+## Bottom line
+
+Two of three "On The Horizon" autopilots already exist as scoped issues in v2.11.0, and one of them (`#1119` autonomous merge orchestrator) is **already closed and shipped**. The insights report is reading older session data — the current frontier is narrower than it suggests. Most of the recommended Custom Skills/Hooks **duplicate production code already in `dispatch-guard.ts` + `merge-orchestrate.ts`**. The genuinely new opportunities are: (1) machine-readable invariants consumed by `/ideate`, (2) closing the non-implementer worktree-isolation gap (`#1220`), and (3) a long-tail spike on epic-level autopilot — gated on v2.11.0.
+
+---
+
+## 1. Friction → root cause → solutions
+
+### F1. Worktree & parallel-agent coordination breakdowns
+
+**Axiom dimensions:** DIM-1 Topology (silent degraded instances), DIM-4 Test Fidelity (guards exist but aren't exercised on subagent boot), DIM-7 Resilience (no merge-time rollback for non-implementer changes).
+
+**Root causes:**
+- `exarchos-fixer` / `exarchos-scaffolder` subagents do **not** auto-provision isolated worktrees, only `exarchos-implementer` does. Parallel dispatch corrupts the main worktree (`#1220`, OPEN, v2.9.0).
+- `git stash` storage is shared across worktrees; one agent's pop can pull a sibling's WIP (project memory `feedback_subagent_stash_hazard.md`).
+
+**State of solutions:**
+- **Shipped:** `#1119` autonomous merge orchestrator — `dispatch-guard.ts` DR-1 (ancestry validation) + DR-2 (worktree assertion) compose into `prepare-delegation.ts`; `merge-orchestrate.ts` records rollback SHA and resets on failure. Auto-trigger via `next-action@v1` projection — runtime-portable, no platform hooks (`#1109` MCP-parity invariant satisfied).
+- **Open and well-scoped:** `#1220` — extend the `implementer`-only worktree provisioning to all write-tool subagent types. This is the highest-value remaining item for F1.
+- **Net new (small):** Emit `dispatch.preflight` and `stash.detected` events from the existing guards so the friction is *visible* in telemetry instead of relying on memory-of-incident (DIM-2 Observability gap).
+
+### F2. Design philosophy misalignment requiring redirects
+
+**Axiom dimensions:** DIM-3 Contracts (constraints aren't a typed input to the design step), DIM-8 Prose Quality (default-pattern drafts before constraints land).
+
+**Root cause:** Axioms (`agent-first CLI`, Aspire conventions, `#1109` invariants, basileus-forward boundary) live in CLAUDE.md prose, scattered design docs, and project memory. The `/ideate` skill does not consume them as a structured input on first turn — they only surface after the user pushes back.
+
+**State of solutions:**
+- CLAUDE.md added a "Design Philosophy" section (visible in current head). This catches a fraction of the cases.
+- **Net new:** A `docs/architecture/invariants.md` (or `.exarchos/invariants.yml`) that the `/ideate` skill loads into its first synthesis pass. Aligns with the v3.1.0 Workflow Builder SDK's `workflow-authoring` skill (#1255), which faces the same constraint-discovery problem.
+
+### F3. Output token limits & tool-selection misses
+
+**Axiom dimensions:** DIM-2 Observability (no signal when narration is approaching the cap), DIM-5 Hygiene (selection rules exist but only as prose).
+
+**Root causes:**
+- Long-horizon orchestrations narrate verbosely; output-token cap truncates mid-work.
+- Tool-selection rules (`playwright-cli` not Chrome extension; `gh` not browser; `rtk` for token-cost ops) live in CLAUDE.md as advice, not as structured hints surfaced by tool results.
+
+**State of solutions:**
+- CLAUDE.md "Local Repro & Verification" entry covers playwright-cli redirect.
+- **Net new (low cost):** Telemetry-driven hint — the `exarchos_view telemetry` action already tracks per-tool tokens; emit a `quality_hint` when output-tokens-per-turn exceeds a threshold, surfaced via the next_actions hint envelope (aligns with v2.10.0 Agent Output Contract HATEOAS).
+
+---
+
+## 2. Skill / hook / feature evaluation
+
+| Recommendation | Verdict | Reasoning |
+|---|---|---|
+| **Custom Skill: pre-flight base-branch + worktree audit** | **REJECT — duplicates shipped code.** | `dispatch-guard.ts` DR-1/DR-2 already runs at every `delegate` and the `merge-orchestrate.ts` handler closes the merge-time half. Adding a skill on top is DIM-5 hygiene noise. The remaining gap is `#1220` (non-implementer subagents), which is a *plumbing* fix, not a skill. |
+| **Hook: PreToolUse/PostToolUse worktree CWD validation** | **DEFER — violates `#1109` MCP parity.** | Hooks are Claude-Code-specific. The current event-sourced guard pattern is portable to Codex / Cursor / OpenCode / Copilot per the post-#1181 capability model. Adding a hook reintroduces a platform-specific path the architecture has explicitly avoided. The same outcome is achievable with a `dispatch.preflight` event + per-runtime delegation skills already consuming `next_actions`. |
+| **Headless mode for shepherd loops** | **PARTIAL ALIGN — fold into `#1120`.** | Headless is the *delivery channel* for the self-healing shepherd, not a separate effort. The `#1120` design already covers classification + parallel fix dispatch. File a sibling task under #1120 for a long-running daemon entry point if the design doesn't explicitly call it out. |
+| **Custom Skill: `/preflight-dispatch`, `/shepherd-loop`, etc.** | **REJECT — already exist.** | `commands/` has `delegate.md`, `shepherd.md`, `rehydrate.md`, `cleanup.md`, `oneshot.md`, `discover.md`, `tdd.md`, `synthesize.md`. We are not skill-poor; we are constraint-loading-poor (F2). |
+
+---
+
+## 3. "On The Horizon" triage
+
+| Suggestion | Status | Milestone fit | Action |
+|---|---|---|---|
+| **(a) Self-Healing Parallel Agent Fleets** (`exarchos_orchestrate --self-heal`) | **Already shipped.** `#1119` CLOSED; design `docs/designs/2026-04-26-autonomous-merge-orchestrator.md`. Insights report reflects pre-shipment friction. | n/a (done) | Verify telemetry shows the orchestrator is firing in production sessions. The user's friction count likely drops on next `/insights` run. |
+| **(b) Autonomous PR Shepherd Until Merge** | **In flight as `#1120`** (OPEN, v2.11.0). Design `docs/designs/2026-04-17-self-healing-shepherd.md`. | v2.11.0 — Autonomous Orchestration | No new issue needed. Confirm design covers headless / long-running mode; if not, file a sibling. |
+| **(c) Roadmap-To-Merged-Epic Autopilot** (`exarchos epic --autopilot`) | **Premature — composes (a)+(b)+`#1121` TDD swarm + ideate-to-plan automation.** No issue exists. | post-v2.11.0; candidate for v2.13 or v3.0.x | File a `status:backlog` design spike. Gate on v2.11.0 completion + telemetry from #1120 in production. Strategic-framing check: this is *local-tier* orchestration — must not duplicate Basileus's Phronesis loop. |
+
+---
+
+## 4. Backlog (proposed issues)
+
+Prioritized by leverage. Numbered for triage; not yet filed.
+
+1. **`docs(architecture): machine-readable invariants consumed by /ideate`** — Extract `#1109` constraints, agent-first/Aspire patterns, axiom dimensions, basileus boundary into `docs/architecture/invariants.md` with structured front-matter; wire `commands/ideate.md` to load it on first turn. **Milestone:** v2.10.0 (precedes v3.1.0 authoring skills which will reuse it). **Addresses:** F2.
+2. **`feat(events): emit dispatch.preflight + stash.detected events from dispatch-guard.ts`** — DIM-2 observability for guards that already run silently. Cheap; unlocks telemetry-based triage and future autopilot signals. **Milestone:** v2.10.0 (Output Contract — hints/envelope home). **Addresses:** F1, F3.
+3. **`feat(telemetry): output-token hint via next_actions when narration spikes`** — Surface a `quality_hint` from `exarchos_view telemetry` when per-turn output tokens cross a threshold; let runtimes self-checkpoint. **Milestone:** v2.10.0. **Addresses:** F3.
+4. **(Already filed) `#1220` subagent worktree isolation for non-implementer types** — Confirm scoped + prioritized in v2.9.0. No new issue. **Addresses:** F1 (highest residual leverage).
+5. **`feat(shepherd): long-running headless daemon entry point` (sibling of `#1120`)** — Only if `#1120` design doesn't already cover. **Milestone:** v2.11.0.
+6. **`spike: roadmap-to-merged-epic autopilot — design only`** — `status:backlog`, no milestone. Gate on v2.11.0 closure. Must include human-checkpoint UX, basileus-overlap analysis, and a small-epic integration test plan. **Addresses:** "On The Horizon (c)".
+
+---
+
+## 5. Cross-cutting verification
+
+This discovery itself touches `#1109` invariants only as analysis input — no code or schema changes here. The proposed backlog items must each carry the `## #1109 Invariant Verification` block when filed:
+
+- Items 1, 2, 3, 5, 6: event-sourcing integrity (events emitted? projections read? reconstructable?), MCP parity (CLI ↔ MCP envelope identical?), basileus-forward (no MCP-second-class assumptions?), capability resolution (no runtime yaml reads?).
+- Item 4 (`#1220`) is plumbing in the subagent harness — verification block applies on the implementing PR.
+
+## 6. Out of scope
+
+- Per-PR "ultrareview"-style autonomous review composition — Phronesis territory (basileus / v3.2.0).
+- Custom-user-authored workflows beyond what `#1258` v3.1.0 already covers — gated on Workflow Builder SDK landing.
+- GUI surfaces — explicitly excluded by `feedback_extensibility_design_envelope.md`.

--- a/docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md
+++ b/docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md
@@ -2,8 +2,8 @@
 
 **Workflow:** `v29-bug-cluster` (feature)
 **Date:** 2026-05-06
-**Status:** Design — pending plan-review and TDD plan
-**Closes:** #1230, #1228, #1241, #1226, #1224, #1220, #1225, #1117
+**Status:** Shipped (2026-05-08) — primitives + C2 consumer migration both landed on `feature/v29-bug-cluster`
+**Closes:** #1230, #1228, #1241, #1226, #1224, #1220, #1225, #1117, #1293
 **Related spikes:** #1239 (parent — checkpoint handoff enrichment), #1259 (follow-up — durable substrate, v2.10.0)
 **Cross-cutting:** #1109 (event-sourcing + MCP parity + basileus-forward)
 

--- a/docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md
+++ b/docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md
@@ -7,6 +7,14 @@
 **Related spikes:** #1239 (parent — checkpoint handoff enrichment), #1259 (follow-up — durable substrate, v2.10.0)
 **Cross-cutting:** #1109 (event-sourcing + MCP parity + basileus-forward)
 
+> **C2 closure note (2026-05-08):** the originally-deferred consumer
+> migration (the second half of the F1 family fix) shipped in #1293 on
+> this branch. PR #1265's primitives now have all consumers wired to
+> them; legacy four-phase `EventStore.append` machinery deleted.
+> Race regression tests (`store.race.test.ts`) close the cross-path
+> window CodeRabbit and Sentry both flagged on the post-fix re-review.
+> Migration design: [`docs/designs/2026-05-08-eventstore-appender-consumer-migration.md`](2026-05-08-eventstore-appender-consumer-migration.md).
+
 ## Problem
 
 Eight open bugs in milestone v2.9.0 collectively block production wiring of the checkpoint handoff enrichment work (#1240–#1246) and any further feature work that touches the event store, subagent dispatch, or workflow state machine. They are not eight independent defects — they cluster into three root-cause families.

--- a/docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md
+++ b/docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md
@@ -1,0 +1,377 @@
+# v2.9.0 bug cluster — combined-fix design (Approach B)
+
+**Workflow:** `v29-bug-cluster` (feature)
+**Date:** 2026-05-06
+**Status:** Design — pending plan-review and TDD plan
+**Closes:** #1230, #1228, #1241, #1226, #1224, #1220, #1225, #1117
+**Related spikes:** #1239 (parent — checkpoint handoff enrichment), #1259 (follow-up — durable substrate, v2.10.0)
+**Cross-cutting:** #1109 (event-sourcing + MCP parity + basileus-forward)
+
+## Problem
+
+Eight open bugs in milestone v2.9.0 collectively block production wiring of the checkpoint handoff enrichment work (#1240–#1246) and any further feature work that touches the event store, subagent dispatch, or workflow state machine. They are not eight independent defects — they cluster into three root-cause families.
+
+| Family | Bugs | Substrate |
+|---|---|---|
+| F1 — Event-store atomicity gap | #1230, #1228, #1241, #1226 | Multi-phase non-transactional append in `servers/exarchos-mcp/src/event-store/store.ts` |
+| F2 — Cross-stream propagation under subagent isolation | #1220 (priority:high), #1224 | Capability declaration mismatch in agent specs + missing parent-stream emission in team coordinator |
+| F3 — Capability/contract enforcement gaps | #1225, #1117 | HSM transition write path bypasses guard evaluation; pruner staleness uses single read-refreshed signal |
+
+The fixes are not interchangeable orderings. F1 must be transactional before #1241's payload-digest key has stable semantics. F2 must land #1220 and #1224 together — fixing #1220 alone (more agents → more isolated streams) would worsen #1224. F3 is two independent fixes coupled only by the milestone.
+
+## Recommendation summary
+
+Three invariant-bearing primitives in `servers/exarchos-mcp/src/`, each with a concrete consumer-side patch closing one or more bugs, plus three surgical fixes for bugs that don't warrant a new primitive. One PR, ~8 commits, eight bugs closed, #1109 verification checklist green by construction.
+
+The three primitives are **interface-shaped to be replaceable** in the v2.10.0 durability spike (#1259). Approach B is the surgical move that codifies invariants today; Approach C swaps substrate behind those interfaces tomorrow without consumer changes.
+
+## Cross-cutting compliance (#1109)
+
+| Constraint | Compliance |
+|---|---|
+| C1 — event-sourcing integrity | F1 restores replay determinism (sequence uniqueness + commit-on-success idempotency). F2 ensures parent-stream events match committed work. F3 prevents guard-violating transitions from reaching the event log. Replay reconstructs identical state. |
+| C2 — MCP parity | Single dispatch core unchanged. Both facades route through the same handlers. New primitives are server-internal. |
+| C3 — basileus-forward | Primitives are transport-agnostic. The cross-stream router (F2) is the local analog of remote workflow propagation; #1259 generalizes it. |
+
+## Backend-quality compliance (axiom)
+
+| Dimension | Constraint applied to this design |
+|---|---|
+| DIM-1 Topology | Single writer per family — `AtomicAppender` for events, `SubagentStreamRouter` for cross-stream propagation, `HSMTransitionGuard.fail_closed` for phase transitions. No parallel paths. |
+| DIM-2 Observability | Every fail-closed path emits a structured rejection (e.g. `IDEMPOTENCY_CLAIMED`, `GUARD_FAILED`); no silent drops. `success: true` becomes a contract: returns true only after durable commit. |
+| DIM-3 Contracts | `AtomicAppender.append` returns `Result<{sequences}, Reason>` — explicit success/failure replaces today's silent-drop semantics. Posture-derived isolation declared at the spec level (#1220 surgical fix). |
+| DIM-4 Test fidelity | Roundtrip tests exercise the same wiring as production: real `AtomicAppender`, real projection store, no mocked event boundaries. `assertParity` for CLI/MCP. |
+| DIM-5 Hygiene | The four-phase append in `store.ts` collapses to one entry point. `team.disbanded.tasksCompleted` stops being a doubly-bookkept counter. |
+| DIM-6 Architecture | Primitives have single responsibility and no upward dependencies. Replaceable behind their interface (proves out in #1259). |
+| DIM-7 Resilience | Bounded retry on `AtomicAppender` failure with structured reasons. Pruner gains multi-signal staleness scoring (no single point of mis-classification). |
+
+## Primitive 1 — `AtomicAppender`
+
+**Closes:** #1230, #1228, #1241 (#1226 closed via consumer-side dedup once duplicates can't enter the stream)
+
+### Why
+
+Today the append path in `servers/exarchos-mcp/src/event-store/store.ts:529–751` is four phases with no atomic boundary:
+
+1. Read sequence counter (in-memory or `.seq` file)
+2. Write JSONL
+3. Write `.seq` file (best-effort; can fail silently)
+4. Cache `idempotencyKey` (skipped if step 2 or 3 throws)
+
+Concurrent appenders allocate overlapping sequences (#1230). Partial failures leave `idempotencyKey` claimed-as-pending without an event in the log (#1228 phantom claim). The handler returns `success: true` regardless. Refinement of `handleCheckpoint` (#1241) collides on the version-only key, lands on the phantom-claim path, returns `success: true`, drops the event.
+
+### Interface
+
+```ts
+// servers/exarchos-mcp/src/event-store/atomic-appender.ts
+export type AppendResult =
+  | { ok: true; sequences: number[]; eventIds: string[] }
+  | { ok: false; reason: 'idempotency-claimed' | 'sequence-conflict' | 'io-error'; cause?: Error };
+
+export interface AtomicAppender {
+  append(streamId: string, events: EventInput[], idempotencyKey: string): Promise<AppendResult>;
+  query(streamId: string, opts?: QueryOpts): Promise<Event[]>;
+  // Existing read paths unchanged.
+}
+```
+
+### Behavior contract
+
+- **Atomicity.** A successful return guarantees: sequences allocated, events written to JSONL, `.seq` file durably updated, `idempotencyKey` cached. A failed return guarantees: zero of the above (no partial commit).
+- **Sequence uniqueness.** Within a stream, no two successful appends ever return overlapping sequence ranges. Enforced by serializing append operations on a per-stream lock — single writer per stream at any instant.
+- **Idempotency commit-on-success.** `idempotencyKey` is added to the cache *only* after JSONL write and `.seq` write both succeed. A failed append leaves the key uncommitted; retries are admissible.
+- **Failure observability.** Every failure mode returns a structured `reason`. No `catch { return { success: true } }`. Callers receive enough information to decide retry vs surface vs degrade.
+
+### Implementation sketch (v2.9.0)
+
+Per-stream `Mutex` (using `async-mutex` or a small inline implementation) wrapping the four-phase write. `idempotencyKey` cache mutation moved to *after* the JSONL + `.seq` writes both resolve. Failures unwind any partial state by *not* writing it — there is no rollback because there are no commits to roll back. The mutex is in-process; cross-process contention on the same JSONL file is out of scope for v2.9.0 and is exactly what the #1259 spike resolves with SQLite WAL.
+
+### Consumer changes
+
+- `handleEventBatchAppend` in `servers/exarchos-mcp/src/event/tools.ts` — switch from current path to `appender.append(...)`; surface structured failures instead of `success: true` over silent drops.
+- `handleCheckpoint` in `servers/exarchos-mcp/src/workflow/tools.ts:988` — change `idempotencyKey` from `${featureId}:checkpoint:${phase}:${state._version}` to `${featureId}:checkpoint:${phase}:${state._version}:${handoffDigest}` where `handoffDigest = sha256(JSON.stringify(input.handoff ?? {})).slice(0, 16)`. A no-handoff checkpoint keeps the prior key shape (digest of `{}` is stable), so historical replay is unaffected. This change is independent of the substrate — it ships in this PR alongside the appender, not after.
+
+### B → C seam
+
+The `AtomicAppender` interface is the seam #1259's SQLite implementation drops into. Same return shape, same failure reasons, same per-stream serialization semantics. Consumers don't move.
+
+## Primitive 2 — `SubagentStreamRouter`
+
+**Closes:** #1224. Couples with #1220 surgical fix below.
+
+### Why
+
+Subagents in isolated worktrees emit `task.completed` events to their child stream. The team coordinator runs in the main worktree, accumulates an in-memory completion count, and emits `team.disbanded` with that count — but never propagates the underlying `task.completed` events to the parent stream. The parent's projection sees a `team.disbanded` claim with no supporting events. The all-tasks-complete guard (in #1225's transition) relies on parent-stream presence, so the workflow looks done when it isn't.
+
+Because today's append substrate doesn't support concurrent writers across processes well (JSONL + lockfile is brittle), the simplest v2.9.0 fix is an explicit emit on the coordinator's side. #1259 generalizes this to a query over namespaced shared streams.
+
+### Interface
+
+```ts
+// servers/exarchos-mcp/src/agents/subagent-stream-router.ts
+export interface SubagentStreamRouter {
+  onTaskCompleted(parentStreamId: string, childStreamId: string, taskId: string, payload: TaskCompletedPayload): Promise<void>;
+  emitDisbanded(parentStreamId: string, summary: DisbandedSummary): Promise<void>;
+}
+```
+
+### Behavior contract
+
+- **Causal ordering.** For each task that completed in a child stream, the corresponding `task.completed` event lands in the parent stream *before* `team.disbanded`. Single-writer ordering is enforced by routing both events through `AtomicAppender` on the parent stream.
+- **Source of truth.** `team.disbanded.tasksCompleted` is computed from the parent stream's `task.completed` event count at emission time, never from an in-memory accumulator. The double-bookkeeping that produces #1224's off-by-N gets removed.
+- **Idempotency.** Each child task gets a single `task.completed` parent-stream event keyed by `<childStreamId>:<taskId>`. Replays don't multiply.
+
+### Implementation sketch
+
+The team coordinator (current location to be confirmed during implementation; likely in `servers/exarchos-mcp/src/orchestrate/dispatch.ts` or `agents/team-coordinator.ts`) is refactored to:
+
+1. On child-stream `task.completed` — route through `SubagentStreamRouter.onTaskCompleted` which appends a `task.completed` event to the parent stream via the parent's `AtomicAppender`.
+2. On disband — query the parent stream for `task.completed` count *for this team's tasks*, populate `tasksCompleted` from that, append `team.disbanded`.
+
+Concrete child-stream → parent-stream wiring depends on whether the coordinator already holds parent-stream references at child-event-receipt time. If not, the team metadata (parent stream id, task id list) is captured at dispatch time and threaded through.
+
+### Consumer changes
+
+- `team-coordinator` (path TBD at implementation) — replace counter accumulator with router calls.
+- Any test fixtures that asserted on the in-memory counter shape — move to assertions against the parent stream.
+
+### B → C seam
+
+The router becomes a thin pass-through over namespaced SQLite reads in #1259: parent-stream "view" is `SELECT * FROM events WHERE stream_id LIKE '<parent>/%' ORDER BY sequence`. The interface stays; the implementation flattens to a query.
+
+## Primitive 3 — `HSMTransitionGuard.fail_closed`
+
+**Closes:** #1225.
+
+### Why
+
+The HSM transition table at `servers/exarchos-mcp/src/workflow/hsm-definitions.ts:201–206` declares the `delegate→review` transition with a non-advisory composite guard (`all-tasks-complete+team-disbanded`). Guards are correctly evaluated and emit `workflow.guard-failed` when they fail. But the `workflow.set({ phase: 'review' })` orchestration write path doesn't consult guards — it writes the transition directly. So the transition lands ~6s after `workflow.guard-failed` fires for the same target phase. The event log records both events.
+
+This is a missing fail-closed invariant on the dispatcher. The substrate fix in #1259 removes the `workflow.set({ phase })` API entirely; the v2.9.0 fix introduces strict mode as an opt-in flag that becomes the primary flag in this codebase.
+
+### Interface
+
+```ts
+// servers/exarchos-mcp/src/workflow/hsm-transition-guard.ts
+export interface HSMTransitionGuard {
+  attempt(featureId: string, currentPhase: string, targetPhase: string, context: GuardContext): Promise<TransitionResult>;
+}
+
+export type TransitionResult =
+  | { ok: true; transitionEvent: WorkflowTransitionEvent }
+  | { ok: false; reason: 'guard-failed'; failures: GuardFailure[] }
+  | { ok: false; reason: 'no-transition-defined' };
+```
+
+### Behavior contract
+
+- **Single decision point.** Every phase transition flows through `HSMTransitionGuard.attempt`. There is no second write path that bypasses guard evaluation.
+- **Atomicity of guard + transition.** A successful return appends the `workflow.transition` event. A failed return appends only `workflow.guard-failed`. Both events are never appended for the same target phase in the same attempt.
+- **Strict by default.** `workflow.set({ phase })` is patched to delegate to `attempt`; the existing `set` API on non-phase fields is unchanged. Callers passing a `phase` field receive a structured failure, not a silent write.
+
+### Implementation sketch
+
+`workflow.set` in `servers/exarchos-mcp/src/workflow/tools.ts` adds a check: if `updates` includes `phase`, route through `HSMTransitionGuard.attempt(currentPhase, updates.phase, ...)` and apply the transition event only on `ok: true`. The existing guard composition logic in `workflow/guards.ts` is reused; this primitive owns the dispatch contract, not the guard evaluation.
+
+### Consumer changes
+
+- `workflow.set` handler — phase routing.
+- Any in-tree caller of `workflow.set({ phase })` that relied on the bypass — surfaced at type level once the route is added; migrated to use the same call (semantics now correct).
+
+### B → C seam
+
+#1259 removes the `phase` field from `workflow.set`'s input schema entirely; callers migrate to `workflow.transition(target)`. Strict mode goes from "the way it works" to "the only way it can work."
+
+## Surgical fixes (no primitive needed)
+
+### #1226 — `workflow_status` projection dedup
+
+`servers/exarchos-mcp/src/views/workflow-status-view.ts:22–82` increments `tasksCompleted` on every `task.completed` event seen during projection fold. Once `AtomicAppender` and `SubagentStreamRouter` make duplicate `task.completed` events impossible at write time, replay-time duplication can still occur for events written before this PR. Add task-id-keyed dedup in the projection: maintain a `Set<taskId>` during fold; increment only on first occurrence per task. Same fix applies symmetrically to `tasksTotal` if the bug repros there.
+
+This is the right shape regardless of substrate — projections should be idempotent under replay.
+
+### #1117 — pruner multi-signal staleness
+
+`servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts:96–173` gates staleness on `_checkpoint.lastActivityTimestamp`, refreshed by any MCP read. Add two secondary signals to `selectPruneCandidates`:
+
+- **`phaseTransitionTimestamp`** — last `workflow.transition` event's timestamp. Captures "stuck in phase X for N days" even when reads keep activity fresh.
+- **`branchActivity`** — `git log -1 --format=%ct` on the feature branch when the workflow tracks a branch. Captures "branch hasn't moved" as an independent signal.
+
+Staleness becomes the AND of `lastActivityTimestamp > threshold` OR (`phaseTransitionTimestamp > threshold` AND no branch activity in window). The exact composition gets refined in TDD; the contract is multi-signal scoring rather than single-signal heuristic.
+
+#1259 generalizes this to phase-declared activity contracts. v2.9.0 ships hardcoded signal composition; v2.10/v2.11 generalizes to a contract.
+
+### #1220 — agent capability declaration
+
+`servers/exarchos-mcp/src/agents/definitions.ts` — the FIXER spec at `:150–214` and the SCAFFOLDER spec at `:296–358` declare `fs:write` + `shell:exec` but lack `'isolation:worktree'` in their capability arrays. The Claude adapter at `agents/adapters/claude.ts:135–137` only renders worktree isolation when that capability is present. Three-line fix: add `'isolation:worktree'` to both capability arrays. Reviewer spec gets the same review (per #1220's title — "all task-isolated agent types").
+
+The declarative type-level enforcement (impossible-to-misdeclare specs) is the #1259 C5 work; v2.9.0 does the data fix.
+
+## Bug → fix matrix
+
+| Bug | Closed by | How |
+|---|---|---|
+| #1230 | `AtomicAppender` | Per-stream serialization makes duplicate sequence allocation impossible at append time. |
+| #1228 | `AtomicAppender` | Idempotency commit-on-success eliminates phantom-claim path; `success: true` becomes truthful. |
+| #1241 | `AtomicAppender` + payload-digest idempotencyKey | Refinement calls within same phase land as distinct events because key digests differ. |
+| #1226 | Projection dedup (surgical) + `AtomicAppender` upstream | Projection becomes replay-idempotent; new events can't duplicate. |
+| #1224 | `SubagentStreamRouter` | Parent-stream `task.completed` emission before `team.disbanded`; counts queried not accumulated. |
+| #1220 | Capability declaration (surgical) | Add `'isolation:worktree'` to FIXER/SCAFFOLDER specs. |
+| #1225 | `HSMTransitionGuard.fail_closed` | `workflow.set({ phase })` routes through guard; transition appears in log only on `ok: true`. |
+| #1117 | Multi-signal pruner (surgical) | Add `phaseTransitionTimestamp` + `branchActivity` signals to staleness scoring. |
+
+## Test strategy (TDD red-green per fix)
+
+Each fix lands as a separate commit with a failing test first. Co-located test files per existing convention.
+
+### Family F1 (event-store atomicity)
+
+```ts
+// store.test.ts
+it('serializes concurrent appends — no duplicate sequences', async () => {
+  const appender = new AtomicAppender(streamPath);
+  const results = await Promise.all([
+    appender.append('s1', [evt1], 'k1'),
+    appender.append('s1', [evt2], 'k2'),
+    appender.append('s1', [evt3], 'k3'),
+  ]);
+  const sequences = results.flatMap(r => r.ok ? r.sequences : []);
+  expect(new Set(sequences).size).toBe(sequences.length);
+  expect(sequences.sort()).toEqual([1, 2, 3]);
+});
+
+it('does not commit idempotencyKey when JSONL write fails', async () => {
+  const appender = new AtomicAppender(streamPath, { writeFn: failingWriter });
+  const r = await appender.append('s1', [evt1], 'k1');
+  expect(r.ok).toBe(false);
+  // Retry must be admissible — key must be unclaimed.
+  const r2 = await appender.append('s1', [evt1], 'k1', { writeFn: succeedingWriter });
+  expect(r2.ok).toBe(true);
+});
+
+// tools.test.ts
+it('checkpoint refinement in same phase lands two events (#1241 regression)', async () => {
+  await handleCheckpoint({ featureId, handoff: { context: 'first' } }, ctx);
+  await handleCheckpoint({ featureId, handoff: { context: 'second' } }, ctx);
+  const events = await ctx.eventStore.query(featureId, { type: 'workflow.checkpoint' });
+  expect(events).toHaveLength(2);
+});
+```
+
+### Family F2 (cross-stream + capability)
+
+```ts
+// subagent-stream-router.test.ts
+it('emits parent-stream task.completed before team.disbanded', async () => {
+  await router.onTaskCompleted('parent', 'child-1', 'task-1', payload);
+  await router.emitDisbanded('parent', summary);
+  const events = await parentStream.query();
+  const completedIdx = events.findIndex(e => e.type === 'task.completed');
+  const disbandedIdx = events.findIndex(e => e.type === 'team.disbanded');
+  expect(completedIdx).toBeLessThan(disbandedIdx);
+});
+
+it('team.disbanded.tasksCompleted reflects parent-stream count, not in-memory tally', async () => {
+  // Arrange: 3 child tasks complete, but coordinator's in-memory counter is corrupted.
+  // Assert: emitted disbanded.tasksCompleted equals parent-stream task.completed count.
+});
+
+// definitions.test.ts (#1220)
+it('FIXER spec declares isolation:worktree', () => {
+  expect(FIXER.capabilities).toContain('isolation:worktree');
+});
+it('SCAFFOLDER spec declares isolation:worktree', () => {
+  expect(SCAFFOLDER.capabilities).toContain('isolation:worktree');
+});
+```
+
+### Family F3 (guards + pruner)
+
+```ts
+// hsm-transition-guard.test.ts
+it('workflow.set with phase routes through guard; failed guard does not transition', async () => {
+  // Arrange: state where allTasksComplete returns failure.
+  const r = await workflow.set(featureId, { phase: 'review' });
+  expect(r.ok).toBe(false);
+  const events = await eventStore.query(featureId);
+  expect(events.find(e => e.type === 'workflow.transition' && e.data.to === 'review')).toBeUndefined();
+  expect(events.find(e => e.type === 'workflow.guard-failed')).toBeDefined();
+});
+
+// prune-stale-workflows.test.ts
+it('flags stuck workflow even when read activity is fresh', async () => {
+  // Arrange: workflow with phase X entered 7 days ago; lastActivityTimestamp updated 1h ago by read.
+  const candidates = await selectPruneCandidates(entries, config, now);
+  expect(candidates.map(c => c.featureId)).toContain('stuck-workflow');
+});
+```
+
+### Replay determinism (#1109 C1 verification)
+
+```ts
+it('replay reconstructs identical projection state across all closed bugs', async () => {
+  // For each bug-shaped scenario: build event log, project once, project again from scratch, byte-compare.
+});
+```
+
+## Implementation sequencing
+
+Single PR, ~8 commits, in this order:
+
+1. `AtomicAppender` interface + impl + tests (closes #1230, #1228 at substrate level)
+2. `handleEventBatchAppend` migrated to `AtomicAppender`
+3. `handleCheckpoint` payload-digest key + migrated to `AtomicAppender` (closes #1241)
+4. `workflow_status` projection dedup (closes #1226)
+5. FIXER/SCAFFOLDER capability declarations (closes #1220)
+6. `SubagentStreamRouter` interface + impl + tests + team-coordinator migration (closes #1224)
+7. `HSMTransitionGuard.fail_closed` + `workflow.set` routing (closes #1225)
+8. Pruner multi-signal staleness (closes #1117)
+
+Each commit is independently reviewable. Each closes its bug(s) with regression tests. The PR description includes the #1109 verification checklist.
+
+## Migration / risk
+
+- **No on-disk format change.** JSONL + `.seq` substrate is unchanged. Existing event logs in `~/.claude/workflow-state/` continue to work. The `AtomicAppender` mutex is in-process; existing readers (replay, projection) see no change.
+- **Backwards compatibility.** `workflow.set({ phase })` callers continue to function; semantics are now correct (guard-checked) rather than fail-open. The public API is unchanged.
+- **Existing tests.** Unit tests that mocked the four-phase append path may need updates to mock `AtomicAppender` instead. Integration tests that exercised the silent-drop path will fail by design — they should be updated to assert structured failure.
+- **Capability declaration fix.** Adding `'isolation:worktree'` to FIXER/SCAFFOLDER changes the dispatch shape for those agents. Existing in-flight team dispatches that relied on the broken behavior will now correctly isolate; this is the desired outcome but should be smoke-tested before release.
+
+## Future work — Approach C (#1259)
+
+The three primitives in this design are interface-shaped to be replaced wholesale by Approach C (the v2.10.0 spike). The B → C evolution map:
+
+| B primitive | C replacement | Consumer change |
+|---|---|---|
+| `AtomicAppender` (mutex over JSONL+seq) | SQLite + WAL-backed; `PRIMARY KEY (stream_id, sequence)` enforces uniqueness; `UNIQUE` index on `idempotency_key` makes claim/commit atomic | None. Same interface. |
+| `SubagentStreamRouter` (explicit parent emit) | Thin pass-through over namespaced SQLite reads (`stream_id LIKE 'parent/%'`) | Coordinator stops accumulating counts; queries the store. |
+| `HSMTransitionGuard.fail_closed` (strict-mode flag) | Strict mode is the only mode; `workflow.set({ phase })` removed | Callers migrate from `set({ phase })` to `transition(target)`. |
+| Surgical capability declaration | Posture-derived capability (`AgentPosture` type) | Specs migrate from capability arrays to a `posture` field. |
+| Surgical multi-signal pruner | Phase-declared activity contract; pruner becomes a generic scorer | Phase playbooks add `staleness_signals`. |
+
+This is the essential property: B is C-shaped, not C-blocked. Three of five C moves require zero consumer changes; two are additive.
+
+## Open follow-up issues
+
+- **#1259** — durable substrate spike (v2.10.0). Investigates SQLite-backed `AtomicAppender`, namespaced shared streams, single-path HSM API, posture-derived capabilities, phase activity contracts.
+- **#1240–#1246** — checkpoint handoff enrichment work. Hard-blocked on this PR. Lands after merge.
+- **#1118** — codify event-sourcing principles. Partial advance; #1259 completes.
+
+## Decision log
+
+| Decision | Alternative considered | Why rejected |
+|---|---|---|
+| Three primitives + three surgical fixes | All-surgical (Approach A) | Bug-shaped fixes don't codify invariants; same class re-emerges. |
+| Three primitives + three surgical fixes | Full substrate refactor (Approach C) | Substrate refactor *becomes* the next feature work; misses v2.9.0 release window. |
+| In-process mutex on `AtomicAppender` | File-system advisory lock | Cross-process coordination is exactly what #1259 solves with SQLite WAL; in-process is sufficient for v2.9.0's concurrency model. |
+| Explicit parent emit in `SubagentStreamRouter` | Shared event store with namespaced streams | Shared store requires cross-process atomic writers — out of scope for v2.9.0; in scope for #1259. |
+| `HSMTransitionGuard.fail_closed` as routing in `workflow.set` | Remove `workflow.set({ phase })` API | API removal is a breaking change; defer to #1259. |
+| Surgical multi-signal pruner | Phase activity contract | Contract needs a schema location decision (yaml topology vs Zod); defer to #1259. |
+| Surgical capability declaration | Posture-derived capability | Type-level enforcement requires schema rev across all agent specs; defer to #1259. |
+| Payload-digest checkpoint key in this PR | Defer to #1240 | Hard prerequisite for #1240 per #1241; ship together to avoid silent-dedup regression window. |
+
+## Verification checklist (#1109 PR section)
+
+- [ ] **Event-sourcing:** `AtomicAppender` events emitted; `SubagentStreamRouter` parent-stream events emitted; `HSMTransitionGuard.fail_closed` `workflow.transition` / `workflow.guard-failed` events emitted. Replay reconstructs identical projection state (verified by replay determinism test).
+- [ ] **MCP parity:** No new CLI/MCP branch. `assertParity` test pair confirms identical output for `workflow_status`, `event_batch_append`, `workflow_checkpoint`, `workflow_set` after the fix.
+- [ ] **Basileus-forward:** No hard-coded MCP-local-only assumption. `SubagentStreamRouter` interface is the local analog of #1259's namespaced-stream model.
+- [ ] **Capability resolution:** No yaml-runtime read introduced. The capability declaration fix is on-disk producer-side; #1139 covers the runtime consumer.

--- a/docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md
+++ b/docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md
@@ -205,7 +205,8 @@ This is the right shape regardless of substrate — projections should be idempo
 - **`phaseTransitionTimestamp`** — last `workflow.transition` event's timestamp. Captures "stuck in phase X for N days" even when reads keep activity fresh.
 - **`branchActivity`** — `git log -1 --format=%ct` on the feature branch when the workflow tracks a branch. Captures "branch hasn't moved" as an independent signal.
 
-Staleness becomes the AND of `lastActivityTimestamp > threshold` OR (`phaseTransitionTimestamp > threshold` AND no branch activity in window). The exact composition gets refined in TDD; the contract is multi-signal scoring rather than single-signal heuristic.
+Shipped composition (per `prune-stale-workflows.ts:248`):
+`isStale = phaseStale && (lastActivityStale || branchInactive)`. The phase-stale gate is the dominant predicate — recent phase progress alone keeps a workflow fresh — and the inner OR closes the false-fresh path that #1117 originally caught (orchestrator polls keep `lastActivityTimestamp` artificially fresh, but no branch activity over the window flips `branchInactive` true and the workflow is flagged). When neither secondary signal is supplied, the legacy single-signal `lastActivityStale` path is preserved for backward compat.
 
 #1259 generalizes this to phase-declared activity contracts. v2.9.0 ships hardcoded signal composition; v2.10/v2.11 generalizes to a contract.
 

--- a/docs/designs/2026-05-08-eventstore-appender-consumer-migration.md
+++ b/docs/designs/2026-05-08-eventstore-appender-consumer-migration.md
@@ -1,0 +1,167 @@
+---
+title: EventStore consumer migration to AtomicAppender (C2 completion)
+date: 2026-05-08
+status: design
+tracking: "#1293"
+related: ["#1224", "#1228", "#1230", "#1259", "#1265"]
+---
+
+# EventStore consumer migration to AtomicAppender
+
+## Problem
+
+`EventStore.append`, `appendValidated`, and `batchAppend` operate through a
+separate per-stream lock + in-memory sequence counter + idempotency cache
+from `AtomicAppender` (the substrate added in PR #1265's C1). Both write the
+same `<stream>.events.jsonl` files. The lock graphs are disjoint, so:
+
+- Concurrent appends across the two paths can allocate the same sequence.
+- Idempotency dedup is not coordinated across paths.
+- Sidecar / outbox / backend wiring lives only on the legacy path.
+
+CodeRabbit flagged the architectural gap on the initial #1265 review
+(thread 3199528959). After the bug-cluster fixes shipped, Sentry's
+re-review found the race firing in code:
+
+> *"Concurrent calls to `handleEventAppend` and `handleBatchAppend` can cause
+> a race condition" — `event-store/tools.ts:424`*
+
+The C2 consumer migration was scoped out of #1265 and filed as #1293. This
+refactor closes it.
+
+## Bugs this fully resolves
+
+| Bug | Currently mitigated for | This refactor closes |
+|---|---|---|
+| #1228 phantom idempotencyKey on partial-write failure | Path B only (batch + router) | Path A (single appends + HSM transitions) |
+| #1230 overlapping sequence allocation | Path B only | Path A |
+| #1224 off-by-N `tasksCompleted` | Surface fixed; substrate race open on same stream | Substrate race |
+
+## Goals
+
+1. All EventStore append paths route through `AtomicAppender`; legacy
+   four-phase logic deleted.
+2. Sidecar mode, outbox replication, backend dual-write, schema validation,
+   and `expectedSequence` semantics preserved.
+3. Idempotency-key contract preserved — legacy "no key = no dedup" surfaced
+   as an explicit `appendUnkeyed` primitive (not synthetic keys).
+4. `EventStore` becomes a thin wrapper around an appender abstraction so
+   #1259's SQLite backend is a one-line swap at the construction site.
+5. All existing tests pass; new regression test covers the cross-path race.
+
+## Key decisions
+
+### D1 — Idempotency-key adapter shape: explicit `appendUnkeyed`
+
+Legacy `EventStore.append` accepts no key (skips dedup). `AtomicAppender`
+requires a non-empty key. Two options were weighed:
+
+- **(rejected) Synthesize `event:${randomUUID()}` per call.** Leaky
+  abstraction — the cache fills with one-shot keys that FIFO-evict
+  legitimate retry keys. With the 200-key cap, ~200 unkeyed appends can
+  evict every dedup entry (D4 operational resilience violation, axiom).
+- **(chosen) Add `appendUnkeyed(streamId, events)` to `AtomicAppender`.**
+  Explicit at call site, no cache pollution. ~10 lines: a thin wrapper
+  around a private `appendLocked` that takes a `keyed: boolean` flag.
+
+### D2 — `expectedSequence` support: native parameter on `append`
+
+Two options:
+
+- **(rejected) Expose `runExclusive` so `EventStore` pre-checks under the
+  lock.** Re-entrancy hazard — same footgun we documented for
+  `appendComputed` ("must NOT call back into append for the same
+  streamId"). Invites deadlocks at consumer sites.
+- **(chosen) Add fourth options parameter:**
+  `append(streamId, events, idempotencyKey, options?: { expectedSequence?: number })`.
+  Concurrency control stays inside one class. Inside `appendLocked` (already
+  under the lock), compare `sequenceCounters.get(streamId) ?? 0` against
+  `expectedSequence` after the rebuild step; return
+  `{ ok: false, reason: 'sequence-conflict' }` (already in the
+  `AppendResult` union).
+
+### D3 — PR strategy: standalone after #1265 merges
+
+#1265 is at approval-pending with all original threads addressed and CI
+green. Stacking this refactor risks re-litigation of the 7 already-approved
+fixes. Per axiom D2/D3: one PR = one concern.
+
+This refactor's TDD red test = Sentry's race finding. Direct line from
+observation to fix.
+
+## Architecture after migration
+
+```text
+                                      consumers
+                                          │
+                                          ▼
+                              ┌───────────────────────┐
+                              │      EventStore       │
+                              │  (thin orchestration) │
+                              ├───────────────────────┤
+                              │  - sidecar routing    │
+                              │  - outbox wrap        │
+                              │  - backend dual-write │
+                              │  - schema validation  │
+                              │  - expectedSequence   │
+                              └─────────┬─────────────┘
+                                        │ delegate
+                                        ▼
+                              ┌───────────────────────┐
+                              │    AtomicAppender     │
+                              │  (single substrate)   │
+                              ├───────────────────────┤
+                              │  - per-stream lock    │
+                              │  - sequence allocate  │
+                              │  - idempotency cache  │
+                              │  - JSONL write        │
+                              │  - .seq write         │
+                              │  - rollback           │
+                              └───────────────────────┘
+                                        │
+                                        ▼
+                              <stream>.events.jsonl
+                              <stream>.seq
+
+#1259 swap point: replace `new AtomicAppender(...)` at the EventStore
+constructor with `new SqliteAppender(...)`. Same `AppendResult` shape,
+same per-stream serialization semantics.
+```
+
+## Out of scope
+
+- SQLite backend implementation itself (#1259).
+- Outbox protocol changes — kept supplementary, behavior unchanged.
+- Backend interface changes — `appendEvent` hook called the same way.
+- Sidecar protocol changes — `writeToSidecar` short-circuit kept
+  identical; unchanged tests prove it.
+
+## Success criteria
+
+1. **#1228 fully closed**: No phantom idempotencyKey claim on partial-write
+   failure for any append path. Verified by extending existing
+   `atomic-appender` partial-failure test to call through `EventStore.append`.
+2. **#1230 fully closed**: No overlapping sequence allocation under
+   concurrency for any append path. Verified by property test that drives
+   N concurrent appends across mixed paths and asserts strict sequence
+   monotonicity.
+3. **#1224 cross-path race window closed**: Concurrent `handleEventAppend`
+   (HSM transition) + `SubagentStreamRouter.emitDisbanded` on the same
+   stream produces no interleaving violations. Direct regression test.
+4. **Sentry race regression test passes**: Concurrent
+   `handleEventAppend` + `handleBatchAppend` on the same stream → strict
+   sequence monotonicity, no duplicate sequences, no JSONL corruption.
+5. **`EventStore` ≤ 500 LoC** after legacy cleanup (down from 1380).
+6. **#1259 swap is one-line**: Verified by adding a sketch comment at
+   the constructor showing the swap site, and by ensuring no consumer
+   reaches into appender internals.
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Sidecar-mode regression (writeToSidecar bypassed lock entirely) | Med | Keep short-circuit at top of each public method; existing sidecar tests gate the change |
+| Outbox ordering relative to JSONL flips | Low | Keep outbox call as post-append wrap; existing outbox tests gate |
+| `expectedSequence` semantics drift (was thrown error, becomes result) | Med | Translate `{ ok: false, reason: 'sequence-conflict' }` back to `SequenceConflictError` in EventStore wrapper to preserve caller contract |
+| Backend dual-write timing (was inside lock, becomes outside) | Low | Move backend call inside `AtomicAppender` via post-success hook, OR accept post-lock placement (backend is best-effort already) |
+| Tests poke at deleted private state | Med | Audit pass before delete; convert state-poking tests to behavior tests |

--- a/docs/designs/2026-05-08-eventstore-appender-consumer-migration.md
+++ b/docs/designs/2026-05-08-eventstore-appender-consumer-migration.md
@@ -1,10 +1,16 @@
 ---
 title: EventStore consumer migration to AtomicAppender (C2 completion)
 date: 2026-05-08
-status: design
+status: implemented
 tracking: "#1293"
 related: ["#1224", "#1228", "#1230", "#1259", "#1265"]
 ---
+
+> **Status: Implemented on `feature/v29-bug-cluster` (2026-05-08).**
+> Commits: B1 `33bdaef3` (primitives) → B2 `95708da4` (migration + race
+> tests) → B3 `1e0fae7c` (legacy delete) → B4 (this docs pass). All
+> 6393 tests pass; `store.race.test.ts` closes the cross-path race
+> window. #1259 swap is now a one-line change at `EventStore.getAppender()`.
 
 # EventStore consumer migration to AtomicAppender
 

--- a/docs/designs/2026-05-08-eventstore-appender-consumer-migration.md
+++ b/docs/designs/2026-05-08-eventstore-appender-consumer-migration.md
@@ -129,9 +129,10 @@ observation to fix.
                               <stream>.events.jsonl
                               <stream>.seq
 
-#1259 swap point: replace `new AtomicAppender(...)` at the EventStore
-constructor with `new SqliteAppender(...)`. Same `AppendResult` shape,
-same per-stream serialization semantics.
+#1259 swap point: replace `new AtomicAppender(...)` inside
+`EventStore.getAppender()` (the lazy-construction site) with
+`new SqliteAppender(...)`. Same `AppendResult` shape, same per-stream
+serialization semantics.
 ```
 
 ## Out of scope

--- a/docs/plans/2026-05-06-v29-bug-cluster-combined-fix.md
+++ b/docs/plans/2026-05-06-v29-bug-cluster-combined-fix.md
@@ -1,0 +1,589 @@
+# Implementation plan — v2.9.0 bug cluster combined fix
+
+**Design:** `docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md`
+**Workflow:** `v29-bug-cluster`
+**Date:** 2026-05-06
+**Iron law:** No production code without a failing test first.
+
+## Overview
+
+Single PR, 9 commits, eight bugs closed. Tasks are grouped by commit family. Each task is a discrete TDD step (RED → GREEN → REFACTOR) at 2–5 minute granularity. Test names follow `Method_Scenario_Outcome`.
+
+## Branch strategy
+
+- **Integration branch:** `feature/v29-bug-cluster`
+- **Per-commit branches:** `feature/v29-bug-cluster/<commit-id>` for parallel-safe commits, merged into integration in dependency order.
+
+## Wave decomposition (parallelization)
+
+```
+Wave 1 (parallel — independent files):
+  C1 AtomicAppender ───────────────────┐
+  C4 workflow_status dedup ─────────────┤
+  C5 capability declarations ───────────┼───→ Wave 2
+  C7 HSMTransitionGuard.fail_closed ────┤
+  C8 pruner multi-signal ──────────────┘
+
+Wave 2 (depend on AtomicAppender):
+  C2 event_batch_append migration ─────┐
+  C6 SubagentStreamRouter ─────────────┴───→ Wave 3
+
+Wave 3 (depend on C2):
+  C3 handleCheckpoint payload-digest ──────→ Wave 4
+
+Wave 4 (integration verification):
+  C9 replay determinism + parity tests
+```
+
+---
+
+## Commit C1 — `AtomicAppender` primitive
+
+Closes #1230, #1228 at substrate level.
+
+### Task 1.1 [RED] Test: concurrent appends produce unique sequences
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/event-store/atomic-appender.test.ts`
+   - Test: `AtomicAppender_concurrentAppends_uniqueMonotonicSequences`
+   - Expected failure: module does not exist
+2. Test asserts: 3 concurrent `append` calls on same `streamId` return disjoint sequence ranges; union sorted equals `[1,2,3]`.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 1.2 [RED] Test: failed JSONL write leaves idempotencyKey unclaimed
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/event-store/atomic-appender.test.ts`
+   - Test: `AtomicAppender_jsonlWriteFails_idempotencyKeyAdmissibleForRetry`
+   - Expected failure: module does not exist
+2. Test asserts: append with failing writer returns `{ok: false, reason: 'io-error'}`; subsequent retry with same idempotencyKey on a working writer returns `{ok: true}`.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 1.3 [RED] Test: structured failure on `.seq` write failure
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/event-store/atomic-appender.test.ts`
+   - Test: `AtomicAppender_seqFileWriteFails_returnsStructuredFailureNotSilentSuccess`
+   - Expected failure: module does not exist
+2. Test asserts: `.seq` write failure surfaces as `{ok: false, reason: 'io-error'}`, not `{success: true}`.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 1.4 [RED] Test: successful append commits all phases atomically
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/event-store/atomic-appender.test.ts`
+   - Test: `AtomicAppender_successfulAppend_commitsAllPhases`
+   - Expected failure: module does not exist
+2. Test asserts on success: events present in JSONL, `.seq` reflects max sequence, idempotencyKey cached. All three or none.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 1.5 [GREEN] Implement `AtomicAppender`
+
+1. Implement minimum code to pass 1.1–1.4
+   - File: `servers/exarchos-mcp/src/event-store/atomic-appender.ts`
+   - Per-stream `Mutex` (use `async-mutex` or inline `Promise`-chain mutex)
+   - Single `append(streamId, events, idempotencyKey)` method serialized under mutex
+   - Phase order: validate → allocate sequences → write JSONL → write `.seq` → cache idempotencyKey (only if all prior succeeded)
+   - Return discriminated `AppendResult`
+
+**Dependencies:** Tasks 1.1–1.4
+**Parallelizable:** No (within commit)
+
+### Task 1.6 [REFACTOR] Extract per-stream lock manager
+
+1. If lock acquisition logic clutters `append`, extract `StreamLockManager`.
+2. Otherwise skip.
+
+**Dependencies:** Task 1.5
+**Parallelizable:** No
+
+---
+
+## Commit C2 — `handleEventBatchAppend` migration
+
+Surfaces structured failures previously hidden by `success: true`.
+
+### Task 2.1 [RED] Test: partial failure surfaces structured error (#1228 regression)
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/event/tools.test.ts` (extend existing)
+   - Test: `handleEventBatchAppend_appenderFails_returnsStructuredErrorNotSilentSuccess`
+   - Expected failure: handler currently returns `{success: true}` regardless of underlying state.
+2. Test asserts: when `AtomicAppender` returns `{ok: false}`, handler returns a structured error envelope, not `{success: true}`.
+
+**Dependencies:** Commit C1 complete
+**Parallelizable:** Wave 2
+
+### Task 2.2 [RED] Test: concurrent batches no duplicate sequences (#1230 regression)
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/event/tools.test.ts`
+   - Test: `handleEventBatchAppend_concurrentCalls_noDuplicateSequences`
+   - Expected failure: existing four-phase path allocates duplicates.
+2. Test asserts: two concurrent `handleEventBatchAppend` calls produce events with disjoint sequence numbers in the resulting stream.
+
+**Dependencies:** Commit C1 complete
+**Parallelizable:** Wave 2
+
+### Task 2.3 [GREEN] Migrate handler to `AtomicAppender`
+
+1. Implement
+   - File: `servers/exarchos-mcp/src/event/tools.ts` (`handleEventBatchAppend`)
+   - Replace four-phase append with `appender.append(streamId, events, idempotencyKey)`
+   - Map `AppendResult` to existing handler envelope (success preserved on `ok: true`; failure surfaced explicitly on `ok: false`).
+2. Update any callers that branched on `{success: true}` shape.
+
+**Dependencies:** Tasks 2.1, 2.2
+**Parallelizable:** No (within commit)
+
+### Task 2.4 [REFACTOR] Remove dead four-phase code
+
+1. Delete unused helpers in `event-store/store.ts` once `handleEventBatchAppend` no longer references them.
+2. Verify no other consumer exists via grep.
+
+**Dependencies:** Task 2.3
+**Parallelizable:** No
+
+---
+
+## Commit C3 — `handleCheckpoint` payload-digest idempotencyKey
+
+Closes #1241.
+
+### Task 3.1 [RED] Test: refinement in same phase lands two events
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/workflow/tools.test.ts`
+   - Test: `handleCheckpoint_refinementInSamePhase_landsTwoEvents`
+   - Expected failure: current `idempotencyKey` shape (`${featureId}:checkpoint:${phase}:${_version}`) collides; second call deduped.
+2. Test asserts: two `handleCheckpoint` calls in same phase with distinct `handoff` payloads → two `workflow.checkpoint` events visible via `eventStore.query`.
+
+**Dependencies:** Commits C1, C2 complete
+**Parallelizable:** Wave 3
+
+### Task 3.2 [RED] Test: no-handoff checkpoint preserves legacy key shape
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/workflow/tools.test.ts`
+   - Test: `handleCheckpoint_noHandoffPayload_legacyKeyShapeStable`
+   - Expected failure: until digest stable across `undefined` payloads, replay of historical events would diverge.
+2. Test asserts: digest of `{}` and digest of missing handoff produce stable, equal idempotencyKey suffixes (replay backwards compat).
+
+**Dependencies:** Commits C1, C2 complete
+**Parallelizable:** Wave 3
+
+### Task 3.3 [GREEN] Add `handoffDigest` to idempotencyKey
+
+1. Implement
+   - File: `servers/exarchos-mcp/src/workflow/tools.ts` (`handleCheckpoint`, line ~988)
+   - `const handoffDigest = createHash('sha256').update(JSON.stringify(input.handoff ?? {})).digest('hex').slice(0, 16);`
+   - `const idempotencyKey = \`${featureId}:checkpoint:${phase}:${_version}:${handoffDigest}\`;`
+2. Route through `AtomicAppender` (already migrated in C2).
+
+**Dependencies:** Tasks 3.1, 3.2
+**Parallelizable:** No
+
+### Task 3.4 [REFACTOR] None expected
+
+Skip unless duplication emerges.
+
+---
+
+## Commit C4 — `workflow_status` projection dedup
+
+Closes #1226.
+
+### Task 4.1 [RED] Test: replay with duplicate task.completed dedups by taskId
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/views/workflow-status-view.test.ts`
+   - Test: `workflowStatus_replayWithDuplicateTaskCompleted_dedupsByTaskId`
+   - Expected failure: current projection increments naively.
+2. Test asserts: event log with duplicate `task.completed` for same `taskId` produces `tasksCompleted` counted once.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 4.2 [RED] Test: tasksCompleted never exceeds tasksTotal (#1226 regression)
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/views/workflow-status-view.test.ts`
+   - Test: `workflowStatus_tasksCompletedExceedsTotal_invariantHolds`
+   - Expected failure: bug repro.
+2. Test asserts: `tasksCompleted <= tasksTotal` invariant under any duplicate-event sequence.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 4.3 [GREEN] Add task-id-keyed dedup to projection fold
+
+1. Implement
+   - File: `servers/exarchos-mcp/src/views/workflow-status-view.ts:22–82`
+   - Maintain `Set<taskId>` during fold; increment `tasksCompleted` only on first occurrence.
+   - Apply same dedup to `tasksTotal` (via `Set<taskId>` from `task.assigned`/equivalent).
+
+**Dependencies:** Tasks 4.1, 4.2
+**Parallelizable:** No
+
+### Task 4.4 [REFACTOR] Generalize dedup helper if used elsewhere
+
+Skip unless other projections show the same pattern.
+
+---
+
+## Commit C5 — agent capability declarations
+
+Closes #1220.
+
+### Task 5.1 [RED] Test: FIXER spec declares `isolation:worktree`
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/agents/definitions.test.ts`
+   - Test: `FIXER_capabilities_includesIsolationWorktree`
+   - Expected failure: capability missing today.
+2. Test asserts: `FIXER.capabilities.includes('isolation:worktree') === true`.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 5.2 [RED] Test: SCAFFOLDER spec declares `isolation:worktree`
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/agents/definitions.test.ts`
+   - Test: `SCAFFOLDER_capabilities_includesIsolationWorktree`
+   - Expected failure: capability missing today.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 5.3 [RED] Test: REVIEWER spec correctness for read-only posture
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/agents/definitions.test.ts`
+   - Test: `REVIEWER_capabilities_readOnlyDoesNotRequireIsolation`
+   - Expected: passes today (verifies intentional state, prevents over-correction).
+2. Test asserts: `REVIEWER.capabilities` does NOT include `'fs:write'` or `'shell:exec'`; correspondingly does NOT require isolation.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 5.4 [RED] Test: Claude adapter renders `isolation: worktree` for FIXER + SCAFFOLDER
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/agents/adapters/claude.test.ts`
+   - Test: `claudeAdapter_fixerSpec_rendersWorktreeIsolation`
+   - Test: `claudeAdapter_scaffolderSpec_rendersWorktreeIsolation`
+   - Expected failure: capability missing → frontmatter `isolation` field absent.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 5.5 [GREEN] Add `isolation:worktree` to FIXER + SCAFFOLDER capability arrays
+
+1. Implement
+   - File: `servers/exarchos-mcp/src/agents/definitions.ts:150–214` (FIXER)
+   - File: `servers/exarchos-mcp/src/agents/definitions.ts:296–358` (SCAFFOLDER)
+2. Three-line additions; no other change.
+
+**Dependencies:** Tasks 5.1–5.4
+**Parallelizable:** No
+
+### Task 5.6 [REFACTOR] None expected
+
+Skip.
+
+---
+
+## Commit C6 — `SubagentStreamRouter`
+
+Closes #1224.
+
+### Task 6.1 [RED] Test: parent-stream `task.completed` emitted before `team.disbanded`
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/agents/subagent-stream-router.test.ts`
+   - Test: `SubagentStreamRouter_onTaskCompleted_emittedBeforeDisbanded`
+   - Expected failure: module does not exist.
+2. Test asserts: parent stream has `task.completed` event with sequence < `team.disbanded` sequence for that team.
+
+**Dependencies:** Commit C1 complete
+**Parallelizable:** Wave 2
+
+### Task 6.2 [RED] Test: `team.disbanded.tasksCompleted` matches parent-stream count
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/agents/subagent-stream-router.test.ts`
+   - Test: `SubagentStreamRouter_disbandedTasksCount_reflectsParentStreamNotInMemoryTally`
+   - Expected failure: today's coordinator uses an in-memory accumulator that diverges from the stream.
+2. Test asserts: with corrupted/diverged in-memory counter, `tasksCompleted` field on the emitted `team.disbanded` equals actual parent-stream `task.completed` count for that team.
+
+**Dependencies:** Commit C1 complete
+**Parallelizable:** Wave 2
+
+### Task 6.3 [RED] Test: replayed `task.completed` is idempotent
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/agents/subagent-stream-router.test.ts`
+   - Test: `SubagentStreamRouter_replayedTaskCompleted_singleParentEvent`
+   - Expected failure: module does not exist.
+2. Test asserts: replaying child-stream `task.completed` twice with same `<childStreamId>:<taskId>` key produces a single parent-stream `task.completed` event.
+
+**Dependencies:** Commit C1 complete
+**Parallelizable:** Wave 2
+
+### Task 6.4 [GREEN] Implement `SubagentStreamRouter`
+
+1. Implement
+   - File: `servers/exarchos-mcp/src/agents/subagent-stream-router.ts`
+   - `onTaskCompleted(parentStreamId, childStreamId, taskId, payload)` — appends to parent stream via `AtomicAppender` with idempotencyKey `<childStreamId>:<taskId>:task.completed`.
+   - `emitDisbanded(parentStreamId, summary)` — queries parent stream for `task.completed` count for the team; populates `tasksCompleted`; appends `team.disbanded`.
+
+**Dependencies:** Tasks 6.1–6.3
+**Parallelizable:** No
+
+### Task 6.5 [GREEN] Migrate team coordinator to use router
+
+1. Implement
+   - File: team-coordinator location (likely `servers/exarchos-mcp/src/orchestrate/dispatch.ts` or `agents/team-coordinator.ts` — implementer to confirm)
+   - Replace in-memory completion counter logic with `SubagentStreamRouter.onTaskCompleted` calls on child-event receipt.
+   - Replace `team.disbanded` emission with `SubagentStreamRouter.emitDisbanded`.
+2. Capture parent-stream id + team metadata at dispatch time so router has the data it needs at child-event-receipt time.
+
+**Dependencies:** Task 6.4
+**Parallelizable:** No
+
+### Task 6.6 [REFACTOR] Remove dead in-memory counter
+
+1. Delete the accumulator field and its update sites once router migration is complete.
+2. Verify no other consumer.
+
+**Dependencies:** Task 6.5
+**Parallelizable:** No
+
+---
+
+## Commit C7 — `HSMTransitionGuard.fail_closed`
+
+Closes #1225.
+
+### Task 7.1 [RED] Test: `workflow.set` with phase + failed guard does not transition
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/workflow/hsm-transition-guard.test.ts`
+   - Test: `workflowSet_phaseUpdateWithFailedGuard_doesNotEmitTransition`
+   - Expected failure: today's `set` writes the transition regardless.
+2. Test asserts: with state where `allTasksComplete` returns failure, `workflow.set(featureId, { phase: 'review' })` returns `ok: false`; event log contains no `workflow.transition` event with `to: 'review'` for that attempt.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 7.2 [RED] Test: failed guard emits only `workflow.guard-failed`
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/workflow/hsm-transition-guard.test.ts`
+   - Test: `workflowSet_phaseUpdateWithFailedGuard_emitsGuardFailedOnly`
+   - Expected failure: today's flow emits both `workflow.guard-failed` and `workflow.transition` ~6s apart.
+2. Test asserts: failed attempt produces exactly one `workflow.guard-failed` event and zero `workflow.transition` events for that target.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 7.3 [RED] Test: non-phase `workflow.set` updates unchanged
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/workflow/hsm-transition-guard.test.ts`
+   - Test: `workflowSet_nonPhaseUpdates_passThroughUnchanged`
+   - Expected: passes today; pin behavior to prevent regression.
+2. Test asserts: `workflow.set(featureId, { artifacts: {...} })` (no `phase` key) succeeds without invoking guard logic.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 7.4 [RED] Test: successful guard produces single `workflow.transition`
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/workflow/hsm-transition-guard.test.ts`
+   - Test: `workflowSet_phaseUpdateWithPassingGuard_emitsSingleTransition`
+   - Expected: must pass after fix.
+2. Test asserts: with state satisfying guard, `workflow.set(featureId, { phase: 'review' })` returns `ok: true`; exactly one `workflow.transition` event present, zero `workflow.guard-failed`.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 7.5 [GREEN] Implement `HSMTransitionGuard.attempt`
+
+1. Implement
+   - File: `servers/exarchos-mcp/src/workflow/hsm-transition-guard.ts`
+   - `attempt(featureId, currentPhase, targetPhase, context)` — looks up transition definition; evaluates composite guard; on success emits `workflow.transition`; on failure emits `workflow.guard-failed` and returns structured failure.
+   - Reuses existing guard composition logic in `workflow/guards.ts`.
+
+**Dependencies:** Tasks 7.1–7.4
+**Parallelizable:** No
+
+### Task 7.6 [GREEN] Route `workflow.set` phase updates through guard
+
+1. Implement
+   - File: `servers/exarchos-mcp/src/workflow/tools.ts` (`workflow.set` handler)
+   - When `updates.phase` is present, route through `HSMTransitionGuard.attempt`; apply the transition only on `ok: true`; surface the structured failure to the caller on `ok: false`.
+   - Non-phase updates remain on the existing path.
+
+**Dependencies:** Task 7.5
+**Parallelizable:** No
+
+### Task 7.7 [REFACTOR] None expected
+
+Skip.
+
+---
+
+## Commit C8 — pruner multi-signal staleness
+
+Closes #1117.
+
+### Task 8.1 [RED] Test: stuck workflow flagged even with fresh read activity
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts`
+   - Test: `selectPruneCandidates_phaseStuckButReadActive_flagsAsStale`
+   - Expected failure: today's single-signal gate misses this case.
+2. Test asserts: workflow with `phaseTransitionTimestamp` 7 days old but `lastActivityTimestamp` 1h old (refreshed by reads) is flagged stale.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 8.2 [RED] Test: branch inactivity + phase stuck → flagged
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts`
+   - Test: `selectPruneCandidates_branchInactiveAndPhaseStuck_flagsAsStale`
+   - Expected failure.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 8.3 [RED] Test: recent legitimate activity does not flag
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts`
+   - Test: `selectPruneCandidates_recentTransitionAndCommit_doesNotFlag`
+   - Expected: passes today; pin behavior to prevent false positives in fix.
+
+**Dependencies:** None
+**Parallelizable:** Yes (Wave 1)
+
+### Task 8.4 [GREEN] Add `phaseTransitionTimestamp` signal
+
+1. Implement
+   - File: `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts:96–173`
+   - Read most-recent `workflow.transition` event timestamp; expose as a signal in `selectPruneCandidates`.
+   - Compose with existing `lastActivityTimestamp` per design (fresh on either signal alone is not enough; both stale → stale).
+
+**Dependencies:** Tasks 8.1–8.3
+**Parallelizable:** No
+
+### Task 8.5 [GREEN] Add `branchActivity` signal
+
+1. Implement
+   - File: `servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts`
+   - When workflow tracks a branch, run `git log -1 --format=%ct` (or library equivalent) and treat absence-of-activity as a stale signal.
+   - Skip silently when no branch is tracked (don't penalize workflows without branches).
+
+**Dependencies:** Task 8.4
+**Parallelizable:** No
+
+### Task 8.6 [REFACTOR] None expected
+
+Skip.
+
+---
+
+## Commit C9 — integration verification
+
+#1109 verification checklist closure.
+
+### Task 9.1 [RED] Test: replay reconstructs identical projection state across all closed bugs
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/event-store/replay-determinism.test.ts`
+   - Test: `replay_v29BugClusterScenarios_reconstructsIdenticalState`
+   - Expected: passes after all prior commits land; pin determinism.
+2. Test asserts: for each bug-shaped scenario (concurrent appends, refinement checkpoints, child-stream task.completed, failed-guard transitions), build event log → project once → re-project from scratch → byte-compare.
+
+**Dependencies:** Commits C1–C8 complete
+**Parallelizable:** Wave 4
+
+### Task 9.2 [RED] Test: CLI/MCP parity for `workflow_status`
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/parity.test.ts` (extend existing if present)
+   - Test: `assertParity_workflowStatus_cliAndMcpByteEqual`
+   - Expected: passes after C4 lands.
+2. Test asserts: identical event log → identical envelope (modulo timestamp normalization) from CLI and MCP invocations.
+
+**Dependencies:** Commit C4 complete
+**Parallelizable:** Wave 4
+
+### Task 9.3 [RED] Test: CLI/MCP parity for `workflow_checkpoint`
+
+1. Write failing test
+   - File: `servers/exarchos-mcp/src/parity.test.ts`
+   - Test: `assertParity_workflowCheckpoint_cliAndMcpByteEqual`
+
+**Dependencies:** Commit C3 complete
+**Parallelizable:** Wave 4
+
+### Task 9.4 [GREEN] Address any test failures
+
+If 9.1–9.3 pass on first run, commit is verification-only. Otherwise, route fix back to the responsible commit family.
+
+**Dependencies:** Tasks 9.1–9.3
+**Parallelizable:** No
+
+---
+
+## Test fixture / setup notes
+
+Several tasks need shared fixtures. Implementer agents should:
+
+- **Concurrent-append fixture:** A test helper that creates an `AtomicAppender` instance pointed at a tmp-dir stream path; cleans up on teardown.
+- **Failing-writer injection:** A `writeFn` parameter on `AtomicAppender` constructor (for test injection only) so 1.2/1.3 can simulate IO failure deterministically.
+- **In-memory counter corruption helper:** For 6.2, a way to corrupt the team-coordinator's accumulator post-hoc to exercise the "diverged from stream" assertion.
+- **Guard-failure fixture:** For 7.x, a workflow state with `allTasksComplete` returning failure (e.g. `tasks: [{status: 'assigned'}]`) and `teamDisbandedEmitted` returning success (or vice versa).
+- **Phase-stuck fixture:** For 8.1, a workflow state plus event log with a 7-day-old `workflow.transition` and a 1-hour-old read marker.
+
+These fixtures are co-located with the tests that need them; not factored into `__fixtures__` unless reused across files.
+
+## Risk register
+
+- **Mutex semantics under errors.** `AtomicAppender`'s mutex must release on thrown exceptions. Test 1.3 partially covers; an explicit "mutex released after error" assertion is in scope for 1.5's REFACTOR step if needed.
+- **Team coordinator file location.** Design names this as TBD. First implementer task on C6.5 should `grep` for existing `team.disbanded` emission site and confirm the coordinator's location before editing.
+- **Existing in-tree callers of `workflow.set({ phase })`.** C7.6 may surface migrations. Implementer should `grep` for `workflow.set` calls with `phase` field and confirm each is intended.
+- **Replay determinism on pre-existing event logs.** C9.1 is the canary. If older event logs in `~/.claude/workflow-state/` produce divergent projections post-fix, that's a migration discussion.
+
+## Parallelization summary
+
+| Wave | Commits | Concurrency |
+|---|---|---|
+| 1 | C1, C4, C5, C7, C8 | 5 parallel implementer agents (independent files) |
+| 2 | C2, C6 | 2 parallel implementer agents (depend on C1's `AtomicAppender`) |
+| 3 | C3 | 1 implementer agent (depends on C2's migrated handler) |
+| 4 | C9 | 1 implementer agent (integration) |
+
+Total: 9 commits, 38 tasks, 4 sequential waves with parallel slots within waves.
+
+## Verification checklist (#1109 PR section)
+
+- [ ] All 38 tasks complete with passing tests
+- [ ] Replay determinism test (9.1) green
+- [ ] CLI/MCP parity tests (9.2, 9.3) green
+- [ ] No bypass paths to event store outside `AtomicAppender`
+- [ ] No phase-write paths outside `HSMTransitionGuard.fail_closed`
+- [ ] FIXER, SCAFFOLDER, (REVIEWER if applicable) capability declarations match posture

--- a/docs/plans/2026-05-08-eventstore-appender-consumer-migration.md
+++ b/docs/plans/2026-05-08-eventstore-appender-consumer-migration.md
@@ -1,0 +1,265 @@
+---
+title: TDD plan — EventStore consumer migration to AtomicAppender
+date: 2026-05-08
+design: docs/designs/2026-05-08-eventstore-appender-consumer-migration.md
+tracking: "#1293"
+---
+
+# TDD Plan: EventStore consumer migration to AtomicAppender
+
+Strict Red-Green-Refactor. Each task lands as a single commit. Wave numbers
+are dispatch order; tasks within a wave run in parallel via `/exarchos:delegate`.
+
+## Wave 1 — AtomicAppender primitives
+
+### T1: AtomicAppender.append supports `options.expectedSequence`
+
+**Red test** (`atomic-appender.test.ts`):
+```
+AtomicAppender_appendWithStaleExpectedSequence_returnsSequenceConflict
+AtomicAppender_appendWithMatchingExpectedSequence_succeeds
+AtomicAppender_expectedSequenceUndefined_skipsCheck
+```
+
+**Green**:
+- Add `options?: { expectedSequence?: number }` as fourth parameter on
+  `append`.
+- Inside `appendLocked`, after `rebuildCachesFromJsonl` (so the counter is
+  authoritative), compare `sequenceCounters.get(streamId) ?? 0` against
+  `expectedSequence`. On mismatch: return
+  `{ ok: false, reason: 'sequence-conflict' }`.
+- The return-as-result (vs throw) shape matches existing `AppendResult`
+  union; callers translate to throws at their boundary.
+
+**Files**: `src/event-store/atomic-appender.ts`,
+`src/event-store/atomic-appender.test.ts`.
+
+**Effort**: ~30 LoC + 3 tests.
+
+### T2: AtomicAppender.appendUnkeyed primitive
+
+**Red test**:
+```
+AtomicAppender_appendUnkeyed_writesEventsAndAdvancesSequence
+AtomicAppender_appendUnkeyed_doesNotPopulateIdempotencyCache
+AtomicAppender_appendUnkeyed_concurrentCallsSerialize
+```
+
+**Green**:
+- Add `appendUnkeyed(streamId, events): Promise<AppendResult>`.
+- Refactor `appendLocked` to take a `keyedAppend: { idempotencyKey: string } | null`
+  parameter. When null: skip cache lookup, skip cache write, still allocate
+  sequence + write JSONL + write .seq under the lock.
+- `append(streamId, events, key, opts?)` → `appendLocked(streamId, events, { idempotencyKey: key }, opts)`.
+- `appendUnkeyed(streamId, events)` → `appendLocked(streamId, events, null, undefined)`.
+
+**Files**: `src/event-store/atomic-appender.ts`,
+`src/event-store/atomic-appender.test.ts`.
+
+**Effort**: ~40 LoC + 3 tests.
+
+## Wave 2 — Cross-path race regression test (independent of Wave 1)
+
+### T3: Cross-path race regression test (RED on legacy)
+
+**Red test** (`store.property.test.ts` or new `store.race.test.ts`):
+```
+EventStore_concurrentLegacyAppendAndBatchAppend_strictSequenceMonotonicity
+EventStore_concurrentHsmTransitionAndStreamRouter_noOverlappingSequences
+```
+
+The first test drives `eventStore.append(stream, ...)` concurrently with
+`eventStore.batchAppend(stream, ...)` and `getAppender().append(stream, ...)`,
+N=100 each, asserts:
+- All sequences are strictly monotonic.
+- No duplicate sequences.
+- JSONL parses cleanly line-by-line.
+
+The second test drives `handleEventAppend` (via `tools.ts`) on
+`workflow.transition` concurrent with `getStreamRouter().emitDisbanded` on
+the same stream, asserts no interleaving violations.
+
+**Expected status before migration**: BOTH tests fail on current `main`
+(the gap they capture is the bug we're closing).
+
+**Files**: new `src/event-store/store.race.test.ts`.
+
+**Effort**: ~80 LoC, 2 tests.
+
+## Wave 3 — EventStore migration (depends on Wave 1)
+
+### T4: EventStore.appendValidated delegates to AtomicAppender
+
+**Red test** (existing `store.test.ts` tests must continue to pass; add):
+```
+EventStore_appendValidated_delegatesToAtomicAppender
+EventStore_appendValidated_sidecarMode_unchanged
+EventStore_appendValidated_outboxStillCalled
+EventStore_appendValidated_backendStillCalled
+EventStore_appendValidated_expectedSequenceMismatch_throwsSequenceConflictError
+```
+
+**Green**:
+- Replace body of `appendValidated` with:
+  ```ts
+  if (this.sidecarMode) return this.writeToSidecar(streamId, event, key);
+  const key = options?.idempotencyKey ?? event.idempotencyKey;
+  const appender = this.getAppender();
+  const result = key
+    ? await appender.append(streamId, [event], key, { expectedSequence: options?.expectedSequence })
+    : await appender.appendUnkeyed(streamId, [event]);
+  if (!result.ok) {
+    if (result.reason === 'sequence-conflict') {
+      throw new SequenceConflictError(options!.expectedSequence!, /* read */);
+    }
+    throw new Error(/* io-error */);
+  }
+  const fullEvent = synthesizeEvent(event, result.sequences[0], result.eventIds[0]);
+  this.replicateBackend(streamId, fullEvent);  // best-effort
+  await this.writeOutbox(streamId, fullEvent);  // best-effort
+  return fullEvent;
+  ```
+- Extract `replicateBackend` and `writeOutbox` as small private helpers
+  (clarifies the supplementary nature).
+
+**Files**: `src/event-store/store.ts`,
+`src/event-store/store.test.ts`.
+
+**Effort**: ~80 LoC store.ts, ~50 LoC tests.
+
+### T5: EventStore.append delegates to AtomicAppender
+
+**Red test**:
+```
+EventStore_append_delegatesToAtomicAppender
+EventStore_append_schemaValidationStillRuns
+EventStore_append_unkeyed_skipsDedup
+EventStore_append_keyedRetry_returnsCachedEvent
+```
+
+**Green**: same shape as T4, with `WorkflowEventBase.parse(...)` step
+preceding the delegation. Reuses `replicateBackend` / `writeOutbox` helpers
+from T4.
+
+**Files**: `src/event-store/store.ts`,
+`src/event-store/store.test.ts`.
+
+**Effort**: ~70 LoC store.ts, ~40 LoC tests.
+
+### T6: EventStore.batchAppend delegates to AtomicAppender
+
+**Red test**:
+```
+EventStore_batchAppend_delegatesToAtomicAppender
+EventStore_batchAppend_intraBatchDedup_preserved
+EventStore_batchAppend_sidecarMode_unchanged
+EventStore_batchAppend_outboxCalledForEachEvent
+```
+
+**Green**:
+- The `tools.ts:handleBatchAppend` already delegates via `getAppender()`.
+- This task migrates `EventStore.batchAppend` (the method on the class,
+  used by some internal callers) to the same path.
+- Mixed-key batches: derive batch key as in `tools.ts` — all-same-key uses
+  it; mixed/absent synthesizes `batch:${randomUUID()}`.
+- All-unkeyed batches use `appendUnkeyed` to avoid cache pollution.
+
+**Files**: `src/event-store/store.ts`,
+`src/event-store/store.test.ts`.
+
+**Effort**: ~60 LoC store.ts, ~40 LoC tests.
+
+## Wave 4 — Legacy cleanup (depends on Wave 3)
+
+### T7: Delete legacy private helpers
+
+After T4-T6 land, the following are unused — verify with grep, then delete:
+- `EventStore.withLock`
+- `EventStore.sequenceCounters`
+- `EventStore.idempotencyCache`
+- `EventStore.idempotencyCacheInitialized`
+- `EventStore.checkIdempotencyAndSequence`
+- `EventStore.persistAndReplicate` (replaced by `replicateBackend` +
+  `writeOutbox` helpers)
+- `EventStore.cacheIdempotencyKey`
+- `EventStore.rebuildIdempotencyCache`
+- `EventStore.initializeSequence`
+- Any `EventStore.writeEvents` / file-write helpers solely used by the
+  legacy path.
+- Locks Map, related cleanup logic.
+
+**Red test**: typecheck passes; full test suite green.
+
+**Effort**: deletion-only commit; should be ~400 LoC removed from store.ts.
+Target: store.ts ≤ 500 LoC post-delete (down from 1380).
+
+**Files**: `src/event-store/store.ts`.
+
+## Wave 5 — Verification & docs (depends on Wave 4)
+
+### T8: Audit tests/benches that reference deleted private state
+
+Grep for references to deleted symbols across `__tests__/`, `*.test.ts`,
+`*.bench.ts`:
+
+```
+grep -rn "withLock\|sequenceCounters\|idempotencyCache" src --include='*.ts'
+```
+
+For each hit:
+- If the test asserts behavior that's still observable through the public
+  API: rewrite to use the public API.
+- If the test asserts internal state that's no longer meaningful: delete.
+
+**Files**: any test/bench file with hits.
+
+### T9: Race regression test transitions RED → GREEN
+
+Run T3's tests against the migrated code. Both must now pass. If either
+still fails, root-cause and fix BEFORE merging — that is the gating proof
+of the migration.
+
+**Files**: no new code; verification only.
+
+### T10: #1259 swap-site comment + cross-cutting docs
+
+- Add a comment at `EventStore` constructor showing the SQLite swap point:
+  ```ts
+  // #1259 swap point: replace `new AtomicAppender(...)` with
+  // `new SqliteAppender(...)`. Same AppendResult shape, same per-stream
+  // serialization semantics.
+  ```
+- Update `docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md` with a
+  link to this design doc and a note that C2 is now fully closed.
+- Update `#1109` cross-cutting concerns doc (if exists) to mark
+  event-store atomicity as `closed`.
+- Close `#1293` with a link to the merged PR.
+
+**Files**: `src/event-store/store.ts` (comment),
+`docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md` (link),
+this design doc (status → implemented).
+
+## Dispatch order
+
+```
+W1: T1, T2          (parallel; both touch atomic-appender.ts — sequential within file)
+W2: T3              (parallel with W1; touches new test file only)
+W3: T4, T5, T6      (sequential; all touch store.ts)
+W4: T7              (sequential after W3)
+W5: T8, T9, T10     (parallel)
+```
+
+Total: 10 tasks. Estimated implementer-agent dispatches: 10 (one per task).
+Two-wave parallelism (W1 || W2) saves one round trip.
+
+## Success gate
+
+Merge unblocked when:
+1. All 10 tasks complete.
+2. `npm run test:run` green (vitest, all suites).
+3. T3's race regression tests pass.
+4. `wc -l src/event-store/store.ts` ≤ 500.
+5. Grep finds zero references to deleted private members.
+6. Manual sanity: replace `new AtomicAppender(...)` in EventStore with
+   `new MockAppender(...)` and verify the swap requires zero other changes
+   (proves #1259-readiness).

--- a/docs/plans/2026-05-08-eventstore-appender-consumer-migration.md
+++ b/docs/plans/2026-05-08-eventstore-appender-consumer-migration.md
@@ -200,10 +200,13 @@ Target: store.ts ≤ 500 LoC post-delete (down from 1380).
 ### T8: Audit tests/benches that reference deleted private state
 
 Grep for references to deleted symbols across `__tests__/`, `*.test.ts`,
-`*.bench.ts`:
+`*.bench.ts`. Run from the repo root with the qualified path (the
+EventStore lives under `servers/exarchos-mcp/src/`, not the repo-root
+`src/`):
 
-```
-grep -rn "withLock\|sequenceCounters\|idempotencyCache" src --include='*.ts'
+```bash
+grep -rn "withLock\|sequenceCounters\|idempotencyCache" \
+  servers/exarchos-mcp/src --include='*.ts'
 ```
 
 For each hit:

--- a/docs/research/2026-05-06-rank-fusion-algorithm-spike-strategos-57.md
+++ b/docs/research/2026-05-06-rank-fusion-algorithm-spike-strategos-57.md
@@ -7,7 +7,7 @@
 
 ## TL;DR
 
-**Keep RRF as the core algorithm.** No published method beats RRF zero-shot on out-of-domain workloads, and Strategos's position as a library — score-scale agnostic, no labeled data, no LLM access, no GPU — rules out the methods that beat it (TM2C2 with tuned α, DAT, LTR). The literature is unanimous on this: production-default RRF, with per-source weighting as the highest-leverage knob.
+**Keep RRF as the core algorithm.** Based on the studies cited in this spike, no published method has been shown to beat RRF zero-shot on out-of-domain workloads, and Strategos's position as a library — score-scale agnostic, no labeled data, no LLM access, no GPU — rules out the methods that beat it on tuned settings (TM2C2 with tuned α, DAT, LTR). The reviewed literature converges on production-default RRF, with per-source weighting as the highest-leverage knob.
 
 **Two principled extensions to the original spec:**
 
@@ -34,15 +34,21 @@
 
 ### Production implementations
 
-- **Elasticsearch 8.16+:** RRF default; **weighted RRF** GA in 8.16 ([blog 2025-09-15](https://www.elastic.co/search-labs/blog/weighted-reciprocal-rank-fusion-rrf)).
-- **OpenSearch 2.19:** RRF in Neural Search plugin (Feb 2025).
-- **Qdrant 1.11+:** RRF + DBSF (Distribution-Based Score Fusion); supports weighted RRF in client lib.
-- **Weaviate 1.24+:** Relative Score Fusion (RSF) default; rankedFusion (RRF) optional.
-- **Azure AI Search:** RRF only.
-- **Pinecone:** convex combination (alpha) on hybrid index.
-- **Vespa:** linear combination + RRF.
-- **Solr (in flight):** RRF being added natively (KandaSearch blog).
-- **Pearson, kdb-x:** weighted RRF in production APIs.
+Each entry below is annotated with a confidence marker:
+- ✅ — direct citation in the linked source
+- ⚠️ provisional — claim is based on vendor docs/blog cross-referenced during this spike but not pinned to a specific release-note URL; verify before quoting.
+
+- **Elasticsearch 8.16+:** RRF default; **weighted RRF** GA in 8.16. ✅ ([Elastic search-labs blog, 2025-09-15](https://www.elastic.co/search-labs/blog/weighted-reciprocal-rank-fusion-rrf)).
+- **OpenSearch 2.19:** RRF in Neural Search plugin (Feb 2025). ⚠️ provisional — check OpenSearch 2.19 release notes / Neural Search plugin changelog.
+- **Qdrant 1.11+:** RRF + DBSF (Distribution-Based Score Fusion); weighted RRF in client lib. ⚠️ provisional — see Qdrant changelog for 1.11; DBSF announcement post.
+- **Weaviate 1.24+:** Relative Score Fusion (RSF) default; rankedFusion (RRF) optional. ⚠️ provisional — see Weaviate hybrid-search docs for the specific minor version.
+- **Azure AI Search:** RRF only. ⚠️ provisional — Microsoft Learn hybrid-search article.
+- **Pinecone:** convex combination (alpha) on hybrid index. ⚠️ provisional — Pinecone hybrid-search docs.
+- **Vespa:** linear combination + RRF. ⚠️ provisional — Vespa documentation on rank profiles.
+- **Solr (in flight):** RRF being added natively (KandaSearch blog). ⚠️ provisional — KandaSearch blog post; Solr JIRA ticket not pinned.
+- **Pearson, kdb-x:** weighted RRF in production APIs. ⚠️ provisional — vendor case studies, not pinned to a release.
+
+(The conclusion of the spike — "production-default RRF, with per-source weighting as the highest-leverage knob" — does not depend on any single platform claim being precise to the minor version. The Elasticsearch entry, which has a direct citation, is the load-bearing data point.)
 
 ### Critique / pragmatic posts
 

--- a/docs/research/2026-05-06-rank-fusion-algorithm-spike-strategos-57.md
+++ b/docs/research/2026-05-06-rank-fusion-algorithm-spike-strategos-57.md
@@ -94,7 +94,7 @@ This means the highest-leverage knob Strategos can expose is not a fancier algor
 
 In the past 18 months, weighted RRF has gone from a Qdrant-client convenience to a first-class feature in Elasticsearch (8.16 GA, 2025-09), Qdrant (server-side), Pearson, and kdb-x. The math is a one-line generalization of Cormack RRF:
 
-```
+```text
 fused_score(d) = Σ_L  weight_L  /  (k + rank_L(d))
 ```
 
@@ -104,7 +104,7 @@ When all `weight_L = 1.0`, this reduces exactly to Cormack 2009. So weighted RRF
 
 Among score-aware fusion methods, only **DBSF** (Distribution-Based Score Fusion, Qdrant) is genuinely stateless per query and preserves library purity:
 
-```
+```text
 For each ranked list:
   μ ← mean(scores), σ ← stdev(scores)
   low ← μ - 3σ, high ← μ + 3σ

--- a/docs/research/2026-05-06-rank-fusion-algorithm-spike-strategos-57.md
+++ b/docs/research/2026-05-06-rank-fusion-algorithm-spike-strategos-57.md
@@ -1,0 +1,215 @@
+# Rank fusion algorithm spike for Strategos #57
+
+**Date:** 2026-05-06
+**Status:** Applied — #57 and #58 revised; #47 umbrella updated
+**Driver:** [strategos#57 — RankFusion.Reciprocal utility (DR-2, 2.6.0)](https://github.com/lvlup-sw/strategos/issues/57)
+**Question:** Is the Cormack 2009 RRF currently spec'd for #57 still the right algorithm, or has the IR literature produced a more optimal modern replacement?
+
+## TL;DR
+
+**Keep RRF as the core algorithm.** No published method beats RRF zero-shot on out-of-domain workloads, and Strategos's position as a library — score-scale agnostic, no labeled data, no LLM access, no GPU — rules out the methods that beat it (TM2C2 with tuned α, DAT, LTR). The literature is unanimous on this: production-default RRF, with per-source weighting as the highest-leverage knob.
+
+**Two principled extensions to the original spec:**
+
+1. **Generalize to Weighted RRF (wRRF).** Production-validated (Elasticsearch 8.16+, Qdrant, OpenSearch, Pearson, kdb-x). Per-list weights default to `1.0` so unweighted callers get bit-identical Cormack RRF behavior; weighted callers tune per-source influence without leaving the library.
+2. **Add `RankFusion.DistributionBased` as a sibling utility.** Qdrant's μ±3σ normalization. Stateless per-query (still pure utility). Uses score-distribution information that RRF discards. Best when callers have score-distribution variance.
+
+**Do not adopt in 2.6.0:** TM2C2 (needs α tuning per domain), DAT (needs LLM), LTR (needs labeled data + GPU), TRF (needs tensor/ColBERT model). All are application-layer concerns; Basileus owns them, not the Strategos library.
+
+## Sources
+
+### Foundational
+
+- **Cormack, Clarke, Buettcher (2009).** *Reciprocal Rank Fusion outperforms Condorcet and individual Rank Learning Methods.* SIGIR 2009. → `k=60` default; rank-based; no normalization.
+- **Fox & Shaw (1994).** CombSUM, CombMNZ — score-based fusion baselines.
+
+### State-of-the-art papers (2022–2026)
+
+- **Bruch, Gai, Ingber (2024).** *An Analysis of Fusion Functions for Hybrid Retrieval.* ACM TOIS (arXiv:2210.11934). Pinecone Research. → Finds **TM2C2 (Theoretical Min-Max Convex Combination) outperforms RRF on all tested datasets** in NDCG and Recall, both in-domain and out-of-domain. Sample-efficient: handful of labeled queries to tune α (≈ 0.8). Critically: tuned-vs-tuned comparison.
+- **Chen et al. (2022).** Counter-position: argues RRF outperforms convex combination in zero-shot. Both papers cite each other.
+- **Hsu, Tzeng (2025).** *DAT: Dynamic Alpha Tuning for Hybrid Retrieval in RAG* (arXiv:2503.23013). → Per-query α via LLM scoring of top-1 from each retriever. Outperforms fixed-weight hybrid. Adds LLM call per query.
+- **Algoverse / Perez et al. (2025, ICML VecDB workshop).** *Entropy-Based Dynamic Hybrid Retrieval.* → Multi-round Shannon-entropy-based reweighting. Retriever-agnostic.
+- **Balancing the Blend (arXiv:2508.01405v2, 2025).** → Tensor-based Re-ranking Fusion (TRF) consistently beats RRF and weighted-sum on multi-paradigm hybrid (FTS + sparse + dense + tensor). Identifies "weakest link" phenomenon: a single bad retriever degrades the whole hybrid.
+- **Liu, Zhang (ACL 2025 Findings).** Exp4Fuse — modified RRF + LLM query expansion for sparse retrieval.
+
+### Production implementations
+
+- **Elasticsearch 8.16+:** RRF default; **weighted RRF** GA in 8.16 ([blog 2025-09-15](https://www.elastic.co/search-labs/blog/weighted-reciprocal-rank-fusion-rrf)).
+- **OpenSearch 2.19:** RRF in Neural Search plugin (Feb 2025).
+- **Qdrant 1.11+:** RRF + DBSF (Distribution-Based Score Fusion); supports weighted RRF in client lib.
+- **Weaviate 1.24+:** Relative Score Fusion (RSF) default; rankedFusion (RRF) optional.
+- **Azure AI Search:** RRF only.
+- **Pinecone:** convex combination (alpha) on hybrid index.
+- **Vespa:** linear combination + RRF.
+- **Solr (in flight):** RRF being added natively (KandaSearch blog).
+- **Pearson, kdb-x:** weighted RRF in production APIs.
+
+### Critique / pragmatic posts
+
+- **Doug Turnbull (2024).** *RRF is Not Enough.* → "RRF'ing bad search into good search will just drag down the good search." Per-source precision tuning > fusion-method choice.
+- **Cole Hoffer.** *RRF for Hybrid Search.* → "RRF hits the sweet spot: simple, fast, and accurate enough."
+- **wiki.charleschen.ai.** Production-data table comparing methods.
+
+### Empirical numbers (from cited sources)
+
+| Method | nDCG@10 (BEIR avg) | Latency overhead | Training data | Zero-shot | Score normalization |
+|---|---|---|---|---|---|
+| BM25-only | ~34 | — | — | — | — |
+| Dense-only | ~43 | — | — | — | — |
+| **RRF (k=60)** | **45–46.5** | <5ms | None | ✓ | Not required |
+| Weighted Sum / Linear CC | 44.3 | <5ms | Required (α) | ✗ | Required |
+| TM2C2 (tuned α=0.8) | beats RRF on every dataset tested | <5ms | ~10 labeled queries | ✗ | Min-max + theoretical-min |
+| DBSF | ~45–46 | <5ms | None | ✓ | μ±3σ stateless |
+| LTR (LambdaMART) | 48.2 | 7–15ms | 30–50 queries min | ✗ | Learned features |
+| Triple-stage (RRF + ColBERT + cross-enc) | 48.5 | ~350ms | None | ✓ | N/A |
+| TRF (Tensor RRF) | RRF + 5–8% on multi-paradigm | higher | needs tensor model | ✓ | N/A |
+
+## Findings
+
+### F1. RRF remains the production default by overwhelming consensus
+
+Every major hybrid-search platform offers RRF, and most default to it: Azure AI Search, Elasticsearch, OpenSearch, Qdrant, Vespa, Solr (in flight). Weaviate is the notable exception (RSF default). The convergence reflects a real property: RRF is the only major fusion method that requires neither score normalization nor parameter tuning to behave well across domains.
+
+### F2. The single paper that beats RRF (Bruch 2024) requires labeled data
+
+Bruch, Gai, Ingber's 2024 ACM TOIS paper is the strongest published critique of RRF. They show **TM2C2** (Theoretical Min-Max convex combination of normalized scores, α≈0.8) outperforms RRF in NDCG on every dataset tested. Crucially:
+
+- The win requires α to be tuned. They tune on validation splits.
+- Out-of-domain, untuned, RRF wins.
+- TM2C2 is "sample-efficient" — ~10 labeled queries suffice — but Strategos as a library has zero labeled queries.
+
+This positions TM2C2 as an **application-layer** choice. Basileus, with its application context and ability to collect labeled queries, can implement TM2C2 on top of Strategos's interface. Strategos cannot ship a tuned α.
+
+### F3. Adaptive methods (DAT, entropy-based) require runtime LLM or multi-round overhead
+
+DAT (Hsu & Tzeng 2025) calls an LLM per query to score top-1 effectiveness from each retriever. Entropy-based dynamic hybrid (Algoverse 2025) iterates multiple rounds of reweighting until convergence. Both produce gains over fixed-weight hybrid but at meaningful latency cost (LLM call) or complexity cost (multi-round). Neither belongs in a `< 1ms` pure-utility static class.
+
+### F4. The pragmatic literature consistently identifies "fix retrieval before fusion"
+
+Doug Turnbull's "RRF is Not Enough" and the production wisdom in Pinecone/Weaviate/Elastic blogs converge: the largest gains come from **upstream** quality (better embeddings, BM25 phrase queries, query understanding) rather than swapping fusion algorithms. The Balancing-the-Blend paper formalizes this as the "weakest link" phenomenon: a single bad retriever drags the whole hybrid down regardless of fusion method.
+
+This means the highest-leverage knob Strategos can expose is not a fancier algorithm — it's **per-source weighting** so callers can de-emphasize a weaker retriever.
+
+### F5. Per-source weighting has hardened into a production default
+
+In the past 18 months, weighted RRF has gone from a Qdrant-client convenience to a first-class feature in Elasticsearch (8.16 GA, 2025-09), Qdrant (server-side), Pearson, and kdb-x. The math is a one-line generalization of Cormack RRF:
+
+```
+fused_score(d) = Σ_L  weight_L  /  (k + rank_L(d))
+```
+
+When all `weight_L = 1.0`, this reduces exactly to Cormack 2009. So weighted RRF is strictly additive — no breaking change, no regression risk for unweighted callers.
+
+### F6. DBSF is the strongest score-aware drop-in
+
+Among score-aware fusion methods, only **DBSF** (Distribution-Based Score Fusion, Qdrant) is genuinely stateless per query and preserves library purity:
+
+```
+For each ranked list:
+  μ ← mean(scores), σ ← stdev(scores)
+  low ← μ - 3σ, high ← μ + 3σ
+  normalize(s) ← (clamp(s, low, high) - low) / (high - low)
+Sum the normalized scores per document; sort descending.
+```
+
+Per-query distribution; no global state; no training; no normalization configuration. DBSF is well-defined for any positive-scored ranker (BM25 included). It uses information RRF discards (the score distribution) without requiring callers to ship calibrated scores.
+
+Empirically DBSF performs ~RRF on average but better when score variance differs significantly between paths. Industrial adoption: Qdrant 1.11+ ships it as a peer of RRF.
+
+### F7. The current spec's `BmSaturationThreshold` field is symptomatic
+
+Issue #58's `HybridQueryOptions.BmSaturationThreshold` (default 18.0) was already pointing at score-distribution awareness — but as RRF is rank-based, the field is observational only. Adding DBSF turns that observation into a real algorithmic option.
+
+### F8. TRF (tensor reranking) is not a fusion replacement
+
+The Balancing-the-Blend paper presents TRF as a re-ranking strategy, not a fusion replacement. It runs ColBERT/MaxSim over candidates from upstream first-stage retrievers. This is a downstream rerank step, not a fusion algorithm in the same sense as RRF/DBSF/LTR. It belongs alongside cross-encoder rerankers in the application layer (Basileus), not in the fusion utility.
+
+## Algorithm comparison matrix (Strategos library lens)
+
+| Algorithm | Library-fit | Reason |
+|---|---|---|
+| **RRF (Cormack 2009)** | ✅ canonical | Pure utility, score-agnostic, zero-shot strong, deterministic, sub-1ms |
+| **Weighted RRF** | ✅ additive extension | Strictly generalizes RRF; weights default to 1.0; production-validated |
+| **DBSF (Qdrant)** | ✅ optional sibling | Stateless per-query, score-aware, no training; useful when score distributions differ across paths |
+| **CombSUM / CombMNZ** | ⚠ caller-controlled | Requires score normalization layer; expose as building blocks if needed |
+| **Relative Score Fusion (Weaviate)** | ⚠ caller-controlled | Min-max norm + weighted sum; assumes scores are roughly comparable |
+| **TM2C2 / Convex Combination** | ❌ application | Best-in-class tuned, but α is a domain parameter Strategos can't pick |
+| **DAT (Dynamic Alpha Tuning)** | ❌ application | Needs LLM call per query; not a pure utility |
+| **Entropy-based dynamic** | ❌ application | Multi-round; not deterministic-bounded |
+| **LTR (LambdaMART, etc.)** | ❌ application | Needs labeled data, model serving, feature pipeline |
+| **TRF (Tensor RRF)** | ❌ paradigm shift | Needs tensor/ColBERT model; not a fusion algorithm in the same class |
+
+## Recommendation
+
+Update issue #57 to ship **two complementary fusion methods** under `Strategos.Ontology.Retrieval.RankFusion`:
+
+### `RankFusion.Reciprocal` (canonical, generalized to wRRF)
+
+```csharp
+public static IReadOnlyList<FusedResult> Reciprocal(
+    IReadOnlyList<IReadOnlyList<RankedCandidate>> rankedLists,
+    IReadOnlyList<double>? weights = null,    // NEW; defaults to all-1.0 → Cormack RRF
+    int k = 60,
+    int topK = 10);
+```
+
+Score formula: `Σ_L  weight_L / (k + rank_L(d))`. When `weights == null` or all weights are `1.0`, output is bit-identical to the originally spec'd Cormack RRF.
+
+### `RankFusion.DistributionBased` (sibling, score-aware)
+
+```csharp
+public static IReadOnlyList<FusedResult> DistributionBased(
+    IReadOnlyList<IReadOnlyList<ScoredCandidate>> scoredLists,
+    IReadOnlyList<double>? weights = null,    // optional weighted sum after normalization
+    int topK = 10);
+```
+
+Per-list normalize via μ±3σ, clamp to `[low, high]`, scale to `[0, 1]`, then weighted sum; sort descending. Stateless per query.
+
+### What stays unchanged
+
+- `k = 60` default for `Reciprocal`. Empirically validated; production wisdom is "do not change without evaluation data."
+- Pure static utility; no DI; no global state.
+- Sub-1ms benchmark gate.
+- Cormack 2009 cited in doc-comments; Qdrant's DBSF cited for the new sibling.
+- All existing acceptance criteria (deterministic, edge cases, property tests) carry over to both methods.
+
+### XML doc-comment guidance for callers
+
+The library's recommended use, documented inline:
+
+> **Default to `RankFusion.Reciprocal` with all weights = 1.0.** This is the production default across Elasticsearch, OpenSearch, Azure AI Search, Qdrant, and Vespa.
+>
+> **Add per-source weights** when you have a known quality asymmetry (e.g., a domain where BM25 outperforms dense). Production data shows per-source weighting moves NDCG more than `k` tuning.
+>
+> **Switch to `RankFusion.DistributionBased`** when score variance across paths is high enough that rank-only fusion ignores meaningful signal — e.g., one path consistently produces tightly clustered scores while another produces a long tail.
+>
+> **Look outside the library** for adaptive (DAT-style), learned (LTR), or tensor-rerank (ColBERT/TRF) fusion. These are application concerns; Strategos exposes the primitives, not the policy.
+
+## Risks of *not* adopting this update
+
+- **Stuck at single algorithm.** If 2.6.0 ships RRF only and a 2.7.0 caller (Basileus or other) needs weighted fusion, they either (a) re-implement RRF, (b) ship their own weighted variant, or (c) wait for a 2.7.x point release. Per-source weighting is too production-common to leave to the next milestone.
+- **`BmSaturationThreshold` remains a vestigial knob.** It was already pointing at distribution-awareness; without DBSF it stays observational forever. DIM-5 (hygiene) risk.
+- **Reactive change later.** Elasticsearch retroactively added weighted RRF in 8.16 (2025-09) and the upgrade path was painful for callers. Designing for it upfront is cheap.
+
+## Open questions
+
+1. **Does Issue #58 (`HybridQueryOptions`) need an option to select fusion method?** With two methods available, `HybridQueryOptions.FusionMethod: enum { Reciprocal, DistributionBased }` becomes natural. Default = `Reciprocal`. Adds one field but unlocks DBSF without a new wiring PR.
+2. **Should `RankFusion` expose lower-level building blocks** (e.g., `Normalize.MinMax`, `Normalize.MuSigma`, `Combine.WeightedSum`) for callers who want CombSUM or RSF-style fusion? Likely yes for completeness, but not required for 2.6.0. Could be 2.7.0 follow-up if Basileus asks.
+3. **Should weighted RRF use Qdrant's `1 / ((pos+1)/weight + k - 1)` form or the simpler `weight / (k + rank)` form** that Elasticsearch and Pearson use? They give different curves. Recommendation: Elasticsearch form. It is the simpler interpretation ("multiply each contribution by weight"), what every non-Qdrant production system implements, and what the Bruch 2024 paper's parametric RRF analysis assumes. Qdrant's form is a Qdrant convention only.
+4. **Should DBSF support `+∞`/`-∞` clamp escape** for callers passing already-normalized `[0,1]` scores where σ=0? Recommendation: when `σ < ε`, all-equal scores → all docs get fused score `0.5 * weight_L` from that list. Matches Qdrant client behavior.
+
+## Suggested revision to #57
+
+1. Update the issue title from `feat(retrieval): RankFusion.Reciprocal utility (DR-2, 2.6.0)` to `feat(retrieval): RankFusion utilities — wRRF + DBSF (DR-2, 2.6.0)`.
+2. Add the two methods above to the design.
+3. Add a new acceptance criterion: weights default reproduces Cormack 2009 bit-identically (regression test against a fixed reference).
+4. Add a new acceptance criterion: DBSF parity test against Qdrant's reference Python implementation (used as oracle).
+5. Add `## Algorithm references` section linking Cormack 2009, Qdrant DBSF source, Elasticsearch wRRF blog, Bruch 2024 (as the case for "this is the best we can do without callers shipping labeled data").
+6. Optionally update #58's `HybridQueryOptions` to add `FusionMethod` enum.
+
+## Application log
+
+- [strategos#57](https://github.com/lvlup-sw/strategos/issues/57) — title and body revised. New title: `feat(retrieval): RankFusion utilities — wRRF + DBSF (DR-2, 2.6.0)`. Adds wRRF as the canonical method and DBSF as a sibling, with Qdrant-parity oracle and Cormack-regression gates.
+- [strategos#58](https://github.com/lvlup-sw/strategos/issues/58) — body revised. `HybridQueryOptions` adds `FusionMethod` enum (`Reciprocal` default, `DistributionBased` opt-in) and `SourceWeights` field. `_meta.fusion_method` exposed for observability. Acceptance criteria expanded to cover both methods + weighted variants.
+- [strategos#47](https://github.com/lvlup-sw/strategos/issues/47) — child-issue table updated to reflect new naming; comment added summarizing the spike and the rejected alternatives.

--- a/docs/research/2026-05-06-strategos-issues-for-workflow-builder-sdk.md
+++ b/docs/research/2026-05-06-strategos-issues-for-workflow-builder-sdk.md
@@ -1,0 +1,313 @@
+# Strategos issues for exarchos v3.1.0 Workflow Builder SDK
+
+**Date:** 2026-05-06
+**Status:** Filed; milestone consolidated into `Strategos 2.7.0 — Convergence`
+**Driver:** [exarchos#1258 — Epic: Workflow Builder SDK (v3.1.0)](https://github.com/lvlup-sw/exarchos/issues/1258)
+
+## Question
+
+What does Strategos need to ship for exarchos v3.1.0 to land?
+
+## Sources
+
+- [exarchos#1258](https://github.com/lvlup-sw/exarchos/issues/1258) — Workflow Builder SDK epic
+- [exarchos#1247 (P1)](https://github.com/lvlup-sw/exarchos/issues/1247) — IR substrate (DR-2)
+- [exarchos#1256 (P10)](https://github.com/lvlup-sw/exarchos/issues/1256) — Strategos integration (T1/T5/T6 + R4)
+- [exarchos#1125](https://github.com/lvlup-sw/exarchos/issues/1125) — consumer side of `Strategos.Contracts`
+- [strategos#36](https://github.com/lvlup-sw/strategos/issues/36) — `Strategos.Contracts` (events-only today, unmilestoned)
+- [`docs/designs/2026-05-06-workflow-builder-sdk.md`](../designs/2026-05-06-workflow-builder-sdk.md) — DR-1…DR-12, §Strategos Integration, R4
+- [`docs/designs/2026-04-18-strategic-framing-exarchos-basileus.md`](../designs/2026-04-18-strategic-framing-exarchos-basileus.md)
+- Strategos open milestones: `Ontology 2.5.0` (#1), `Ontology 2.6.0` (#2). No workflow milestone exists.
+
+## Findings
+
+### F1. `#36` is events-only and unmilestoned
+
+The current `Strategos.Contracts` issue covers the 26-event TypeSpec surface (`SdlcEventEnvelope`, ontological-record lifecycle, fabric query audit, remote delegation). It does not cover workflow IR, and exarchos `#1247` blocks on that extension.
+
+### F2. Strategos has the C# definitions; it lacks the TypeSpec source
+
+`src/Strategos/Definitions/*.cs` ships all 18 records (`WorkflowDefinition`, `StepDefinition`, `TransitionDefinition`, `BranchPointDefinition`, `BranchPathDefinition`, `BranchCase`, `LoopDefinition`, `ForkPointDefinition`, `ForkPathDefinition`, `ApprovalDefinition`, `ApprovalEscalationDefinition`, `ApprovalRejectionDefinition`, `FailureHandlerDefinition`, `StepConfigurationDefinition`, `RetryConfiguration`, `CompensationConfiguration`, `ValidationDefinition`, `LowConfidenceHandlerDefinition`). The missing piece is TypeSpec source that emits matching JSON Schema for exarchos to consume.
+
+### F3. The C# records become generated output
+
+Per user decision, the migration is a single-step swap: in the same PR that lands TypeSpec source, hand-authored `Definitions/*.cs` is deleted and replaced with generated code. Two sources of truth is a DIM-5 hygiene risk; the swap eliminates it before it ships.
+
+### F4. Fixture export belongs on the Strategos side and must use the runtime serializer
+
+The ~3,400 builder cases in `Strategos.Tests/Builders/*.cs` are .NET-bound. A standalone exporter that writes JSON via a sidecar serializer would diverge from runtime serialization (DIM-4 risk). The exporter must call the same `WorkflowDefinition<TState>` → JSON path that production code uses, so fixture and runtime cannot drift.
+
+### F5. AGWF catalog must be the single source
+
+Today `AGWF001`–`AGWF014` exist in analyzer code, runtime checks, and (informally) docs. Without a single canonical artifact, parallel lists drift. Resolution: one catalog file (TypeSpec or embedded JSON), all consumers (analyzers, runtime, exporter, downstream exarchos) read from generated output of that file.
+
+### F6. `IWorkflowBuilder<TState>` becomes a published contract surface
+
+Exarchos's R4 mitigation parses the C# interface for drift. That elevates seven interfaces to versioned API: `IWorkflowBuilder`, `IBranchBuilder`, `ILoopBuilder`, `IForkJoinBuilder`, `IApprovalBuilder`, `IFailureBuilder`, `IStepConfiguration`. They need a public-API baseline test on the Strategos side that fires before exarchos's CI does.
+
+### F7. T4 is deferred
+
+`StepDefinition.runtime: "exarchos" | "strategos" | "remote"` is reserved in the TypeSpec but not wired. v3.3.0 owns federation; no Strategos work for v3.1.0 beyond reserving the field.
+
+### F8. Strategos has no milestone for this work
+
+Both open milestones are ontology-scoped. exarchos v3.1.0 has a hard dependency on landing the four issues below. A new milestone groups them and signals release timing.
+
+## Resolved decisions (from review)
+
+| Question | Decision |
+|---|---|
+| `Strategos.Contracts` version bump | `0.2.0` — additive contract surface |
+| C# definition migration mode | Single-step swap; hand-authored `Definitions/*.cs` deleted in the same PR |
+| Fixture distribution channel | Embedded in `Strategos.Contracts` NuGet (versioned with the contract) |
+| `IWorkflowBuilder<TState>` breaking-change protocol | Both: CHANGELOG release notes + auto-opened cross-repo issue on `lvlup-sw/exarchos` |
+
+## Resolved decisions (review round 2)
+
+| Question | Decision |
+|---|---|
+| Milestone title | `Strategos.Contracts 0.2.0 — Workflow IR Convergence` (matches `Ontology 2.5.0 — Coordination Floor` idiom) |
+| Issue A vs scope-extending #36 | New sibling. #36 stays as the events-only umbrella. |
+
+## Cross-product invariants (apply to every issue below)
+
+These are DIM-3 obligations that must show up in acceptance criteria:
+
+- **Schema versioning.** `WorkflowDefinitionV1.schemaVersion: "1.0"` literal in TypeSpec. Minor bumps are additive; major bumps break.
+- **Drift fails closed.** CI gates fail the build, not warn. No green-with-known-divergence.
+- **Single source.** Every artifact (C# records, JSON Schema, AGWF enum, fixtures) is generated from one file. No parallel hand-authored copies.
+- **Round-trip.** An exarchos-emitted IR JSON must validate against this milestone's emitted JSON Schema and vice versa.
+
+## Proposed Strategos issues
+
+Each issue below is a ready-to-file body. All carry `scope:workflow`, `type:feature`, `status:triage`, and the new milestone.
+
+---
+
+### Issue A — TypeSpec workflow IR (extends `Strategos.Contracts` 0.2.0)
+
+**Title:** `Strategos.Contracts 0.2.0: TypeSpec workflow IR (18 sub-definitions, single-step swap of Definitions/*.cs)`
+
+**Labels:** `type:feature`, `scope:workflow`, `priority:high`, `status:triage`
+
+**Depends on:** #36
+
+**Cross-repo blocker for:** [exarchos#1247](https://github.com/lvlup-sw/exarchos/issues/1247) (P1), [exarchos#1258](https://github.com/lvlup-sw/exarchos/issues/1258)
+
+**Body:**
+
+> Extend `Strategos.Contracts` from events-only (#36) to events + workflow IR. `0.2.0` minor bump.
+>
+> **Models (18, 1:1 with `src/Strategos/Definitions/*.cs`):**
+> `WorkflowDefinitionV1`, `StepDefinition` (discriminated: `skill | handler | gate | delegate | approval`), `TransitionDefinition`, `BranchPointDefinition`, `BranchPathDefinition`, `BranchCase`, `LoopDefinition`, `ForkPointDefinition`, `ForkPathDefinition`, `ApprovalDefinition`, `ApprovalEscalationDefinition`, `ApprovalRejectionDefinition`, `FailureHandlerDefinition`, `StepConfigurationDefinition`, `RetryConfiguration`, `CompensationConfiguration`, `ValidationDefinition`, `LowConfidenceHandlerDefinition`.
+>
+> Reserve `StepDefinition.runtime: "exarchos" | "strategos" | "remote"` (optional, default `"exarchos"`) for v3.3.0 federation.
+>
+> **Schema versioning.** `WorkflowDefinitionV1.schemaVersion: "1.0"` literal at IR root. Future minor bumps additive only; breaking changes require V2.
+>
+> **Migration: single-step swap.** Same PR that lands TypeSpec source:
+> - emits generated C# records to `src/Strategos/Definitions.Generated/`,
+> - replaces wiring to point at the generated namespace,
+> - deletes hand-authored `src/Strategos/Definitions/*.cs`.
+>
+> **Build pipeline.**
+> - TypeSpec source under `src/Strategos.Contracts/Workflow/`.
+> - JSON Schema emitted to `src/Strategos.Contracts/schemas/workflow/` and embedded as NuGet content.
+> - Spike-known issues (`$ref` dereferencing, `int64` mapping, reserved-word handling) addressed in the build.
+>
+> **Acceptance criteria.**
+> - [ ] All 18 sub-definitions present in TypeSpec; `tsp compile` succeeds.
+> - [ ] JSON Schema artifact `workflow-definition-v1.schema.json` emitted with stable `$id`.
+> - [ ] Generated C# records consumed by `Strategos` core; `grep -r "namespace Strategos.Definitions[^.]" src/Strategos/Definitions/` returns zero hits.
+> - [ ] Round-trip: a `WorkflowDefinition<TState>` from any `Strategos.Tests/Builders` case serializes to JSON that validates against the emitted schema.
+> - [ ] Cross-product round-trip (coordinated with exarchos#1247): an exarchos-emitted IR JSON validates against the schema, and an IR fixture from this repo parses against exarchos's generated Zod.
+> - [ ] CI codegen-guard fails when generated files are hand-edited.
+> - [ ] Hand-authored `Definitions/*.cs` files deleted in the same PR (verified by file count, not just diff).
+>
+> **References.**
+> - exarchos design: `docs/designs/2026-05-06-workflow-builder-sdk.md` §The IR Substrate, DR-2
+> - exarchos plan: T-001…T-006
+
+---
+
+### Issue B — Builder fixture export (uses runtime serializer)
+
+**Title:** `Strategos.Tests fixture export: ≥ 100 builder cases → JSON IR via runtime serializer`
+
+**Labels:** `type:feature`, `scope:workflow`, `status:triage`
+
+**Cross-repo blocker for:** [exarchos#1256](https://github.com/lvlup-sw/exarchos/issues/1256) (P10) — T5
+
+**Depends on:** Issue A
+
+**Body:**
+
+> Export `Strategos.Tests/Builders/*.cs` cases as JSON IR fixtures. Exarchos consumes them as Zod validation cases.
+>
+> **Constraint (DIM-4 fidelity).** The exporter must call the same serialization path that production code uses. No sidecar writer, no parallel JSON shaping. If runtime serialization changes, fixtures change in the same commit.
+>
+> **Approach.**
+> - New test category `Category=FixtureExport` in `Strategos.Tests`.
+> - Each test runs an existing builder case, captures `WorkflowDefinition<TState>`, and writes via `Strategos.Contracts`'s canonical serializer (Issue A) to `artifacts/builder-fixtures/<category>/<test-name>.json`.
+> - Manifest `index.json` enumerates fixtures with combinator-coverage tags (`startWith`, `then`, `branch`, `repeatUntil`, `fork-join`, `awaitApproval`, `onFailure`, configuration variants).
+>
+> **Distribution.** Embedded in the `Strategos.Contracts` 0.2.0 NuGet under `contentFiles/any/any/fixtures/`. Exarchos pins the contract version and extracts at build time.
+>
+> **Acceptance criteria.**
+> - [ ] `dotnet test --filter Category=FixtureExport` produces ≥ 100 JSON fixtures across all 8 combinator-coverage tags (≥ 1 per tag).
+> - [ ] Every emitted fixture validates against the JSON Schema from Issue A.
+> - [ ] Manifest schema present and validated.
+> - [ ] Partial export rejected: a single test failure fails the run, no half-written `artifacts/` directory.
+> - [ ] Fixtures NuGet-content path verified by a smoke test that unpacks the published `.nupkg`.
+> - [ ] Exporter uses `Strategos.Contracts` serializer; no parallel `JsonSerializer.Serialize` call sites in the export code (grep verified).
+>
+> **References.**
+> - exarchos design: §Strategos Integration → T5
+> - exarchos plan: T-078
+
+---
+
+### Issue C — AGWF diagnostic catalog (single source)
+
+**Title:** `AGWF001–AGWF014: single-source catalog (TypeSpec → JSON enum + C# enum + Markdown reference)`
+
+**Labels:** `type:feature`, `scope:workflow`, `type:docs`, `status:triage`
+
+**Cross-repo blocker for:** [exarchos#1256](https://github.com/lvlup-sw/exarchos/issues/1256) (P10) — T6
+
+**Body:**
+
+> Promote AGWF codes to a single canonical artifact. Today they are spread across analyzer source, runtime checks, and informal docs. exarchos v3.1.0 needs a 1:1 mapping target.
+>
+> **Source of truth.** `src/Strategos.Contracts/Diagnostics/AgwfCatalog.tsp`. One entry per code: `id`, `severity` (`error | warning | info`), `summary`, `remediation`, `since` (semver).
+>
+> **Generated outputs (single PR).**
+> - `agwf-catalog.json` (NuGet content artifact).
+> - `LevelUp.Strategos.Contracts.Diagnostics.AgwfCode` C# enum.
+> - `docs/diagnostics/agwf.md` reference page (Markdown table).
+>
+> **Consumers (rewired in the same PR, DIM-5 hygiene).** Strategos analyzers and runtime read from the generated enum; no hand-authored `case "AGWF003":` switch arms or string literals remain. Verified by grep:
+> - `grep -rn 'AGWF0[0-9]\{2\}' src/Strategos/ --include='*.cs' | grep -v Generated/` returns zero hits.
+>
+> **Change-control.** Adding a code is a minor bump. Renaming or removing is a major bump.
+>
+> **Acceptance criteria.**
+> - [ ] `AgwfCatalog.tsp` contains all 14 codes with full metadata.
+> - [ ] `agwf-catalog.json` and C# enum generated; CI fails on hand-edits.
+> - [ ] Zero hand-authored AGWF string literals in non-generated source (grep gate).
+> - [ ] Markdown reference page generated from the catalog.
+> - [ ] Exarchos can consume `agwf-catalog.json` and produce a TS enum that round-trips by name.
+>
+> **References.**
+> - exarchos design: §Strategos Integration → T6, DR-10
+
+---
+
+### Issue D — `IWorkflowBuilder<TState>` API stability + cross-repo drift detection
+
+**Title:** `IWorkflowBuilder<TState>: PublicAPI baseline + CHANGELOG protocol + auto-opened drift issue on lvlup-sw/exarchos`
+
+**Labels:** `type:feature`, `scope:workflow`, `priority:high`, `status:triage`
+
+**Cross-repo coordination with:** [exarchos#1256](https://github.com/lvlup-sw/exarchos/issues/1256) (P10) — R4
+
+**Body:**
+
+> Treat the seven builder interfaces as a published contract. Exarchos's `strategos-api-mirror.test.ts` parses these signatures; drift detection on the Strategos side fires before exarchos CI does.
+>
+> **Baselined surface (7 interfaces).** `IWorkflowBuilder<TState>`, `IBranchBuilder<TState>`, `ILoopBuilder<TState>`, `IForkJoinBuilder<TState>`, `IApprovalBuilder<TState>`, `IFailureBuilder<TState>`, `IStepConfiguration<TState>`.
+>
+> **Tooling.**
+> - `Microsoft.DotNet.PublicApiAnalyzers` with `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` per project.
+> - Baseline scope = the 7 interfaces only (not the whole `Strategos.Abstractions` surface, to keep the gate signal-rich).
+>
+> **CHANGELOG.** Every release that bumps `Strategos.Contracts` includes a `## Cross-product breaking changes` section, even when empty (forces the author to think about it).
+>
+> **Auto-issue (cross-repo).** A GitHub Action on `main` opens an issue on `lvlup-sw/exarchos` when `PublicAPI.Shipped.txt` diverges from the previous tag. Issue body links the diff and tags `cross-product:strategos`. Workflow uses a fine-grained PAT scoped to issues:write on `lvlup-sw/exarchos`.
+>
+> **Failure mode (DIM-7 fails closed).** A baseline change without a matching `Unshipped` entry fails CI. The CI message names the protocol: "Update PublicAPI.Unshipped.txt and add a CHANGELOG entry under Cross-product breaking changes."
+>
+> **Acceptance criteria.**
+> - [ ] `PublicAPI.Shipped.txt` baseline committed for the 7 interfaces.
+> - [ ] CI fails on baseline divergence with the named remediation message.
+> - [ ] Auto-issue workflow tested via a dry-run divergence; opens an issue on `lvlup-sw/exarchos` with the correct labels and a link to the public-API diff.
+> - [ ] CHANGELOG protocol documented in `CONTRIBUTING.md`.
+> - [ ] Doc-comment on `IWorkflowBuilder<TState>.cs` references the protocol.
+>
+> **References.**
+> - exarchos design: §Risks R4
+> - exarchos plan: T-080
+
+---
+
+### Issue E — Coordination meta-issue
+
+**Title:** `Workflow IR Convergence (exarchos v3.1.0): tracking + acceptance gate`
+
+**Labels:** `type:epic`, `scope:workflow`, `priority:high`, `status:triage`
+
+**Body:**
+
+> Tracks Strategos's commitments to [exarchos#1258](https://github.com/lvlup-sw/exarchos/issues/1258).
+>
+> | Tier | Issue | Exarchos consumer |
+> |---|---|---|
+> | T1 | Issue A — TypeSpec workflow IR | exarchos#1247 |
+> | T5 | Issue B — Fixture export | exarchos#1256 |
+> | T6 | Issue C — AGWF catalog | exarchos#1256 |
+> | R4 | Issue D — API stability | exarchos#1256 |
+> | T4 | (deferred) | exarchos v3.3.0 |
+>
+> **Milestone close gate.**
+> - All four child issues closed.
+> - `Strategos.Contracts` 0.2.0 published.
+> - exarchos cross-product round-trip test green: an exarchos-emitted IR JSON validates against this milestone's JSON Schema, and a Strategos fixture parses against exarchos's generated Zod.
+> - exarchos `strategos-api-mirror.test.ts` green against the 0.2.0 baseline.
+>
+> **Out of scope.** T4 cross-runtime dispatch (saga compensation across event stores) — exarchos v3.3.0 + future Strategos remoting milestone.
+>
+> **References.**
+> - Strategic framing: [`basileus/docs/decisions/2026-04-18-strategic-framing-exarchos-basileus.md`](https://github.com/lvlup-sw/basileus/blob/main/docs/decisions/2026-04-18-strategic-framing-exarchos-basileus.md)
+> - exarchos design: [`docs/designs/2026-05-06-workflow-builder-sdk.md`](https://github.com/lvlup-sw/exarchos/blob/main/docs/designs/2026-05-06-workflow-builder-sdk.md)
+
+---
+
+## Recommended milestone
+
+**Title:** `Strategos.Contracts 0.2.0 — Workflow IR Convergence`
+
+**Description:**
+> Strategos prerequisites for the exarchos Workflow Builder SDK epic ([exarchos#1258](https://github.com/lvlup-sw/exarchos/issues/1258), v3.1.0). Extends `Strategos.Contracts` from events-only (#36) to events + workflow IR (`0.2.0`), ports ≥ 100 builder fixtures via the runtime serializer, canonicalizes the AGWF catalog as a single source, and adds a public-API baseline + cross-repo drift detection on `IWorkflowBuilder<TState>`. Cross-runtime dispatch (T4) deferred to a later milestone.
+
+## Filing log
+
+### Final milestone shape (after rightsizing review)
+
+The original `Strategos.Contracts 0.2.0 — Workflow IR Convergence` milestone was renamed and rescoped to track a Strategos main release. Strategos uses unified MinVer-driven versioning: existing milestones (`Ontology 2.5.0`, `Ontology 2.6.0`) map to Strategos main releases. The Contracts package debuts at 0.2.0 inside the Strategos 2.7.0 release; no separate 0.1.0 ships.
+
+| Milestone | Open | Scope |
+|---|---|---|
+| [Ontology 2.5.0 — Coordination Floor (#1)](https://github.com/lvlup-sw/strategos/milestone/1) | 12 | Coordination-floor seams + absorbed cleanups (#23, #32, #33) |
+| [Ontology 2.6.0 — Hybrid Retrieval Seams (#2)](https://github.com/lvlup-sw/strategos/milestone/2) | 1 | #47 |
+| [**Strategos 2.7.0 — Convergence** (#3)](https://github.com/lvlup-sw/strategos/milestone/3) | 7 | Slice (A) Contracts foundation #36; Slice (B) Workflow IR #50–#54; Slice (C) Agents MEAI 10.5 #45 |
+
+### Slice B issues (this discovery's deliverables)
+
+| Issue | Title | URL |
+|---|---|---|
+| A (T1) | TypeSpec workflow IR | [lvlup-sw/strategos#50](https://github.com/lvlup-sw/strategos/issues/50) |
+| D (R4) | IWorkflowBuilder PublicAPI baseline | [lvlup-sw/strategos#51](https://github.com/lvlup-sw/strategos/issues/51) |
+| C (T6) | AGWF single-source catalog | [lvlup-sw/strategos#52](https://github.com/lvlup-sw/strategos/issues/52) |
+| B (T5) | Fixture export via runtime serializer | [lvlup-sw/strategos#53](https://github.com/lvlup-sw/strategos/issues/53) |
+| E | Slice-B sub-tracker (was umbrella) | [lvlup-sw/strategos#54](https://github.com/lvlup-sw/strategos/issues/54) |
+
+**Slice ordering inside 2.7.0.** (B) blocks on (A); (C) is independent.
+
+**Cross-links posted on exarchos:**
+- [exarchos#1247 comment](https://github.com/lvlup-sw/exarchos/issues/1247#issuecomment-4394488562)
+- [exarchos#1256 comment](https://github.com/lvlup-sw/exarchos/issues/1256#issuecomment-4394488911)
+- [exarchos#1258 comment](https://github.com/lvlup-sw/exarchos/issues/1258#issuecomment-4394489214)
+
+### Out of scope for this milestone
+
+- `#24` (`Agentic.*` namespace references in generators, `status:stale`) — left unmilestoned; recommend triaging separately (close as superseded or assign to a future maintenance milestone).

--- a/servers/exarchos-mcp/src/__tests__/integration/prune-stale-workflows.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/integration/prune-stale-workflows.test.ts
@@ -92,6 +92,11 @@ function makeRealDeps(
     // a non-undefined value so safeguard stubs are actually consulted.
     readBranchName: async (featureId) => `feat/${featureId}`,
     safeguards,
+    // C8 (#1117): integration tests don't seed `workflow.transition` events
+    // or fixture branches; default to "no signal" so `selectPruneCandidates`
+    // stays on the legacy single-signal path it was authored against.
+    readPhaseTransitionTimestamp: async () => undefined,
+    readBranchActivityTimestamp: async () => undefined,
   };
 }
 

--- a/servers/exarchos-mcp/src/__tests__/views/workflow-status-view.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/views/workflow-status-view.test.ts
@@ -182,4 +182,73 @@ describe('WorkflowStatusView', () => {
       expect(view.tasksFailed).toBe(0);
     });
   });
+
+  // ── C4 (#1226): projection dedup by taskId ────────────────────────────
+  // Duplicate task.assigned / task.completed events (from #1228 retries or
+  // #1230 historical replay) must be counted at most once per taskId so the
+  // counters remain monotonic and tasksCompleted <= tasksTotal.
+
+  describe('workflowStatus_replayWithDuplicateTaskCompleted_dedupsByTaskId', () => {
+    it('counts a single task.completed when the same taskId appears twice', () => {
+      const events = [
+        makeEvent(1, 'workflow.started', { featureId: 'f1', workflowType: 'feature' }),
+        makeEvent(2, 'task.assigned', { taskId: 't1', title: 'Task 1' }),
+        makeEvent(3, 'task.completed', { taskId: 't1' }),
+        makeEvent(4, 'task.completed', { taskId: 't1' }),
+      ];
+
+      const view = materializer.materialize<WorkflowStatusViewState>(
+        'wf-dedup-1',
+        WORKFLOW_STATUS_VIEW,
+        events,
+      );
+
+      expect(view.tasksTotal).toBe(1);
+      expect(view.tasksCompleted).toBe(1);
+    });
+
+    it('also dedups task.assigned by taskId (symmetric guard)', () => {
+      const events = [
+        makeEvent(1, 'workflow.started', { featureId: 'f1', workflowType: 'feature' }),
+        makeEvent(2, 'task.assigned', { taskId: 't1', title: 'Task 1' }),
+        makeEvent(3, 'task.assigned', { taskId: 't1', title: 'Task 1 (retry)' }),
+        makeEvent(4, 'task.assigned', { taskId: 't2', title: 'Task 2' }),
+      ];
+
+      const view = materializer.materialize<WorkflowStatusViewState>(
+        'wf-dedup-2',
+        WORKFLOW_STATUS_VIEW,
+        events,
+      );
+
+      expect(view.tasksTotal).toBe(2);
+    });
+  });
+
+  describe('workflowStatus_tasksCompletedExceedsTotal_invariantHolds', () => {
+    it('keeps tasksCompleted <= tasksTotal under any duplicate-event sequence (#1226)', () => {
+      // Pathological log: two assigns and many duplicate completes for the
+      // same taskId. Pre-fix this drove tasksCompleted past tasksTotal.
+      const events = [
+        makeEvent(1, 'workflow.started', { featureId: 'f1', workflowType: 'feature' }),
+        makeEvent(2, 'task.assigned', { taskId: 't1', title: 'Task 1' }),
+        makeEvent(3, 'task.assigned', { taskId: 't2', title: 'Task 2' }),
+        makeEvent(4, 'task.completed', { taskId: 't1' }),
+        makeEvent(5, 'task.completed', { taskId: 't1' }),
+        makeEvent(6, 'task.completed', { taskId: 't1' }),
+        makeEvent(7, 'task.completed', { taskId: 't2' }),
+        makeEvent(8, 'task.completed', { taskId: 't2' }),
+      ];
+
+      const view = materializer.materialize<WorkflowStatusViewState>(
+        'wf-invariant',
+        WORKFLOW_STATUS_VIEW,
+        events,
+      );
+
+      expect(view.tasksCompleted).toBeLessThanOrEqual(view.tasksTotal);
+      expect(view.tasksTotal).toBe(2);
+      expect(view.tasksCompleted).toBe(2);
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/tools.test.ts
@@ -2051,13 +2051,16 @@ describe('Guaranteed Event Append', () => {
     const checkpointCalls = appendCalls.filter((c) => c.type === 'workflow.checkpoint');
     expect(checkpointCalls.length).toBe(1);
     expect(checkpointCalls[0].idempotencyKey).toBeDefined();
-    // Key pattern: ${featureId}:checkpoint:${phase}:${version}
+    // Key pattern: ${featureId}:checkpoint:${phase}:${version}:${handoffDigest}
     // The version used in the key is the state's version at read time (before checkpoint writes).
     // handleInit writes with version increment, so the on-disk version after init is 2,
     // but handleCheckpoint reads the state and uses _version from that read.
-    // Verify the key matches the expected pattern (phase=ideate, version from state read)
+    // C3 (#1241): a 16-char sha256 prefix of `JSON.stringify(input.handoff ?? {})`
+    // is appended so refinement calls within the same phase land as
+    // distinct events. No-handoff calls produce a stable digest (`{}`),
+    // preserving prior dedup behavior.
     expect(checkpointCalls[0].idempotencyKey).toMatch(
-      /^ckpt-idem-key:checkpoint:ideate:\d+$/,
+      /^ckpt-idem-key:checkpoint:ideate:\d+:[0-9a-f]{16}$/,
     );
   });
 });

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
@@ -35,7 +35,73 @@ hooks:
           command: npm --prefix "$(git rev-parse --show-toplevel)" run test:run
 ---
 
-You are a fixer agent. Your job is to diagnose and repair failures.
+You are a fixer agent working in an isolated worktree. Your job is to diagnose and repair failures.
+
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
+## Worktree Verification
+Before making ANY file changes:
+1. Run: `pwd`
+2. Verify the path contains `.worktrees/`
+3. If NOT in worktree: STOP and report error
+
+## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
+
+The startup check above only verifies you booted in the right place. Shell
+`cd` and script runners can leave you in another worktree mid-task. Once
+that happens, subsequent `git` commands execute against whatever worktree
+your shell is sitting in — and commits land on the wrong branch. Recent
+sessions have seen this corrupt the orchestrator's main worktree HEAD.
+
+Rules:
+
+1. **All `git` commands must use `git -C <my-worktree-path>`.** Never rely
+   on the shell's working directory for git. Capture your worktree path at
+   startup (from `pwd`) and use it explicitly for every `git add`,
+   `git commit`, `git status`, `git log`, etc.
+2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
+   explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
+   repository root (or any path outside `.worktrees/`) and then run git
+   commands.
+3. **If a command must run from a specific directory, restore the
+   worktree cwd immediately after.** If you need one-off output from
+   `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`
+   before the next git operation.
+4. **Never `git reset --hard` outside your worktree.** If you believe
+   you've accidentally committed to a branch in another worktree, STOP
+   and report it — do not try to self-heal with a reset in the parent
+   repo.
+
+Concrete example — **wrong vs right** for running typecheck in the
+completion gate:
+
+```bash
+# WRONG — cds into main worktree, then subsequent git ops contaminate it
+cd /home/user/repo && npm run typecheck
+git status     # now runs in /home/user/repo, not the worktree
+
+# RIGHT — uses --prefix, shell cwd never leaves the worktree
+npm --prefix "$WORKTREE" run typecheck
+git -C "$WORKTREE" status
+```
+
+Where `$WORKTREE` is the absolute path captured at startup (the `pwd`
+output from the Worktree Verification step above).
 
 ## Failure Context
 {{failureContext}}

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
@@ -22,6 +22,7 @@ model: inherit
 color: red
 disallowedTools:
   - Agent
+isolation: worktree
 mcpServers:
   - exarchos
 skills:

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
@@ -56,8 +56,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -76,8 +80,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
@@ -58,8 +58,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -78,8 +82,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
@@ -48,8 +48,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: `pwd`
-2. Verify the path contains `.worktrees/`
+1. Run: `pwd` (or `Get-Location` on PowerShell)
+2. Verify the path contains `.worktrees` (path separator can be either
+   forward slash or backslash — Linux/macOS `pwd` returns
+   `/path/.worktrees/agent-foo`; PowerShell `Get-Location` typically
+   returns `C:\path\.worktrees\agent-foo`. Match the segment
+   `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -68,8 +72,8 @@ Rules:
    `git commit`, `git status`, `git log`, etc.
 2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
    explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
-   repository root (or any path outside `.worktrees/`) and then run git
-   commands.
+   repository root (or any path outside the `.worktrees` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
@@ -29,11 +29,71 @@ mcpServers:
 
 You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.
 
+## Working Directory Setup (MANDATORY)
+
+Your shell may have started in the parent repo cwd, depending on the runtime.
+Native-isolation runtimes (Claude Code's `isolation: "worktree"`) chdir for
+you; other runtimes (Copilot CLI, generic MCP, Cursor at the time of writing)
+spawn subagents in the parent. Your FIRST command must be:
+
+```bash
+cd "<absolute worktree path>"             # bash / zsh / sh
+```
+```powershell
+Set-Location "<absolute worktree path>"   # PowerShell
+```
+
+Where `<absolute worktree path>` is the path you were dispatched to.
+After that, the verification block below confirms you landed correctly.
+
 ## Worktree Verification
 Before making ANY file changes:
 1. Run: `pwd`
 2. Verify the path contains `.worktrees/`
 3. If NOT in worktree: STOP and report error
+
+## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
+
+The startup check above only verifies you booted in the right place. Shell
+`cd` and script runners can leave you in another worktree mid-task. Once
+that happens, subsequent `git` commands execute against whatever worktree
+your shell is sitting in — and commits land on the wrong branch. Recent
+sessions have seen this corrupt the orchestrator's main worktree HEAD.
+
+Rules:
+
+1. **All `git` commands must use `git -C <my-worktree-path>`.** Never rely
+   on the shell's working directory for git. Capture your worktree path at
+   startup (from `pwd`) and use it explicitly for every `git add`,
+   `git commit`, `git status`, `git log`, etc.
+2. **Run scripts with `npm --prefix <my-worktree-path> run …`** or with an
+   explicit `cd <my-worktree-path> && …` guard. Do not `cd` to the main
+   repository root (or any path outside `.worktrees/`) and then run git
+   commands.
+3. **If a command must run from a specific directory, restore the
+   worktree cwd immediately after.** If you need one-off output from
+   `cd /some/other/place && some-cmd`, follow it with `cd <my-worktree-path>`
+   before the next git operation.
+4. **Never `git reset --hard` outside your worktree.** If you believe
+   you've accidentally committed to a branch in another worktree, STOP
+   and report it — do not try to self-heal with a reset in the parent
+   repo.
+
+Concrete example — **wrong vs right** for running typecheck in the
+completion gate:
+
+```bash
+# WRONG — cds into main worktree, then subsequent git ops contaminate it
+cd /home/user/repo && npm run typecheck
+git status     # now runs in /home/user/repo, not the worktree
+
+# RIGHT — uses --prefix, shell cwd never leaves the worktree
+npm --prefix "$WORKTREE" run typecheck
+git -C "$WORKTREE" status
+```
+
+Where `$WORKTREE` is the absolute path captured at startup (the `pwd`
+output from the Worktree Verification step above).
 
 ## Task
 {{taskDescription}}

--- a/servers/exarchos-mcp/src/agents/adapters/claude.test.ts
+++ b/servers/exarchos-mcp/src/agents/adapters/claude.test.ts
@@ -69,6 +69,25 @@ describe('Claude adapter', () => {
       expect(claudeAdapter.validateSupport(spec)).toEqual({ ok: true });
     }
   });
+
+  // ─── C5 (#1220): worktree isolation rendered for write-capable specs ─────
+  //
+  // The adapter renders `isolation: worktree` only when the spec declares
+  // the `'isolation:worktree'` capability (see claude.ts:135–137). FIXER
+  // and SCAFFOLDER must produce that frontmatter field so the Claude Code
+  // runtime spawns them in an isolated worktree on parallel dispatch.
+
+  it('claudeAdapter_fixerSpec_rendersWorktreeIsolation', () => {
+    const out = claudeAdapter.lowerSpec(FIXER);
+    const fm = parseYaml(extractFrontmatter(out.contents)) as Record<string, unknown>;
+    expect(fm.isolation).toBe('worktree');
+  });
+
+  it('claudeAdapter_scaffolderSpec_rendersWorktreeIsolation', () => {
+    const out = claudeAdapter.lowerSpec(SCAFFOLDER);
+    const fm = parseYaml(extractFrontmatter(out.contents)) as Record<string, unknown>;
+    expect(fm.isolation).toBe('worktree');
+  });
 });
 
 // ─── Adversarial YAML field tests ──────────────────────────────────────────

--- a/servers/exarchos-mcp/src/agents/definitions.test.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.test.ts
@@ -94,6 +94,33 @@ describe('AgentSpec capability declarations', () => {
     );
   });
 
+  // ─── C5 (#1220): isolation:worktree on write-capable specs ────────────────
+  //
+  // The Claude adapter only renders `isolation: worktree` frontmatter when the
+  // spec declares the `'isolation:worktree'` capability (see
+  // `adapters/claude.ts:135–137`). FIXER and SCAFFOLDER both have `fs:write`
+  // and `shell:exec`, so they must declare `isolation:worktree` — otherwise
+  // parallel dispatch corrupts the orchestrator's main worktree (#1220).
+  // REVIEWER is read-only and intentionally does NOT declare it; this test
+  // pins that posture so the C5 fix doesn't over-correct.
+
+  it('FIXER_capabilities_includesIsolationWorktree', () => {
+    expect(FIXER.capabilities).toContain('isolation:worktree');
+  });
+
+  it('SCAFFOLDER_capabilities_includesIsolationWorktree', () => {
+    expect(SCAFFOLDER.capabilities).toContain('isolation:worktree');
+  });
+
+  it('REVIEWER_capabilities_readOnlyDoesNotRequireIsolation', () => {
+    // Pin the read-only posture: REVIEWER must not have write/shell caps,
+    // and correspondingly does not need worktree isolation. This prevents
+    // C5 from accidentally adding isolation everywhere.
+    expect(REVIEWER.capabilities).not.toContain('fs:write');
+    expect(REVIEWER.capabilities).not.toContain('shell:exec');
+    expect(REVIEWER.capabilities).not.toContain('isolation:worktree');
+  });
+
   it('AgentSpec_RejectsUnknownCapability_TypecheckFails', () => {
     // @ts-expect-error - 'bogus' is not a valid Capability
     const bad: AgentSpec = {

--- a/servers/exarchos-mcp/src/agents/definitions.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.ts
@@ -38,8 +38,12 @@ After that, the verification block below confirms you landed correctly.
 
 ## Worktree Verification
 Before making ANY file changes:
-1. Run: \`pwd\`
-2. Verify the path contains \`.worktrees/\`
+1. Run: \`pwd\` (or \`Get-Location\` on PowerShell)
+2. Verify the path contains \`.worktrees\` (path separator can be either
+   forward slash or backslash — Linux/macOS \`pwd\` returns
+   \`/path/.worktrees/agent-foo\`; PowerShell \`Get-Location\` typically
+   returns \`C:\\path\\.worktrees\\agent-foo\`. Match the segment
+   \`.worktrees\`, not the literal substring \`.worktrees/\`.)
 3. If NOT in worktree: STOP and report error
 
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
@@ -58,8 +62,8 @@ Rules:
    \`git commit\`, \`git status\`, \`git log\`, etc.
 2. **Run scripts with \`npm --prefix <my-worktree-path> run …\`** or with an
    explicit \`cd <my-worktree-path> && …\` guard. Do not \`cd\` to the main
-   repository root (or any path outside \`.worktrees/\`) and then run git
-   commands.
+   repository root (or any path outside the \`.worktrees\` segment) and
+   then run git commands.
 3. **If a command must run from a specific directory, restore the
    worktree cwd immediately after.** If you need one-off output from
    \`cd /some/other/place && some-cmd\`, follow it with \`cd <my-worktree-path>\`

--- a/servers/exarchos-mcp/src/agents/definitions.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.ts
@@ -8,24 +8,18 @@
 
 import type { AgentSpec } from './types.js';
 
-// ─── Implementer ────────────────────────────────────────────────────────────
-
-export const IMPLEMENTER: AgentSpec = {
-  id: 'implementer',
-  description: `Use this agent when dispatching TDD implementation tasks to a subagent in an isolated worktree.
-
-<example>
-Context: Orchestrator is dispatching a task from an implementation plan
-user: "Implement the agent spec handler (task-003)"
-assistant: "I'll dispatch the exarchos-implementer agent to implement this task using TDD in an isolated worktree."
-<commentary>
-Implementation task requiring test-first development triggers the implementer agent.
-</commentary>
-</example>`,
-  color: 'blue',
-  systemPrompt: `You are a TDD implementer agent working in an isolated worktree.
-
-## Working Directory Setup (MANDATORY)
+// ─── Shared worktree-entry contract ─────────────────────────────────────────
+//
+// Every isolated agent (IMPLEMENTER, FIXER, SCAFFOLDER) must boot into the
+// dispatched worktree before touching the filesystem. Native-isolation
+// runtimes (Claude Code's `isolation: "worktree"`) chdir for the agent;
+// other runtimes (Copilot CLI, generic MCP, Cursor) spawn subagents in the
+// parent. Without an explicit cd + verify, the agent can edit the parent
+// repo and corrupt the orchestrator's main worktree HEAD.
+//
+// Single source of truth — avoids drift across agent prompts (the gap that
+// produced the original C11 review finding for FIXER).
+const WORKTREE_ENTRY_CONTRACT = `## Working Directory Setup (MANDATORY)
 
 Your shell may have started in the parent repo cwd, depending on the runtime.
 Native-isolation runtimes (Claude Code's \`isolation: "worktree"\`) chdir for
@@ -89,7 +83,26 @@ git -C "$WORKTREE" status
 \`\`\`
 
 Where \`$WORKTREE\` is the absolute path captured at startup (the \`pwd\`
-output from the Worktree Verification step above).
+output from the Worktree Verification step above).`;
+
+// ─── Implementer ────────────────────────────────────────────────────────────
+
+export const IMPLEMENTER: AgentSpec = {
+  id: 'implementer',
+  description: `Use this agent when dispatching TDD implementation tasks to a subagent in an isolated worktree.
+
+<example>
+Context: Orchestrator is dispatching a task from an implementation plan
+user: "Implement the agent spec handler (task-003)"
+assistant: "I'll dispatch the exarchos-implementer agent to implement this task using TDD in an isolated worktree."
+<commentary>
+Implementation task requiring test-first development triggers the implementer agent.
+</commentary>
+</example>`,
+  color: 'blue',
+  systemPrompt: `You are a TDD implementer agent working in an isolated worktree.
+
+${WORKTREE_ENTRY_CONTRACT}
 
 ## Task
 {{taskDescription}}
@@ -160,7 +173,9 @@ Failed task requiring root cause analysis and targeted fix triggers the fixer ag
 </commentary>
 </example>`,
   color: 'red',
-  systemPrompt: `You are a fixer agent. Your job is to diagnose and repair failures.
+  systemPrompt: `You are a fixer agent working in an isolated worktree. Your job is to diagnose and repair failures.
+
+${WORKTREE_ENTRY_CONTRACT}
 
 ## Failure Context
 {{failureContext}}
@@ -310,11 +325,7 @@ Simple file creation and boilerplate generation triggers the scaffolder agent wi
   color: 'cyan',
   systemPrompt: `You are a scaffolder agent working in an isolated worktree. Be concise — generate files with minimal commentary.
 
-## Worktree Verification
-Before making ANY file changes:
-1. Run: \`pwd\`
-2. Verify the path contains \`.worktrees/\`
-3. If NOT in worktree: STOP and report error
+${WORKTREE_ENTRY_CONTRACT}
 
 ## Task
 {{taskDescription}}

--- a/servers/exarchos-mcp/src/agents/definitions.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.ts
@@ -200,9 +200,11 @@ When done, output a JSON completion report:
     'fs:write',
     'shell:exec',
     'mcp:exarchos',
+    'isolation:worktree',
   ],
   disallowedTools: ['Agent'],
   model: 'inherit',
+  isolation: 'worktree',
   skills: [
     { name: 'tdd-patterns', content: '' },
   ],

--- a/servers/exarchos-mcp/src/agents/subagent-stream-router.test.ts
+++ b/servers/exarchos-mcp/src/agents/subagent-stream-router.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { AtomicAppender } from '../event-store/atomic-appender.js';
+import { SubagentStreamRouter } from './subagent-stream-router.js';
+
+/**
+ * SubagentStreamRouter — primitive for v2.9 bug cluster (#1224).
+ *
+ * Subagents in isolated worktrees emit `task.completed` events to their child
+ * stream. The team coordinator runs in the main worktree and emits
+ * `team.disbanded`. Without explicit propagation the parent stream never sees
+ * the supporting `task.completed` events; the all-tasks-complete guard sees
+ * `team.disbanded` with no backing events. The router fixes that by emitting
+ * the parent-stream `task.completed` events and computing
+ * `team.disbanded.tasksCompleted` from the parent stream's actual event count
+ * — never from an in-memory accumulator.
+ */
+describe('SubagentStreamRouter', () => {
+  let stateDir: string;
+  let appender: AtomicAppender;
+  let router: SubagentStreamRouter;
+
+  beforeEach(async () => {
+    stateDir = await mkdtemp(path.join(tmpdir(), 'subagent-stream-router-test-'));
+    appender = new AtomicAppender({ stateDir });
+    router = new SubagentStreamRouter({ appender, stateDir });
+  });
+
+  afterEach(async () => {
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  /**
+   * RED test 1: parent-stream `task.completed` events land BEFORE
+   * `team.disbanded` in the parent stream sequence. AtomicAppender's
+   * per-stream serialization gives this property by construction; the router
+   * just has to route both writes through the same appender.
+   */
+  it('SubagentStreamRouter_onTaskCompleted_emittedBeforeDisbanded', async () => {
+    const parentStreamId = 'workflow-parent-1';
+    const childStreamId = 'workflow-child-1';
+    const teamId = 'team-alpha';
+
+    await router.onTaskCompleted(parentStreamId, childStreamId, 'task-1', {
+      taskId: 'task-1',
+      teamId,
+    });
+    await router.onTaskCompleted(parentStreamId, childStreamId, 'task-2', {
+      taskId: 'task-2',
+      teamId,
+    });
+    await router.emitDisbanded(parentStreamId, {
+      teamId,
+      totalDurationMs: 1234,
+      tasksFailed: 0,
+    });
+
+    const jsonlPath = path.join(stateDir, `${parentStreamId}.events.jsonl`);
+    const contents = await readFile(jsonlPath, 'utf-8');
+    const events = contents
+      .trim()
+      .split('\n')
+      .filter(l => l.length > 0)
+      .map(l => JSON.parse(l));
+
+    const taskCompletedEvents = events.filter(e => e.type === 'task.completed');
+    const disbandedEvents = events.filter(e => e.type === 'team.disbanded');
+
+    expect(taskCompletedEvents).toHaveLength(2);
+    expect(disbandedEvents).toHaveLength(1);
+
+    const maxTaskCompletedSeq = Math.max(...taskCompletedEvents.map(e => e.sequence));
+    const disbandedSeq = disbandedEvents[0].sequence;
+    expect(maxTaskCompletedSeq).toBeLessThan(disbandedSeq);
+  });
+
+  /**
+   * RED test 2: this is the #1224 regression. `team.disbanded.tasksCompleted`
+   * MUST be derived from querying the parent stream's actual `task.completed`
+   * count for the team — NEVER from an in-memory accumulator. We don't pass
+   * a count into `emitDisbanded`; the router queries.
+   */
+  it('SubagentStreamRouter_disbandedTasksCount_reflectsParentStreamNotInMemoryTally', async () => {
+    const parentStreamId = 'workflow-parent-2';
+    const childStreamId = 'workflow-child-2';
+    const teamId = 'team-beta';
+
+    // Emit three child task.completed events for this team.
+    await router.onTaskCompleted(parentStreamId, childStreamId, 'task-1', {
+      taskId: 'task-1',
+      teamId,
+    });
+    await router.onTaskCompleted(parentStreamId, childStreamId, 'task-2', {
+      taskId: 'task-2',
+      teamId,
+    });
+    await router.onTaskCompleted(parentStreamId, childStreamId, 'task-3', {
+      taskId: 'task-3',
+      teamId,
+    });
+
+    // Emit a task.completed for an UNRELATED team — the router must scope its
+    // count to teamId, not all task.completed events on the stream.
+    await router.onTaskCompleted(parentStreamId, 'workflow-child-other', 'task-x', {
+      taskId: 'task-x',
+      teamId: 'team-other',
+    });
+
+    // emitDisbanded does NOT take a tasksCompleted argument — it queries.
+    await router.emitDisbanded(parentStreamId, {
+      teamId,
+      totalDurationMs: 5000,
+      tasksFailed: 0,
+    });
+
+    const jsonlPath = path.join(stateDir, `${parentStreamId}.events.jsonl`);
+    const contents = await readFile(jsonlPath, 'utf-8');
+    const events = contents
+      .trim()
+      .split('\n')
+      .filter(l => l.length > 0)
+      .map(l => JSON.parse(l));
+
+    const disbanded = events.find(
+      e => e.type === 'team.disbanded' && (e.data?.teamId === teamId),
+    );
+    expect(disbanded).toBeDefined();
+    expect(disbanded.data.tasksCompleted).toBe(3);
+  });
+
+  /**
+   * RED test 3: idempotency. Replaying the same `<childStreamId>:<taskId>`
+   * produces a single parent-stream event. Backed by AtomicAppender's
+   * commit-on-success idempotencyKey cache.
+   */
+  it('SubagentStreamRouter_replayedTaskCompleted_singleParentEvent', async () => {
+    const parentStreamId = 'workflow-parent-3';
+    const childStreamId = 'workflow-child-3';
+    const teamId = 'team-gamma';
+    const taskId = 'task-replay';
+
+    await router.onTaskCompleted(parentStreamId, childStreamId, taskId, {
+      taskId,
+      teamId,
+    });
+    // Same child stream + task id — must NOT produce a duplicate parent event.
+    await router.onTaskCompleted(parentStreamId, childStreamId, taskId, {
+      taskId,
+      teamId,
+    });
+    await router.onTaskCompleted(parentStreamId, childStreamId, taskId, {
+      taskId,
+      teamId,
+    });
+
+    const jsonlPath = path.join(stateDir, `${parentStreamId}.events.jsonl`);
+    const contents = await readFile(jsonlPath, 'utf-8');
+    const events = contents
+      .trim()
+      .split('\n')
+      .filter(l => l.length > 0)
+      .map(l => JSON.parse(l));
+
+    const taskCompleted = events.filter(
+      e => e.type === 'task.completed' && e.data?.taskId === taskId,
+    );
+    expect(taskCompleted).toHaveLength(1);
+  });
+});

--- a/servers/exarchos-mcp/src/agents/subagent-stream-router.ts
+++ b/servers/exarchos-mcp/src/agents/subagent-stream-router.ts
@@ -33,6 +33,10 @@ import type { AtomicAppender } from '../event-store/atomic-appender.js';
  * model — when that lands, this implementation flattens to a query over
  * `stream_id LIKE '<parent>/%'` and the parent emit on `team.disbanded`
  * remains.
+ *
+ * This module ships ahead of its consumer site. Wiring lands in commit C11
+ * (intercepting `team.disbanded` in `handleEventAppend`); see design
+ * Primitive 2 'Consumer changes' subsection.
  */
 
 /**

--- a/servers/exarchos-mcp/src/agents/subagent-stream-router.ts
+++ b/servers/exarchos-mcp/src/agents/subagent-stream-router.ts
@@ -160,25 +160,33 @@ export class SubagentStreamRouter implements SubagentStreamRouterContract {
     // Source of truth: query the parent stream for task.completed events
     // scoped to this team. NEVER use an in-memory counter — that's the
     // exact double-bookkeeping that produced #1224.
-    const tasksCompleted = await this.countTaskCompletedForTeam(
-      parentStreamId,
-      summary.teamId,
-    );
-
+    //
+    // The count read MUST run under the appender's per-stream lock. A naive
+    // `count() ; append()` two-step lets concurrent `onTaskCompleted` calls
+    // (which serialize through the same lock for their writes) sit between
+    // the steps — the read sees a stale JSONL, and `team.disbanded` lands
+    // with a count that misses the in-flight completions. `appendComputed`
+    // closes the read+append into a single critical section.
     const idempotencyKey = `${summary.teamId}:team.disbanded`;
-    const result = await this.appender.append(
+    const result = await this.appender.appendComputed(
       parentStreamId,
-      [
-        {
-          type: 'team.disbanded',
-          data: {
-            ...summary,
-            tasksCompleted,
-          },
-          source: 'subagent-stream-router',
-        },
-      ],
       idempotencyKey,
+      async () => {
+        const tasksCompleted = await this.countTaskCompletedForTeam(
+          parentStreamId,
+          summary.teamId,
+        );
+        return [
+          {
+            type: 'team.disbanded',
+            data: {
+              ...summary,
+              tasksCompleted,
+            },
+            source: 'subagent-stream-router',
+          },
+        ];
+      },
     );
     if (!result.ok) {
       throw new Error(

--- a/servers/exarchos-mcp/src/agents/subagent-stream-router.ts
+++ b/servers/exarchos-mcp/src/agents/subagent-stream-router.ts
@@ -1,0 +1,232 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import type { AtomicAppender } from '../event-store/atomic-appender.js';
+
+/**
+ * SubagentStreamRouter — primitive for v2.9 bug cluster (#1224).
+ *
+ * Subagents in isolated worktrees emit `task.completed` events to their child
+ * stream. The team coordinator (which runs in the parent / main worktree)
+ * historically tracked completion via an in-memory accumulator and emitted
+ * `team.disbanded` with that accumulated count — without ever propagating the
+ * underlying `task.completed` events to the parent stream. The parent's
+ * projection then saw a `team.disbanded` claim with no supporting events;
+ * the all-tasks-complete guard (#1225) signed off on a workflow that wasn't
+ * actually done.
+ *
+ * This router replaces that double bookkeeping with two operations that both
+ * route through `AtomicAppender` on the parent stream:
+ *
+ *   - `onTaskCompleted` — emit a parent-stream `task.completed` event keyed
+ *     by `<childStreamId>:<taskId>:task.completed`. Idempotent on replay
+ *     because AtomicAppender's idempotencyKey cache is commit-on-success.
+ *
+ *   - `emitDisbanded` — query the parent stream for `task.completed` events
+ *     scoped to this team, populate `tasksCompleted` from that count, and
+ *     append `team.disbanded`. Single-writer per stream gives causal
+ *     ordering (`task.completed` events have lower sequence than the
+ *     subsequent `team.disbanded`) by construction, so the parent
+ *     projection sees a coherent fold.
+ *
+ * The interface is the local analog of #1259's namespaced shared-stream
+ * model — when that lands, this implementation flattens to a query over
+ * `stream_id LIKE '<parent>/%'` and the parent emit on `team.disbanded`
+ * remains.
+ */
+
+/**
+ * Payload for a child-stream task completion that the router will propagate
+ * to the parent stream. `teamId` is required so `emitDisbanded` can scope
+ * its count to the right team — multiple teams can write `task.completed`
+ * to the same parent stream.
+ */
+export interface TaskCompletedPayload {
+  taskId: string;
+  teamId: string;
+  /** Optional pass-through fields; persisted on the parent-stream event. */
+  acceptanceTestRef?: string;
+  artifacts?: string[];
+  duration?: number;
+  evidence?: {
+    type: 'test' | 'build' | 'typecheck' | 'manual';
+    output: string;
+    passed: boolean;
+  };
+  verified?: boolean;
+  implements?: string[];
+  tests?: { name: string; file: string }[];
+  files?: string[];
+  [k: string]: unknown;
+}
+
+/**
+ * Summary fields for `team.disbanded`. `tasksCompleted` is intentionally
+ * NOT part of this shape — it is computed by querying the parent stream.
+ * The double-bookkeeping that produces #1224's off-by-N is the reason the
+ * accumulator is removed, not just hidden.
+ */
+export interface DisbandedSummary {
+  teamId: string;
+  totalDurationMs: number;
+  tasksFailed: number;
+  /** Optional pass-through fields persisted on the disbanded event. */
+  [k: string]: unknown;
+}
+
+/**
+ * The router contract. Two operations, both of which append to the parent
+ * stream via `AtomicAppender`. `tasksCompleted` is computed from the
+ * parent stream at emission time, never from an accumulator.
+ */
+export interface SubagentStreamRouterContract {
+  onTaskCompleted(
+    parentStreamId: string,
+    childStreamId: string,
+    taskId: string,
+    payload: TaskCompletedPayload,
+  ): Promise<void>;
+  emitDisbanded(parentStreamId: string, summary: DisbandedSummary): Promise<void>;
+}
+
+export interface SubagentStreamRouterOptions {
+  /** Parent-stream appender — single writer per stream. */
+  appender: AtomicAppender;
+  /**
+   * Directory under which `<streamId>.events.jsonl` lives. Must match the
+   * `stateDir` configured on the appender so `emitDisbanded` can read the
+   * same JSONL the appender writes.
+   */
+  stateDir: string;
+}
+
+interface PersistedEvent {
+  type: string;
+  sequence: number;
+  data?: { teamId?: string; taskId?: string; [k: string]: unknown };
+  [k: string]: unknown;
+}
+
+/**
+ * Default implementation. Stateless w.r.t. completion counts — that's the
+ * whole point.
+ */
+export class SubagentStreamRouter implements SubagentStreamRouterContract {
+  private readonly appender: AtomicAppender;
+  private readonly stateDir: string;
+
+  constructor(options: SubagentStreamRouterOptions) {
+    this.appender = options.appender;
+    this.stateDir = options.stateDir;
+  }
+
+  async onTaskCompleted(
+    parentStreamId: string,
+    childStreamId: string,
+    taskId: string,
+    payload: TaskCompletedPayload,
+  ): Promise<void> {
+    const idempotencyKey = `${childStreamId}:${taskId}:task.completed`;
+    const result = await this.appender.append(
+      parentStreamId,
+      [
+        {
+          type: 'task.completed',
+          data: {
+            ...payload,
+            taskId,
+          },
+          source: 'subagent-stream-router',
+        },
+      ],
+      idempotencyKey,
+    );
+    if (!result.ok) {
+      throw new Error(
+        `SubagentStreamRouter.onTaskCompleted failed: ${result.reason}` +
+          (result.cause ? ` — ${result.cause.message}` : ''),
+      );
+    }
+  }
+
+  async emitDisbanded(
+    parentStreamId: string,
+    summary: DisbandedSummary,
+  ): Promise<void> {
+    // Source of truth: query the parent stream for task.completed events
+    // scoped to this team. NEVER use an in-memory counter — that's the
+    // exact double-bookkeeping that produced #1224.
+    const tasksCompleted = await this.countTaskCompletedForTeam(
+      parentStreamId,
+      summary.teamId,
+    );
+
+    const idempotencyKey = `${summary.teamId}:team.disbanded`;
+    const result = await this.appender.append(
+      parentStreamId,
+      [
+        {
+          type: 'team.disbanded',
+          data: {
+            ...summary,
+            tasksCompleted,
+          },
+          source: 'subagent-stream-router',
+        },
+      ],
+      idempotencyKey,
+    );
+    if (!result.ok) {
+      throw new Error(
+        `SubagentStreamRouter.emitDisbanded failed: ${result.reason}` +
+          (result.cause ? ` — ${result.cause.message}` : ''),
+      );
+    }
+  }
+
+  /**
+   * Read the parent-stream JSONL and count `task.completed` events whose
+   * `data.teamId` matches. Cheap (linear scan, in-memory after first read);
+   * this is the seam #1259 replaces with `SELECT COUNT(*) FROM events
+   * WHERE type='task.completed' AND data->>'teamId'=?`.
+   */
+  private async countTaskCompletedForTeam(
+    parentStreamId: string,
+    teamId: string,
+  ): Promise<number> {
+    const filePath = path.join(this.stateDir, `${parentStreamId}.events.jsonl`);
+    let raw: string;
+    try {
+      raw = await fs.readFile(filePath, 'utf-8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return 0;
+      }
+      throw err;
+    }
+    let count = 0;
+    for (const line of raw.split('\n')) {
+      if (line.length === 0) continue;
+      let parsed: PersistedEvent;
+      try {
+        parsed = JSON.parse(line) as PersistedEvent;
+      } catch {
+        continue; // tolerate corruption; JSONL is line-delimited
+      }
+      if (parsed.type === 'task.completed' && parsed.data?.teamId === teamId) {
+        count += 1;
+      }
+    }
+    return count;
+  }
+}
+
+/**
+ * Convenience factory for consumers who don't want to instantiate the class
+ * directly. Mirrors the `AtomicAppender` constructor shape.
+ */
+export function createSubagentStreamRouter(
+  options: SubagentStreamRouterOptions,
+): SubagentStreamRouterContract {
+  return new SubagentStreamRouter(options);
+}

--- a/servers/exarchos-mcp/src/event-store/atomic-appender.test.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender.test.ts
@@ -119,6 +119,94 @@ describe('AtomicAppender', () => {
     }
   });
 
+  // ─── WriteFn after-runDefault rollback (CR review 4248981786) ────────────
+  //
+  // The WriteFn contract permits throwing AFTER `runDefault()` completes
+  // (partial-failure simulation). Without rollback, the JSONL/.seq writes
+  // are durable on disk but the append returns `ok: false`, so a retry
+  // would produce duplicate sequences (JSONL phase) or leave .seq ahead
+  // of the rolled-back JSONL (seq phase).
+
+  it('AtomicAppender_jsonlWriteFnThrowsAfterRunDefault_rollsBackJsonl', async () => {
+    const streamId = 'after-run-default-jsonl';
+    const appender = new AtomicAppender({
+      stateDir,
+      writeFn: async (phase, _filePath, _contents, runDefault) => {
+        if (phase === 'jsonl') {
+          await runDefault(); // actually writes the JSONL
+          throw new Error('after-runDefault failure'); // then throws
+        }
+        await runDefault();
+      },
+    });
+
+    const result = await appender.append(
+      streamId,
+      [{ type: 'task.assigned', data: { n: 1 } }],
+      'idem-after-default',
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('io-error');
+
+    // The append should have been rolled back. Either the file does not
+    // exist or it is empty.
+    const jsonlPath = path.join(stateDir, `${streamId}.events.jsonl`);
+    let exists = true;
+    try {
+      await access(jsonlPath);
+    } catch {
+      exists = false;
+    }
+    if (exists) {
+      const raw = await readFile(jsonlPath, 'utf-8');
+      expect(raw.trim()).toBe('');
+    }
+  });
+
+  it('AtomicAppender_seqWriteFnThrowsAfterRunDefault_rollsBackJsonlAndDeletesSeq', async () => {
+    const streamId = 'after-run-default-seq';
+    const appender = new AtomicAppender({
+      stateDir,
+      writeFn: async (phase, _filePath, _contents, runDefault) => {
+        if (phase === 'seq') {
+          await runDefault(); // .seq is renamed into place
+          throw new Error('after-runDefault seq failure');
+        }
+        await runDefault();
+      },
+    });
+
+    const result = await appender.append(
+      streamId,
+      [{ type: 'task.assigned', data: { n: 1 } }],
+      'idem-seq-after-default',
+    );
+    expect(result.ok).toBe(false);
+
+    // JSONL must be empty / absent (rolled back).
+    const jsonlPath = path.join(stateDir, `${streamId}.events.jsonl`);
+    let jsonlExists = true;
+    try {
+      await access(jsonlPath);
+    } catch {
+      jsonlExists = false;
+    }
+    if (jsonlExists) {
+      const raw = await readFile(jsonlPath, 'utf-8');
+      expect(raw.trim()).toBe('');
+    }
+
+    // .seq must NOT remain ahead of the rolled-back JSONL.
+    const seqPath = path.join(stateDir, `${streamId}.seq`);
+    let seqExists = true;
+    try {
+      await access(seqPath);
+    } catch {
+      seqExists = false;
+    }
+    expect(seqExists).toBe(false);
+  });
+
   it('AtomicAppender_successfulAppend_commitsAllPhases', async () => {
     const appender = new AtomicAppender({ stateDir });
     const streamId = 'test-stream-success';

--- a/servers/exarchos-mcp/src/event-store/atomic-appender.test.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender.test.ts
@@ -236,4 +236,129 @@ describe('AtomicAppender', () => {
       }
     }
   });
+
+  // ─── expectedSequence (T1, #1293) ────────────────────────────────────────
+  //
+  // Optimistic-concurrency check: callers that observed a sequence before
+  // calling append want to fail the append if the stream advanced under
+  // them. The check must run under the per-stream lock so concurrent
+  // appends can't slip a counter advance between the read and the write.
+
+  it('AtomicAppender_appendWithMatchingExpectedSequence_succeeds', async () => {
+    const appender = new AtomicAppender({ stateDir });
+    const streamId = 'expected-seq-match';
+
+    // Stream is empty → counter is 0.
+    const result = await appender.append(
+      streamId,
+      [{ type: 'task.assigned', data: { n: 1 } }],
+      'k1',
+      { expectedSequence: 0 },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.sequences).toEqual([1]);
+  });
+
+  it('AtomicAppender_appendWithStaleExpectedSequence_returnsSequenceConflict', async () => {
+    const appender = new AtomicAppender({ stateDir });
+    const streamId = 'expected-seq-stale';
+
+    // Advance counter to 1.
+    await appender.append(streamId, [{ type: 'task.assigned', data: { n: 1 } }], 'k1');
+
+    // Caller observed sequence 0 but counter is now 1 — conflict.
+    const result = await appender.append(
+      streamId,
+      [{ type: 'task.assigned', data: { n: 2 } }],
+      'k2',
+      { expectedSequence: 0 },
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('sequence-conflict');
+      expect(result.expected).toBe(0);
+      expect(result.actual).toBe(1);
+    }
+  });
+
+  it('AtomicAppender_expectedSequenceUndefined_skipsCheck', async () => {
+    const appender = new AtomicAppender({ stateDir });
+    const streamId = 'expected-seq-undef';
+
+    // Without expectedSequence, counter mismatches don't fail.
+    await appender.append(streamId, [{ type: 'task.assigned' }], 'k1');
+    const result = await appender.append(
+      streamId,
+      [{ type: 'task.assigned' }],
+      'k2', // no options — must succeed regardless of counter state
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  // ─── appendUnkeyed (T2, #1293) ───────────────────────────────────────────
+  //
+  // Bypasses idempotency dedup for callers that don't have a meaningful
+  // retry semantics (e.g. EventStore.append callers with no key). The
+  // alternative — synthesizing a random key per call — would FIFO-evict
+  // legitimate retry keys at the cap.
+
+  it('AtomicAppender_appendUnkeyed_writesEventsAndAdvancesSequence', async () => {
+    const appender = new AtomicAppender({ stateDir });
+    const streamId = 'unkeyed-basic';
+
+    const r1 = await appender.appendUnkeyed(streamId, [{ type: 'task.assigned' }]);
+    const r2 = await appender.appendUnkeyed(streamId, [{ type: 'task.completed' }]);
+    expect(r1.ok && r2.ok).toBe(true);
+    if (r1.ok) expect(r1.sequences).toEqual([1]);
+    if (r2.ok) expect(r2.sequences).toEqual([2]);
+
+    // JSONL persists both events with no idempotencyKey field.
+    const jsonl = await readFile(path.join(stateDir, `${streamId}.events.jsonl`), 'utf-8');
+    const lines = jsonl.trim().split('\n');
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      const evt = JSON.parse(line);
+      expect(evt.idempotencyKey).toBeUndefined();
+    }
+  });
+
+  it('AtomicAppender_appendUnkeyed_doesNotPopulateIdempotencyCache', async () => {
+    // Cap the cache aggressively so legitimate keys would evict if unkeyed
+    // calls polluted the cache. With the bypass, the cap is unaffected.
+    const appender = new AtomicAppender({ stateDir, maxIdempotencyKeys: 2 });
+    const streamId = 'unkeyed-no-pollute';
+
+    // Seed two keyed entries — these MUST stay in the cache.
+    await appender.append(streamId, [{ type: 'task.assigned' }], 'keep-a');
+    await appender.append(streamId, [{ type: 'task.assigned' }], 'keep-b');
+
+    // 5 unkeyed appends — would evict both if the cache were polluted.
+    for (let i = 0; i < 5; i++) {
+      await appender.appendUnkeyed(streamId, [{ type: 'task.assigned' }]);
+    }
+
+    // Retry both keyed entries; they should still be cache-hit (returns
+    // the original sequence, no new events appended).
+    const retryA = await appender.append(streamId, [{ type: 'x' }], 'keep-a');
+    const retryB = await appender.append(streamId, [{ type: 'x' }], 'keep-b');
+    expect(retryA.ok && retryB.ok).toBe(true);
+    if (retryA.ok) expect(retryA.sequences).toEqual([1]);
+    if (retryB.ok) expect(retryB.sequences).toEqual([2]);
+  });
+
+  it('AtomicAppender_appendUnkeyed_concurrentCallsSerialize', async () => {
+    const appender = new AtomicAppender({ stateDir });
+    const streamId = 'unkeyed-concurrent';
+
+    const results = await Promise.all([
+      appender.appendUnkeyed(streamId, [{ type: 'task.assigned' }]),
+      appender.appendUnkeyed(streamId, [{ type: 'task.assigned' }]),
+      appender.appendUnkeyed(streamId, [{ type: 'task.assigned' }]),
+    ]);
+    for (const r of results) expect(r.ok).toBe(true);
+
+    const seqs = results.flatMap(r => (r.ok ? r.sequences : []));
+    expect([...seqs].sort((a, b) => a - b)).toEqual([1, 2, 3]);
+    expect(new Set(seqs).size).toBe(3);
+  });
 });

--- a/servers/exarchos-mcp/src/event-store/atomic-appender.test.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { AtomicAppender } from './atomic-appender.js';
+
+/**
+ * AtomicAppender — substrate primitive for v2.9 bug cluster (#1230, #1228, #1241).
+ *
+ * Tests verify the four-phase append (validate → allocate → write JSONL → write .seq
+ * → cache idempotencyKey) is atomic from the caller's perspective: either all phases
+ * commit (success path) or none of them are observable (failure path). The
+ * idempotencyKey cache is the LAST write so a partial failure never claims a key
+ * that has no underlying event in the log (#1228 phantom claim).
+ */
+describe('AtomicAppender', () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await mkdtemp(path.join(tmpdir(), 'atomic-appender-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  it('AtomicAppender_concurrentAppends_uniqueMonotonicSequences', async () => {
+    const appender = new AtomicAppender({ stateDir });
+    const streamId = 'test-stream-concurrent';
+
+    const results = await Promise.all([
+      appender.append(streamId, [{ type: 'task.assigned', data: { n: 1 } }], 'idem-1'),
+      appender.append(streamId, [{ type: 'task.assigned', data: { n: 2 } }], 'idem-2'),
+      appender.append(streamId, [{ type: 'task.assigned', data: { n: 3 } }], 'idem-3'),
+    ]);
+
+    for (const r of results) {
+      expect(r.ok).toBe(true);
+    }
+
+    const allSequences = results.flatMap(r => (r.ok ? r.sequences : []));
+    const sorted = [...allSequences].sort((a, b) => a - b);
+    expect(sorted).toEqual([1, 2, 3]);
+    // Uniqueness implied by the sort equality, but assert explicitly:
+    expect(new Set(allSequences).size).toBe(3);
+  });
+
+  it('AtomicAppender_jsonlWriteFails_idempotencyKeyAdmissibleForRetry', async () => {
+    const streamId = 'test-stream-retry';
+    const idempotencyKey = 'retry-key-1';
+
+    // First attempt with a writer that always fails on JSONL write
+    let calls = 0;
+    const failingWriteFn = async (): Promise<void> => {
+      calls++;
+      throw new Error('simulated disk full');
+    };
+
+    const failingAppender = new AtomicAppender({ stateDir, writeFn: failingWriteFn });
+    const failed = await failingAppender.append(
+      streamId,
+      [{ type: 'task.assigned', data: { attempt: 1 } }],
+      idempotencyKey,
+    );
+    expect(failed.ok).toBe(false);
+    if (!failed.ok) {
+      expect(failed.reason).toBe('io-error');
+    }
+    expect(calls).toBeGreaterThan(0);
+
+    // Retry with a working appender — same idempotencyKey must be admissible
+    // (i.e. not phantom-claimed by the prior failure).
+    const workingAppender = new AtomicAppender({ stateDir });
+    const retried = await workingAppender.append(
+      streamId,
+      [{ type: 'task.assigned', data: { attempt: 2 } }],
+      idempotencyKey,
+    );
+    expect(retried.ok).toBe(true);
+    if (retried.ok) {
+      expect(retried.sequences).toEqual([1]);
+    }
+  });
+
+  it('AtomicAppender_seqFileWriteFails_returnsStructuredFailureNotSilentSuccess', async () => {
+    const streamId = 'test-stream-seq-fail';
+
+    // writeFn signature: ('jsonl' | 'seq', filePath, contents) — caller decides which
+    // phase to fail. A failure on the .seq phase must surface as ok:false, not the
+    // best-effort silent success the legacy four-phase path produces.
+    const failingOnSeq = async (phase: 'jsonl' | 'seq'): Promise<void> => {
+      if (phase === 'seq') throw new Error('seq write failed');
+      // Allow JSONL write to proceed normally — defer to default impl
+      throw new Error('default-fallthrough');
+    };
+
+    // We need JSONL write to succeed but .seq to fail. So inject a writer that
+    // delegates to default behavior on jsonl and throws on seq. The simplest
+    // way is to pass a partial-failure writer that the default impl can call
+    // through; expose this via writeFn that receives phase + a default executor.
+    const appender = new AtomicAppender({
+      stateDir,
+      writeFn: async (phase, _filePath, _contents, runDefault) => {
+        if (phase === 'seq') throw new Error('seq write failed');
+        await runDefault();
+      },
+    });
+
+    const result = await appender.append(
+      streamId,
+      [{ type: 'task.assigned', data: { n: 1 } }],
+      'idem-seq-fail',
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('io-error');
+    }
+  });
+
+  it('AtomicAppender_successfulAppend_commitsAllPhases', async () => {
+    const appender = new AtomicAppender({ stateDir });
+    const streamId = 'test-stream-success';
+    const idempotencyKey = 'idem-success';
+
+    const result = await appender.append(
+      streamId,
+      [
+        { type: 'task.assigned', data: { n: 1 } },
+        { type: 'task.completed', data: { n: 1 } },
+      ],
+      idempotencyKey,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.sequences).toEqual([1, 2]);
+    expect(result.eventIds).toHaveLength(2);
+
+    // Phase 1: events present in JSONL
+    const jsonlPath = path.join(stateDir, `${streamId}.events.jsonl`);
+    await access(jsonlPath);
+    const contents = await readFile(jsonlPath, 'utf-8');
+    const lines = contents.trim().split('\n').filter(l => l.length > 0);
+    expect(lines).toHaveLength(2);
+    const events = lines.map(l => JSON.parse(l));
+    expect(events[0].sequence).toBe(1);
+    expect(events[1].sequence).toBe(2);
+    expect(events[0].type).toBe('task.assigned');
+    expect(events[1].type).toBe('task.completed');
+
+    // Phase 2: .seq reflects max sequence
+    const seqPath = path.join(stateDir, `${streamId}.seq`);
+    const seqContents = JSON.parse(await readFile(seqPath, 'utf-8'));
+    expect(seqContents.sequence).toBe(2);
+
+    // Phase 3: idempotencyKey cached — observable as a duplicate-detection on retry
+    const retry = await appender.append(
+      streamId,
+      [{ type: 'task.assigned', data: { n: 99 } }],
+      idempotencyKey,
+    );
+    expect(retry.ok).toBe(true);
+    if (retry.ok) {
+      // Cached: no new sequences allocated, original sequences returned
+      expect(retry.sequences).toEqual([1, 2]);
+    }
+    // Verify no extra events were written
+    const contentsAfter = await readFile(jsonlPath, 'utf-8');
+    const linesAfter = contentsAfter.trim().split('\n').filter(l => l.length > 0);
+    expect(linesAfter).toHaveLength(2);
+  });
+});

--- a/servers/exarchos-mcp/src/event-store/atomic-appender.test.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender.test.ts
@@ -170,4 +170,70 @@ describe('AtomicAppender', () => {
     const linesAfter = contentsAfter.trim().split('\n').filter(l => l.length > 0);
     expect(linesAfter).toHaveLength(2);
   });
+
+  it('AtomicAppender_idempotencyCache_capsAtThreshold', async () => {
+    // C10 polish: port EXARCHOS_MAX_IDEMPOTENCY_KEYS cap from legacy EventStore
+    // (store.ts:798) to AtomicAppender so long-running streams don't grow the
+    // idempotency cache unboundedly. Eviction is FIFO (insertion order) to
+    // match the legacy semantics — oldest key out first.
+    const prevCap = process.env.EXARCHOS_MAX_IDEMPOTENCY_KEYS;
+    process.env.EXARCHOS_MAX_IDEMPOTENCY_KEYS = '5';
+    try {
+      const appender = new AtomicAppender({ stateDir });
+      const streamId = 'test-stream-cap';
+
+      // Append 7 events with 7 distinct idempotencyKeys.
+      for (let i = 1; i <= 7; i++) {
+        const r = await appender.append(
+          streamId,
+          [{ type: 'task.assigned', data: { n: i } }],
+          `key-${i}`,
+        );
+        expect(r.ok).toBe(true);
+      }
+
+      // The two oldest keys (`key-1`, `key-2`) must have been evicted.
+      // Retrying them therefore does NOT hit the cache — a fresh event with
+      // a NEW sequence is appended (acceptable since JSONL replay still
+      // serves the original event, but the in-memory cache is bounded).
+      const retryOldest = await appender.append(
+        streamId,
+        [{ type: 'task.assigned', data: { n: 1, retry: true } }],
+        'key-1',
+      );
+      expect(retryOldest.ok).toBe(true);
+      if (retryOldest.ok) {
+        // Cache miss → new sequence allocated (would have been [1] had it cached).
+        expect(retryOldest.sequences).toEqual([8]);
+      }
+
+      const retrySecondOldest = await appender.append(
+        streamId,
+        [{ type: 'task.assigned', data: { n: 2, retry: true } }],
+        'key-2',
+      );
+      expect(retrySecondOldest.ok).toBe(true);
+      if (retrySecondOldest.ok) {
+        expect(retrySecondOldest.sequences).toEqual([9]);
+      }
+
+      // Conversely, a still-cached recent key (`key-7`) MUST hit the cache:
+      // retry returns the original sequence (7), no new event appended.
+      const retryRecent = await appender.append(
+        streamId,
+        [{ type: 'task.assigned', data: { n: 7, retry: true } }],
+        'key-7',
+      );
+      expect(retryRecent.ok).toBe(true);
+      if (retryRecent.ok) {
+        expect(retryRecent.sequences).toEqual([7]);
+      }
+    } finally {
+      if (prevCap === undefined) {
+        delete process.env.EXARCHOS_MAX_IDEMPOTENCY_KEYS;
+      } else {
+        process.env.EXARCHOS_MAX_IDEMPOTENCY_KEYS = prevCap;
+      }
+    }
+  });
 });

--- a/servers/exarchos-mcp/src/event-store/atomic-appender.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender.ts
@@ -148,6 +148,35 @@ export class AtomicAppender {
     return this.locks.runExclusive(streamId, () => this.appendLocked(streamId, events, idempotencyKey));
   }
 
+  /**
+   * Compute-then-append under a single per-stream lock.
+   *
+   * `compute` runs while the per-stream lock is held; the events it returns
+   * are appended in the same critical section. This is the primitive
+   * `SubagentStreamRouter.emitDisbanded` needs: it queries the parent stream
+   * for `task.completed` events scoped to a team and immediately appends
+   * `team.disbanded` with the count. Without the lock-coupled compute,
+   * concurrent `onTaskCompleted` calls (which are serialized through the
+   * same lock) can be in flight when the read happens, producing a stale
+   * count and an off-by-N `tasksCompleted` — the exact regression #1224
+   * was meant to close.
+   *
+   * `compute` must NOT call back into `append`/`appendComputed` for the
+   * same `streamId`: the Promise-chain mutex is non-reentrant and a
+   * recursive call deadlocks the chain. Side reads (e.g. `fs.readFile`
+   * on the JSONL) are fine.
+   */
+  async appendComputed(
+    streamId: string,
+    idempotencyKey: string,
+    compute: () => Promise<EventInput[]>,
+  ): Promise<AppendResult> {
+    return this.locks.runExclusive(streamId, async () => {
+      const events = await compute();
+      return this.appendLocked(streamId, events, idempotencyKey);
+    });
+  }
+
   private async appendLocked(
     streamId: string,
     events: EventInput[],
@@ -325,6 +354,12 @@ export class AtomicAppender {
    * Truncate the most-recent N JSONL lines from a stream file. Used to unwind
    * a partial append on `.seq` failure so the caller's all-or-none contract
    * holds. JSONL is line-delimited so truncation by line count is safe.
+   *
+   * Performs an atomic temp-file + rename rather than an in-place rewrite:
+   * concurrent readers (projection materializers, log tailers) never observe
+   * a partially written file. The per-stream lock already serializes
+   * appenders, so this only matters for external readers that don't
+   * coordinate through the lock.
    */
   private async rollbackJsonlAppend(filePath: string, lineCount: number): Promise<void> {
     const raw = await fs.readFile(filePath, 'utf-8');
@@ -336,7 +371,14 @@ export class AtomicAppender {
     const trailingEmpty = allLines[allLines.length - 1] === '' ? 1 : 0;
     const keep = allLines.slice(0, allLines.length - lineCount - trailingEmpty);
     const rewritten = keep.length === 0 ? '' : keep.join('\n') + '\n';
-    await fs.writeFile(filePath, rewritten, 'utf-8');
+    const tmpPath = `${filePath}.rollback-${randomUUID()}.tmp`;
+    try {
+      await fs.writeFile(tmpPath, rewritten, 'utf-8');
+      await fs.rename(tmpPath, filePath);
+    } catch (err) {
+      await fs.rm(tmpPath, { force: true }).catch(() => {});
+      throw err;
+    }
   }
 
   private getEventFilePath(streamId: string): string {

--- a/servers/exarchos-mcp/src/event-store/atomic-appender.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender.ts
@@ -24,7 +24,14 @@ import { randomUUID } from 'node:crypto';
 
 export type AppendResult =
   | { ok: true; sequences: number[]; eventIds: string[] }
-  | { ok: false; reason: 'idempotency-claimed' | 'sequence-conflict' | 'io-error'; cause?: Error };
+  | {
+      ok: false;
+      reason: 'idempotency-claimed' | 'sequence-conflict' | 'io-error';
+      cause?: Error;
+      /** Populated on `sequence-conflict` so callers can translate to typed errors. */
+      expected?: number;
+      actual?: number;
+    };
 
 export interface EventInput {
   type: string;
@@ -37,6 +44,26 @@ export interface EventInput {
   source?: string;
   schemaVersion?: string;
   [k: string]: unknown;
+}
+
+/**
+ * Per-call append options. Optimistic-concurrency support lives here so
+ * `EventStore`'s legacy `expectedSequence` callers can migrate cleanly.
+ *
+ * Re-entrancy: do NOT pass `expectedSequence` from inside an
+ * `appendComputed` callback — the check runs after `rebuildCachesFromJsonl`
+ * which is the same lock context the callback is already holding. The
+ * caller's outer-most `append` invocation owns the check.
+ */
+export interface AppendOptions {
+  /**
+   * The current sequence counter the caller observed before issuing this
+   * append. Compared against the in-memory counter under the per-stream
+   * lock; a mismatch returns `{ ok: false, reason: 'sequence-conflict',
+   * expected, actual }` so the caller can translate to a typed error
+   * without needing access to internal state.
+   */
+  expectedSequence?: number;
 }
 
 /**
@@ -144,8 +171,35 @@ export class AtomicAppender {
     streamId: string,
     events: EventInput[],
     idempotencyKey: string,
+    options?: AppendOptions,
   ): Promise<AppendResult> {
-    return this.locks.runExclusive(streamId, () => this.appendLocked(streamId, events, idempotencyKey));
+    return this.locks.runExclusive(streamId, () =>
+      this.appendLocked(streamId, events, { idempotencyKey }, options),
+    );
+  }
+
+  /**
+   * Append without idempotency dedup.
+   *
+   * Used by callers (e.g. `EventStore.append` for events without an explicit
+   * key) that want a single write but no cache entry. Equivalent to passing
+   * a synthetic key, except:
+   *   - The idempotency cache is NOT polluted with one-shot keys (which
+   *     would FIFO-evict legitimate retry keys at the configured cap).
+   *   - The persisted event has `idempotencyKey: undefined`, so a JSONL
+   *     scan will not associate it with any retry chain.
+   *
+   * Sequence allocation, JSONL write, .seq write, and rollback semantics
+   * are identical to `append`.
+   */
+  async appendUnkeyed(
+    streamId: string,
+    events: EventInput[],
+    options?: AppendOptions,
+  ): Promise<AppendResult> {
+    return this.locks.runExclusive(streamId, () =>
+      this.appendLocked(streamId, events, null, options),
+    );
   }
 
   /**
@@ -173,14 +227,15 @@ export class AtomicAppender {
   ): Promise<AppendResult> {
     return this.locks.runExclusive(streamId, async () => {
       const events = await compute();
-      return this.appendLocked(streamId, events, idempotencyKey);
+      return this.appendLocked(streamId, events, { idempotencyKey });
     });
   }
 
   private async appendLocked(
     streamId: string,
     events: EventInput[],
-    idempotencyKey: string,
+    keyed: { idempotencyKey: string } | null,
+    options?: AppendOptions,
   ): Promise<AppendResult> {
     // ─── Phase 1: validate ───────────────────────────────────────────────
     if (!streamId || streamId.length === 0) {
@@ -189,11 +244,15 @@ export class AtomicAppender {
     if (!Array.isArray(events) || events.length === 0) {
       return { ok: false, reason: 'io-error', cause: new Error('events must be non-empty array') };
     }
-    if (!idempotencyKey || idempotencyKey.length === 0) {
+    if (keyed !== null && (!keyed.idempotencyKey || keyed.idempotencyKey.length === 0)) {
       return { ok: false, reason: 'io-error', cause: new Error('idempotencyKey required') };
     }
 
     // Idempotency check — rebuild cache from JSONL on first contact with stream.
+    // Even unkeyed appends rebuild here so the sequence counter is authoritative
+    // (the `.seq` value is read during rebuild). Skipping the rebuild for
+    // unkeyed callers would re-introduce overlapping-allocation under
+    // concurrency from a fresh process.
     if (!this.idempotencyInitialized.has(streamId)) {
       try {
         await this.rebuildCachesFromJsonl(streamId);
@@ -202,27 +261,51 @@ export class AtomicAppender {
       }
       this.idempotencyInitialized.add(streamId);
     }
-    const streamIdemCache = this.idempotencyCache.get(streamId);
-    const cachedEvents = streamIdemCache?.get(idempotencyKey);
-    if (cachedEvents && cachedEvents.length > 0) {
-      return {
-        ok: true,
-        sequences: cachedEvents.map(e => e.sequence),
-        eventIds: cachedEvents.map(e => e.eventId),
-      };
+    if (keyed !== null) {
+      const streamIdemCache = this.idempotencyCache.get(streamId);
+      const cachedEvents = streamIdemCache?.get(keyed.idempotencyKey);
+      if (cachedEvents && cachedEvents.length > 0) {
+        return {
+          ok: true,
+          sequences: cachedEvents.map(e => e.sequence),
+          eventIds: cachedEvents.map(e => e.eventId),
+        };
+      }
+    }
+
+    // ─── Phase 1b: optimistic-concurrency check ──────────────────────────
+    // Compare the caller's observed sequence (if any) against the
+    // post-rebuild authoritative counter. Mismatch returns a typed result
+    // so callers can translate to their own error shape (e.g.
+    // EventStore.SequenceConflictError) without reaching into internals.
+    if (options?.expectedSequence !== undefined) {
+      const actual = this.sequenceCounters.get(streamId) ?? 0;
+      if (actual !== options.expectedSequence) {
+        return {
+          ok: false,
+          reason: 'sequence-conflict',
+          expected: options.expectedSequence,
+          actual,
+        };
+      }
     }
 
     // ─── Phase 2: allocate sequences ─────────────────────────────────────
     const baseSeq = (this.sequenceCounters.get(streamId) ?? 0);
-    const persisted: PersistedEvent[] = events.map((evt, i) => ({
-      ...evt,
-      streamId,
-      sequence: baseSeq + i + 1,
-      timestamp: evt.timestamp ?? new Date().toISOString(),
-      type: evt.type,
-      eventId: randomUUID(),
-      idempotencyKey,
-    }));
+    const persisted: PersistedEvent[] = events.map((evt, i) => {
+      const event: PersistedEvent = {
+        ...evt,
+        streamId,
+        sequence: baseSeq + i + 1,
+        timestamp: evt.timestamp ?? new Date().toISOString(),
+        type: evt.type,
+        eventId: randomUUID(),
+      };
+      if (keyed !== null) {
+        event.idempotencyKey = keyed.idempotencyKey;
+      }
+      return event;
+    });
     const finalSequence = persisted[persisted.length - 1].sequence;
 
     // ─── Phase 3: write JSONL ────────────────────────────────────────────
@@ -265,19 +348,24 @@ export class AtomicAppender {
     // ─── Phase 5: cache idempotencyKey (commit point) ────────────────────
     // ONLY reached if all prior phases succeeded. This is the bug-#1228 fix:
     // the key is admissible for retry until and unless the append commits.
-    let cache = this.idempotencyCache.get(streamId);
-    if (!cache) {
-      cache = new Map();
-      this.idempotencyCache.set(streamId, cache);
-    }
-    cache.set(idempotencyKey, persisted);
-    // FIFO eviction at cap — matches legacy EventStore.cacheIdempotencyKey
-    // semantics (store.ts:798). Map iteration order is insertion order, so
-    // `keys().next().value` is the oldest entry.
-    while (cache.size > this.maxIdempotencyKeys) {
-      const oldest = cache.keys().next().value;
-      if (oldest === undefined) break;
-      cache.delete(oldest);
+    // Skipped entirely for unkeyed appends — those callers explicitly opted
+    // out of dedup, and writing them to the cache would FIFO-evict
+    // legitimate retry keys at the configured cap.
+    if (keyed !== null) {
+      let cache = this.idempotencyCache.get(streamId);
+      if (!cache) {
+        cache = new Map();
+        this.idempotencyCache.set(streamId, cache);
+      }
+      cache.set(keyed.idempotencyKey, persisted);
+      // FIFO eviction at cap — matches legacy EventStore.cacheIdempotencyKey
+      // semantics (store.ts:798). Map iteration order is insertion order, so
+      // `keys().next().value` is the oldest entry.
+      while (cache.size > this.maxIdempotencyKeys) {
+        const oldest = cache.keys().next().value;
+        if (oldest === undefined) break;
+        cache.delete(oldest);
+      }
     }
     this.sequenceCounters.set(streamId, finalSequence);
 

--- a/servers/exarchos-mcp/src/event-store/atomic-appender.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender.ts
@@ -62,6 +62,21 @@ export interface AtomicAppenderOptions {
   stateDir: string;
   /** Test-only failure-injection writer; defaults to the production filesystem writer. */
   writeFn?: WriteFn;
+  /**
+   * Per-stream cap on cached idempotencyKey entries. Defaults to env
+   * `EXARCHOS_MAX_IDEMPOTENCY_KEYS` (or 200 when unset / invalid). Eviction
+   * is FIFO (insertion order) — matches the legacy `EventStore` semantics
+   * at `event-store/store.ts:798`.
+   */
+  maxIdempotencyKeys?: number;
+}
+
+function parseEnvInt(envVar: string, defaultValue: number): number {
+  const raw = process.env[envVar];
+  if (raw === undefined) return defaultValue;
+  const parsed = parseInt(raw, 10);
+  if (isNaN(parsed) || parsed <= 0) return defaultValue;
+  return parsed;
 }
 
 interface PersistedEvent {
@@ -115,10 +130,14 @@ export class AtomicAppender {
   /** streamId → idempotencyKey → committed event(s). Populated only after success. */
   private readonly idempotencyCache = new Map<string, Map<string, PersistedEvent[]>>();
   private readonly idempotencyInitialized = new Set<string>();
+  /** Per-stream cap on idempotencyCache size; FIFO eviction matches legacy EventStore. */
+  private readonly maxIdempotencyKeys: number;
 
   constructor(options: AtomicAppenderOptions) {
     this.stateDir = options.stateDir;
     this.writeFn = options.writeFn;
+    this.maxIdempotencyKeys =
+      options.maxIdempotencyKeys ?? parseEnvInt('EXARCHOS_MAX_IDEMPOTENCY_KEYS', 200);
   }
 
   async append(
@@ -223,6 +242,14 @@ export class AtomicAppender {
       this.idempotencyCache.set(streamId, cache);
     }
     cache.set(idempotencyKey, persisted);
+    // FIFO eviction at cap — matches legacy EventStore.cacheIdempotencyKey
+    // semantics (store.ts:798). Map iteration order is insertion order, so
+    // `keys().next().value` is the oldest entry.
+    while (cache.size > this.maxIdempotencyKeys) {
+      const oldest = cache.keys().next().value;
+      if (oldest === undefined) break;
+      cache.delete(oldest);
+    }
     this.sequenceCounters.set(streamId, finalSequence);
 
     return {
@@ -280,6 +307,14 @@ export class AtomicAppender {
         const existing = cache.get(parsed.idempotencyKey) ?? [];
         existing.push(parsed);
         cache.set(parsed.idempotencyKey, existing);
+        // FIFO eviction at cap during rebuild — preserves the most-recent
+        // N keys (matches legacy `keyed.slice(-this.maxIdempotencyKeys)` at
+        // store.ts:1227 since insertion order tracks file order).
+        while (cache.size > this.maxIdempotencyKeys) {
+          const oldest = cache.keys().next().value;
+          if (oldest === undefined) break;
+          cache.delete(oldest);
+        }
       }
     }
     this.sequenceCounters.set(streamId, maxSeq);

--- a/servers/exarchos-mcp/src/event-store/atomic-appender.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender.ts
@@ -382,17 +382,33 @@ export class AtomicAppender {
     const finalSequence = persisted[persisted.length - 1].sequence;
 
     // ─── Phase 3: write JSONL ────────────────────────────────────────────
+    //
+    // The `WriteFn` test hook contract explicitly permits throwing AFTER
+    // `runDefault()` completes (see WriteFn comment for the use case:
+    // partial-failure simulation). The naive catch path "nothing was
+    // written" assumption is therefore wrong for after-runDefault throws;
+    // the JSONL lines are on disk but we'd return ok:false, causing
+    // a retry to write the same lines again — duplicate sequences.
+    // Track runDefault completion and roll back on after-runDefault throws
+    // so the all-or-none contract holds for both pre- and post-runDefault
+    // failures.
     const jsonlPath = this.getEventFilePath(streamId);
     const seqPath = this.getSeqFilePath(streamId);
     const lines = persisted.map(e => JSON.stringify(e)).join('\n') + '\n';
+    let jsonlRunDefaultCompleted = false;
     try {
       await fs.mkdir(path.dirname(jsonlPath), { recursive: true });
       await this.runWrite('jsonl', jsonlPath, lines, async () => {
         await fs.appendFile(jsonlPath, lines, 'utf-8');
+        jsonlRunDefaultCompleted = true;
       });
     } catch (err) {
-      // No partial state to roll back: nothing was written, idempotencyKey
-      // never reached the cache, sequence counter never advanced.
+      if (jsonlRunDefaultCompleted) {
+        // Test hook (or future custom WriteFn) threw after the actual
+        // append. Roll back the partial write so the next attempt starts
+        // from a clean slate.
+        await this.rollbackJsonlAppend(jsonlPath, persisted.length).catch(() => {});
+      }
       return { ok: false, reason: 'io-error', cause: toError(err) };
     }
 
@@ -401,12 +417,22 @@ export class AtomicAppender {
     // caller MUST NOT see a silent success — that's exactly what hid #1228.
     // We unwind the JSONL append on .seq failure to preserve the all-or-none
     // contract callers rely on.
+    //
+    // Same WriteFn-after-runDefault hazard as Phase 3: if `writeFn` throws
+    // AFTER the rename completed, the .seq is durable on disk but we're
+    // about to roll back the JSONL. That leaves .seq pointing past the
+    // rolled-back JSONL — the bug that mis-sized sidecar synthetic
+    // sequences. Track the seq runDefault completion and remove .seq when
+    // it ran but the wrapper threw, so the next caller's rebuild reads
+    // max-sequence from JSONL fresh.
     const tmpPath = `${seqPath}.tmp`;
     const seqContents = JSON.stringify({ sequence: finalSequence });
+    let seqRunDefaultCompleted = false;
     try {
       await this.runWrite('seq', seqPath, seqContents, async () => {
         await fs.writeFile(tmpPath, seqContents, 'utf-8');
         await fs.rename(tmpPath, seqPath);
+        seqRunDefaultCompleted = true;
       });
     } catch (err) {
       // Roll back the JSONL append: rewrite the file without the lines we just
@@ -415,6 +441,13 @@ export class AtomicAppender {
       // becomes the recovery target for the next appender via the cache rebuild).
       await fs.rm(tmpPath, { force: true }).catch(() => {});
       await this.rollbackJsonlAppend(jsonlPath, persisted.length).catch(() => {});
+      if (seqRunDefaultCompleted) {
+        // The .seq was actually renamed into place before the wrapper
+        // threw. Remove it so it doesn't sit ahead of the rolled-back
+        // JSONL; rebuild paths re-derive max-sequence from JSONL on
+        // first contact.
+        await fs.rm(seqPath, { force: true }).catch(() => {});
+      }
       return { ok: false, reason: 'io-error', cause: toError(err) };
     }
 

--- a/servers/exarchos-mcp/src/event-store/atomic-appender.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender.ts
@@ -2,6 +2,8 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 
+import { validateStreamId } from '../shared/validation.js';
+
 /**
  * AtomicAppender — single-writer-per-stream append primitive (v2.9.0).
  *
@@ -251,6 +253,16 @@ export class AtomicAppender {
     // ─── Phase 1: validate ───────────────────────────────────────────────
     if (!streamId || streamId.length === 0) {
       return { ok: false, reason: 'io-error', cause: new Error('streamId required') };
+    }
+    // Defense in depth: reject streamIds that could escape `stateDir` via
+    // path separators or `..` segments. EventStore consumers already
+    // validate at the boundary, but AtomicAppender is also exposed to
+    // SubagentStreamRouter and event_batch_append directly; a guard here
+    // means future consumers can't bypass it.
+    try {
+      validateStreamId(streamId);
+    } catch (err) {
+      return { ok: false, reason: 'io-error', cause: toError(err) };
     }
     if (!Array.isArray(events) || events.length === 0) {
       return { ok: false, reason: 'io-error', cause: new Error('events must be non-empty array') };

--- a/servers/exarchos-mcp/src/event-store/atomic-appender.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender.ts
@@ -24,18 +24,62 @@ import { validateStreamId } from '../shared/validation.js';
  * `AppendResult` shape, same per-stream serialization semantics.
  */
 
+/**
+ * Public-shaped persisted event surfaced on cache-hit so callers can return
+ * the actual stored shape (not a synthesized event from the request body).
+ *
+ * Mirrors the internal `PersistedEvent` but is exported so consumers like
+ * `EventStore.delegateAppend` can hand it back to their own callers without
+ * reaching into AtomicAppender internals.
+ *
+ * `eventId` is included for traceability — callers that don't need it can
+ * ignore the field. Other extension fields flow through the index signature.
+ */
+export interface PublicPersistedEvent {
+  streamId: string;
+  sequence: number;
+  type: string;
+  timestamp: string;
+  eventId: string;
+  idempotencyKey?: string;
+  data?: Record<string, unknown>;
+  [k: string]: unknown;
+}
+
 export type AppendResult =
   | {
       ok: true;
+      /**
+       * Distinguishes a fresh commit from a cache-hit so callers can:
+       *   - Return the actual persisted shape (not a synthesized version
+       *     of the current request body — a retry with the same key but
+       *     a different payload would otherwise replicate the wrong data).
+       *   - Skip supplementary side effects (backend dual-write, outbox)
+       *     that already ran when the original commit happened.
+       */
+      kind: 'committed';
       sequences: number[];
       eventIds: string[];
       /**
        * The timestamp on each persisted event, in the same order as
-       * `sequences` / `eventIds`. On cache hits these are the original
-       * persisted timestamps (NOT recomputed), so callers reconstructing
-       * the public event shape get a stable round-trip across retries.
+       * `sequences` / `eventIds`. Callers reconstructing the public event
+       * shape get a stable round-trip across retries.
        */
       timestamps: string[];
+    }
+  | {
+      ok: true;
+      kind: 'cache-hit';
+      sequences: number[];
+      eventIds: string[];
+      timestamps: string[];
+      /**
+       * The events ORIGINALLY persisted under this idempotency key. The
+       * caller's CURRENT request payload is irrelevant — return THIS to
+       * the caller and skip backend/outbox replication (already done at
+       * commit time).
+       */
+      persistedEvents: PublicPersistedEvent[];
     }
   | {
       ok: false;
@@ -290,9 +334,14 @@ export class AtomicAppender {
       if (cachedEvents && cachedEvents.length > 0) {
         return {
           ok: true,
+          kind: 'cache-hit',
           sequences: cachedEvents.map(e => e.sequence),
           eventIds: cachedEvents.map(e => e.eventId),
           timestamps: cachedEvents.map(e => e.timestamp),
+          // Surface the originally-persisted events so callers don't
+          // reconstruct from the (possibly different) current request
+          // payload — that's the bug CR-thread #3205805943 closes.
+          persistedEvents: cachedEvents.map(e => ({ ...e } as PublicPersistedEvent)),
         };
       }
     }
@@ -395,6 +444,7 @@ export class AtomicAppender {
 
     return {
       ok: true,
+      kind: 'committed',
       sequences: persisted.map(e => e.sequence),
       eventIds: persisted.map(e => e.eventId),
       timestamps: persisted.map(e => e.timestamp),

--- a/servers/exarchos-mcp/src/event-store/atomic-appender.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender.ts
@@ -23,7 +23,18 @@ import { randomUUID } from 'node:crypto';
  */
 
 export type AppendResult =
-  | { ok: true; sequences: number[]; eventIds: string[] }
+  | {
+      ok: true;
+      sequences: number[];
+      eventIds: string[];
+      /**
+       * The timestamp on each persisted event, in the same order as
+       * `sequences` / `eventIds`. On cache hits these are the original
+       * persisted timestamps (NOT recomputed), so callers reconstructing
+       * the public event shape get a stable round-trip across retries.
+       */
+      timestamps: string[];
+    }
   | {
       ok: false;
       reason: 'idempotency-claimed' | 'sequence-conflict' | 'io-error';
@@ -269,6 +280,7 @@ export class AtomicAppender {
           ok: true,
           sequences: cachedEvents.map(e => e.sequence),
           eventIds: cachedEvents.map(e => e.eventId),
+          timestamps: cachedEvents.map(e => e.timestamp),
         };
       }
     }
@@ -373,6 +385,7 @@ export class AtomicAppender {
       ok: true,
       sequences: persisted.map(e => e.sequence),
       eventIds: persisted.map(e => e.eventId),
+      timestamps: persisted.map(e => e.timestamp),
     };
   }
 

--- a/servers/exarchos-mcp/src/event-store/atomic-appender.ts
+++ b/servers/exarchos-mcp/src/event-store/atomic-appender.ts
@@ -1,0 +1,319 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * AtomicAppender — single-writer-per-stream append primitive (v2.9.0).
+ *
+ * Closes the substrate-level half of #1230 (overlapping sequence allocation under
+ * concurrency) and #1228 (phantom idempotencyKey claim on partial-write failure).
+ *
+ * The four-phase append (validate → allocate sequences → write JSONL → write .seq
+ * → cache idempotencyKey) is serialized per stream with a Promise-chain mutex
+ * (no `async-mutex` dep — the chain primitive is ~5 lines and matches semantics).
+ * The idempotencyKey cache mutation is the LAST step: it commits ONLY after JSONL
+ * and `.seq` writes both succeed. A failed append leaves the key uncommitted, so
+ * retries are admissible (the bug #1228 closes).
+ *
+ * This module is a NEW substrate; the existing four-phase path in `store.ts` is
+ * intentionally untouched in this commit. Consumer migration lands in C2.
+ *
+ * The interface is the seam #1259's SQLite implementation drops into: same
+ * `AppendResult` shape, same per-stream serialization semantics.
+ */
+
+export type AppendResult =
+  | { ok: true; sequences: number[]; eventIds: string[] }
+  | { ok: false; reason: 'idempotency-claimed' | 'sequence-conflict' | 'io-error'; cause?: Error };
+
+export interface EventInput {
+  type: string;
+  data?: Record<string, unknown>;
+  timestamp?: string;
+  correlationId?: string;
+  causationId?: string;
+  agentId?: string;
+  agentRole?: string;
+  source?: string;
+  schemaVersion?: string;
+  [k: string]: unknown;
+}
+
+/**
+ * Test-only failure-injection hook.
+ *
+ * Receives the phase being executed (`'jsonl'` or `'seq'`), the absolute file
+ * path the default writer would target, the contents the default writer would
+ * write, and a `runDefault` callback that performs the actual filesystem write.
+ *
+ * Production code passes no `writeFn`; the appender uses the default writer.
+ * Tests can throw before / after / instead of calling `runDefault` to simulate
+ * partial failures deterministically.
+ */
+export type WriteFn = (
+  phase: 'jsonl' | 'seq',
+  filePath: string,
+  contents: string,
+  runDefault: () => Promise<void>,
+) => Promise<void>;
+
+export interface AtomicAppenderOptions {
+  /** Directory under which `<streamId>.events.jsonl` and `<streamId>.seq` live. */
+  stateDir: string;
+  /** Test-only failure-injection writer; defaults to the production filesystem writer. */
+  writeFn?: WriteFn;
+}
+
+interface PersistedEvent {
+  streamId: string;
+  sequence: number;
+  type: string;
+  timestamp: string;
+  eventId: string;
+  idempotencyKey?: string;
+  data?: Record<string, unknown>;
+  [k: string]: unknown;
+}
+
+const SEQUENCE_REGEX = /"sequence":(\d+)/;
+
+/**
+ * Per-stream Promise-chain mutex. Each `runExclusive` call appends a new step
+ * to the chain; the next caller awaits the prior tail before its critical
+ * section runs. The chain release is non-throwing so a critical-section error
+ * does not poison subsequent acquirers.
+ */
+class StreamLockManager {
+  private tails = new Map<string, Promise<unknown>>();
+
+  async runExclusive<T>(streamId: string, fn: () => Promise<T>): Promise<T> {
+    const prior = this.tails.get(streamId) ?? Promise.resolve();
+    let release!: () => void;
+    const next = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    this.tails.set(streamId, next);
+    try {
+      await prior;
+      return await fn();
+    } finally {
+      release();
+      // Trim if no further appenders are queued (avoid Map growth)
+      if (this.tails.get(streamId) === next) {
+        this.tails.delete(streamId);
+      }
+    }
+  }
+}
+
+export class AtomicAppender {
+  private readonly stateDir: string;
+  private readonly writeFn?: WriteFn;
+  private readonly locks = new StreamLockManager();
+  /** Per-stream in-memory sequence high-water mark. Authoritative source is JSONL. */
+  private readonly sequenceCounters = new Map<string, number>();
+  /** streamId → idempotencyKey → committed event(s). Populated only after success. */
+  private readonly idempotencyCache = new Map<string, Map<string, PersistedEvent[]>>();
+  private readonly idempotencyInitialized = new Set<string>();
+
+  constructor(options: AtomicAppenderOptions) {
+    this.stateDir = options.stateDir;
+    this.writeFn = options.writeFn;
+  }
+
+  async append(
+    streamId: string,
+    events: EventInput[],
+    idempotencyKey: string,
+  ): Promise<AppendResult> {
+    return this.locks.runExclusive(streamId, () => this.appendLocked(streamId, events, idempotencyKey));
+  }
+
+  private async appendLocked(
+    streamId: string,
+    events: EventInput[],
+    idempotencyKey: string,
+  ): Promise<AppendResult> {
+    // ─── Phase 1: validate ───────────────────────────────────────────────
+    if (!streamId || streamId.length === 0) {
+      return { ok: false, reason: 'io-error', cause: new Error('streamId required') };
+    }
+    if (!Array.isArray(events) || events.length === 0) {
+      return { ok: false, reason: 'io-error', cause: new Error('events must be non-empty array') };
+    }
+    if (!idempotencyKey || idempotencyKey.length === 0) {
+      return { ok: false, reason: 'io-error', cause: new Error('idempotencyKey required') };
+    }
+
+    // Idempotency check — rebuild cache from JSONL on first contact with stream.
+    if (!this.idempotencyInitialized.has(streamId)) {
+      try {
+        await this.rebuildCachesFromJsonl(streamId);
+      } catch (err) {
+        return { ok: false, reason: 'io-error', cause: toError(err) };
+      }
+      this.idempotencyInitialized.add(streamId);
+    }
+    const streamIdemCache = this.idempotencyCache.get(streamId);
+    const cachedEvents = streamIdemCache?.get(idempotencyKey);
+    if (cachedEvents && cachedEvents.length > 0) {
+      return {
+        ok: true,
+        sequences: cachedEvents.map(e => e.sequence),
+        eventIds: cachedEvents.map(e => e.eventId),
+      };
+    }
+
+    // ─── Phase 2: allocate sequences ─────────────────────────────────────
+    const baseSeq = (this.sequenceCounters.get(streamId) ?? 0);
+    const persisted: PersistedEvent[] = events.map((evt, i) => ({
+      ...evt,
+      streamId,
+      sequence: baseSeq + i + 1,
+      timestamp: evt.timestamp ?? new Date().toISOString(),
+      type: evt.type,
+      eventId: randomUUID(),
+      idempotencyKey,
+    }));
+    const finalSequence = persisted[persisted.length - 1].sequence;
+
+    // ─── Phase 3: write JSONL ────────────────────────────────────────────
+    const jsonlPath = this.getEventFilePath(streamId);
+    const seqPath = this.getSeqFilePath(streamId);
+    const lines = persisted.map(e => JSON.stringify(e)).join('\n') + '\n';
+    try {
+      await fs.mkdir(path.dirname(jsonlPath), { recursive: true });
+      await this.runWrite('jsonl', jsonlPath, lines, async () => {
+        await fs.appendFile(jsonlPath, lines, 'utf-8');
+      });
+    } catch (err) {
+      // No partial state to roll back: nothing was written, idempotencyKey
+      // never reached the cache, sequence counter never advanced.
+      return { ok: false, reason: 'io-error', cause: toError(err) };
+    }
+
+    // ─── Phase 4: write .seq ─────────────────────────────────────────────
+    // Failure here is structured: the JSONL is the source of truth, but the
+    // caller MUST NOT see a silent success — that's exactly what hid #1228.
+    // We unwind the JSONL append on .seq failure to preserve the all-or-none
+    // contract callers rely on.
+    const tmpPath = `${seqPath}.tmp`;
+    const seqContents = JSON.stringify({ sequence: finalSequence });
+    try {
+      await this.runWrite('seq', seqPath, seqContents, async () => {
+        await fs.writeFile(tmpPath, seqContents, 'utf-8');
+        await fs.rename(tmpPath, seqPath);
+      });
+    } catch (err) {
+      // Roll back the JSONL append: rewrite the file without the lines we just
+      // appended. Best-effort cleanup of any tmp file. If rollback itself fails,
+      // we still surface the original .seq failure (the JSONL on-disk state
+      // becomes the recovery target for the next appender via the cache rebuild).
+      await fs.rm(tmpPath, { force: true }).catch(() => {});
+      await this.rollbackJsonlAppend(jsonlPath, persisted.length).catch(() => {});
+      return { ok: false, reason: 'io-error', cause: toError(err) };
+    }
+
+    // ─── Phase 5: cache idempotencyKey (commit point) ────────────────────
+    // ONLY reached if all prior phases succeeded. This is the bug-#1228 fix:
+    // the key is admissible for retry until and unless the append commits.
+    let cache = this.idempotencyCache.get(streamId);
+    if (!cache) {
+      cache = new Map();
+      this.idempotencyCache.set(streamId, cache);
+    }
+    cache.set(idempotencyKey, persisted);
+    this.sequenceCounters.set(streamId, finalSequence);
+
+    return {
+      ok: true,
+      sequences: persisted.map(e => e.sequence),
+      eventIds: persisted.map(e => e.eventId),
+    };
+  }
+
+  private async runWrite(
+    phase: 'jsonl' | 'seq',
+    filePath: string,
+    contents: string,
+    runDefault: () => Promise<void>,
+  ): Promise<void> {
+    if (this.writeFn) {
+      await this.writeFn(phase, filePath, contents, runDefault);
+    } else {
+      await runDefault();
+    }
+  }
+
+  /**
+   * Rebuild sequence counter and idempotencyKey cache from JSONL on first
+   * contact with a stream. Cheap on cold start; subsequent appends use the
+   * in-memory counters.
+   */
+  private async rebuildCachesFromJsonl(streamId: string): Promise<void> {
+    const filePath = this.getEventFilePath(streamId);
+    let raw: string;
+    try {
+      raw = await fs.readFile(filePath, 'utf-8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return; // fresh stream
+      }
+      throw err;
+    }
+    let maxSeq = 0;
+    const cache = new Map<string, PersistedEvent[]>();
+    for (const line of raw.split('\n')) {
+      if (line.length === 0) continue;
+      const seqMatch = SEQUENCE_REGEX.exec(line);
+      if (seqMatch) {
+        const s = Number.parseInt(seqMatch[1], 10);
+        if (s > maxSeq) maxSeq = s;
+      }
+      let parsed: PersistedEvent;
+      try {
+        parsed = JSON.parse(line) as PersistedEvent;
+      } catch {
+        continue; // skip malformed line; JSONL is source of truth, but tolerate corruption
+      }
+      if (parsed.idempotencyKey) {
+        const existing = cache.get(parsed.idempotencyKey) ?? [];
+        existing.push(parsed);
+        cache.set(parsed.idempotencyKey, existing);
+      }
+    }
+    this.sequenceCounters.set(streamId, maxSeq);
+    this.idempotencyCache.set(streamId, cache);
+  }
+
+  /**
+   * Truncate the most-recent N JSONL lines from a stream file. Used to unwind
+   * a partial append on `.seq` failure so the caller's all-or-none contract
+   * holds. JSONL is line-delimited so truncation by line count is safe.
+   */
+  private async rollbackJsonlAppend(filePath: string, lineCount: number): Promise<void> {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    // The append wrote `lines.join('\n') + '\n'` so the file ends with a
+    // newline-terminated block of `lineCount` lines. Drop them.
+    const allLines = raw.split('\n');
+    // The trailing '\n' after the last newline yields an empty final element;
+    // preserve that to keep the file's line-terminator semantics consistent.
+    const trailingEmpty = allLines[allLines.length - 1] === '' ? 1 : 0;
+    const keep = allLines.slice(0, allLines.length - lineCount - trailingEmpty);
+    const rewritten = keep.length === 0 ? '' : keep.join('\n') + '\n';
+    await fs.writeFile(filePath, rewritten, 'utf-8');
+  }
+
+  private getEventFilePath(streamId: string): string {
+    return path.join(this.stateDir, `${streamId}.events.jsonl`);
+  }
+
+  private getSeqFilePath(streamId: string): string {
+    return path.join(this.stateDir, `${streamId}.seq`);
+  }
+}
+
+function toError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  return new Error(String(err));
+}

--- a/servers/exarchos-mcp/src/event-store/replay-determinism.test.ts
+++ b/servers/exarchos-mcp/src/event-store/replay-determinism.test.ts
@@ -1,0 +1,302 @@
+// ─── Replay Determinism — v2.9.0 Bug Cluster (Commit C9, #1109) ──────────────
+//
+// Closes the #1109 verification checklist by pinning the projection-
+// determinism invariant across the v2.9.0 bug-cluster scenarios. For each
+// closed-bug shape we:
+//
+//   1. Construct an event log that exercises the bug's failure mode.
+//   2. Fold the log through `workflowStatusProjection` once.
+//   3. Re-fold the same log from a fresh `init()` state.
+//   4. Byte-compare the two projection states.
+//
+// A divergence here would indicate non-determinism in either the projection
+// or in event-log ordering — the substrate invariant `AtomicAppender`
+// (Commit C1) and the `task.completed` dedup (Commit C4) are designed to
+// guarantee. This test pins those guarantees behind a regression gate so
+// future projection changes can't silently re-introduce non-determinism.
+//
+// Per scenarios 1 (concurrent appends) we exercise the real `AtomicAppender`
+// against a tmp-dir to also verify the substrate-side determinism story:
+// the union of events written under concurrency must order deterministically
+// when read back from JSONL.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  workflowStatusProjection,
+  type WorkflowStatusViewState,
+} from '../views/workflow-status-view.js';
+import type { WorkflowEvent } from './schemas.js';
+import { AtomicAppender } from './atomic-appender.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Fold the projection over a list of events from a fresh `init()` state.
+ * We intentionally avoid the `ViewMaterializer` cache here — replay
+ * determinism is a pure-function property of the projection's `apply`
+ * fold and using the cache would muddy the assertion (cache hits would
+ * skip the fold entirely).
+ */
+function project(events: readonly WorkflowEvent[]): WorkflowStatusViewState {
+  let state = workflowStatusProjection.init();
+  for (const evt of events) {
+    state = workflowStatusProjection.apply(state, evt);
+  }
+  return state;
+}
+
+/**
+ * Build a structurally-valid `WorkflowEvent` from the minimum fields the
+ * projection inspects. The schema-versioned fields (`schemaVersion`,
+ * absent `correlationId`, etc.) are populated to defaults so the value
+ * round-trips through any downstream Zod parse should one ever land
+ * here. The projection itself reads only `type`, `data`, `timestamp`,
+ * so the rest is incidental.
+ */
+function makeEvent(
+  streamId: string,
+  sequence: number,
+  type: string,
+  data: Record<string, unknown>,
+  timestampMs = 1_700_000_000_000,
+): WorkflowEvent {
+  return {
+    streamId,
+    sequence,
+    timestamp: new Date(timestampMs + sequence * 1000).toISOString(),
+    type,
+    data,
+    schemaVersion: '1.0',
+  } as WorkflowEvent;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('replay determinism (C9, #1109 verification)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'replay-determinism-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('replay_v29BugClusterScenarios_reconstructsIdenticalState', () => {
+    /**
+     * Scenario 1 — concurrent appends through `AtomicAppender`.
+     *
+     * Three concurrent `append` calls on the same stream must (a) succeed
+     * without sequence collision and (b) produce a JSONL whose reader
+     * yields a deterministic event order. We project the resulting log
+     * twice and byte-compare. This is the C1 invariant in projection
+     * terms: even when the writer order is non-deterministic, the
+     * *committed* ordering is what the projection sees.
+     */
+    it('Scenario1_concurrentAppends_reproject_byteIdentical', async () => {
+      const streamId = 'replay-scenario-1';
+      const appender = new AtomicAppender({ stateDir: tmpDir });
+
+      // Three concurrent appends, each carrying one task lifecycle event.
+      // Distinct idempotencyKeys so all three are admitted.
+      const results = await Promise.all([
+        appender.append(streamId, [
+          { type: 'workflow.started', data: { featureId: streamId, workflowType: 'feature' } },
+        ], `${streamId}:k1`),
+        appender.append(streamId, [
+          { type: 'task.assigned', data: { taskId: 't1' } },
+        ], `${streamId}:k2`),
+        appender.append(streamId, [
+          { type: 'task.completed', data: { taskId: 't1' } },
+        ], `${streamId}:k3`),
+      ]);
+      for (const r of results) {
+        expect(r.ok).toBe(true);
+      }
+
+      // Read the JSONL the appender just wrote and reconstruct events.
+      const jsonlPath = path.join(tmpDir, `${streamId}.events.jsonl`);
+      const raw = await fs.readFile(jsonlPath, 'utf-8');
+      const events = raw
+        .split('\n')
+        .filter(line => line.length > 0)
+        .map(line => JSON.parse(line) as WorkflowEvent);
+
+      // Project twice from the same log; byte-compare.
+      const p1 = project(events);
+      const p2 = project(events);
+      expect(JSON.stringify(p2)).toBe(JSON.stringify(p1));
+    });
+
+    /**
+     * Scenario 2 — refinement checkpoints in same phase (C3 / #1241).
+     *
+     * Before the C3 fix, two checkpoint events with the same featureId +
+     * phase + version collapsed to one because the idempotencyKey didn't
+     * include a digest of the handoff payload. After C3, distinct
+     * handoffs land as distinct events. The projection treats
+     * `workflow.checkpoint` as unhandled, so this scenario doesn't move
+     * the projection's counters — but it MUST still byte-compare across
+     * re-projection. Determinism is the thing under test.
+     */
+    it('Scenario2_refinementCheckpoints_reproject_byteIdentical', () => {
+      const streamId = 'replay-scenario-2';
+      const events: WorkflowEvent[] = [
+        makeEvent(streamId, 1, 'workflow.started', { featureId: streamId, workflowType: 'feature' }),
+        // Two checkpoints in the same phase with distinct handoffs.
+        // Cast through `any` for `handoff` since the schema doesn't yet
+        // declare it (mirrors handleCheckpoint's forward-compat read).
+        makeEvent(streamId, 2, 'workflow.checkpoint', {
+          counter: 0,
+          phase: 'started',
+          featureId: streamId,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          handoff: { delivered: 'design-v1' } as any,
+        }),
+        makeEvent(streamId, 3, 'workflow.checkpoint', {
+          counter: 0,
+          phase: 'started',
+          featureId: streamId,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          handoff: { delivered: 'design-v2' } as any,
+        }),
+      ];
+
+      const p1 = project(events);
+      const p2 = project(events);
+      expect(JSON.stringify(p2)).toBe(JSON.stringify(p1));
+    });
+
+    /**
+     * Scenario 3 — duplicate `task.completed` for same taskId (C4 / #1226).
+     *
+     * Whether the duplicate originated as a #1228 retry survivor or as a
+     * historical replay artifact, the projection must dedup by taskId.
+     * The C4 fix uses `_seenCompletedTaskIds` to count once. Here we
+     * additionally pin the determinism property: re-projecting yields
+     * a byte-identical state.
+     */
+    it('Scenario3_duplicateTaskCompleted_reproject_byteIdentical', () => {
+      const streamId = 'replay-scenario-3';
+      const events: WorkflowEvent[] = [
+        makeEvent(streamId, 1, 'workflow.started', { featureId: streamId, workflowType: 'feature' }),
+        makeEvent(streamId, 2, 'task.assigned', { taskId: 't1' }),
+        makeEvent(streamId, 3, 'task.completed', { taskId: 't1' }),
+        // Duplicate `task.completed` — same taskId. Post-C4 must not
+        // double-count. Pin the dedup outcome and the determinism.
+        makeEvent(streamId, 4, 'task.completed', { taskId: 't1' }),
+      ];
+
+      const p1 = project(events);
+      const p2 = project(events);
+
+      // Byte-equal under re-projection.
+      expect(JSON.stringify(p2)).toBe(JSON.stringify(p1));
+      // The C4 invariant: duplicate counts once, never exceeding total.
+      expect(p1.tasksCompleted).toBe(1);
+      expect(p1.tasksTotal).toBe(1);
+      expect(p1.tasksCompleted <= p1.tasksTotal).toBe(true);
+    });
+
+    /**
+     * Scenario 4 — failed-then-passed guard (C7 / #1225).
+     *
+     * Before C7, a guard failure could be followed by a `workflow.transition`
+     * event ~6s later, leaving both in the log. After C7's fail_closed,
+     * the log carries either guard-failed or transition for a given
+     * attempt — never both. We can't replay the C7 substrate guarantee
+     * here (that's covered by `hsm-transition-guard.test.ts`), but we
+     * pin determinism for the historical-log shape: an event log that
+     * happens to carry both must still re-project byte-identically.
+     */
+    it('Scenario4_failedThenPassedGuard_reproject_byteIdentical', () => {
+      const streamId = 'replay-scenario-4';
+      const events: WorkflowEvent[] = [
+        makeEvent(streamId, 1, 'workflow.started', { featureId: streamId, workflowType: 'feature' }),
+        // Historical-shape: guard failure followed by transition. Pinning
+        // determinism, not the C7 atomicity property.
+        makeEvent(streamId, 2, 'workflow.guard-failed', {
+          featureId: streamId,
+          from: 'delegate',
+          to: 'review',
+          reason: 'all-tasks-complete failed',
+        }),
+        makeEvent(streamId, 3, 'workflow.transition', {
+          featureId: streamId,
+          from: 'delegate',
+          to: 'review',
+          trigger: 'manual',
+        }),
+      ];
+
+      const p1 = project(events);
+      const p2 = project(events);
+      expect(JSON.stringify(p2)).toBe(JSON.stringify(p1));
+      // The transition event is the last one folded; phase reflects it.
+      expect(p1.phase).toBe('review');
+    });
+
+    /**
+     * Combined scenario — all four bug shapes interleaved on one log.
+     *
+     * The strongest version of the #1109 invariant: the union of bug
+     * shapes folded as one log re-projects byte-identically. Demonstrates
+     * that determinism is a property of the projection over the entire
+     * cluster, not just per-bug locality.
+     */
+    it('CombinedScenario_allBugShapes_reproject_byteIdentical', () => {
+      const streamId = 'replay-combined';
+      const events: WorkflowEvent[] = [
+        makeEvent(streamId, 1, 'workflow.started', { featureId: streamId, workflowType: 'feature' }),
+        makeEvent(streamId, 2, 'task.assigned', { taskId: 'tA' }),
+        makeEvent(streamId, 3, 'task.assigned', { taskId: 'tB' }),
+        // Duplicate task.assigned (#1226 dedup also applies to total).
+        makeEvent(streamId, 4, 'task.assigned', { taskId: 'tA' }),
+        makeEvent(streamId, 5, 'workflow.checkpoint', { counter: 0, phase: 'delegate', featureId: streamId }),
+        makeEvent(streamId, 6, 'task.completed', { taskId: 'tA' }),
+        // Duplicate task.completed (#1226).
+        makeEvent(streamId, 7, 'task.completed', { taskId: 'tA' }),
+        // Refinement checkpoint with handoff (#1241 — distinct event after C3).
+        makeEvent(streamId, 8, 'workflow.checkpoint', {
+          counter: 0,
+          phase: 'delegate',
+          featureId: streamId,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          handoff: { delivered: 'wave-2-summary' } as any,
+        }),
+        makeEvent(streamId, 9, 'task.completed', { taskId: 'tB' }),
+        makeEvent(streamId, 10, 'workflow.guard-failed', {
+          featureId: streamId,
+          from: 'delegate',
+          to: 'review',
+          reason: 'team-disbanded missing',
+        }),
+        makeEvent(streamId, 11, 'workflow.transition', {
+          featureId: streamId,
+          from: 'delegate',
+          to: 'review',
+          trigger: 'manual',
+        }),
+      ];
+
+      const p1 = project(events);
+      const p2 = project(events);
+      expect(JSON.stringify(p2)).toBe(JSON.stringify(p1));
+
+      // Sanity: invariants from the cluster fixes — tasksCompleted (=2)
+      // never exceeds tasksTotal (=2 distinct, dedup'd). Phase advances
+      // to the last applied transition's `to`.
+      expect(p1.tasksTotal).toBe(2);
+      expect(p1.tasksCompleted).toBe(2);
+      expect(p1.tasksCompleted <= p1.tasksTotal).toBe(true);
+      expect(p1.phase).toBe('review');
+    });
+  });
+});

--- a/servers/exarchos-mcp/src/event-store/store.race.test.ts
+++ b/servers/exarchos-mcp/src/event-store/store.race.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { EventStore } from './store.js';
+
+/**
+ * Cross-path race regression suite (#1293, post-#1265).
+ *
+ * Before the C2 consumer migration, `EventStore.append` and
+ * `AtomicAppender.append` (the path used by `event_batch_append` and the
+ * subagent stream router) maintained disjoint per-stream locks and
+ * sequence counters while writing the same JSONL file. CodeRabbit flagged
+ * this on PR #1265 review (thread 3199528959); Sentry surfaced the race
+ * firing in code on the post-fix re-review.
+ *
+ * These tests drive concurrent writes from both legacy-shaped paths
+ * (`EventStore.append`, `EventStore.batchAppend`) and the underlying
+ * `AtomicAppender` directly, then assert the cross-path invariants:
+ *
+ *   - Strict sequence monotonicity per stream — no overlapping sequences,
+ *     no gaps from collision retries.
+ *   - JSONL parses cleanly line-by-line — no truncated or interleaved
+ *     records from concurrent appendFile calls.
+ *   - Total event count matches the number of writes issued — no drops,
+ *     no duplicates beyond the explicit idempotency-dedup contract.
+ *
+ * Pre-migration these tests fail (overlapping sequences and JSONL
+ * corruption). Post-migration they pass because both paths now share the
+ * single `AtomicAppender` instance returned by `EventStore.getAppender()`.
+ */
+describe('EventStore cross-path race (#1293)', () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await mkdtemp(path.join(tmpdir(), 'eventstore-race-'));
+  });
+
+  afterEach(async () => {
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  it('EventStore_concurrentLegacyAppendAndBatchAppend_strictSequenceMonotonicity', async () => {
+    const store = new EventStore(stateDir);
+    const streamId = 'race-stream';
+    const N = 50;
+
+    // Mix three paths concurrently: single append, batch append, and direct
+    // AtomicAppender. Production load looks like this — HSM transitions go
+    // through `append`, `event_batch_append` goes through batch, and the
+    // subagent stream router goes through the appender directly.
+    const single = Array.from({ length: N }, (_, i) =>
+      store.append(streamId, { type: 'task.assigned', data: { i, source: 'single' } }),
+    );
+    const batched = Array.from({ length: N }, (_, i) =>
+      store.batchAppend(streamId, [
+        { type: 'task.completed', data: { i, source: 'batched' } },
+      ]),
+    );
+    const direct = Array.from({ length: N }, (_, i) =>
+      store.getAppender().append(
+        streamId,
+        [{ type: 'workflow.transition', data: { i, source: 'direct' } }],
+        `direct-${i}`,
+      ),
+    );
+
+    const allResults = await Promise.all([
+      ...single,
+      ...batched.map(p => p.then(arr => arr[0])),
+      ...direct.map(p => p.then(r => (r.ok ? r.sequences[0] : -1))),
+    ]);
+    expect(allResults).toHaveLength(3 * N);
+
+    // Read the JSONL and assert monotonicity + no duplicates.
+    const jsonl = await readFile(
+      path.join(stateDir, `${streamId}.events.jsonl`),
+      'utf-8',
+    );
+    const lines = jsonl.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(3 * N);
+
+    const sequences = lines.map((line) => JSON.parse(line).sequence as number);
+    const sorted = [...sequences].sort((a, b) => a - b);
+    // Sequences cover 1..3N exactly (strict monotonicity, no gaps).
+    expect(sorted).toEqual(Array.from({ length: 3 * N }, (_, i) => i + 1));
+    // Uniqueness check — implied by sorted equality, but explicit for clarity.
+    expect(new Set(sequences).size).toBe(3 * N);
+  });
+
+  it('EventStore_concurrentSingleAppendOnly_noOverlappingSequences', async () => {
+    // Targeted regression for the path that #1265 left unmigrated: pure
+    // EventStore.append concurrency. Pre-migration this contended on a
+    // separate lock from the AtomicAppender path; post-migration it
+    // routes through the same per-stream serialization.
+    const store = new EventStore(stateDir);
+    const streamId = 'append-only-race';
+    const N = 100;
+
+    const results = await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        store.append(streamId, { type: 'task.assigned', data: { i } }),
+      ),
+    );
+    const sequences = results.map(r => r.sequence).sort((a, b) => a - b);
+    expect(sequences).toEqual(Array.from({ length: N }, (_, i) => i + 1));
+
+    const jsonl = await readFile(
+      path.join(stateDir, `${streamId}.events.jsonl`),
+      'utf-8',
+    );
+    const lines = jsonl.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(N);
+    // Every line must parse cleanly — no truncated or interleaved records.
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+  });
+
+  it('EventStore_concurrentLegacyAndDirectAppender_jsonlIntegrity', async () => {
+    // Sentry's specific concern from the #1265 re-review:
+    // "Concurrent calls to handleEventAppend and handleBatchAppend can
+    //  cause a race condition" (event-store/tools.ts:424). This test
+    // reproduces that interleaving by issuing N legacy + N direct writes
+    // simultaneously and verifying the on-disk JSONL is internally
+    // consistent (every line parses; sequences are unique and dense).
+    const store = new EventStore(stateDir);
+    const streamId = 'sentry-flag';
+    const N = 50;
+
+    await Promise.all([
+      ...Array.from({ length: N }, () =>
+        store.append(streamId, { type: 'task.assigned' }),
+      ),
+      ...Array.from({ length: N }, (_, i) =>
+        store
+          .getAppender()
+          .append(streamId, [{ type: 'task.completed' }], `direct-${i}`),
+      ),
+    ]);
+
+    const jsonl = await readFile(
+      path.join(stateDir, `${streamId}.events.jsonl`),
+      'utf-8',
+    );
+    const lines = jsonl.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(2 * N);
+
+    const parsed = lines.map((l) => JSON.parse(l));
+    const sequences = parsed.map((e) => e.sequence as number);
+    expect(new Set(sequences).size).toBe(2 * N);
+    expect([...sequences].sort((a, b) => a - b)).toEqual(
+      Array.from({ length: 2 * N }, (_, i) => i + 1),
+    );
+  });
+});

--- a/servers/exarchos-mcp/src/event-store/store.test.ts
+++ b/servers/exarchos-mcp/src/event-store/store.test.ts
@@ -1974,18 +1974,30 @@ describe('EventStore StorageBackend Integration', () => {
     // longer the seq-init source — JSONL is the source of truth, backend
     // is a supplementary dual-write target. The test verifies that a new
     // EventStore instance (simulating restart) correctly continues
-    // sequence numbering across the boundary.
-    const backend = new InMemoryBackend();
-    const store = new EventStore(tempDir, { backend });
+    // sequence numbering across the boundary EVEN WHEN backend disagrees.
+    //
+    // Per CR review 4249046281: the prior version of this test reused the
+    // same `InMemoryBackend` instance, so `backend.getSequence()` would
+    // happily return 3 too. To prove JSONL is the load-bearing source, the
+    // restart store gets a FRESH backend that returns 0 — if AtomicAppender
+    // were still consulting backend.getSequence on init, the next append
+    // would land at sequence 1 (backend's view) and collide with the
+    // existing JSONL events at 1..3. The test asserts seq=4, so the
+    // initialization path went through JSONL.
+    const backend1 = new InMemoryBackend();
+    const store = new EventStore(tempDir, { backend: backend1 });
 
     await store.append('my-workflow', { type: 'workflow.started' });
     await store.append('my-workflow', { type: 'task.assigned' });
     await store.append('my-workflow', { type: 'workflow.transition' });
 
-    // Restart simulation — a fresh EventStore reads the JSONL state.
-    const store2 = new EventStore(tempDir, { backend });
+    // Restart with a *fresh* backend whose getSequence returns 0. Forces
+    // the diverged-state path: backend says 0, JSONL says 3.
+    const backend2 = new InMemoryBackend();
+    expect(backend2.getSequence('my-workflow')).toBe(0);
+    const store2 = new EventStore(tempDir, { backend: backend2 });
     const event = await store2.append('my-workflow', { type: 'task.claimed' });
-    expect(event.sequence).toBe(4);
+    expect(event.sequence).toBe(4); // JSONL wins over backend.
   });
 
   it('append_BackendWriteFails_StillSucceedsWithWarning', async () => {
@@ -2105,14 +2117,25 @@ describe('EventStore appendValidated', () => {
   //      commit time — re-running would create duplicate/inconsistent state).
 
   it('append_idempotencyRetryWithDifferentPayload_returnsOriginalAndSkipsReplication', async () => {
+    // Two side-effect counters cover both supplementary replication paths:
+    // backend dual-write AND outbox replay. Both must fire exactly once
+    // (on the original commit), not on the cache-hit retry. CR review
+    // 4249046281 asked for the outbox half explicitly — without it, a
+    // future regression that re-fired the outbox on cache-hit could
+    // pass the original test.
     let backendCalls = 0;
+    let outboxCalls = 0;
     const backend = {
       appendEvent: () => { backendCalls++; },
       getSequence: () => 0,
       queryEvents: async () => [],
       getMaxSequence: () => 0,
     };
+    const outbox = {
+      addEntry: async () => { outboxCalls++; },
+    };
     const store = new EventStore(tempDir, { backend: backend as never });
+    store.setOutbox(outbox as never);
 
     // Original commit: payload A
     const first = await store.append(
@@ -2123,9 +2146,10 @@ describe('EventStore appendValidated', () => {
     expect(first.sequence).toBe(1);
     expect((first.data as { payload: string }).payload).toBe('A');
     expect(backendCalls).toBe(1);
+    expect(outboxCalls).toBe(1);
 
     // Retry with same key, DIFFERENT payload. Must return original (A, seq 1)
-    // and NOT call backend a second time.
+    // AND must skip BOTH supplementary replications.
     const retry = await store.append(
       'my-workflow',
       { type: 'task.assigned', data: { payload: 'B-DIFFERENT' } },
@@ -2133,7 +2157,8 @@ describe('EventStore appendValidated', () => {
     );
     expect(retry.sequence).toBe(1);
     expect((retry.data as { payload: string }).payload).toBe('A'); // not 'B-DIFFERENT'
-    expect(backendCalls).toBe(1); // unchanged — no second replication
+    expect(backendCalls).toBe(1); // unchanged — no second backend replication
+    expect(outboxCalls).toBe(1); // unchanged — no second outbox entry
   });
 
   it('appendValidated_RespectsExpectedSequence', async () => {

--- a/servers/exarchos-mcp/src/event-store/store.test.ts
+++ b/servers/exarchos-mcp/src/event-store/store.test.ts
@@ -2095,6 +2095,47 @@ describe('EventStore appendValidated', () => {
     expect(content.trim().split('\n')).toHaveLength(1);
   });
 
+  // ─── Cache-hit semantics (#1293 D1, CR review 4248944836 thread 3205805943) ─
+  //
+  // Retrying with the same idempotencyKey but a DIFFERENT payload must:
+  //   1. Return the ORIGINALLY persisted event (not a synthesized version of
+  //      the current request body — that would replicate data that was never
+  //      written to JSONL).
+  //   2. NOT trigger backend/outbox replication (already done at original
+  //      commit time — re-running would create duplicate/inconsistent state).
+
+  it('append_idempotencyRetryWithDifferentPayload_returnsOriginalAndSkipsReplication', async () => {
+    let backendCalls = 0;
+    const backend = {
+      appendEvent: () => { backendCalls++; },
+      getSequence: () => 0,
+      queryEvents: async () => [],
+      getMaxSequence: () => 0,
+    };
+    const store = new EventStore(tempDir, { backend: backend as never });
+
+    // Original commit: payload A
+    const first = await store.append(
+      'my-workflow',
+      { type: 'task.assigned', data: { payload: 'A' } },
+      { idempotencyKey: 'shared-key' },
+    );
+    expect(first.sequence).toBe(1);
+    expect((first.data as { payload: string }).payload).toBe('A');
+    expect(backendCalls).toBe(1);
+
+    // Retry with same key, DIFFERENT payload. Must return original (A, seq 1)
+    // and NOT call backend a second time.
+    const retry = await store.append(
+      'my-workflow',
+      { type: 'task.assigned', data: { payload: 'B-DIFFERENT' } },
+      { idempotencyKey: 'shared-key' },
+    );
+    expect(retry.sequence).toBe(1);
+    expect((retry.data as { payload: string }).payload).toBe('A'); // not 'B-DIFFERENT'
+    expect(backendCalls).toBe(1); // unchanged — no second replication
+  });
+
   it('appendValidated_RespectsExpectedSequence', async () => {
     const store = new EventStore(tempDir);
 

--- a/servers/exarchos-mcp/src/event-store/store.test.ts
+++ b/servers/exarchos-mcp/src/event-store/store.test.ts
@@ -584,29 +584,32 @@ describe('EventStore Sequence Persistence', () => {
   });
 
   // Append succeeds even when .seq write fails
-  it('EventStore_SeqWriteFails_AppendStillSucceeds', async () => {
+  it('EventStore_SeqWriteFails_AppendRollsBackJsonl', async () => {
+    // After the AtomicAppender migration (#1293), `.seq` failure is no
+    // longer swallowed: that silent-success path was the substrate-level
+    // half of #1228 (phantom idempotencyKey on partial-write failure).
+    // The all-or-none contract requires the JSONL append to roll back
+    // when the .seq write fails, and the error to surface to the caller.
     const store = new EventStore(tempDir);
 
-    // First append succeeds normally
     await store.append('my-workflow', { type: 'workflow.started' });
 
-    // Make the .seq file path a directory so writeFile will fail
+    // Make the .seq file path a directory so the rename target fails.
     const seqPath = path.join(tempDir, 'my-workflow.seq');
     await fs.rm(seqPath, { force: true });
     await fs.mkdir(seqPath);
 
-    // Second append should still succeed despite .seq write failure
-    const event = await store.append('my-workflow', { type: 'task.assigned' });
-    expect(event.sequence).toBe(2);
-    expect(event.type).toBe('task.assigned');
+    // Second append must surface the error; JSONL is rolled back to its
+    // pre-attempt state (1 line, not 2).
+    await expect(
+      store.append('my-workflow', { type: 'task.assigned' }),
+    ).rejects.toThrow();
 
-    // Verify the JSONL file has both events (source of truth)
     const filePath = path.join(tempDir, 'my-workflow.events.jsonl');
     const content = await fs.readFile(filePath, 'utf-8');
-    const lines = content.trim().split('\n');
-    expect(lines).toHaveLength(2);
+    const lines = content.trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(1);
 
-    // Clean up: remove the directory so afterEach can clean up
     await fs.rm(seqPath, { recursive: true, force: true });
   });
 
@@ -1445,31 +1448,31 @@ describe('EventStore Sequence Invariant', () => {
     expect(event.sequence).toBe(4);
   });
 
-  it('InitializeSequence_BrokenInvariant_AutoRepairs', async () => {
-    // Create a JSONL file where first line has wrong sequence
+  it('InitializeSequence_BrokenInvariant_ContinuesFromMaxSequence', async () => {
+    // Post-#1293 migration: the legacy auto-repair-by-rewriting-JSONL behavior
+    // is gone. AtomicAppender reads max(sequence) from the JSONL and continues
+    // from max+1, leaving the corrupted history in place. This is correct
+    // for #1259 (SQLite uses MAX(sequence)+1; aggressive in-place rewrites
+    // were a JSONL-era hack that risks data loss on flaky disks).
     const filePath = path.join(tempDir, 'broken-seq.events.jsonl');
     const events = [
       { streamId: 'broken-seq', sequence: 5, type: 'workflow.started', timestamp: '2025-01-01T00:00:00.000Z', schemaVersion: '1.0' },
       { streamId: 'broken-seq', sequence: 6, type: 'task.assigned', timestamp: '2025-01-01T00:00:01.000Z', schemaVersion: '1.0' },
     ];
     await fs.writeFile(filePath, events.map(e => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
-
-    // Delete .seq file to force fallback path with invariant check
-    const seqPath = path.join(tempDir, 'broken-seq.seq');
-    await fs.rm(seqPath, { force: true });
+    await fs.rm(path.join(tempDir, 'broken-seq.seq'), { force: true });
 
     const store = new EventStore(tempDir);
-    // Auto-repair: re-sequences to 1,2 then appends as 3
     const event = await store.append('broken-seq', { type: 'task.claimed' });
-    expect(event.sequence).toBe(3);
+    // Continues from max(seq)+1 = 7; the existing offset-5 lines are unchanged.
+    expect(event.sequence).toBe(7);
 
-    // Verify repaired file
     const content = await fs.readFile(filePath, 'utf-8');
     const lines = content.trim().split('\n').filter(Boolean);
     expect(lines).toHaveLength(3);
-    for (let i = 0; i < lines.length; i++) {
-      expect(JSON.parse(lines[i]).sequence).toBe(i + 1);
-    }
+    expect(JSON.parse(lines[0]).sequence).toBe(5);
+    expect(JSON.parse(lines[1]).sequence).toBe(6);
+    expect(JSON.parse(lines[2]).sequence).toBe(7);
   });
 
   // T25: Blank-line tolerance
@@ -1499,9 +1502,10 @@ describe('EventStore Sequence Invariant', () => {
 // ─── Sequence Invariant Under Compaction ──────────────────────────────────────
 
 describe('EventStore Sequence Invariant Under Compaction', () => {
-  it('initializeSequence_CompactedFile_AutoRepairsSequences', async () => {
-    // Arrange: create a JSONL file simulating compaction where middle events
-    // were removed. 3 lines but last event has sequence 5 (gap).
+  it('initializeSequence_CompactedFile_ContinuesFromMaxSequence', async () => {
+    // Post-#1293: max(sequence)+1 semantics. Compaction-style gaps are
+    // preserved in the history; new appends continue past the highest
+    // observed sequence. SQL `MAX(sequence)+1` does the same for #1259.
     const filePath = path.join(tempDir, 'compacted.events.jsonl');
     const events = [
       { streamId: 'compacted', sequence: 1, type: 'workflow.started', timestamp: '2025-01-01T00:00:00.000Z', schemaVersion: '1.0' },
@@ -1509,24 +1513,16 @@ describe('EventStore Sequence Invariant Under Compaction', () => {
       { streamId: 'compacted', sequence: 5, type: 'workflow.transition', timestamp: '2025-01-01T00:00:02.000Z', schemaVersion: '1.0' },
     ];
     await fs.writeFile(filePath, events.map(e => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
-
-    // Delete .seq file to force fallback to JSONL line counting with invariant check
-    const seqPath = path.join(tempDir, 'compacted.seq');
-    await fs.rm(seqPath, { force: true });
+    await fs.rm(path.join(tempDir, 'compacted.seq'), { force: true });
 
     const store = new EventStore(tempDir);
-
-    // Act: auto-repair re-sequences the 3 events to 1,2,3 then appends as 4
     const event = await store.append('compacted', { type: 'task.claimed' });
-    expect(event.sequence).toBe(4);
+    expect(event.sequence).toBe(6);
 
-    // Verify repaired file
     const content = await fs.readFile(filePath, 'utf-8');
     const lines = content.trim().split('\n').filter(Boolean);
     expect(lines).toHaveLength(4);
-    for (let i = 0; i < lines.length; i++) {
-      expect(JSON.parse(lines[i]).sequence).toBe(i + 1);
-    }
+    expect(JSON.parse(lines[3]).sequence).toBe(6);
   });
 
   it('initializeSequence_ValidFile_SetsCorrectSequence', async () => {
@@ -1552,8 +1548,10 @@ describe('EventStore Sequence Invariant Under Compaction', () => {
     expect(event.sequence).toBe(4);
   });
 
-  it('initializeSequence_FirstEventNotOne_AutoRepairsSequences', async () => {
-    // Arrange: create a JSONL file where first event starts at sequence 2
+  it('initializeSequence_FirstEventNotOne_ContinuesFromMaxSequence', async () => {
+    // Post-#1293: offset-from-1 history is preserved; appends continue
+    // past max(sequence). The legacy "renumber from 1" rewrite was a
+    // JSONL-era hack incompatible with #1259's SQL semantics.
     const filePath = path.join(tempDir, 'offset-seq.events.jsonl');
     const events = [
       { streamId: 'offset-seq', sequence: 2, type: 'workflow.started', timestamp: '2025-01-01T00:00:00.000Z', schemaVersion: '1.0' },
@@ -1561,24 +1559,16 @@ describe('EventStore Sequence Invariant Under Compaction', () => {
       { streamId: 'offset-seq', sequence: 4, type: 'workflow.transition', timestamp: '2025-01-01T00:00:02.000Z', schemaVersion: '1.0' },
     ];
     await fs.writeFile(filePath, events.map(e => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
-
-    // Delete .seq file to force fallback
-    const seqPath = path.join(tempDir, 'offset-seq.seq');
-    await fs.rm(seqPath, { force: true });
+    await fs.rm(path.join(tempDir, 'offset-seq.seq'), { force: true });
 
     const store = new EventStore(tempDir);
-
-    // Act: auto-repair re-sequences to 1,2,3 then appends as 4
     const event = await store.append('offset-seq', { type: 'task.claimed' });
-    expect(event.sequence).toBe(4);
+    expect(event.sequence).toBe(5);
 
-    // Verify repaired file
     const content = await fs.readFile(filePath, 'utf-8');
     const lines = content.trim().split('\n').filter(Boolean);
     expect(lines).toHaveLength(4);
-    for (let i = 0; i < lines.length; i++) {
-      expect(JSON.parse(lines[i]).sequence).toBe(i + 1);
-    }
+    expect(JSON.parse(lines[3]).sequence).toBe(5);
   });
 });
 
@@ -1978,7 +1968,13 @@ describe('EventStore StorageBackend Integration', () => {
     expect(content.trim().split('\n')).toHaveLength(1);
   });
 
-  it('EventStore_getSequence_DelegatesToBackend', async () => {
+  it('EventStore_acrossRestart_continuesFromJsonlMaxSequence', async () => {
+    // Post-#1293 migration: AtomicAppender owns the sequence counter and
+    // rebuilds it from JSONL on first contact. Backend.getSequence is no
+    // longer the seq-init source — JSONL is the source of truth, backend
+    // is a supplementary dual-write target. The test verifies that a new
+    // EventStore instance (simulating restart) correctly continues
+    // sequence numbering across the boundary.
     const backend = new InMemoryBackend();
     const store = new EventStore(tempDir, { backend });
 
@@ -1986,14 +1982,9 @@ describe('EventStore StorageBackend Integration', () => {
     await store.append('my-workflow', { type: 'task.assigned' });
     await store.append('my-workflow', { type: 'workflow.transition' });
 
-    const seqSpy = vi.spyOn(backend, 'getSequence');
-
-    // Create a new store with the same backend (simulating restart)
+    // Restart simulation — a fresh EventStore reads the JSONL state.
     const store2 = new EventStore(tempDir, { backend });
     const event = await store2.append('my-workflow', { type: 'task.claimed' });
-
-    // Backend's getSequence should have been used for initialization
-    expect(seqSpy).toHaveBeenCalledWith('my-workflow');
     expect(event.sequence).toBe(4);
   });
 
@@ -2181,8 +2172,9 @@ describe('EventStore appendValidated', () => {
 // ─── Sequence Corruption Detection and Repair (#943) ────────────────────────
 
 describe('EventStore Sequence Corruption Repair', () => {
-  it('initializeSequence_DuplicateSequences_RepairsAutomatically', async () => {
-    // Arrange: manually write a JSONL file with duplicate sequence numbers
+  it('initializeSequence_DuplicateSequences_ContinuesFromMaxSequence', async () => {
+    // Post-#1293: max(sequence)+1 semantics. Duplicate sequences are
+    // preserved in history; new appends continue from max+1.
     const filePath = path.join(tempDir, 'corrupt-stream.events.jsonl');
     const corruptEvents = [
       JSON.stringify({ streamId: 'corrupt-stream', sequence: 1, type: 'workflow.started', timestamp: '2026-01-01T00:00:00Z', schemaVersion: '1.0' }),
@@ -2192,25 +2184,21 @@ describe('EventStore Sequence Corruption Repair', () => {
     ];
     await fs.writeFile(filePath, corruptEvents.join('\n') + '\n', 'utf-8');
 
-    // Act: create a new EventStore and append (triggers initializeSequence)
     const store = new EventStore(tempDir);
     const event = await store.append('corrupt-stream', { type: 'task.completed' });
+    // max(1, 2, 3, 3) + 1 = 4. Original duplicates preserved.
+    expect(event.sequence).toBe(4);
 
-    // Assert: the new event gets sequence 5 (4 existing + 1 new)
-    expect(event.sequence).toBe(5);
-
-    // Verify the repaired file has monotonic sequences
     const content = await fs.readFile(filePath, 'utf-8');
     const lines = content.trim().split('\n').filter(Boolean);
-    expect(lines).toHaveLength(5); // 4 repaired + 1 new
-    for (let i = 0; i < lines.length; i++) {
-      const parsed = JSON.parse(lines[i]);
-      expect(parsed.sequence).toBe(i + 1);
-    }
+    expect(lines).toHaveLength(5);
+    expect(JSON.parse(lines[2]).sequence).toBe(3);
+    expect(JSON.parse(lines[3]).sequence).toBe(3); // duplicate preserved
+    expect(JSON.parse(lines[4]).sequence).toBe(4);
   });
 
-  it('initializeSequence_GapInSequences_RepairsAutomatically', async () => {
-    // Arrange: JSONL with a gap (1, 2, 4 — missing 3)
+  it('initializeSequence_GapInSequences_ContinuesFromMaxSequence', async () => {
+    // Post-#1293: gaps are preserved; new appends continue from max+1.
     const filePath = path.join(tempDir, 'gap-stream.events.jsonl');
     const gapEvents = [
       JSON.stringify({ streamId: 'gap-stream', sequence: 1, type: 'workflow.started', timestamp: '2026-01-01T00:00:00Z', schemaVersion: '1.0' }),
@@ -2219,21 +2207,15 @@ describe('EventStore Sequence Corruption Repair', () => {
     ];
     await fs.writeFile(filePath, gapEvents.join('\n') + '\n', 'utf-8');
 
-    // Act: create store and append
     const store = new EventStore(tempDir);
     const event = await store.append('gap-stream', { type: 'workflow.transition' });
+    expect(event.sequence).toBe(5);
 
-    // Assert: new event gets sequence 4 (3 existing lines + 1)
-    expect(event.sequence).toBe(4);
-
-    // Verify repaired sequences
     const content = await fs.readFile(filePath, 'utf-8');
     const lines = content.trim().split('\n').filter(Boolean);
     expect(lines).toHaveLength(4);
-    for (let i = 0; i < lines.length; i++) {
-      const parsed = JSON.parse(lines[i]);
-      expect(parsed.sequence).toBe(i + 1);
-    }
+    expect(JSON.parse(lines[2]).sequence).toBe(4); // gap preserved
+    expect(JSON.parse(lines[3]).sequence).toBe(5);
   });
 
   it('initializeSequence_HealthyStream_NoRepairNeeded', async () => {

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -633,13 +633,35 @@ export class EventStore {
       throw result.cause ?? new Error(`Append failed: ${result.reason}`);
     }
 
+    // Cache-hit branch: return the originally-persisted event verbatim and
+    // SKIP backend/outbox replication. Those side effects already ran when
+    // the original commit landed; running them again with the current
+    // request payload would replicate data that was never written to JSONL
+    // (the bug CR-thread #3205805943 closes).
+    if (result.kind === 'cache-hit') {
+      const cached = result.persistedEvents[0];
+      return {
+        streamId: cached.streamId,
+        sequence: cached.sequence,
+        type: cached.type,
+        timestamp: cached.timestamp,
+        ...(cached.idempotencyKey !== undefined ? { idempotencyKey: cached.idempotencyKey } : {}),
+        ...(cached.data !== undefined ? { data: cached.data } : {}),
+        ...(cached.correlationId !== undefined ? { correlationId: cached.correlationId } : {}),
+        ...(cached.causationId !== undefined ? { causationId: cached.causationId } : {}),
+        ...(cached.agentId !== undefined ? { agentId: cached.agentId } : {}),
+        ...(cached.agentRole !== undefined ? { agentRole: cached.agentRole } : {}),
+        ...(cached.source !== undefined ? { source: cached.source } : {}),
+        ...(cached.schemaVersion !== undefined ? { schemaVersion: cached.schemaVersion } : {}),
+      } as WorkflowEvent;
+    }
+
     const fullEvent: WorkflowEvent = {
       ...event,
       streamId,
       sequence: result.sequences[0],
-      // Timestamp comes back from the appender so cache-hit retries return
-      // the original persisted timestamp (the legacy contract some tests
-      // assert via `expect(second).toEqual(first)`).
+      // Timestamp comes back from the appender so the synthesized event
+      // matches the persisted shape exactly.
       timestamp: result.timestamps[0],
     } as WorkflowEvent;
 
@@ -756,6 +778,28 @@ export class EventStore {
       throw result.cause ?? new Error(`Batch append failed: ${result.reason}`);
     }
 
+    // Cache-hit branch: return the original persisted events verbatim and
+    // skip backend/outbox (already done at original commit time). See
+    // delegateAppend for the same pattern + design rationale.
+    if (result.kind === 'cache-hit') {
+      return result.persistedEvents.map(
+        (e) => ({
+          streamId: e.streamId,
+          sequence: e.sequence,
+          type: e.type,
+          timestamp: e.timestamp,
+          ...(e.idempotencyKey !== undefined ? { idempotencyKey: e.idempotencyKey } : {}),
+          ...(e.data !== undefined ? { data: e.data } : {}),
+          ...(e.correlationId !== undefined ? { correlationId: e.correlationId } : {}),
+          ...(e.causationId !== undefined ? { causationId: e.causationId } : {}),
+          ...(e.agentId !== undefined ? { agentId: e.agentId } : {}),
+          ...(e.agentRole !== undefined ? { agentRole: e.agentRole } : {}),
+          ...(e.source !== undefined ? { source: e.source } : {}),
+          ...(e.schemaVersion !== undefined ? { schemaVersion: e.schemaVersion } : {}),
+        } as WorkflowEvent),
+      );
+    }
+
     const fullEvents: WorkflowEvent[] = deduped.map((event, i) => ({
       ...event,
       sequence: result.sequences[i],
@@ -841,11 +885,23 @@ export class EventStore {
    * Read the current max sequence for a stream directly from JSONL
    * (bypassing any storage backend). Used by the sidecar merge path so
    * synthetic sidecar sequences never collide with real JSONL-durable
-   * events when the backend is lagging — the JSONL append is the barrier
-   * for correctness (see `replicateBackend`/`writeOutbox`: JSONL is source of truth,
-   * backend dual-write is best-effort). Prefers the O(1) `.seq` file and
-   * falls back to JSONL line-counting; returns the backend sequence only
-   * when no local JSONL exists.
+   * events when the backend is lagging.
+   *
+   * Post-#1293, the substrate preserves corrupt histories (gaps, duplicate
+   * sequences, offset starts). The previous cross-validation —
+   * `parsed.sequence === lineCount` — was a JSONL-era hack that flagged
+   * legitimate post-migration histories as stale and rebased the sidecar
+   * baseline below the real high-water mark. The current logic trusts a
+   * valid `.seq` value as the authoritative max-sequence read; the
+   * line-count fallback is reserved for the genuinely-missing-or-corrupt
+   * `.seq` case (no `.seq` file, or contents that don't parse as a
+   * non-negative integer).
+   *
+   * For broken histories where line count diverges from max-sequence
+   * (e.g. JSONL `[5,6,7]`), the JSONL line count would have returned 3,
+   * causing sidecar synthetic sequences to start at 4 — colliding with
+   * already-durable events at 5,6,7. Reading max-sequence from the JSONL
+   * directly (via `SEQUENCE_REGEX`) gives the correct baseline.
    */
   private async readJsonlMaxSequence(streamId: string): Promise<number> {
     const mainPath = this.getEventFilePath(streamId);
@@ -860,23 +916,32 @@ export class EventStore {
       const content = await fs.readFile(seqPath, 'utf-8');
       const parsed = JSON.parse(content);
       if (typeof parsed.sequence === 'number' && parsed.sequence >= 0) {
-        // Cross-validate against JSONL so a stale .seq (e.g. interrupted
-        // write) doesn't feed the sidecar path a wrong baseline.
-        try {
-          const jsonl = await fs.readFile(mainPath, 'utf-8');
-          const lineCount = jsonl.trim().split('\n').filter(Boolean).length;
-          if (parsed.sequence === lineCount) return parsed.sequence;
-        } catch {
-          return parsed.sequence;
-        }
+        // Trust the .seq value. Cross-validating against JSONL line count
+        // mis-flagged broken histories that the migration explicitly
+        // preserves (see CR thread 3205805932 / outside-diff for store.ts:858-879).
+        return parsed.sequence;
       }
     } catch {
-      // .seq unreadable — fall through to JSONL line count.
+      // .seq missing or malformed — fall through to JSONL max-sequence scan.
     }
 
+    // Fallback: scan JSONL for the highest persisted sequence. Uses
+    // SEQUENCE_REGEX to avoid full JSON.parse per line; this is the same
+    // recovery semantic AtomicAppender.rebuildCachesFromJsonl uses on
+    // first contact, kept consistent so sidecar and appender agree on
+    // the baseline.
     try {
       const jsonl = await fs.readFile(mainPath, 'utf-8');
-      return jsonl.trim().split('\n').filter(Boolean).length;
+      let maxSeq = 0;
+      for (const line of jsonl.split('\n')) {
+        if (line.length === 0) continue;
+        const m = SEQUENCE_REGEX.exec(line);
+        if (m) {
+          const s = Number.parseInt(m[1], 10);
+          if (Number.isFinite(s) && s > maxSeq) maxSeq = s;
+        }
+      }
+      return maxSeq;
     } catch {
       return 0;
     }
@@ -908,19 +973,19 @@ export class EventStore {
     const offset = filters?.offset ?? 0;
     const limit = filters?.limit;
 
-    // Fast-skip relies on the invariant that line N contains sequence N
-    // (monotonically increasing); only safe when filtering solely by sequence.
-    const canFastSkip = filters?.sinceSequence !== undefined
-      && !filters.type && !filters.since && !filters.until;
-    let lineCount = 0;
-
+    // Pre-#1293, a "fast-skip" optimization assumed line N contains sequence
+    // N and skipped by physical line count alone. After the migration
+    // preserves corrupt histories (gaps, duplicates, offset starts), that
+    // invariant no longer holds — `[5,6,7]` with `sinceSequence: 6` would
+    // skip all three lines and miss event 7. Always use the regex-based
+    // parsed-sequence comparison; the JSON.parse cost is paid only by
+    // events that survive the filter, so the optimization wasn't load-
+    // bearing for the common case anyway. (CR thread 3205805940 /
+    // outside-diff for store.ts:911-922.)
     for await (const line of rl) {
       if (!line.trim()) continue;
-      lineCount++;
 
-      if (canFastSkip && lineCount <= filters!.sinceSequence!) continue;
-
-      if (!canFastSkip && filters?.sinceSequence !== undefined) {
+      if (filters?.sinceSequence !== undefined) {
         const seqMatch = SEQUENCE_REGEX.exec(line);
         if (seqMatch) {
           const extractedSeq = parseInt(seqMatch[1], 10);
@@ -931,11 +996,9 @@ export class EventStore {
       const parsed = JSON.parse(line);
       const event = migrateEvent(parsed) as WorkflowEvent;
 
-      if (!canFastSkip) {
-        if (filters?.type && event.type !== filters.type) continue;
-        if (filters?.since && event.timestamp < filters.since) continue;
-        if (filters?.until && event.timestamp > filters.until) continue;
-      }
+      if (filters?.type && event.type !== filters.type) continue;
+      if (filters?.since && event.timestamp < filters.since) continue;
+      if (filters?.until && event.timestamp > filters.until) continue;
 
       if (skipped < offset) {
         skipped++;

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -11,6 +11,7 @@ import { storeLogger } from '../logger.js';
 import { isPidAlive } from '../utils/process.js';
 import { getSidecarPath } from './hook-event-writer.js';
 import { validateStreamId } from '../shared/validation.js';
+import { AtomicAppender } from './atomic-appender.js';
 
 // ─── Sequence Conflict Error ────────────────────────────────────────────────
 
@@ -227,6 +228,10 @@ export class EventStore {
   /** Optional storage backend for delegating reads */
   private readonly backend?: StorageBackend;
 
+  /** Lazily-instantiated AtomicAppender — single instance per stateDir so per-stream
+   *  locks and sequence counters share state across handler calls. */
+  private atomicAppender?: AtomicAppender;
+
   constructor(private readonly stateDir: string, options?: EventStoreOptions) {
     this.lockFilePath = path.join(stateDir, '.event-store.lock');
     this.maxIdempotencyKeys = parseEnvInt('EXARCHOS_MAX_IDEMPOTENCY_KEYS', 200);
@@ -246,6 +251,18 @@ export class EventStore {
   /** Returns true when this instance is in sidecar mode (PID lock held by another process). */
   get inSidecarMode(): boolean {
     return this.sidecarMode;
+  }
+
+  /**
+   * Returns the lazily-created AtomicAppender bound to this event store's
+   * state directory. Single instance per EventStore so per-stream locks and
+   * the in-memory sequence/idempotency caches share state across consumers.
+   */
+  getAppender(): AtomicAppender {
+    if (!this.atomicAppender) {
+      this.atomicAppender = new AtomicAppender({ stateDir: this.stateDir });
+    }
+    return this.atomicAppender;
   }
 
   // ─── PID Lock ──────────────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -12,6 +12,10 @@ import { isPidAlive } from '../utils/process.js';
 import { getSidecarPath } from './hook-event-writer.js';
 import { validateStreamId } from '../shared/validation.js';
 import { AtomicAppender } from './atomic-appender.js';
+import {
+  SubagentStreamRouter,
+  type SubagentStreamRouterContract,
+} from '../agents/subagent-stream-router.js';
 
 // ─── Sequence Conflict Error ────────────────────────────────────────────────
 
@@ -232,6 +236,11 @@ export class EventStore {
    *  locks and sequence counters share state across handler calls. */
   private atomicAppender?: AtomicAppender;
 
+  /** Lazily-instantiated SubagentStreamRouter — single instance per EventStore
+   *  so the router shares the same AtomicAppender (and therefore the same
+   *  per-stream lock + idempotency cache) used by every other consumer. */
+  private streamRouter?: SubagentStreamRouterContract;
+
   constructor(private readonly stateDir: string, options?: EventStoreOptions) {
     this.lockFilePath = path.join(stateDir, '.event-store.lock');
     this.maxIdempotencyKeys = parseEnvInt('EXARCHOS_MAX_IDEMPOTENCY_KEYS', 200);
@@ -263,6 +272,24 @@ export class EventStore {
       this.atomicAppender = new AtomicAppender({ stateDir: this.stateDir });
     }
     return this.atomicAppender;
+  }
+
+  /**
+   * Returns the lazily-created SubagentStreamRouter bound to this event
+   * store's state directory. Backed by `getAppender()` so the router shares
+   * the per-stream lock + idempotency cache. Used by `handleEventAppend` to
+   * intercept `team.disbanded` events and recompute `tasksCompleted` from
+   * the parent stream — discarding the agent-side in-memory tally that
+   * produces #1224's off-by-N counts.
+   */
+  getStreamRouter(): SubagentStreamRouterContract {
+    if (!this.streamRouter) {
+      this.streamRouter = new SubagentStreamRouter({
+        appender: this.getAppender(),
+        stateDir: this.stateDir,
+      });
+    }
+    return this.streamRouter;
   }
 
   // ─── PID Lock ──────────────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -259,6 +259,14 @@ export class EventStore {
    * Returns the lazily-created AtomicAppender bound to this event store's
    * state directory. Single instance per EventStore so per-stream locks and
    * the in-memory sequence/idempotency caches share state across consumers.
+   *
+   * #1259 swap point: replace the constructor call below with a SQLite
+   * (or other durable) appender that exposes the same `AppendResult`
+   * shape and per-stream serialization semantics. No other change is
+   * required — `append`, `appendValidated`, `batchAppend`, and the
+   * `SubagentStreamRouter` all delegate through this instance, so a
+   * one-line swap here flips the entire write substrate. The migration
+   * doc is at docs/designs/2026-05-08-eventstore-appender-consumer-migration.md.
    */
   getAppender(): AtomicAppender {
     if (!this.atomicAppender) {

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -111,15 +111,6 @@ function mergeByTimestamp(
   return out;
 }
 
-/** Parse an integer from an environment variable with a fallback default. */
-function parseEnvInt(envVar: string, defaultValue: number): number {
-  const raw = process.env[envVar];
-  if (raw === undefined) return defaultValue;
-  const parsed = parseInt(raw, 10);
-  if (isNaN(parsed) || parsed <= 0) return defaultValue;
-  return parsed;
-}
-
 // ─── Event Store Options ────────────────────────────────────────────────────
 
 export interface EventStoreOptions {
@@ -198,21 +189,23 @@ const DEFAULT_WAIT_MAX_DELAY_MS = 100;
  * Multiple EventStore instances sharing the same stateDir without PID lock will corrupt data.
  */
 export class EventStore {
-  private sequenceCounters: Map<string, number> = new Map();
-  private locks: Map<string, Promise<void>> = new Map();
-
-  /** In-memory dedup cache: streamId -> (idempotencyKey -> event) */
-  private idempotencyCache: Map<string, Map<string, WorkflowEvent>> = new Map();
   /**
-   * Maximum number of idempotency keys retained per stream.
-   * Keys older than this limit are evicted via FIFO.
-   * Retries with evicted keys will NOT be deduplicated.
-   * Acceptable because retries occur within the same session, not across long time spans.
+   * After the #1293 consumer migration, all append paths delegate to a
+   * single shared AtomicAppender (see `getAppender()` below). The previous
+   * per-EventStore lock map, sequence counter map, and idempotency cache
+   * are removed — they were the second of two disjoint write paths that
+   * raced on the same JSONL files. The AtomicAppender now owns:
+   *   - per-stream lock (`StreamLockManager`)
+   *   - sequence counter (rebuilt from JSONL on first contact)
+   *   - idempotency cache (with `appendUnkeyed` for callers that don't
+   *     want dedup — preserves the legacy "no-key-skips-dedup" contract
+   *     without polluting the cache with synthetic one-shot keys)
+   *
+   * #1259 swap point: `getAppender()` returns the substrate. Replacing
+   * `new AtomicAppender(...)` with `new SqliteAppender(...)` in that
+   * lazy-construction site is the only change SQLite migration requires
+   * at the EventStore boundary.
    */
-  private readonly maxIdempotencyKeys: number;
-
-  /** Tracks which streams have had their idempotency cache rebuilt from JSONL */
-  private idempotencyCacheInitialized: Set<string> = new Set();
 
   /** Whether initialize() has been called */
   private initialized = false;
@@ -244,7 +237,6 @@ export class EventStore {
 
   constructor(private readonly stateDir: string, options?: EventStoreOptions) {
     this.lockFilePath = path.join(stateDir, '.event-store.lock');
-    this.maxIdempotencyKeys = parseEnvInt('EXARCHOS_MAX_IDEMPOTENCY_KEYS', 200);
     this.backend = options?.backend;
   }
 
@@ -496,24 +488,6 @@ export class EventStore {
     });
   }
 
-  private async withLock<T>(streamId: string, fn: () => Promise<T>): Promise<T> {
-    const existing = this.locks.get(streamId) ?? Promise.resolve();
-    let release: () => void;
-    const lock = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    this.locks.set(streamId, lock);
-    try {
-      await existing;
-      return await fn();
-    } finally {
-      release!();
-      if (this.locks.get(streamId) === lock) {
-        this.locks.delete(streamId);
-      }
-    }
-  }
-
   /**
    * Write an event to the sidecar file for later merging by the primary process.
    * Returns a synthetic WorkflowEvent with sequence 0 (pending assignment).
@@ -701,90 +675,6 @@ export class EventStore {
     }
   }
 
-  /**
-   * Shared pre-append checks: rebuild idempotency cache, check for cached duplicate,
-   * initialize sequence counter, and validate optimistic concurrency.
-   * Returns the cached event if idempotency key matched, otherwise undefined.
-   * Must be called within withLock().
-   */
-  private async checkIdempotencyAndSequence(
-    streamId: string,
-    options?: AppendOptions,
-  ): Promise<WorkflowEvent | undefined> {
-    // Rebuild idempotency cache from JSONL on first access per stream
-    if (options?.idempotencyKey && !this.idempotencyCacheInitialized.has(streamId)) {
-      await this.rebuildIdempotencyCache(streamId);
-    }
-
-    // Idempotency check: return cached event if key was already seen
-    if (options?.idempotencyKey) {
-      const streamCache = this.idempotencyCache.get(streamId);
-      const cached = streamCache?.get(options.idempotencyKey);
-      if (cached) return cached;
-    }
-
-    // Initialize sequence from file if not cached
-    if (!this.sequenceCounters.has(streamId)) {
-      await this.initializeSequence(streamId);
-    }
-
-    // Optimistic concurrency check
-    if (options?.expectedSequence !== undefined) {
-      // Re-read from file for freshest state
-      await this.initializeSequence(streamId);
-      const actualSequence = this.sequenceCounters.get(streamId) ?? 0;
-
-      if (actualSequence !== options.expectedSequence) {
-        throw new SequenceConflictError(options.expectedSequence, actualSequence);
-      }
-    }
-
-    return undefined;
-  }
-
-  /**
-   * Shared post-construct logic: write to JSONL, cache idempotency key,
-   * dual-write to backend, and write to outbox.
-   * Must be called within withLock().
-   */
-  private async persistAndReplicate(streamId: string, fullEvent: WorkflowEvent): Promise<void> {
-    await this.writeEvents(streamId, [fullEvent]);
-    this.cacheIdempotencyKey(streamId, fullEvent);
-
-    // Backend dual-write: replicate to backend if available
-    // JSONL is the source of truth; backend write failure is logged but does not fail the append
-    if (this.backend) {
-      try {
-        this.backend.appendEvent(streamId, fullEvent);
-      } catch (err) {
-        storeLogger.warn(
-          { err: err instanceof Error ? err.message : String(err), streamId, sequence: fullEvent.sequence },
-          'Backend dual-write failed — stores may diverge',
-        );
-      }
-    }
-
-    /**
-     * Outbox integration: write supplementary entry under the same lock.
-     *
-     * KNOWN LIMITATION — Atomicity gap: The JSONL event append (above) and
-     * this outbox write are NOT transactionally atomic. A crash between them
-     * could leave an event in JSONL without a corresponding outbox entry.
-     * This is acceptable because:
-     * 1. The outbox is supplementary — JSONL is the source of truth
-     * 2. The sync layer reconciles from JSONL, catching any missed entries
-     * 3. In-process lock serialization prevents concurrent partial writes
-     */
-    if (this.outbox) {
-      try {
-        await this.outbox.addEntry(streamId, fullEvent);
-      } catch (err) {
-        // Outbox is supplementary; log but don't fail the append
-        storeLogger.error({ err: err instanceof Error ? err.message : String(err) }, 'Outbox entry failed');
-      }
-    }
-  }
-
   async batchAppend(
     streamId: string,
     events: Array<Partial<Omit<WorkflowEvent, 'sequence' | 'streamId'>> & { type: string; idempotencyKey?: string }>,
@@ -875,56 +765,6 @@ export class EventStore {
     return fullEvents;
   }
 
-  // ─── Shared Helpers ────────────────────────────────────────────────────────
-
-  /** Writes events to JSONL and updates the .seq counter file. */
-  private async writeEvents(streamId: string, events: WorkflowEvent[]): Promise<void> {
-    if (events.length === 0) return;
-
-    const filePath = this.getEventFilePath(streamId);
-
-    // Ensure directory exists
-    await fs.mkdir(path.dirname(filePath), { recursive: true });
-
-    // Append as JSONL
-    const lines = events.map(e => JSON.stringify(e)).join('\n') + '\n';
-    await fs.appendFile(filePath, lines, 'utf-8');
-
-    // Update in-memory sequence counter
-    const finalSequence = events[events.length - 1].sequence;
-    this.sequenceCounters.set(streamId, finalSequence);
-
-    // Write sequence counter atomically (best-effort: JSONL is source of truth)
-    const seqPath = this.getSeqFilePath(streamId);
-    const tmpPath = `${seqPath}.tmp`;
-    try {
-      await fs.writeFile(tmpPath, JSON.stringify({ sequence: finalSequence }), 'utf-8');
-      await fs.rename(tmpPath, seqPath);
-    } catch {
-      // Best-effort: JSONL is source of truth, .seq is just a cache
-      await fs.rm(tmpPath, { force: true }).catch(() => {});
-      await fs.rm(seqPath, { force: true }).catch(() => {});
-    }
-  }
-
-  /** Caches an event's idempotency key with FIFO eviction. */
-  private cacheIdempotencyKey(streamId: string, event: WorkflowEvent): void {
-    if (!event.idempotencyKey) return;
-
-    let streamCache = this.idempotencyCache.get(streamId);
-    if (!streamCache) {
-      streamCache = new Map();
-      this.idempotencyCache.set(streamId, streamCache);
-    }
-    streamCache.set(event.idempotencyKey, event);
-
-    // FIFO eviction: remove oldest key when cache exceeds max
-    if (streamCache.size > this.maxIdempotencyKeys) {
-      const oldest = streamCache.keys().next().value;
-      if (oldest) streamCache.delete(oldest);
-    }
-  }
-
   async query(streamId: string, filters?: QueryFilters): Promise<WorkflowEvent[]> {
     // Issue #1082: when a sibling process is in sidecar mode, its events land
     // in `{streamId}.hook-events.jsonl` and are invisible to readers that look
@@ -974,7 +814,7 @@ export class EventStore {
 
     // Derive `mainMax` from the JSONL source-of-truth whenever it exists,
     // even in backend mode. Backend dual-write is best-effort (see
-    // `persistAndReplicate`), so `backend.getSequence()` can lag the real
+    // `replicateBackend`/`writeOutbox`), so `backend.getSequence()` can lag the real
     // JSONL high-water mark and cause synthetic sidecar sequences to
     // collide with already-durable events. Only fall back to the backend
     // counter when there is no local JSONL to read (e.g., remote-only
@@ -994,7 +834,7 @@ export class EventStore {
    * (bypassing any storage backend). Used by the sidecar merge path so
    * synthetic sidecar sequences never collide with real JSONL-durable
    * events when the backend is lagging — the JSONL append is the barrier
-   * for correctness (see `persistAndReplicate`: JSONL is source of truth,
+   * for correctness (see `replicateBackend`/`writeOutbox`: JSONL is source of truth,
    * backend dual-write is best-effort). Prefers the O(1) `.seq` file and
    * falls back to JSONL line-counting; returns the backend sequence only
    * when no local JSONL exists.
@@ -1315,146 +1155,22 @@ export class EventStore {
     }
   }
 
+  /**
+   * Clean up orphaned `.seq.tmp` files left behind by a crashed atomic
+   * sequence write, and ensure the AtomicAppender will rebuild its
+   * sequence counter for this stream from JSONL on next contact.
+   *
+   * Pre-#1293 this was the legacy "re-read sequence from disk" recovery
+   * path used after a SequenceConflictError. The new substrate makes
+   * sequence rebuild implicit (every first-contact append rebuilds from
+   * JSONL under the lock), so this method now does only the housekeeping
+   * the rebuild can't safely do during an append:
+   *   - delete `<stream>.seq.tmp` if a previous process crashed mid-write.
+   * Sequence counters live inside AtomicAppender and self-recover via the
+   * normal append path.
+   */
   async refreshSequence(streamId: string): Promise<void> {
-    await this.initializeSequence(streamId);
-  }
-
-  private async rebuildIdempotencyCache(streamId: string): Promise<void> {
-    if (this.idempotencyCacheInitialized.has(streamId)) return;
-    // Do NOT mark as initialized yet — wait until cache is fully populated
-
-    const filePath = this.getEventFilePath(streamId);
-    try {
-      await fs.access(filePath);
-    } catch {
-      this.idempotencyCacheInitialized.add(streamId); // Mark even if no file
-      return;
-    }
-
-    const input = createReadStream(filePath, { encoding: 'utf-8' });
-    const rl = createInterface({ input, crlfDelay: Infinity });
-
-    // Collect all events with idempotency keys
-    const keyed: Array<{ key: string; event: WorkflowEvent }> = [];
-
-    for await (const line of rl) {
-      if (!line.trim()) continue;
-      // Pre-filter: skip lines that don't contain an idempotency key (avoids JSON.parse)
-      if (!line.includes('"idempotencyKey"')) continue;
-      const event = JSON.parse(line) as WorkflowEvent;
-      if (event.idempotencyKey) {
-        keyed.push({ key: event.idempotencyKey, event });
-      }
-    }
-
-    // Take only the last MAX_IDEMPOTENCY_KEYS entries
-    const toCache = keyed.slice(-this.maxIdempotencyKeys);
-
-    if (toCache.length > 0) {
-      const streamCache = new Map<string, WorkflowEvent>();
-      for (const { key, event } of toCache) {
-        streamCache.set(key, event);
-      }
-      this.idempotencyCache.set(streamId, streamCache);
-    }
-
-    this.idempotencyCacheInitialized.add(streamId); // Mark AFTER fully populated
-  }
-
-  private async initializeSequence(streamId: string): Promise<void> {
-    // Delegate to backend if available
-    if (this.backend) {
-      const seq = this.backend.getSequence(streamId);
-      this.sequenceCounters.set(streamId, seq);
-      return;
-    }
-
-    // Try .seq file first (O(1)), cross-validated against JSONL line count
-    const seqPath = this.getSeqFilePath(streamId);
-    // Clean up orphaned .seq.tmp files left by crashed atomic writes
-    const tmpPath = `${seqPath}.tmp`;
+    const tmpPath = `${this.getSeqFilePath(streamId)}.tmp`;
     await fs.rm(tmpPath, { force: true }).catch(() => {});
-    try {
-      const content = await fs.readFile(seqPath, 'utf-8');
-      const parsed = JSON.parse(content);
-      if (typeof parsed.sequence === 'number' && parsed.sequence >= 0) {
-        // Cross-validate against JSONL line count to detect stale .seq files
-        const filePath = this.getEventFilePath(streamId);
-        try {
-          const jsonlContent = await fs.readFile(filePath, 'utf-8');
-          const lineCount = jsonlContent.trim().split('\n').filter(Boolean).length;
-          if (parsed.sequence !== lineCount) {
-            storeLogger.warn(
-              { streamId, seqFile: parsed.sequence, jsonlLines: lineCount },
-              'Stale .seq detected — falling through to JSONL',
-            );
-            // Fall through to JSONL line counting below
-          } else {
-            this.sequenceCounters.set(streamId, parsed.sequence);
-            return;
-          }
-        } catch {
-          // JSONL unreadable — trust .seq value
-          this.sequenceCounters.set(streamId, parsed.sequence);
-          return;
-        }
-      }
-    } catch {
-      // Fall through to line counting
-    }
-
-    // Fallback: count lines in JSONL file (O(n)) with full monotonicity validation
-    const filePath = this.getEventFilePath(streamId);
-    try {
-      const content = await fs.readFile(filePath, 'utf-8');
-      const lines = content.trim().split('\n').filter(Boolean);
-
-      if (lines.length > 0) {
-        // Full monotonicity check: every event must have sequence === lineIndex + 1
-        let needsRepair = false;
-        for (let i = 0; i < lines.length; i++) {
-          const match = SEQUENCE_REGEX.exec(lines[i]);
-          const seq = match ? parseInt(match[1], 10) : NaN;
-          if (seq !== i + 1) {
-            needsRepair = true;
-            break;
-          }
-        }
-
-        if (needsRepair) {
-          storeLogger.warn(
-            { streamId, lineCount: lines.length },
-            'Sequence corruption detected — repairing stream with monotonic re-sequencing',
-          );
-          // Re-sequence all events with correct monotonic sequence numbers
-          const repaired: string[] = [];
-          for (let i = 0; i < lines.length; i++) {
-            const event = JSON.parse(lines[i]) as WorkflowEvent;
-            const fixed = { ...event, sequence: i + 1 };
-            repaired.push(JSON.stringify(fixed));
-          }
-          const tmpJsonl = `${filePath}.repair.tmp`;
-          await fs.writeFile(tmpJsonl, repaired.join('\n') + '\n', 'utf-8');
-          await fs.rename(tmpJsonl, filePath);
-          // Update .seq cache to match repaired state
-          const seqPath = this.getSeqFilePath(streamId);
-          const tmpPath = `${seqPath}.tmp`;
-          try {
-            await fs.writeFile(tmpPath, JSON.stringify({ sequence: lines.length }), 'utf-8');
-            await fs.rename(tmpPath, seqPath);
-          } catch {
-            await fs.rm(tmpPath, { force: true }).catch(() => {});
-          }
-        }
-      }
-
-      this.sequenceCounters.set(streamId, lines.length);
-    } catch (err) {
-      storeLogger.warn(
-        { streamId, err: err instanceof Error ? err.message : String(err) },
-        'Failed to initialize sequence from JSONL — defaulting to 0',
-      );
-      this.sequenceCounters.set(streamId, 0);
-    }
   }
 }

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs/promises';
 import { createReadStream, openSync, closeSync, writeSync, unlinkSync } from 'node:fs';
 import { createInterface } from 'node:readline';
 import * as path from 'node:path';
+import { randomUUID as randomUUIDFn } from 'node:crypto';
 import { WorkflowEventBase } from './schemas.js';
 import type { WorkflowEvent } from './schemas.js';
 import type { Outbox } from '../sync/outbox.js';
@@ -566,24 +567,22 @@ export class EventStore {
     if (this.sidecarMode) {
       return this.writeToSidecar(streamId, event, options?.idempotencyKey);
     }
-    return this.withLock(streamId, async () => {
-      const cached = await this.checkIdempotencyAndSequence(streamId, options);
-      if (cached) return cached;
-
-      const sequence = (this.sequenceCounters.get(streamId) ?? 0) + 1;
-
-      const fullEvent = WorkflowEventBase.parse({
-        ...event,
-        streamId,
-        sequence,
-        timestamp: event.timestamp || new Date().toISOString(),
-        idempotencyKey: options?.idempotencyKey ?? event.idempotencyKey,
-      });
-
-      await this.persistAndReplicate(streamId, fullEvent);
-      this.sequenceCounters.set(streamId, sequence);
-      return fullEvent;
+    // Validate FIRST, before delegating: the legacy contract throws synchronously
+    // on schema violations, so callers don't need to await the AtomicAppender
+    // round-trip for that error class.
+    const idempotencyKey = options?.idempotencyKey ?? event.idempotencyKey;
+    const timestamp = event.timestamp || new Date().toISOString();
+    // Sequence is allocated by AtomicAppender; pass a placeholder so Zod's
+    // positive-integer guard accepts the schema. The synthesized return value
+    // overwrites this with the authoritative sequence.
+    const candidate = WorkflowEventBase.parse({
+      ...event,
+      streamId,
+      sequence: 1,
+      timestamp,
+      idempotencyKey,
     });
+    return this.delegateAppend(streamId, candidate, idempotencyKey, options);
   }
 
   /**
@@ -599,25 +598,107 @@ export class EventStore {
     if (this.sidecarMode) {
       return this.writeToSidecar(streamId, event, options?.idempotencyKey ?? event.idempotencyKey);
     }
-    return this.withLock(streamId, async () => {
-      const cached = await this.checkIdempotencyAndSequence(streamId, options);
-      if (cached) return cached;
+    const idempotencyKey = options?.idempotencyKey ?? event.idempotencyKey;
+    const timestamp = event.timestamp || new Date().toISOString();
+    const prepared: WorkflowEvent = {
+      ...event,
+      streamId,
+      timestamp,
+      idempotencyKey,
+    } as WorkflowEvent;
+    return this.delegateAppend(streamId, prepared, idempotencyKey, options);
+  }
 
-      const sequence = (this.sequenceCounters.get(streamId) ?? 0) + 1;
+  /**
+   * Shared post-validation path: delegate to AtomicAppender, translate the
+   * typed result back into the legacy `WorkflowEvent` return shape, then run
+   * supplementary backend + outbox replication. Sidecar mode short-circuits
+   * before this method is reached.
+   *
+   * The AtomicAppender holds the per-stream lock for the duration of its
+   * append; backend and outbox writes happen after the lock is released.
+   * That ordering matches the legacy semantics — both were already
+   * "supplementary, log-on-failure" — and avoids extending the critical
+   * section across remote calls.
+   */
+  private async delegateAppend(
+    streamId: string,
+    event: WorkflowEvent,
+    idempotencyKey: string | undefined,
+    options?: AppendOptions,
+  ): Promise<WorkflowEvent> {
+    const appender = this.getAppender();
+    const appendOptions =
+      options?.expectedSequence !== undefined
+        ? { expectedSequence: options.expectedSequence }
+        : undefined;
+    // Strip mutable scaffolding fields that AtomicAppender re-derives.
+    // sequence + eventId come back from the appender; streamId + timestamp +
+    // idempotencyKey are passed through verbatim because we already pinned
+    // them above.
+    const { sequence: _ignoredSeq, ...eventInputBase } = event as WorkflowEvent & { sequence?: number };
+    const result = idempotencyKey
+      ? await appender.append(streamId, [eventInputBase], idempotencyKey, appendOptions)
+      : await appender.appendUnkeyed(streamId, [eventInputBase], appendOptions);
 
-      // Construct the final event WITHOUT Zod parse
-      const fullEvent: WorkflowEvent = {
-        ...event,
-        streamId,
-        sequence,
-        timestamp: event.timestamp || new Date().toISOString(),
-        idempotencyKey: options?.idempotencyKey ?? event.idempotencyKey,
-      } as WorkflowEvent;
+    if (!result.ok) {
+      if (result.reason === 'sequence-conflict') {
+        throw new SequenceConflictError(
+          result.expected ?? options?.expectedSequence ?? -1,
+          result.actual ?? -1,
+        );
+      }
+      throw result.cause ?? new Error(`Append failed: ${result.reason}`);
+    }
 
-      await this.persistAndReplicate(streamId, fullEvent);
-      this.sequenceCounters.set(streamId, sequence);
-      return fullEvent;
-    });
+    const fullEvent: WorkflowEvent = {
+      ...event,
+      streamId,
+      sequence: result.sequences[0],
+      // Timestamp comes back from the appender so cache-hit retries return
+      // the original persisted timestamp (the legacy contract some tests
+      // assert via `expect(second).toEqual(first)`).
+      timestamp: result.timestamps[0],
+    } as WorkflowEvent;
+
+    this.replicateBackend(streamId, fullEvent);
+    await this.writeOutbox(streamId, fullEvent);
+    return fullEvent;
+  }
+
+  /** Best-effort backend dual-write — JSONL is the source of truth. */
+  private replicateBackend(streamId: string, event: WorkflowEvent): void {
+    if (!this.backend) return;
+    try {
+      this.backend.appendEvent(streamId, event);
+    } catch (err) {
+      storeLogger.warn(
+        { err: err instanceof Error ? err.message : String(err), streamId, sequence: event.sequence },
+        'Backend dual-write failed — stores may diverge',
+      );
+    }
+  }
+
+  /**
+   * Best-effort outbox replication. JSONL is the source of truth; the sync
+   * layer reconciles any missed entries from JSONL on next pass.
+   *
+   * KNOWN LIMITATION — Atomicity gap (carried over from the legacy path):
+   * The JSONL append (in AtomicAppender) and this outbox write are NOT
+   * transactionally atomic. A crash between them leaves an event in JSONL
+   * without a corresponding outbox entry. Sync reconciliation closes the
+   * gap on next pass.
+   */
+  private async writeOutbox(streamId: string, event: WorkflowEvent): Promise<void> {
+    if (!this.outbox) return;
+    try {
+      await this.outbox.addEntry(streamId, event);
+    } catch (err) {
+      storeLogger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        'Outbox entry failed',
+      );
+    }
   }
 
   /**
@@ -715,84 +796,83 @@ export class EventStore {
       }
       return results;
     }
-    return this.withLock(streamId, async () => {
-      // Rebuild idempotency cache if any event has an idempotency key
-      const hasIdempotencyKeys = events.some(e => e.idempotencyKey);
-      if (hasIdempotencyKeys && !this.idempotencyCacheInitialized.has(streamId)) {
-        await this.rebuildIdempotencyCache(streamId);
-      }
 
-      // Initialize sequence from file if not cached
-      if (!this.sequenceCounters.has(streamId)) {
-        await this.initializeSequence(streamId);
-      }
+    if (events.length === 0) return [];
 
-      // Phase 1: Validate all events before writing any (atomic: all-or-nothing)
-      const toAppend: WorkflowEvent[] = [];
-      const batchKeys = new Set<string>();
-      let nextSequence = (this.sequenceCounters.get(streamId) ?? 0) + 1;
-
-      for (const event of events) {
-        // Idempotency dedup within batch and against cache
-        if (event.idempotencyKey) {
-          const streamCache = this.idempotencyCache.get(streamId);
-          const cached = streamCache?.get(event.idempotencyKey);
-          if (cached) continue;
-
-          // Also check within this batch (O(1) Set lookup)
-          if (batchKeys.has(event.idempotencyKey)) continue;
-          batchKeys.add(event.idempotencyKey);
-        }
-
-        const fullEvent = WorkflowEventBase.parse({
-          ...event,
-          streamId,
-          sequence: nextSequence,
-          timestamp: event.timestamp || new Date().toISOString(),
-          idempotencyKey: event.idempotencyKey,
-        });
-        toAppend.push(fullEvent);
-        nextSequence++;
-      }
-
-      // Phase 2: Write all validated events in a single append
-      if (toAppend.length > 0) {
-        await this.writeEvents(streamId, toAppend);
-        for (const fullEvent of toAppend) {
-          this.cacheIdempotencyKey(streamId, fullEvent);
-        }
-
-        // Backend dual-write: replicate batch to backend if available
-        if (this.backend) {
-          try {
-            for (const fullEvent of toAppend) {
-              this.backend.appendEvent(streamId, fullEvent);
-            }
-          } catch (err) {
-            storeLogger.warn(
-              { err: err instanceof Error ? err.message : String(err), streamId, count: toAppend.length },
-              'Backend batch dual-write failed — stores may diverge',
-            );
-          }
-        }
-
-        // Outbox replication: write entries for at-least-once delivery
-        if (this.outbox) {
-          for (const fullEvent of toAppend) {
-            try {
-              await this.outbox.addEntry(streamId, fullEvent);
-            } catch (err) {
-              storeLogger.error(
-                { err: err instanceof Error ? err.message : String(err) },
-                'Outbox entry failed during batch append',
-              );
-            }
-          }
-        }
-      }
-
-      return toAppend;
+    // Validate every event up front so a malformed input fails before any
+    // sequence is allocated. Sequence is a placeholder; AtomicAppender
+    // re-derives the authoritative values inside the lock.
+    const validated: WorkflowEvent[] = events.map((event) => {
+      const timestamp = event.timestamp || new Date().toISOString();
+      return WorkflowEventBase.parse({
+        ...event,
+        streamId,
+        sequence: 1,
+        timestamp,
+        idempotencyKey: event.idempotencyKey,
+      });
     });
+
+    // Intra-batch dedup: if any two events share an idempotencyKey, keep
+    // the first and drop the rest. Matches the legacy contract.
+    const seenBatchKeys = new Set<string>();
+    const deduped: WorkflowEvent[] = [];
+    for (const event of validated) {
+      if (event.idempotencyKey && seenBatchKeys.has(event.idempotencyKey)) continue;
+      if (event.idempotencyKey) seenBatchKeys.add(event.idempotencyKey);
+      deduped.push(event);
+    }
+    if (deduped.length === 0) return [];
+
+    // Choose a batch idempotency key:
+    //   - all events share one key  → that key (preserves cross-batch retry).
+    //   - any event has a key but they differ → synthesize batch:<uuid> so
+    //     cross-batch retries don't dedup against a partial overlap.
+    //   - all events keyless → unkeyed append (no cache pollution).
+    const eventKeys = deduped.map((e) => e.idempotencyKey).filter((k): k is string => !!k);
+    const allHaveKeys = eventKeys.length === deduped.length;
+    const allSameKey = allHaveKeys && eventKeys.every((k) => k === eventKeys[0]);
+
+    const appender = this.getAppender();
+    const eventInputs = deduped.map((e) => {
+      const { sequence: _ignored, ...input } = e as WorkflowEvent & { sequence?: number };
+      return input;
+    });
+
+    let result: import('./atomic-appender.js').AppendResult;
+    if (eventKeys.length === 0) {
+      result = await appender.appendUnkeyed(streamId, eventInputs);
+    } else {
+      const batchKey = allSameKey ? eventKeys[0] : `batch:${randomUUIDFn()}`;
+      result = await appender.append(streamId, eventInputs, batchKey);
+    }
+
+    if (!result.ok) {
+      if (result.reason === 'idempotency-claimed') {
+        // Legacy semantics: a cache hit on the (single) batch key returns the
+        // cached events. AtomicAppender already returns ok:true with cached
+        // sequences/eventIds for that path, so this branch only fires on the
+        // structural failure case — surface it.
+        throw new Error(`Batch append failed: ${result.reason}`);
+      }
+      throw result.cause ?? new Error(`Batch append failed: ${result.reason}`);
+    }
+
+    const fullEvents: WorkflowEvent[] = deduped.map((event, i) => ({
+      ...event,
+      sequence: result.sequences[i],
+      timestamp: result.timestamps[i],
+    }));
+
+    // Supplementary replication, post-success, mirrors the legacy ordering.
+    for (const fullEvent of fullEvents) {
+      this.replicateBackend(streamId, fullEvent);
+    }
+    for (const fullEvent of fullEvents) {
+      await this.writeOutbox(streamId, fullEvent);
+    }
+
+    return fullEvents;
   }
 
   // ─── Shared Helpers ────────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/tools.test.ts
+++ b/servers/exarchos-mcp/src/event-store/tools.test.ts
@@ -505,6 +505,51 @@ describe('handleBatchAppend', () => {
       expect(persistedSeqs[i]).toBe(i + 1);
     }
   });
+
+  it('batchAppend_MixedKeysAcrossBatches_NoCrossBatchDedup', async () => {
+    // C10 polish: pin the cross-batch idempotency divergence documented at
+    // tools.ts:295-309. When events in a batch carry distinct per-event
+    // idempotencyKeys, the handler synthesizes a fresh `batch:<uuid>`
+    // idempotencyKey for the AtomicAppender. Resubmitting the SAME logical
+    // batch a second time gets a DIFFERENT synthesized key, so cross-batch
+    // dedup is intentionally not preserved — both batches land in the stream.
+    const batchEvents = [
+      { type: 'task.assigned', data: { taskId: 't1' }, idempotencyKey: 'mixed-k1' },
+      { type: 'task.assigned', data: { taskId: 't2' }, idempotencyKey: 'mixed-k2' },
+    ];
+
+    const first = await handleBatchAppend(
+      { stream: 'mixed-keys-test', events: batchEvents },
+      tempDir,
+      eventStore,
+    );
+    expect(first.success).toBe(true);
+    expect((first.data as EventAck[]).length).toBe(2);
+
+    // Resubmit the IDENTICAL batch payload (same per-event keys, same data).
+    const second = await handleBatchAppend(
+      { stream: 'mixed-keys-test', events: batchEvents },
+      tempDir,
+      eventStore,
+    );
+    expect(second.success).toBe(true);
+    // Documented divergence: NOT deduped against the first batch — fresh events.
+    expect((second.data as EventAck[]).length).toBe(2);
+
+    // Sequences from the second batch must be strictly greater than first.
+    const firstSeqs = (first.data as EventAck[]).map(a => a.sequence);
+    const secondSeqs = (second.data as EventAck[]).map(a => a.sequence);
+    expect(Math.min(...secondSeqs)).toBeGreaterThan(Math.max(...firstSeqs));
+
+    // The stream contains 4 distinct events — no cross-batch dedup occurred.
+    const queryResult = await handleEventQuery(
+      { stream: 'mixed-keys-test' },
+      tempDir,
+      eventStore,
+    );
+    expect(queryResult.success).toBe(true);
+    expect(queryResult.data).toHaveLength(4);
+  });
 });
 
 // ─── Dot-path field projection in event queries ─────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/tools.test.ts
+++ b/servers/exarchos-mcp/src/event-store/tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as path from 'node:path';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { EventStore } from './store.js';
 import { AtomicAppender } from './atomic-appender.js';
@@ -687,5 +687,183 @@ describe('sidecar mode sequencePending', () => {
       expect(ack.sequencePending).toBe(true);
       expect(ack.sequence).toBe(-1);
     }
+  });
+});
+
+// ─── C11: SubagentStreamRouter wiring on team.disbanded (#1224) ─────────────
+//
+// `handleEventAppend` MUST intercept `team.disbanded` events and route them
+// through `SubagentStreamRouter.emitDisbanded`. The router queries the parent
+// stream for the actual `task.completed` count scoped to the team and writes
+// the corrected event — discarding any agent-supplied `tasksCompleted` value.
+// This closes #1224 at the consumer level: the off-by-N bug originates in the
+// agent-side in-memory tally; the server is now the single source of truth.
+
+describe('handleEventAppend team.disbanded routing (C11, #1224)', () => {
+  /**
+   * Helper: seed the parent stream with N task.completed events for a given
+   * team via `handleEventAppend`. The router scans the parent JSONL and
+   * counts entries whose `data.teamId` matches.
+   */
+  async function seedTaskCompleted(
+    stream: string,
+    teamId: string,
+    taskIds: string[],
+  ): Promise<void> {
+    for (const taskId of taskIds) {
+      const result = await handleEventAppend(
+        {
+          stream,
+          event: {
+            type: 'task.completed',
+            data: { taskId, teamId },
+          },
+        },
+        tempDir,
+        eventStore,
+      );
+      if (!result.success) {
+        throw new Error(`seed task.completed failed: ${JSON.stringify(result.error)}`);
+      }
+    }
+  }
+
+  /**
+   * Read all events from a parent stream's JSONL. Returns parsed records.
+   */
+  async function readStreamJsonl(stream: string): Promise<Array<Record<string, unknown>>> {
+    const jsonlPath = path.join(tempDir, `${stream}.events.jsonl`);
+    const contents = await readFile(jsonlPath, 'utf-8');
+    return contents
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+  }
+
+  it('handleEventAppend_teamDisbanded_recomputesTasksCompleted', async () => {
+    const stream = 'parent-stream-c11-1';
+    const teamId = 'team-alpha';
+
+    // Seed parent stream with 3 task.completed events for the team.
+    await seedTaskCompleted(stream, teamId, ['t-1', 't-2', 't-3']);
+
+    // Caller supplies a wildly wrong tasksCompleted (the #1224 regression).
+    const result = await handleEventAppend(
+      {
+        stream,
+        event: {
+          type: 'team.disbanded',
+          data: {
+            teamId,
+            tasksCompleted: 999, // caller-supplied tally — MUST be overridden
+            tasksFailed: 0,
+            totalDurationMs: 1000,
+          },
+        },
+      },
+      tempDir,
+      eventStore,
+    );
+
+    expect(result.success).toBe(true);
+
+    const events = await readStreamJsonl(stream);
+    const disbanded = events.find((e) => e.type === 'team.disbanded');
+    expect(disbanded).toBeDefined();
+    const data = disbanded!.data as Record<string, unknown>;
+    // The router queried the parent stream and recomputed tasksCompleted = 3,
+    // overriding the 999 the caller supplied.
+    expect(data.tasksCompleted).toBe(3);
+    expect(data.tasksFailed).toBe(0);
+    expect(data.totalDurationMs).toBe(1000);
+    expect(data.teamId).toBe(teamId);
+  });
+
+  it('handleEventAppend_teamDisbanded_supplyAgnosticTallyIgnored', async () => {
+    // Three independent streams — each with the same N task.completed events —
+    // but the caller passes a different (wrong) tasksCompleted in each call.
+    // All three persisted events MUST report the same recomputed value (2).
+    const cases: Array<{ stream: string; supplied: number | undefined }> = [
+      { stream: 'parent-stream-c11-2a', supplied: 0 },
+      { stream: 'parent-stream-c11-2b', supplied: 999 },
+      { stream: 'parent-stream-c11-2c', supplied: undefined },
+    ];
+
+    for (const { stream, supplied } of cases) {
+      const teamId = `team-${stream}`;
+      await seedTaskCompleted(stream, teamId, ['x-1', 'x-2']);
+
+      const data: Record<string, unknown> = {
+        teamId,
+        tasksFailed: 0,
+        totalDurationMs: 500,
+      };
+      if (supplied !== undefined) {
+        data.tasksCompleted = supplied;
+      }
+
+      const result = await handleEventAppend(
+        {
+          stream,
+          event: { type: 'team.disbanded', data },
+        },
+        tempDir,
+        eventStore,
+      );
+      expect(result.success).toBe(true);
+
+      const events = await readStreamJsonl(stream);
+      const disbanded = events.find((e) => e.type === 'team.disbanded');
+      expect(disbanded).toBeDefined();
+      const persisted = disbanded!.data as Record<string, unknown>;
+      // Recomputed from parent-stream task.completed query — always 2 here.
+      expect(persisted.tasksCompleted).toBe(2);
+    }
+  });
+
+  it('handleEventAppend_nonDisbandedTypes_unchanged', async () => {
+    // Pinning regression: the interception MUST only fire for type ===
+    // 'team.disbanded'. Other event types follow the legacy `appendValidated`
+    // path and persist whatever the caller supplied.
+    const stream = 'parent-stream-c11-3';
+
+    // task.completed should NOT be intercepted — caller's data is preserved.
+    const taskRes = await handleEventAppend(
+      {
+        stream,
+        event: {
+          type: 'task.completed',
+          data: { taskId: 'pinning-task', verified: true },
+        },
+      },
+      tempDir,
+      eventStore,
+    );
+    expect(taskRes.success).toBe(true);
+
+    // workflow.started should NOT be intercepted.
+    const wfRes = await handleEventAppend(
+      {
+        stream,
+        event: {
+          type: 'workflow.started',
+          data: { featureId: 'pinning-feat', workflowType: 'feature' },
+        },
+      },
+      tempDir,
+      eventStore,
+    );
+    expect(wfRes.success).toBe(true);
+
+    const events = await readStreamJsonl(stream);
+    const taskCompleted = events.find((e) => e.type === 'task.completed');
+    expect(taskCompleted).toBeDefined();
+    const taskData = taskCompleted!.data as Record<string, unknown>;
+    expect(taskData.verified).toBe(true);
+
+    const workflowStarted = events.find((e) => e.type === 'workflow.started');
+    expect(workflowStarted).toBeDefined();
+    const wfData = workflowStarted!.data as Record<string, unknown>;
+    expect(wfData.featureId).toBe('pinning-feat');
   });
 });

--- a/servers/exarchos-mcp/src/event-store/tools.test.ts
+++ b/servers/exarchos-mcp/src/event-store/tools.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as path from 'node:path';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { EventStore } from './store.js';
+import { AtomicAppender } from './atomic-appender.js';
 import { handleEventAppend, handleEventQuery, handleBatchAppend } from './tools.js';
 import type { EventAck } from '../format.js';
 
@@ -408,6 +409,101 @@ describe('handleBatchAppend', () => {
     expect(batch1Seqs[2] - batch1Seqs[1]).toBe(1);
     expect(batch2Seqs[1] - batch2Seqs[0]).toBe(1);
     expect(batch2Seqs[2] - batch2Seqs[1]).toBe(1);
+  });
+
+  // ─── C2: AtomicAppender migration regression tests ────────────────────────
+
+  it('handleEventBatchAppend_appenderFails_returnsStructuredErrorNotSilentSuccess', async () => {
+    // #1228 regression: when the underlying appender returns a structured
+    // failure, the handler MUST NOT swallow it into `{success: true}`. The
+    // four-phase legacy path could silently lose the partial-write failure
+    // mode that AtomicAppender now surfaces explicitly.
+    //
+    // Inject a failure by spying on AtomicAppender.prototype.append. The post-
+    // migration handler obtains its appender via the EventStore wiring, so a
+    // prototype spy intercepts it regardless of where it's instantiated.
+    const appendSpy = vi
+      .spyOn(AtomicAppender.prototype, 'append')
+      .mockResolvedValueOnce({
+        ok: false,
+        reason: 'io-error',
+        cause: new Error('simulated jsonl write failure'),
+      });
+
+    try {
+      const result = await handleBatchAppend(
+        {
+          stream: 'failure-test',
+          events: [
+            { type: 'task.assigned', data: { taskId: 't1' } },
+            { type: 'task.assigned', data: { taskId: 't2' } },
+          ],
+        },
+        tempDir,
+        eventStore,
+      );
+
+      // Must surface a structured error envelope, not silent success.
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(result.error!.code).toBe('BATCH_APPEND_FAILED');
+      // The cause's message must propagate to the caller (observability).
+      expect(result.error!.message).toContain('simulated jsonl write failure');
+
+      // No events landed in the stream.
+      const queryResult = await handleEventQuery({ stream: 'failure-test' }, tempDir, eventStore);
+      expect(queryResult.success).toBe(true);
+      expect(queryResult.data).toHaveLength(0);
+    } finally {
+      appendSpy.mockRestore();
+    }
+  });
+
+  it('handleEventBatchAppend_concurrentCalls_noDuplicateSequences', async () => {
+    // #1230 regression: many concurrent handler calls must produce events with
+    // disjoint sequence numbers in the resulting stream — no two events share
+    // a sequence, and the persisted set is exactly 1..(2*N).
+    const N = 8;
+    const batches = Array.from({ length: N }, (_, i) =>
+      handleBatchAppend(
+        {
+          stream: 'concurrent-test',
+          events: [
+            { type: 'task.assigned', data: { taskId: `b${i}-1` } },
+            { type: 'task.assigned', data: { taskId: `b${i}-2` } },
+          ],
+        },
+        tempDir,
+        eventStore,
+      ),
+    );
+
+    const results = await Promise.all(batches);
+
+    for (const r of results) {
+      expect(r.success).toBe(true);
+    }
+
+    // Sequence numbers returned to handlers must all be unique.
+    const allSeqs: number[] = [];
+    for (const r of results) {
+      const acks = r.data as EventAck[];
+      for (const ack of acks) {
+        allSeqs.push(ack.sequence);
+      }
+    }
+    const uniqueSeqs = new Set(allSeqs);
+    expect(uniqueSeqs.size).toBe(allSeqs.length);
+
+    // Stream-level invariant: 2*N events, sequences 1..2*N exactly.
+    const queryResult = await handleEventQuery({ stream: 'concurrent-test' }, tempDir, eventStore);
+    expect(queryResult.success).toBe(true);
+    const events = queryResult.data as Array<{ sequence: number }>;
+    expect(events).toHaveLength(2 * N);
+    const persistedSeqs = events.map(e => e.sequence).sort((a, b) => a - b);
+    for (let i = 0; i < persistedSeqs.length; i++) {
+      expect(persistedSeqs[i]).toBe(i + 1);
+    }
   });
 });
 

--- a/servers/exarchos-mcp/src/event-store/tools.test.ts
+++ b/servers/exarchos-mcp/src/event-store/tools.test.ts
@@ -350,6 +350,54 @@ describe('handleBatchAppend', () => {
     expect(queryResult.data).toHaveLength(1);
   });
 
+  // ─── Cache-hit out-of-bounds (Sentry comment 3205861163) ─────────────────
+  //
+  // A batch retry that reuses the same per-event idempotencyKey but submits
+  // FEWER events than the originally-cached batch must not crash on
+  // out-of-bounds access of validatedEvents[i]. Cache-hit returns the
+  // ORIGINAL persisted batch (longer than current request).
+
+  it('batchAppend_cacheHitWithFewerCurrentEvents_returnsOriginalBatchWithoutCrash', async () => {
+    const store = new EventStore(tempDir);
+
+    // Original commit: 3 events, all sharing one idempotencyKey so the
+    // batch derives that as the batchIdempotencyKey.
+    const first = await handleBatchAppend(
+      {
+        stream: 'my-workflow',
+        events: [
+          { type: 'task.assigned', data: { taskId: 't1' }, idempotencyKey: 'shared-batch' },
+          { type: 'task.assigned', data: { taskId: 't2' }, idempotencyKey: 'shared-batch' },
+          { type: 'task.assigned', data: { taskId: 't3' }, idempotencyKey: 'shared-batch' },
+        ],
+      },
+      tempDir,
+      store,
+    );
+    expect(first.success).toBe(true);
+
+    // Retry with FEWER events but same shared key. Pre-fix this would
+    // crash (TypeError: cannot read properties of undefined) because
+    // result.sequences had 3 entries but validatedEvents (post intra-
+    // batch dedup) had only 1. Post-fix: the cache-hit branch reads
+    // type from persistedEvents[i].type instead.
+    const retry = await handleBatchAppend(
+      {
+        stream: 'my-workflow',
+        events: [
+          { type: 'task.assigned', data: { taskId: 't1' }, idempotencyKey: 'shared-batch' },
+        ],
+      },
+      tempDir,
+      store,
+    );
+    expect(retry.success).toBe(true);
+    const acks = retry.data as Array<{ streamId: string; sequence: number; type: string }>;
+    // Returns the ORIGINAL committed batch, not the truncated retry.
+    expect(acks.length).toBeGreaterThanOrEqual(1);
+    expect(acks[0].sequence).toBe(1);
+  });
+
   it('batchAppend_ConcurrentWrite_RespectsStreamLock', async () => {
     // Arrange: two concurrent batch appends on the same stream
     const batch1 = handleBatchAppend(

--- a/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/servers/exarchos-mcp/src/event-store/tools.ts
@@ -1,9 +1,51 @@
 import { z, ZodError } from 'zod';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import { EventStore, SequenceConflictError } from './store.js';
 import { EVENT_DATA_SCHEMAS, type EventType, WorkflowEventBase } from './schemas.js';
 import { pickFields, toEventAck, type EventAck, type ToolResult } from '../format.js';
 import { buildValidatedEvent } from './event-factory.js';
 import { randomUUID } from 'node:crypto';
+
+/**
+ * Find the highest-sequence `team.disbanded` event for a given team in the
+ * parent stream's JSONL. Used by the C11 router-interception path to fabricate
+ * an EventAck after `SubagentStreamRouter.emitDisbanded` (which has a void
+ * return type) writes the corrected event. Returns -1 when the file can't be
+ * read; the caller maps that to `sequencePending` via `toSafeEventAck`.
+ */
+async function readLatestDisbandedSequence(
+  stateDir: string,
+  streamId: string,
+  teamId: string,
+): Promise<number> {
+  const filePath = path.join(stateDir, `${streamId}.events.jsonl`);
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf-8');
+  } catch {
+    return -1;
+  }
+  let maxSeq = -1;
+  for (const line of raw.split('\n')) {
+    if (line.length === 0) continue;
+    let parsed: { type?: string; sequence?: number; data?: { teamId?: string } };
+    try {
+      parsed = JSON.parse(line) as typeof parsed;
+    } catch {
+      continue;
+    }
+    if (
+      parsed.type === 'team.disbanded'
+      && parsed.data?.teamId === teamId
+      && typeof parsed.sequence === 'number'
+      && parsed.sequence > maxSeq
+    ) {
+      maxSeq = parsed.sequence;
+    }
+  }
+  return maxSeq;
+}
 
 /**
  * Build an EventAck from a stored event. When the event has a non-positive
@@ -97,6 +139,76 @@ export async function handleEventAppend(
         message: `Event fields placed at wrong level — ${misplaced.map(f => `"${f}"`).join(', ')} should be inside "data", not at the top level. Wrap them: { type: "${eventType}", data: { ${misplaced.join(', ')}: ... } }`,
       },
     };
+  }
+
+  // ─── C11: SubagentStreamRouter interception for team.disbanded (#1224) ───
+  //
+  // Agents bookkeep `tasksCompleted` in memory and frequently get the count
+  // wrong (the #1224 off-by-N regression). The router queries the parent
+  // stream for the actual `task.completed` count scoped to `teamId` — server
+  // side enforcement at the boundary. Sidecar mode skips the router because
+  // the router's JSONL scan won't see writes that haven't been merged from
+  // the sidecar yet; the legacy path still preserves order.
+  if (eventType === 'team.disbanded' && !store.inSidecarMode) {
+    const data = (args.event.data ?? {}) as Record<string, unknown>;
+    const teamId = data.teamId as string | undefined;
+    if (typeof teamId === 'string' && teamId.length > 0) {
+      // Construct DisbandedSummary — explicitly DROP `tasksCompleted` even if
+      // the caller supplied one. The router computes the authoritative value.
+      // Pass through every other field; the router persists them verbatim.
+      const summary: Record<string, unknown> = { teamId };
+      for (const [key, value] of Object.entries(data)) {
+        if (key === 'tasksCompleted' || key === 'teamId') continue;
+        summary[key] = value;
+      }
+      // Required by the schema and the router's DisbandedSummary contract.
+      if (typeof summary.totalDurationMs !== 'number') {
+        summary.totalDurationMs = 0;
+      }
+      if (typeof summary.tasksFailed !== 'number') {
+        summary.tasksFailed = 0;
+      }
+
+      try {
+        const router = store.getStreamRouter();
+        await router.emitDisbanded(args.stream, summary as {
+          teamId: string;
+          totalDurationMs: number;
+          tasksFailed: number;
+          [k: string]: unknown;
+        });
+        // Recover the allocated sequence from the JSONL — the router's
+        // void return type doesn't surface it, and AtomicAppender's per-
+        // stream lock guarantees the most recent `team.disbanded` for this
+        // teamId is the one we just wrote. Falls back to -1/sequencePending
+        // when the file isn't readable for any reason; callers already
+        // tolerate that shape via `toSafeEventAck`.
+        const sequence = await readLatestDisbandedSequence(
+          stateDir,
+          args.stream,
+          teamId,
+        );
+        return {
+          success: true,
+          data: toSafeEventAck({
+            streamId: args.stream,
+            sequence,
+            type: eventType,
+          }),
+        };
+      } catch (err) {
+        return {
+          success: false,
+          error: {
+            code: 'APPEND_FAILED',
+            message: err instanceof Error ? err.message : String(err),
+          },
+        };
+      }
+    }
+    // Fall through to the legacy path when teamId is missing — the router
+    // can't scope its query without it, and the schema-level validation
+    // below will produce the right error message.
   }
 
   try {

--- a/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/servers/exarchos-mcp/src/event-store/tools.ts
@@ -435,14 +435,33 @@ export async function handleBatchAppend(
 
   // Map AppendResult.sequences/eventIds back to EventAck shape — preserves the
   // success envelope `{success: true, data: EventAck[]}` callers depend on.
-  const acks: EventAck[] = result.sequences.map((sequence, i) => {
-    const ack = toEventAck({
-      streamId: args.stream,
-      sequence,
-      type: validatedEvents[i].type,
-    });
-    return ack.sequence <= 0 ? { ...ack, sequence: -1, sequencePending: true } : ack;
-  });
+  //
+  // Cache-hit branch: a retry reusing the same `batchIdempotencyKey` may
+  // pass FEWER events than the originally-cached batch (or different
+  // events entirely). `result.sequences.length` reflects the cached
+  // batch, NOT `validatedEvents.length`. Indexing `validatedEvents[i]`
+  // for the type field would crash with `Cannot read properties of
+  // undefined` whenever the cached batch is longer (Sentry comment
+  // 3205861163). Use `persistedEvents[i].type` from the appender's
+  // cache-hit payload instead — that's the type ACTUALLY persisted, which
+  // is what the EventAck should reflect.
+  const acks: EventAck[] = result.kind === 'cache-hit'
+    ? result.persistedEvents.map((e, i) => {
+        const ack = toEventAck({
+          streamId: args.stream,
+          sequence: result.sequences[i],
+          type: e.type,
+        });
+        return ack.sequence <= 0 ? { ...ack, sequence: -1, sequencePending: true } : ack;
+      })
+    : result.sequences.map((sequence, i) => {
+        const ack = toEventAck({
+          streamId: args.stream,
+          sequence,
+          type: validatedEvents[i].type,
+        });
+        return ack.sequence <= 0 ? { ...ack, sequence: -1, sequencePending: true } : ack;
+      });
   return { success: true, data: acks };
 }
 

--- a/servers/exarchos-mcp/src/event-store/tools.ts
+++ b/servers/exarchos-mcp/src/event-store/tools.ts
@@ -1,8 +1,9 @@
 import { z, ZodError } from 'zod';
 import { EventStore, SequenceConflictError } from './store.js';
-import { EVENT_DATA_SCHEMAS, type EventType } from './schemas.js';
+import { EVENT_DATA_SCHEMAS, type EventType, WorkflowEventBase } from './schemas.js';
 import { pickFields, toEventAck, type EventAck, type ToolResult } from '../format.js';
 import { buildValidatedEvent } from './event-factory.js';
+import { randomUUID } from 'node:crypto';
 
 /**
  * Build an EventAck from a stored event. When the event has a non-positive
@@ -205,6 +206,146 @@ export async function handleBatchAppend(
 
   const store = eventStore;
 
+  // Sidecar mode: AtomicAppender does not model the JSONL/sidecar split, so we
+  // preserve the legacy EventStore.batchAppend path when another process holds
+  // the PID lock. Normal-mode batches route through AtomicAppender (C2).
+  if (store.inSidecarMode) {
+    return handleBatchAppendLegacy(args, store);
+  }
+
+  // Pre-dedup within batch by per-event idempotencyKey (preserves the
+  // single-key-dedup contract `batchAppend_IdempotencyKey_DeduplicatesAcrossBatch`
+  // exercises). The appender itself dedups across calls via the batch
+  // idempotencyKey we derive below.
+  const seenBatchKeys = new Set<string>();
+  const dedupedEvents: Array<Record<string, unknown>> = [];
+  for (const event of args.events) {
+    const key = event.idempotencyKey as string | undefined;
+    if (key !== undefined) {
+      if (seenBatchKeys.has(key)) continue;
+      seenBatchKeys.add(key);
+    }
+    dedupedEvents.push(event);
+  }
+
+  // Validate envelope only (matches legacy EventStore.batchAppend behavior:
+  // type must be a known EventType, but the per-type data schema is enforced
+  // elsewhere — we don't tighten that contract here). Boundary misplaced-field
+  // detection already ran above. The placeholder sequence/streamId fields are
+  // overwritten by AtomicAppender; they're present only because the schema
+  // requires them.
+  type ValidatedEvent = {
+    type: EventType;
+    data?: Record<string, unknown>;
+    correlationId?: string;
+    causationId?: string;
+    agentId?: string;
+    agentRole?: string;
+    tenantId?: string;
+    organizationId?: string;
+    source?: string;
+    timestamp?: string;
+  };
+  let validatedEvents: ValidatedEvent[];
+  try {
+    validatedEvents = dedupedEvents.map((event) => {
+      const parsed = WorkflowEventBase.parse({
+        ...event,
+        streamId: args.stream,
+        sequence: 1, // placeholder; AtomicAppender allocates the real sequence
+        timestamp: event.timestamp ?? new Date().toISOString(),
+      });
+      const out: ValidatedEvent = { type: parsed.type as EventType };
+      if (parsed.data !== undefined) out.data = parsed.data;
+      if (parsed.correlationId !== undefined) out.correlationId = parsed.correlationId;
+      if (parsed.causationId !== undefined) out.causationId = parsed.causationId;
+      if (parsed.agentId !== undefined) out.agentId = parsed.agentId;
+      if (parsed.agentRole !== undefined) out.agentRole = parsed.agentRole;
+      if (parsed.tenantId !== undefined) out.tenantId = parsed.tenantId;
+      if (parsed.organizationId !== undefined) out.organizationId = parsed.organizationId;
+      if (parsed.source !== undefined) out.source = parsed.source;
+      if (parsed.timestamp !== undefined) out.timestamp = parsed.timestamp;
+      return out;
+    });
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return {
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: `Batch validation failed: ${err.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ')}`,
+        },
+      };
+    }
+    return {
+      success: false,
+      error: {
+        code: 'BATCH_APPEND_FAILED',
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+
+  // If dedup pruned everything (all events shared a key already in flight), the
+  // legacy contract returns success with empty data. Match that for byte-compat.
+  if (validatedEvents.length === 0) {
+    return { success: true, data: [] };
+  }
+
+  // Derive the batch idempotencyKey:
+  //   - All events share one key  -> use it (preserves cross-batch retry semantics).
+  //   - Mixed or absent           -> synthesize a fresh UUID (no cross-batch dedup).
+  // The AtomicAppender's idempotency cache is keyed by this batch key; subsequent
+  // batches that pass the same key get the cached events back without re-appending.
+  const perEventKeys = dedupedEvents
+    .map((e) => e.idempotencyKey as string | undefined)
+    .filter((k): k is string => typeof k === 'string');
+  let batchIdempotencyKey: string;
+  if (perEventKeys.length === dedupedEvents.length && perEventKeys.length > 0) {
+    const allSame = perEventKeys.every((k) => k === perEventKeys[0]);
+    batchIdempotencyKey = allSame ? perEventKeys[0] : `batch:${randomUUID()}`;
+  } else {
+    batchIdempotencyKey = `batch:${randomUUID()}`;
+  }
+
+  const appender = store.getAppender();
+  const result = await appender.append(args.stream, validatedEvents, batchIdempotencyKey);
+
+  if (!result.ok) {
+    return {
+      success: false,
+      error: {
+        code: 'BATCH_APPEND_FAILED',
+        message: result.cause ? result.cause.message : `Append failed: ${result.reason}`,
+      },
+    };
+  }
+
+  // Map AppendResult.sequences/eventIds back to EventAck shape — preserves the
+  // success envelope `{success: true, data: EventAck[]}` callers depend on.
+  const acks: EventAck[] = result.sequences.map((sequence, i) => {
+    const ack = toEventAck({
+      streamId: args.stream,
+      sequence,
+      type: validatedEvents[i].type,
+    });
+    return ack.sequence <= 0 ? { ...ack, sequence: -1, sequencePending: true } : ack;
+  });
+  return { success: true, data: acks };
+}
+
+/**
+ * Legacy four-phase batch append path. Retained for sidecar mode where the
+ * AtomicAppender's filesystem assumptions don't hold (sidecar mode routes
+ * writes to a separate file with deferred sequence allocation).
+ */
+async function handleBatchAppendLegacy(
+  args: {
+    stream: string;
+    events: Array<Record<string, unknown>>;
+  },
+  store: EventStore,
+): Promise<ToolResult> {
   try {
     const storeEvents = args.events.map((event) => ({
       type: event.type as EventType,

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.test.ts
@@ -211,6 +211,89 @@ describe('selectPruneCandidates', () => {
     expect(candidates.map((c) => c.featureId)).toEqual(['impl']);
     expect(excluded.find((e) => e.featureId === 'plan')?.reason).toBe('phase-excluded');
   });
+
+  // ─── C8 (#1117): multi-signal staleness ──────────────────────────────────
+  //
+  // The single-signal gate on `_checkpoint.lastActivityTimestamp` is refreshed
+  // by ANY MCP read (`get`, `describe`), so a workflow polled by the
+  // orchestrator looks "fresh" forever. Two secondary signals close the
+  // false-fresh path:
+  //
+  // - `phaseTransitionTimestamp` — derived from the most-recent
+  //   `workflow.transition` event. Captures "stuck in phase X for N days"
+  //   even when reads keep `lastActivityTimestamp` fresh.
+  // - `branchActivityTimestamp` — `git log -1 --format=%ct` on the tracked
+  //   branch. Treats absence-of-activity in the threshold window as a
+  //   stale signal. Skipped silently when no branch is tracked.
+  //
+  // Composition:
+  //   stale = phaseTransition stale AND (lastActivity stale OR branch inactive)
+  // When neither secondary signal is supplied, the legacy single-signal path
+  // is preserved (existing tests above keep their semantics).
+
+  it('selectPruneCandidates_phaseStuckButReadActive_flagsAsStale', () => {
+    // Repro of #1117: phase entered 7d ago, but lastActivityTimestamp is 1h
+    // old because the orchestrator polls the workflow with read tools that
+    // refresh the checkpoint. The pruner used to mark this fresh and never
+    // touch it. Multi-signal scoring must catch it.
+    const entries: WorkflowListEntry[] = [
+      {
+        featureId: 'stuck-but-polled',
+        workflowType: 'feature',
+        phase: 'implementing',
+        stateFile: '/tmp/stuck-but-polled.state.json',
+        _checkpoint: { lastActivityTimestamp: minutesAgo(60) }, // 1h — fresh
+        phaseTransitionTimestamp: minutesAgo(60 * 24 * 21), // 21d — stale vs 14d default
+      },
+    ];
+
+    const { candidates } = selectPruneCandidates(entries, {}, NOW);
+
+    expect(candidates.map((c) => c.featureId)).toEqual(['stuck-but-polled']);
+  });
+
+  it('selectPruneCandidates_branchInactiveAndPhaseStuck_flagsAsStale', () => {
+    // Both secondary signals stale → flagged.
+    const entries: WorkflowListEntry[] = [
+      {
+        featureId: 'branch-and-phase-stuck',
+        workflowType: 'feature',
+        phase: 'implementing',
+        stateFile: '/tmp/branch-and-phase-stuck.state.json',
+        _checkpoint: { lastActivityTimestamp: minutesAgo(60) }, // fresh by reads
+        phaseTransitionTimestamp: minutesAgo(60 * 24 * 21), // 21d — stale vs 14d
+        branchActivityTimestamp: minutesAgo(60 * 24 * 21), // 21d — stale vs 14d
+      },
+    ];
+
+    const { candidates } = selectPruneCandidates(entries, {}, NOW);
+
+    expect(candidates.map((c) => c.featureId)).toEqual(['branch-and-phase-stuck']);
+  });
+
+  it('selectPruneCandidates_recentTransitionAndCommit_doesNotFlag', () => {
+    // Recent phase transition AND recent branch activity → NOT flagged.
+    // Pinned to prevent the new signals from creating false positives on
+    // legitimately active workflows.
+    const entries: WorkflowListEntry[] = [
+      {
+        featureId: 'actively-progressing',
+        workflowType: 'feature',
+        phase: 'implementing',
+        stateFile: '/tmp/actively-progressing.state.json',
+        // Even with an old lastActivityTimestamp, recent phase progress
+        // should keep this fresh.
+        _checkpoint: { lastActivityTimestamp: minutesAgo(60 * 24 * 30) }, // 30d
+        phaseTransitionTimestamp: minutesAgo(60), // 1h — fresh
+        branchActivityTimestamp: minutesAgo(60), // 1h — fresh
+      },
+    ];
+
+    const { candidates, excluded } = selectPruneCandidates(entries, {}, NOW);
+
+    expect(candidates.map((c) => c.featureId)).toEqual([]);
+    expect(excluded.map((e) => e.featureId)).toEqual(['actively-progressing']);
+  });
 });
 
 // ─── Handler Tests ──────────────────────────────────────────────────────────
@@ -267,11 +350,19 @@ function makeDeps(overrides: Partial<PruneHandlerDeps> = {}): PruneHandlerDeps &
     hasOpenPR: vi.fn().mockResolvedValue(false),
     hasRecentCommits: vi.fn().mockResolvedValue(false),
   };
+  // C8 (#1117): default to "no signal" for the secondary staleness signals.
+  // Existing handler tests gated only on `_checkpoint.lastActivityTimestamp`;
+  // returning `undefined` keeps the selector on the legacy single-signal
+  // path so those tests retain their semantics.
+  const phaseTransitionSpy = vi.fn().mockResolvedValue(undefined);
+  const branchActivitySpy = vi.fn().mockResolvedValue(undefined);
   return {
     handleList: listSpy,
     handleCancel: cancelSpy,
     readBranchName: branchSpy,
     safeguards,
+    readPhaseTransitionTimestamp: phaseTransitionSpy,
+    readBranchActivityTimestamp: branchActivitySpy,
     listSpy,
     cancelSpy,
     branchSpy,

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
@@ -44,6 +44,24 @@ export interface WorkflowListEntry {
   _checkpoint: {
     lastActivityTimestamp: string;
   };
+  /**
+   * C8 (#1117) — secondary staleness signal: ISO timestamp of the most-recent
+   * `workflow.transition` event for the workflow. Captures "stuck in phase X
+   * for N days" even when reads keep `lastActivityTimestamp` fresh. Optional
+   * for backward compatibility; legacy entries fall back to single-signal
+   * scoring on `_checkpoint.lastActivityTimestamp`.
+   */
+  phaseTransitionTimestamp?: string;
+  /**
+   * C8 (#1117) — secondary staleness signal: ISO timestamp of the latest
+   * commit on the workflow's tracked branch (UTC seconds from
+   * `git log -1 --format=%ct`, converted to ISO). Absence of activity within
+   * the threshold window contributes a stale signal. Optional — workflows
+   * without a tracked branch (and absent-branch readers) leave this
+   * undefined; the selector treats undefined as "no evidence of branch
+   * progress" rather than penalising the workflow.
+   */
+  branchActivityTimestamp?: string;
 }
 
 export interface PruneConfig {
@@ -109,6 +127,23 @@ function isBeyondThreshold(
   return minutesSince(checkpoint.lastActivityTimestamp, now) > thresholdMinutes;
 }
 
+/**
+ * C8 (#1117): is a secondary signal timestamp stale relative to the
+ * threshold? Treats `undefined` as "no evidence of progress" — the
+ * caller decides whether that means stale (true) or fresh (false) by
+ * passing an explicit `whenAbsent` flag.
+ */
+function signalIsStale(
+  timestamp: string | undefined,
+  thresholdMinutes: number,
+  now: Date,
+  whenAbsent: boolean,
+): boolean {
+  if (timestamp === undefined) return whenAbsent;
+  if (Number.isNaN(new Date(timestamp).valueOf())) return whenAbsent;
+  return minutesSince(timestamp, now) > thresholdMinutes;
+}
+
 function isTerminalPhase(phase: string): boolean {
   return baseIsTerminalPhase(phase);
 }
@@ -156,7 +191,64 @@ export function selectPruneCandidates(
       continue;
     }
 
-    if (!isBeyondThreshold(entry._checkpoint, thresholdMinutes, now)) {
+    // C8 (#1117): multi-signal staleness scoring.
+    //
+    // Single-signal gating on `_checkpoint.lastActivityTimestamp` produced
+    // false-fresh reads because that field is bumped by every MCP `get` /
+    // `describe` call. The orchestrator's polling kept stuck workflows
+    // perpetually fresh.
+    //
+    // Composition (no single false-fresh path):
+    //   - When neither secondary signal is supplied (legacy entries),
+    //     fall back to the original single-signal threshold check. This
+    //     preserves the contract for callers that haven't yet been wired
+    //     to derive the secondary signals.
+    //   - When at least one secondary signal IS supplied, a workflow is
+    //     stale iff the phase-transition signal is stale AND
+    //     (the lastActivity signal is stale OR the branch is inactive).
+    //     Recent phase progress alone keeps a workflow fresh; recent
+    //     branch activity combined with a fresh `lastActivityTimestamp`
+    //     also keeps it fresh.
+    //
+    // `branchActivityTimestamp === undefined` is treated as "no evidence
+    // of branch progress" (i.e. stale), but the workflow is only flagged
+    // when the phase-transition signal is ALSO stale, so workflows
+    // without a tracked branch are not penalised on that signal alone.
+    const lastActivityStale = isBeyondThreshold(
+      entry._checkpoint,
+      thresholdMinutes,
+      now,
+    );
+    const hasSecondarySignal =
+      entry.phaseTransitionTimestamp !== undefined ||
+      entry.branchActivityTimestamp !== undefined;
+
+    let isStale: boolean;
+    if (!hasSecondarySignal) {
+      // Legacy single-signal path.
+      isStale = lastActivityStale;
+    } else {
+      const phaseStale = signalIsStale(
+        entry.phaseTransitionTimestamp,
+        thresholdMinutes,
+        now,
+        // No phaseTransition timestamp recorded → treat as stale (no
+        // evidence of progress). This is the #1117 false-fresh path.
+        true,
+      );
+      const branchInactive = signalIsStale(
+        entry.branchActivityTimestamp,
+        thresholdMinutes,
+        now,
+        // No branchActivityTimestamp recorded → treat as "no evidence of
+        // branch progress" (stale signal). The phase-stale gate prevents
+        // this from over-flagging branch-less workflows.
+        true,
+      );
+      isStale = phaseStale && (lastActivityStale || branchInactive);
+    }
+
+    if (!isStale) {
       excluded.push({ featureId: entry.featureId, reason: 'fresh' });
       continue;
     }
@@ -211,6 +303,26 @@ export interface PruneHandlerDeps {
   /** Reads the top-level branchName from a workflow state file. */
   readBranchName: (featureId: string, stateDir: string) => Promise<string | undefined>;
   safeguards: PruneSafeguards;
+  /**
+   * C8 (#1117) — read the most-recent `workflow.transition` event timestamp
+   * for a workflow. Returns `undefined` when the event store has no transition
+   * events on that stream (or when querying fails). The handler enriches
+   * `WorkflowListEntry`s with this value so `selectPruneCandidates` can apply
+   * multi-signal staleness scoring without doing IO itself.
+   */
+  readPhaseTransitionTimestamp: (featureId: string) => Promise<string | undefined>;
+  /**
+   * C8 (#1117) — read the latest commit timestamp on a workflow's tracked
+   * branch as an ISO string. Returns `undefined` when:
+   *   - the workflow has no tracked branch
+   *   - `git log` fails (no remote, branch missing, git not installed)
+   * Workflows without a branch are not penalised: the selector treats
+   * `undefined` as "no evidence of branch progress" but the phase-transition
+   * gate prevents that from forcing a stale verdict on its own.
+   */
+  readBranchActivityTimestamp: (
+    branchName: string | undefined,
+  ) => Promise<string | undefined>;
 }
 
 export interface PruneSkipped {
@@ -313,6 +425,80 @@ async function defaultReadBranchName(
   }
 }
 
+/**
+ * C8 (#1117) — production reader for the latest `workflow.transition` event
+ * timestamp on a stream. Returns `undefined` when the stream has no
+ * transition events or when the query throws (a query failure is treated as
+ * "no signal", matching the safeguard convention elsewhere in this module).
+ *
+ * The `EventStore.query` filter accepts a `type` and a `limit`; we ask only
+ * for the most recent transition rather than scanning the full history. The
+ * store returns events in stream order, so the last element is the newest.
+ */
+function makeReadPhaseTransitionTimestamp(
+  ctx?: DispatchContext,
+): (featureId: string) => Promise<string | undefined> {
+  if (!ctx?.eventStore) {
+    return async () => undefined;
+  }
+  const eventStore = ctx.eventStore;
+  return async (featureId: string) => {
+    try {
+      const events = await eventStore.query(featureId, {
+        type: 'workflow.transition',
+      });
+      if (!Array.isArray(events) || events.length === 0) return undefined;
+      const newest = events[events.length - 1];
+      const ts = newest?.timestamp;
+      return typeof ts === 'string' ? ts : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+}
+
+/**
+ * C8 (#1117) — production reader for the latest commit timestamp on a
+ * workflow's tracked branch. Reuses the `git log` shell-out pattern from
+ * {@link defaultHasRecentCommits} in `prune-safeguards.ts` rather than
+ * introducing a new VCS dependency. `--format=%ct` returns UTC seconds since
+ * epoch, which we convert to an ISO timestamp so it composes with the other
+ * signals.
+ *
+ * Returns `undefined` when:
+ *   - `branchName` is absent or contains characters outside the safe
+ *     git-ref alphabet
+ *   - `git log` fails (unknown ref, git not installed, timeout)
+ */
+async function defaultReadBranchActivityTimestamp(
+  branchName: string | undefined,
+): Promise<string | undefined> {
+  if (!branchName) return undefined;
+  // Same allowed-character guard `prune-safeguards.ts` uses before
+  // embedding the branch name in a shell argument. Refuse to run git
+  // against suspicious refs rather than passing them through.
+  if (!/^[A-Za-z0-9/_.\-]+$/.test(branchName) || branchName.includes('..')) {
+    return undefined;
+  }
+  try {
+    const { execSync } = await import('node:child_process');
+    const output = execSync(
+      `git log -1 --format=%ct refs/heads/${branchName}`,
+      {
+        encoding: 'utf-8',
+        timeout: 10_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    ).trim();
+    if (!output) return undefined;
+    const epochSeconds = Number.parseInt(output, 10);
+    if (!Number.isFinite(epochSeconds) || epochSeconds <= 0) return undefined;
+    return new Date(epochSeconds * 1000).toISOString();
+  } catch {
+    return undefined;
+  }
+}
+
 /** Production dep bundle — real `handleList`/`handleCancel` + default safeguards. */
 function productionDeps(_ctx?: DispatchContext): PruneHandlerDeps {
   return {
@@ -325,6 +511,8 @@ function productionDeps(_ctx?: DispatchContext): PruneHandlerDeps {
       ),
     readBranchName: defaultReadBranchName,
     safeguards: defaultSafeguards(),
+    readPhaseTransitionTimestamp: makeReadPhaseTransitionTimestamp(_ctx),
+    readBranchActivityTimestamp: defaultReadBranchActivityTimestamp,
   };
 }
 
@@ -706,9 +894,35 @@ export async function handlePruneStaleWorkflows(
   //   - 'skip': malformed silently excluded, diagnostics omitted from response
   const malformedHandling = pruneConfig?.malformedHandling ?? 'report';
 
+  // 1a. C8 (#1117): enrich each entry with secondary staleness signals
+  // BEFORE pure selection. The selector stays IO-free; the handler is the
+  // only layer that touches the event store / git. Failures on individual
+  // entries fall back to `undefined`, which the selector treats as "no
+  // evidence of progress" without bypassing the phase-stale gate.
+  const enrichedEntries: WorkflowListEntry[] = await Promise.all(
+    entries.map(async (entry) => {
+      const [phaseTransitionTimestamp, branchName] = await Promise.all([
+        deps.readPhaseTransitionTimestamp(entry.featureId),
+        deps.readBranchName(entry.featureId, stateDir),
+      ]);
+      const branchActivityTimestamp = await deps.readBranchActivityTimestamp(
+        branchName,
+      );
+      return {
+        ...entry,
+        ...(phaseTransitionTimestamp !== undefined
+          ? { phaseTransitionTimestamp }
+          : {}),
+        ...(branchActivityTimestamp !== undefined
+          ? { branchActivityTimestamp }
+          : {}),
+      };
+    }),
+  );
+
   // 2. Pure selection.
   const { candidates: selectedCandidates } = selectPruneCandidates(
-    entries,
+    enrichedEntries,
     {
       thresholdMinutes,
       ...(includeOneShot !== undefined ? { includeOneShot } : {}),

--- a/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prune-stale-workflows.ts
@@ -481,15 +481,19 @@ async function defaultReadBranchActivityTimestamp(
     return undefined;
   }
   try {
-    const { execSync } = await import('node:child_process');
-    const output = execSync(
-      `git log -1 --format=%ct refs/heads/${branchName}`,
-      {
-        encoding: 'utf-8',
-        timeout: 10_000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      },
-    ).trim();
+    const { execFile } = await import('node:child_process');
+    const { promisify } = await import('node:util');
+    const execFileAsync = promisify(execFile);
+    // execFile (not execSync) so that handlePruneStaleWorkflows's
+    // Promise.all over per-workflow readers does not block the event loop.
+    // Args are passed as an array — branchName is regex-validated above so
+    // shell metacharacters can't reach the spawned process either way.
+    const { stdout } = await execFileAsync(
+      'git',
+      ['log', '-1', '--format=%ct', `refs/heads/${branchName}`],
+      { encoding: 'utf-8', timeout: 10_000 },
+    );
+    const output = stdout.trim();
     if (!output) return undefined;
     const epochSeconds = Number.parseInt(output, 10);
     if (!Number.isFinite(epochSeconds) || epochSeconds <= 0) return undefined;

--- a/servers/exarchos-mcp/src/parity.test.ts
+++ b/servers/exarchos-mcp/src/parity.test.ts
@@ -1,0 +1,236 @@
+// ─── CLI/MCP Parity — v2.9.0 Bug Cluster (Commit C9, #1109) ───────────────
+//
+// Closes the second half of the #1109 verification checklist: identical
+// event log → identical ToolResult envelope from CLI invocation and MCP
+// invocation. The existing per-tool parity suites (`views/parity.test.ts`,
+// `workflow/parity.test.ts`, `event-store/parity.test.ts`) cover empty
+// or trivial state. The C9 tests here drive the assertion through the
+// concrete bug-cluster shapes: a duplicate-task.completed event log for
+// `workflow_status` (the C4 dedup target), and a no-handoff invocation
+// of `workflow_checkpoint` (the C3 idempotency-key digest target).
+//
+// The shared parity-harness primitives (`callCli`, `callMcp`, `normalize`)
+// from `src/__tests__/parity-harness.ts` are the same ones the older
+// suites use — single source of truth for normalization (timestamps,
+// UUIDs, `_perf` telemetry).
+//
+// Strategy:
+//   - Per-test pair of tmp state dirs (CLI arm + MCP arm) so neither side
+//     sees the other's state.
+//   - Seed both arms with the SAME event log via direct `EventStore.append`
+//     calls, then issue the same query through CLI and MCP adapters.
+//   - Normalize and deep-equal the two ToolResult payloads.
+//
+// ─────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { DispatchContext } from './core/dispatch.js';
+import { EventStore } from './event-store/store.js';
+import type { ToolResult } from './format.js';
+import { CLI_EXIT_CODES } from './adapters/cli.js';
+import { resetMaterializerCache } from './views/tools.js';
+import {
+  callCli as harnessCallCli,
+  callMcp as harnessCallMcp,
+  normalize as harnessNormalize,
+  UUID_ANY_RE,
+} from './__tests__/parity-harness.js';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+interface ParityArm {
+  readonly stateDir: string;
+  readonly ctx: DispatchContext;
+}
+
+async function makeArm(label: string): Promise<ParityArm> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), `c9-parity-${label}-`));
+  const eventStore = new EventStore(stateDir);
+  await eventStore.initialize();
+  const ctx: DispatchContext = { stateDir, eventStore, enableTelemetry: false };
+  return { stateDir, ctx };
+}
+
+async function teardownArm(arm: ParityArm): Promise<void> {
+  await fs.rm(arm.stateDir, { recursive: true, force: true });
+}
+
+// ─── Normalization ─────────────────────────────────────────────────────────
+
+/**
+ * C9 normalizer — the views suite's defaults (`<ISO>` placeholder,
+ * `<UUID>` placeholder, any-version UUID regex, `_perf` dropped) plus
+ * the workflow-suite's `minutesSinceActivity` keyed transform so a
+ * `workflow_status` envelope that includes that derived field renders
+ * stably across arms.
+ */
+function normalize(value: unknown): unknown {
+  return harnessNormalize(value, {
+    timestampPlaceholder: '<ISO>',
+    uuidPlaceholder: '<UUID>',
+    uuidRegex: UUID_ANY_RE,
+    keyPlaceholders: { minutesSinceActivity: '<MINUTES>' },
+    dropKeys: new Set(['_perf']),
+  });
+}
+
+// ─── Test 9.2 — workflow_status parity under C4 dedup shape ────────────────
+
+describe('CLI/MCP parity — workflow_status (C9, #1109)', () => {
+  let cliArm: ParityArm;
+  let mcpArm: ParityArm;
+
+  beforeEach(async () => {
+    // The view materializer caches projection state per-stream across
+    // the in-process call; without a reset the second arm reuses the
+    // first arm's cached state, contaminating the parity assertion.
+    resetMaterializerCache();
+    cliArm = await makeArm('status-cli');
+    mcpArm = await makeArm('status-mcp');
+  });
+
+  afterEach(async () => {
+    resetMaterializerCache();
+    await teardownArm(cliArm);
+    await teardownArm(mcpArm);
+  });
+
+  /**
+   * Seed both arms with an identical event log that exercises the C4
+   * dedup invariant (#1226): two `task.completed` events for the same
+   * taskId. The post-C4 projection counts the duplicate once. CLI and
+   * MCP must surface the same envelope.
+   */
+  async function seedDuplicateTaskCompleted(arm: ParityArm, featureId: string): Promise<void> {
+    await arm.ctx.eventStore.append(featureId, {
+      type: 'workflow.started',
+      correlationId: featureId,
+      data: { featureId, workflowType: 'feature' },
+    });
+    await arm.ctx.eventStore.append(featureId, {
+      type: 'task.assigned',
+      correlationId: featureId,
+      data: { taskId: 't1' },
+    });
+    await arm.ctx.eventStore.append(featureId, {
+      type: 'task.completed',
+      correlationId: featureId,
+      data: { taskId: 't1' },
+    });
+    // Duplicate — what the C4 dedup must collapse.
+    await arm.ctx.eventStore.append(
+      featureId,
+      {
+        type: 'task.completed',
+        correlationId: featureId,
+        data: { taskId: 't1' },
+      },
+      // Distinct idempotencyKey so the AtomicAppender admits it; the
+      // dedup that matters here is the projection's, not the appender's.
+      { idempotencyKey: `${featureId}:dup-completed` },
+    );
+  }
+
+  it('assertParity_workflowStatus_cliAndMcpByteEqual', async () => {
+    const featureId = 'c9-parity-status';
+
+    // Arrange — seed both arms with identical event logs.
+    await seedDuplicateTaskCompleted(cliArm, featureId);
+    await seedDuplicateTaskCompleted(mcpArm, featureId);
+
+    // Act — issue the same `workflow_status` query through both adapters.
+    const mcpResult: ToolResult = await harnessCallMcp(
+      mcpArm.ctx,
+      'exarchos_view',
+      { action: 'workflow_status', workflowId: featureId },
+    );
+
+    const { result: cliResult, exitCode } = await harnessCallCli(
+      cliArm.ctx,
+      'vw',
+      'workflow_status',
+      { workflowId: featureId },
+    );
+
+    // Assert — both arms succeed with byte-equal payloads after
+    // normalization. The C4 dedup invariant means tasksCompleted in
+    // both envelopes equals 1, not 2.
+    expect(exitCode).toBe(CLI_EXIT_CODES.SUCCESS);
+    expect(mcpResult.success).toBe(true);
+    expect(cliResult.success).toBe(true);
+    expect(normalize(cliResult)).toEqual(normalize(mcpResult));
+  });
+});
+
+// ─── Test 9.3 — workflow_checkpoint parity (no-handoff, stable digest) ─────
+
+describe('CLI/MCP parity — workflow_checkpoint (C9, #1109)', () => {
+  let cliArm: ParityArm;
+  let mcpArm: ParityArm;
+
+  beforeEach(async () => {
+    resetMaterializerCache();
+    cliArm = await makeArm('checkpoint-cli');
+    mcpArm = await makeArm('checkpoint-mcp');
+  });
+
+  afterEach(async () => {
+    resetMaterializerCache();
+    await teardownArm(cliArm);
+    await teardownArm(mcpArm);
+  });
+
+  /**
+   * Initialize a workflow on the given arm so `handleCheckpoint` has
+   * persisted state to read. Both arms see the same init payload, so
+   * the resulting state file is identical modulo wall-clock timestamps
+   * (which the parity normalizer strips).
+   */
+  async function initWorkflow(arm: ParityArm, featureId: string): Promise<void> {
+    await harnessCallMcp(arm.ctx, 'exarchos_workflow', {
+      action: 'init',
+      featureId,
+      workflowType: 'feature',
+    });
+  }
+
+  it('assertParity_workflowCheckpoint_cliAndMcpByteEqual', async () => {
+    const featureId = 'c9-parity-checkpoint';
+
+    // Arrange — both arms initialized to the same starting state.
+    await initWorkflow(cliArm, featureId);
+    await initWorkflow(mcpArm, featureId);
+
+    // Act — issue a no-handoff checkpoint through both adapters. With
+    // no `handoff` payload, C3's sha256(handoff ?? {}) digest is
+    // identical between the two calls, so the idempotencyKey is too.
+    // (A handoff-bearing call would still parity, but the digest path
+    // is best exercised by the deterministic empty-payload shape.)
+    const mcpResult: ToolResult = await harnessCallMcp(
+      mcpArm.ctx,
+      'exarchos_workflow',
+      { action: 'checkpoint', featureId, summary: 'C9 parity checkpoint' },
+    );
+
+    const { result: cliResult, exitCode } = await harnessCallCli(
+      cliArm.ctx,
+      'wf',
+      'checkpoint',
+      { featureId, summary: 'C9 parity checkpoint' },
+    );
+
+    // Assert — exit-code success on the CLI arm, both envelopes equal
+    // after normalization. The interesting normalization here is around
+    // the wall-clock timestamps `handleCheckpoint` writes into the
+    // `_checkpoint` block; the harness's `stripTimeSensitiveValues`-
+    // equivalent ISO regex collapses them to `<ISO>` on both sides.
+    expect(exitCode).toBe(CLI_EXIT_CODES.SUCCESS);
+    expect(mcpResult.success).toBe(true);
+    expect(cliResult.success).toBe(true);
+    expect(normalize(cliResult)).toEqual(normalize(mcpResult));
+  });
+});

--- a/servers/exarchos-mcp/src/views/tools.ts
+++ b/servers/exarchos-mcp/src/views/tools.ts
@@ -270,7 +270,16 @@ export async function handleViewWorkflowStatus(
     const stateTasks = state?.['tasks'];
     const tasksTotal = Array.isArray(stateTasks) ? stateTasks.length : view.tasksTotal;
 
-    return { success: true, data: { ...view, tasksTotal } };
+    // C4 (#1226) — strip projection-internal dedup bookkeeping from the
+    // public envelope. The `_seen*TaskIds` arrays are needed for replay
+    // correctness but must not leak into the response shape.
+    const {
+      _seenAssignedTaskIds: _ignoredAssigned,
+      _seenCompletedTaskIds: _ignoredCompleted,
+      ...publicView
+    } = view;
+
+    return { success: true, data: { ...publicView, tasksTotal } };
   } catch (err) {
     return {
       success: false,

--- a/servers/exarchos-mcp/src/views/workflow-status-view.ts
+++ b/servers/exarchos-mcp/src/views/workflow-status-view.ts
@@ -8,12 +8,21 @@ export const WORKFLOW_STATUS_VIEW = 'workflow-status';
 // ─── View State ────────────────────────────────────────────────────────────
 
 /**
- * Public view shape returned to callers.
+ * Internal projection state. Public callers receive the strip-down version
+ * via `views/tools.ts` (the `_seen*` fields are deleted before the view
+ * envelope is returned).
  *
- * The `_seenAssignedTaskIds` / `_seenCompletedTaskIds` arrays are projection
- * bookkeeping for taskId dedup (#1226). They are arrays (not `Set`s) so that
- * snapshot serialization through `JSON.stringify` round-trips losslessly. The
- * leading underscore signals that callers should not inspect them.
+ * Dedup bookkeeping for taskId (#1226) is stored as `Record<string, true>`
+ * rather than `string[]`:
+ *
+ *   - O(1) membership check (was O(n) `.includes` per event → O(n²) replay).
+ *   - O(1) insert (was `[...arr, id]` per event → O(n) per insert).
+ *   - JSON-serializable (Sets are not), so snapshot round-trip is preserved.
+ *
+ * The maps grow with the number of distinct taskIds seen; for pathological
+ * long-running workflows callers should compact via snapshot truncation.
+ * The replay-cost / memory-growth tradeoff favours the map for any workflow
+ * with more than ~100 tasks, which all production workflows now exceed.
  */
 export interface WorkflowStatusViewState {
   featureId: string;
@@ -24,9 +33,9 @@ export interface WorkflowStatusViewState {
   tasksCompleted: number;
   tasksFailed: number;
   /** Internal: taskIds already counted toward tasksTotal. */
-  _seenAssignedTaskIds: string[];
+  _seenAssignedTaskIds: Record<string, true>;
   /** Internal: taskIds already counted toward tasksCompleted. */
-  _seenCompletedTaskIds: string[];
+  _seenCompletedTaskIds: Record<string, true>;
 }
 
 // ─── Projection ────────────────────────────────────────────────────────────
@@ -38,6 +47,29 @@ function extractTaskId(event: WorkflowEvent): string | undefined {
   return typeof data.taskId === 'string' ? data.taskId : undefined;
 }
 
+/**
+ * Coerce legacy snapshot shapes (the original `string[]`) to the current
+ * `Record<string, true>` shape. Snapshots written before this projection
+ * was migrated still load with arrays; without the coercion, the new
+ * `view._seen*[taskId]` lookup returns `undefined` (because non-numeric
+ * indexing on arrays does), the dedup guard collapses, and tasksCompleted
+ * can exceed tasksTotal — exactly the #1226 invariant violation the dedup
+ * is supposed to prevent.
+ */
+function asSeenSet(seen: unknown): Record<string, true> {
+  if (Array.isArray(seen)) {
+    const result: Record<string, true> = {};
+    for (const id of seen) {
+      if (typeof id === 'string') result[id] = true;
+    }
+    return result;
+  }
+  if (seen && typeof seen === 'object') {
+    return seen as Record<string, true>;
+  }
+  return {};
+}
+
 export const workflowStatusProjection: ViewProjection<WorkflowStatusViewState> = {
   init: () => ({
     featureId: '',
@@ -47,8 +79,8 @@ export const workflowStatusProjection: ViewProjection<WorkflowStatusViewState> =
     tasksTotal: 0,
     tasksCompleted: 0,
     tasksFailed: 0,
-    _seenAssignedTaskIds: [],
-    _seenCompletedTaskIds: [],
+    _seenAssignedTaskIds: {},
+    _seenCompletedTaskIds: {},
   }),
 
   apply: (view, event) => {
@@ -85,13 +117,17 @@ export const workflowStatusProjection: ViewProjection<WorkflowStatusViewState> =
         if (taskId === undefined) {
           return { ...view, tasksTotal: view.tasksTotal + 1 };
         }
-        if (view._seenAssignedTaskIds.includes(taskId)) {
-          return view;
+        const seen = asSeenSet(view._seenAssignedTaskIds);
+        if (seen[taskId]) {
+          // Defensive coercion: ensure post-condition is the new shape so
+          // subsequent applies do O(1) lookups instead of falling back to
+          // asSeenSet on every event.
+          return { ...view, _seenAssignedTaskIds: seen };
         }
         return {
           ...view,
           tasksTotal: view.tasksTotal + 1,
-          _seenAssignedTaskIds: [...view._seenAssignedTaskIds, taskId],
+          _seenAssignedTaskIds: { ...seen, [taskId]: true },
         };
       }
 
@@ -100,13 +136,14 @@ export const workflowStatusProjection: ViewProjection<WorkflowStatusViewState> =
         if (taskId === undefined) {
           return { ...view, tasksCompleted: view.tasksCompleted + 1 };
         }
-        if (view._seenCompletedTaskIds.includes(taskId)) {
-          return view;
+        const seen = asSeenSet(view._seenCompletedTaskIds);
+        if (seen[taskId]) {
+          return { ...view, _seenCompletedTaskIds: seen };
         }
         return {
           ...view,
           tasksCompleted: view.tasksCompleted + 1,
-          _seenCompletedTaskIds: [...view._seenCompletedTaskIds, taskId],
+          _seenCompletedTaskIds: { ...seen, [taskId]: true },
         };
       }
 

--- a/servers/exarchos-mcp/src/views/workflow-status-view.ts
+++ b/servers/exarchos-mcp/src/views/workflow-status-view.ts
@@ -7,6 +7,14 @@ export const WORKFLOW_STATUS_VIEW = 'workflow-status';
 
 // ─── View State ────────────────────────────────────────────────────────────
 
+/**
+ * Public view shape returned to callers.
+ *
+ * The `_seenAssignedTaskIds` / `_seenCompletedTaskIds` arrays are projection
+ * bookkeeping for taskId dedup (#1226). They are arrays (not `Set`s) so that
+ * snapshot serialization through `JSON.stringify` round-trips losslessly. The
+ * leading underscore signals that callers should not inspect them.
+ */
 export interface WorkflowStatusViewState {
   featureId: string;
   workflowType: string;
@@ -15,9 +23,20 @@ export interface WorkflowStatusViewState {
   tasksTotal: number;
   tasksCompleted: number;
   tasksFailed: number;
+  /** Internal: taskIds already counted toward tasksTotal. */
+  _seenAssignedTaskIds: string[];
+  /** Internal: taskIds already counted toward tasksCompleted. */
+  _seenCompletedTaskIds: string[];
 }
 
 // ─── Projection ────────────────────────────────────────────────────────────
+
+/** Pull a string `taskId` from `event.data` if present, else undefined. */
+function extractTaskId(event: WorkflowEvent): string | undefined {
+  const data = event.data as { taskId?: unknown } | undefined;
+  if (!data) return undefined;
+  return typeof data.taskId === 'string' ? data.taskId : undefined;
+}
 
 export const workflowStatusProjection: ViewProjection<WorkflowStatusViewState> = {
   init: () => ({
@@ -28,6 +47,8 @@ export const workflowStatusProjection: ViewProjection<WorkflowStatusViewState> =
     tasksTotal: 0,
     tasksCompleted: 0,
     tasksFailed: 0,
+    _seenAssignedTaskIds: [],
+    _seenCompletedTaskIds: [],
   }),
 
   apply: (view, event) => {
@@ -57,17 +78,37 @@ export const workflowStatusProjection: ViewProjection<WorkflowStatusViewState> =
         };
       }
 
-      case 'task.assigned':
+      case 'task.assigned': {
+        const taskId = extractTaskId(event);
+        // Missing taskId: legacy/malformed event — count it (preserves
+        // pre-dedup behavior for events that can't be deduped).
+        if (taskId === undefined) {
+          return { ...view, tasksTotal: view.tasksTotal + 1 };
+        }
+        if (view._seenAssignedTaskIds.includes(taskId)) {
+          return view;
+        }
         return {
           ...view,
           tasksTotal: view.tasksTotal + 1,
+          _seenAssignedTaskIds: [...view._seenAssignedTaskIds, taskId],
         };
+      }
 
-      case 'task.completed':
+      case 'task.completed': {
+        const taskId = extractTaskId(event);
+        if (taskId === undefined) {
+          return { ...view, tasksCompleted: view.tasksCompleted + 1 };
+        }
+        if (view._seenCompletedTaskIds.includes(taskId)) {
+          return view;
+        }
         return {
           ...view,
           tasksCompleted: view.tasksCompleted + 1,
+          _seenCompletedTaskIds: [...view._seenCompletedTaskIds, taskId],
         };
+      }
 
       case 'task.failed':
         return {

--- a/servers/exarchos-mcp/src/workflow/hsm-transition-guard.test.ts
+++ b/servers/exarchos-mcp/src/workflow/hsm-transition-guard.test.ts
@@ -1,0 +1,184 @@
+// ─── HSMTransitionGuard.fail_closed (Commit C7, closes #1225) ─────────────
+//
+// `workflow.set({ phase })` must route every phase update through
+// `HSMTransitionGuard.attempt`, which is the single decision point for
+// guarded phase transitions. The atomicity invariant: a guarded transition
+// either appends `workflow.transition` (on guard pass) OR
+// `workflow.guard-failed` (on guard fail) — NEVER both for the same target
+// phase in the same attempt.
+//
+// Tests treat `handleSet` as the entry point: each test exercises the full
+// composed path that `workflow.set` will follow once routed through the
+// guard primitive. Test 3 pins non-phase updates so they remain on the
+// existing field-only path with no guard involvement.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { handleInit, handleSet } from './tools.js';
+import { EventStore } from '../event-store/store.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+
+let tmpDir: string;
+const featureId = 'hsm-guard-test';
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'hsm-guard-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+/**
+ * Patch the raw state file to advance phase to `delegate` and seed tasks.
+ * The feature HSM transition `delegate → review` requires the composite
+ * guard `all-tasks-complete + team-disbanded` to pass. We bypass earlier
+ * phases by editing the state file directly so each test isolates the
+ * guard-on-set behavior, not the multi-phase walk.
+ */
+async function patchStateForDelegatePhase(opts: {
+  tasks?: Array<{ id: string; title: string; status: string }>;
+}): Promise<void> {
+  const stateFile = path.join(tmpDir, `${featureId}.state.json`);
+  const raw = JSON.parse(await fs.readFile(stateFile, 'utf-8'));
+  raw.phase = 'delegate';
+  if (opts.tasks !== undefined) raw.tasks = opts.tasks;
+  await fs.writeFile(stateFile, JSON.stringify(raw, null, 2), 'utf-8');
+}
+
+/** Count events of a given type in the JSONL store for `featureId`. */
+async function countEvents(
+  store: EventStore,
+  type: string,
+  filter?: (e: WorkflowEvent) => boolean,
+): Promise<number> {
+  const events = await store.query(featureId, { type: type as never });
+  return filter ? events.filter(filter).length : events.length;
+}
+
+describe('HSMTransitionGuard.fail_closed (C7, closes #1225)', () => {
+  it('workflowSet_phaseUpdateWithFailedGuard_doesNotEmitTransition', async () => {
+    const eventStore = new EventStore(tmpDir);
+    await eventStore.initialize();
+
+    await handleInit({ featureId, workflowType: 'feature' }, tmpDir, eventStore);
+    // Force phase=delegate with an INCOMPLETE task. allTasksComplete must
+    // fail; the composite delegate→review guard must therefore fail.
+    await patchStateForDelegatePhase({
+      tasks: [{ id: 't1', title: 'task one', status: 'in_progress' }],
+    });
+
+    const result = await handleSet(
+      { featureId, phase: 'review' },
+      tmpDir,
+      eventStore,
+    );
+
+    // The set returns ok:false (success:false in ToolResult terms).
+    expect(result.success).toBe(false);
+
+    // Atomicity invariant: ZERO workflow.transition events with to:'review'.
+    // The bug being closed (#1225) shows both events landing ~6s apart.
+    const transitionsToReview = await countEvents(
+      eventStore,
+      'workflow.transition',
+      (e) => (e.data as Record<string, unknown>).to === 'review',
+    );
+    expect(transitionsToReview).toBe(0);
+  });
+
+  it('workflowSet_phaseUpdateWithFailedGuard_emitsGuardFailedOnly', async () => {
+    const eventStore = new EventStore(tmpDir);
+    await eventStore.initialize();
+
+    await handleInit({ featureId, workflowType: 'feature' }, tmpDir, eventStore);
+    await patchStateForDelegatePhase({
+      tasks: [{ id: 't1', title: 'task one', status: 'in_progress' }],
+    });
+
+    const result = await handleSet(
+      { featureId, phase: 'review' },
+      tmpDir,
+      eventStore,
+    );
+    expect(result.success).toBe(false);
+
+    // Atomicity invariant: exactly ONE guard-failed for the attempted target.
+    const guardFailures = await countEvents(
+      eventStore,
+      'workflow.guard-failed',
+      (e) => (e.data as Record<string, unknown>).to === 'review',
+    );
+    expect(guardFailures).toBe(1);
+
+    // And ZERO transitions for the same target.
+    const transitions = await countEvents(
+      eventStore,
+      'workflow.transition',
+      (e) => (e.data as Record<string, unknown>).to === 'review',
+    );
+    expect(transitions).toBe(0);
+  });
+
+  it('workflowSet_nonPhaseUpdates_passThroughUnchanged', async () => {
+    const eventStore = new EventStore(tmpDir);
+    await eventStore.initialize();
+
+    await handleInit({ featureId, workflowType: 'feature' }, tmpDir, eventStore);
+
+    // Pin: a field-only update (no `phase` key) does NOT invoke guard logic
+    // and does NOT emit transition or guard-failed events. Prevents
+    // regression where the phase-routing wrapper fires for any update.
+    const result = await handleSet(
+      { featureId, updates: { 'artifacts.design': 'docs/design.md' } },
+      tmpDir,
+      eventStore,
+    );
+
+    expect(result.success).toBe(true);
+
+    const transitions = await countEvents(eventStore, 'workflow.transition');
+    expect(transitions).toBe(0);
+    const guardFailures = await countEvents(eventStore, 'workflow.guard-failed');
+    expect(guardFailures).toBe(0);
+  });
+
+  it('workflowSet_phaseUpdateWithPassingGuard_emitsSingleTransition', async () => {
+    const eventStore = new EventStore(tmpDir);
+    await eventStore.initialize();
+
+    await handleInit({ featureId, workflowType: 'feature' }, tmpDir, eventStore);
+    // Empty tasks ⇒ allTasksComplete passes (vacuously). No team.spawned in
+    // event log ⇒ teamDisbandedEmitted passes. The composite guard
+    // therefore returns true, so delegate → review transitions cleanly.
+    await patchStateForDelegatePhase({ tasks: [] });
+
+    const result = await handleSet(
+      { featureId, phase: 'review' },
+      tmpDir,
+      eventStore,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase).toBe('review');
+
+    // Exactly one workflow.transition for to:'review'.
+    const transitions = await countEvents(
+      eventStore,
+      'workflow.transition',
+      (e) => (e.data as Record<string, unknown>).to === 'review',
+    );
+    expect(transitions).toBe(1);
+
+    // Zero guard-failed events for the same target.
+    const guardFailures = await countEvents(
+      eventStore,
+      'workflow.guard-failed',
+      (e) => (e.data as Record<string, unknown>).to === 'review',
+    );
+    expect(guardFailures).toBe(0);
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/hsm-transition-guard.ts
+++ b/servers/exarchos-mcp/src/workflow/hsm-transition-guard.ts
@@ -159,10 +159,14 @@ function resolveHSM(
  *      success, emit ONLY `workflow.transition` (plus any compound
  *      entry/exit / fix-cycle siblings produced by the HSM walk).
  *
- * Atomicity invariant: at most one of `workflow.transition` /
- * `workflow.guard-failed` is appended per (featureId, targetPhase,
- * attempt) tuple. The idempotency key on the event store dedups CAS
- * retries from the orchestrator.
+ * Atomicity guarantees:
+ *   - Binary outcome atomicity: at most one of `workflow.transition` /
+ *     `workflow.guard-failed` is appended per attempt outcome. The
+ *     idempotency key on the event store dedups CAS retries.
+ *   - Compound entry/exit events in the success path are NOT all-or-none:
+ *     they are sequenced through `EventStore.append` independently, so a
+ *     mid-loop throw can leave a partial trail. Stronger atomicity
+ *     arrives in #1259's substrate refactor.
  */
 export class DefaultHSMTransitionGuard implements HSMTransitionGuard {
   async attempt(

--- a/servers/exarchos-mcp/src/workflow/hsm-transition-guard.ts
+++ b/servers/exarchos-mcp/src/workflow/hsm-transition-guard.ts
@@ -372,7 +372,17 @@ export class DefaultHSMTransitionGuard implements HSMTransitionGuard {
           },
           idempotencyKey ? { idempotencyKey } : undefined,
         );
-        if (evt.type === 'transition') {
+        // The state machine emits one primary lifecycle event per attempt:
+        // 'transition' for normal phase moves, 'cancel' for user-cancel,
+        // 'cleanup' for the universal mergeVerified→completed transition
+        // (state-machine.ts:532, :578, :752). Capture the sequence on any of
+        // these so the caller's _eventSequence projection cursor advances on
+        // cancel/cleanup paths too.
+        if (
+          evt.type === 'transition' ||
+          evt.type === 'cancel' ||
+          evt.type === 'cleanup'
+        ) {
           transitionSequence = appended.sequence;
         }
       }

--- a/servers/exarchos-mcp/src/workflow/hsm-transition-guard.ts
+++ b/servers/exarchos-mcp/src/workflow/hsm-transition-guard.ts
@@ -1,0 +1,440 @@
+// ─── HSMTransitionGuard.fail_closed (Primitive 3 — closes #1225) ─────────
+//
+// Single decision point for guarded HSM phase transitions. `workflow.set`
+// in `tools.ts` delegates every `phase` update through `attempt`, which
+// evaluates the composite guard and either appends `workflow.transition`
+// (on guard pass) OR `workflow.guard-failed` (on guard fail) — never both
+// for the same target in the same attempt. Non-phase updates remain on
+// the existing `handleSet` field-only path; this primitive owns the
+// dispatch contract for phase transitions only.
+//
+// Guard composition logic itself lives in `workflow/guards.ts`; this
+// primitive reuses it via `executeTransition` rather than re-implementing
+// it. The contract under #1259 is a strict-mode flag — once that lands,
+// strict mode is the only mode and `workflow.set({ phase })` is removed.
+// Until then, the routing here is the strict mode.
+
+import type { EventStore } from '../event-store/store.js';
+import type { GuardFailure } from './guards.js';
+import {
+  executeTransition,
+  getHSMDefinition,
+  findTransition,
+  getValidTransitions,
+} from './state-machine.js';
+import type { HSMDefinition, ValidTransitionTarget } from './state-machine.js';
+import { applyPhaseSkips } from './phase-skip.js';
+import { mapInternalToExternalType } from './events.js';
+import { getRegisteredGuard } from '../config/register.js';
+import { executeGuard } from '../config/guards.js';
+
+// ─── Public types ────────────────────────────────────────────────────────
+
+/** Event payload appended on a successful attempt. */
+export interface WorkflowTransitionEvent {
+  readonly type: 'workflow.transition';
+  readonly from: string;
+  readonly to: string;
+  readonly trigger: string;
+  readonly featureId: string;
+  /** Sequence number assigned by the event store on append. */
+  readonly sequence: number;
+}
+
+/**
+ * Caller-supplied context for a transition attempt. Holds everything the
+ * primitive needs to evaluate and emit, with no upward dependencies on
+ * `tools.ts` or the orchestrator.
+ */
+export interface GuardContext {
+  /** Live state object — guards read this directly. */
+  readonly state: Record<string, unknown>;
+  /** Workflow type used to look up the HSM definition. */
+  readonly workflowType: string;
+  /** Optional phase-skip overrides applied before transition lookup. */
+  readonly skipPhases?: readonly string[];
+  /** Idempotency key suffix to deduplicate retried event appends. */
+  readonly idempotencyKeySuffix?: string;
+  /**
+   * Event store the primitive writes to. Pure-evaluation callers can pass
+   * `null` to skip emission and only learn the would-be outcome — useful
+   * for the v3 substrate (#1259) where evaluation and emission split.
+   */
+  readonly eventStore: EventStore | null;
+}
+
+export type TransitionResult =
+  | {
+      readonly ok: true;
+      readonly transitionEvent: WorkflowTransitionEvent;
+      /**
+       * Whether this attempt was a no-op because the workflow was already
+       * in `targetPhase`. The HSM treats this as a successful transition
+       * (idempotent), but no events are emitted and no state mutation
+       * is required.
+       */
+      readonly idempotent: boolean;
+      /** Resolved phase after the transition (may equal currentPhase on idempotent). */
+      readonly newPhase: string;
+      /**
+       * History updates the HSM walk produced (compound exit recording).
+       * Caller merges these into `state._history` after a successful CAS
+       * write. Empty on idempotent attempts.
+       */
+      readonly historyUpdates: Readonly<Record<string, string>>;
+      /**
+       * The full set of internal events emitted (including compound
+       * entry/exit and fix-cycle events). Surfaced so the caller can
+       * report structured `next_actions` without re-querying the store.
+       */
+      readonly emittedEvents: ReadonlyArray<{
+        readonly type: string;
+        readonly from: string;
+        readonly to: string;
+        readonly trigger: string;
+        readonly metadata?: Record<string, unknown>;
+      }>;
+    }
+  | {
+      readonly ok: false;
+      readonly reason: 'guard-failed';
+      readonly failures: readonly GuardFailure[];
+      /**
+       * The guard id that failed (composite or atomic). Useful for
+       * structured surfacing into MCP error responses.
+       */
+      readonly guardId: string;
+      /** Stable error code used by `tools.ts` to surface failures over MCP. */
+      readonly errorCode: 'GUARD_FAILED' | 'CIRCUIT_OPEN';
+      /** Human-readable error message. */
+      readonly errorMessage: string;
+    }
+  | {
+      readonly ok: false;
+      readonly reason: 'no-transition-defined';
+      /**
+       * Valid targets from `currentPhase`, enriched with the guard
+       * metadata callers need to surface as MCP error context. Mirrors
+       * `executeTransition`'s contract so `tools.ts` can pass the value
+       * straight through.
+       */
+      readonly validTargets: readonly ValidTransitionTarget[];
+      /** Stable error code used by `tools.ts`. */
+      readonly errorCode: 'INVALID_TRANSITION';
+      readonly errorMessage: string;
+    };
+
+export interface HSMTransitionGuard {
+  attempt(
+    featureId: string,
+    currentPhase: string,
+    targetPhase: string,
+    context: GuardContext,
+  ): Promise<TransitionResult>;
+}
+
+// ─── Implementation ──────────────────────────────────────────────────────
+
+function resolveHSM(
+  workflowType: string,
+  skipPhases?: readonly string[],
+): HSMDefinition {
+  const base = getHSMDefinition(workflowType);
+  if (!skipPhases || skipPhases.length === 0) return base;
+  return applyPhaseSkips(base, skipPhases);
+}
+
+/**
+ * Default `HSMTransitionGuard` implementation. Owns the entire dispatch
+ * contract for guarded phase transitions:
+ *
+ *   1. Look up the transition definition (may be undefined for invalid
+ *      target phases — returns `no-transition-defined`).
+ *   2. Run any registered async/custom guards before the synchronous
+ *      `executeTransition` call. A failure here emits
+ *      `workflow.guard-failed` and returns `guard-failed` — the
+ *      transition event is NEVER appended.
+ *   3. Run `executeTransition` for the synchronous guard composition
+ *      path. On guard fail, emit ONLY `workflow.guard-failed`. On
+ *      success, emit ONLY `workflow.transition` (plus any compound
+ *      entry/exit / fix-cycle siblings produced by the HSM walk).
+ *
+ * Atomicity invariant: at most one of `workflow.transition` /
+ * `workflow.guard-failed` is appended per (featureId, targetPhase,
+ * attempt) tuple. The idempotency key on the event store dedups CAS
+ * retries from the orchestrator.
+ */
+export class DefaultHSMTransitionGuard implements HSMTransitionGuard {
+  async attempt(
+    featureId: string,
+    currentPhase: string,
+    targetPhase: string,
+    context: GuardContext,
+  ): Promise<TransitionResult> {
+    const hsm = resolveHSM(context.workflowType, context.skipPhases);
+
+    // ─── Idempotency check ────────────────────────────────────────────
+    // A no-op self-transition is a valid success case — no events, no
+    // state mutation. Mirrors `executeTransition`'s behavior so callers
+    // see a stable contract regardless of whether they reach the HSM
+    // walk or short-circuit here.
+    if (currentPhase === targetPhase) {
+      return {
+        ok: true,
+        idempotent: true,
+        newPhase: currentPhase,
+        historyUpdates: {},
+        emittedEvents: [],
+        transitionEvent: {
+          type: 'workflow.transition',
+          from: currentPhase,
+          to: currentPhase,
+          trigger: 'execute-transition',
+          featureId,
+          sequence: -1,
+        },
+      };
+    }
+
+    // ─── Step 1: Lookup transition ────────────────────────────────────
+    const transition = findTransition(hsm, currentPhase, targetPhase);
+    if (!transition) {
+      // No definition for this target. The HSM is the source of truth on
+      // valid edges — surface `no-transition-defined` so the caller can
+      // surface a structured error. We do NOT emit any event here: this
+      // is a programming error, not a guard failure, and emitting a
+      // guard-failed for a non-existent edge would corrupt projections.
+      // Enriched targets (phase + guard metadata) come from
+      // `getValidTransitions` so callers can render actionable MCP
+      // error responses.
+      return {
+        ok: false,
+        reason: 'no-transition-defined',
+        validTargets: getValidTransitions(hsm, currentPhase),
+        errorCode: 'INVALID_TRANSITION',
+        errorMessage: `No transition from '${currentPhase}' to '${targetPhase}'`,
+      };
+    }
+
+    // ─── Step 2: Custom (async) guard pre-check ───────────────────────
+    // Built-in guards remain inline in `executeTransition`. Custom guards
+    // are async (shell-out) and registered via the project config; if
+    // present, they must pass before the HSM walk runs. A failed custom
+    // guard emits `workflow.guard-failed` and returns immediately.
+    if (transition.guard) {
+      const registeredGuard = getRegisteredGuard(
+        `${context.workflowType}:${transition.guard.id}`,
+      );
+      if (registeredGuard) {
+        const customResult = await executeGuard(registeredGuard);
+        if (!customResult.passed) {
+          await emitGuardFailed(
+            featureId,
+            currentPhase,
+            targetPhase,
+            transition.guard.id,
+            context,
+          );
+          const message = `Custom guard '${transition.guard.id}' failed: ${customResult.error ?? 'command exited non-zero'}`;
+          return {
+            ok: false,
+            reason: 'guard-failed',
+            failures: [
+              {
+                passed: false,
+                reason:
+                  customResult.error ??
+                  `Custom guard '${transition.guard.id}' failed`,
+              },
+            ],
+            guardId: transition.guard.id,
+            errorCode: 'GUARD_FAILED',
+            errorMessage: message,
+          };
+        }
+      } else if (transition.guard.custom) {
+        // Fail-closed: a config-declared custom guard with no registry
+        // entry is an unsatisfiable dependency. Treat it as a guard
+        // failure (DIM-2 — explicit rejection, no silent drop). Note
+        // we do NOT emit `workflow.guard-failed` here — this is a
+        // configuration error, not a runtime guard failure, and
+        // matches the pre-refactor `handleSet` behavior at #1225's
+        // closure point.
+        return {
+          ok: false,
+          reason: 'guard-failed',
+          failures: [
+            {
+              passed: false,
+              reason: `Custom guard '${transition.guard.id}' is not registered`,
+            },
+          ],
+          guardId: transition.guard.id,
+          errorCode: 'GUARD_FAILED',
+          errorMessage: `Custom guard '${transition.guard.id}' is not registered. Ensure registerCustomWorkflows() was called.`,
+        };
+      }
+    }
+
+    // ─── Step 3: Synchronous HSM walk (composite guard) ───────────────
+    const result = executeTransition(hsm, context.state, targetPhase);
+
+    if (!result.success) {
+      // Emit any diagnostic events `executeTransition` produced
+      // (typically a single `guard-failed`, possibly `circuit-open`).
+      // We deliberately do NOT also append a `workflow.transition` —
+      // this is the atomicity invariant the primitive enforces.
+      if (context.eventStore) {
+        for (const evt of result.events) {
+          await context.eventStore.append(featureId, {
+            type: mapInternalToExternalType(evt.type) as import(
+              '../event-store/schemas.js'
+            ).EventType,
+            correlationId: featureId,
+            source: 'workflow',
+            data: {
+              from: evt.from,
+              to: evt.to,
+              trigger: evt.trigger,
+              featureId,
+              ...(evt.metadata ?? {}),
+              // Mirror the existing event-store contract: guard-failed
+              // events carry the offending guard id under `guard`.
+              ...(evt.type === 'guard-failed' && transition.guard
+                ? { guard: transition.guard.id }
+                : {}),
+            },
+          });
+        }
+      }
+
+      const guardFailures: GuardFailure[] = [
+        {
+          passed: false,
+          reason: result.errorMessage ?? 'guard failed',
+          ...(result.guardExpectedShape
+            ? { expectedShape: result.guardExpectedShape }
+            : {}),
+          ...(result.guardSuggestedFix
+            ? { suggestedFix: result.guardSuggestedFix }
+            : {}),
+        },
+      ];
+
+      // CIRCUIT_OPEN comes back as `errorCode === 'CIRCUIT_OPEN'` — we
+      // surface it under the same `guard-failed` reason because from
+      // the dispatcher's perspective it's still "transition not
+      // permitted". Callers that need the distinction read the inner
+      // failure metadata or `errorCode`.
+      const errorCode = result.errorCode === 'CIRCUIT_OPEN' ? 'CIRCUIT_OPEN' : 'GUARD_FAILED';
+      return {
+        ok: false,
+        reason: 'guard-failed',
+        failures: guardFailures,
+        guardId: transition.guard?.id ?? 'unknown',
+        errorCode,
+        errorMessage:
+          result.errorMessage ?? `Transition failed to '${targetPhase}'`,
+      };
+    }
+
+    // ─── Step 4: Success path — emit transition (+ siblings) ──────────
+    // executeTransition returns one or more events on success: the
+    // primary `transition` plus optional compound-entry/-exit and
+    // fix-cycle events from the HSM walk. All of them belong to this
+    // single attempt; the atomicity invariant is per-attempt, not
+    // per-event-type.
+    let transitionSequence = -1;
+    if (context.eventStore) {
+      for (const evt of result.events) {
+        const idempotencyKey = context.idempotencyKeySuffix
+          ? `${featureId}:${evt.type}:${evt.from}:${evt.to}:${context.idempotencyKeySuffix}`
+          : undefined;
+        const appended = await context.eventStore.append(
+          featureId,
+          {
+            type: mapInternalToExternalType(evt.type) as import(
+              '../event-store/schemas.js'
+            ).EventType,
+            correlationId: featureId,
+            source: 'workflow',
+            data: {
+              from: evt.from,
+              to: evt.to,
+              trigger: evt.trigger,
+              featureId,
+              ...(evt.metadata ?? {}),
+            },
+          },
+          idempotencyKey ? { idempotencyKey } : undefined,
+        );
+        if (evt.type === 'transition') {
+          transitionSequence = appended.sequence;
+        }
+      }
+    }
+
+    return {
+      ok: true,
+      idempotent: result.idempotent === true,
+      newPhase: result.newPhase ?? targetPhase,
+      historyUpdates: { ...(result.historyUpdates ?? {}) },
+      emittedEvents: result.events.map((e) => ({
+        type: e.type,
+        from: e.from,
+        to: e.to,
+        trigger: e.trigger,
+        ...(e.metadata !== undefined ? { metadata: e.metadata } : {}),
+      })),
+      transitionEvent: {
+        type: 'workflow.transition',
+        from: currentPhase,
+        to: result.newPhase ?? targetPhase,
+        trigger: 'execute-transition',
+        featureId,
+        sequence: transitionSequence,
+      },
+    };
+  }
+}
+
+/**
+ * Emit a single `workflow.guard-failed` event. Best-effort: a failure to
+ * persist the diagnostic must not mask the underlying guard failure
+ * surfaced to the caller. The caller still returns `ok: false`.
+ */
+async function emitGuardFailed(
+  featureId: string,
+  fromPhase: string,
+  targetPhase: string,
+  guardId: string,
+  context: GuardContext,
+): Promise<void> {
+  if (!context.eventStore) return;
+  try {
+    await context.eventStore.append(featureId, {
+      type: 'workflow.guard-failed',
+      correlationId: featureId,
+      source: 'workflow',
+      data: {
+        from: fromPhase,
+        to: targetPhase,
+        guard: guardId,
+        featureId,
+      },
+    });
+  } catch {
+    // Diagnostic emission is best-effort. The structured failure in the
+    // returned `TransitionResult` is the source of truth for the caller.
+  }
+}
+
+// ─── Module-level singleton ──────────────────────────────────────────────
+//
+// One instance per process — the primitive is stateless beyond its
+// dependencies, which arrive via `GuardContext`. Co-located with the
+// implementation so callers don't have to manage construction. Tests
+// can construct fresh `DefaultHSMTransitionGuard` instances if they
+// need isolation.
+
+export const hsmTransitionGuard: HSMTransitionGuard = new DefaultHSMTransitionGuard();

--- a/servers/exarchos-mcp/src/workflow/tools.test.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.test.ts
@@ -256,3 +256,144 @@ describe('WorkflowTool_RegistersRehydrateAction (T033, DR-5)', () => {
     expect(parsed.success).toBe(true);
   });
 });
+
+// ─── C3 (#1241): handleCheckpoint payload-digest idempotencyKey ─────────────
+//
+// `handleCheckpoint` previously built its idempotencyKey from
+// `${featureId}:checkpoint:${phase}:${state._version}`. Because
+// `handleCheckpoint` does NOT bump `state._version`, a second checkpoint
+// within the same phase (no version-bumping action between calls)
+// collided on this key. Combined with #1228's phantom-claim path (closed
+// by C2 at the handler boundary), the second call returned `success:
+// true` while the event was silently dropped.
+//
+// Fix: include a sha256 prefix of the handoff payload in the key.
+// `JSON.stringify(undefined ?? {}) === '{}'` is stable, so no-handoff
+// callers continue to dedup as before. Refinement callers passing
+// distinct handoff payloads now produce distinct events.
+//
+// (The `handoff` field is not yet in `CheckpointInputSchema` — that's
+// #1240. We cast through `any` here so the digest path is exercised
+// even with the current schema; behavior for today's callers is
+// unchanged because none populate `handoff`.)
+
+describe('HandleCheckpoint_PayloadDigestIdempotencyKey (C3, closes #1241)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    // Un-mock `./tools.js` so this suite hits real `handleInit` and
+    // `handleCheckpoint`; the file-level mock above stubs them for
+    // envelope-conformance assertions only.
+    vi.doUnmock('./tools.js');
+    vi.resetModules();
+
+    tempDir = await mkdtemp(path.join(tmpdir(), 'checkpoint-idem-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('handleCheckpoint_refinementInSamePhase_landsTwoEvents', async () => {
+    // GIVEN: a feature initialized in `ideate` with `_version=1` and no
+    // intervening phase transition between two checkpoint calls (so
+    // `state._version` is identical on both calls — the prior key shape
+    // collided on this).
+    const { handleInit, handleCheckpoint } = await import('./tools.js');
+    const store = new EventStore(tempDir);
+    const featureId = 'wf-c3-refinement';
+
+    const init = await handleInit(
+      { featureId, workflowType: 'feature' },
+      tempDir,
+      store,
+    );
+    expect(init.success).toBe(true);
+
+    // WHEN: two `handleCheckpoint` calls land in the same phase with
+    // distinct `handoff` payloads. The schema doesn't formally accept
+    // `handoff` yet (see #1240) — cast through `any` so the digest path
+    // is exercised today.
+    const first = await handleCheckpoint(
+      { featureId, handoff: { context: 'first' } } as unknown as Parameters<typeof handleCheckpoint>[0],
+      tempDir,
+      store,
+    );
+    expect(first.success).toBe(true);
+
+    const second = await handleCheckpoint(
+      { featureId, handoff: { context: 'second' } } as unknown as Parameters<typeof handleCheckpoint>[0],
+      tempDir,
+      store,
+    );
+    expect(second.success).toBe(true);
+
+    // THEN: two `workflow.checkpoint` events are visible AND each
+    // event's `idempotencyKey` carries a distinct sha256-prefix segment
+    // for its `handoff` payload. (Asserting only `length === 2` is too
+    // weak: `writeStateFile` auto-bumps `_version`, so the legacy
+    // version-only key also yielded two events — but for the wrong
+    // reason. The digest segment is the load-bearing fix for #1241,
+    // because production refinement may land at the same `_version`.)
+    const { createHash } = await import('node:crypto');
+    const firstDigest = createHash('sha256')
+      .update(JSON.stringify({ context: 'first' }))
+      .digest('hex')
+      .slice(0, 16);
+    const secondDigest = createHash('sha256')
+      .update(JSON.stringify({ context: 'second' }))
+      .digest('hex')
+      .slice(0, 16);
+
+    const events = await store.query(featureId, { type: 'workflow.checkpoint' });
+    expect(events.length).toBe(2);
+    const keys = events.map((e) => (e as unknown as { idempotencyKey?: string }).idempotencyKey ?? '');
+    expect(keys[0].endsWith(`:${firstDigest}`)).toBe(true);
+    expect(keys[1].endsWith(`:${secondDigest}`)).toBe(true);
+    expect(keys[0]).not.toBe(keys[1]);
+  });
+
+  it('handleCheckpoint_noHandoffPayload_legacyKeyShapeStable', async () => {
+    // GIVEN: a feature initialized in `ideate`, then a single no-handoff
+    // checkpoint. Backwards compat: callers passing no `handoff` must
+    // produce a key whose digest segment matches `sha256('{}').slice(0, 16)`
+    // (since `JSON.stringify(undefined ?? {}) === '{}'`). This pins the
+    // digest segment so historical replay (events written before #1240
+    // wires `handoff`) remains dedup-stable across versions of the
+    // codebase: the same call shape always produces the same key.
+    const { createHash } = await import('node:crypto');
+    const { handleInit, handleCheckpoint } = await import('./tools.js');
+    const store = new EventStore(tempDir);
+    const featureId = 'wf-c3-no-handoff';
+
+    const init = await handleInit(
+      { featureId, workflowType: 'feature' },
+      tempDir,
+      store,
+    );
+    expect(init.success).toBe(true);
+
+    // WHEN: a `handleCheckpoint` call lands with no handoff payload.
+    const result = await handleCheckpoint(
+      { featureId },
+      tempDir,
+      store,
+    );
+    expect(result.success).toBe(true);
+
+    // THEN: the persisted `workflow.checkpoint` event's `idempotencyKey`
+    // ends with the deterministic digest of `{}` — the digest is stable
+    // across calls, so a *second* no-handoff checkpoint at the same
+    // version would collide on this exact key (legacy dedup preserved).
+    const expectedDigest = createHash('sha256')
+      .update(JSON.stringify({}))
+      .digest('hex')
+      .slice(0, 16);
+
+    const events = await store.query(featureId, { type: 'workflow.checkpoint' });
+    expect(events.length).toBe(1);
+    const persisted = events[0] as unknown as { idempotencyKey?: string };
+    expect(persisted.idempotencyKey).toBeTypeOf('string');
+    expect(persisted.idempotencyKey?.endsWith(`:${expectedDigest}`)).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -29,12 +29,9 @@ import {
   shouldEnforceCheckpoint,
   type CheckpointEnforcementConfig,
 } from './checkpoint.js';
-import { mapInternalToExternalType } from './events.js';
 import { workflowLogger } from '../logger.js';
-import { getHSMDefinition, executeTransition, findTransition, isBuiltInWorkflowType } from './state-machine.js';
-import { applyPhaseSkips } from './phase-skip.js';
-import { getRegisteredGuard } from '../config/register.js';
-import { executeGuard } from '../config/guards.js';
+import { getHSMDefinition, isBuiltInWorkflowType } from './state-machine.js';
+import { hsmTransitionGuard } from './hsm-transition-guard.js';
 import { getPlaybook } from './playbooks.js';
 import { getRequiredReviews } from './review-contract.js';
 import { formatResult, type ToolResult } from '../format.js';
@@ -395,50 +392,6 @@ function projectState(
   };
 }
 
-// ─── Event Emission Helper ──────────────────────────────────────────────────
-
-interface TransitionEventRecord {
-  readonly type: string;
-  readonly from: string;
-  readonly to: string;
-  readonly trigger: string;
-  readonly metadata?: Record<string, unknown>;
-}
-
-/**
- * Emit transition events to the external JSONL event store.
- * Used by both the success path (after CAS write) and the failure path
- * (diagnostic events like guard-failed, circuit-open).
- *
- * @returns Error message string on failure, undefined on success or when no events to emit.
- */
-async function emitTransitionEvents(
-  featureId: string,
-  events: readonly TransitionEventRecord[],
-  eventStore: EventStore | null,
-): Promise<string | undefined> {
-  if (!eventStore || events.length === 0) return undefined;
-  try {
-    for (const evt of events) {
-      await eventStore.append(featureId, {
-        type: mapInternalToExternalType(evt.type) as import('../event-store/schemas.js').EventType,
-        correlationId: featureId,
-        source: 'workflow',
-        data: {
-          from: evt.from,
-          to: evt.to,
-          trigger: evt.trigger,
-          featureId,
-          ...(evt.metadata ?? {}),
-        },
-      });
-    }
-    return undefined;
-  } catch (err) {
-    return err instanceof Error ? err.message : String(err);
-  }
-}
-
 // ─── handleSet ──────────────────────────────────────────────────────────────
 
 const MAX_CAS_RETRIES = 3;
@@ -619,146 +572,44 @@ export async function handleSet(
       );
     }
 
-    // ─── Phase transition (guards evaluate against updated state) ──────
-    // Collect transition events for event-first emission before CAS write
-    let pendingTransitionEvents: TransitionEventRecord[] = [];
+    // ─── Phase transition — routed through HSMTransitionGuard ──────────
+    // The dispatch contract for guarded phase transitions is owned by the
+    // `HSMTransitionGuard` primitive (see `hsm-transition-guard.ts` /
+    // Primitive 3 in `docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md`).
+    // It evaluates the composite guard, emits exactly one of
+    // `workflow.transition` or `workflow.guard-failed` per attempt, and
+    // returns a structured result. `handleSet` is now responsible only
+    // for state mutation on success and CAS persistence — guard evaluation
+    // and event emission live behind the primitive's interface.
+    //
+    // `pendingTransitionEventsCount` and `transitionTopSequence` are kept
+    // so the post-transition path can update `_eventSequence` and surface
+    // `sidecarPending` without re-querying the event store.
+    let pendingTransitionEventsCount = 0;
+    let transitionTopSequence: number | undefined;
 
     if (input.phase) {
-      let hsm = getHSMDefinition(state.workflowType);
-
-      // Apply phase skips from project config if configured
-      if (options?.skipPhases && options.skipPhases.length > 0) {
-        hsm = applyPhaseSkips(hsm, options.skipPhases);
-      }
-
-      // ─── Custom guard pre-check (async) ──────────────────────────────
-      // Custom guards run shell commands (async) so they execute here at
-      // the orchestrator layer, before the synchronous HSM transition.
-      // Built-in guards remain inline in executeTransition.
       const fromPhase = state.phase;
-      const pendingTransition = findTransition(hsm, fromPhase, input.phase);
-      if (pendingTransition?.guard) {
-        const registeredGuard = getRegisteredGuard(
-          `${state.workflowType}:${pendingTransition.guard.id}`,
-        );
-        if (registeredGuard) {
-          const guardResult = await executeGuard(registeredGuard);
-          if (!guardResult.passed) {
-            if (eventStore) {
-              await emitTransitionEvents(input.featureId, [{
-                type: 'guard-failed',
-                from: fromPhase,
-                to: input.phase,
-                trigger: 'execute-transition',
-                metadata: {
-                  guard: pendingTransition.guard.id,
-                  error: guardResult.error,
-                },
-              }], eventStore);
-            }
-            return {
-              success: false,
-              error: {
-                code: ErrorCode.GUARD_FAILED,
-                message: `Custom guard '${pendingTransition.guard.id}' failed: ${guardResult.error ?? 'command exited non-zero'}`,
-                ...(guardResult.output ? { output: guardResult.output } : {}),
-              },
-            };
-          }
-        } else if (pendingTransition.guard.custom) {
-          // Fail closed: custom guard not found in registry — only applies to
-          // guards explicitly defined in custom workflow configs (guard.custom
-          // flag), not inherited built-in guards from extended parent HSMs.
-          return {
-            success: false,
-            error: {
-              code: ErrorCode.GUARD_FAILED,
-              message: `Custom guard '${pendingTransition.guard.id}' is not registered. Ensure registerCustomWorkflows() was called.`,
-            },
-          };
-        }
-      }
-
-      const result = executeTransition(hsm, mutableState, input.phase);
-
-      if (!result.success) {
-        // Emit diagnostic events (guard-failed, circuit-open) before returning error.
-        // These are emitted BEFORE state write since no state change occurs on failure.
-        await emitTransitionEvents(input.featureId, result.events, eventStore);
-
-        const errorCode = result.errorCode ?? ErrorCode.INVALID_TRANSITION;
-        return {
-          success: false,
-          error: {
-            code: errorCode,
-            message: result.errorMessage ?? `Transition failed to '${input.phase}'`,
-            ...(result.validTargets?.length ? { validTargets: result.validTargets } : {}),
-            ...(result.guardExpectedShape ? { expectedShape: result.guardExpectedShape } : {}),
-            ...(result.guardSuggestedFix ? { suggestedFix: result.guardSuggestedFix } : {}),
-          },
-        };
-      }
-
-      if (!result.idempotent && result.newPhase) {
-        // Collect transition events for event-first emission
-        pendingTransitionEvents = result.events.map((e) => ({
-          type: e.type,
-          from: e.from,
-          to: e.to,
-          trigger: e.trigger,
-          metadata: e.metadata,
-        }));
-
-        // Mutate state
-        mutableState.phase = result.newPhase;
-
-        // Apply history updates
-        if (result.historyUpdates) {
-          const history = { ...(mutableState._history as Record<string, string>) };
-          for (const [key, value] of Object.entries(result.historyUpdates)) {
-            history[key] = value;
-          }
-          mutableState._history = history;
-        }
-
-        // Reset checkpoint counter on phase transition
-        mutableState._checkpoint = resetCounter(
-          mutableState._checkpoint as WorkflowState['_checkpoint'],
-          result.newPhase,
-        );
-      }
-
-      // Clean up transient guard-evaluation field — not persisted to state
-      delete mutableState._requiredReviews;
-    }
-
-    // ─── Event-first: append transition events BEFORE CAS write ───────
-    // Idempotency keys prevent duplicate events on CAS retry.
-    let highestEventSequence: number | undefined;
-
-    if (eventStore && pendingTransitionEvents.length > 0) {
+      let attemptResult;
       try {
-        for (const transitionEvent of pendingTransitionEvents) {
-          const idempotencyKey = `${input.featureId}:${transitionEvent.type}:${transitionEvent.from}:${transitionEvent.to}:${expectedVersion}`;
-          const event = await eventStore.append(input.featureId, {
-            type: mapInternalToExternalType(transitionEvent.type) as import('../event-store/schemas.js').EventType,
-            correlationId: input.featureId,
-            source: 'workflow',
-            data: {
-              from: transitionEvent.from,
-              to: transitionEvent.to,
-              trigger: transitionEvent.trigger,
-              featureId: input.featureId,
-              ...(transitionEvent.metadata ?? {}),
-            },
-          }, { idempotencyKey });
-
-          if (highestEventSequence === undefined || event.sequence > highestEventSequence) {
-            highestEventSequence = event.sequence;
-          }
-        }
+        attemptResult = await hsmTransitionGuard.attempt(
+          input.featureId,
+          fromPhase,
+          input.phase,
+          {
+            state: mutableState,
+            workflowType: state.workflowType as string,
+            skipPhases: options?.skipPhases,
+            idempotencyKeySuffix: String(expectedVersion),
+            eventStore,
+          },
+        );
       } catch (err) {
-        // Event-first: if event append fails, do NOT update state
+        // Event-first contract: a thrown error from the primitive
+        // means an event-store append failed (the only synchronous
+        // failure mode on the success path). Surface it as
+        // EVENT_APPEND_FAILED and abort the CAS write — state must
+        // not advance past the unwritten event boundary.
         return {
           success: false,
           error: {
@@ -767,7 +618,78 @@ export async function handleSet(
           },
         };
       }
+
+      if (!attemptResult.ok) {
+        if (attemptResult.reason === 'no-transition-defined') {
+          return {
+            success: false,
+            error: {
+              code: ErrorCode.INVALID_TRANSITION,
+              message: attemptResult.errorMessage,
+              ...(attemptResult.validTargets.length
+                ? { validTargets: attemptResult.validTargets }
+                : {}),
+            },
+          };
+        }
+        // reason === 'guard-failed' (or CIRCUIT_OPEN, mapped to errorCode)
+        const guardFailure = attemptResult.failures[0];
+        const errorPayload: Record<string, unknown> = {
+          code:
+            attemptResult.errorCode === 'CIRCUIT_OPEN'
+              ? ErrorCode.CIRCUIT_OPEN
+              : ErrorCode.GUARD_FAILED,
+          message: attemptResult.errorMessage,
+        };
+        if (guardFailure?.expectedShape) {
+          errorPayload.expectedShape = guardFailure.expectedShape;
+        }
+        if (guardFailure?.suggestedFix) {
+          errorPayload.suggestedFix = guardFailure.suggestedFix;
+        }
+        return {
+          success: false,
+          error: errorPayload as ToolResult['error'],
+        };
+      }
+
+      // ok: true — apply state mutation. Idempotent attempts are no-ops.
+      if (!attemptResult.idempotent) {
+        mutableState.phase = attemptResult.newPhase;
+
+        if (Object.keys(attemptResult.historyUpdates).length > 0) {
+          const history = {
+            ...(mutableState._history as Record<string, string>),
+          };
+          for (const [key, value] of Object.entries(
+            attemptResult.historyUpdates,
+          )) {
+            history[key] = value;
+          }
+          mutableState._history = history;
+        }
+
+        // Reset checkpoint counter on phase transition.
+        mutableState._checkpoint = resetCounter(
+          mutableState._checkpoint as WorkflowState['_checkpoint'],
+          attemptResult.newPhase,
+        );
+
+        pendingTransitionEventsCount = attemptResult.emittedEvents.length;
+        if (attemptResult.transitionEvent.sequence > 0) {
+          transitionTopSequence = attemptResult.transitionEvent.sequence;
+        }
+      }
+
+      // Clean up transient guard-evaluation field — not persisted to state.
+      delete mutableState._requiredReviews;
     }
+
+    // Transition events are now emitted inside `hsmTransitionGuard.attempt`
+    // — see Primitive 3 in `docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md`.
+    // Idempotency keys are derived from `expectedVersion`, so CAS retries
+    // through this loop are still safely deduplicated by the event store.
+    let highestEventSequence: number | undefined = transitionTopSequence;
 
     // ─── Event-first: append state.patched event for v2 field updates ──
     const updateKeys = input.updates ? Object.keys(input.updates) : [];
@@ -917,7 +839,7 @@ export async function handleSet(
     // does not change within a single handleSet invocation.
     const patchEmitted = isEventSourced(state as unknown as Record<string, unknown>)
       && eventStore != null && updateKeys.length > 0;
-    const emittedEvents = pendingTransitionEvents.length > 0 || patchEmitted;
+    const emittedEvents = pendingTransitionEventsCount > 0 || patchEmitted;
     const sidecarPending = emittedEvents && eventStore?.inSidecarMode === true;
 
     return {

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -35,6 +35,7 @@ import { hsmTransitionGuard } from './hsm-transition-guard.js';
 import { getPlaybook } from './playbooks.js';
 import { getRequiredReviews } from './review-contract.js';
 import { formatResult, type ToolResult } from '../format.js';
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import type { EventStore } from '../event-store/store.js';
 import type { ViewMaterializer } from '../views/materializer.js';
@@ -895,7 +896,24 @@ export async function handleCheckpoint(
     input.summary,
   );
 
-  // Emit checkpoint event to external store (event-first, guaranteed)
+  // Emit checkpoint event to external store (event-first, guaranteed).
+  //
+  // C3 (#1241): include a sha256 prefix of the `handoff` payload in the
+  // idempotency key so refinement calls (same featureId+phase+version
+  // but distinct handoff content) land as distinct events. The schema
+  // does not yet declare `handoff` — that wiring is #1240, scheduled to
+  // land after this PR. Reading the field from `input` via a typed
+  // cast keeps the digest path forward-compatible without scope-creep
+  // into the schema. `JSON.stringify(undefined ?? {})` is `'{}'`, so
+  // current callers (which never set `handoff`) get a stable digest
+  // and identical dedup behavior to the prior version-only key.
+  const handoff = (input as { handoff?: unknown }).handoff ?? {};
+  const handoffDigest = createHash('sha256')
+    .update(JSON.stringify(handoff))
+    .digest('hex')
+    .slice(0, 16);
+  const checkpointIdempotencyKey =
+    `${input.featureId}:checkpoint:${state.phase}:${state._version}:${handoffDigest}`;
   if (eventStore) {
     try {
       await eventStore.append(input.featureId, {
@@ -907,7 +925,7 @@ export async function handleCheckpoint(
           phase: state.phase,
           featureId: input.featureId,
         },
-      }, { idempotencyKey: `${input.featureId}:checkpoint:${state.phase}:${state._version}` });
+      }, { idempotencyKey: checkpointIdempotencyKey });
     } catch (err) {
       return {
         success: false,


### PR DESCRIPTION
## Summary

Closes the v2.9.0 milestone bug cluster (8 bugs) via three invariant-bearing primitives + targeted surgical fixes. Single PR per the design's coherent-root-cause-story framing. Interfaces are shaped to be drop-in replaceable in the v2.10.0 substrate refactor (#1259).

**Bugs closed:**
- **#1230** — duplicate per-event sequence numbers (substrate-level fix at `AtomicAppender`)
- **#1228** — `batch_append` silent drops + phantom idempotencyKey (substrate-level fix at `AtomicAppender`; handler-boundary surfacing in `handleEventBatchAppend`)
- **#1241** — checkpoint idempotencyKey lacks payload digest (key-shape fix in `handleCheckpoint`)
- **#1226** — `workflow_status` counter mismatch (projection dedup by taskId)
- **#1224** — subagent `task.completed` not propagated on team disband (primitive `SubagentStreamRouter` + server-side wiring at `handleEventAppend`)
- **#1220** — non-implementer subagents skip worktree isolation (capability declaration on FIXER spec)
- **#1225** — `delegate→review` transition fires after `workflow.guard-failed` (primitive `HSMTransitionGuard.fail_closed` routing in `workflow.set`)
- **#1117** — pruner misses stale workflows (multi-signal staleness: phase-transition timestamp + branch activity)

## Changes

**Three invariant primitives** (interface-shaped for #1259 substrate swap):
- `AtomicAppender` (`event-store/atomic-appender.ts`) — per-stream serialization, commit-on-success idempotency, structured `AppendResult`. Idempotency cache enforces `EXARCHOS_MAX_IDEMPOTENCY_KEYS` (default 200, FIFO eviction) — matches legacy semantics.
- `SubagentStreamRouter` (`agents/subagent-stream-router.ts`) — explicit parent-stream `task.completed` emission with idempotency keyed by `<childStreamId>:<taskId>`; `team.disbanded.tasksCompleted` derived from parent-stream query, not in-memory accumulator. Wired into `handleEventAppend` to intercept `team.disbanded` events server-side.
- `HSMTransitionGuard.fail_closed` (`workflow/hsm-transition-guard.ts`) — single dispatch point for phase transitions; `workflow.set({ phase })` routes through it. Binary atomicity guaranteed (only one of `workflow.transition` / `workflow.guard-failed` per attempt).

**Three surgical fixes** (no primitive needed):
- `workflow_status` projection: task-id-keyed dedup on `tasksCompleted` and `tasksTotal`. Internal `_seen*` arrays stripped from public envelope.
- FIXER spec: `'isolation:worktree'` capability added (SCAFFOLDER and IMPLEMENTER already had it). Generated artifacts (`agents/fixer.md`, `.codex/agents/fixer.toml`, snapshot fixture) updated.
- Pruner: secondary signals `phaseTransitionTimestamp` (from latest `workflow.transition` event) and `branchActivity` (`git log -1 --format=%ct`) added to `selectPruneCandidates`. Composition: `phaseStale AND (lastActivityStale OR branchInactive)`.

**Verification**: 5 replay-determinism scenarios (concurrent appends, refinement checkpoints, duplicate task.completed, failed-then-passed guard, combined) + 2 CLI/MCP parity tests (`workflow_status`, `workflow_checkpoint`).

## Test Plan

- [x] All 9 commit families have RED→GREEN evidence in their test files
- [x] Server suite: 6384 tests pass (24 skipped, intentional benchmarks/perf), 0 failures
- [x] Typecheck: clean (`npm run typecheck`)
- [x] Replay determinism test pins #1109 C1 invariant across all bug-cluster shapes
- [x] CLI/MCP parity tests pin #1109 C2 invariant

## Cross-Cutting (#1109) Verification

- [x] **Event-sourcing integrity (C1):** `AtomicAppender` events emitted; `workflow.transition` / `workflow.guard-failed` exclusive; `task.completed` parent-stream propagation; replay reconstructs identical state (verified by `replay-determinism.test.ts`).
- [x] **MCP parity (C2):** No CLI/MCP branch introduced; `assertParity` tests for `workflow_status` and `workflow_checkpoint` confirm byte-equal envelopes after normalization.
- [x] **Basileus-forward (C3):** No hard-coded MCP-local-only assumption. `SubagentStreamRouter` is the local analog of #1259's namespaced-stream model.
- [x] **Capability resolution:** No yaml-runtime read introduced. Capability declaration is producer-side.

## Honest Scope Notes

This PR is **Approach B** from the design — substrate primitives + surgical fixes — explicitly scoped to be evolvable into Approach C (the v2.10.0 spike #1259). Two scope-bounding decisions made during review:

1. **#1228 / #1230 substrate fix is at the batch-append boundary.** `handleEventBatchAppend` migrates to `AtomicAppender`. `EventStore.append` (used by `handleCheckpoint`, `HSMTransitionGuard`, and other event types) still uses the legacy four-phase path. Wholesale migration is **deferred to #1259** — its substrate refactor (SQLite + WAL) replaces `AtomicAppender` entirely, making mid-PR migration throwaway work. The core append failures (#1228 phantom claim, #1230 sequence collisions) are fixed in `AtomicAppender` itself; non-batch consumers of the legacy path remain at parity with main until #1259.

2. **#1224 closure is a substrate primitive + server-side wiring.** Agent-side skill markdown still emits `team.disbanded` with a manual tally, but the wiring intercepts and recomputes `tasksCompleted` from the parent stream at the `handleEventAppend` boundary. No agent-skill changes were needed.

## B → C Evolution (#1259)

The three primitives are interface-shaped to be drop-in replaceable:

| Primitive | C replacement | Consumer change |
|---|---|---|
| `AtomicAppender` | SQLite + WAL with `PRIMARY KEY (stream_id, sequence)` + `UNIQUE` on idempotencyKey | None — same interface |
| `SubagentStreamRouter` | Thin pass-through over namespaced SQLite reads | Coordinator stops accumulating; queries the store |
| `HSMTransitionGuard.fail_closed` | `workflow.set({ phase })` API removed; only `workflow.transition(target)` remains | Callers migrate from `set({ phase })` to `transition(target)` |

## Known Follow-Up Items (Non-Blocking)

- Function size refactors (4 over 50-line threshold): `handleBatchAppend`, `handlePruneStaleWorkflows`, `HSMTransitionGuard.attempt`, `AtomicAppender.appendLocked` — polish before #1259
- Type-assertion gymnastics in `prune-stale-workflows.ts:825` (`ctx.eventStore as unknown as ...`) and `hsm-transition-guard.ts:290` (inline type-cast)
- Compound-event sequencing in `HSMTransitionGuard` success path: binary atomicity guaranteed; multi-event compound sequences are not all-or-none (clarified in docstring; addressed wholesale by #1259's substrate)

## Pre-existing Test Flakiness (Not Introduced by This PR)

`scripts/build-binary.test.ts > BuildBinary_CompiledBinary_RespondsToVersionFlag` failed locally with `result.status === null` (process timeout > 30s). This file is unmodified by this PR — last touched by `164242d5` (P1 foundation harness, on main). The bun-compile binary build is environment-sensitive; this is pre-existing flakiness orthogonal to the bug cluster.

## Cross-References

- Design: `docs/designs/2026-05-06-v29-bug-cluster-combined-fix.md`
- Plan: `docs/plans/2026-05-06-v29-bug-cluster-combined-fix.md`
- v2.10.0 substrate refactor spike: #1259
- Cross-cutting invariants: #1109
- Codify event-sourcing principles: #1118
- Capability resolver: #1139
- Spike that consumes these fixes: #1239 (handoff enrichment) and follow-ups #1240–#1246

🤖 Generated with [Claude Code](https://claude.com/claude-code)