### PR TITLE
chore(bun): add minimumReleaseAge=7d gate (root + exarchos-mcp)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,5 @@
+[install]
+# Block npm packages published less than 7 days ago to defend against
+# fast-published supply-chain worms. Override with: bun add <pkg> --minimum-release-age 0
+minimumReleaseAge = 604800
+minimumReleaseAgeExcludes = []

--- a/servers/exarchos-mcp/bunfig.toml
+++ b/servers/exarchos-mcp/bunfig.toml
@@ -1,0 +1,5 @@
+[install]
+# Block npm packages published less than 7 days ago to defend against
+# fast-published supply-chain worms. Override with: bun add <pkg> --minimum-release-age 0
+minimumReleaseAge = 604800
+minimumReleaseAgeExcludes = []


### PR DESCRIPTION
## Summary

- Adds `bunfig.toml` at two locations with `minimumReleaseAge = 604800` (7 days):
  - **Repo root** — protects the active bun path (`build:binary`, `codegen:runtimes`, `bun build --compile`)
  - **`servers/exarchos-mcp/`** — symmetry with the existing (stale) `bun.lock` there

## Changes

- New `bunfig.toml` at repo root with `[install] minimumReleaseAge = 604800`
- New `servers/exarchos-mcp/bunfig.toml` mirroring the root gate

## Rationale

Mini Shai-Hulud (CVE-2026-45321) broke on 2026-05-11 and compromised 169+ npm packages. Malicious versions were yanked within hours — a 7-day age gate would have blocked the entire blast radius.

This repo was audited as part of the 2026-05-12 incident response. **Clear** — no compromised package families present in any of the 4 lockfiles (`package-lock.json`, `documentation/package-lock.json`, `servers/exarchos-mcp/bun.lock`, `servers/exarchos-mcp/package-lock.json`). Full audit: [lvlup-sw/docs#1](https://github.com/lvlup-sw/docs/pull/1).

## Where bun is used here — and why the gate is forward-protective

Bun is deeply integrated for runtime/bundling but **not** as the installer:

- `build:binary` runs `bun run scripts/build-binary.ts --all`, which uses `#!/usr/bin/env bun`, Bun's `$\`…\`` API, and `bun build --compile --target=…` to cross-compile the 5 release binaries (each embeds the bun runtime).
- `codegen:runtimes` runs `bun run scripts/codegen-runtimes.ts` (also `#!/usr/bin/env bun`).
- **Install is `npm install`** everywhere; `servers/exarchos-mcp/bun.lock` is stale (last touched 2026-03-31 vs. its sibling `package-lock.json` regenerated 2026-05-12).

`minimumReleaseAge` only activates on `bun install` / `bun add` / `bun remove`, so the gate is dormant today. It's forward-protective for the natural future-state of "exarchos uses bun more, so let's standardize on bun for installs too" — cheap insurance given the bun-shebanged scripts already make bun an obvious tool to reach for.

## When this bites you

1. Verify the version isn't in the most recently published worm wave
2. Then either `bun add <pkg> --minimum-release-age 0` (one-off) or add to `minimumReleaseAgeExcludes` in `bunfig.toml`

## Test Plan

- [ ] `npm run build` still works at the root (bun gate is unrelated to this path; build invokes `bun build --compile`, not `bun install`)
- [ ] CI still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
