### PR TITLE
refactor(2.10.0): remove legacy register*Tools wrappers + formatResult (#1367)

### DIFF
--- a/docs/followups/2026-05-13-pr-a-1367-formatresult-cleanup.md
+++ b/docs/followups/2026-05-13-pr-a-1367-formatresult-cleanup.md
@@ -91,7 +91,7 @@ The cleanup is mechanical but has audit-first phases. **Iron Law: no production 
 |---|---|
 | A4.1 | For each production hit from A1.3 category (c) — migrate the call site to `toMcpResult(toEnvelope(result))` or remove if unreachable. |
 | A4.2 | Update any imports that bring `formatResult` into a test file: either remove the import (if the call site was deleted) or replace with `toEnvelope` (if the test still needs envelope-bound output for assertions). |
-| A4.3 | Verify `grep -rn "formatResult\b" servers/exarchos-mcp/src --include="*.ts" | grep -v "node_modules"` returns zero hits. |
+| A4.3 | Verify `grep -rn "formatResult\b" servers/exarchos-mcp/src --include="*.ts" \| grep -v "node_modules"` returns zero hits. |
 
 ### Phase 5 — Delete formatResult itself
 

--- a/docs/followups/2026-05-13-pr-a-audit.md
+++ b/docs/followups/2026-05-13-pr-a-audit.md
@@ -1,0 +1,266 @@
+# PR-A audit findings — #1367 formatResult + register*Tools cleanup
+
+**Stack position:** PR-A Phase 1 (audit) of the Wave 0 follow-up stack
+**Source brief:** `docs/followups/2026-05-13-pr-a-1367-formatresult-cleanup.md`
+**Audit branch:** `refactor/wave-0-followups/1367-formatresult-cleanup`
+**Audit date:** 2026-05-13
+
+## Summary
+
+The audit confirms the brief's core premise: **zero production callers exist for any of `registerWorkflowTools` / `registerViewTools` / `registerStackTools`.** A1.1 returns three definers and ten test-callers — no prod-caller hits.
+
+However, the audit also surfaces **one significant scope gap**: three additional `register*Tools` functions (`registerTaskTools`, `registerQueryTools`, `registerCancelTool`) — all consuming `formatResult` and all with zero production callers — were not enumerated in the brief. If they are left in place, `grep -rn "formatResult\b" servers/exarchos-mcp/src --include="*.ts" | grep -v ".test.ts"` will return non-zero after Phase 3, blocking the acceptance criterion at line 108 of the brief and leaving `formatResult` itself un-deletable in Phase 5.
+
+The brief's "tests to keep but possibly update" list (lines 50–54) is stale — none of those five files reference `formatResult` anymore (Wave 0 already migrated them). The only test-fixture references to `formatResult` outside the doomed wrappers are in three telemetry benchmark files plus one comment-titled test (`should wrap results with formatResult`).
+
+Counts:
+- A1.1: 3 definers, 0 prod-callers, 10 test-callers (across 3 legacy test files)
+- A1.2: 67 unique `it(...)` tests across the three legacy test files; **63 port-recommended** (test kept handlers), **3 discard** (test wrapper-only behavior, covered by composite tests), **1 incomplete** (one skipped test)
+- A1.3: `formatResult` appears in 14 files (37 line hits); **15 legacy-wrapper hits** (inside the three doomed funcs), **9 test-fixture hits**, **13 other-prod hits** (in three additional `register*Tools` not listed in the brief)
+
+## A1.1 — `register*Tools` call sites
+
+| File | Line | Symbol | Classification | Notes |
+|---|---|---|---|---|
+| `servers/exarchos-mcp/src/workflow/tools.ts` | 1658 | `registerWorkflowTools` | definer | Slated for deletion in Phase 3 |
+| `servers/exarchos-mcp/src/views/tools.ts` | 1154 | `registerViewTools` | definer | Slated for deletion in Phase 3 |
+| `servers/exarchos-mcp/src/stack/tools.ts` | 127 | `registerStackTools` | definer | Slated for deletion in Phase 3 |
+| `servers/exarchos-mcp/src/views/tools.test.ts` | 1171–1240 | `registerViewTools` (3× call sites) | test-caller | Inside `describe('Backend Integration (Task 12)', ...)` — wires server-mock for spy setup, but assertions use `handle*` directly |
+| `servers/exarchos-mcp/src/__tests__/views/tools.test.ts` | 769, 777 | `registerViewTools` | test-caller | Inside `describe('registerViewTools', ...)` — wrapper-shape assertions |
+| `servers/exarchos-mcp/src/__tests__/stack/tools.test.ts` | 9 (import), 461, 473 | `registerStackTools` | test-caller | Inside `describe('registerStackTools', ...)` — wrapper-shape assertions |
+
+**Prod-caller count: 0.** PR-A's premise holds.
+
+## A1.2 — Port-or-discard manifest
+
+The brief lists three legacy test files for deletion. The audit's nuance: most of the `it(...)` tests in these files exercise the **`handle*` functions that are KEPT** (only the registration wrappers are deleted). Deleting these files wholesale would lose unique handler-logic coverage. Recommendation: **relocate (not discard) these to co-located non-wrapper test files** unless the assertion is covered elsewhere.
+
+### `servers/exarchos-mcp/src/views/tools.test.ts` (45 it() tests)
+
+| Line | `it(...)` description | Decision | Rationale |
+|---|---|---|---|
+| 35 | `returns same materializer for same stateDir` | port | Tests `getOrCreateMaterializer` cache in `views/tools.ts`; not covered by `materializer.test.ts` (which tests the class, not the by-stateDir cache map) |
+| 41 | `creates new materializer when stateDir changes` | port | Same — unique cache-by-stateDir behavior |
+| 66 | `handleViewTeamPerformance_WithTeamEvents_ReturnsMaterializedView` | port | Exercises `handleViewTeamPerformance` end-to-end; `composite.test.ts` only mocks the handler |
+| 98 | `handleViewDelegationTimeline_WithTeamEvents_ReturnsTimeline` | port | Same end-to-end shape coverage; composite test is delegation-only |
+| 143 | `HandleViewCodeQuality_ReturnsEmptyState_WhenNoEvents` | port | Handler-level coverage unique to this file |
+| 158 | `HandleViewCodeQuality_WithWorkflowId_FiltersToStream` | port | Same |
+| 203 | `HandleViewCodeQuality_WithSkillFilter_ReturnsOnlyMatchingSkill` | port | Same |
+| 246 | `HandleViewCodeQuality_WithGateFilter_ReturnsOnlyMatchingGate` | port | Same |
+| 289 | `HandleViewCodeQuality_WithRegressions_EmitsQualityRegressionEvents` | port | Unique event-emission side-effect assertion |
+| 326 | `HandleViewCodeQuality_CalledTwice_DoesNotEmitDuplicateRegressions` | port | Unique deduplication invariant |
+| 356 | `HandleViewCodeQuality_WithLimit_LimitsArrays` | port | Pagination behavior |
+| 409 | `handleViewEvalResults_NoEvents_ReturnsEmptyState` | port | Handler-level coverage |
+| 424 | `handleViewEvalResults_WithSkillFilter_FiltersResults` | port | Same |
+| 473 | `handleViewEvalResults_WithLimit_LimitsRunsAndRegressions` | port | Same |
+| 510 | `handleViewProvenance_ReturnsProvenanceState` | port | Handler-level coverage |
+| 538 | `handleViewIdeateReadiness_ReturnsReadinessState` | port | Handler-level coverage |
+| 565 | `HandleViewQualityCorrelation_NoEvents_ReturnsEmptyCorrelation` | port | Handler-level coverage |
+| 576 | `HandleViewQualityCorrelation_WithMatchingEvents_ReturnsCorrelatedData` | port | Same |
+| 691 | `SynthesisReadiness_StateReviewsPassed_NoGateExecutedEvents_ReportsSpecAndQualityPassed` | port | Fix 2 — state-file fallback semantics; not duplicated elsewhere |
+| 721 | `WorkflowStatus_StateTasksLengthFive_OnlyTwoCompletedEvents_ReportsTasksTotalFive` | port | Fix 2 — tasksTotal sourcing from state.json |
+| 768 | `ViewTasks_StateTasksDeclaredButFewEvents_ReturnsAllStateEntries` | port | Fix 2 — full state.tasks list |
+| 815 | `SynthesisReadiness_TestsAndTypecheckNeverRan_ReportsNotMeasuredBlockers` | port | Fix 2 — null vs false semantics |
+| 870 | `Convergence_StateFindingsCoverDimensions_RemovesFromUnchecked` | port | Fix 2 — state.reviews.findingsByDimension fallback |
+| 919 | `handleViewWorkflowStatus_WarmCall_QueriesOnlyDeltaEvents` | port | Delta-query optimization invariant; not in `materializer.test.ts` |
+| 959 | `handleViewTasks_WarmCall_QueriesOnlyDeltaEvents` | port | Same |
+| 991 | `handleViewPipeline_WarmCall_QueriesOnlyDeltaEvents` | port | Same |
+| 1023 | `handleViewTeamPerformance_WarmCall_QueriesOnlyDeltaEvents` | port | Same |
+| 1087 | `handleViewWorkflowStatus_WarmCall_SkipsSnapshotLoad` | port | Snapshot-load skip optimization |
+| 1111 | `handleViewWorkflowStatus_ColdCall_LoadsSnapshot` | port | Cold-path snapshot load |
+| 1154 | `handleViewWorkflowStatus_WithBackend_QueriesSQLite` | port | StorageBackend delegation contract; spy on sqliteBackend.queryEvents |
+| 1187 | `handleViewPipeline_WithBackend_DiscoverStreamsFromBackend` | port | listStreams() abstraction contract |
+| 1222 | `handleViewTasks_WithBackend_QueriesSQLite` | port | Same as 1154 |
+| 1260 | `Pipeline_WithInfraStreams_ExcludesPhantomRows` (#1187) | port | Infra-stream filter regression test; only place this is exercised |
+
+**Subtotal for this file:** 33 port. None discard.
+
+### `servers/exarchos-mcp/src/__tests__/views/tools.test.ts` (34 it() tests)
+
+| Line | `it(...)` description | Decision | Rationale |
+|---|---|---|---|
+| 65 | `should return workflow status view data` | port | Handler shape — kept handler |
+| 79 | `should return empty view for nonexistent workflow` | port | Edge case on kept handler |
+| 88 | `should use default streamId when workflowId is omitted` | port | Default-arg behavior |
+| 101 | `should return VIEW_ERROR when workflowId contains invalid characters` | port | Input validation |
+| 116 | `should return task details for a workflow` | port | Kept handler |
+| 131 | `should filter tasks by status` | port | Filter semantics |
+| 146 | `should return all tasks when filter is empty object` | port | Edge case |
+| 160 | `should return empty array when filter matches nothing` | port | Edge case |
+| 174 | `should use default streamId when workflowId is omitted` | port | Default-arg behavior |
+| 188 | `should return VIEW_ERROR when workflowId contains invalid characters` | port | Input validation |
+| 205 | `handleViewTasks_WithLimit_ReturnsLimitedResults` | port | Pagination |
+| 233 | `handleViewTasks_WithFilter_ReturnsOnlyMatching` | port | Same |
+| 262 | `handleViewTasks_FilterAndLimit_AppliesBoth` | port | Combined filter+limit |
+| 314 | `handleViewTasks_WithOffset_SkipsTasks` | port | Offset |
+| 342 | `handleViewTasks_WithFields_ReturnsOnlyRequestedFields` | port | Field projection |
+| 367 | `handleViewTasks_WithFieldsAndFilter_AppliesBoth` | port | Combined fields+filter |
+| 399 | `handleViewTasks_WithOffsetAndLimit_PaginatesCorrectly` | port | Offset+limit |
+| 429 | `should aggregate pipeline data across workflows` | port | Pipeline aggregation |
+| 457 | `should return empty workflows array when no event streams exist` | port | Edge case |
+| 466 | `handleViewPipeline_WithLimit_ReturnsLimitedWorkflows` | port | Pipeline pagination |
+| 491 | `handleViewPipeline_WithOffset_SkipsWorkflows` | port | Same |
+| 516 | `handleViewPipeline_WithLimitAndOffset_ReturnsSlice` | port | Same |
+| 541 | `handleViewPipeline_NoParams_ReturnsAll` | port | Default-arg behavior |
+| 566 | `handleViewPipeline_WithLimit_OnlyMaterializesSubset` | port | Lazy-materialize optimization |
+| 585 | `handleViewPipeline_WithOffsetAndLimit_ReturnsCorrectSlice` | port | Pagination correctness |
+| 604 | `handleViewPipeline_ReturnsTotal` | port | Total count |
+| 632 | `should return VIEW_ERROR when discovered stream has invalid ID` (`.skip`) | incomplete | Skipped test — preserve skip status when porting; defer decision to author |
+| 647 | `handleViewPipeline_ExcludesTerminalPhases_ByDefault` | port | Filtering invariant |
+| 681 | `handleViewPipeline_IncludesTerminalPhases_WhenRequested` | port | Same |
+| 710 | `ViewMaterializer_Singleton_ReusedAcrossQueries: second call sees updated data via high-water mark` | port | Cache reuse — unique |
+| 737 | `resetMaterializerCache_CreatesNewInstance: after reset, fresh state is used` | port | Cache reset behavior |
+| 757 | `should invalidate materializer cache when stateDir changes` | port | Cache key correctness |
+| 768 | `should accept eventStore parameter in registration` | discard | Tests `registerViewTools.length === 3` and no-throw — wrapper-shape only; covered by Phase 3 deletion (function will not exist) |
+| 776 | `should use the injected EventStore for view materialization` | discard | Tests wrapper wiring; the equivalent assertion lives in `views/composite.test.ts:165` and `views/composite.envelope.test.ts:113` which exercise the composite dispatch path |
+
+**Subtotal for this file:** 31 port, 2 discard, 1 incomplete.
+
+### `servers/exarchos-mcp/src/__tests__/stack/tools.test.ts` (24 it() tests)
+
+| Line | `it(...)` description | Decision | Rationale |
+|---|---|---|---|
+| 30 | `with positions returns stack state` | port | `handleStackStatus` direct |
+| 57 | `without streamId returns empty positions` | port | Edge case |
+| 64 | `with non-existent stream returns empty positions` | port | Edge case |
+| 71 | `filters only stack.position-filled events` | port | Event-type filtering |
+| 98 | `valid position emits stack event` | port | `handleStackPlace` direct |
+| 119 | `with prUrl includes it in event data` | port | Optional-field threading |
+| 139 | `success returns EventAck with only streamId, sequence, type keys` | port | EventAck contract |
+| 152 | `missing streamId returns error` | port | Input validation |
+| 163 | `missing taskId returns error` | port | Input validation |
+| 174 | `status after place reflects new position` | port | Place→status integration |
+| 193 | `multiple places accumulate positions` | port | Aggregation |
+| 220 | `negative position returns INVALID_INPUT` | port | Input validation |
+| 232 | `float position returns INVALID_INPUT` | port | Same |
+| 244 | `NaN position returns INVALID_INPUT` | port | Same |
+| 256 | `without optional branch and prUrl includes only required fields` | port | Required-only path |
+| 272 | `when store.append() throws returns PLACE_FAILED` | port | Error path |
+| 294 | `when store.query() throws returns STATUS_FAILED` | port | Error path |
+| 320 | `with limit returns subset of positions` | port | Pagination |
+| 340 | `with offset and limit skips and returns correct positions` | port | Same |
+| 360 | `without pagination params returns all positions` | port | Default-arg behavior |
+| 377 | `with offset beyond array length returns empty` | port | Edge case |
+| 394 | `with only offset returns remaining positions` | port | Same |
+| 422 | `handleStackStatus_AfterRewire_ReturnsCorrectPositions` (CQRS rewire) | port | Post-rewire regression |
+| 448 | `handleStackStatus_NoStreamId_ReturnsEmpty` | port | Edge case (post-rewire) |
+| 459 | `should accept eventStore parameter in registration` | discard | Wrapper-shape only; covered by Phase 3 deletion |
+| 465 | `should register handlers that use the provided EventStore` | discard | Wrapper-wiring; covered by `views/composite.test.ts:165` (stack_status delegation) and `:192` (stack_place delegation) plus `composite.envelope.test.ts:113` |
+| 500 | `both handlers share the same EventStore via the injected store` | port | Cross-handler shared-state invariant — not exercised by composite tests; valuable to retain on the kept handlers |
+
+**Subtotal for this file:** 23 port, 2 discard, 0 incomplete (manifest counts 27 rows — file has 24 `it()` calls plus the 3 wrapper-describe `it()` calls).
+
+**Note on file total:** the grep counted 27 `it()` declarations; this manifest enumerates 27 rows. Discrepancy in count vs the "24 it() tests" header is resolved here — total it() across the file is 27.
+
+### A1.2 totals
+
+- **Port: 87** (33 + 31 + 23 from the three files = 87)
+- **Discard: 4** (0 + 2 + 2 = 4)
+- **Incomplete: 1** (1 in `__tests__/views/tools.test.ts`)
+- **Net file count for deletion:** 0 — recommend renaming each file (e.g., `views/tools.test.ts` → `views/handlers.test.ts`) and stripping the 4 discard tests + the `registerViewTools` import/usage inside the `Backend Integration (Task 12)` describe block (lines 1171–1240) rather than deleting the file outright.
+
+## A1.3 — `formatResult` reference categorization
+
+| File:Line | Category | Notes |
+|---|---|---|
+| `format.ts:487` | other-prod (definition) | The function declaration itself; deleted in Phase 5 |
+| `views/tools.ts:8` | legacy-wrapper (import) | Import line — removed when `registerViewTools` deleted |
+| `views/tools.ts:1164` | legacy-wrapper | Inside `registerViewTools` body |
+| `views/tools.ts:1177` | legacy-wrapper | Same |
+| `views/tools.ts:1184` | legacy-wrapper | Same |
+| `workflow/tools.ts:44` | legacy-wrapper (import) | Import line — removed when `registerWorkflowTools` deleted |
+| `workflow/tools.ts:1663` | legacy-wrapper | Inside `registerWorkflowTools` body |
+| `workflow/tools.ts:1670` | legacy-wrapper | Same |
+| `workflow/tools.ts:1677` | legacy-wrapper | Same |
+| `workflow/tools.ts:1688` | legacy-wrapper | Same |
+| `workflow/tools.ts:1710` | legacy-wrapper | Same |
+| `stack/tools.ts:6` | legacy-wrapper (import) | Import line — removed when `registerStackTools` deleted |
+| `stack/tools.ts:136` | legacy-wrapper | Inside `registerStackTools` body |
+| `stack/tools.ts:149` | legacy-wrapper | Same |
+| `workflow/query.ts:19` | **other-prod** | Import line — `registerQueryTools` (not in brief) |
+| `workflow/query.ts:434` | **other-prod** | Inside `registerQueryTools` body |
+| `workflow/query.ts:441` | **other-prod** | Same |
+| `workflow/query.ts:451` | **other-prod** | Same |
+| `workflow/cancel.ts:21` | **other-prod** | Import line — `registerCancelTool` (not in brief) |
+| `workflow/cancel.ts:305` | **other-prod** | Inside `registerCancelTool` body |
+| `tasks/tools.ts:8` | **other-prod** | Import line — `registerTaskTools` (not in brief) |
+| `tasks/tools.ts:431` | **other-prod** | Inside `registerTaskTools` body |
+| `tasks/tools.ts:447` | **other-prod** | Same |
+| `tasks/tools.ts:459` | **other-prod** | Same |
+| `adapters/mcp.ts:217` | comment-only | Comment describing migration history — keep or update text |
+| `adapters/mcp.test.ts:53` | comment-only | Test-comment string |
+| `adapters/mcp.test.ts:352` | comment-only | Same |
+| `adapters/mcp.test.ts:385` | comment-only | Same |
+| `adapters/mcp.test.ts:477` | comment-only | Same |
+| `__tests__/stack/tools.test.ts:492` | test-fixture (comment) | Inline comment inside `registerStackTools` test that the audit recommends discarding (line 465 row above) |
+| `__tests__/workflow/index.test.ts:236` | test-fixture (test title) | Test name `should wrap results with formatResult`; assertions are on `content/isError` shape only — rename to `should wrap results with toEnvelope/toMcpResult` |
+| `telemetry/benchmarks/integration.test.ts:48` | test-fixture (import) | Used in mock-handler factory |
+| `telemetry/benchmarks/integration.test.ts:50` | test-fixture | `formatResult({ success: true, data: { test: true } })` as mock handler output |
+| `telemetry/benchmarks/latency.test.ts:8` | test-fixture (import) | Same pattern |
+| `telemetry/benchmarks/latency.test.ts:30` | test-fixture | Same |
+| `telemetry/benchmarks/token-economy.test.ts:8` | test-fixture (import) | Same pattern |
+| `telemetry/benchmarks/token-economy.test.ts:69` | test-fixture | Same |
+
+### A1.3 totals
+
+- **legacy-wrapper: 15** (definitions + imports + body calls inside `registerWorkflowTools` / `registerViewTools` / `registerStackTools`; removed by Phase 3)
+- **test-fixture: 7** (1 in `__tests__/workflow/index.test.ts` + 6 across three telemetry benchmark files)
+- **other-prod: 10** (3 in `registerQueryTools` body + 1 import; 1 in `registerCancelTool` body + 1 import; 3 in `registerTaskTools` body + 1 import) — **plus** the `format.ts:487` definition itself
+- **comment-only: 5** (1 in `adapters/mcp.ts`, 4 in `adapters/mcp.test.ts`) — cosmetic, no blocker
+
+### Stale references in the brief
+
+The brief lists five files at lines 50–54 as "tests to keep but possibly update" because they reference `formatResult`. **Audit-verified: zero hits** in any of:
+
+- `__tests__/mcp-tools.integration.test.ts`
+- `__tests__/integration/oneshot-workflow.test.ts`
+- `__tests__/workflow/integration.test.ts`
+- `__tests__/workflow/cancel.test.ts`
+- `parity/readonly-cap-parity.test.ts`
+
+Wave 0 (#1369) already migrated these. The brief's "audit" advice for those files is a no-op.
+
+## Next-wave recommendations
+
+### W2 (port unique test coverage)
+
+**Needed: yes.** Scope is **larger than the brief assumed**. Recommend:
+
+- Rename `views/tools.test.ts` → `views/handlers.test.ts` (or similar) and strip the wrapper-import lines 1171–1240 (3 occurrences inside `Backend Integration (Task 12)` describe block). The 45 `handle*` assertions stay where they are.
+- Rename `__tests__/views/tools.test.ts` → `__tests__/views/handlers.test.ts` (or relocate to `views/`) and drop the wrapper-shape describe block (lines 767–794, 2 tests).
+- Rename `__tests__/stack/tools.test.ts` → `__tests__/stack/handlers.test.ts` (or relocate to `stack/`) and drop the wrapper-shape describe block (lines 458–499, 2 tests); **retain** the `both handlers share the same EventStore` test at line 500 (unique cross-handler invariant).
+- Honor the `.skip` on `__tests__/views/tools.test.ts:632` until the original author decides.
+
+Effort: 1–2 hours (mechanical rename + delete of 4 discard tests).
+
+### W3 (delete legacy registration wrappers)
+
+**Unblocked: yes** — for the three wrappers named in the brief. After W2 strips the test-callers, Phase 3's `npm run test:run` should be green.
+
+However, an **expanded W3** is recommended (see W4) to also remove `registerQueryTools`, `registerCancelTool`, and `registerTaskTools`. None has any production caller. If the expanded scope is rejected, W3-as-briefed still works — but Phase 5 (`formatResult` deletion) will not satisfy the acceptance grep until the three additional wrappers are addressed.
+
+### W4 (residual `formatResult` sweep)
+
+**Scope change: yes (significant).** The brief's "category (c)" sites are real and unaddressed:
+
+- `tasks/tools.ts` `registerTaskTools` — 1 import + 3 body refs, plus a `__tests__/tasks/tools.test.ts:502` describe block testing the wrapper
+- `workflow/query.ts` `registerQueryTools` — 1 import + 3 body refs, no test-callers
+- `workflow/cancel.ts` `registerCancelTool` — 1 import + 1 body ref, no test-callers
+
+**Recommendation:** expand W3 to delete all six legacy wrappers in one motion (or expand W4 to do so before the `formatResult` removal). The three additional wrappers have:
+- Zero production callers (composite-tool dispatch handles their actions via the same `handle*` functions)
+- Only one test-caller (in `__tests__/tasks/tools.test.ts`) which is a wrapper-shape test analogous to the four discards above
+
+Additionally:
+
+- Three telemetry benchmark files use `formatResult` as a mock-handler factory. Each is a 2-line edit: replace with an inline `async () => ({ content: [...], isError: false })` literal or with `toMcpResult(toEnvelope(...))`. No production impact.
+- `__tests__/workflow/index.test.ts:236` is a stale test name; rename to `should wrap results with toEnvelope/toMcpResult`. Assertions are already carrier-agnostic.
+- The five `formatResult` comments in `adapters/mcp.{ts,test.ts}` are historical/explanatory; update text in Phase 5 (one-line edit each).
+
+## Blockers
+
+1. **Hidden legacy wrappers** (`registerTaskTools`, `registerQueryTools`, `registerCancelTool`) consume `formatResult` and are not enumerated in the brief. Without addressing them, the acceptance criterion at line 108 (`grep -rn "formatResult\b" ... --include="*.ts" | grep -v ".test.ts"` returns zero) **cannot be met**, and `formatResult` itself cannot be deleted from `format.ts` (referenced from non-test files). Recommendation: expand PR-A scope to delete these three additional wrappers, or split into a follow-up PR-A2 before PR-B.
+
+2. **File-deletion semantics in the brief** ("Test files to delete" header at line 31) overcounts what should actually be removed. The three named files contain **87 valuable `handle*`-level tests** that exercise functions that are kept. Wholesale file deletion would lose this coverage and likely break vitest coverage gates. Recommendation: treat the three files as "files to rename + reduce" rather than "files to delete."
+
+3. **Stale brief reference list** (lines 50–54) — the five `formatResult`-touching tests listed in the brief no longer reference `formatResult`. Their "audit" tasks are no-ops; no impact on PR-A scope but worth confirming with the brief author so the PR description doesn't mislead reviewers.

--- a/servers/exarchos-mcp/src/__tests__/stack/handlers.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/stack/handlers.test.ts
@@ -6,7 +6,6 @@ import { EventStore } from '../../event-store/store.js';
 import {
   handleStackStatus,
   handleStackPlace,
-  registerStackTools,
 } from '../../stack/tools.js';
 import { resetMaterializerCache } from '../../views/tools.js';
 
@@ -455,48 +454,7 @@ describe('handleStackStatus CQRS rewire', () => {
 
 // ─── EventStore Consolidation ────────────────────────────────────────────────
 
-describe('registerStackTools', () => {
-  it('should accept eventStore parameter in registration', () => {
-    const mockServer = { tool: vi.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
-    expect(() => registerStackTools(mockServer, tempDir, store)).not.toThrow();
-    expect(registerStackTools.length).toBe(3);
-  });
-
-  it('should register handlers that use the provided EventStore', async () => {
-    // Drive the registered MCP callback (not the bare handler) so this test
-    // actually catches a regression where registerStackTools wired the wrong
-    // store. Capture the callback passed to mockServer.tool() — see the
-    // server.tool(...) registrations in src/stack/tools.ts for the arg shape.
-    // CR review 4177990662: "Test behavior not implementation".
-    const toolMock = vi.fn();
-    const mockServer = { tool: toolMock } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
-    registerStackTools(mockServer, tempDir, store);
-
-    // The 4th positional arg to server.tool() is the async callback. Find
-    // the exarchos_stack_place registration and invoke its callback.
-    const placeCall = toolMock.mock.calls.find(
-      (call) => call[0] === 'exarchos_stack_place',
-    );
-    expect(placeCall).toBeDefined();
-    const placeCallback = placeCall![3] as (
-      args: Record<string, unknown>,
-    ) => Promise<unknown>;
-
-    const result = (await placeCallback({
-      streamId: 'wf-consolidation',
-      position: 1,
-      taskId: 't1',
-      branch: 'feature/t1',
-    })) as { content: Array<{ type: string; text: string }> };
-
-    // formatResult wraps successful results — the callback returns an MCP
-    // tool response envelope, but we only need to assert the side effect
-    // landed on the injected `store` to confirm wiring is correct.
-    expect(result).toBeDefined();
-    const events = await store.query('wf-consolidation', { type: 'stack.position-filled' });
-    expect(events).toHaveLength(1);
-  });
-
+describe('stack handlers shared EventStore', () => {
   it('both handlers share the same EventStore via the injected store', async () => {
     // Both handlers receive the same `store` instance through their third
     // positional arg — events written by handleStackPlace must be visible

--- a/servers/exarchos-mcp/src/__tests__/tasks/handlers.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/tasks/handlers.test.ts
@@ -7,7 +7,6 @@ import {
   handleTaskClaim,
   handleTaskComplete,
   handleTaskFail,
-  registerTaskTools,
   resetModuleEventStore,
 } from '../../tasks/tools.js';
 import {
@@ -494,34 +493,6 @@ describe('handleTaskFail', () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('FAIL_FAILED');
-  });
-});
-
-// ─── EventStore Consolidation ────────────────────────────────────────────────
-
-describe('registerTaskTools', () => {
-  it('should accept eventStore parameter in registration', () => {
-    const mockServer = { tool: vi.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
-    // Should accept 3 args: server, stateDir, eventStore
-    expect(() => registerTaskTools(mockServer, tempDir, store)).not.toThrow();
-    // Verify the function's declared parameter count is 3
-    expect(registerTaskTools.length).toBe(3);
-  });
-
-  it('should use shared EventStore singleton after registration', async () => {
-    const mockServer = { tool: vi.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
-    registerTaskTools(mockServer, tempDir, store);
-
-    const result = await handleTaskClaim(
-      { taskId: 't1', agentId: 'agent-1', streamId: 'wf-consolidation' },
-      tempDir,
-      store,
-    );
-    expect(result.success).toBe(true);
-
-    // The events should be readable from the JSONL file via any EventStore instance
-    const events = await store.query('wf-consolidation', { type: 'task.claimed' });
-    expect(events).toHaveLength(1);
   });
 });
 

--- a/servers/exarchos-mcp/src/__tests__/views/handlers.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/views/handlers.test.ts
@@ -762,33 +762,3 @@ describe('ViewMaterializer Singleton Cache', () => {
   });
 });
 
-// ─── EventStore Consolidation: 3-arg registration ───────────────────────────
-
-describe('registerViewTools', () => {
-  it('should accept eventStore parameter in registration', async () => {
-    const { registerViewTools } = await import('../../views/tools.js');
-    const { vi: viMock } = await import('vitest');
-    const mockServer = { tool: viMock.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
-    expect(() => registerViewTools(mockServer, tempDir, store)).not.toThrow();
-    expect(registerViewTools.length).toBe(3);
-  });
-
-  it('should use the injected EventStore for view materialization', async () => {
-    const { registerViewTools } = await import('../../views/tools.js');
-    const { vi: viMock } = await import('vitest');
-    const mockServer = { tool: viMock.fn() } as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
-    registerViewTools(mockServer, tempDir, store);
-
-    // Populate via the injected store
-    await store.append('wf-view-test', {
-      type: 'workflow.started',
-      data: { featureId: 'view-consolidation', workflowType: 'feature' },
-    });
-
-    // The handler should see data from the injected store
-    const result = await handleViewWorkflowStatus({ workflowId: 'wf-view-test' }, tempDir, store);
-    expect(result.success).toBe(true);
-    const data = result.data as Record<string, unknown>;
-    expect(data.featureId).toBe('view-consolidation');
-  });
-});

--- a/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
@@ -233,7 +233,7 @@ describe('MCP Server Entry Point', () => {
       );
     });
 
-    it('should wrap results with formatResult', async () => {
+    it('should wrap results with toEnvelope/toMcpResult', async () => {
       await createServer('/tmp/test-state-dir');
       const result = await toolRegistrations.get('exarchos_workflow')!.handler({
         action: 'init', featureId: 'test-feat', workflowType: 'feature',

--- a/servers/exarchos-mcp/src/adapters/mcp.test.ts
+++ b/servers/exarchos-mcp/src/adapters/mcp.test.ts
@@ -50,7 +50,7 @@ describe('createMcpServer', () => {
 
   it('CreateMcpServer_HandlerReturns_McpToolResult', async () => {
     // Arrange — We can't easily call registered handlers directly via McpServer API,
-    // so we test via dispatch → formatResult by verifying the adapter creates a valid server
+    // so we test via dispatch → toEnvelope → toMcpResult by verifying the adapter creates a valid server
     const { createMcpServer } = await import('./mcp.js');
 
     // Act
@@ -349,9 +349,9 @@ describe('createMcpServer', () => {
   //
   // The MCP handler must:
   //   1. Convert the dispatch core's ToolResult into the canonical Envelope
-  //      via `toEnvelope` (NOT `formatResult`), then ride the carrier via
-  //      `toMcpResult` so `structuredContent` is populated alongside the
-  //      legacy text content. This is the D.7 cutover.
+  //      via `toEnvelope`, then ride the carrier via `toMcpResult` so
+  //      `structuredContent` is populated alongside the legacy text
+  //      content. This is the D.7 cutover.
   //   2. After conversion, validate the envelope against the per-action
   //      outputSchema declared in the registry. On violation, return an
   //      INTERNAL_ERROR envelope whose `_meta.outputSchemaViolation`
@@ -383,7 +383,7 @@ describe('createMcpServer', () => {
       };
 
       // Assert — D.7 cutover: handler emits structuredContent (the envelope),
-      // not just the legacy formatResult shape (content + isError only).
+      // not just the legacy text-only shape (content + isError only).
       expect(result.structuredContent).toBeDefined();
       expect(result.content[0].type).toBe('text');
       // Envelope validates against the action's per-action outputSchema.
@@ -479,9 +479,9 @@ describe('createMcpServer', () => {
   });
 
   // ─── D.7: cutover regression guard — structuredContent must be populated.
-  // formatResult-only output (no structuredContent) would silently drop the
-  // typed envelope and revert to the legacy text-only carrier.
-  it('MCPHandler_OutputShape_ContainsStructuredContent_NotFormatResultOnly', async () => {
+  // A text-content-only output (no structuredContent) would silently drop
+  // the typed envelope and revert to the legacy text-only carrier.
+  it('MCPHandler_OutputShape_ContainsStructuredContent_NotTextOnly', async () => {
     // Arrange
     const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
     const spy = vi.spyOn(McpServer.prototype, 'registerTool');

--- a/servers/exarchos-mcp/src/adapters/mcp.ts
+++ b/servers/exarchos-mcp/src/adapters/mcp.ts
@@ -54,8 +54,8 @@ const LCD_OUTPUT_SCHEMA = z
  *
  * Envelope construction lives in `format.ts` (`toEnvelope`); this adapter
  * only handles the carrier mapping. `createMcpServer` (this file's main
- * export, below) wires `toMcpResult` into the per-tool MCP handler — the
- * D.7 cutover; legacy `formatResult` is no longer on the carrier path.
+ * export, below) wires `toMcpResult` into the per-tool MCP handler — that
+ * cutover landed in D.7.
  *
  * Design §2.3. Issue #1287.
  */
@@ -215,8 +215,9 @@ export function createMcpServer(ctx: DispatchContext): McpServer {
     const toolName = tool.name;
 
     // MCP handler: dispatch → toEnvelope → per-action schema validation
-    // → toMcpResult. Replaces the legacy `formatResult` carrier (D.7) and
-    // adds per-call enforcement of the per-action outputSchema (D.5).
+    // → toMcpResult. The `toEnvelope` + `toMcpResult` carriers replace the
+    // pre-D.7 single-carrier path and add per-call enforcement of the
+    // per-action outputSchema (D.5).
     const mcpHandler = async (args: Record<string, unknown>) => {
       let env: Envelope<unknown> | ErrorEnvelope;
       try {

--- a/servers/exarchos-mcp/src/format.ts
+++ b/servers/exarchos-mcp/src/format.ts
@@ -518,16 +518,6 @@ export function toEventAck(event: { streamId: string; sequence: number; type: st
   return { streamId: event.streamId, sequence: event.sequence, type: event.type };
 }
 
-// ─── Result Formatting ──────────────────────────────────────────────────────
-
-/** Converts a ToolResult into the MCP content format expected by the SDK. */
-export function formatResult(result: ToolResult) {
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(result) }],
-    isError: !result.success,
-  };
-}
-
 /**
  * Strip null, undefined, and empty-array values from a flat object.
  * Preserves false, 0, and other falsy-but-meaningful values.

--- a/servers/exarchos-mcp/src/stack/tools.ts
+++ b/servers/exarchos-mcp/src/stack/tools.ts
@@ -1,9 +1,7 @@
 // ─── Stack MCP Tool Handlers ────────────────────────────────────────────────
 
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
 import type { EventStore } from '../event-store/store.js';
-import { formatResult, toEventAck, type ToolResult } from '../format.js';
+import { toEventAck, type ToolResult } from '../format.js';
 import { getOrCreateMaterializer } from '../views/tools.js';
 import { STACK_VIEW } from '../views/stack-view.js';
 import type { StackViewState } from '../views/stack-view.js';
@@ -122,30 +120,3 @@ export async function handleStackPlace(
   }
 }
 
-// ─── Registration Function ──────────────────────────────────────────────────
-
-export function registerStackTools(server: McpServer, stateDir: string, eventStore: EventStore): void {
-  server.tool(
-    'exarchos_stack_status',
-    'Get current stack positions from stack.position-filled events',
-    {
-      streamId: z.string().optional(),
-      limit: z.number().int().positive().optional(),
-      offset: z.number().int().nonnegative().optional(),
-    },
-    async (args) => formatResult(await handleStackStatus(args, stateDir, eventStore)),
-  );
-
-  server.tool(
-    'exarchos_stack_place',
-    'Place an item on the stack by emitting a stack.position-filled event',
-    {
-      streamId: z.string().min(1),
-      position: z.number().int().nonnegative(),
-      taskId: z.string().min(1),
-      branch: z.string().optional(),
-      prUrl: z.string().optional(),
-    },
-    async (args) => formatResult(await handleStackPlace(args, stateDir, eventStore)),
-  );
-}

--- a/servers/exarchos-mcp/src/tasks/tools.ts
+++ b/servers/exarchos-mcp/src/tasks/tools.ts
@@ -1,11 +1,9 @@
 // ─── Task MCP Tool Handlers ─────────────────────────────────────────────────
 
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
 import * as path from 'node:path';
 import { EventStore, SequenceConflictError } from '../event-store/store.js';
 import { validateAgentEvent } from '../event-store/schemas.js';
-import { formatResult, toEventAck, type ToolResult } from '../format.js';
+import { toEventAck, type ToolResult } from '../format.js';
 import { getOrCreateMaterializer, resetMaterializerCache } from '../views/tools.js';
 import { TASK_DETAIL_VIEW } from '../views/task-detail-view.js';
 import type { TaskDetailViewState } from '../views/task-detail-view.js';
@@ -417,45 +415,3 @@ export async function handleTaskFail(
   }
 }
 
-// ─── Registration Function ──────────────────────────────────────────────────
-
-export function registerTaskTools(server: McpServer, stateDir: string, eventStore: EventStore): void {
-  server.tool(
-    'exarchos_task_claim',
-    'Claim a task for execution by an agent',
-    {
-      taskId: z.string().min(1),
-      agentId: z.string().min(1),
-      streamId: z.string().min(1),
-    },
-    async (args) => formatResult(await handleTaskClaim(args, stateDir, eventStore)),
-  );
-
-  server.tool(
-    'exarchos_task_complete',
-    'Mark a task as complete with optional artifacts and evidence',
-    {
-      taskId: z.string().min(1),
-      result: z.record(z.string(), z.unknown()).optional(),
-      evidence: z.object({
-        type: z.enum(['test', 'build', 'typecheck', 'manual']),
-        output: z.string(),
-        passed: z.boolean(),
-      }).optional(),
-      streamId: z.string().min(1),
-    },
-    async (args) => formatResult(await handleTaskComplete(args, stateDir, eventStore)),
-  );
-
-  server.tool(
-    'exarchos_task_fail',
-    'Mark a task as failed with error details and optional diagnostics',
-    {
-      taskId: z.string().min(1),
-      error: z.string().min(1),
-      diagnostics: z.record(z.string(), z.unknown()).optional(),
-      streamId: z.string().min(1),
-    },
-    async (args) => formatResult(await handleTaskFail(args, stateDir, eventStore)),
-  );
-}

--- a/servers/exarchos-mcp/src/telemetry/benchmarks/integration.test.ts
+++ b/servers/exarchos-mcp/src/telemetry/benchmarks/integration.test.ts
@@ -45,9 +45,11 @@ describe('Telemetry Integration', () => {
     // Arrange
     const store = new EventStore(stateDir);
     const { withTelemetry } = await import('../middleware.js');
-    const { formatResult } = await import('../../format.js');
 
-    const mockHandler = async () => formatResult({ success: true, data: { test: true } });
+    const mockHandler = async () => ({
+      content: [{ type: 'text' as const, text: JSON.stringify({ success: true, data: { test: true } }) }],
+      isError: false,
+    });
     const instrumented = withTelemetry(mockHandler, 'test_handler', store);
 
     // Act

--- a/servers/exarchos-mcp/src/telemetry/benchmarks/latency.test.ts
+++ b/servers/exarchos-mcp/src/telemetry/benchmarks/latency.test.ts
@@ -5,7 +5,6 @@ import * as os from 'node:os';
 import { EventStore } from '../../event-store/store.js';
 import { handleViewTelemetry } from '../tools.js';
 import { withTelemetry } from '../middleware.js';
-import { formatResult } from '../../format.js';
 import { resetMaterializerCache } from '../../views/tools.js';
 import { TELEMETRY_STREAM } from '../constants.js';
 
@@ -27,7 +26,10 @@ describe('Latency Benchmarks', () => {
 
   it.skipIf(!RUN_BENCHMARKS)('withTelemetry wrapper adds less than 10ms overhead', async () => {
     // Arrange
-    const mockHandler = async () => formatResult({ success: true, data: {} });
+    const mockHandler = async () => ({
+      content: [{ type: 'text' as const, text: JSON.stringify({ success: true, data: {} }) }],
+      isError: false,
+    });
     const instrumented = withTelemetry(mockHandler, 'latency_test', store);
 
     // Warm up

--- a/servers/exarchos-mcp/src/telemetry/benchmarks/token-economy.test.ts
+++ b/servers/exarchos-mcp/src/telemetry/benchmarks/token-economy.test.ts
@@ -5,7 +5,6 @@ import * as os from 'node:os';
 import { EventStore } from '../../event-store/store.js';
 import { handleViewTelemetry } from '../tools.js';
 import { withTelemetry } from '../middleware.js';
-import { formatResult } from '../../format.js';
 import { resetMaterializerCache } from '../../views/tools.js';
 import { TELEMETRY_STREAM } from '../constants.js';
 
@@ -66,7 +65,10 @@ describe('Token Economy Benchmarks', () => {
 
   it('_perf field adds less than 15 tokens overhead per response', async () => {
     // Arrange
-    const mockHandler = async () => formatResult({ success: true, data: { key: 'value' } });
+    const mockHandler = async () => ({
+      content: [{ type: 'text' as const, text: JSON.stringify({ success: true, data: { key: 'value' } }) }],
+      isError: false,
+    });
     const instrumented = withTelemetry(mockHandler, 'overhead_test', store);
 
     // Act

--- a/servers/exarchos-mcp/src/views/handlers.test.ts
+++ b/servers/exarchos-mcp/src/views/handlers.test.ts
@@ -1168,9 +1168,6 @@ describe('Backend Integration (Task 12)', () => {
     const querySpy = vi.spyOn(sqliteBackend, 'queryEvents');
 
     resetMaterializerCache();
-    const { registerViewTools } = await import('./tools.js');
-    const mockServer = { tool: vi.fn() } as unknown as Parameters<typeof registerViewTools>[0];
-    registerViewTools(mockServer, tmpDir, store);
 
     // Act
     const result = await handleViewWorkflowStatus({ workflowId: 'wf-backend' }, tmpDir, store);
@@ -1200,9 +1197,6 @@ describe('Backend Integration (Task 12)', () => {
     const listStreamsSpy = vi.spyOn(sqliteBackend, 'listStreams');
 
     resetMaterializerCache();
-    const { registerViewTools } = await import('./tools.js');
-    const mockServer = { tool: vi.fn() } as unknown as Parameters<typeof registerViewTools>[0];
-    registerViewTools(mockServer, tmpDir, store);
 
     // Act
     const result = await handleViewPipeline({}, tmpDir, store);
@@ -1235,9 +1229,6 @@ describe('Backend Integration (Task 12)', () => {
     const querySpy = vi.spyOn(sqliteBackend, 'queryEvents');
 
     resetMaterializerCache();
-    const { registerViewTools } = await import('./tools.js');
-    const mockServer = { tool: vi.fn() } as unknown as Parameters<typeof registerViewTools>[0];
-    registerViewTools(mockServer, tmpDir, store);
 
     // Act
     const result = await handleViewTasks({ workflowId: 'wf-tasks-backend' }, tmpDir, store);

--- a/servers/exarchos-mcp/src/views/tools.ts
+++ b/servers/exarchos-mcp/src/views/tools.ts
@@ -1,11 +1,8 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
-import { coercedStringArray } from '../coerce.js';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { EventStore } from '../event-store/store.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
-import { formatResult, pickFields, type ToolResult } from '../format.js';
+import { pickFields, type ToolResult } from '../format.js';
 import { logger } from '../logger.js';
 import { TERMINAL_PHASES } from '../workflow/terminal-phases.js';
 import { isFeatureStream } from '../core/infra-streams.js';
@@ -1149,39 +1146,3 @@ export async function handleViewIdeateReadiness(
   }
 }
 
-// ─── Registration Function ──────────────────────────────────────────────────
-
-export function registerViewTools(server: McpServer, stateDir: string, eventStore: EventStore): void {
-  // eventStore is now threaded via parameters to each handler
-  server.tool(
-    'exarchos_view_pipeline',
-    'Get CQRS pipeline view aggregating all workflows with stack positions and phase tracking',
-    {
-      limit: z.number().int().positive().optional(),
-      offset: z.number().int().nonnegative().optional(),
-      includeCompleted: z.boolean().optional(),
-    },
-    async (args) => formatResult(await handleViewPipeline(args, stateDir, eventStore)),
-  );
-
-  server.tool(
-    'exarchos_view_tasks',
-    'Get CQRS task detail view with optional filtering by workflowId and task properties, pagination, and field projection',
-    {
-      workflowId: z.string().optional(),
-      filter: z.record(z.string(), z.unknown()).optional(),
-      limit: z.number().int().positive().optional(),
-      offset: z.number().int().nonnegative().optional(),
-      fields: coercedStringArray().optional(),
-    },
-    async (args) => formatResult(await handleViewTasks(args, stateDir, eventStore)),
-  );
-
-  server.tool(
-    'exarchos_view_workflow_status',
-    'Get CQRS workflow status view with phase, task counts, and feature metadata',
-    { workflowId: z.string().optional() },
-    async (args) => formatResult(await handleViewWorkflowStatus(args, stateDir, eventStore)),
-  );
-
-}

--- a/servers/exarchos-mcp/src/workflow/cancel.ts
+++ b/servers/exarchos-mcp/src/workflow/cancel.ts
@@ -1,5 +1,3 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
 import type {
   CancelInput,
   WorkflowState,
@@ -18,7 +16,7 @@ import { mapInternalToExternalType } from './events.js';
 import { getHSMDefinition, executeTransition } from './state-machine.js';
 import { executeCompensation, type CompensationCheckpoint } from './compensation.js';
 import type { EventStore } from '../event-store/store.js';
-import { formatResult, type ToolResult } from '../format.js';
+import { type ToolResult } from '../format.js';
 import * as path from 'node:path';
 
 // ─── Event-Sourcing Version Discriminator ───────────────────────────────────
@@ -291,17 +289,3 @@ export async function handleCancel(
   };
 }
 
-// ─── Registration Function ──────────────────────────────────────────────────
-
-export function registerCancelTool(server: McpServer, stateDir: string, eventStore: EventStore | null): void {
-  server.tool(
-    'exarchos_workflow_cancel',
-    'Cancel a workflow with saga compensation and cleanup',
-    {
-      featureId: z.string().min(1).regex(/^[a-z0-9-]+$/),
-      reason: z.string().optional(),
-      dryRun: z.boolean().optional(),
-    },
-    async (args) => formatResult(await handleCancel(args, stateDir, eventStore)),
-  );
-}

--- a/servers/exarchos-mcp/src/workflow/query.ts
+++ b/servers/exarchos-mcp/src/workflow/query.ts
@@ -1,12 +1,10 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
 import type {
   SummaryInput,
   ReconcileInput,
   TransitionsInput,
   WorkflowState,
 } from './types.js';
-import { ErrorCode, WorkflowTypeSchema } from './schemas.js';
+import { ErrorCode } from './schemas.js';
 import {
   readStateFile,
   StateStoreError,
@@ -16,7 +14,7 @@ import { getRecentEventsFromStore } from './events.js';
 import { getHSMDefinition } from './state-machine.js';
 import { checkCircuitBreakerFromStore } from './circuit-breaker.js';
 import type { EventStore } from '../event-store/store.js';
-import { formatResult, stripNullish, type ToolResult } from '../format.js';
+import { stripNullish, type ToolResult } from '../format.js';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import { resolveTasksDir } from '../utils/paths.js';
@@ -422,32 +420,3 @@ export async function handleTransitions(
   };
 }
 
-// ─── Registration Function ──────────────────────────────────────────────────
-
-const featureIdParam = z.string().min(1).regex(/^[a-z0-9-]+$/);
-
-export function registerQueryTools(server: McpServer, stateDir: string, eventStore: EventStore | null): void {
-  server.tool(
-    'exarchos_workflow_summary',
-    'Get structured summary of workflow progress, events, and circuit breaker status',
-    { featureId: featureIdParam },
-    async (args) => formatResult(await handleSummary(args, stateDir, eventStore)),
-  );
-
-  server.tool(
-    'exarchos_workflow_reconcile',
-    'Verify worktree paths and branches match state file',
-    { featureId: featureIdParam },
-    async (args) => formatResult(await handleReconcile(args, stateDir, eventStore)),
-  );
-
-  server.tool(
-    'exarchos_workflow_transitions',
-    'Get available state machine transitions for a workflow type',
-    {
-      workflowType: WorkflowTypeSchema,
-      fromPhase: z.string().optional(),
-    },
-    async (args) => formatResult(await handleTransitions(args, stateDir, eventStore)),
-  );
-}

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -1,6 +1,3 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
-import { coercedStringArray } from '../coerce.js';
 import type {
   InitInput,
   ListInput,
@@ -10,12 +7,10 @@ import type {
   WorkflowState,
 } from './types.js';
 import {
-  CheckpointHandoffSchema,
   CheckpointInputSchema,
   ErrorCode,
   InitInputSchema,
   isReservedField,
-  WorkflowTypeSchema,
 } from './schemas.js';
 import {
   initStateFile,
@@ -41,7 +36,7 @@ import { getHSMDefinition, isBuiltInWorkflowType, getValidTransitions } from './
 import { hsmTransitionGuard } from './hsm-transition-guard.js';
 import { getPlaybook, composePhasePlaybook } from './playbooks.js';
 import { getRequiredReviews } from './review-contract.js';
-import { formatResult, type ToolResult } from '../format.js';
+import { type ToolResult } from '../format.js';
 import { createHash } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import type { EventStore } from '../event-store/store.js';
@@ -1648,65 +1643,3 @@ function resolveDotPath(obj: Record<string, unknown>, dotPath: string): unknown 
   return current;
 }
 
-// ─── Shared Schema Components ───────────────────────────────────────────────
-
-const featureIdParam = z.string().min(1).regex(/^[a-z0-9-]+$/);
-const workflowTypeParam = WorkflowTypeSchema;
-
-// ─── Registration Function ──────────────────────────────────────────────────
-
-export function registerWorkflowTools(server: McpServer, stateDir: string, eventStore: EventStore | null): void {
-  server.tool(
-    'exarchos_workflow_init',
-    'Initialize a new workflow state file for a feature/debug/refactor workflow',
-    { featureId: featureIdParam, workflowType: workflowTypeParam },
-    async (args) => formatResult(await handleInit(args, stateDir, eventStore)),
-  );
-
-  server.tool(
-    'exarchos_workflow_list',
-    'List all active workflow state files with staleness information',
-    {},
-    async (args) => formatResult(await handleList(args, stateDir)),
-  );
-
-  server.tool(
-    'exarchos_workflow_get',
-    'Query a field via dot-path (e.g. query:"phase"), project specific fields (fields:["phase","featureId"]), or get full state if neither',
-    { featureId: featureIdParam, query: z.string().optional(), fields: coercedStringArray().optional() },
-    async (args) => formatResult(await handleGet(args, stateDir, eventStore)),
-  );
-
-  server.tool(
-    'exarchos_workflow_set',
-    'Update fields and/or transition phase. Returns {phase, updatedAt}',
-    {
-      featureId: featureIdParam,
-      updates: z.record(z.string(), z.unknown()).optional(),
-      phase: z.string().optional(),
-    },
-    async (args) => formatResult(await handleSet(args, stateDir, eventStore)),
-  );
-
-  server.tool(
-    'exarchos_workflow_checkpoint',
-    'Create an explicit checkpoint, resetting the operation counter. Optional `handoff` payload (context/nextSteps/suggestions) is persisted on the workflow.checkpoint event for the rehydration projection (#1240).',
-    {
-      featureId: featureIdParam,
-      summary: z.string().optional(),
-      // T4 (#1240): expose the handoff field at the MCP tool boundary.
-      // The handler re-validates against `CheckpointInputSchema` (which
-      // composes `HandoffEntryData`) so an MCP caller bypassing this
-      // shape — older client, manual JSON-RPC — still hits the same
-      // byte-cap rejection path.
-      //
-      // CodeRabbit nitpick on PR #1297: reuse the canonical
-      // `CheckpointHandoffSchema` instead of an inline z.object copy.
-      // Same shape, single source of truth — a future cap change
-      // can't desync this surface from `CheckpointInputSchema` and
-      // strictObject rejection of unknown keys carries through.
-      handoff: CheckpointHandoffSchema.optional(),
-    },
-    async (args) => formatResult(await handleCheckpoint(args, stateDir, eventStore)),
-  );
-}


### PR DESCRIPTION
## Summary

PR-A of the Wave 0 follow-up stack ([plan](docs/plans/2026-05-13-wave-0-followups-stack-execution.md)). Removes six legacy `register*Tools` registration wrappers and the `formatResult` helper they consumed. The composite-tool dispatch path through `createMcpServer` is now the single carrier surface for MCP tools.

Closes #1367.

**Base:** `feature/v2-10-wave-0-carrier-swap` (#1369). Auto-retargets to `main` when #1369 merges.

## Audit-driven scope expansion

A Wave 1 audit (`docs/followups/2026-05-13-pr-a-audit.md`) surfaced two corrections to the original brief:

1. **Three additional hidden wrappers** (`registerTaskTools`, `registerQueryTools`, `registerCancelTool`) — all with zero production callers — consumed `formatResult`. Without removing them, the brief's acceptance criterion (`grep -rn formatResult ... | grep -v .test.ts` returns zero) was unsatisfiable. Scope expanded from 3 → 6 wrappers.
2. **Wholesale test-file deletion overcounted** — the three named test files contain 87 valuable `handle*`-level tests. Strategy switched from delete-files to rename-and-reduce: files renamed to `handlers.test.ts`, only wrapper-shape coverage stripped.

## Changes

### Wave 2 — rename + strip wrapper-shape tests (4 commits)
- `views/tools.test.ts` → `views/handlers.test.ts` (registerViewTools imports stripped; 33 handler tests preserved)
- `__tests__/views/tools.test.ts` → `__tests__/views/handlers.test.ts` (2 wrapper-shape tests dropped; 31 tests + 1 `.skip` preserved)
- `__tests__/stack/tools.test.ts` → `__tests__/stack/handlers.test.ts` (2 wrapper-shape tests dropped; cross-handler invariant test retained via describe-rename)
- `__tests__/tasks/tools.test.ts` → `__tests__/tasks/handlers.test.ts` (2 wrapper-shape tests dropped)

### Wave 3 — delete all six legacy wrappers (6 commits)
- `registerWorkflowTools` (workflow/tools.ts)
- `registerViewTools` (views/tools.ts)
- `registerStackTools` (stack/tools.ts)
- `registerTaskTools` (tasks/tools.ts)
- `registerQueryTools` (workflow/query.ts)
- `registerCancelTool` (workflow/cancel.ts)

All `handle*` business-logic functions in these files are **kept** — they're consumed by the composite-tool dispatch path at `createMcpServer` (`adapters/mcp.ts`).

### Wave 4 — residual sweep + delete `formatResult` (4 commits)
- 3 telemetry benchmark files (`telemetry/benchmarks/*.test.ts`) — inlined `formatResult` mock-handler call sites as direct `ToolResult` literals
- Renamed stale test title `should wrap results with formatResult` → `should wrap results with toEnvelope/toMcpResult` in `__tests__/workflow/index.test.ts`
- Refreshed 4 comment-only references in `adapters/mcp.{ts,test.ts}`; renamed `MCPHandler_OutputShape_..._NotFormatResultOnly` → `..._NotTextOnly` (CamelCase token found beyond `formatResult\b` grep — full symbol fingerprint now clean)
- **Deleted `formatResult` function + JSDoc + section header from `format.ts`** (10 lines)

## Acceptance (verified)

- [x] `grep -rn "registerWorkflowTools\|registerViewTools\|registerStackTools\|registerTaskTools\|registerQueryTools\|registerCancelTool" servers/exarchos-mcp/src --include="*.ts"` → **zero hits** (definers gone, callers gone)
- [x] `grep -rn "formatResult\b" servers/exarchos-mcp/src --include="*.ts"` → **zero hits** (definition deleted, all production + test refs removed)
- [x] `formatResult` symbol no longer exported from `format.ts`
- [x] `npm run test:run` from MCP server: **6629 passed | 25 skipped | 1 todo (0 failed; 507 files)**
- [x] `npx tsc --noEmit` clean (MCP server)
- [x] Composite-tool integration tests cover the dispatched-action surface (preserved via rename, not lost)

## Test Plan

- [x] Full vitest suite: 6629 passed | 25 skipped | 1 todo (0 failed)
- [x] Scoped vitest verified GREEN at every wrapper-deletion commit (W3.1–W3.6)
- [x] `npx tsc --noEmit` clean at every commit
- [x] Final grep proofs (both legacy wrapper symbols and `formatResult\b`) return zero hits
- [x] No `handle*` business-logic function deleted — composite-tool dispatch surface intact

## Out of scope (deferred to PR-B / PR-C)

- Wiring `toCliResult` into `adapters/cli.ts:emitResult` → **PR-B (#1368)**
- Updating ~61 in-tree parity tests for the envelope shape → **PR-B (#1368)**
- Migrating from Zod v3 to Zod v4 → **PR-C (#1366)**

Brief lines 50–54 listed five files as "tests to keep but possibly update"; the audit confirmed all five had zero `formatResult` hits already (Wave 0 already migrated them). No action needed; documented in the audit for the record.

## Workflow trace

`/exarchos:rehydrate wave-0-followups` → stack plan authored → `/exarchos:delegate` × 4 waves → audit + rename-reduce + delete wrappers + sweep + delete `formatResult` → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)