### PR TITLE
fix(wave1): #1355 install-skills + #1356 merge-orchestrate preflight + #1357 skill rewrite (PR2, stacked)

### DIFF
--- a/docs/plans/2026-05-14-wave1-fixes.md
+++ b/docs/plans/2026-05-14-wave1-fixes.md
@@ -1,0 +1,273 @@
+# Implementation Plan — Wave 1 Fixes (PR2)
+
+**Design:** [`docs/designs/2026-05-14-wave1-data-safety-substrate.md`](../designs/2026-05-14-wave1-data-safety-substrate.md)
+**Date:** 2026-05-14
+**Workflow:** `wave1-fixes`
+**Stacked on:** PR1 `feature/wave1-substrate` (#1388 — must merge first or be the base of this stacked PR)
+**Issues:** [#1355](https://github.com/lvlup-sw/exarchos/issues/1355), [#1356](https://github.com/lvlup-sw/exarchos/issues/1356), [#1357](https://github.com/lvlup-sw/exarchos/issues/1357)
+**Iron Law:** NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST — **and** each fix MUST atomically remove the corresponding `it.fails()` annotation in the same commit that lands the fix.
+
+## The atomic-flip contract
+
+PR1 landed three RED outcome seed tests wrapped in `it.fails(...)`. Each test encodes a regression as an executable spec. Every fix in PR2 satisfies its corresponding seed test, and **the same commit that introduces the fix MUST remove the `.fails` from `it.fails`** (turning it into a plain `it(...)`). Reviewers verify operator-visible correctness by grepping for the annotation removal — that single bit is the spec-conformance signal.
+
+If a fix lands without the flip, the test stays RED forever and the bug is not actually verified fixed.
+If a fix is incomplete and the flipped test fails, CI breaks (now a real failure, not an expected one).
+
+## Surface inventory
+
+- **#1355 install-skills:** CLI command lives in the bun-compiled binary. Source likely at `src/install.ts` or `servers/exarchos-mcp/src/install/` (verify on entry). Manifest of expected skills per runtime is `skills/<runtime>/` in the repo (built by `npm run build:skills`).
+- **#1356 merge-orchestrate:** `servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts` exports `handleMergeOrchestrate`. Preflight currently captures `rollbackSha` from cwd HEAD (wrong when target is checked out elsewhere). Outcome test `tests/outcome/merge-orchestrate-multiworktree.test.ts` asserts the correct shape.
+- **#1357 merge-orchestrator skill:** `skills-src/merge-orchestrator/SKILL.md` (published skill — rendered to per-runtime variants). Must pass INV-6 audit (PR1 added the lint advisory; PR2 must demonstrate INV-6 compliance for this skill).
+- **Annotation flips:**
+  - `tests/outcome/install-skills.test.ts:77` — currently `it.fails(...)` wrapping a for-loop over 6 runtimes
+  - `tests/outcome/merge-orchestrate-multiworktree.test.ts:41` — currently `it.fails(...)`
+  - **NOT flipped in PR2:** `tests/outcome/rehydrate-projection-drift.test.ts` — that test stays `it.fails` until Wave 2 (#1359)
+
+## Phase map
+
+```text
+Phase A — #1355 install-skills fix + flip   ───┐
+                                                 │
+Phase B — #1356 preflight + executor + flip   ───┼──→ Phase D — INV-6 audit + full suite
+                                                 │
+Phase C — #1357 skill rewrite (INV-6 audited) ───┘
+```
+
+- **Phase A** (#1355) is independent of B and C.
+- **Phase B** (#1356) is independent of A and C.
+- **Phase C** (#1357) depends on Phase B *if* the rewritten skill cites the new payload shape from #1356; otherwise can run in parallel. Treat as serializable after B for safety.
+- **Phase D** is the integration gate.
+
+**Group 1 (parallel):** Phase A + Phase B
+**Group 2 (after B):** Phase C
+**Phase D:** serial gate
+
+## Provenance map (issue → tasks)
+
+| Issue | Tasks | PR |
+|---|---|---|
+| #1355 | F-001, F-002, F-003 | PR2 |
+| #1356 | F-004, F-005, F-006 | PR2 |
+| #1357 | F-007, F-008 | PR2 |
+| (gate) | F-009, F-010 | PR2 |
+
+---
+
+## Phase A — #1355 install-skills fix
+
+### Task F-001: Diagnose root cause
+
+**Phase:** investigation
+**Implements:** #1355
+
+1. Run `npm run build` to ensure `dist/bin/exarchos-<os>-<arch>` is current.
+2. Reproduce the failure: invoke `exarchos install-skills --agent copilot` with `HOME=$(mktemp -d)` and observe install output.
+3. Inspect the install handler source. Likely paths: `src/install.ts`, `servers/exarchos-mcp/src/install/`, or `src/cli/install-skills.ts`. The handler MUST walk `skills/<runtime>/` and copy every directory containing a `SKILL.md` to the per-runtime install path under HOME.
+4. Identify the bug: probable causes include (a) hardcoded single-skill copy (e.g., only `design-invariants`), (b) a missing iteration over the manifest, (c) a runtime-conditional that breaks for non-claude runtimes.
+5. Document the diagnosis in your task report — file:line of the bug, root cause sentence.
+
+**Dependencies:** None.
+**Testing strategy:** investigation (no commit).
+
+### Task F-002: Fix install-skills + flip annotation
+
+**Phase:** RED→GREEN
+**Implements:** #1355
+
+1. **[RED VERIFICATION]** Before any fix, confirm the install-skills test currently reports `it.fails` (passes by failing). Run `npm run test:outcome -- install-skills`. Expected: 6 cases, each `it.fails` reporting "expected failure" → pass.
+2. **[FIX + FLIP — single atomic commit]**:
+   - Apply the fix identified in F-001 to the install handler.
+   - Edit `tests/outcome/install-skills.test.ts`: change `it.fails(...)` → `it(...)` on the per-runtime case (single line edit, line ~77).
+   - Run `npm run build` (if the fix touched anything compiled into the binary).
+   - Run `npm run test:outcome -- install-skills` — verify all 6 cases now pass for real (not as expected failures).
+3. **[COMMIT]** Single commit: `fix(install-skills): copy full manifest per runtime + flip it.fails annotation (#1355)`. Commit MUST include both the handler fix AND the annotation removal — the atomic-flip contract is non-negotiable.
+
+**Dependencies:** F-001.
+**Testing strategy:** outcome (real CLI, real fs via `withTmpHome`).
+
+### Task F-003: Verify install-skills coverage
+
+**Phase:** GREEN-only (gate)
+**Implements:** #1355
+
+1. Run `npm run test:outcome -- install-skills` — assert all 6 cases pass (no expected failures).
+2. Run `npm run test:run` — assert no regressions in unit/integration tests.
+3. Run a manual smoke: invoke `exarchos install-skills --agent copilot` with `HOME=$(mktemp -d)`, walk the install path, count SKILL.md files. Confirm it matches the `skills/copilot/` manifest count.
+4. No commit unless verification fails and requires re-work.
+
+**Dependencies:** F-002.
+**Testing strategy:** integration.
+
+---
+
+## Phase B — #1356 merge-orchestrate preflight + executor
+
+### Task F-004: Add `targetWorktreeAvailability` preflight to `handleMergeOrchestrate`
+
+**Phase:** RED→GREEN
+**Implements:** #1356
+
+1. **[RED VERIFICATION]** Confirm the merge-orchestrate seed test (`tests/outcome/merge-orchestrate-multiworktree.test.ts`) currently reports `it.fails` (passes by failing).
+2. **[GREEN]** Edit `servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts`:
+   - Add a preflight that, before any merge attempt, runs `git -C <repoRoot> worktree list --porcelain` and parses for branches with `branch refs/heads/<target>` entries pointing to a worktree path other than `<repoRoot>`.
+   - If the target is checked out in a sibling worktree: return `{success: true, data: {phase: 'aborted', reason: 'target-checked-out-elsewhere', siblingWorktreePath: '<path>'}}`. Do NOT capture a `rollbackSha`. Do NOT fire a `merge.requested` event.
+   - Otherwise continue with the existing flow.
+3. Run unit tests scoped to merge-orchestrate (`cd servers/exarchos-mcp && npm run test:run -- merge-orchestrate` or equivalent) to ensure existing behavior is preserved.
+4. **[COMMIT — partial, no flip yet]**: `feat(merge-orchestrate): add targetWorktreeAvailability preflight (#1356)`. **Do NOT flip the annotation in this commit** — F-005 owns the atomic flip after the executor hardening lands.
+
+**Dependencies:** None.
+**Testing strategy:** unit (existing merge-orchestrate tests) + outcome (after F-005).
+
+### Task F-005: Executor hardening + flip annotation
+
+**Phase:** GREEN-only (atomic flip)
+**Implements:** #1356
+
+1. **[GREEN]** Audit the merge executor downstream of the preflight: confirm no path captures the cwd HEAD as a `rollbackSha` when the abort case fires. Tighten if F-004's preflight missed an edge.
+2. **[FLIP]** Edit `tests/outcome/merge-orchestrate-multiworktree.test.ts`: change `it.fails(...)` → `it(...)` on line ~41.
+3. Run `npm run test:outcome -- merge-orchestrate-multiworktree` — assert the test now passes for real.
+4. Run `cd servers/exarchos-mcp && npm run test:run` — assert no regressions.
+5. **[COMMIT — atomic]**: `fix(merge-orchestrate): harden multi-worktree abort path + flip it.fails (#1356)`. This is the atomic-flip commit.
+
+**Dependencies:** F-004.
+**Testing strategy:** outcome (real git topology via `withTmpGit` + `addSiblingWorktree`).
+
+### Task F-006: Verify merge-orchestrate coverage
+
+**Phase:** GREEN-only (gate)
+**Implements:** #1356
+
+1. Run `npm run test:outcome -- merge-orchestrate-multiworktree` — assert pass (not expected failure).
+2. Run `cd servers/exarchos-mcp && npm run test:run` — assert clean.
+3. No commit unless verification fails.
+
+**Dependencies:** F-005.
+**Testing strategy:** integration.
+
+---
+
+## Phase C — #1357 merge-orchestrator skill rewrite (INV-6 audited)
+
+### Task F-007: Rewrite `skills-src/merge-orchestrator/SKILL.md`
+
+**Phase:** GREEN-only (documentation)
+**Implements:** #1357
+
+1. **[RED VERIFICATION]** Run `npm run lint:inv6` — capture baseline findings against `skills-src/merge-orchestrator/SKILL.md`. The lint is advisory; the goal here is to count current INV-6 violations on this specific skill.
+2. **[GREEN]** Rewrite `skills-src/merge-orchestrator/SKILL.md`:
+   - Cite the new preflight payload shape from F-004 (`phase: 'aborted', reason: 'target-checked-out-elsewhere'`).
+   - Describe triggers in workflow-neutral terms — describe the *behavior* (merge attempt → preflight → executor or abort), not the workflow phase that calls it.
+   - If the skill is genuinely workflow-specific, add `workflow-type: feature` (or equivalent) to the frontmatter so the INV-6 audit recognizes the declaration.
+3. **[INV-6 AUDIT GATE]** Run `npm run lint:inv6` again, scoped to `skills-src/merge-orchestrator/`. Assert findings count for this file = 0 (or all findings are LOW + accompanied by a `workflow-type:` declaration justifying the literal). Use `jq` or grep on the JSON output:
+   ```bash
+   node scripts/lint-inv6.mjs skills-src/ | jq '.findings | map(select(.file | contains("merge-orchestrator"))) | length'
+   ```
+   Expected output: `0`.
+4. Run `npm run build:skills` to render the rewritten skill into per-runtime variants under `skills/<runtime>/merge-orchestrator/`.
+5. Run `npm run skills:guard` — assert no drift.
+6. **[COMMIT]**: `docs(merge-orchestrator): rewrite skill to use new preflight payload + INV-6 compliant (#1357)`.
+
+**Dependencies:** F-005 (the new payload shape must be canonical before the skill cites it).
+**Testing strategy:** structural (INV-6 audit + skills:guard).
+
+### Task F-008: Verify #1357 INV-6 audit
+
+**Phase:** GREEN-only (gate)
+**Implements:** #1357
+
+1. Re-run the scoped INV-6 lint check from F-007 step 3 — confirm 0 findings on `merge-orchestrator/SKILL.md`.
+2. Run `npm run skills:guard` — assert no drift.
+3. Run `npm run test:run` — assert no regressions in any structural skill tests.
+4. No commit unless audit fails.
+
+**Dependencies:** F-007.
+**Testing strategy:** integration.
+
+---
+
+## Phase D — Integration gate
+
+### Task F-009: Full test suite + outcome flips verified
+
+**Phase:** GREEN-only (gate)
+**Implements:** #1355, #1356, #1357
+
+1. Run `npm run test:run` — assert clean.
+2. Run `cd servers/exarchos-mcp && npm run test:run` — assert clean.
+3. Run `npm run test:outcome` — assert exit code 0 and assert the summary shows:
+   - **6 install-skills tests passing for real** (no longer expected failures)
+   - **1 merge-orchestrate test passing for real** (no longer expected failure)
+   - **1 rehydrate test still `it.fails`** (intentional — stays RED until Wave 2 #1359)
+   - **3 helper tests passing**
+   - Total: 10 passing for real + 1 expected failure = 11 tests reporting in summary.
+4. Run `npm run typecheck` — assert clean.
+5. Run `npm run skills:guard` — assert clean.
+
+**Dependencies:** F-002, F-005, F-007.
+**Testing strategy:** integration.
+
+### Task F-010: TDD compliance verification per task
+
+**Phase:** GREEN-only (gate)
+**Implements:** #1355, #1356, #1357
+
+1. For each task with a fix commit (F-002, F-005, F-007), run:
+   ```ts
+   exarchos_orchestrate({
+     action: "check_tdd_compliance",
+     featureId: "wave1-fixes",
+     taskId: "<id>",
+     branch: "feature/wave1-fixes"
+   })
+   ```
+2. Per memory `feedback_tdd_gate_per_commit.md`, false-negatives are possible when GREEN commits modify only source files. If a task false-negatives, inspect the corresponding seed test (from PR1) and the fix commit — confirm the annotation flip is present and the test passes. False-negative is advisory.
+
+**Dependencies:** F-009.
+**Testing strategy:** integration (orchestrator gate).
+
+---
+
+## Parallelization summary
+
+```text
+Group 1 (parallel after dispatch):
+  Phase A: F-001 (investigation) → F-002 (atomic fix+flip) → F-003 (verify)
+  Phase B: F-004 (preflight) → F-005 (executor+flip) → F-006 (verify)
+
+Group 2 (after B):
+  Phase C: F-007 (skill rewrite) → F-008 (INV-6 audit verify)
+
+Phase D: serial gate (F-009 → F-010)
+```
+
+Estimated wall-clock: ~30–60 min in parallel via `exarchos:delegate`.
+
+## Atomic-flip discipline (BLOCKING reviewer check)
+
+Each fix commit MUST satisfy:
+
+| Fix | Commit MUST contain | Test file annotation MUST change |
+|---|---|---|
+| #1355 | install-handler source change + `tests/outcome/install-skills.test.ts` annotation removal | `it.fails(...)` → `it(...)` (single line, ~line 77) |
+| #1356 | `merge-orchestrate.ts` executor change + `tests/outcome/merge-orchestrate-multiworktree.test.ts` annotation removal | `it.fails(...)` → `it(...)` (single line, ~line 41) |
+| #1357 | `skills-src/merge-orchestrator/SKILL.md` rewrite + regenerated `skills/<runtime>/merge-orchestrator/` outputs | No annotation flip — this is a skill rewrite, not a behavior fix tied to an `it.fails` test |
+
+Reviewer grep:
+```bash
+git diff main..feature/wave1-fixes -- 'tests/outcome/*.test.ts' | grep -E '^-.*it\.fails|^\+.*\bit\('
+```
+Should show exactly 2 annotation removals (one per behavior fix). #1357 has no annotation diff.
+
+## Risk acknowledgements
+
+- **#1355 root cause unknown at plan time:** F-001 is a discovery task; the fix shape (F-002) depends on what F-001 finds. The plan assumes the fix is local to one or two handlers; if the bug is structural (e.g., the runtime detection logic is fundamentally wrong), F-002 may need a partial replan.
+- **#1357 INV-6 audit may surface unexpected violations:** The lint produces ~374 advisory findings on the full catalog today; on a single skill the count is unknown. If the rewrite cannot reach 0 findings without changing skill semantics, fall back to declaring `workflow-type:` in frontmatter (the sanctioned escape hatch per INV-6 spec).
+- **Stacked-PR rebase risk:** This PR is stacked on PR1 (`feature/wave1-substrate` → main, #1388). If PR1 receives revision feedback that changes any outcome-tier file, this branch will need to rebase. Plan accordingly.
+
+## Out of scope
+
+- Wave 2 (#1359 #1360) — not addressed here.
+- Full INV-6 catalog audit (delegation/synthesis/oneshot-workflow/workflow-state skills) — deferred to v2.10.0 GA.
+- Lint promotion from advisory to blocking — separate follow-up issue.
+- Branch-protection required-check wiring for `outcome-tests` job — manual repo-settings step (also captured in PR1's body).

--- a/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.js
+++ b/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.js
@@ -44,7 +44,7 @@
  *             #1213 review-item #4 reversal, #1214.
  */
 
-import { installSkills } from '../../../../src/install-skills.js';
+import { installSkills, findSkillsSourceDir } from '../../../../src/install-skills.js';
 import { loadAllRuntimes } from '../../../../src/runtimes/load.js';
 import { EMBEDDED_RUNTIMES } from '../../../../src/runtimes/embedded.js';
 import { fileURLToPath } from 'node:url';
@@ -106,5 +106,14 @@ export async function runInstallSkills(opts, deps = {}) {
     ? loadFromDisk(resolveRuntimesDir())
     : embedded;
 
-  await installer({ agent: opts.agent, runtimes });
+  // #1355 fix: opt the binary entry point in to the local-copy fast
+  // path by resolving `skillsSource` here. Auto-detection lives in
+  // `findSkillsSourceDir()` and walks the standard candidate list
+  // (cwd/skills, binary-relative dist/bin/../../skills, src/-relative
+  // dev path). When all three miss, the value is `undefined` and
+  // `installSkills` falls back to the upstream `npx skills add`
+  // shell-out — same behavior as before #1355.
+  const skillsSource = findSkillsSourceDir();
+
+  await installer({ agent: opts.agent, runtimes, skillsSource });
 }

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
@@ -35,6 +35,7 @@
 // ───────────────────────────────────────────────────────────────────────────
 
 import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { z } from 'zod';
 
@@ -166,6 +167,23 @@ export interface HandleMergeOrchestrateInput extends HandleMergeOrchestrateArgs 
   readonly gitExec?: GitExec;
   readonly persistState?: OrchestratorPersistState;
   readonly readState?: OrchestratorReadState;
+}
+
+// ─── Path normalization ────────────────────────────────────────────────────
+
+/**
+ * Resolve a filesystem path to its canonical form. Prefers `realpathSync`
+ * so symlink segments are followed (matching git's internal canonicalization
+ * of worktree paths), falling back to `path.resolve` if the path does not
+ * exist on disk (rare: covers a caller passing a stale repoRoot before any
+ * disk operation has had the chance to fail with a clearer error).
+ */
+function normalizePath(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
 }
 
 // ─── Default gitExec ───────────────────────────────────────────────────────
@@ -360,7 +378,14 @@ export async function handleMergeOrchestrate(
   //     <blank line separator>
   // If any record's branch equals our target AND its path is NOT the
   // repoRoot we're about to operate on, the topology is unsafe — abort.
-  const repoRoot = args.repoRoot ?? process.cwd();
+  // Normalize repoRoot so the string comparison against `git worktree list`
+  // output is robust on macOS / Windows. `git worktree list --porcelain`
+  // emits symlink-resolved absolute paths (git canonicalizes internally),
+  // so without realpath here the equality test below would false-negative
+  // when the caller's cwd traverses a symlinked segment (a common case on
+  // macOS where /var → /private/var, or developer-symlinked checkouts).
+  // realpathSync requires the path to exist; fall back to resolve() if not.
+  const repoRoot = normalizePath(args.repoRoot ?? process.cwd());
   const worktreeListResult = gitExec(repoRoot, ['worktree', 'list', '--porcelain']);
   if (worktreeListResult.exitCode === 0) {
     const targetRef = `refs/heads/${args.targetBranch}`;
@@ -369,7 +394,9 @@ export async function handleMergeOrchestrate(
     for (const rawLine of worktreeListResult.stdout.split('\n')) {
       const line = rawLine.trimEnd();
       if (line.startsWith('worktree ')) {
-        currentPath = line.slice('worktree '.length);
+        // Normalize the path emitted by git so the equality test below
+        // compares apples to apples regardless of separator normalization.
+        currentPath = normalizePath(line.slice('worktree '.length));
       } else if (line.startsWith('branch ')) {
         const ref = line.slice('branch '.length);
         if (ref === targetRef && currentPath !== undefined && currentPath !== repoRoot) {

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
@@ -337,6 +337,65 @@ export async function handleMergeOrchestrate(
   const readState =
     input.readState ?? buildDefaultReadState(args.featureId, ctx.stateDir);
 
+  // ─── 0a. Target-worktree availability preflight (#1356) ──────────────────
+  //
+  // When the merge target branch is checked out in a SIBLING worktree of
+  // the same repository, the executor's local `git merge` against the
+  // target would fail with a confusing "fatal: '<branch>' is already
+  // checked out at '<other-worktree-path>'", and worse — the executor
+  // captures `rollbackSha` from the cwd's HEAD (which is on a different
+  // branch), so a rollback would `git reset --hard` to the wrong commit.
+  //
+  // Detect this topology BEFORE any event emission or executor delegation
+  // so the abort path:
+  //   • does NOT fire a `merge.requested` event (Phase A intent)
+  //   • does NOT fire a `merge.preflight` event
+  //   • does NOT capture a wrong rollback SHA
+  //   • does NOT touch workflow state on disk
+  //
+  // We parse `git worktree list --porcelain`, whose record shape is:
+  //     worktree <absolute-path>
+  //     HEAD <sha>
+  //     branch refs/heads/<branchname>      (omitted for detached HEAD)
+  //     <blank line separator>
+  // If any record's branch equals our target AND its path is NOT the
+  // repoRoot we're about to operate on, the topology is unsafe — abort.
+  const repoRoot = args.repoRoot ?? process.cwd();
+  const worktreeListResult = gitExec(repoRoot, ['worktree', 'list', '--porcelain']);
+  if (worktreeListResult.exitCode === 0) {
+    const targetRef = `refs/heads/${args.targetBranch}`;
+    let currentPath: string | undefined;
+    let siblingHoldingTarget: string | undefined;
+    for (const rawLine of worktreeListResult.stdout.split('\n')) {
+      const line = rawLine.trimEnd();
+      if (line.startsWith('worktree ')) {
+        currentPath = line.slice('worktree '.length);
+      } else if (line.startsWith('branch ')) {
+        const ref = line.slice('branch '.length);
+        if (ref === targetRef && currentPath !== undefined && currentPath !== repoRoot) {
+          siblingHoldingTarget = currentPath;
+          break;
+        }
+      } else if (line === '') {
+        currentPath = undefined;
+      }
+    }
+    if (siblingHoldingTarget !== undefined) {
+      return {
+        success: false,
+        error: {
+          code: 'PREFLIGHT_FAILED',
+          message: `Target branch '${args.targetBranch}' is checked out in sibling worktree: ${siblingHoldingTarget}`,
+        },
+        data: {
+          phase: 'aborted' as const,
+          reason: 'target-checked-out-elsewhere' as const,
+          siblingWorktreePath: siblingHoldingTarget,
+        },
+      };
+    }
+  }
+
   // ─── 0. Resume short-circuit (T14) ───────────────────────────────────────
   // When `resume: true`, consult existing `mergeOrchestrator` state. If the
   // phase is terminal (per EXCLUDED_MERGE_PHASES — `completed`, `rolled-back`,

--- a/skills-src/merge-orchestrator/SKILL.md
+++ b/skills-src/merge-orchestrator/SKILL.md
@@ -111,17 +111,18 @@ For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
 These events are auto-emitted by the handler — do **not** manually append them via `{{MCP_PREFIX}}exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `{{MCP_PREFIX}}exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `{{MCP_PREFIX}}exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 

--- a/skills-src/merge-orchestrator/SKILL.md
+++ b/skills-src/merge-orchestrator/SKILL.md
@@ -57,12 +57,12 @@ Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-
 
 ### Step 2: Invoke
 
-Via MCP:
+Via MCP (illustrative — the canonical arg names come from `describe`):
 
 ```typescript
 {{MCP_PREFIX}}exarchos_orchestrate({
   action: "merge_orchestrate",
-  streamId: "<id>",
+  // workflow-correlation identifier — name per the action's schema
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
   taskId: "<task-id>",          // present when auto-dispatched from next_actions
@@ -76,11 +76,11 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
   --strategy squash
+  # plus the workflow-correlation id flag — see `--help`
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 

--- a/skills-src/merge-orchestrator/SKILL.md
+++ b/skills-src/merge-orchestrator/SKILL.md
@@ -1,31 +1,31 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto the integration branch with preflight + recorded rollback. Triggers: HSM `merge-pending` substate, `merge_orchestrate` next_action verb. Local git operation — NOT remote PR merging (that is `merge_pr` in the synthesize phase)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.0.0
+  version: 1.1.0
   mcp-server: exarchos
-  category: workflow
-  phase-affinity: merge-pending
+  category: behavior
 ---
 
 # Merge Orchestrator Skill
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a subagent's worktree branch into the integration branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging during the synthesize phase, see `@skills/synthesis/SKILL.md` (`merge_pr` action).
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
 ## Overview
 
-Closes the loop between `{{COMMAND_PREFIX}}delegate` (which spawns subagents into worktrees) and the integration branch that needs their work. After a delegated task completes inside a worktree, this skill:
+This skill activates whenever an operator (or an automated `next_actions` dispatcher) invokes the `merge_orchestrate` action against Exarchos MCP. After the source branch has been prepared in a worktree, this skill:
 
-1. Composes preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-2. Records pre-merge `HEAD` of the integration branch as a rollback anchor.
-3. Performs a local `git merge` of the source (subagent) branch into the target (integration) branch.
-4. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
-5. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
+1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
+2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
+3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+4. Performs a local `git merge` of the source branch into the target branch.
+5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
 
@@ -33,13 +33,13 @@ Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circu
 
 Activate this skill when:
 
-- The HSM is parked in `feature/merge-pending` (entry guard fires when the most recent `task.completed` carries a worktree association).
-- The `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `${streamId}:merge_orchestrate:${taskId}`.
-- The user runs `exarchos merge-orchestrate ...` (CLI) or invokes `{{MCP_PREFIX}}exarchos_orchestrate({ action: "merge_orchestrate", ... })` directly.
+- The operator runs `exarchos merge-orchestrate ...` (CLI).
+- `{{MCP_PREFIX}}exarchos_orchestrate({ action: "merge_orchestrate", ... })` is invoked directly.
+- An automated `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `<streamId>:merge_orchestrate:<taskId>`.
 
 Do **not** activate this skill:
-- During the synthesize phase to merge a remote PR — that is `merge_pr`.
-- When the workflow's `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
+- To merge a remote PR — that is `merge_pr`. The two are disjoint actions; see Disambiguation below.
+- When the orchestrator's recorded `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
 
 ## Process
 
@@ -62,13 +62,13 @@ Via MCP:
 ```typescript
 {{MCP_PREFIX}}exarchos_orchestrate({
   action: "merge_orchestrate",
-  featureId: "<id>",
+  streamId: "<id>",
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
-  taskId: "<task-id>",        // present when auto-dispatched from next_actions
-  strategy: "squash",          // required
-  dryRun: false,               // optional — preflight only, no executor invocation
-  resume: false,               // optional — short-circuit on terminal phases
+  taskId: "<task-id>",          // present when auto-dispatched from next_actions
+  strategy: "squash",            // required
+  dryRun: false,                 // optional — preflight only, no executor invocation
+  resume: false,                 // optional — short-circuit on terminal phases
 })
 ```
 
@@ -76,7 +76,7 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --feature-id <id> \
+  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
@@ -92,19 +92,30 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 
 | `phase` | Meaning | Operator action |
 |---------|---------|-----------------|
-| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow exits `merge-pending` back to `delegate` (HSM) and continues. |
-| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results. | Inspect `preflight.ancestry / worktree / currentBranchProtection / drift` to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The integration branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
+| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+
+#### Abort-reason payload shapes
+
+When `phase === 'aborted'`, the data payload discriminates the cause:
+
+| `data.reason` | Payload fields | Cause | Operator remediation |
+|---------------|----------------|-------|----------------------|
+| `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
+| *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
+
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the workflow's event stream (stream id = `featureId`) — **not** wrapped in `gate.executed`:
+Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
-| `merge.preflight` | Always (after preflight runs, before any merge attempt) | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
@@ -116,11 +127,10 @@ These events are auto-emitted by the handler — do **not** manually append them
 
 Two related actions, two distinct concerns:
 
-| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (synthesis skill) |
+| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (companion skill) |
 |--------|----------------------------------|------------------------------|
 | **Layer** | Local SDLC handoff | Remote PR primitive |
-| **Phase affinity** | `merge-pending` (between delegate and review) | `synthesize` |
-| **What it merges** | A subagent worktree branch into the integration branch | A user-facing PR via the VCS provider API |
+| **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
@@ -134,41 +144,33 @@ When invoked with `resume: true`, the handler reads existing `mergeOrchestrator`
 
 When invoked without `resume`, prior state is deliberately ignored — fresh-dispatch semantics.
 
+Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resume state read, so it short-circuits regardless of `resume` and never persists state.
+
 ## Dry-Run
 
-`dryRun: true` runs preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens.
+`dryRun: true` runs the body preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens. Dry-run still observes the worktree-availability early abort — a sibling-worktree conflict aborts with `reason: 'target-checked-out-elsewhere'` even under `dryRun`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Use this skill to merge a remote PR | Use `merge_pr` in the synthesize phase |
+| Use this skill to merge a remote PR | Use the `merge_pr` skill |
 | Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
-## Phase Transitions and Guards
-
-For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
-
-**Quick reference:**
-- `delegate` → `merge-pending` requires guard `merge-pending-entry` — fires when the most recent `task.completed` carries a worktree association AND `mergeOrchestrator.phase` is not in `EXCLUDED_MERGE_PHASES`.
-- `merge-pending` → `delegate` requires guard `merge-pending-exit` — fires when `mergeOrchestrator.phase` enters a terminal value (`completed` / `rolled-back` / `aborted`).
-
-The HSM exits `merge-pending` back to `delegate` regardless of merge outcome — `delegate` then re-evaluates whether more worktree-bearing tasks remain and either re-enters `merge-pending` for the next, or transitions on to `review` when all delegation is complete.
-
 ## Schema Discovery
 
-For the argument schema, call `{{MCP_PREFIX}}exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. The full feature-workflow phase playbook (which includes `merge-pending`) is available via `{{MCP_PREFIX}}exarchos_workflow({ action: "describe", playbook: "feature" })`. Event payload shapes come from `{{MCP_PREFIX}}exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `{{MCP_PREFIX}}exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `{{MCP_PREFIX}}exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
-- [ ] `mergeOrchestrator.phase === 'completed'` in workflow state
+- [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
 - [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
-- [ ] HSM has exited `merge-pending` back to `delegate`
-- [ ] Integration branch's HEAD matches the recorded `mergeSha`
+- [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills-src/merge-orchestrator/SKILL.md
+++ b/skills-src/merge-orchestrator/SKILL.md
@@ -135,7 +135,7 @@ Two related actions, two distinct concerns:
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,7 +156,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
@@ -165,7 +165,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 
 ## Schema Discovery
 
-For the argument schema, call `{{MCP_PREFIX}}exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `{{MCP_PREFIX}}exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `{{MCP_PREFIX}}exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `{{MCP_PREFIX}}exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 

--- a/skills/claude/merge-orchestrator/SKILL.md
+++ b/skills/claude/merge-orchestrator/SKILL.md
@@ -135,7 +135,7 @@ Two related actions, two distinct concerns:
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,7 +156,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
@@ -165,7 +165,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 
 ## Schema Discovery
 
-For the argument schema, call `mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 

--- a/skills/claude/merge-orchestrator/SKILL.md
+++ b/skills/claude/merge-orchestrator/SKILL.md
@@ -1,31 +1,31 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto the integration branch with preflight + recorded rollback. Triggers: HSM `merge-pending` substate, `merge_orchestrate` next_action verb. Local git operation — NOT remote PR merging (that is `merge_pr` in the synthesize phase)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.0.0
+  version: 1.1.0
   mcp-server: exarchos
-  category: workflow
-  phase-affinity: merge-pending
+  category: behavior
 ---
 
 # Merge Orchestrator Skill
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a subagent's worktree branch into the integration branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging during the synthesize phase, see `@skills/synthesis/SKILL.md` (`merge_pr` action).
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
 ## Overview
 
-Closes the loop between `/exarchos:delegate` (which spawns subagents into worktrees) and the integration branch that needs their work. After a delegated task completes inside a worktree, this skill:
+This skill activates whenever an operator (or an automated `next_actions` dispatcher) invokes the `merge_orchestrate` action against Exarchos MCP. After the source branch has been prepared in a worktree, this skill:
 
-1. Composes preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-2. Records pre-merge `HEAD` of the integration branch as a rollback anchor.
-3. Performs a local `git merge` of the source (subagent) branch into the target (integration) branch.
-4. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
-5. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
+1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
+2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
+3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+4. Performs a local `git merge` of the source branch into the target branch.
+5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
 
@@ -33,13 +33,13 @@ Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circu
 
 Activate this skill when:
 
-- The HSM is parked in `feature/merge-pending` (entry guard fires when the most recent `task.completed` carries a worktree association).
-- The `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `${streamId}:merge_orchestrate:${taskId}`.
-- The user runs `exarchos merge-orchestrate ...` (CLI) or invokes `mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })` directly.
+- The operator runs `exarchos merge-orchestrate ...` (CLI).
+- `mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })` is invoked directly.
+- An automated `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `<streamId>:merge_orchestrate:<taskId>`.
 
 Do **not** activate this skill:
-- During the synthesize phase to merge a remote PR — that is `merge_pr`.
-- When the workflow's `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
+- To merge a remote PR — that is `merge_pr`. The two are disjoint actions; see Disambiguation below.
+- When the orchestrator's recorded `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
 
 ## Process
 
@@ -62,13 +62,13 @@ Via MCP:
 ```typescript
 mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  featureId: "<id>",
+  streamId: "<id>",
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
-  taskId: "<task-id>",        // present when auto-dispatched from next_actions
-  strategy: "squash",          // required
-  dryRun: false,               // optional — preflight only, no executor invocation
-  resume: false,               // optional — short-circuit on terminal phases
+  taskId: "<task-id>",          // present when auto-dispatched from next_actions
+  strategy: "squash",            // required
+  dryRun: false,                 // optional — preflight only, no executor invocation
+  resume: false,                 // optional — short-circuit on terminal phases
 })
 ```
 
@@ -76,7 +76,7 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --feature-id <id> \
+  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
@@ -92,19 +92,30 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 
 | `phase` | Meaning | Operator action |
 |---------|---------|-----------------|
-| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow exits `merge-pending` back to `delegate` (HSM) and continues. |
-| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results. | Inspect `preflight.ancestry / worktree / currentBranchProtection / drift` to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The integration branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
+| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+
+#### Abort-reason payload shapes
+
+When `phase === 'aborted'`, the data payload discriminates the cause:
+
+| `data.reason` | Payload fields | Cause | Operator remediation |
+|---------------|----------------|-------|----------------------|
+| `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
+| *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
+
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the workflow's event stream (stream id = `featureId`) — **not** wrapped in `gate.executed`:
+Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
-| `merge.preflight` | Always (after preflight runs, before any merge attempt) | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
@@ -116,11 +127,10 @@ These events are auto-emitted by the handler — do **not** manually append them
 
 Two related actions, two distinct concerns:
 
-| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (synthesis skill) |
+| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (companion skill) |
 |--------|----------------------------------|------------------------------|
 | **Layer** | Local SDLC handoff | Remote PR primitive |
-| **Phase affinity** | `merge-pending` (between delegate and review) | `synthesize` |
-| **What it merges** | A subagent worktree branch into the integration branch | A user-facing PR via the VCS provider API |
+| **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
@@ -134,41 +144,33 @@ When invoked with `resume: true`, the handler reads existing `mergeOrchestrator`
 
 When invoked without `resume`, prior state is deliberately ignored — fresh-dispatch semantics.
 
+Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resume state read, so it short-circuits regardless of `resume` and never persists state.
+
 ## Dry-Run
 
-`dryRun: true` runs preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens.
+`dryRun: true` runs the body preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens. Dry-run still observes the worktree-availability early abort — a sibling-worktree conflict aborts with `reason: 'target-checked-out-elsewhere'` even under `dryRun`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Use this skill to merge a remote PR | Use `merge_pr` in the synthesize phase |
+| Use this skill to merge a remote PR | Use the `merge_pr` skill |
 | Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
-## Phase Transitions and Guards
-
-For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
-
-**Quick reference:**
-- `delegate` → `merge-pending` requires guard `merge-pending-entry` — fires when the most recent `task.completed` carries a worktree association AND `mergeOrchestrator.phase` is not in `EXCLUDED_MERGE_PHASES`.
-- `merge-pending` → `delegate` requires guard `merge-pending-exit` — fires when `mergeOrchestrator.phase` enters a terminal value (`completed` / `rolled-back` / `aborted`).
-
-The HSM exits `merge-pending` back to `delegate` regardless of merge outcome — `delegate` then re-evaluates whether more worktree-bearing tasks remain and either re-enters `merge-pending` for the next, or transitions on to `review` when all delegation is complete.
-
 ## Schema Discovery
 
-For the argument schema, call `mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. The full feature-workflow phase playbook (which includes `merge-pending`) is available via `mcp__plugin_exarchos_exarchos__exarchos_workflow({ action: "describe", playbook: "feature" })`. Event payload shapes come from `mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
-- [ ] `mergeOrchestrator.phase === 'completed'` in workflow state
+- [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
 - [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
-- [ ] HSM has exited `merge-pending` back to `delegate`
-- [ ] Integration branch's HEAD matches the recorded `mergeSha`
+- [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills/claude/merge-orchestrator/SKILL.md
+++ b/skills/claude/merge-orchestrator/SKILL.md
@@ -111,17 +111,18 @@ For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
 These events are auto-emitted by the handler — do **not** manually append them via `mcp__plugin_exarchos_exarchos__exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 

--- a/skills/claude/merge-orchestrator/SKILL.md
+++ b/skills/claude/merge-orchestrator/SKILL.md
@@ -57,12 +57,12 @@ Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-
 
 ### Step 2: Invoke
 
-Via MCP:
+Via MCP (illustrative — the canonical arg names come from `describe`):
 
 ```typescript
 mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  streamId: "<id>",
+  // workflow-correlation identifier — name per the action's schema
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
   taskId: "<task-id>",          // present when auto-dispatched from next_actions
@@ -76,11 +76,11 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
   --strategy squash
+  # plus the workflow-correlation id flag — see `--help`
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 

--- a/skills/codex/merge-orchestrator/SKILL.md
+++ b/skills/codex/merge-orchestrator/SKILL.md
@@ -1,31 +1,31 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto the integration branch with preflight + recorded rollback. Triggers: HSM `merge-pending` substate, `merge_orchestrate` next_action verb. Local git operation — NOT remote PR merging (that is `merge_pr` in the synthesize phase)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.0.0
+  version: 1.1.0
   mcp-server: exarchos
-  category: workflow
-  phase-affinity: merge-pending
+  category: behavior
 ---
 
 # Merge Orchestrator Skill
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a subagent's worktree branch into the integration branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging during the synthesize phase, see `@skills/synthesis/SKILL.md` (`merge_pr` action).
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
 ## Overview
 
-Closes the loop between `delegate` (which spawns subagents into worktrees) and the integration branch that needs their work. After a delegated task completes inside a worktree, this skill:
+This skill activates whenever an operator (or an automated `next_actions` dispatcher) invokes the `merge_orchestrate` action against Exarchos MCP. After the source branch has been prepared in a worktree, this skill:
 
-1. Composes preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-2. Records pre-merge `HEAD` of the integration branch as a rollback anchor.
-3. Performs a local `git merge` of the source (subagent) branch into the target (integration) branch.
-4. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
-5. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
+1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
+2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
+3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+4. Performs a local `git merge` of the source branch into the target branch.
+5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
 
@@ -33,13 +33,13 @@ Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circu
 
 Activate this skill when:
 
-- The HSM is parked in `feature/merge-pending` (entry guard fires when the most recent `task.completed` carries a worktree association).
-- The `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `${streamId}:merge_orchestrate:${taskId}`.
-- The user runs `exarchos merge-orchestrate ...` (CLI) or invokes `mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })` directly.
+- The operator runs `exarchos merge-orchestrate ...` (CLI).
+- `mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })` is invoked directly.
+- An automated `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `<streamId>:merge_orchestrate:<taskId>`.
 
 Do **not** activate this skill:
-- During the synthesize phase to merge a remote PR — that is `merge_pr`.
-- When the workflow's `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
+- To merge a remote PR — that is `merge_pr`. The two are disjoint actions; see Disambiguation below.
+- When the orchestrator's recorded `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
 
 ## Process
 
@@ -62,13 +62,13 @@ Via MCP:
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  featureId: "<id>",
+  streamId: "<id>",
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
-  taskId: "<task-id>",        // present when auto-dispatched from next_actions
-  strategy: "squash",          // required
-  dryRun: false,               // optional — preflight only, no executor invocation
-  resume: false,               // optional — short-circuit on terminal phases
+  taskId: "<task-id>",          // present when auto-dispatched from next_actions
+  strategy: "squash",            // required
+  dryRun: false,                 // optional — preflight only, no executor invocation
+  resume: false,                 // optional — short-circuit on terminal phases
 })
 ```
 
@@ -76,7 +76,7 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --feature-id <id> \
+  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
@@ -92,19 +92,30 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 
 | `phase` | Meaning | Operator action |
 |---------|---------|-----------------|
-| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow exits `merge-pending` back to `delegate` (HSM) and continues. |
-| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results. | Inspect `preflight.ancestry / worktree / currentBranchProtection / drift` to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The integration branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
+| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+
+#### Abort-reason payload shapes
+
+When `phase === 'aborted'`, the data payload discriminates the cause:
+
+| `data.reason` | Payload fields | Cause | Operator remediation |
+|---------------|----------------|-------|----------------------|
+| `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
+| *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
+
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the workflow's event stream (stream id = `featureId`) — **not** wrapped in `gate.executed`:
+Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
-| `merge.preflight` | Always (after preflight runs, before any merge attempt) | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
@@ -116,11 +127,10 @@ These events are auto-emitted by the handler — do **not** manually append them
 
 Two related actions, two distinct concerns:
 
-| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (synthesis skill) |
+| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (companion skill) |
 |--------|----------------------------------|------------------------------|
 | **Layer** | Local SDLC handoff | Remote PR primitive |
-| **Phase affinity** | `merge-pending` (between delegate and review) | `synthesize` |
-| **What it merges** | A subagent worktree branch into the integration branch | A user-facing PR via the VCS provider API |
+| **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
@@ -134,41 +144,33 @@ When invoked with `resume: true`, the handler reads existing `mergeOrchestrator`
 
 When invoked without `resume`, prior state is deliberately ignored — fresh-dispatch semantics.
 
+Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resume state read, so it short-circuits regardless of `resume` and never persists state.
+
 ## Dry-Run
 
-`dryRun: true` runs preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens.
+`dryRun: true` runs the body preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens. Dry-run still observes the worktree-availability early abort — a sibling-worktree conflict aborts with `reason: 'target-checked-out-elsewhere'` even under `dryRun`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Use this skill to merge a remote PR | Use `merge_pr` in the synthesize phase |
+| Use this skill to merge a remote PR | Use the `merge_pr` skill |
 | Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
-## Phase Transitions and Guards
-
-For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
-
-**Quick reference:**
-- `delegate` → `merge-pending` requires guard `merge-pending-entry` — fires when the most recent `task.completed` carries a worktree association AND `mergeOrchestrator.phase` is not in `EXCLUDED_MERGE_PHASES`.
-- `merge-pending` → `delegate` requires guard `merge-pending-exit` — fires when `mergeOrchestrator.phase` enters a terminal value (`completed` / `rolled-back` / `aborted`).
-
-The HSM exits `merge-pending` back to `delegate` regardless of merge outcome — `delegate` then re-evaluates whether more worktree-bearing tasks remain and either re-enters `merge-pending` for the next, or transitions on to `review` when all delegation is complete.
-
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. The full feature-workflow phase playbook (which includes `merge-pending`) is available via `mcp__exarchos__exarchos_workflow({ action: "describe", playbook: "feature" })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
-- [ ] `mergeOrchestrator.phase === 'completed'` in workflow state
+- [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
 - [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
-- [ ] HSM has exited `merge-pending` back to `delegate`
-- [ ] Integration branch's HEAD matches the recorded `mergeSha`
+- [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills/codex/merge-orchestrator/SKILL.md
+++ b/skills/codex/merge-orchestrator/SKILL.md
@@ -111,17 +111,18 @@ For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
 These events are auto-emitted by the handler — do **not** manually append them via `mcp__exarchos__exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 

--- a/skills/codex/merge-orchestrator/SKILL.md
+++ b/skills/codex/merge-orchestrator/SKILL.md
@@ -57,12 +57,12 @@ Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-
 
 ### Step 2: Invoke
 
-Via MCP:
+Via MCP (illustrative — the canonical arg names come from `describe`):
 
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  streamId: "<id>",
+  // workflow-correlation identifier — name per the action's schema
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
   taskId: "<task-id>",          // present when auto-dispatched from next_actions
@@ -76,11 +76,11 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
   --strategy squash
+  # plus the workflow-correlation id flag — see `--help`
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 

--- a/skills/codex/merge-orchestrator/SKILL.md
+++ b/skills/codex/merge-orchestrator/SKILL.md
@@ -135,7 +135,7 @@ Two related actions, two distinct concerns:
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,7 +156,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
@@ -165,7 +165,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 

--- a/skills/copilot/merge-orchestrator/SKILL.md
+++ b/skills/copilot/merge-orchestrator/SKILL.md
@@ -1,31 +1,31 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto the integration branch with preflight + recorded rollback. Triggers: HSM `merge-pending` substate, `merge_orchestrate` next_action verb. Local git operation — NOT remote PR merging (that is `merge_pr` in the synthesize phase)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.0.0
+  version: 1.1.0
   mcp-server: exarchos
-  category: workflow
-  phase-affinity: merge-pending
+  category: behavior
 ---
 
 # Merge Orchestrator Skill
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a subagent's worktree branch into the integration branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging during the synthesize phase, see `@skills/synthesis/SKILL.md` (`merge_pr` action).
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
 ## Overview
 
-Closes the loop between `/delegate` (which spawns subagents into worktrees) and the integration branch that needs their work. After a delegated task completes inside a worktree, this skill:
+This skill activates whenever an operator (or an automated `next_actions` dispatcher) invokes the `merge_orchestrate` action against Exarchos MCP. After the source branch has been prepared in a worktree, this skill:
 
-1. Composes preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-2. Records pre-merge `HEAD` of the integration branch as a rollback anchor.
-3. Performs a local `git merge` of the source (subagent) branch into the target (integration) branch.
-4. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
-5. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
+1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
+2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
+3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+4. Performs a local `git merge` of the source branch into the target branch.
+5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
 
@@ -33,13 +33,13 @@ Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circu
 
 Activate this skill when:
 
-- The HSM is parked in `feature/merge-pending` (entry guard fires when the most recent `task.completed` carries a worktree association).
-- The `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `${streamId}:merge_orchestrate:${taskId}`.
-- The user runs `exarchos merge-orchestrate ...` (CLI) or invokes `mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })` directly.
+- The operator runs `exarchos merge-orchestrate ...` (CLI).
+- `mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })` is invoked directly.
+- An automated `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `<streamId>:merge_orchestrate:<taskId>`.
 
 Do **not** activate this skill:
-- During the synthesize phase to merge a remote PR — that is `merge_pr`.
-- When the workflow's `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
+- To merge a remote PR — that is `merge_pr`. The two are disjoint actions; see Disambiguation below.
+- When the orchestrator's recorded `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
 
 ## Process
 
@@ -62,13 +62,13 @@ Via MCP:
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  featureId: "<id>",
+  streamId: "<id>",
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
-  taskId: "<task-id>",        // present when auto-dispatched from next_actions
-  strategy: "squash",          // required
-  dryRun: false,               // optional — preflight only, no executor invocation
-  resume: false,               // optional — short-circuit on terminal phases
+  taskId: "<task-id>",          // present when auto-dispatched from next_actions
+  strategy: "squash",            // required
+  dryRun: false,                 // optional — preflight only, no executor invocation
+  resume: false,                 // optional — short-circuit on terminal phases
 })
 ```
 
@@ -76,7 +76,7 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --feature-id <id> \
+  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
@@ -92,19 +92,30 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 
 | `phase` | Meaning | Operator action |
 |---------|---------|-----------------|
-| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow exits `merge-pending` back to `delegate` (HSM) and continues. |
-| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results. | Inspect `preflight.ancestry / worktree / currentBranchProtection / drift` to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The integration branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
+| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+
+#### Abort-reason payload shapes
+
+When `phase === 'aborted'`, the data payload discriminates the cause:
+
+| `data.reason` | Payload fields | Cause | Operator remediation |
+|---------------|----------------|-------|----------------------|
+| `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
+| *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
+
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the workflow's event stream (stream id = `featureId`) — **not** wrapped in `gate.executed`:
+Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
-| `merge.preflight` | Always (after preflight runs, before any merge attempt) | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
@@ -116,11 +127,10 @@ These events are auto-emitted by the handler — do **not** manually append them
 
 Two related actions, two distinct concerns:
 
-| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (synthesis skill) |
+| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (companion skill) |
 |--------|----------------------------------|------------------------------|
 | **Layer** | Local SDLC handoff | Remote PR primitive |
-| **Phase affinity** | `merge-pending` (between delegate and review) | `synthesize` |
-| **What it merges** | A subagent worktree branch into the integration branch | A user-facing PR via the VCS provider API |
+| **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
@@ -134,41 +144,33 @@ When invoked with `resume: true`, the handler reads existing `mergeOrchestrator`
 
 When invoked without `resume`, prior state is deliberately ignored — fresh-dispatch semantics.
 
+Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resume state read, so it short-circuits regardless of `resume` and never persists state.
+
 ## Dry-Run
 
-`dryRun: true` runs preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens.
+`dryRun: true` runs the body preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens. Dry-run still observes the worktree-availability early abort — a sibling-worktree conflict aborts with `reason: 'target-checked-out-elsewhere'` even under `dryRun`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Use this skill to merge a remote PR | Use `merge_pr` in the synthesize phase |
+| Use this skill to merge a remote PR | Use the `merge_pr` skill |
 | Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
-## Phase Transitions and Guards
-
-For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
-
-**Quick reference:**
-- `delegate` → `merge-pending` requires guard `merge-pending-entry` — fires when the most recent `task.completed` carries a worktree association AND `mergeOrchestrator.phase` is not in `EXCLUDED_MERGE_PHASES`.
-- `merge-pending` → `delegate` requires guard `merge-pending-exit` — fires when `mergeOrchestrator.phase` enters a terminal value (`completed` / `rolled-back` / `aborted`).
-
-The HSM exits `merge-pending` back to `delegate` regardless of merge outcome — `delegate` then re-evaluates whether more worktree-bearing tasks remain and either re-enters `merge-pending` for the next, or transitions on to `review` when all delegation is complete.
-
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. The full feature-workflow phase playbook (which includes `merge-pending`) is available via `mcp__exarchos__exarchos_workflow({ action: "describe", playbook: "feature" })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
-- [ ] `mergeOrchestrator.phase === 'completed'` in workflow state
+- [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
 - [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
-- [ ] HSM has exited `merge-pending` back to `delegate`
-- [ ] Integration branch's HEAD matches the recorded `mergeSha`
+- [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills/copilot/merge-orchestrator/SKILL.md
+++ b/skills/copilot/merge-orchestrator/SKILL.md
@@ -111,17 +111,18 @@ For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
 These events are auto-emitted by the handler — do **not** manually append them via `mcp__exarchos__exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 

--- a/skills/copilot/merge-orchestrator/SKILL.md
+++ b/skills/copilot/merge-orchestrator/SKILL.md
@@ -57,12 +57,12 @@ Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-
 
 ### Step 2: Invoke
 
-Via MCP:
+Via MCP (illustrative — the canonical arg names come from `describe`):
 
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  streamId: "<id>",
+  // workflow-correlation identifier — name per the action's schema
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
   taskId: "<task-id>",          // present when auto-dispatched from next_actions
@@ -76,11 +76,11 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
   --strategy squash
+  # plus the workflow-correlation id flag — see `--help`
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 

--- a/skills/copilot/merge-orchestrator/SKILL.md
+++ b/skills/copilot/merge-orchestrator/SKILL.md
@@ -135,7 +135,7 @@ Two related actions, two distinct concerns:
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,7 +156,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
@@ -165,7 +165,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 

--- a/skills/cursor/merge-orchestrator/SKILL.md
+++ b/skills/cursor/merge-orchestrator/SKILL.md
@@ -1,31 +1,31 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto the integration branch with preflight + recorded rollback. Triggers: HSM `merge-pending` substate, `merge_orchestrate` next_action verb. Local git operation — NOT remote PR merging (that is `merge_pr` in the synthesize phase)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.0.0
+  version: 1.1.0
   mcp-server: exarchos
-  category: workflow
-  phase-affinity: merge-pending
+  category: behavior
 ---
 
 # Merge Orchestrator Skill
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a subagent's worktree branch into the integration branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging during the synthesize phase, see `@skills/synthesis/SKILL.md` (`merge_pr` action).
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
 ## Overview
 
-Closes the loop between `delegate` (which spawns subagents into worktrees) and the integration branch that needs their work. After a delegated task completes inside a worktree, this skill:
+This skill activates whenever an operator (or an automated `next_actions` dispatcher) invokes the `merge_orchestrate` action against Exarchos MCP. After the source branch has been prepared in a worktree, this skill:
 
-1. Composes preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-2. Records pre-merge `HEAD` of the integration branch as a rollback anchor.
-3. Performs a local `git merge` of the source (subagent) branch into the target (integration) branch.
-4. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
-5. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
+1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
+2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
+3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+4. Performs a local `git merge` of the source branch into the target branch.
+5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
 
@@ -33,13 +33,13 @@ Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circu
 
 Activate this skill when:
 
-- The HSM is parked in `feature/merge-pending` (entry guard fires when the most recent `task.completed` carries a worktree association).
-- The `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `${streamId}:merge_orchestrate:${taskId}`.
-- The user runs `exarchos merge-orchestrate ...` (CLI) or invokes `mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })` directly.
+- The operator runs `exarchos merge-orchestrate ...` (CLI).
+- `mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })` is invoked directly.
+- An automated `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `<streamId>:merge_orchestrate:<taskId>`.
 
 Do **not** activate this skill:
-- During the synthesize phase to merge a remote PR — that is `merge_pr`.
-- When the workflow's `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
+- To merge a remote PR — that is `merge_pr`. The two are disjoint actions; see Disambiguation below.
+- When the orchestrator's recorded `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
 
 ## Process
 
@@ -62,13 +62,13 @@ Via MCP:
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  featureId: "<id>",
+  streamId: "<id>",
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
-  taskId: "<task-id>",        // present when auto-dispatched from next_actions
-  strategy: "squash",          // required
-  dryRun: false,               // optional — preflight only, no executor invocation
-  resume: false,               // optional — short-circuit on terminal phases
+  taskId: "<task-id>",          // present when auto-dispatched from next_actions
+  strategy: "squash",            // required
+  dryRun: false,                 // optional — preflight only, no executor invocation
+  resume: false,                 // optional — short-circuit on terminal phases
 })
 ```
 
@@ -76,7 +76,7 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --feature-id <id> \
+  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
@@ -92,19 +92,30 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 
 | `phase` | Meaning | Operator action |
 |---------|---------|-----------------|
-| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow exits `merge-pending` back to `delegate` (HSM) and continues. |
-| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results. | Inspect `preflight.ancestry / worktree / currentBranchProtection / drift` to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The integration branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
+| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+
+#### Abort-reason payload shapes
+
+When `phase === 'aborted'`, the data payload discriminates the cause:
+
+| `data.reason` | Payload fields | Cause | Operator remediation |
+|---------------|----------------|-------|----------------------|
+| `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
+| *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
+
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the workflow's event stream (stream id = `featureId`) — **not** wrapped in `gate.executed`:
+Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
-| `merge.preflight` | Always (after preflight runs, before any merge attempt) | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
@@ -116,11 +127,10 @@ These events are auto-emitted by the handler — do **not** manually append them
 
 Two related actions, two distinct concerns:
 
-| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (synthesis skill) |
+| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (companion skill) |
 |--------|----------------------------------|------------------------------|
 | **Layer** | Local SDLC handoff | Remote PR primitive |
-| **Phase affinity** | `merge-pending` (between delegate and review) | `synthesize` |
-| **What it merges** | A subagent worktree branch into the integration branch | A user-facing PR via the VCS provider API |
+| **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
@@ -134,41 +144,33 @@ When invoked with `resume: true`, the handler reads existing `mergeOrchestrator`
 
 When invoked without `resume`, prior state is deliberately ignored — fresh-dispatch semantics.
 
+Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resume state read, so it short-circuits regardless of `resume` and never persists state.
+
 ## Dry-Run
 
-`dryRun: true` runs preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens.
+`dryRun: true` runs the body preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens. Dry-run still observes the worktree-availability early abort — a sibling-worktree conflict aborts with `reason: 'target-checked-out-elsewhere'` even under `dryRun`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Use this skill to merge a remote PR | Use `merge_pr` in the synthesize phase |
+| Use this skill to merge a remote PR | Use the `merge_pr` skill |
 | Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
-## Phase Transitions and Guards
-
-For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
-
-**Quick reference:**
-- `delegate` → `merge-pending` requires guard `merge-pending-entry` — fires when the most recent `task.completed` carries a worktree association AND `mergeOrchestrator.phase` is not in `EXCLUDED_MERGE_PHASES`.
-- `merge-pending` → `delegate` requires guard `merge-pending-exit` — fires when `mergeOrchestrator.phase` enters a terminal value (`completed` / `rolled-back` / `aborted`).
-
-The HSM exits `merge-pending` back to `delegate` regardless of merge outcome — `delegate` then re-evaluates whether more worktree-bearing tasks remain and either re-enters `merge-pending` for the next, or transitions on to `review` when all delegation is complete.
-
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. The full feature-workflow phase playbook (which includes `merge-pending`) is available via `mcp__exarchos__exarchos_workflow({ action: "describe", playbook: "feature" })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
-- [ ] `mergeOrchestrator.phase === 'completed'` in workflow state
+- [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
 - [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
-- [ ] HSM has exited `merge-pending` back to `delegate`
-- [ ] Integration branch's HEAD matches the recorded `mergeSha`
+- [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills/cursor/merge-orchestrator/SKILL.md
+++ b/skills/cursor/merge-orchestrator/SKILL.md
@@ -111,17 +111,18 @@ For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
 These events are auto-emitted by the handler — do **not** manually append them via `mcp__exarchos__exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 

--- a/skills/cursor/merge-orchestrator/SKILL.md
+++ b/skills/cursor/merge-orchestrator/SKILL.md
@@ -57,12 +57,12 @@ Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-
 
 ### Step 2: Invoke
 
-Via MCP:
+Via MCP (illustrative — the canonical arg names come from `describe`):
 
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  streamId: "<id>",
+  // workflow-correlation identifier — name per the action's schema
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
   taskId: "<task-id>",          // present when auto-dispatched from next_actions
@@ -76,11 +76,11 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
   --strategy squash
+  # plus the workflow-correlation id flag — see `--help`
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 

--- a/skills/cursor/merge-orchestrator/SKILL.md
+++ b/skills/cursor/merge-orchestrator/SKILL.md
@@ -135,7 +135,7 @@ Two related actions, two distinct concerns:
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,7 +156,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
@@ -165,7 +165,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 

--- a/skills/generic/merge-orchestrator/SKILL.md
+++ b/skills/generic/merge-orchestrator/SKILL.md
@@ -1,31 +1,31 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto the integration branch with preflight + recorded rollback. Triggers: HSM `merge-pending` substate, `merge_orchestrate` next_action verb. Local git operation — NOT remote PR merging (that is `merge_pr` in the synthesize phase)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.0.0
+  version: 1.1.0
   mcp-server: exarchos
-  category: workflow
-  phase-affinity: merge-pending
+  category: behavior
 ---
 
 # Merge Orchestrator Skill
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a subagent's worktree branch into the integration branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging during the synthesize phase, see `@skills/synthesis/SKILL.md` (`merge_pr` action).
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
 ## Overview
 
-Closes the loop between `delegate` (which spawns subagents into worktrees) and the integration branch that needs their work. After a delegated task completes inside a worktree, this skill:
+This skill activates whenever an operator (or an automated `next_actions` dispatcher) invokes the `merge_orchestrate` action against Exarchos MCP. After the source branch has been prepared in a worktree, this skill:
 
-1. Composes preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-2. Records pre-merge `HEAD` of the integration branch as a rollback anchor.
-3. Performs a local `git merge` of the source (subagent) branch into the target (integration) branch.
-4. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
-5. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
+1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
+2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
+3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+4. Performs a local `git merge` of the source branch into the target branch.
+5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
 
@@ -33,13 +33,13 @@ Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circu
 
 Activate this skill when:
 
-- The HSM is parked in `feature/merge-pending` (entry guard fires when the most recent `task.completed` carries a worktree association).
-- The `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `${streamId}:merge_orchestrate:${taskId}`.
-- The user runs `exarchos merge-orchestrate ...` (CLI) or invokes `mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })` directly.
+- The operator runs `exarchos merge-orchestrate ...` (CLI).
+- `mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })` is invoked directly.
+- An automated `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `<streamId>:merge_orchestrate:<taskId>`.
 
 Do **not** activate this skill:
-- During the synthesize phase to merge a remote PR — that is `merge_pr`.
-- When the workflow's `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
+- To merge a remote PR — that is `merge_pr`. The two are disjoint actions; see Disambiguation below.
+- When the orchestrator's recorded `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
 
 ## Process
 
@@ -62,13 +62,13 @@ Via MCP:
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  featureId: "<id>",
+  streamId: "<id>",
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
-  taskId: "<task-id>",        // present when auto-dispatched from next_actions
-  strategy: "squash",          // required
-  dryRun: false,               // optional — preflight only, no executor invocation
-  resume: false,               // optional — short-circuit on terminal phases
+  taskId: "<task-id>",          // present when auto-dispatched from next_actions
+  strategy: "squash",            // required
+  dryRun: false,                 // optional — preflight only, no executor invocation
+  resume: false,                 // optional — short-circuit on terminal phases
 })
 ```
 
@@ -76,7 +76,7 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --feature-id <id> \
+  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
@@ -92,19 +92,30 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 
 | `phase` | Meaning | Operator action |
 |---------|---------|-----------------|
-| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow exits `merge-pending` back to `delegate` (HSM) and continues. |
-| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results. | Inspect `preflight.ancestry / worktree / currentBranchProtection / drift` to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The integration branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
+| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+
+#### Abort-reason payload shapes
+
+When `phase === 'aborted'`, the data payload discriminates the cause:
+
+| `data.reason` | Payload fields | Cause | Operator remediation |
+|---------------|----------------|-------|----------------------|
+| `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
+| *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
+
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the workflow's event stream (stream id = `featureId`) — **not** wrapped in `gate.executed`:
+Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
-| `merge.preflight` | Always (after preflight runs, before any merge attempt) | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
@@ -116,11 +127,10 @@ These events are auto-emitted by the handler — do **not** manually append them
 
 Two related actions, two distinct concerns:
 
-| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (synthesis skill) |
+| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (companion skill) |
 |--------|----------------------------------|------------------------------|
 | **Layer** | Local SDLC handoff | Remote PR primitive |
-| **Phase affinity** | `merge-pending` (between delegate and review) | `synthesize` |
-| **What it merges** | A subagent worktree branch into the integration branch | A user-facing PR via the VCS provider API |
+| **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
@@ -134,41 +144,33 @@ When invoked with `resume: true`, the handler reads existing `mergeOrchestrator`
 
 When invoked without `resume`, prior state is deliberately ignored — fresh-dispatch semantics.
 
+Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resume state read, so it short-circuits regardless of `resume` and never persists state.
+
 ## Dry-Run
 
-`dryRun: true` runs preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens.
+`dryRun: true` runs the body preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens. Dry-run still observes the worktree-availability early abort — a sibling-worktree conflict aborts with `reason: 'target-checked-out-elsewhere'` even under `dryRun`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Use this skill to merge a remote PR | Use `merge_pr` in the synthesize phase |
+| Use this skill to merge a remote PR | Use the `merge_pr` skill |
 | Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
-## Phase Transitions and Guards
-
-For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
-
-**Quick reference:**
-- `delegate` → `merge-pending` requires guard `merge-pending-entry` — fires when the most recent `task.completed` carries a worktree association AND `mergeOrchestrator.phase` is not in `EXCLUDED_MERGE_PHASES`.
-- `merge-pending` → `delegate` requires guard `merge-pending-exit` — fires when `mergeOrchestrator.phase` enters a terminal value (`completed` / `rolled-back` / `aborted`).
-
-The HSM exits `merge-pending` back to `delegate` regardless of merge outcome — `delegate` then re-evaluates whether more worktree-bearing tasks remain and either re-enters `merge-pending` for the next, or transitions on to `review` when all delegation is complete.
-
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. The full feature-workflow phase playbook (which includes `merge-pending`) is available via `mcp__exarchos__exarchos_workflow({ action: "describe", playbook: "feature" })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
-- [ ] `mergeOrchestrator.phase === 'completed'` in workflow state
+- [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
 - [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
-- [ ] HSM has exited `merge-pending` back to `delegate`
-- [ ] Integration branch's HEAD matches the recorded `mergeSha`
+- [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills/generic/merge-orchestrator/SKILL.md
+++ b/skills/generic/merge-orchestrator/SKILL.md
@@ -111,17 +111,18 @@ For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
 These events are auto-emitted by the handler — do **not** manually append them via `mcp__exarchos__exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 

--- a/skills/generic/merge-orchestrator/SKILL.md
+++ b/skills/generic/merge-orchestrator/SKILL.md
@@ -57,12 +57,12 @@ Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-
 
 ### Step 2: Invoke
 
-Via MCP:
+Via MCP (illustrative — the canonical arg names come from `describe`):
 
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  streamId: "<id>",
+  // workflow-correlation identifier — name per the action's schema
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
   taskId: "<task-id>",          // present when auto-dispatched from next_actions
@@ -76,11 +76,11 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
   --strategy squash
+  # plus the workflow-correlation id flag — see `--help`
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 

--- a/skills/generic/merge-orchestrator/SKILL.md
+++ b/skills/generic/merge-orchestrator/SKILL.md
@@ -135,7 +135,7 @@ Two related actions, two distinct concerns:
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,7 +156,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
@@ -165,7 +165,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 

--- a/skills/opencode/merge-orchestrator/SKILL.md
+++ b/skills/opencode/merge-orchestrator/SKILL.md
@@ -1,31 +1,31 @@
 ---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto the integration branch with preflight + recorded rollback. Triggers: HSM `merge-pending` substate, `merge_orchestrate` next_action verb. Local git operation — NOT remote PR merging (that is `merge_pr` in the synthesize phase)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or `next_actions`) surfaces verb `merge_orchestrate` via Exarchos MCP. Local git operation — NOT remote PR merging (that is `merge_pr`)."
 metadata:
   author: exarchos
-  version: 1.0.0
+  version: 1.1.0
   mcp-server: exarchos
-  category: workflow
-  phase-affinity: merge-pending
+  category: behavior
 ---
 
 # Merge Orchestrator Skill
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local `git merge`** of a subagent's worktree branch into the integration branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging during the synthesize phase, see `@skills/synthesis/SKILL.md` (`merge_pr` action).
+This skill performs **local `git merge`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a `git reset --hard` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the `merge_pr` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in `references/local-git-semantics.md`.
 
 ## Overview
 
-Closes the loop between `/delegate` (which spawns subagents into worktrees) and the integration branch that needs their work. After a delegated task completes inside a worktree, this skill:
+This skill activates whenever an operator (or an automated `next_actions` dispatcher) invokes the `merge_orchestrate` action against Exarchos MCP. After the source branch has been prepared in a worktree, this skill:
 
-1. Composes preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-2. Records pre-merge `HEAD` of the integration branch as a rollback anchor.
-3. Performs a local `git merge` of the source (subagent) branch into the target (integration) branch.
-4. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
-5. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
+1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
+2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
+3. Records pre-merge `HEAD` of the target branch as a rollback anchor.
+4. Performs a local `git merge` of the source branch into the target branch.
+5. On any failure, runs `git reset --hard <rollbackSha>` and surfaces a categorized failure reason.
+6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same `taskId` collapses via the `next_actions` idempotency key.
 
@@ -33,13 +33,13 @@ Resumable: terminal phases (`completed` / `rolled-back` / `aborted`) short-circu
 
 Activate this skill when:
 
-- The HSM is parked in `feature/merge-pending` (entry guard fires when the most recent `task.completed` carries a worktree association).
-- The `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `${streamId}:merge_orchestrate:${taskId}`.
-- The user runs `exarchos merge-orchestrate ...` (CLI) or invokes `mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })` directly.
+- The operator runs `exarchos merge-orchestrate ...` (CLI).
+- `mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })` is invoked directly.
+- An automated `next_actions` envelope surfaces a `merge_orchestrate` verb with idempotency key `<streamId>:merge_orchestrate:<taskId>`.
 
 Do **not** activate this skill:
-- During the synthesize phase to merge a remote PR — that is `merge_pr`.
-- When the workflow's `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
+- To merge a remote PR — that is `merge_pr`. The two are disjoint actions; see Disambiguation below.
+- When the orchestrator's recorded `mergeOrchestrator.phase` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
 
 ## Process
 
@@ -62,13 +62,13 @@ Via MCP:
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  featureId: "<id>",
+  streamId: "<id>",
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
-  taskId: "<task-id>",        // present when auto-dispatched from next_actions
-  strategy: "squash",          // required
-  dryRun: false,               // optional — preflight only, no executor invocation
-  resume: false,               // optional — short-circuit on terminal phases
+  taskId: "<task-id>",          // present when auto-dispatched from next_actions
+  strategy: "squash",            // required
+  dryRun: false,                 // optional — preflight only, no executor invocation
+  resume: false,                 // optional — short-circuit on terminal phases
 })
 ```
 
@@ -76,7 +76,7 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --feature-id <id> \
+  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
@@ -92,19 +92,30 @@ The handler returns a `ToolResult` whose `data.phase` discriminates the outcome:
 
 | `phase` | Meaning | Operator action |
 |---------|---------|-----------------|
-| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow exits `merge-pending` back to `delegate` (HSM) and continues. |
-| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results. | Inspect `preflight.ancestry / worktree / currentBranchProtection / drift` to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
-| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The integration branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| `completed` | Local merge landed; `mergeSha` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
+| `aborted` | Preflight failed; no merge attempted. `data.preflight` carries the structured guard sub-results (when produced by the body preflight) OR `data.reason` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
+| `rolled-back` | Merge was attempted, failed (`reason: 'merge-failed' / 'verification-failed' / 'timeout'`), and `git reset --hard <rollbackSha>` ran. The target branch is restored. | Inspect `data.reason`. If `data.rollbackError` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+
+#### Abort-reason payload shapes
+
+When `phase === 'aborted'`, the data payload discriminates the cause:
+
+| `data.reason` | Payload fields | Cause | Operator remediation |
+|---------------|----------------|-------|----------------------|
+| `target-checked-out-elsewhere` | `siblingWorktreePath: string` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (`git worktree remove <path>`), switch its checkout to another branch, or invoke `merge_orchestrate` against a different target. Then re-dispatch. |
+| *(body preflight failures)* | `data.preflight: { ancestry, worktree, currentBranchProtection, drift }` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect `preflight.*` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
+
+The `target-checked-out-elsewhere` abort path is special: it suppresses both the `merge.requested` and `merge.preflight` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the workflow's event stream (stream id = `featureId`) — **not** wrapped in `gate.executed`:
+Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
-| `merge.preflight` | Always (after preflight runs, before any merge attempt) | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
@@ -116,11 +127,10 @@ These events are auto-emitted by the handler — do **not** manually append them
 
 Two related actions, two distinct concerns:
 
-| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (synthesis skill) |
+| Aspect | `merge_orchestrate` (this skill) | `merge_pr` (companion skill) |
 |--------|----------------------------------|------------------------------|
 | **Layer** | Local SDLC handoff | Remote PR primitive |
-| **Phase affinity** | `merge-pending` (between delegate and review) | `synthesize` |
-| **What it merges** | A subagent worktree branch into the integration branch | A user-facing PR via the VCS provider API |
+| **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
@@ -134,41 +144,33 @@ When invoked with `resume: true`, the handler reads existing `mergeOrchestrator`
 
 When invoked without `resume`, prior state is deliberately ignored — fresh-dispatch semantics.
 
+Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resume state read, so it short-circuits regardless of `resume` and never persists state.
+
 ## Dry-Run
 
-`dryRun: true` runs preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens.
+`dryRun: true` runs the body preflight, emits `merge.preflight`, and short-circuits before the executor runs and before any state persistence. Returns `{ dryRun: true, preflight, phase: 'pending' | 'aborted' }`. Useful for CI integrations that check merge readiness before the merge window opens. Dry-run still observes the worktree-availability early abort — a sibling-worktree conflict aborts with `reason: 'target-checked-out-elsewhere'` even under `dryRun`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Use this skill to merge a remote PR | Use `merge_pr` in the synthesize phase |
+| Use this skill to merge a remote PR | Use the `merge_pr` skill |
 | Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
+| Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
-## Phase Transitions and Guards
-
-For the full transition table, consult `@skills/workflow-state/references/phase-transitions.md`.
-
-**Quick reference:**
-- `delegate` → `merge-pending` requires guard `merge-pending-entry` — fires when the most recent `task.completed` carries a worktree association AND `mergeOrchestrator.phase` is not in `EXCLUDED_MERGE_PHASES`.
-- `merge-pending` → `delegate` requires guard `merge-pending-exit` — fires when `mergeOrchestrator.phase` enters a terminal value (`completed` / `rolled-back` / `aborted`).
-
-The HSM exits `merge-pending` back to `delegate` regardless of merge outcome — `delegate` then re-evaluates whether more worktree-bearing tasks remain and either re-enters `merge-pending` for the next, or transitions on to `review` when all delegation is complete.
-
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. The full feature-workflow phase playbook (which includes `merge-pending`) is available via `mcp__exarchos__exarchos_workflow({ action: "describe", playbook: "feature" })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 
 - [ ] Preflight result `passed: true` (or operator has decided to proceed despite a documented preflight gap)
-- [ ] `mergeOrchestrator.phase === 'completed'` in workflow state
+- [ ] `mergeOrchestrator.phase === 'completed'` in orchestrator state
 - [ ] `merge.executed` event present in the stream with the recorded `mergeSha` and `rollbackSha`
-- [ ] HSM has exited `merge-pending` back to `delegate`
-- [ ] Integration branch's HEAD matches the recorded `mergeSha`
+- [ ] Target branch's HEAD matches the recorded `mergeSha`
 
 If any criterion fails, consult `references/recovery-runbook.md` before re-dispatching.

--- a/skills/opencode/merge-orchestrator/SKILL.md
+++ b/skills/opencode/merge-orchestrator/SKILL.md
@@ -111,17 +111,18 @@ For the full recovery flow per outcome, see `references/recovery-runbook.md`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
+Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as `streamId`) — **not** wrapped in `gate.executed`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | `merge.preflight` | Always (after preflight runs, before any merge attempt) — except for the early-abort `target-checked-out-elsewhere` path, which emits nothing | Full structured guard sub-results + `failureReasons` if `passed: false` |
+| `merge.requested` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort `target-checked-out-elsewhere` path | `sourceBranch`, `targetBranch`, `strategy`, `taskId` |
 | `merge.executed`  | On successful local merge | `mergeSha`, `rollbackSha`, `taskId`, source/target branches |
 | `merge.rollback`  | On post-merge failure followed by reset | `rollbackSha`, `reason`, `taskId`, source/target branches |
 
 These events are auto-emitted by the handler — do **not** manually append them via `mcp__exarchos__exarchos_event` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+> Discover the event payload schemas via `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Disambiguation: `merge_orchestrate` vs `merge_pr`
 

--- a/skills/opencode/merge-orchestrator/SKILL.md
+++ b/skills/opencode/merge-orchestrator/SKILL.md
@@ -57,12 +57,12 @@ Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-
 
 ### Step 2: Invoke
 
-Via MCP:
+Via MCP (illustrative — the canonical arg names come from `describe`):
 
 ```typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  streamId: "<id>",
+  // workflow-correlation identifier — name per the action's schema
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
   taskId: "<task-id>",          // present when auto-dispatched from next_actions
@@ -76,11 +76,11 @@ Via CLI:
 
 ```bash
 exarchos merge-orchestrate \
-  --stream-id <id> \
   --source-branch <subagent-branch> \
   --target-branch <integration-branch> \
   --task-id <task-id> \
   --strategy squash
+  # plus the workflow-correlation id flag — see `--help`
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 ```
 

--- a/skills/opencode/merge-orchestrator/SKILL.md
+++ b/skills/opencode/merge-orchestrator/SKILL.md
@@ -135,7 +135,7 @@ Two related actions, two distinct concerns:
 | **Identifier required** | `sourceBranch` + `targetBranch` | `prId` |
 | **Underlying operation** | `git merge` (local) | `provider.mergePr()` (remote API) |
 | **Rollback** | `git reset --hard <rollbackSha>` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | `merge.preflight` / `merge.executed` / `merge.rollback` | `pr.merged` |
+| **Events** | `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` | `pr.merged` |
 
 If you reach for `merge_orchestrate` thinking "I want to merge a PR," you want `merge_pr` instead.
 
@@ -156,7 +156,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the `merge_pr` skill |
-| Manually emit `merge.preflight` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
+| Manually emit `merge.preflight` / `merge.requested` / `merge.executed` / `merge.rollback` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [`recovery-runbook.md`](references/recovery-runbook.md)) |
 | Wrap merge events under `gate.executed` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a `rolled-back` outcome without inspecting the reason | Read `data.reason` and `data.rollbackError`; address the root cause first |
 | Re-dispatch after `reason: 'target-checked-out-elsewhere'` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by `data.siblingWorktreePath`, then re-dispatch |
@@ -165,7 +165,7 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 
 ## Schema Discovery
 
-For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })`.
+For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.
 
 ## Completion Criteria
 

--- a/src/install-skills.ts
+++ b/src/install-skills.ts
@@ -37,6 +37,7 @@ import { spawn as nodeSpawn, type SpawnOptions } from 'node:child_process';
 import { homedir } from 'node:os';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { RuntimeMap } from './runtimes/types.js';
 import { detectRuntime, AmbiguousRuntimeError, type DetectDeps } from './runtimes/detect.js';
 import {
@@ -114,6 +115,36 @@ export interface InstallSkillsOpts {
    * the `claude` runtime.
    */
   registerMcp?: (home: string) => void;
+  /**
+   * Optional explicit path to the per-runtime skills source tree (the
+   * directory that contains `<runtime>/<skill>/SKILL.md` children — i.e.
+   * the repo's `skills/` directory). When provided and the resolved
+   * `<skillsSource>/<runtime.name>/` exists, `installSkills()` performs
+   * a direct local-disk copy of every skill directory in that subtree
+   * to `runtime.skillsInstallPath` and skips the upstream `npx skills
+   * add` shell-out entirely. This is the #1355 fix path: the upstream
+   * CLI mis-installed for every non-claude runtime because it (a)
+   * cloned the repo and walked only the root level (missing the
+   * per-runtime trees) and (b) used its own per-agent home-dir mapping
+   * (`github-copilot` → `~/.agents/skills`) that does not align with
+   * our `runtimes/*.yaml` `skillsInstallPath` values. Copying locally
+   * sidesteps both bugs.
+   *
+   * When `undefined`, `installSkills()` calls `findSkillsSourceDir()`
+   * (which checks `<cwd>/skills`, then `<binary-dir>/../../skills`).
+   * If neither auto-detection step finds a viable source dir, the
+   * function falls back to the legacy `npx skills add` shell-out so
+   * existing unit tests (which never set this option) continue to
+   * verify the upstream invocation contract.
+   */
+  skillsSource?: string;
+  /**
+   * Injectable recursive directory copy. Default wraps
+   * `fs.cpSync(src, dest, { recursive: true })`. Tests inject a
+   * recorder so they can assert what was copied without touching disk.
+   * Only invoked when the local-copy fast path runs (see `skillsSource`).
+   */
+  copyDir?: (src: string, dest: string) => void;
 }
 
 /**
@@ -126,14 +157,137 @@ export interface InstallSkillsError extends Error {
 }
 
 /**
- * Expand a leading `~` in a path to the user's home directory. We do not use
- * `os.homedir()` directly so tests can pass a deterministic home. Also handles
- * the no-tilde case (returns input unchanged) and a bare `~` (returns home).
+ * Expand a leading `~` or `$HOME` in a path to the user's home directory.
+ * We do not use `os.homedir()` directly so tests can pass a deterministic
+ * home. Handles the no-marker case (returns input unchanged), a bare `~`
+ * or `$HOME` (returns home), and the `~/...` / `$HOME/...` prefixes. The
+ * `$HOME` form is recognized because `runtimes/codex.yaml` and any future
+ * shell-literal-style entry will not otherwise be expanded by the
+ * local-copy fast path (the upstream shell-out used to mask this because
+ * its child shell expanded `$HOME` itself, but the in-process copy never
+ * sees a shell).
  */
 export function expandTilde(p: string, home: string): string {
   if (p === '~') return home;
   if (p.startsWith('~/')) return `${home}${p.slice(1)}`;
+  if (p === '$HOME') return home;
+  if (p.startsWith('$HOME/')) return `${home}${p.slice('$HOME'.length)}`;
   return p;
+}
+
+/**
+ * Auto-detect the local skills source directory — the parent of
+ * `<runtime>/<skill>/SKILL.md` (i.e. the repo's `skills/` directory).
+ *
+ * Resolution order:
+ *   1. `<process.cwd()>/skills` — the outcome-test invocation path
+ *      (vitest runs from REPO_ROOT, so `process.cwd()` equals the
+ *      repo root and `skills/` is one level below).
+ *   2. `<dirname(process.execPath)>/../../skills` — the compiled-binary
+ *      install layout where the executable lives at
+ *      `<repo>/dist/bin/exarchos-<os>-<arch>`. Two `..` hops climb from
+ *      `dist/bin/` back to the repo root.
+ *   3. `<dirname(import.meta.url)>/../skills` — the Node-import dev
+ *      path. `src/install-skills.ts` is one directory below the repo
+ *      root, so a single `..` resolves to the `skills/` sibling.
+ *
+ * Returns the first candidate that exists as a directory, or `undefined`
+ * when none do. The caller (installSkills) falls back to the legacy
+ * upstream shell-out when this returns `undefined`.
+ *
+ * Implements: #1355 fix — auto-detection seam so the binary's local-copy
+ * fast path works in both the test harness and a developer-checkout
+ * production install.
+ */
+export function findSkillsSourceDir(): string | undefined {
+  const candidates: string[] = [];
+
+  // Candidate 1: process.cwd()/skills.
+  candidates.push(path.join(process.cwd(), 'skills'));
+
+  // Candidate 2: <binary-dir>/../../skills (dist/bin/ layout).
+  try {
+    if (typeof process.execPath === 'string' && process.execPath.length > 0) {
+      candidates.push(path.resolve(path.dirname(process.execPath), '..', '..', 'skills'));
+    }
+  } catch {
+    // process.execPath is always defined under Node/Bun, but guard anyway.
+  }
+
+  // Candidate 3: <this-file-dir>/../skills (src/ layout under tsx/ts-node).
+  try {
+    if (typeof import.meta.url === 'string' && import.meta.url.startsWith('file:')) {
+      const here = path.dirname(fileURLToPath(import.meta.url));
+      candidates.push(path.resolve(here, '..', 'skills'));
+    }
+  } catch {
+    // import.meta.url may be a non-file: URL inside bun-compile output.
+  }
+
+  for (const c of candidates) {
+    try {
+      const st = fs.statSync(c);
+      if (st.isDirectory()) return c;
+    } catch {
+      // Candidate doesn't exist — try next.
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Recursively copy `src` to `dest` using `fs.cpSync`. Pulled into a
+ * named helper so `installSkills` can default `opts.copyDir` to a
+ * stable function reference and tests can inject a recorder. Errors
+ * propagate to the caller — the upstream loop decides whether to
+ * partial-fail or abort.
+ */
+function defaultCopyDir(src: string, dest: string): void {
+  fs.cpSync(src, dest, { recursive: true });
+}
+
+/**
+ * Copy every skill directory under `sourceDir` (a directory containing
+ * `<skill>/SKILL.md` children) into `destDir`, creating `destDir` if
+ * needed. Returns the list of skill directory names that were copied
+ * so the caller can log a manifest.
+ *
+ * Idempotent at the directory-replace level: each skill subdir is
+ * removed from `destDir` before re-copy so stale files (left over from
+ * a previous install of an older version) are cleaned up. Files outside
+ * of a skill subdir under `destDir` are left untouched — we never
+ * blow away `destDir` itself in case the user keeps other skills there.
+ */
+export function copyLocalSkills(
+  sourceDir: string,
+  destDir: string,
+  copyDir: (src: string, dest: string) => void = defaultCopyDir,
+): string[] {
+  const entries = fs.readdirSync(sourceDir, { withFileTypes: true });
+  const skillDirs = entries
+    .filter((e) => e.isDirectory())
+    .filter((e) => {
+      try {
+        return fs.statSync(path.join(sourceDir, e.name, 'SKILL.md')).isFile();
+      } catch {
+        return false;
+      }
+    })
+    .map((e) => e.name);
+
+  fs.mkdirSync(destDir, { recursive: true });
+
+  for (const skill of skillDirs) {
+    const src = path.join(sourceDir, skill);
+    const dest = path.join(destDir, skill);
+    // Remove any prior copy so the install is byte-stable across runs.
+    // `force: true` makes ENOENT a no-op; `recursive: true` follows into
+    // subdirectories (reference files etc.).
+    fs.rmSync(dest, { recursive: true, force: true });
+    copyDir(src, dest);
+  }
+
+  return skillDirs;
 }
 
 /**
@@ -266,6 +420,65 @@ export async function installSkills(opts: InstallSkillsOpts): Promise<void> {
       } else {
         throw err;
       }
+    }
+  }
+
+  // #1355 fix — local-copy fast path.
+  //
+  // The upstream `npx skills add github:lvlup-sw/exarchos ...` shell-out
+  // mis-installed for every non-claude runtime: it cloned the repo and
+  // walked only the root level (finding just `design-invariants`,
+  // missing every skill under `skills/<runtime>/`) and used its own
+  // per-agent home-dir mapping that does not match our
+  // `runtimes/*.yaml` `skillsInstallPath` values. We sidestep both
+  // bugs by copying the rendered per-runtime tree directly to the
+  // runtime's canonical install path when a local skills source is
+  // available. The shell-out path below is retained as a fallback so
+  // existing unit tests (which never set `opts.skillsSource`) keep
+  // verifying the upstream invocation contract.
+  //
+  // `skillsSource` is strictly opt-in: callers (the install-skills
+  // bridge) explicitly supply `findSkillsSourceDir()` when they want
+  // the fast path. Library-level callers and the existing unit tests
+  // that assert on the upstream spawn argv (`src/install-skills.test.ts`)
+  // pass no `skillsSource`, so the spawn path stays the default. Doing
+  // implicit auto-detection inside `installSkills()` itself would
+  // regress those unit tests every time they ran from REPO_ROOT.
+  const skillsSource = opts.skillsSource;
+  if (skillsSource) {
+    const runtimeSourceDir = path.join(skillsSource, runtime.name);
+    let sourceIsViable = false;
+    try {
+      sourceIsViable = fs.statSync(runtimeSourceDir).isDirectory();
+    } catch {
+      sourceIsViable = false;
+    }
+    if (sourceIsViable) {
+      const home = homeDirFn();
+      const destDir = expandTilde(runtime.skillsInstallPath, home);
+      const copyDir = opts.copyDir ?? defaultCopyDir;
+      log(
+        `Installing skills locally from ${runtimeSourceDir} → ${destDir}`,
+      );
+      const installed = copyLocalSkills(runtimeSourceDir, destDir, copyDir);
+      log(`Installed ${installed.length} skill${installed.length === 1 ? '' : 's'}: ${installed.join(', ')}`);
+
+      // Mirror the post-success MCP registration that the spawn path
+      // performs for the `claude` runtime — install-skills' contract
+      // is "skills land + claude gets MCP wired up", regardless of
+      // which install transport ran.
+      if (runtime.name === 'claude') {
+        try {
+          registerMcp(home);
+        } catch (err) {
+          errLog(
+            `install-skills: skills installed, but failed to register MCP server in ~/.claude.json: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }
+      return;
     }
   }
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -1975,32 +1975,32 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 exports[`task 025 — per-runtime snapshot baselines > runtime: claude > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/claude/merge-orchestrator/SKILL.md > skills/claude/merge-orchestrator/SKILL.md 1`] = `
 "---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto the integration branch with preflight + recorded rollback. Triggers: HSM \`merge-pending\` substate, \`merge_orchestrate\` next_action verb. Local git operation — NOT remote PR merging (that is \`merge_pr\` in the synthesize phase)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
 metadata:
   author: exarchos
-  version: 1.0.0
+  version: 1.1.0
   mcp-server: exarchos
-  category: workflow
-  phase-affinity: merge-pending
+  category: behavior
 ---
 
 # Merge Orchestrator Skill
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local \`git merge\`** of a subagent's worktree branch into the integration branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging during the synthesize phase, see \`@skills/synthesis/SKILL.md\` (\`merge_pr\` action).
+This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in \`references/local-git-semantics.md\`.
 
 ## Overview
 
-Closes the loop between \`/exarchos:delegate\` (which spawns subagents into worktrees) and the integration branch that needs their work. After a delegated task completes inside a worktree, this skill:
+This skill activates whenever an operator (or an automated \`next_actions\` dispatcher) invokes the \`merge_orchestrate\` action against Exarchos MCP. After the source branch has been prepared in a worktree, this skill:
 
-1. Composes preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-2. Records pre-merge \`HEAD\` of the integration branch as a rollback anchor.
-3. Performs a local \`git merge\` of the source (subagent) branch into the target (integration) branch.
-4. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
-5. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
+1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
+2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
+3. Records pre-merge \`HEAD\` of the target branch as a rollback anchor.
+4. Performs a local \`git merge\` of the source branch into the target branch.
+5. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
+6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same \`taskId\` collapses via the \`next_actions\` idempotency key.
 
@@ -2008,13 +2008,13 @@ Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short
 
 Activate this skill when:
 
-- The HSM is parked in \`feature/merge-pending\` (entry guard fires when the most recent \`task.completed\` carries a worktree association).
-- The \`next_actions\` envelope surfaces a \`merge_orchestrate\` verb with idempotency key \`\${streamId}:merge_orchestrate:\${taskId}\`.
-- The user runs \`exarchos merge-orchestrate ...\` (CLI) or invokes \`mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })\` directly.
+- The operator runs \`exarchos merge-orchestrate ...\` (CLI).
+- \`mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })\` is invoked directly.
+- An automated \`next_actions\` envelope surfaces a \`merge_orchestrate\` verb with idempotency key \`<streamId>:merge_orchestrate:<taskId>\`.
 
 Do **not** activate this skill:
-- During the synthesize phase to merge a remote PR — that is \`merge_pr\`.
-- When the workflow's \`mergeOrchestrator.phase\` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
+- To merge a remote PR — that is \`merge_pr\`. The two are disjoint actions; see Disambiguation below.
+- When the orchestrator's recorded \`mergeOrchestrator.phase\` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
 
 ## Process
 
@@ -2037,13 +2037,13 @@ Via MCP:
 \`\`\`typescript
 mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  featureId: "<id>",
+  streamId: "<id>",
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
-  taskId: "<task-id>",        // present when auto-dispatched from next_actions
-  strategy: "squash",          // required
-  dryRun: false,               // optional — preflight only, no executor invocation
-  resume: false,               // optional — short-circuit on terminal phases
+  taskId: "<task-id>",          // present when auto-dispatched from next_actions
+  strategy: "squash",            // required
+  dryRun: false,                 // optional — preflight only, no executor invocation
+  resume: false,                 // optional — short-circuit on terminal phases
 })
 \`\`\`
 
@@ -2051,7 +2051,7 @@ Via CLI:
 
 \`\`\`bash
 exarchos merge-orchestrate \\
-  --feature-id <id> \\
+  --stream-id <id> \\
   --source-branch <subagent-branch> \\
   --target-branch <integration-branch> \\
   --task-id <task-id> \\
@@ -2067,19 +2067,30 @@ The handler returns a \`ToolResult\` whose \`data.phase\` discriminates the outc
 
 | \`phase\` | Meaning | Operator action |
 |---------|---------|-----------------|
-| \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow exits \`merge-pending\` back to \`delegate\` (HSM) and continues. |
-| \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results. | Inspect \`preflight.ancestry / worktree / currentBranchProtection / drift\` to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
-| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The integration branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
+| \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results (when produced by the body preflight) OR \`data.reason\` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
+| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The target branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+
+#### Abort-reason payload shapes
+
+When \`phase === 'aborted'\`, the data payload discriminates the cause:
+
+| \`data.reason\` | Payload fields | Cause | Operator remediation |
+|---------------|----------------|-------|----------------------|
+| \`target-checked-out-elsewhere\` | \`siblingWorktreePath: string\` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (\`git worktree remove <path>\`), switch its checkout to another branch, or invoke \`merge_orchestrate\` against a different target. Then re-dispatch. |
+| *(body preflight failures)* | \`data.preflight: { ancestry, worktree, currentBranchProtection, drift }\` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect \`preflight.*\` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
+
+The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the workflow's event stream (stream id = \`featureId\`) — **not** wrapped in \`gate.executed\`:
+Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
-| \`merge.preflight\` | Always (after preflight runs, before any merge attempt) | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
+| \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
 | \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
 
@@ -2091,11 +2102,10 @@ These events are auto-emitted by the handler — do **not** manually append them
 
 Two related actions, two distinct concerns:
 
-| Aspect | \`merge_orchestrate\` (this skill) | \`merge_pr\` (synthesis skill) |
+| Aspect | \`merge_orchestrate\` (this skill) | \`merge_pr\` (companion skill) |
 |--------|----------------------------------|------------------------------|
 | **Layer** | Local SDLC handoff | Remote PR primitive |
-| **Phase affinity** | \`merge-pending\` (between delegate and review) | \`synthesize\` |
-| **What it merges** | A subagent worktree branch into the integration branch | A user-facing PR via the VCS provider API |
+| **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
 | **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
@@ -2109,42 +2119,34 @@ When invoked with \`resume: true\`, the handler reads existing \`mergeOrchestrat
 
 When invoked without \`resume\`, prior state is deliberately ignored — fresh-dispatch semantics.
 
+Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the resume state read, so it short-circuits regardless of \`resume\` and never persists state.
+
 ## Dry-Run
 
-\`dryRun: true\` runs preflight, emits \`merge.preflight\`, and short-circuits before the executor runs and before any state persistence. Returns \`{ dryRun: true, preflight, phase: 'pending' | 'aborted' }\`. Useful for CI integrations that check merge readiness before the merge window opens.
+\`dryRun: true\` runs the body preflight, emits \`merge.preflight\`, and short-circuits before the executor runs and before any state persistence. Returns \`{ dryRun: true, preflight, phase: 'pending' | 'aborted' }\`. Useful for CI integrations that check merge readiness before the merge window opens. Dry-run still observes the worktree-availability early abort — a sibling-worktree conflict aborts with \`reason: 'target-checked-out-elsewhere'\` even under \`dryRun\`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Use this skill to merge a remote PR | Use \`merge_pr\` in the synthesize phase |
+| Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
 | Manually emit \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
+| Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
-## Phase Transitions and Guards
-
-For the full transition table, consult \`@skills/workflow-state/references/phase-transitions.md\`.
-
-**Quick reference:**
-- \`delegate\` → \`merge-pending\` requires guard \`merge-pending-entry\` — fires when the most recent \`task.completed\` carries a worktree association AND \`mergeOrchestrator.phase\` is not in \`EXCLUDED_MERGE_PHASES\`.
-- \`merge-pending\` → \`delegate\` requires guard \`merge-pending-exit\` — fires when \`mergeOrchestrator.phase\` enters a terminal value (\`completed\` / \`rolled-back\` / \`aborted\`).
-
-The HSM exits \`merge-pending\` back to \`delegate\` regardless of merge outcome — \`delegate\` then re-evaluates whether more worktree-bearing tasks remain and either re-enters \`merge-pending\` for the next, or transitions on to \`review\` when all delegation is complete.
-
 ## Schema Discovery
 
-For the argument schema, call \`mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. The full feature-workflow phase playbook (which includes \`merge-pending\`) is available via \`mcp__plugin_exarchos_exarchos__exarchos_workflow({ action: "describe", playbook: "feature" })\`. Event payload shapes come from \`mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
 
 ## Completion Criteria
 
 - [ ] Preflight result \`passed: true\` (or operator has decided to proceed despite a documented preflight gap)
-- [ ] \`mergeOrchestrator.phase === 'completed'\` in workflow state
+- [ ] \`mergeOrchestrator.phase === 'completed'\` in orchestrator state
 - [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\`
-- [ ] HSM has exited \`merge-pending\` back to \`delegate\`
-- [ ] Integration branch's HEAD matches the recorded \`mergeSha\`
+- [ ] Target branch's HEAD matches the recorded \`mergeSha\`
 
 If any criterion fails, consult \`references/recovery-runbook.md\` before re-dispatching.
 "
@@ -6552,32 +6554,32 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 exports[`task 025 — per-runtime snapshot baselines > runtime: codex > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/codex/merge-orchestrator/SKILL.md > skills/codex/merge-orchestrator/SKILL.md 1`] = `
 "---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto the integration branch with preflight + recorded rollback. Triggers: HSM \`merge-pending\` substate, \`merge_orchestrate\` next_action verb. Local git operation — NOT remote PR merging (that is \`merge_pr\` in the synthesize phase)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
 metadata:
   author: exarchos
-  version: 1.0.0
+  version: 1.1.0
   mcp-server: exarchos
-  category: workflow
-  phase-affinity: merge-pending
+  category: behavior
 ---
 
 # Merge Orchestrator Skill
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local \`git merge\`** of a subagent's worktree branch into the integration branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging during the synthesize phase, see \`@skills/synthesis/SKILL.md\` (\`merge_pr\` action).
+This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in \`references/local-git-semantics.md\`.
 
 ## Overview
 
-Closes the loop between \`delegate\` (which spawns subagents into worktrees) and the integration branch that needs their work. After a delegated task completes inside a worktree, this skill:
+This skill activates whenever an operator (or an automated \`next_actions\` dispatcher) invokes the \`merge_orchestrate\` action against Exarchos MCP. After the source branch has been prepared in a worktree, this skill:
 
-1. Composes preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-2. Records pre-merge \`HEAD\` of the integration branch as a rollback anchor.
-3. Performs a local \`git merge\` of the source (subagent) branch into the target (integration) branch.
-4. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
-5. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
+1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
+2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
+3. Records pre-merge \`HEAD\` of the target branch as a rollback anchor.
+4. Performs a local \`git merge\` of the source branch into the target branch.
+5. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
+6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same \`taskId\` collapses via the \`next_actions\` idempotency key.
 
@@ -6585,13 +6587,13 @@ Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short
 
 Activate this skill when:
 
-- The HSM is parked in \`feature/merge-pending\` (entry guard fires when the most recent \`task.completed\` carries a worktree association).
-- The \`next_actions\` envelope surfaces a \`merge_orchestrate\` verb with idempotency key \`\${streamId}:merge_orchestrate:\${taskId}\`.
-- The user runs \`exarchos merge-orchestrate ...\` (CLI) or invokes \`mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })\` directly.
+- The operator runs \`exarchos merge-orchestrate ...\` (CLI).
+- \`mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })\` is invoked directly.
+- An automated \`next_actions\` envelope surfaces a \`merge_orchestrate\` verb with idempotency key \`<streamId>:merge_orchestrate:<taskId>\`.
 
 Do **not** activate this skill:
-- During the synthesize phase to merge a remote PR — that is \`merge_pr\`.
-- When the workflow's \`mergeOrchestrator.phase\` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
+- To merge a remote PR — that is \`merge_pr\`. The two are disjoint actions; see Disambiguation below.
+- When the orchestrator's recorded \`mergeOrchestrator.phase\` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
 
 ## Process
 
@@ -6614,13 +6616,13 @@ Via MCP:
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  featureId: "<id>",
+  streamId: "<id>",
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
-  taskId: "<task-id>",        // present when auto-dispatched from next_actions
-  strategy: "squash",          // required
-  dryRun: false,               // optional — preflight only, no executor invocation
-  resume: false,               // optional — short-circuit on terminal phases
+  taskId: "<task-id>",          // present when auto-dispatched from next_actions
+  strategy: "squash",            // required
+  dryRun: false,                 // optional — preflight only, no executor invocation
+  resume: false,                 // optional — short-circuit on terminal phases
 })
 \`\`\`
 
@@ -6628,7 +6630,7 @@ Via CLI:
 
 \`\`\`bash
 exarchos merge-orchestrate \\
-  --feature-id <id> \\
+  --stream-id <id> \\
   --source-branch <subagent-branch> \\
   --target-branch <integration-branch> \\
   --task-id <task-id> \\
@@ -6644,19 +6646,30 @@ The handler returns a \`ToolResult\` whose \`data.phase\` discriminates the outc
 
 | \`phase\` | Meaning | Operator action |
 |---------|---------|-----------------|
-| \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow exits \`merge-pending\` back to \`delegate\` (HSM) and continues. |
-| \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results. | Inspect \`preflight.ancestry / worktree / currentBranchProtection / drift\` to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
-| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The integration branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
+| \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results (when produced by the body preflight) OR \`data.reason\` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
+| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The target branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+
+#### Abort-reason payload shapes
+
+When \`phase === 'aborted'\`, the data payload discriminates the cause:
+
+| \`data.reason\` | Payload fields | Cause | Operator remediation |
+|---------------|----------------|-------|----------------------|
+| \`target-checked-out-elsewhere\` | \`siblingWorktreePath: string\` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (\`git worktree remove <path>\`), switch its checkout to another branch, or invoke \`merge_orchestrate\` against a different target. Then re-dispatch. |
+| *(body preflight failures)* | \`data.preflight: { ancestry, worktree, currentBranchProtection, drift }\` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect \`preflight.*\` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
+
+The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the workflow's event stream (stream id = \`featureId\`) — **not** wrapped in \`gate.executed\`:
+Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
-| \`merge.preflight\` | Always (after preflight runs, before any merge attempt) | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
+| \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
 | \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
 
@@ -6668,11 +6681,10 @@ These events are auto-emitted by the handler — do **not** manually append them
 
 Two related actions, two distinct concerns:
 
-| Aspect | \`merge_orchestrate\` (this skill) | \`merge_pr\` (synthesis skill) |
+| Aspect | \`merge_orchestrate\` (this skill) | \`merge_pr\` (companion skill) |
 |--------|----------------------------------|------------------------------|
 | **Layer** | Local SDLC handoff | Remote PR primitive |
-| **Phase affinity** | \`merge-pending\` (between delegate and review) | \`synthesize\` |
-| **What it merges** | A subagent worktree branch into the integration branch | A user-facing PR via the VCS provider API |
+| **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
 | **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
@@ -6686,42 +6698,34 @@ When invoked with \`resume: true\`, the handler reads existing \`mergeOrchestrat
 
 When invoked without \`resume\`, prior state is deliberately ignored — fresh-dispatch semantics.
 
+Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the resume state read, so it short-circuits regardless of \`resume\` and never persists state.
+
 ## Dry-Run
 
-\`dryRun: true\` runs preflight, emits \`merge.preflight\`, and short-circuits before the executor runs and before any state persistence. Returns \`{ dryRun: true, preflight, phase: 'pending' | 'aborted' }\`. Useful for CI integrations that check merge readiness before the merge window opens.
+\`dryRun: true\` runs the body preflight, emits \`merge.preflight\`, and short-circuits before the executor runs and before any state persistence. Returns \`{ dryRun: true, preflight, phase: 'pending' | 'aborted' }\`. Useful for CI integrations that check merge readiness before the merge window opens. Dry-run still observes the worktree-availability early abort — a sibling-worktree conflict aborts with \`reason: 'target-checked-out-elsewhere'\` even under \`dryRun\`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Use this skill to merge a remote PR | Use \`merge_pr\` in the synthesize phase |
+| Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
 | Manually emit \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
+| Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
-## Phase Transitions and Guards
-
-For the full transition table, consult \`@skills/workflow-state/references/phase-transitions.md\`.
-
-**Quick reference:**
-- \`delegate\` → \`merge-pending\` requires guard \`merge-pending-entry\` — fires when the most recent \`task.completed\` carries a worktree association AND \`mergeOrchestrator.phase\` is not in \`EXCLUDED_MERGE_PHASES\`.
-- \`merge-pending\` → \`delegate\` requires guard \`merge-pending-exit\` — fires when \`mergeOrchestrator.phase\` enters a terminal value (\`completed\` / \`rolled-back\` / \`aborted\`).
-
-The HSM exits \`merge-pending\` back to \`delegate\` regardless of merge outcome — \`delegate\` then re-evaluates whether more worktree-bearing tasks remain and either re-enters \`merge-pending\` for the next, or transitions on to \`review\` when all delegation is complete.
-
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. The full feature-workflow phase playbook (which includes \`merge-pending\`) is available via \`mcp__exarchos__exarchos_workflow({ action: "describe", playbook: "feature" })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
 
 ## Completion Criteria
 
 - [ ] Preflight result \`passed: true\` (or operator has decided to proceed despite a documented preflight gap)
-- [ ] \`mergeOrchestrator.phase === 'completed'\` in workflow state
+- [ ] \`mergeOrchestrator.phase === 'completed'\` in orchestrator state
 - [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\`
-- [ ] HSM has exited \`merge-pending\` back to \`delegate\`
-- [ ] Integration branch's HEAD matches the recorded \`mergeSha\`
+- [ ] Target branch's HEAD matches the recorded \`mergeSha\`
 
 If any criterion fails, consult \`references/recovery-runbook.md\` before re-dispatching.
 "
@@ -11121,32 +11125,32 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 exports[`task 025 — per-runtime snapshot baselines > runtime: copilot > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/copilot/merge-orchestrator/SKILL.md > skills/copilot/merge-orchestrator/SKILL.md 1`] = `
 "---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto the integration branch with preflight + recorded rollback. Triggers: HSM \`merge-pending\` substate, \`merge_orchestrate\` next_action verb. Local git operation — NOT remote PR merging (that is \`merge_pr\` in the synthesize phase)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
 metadata:
   author: exarchos
-  version: 1.0.0
+  version: 1.1.0
   mcp-server: exarchos
-  category: workflow
-  phase-affinity: merge-pending
+  category: behavior
 ---
 
 # Merge Orchestrator Skill
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local \`git merge\`** of a subagent's worktree branch into the integration branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging during the synthesize phase, see \`@skills/synthesis/SKILL.md\` (\`merge_pr\` action).
+This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in \`references/local-git-semantics.md\`.
 
 ## Overview
 
-Closes the loop between \`/delegate\` (which spawns subagents into worktrees) and the integration branch that needs their work. After a delegated task completes inside a worktree, this skill:
+This skill activates whenever an operator (or an automated \`next_actions\` dispatcher) invokes the \`merge_orchestrate\` action against Exarchos MCP. After the source branch has been prepared in a worktree, this skill:
 
-1. Composes preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-2. Records pre-merge \`HEAD\` of the integration branch as a rollback anchor.
-3. Performs a local \`git merge\` of the source (subagent) branch into the target (integration) branch.
-4. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
-5. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
+1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
+2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
+3. Records pre-merge \`HEAD\` of the target branch as a rollback anchor.
+4. Performs a local \`git merge\` of the source branch into the target branch.
+5. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
+6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same \`taskId\` collapses via the \`next_actions\` idempotency key.
 
@@ -11154,13 +11158,13 @@ Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short
 
 Activate this skill when:
 
-- The HSM is parked in \`feature/merge-pending\` (entry guard fires when the most recent \`task.completed\` carries a worktree association).
-- The \`next_actions\` envelope surfaces a \`merge_orchestrate\` verb with idempotency key \`\${streamId}:merge_orchestrate:\${taskId}\`.
-- The user runs \`exarchos merge-orchestrate ...\` (CLI) or invokes \`mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })\` directly.
+- The operator runs \`exarchos merge-orchestrate ...\` (CLI).
+- \`mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })\` is invoked directly.
+- An automated \`next_actions\` envelope surfaces a \`merge_orchestrate\` verb with idempotency key \`<streamId>:merge_orchestrate:<taskId>\`.
 
 Do **not** activate this skill:
-- During the synthesize phase to merge a remote PR — that is \`merge_pr\`.
-- When the workflow's \`mergeOrchestrator.phase\` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
+- To merge a remote PR — that is \`merge_pr\`. The two are disjoint actions; see Disambiguation below.
+- When the orchestrator's recorded \`mergeOrchestrator.phase\` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
 
 ## Process
 
@@ -11183,13 +11187,13 @@ Via MCP:
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  featureId: "<id>",
+  streamId: "<id>",
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
-  taskId: "<task-id>",        // present when auto-dispatched from next_actions
-  strategy: "squash",          // required
-  dryRun: false,               // optional — preflight only, no executor invocation
-  resume: false,               // optional — short-circuit on terminal phases
+  taskId: "<task-id>",          // present when auto-dispatched from next_actions
+  strategy: "squash",            // required
+  dryRun: false,                 // optional — preflight only, no executor invocation
+  resume: false,                 // optional — short-circuit on terminal phases
 })
 \`\`\`
 
@@ -11197,7 +11201,7 @@ Via CLI:
 
 \`\`\`bash
 exarchos merge-orchestrate \\
-  --feature-id <id> \\
+  --stream-id <id> \\
   --source-branch <subagent-branch> \\
   --target-branch <integration-branch> \\
   --task-id <task-id> \\
@@ -11213,19 +11217,30 @@ The handler returns a \`ToolResult\` whose \`data.phase\` discriminates the outc
 
 | \`phase\` | Meaning | Operator action |
 |---------|---------|-----------------|
-| \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow exits \`merge-pending\` back to \`delegate\` (HSM) and continues. |
-| \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results. | Inspect \`preflight.ancestry / worktree / currentBranchProtection / drift\` to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
-| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The integration branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
+| \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results (when produced by the body preflight) OR \`data.reason\` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
+| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The target branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+
+#### Abort-reason payload shapes
+
+When \`phase === 'aborted'\`, the data payload discriminates the cause:
+
+| \`data.reason\` | Payload fields | Cause | Operator remediation |
+|---------------|----------------|-------|----------------------|
+| \`target-checked-out-elsewhere\` | \`siblingWorktreePath: string\` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (\`git worktree remove <path>\`), switch its checkout to another branch, or invoke \`merge_orchestrate\` against a different target. Then re-dispatch. |
+| *(body preflight failures)* | \`data.preflight: { ancestry, worktree, currentBranchProtection, drift }\` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect \`preflight.*\` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
+
+The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the workflow's event stream (stream id = \`featureId\`) — **not** wrapped in \`gate.executed\`:
+Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
-| \`merge.preflight\` | Always (after preflight runs, before any merge attempt) | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
+| \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
 | \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
 
@@ -11237,11 +11252,10 @@ These events are auto-emitted by the handler — do **not** manually append them
 
 Two related actions, two distinct concerns:
 
-| Aspect | \`merge_orchestrate\` (this skill) | \`merge_pr\` (synthesis skill) |
+| Aspect | \`merge_orchestrate\` (this skill) | \`merge_pr\` (companion skill) |
 |--------|----------------------------------|------------------------------|
 | **Layer** | Local SDLC handoff | Remote PR primitive |
-| **Phase affinity** | \`merge-pending\` (between delegate and review) | \`synthesize\` |
-| **What it merges** | A subagent worktree branch into the integration branch | A user-facing PR via the VCS provider API |
+| **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
 | **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
@@ -11255,42 +11269,34 @@ When invoked with \`resume: true\`, the handler reads existing \`mergeOrchestrat
 
 When invoked without \`resume\`, prior state is deliberately ignored — fresh-dispatch semantics.
 
+Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the resume state read, so it short-circuits regardless of \`resume\` and never persists state.
+
 ## Dry-Run
 
-\`dryRun: true\` runs preflight, emits \`merge.preflight\`, and short-circuits before the executor runs and before any state persistence. Returns \`{ dryRun: true, preflight, phase: 'pending' | 'aborted' }\`. Useful for CI integrations that check merge readiness before the merge window opens.
+\`dryRun: true\` runs the body preflight, emits \`merge.preflight\`, and short-circuits before the executor runs and before any state persistence. Returns \`{ dryRun: true, preflight, phase: 'pending' | 'aborted' }\`. Useful for CI integrations that check merge readiness before the merge window opens. Dry-run still observes the worktree-availability early abort — a sibling-worktree conflict aborts with \`reason: 'target-checked-out-elsewhere'\` even under \`dryRun\`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Use this skill to merge a remote PR | Use \`merge_pr\` in the synthesize phase |
+| Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
 | Manually emit \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
+| Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
-## Phase Transitions and Guards
-
-For the full transition table, consult \`@skills/workflow-state/references/phase-transitions.md\`.
-
-**Quick reference:**
-- \`delegate\` → \`merge-pending\` requires guard \`merge-pending-entry\` — fires when the most recent \`task.completed\` carries a worktree association AND \`mergeOrchestrator.phase\` is not in \`EXCLUDED_MERGE_PHASES\`.
-- \`merge-pending\` → \`delegate\` requires guard \`merge-pending-exit\` — fires when \`mergeOrchestrator.phase\` enters a terminal value (\`completed\` / \`rolled-back\` / \`aborted\`).
-
-The HSM exits \`merge-pending\` back to \`delegate\` regardless of merge outcome — \`delegate\` then re-evaluates whether more worktree-bearing tasks remain and either re-enters \`merge-pending\` for the next, or transitions on to \`review\` when all delegation is complete.
-
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. The full feature-workflow phase playbook (which includes \`merge-pending\`) is available via \`mcp__exarchos__exarchos_workflow({ action: "describe", playbook: "feature" })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
 
 ## Completion Criteria
 
 - [ ] Preflight result \`passed: true\` (or operator has decided to proceed despite a documented preflight gap)
-- [ ] \`mergeOrchestrator.phase === 'completed'\` in workflow state
+- [ ] \`mergeOrchestrator.phase === 'completed'\` in orchestrator state
 - [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\`
-- [ ] HSM has exited \`merge-pending\` back to \`delegate\`
-- [ ] Integration branch's HEAD matches the recorded \`mergeSha\`
+- [ ] Target branch's HEAD matches the recorded \`mergeSha\`
 
 If any criterion fails, consult \`references/recovery-runbook.md\` before re-dispatching.
 "
@@ -15700,32 +15706,32 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 exports[`task 025 — per-runtime snapshot baselines > runtime: cursor > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/cursor/merge-orchestrator/SKILL.md > skills/cursor/merge-orchestrator/SKILL.md 1`] = `
 "---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto the integration branch with preflight + recorded rollback. Triggers: HSM \`merge-pending\` substate, \`merge_orchestrate\` next_action verb. Local git operation — NOT remote PR merging (that is \`merge_pr\` in the synthesize phase)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
 metadata:
   author: exarchos
-  version: 1.0.0
+  version: 1.1.0
   mcp-server: exarchos
-  category: workflow
-  phase-affinity: merge-pending
+  category: behavior
 ---
 
 # Merge Orchestrator Skill
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local \`git merge\`** of a subagent's worktree branch into the integration branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging during the synthesize phase, see \`@skills/synthesis/SKILL.md\` (\`merge_pr\` action).
+This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in \`references/local-git-semantics.md\`.
 
 ## Overview
 
-Closes the loop between \`delegate\` (which spawns subagents into worktrees) and the integration branch that needs their work. After a delegated task completes inside a worktree, this skill:
+This skill activates whenever an operator (or an automated \`next_actions\` dispatcher) invokes the \`merge_orchestrate\` action against Exarchos MCP. After the source branch has been prepared in a worktree, this skill:
 
-1. Composes preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-2. Records pre-merge \`HEAD\` of the integration branch as a rollback anchor.
-3. Performs a local \`git merge\` of the source (subagent) branch into the target (integration) branch.
-4. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
-5. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
+1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
+2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
+3. Records pre-merge \`HEAD\` of the target branch as a rollback anchor.
+4. Performs a local \`git merge\` of the source branch into the target branch.
+5. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
+6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same \`taskId\` collapses via the \`next_actions\` idempotency key.
 
@@ -15733,13 +15739,13 @@ Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short
 
 Activate this skill when:
 
-- The HSM is parked in \`feature/merge-pending\` (entry guard fires when the most recent \`task.completed\` carries a worktree association).
-- The \`next_actions\` envelope surfaces a \`merge_orchestrate\` verb with idempotency key \`\${streamId}:merge_orchestrate:\${taskId}\`.
-- The user runs \`exarchos merge-orchestrate ...\` (CLI) or invokes \`mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })\` directly.
+- The operator runs \`exarchos merge-orchestrate ...\` (CLI).
+- \`mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })\` is invoked directly.
+- An automated \`next_actions\` envelope surfaces a \`merge_orchestrate\` verb with idempotency key \`<streamId>:merge_orchestrate:<taskId>\`.
 
 Do **not** activate this skill:
-- During the synthesize phase to merge a remote PR — that is \`merge_pr\`.
-- When the workflow's \`mergeOrchestrator.phase\` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
+- To merge a remote PR — that is \`merge_pr\`. The two are disjoint actions; see Disambiguation below.
+- When the orchestrator's recorded \`mergeOrchestrator.phase\` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
 
 ## Process
 
@@ -15762,13 +15768,13 @@ Via MCP:
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  featureId: "<id>",
+  streamId: "<id>",
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
-  taskId: "<task-id>",        // present when auto-dispatched from next_actions
-  strategy: "squash",          // required
-  dryRun: false,               // optional — preflight only, no executor invocation
-  resume: false,               // optional — short-circuit on terminal phases
+  taskId: "<task-id>",          // present when auto-dispatched from next_actions
+  strategy: "squash",            // required
+  dryRun: false,                 // optional — preflight only, no executor invocation
+  resume: false,                 // optional — short-circuit on terminal phases
 })
 \`\`\`
 
@@ -15776,7 +15782,7 @@ Via CLI:
 
 \`\`\`bash
 exarchos merge-orchestrate \\
-  --feature-id <id> \\
+  --stream-id <id> \\
   --source-branch <subagent-branch> \\
   --target-branch <integration-branch> \\
   --task-id <task-id> \\
@@ -15792,19 +15798,30 @@ The handler returns a \`ToolResult\` whose \`data.phase\` discriminates the outc
 
 | \`phase\` | Meaning | Operator action |
 |---------|---------|-----------------|
-| \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow exits \`merge-pending\` back to \`delegate\` (HSM) and continues. |
-| \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results. | Inspect \`preflight.ancestry / worktree / currentBranchProtection / drift\` to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
-| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The integration branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
+| \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results (when produced by the body preflight) OR \`data.reason\` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
+| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The target branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+
+#### Abort-reason payload shapes
+
+When \`phase === 'aborted'\`, the data payload discriminates the cause:
+
+| \`data.reason\` | Payload fields | Cause | Operator remediation |
+|---------------|----------------|-------|----------------------|
+| \`target-checked-out-elsewhere\` | \`siblingWorktreePath: string\` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (\`git worktree remove <path>\`), switch its checkout to another branch, or invoke \`merge_orchestrate\` against a different target. Then re-dispatch. |
+| *(body preflight failures)* | \`data.preflight: { ancestry, worktree, currentBranchProtection, drift }\` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect \`preflight.*\` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
+
+The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the workflow's event stream (stream id = \`featureId\`) — **not** wrapped in \`gate.executed\`:
+Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
-| \`merge.preflight\` | Always (after preflight runs, before any merge attempt) | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
+| \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
 | \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
 
@@ -15816,11 +15833,10 @@ These events are auto-emitted by the handler — do **not** manually append them
 
 Two related actions, two distinct concerns:
 
-| Aspect | \`merge_orchestrate\` (this skill) | \`merge_pr\` (synthesis skill) |
+| Aspect | \`merge_orchestrate\` (this skill) | \`merge_pr\` (companion skill) |
 |--------|----------------------------------|------------------------------|
 | **Layer** | Local SDLC handoff | Remote PR primitive |
-| **Phase affinity** | \`merge-pending\` (between delegate and review) | \`synthesize\` |
-| **What it merges** | A subagent worktree branch into the integration branch | A user-facing PR via the VCS provider API |
+| **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
 | **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
@@ -15834,42 +15850,34 @@ When invoked with \`resume: true\`, the handler reads existing \`mergeOrchestrat
 
 When invoked without \`resume\`, prior state is deliberately ignored — fresh-dispatch semantics.
 
+Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the resume state read, so it short-circuits regardless of \`resume\` and never persists state.
+
 ## Dry-Run
 
-\`dryRun: true\` runs preflight, emits \`merge.preflight\`, and short-circuits before the executor runs and before any state persistence. Returns \`{ dryRun: true, preflight, phase: 'pending' | 'aborted' }\`. Useful for CI integrations that check merge readiness before the merge window opens.
+\`dryRun: true\` runs the body preflight, emits \`merge.preflight\`, and short-circuits before the executor runs and before any state persistence. Returns \`{ dryRun: true, preflight, phase: 'pending' | 'aborted' }\`. Useful for CI integrations that check merge readiness before the merge window opens. Dry-run still observes the worktree-availability early abort — a sibling-worktree conflict aborts with \`reason: 'target-checked-out-elsewhere'\` even under \`dryRun\`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Use this skill to merge a remote PR | Use \`merge_pr\` in the synthesize phase |
+| Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
 | Manually emit \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
+| Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
-## Phase Transitions and Guards
-
-For the full transition table, consult \`@skills/workflow-state/references/phase-transitions.md\`.
-
-**Quick reference:**
-- \`delegate\` → \`merge-pending\` requires guard \`merge-pending-entry\` — fires when the most recent \`task.completed\` carries a worktree association AND \`mergeOrchestrator.phase\` is not in \`EXCLUDED_MERGE_PHASES\`.
-- \`merge-pending\` → \`delegate\` requires guard \`merge-pending-exit\` — fires when \`mergeOrchestrator.phase\` enters a terminal value (\`completed\` / \`rolled-back\` / \`aborted\`).
-
-The HSM exits \`merge-pending\` back to \`delegate\` regardless of merge outcome — \`delegate\` then re-evaluates whether more worktree-bearing tasks remain and either re-enters \`merge-pending\` for the next, or transitions on to \`review\` when all delegation is complete.
-
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. The full feature-workflow phase playbook (which includes \`merge-pending\`) is available via \`mcp__exarchos__exarchos_workflow({ action: "describe", playbook: "feature" })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
 
 ## Completion Criteria
 
 - [ ] Preflight result \`passed: true\` (or operator has decided to proceed despite a documented preflight gap)
-- [ ] \`mergeOrchestrator.phase === 'completed'\` in workflow state
+- [ ] \`mergeOrchestrator.phase === 'completed'\` in orchestrator state
 - [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\`
-- [ ] HSM has exited \`merge-pending\` back to \`delegate\`
-- [ ] Integration branch's HEAD matches the recorded \`mergeSha\`
+- [ ] Target branch's HEAD matches the recorded \`mergeSha\`
 
 If any criterion fails, consult \`references/recovery-runbook.md\` before re-dispatching.
 "
@@ -20250,32 +20258,32 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 exports[`task 025 — per-runtime snapshot baselines > runtime: generic > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/generic/merge-orchestrator/SKILL.md > skills/generic/merge-orchestrator/SKILL.md 1`] = `
 "---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto the integration branch with preflight + recorded rollback. Triggers: HSM \`merge-pending\` substate, \`merge_orchestrate\` next_action verb. Local git operation — NOT remote PR merging (that is \`merge_pr\` in the synthesize phase)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
 metadata:
   author: exarchos
-  version: 1.0.0
+  version: 1.1.0
   mcp-server: exarchos
-  category: workflow
-  phase-affinity: merge-pending
+  category: behavior
 ---
 
 # Merge Orchestrator Skill
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local \`git merge\`** of a subagent's worktree branch into the integration branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging during the synthesize phase, see \`@skills/synthesis/SKILL.md\` (\`merge_pr\` action).
+This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in \`references/local-git-semantics.md\`.
 
 ## Overview
 
-Closes the loop between \`delegate\` (which spawns subagents into worktrees) and the integration branch that needs their work. After a delegated task completes inside a worktree, this skill:
+This skill activates whenever an operator (or an automated \`next_actions\` dispatcher) invokes the \`merge_orchestrate\` action against Exarchos MCP. After the source branch has been prepared in a worktree, this skill:
 
-1. Composes preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-2. Records pre-merge \`HEAD\` of the integration branch as a rollback anchor.
-3. Performs a local \`git merge\` of the source (subagent) branch into the target (integration) branch.
-4. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
-5. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
+1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
+2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
+3. Records pre-merge \`HEAD\` of the target branch as a rollback anchor.
+4. Performs a local \`git merge\` of the source branch into the target branch.
+5. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
+6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same \`taskId\` collapses via the \`next_actions\` idempotency key.
 
@@ -20283,13 +20291,13 @@ Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short
 
 Activate this skill when:
 
-- The HSM is parked in \`feature/merge-pending\` (entry guard fires when the most recent \`task.completed\` carries a worktree association).
-- The \`next_actions\` envelope surfaces a \`merge_orchestrate\` verb with idempotency key \`\${streamId}:merge_orchestrate:\${taskId}\`.
-- The user runs \`exarchos merge-orchestrate ...\` (CLI) or invokes \`mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })\` directly.
+- The operator runs \`exarchos merge-orchestrate ...\` (CLI).
+- \`mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })\` is invoked directly.
+- An automated \`next_actions\` envelope surfaces a \`merge_orchestrate\` verb with idempotency key \`<streamId>:merge_orchestrate:<taskId>\`.
 
 Do **not** activate this skill:
-- During the synthesize phase to merge a remote PR — that is \`merge_pr\`.
-- When the workflow's \`mergeOrchestrator.phase\` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
+- To merge a remote PR — that is \`merge_pr\`. The two are disjoint actions; see Disambiguation below.
+- When the orchestrator's recorded \`mergeOrchestrator.phase\` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
 
 ## Process
 
@@ -20312,13 +20320,13 @@ Via MCP:
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  featureId: "<id>",
+  streamId: "<id>",
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
-  taskId: "<task-id>",        // present when auto-dispatched from next_actions
-  strategy: "squash",          // required
-  dryRun: false,               // optional — preflight only, no executor invocation
-  resume: false,               // optional — short-circuit on terminal phases
+  taskId: "<task-id>",          // present when auto-dispatched from next_actions
+  strategy: "squash",            // required
+  dryRun: false,                 // optional — preflight only, no executor invocation
+  resume: false,                 // optional — short-circuit on terminal phases
 })
 \`\`\`
 
@@ -20326,7 +20334,7 @@ Via CLI:
 
 \`\`\`bash
 exarchos merge-orchestrate \\
-  --feature-id <id> \\
+  --stream-id <id> \\
   --source-branch <subagent-branch> \\
   --target-branch <integration-branch> \\
   --task-id <task-id> \\
@@ -20342,19 +20350,30 @@ The handler returns a \`ToolResult\` whose \`data.phase\` discriminates the outc
 
 | \`phase\` | Meaning | Operator action |
 |---------|---------|-----------------|
-| \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow exits \`merge-pending\` back to \`delegate\` (HSM) and continues. |
-| \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results. | Inspect \`preflight.ancestry / worktree / currentBranchProtection / drift\` to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
-| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The integration branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
+| \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results (when produced by the body preflight) OR \`data.reason\` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
+| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The target branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+
+#### Abort-reason payload shapes
+
+When \`phase === 'aborted'\`, the data payload discriminates the cause:
+
+| \`data.reason\` | Payload fields | Cause | Operator remediation |
+|---------------|----------------|-------|----------------------|
+| \`target-checked-out-elsewhere\` | \`siblingWorktreePath: string\` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (\`git worktree remove <path>\`), switch its checkout to another branch, or invoke \`merge_orchestrate\` against a different target. Then re-dispatch. |
+| *(body preflight failures)* | \`data.preflight: { ancestry, worktree, currentBranchProtection, drift }\` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect \`preflight.*\` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
+
+The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the workflow's event stream (stream id = \`featureId\`) — **not** wrapped in \`gate.executed\`:
+Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
-| \`merge.preflight\` | Always (after preflight runs, before any merge attempt) | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
+| \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
 | \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
 
@@ -20366,11 +20385,10 @@ These events are auto-emitted by the handler — do **not** manually append them
 
 Two related actions, two distinct concerns:
 
-| Aspect | \`merge_orchestrate\` (this skill) | \`merge_pr\` (synthesis skill) |
+| Aspect | \`merge_orchestrate\` (this skill) | \`merge_pr\` (companion skill) |
 |--------|----------------------------------|------------------------------|
 | **Layer** | Local SDLC handoff | Remote PR primitive |
-| **Phase affinity** | \`merge-pending\` (between delegate and review) | \`synthesize\` |
-| **What it merges** | A subagent worktree branch into the integration branch | A user-facing PR via the VCS provider API |
+| **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
 | **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
@@ -20384,42 +20402,34 @@ When invoked with \`resume: true\`, the handler reads existing \`mergeOrchestrat
 
 When invoked without \`resume\`, prior state is deliberately ignored — fresh-dispatch semantics.
 
+Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the resume state read, so it short-circuits regardless of \`resume\` and never persists state.
+
 ## Dry-Run
 
-\`dryRun: true\` runs preflight, emits \`merge.preflight\`, and short-circuits before the executor runs and before any state persistence. Returns \`{ dryRun: true, preflight, phase: 'pending' | 'aborted' }\`. Useful for CI integrations that check merge readiness before the merge window opens.
+\`dryRun: true\` runs the body preflight, emits \`merge.preflight\`, and short-circuits before the executor runs and before any state persistence. Returns \`{ dryRun: true, preflight, phase: 'pending' | 'aborted' }\`. Useful for CI integrations that check merge readiness before the merge window opens. Dry-run still observes the worktree-availability early abort — a sibling-worktree conflict aborts with \`reason: 'target-checked-out-elsewhere'\` even under \`dryRun\`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Use this skill to merge a remote PR | Use \`merge_pr\` in the synthesize phase |
+| Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
 | Manually emit \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
+| Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
-## Phase Transitions and Guards
-
-For the full transition table, consult \`@skills/workflow-state/references/phase-transitions.md\`.
-
-**Quick reference:**
-- \`delegate\` → \`merge-pending\` requires guard \`merge-pending-entry\` — fires when the most recent \`task.completed\` carries a worktree association AND \`mergeOrchestrator.phase\` is not in \`EXCLUDED_MERGE_PHASES\`.
-- \`merge-pending\` → \`delegate\` requires guard \`merge-pending-exit\` — fires when \`mergeOrchestrator.phase\` enters a terminal value (\`completed\` / \`rolled-back\` / \`aborted\`).
-
-The HSM exits \`merge-pending\` back to \`delegate\` regardless of merge outcome — \`delegate\` then re-evaluates whether more worktree-bearing tasks remain and either re-enters \`merge-pending\` for the next, or transitions on to \`review\` when all delegation is complete.
-
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. The full feature-workflow phase playbook (which includes \`merge-pending\`) is available via \`mcp__exarchos__exarchos_workflow({ action: "describe", playbook: "feature" })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
 
 ## Completion Criteria
 
 - [ ] Preflight result \`passed: true\` (or operator has decided to proceed despite a documented preflight gap)
-- [ ] \`mergeOrchestrator.phase === 'completed'\` in workflow state
+- [ ] \`mergeOrchestrator.phase === 'completed'\` in orchestrator state
 - [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\`
-- [ ] HSM has exited \`merge-pending\` back to \`delegate\`
-- [ ] Integration branch's HEAD matches the recorded \`mergeSha\`
+- [ ] Target branch's HEAD matches the recorded \`mergeSha\`
 
 If any criterion fails, consult \`references/recovery-runbook.md\` before re-dispatching.
 "
@@ -24827,32 +24837,32 @@ Phase transitions auto-emit \`workflow.transition\` events via \`exarchos_workfl
 exports[`task 025 — per-runtime snapshot baselines > runtime: opencode > Snapshots_AllSkillsAllRuntimes_MatchBaseline: skills/opencode/merge-orchestrator/SKILL.md > skills/opencode/merge-orchestrator/SKILL.md 1`] = `
 "---
 name: merge-orchestrator
-description: "Land a subagent worktree branch onto the integration branch with preflight + recorded rollback. Triggers: HSM \`merge-pending\` substate, \`merge_orchestrate\` next_action verb. Local git operation — NOT remote PR merging (that is \`merge_pr\` in the synthesize phase)."
+description: "Land a subagent worktree branch onto an integration branch with preflight + recorded rollback. Triggers: operator (or \`next_actions\`) surfaces verb \`merge_orchestrate\` via Exarchos MCP. Local git operation — NOT remote PR merging (that is \`merge_pr\`)."
 metadata:
   author: exarchos
-  version: 1.0.0
+  version: 1.1.0
   mcp-server: exarchos
-  category: workflow
-  phase-affinity: merge-pending
+  category: behavior
 ---
 
 # Merge Orchestrator Skill
 
 ## Local Git, Not Remote VCS
 
-This skill performs **local \`git merge\`** of a subagent's worktree branch into the integration branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging during the synthesize phase, see \`@skills/synthesis/SKILL.md\` (\`merge_pr\` action).
+This skill performs **local \`git merge\`** of a source (subagent) worktree branch into a target (integration) branch, recording a rollback SHA so a \`git reset --hard\` can undo the merge on any failure. It does **not** call the VCS provider (GitHub / GitLab / Azure DevOps) and does not require a PR id. For remote PR merging, see the companion skill that wraps the \`merge_pr\` action.
 
 The mental model and the rationale for why these are two separate concerns are documented in \`references/local-git-semantics.md\`.
 
 ## Overview
 
-Closes the loop between \`/delegate\` (which spawns subagents into worktrees) and the integration branch that needs their work. After a delegated task completes inside a worktree, this skill:
+This skill activates whenever an operator (or an automated \`next_actions\` dispatcher) invokes the \`merge_orchestrate\` action against Exarchos MCP. After the source branch has been prepared in a worktree, this skill:
 
-1. Composes preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
-2. Records pre-merge \`HEAD\` of the integration branch as a rollback anchor.
-3. Performs a local \`git merge\` of the source (subagent) branch into the target (integration) branch.
-4. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
-5. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
+1. Performs a worktree-availability preflight (target branch must not be checked out in a sibling worktree).
+2. Composes additional preflight guards (ancestry, current-branch protection, main-worktree assertion, working-tree drift).
+3. Records pre-merge \`HEAD\` of the target branch as a rollback anchor.
+4. Performs a local \`git merge\` of the source branch into the target branch.
+5. On any failure, runs \`git reset --hard <rollbackSha>\` and surfaces a categorized failure reason.
+6. Emits dedicated event types so the merge timeline is reconstructable from the event log alone.
 
 Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short-circuit on re-entry without re-emitting events. Idempotent: re-dispatch with the same \`taskId\` collapses via the \`next_actions\` idempotency key.
 
@@ -24860,13 +24870,13 @@ Resumable: terminal phases (\`completed\` / \`rolled-back\` / \`aborted\`) short
 
 Activate this skill when:
 
-- The HSM is parked in \`feature/merge-pending\` (entry guard fires when the most recent \`task.completed\` carries a worktree association).
-- The \`next_actions\` envelope surfaces a \`merge_orchestrate\` verb with idempotency key \`\${streamId}:merge_orchestrate:\${taskId}\`.
-- The user runs \`exarchos merge-orchestrate ...\` (CLI) or invokes \`mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })\` directly.
+- The operator runs \`exarchos merge-orchestrate ...\` (CLI).
+- \`mcp__exarchos__exarchos_orchestrate({ action: "merge_orchestrate", ... })\` is invoked directly.
+- An automated \`next_actions\` envelope surfaces a \`merge_orchestrate\` verb with idempotency key \`<streamId>:merge_orchestrate:<taskId>\`.
 
 Do **not** activate this skill:
-- During the synthesize phase to merge a remote PR — that is \`merge_pr\`.
-- When the workflow's \`mergeOrchestrator.phase\` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
+- To merge a remote PR — that is \`merge_pr\`. The two are disjoint actions; see Disambiguation below.
+- When the orchestrator's recorded \`mergeOrchestrator.phase\` is already terminal — the resume short-circuit runs but no fresh dispatch is needed.
 
 ## Process
 
@@ -24889,13 +24899,13 @@ Via MCP:
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  featureId: "<id>",
+  streamId: "<id>",
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
-  taskId: "<task-id>",        // present when auto-dispatched from next_actions
-  strategy: "squash",          // required
-  dryRun: false,               // optional — preflight only, no executor invocation
-  resume: false,               // optional — short-circuit on terminal phases
+  taskId: "<task-id>",          // present when auto-dispatched from next_actions
+  strategy: "squash",            // required
+  dryRun: false,                 // optional — preflight only, no executor invocation
+  resume: false,                 // optional — short-circuit on terminal phases
 })
 \`\`\`
 
@@ -24903,7 +24913,7 @@ Via CLI:
 
 \`\`\`bash
 exarchos merge-orchestrate \\
-  --feature-id <id> \\
+  --stream-id <id> \\
   --source-branch <subagent-branch> \\
   --target-branch <integration-branch> \\
   --task-id <task-id> \\
@@ -24919,19 +24929,30 @@ The handler returns a \`ToolResult\` whose \`data.phase\` discriminates the outc
 
 | \`phase\` | Meaning | Operator action |
 |---------|---------|-----------------|
-| \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow exits \`merge-pending\` back to \`delegate\` (HSM) and continues. |
-| \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results. | Inspect \`preflight.ancestry / worktree / currentBranchProtection / drift\` to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
-| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The integration branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+| \`completed\` | Local merge landed; \`mergeSha\` is the new HEAD of target. | None — workflow continues per the orchestrator's playbook. |
+| \`aborted\` | Preflight failed; no merge attempted. \`data.preflight\` carries the structured guard sub-results (when produced by the body preflight) OR \`data.reason\` discriminates the early-abort cause. | See the abort-reason table below. Resolve the underlying condition and re-dispatch. |
+| \`rolled-back\` | Merge was attempted, failed (\`reason: 'merge-failed' / 'verification-failed' / 'timeout'\`), and \`git reset --hard <rollbackSha>\` ran. The target branch is restored. | Inspect \`data.reason\`. If \`data.rollbackError\` is also present, the reset itself failed — the working tree is stranded and requires operator intervention. |
+
+#### Abort-reason payload shapes
+
+When \`phase === 'aborted'\`, the data payload discriminates the cause:
+
+| \`data.reason\` | Payload fields | Cause | Operator remediation |
+|---------------|----------------|-------|----------------------|
+| \`target-checked-out-elsewhere\` | \`siblingWorktreePath: string\` (absolute path) | Target branch is already checked out in a sibling worktree of the same repository. Detected by the worktree-availability preflight (issue #1356) *before* any event emission, executor invocation, or state persistence. | Resolve the sibling worktree: either remove it (\`git worktree remove <path>\`), switch its checkout to another branch, or invoke \`merge_orchestrate\` against a different target. Then re-dispatch. |
+| *(body preflight failures)* | \`data.preflight: { ancestry, worktree, currentBranchProtection, drift }\` | Body-preflight guard failed (ancestry mismatch, worktree drift, protected current branch, etc.). | Inspect \`preflight.*\` sub-results to identify which guard failed. Resolve the underlying condition (e.g., commit/stash drift, switch off a protected branch) and re-dispatch. |
+
+The \`target-checked-out-elsewhere\` abort path is special: it suppresses both the \`merge.requested\` and \`merge.preflight\` events and skips state persistence entirely. This guarantees the event log is never contaminated with an attempt that could not have captured a correct rollback SHA (the executor would have read HEAD from the wrong worktree).
 
 For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the workflow's event stream (stream id = \`featureId\`) — **not** wrapped in \`gate.executed\`:
+Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
-| \`merge.preflight\` | Always (after preflight runs, before any merge attempt) | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
+| \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
 | \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
 
@@ -24943,11 +24964,10 @@ These events are auto-emitted by the handler — do **not** manually append them
 
 Two related actions, two distinct concerns:
 
-| Aspect | \`merge_orchestrate\` (this skill) | \`merge_pr\` (synthesis skill) |
+| Aspect | \`merge_orchestrate\` (this skill) | \`merge_pr\` (companion skill) |
 |--------|----------------------------------|------------------------------|
 | **Layer** | Local SDLC handoff | Remote PR primitive |
-| **Phase affinity** | \`merge-pending\` (between delegate and review) | \`synthesize\` |
-| **What it merges** | A subagent worktree branch into the integration branch | A user-facing PR via the VCS provider API |
+| **What it merges** | A subagent worktree branch into a target branch | A user-facing PR via the VCS provider API |
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
 | **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
@@ -24961,42 +24981,34 @@ When invoked with \`resume: true\`, the handler reads existing \`mergeOrchestrat
 
 When invoked without \`resume\`, prior state is deliberately ignored — fresh-dispatch semantics.
 
+Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the resume state read, so it short-circuits regardless of \`resume\` and never persists state.
+
 ## Dry-Run
 
-\`dryRun: true\` runs preflight, emits \`merge.preflight\`, and short-circuits before the executor runs and before any state persistence. Returns \`{ dryRun: true, preflight, phase: 'pending' | 'aborted' }\`. Useful for CI integrations that check merge readiness before the merge window opens.
+\`dryRun: true\` runs the body preflight, emits \`merge.preflight\`, and short-circuits before the executor runs and before any state persistence. Returns \`{ dryRun: true, preflight, phase: 'pending' | 'aborted' }\`. Useful for CI integrations that check merge readiness before the merge window opens. Dry-run still observes the worktree-availability early abort — a sibling-worktree conflict aborts with \`reason: 'target-checked-out-elsewhere'\` even under \`dryRun\`.
 
 ## Anti-Patterns
 
 | Don't | Do Instead |
 |-------|------------|
-| Use this skill to merge a remote PR | Use \`merge_pr\` in the synthesize phase |
+| Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
 | Manually emit \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
+| Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
-## Phase Transitions and Guards
-
-For the full transition table, consult \`@skills/workflow-state/references/phase-transitions.md\`.
-
-**Quick reference:**
-- \`delegate\` → \`merge-pending\` requires guard \`merge-pending-entry\` — fires when the most recent \`task.completed\` carries a worktree association AND \`mergeOrchestrator.phase\` is not in \`EXCLUDED_MERGE_PHASES\`.
-- \`merge-pending\` → \`delegate\` requires guard \`merge-pending-exit\` — fires when \`mergeOrchestrator.phase\` enters a terminal value (\`completed\` / \`rolled-back\` / \`aborted\`).
-
-The HSM exits \`merge-pending\` back to \`delegate\` regardless of merge outcome — \`delegate\` then re-evaluates whether more worktree-bearing tasks remain and either re-enters \`merge-pending\` for the next, or transitions on to \`review\` when all delegation is complete.
-
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. The full feature-workflow phase playbook (which includes \`merge-pending\`) is available via \`mcp__exarchos__exarchos_workflow({ action: "describe", playbook: "feature" })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
 
 ## Completion Criteria
 
 - [ ] Preflight result \`passed: true\` (or operator has decided to proceed despite a documented preflight gap)
-- [ ] \`mergeOrchestrator.phase === 'completed'\` in workflow state
+- [ ] \`mergeOrchestrator.phase === 'completed'\` in orchestrator state
 - [ ] \`merge.executed\` event present in the stream with the recorded \`mergeSha\` and \`rollbackSha\`
-- [ ] HSM has exited \`merge-pending\` back to \`delegate\`
-- [ ] Integration branch's HEAD matches the recorded \`mergeSha\`
+- [ ] Target branch's HEAD matches the recorded \`mergeSha\`
 
 If any criterion fails, consult \`references/recovery-runbook.md\` before re-dispatching.
 "

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -2110,7 +2110,7 @@ Two related actions, two distinct concerns:
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
 | **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
+| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
 
 If you reach for \`merge_orchestrate\` thinking "I want to merge a PR," you want \`merge_pr\` instead.
 
@@ -2131,7 +2131,7 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
-| Manually emit \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
+| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
@@ -2140,7 +2140,7 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 
 ## Schema Discovery
 
-For the argument schema, call \`mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
 
 ## Completion Criteria
 
@@ -6690,7 +6690,7 @@ Two related actions, two distinct concerns:
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
 | **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
+| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
 
 If you reach for \`merge_orchestrate\` thinking "I want to merge a PR," you want \`merge_pr\` instead.
 
@@ -6711,7 +6711,7 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
-| Manually emit \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
+| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
@@ -6720,7 +6720,7 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
 
 ## Completion Criteria
 
@@ -11262,7 +11262,7 @@ Two related actions, two distinct concerns:
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
 | **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
+| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
 
 If you reach for \`merge_orchestrate\` thinking "I want to merge a PR," you want \`merge_pr\` instead.
 
@@ -11283,7 +11283,7 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
-| Manually emit \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
+| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
@@ -11292,7 +11292,7 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
 
 ## Completion Criteria
 
@@ -15844,7 +15844,7 @@ Two related actions, two distinct concerns:
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
 | **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
+| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
 
 If you reach for \`merge_orchestrate\` thinking "I want to merge a PR," you want \`merge_pr\` instead.
 
@@ -15865,7 +15865,7 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
-| Manually emit \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
+| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
@@ -15874,7 +15874,7 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
 
 ## Completion Criteria
 
@@ -20397,7 +20397,7 @@ Two related actions, two distinct concerns:
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
 | **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
+| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
 
 If you reach for \`merge_orchestrate\` thinking "I want to merge a PR," you want \`merge_pr\` instead.
 
@@ -20418,7 +20418,7 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
-| Manually emit \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
+| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
@@ -20427,7 +20427,7 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
 
 ## Completion Criteria
 
@@ -24977,7 +24977,7 @@ Two related actions, two distinct concerns:
 | **Identifier required** | \`sourceBranch\` + \`targetBranch\` | \`prId\` |
 | **Underlying operation** | \`git merge\` (local) | \`provider.mergePr()\` (remote API) |
 | **Rollback** | \`git reset --hard <rollbackSha>\` (real, undoes the merge) | None — the VCS provider owns merge state |
-| **Events** | \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
+| **Events** | \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` | \`pr.merged\` |
 
 If you reach for \`merge_orchestrate\` thinking "I want to merge a PR," you want \`merge_pr\` instead.
 
@@ -24998,7 +24998,7 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Don't | Do Instead |
 |-------|------------|
 | Use this skill to merge a remote PR | Use the \`merge_pr\` skill |
-| Manually emit \`merge.preflight\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
+| Manually emit \`merge.preflight\` / \`merge.requested\` / \`merge.executed\` / \`merge.rollback\` in normal flow | Let the handler auto-emit; manual emission causes duplicates (one exception: documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md)) |
 | Wrap merge events under \`gate.executed\` | Direct stream append with the dedicated event type — these are state transitions, not gate executions |
 | Re-dispatch after a \`rolled-back\` outcome without inspecting the reason | Read \`data.reason\` and \`data.rollbackError\`; address the root cause first |
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
@@ -25007,7 +25007,7 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 
 ## Schema Discovery
 
-For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
 
 ## Completion Criteria
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -2086,17 +2086,18 @@ For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
+Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
+| \`merge.requested\` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort \`target-checked-out-elsewhere\` path | \`sourceBranch\`, \`targetBranch\`, \`strategy\`, \`taskId\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
 | \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
 
 These events are auto-emitted by the handler — do **not** manually append them via \`mcp__plugin_exarchos_exarchos__exarchos_event\` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via \`mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+> Discover the event payload schemas via \`mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
 
 ## Disambiguation: \`merge_orchestrate\` vs \`merge_pr\`
 
@@ -6665,17 +6666,18 @@ For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
+Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
+| \`merge.requested\` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort \`target-checked-out-elsewhere\` path | \`sourceBranch\`, \`targetBranch\`, \`strategy\`, \`taskId\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
 | \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
 
 These events are auto-emitted by the handler — do **not** manually append them via \`mcp__exarchos__exarchos_event\` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
 
 ## Disambiguation: \`merge_orchestrate\` vs \`merge_pr\`
 
@@ -11236,17 +11238,18 @@ For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
+Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
+| \`merge.requested\` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort \`target-checked-out-elsewhere\` path | \`sourceBranch\`, \`targetBranch\`, \`strategy\`, \`taskId\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
 | \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
 
 These events are auto-emitted by the handler — do **not** manually append them via \`mcp__exarchos__exarchos_event\` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
 
 ## Disambiguation: \`merge_orchestrate\` vs \`merge_pr\`
 
@@ -15817,17 +15820,18 @@ For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
+Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
+| \`merge.requested\` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort \`target-checked-out-elsewhere\` path | \`sourceBranch\`, \`targetBranch\`, \`strategy\`, \`taskId\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
 | \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
 
 These events are auto-emitted by the handler — do **not** manually append them via \`mcp__exarchos__exarchos_event\` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
 
 ## Disambiguation: \`merge_orchestrate\` vs \`merge_pr\`
 
@@ -20369,17 +20373,18 @@ For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
+Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
+| \`merge.requested\` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort \`target-checked-out-elsewhere\` path | \`sourceBranch\`, \`targetBranch\`, \`strategy\`, \`taskId\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
 | \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
 
 These events are auto-emitted by the handler — do **not** manually append them via \`mcp__exarchos__exarchos_event\` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
 
 ## Disambiguation: \`merge_orchestrate\` vs \`merge_pr\`
 
@@ -24948,17 +24953,18 @@ For the full recovery flow per outcome, see \`references/recovery-runbook.md\`.
 
 ### Step 4: Confirm event emissions
 
-Three events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
+Four events are emitted directly to the orchestrator's event stream (stream id is the value passed as \`streamId\`) — **not** wrapped in \`gate.executed\`:
 
 | Event type | When | Carries |
 |------------|------|---------|
 | \`merge.preflight\` | Always (after preflight runs, before any merge attempt) — except for the early-abort \`target-checked-out-elsewhere\` path, which emits nothing | Full structured guard sub-results + \`failureReasons\` if \`passed: false\` |
+| \`merge.requested\` | After preflight passes, before the executor runs (Phase A intent record from the two-event split) — suppressed on the early-abort \`target-checked-out-elsewhere\` path | \`sourceBranch\`, \`targetBranch\`, \`strategy\`, \`taskId\` |
 | \`merge.executed\`  | On successful local merge | \`mergeSha\`, \`rollbackSha\`, \`taskId\`, source/target branches |
 | \`merge.rollback\`  | On post-merge failure followed by reset | \`rollbackSha\`, \`reason\`, \`taskId\`, source/target branches |
 
 These events are auto-emitted by the handler — do **not** manually append them via \`mcp__exarchos__exarchos_event\` during normal operation. Manual emission is only sanctioned during the documented manual-recovery flow in [\`recovery-runbook.md\`](references/recovery-runbook.md) when a merge has been completed out-of-band (e.g., conflict resolution) and the event log must be brought back in sync — follow that runbook's event-first sequencing.
 
-> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.executed", "merge.rollback"] })\`.
+> Discover the event payload schemas via \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
 
 ## Disambiguation: \`merge_orchestrate\` vs \`merge_pr\`
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -2032,12 +2032,12 @@ Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-
 
 ### Step 2: Invoke
 
-Via MCP:
+Via MCP (illustrative — the canonical arg names come from \`describe\`):
 
 \`\`\`typescript
 mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  streamId: "<id>",
+  // workflow-correlation identifier — name per the action's schema
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
   taskId: "<task-id>",          // present when auto-dispatched from next_actions
@@ -2051,11 +2051,11 @@ Via CLI:
 
 \`\`\`bash
 exarchos merge-orchestrate \\
-  --stream-id <id> \\
   --source-branch <subagent-branch> \\
   --target-branch <integration-branch> \\
   --task-id <task-id> \\
   --strategy squash
+  # plus the workflow-correlation id flag — see \`--help\`
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 \`\`\`
 
@@ -6611,12 +6611,12 @@ Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-
 
 ### Step 2: Invoke
 
-Via MCP:
+Via MCP (illustrative — the canonical arg names come from \`describe\`):
 
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  streamId: "<id>",
+  // workflow-correlation identifier — name per the action's schema
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
   taskId: "<task-id>",          // present when auto-dispatched from next_actions
@@ -6630,11 +6630,11 @@ Via CLI:
 
 \`\`\`bash
 exarchos merge-orchestrate \\
-  --stream-id <id> \\
   --source-branch <subagent-branch> \\
   --target-branch <integration-branch> \\
   --task-id <task-id> \\
   --strategy squash
+  # plus the workflow-correlation id flag — see \`--help\`
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 \`\`\`
 
@@ -11182,12 +11182,12 @@ Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-
 
 ### Step 2: Invoke
 
-Via MCP:
+Via MCP (illustrative — the canonical arg names come from \`describe\`):
 
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  streamId: "<id>",
+  // workflow-correlation identifier — name per the action's schema
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
   taskId: "<task-id>",          // present when auto-dispatched from next_actions
@@ -11201,11 +11201,11 @@ Via CLI:
 
 \`\`\`bash
 exarchos merge-orchestrate \\
-  --stream-id <id> \\
   --source-branch <subagent-branch> \\
   --target-branch <integration-branch> \\
   --task-id <task-id> \\
   --strategy squash
+  # plus the workflow-correlation id flag — see \`--help\`
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 \`\`\`
 
@@ -15763,12 +15763,12 @@ Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-
 
 ### Step 2: Invoke
 
-Via MCP:
+Via MCP (illustrative — the canonical arg names come from \`describe\`):
 
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  streamId: "<id>",
+  // workflow-correlation identifier — name per the action's schema
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
   taskId: "<task-id>",          // present when auto-dispatched from next_actions
@@ -15782,11 +15782,11 @@ Via CLI:
 
 \`\`\`bash
 exarchos merge-orchestrate \\
-  --stream-id <id> \\
   --source-branch <subagent-branch> \\
   --target-branch <integration-branch> \\
   --task-id <task-id> \\
   --strategy squash
+  # plus the workflow-correlation id flag — see \`--help\`
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 \`\`\`
 
@@ -20315,12 +20315,12 @@ Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-
 
 ### Step 2: Invoke
 
-Via MCP:
+Via MCP (illustrative — the canonical arg names come from \`describe\`):
 
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  streamId: "<id>",
+  // workflow-correlation identifier — name per the action's schema
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
   taskId: "<task-id>",          // present when auto-dispatched from next_actions
@@ -20334,11 +20334,11 @@ Via CLI:
 
 \`\`\`bash
 exarchos merge-orchestrate \\
-  --stream-id <id> \\
   --source-branch <subagent-branch> \\
   --target-branch <integration-branch> \\
   --task-id <task-id> \\
   --strategy squash
+  # plus the workflow-correlation id flag — see \`--help\`
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 \`\`\`
 
@@ -24894,12 +24894,12 @@ Strategy is required at the schema layer (#1127 collision check, #1109 §2 user-
 
 ### Step 2: Invoke
 
-Via MCP:
+Via MCP (illustrative — the canonical arg names come from \`describe\`):
 
 \`\`\`typescript
 mcp__exarchos__exarchos_orchestrate({
   action: "merge_orchestrate",
-  streamId: "<id>",
+  // workflow-correlation identifier — name per the action's schema
   sourceBranch: "<subagent-branch>",
   targetBranch: "<integration-branch>",
   taskId: "<task-id>",          // present when auto-dispatched from next_actions
@@ -24913,11 +24913,11 @@ Via CLI:
 
 \`\`\`bash
 exarchos merge-orchestrate \\
-  --stream-id <id> \\
   --source-branch <subagent-branch> \\
   --target-branch <integration-branch> \\
   --task-id <task-id> \\
   --strategy squash
+  # plus the workflow-correlation id flag — see \`--help\`
   # add --dry-run for preflight-only, --resume for terminal-phase short-circuit
 \`\`\`
 

--- a/tests/outcome/install-skills.test.ts
+++ b/tests/outcome/install-skills.test.ts
@@ -74,7 +74,7 @@ describe('install-skills outcome (#1355)', () => {
     // `it.fails` (vitest >=2) marks a test as an expected failure — the
     // test PASSES when its assertions throw and FAILS if they unexpectedly
     // pass. Reviewer grep target: `it.fails`.
-    it.fails(
+    it(
       `InstallSkills_${runtime}_FullManifestInstalled`,
       async () => {
         // Source-of-truth: every skill directory under `skills/<runtime>/`

--- a/tests/outcome/install-skills.test.ts
+++ b/tests/outcome/install-skills.test.ts
@@ -1,13 +1,10 @@
-// ─── T-015 — install-skills outcome (RED-by-design) ──────────────────────
+// ─── T-015 — install-skills outcome ──────────────────────────────────────
 //
 // Encodes the #1355 regression: copilot/codex/cursor/opencode/generic
-// runtimes' `install-skills` produces only `design-invariants` instead of
-// the full bundle of skills. Claude alone produces the full bundle.
-//
-// Each per-runtime case is wrapped in `it.failing()` so vitest reports it
-// as an expected failure. The fix in PR2 (wave1-fixes) will atomically
-// remove the `.failing` annotation per runtime as each one regains parity
-// with claude's behavior.
+// runtimes' `install-skills` historically produced only `design-invariants`
+// instead of the full bundle of skills. The fix in wave1-fixes brought
+// every runtime to parity with claude; this test now asserts that parity
+// continues to hold (standard pass/fail; no `it.fails` annotation).
 //
 // This test invokes the real CLI binary (the bun-compiled platform binary
 // at `dist/bin/exarchos-<platform>-<arch>`) under a tmp HOME so the
@@ -70,10 +67,10 @@ const CLI_BINARY = path.join(REPO_ROOT, 'dist', 'bin', platformBinaryName());
 
 describe('install-skills outcome (#1355)', () => {
   for (const runtime of RUNTIMES) {
-    // RED-by-design: removed in PR2 (wave1-fixes) as each runtime is fixed.
-    // `it.fails` (vitest >=2) marks a test as an expected failure — the
-    // test PASSES when its assertions throw and FAILS if they unexpectedly
-    // pass. Reviewer grep target: `it.fails`.
+    // Standard pass/fail test: assertions must pass for each runtime — the
+    // CLI is expected to install the full skills manifest for every runtime.
+    // Regression of #1355 would surface as `installed` lacking entries that
+    // `manifestExpected` carries.
     it(
       `InstallSkills_${runtime}_FullManifestInstalled`,
       async () => {
@@ -89,11 +86,9 @@ describe('install-skills outcome (#1355)', () => {
           );
 
         await withTmpHome(async (home) => {
-          // Run the real CLI. On failure (#1355 manifests as the upstream
-          // `skills add` exiting non-zero or writing an incomplete bundle),
-          // execFileSync throws; we catch so the on-disk assertion below
-          // is the canonical signal — the test is `it.failing`, so the
-          // assertion failing is the expected outcome.
+          // Run the real CLI. If the binary exits non-zero we catch so the
+          // on-disk assertion below is the canonical signal — operator
+          // visibility is what we are validating, not exit-code shape.
           try {
             execFileSync(
               CLI_BINARY,

--- a/tests/outcome/merge-orchestrate-multiworktree.test.ts
+++ b/tests/outcome/merge-orchestrate-multiworktree.test.ts
@@ -38,7 +38,7 @@ function gitRun(repo: string, args: string[]): void {
 describe('merge-orchestrate multi-worktree topology outcome (#1356)', () => {
   // RED-by-design — flipped in PR2 (wave1-fixes) when the preflight gains
   // a target-checked-out-elsewhere guard.
-  it.fails(
+  it(
     'MergeOrchestrate_TargetCheckedOutInSibling_AbortsCleanly',
     async () => {
       await withTmpGit(async (repoPath) => {


### PR DESCRIPTION
## Summary

PR2 of the **Wave 1 data-safety + substrate** two-PR split. **Stacked on PR1 (#1388).** Lands the three behavioral fixes; each fix atomically removes its corresponding `it.fails()` annotation from the seed tests landed by PR1.

After PR1 merges, GitHub will auto-retarget this PR to `main`.

## Changes

### #1355 install-skills bundle (Phase A)

**Root cause:** `src/install-skills.ts:298-311` (pre-PR2) shelled out to `npx skills add github:lvlup-sw/exarchos ...` which (a) walked only the repo root, finding just the `design-invariants` SKILL.md and missing every per-runtime tree under `skills/<runtime>/`, and (b) used hardcoded per-agent install-path mapping (e.g. `github-copilot` → `~/.agents/skills`) misaligned with `runtimes/*.yaml` `skillsInstallPath`.

**Fix:**
- New `findSkillsSourceDir()` resolver in `src/install-skills.ts` (cwd / binary-relative / src-relative candidates).
- New `copyLocalSkills()` walks `<skillsSource>/<runtime>/` and copies every `SKILL.md`-bearing subdir to `runtime.skillsInstallPath`.
- `expandTilde()` correctly handles both `~` and `$HOME` prefixes — the latter is a latent bug surfaced by the new in-process path (the old shell-out had a child shell expand `$HOME`; the in-process path never sees a shell). `runtimes/codex.yaml` uses literal `$HOME/.agents/skills` and now works.
- `install-skills-bridge.js` passes `skillsSource: findSkillsSourceDir()` to the installer.
- Legacy `npx skills add` spawn retained as fallback when `skillsSource` is undefined (preserves backward compatibility).
- **Atomic flip:** `tests/outcome/install-skills.test.ts:77` — `it.fails(...)` → `it(...)` in the same commit (`1e3dd3fa`) as the source fix.

### #1356 merge-orchestrate preflight (Phase B)

**Root cause:** `handleMergeOrchestrate` captured `rollbackSha` from the cwd HEAD without first checking whether the target branch was checked out in a sibling worktree. In multi-worktree topologies, this produced a wrong rollback SHA and falsely reported `phase: 'rolled-back'` against the wrong branch.

**Fix:**
- New `targetWorktreeAvailability` preflight in `servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts` (lines 340-397) runs BEFORE any rollback-SHA capture, event emission, or state persistence. Parses `git worktree list --porcelain` for `branch refs/heads/<targetBranch>` entries whose path differs from `repoRoot`. On detection returns `{success: false, error: {code: 'PREFLIGHT_FAILED', ...}, data: {phase: 'aborted', reason: 'target-checked-out-elsewhere', siblingWorktreePath: <path>}}`.
- F-005 found no executor hardening was needed (preflight short-circuits cleanly).
- **Atomic flip:** `tests/outcome/merge-orchestrate-multiworktree.test.ts:41` — `it.fails(...)` → `it(...)` in commit `fe31b484` paired with preflight commit `fa77b272` (per plan F-005's two-commit allowance — both commits land together on this branch).

### #1357 merge-orchestrator skill rewrite (Phase C)

**Goal:** Rewrite `skills-src/merge-orchestrator/SKILL.md` to (a) cite the new preflight payload from #1356 and (b) pass the INV-6 (workflow-agnosticism) audit landed in PR1.

**Strategy used:** Path A — workflow-neutral rewrite (preferred over Path B's `workflow-type:` frontmatter escape hatch).

- Frontmatter `category: workflow` → `category: behavior`; removed `phase-affinity: merge-pending`; version bumped to `1.1.0`.
- Triggers rewritten in workflow-neutral terms (operator CLI + MCP direct invocation + `next_actions` envelope with idempotency key `<streamId>:merge_orchestrate:<taskId>`).
- New "Abort-reason payload shapes" subsection cites the F-004 preflight payload exactly.
- "Phase Transitions and Guards" section REMOVED (it was the densest source of workflow-typed literals; phase-transition knowledge belongs in feature-workflow playbooks, not behavior skills).
- Completion criteria rewritten to be workflow-neutral.
- 6 per-runtime rendered variants regenerated under `skills/<runtime>/merge-orchestrator/`.
- **INV-6 audit:** findings count on this skill went **14 → 0**. Verify locally with: `node scripts/lint-inv6.mjs skills-src/ | node -e "const d=JSON.parse(require('fs').readFileSync(0,'utf8'));console.log(d.findings.filter(f=>f.file.includes('merge-orchestrator')).length);"` → `0`.
- No `it.fails` annotation flip — this is a skill rewrite, not a behavior fix.

## Test Plan

- [x] `npm run typecheck` — clean
- [x] `npm run skills:guard` — clean (advisory `lint-inv6` produces ~360 LOW findings on the rest of the catalog; merge-orchestrator at 0)
- [x] `npm run test:run` (root) — 760 passed, 6 skipped, 0 failed
- [x] `cd servers/exarchos-mcp && npm run test:run` — 6651 passed, 22 skipped, 0 failed (3 more passing than PR1 due to Phase B's new preflight tests)
- [x] `npm run test:outcome` — 11 reporting as passed (10 real-pass + 1 expected failure on rehydrate which stays `it.fails` until Wave 2 #1359)
- [x] INV-6 scoped audit on `skills-src/merge-orchestrator/` — 0 findings
- [x] Per-task TDD compliance verified (2 false-negatives are pre-documented per `feedback_tdd_gate_per_commit.md`; F-002 install-skills correctly PASS)

### Reviewer-grep for atomic-flip contract

```bash
git diff feature/wave1-substrate..feature/wave1-fixes -- 'tests/outcome/*.test.ts' | grep -E '^-.*it\.fails|^\+.*\bit\('
```

Expected: exactly 2 annotation removals (`install-skills.test.ts:77`, `merge-orchestrate-multiworktree.test.ts:41`). `rehydrate-projection-drift.test.ts` is unchanged.

## Operational Notes for Reviewers

1. **Local dev — rebuild after pulling:** Phase A's fix is in `src/install-skills.ts`. The bun-compiled native binary at `dist/bin/exarchos-<os>-<arch>` does NOT automatically rebuild on a pull. If local `npm run test:outcome` shows install-skills regressions, run `npm run build` first. CI's `outcome-tests` job pre-builds, so CI is unaffected.
2. **`it.fails` semantic interpretation:** Vitest 3.x shows a ✓ checkmark for `it.fails` tests both when they fail-as-expected (the desired RED-by-design state) AND when they unexpectedly-pass (a CI break). To disambiguate, check the runner's exit code. In this PR, exit code is 0 → rehydrate test is correctly RED-by-design.
3. **Plan vs. implementation contract drift (LOW, advisory):** Plan F-004 step 2 said the preflight should return `{success: true, data: {phase: 'aborted', ...}}`. Implementation returns `{success: false, error: {code: 'PREFLIGHT_FAILED'}, data: {phase: 'aborted', ...}}`. The implementation is more correct (an abort is a non-success outcome with an error envelope). Outcome test asserts on the `data` envelope only and is satisfied by either shape.

## Known Follow-Ups (deferred — not blockers)

From code-quality review (3 MEDIUMs, 2 LOWs — all in `servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts`):

- **MEDIUM (`:226`)** — Unchecked double cast on `_version`: `(state as Record<string, unknown>)._version as number | undefined ?? 1`. Add runtime `typeof` guard. Pre-existing pattern; PR2 inherits it.
- **MEDIUM (`:365`)** — Worktree-list parser at depth 4 (if → for → else if → if). Extract `parseWorktreeListForTarget(stdout, targetRef, repoRoot)` helper for independent unit testability.
- **MEDIUM (`:375`)** — Path equality `currentPath !== repoRoot` not normalized. With DI-supplied non-canonical `repoRoot` (trailing slash or relative path), git's canonical absolute path output will mismatch and could false-trigger an abort. Apply `path.resolve()` to both sides. Default (no DI override) uses `process.cwd()` which is always canonical, so this is a latent edge case rather than a regression.
- **LOW (`src/install-skills.ts:447`)** — Add a single `log()` when `findSkillsSourceDir()` returns undefined and the legacy spawn fallback fires. Helps diagnose stale binaries vs. wrong cwd.
- **LOW (`merge-orchestrate.ts:306`)** — `handleMergeOrchestrate` is ~480 LOC; file is 786 LOC. Pre-existing SC-2/SC-3 violation; PR2 adds 59 LOC. Future refactor splitting orchestration phases.

From spec review (4 LOWs — all advisory, captured above):
- Plan vs. implementation contract drift (already documented in Operational Notes).
- INV-6 lint location auditability — orchestrator should attach JSON output of the scoped audit to a follow-up comment for verifiability (this PR body already documents the 14 → 0 count claim).
- `dist/` staleness reviewer-instructions (documented in Operational Notes).
- TDD-compliance false-negatives (pre-documented in `feedback_tdd_gate_per_commit.md`).

## Review

- **Spec compliance:** APPROVED — 0 HIGH, 0 MEDIUM, 4 LOW (all advisory). Atomic-flip contract verified for #1355 and #1356; rehydrate annotation preservation verified.
- **Code quality (Tier 2):** APPROVED — 0 HIGH, 3 MEDIUM, 2 LOW (all captured as follow-ups above). No empty catches without justifying comments. No `vi.mock`, `it.only`, or `it.skip`. No new fetch / unbounded collections / retry loops.

## Wave 2 Outlook

After PR1 + PR2 merge:
- `tests/outcome/rehydrate-projection-drift.test.ts` remains the sole `it.fails` test. #1359 fix in Wave 2 will atomically remove that annotation.
- Wave 2 issues: #1359 (rehydrate projection drift), #1360 (operator trust gates).
- Wave 3 issues: #1362–#1365 (diagnostics + polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)