### PR TITLE
feat(runbooks): add MERGE_ORCHESTRATION for merge-pending phase (#1363)

### DIFF
--- a/servers/exarchos-mcp/src/runbooks/decision-runbooks.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/decision-runbooks.test.ts
@@ -24,6 +24,37 @@ describe('Decision runbooks', () => {
     }
   });
 
+  it('Runbook_MergePending_TemplateVarsExpand', () => {
+    // PR1 / #1363: registry must return the merge-orchestration entry when
+    // queried by phase=merge-pending, and templateVars must declare the
+    // fields the merge-orchestrator skill expects to bind.
+    const mergePendingRunbooks = ALL_RUNBOOKS.filter(r => r.phase === 'merge-pending');
+    expect(mergePendingRunbooks.length).toBeGreaterThanOrEqual(1);
+
+    const mergeOrchestration = mergePendingRunbooks.find(r => r.id === 'merge-orchestration');
+    expect(mergeOrchestration).toBeDefined();
+
+    // templateVars expands the sample binding fields the agent must supply.
+    const expectedVars = ['featureId', 'taskId', 'sourceBranch', 'targetBranch', 'strategy', 'repoRoot'];
+    for (const v of expectedVars) {
+      expect(mergeOrchestration!.templateVars).toContain(v);
+    }
+
+    // Sample binding sanity-check: every templateVar resolves to a non-empty
+    // string when supplied real-looking values (catches typos / empty defaults).
+    const sampleBindings: Record<string, string> = {
+      featureId: 'feat-test',
+      taskId: 'task-001',
+      sourceBranch: 'feature/test-branch',
+      targetBranch: 'main',
+      strategy: 'merge',
+      repoRoot: '/tmp/repo',
+    };
+    for (const v of mergeOrchestration!.templateVars) {
+      expect(sampleBindings[v], `template var "${v}" missing from sample bindings`).toBeTruthy();
+    }
+  });
+
   for (const id of DECISION_RUNBOOK_IDS) {
     describe(id, () => {
       it(`${id}_HasAtLeast2DecideSteps`, () => {

--- a/servers/exarchos-mcp/src/runbooks/definitions.test.ts
+++ b/servers/exarchos-mcp/src/runbooks/definitions.test.ts
@@ -11,6 +11,7 @@ import {
   DESIGN_REFINEMENT,
   PLAN_COVERAGE_CHECK,
   PHASE_COMPRESSION,
+  MERGE_ORCHESTRATION,
   ALL_RUNBOOKS,
 } from './definitions.js';
 
@@ -105,7 +106,37 @@ describe('Runbook definitions', () => {
   });
 
   it('AllRunbooks_Count', () => {
-    expect(ALL_RUNBOOKS).toHaveLength(17);
+    expect(ALL_RUNBOOKS).toHaveLength(18);
+  });
+
+  it('Runbook_PhaseMergePending_ReturnsPopulatedSteps', () => {
+    // MERGE_ORCHESTRATION is the runbook counterpart to the merge-orchestrator
+    // skill. Per #1363, exarchos_orchestrate({action: 'runbook', phase:
+    // 'merge-pending'}) previously returned [] because the registry had no
+    // entry for this phase.
+    expect(MERGE_ORCHESTRATION).toBeDefined();
+    expect(MERGE_ORCHESTRATION.id).toBe('merge-orchestration');
+    expect(MERGE_ORCHESTRATION.phase).toBe('merge-pending');
+    expect(MERGE_ORCHESTRATION.steps).toHaveLength(3);
+    expect(MERGE_ORCHESTRATION.autoEmits).toEqual(
+      expect.arrayContaining([
+        'merge.preflight',
+        'merge.executed',
+        'merge.rollback',
+        'workflow.transition',
+      ]),
+    );
+    // Step 1: preflight dryRun
+    expect(MERGE_ORCHESTRATION.steps[0].tool).toBe('exarchos_orchestrate');
+    expect(MERGE_ORCHESTRATION.steps[0].action).toBe('merge_orchestrate');
+    expect(MERGE_ORCHESTRATION.steps[0].params?.dryRun).toBe(true);
+    // Step 2: real merge
+    expect(MERGE_ORCHESTRATION.steps[1].tool).toBe('exarchos_orchestrate');
+    expect(MERGE_ORCHESTRATION.steps[1].action).toBe('merge_orchestrate');
+    // Step 3: HSM transition back to delegate
+    expect(MERGE_ORCHESTRATION.steps[2].tool).toBe('exarchos_workflow');
+    expect(MERGE_ORCHESTRATION.steps[2].action).toBe('transition');
+    expect(MERGE_ORCHESTRATION.steps[2].params?.target).toBe('delegate');
   });
 
   it('TaskClassification_HasCorrectPhase_Delegate', () => {

--- a/servers/exarchos-mcp/src/runbooks/definitions.ts
+++ b/servers/exarchos-mcp/src/runbooks/definitions.ts
@@ -617,6 +617,25 @@ export const PHASE_COMPRESSION: RunbookDefinition = {
   autoEmits: [],
 };
 
+export const MERGE_ORCHESTRATION: RunbookDefinition = {
+  id: 'merge-orchestration',
+  phase: 'merge-pending',
+  description: 'Land a subagent worktree branch onto integration with preflight + recorded rollback.',
+  steps: [
+    { tool: 'exarchos_orchestrate', action: 'merge_orchestrate',
+      params: { dryRun: true }, onFail: 'stop',
+      note: 'Preflight: ancestry, target-worktree-availability (post-#1356), current-branch, drift.' },
+    { tool: 'exarchos_orchestrate', action: 'merge_orchestrate',
+      onFail: 'continue',
+      note: 'Real merge. preflight-fail → aborted (no executor). merge-fail → rolled-back (post-#1356: structured target-worktree-busy categorization).' },
+    { tool: 'exarchos_workflow', action: 'transition',
+      params: { target: 'delegate' }, onFail: 'continue',
+      note: 'HSM exits merge-pending back to delegate regardless of merge outcome.' },
+  ],
+  templateVars: ['featureId', 'taskId', 'sourceBranch', 'targetBranch', 'strategy', 'repoRoot'],
+  autoEmits: ['merge.preflight', 'merge.executed', 'merge.rollback', 'workflow.transition'],
+};
+
 export const ALL_RUNBOOKS: readonly RunbookDefinition[] = [
   TASK_COMPLETION,
   QUALITY_EVALUATION,
@@ -635,4 +654,5 @@ export const ALL_RUNBOOKS: readonly RunbookDefinition[] = [
   DESIGN_REFINEMENT,
   PLAN_COVERAGE_CHECK,
   PHASE_COMPRESSION,
+  MERGE_ORCHESTRATION,
 ];


### PR DESCRIPTION
## Summary

`exarchos_orchestrate({action: 'runbook', phase: 'merge-pending'})` returned `[]` because the runbook registry had no entry. The merge-orchestrator skill (~12KB) had no structured runbook counterpart. Adds `MERGE_ORCHESTRATION` with three steps (preflight dryRun → real merge → HSM transition back to delegate).

Closes #1363. Part of #1354 Wave 3.

## Changes

- `servers/exarchos-mcp/src/runbooks/definitions.ts` — new `MERGE_ORCHESTRATION` runbook with `templateVars`, `autoEmits`, and three-step flow; wired into `ALL_RUNBOOKS`.
- `servers/exarchos-mcp/src/runbooks/definitions.test.ts` — `Runbook_PhaseMergePending_ReturnsPopulatedSteps`; bump `AllRunbooks_Count` 17 → 18.
- `servers/exarchos-mcp/src/runbooks/decision-runbooks.test.ts` — `Runbook_MergePending_TemplateVarsExpand`.

## Test Plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:run -- runbooks` — 116/116 pass
- [x] `exarchos_orchestrate runbook merge-pending` returns 3 populated steps with `autoEmits` matching the spec

🤖 Stack: PR 1 of 4 (v2.10.0-preview.4 Wave 2 + Wave 3 polish). Base: \`main\`. Stack head: feature/preview4-pr4-projection-drift.

Co-authored by Claude Opus 4.7 (Exarchos orchestrator).