### PR TITLE
feat(telemetry): split transport errors from structured action errors (#1364)

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -428,7 +428,10 @@ describe('EventTypes', () => {
     // merge.preflight / merge.executed / merge.rollback (T03, DR-MO-2). When
     // new event types are added, bump this number alongside their registration
     // in `event-store/schemas.ts`.
-    expect(EventTypes).toHaveLength(103);
+    // PR3/T7 (#1364): bumped 103 → 104 to include `tool.action_errored`,
+    // which splits structured action-level failures off of `tool.errored`
+    // (transport/protocol failures only).
+    expect(EventTypes).toHaveLength(104);
   });
 
   it('should include workflow-level types', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -484,7 +484,10 @@ describe('EventTypes', () => {
   });
 
   it('EventTypes_HasExpectedCount', () => {
-    // Bumped from 93 → 103 with Wave B (#1342) 5×{requested,executed} two-event
+    // Bumped from 103 → 104 with PR3/T7 (#1364): `tool.action_errored`
+    // splits structured action-level failures out from `tool.errored`
+    // (which now counts transport/protocol failures only).
+    // Previous (93 → 103): Wave B (#1342) 5×{requested,executed} two-event
     // split schemas for non-idempotent VCS handlers (B1–B5):
     //   pr.create.requested, pr.create.executed,
     //   pr.comment.requested, pr.comment.executed,
@@ -495,7 +498,7 @@ describe('EventTypes', () => {
     // Previous (92): migration.workflow_type_unknown (Wave 1, R-1 Marten #1313).
     // Previous (91): session.machinery_consumed (T-11, rehydration-machinery-refactor).
     // Previous (84 → 90): six durable event-store substrate types (#1259 T02/T03/T04).
-    expect(EventTypes).toHaveLength(103);
+    expect(EventTypes).toHaveLength(104);
   });
 
   it('EventTypes_IncludesSessionTagged', () => {
@@ -3214,5 +3217,68 @@ describe('EventSchemaRegistry_RegistersAllNewTwoEventSplitTypes', () => {
       head: 'feature/my-feature',
     });
     expect(result.success).toBe(false);
+  });
+});
+
+// ─── PR3 T7: tool.action_errored event type registration (#1364) ────────────
+
+describe('EventStoreSchemas_ToolActionErrored_HasRegisteredType', () => {
+  it('includes tool.action_errored in the EventType union', () => {
+    expect((EventTypes as readonly string[])).toContain('tool.action_errored');
+  });
+
+  it('classifies tool.action_errored as auto-emitted', () => {
+    expect(
+      EVENT_EMISSION_REGISTRY['tool.action_errored' as keyof typeof EVENT_EMISSION_REGISTRY],
+    ).toBe('auto');
+  });
+
+  it('has a data schema accepting the action-errored shape', () => {
+    const schema = EVENT_DATA_SCHEMAS['tool.action_errored' as keyof typeof EVENT_DATA_SCHEMAS];
+    expect(schema).toBeDefined();
+    if (!schema) return;
+    const valid = schema.safeParse({
+      tool: 'exarchos_orchestrate',
+      durationMs: 12,
+      errorCode: 'RESERVED_FIELD',
+      responseBytes: 220,
+      tokenEstimate: 55,
+    });
+    expect(valid.success).toBe(true);
+
+    // Reject when required fields are missing
+    const missingCode = schema.safeParse({
+      tool: 'exarchos_orchestrate',
+      durationMs: 12,
+      responseBytes: 220,
+      tokenEstimate: 55,
+    });
+    expect(missingCode.success).toBe(false);
+
+    const missingTool = schema.safeParse({
+      durationMs: 12,
+      errorCode: 'X',
+      responseBytes: 0,
+      tokenEstimate: 0,
+    });
+    expect(missingTool.success).toBe(false);
+  });
+
+  it('accepts a full WorkflowEventBase append carrying tool.action_errored', () => {
+    const event = WorkflowEventBase.safeParse({
+      streamId: 'telemetry',
+      sequence: 1,
+      timestamp: '2026-05-15T00:00:00.000Z',
+      type: 'tool.action_errored',
+      schemaVersion: '1.0',
+      data: {
+        tool: 'exarchos_orchestrate',
+        durationMs: 12,
+        errorCode: 'MERGE_ROLLED_BACK',
+        responseBytes: 220,
+        tokenEstimate: 55,
+      },
+    });
+    expect(event.success).toBe(true);
   });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -30,6 +30,13 @@ export const EventTypes = [
   'tool.invoked',
   'tool.completed',
   'tool.errored',
+  // PR3/T7 (#1364) — emitted alongside `tool.completed` when the handler
+  // returns the structured failure envelope `{success: false, error: {…}}`.
+  // `tool.errored` continues to count transport/protocol failures (JS throws)
+  // only; this event splits out action-level outcomes (MERGE_ROLLED_BACK,
+  // PREFLIGHT_FAILED, RESERVED_FIELD, etc.) so `view telemetry` can report
+  // them instead of silently rolling them up as completions.
+  'tool.action_errored',
   'benchmark.completed',
   'team.spawned',
   'team.task.assigned',
@@ -244,6 +251,8 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   'tool.invoked': 'auto',
   'tool.completed': 'auto',
   'tool.errored': 'auto',
+  // PR3/T7 (#1364) — see EventTypes registration above.
+  'tool.action_errored': 'auto',
   'quality.hint.generated': 'auto',
   'quality.refinement.suggested': 'auto',
   'stack.position-filled': 'auto',
@@ -749,6 +758,20 @@ export const ToolErroredData = z.object({
   tool: z.string(),
   durationMs: z.number(),
   errorMessage: z.string(),
+});
+
+// PR3/T7 (#1364) — structured action-level failure paired with `tool.completed`.
+// Mirrors `tool.completed`'s perf fields so the projection can fold both events
+// off the same per-tool entry without re-deriving durationMs/responseBytes.
+// `errorCode` is the discriminator carried up from the handler's error envelope
+// (e.g., MERGE_ROLLED_BACK, PREFLIGHT_FAILED, RESERVED_FIELD); falls back to
+// 'UNKNOWN' when the handler emits an envelope without a code.
+export const ToolActionErroredData = z.object({
+  tool: z.string(),
+  durationMs: z.number(),
+  errorCode: z.string(),
+  responseBytes: z.number(),
+  tokenEstimate: z.number(),
 });
 
 // ─── Benchmark Event Data ───────────────────────────────────────────────────
@@ -1533,6 +1556,8 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
   'tool.invoked': ToolInvokedData,
   'tool.completed': ToolCompletedData,
   'tool.errored': ToolErroredData,
+  // PR3/T7 (#1364) — structured action-level failure event.
+  'tool.action_errored': ToolActionErroredData,
 
   // Benchmark
   'benchmark.completed': BenchmarkCompletedData,
@@ -1689,6 +1714,8 @@ export type SynthesizeRequested = z.infer<typeof SynthesizeRequestedData>;
 export type ToolInvoked = z.infer<typeof ToolInvokedData>;
 export type ToolCompleted = z.infer<typeof ToolCompletedData>;
 export type ToolErrored = z.infer<typeof ToolErroredData>;
+// PR3/T7 (#1364)
+export type ToolActionErrored = z.infer<typeof ToolActionErroredData>;
 export type BenchmarkCompleted = z.infer<typeof BenchmarkCompletedData>;
 export type TeamSpawned = z.infer<typeof TeamSpawnedData>;
 export type TeamTaskAssigned = z.infer<typeof TeamTaskAssignedData>;
@@ -1776,6 +1803,8 @@ export type EventDataMap = {
   'tool.invoked': ToolInvoked;
   'tool.completed': ToolCompleted;
   'tool.errored': ToolErrored;
+  // PR3/T7 (#1364)
+  'tool.action_errored': ToolActionErrored;
   'benchmark.completed': BenchmarkCompleted;
   'team.spawned': TeamSpawned;
   'team.task.assigned': TeamTaskAssigned;

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -882,6 +882,55 @@ export const WorkflowTransitionOutputSchema = EnvelopeSchema(z.unknown()).and(
  */
 export const WorkflowUpdateOutputSchema = EnvelopeSchema(z.unknown());
 
+/**
+ * `outputSchema` for `exarchos_view.telemetry` (PR3/T10, #1364 — Wave 3
+ * polish on top of Wave 0 carrier swap).
+ *
+ * Typed envelope so MCP advertises the per-tool `actionErrors` and
+ * `actionErrorBreakdown` fields the `tool.action_errored` projection now
+ * folds. Both fields are required on every tool entry so downstream
+ * consumers (CLI rendering, dashboards, drift detection) can rely on
+ * their presence rather than treating them as optional decorators.
+ *
+ * The per-tool entry is intentionally `.passthrough()` because the
+ * compact-vs-full split adds extra arrays (`durations`, `sizes`,
+ * `tokenEstimates`) on the non-compact path — strict objects would
+ * reject the full shape. `hints[]` items are also passthrough to leave
+ * room for future hint flavours without re-cutting the schema.
+ *
+ * See [`docs/designs/2026-05-15-wave2-wave3-polish.md`](../docs/designs/2026-05-15-wave2-wave3-polish.md)
+ * `#1364 — split transport vs action-level errors` for context.
+ */
+const TelemetryToolEntrySchema = z.object({
+  tool: z.string(),
+  invocations: z.number().nonnegative(),
+  errors: z.number().nonnegative(),
+  totalDurationMs: z.number().nonnegative(),
+  totalBytes: z.number().nonnegative(),
+  totalTokens: z.number().nonnegative(),
+  p50DurationMs: z.number().nonnegative(),
+  p95DurationMs: z.number().nonnegative(),
+  p50Bytes: z.number().nonnegative(),
+  p95Bytes: z.number().nonnegative(),
+  p50Tokens: z.number().nonnegative(),
+  p95Tokens: z.number().nonnegative(),
+  // PR3/T10 (#1364) — structured action-level failure counters.
+  actionErrors: z.number().nonnegative(),
+  actionErrorBreakdown: z.record(z.string(), z.number().nonnegative()),
+}).passthrough();
+
+const TelemetryViewDataSchema = z.object({
+  session: z.object({
+    start: z.string(),
+    totalInvocations: z.number().nonnegative(),
+    totalTokens: z.number().nonnegative(),
+  }),
+  tools: z.array(TelemetryToolEntrySchema),
+  hints: z.array(z.unknown()),
+}).passthrough();
+
+export const TelemetryViewOutputSchema = EnvelopeSchema(TelemetryViewDataSchema);
+
 // ─── Composite Tool: exarchos_workflow ───────────────────────────────────────
 
 const workflowActions: readonly ToolAction[] = [
@@ -2264,7 +2313,10 @@ const viewActions: readonly ToolAction[] = [
     }),
     phases: ALL_PHASES,
     roles: ROLE_ANY,
-    outputSchema: EnvelopeSchema(z.unknown()),
+    // PR3/T10 (#1364) — typed envelope advertises the per-tool
+    // `actionErrors` + `actionErrorBreakdown` fields (post Wave 0 carrier
+    // composition).
+    outputSchema: TelemetryViewOutputSchema,
     annotations: READ_ONLY_LOCAL,
   },
   {

--- a/servers/exarchos-mcp/src/telemetry/middleware.test.ts
+++ b/servers/exarchos-mcp/src/telemetry/middleware.test.ts
@@ -127,6 +127,99 @@ describe('withTelemetry', () => {
     });
   });
 
+  // ─── PR3/T8 (#1364): action-errored emission on structured failure ───────
+  describe('structured action-level failure', () => {
+    it('WithTelemetry_StructuredFailure_EmitsActionErrored', async () => {
+      // Arrange — handler returns the standard MCP envelope failure shape.
+      const handler: CoreHandler = async () => ({
+        success: false,
+        error: { code: 'RESERVED_FIELD', message: 'state.tasks is reserved' },
+      });
+
+      // Act
+      const wrapped = withTelemetry(handler, 'exarchos_orchestrate', eventStore);
+      const result = await wrapped({});
+
+      // Result is propagated unchanged on the success-branch contract;
+      // the wrapper does NOT re-throw structured failures.
+      expect(result.success).toBe(false);
+
+      // Assert — both `tool.completed` AND `tool.action_errored` are emitted.
+      const events = await eventStore.query(TELEMETRY_STREAM);
+      const types = events.map((e) => e.type);
+      expect(types).toContain('tool.invoked');
+      expect(types).toContain('tool.completed');
+      expect(types).toContain('tool.action_errored');
+      // Transport-level errored must NOT fire when the handler returned cleanly.
+      expect(types).not.toContain('tool.errored');
+
+      const completed = events.find((e) => e.type === 'tool.completed');
+      const actionErrored = events.find((e) => e.type === 'tool.action_errored');
+      expect(completed).toBeDefined();
+      expect(actionErrored).toBeDefined();
+      if (!completed || !actionErrored) return;
+
+      const completedData = completed.data as Record<string, unknown>;
+      const aeData = actionErrored.data as Record<string, unknown>;
+      expect(aeData.tool).toBe('exarchos_orchestrate');
+      expect(aeData.errorCode).toBe('RESERVED_FIELD');
+      // Perf fields match the paired tool.completed event.
+      expect(aeData.durationMs).toBe(completedData.durationMs);
+      expect(aeData.responseBytes).toBe(completedData.responseBytes);
+      expect(aeData.tokenEstimate).toBe(completedData.tokenEstimate);
+    });
+
+    it('WithTelemetry_StructuredFailure_MissingErrorCode_DefaultsToUnknown', async () => {
+      const handler: CoreHandler = async () => ({
+        success: false,
+        // Intentionally omit error.code to exercise the fallback path.
+        error: { message: 'opaque failure' },
+      } as unknown as ReturnType<CoreHandler> extends Promise<infer R> ? R : never);
+
+      const wrapped = withTelemetry(handler, 'exarchos_orchestrate', eventStore);
+      await wrapped({});
+
+      const events = await eventStore.query(TELEMETRY_STREAM);
+      const actionErrored = events.find((e) => e.type === 'tool.action_errored');
+      expect(actionErrored).toBeDefined();
+      if (!actionErrored) return;
+      expect((actionErrored.data as Record<string, unknown>).errorCode).toBe('UNKNOWN');
+    });
+
+    it('WithTelemetry_JsThrow_StillEmitsToolErroredOnly', async () => {
+      const handler: CoreHandler = async () => {
+        throw new Error('transport explode');
+      };
+
+      const wrapped = withTelemetry(handler, 'fail_tool', eventStore);
+      await expect(wrapped({})).rejects.toThrow('transport explode');
+
+      const events = await eventStore.query(TELEMETRY_STREAM);
+      const types = events.map((e) => e.type);
+      expect(types).toContain('tool.errored');
+      // Regression guard against double-emitting from the catch branch.
+      expect(types).not.toContain('tool.action_errored');
+      // And no spurious tool.completed.
+      expect(types).not.toContain('tool.completed');
+    });
+
+    it('WithTelemetry_Success_DoesNotEmitActionErrored', async () => {
+      const handler: CoreHandler = async () => ({
+        success: true,
+        data: { ok: true },
+      });
+
+      const wrapped = withTelemetry(handler, 'happy_tool', eventStore);
+      await wrapped({});
+
+      const events = await eventStore.query(TELEMETRY_STREAM);
+      const types = events.map((e) => e.type);
+      expect(types).toContain('tool.completed');
+      expect(types).not.toContain('tool.action_errored');
+      expect(types).not.toContain('tool.errored');
+    });
+  });
+
   describe('telemetry failure resilience', () => {
     it('should succeed even when telemetry append fails', async () => {
       // Arrange - Create a store pointing to a non-existent dir

--- a/servers/exarchos-mcp/src/telemetry/middleware.ts
+++ b/servers/exarchos-mcp/src/telemetry/middleware.ts
@@ -53,6 +53,22 @@ function injectEventHints(result: ToolResult, payload: { missing: readonly Event
   return { ...result, _eventHints: payload };
 }
 
+// PR3/T8 (#1364) — typed predicates for structured action-level failure
+// recognition. Kept micro/local; not exported. A handler that returns
+// `{success: false, error: {…}}` is a structured failure; anything else
+// (success: true, no `success` property at all) is not.
+function isStructuredFailure(result: ToolResult): boolean {
+  return (result as { success?: unknown }).success === false;
+}
+
+function extractErrorCode(result: ToolResult): string {
+  const err = (result as { error?: { code?: unknown } }).error;
+  if (err && typeof err === 'object' && typeof err.code === 'string' && err.code.length > 0) {
+    return err.code;
+  }
+  return 'UNKNOWN';
+}
+
 // ─── withTelemetry HOF ──────────────────────────────────────────────────────
 
 /**
@@ -143,6 +159,22 @@ export function withTelemetry(
           data: { tool: toolName, durationMs, responseBytes, tokenEstimate },
         })
         .catch(() => { /* telemetry drop — non-fatal, never block workflow */ });
+
+      // PR3/T8 (#1364) — split transport vs action-level errors. When the
+      // handler returns the standard MCP envelope failure
+      // `{success: false, error: {code, message}}`, emit a companion
+      // `tool.action_errored` so `view telemetry` can attribute the outcome
+      // by error code (MERGE_ROLLED_BACK, PREFLIGHT_FAILED, RESERVED_FIELD,
+      // …). `tool.errored` continues to fire only on JS throws (transport).
+      if (isStructuredFailure(result)) {
+        const errorCode = extractErrorCode(result);
+        await eventStore
+          .append(TELEMETRY_STREAM, {
+            type: 'tool.action_errored',
+            data: { tool: toolName, durationMs, errorCode, responseBytes, tokenEstimate },
+          })
+          .catch(() => { /* telemetry drop — non-fatal, never block workflow */ });
+      }
 
       // Emit quality.hint.generated when auto-correction was applied
       if (appliedCorrections.length > 0) {

--- a/servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts
+++ b/servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts
@@ -337,3 +337,118 @@ function makeEvent(type: string, data: Record<string, unknown>): WorkflowEvent {
     data,
   };
 }
+
+// ─── PR3/T9 (#1364): tool.action_errored projection ─────────────────────────
+describe('TelemetryProjection_ActionErrored_AggregatesByTool', () => {
+  it('folds action-errored events into per-tool actionErrors + breakdown', () => {
+    let state = telemetryProjection.init();
+
+    // 5× tool.completed for exarchos_orchestrate
+    for (let i = 0; i < 5; i++) {
+      state = telemetryProjection.apply(state, makeEvent('tool.completed', {
+        tool: 'exarchos_orchestrate',
+        durationMs: 10,
+        responseBytes: 100,
+        tokenEstimate: 25,
+      }));
+    }
+
+    // 2× tool.action_errored MERGE_ROLLED_BACK
+    for (let i = 0; i < 2; i++) {
+      state = telemetryProjection.apply(state, makeEvent('tool.action_errored', {
+        tool: 'exarchos_orchestrate',
+        durationMs: 10,
+        errorCode: 'MERGE_ROLLED_BACK',
+        responseBytes: 100,
+        tokenEstimate: 25,
+      }));
+    }
+
+    // 1× tool.action_errored PREFLIGHT_FAILED
+    state = telemetryProjection.apply(state, makeEvent('tool.action_errored', {
+      tool: 'exarchos_orchestrate',
+      durationMs: 10,
+      errorCode: 'PREFLIGHT_FAILED',
+      responseBytes: 100,
+      tokenEstimate: 25,
+    }));
+
+    // 1× tool.errored (transport)
+    state = telemetryProjection.apply(state, makeEvent('tool.errored', {
+      tool: 'exarchos_orchestrate',
+      durationMs: 5,
+      errorMessage: 'crashed',
+    }));
+
+    const entry = state.tools['exarchos_orchestrate'];
+    expect(entry).toBeDefined();
+    // invocations counts tool.completed only (existing rule retained).
+    expect(entry.invocations).toBe(5);
+    // errors counts transport (tool.errored) only.
+    expect(entry.errors).toBe(1);
+    // actionErrors = sum of action-errored events for this tool.
+    expect(entry.actionErrors).toBe(3);
+    // Breakdown by errorCode.
+    expect(entry.actionErrorBreakdown).toEqual({
+      MERGE_ROLLED_BACK: 2,
+      PREFLIGHT_FAILED: 1,
+    });
+  });
+
+  it('initToolMetrics_HasActionErrorFields_ZeroInitialized', () => {
+    const m = initToolMetrics();
+    expect(m.actionErrors).toBe(0);
+    expect(m.actionErrorBreakdown).toEqual({});
+  });
+
+  it('Apply_ActionErrored_MissingFields_ReturnsViewUnchanged', () => {
+    const state = telemetryProjection.init();
+
+    // No data at all
+    const noData = telemetryProjection.apply(state, {
+      streamId: 'telemetry',
+      sequence: 1,
+      timestamp: new Date().toISOString(),
+      type: 'tool.action_errored',
+      schemaVersion: '1.0',
+    } as WorkflowEvent);
+    expect(noData).toBe(state);
+
+    // Non-string tool
+    const numericTool = telemetryProjection.apply(state, makeEvent('tool.action_errored', {
+      tool: 42,
+      durationMs: 10,
+      errorCode: 'X',
+      responseBytes: 0,
+      tokenEstimate: 0,
+    }));
+    expect(numericTool).toBe(state);
+
+    // Missing errorCode
+    const noCode = telemetryProjection.apply(state, makeEvent('tool.action_errored', {
+      tool: 'exarchos_orchestrate',
+      durationMs: 10,
+      responseBytes: 0,
+      tokenEstimate: 0,
+    }));
+    expect(noCode).toBe(state);
+  });
+
+  it('Apply_ActionErrored_NewTool_CreatesEntry', () => {
+    let state = telemetryProjection.init();
+    state = telemetryProjection.apply(state, makeEvent('tool.action_errored', {
+      tool: 'fresh_tool',
+      durationMs: 10,
+      errorCode: 'INVALID_INPUT',
+      responseBytes: 50,
+      tokenEstimate: 12,
+    }));
+
+    expect(state.tools['fresh_tool']).toBeDefined();
+    expect(state.tools['fresh_tool'].actionErrors).toBe(1);
+    expect(state.tools['fresh_tool'].actionErrorBreakdown).toEqual({ INVALID_INPUT: 1 });
+    // No completed events folded — invocations stays 0.
+    expect(state.tools['fresh_tool'].invocations).toBe(0);
+    expect(state.tools['fresh_tool'].errors).toBe(0);
+  });
+});

--- a/servers/exarchos-mcp/src/telemetry/telemetry-projection.ts
+++ b/servers/exarchos-mcp/src/telemetry/telemetry-projection.ts
@@ -27,6 +27,10 @@ export interface ToolMetrics {
   readonly durations: readonly number[];
   readonly sizes: readonly number[];
   readonly tokenEstimates: readonly number[];
+  // PR3/T9 (#1364) — structured action-level failure counters. Split from
+  // `errors` (which counts transport/protocol throws via tool.errored only).
+  readonly actionErrors: number;
+  readonly actionErrorBreakdown: Readonly<Record<string, number>>;
 }
 
 // ─── Telemetry View State ──────────────────────────────────────────────────
@@ -57,6 +61,9 @@ export function initToolMetrics(): ToolMetrics {
     durations: [],
     sizes: [],
     tokenEstimates: [],
+    // PR3/T9 (#1364)
+    actionErrors: 0,
+    actionErrorBreakdown: {},
   };
 }
 
@@ -111,6 +118,11 @@ export const telemetryProjection: ViewProjection<TelemetryViewState> = {
           durations,
           sizes,
           tokenEstimates,
+          // PR3/T9 (#1364) — preserve structured-failure counters across
+          // tool.completed folds. Listed explicitly (rather than ...existing)
+          // to keep the literal exhaustive in the type checker.
+          actionErrors: existing.actionErrors,
+          actionErrorBreakdown: existing.actionErrorBreakdown,
         };
 
         return {
@@ -131,6 +143,44 @@ export const telemetryProjection: ViewProjection<TelemetryViewState> = {
         const updated: ToolMetrics = {
           ...existing,
           errors: existing.errors + 1,
+        };
+
+        return {
+          ...view,
+          tools: { ...view.tools, [toolName]: updated },
+        };
+      }
+
+      // PR3/T9 (#1364) — fold structured action-level failures.
+      // `tool.errored` continues to track transport/protocol failures
+      // (JS throws); `tool.action_errored` carries `errorCode` so the
+      // projection can report `actionErrorBreakdown` per tool. See
+      // [`docs/designs/2026-05-15-wave2-wave3-polish.md`](../../docs/designs/2026-05-15-wave2-wave3-polish.md).
+      case 'tool.action_errored': {
+        const aeData = event.data as {
+          tool?: unknown;
+          errorCode?: unknown;
+        } | undefined;
+        if (
+          !aeData
+          || typeof aeData.tool !== 'string'
+          || typeof aeData.errorCode !== 'string'
+        ) {
+          return view;
+        }
+        const toolName = aeData.tool;
+        const errorCode = aeData.errorCode;
+
+        const existing = view.tools[toolName] ?? initToolMetrics();
+        const breakdown: Record<string, number> = {
+          ...existing.actionErrorBreakdown,
+        };
+        breakdown[errorCode] = (breakdown[errorCode] ?? 0) + 1;
+
+        const updated: ToolMetrics = {
+          ...existing,
+          actionErrors: existing.actionErrors + 1,
+          actionErrorBreakdown: breakdown,
         };
 
         return {

--- a/servers/exarchos-mcp/src/telemetry/tools.test.ts
+++ b/servers/exarchos-mcp/src/telemetry/tools.test.ts
@@ -300,6 +300,71 @@ describe('handleViewTelemetry', () => {
   });
 });
 
+// Sentry follow-up on PR #1393: the registered `TelemetryViewOutputSchema`
+// requires `actionErrors` (number) and `actionErrorBreakdown` (record) on
+// every tool entry, but the `toToolEntry` builder forgot to copy these
+// from the projection metrics. The omission would cause
+// `validateAgainstActionSchema` to surface
+// INTERNAL_ERROR/outputSchemaViolation for any `view.telemetry` call that
+// returned at least one tool entry, swallowing the telemetry payload.
+describe('toToolEntry — action-error fields (Sentry follow-up #1364)', () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await createTempDir();
+    resetMaterializerCache();
+  });
+
+  afterEach(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it('handleViewTelemetry_CompactEntry_IncludesActionErrorFields', async () => {
+    await seedTelemetryEvents(stateDir, [
+      { tool: 'workflow_get', durationMs: 10, responseBytes: 200, tokenEstimate: 50 },
+    ]);
+
+    const result = await handleViewTelemetry({}, stateDir, new EventStore(stateDir));
+
+    expect(result.success).toBe(true);
+    const data = result.data as { tools: Array<Record<string, unknown>> };
+    expect(data.tools).toHaveLength(1);
+    // No action errors seeded → both fields present, but zero-valued.
+    expect(data.tools[0]).toHaveProperty('actionErrors');
+    expect(data.tools[0].actionErrors).toBe(0);
+    expect(data.tools[0]).toHaveProperty('actionErrorBreakdown');
+    expect(data.tools[0].actionErrorBreakdown).toEqual({});
+  });
+
+  it('handleViewTelemetry_CompactEntry_ConformsToTelemetryViewOutputSchema', async () => {
+    await seedTelemetryEvents(stateDir, [
+      { tool: 'workflow_get', durationMs: 10, responseBytes: 200, tokenEstimate: 50 },
+      { tool: 'workflow_get', durationMs: 20, responseBytes: 400, tokenEstimate: 100 },
+    ]);
+
+    const result = await handleViewTelemetry({}, stateDir, new EventStore(stateDir));
+
+    expect(result.success).toBe(true);
+
+    // The registered TelemetryViewOutputSchema is the load-bearing
+    // contract — if any required field is missing, the dispatch
+    // pipeline's validateAgainstActionSchema will return
+    // INTERNAL_ERROR/outputSchemaViolation. Round-trip through a
+    // properly-shaped envelope so the assertion catches missing entry
+    // fields without false positives on optional envelope members.
+    const { TelemetryViewOutputSchema } = await import('../registry.js');
+    const envelope = {
+      success: true as const,
+      data: result.data,
+      next_actions: [],
+      _meta: {},
+      _perf: { ms: 0, bytes: 0, tokens: 0 },
+    };
+    const parsed = TelemetryViewOutputSchema.safeParse(envelope);
+    expect(parsed.success).toBe(true);
+  });
+});
+
 describe('Telemetry projection registered in materializer', () => {
   beforeEach(() => {
     resetMaterializerCache();

--- a/servers/exarchos-mcp/src/telemetry/tools.ts
+++ b/servers/exarchos-mcp/src/telemetry/tools.ts
@@ -33,6 +33,13 @@ interface CompactToolEntry {
   readonly p95Bytes: number;
   readonly p50Tokens: number;
   readonly p95Tokens: number;
+  // PR3/T10 (#1364) — structured action-level failure counters. These
+  // mirror the `TelemetryToolEntrySchema` fields registered for the
+  // `view.telemetry` action's output schema; omitting them here would
+  // make `validateAgainstActionSchema` reject the envelope and surface
+  // INTERNAL_ERROR/outputSchemaViolation to the caller.
+  readonly actionErrors: number;
+  readonly actionErrorBreakdown: Readonly<Record<string, number>>;
 }
 
 interface FullToolEntry extends CompactToolEntry {
@@ -154,6 +161,8 @@ function toToolEntry(
     p95Bytes: metrics.p95Bytes,
     p50Tokens: metrics.p50Tokens,
     p95Tokens: metrics.p95Tokens,
+    actionErrors: metrics.actionErrors,
+    actionErrorBreakdown: metrics.actionErrorBreakdown,
   };
 
   if (compact) {

--- a/servers/exarchos-mcp/src/views/handlers.test.ts
+++ b/servers/exarchos-mcp/src/views/handlers.test.ts
@@ -19,6 +19,7 @@ import {
   handleViewConvergence,
 } from './tools.js';
 import { EventStore } from '../event-store/store.js';
+import { TOOL_REGISTRY } from '../registry.js';
 
 // The "Singleton Cache" describe block that previously tested
 // `getOrCreateEventStore` was deleted alongside that function. The
@@ -1281,5 +1282,79 @@ describe('Backend Integration (Task 12)', () => {
       expect(data.workflows[0]?.featureId).toBe('real-feature');
       expect(data.workflows.every((w) => w.featureId !== '')).toBe(true);
     });
+  });
+});
+
+// ─── PR3/T10 (#1364): view.telemetry outputSchema declares action-error fields ───
+describe('ViewTelemetry_OutputSchema_IncludesActionErrorFields', () => {
+  it('the registered outputSchema validates per-tool entries with actionErrors + actionErrorBreakdown', () => {
+    const viewTool = TOOL_REGISTRY.find((t) => t.name === 'exarchos_view');
+    expect(viewTool).toBeDefined();
+    const telemetryAction = viewTool!.actions.find((a) => a.name === 'telemetry');
+    expect(telemetryAction).toBeDefined();
+    const outputSchema = telemetryAction!.outputSchema;
+    expect(outputSchema).toBeDefined();
+
+    // A canonical success envelope as emitted by handleViewTelemetry, post
+    // PR3/T9 projection extension.
+    const envelope = {
+      success: true,
+      data: {
+        session: {
+          start: '2026-05-15T00:00:00.000Z',
+          totalInvocations: 5,
+          totalTokens: 100,
+        },
+        tools: [
+          {
+            tool: 'exarchos_orchestrate',
+            invocations: 5,
+            errors: 1,
+            totalDurationMs: 50,
+            totalBytes: 500,
+            totalTokens: 100,
+            p50DurationMs: 10,
+            p95DurationMs: 10,
+            p50Bytes: 100,
+            p95Bytes: 100,
+            p50Tokens: 20,
+            p95Tokens: 20,
+            // PR3/T10 (#1364) — the new fields the outputSchema must
+            // recognise on per-tool entries.
+            actionErrors: 3,
+            actionErrorBreakdown: {
+              MERGE_ROLLED_BACK: 2,
+              PREFLIGHT_FAILED: 1,
+            },
+          },
+        ],
+        hints: [],
+      },
+      next_actions: [],
+      _meta: {},
+      _perf: { ms: 1, bytes: 100, tokens: 25 },
+    };
+
+    const result = outputSchema.safeParse(envelope);
+    expect(result.success).toBe(true);
+  });
+
+  it('per-tool data shape advertised by the outputSchema includes actionErrors + actionErrorBreakdown', () => {
+    // Stronger contract assertion: the outputSchema must EXPOSE the new
+    // fields on its per-tool entry shape, not merely accept them inside
+    // a permissive `z.unknown()` payload. We probe via the JSON Schema
+    // round-trip so this remains stable across Zod versions.
+    const viewTool = TOOL_REGISTRY.find((t) => t.name === 'exarchos_view');
+    const telemetryAction = viewTool!.actions.find((a) => a.name === 'telemetry');
+    expect(telemetryAction).toBeDefined();
+
+    // The schema must visibly mention the new field names somewhere in its
+    // declared shape (e.g., on `data.tools[*].actionErrors`).
+    const schemaText = JSON.stringify(telemetryAction!.outputSchema);
+    // If the outputSchema is `EnvelopeSchema(z.unknown())` the JSON form
+    // will not contain these names; once a typed sub-schema is registered
+    // they appear in the parsed schema tree.
+    expect(schemaText).toContain('actionErrors');
+    expect(schemaText).toContain('actionErrorBreakdown');
   });
 });


### PR DESCRIPTION
## Summary

`view telemetry.errors` reported `0` even when handlers returned the standard MCP envelope failure `{success: false, error: {...}}`. The middleware only emitted `tool.errored` on JS `throw`; structured action-level failures (`MERGE_ROLLED_BACK`, `PREFLIGHT_FAILED`, `RESERVED_FIELD`, etc.) passed through as completions and were invisible in telemetry.

Adds a new event type \`tool.action_errored\` emitted alongside `tool.completed` when `result.success === false`. The telemetry projection folds `actionErrors` and `actionErrorBreakdown` per tool. `view.telemetry`'s outputSchema declares the two new fields (Wave-0 carrier composition).

\`errors\` continues to count transport/protocol failures only.

Closes #1364. Part of #1354 Wave 3.

## Changes

- `event-store/schemas.ts` — register `tool.action_errored` event type + `ToolActionErroredData` schema + `EVENT_EMISSION_REGISTRY` entry.
- `telemetry/middleware.ts` — `isStructuredFailure()` / `extractErrorCode()` predicates; emit `tool.action_errored` after the existing `tool.completed` in the success branch when `result.success === false`. Catch branch unchanged.
- `telemetry/telemetry-projection.ts` — `ToolMetrics` gains `actionErrors: number` and `actionErrorBreakdown: Record<string, number>`. Switch case for `tool.action_errored`.
- `registry.ts` — new typed `TelemetryViewOutputSchema` wraps per-tool entries with explicit action-error fields. Wired into `view.telemetry`.

## Test Plan

- [x] `npm run typecheck`
- [x] Scoped: 1170/1171 pass (1 pre-existing race-test failure unrelated)
- [x] Full MCP suite: 6647/6670 pass — 23 pre-existing failures in \`merge-orchestrate.*.test.ts\` + \`store.race.test.ts\`, unchanged from base
- [x] `npm run build`

🤖 Stack: PR 3 of 4. Base: PR 2 (\`feature/preview4-pr2-reserved-fields\`).

Co-authored by Claude Opus 4.7 (Exarchos orchestrator).