### PR TITLE
fix(projections): rehydrate + view.pipeline track canonical tasks[] (#1359)

### DIFF
--- a/servers/exarchos-mcp/src/orchestrate/reconcile-state.projection-drift.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/reconcile-state.projection-drift.test.ts
@@ -1,0 +1,127 @@
+/**
+ * #1359 / PR4 T16 — reconcile_state projection-drift check tests.
+ *
+ * Distinct file from `reconcile-state.test.ts` because the existing tests
+ * `vi.mock('node:fs')` globally, which prevents using a real EventStore
+ * (which writes to disk) and a real state file. Here we keep `node:fs`
+ * real and stub out the git checks via env-controlled execFileSync mocks.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+// Mock execFileSync — git-touching checks should pass-through trivially
+// since the canonical state we craft below has no branches/worktrees.
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(() => Buffer.from('')),
+}));
+
+import { EventStore } from '../event-store/store.js';
+import { handleReconcileState } from './reconcile-state.js';
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(path.join(tmpdir(), 'reconcile-projdrift-'));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('handleReconcileState — projection-drift check (#1359 / PR4 T16)', () => {
+  it('ReconcileState_PipelineCountVsCanonicalDisagree_ReportsDrift', async () => {
+    // GIVEN: a canonical state.json with three `complete` tasks
+    const featureId = 'recon-drift';
+    const stateFile = path.join(tempDir, `${featureId}.state.json`);
+    const canonical = {
+      featureId,
+      workflowType: 'feature',
+      phase: 'delegate',
+      tasks: [
+        { id: 'T001', status: 'complete' },
+        { id: 'T002', status: 'complete' },
+        { id: 'T003', status: 'complete' },
+      ],
+      worktrees: {},
+    };
+    await writeFile(stateFile, JSON.stringify(canonical));
+
+    // AND: an event store carrying only ONE task.completed event (and a
+    // workflow.started so the pipeline view records the workflow at all).
+    // Pre-#1359 the pipeline view would see completedCount=1 — diverging
+    // from canonical=3.
+    const store = new EventStore(tempDir);
+    await store.append(featureId, {
+      type: 'workflow.started',
+      data: { featureId, workflowType: 'feature' },
+    });
+    await store.append(featureId, {
+      type: 'task.completed',
+      data: { taskId: 'T001' },
+    });
+
+    // WHEN: reconcile runs with both state file and event store wired
+    const result = await handleReconcileState({
+      stateFile,
+      featureId,
+      eventStore: store,
+      repoRoot: tempDir,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { passed: boolean; report: string };
+    expect(data.passed).toBe(false);
+    expect(data.report).toContain('projection-drift');
+    expect(data.report).toContain('canonical=3');
+    expect(data.report).toContain('projected=1');
+    expect(data.report).toContain('delta=2');
+  });
+
+  it('ReconcileState_PipelineCountAgreesWithCanonical_PassesDriftCheck', async () => {
+    // Inverse: when state.tasks marks one complete and one task.completed
+    // event matches, the check passes.
+    const featureId = 'recon-agree';
+    const stateFile = path.join(tempDir, `${featureId}.state.json`);
+    const canonical = {
+      featureId,
+      workflowType: 'feature',
+      phase: 'delegate',
+      tasks: [
+        { id: 'T001', status: 'complete' },
+        { id: 'T002', status: 'pending' },
+      ],
+      worktrees: {},
+    };
+    await writeFile(stateFile, JSON.stringify(canonical));
+
+    const store = new EventStore(tempDir);
+    await store.append(featureId, {
+      type: 'workflow.started',
+      data: { featureId, workflowType: 'feature' },
+    });
+    await store.append(featureId, {
+      type: 'state.patched',
+      data: {
+        featureId,
+        fields: ['tasks'],
+        patch: { tasks: canonical.tasks },
+      },
+    });
+
+    const result = await handleReconcileState({
+      stateFile,
+      featureId,
+      eventStore: store,
+      repoRoot: tempDir,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { passed: boolean; report: string };
+    // The drift check passes; other checks (phase validity etc.) should
+    // also pass given the canonical state we constructed.
+    expect(data.report).toContain('Projection drift');
+    expect(data.report).not.toContain('FAIL: Projection drift');
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/reconcile-state.ts
+++ b/servers/exarchos-mcp/src/orchestrate/reconcile-state.ts
@@ -8,11 +8,19 @@
 // Ported from scripts/reconcile-state.sh
 // ────────────────────────────────────────────────────────────────────────────
 
+import * as path from 'node:path';
 import { existsSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { resolveWorkflowState } from './resolve-state.js';
+import { ViewMaterializer } from '../views/materializer.js';
+import { SnapshotStore } from '../views/snapshot-store.js';
+import {
+  pipelineProjection,
+  PIPELINE_VIEW,
+  type PipelineViewState,
+} from '../views/pipeline-view.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -162,6 +170,75 @@ function checkWorktreesExist(acc: CheckAccumulator, state: WorkflowState, repoRo
   }
 }
 
+/**
+ * #1359 / PR4 T16 — projection-drift check.
+ *
+ * Compares canonical `tasks[].status` (the planner's stamp of record) with
+ * the pipeline view projection's `completedCount`. A disagreement here
+ * signals the #1359 root cause: rehydrate / view.pipeline diverging from
+ * the on-disk task list, which has historically caused agents to
+ * re-dispatch already-complete work.
+ *
+ * Best-effort: requires both a featureId AND a wired eventStore so the
+ * pipeline projection can be materialized; otherwise the check is skipped
+ * (recorded as PASS — "skipped" mirrors the existing "no tasks to check"
+ * pass-by-default pattern).
+ */
+/** @internal Exported for testing only. */
+export async function checkProjectionDrift(
+  acc: CheckAccumulator,
+  state: WorkflowState,
+  featureId: string | undefined,
+  eventStore: EventStore | undefined,
+  stateDir: string | undefined,
+): Promise<void> {
+  if (!featureId || !eventStore) {
+    checkPass(acc, 'Projection drift (skipped — no featureId+eventStore wired)');
+    return;
+  }
+
+  const canonicalComplete = (state.tasks ?? []).filter(
+    (t) => t.status === 'complete',
+  ).length;
+
+  let view: PipelineViewState;
+  try {
+    const snapshotStore = stateDir ? new SnapshotStore(stateDir) : undefined;
+    const materializer = new ViewMaterializer(
+      snapshotStore ? { snapshotStore } : {},
+    );
+    materializer.register(PIPELINE_VIEW, pipelineProjection);
+    const events = await eventStore.query(featureId);
+    view = materializer.materialize<PipelineViewState>(
+      featureId,
+      PIPELINE_VIEW,
+      events,
+    );
+  } catch (err) {
+    checkFail(
+      acc,
+      'Projection drift',
+      `Could not materialize pipeline view: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  const projectedComplete = view.completedCount;
+  if (canonicalComplete === projectedComplete) {
+    checkPass(
+      acc,
+      `Projection drift (canonical complete=${canonicalComplete} matches pipeline.completedCount=${projectedComplete})`,
+    );
+    return;
+  }
+  const delta = canonicalComplete - projectedComplete;
+  checkFail(
+    acc,
+    'Projection drift',
+    `projection-drift: canonical=${canonicalComplete}, projected=${projectedComplete}, delta=${delta}`,
+  );
+}
+
 function checkTaskStatusConsistency(acc: CheckAccumulator, state: WorkflowState): void {
   const tasks = state.tasks ?? [];
 
@@ -213,6 +290,11 @@ export async function handleReconcileState(args: ReconcileStateArgs): Promise<To
 
   // Check 5: Task status consistency
   checkTaskStatusConsistency(acc, state);
+
+  // Check 6 (#1359 / PR4 T16): Projection drift — canonical tasks[].status
+  // vs view.pipeline.completedCount.
+  const stateDir = stateFile ? path.dirname(stateFile) : undefined;
+  await checkProjectionDrift(acc, state, featureId, eventStore, stateDir);
 
   // Build markdown report
   const passed = acc.fail === 0;

--- a/servers/exarchos-mcp/src/projections/index.ts
+++ b/servers/exarchos-mcp/src/projections/index.ts
@@ -22,3 +22,17 @@ import './merge-orchestrator/index.js';
 
 export type { ProjectionReducer } from './types.js';
 export { assertReducerImmutable } from './testing.js';
+
+/**
+ * Threshold for surfacing `_meta.projectionLag` on response envelopes
+ * (#1359 / PR4 T15). When the delta between `Date.now()` and the
+ * projection's `projectionAsOf` exceeds this value, the response builder
+ * sets `_meta.projectionLag` to the delta in milliseconds; otherwise the
+ * field is omitted (sparse — fresh projections do not carry the field).
+ *
+ * Five seconds matches the rehydrate audit-event budget used elsewhere in
+ * the workflow surface — long enough that normal cold-cache + tail-event
+ * folds stay below the bar, short enough that a genuinely stale snapshot
+ * (e.g. due to a delayed reducer) surfaces visibly to agents.
+ */
+export const PROJECTION_LAG_THRESHOLD_MS = 5000;

--- a/servers/exarchos-mcp/src/projections/rehydration/reducer.test.ts
+++ b/servers/exarchos-mcp/src/projections/rehydration/reducer.test.ts
@@ -51,8 +51,10 @@ describe('rehydration reducer — initial state (T022, DR-3)', () => {
     // (v:3) and round-trips back to itself.
     expect(RehydrationDocumentSchema.parse(initial)).toEqual(initial);
 
-    // AND: the versioned envelope carries v === 3 and projectionSequence === 0
-    expect(initial.v).toBe(3);
+    // AND: the versioned envelope carries v === 4 and projectionSequence === 0.
+    // Bumped to v:4 in #1359 / PR4 T12 for the canonical task-status
+    // vocabulary contract change.
+    expect(initial.v).toBe(4);
     expect(initial.projectionSequence).toBe(0);
 
     // AND: volatile sections are empty containers
@@ -124,11 +126,11 @@ describe('rehydration reducer — task events fold (T023, DR-3)', () => {
     const afterCompleted = rehydrationReducer.apply(afterAssigned, completed);
 
     // THEN: taskProgress contains exactly one entry for task 001 with a
-    // terminal "completed" status.
+    // terminal "complete" status (canonical vocabulary post #1359 / PR4).
     expect(afterCompleted.taskProgress).toHaveLength(1);
     expect(afterCompleted.taskProgress[0]).toMatchObject({
       id: '001',
-      status: 'completed',
+      status: 'complete',
     });
 
     // AND: projectionSequence was incremented once per handled event.
@@ -178,7 +180,7 @@ describe('rehydration reducer — task events fold (T023, DR-3)', () => {
     expect(afterSecond.taskProgress).toHaveLength(1);
     expect(afterSecond.taskProgress[0]).toMatchObject({
       id: '003',
-      status: 'completed',
+      status: 'complete',
     });
   });
 });
@@ -557,6 +559,42 @@ describe.skip('rehydration reducer — decisions fold (T025, DR-3) — SKIPPED: 
 // (each entry has `id`, `title`, `status`). The reducer must seed taskProgress
 // from this list, then let subsequent dedicated `task.*` events override the
 // status. Status-aware upsert: events win over plan-state for the same id.
+// ─── #1359 / PR4 T11 — canonical task-progress vocabulary ───────────────────
+//
+// Pre-#1359 the reducer renamed `'complete' → 'completed'` and
+// `'in_progress' → 'assigned'`. That divergence from canonical
+// `TaskSchema.status` (`pending|in_progress|complete|failed`) meant a
+// rehydrate consumer comparing `byId.get(taskId) === 'complete'` against
+// canonical state would never match — and the outcome test at
+// `tests/outcome/rehydrate-projection-drift.test.ts` stayed RED.
+describe('rehydration reducer — canonical vocabulary (#1359 / PR4)', () => {
+  it('RehydrationReducer_StatePatchedCompleteTask_SurfacesCanonicalCompleteVocabulary', () => {
+    // GIVEN: a `state.patched` event whose `patch.tasks` declares T001 as
+    // `'complete'` (canonical TaskSchema vocabulary).
+    const initial = rehydrationReducer.initial;
+    const patched = makeEvent(
+      'state.patched',
+      {
+        featureId: 'feat-1359',
+        fields: ['tasks'],
+        patch: {
+          tasks: [{ id: 'T001', title: 'first', status: 'complete' }],
+        },
+      },
+      1,
+    );
+
+    // WHEN: we fold the event
+    const next = rehydrationReducer.apply(initial, patched);
+
+    // THEN: taskProgress surfaces canonical `'complete'` — NOT `'completed'`.
+    // Pre-fix this assertion failed because `extractPlanTasks` mapped
+    // `'complete' → 'completed'`.
+    expect(next.taskProgress[0]?.status).toBe('complete');
+    expect(next.taskProgress[0]?.id).toBe('T001');
+  });
+});
+
 describe('rehydration reducer — state.patched.tasks fold (Fix 2 / #1179)', () => {
   it('Rehydration_StatePatchedTasksWithMixedStatuses_FoldsAllAndAppliesEventOverrides', () => {
     // GIVEN: initial state plus a `workflow.started` event
@@ -608,16 +646,17 @@ describe('rehydration reducer — state.patched.tasks fold (Fix 2 / #1179)', () 
     expect(next.taskProgress).toHaveLength(5);
 
     // AND: the per-task status reflects event overrides where present, and
-    // falls back to the planner-declared "pending" otherwise.
+    // falls back to the planner-declared "pending" otherwise. Canonical
+    // vocabulary post #1359 / PR4 T11: `in_progress` / `complete` / `failed`.
     const byId = new Map(next.taskProgress.map((t) => [t.id, t.status]));
-    expect(byId.get('T1')).toBe('assigned');
-    expect(byId.get('T2')).toBe('completed');
-    expect(byId.get('T3')).toBe('completed');
+    expect(byId.get('T1')).toBe('in_progress');
+    expect(byId.get('T2')).toBe('complete');
+    expect(byId.get('T3')).toBe('complete');
     expect(byId.get('T4')).toBe('failed');
     expect(byId.get('T5')).toBe('pending');
 
-    // AND: the count of completed entries matches the events that fired.
-    const completed = next.taskProgress.filter((t) => t.status === 'completed');
+    // AND: the count of complete entries matches the events that fired.
+    const completed = next.taskProgress.filter((t) => t.status === 'complete');
     expect(completed).toHaveLength(2);
 
     // AND: the resulting document still conforms to the schema.
@@ -650,7 +689,7 @@ describe('rehydration reducer — state.patched.tasks fold (Fix 2 / #1179)', () 
     );
     expect(
       afterCompletion.taskProgress.find((t) => t.id === 'A')?.status,
-    ).toBe('completed');
+    ).toBe('complete');
 
     // AND: a later task.failed event for B
     const afterFailure = rehydrationReducer.apply(
@@ -686,9 +725,10 @@ describe('rehydration reducer — state.patched.tasks fold (Fix 2 / #1179)', () 
       ),
     );
 
-    // THEN: A stays completed, B stays failed, C is added pending.
+    // THEN: A stays complete, B stays failed, C is added pending.
+    // Canonical vocabulary post #1359 / PR4 T11.
     const byId = new Map(secondPlan.taskProgress.map((t) => [t.id, t.status]));
-    expect(byId.get('A')).toBe('completed');
+    expect(byId.get('A')).toBe('complete');
     expect(byId.get('B')).toBe('failed');
     expect(byId.get('C')).toBe('pending');
     expect(secondPlan.taskProgress).toHaveLength(3);
@@ -904,7 +944,7 @@ describe('rehydration reducer — worktree auto-detour (#1208)', () => {
     // taskProgress folds B regardless — only the orchestrator stamp is
     // protected from clobber.
     expect(afterB.taskProgress.find((t) => t.id === 'B')?.status).toBe(
-      'completed',
+      'complete',
     );
   });
 

--- a/servers/exarchos-mcp/src/projections/rehydration/reducer.ts
+++ b/servers/exarchos-mcp/src/projections/rehydration/reducer.ts
@@ -28,22 +28,37 @@ import {
   RehydrationDocumentSchema,
   type RehydrationDocument,
 } from './schema.js';
+import {
+  STATUS_RANK,
+  extractPlanTasksFromPatch,
+  rankOf,
+  type ExtractedPlanTask,
+  type TaskStatus,
+} from '../shared/task-status-fold.js';
 
 /**
- * Task statuses surfaced by this reducer.
+ * Task statuses surfaced by this reducer — post #1359 PR4 canonical
+ * vocabulary aligned with `workflow/schemas.ts`' `TaskSchema.status`.
  *
- *  - `assigned` / `completed` / `failed` come from dedicated `task.*` events.
+ *  - `in_progress` / `complete` / `failed` come from dedicated `task.*` events
+ *    (formerly `assigned` / `completed`).
  *  - `pending` is seeded from `state.patched.patch.tasks` (the planner's
  *    declared task list — see Fix 2 / #1179) so plan-state tasks that have
  *    not yet been dispatched still appear in the rehydration document.
  *
  * Event-derived statuses are *authoritative* over plan-derived statuses:
- * once a task has been observed assigned/completed/failed via events, a
- * later state.patched re-asserting the plan must NOT regress it back to
+ * once a task has been observed in_progress / complete / failed via events,
+ * a later state.patched re-asserting the plan must NOT regress it back to
  * `pending` (the planner stamps the plan repeatedly; events carry execution
  * truth).
+ *
+ * Pre-#1359 the reducer normalized `'complete' → 'completed'`. That divergence
+ * from canonical `TaskSchema.status` was Bug B in the #1359 projection-drift
+ * RCA: an agent reading rehydrate.taskProgress saw `'completed'` and then
+ * compared against `tasks[].status === 'complete'`, never matched, and
+ * re-dispatched already-complete work.
  */
-type TaskProgressStatus = 'pending' | 'assigned' | 'completed' | 'failed';
+type TaskProgressStatus = TaskStatus;
 
 /** Structural shape of a single taskProgress entry in the rehydration doc. */
 type TaskProgressEntry = RehydrationDocument['taskProgress'][number];
@@ -59,7 +74,7 @@ type TaskProgressEntry = RehydrationDocument['taskProgress'][number];
  * is caught the moment this module is imported, rather than at first use.
  */
 const initialRehydrationDocument: RehydrationDocument = RehydrationDocumentSchema.parse({
-  v: 3,
+  v: 4,
   projectionSequence: 0,
   workflowState: {
     featureId: '',
@@ -210,59 +225,15 @@ function upsertTaskProgress(
  * empty / unactionable, so callers can short-circuit and avoid bumping
  * `projectionSequence` for no-op patches.
  */
-interface ExtractedPlanTask {
-  readonly id: string;
-  readonly status: TaskProgressStatus;
-}
+// `extractPlanTasksFromPatch` (canonical-vocabulary plan-task extractor) and
+// `STATUS_RANK` (canonical-vocabulary precedence ladder) live in
+// `../shared/task-status-fold.ts` (#1359 / PR4 T13) so the pipeline view
+// projection can share the same monotonic-fold semantics. The reducer uses
+// the canonical extractor directly; callers pre-#1359 passed `data` through
+// a local extractor whose status mapping renamed `'complete' → 'completed'`,
+// which was Bug B of the #1359 projection-drift RCA.
 
-function extractPlanTasks(
-  data: WorkflowEvent['data'],
-): readonly ExtractedPlanTask[] | undefined {
-  if (!data) return undefined;
-  const patch = data['patch'];
-  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
-    return undefined;
-  }
-  const tasksRaw = (patch as Record<string, unknown>)['tasks'];
-  if (!Array.isArray(tasksRaw)) {
-    return undefined;
-  }
-
-  const out: ExtractedPlanTask[] = [];
-  for (const entry of tasksRaw) {
-    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
-    const e = entry as Record<string, unknown>;
-    const id = typeof e['id'] === 'string' ? (e['id'] as string) : undefined;
-    if (!id) continue;
-    // The plan-side TaskSchema status is `pending|in_progress|complete|failed`.
-    // Map onto the reducer's TaskProgressStatus surface; anything else (or
-    // missing) becomes `pending` because the plan-state assertion is "this
-    // task exists" — refining its execution status is the events' job.
-    const rawStatus = e['status'];
-    const status: TaskProgressStatus =
-      rawStatus === 'failed'
-        ? 'failed'
-        : rawStatus === 'complete' || rawStatus === 'completed'
-          ? 'completed'
-          : rawStatus === 'in_progress'
-            ? 'assigned'
-            : 'pending';
-    out.push({ id, status });
-  }
-
-  return out.length > 0 ? out : undefined;
-}
-
-// Status precedence — higher values "outrank" lower ones. Plan-derived
-// statuses can advance an entry up the ladder but never back down it.
-// `completed` and `failed` are siblings at the top: an event that put a
-// task into either terminal state cannot be regressed by plan re-assertions.
-const STATUS_RANK: Readonly<Record<TaskProgressStatus, number>> = {
-  pending: 0,
-  assigned: 1,
-  completed: 2,
-  failed: 2,
-};
+const extractPlanTasks = extractPlanTasksFromPatch;
 
 /**
  * Pure helper — fold a plan-derived task list into the existing taskProgress.
@@ -290,20 +261,21 @@ function foldPlanTasks(
       continue;
     }
     const existing = next[existingIdx];
-    // The schema widens status to z.string() (forward-compat for explicit
-    // schema revs), so look up via a typed accessor that returns 0 for
-    // any unknown value — anything not in the recognised ladder is treated
-    // as the lowest rank, never blocking a known-status promotion.
-    const rankOf = (s: string): number =>
-      Object.prototype.hasOwnProperty.call(STATUS_RANK, s)
-        ? STATUS_RANK[s as TaskProgressStatus]
-        : 0;
+    // Rank lookup is shared with the pipeline view via
+    // `../shared/task-status-fold.ts` so both surfaces agree on the
+    // precedence ladder (#1359 / PR4 T13).
     if (rankOf(planTask.status) > rankOf(existing.status)) {
       next[existingIdx] = { ...existing, status: planTask.status };
     }
   }
   return next;
 }
+
+// Silence the unused-import warning for `STATUS_RANK` — the ladder is
+// re-exported below for snapshot/migration consumers, but the reducer
+// itself uses `rankOf` exclusively. Without this reference TypeScript's
+// `noUnusedLocals` would flag the import.
+void STATUS_RANK;
 
 // ─── Per-prefix handlers ────────────────────────────────────────────────────
 //
@@ -370,7 +342,7 @@ function applyTaskEvent(
     state.workflowState.phase === 'delegate' ||
     state.workflowState.phase === 'merge-pending';
   if (
-    status === 'completed' &&
+    status === 'complete' &&
     state.workflowState.workflowType === 'feature' &&
     detourablePhase &&
     eventDataHasWorktreeAssociation(event.data)
@@ -874,10 +846,17 @@ export const rehydrationReducer: ProjectionReducer<RehydrationDocument, Workflow
     // monotonic only over *handled* events).
     switch (event.type) {
       // ── task.* — taskProgress fold (T023) ─────────────────────────────────
+      // Canonical vocabulary post #1359 / PR4 T11:
+      //   task.assigned  → 'in_progress'  (was 'assigned')
+      //   task.completed → 'complete'     (was 'completed')
+      //   task.failed    → 'failed'
+      // Aligned with `workflow/schemas.ts`' TaskSchema.status enum so a
+      // rehydrate consumer can compare directly against canonical
+      // `tasks[].status` without translation.
       case 'task.assigned':
-        return applyTaskEvent(state, event, 'assigned');
+        return applyTaskEvent(state, event, 'in_progress');
       case 'task.completed':
-        return applyTaskEvent(state, event, 'completed');
+        return applyTaskEvent(state, event, 'complete');
       case 'task.failed':
         return applyTaskEvent(state, event, 'failed');
 

--- a/servers/exarchos-mcp/src/projections/rehydration/schema.test.ts
+++ b/servers/exarchos-mcp/src/projections/rehydration/schema.test.ts
@@ -96,12 +96,14 @@ describe('rehydration document top-level schema (T013, DR-3)', () => {
     phasePlaybook: null,
   };
 
-  it('RehydrationDoc_VersionedSchema_RequiresV3', () => {
-    // Updated for v:3 envelope bump (T-01). The main schema now requires
-    // v: literal(3); legacy v:2 docs route through RehydrationDocumentSchemaV2
-    // and legacy v:1 docs route through RehydrationDocumentSchemaV1.
+  it('RehydrationDoc_VersionedSchema_RequiresV4', () => {
+    // Updated for v:4 envelope bump (#1359 / PR4 T12). The main schema now
+    // requires v: literal(4); legacy v:3 docs route through
+    // RehydrationDocumentSchemaV3, v:2 docs through
+    // RehydrationDocumentSchemaV2, and v:1 docs through
+    // RehydrationDocumentSchemaV1.
     const validDoc = {
-      v: 3,
+      v: 4,
       projectionSequence: 0,
       ...minimalStable,
       ...minimalVolatile,
@@ -124,7 +126,7 @@ describe('rehydration document top-level schema (T013, DR-3)', () => {
 
   it('RehydrationDoc_ProjectionSequence_RequiresNonNegativeInt', () => {
     const baseDoc = {
-      v: 3 as const,
+      v: 4 as const,
       ...minimalStable,
       ...minimalVolatile,
     };
@@ -170,7 +172,7 @@ describe('rehydration document serializer — stable-before-volatile order (T050
   it('DocumentSerialization_StableSectionsFirst_Always', () => {
     // Forward-declared doc: keys in canonical order.
     const forwardDoc: RehydrationDocument = {
-      v: 3,
+      v: 4,
       projectionSequence: 7,
       workflowState: stable.workflowState,
       taskProgress: volatile.taskProgress,
@@ -195,7 +197,7 @@ describe('rehydration document serializer — stable-before-volatile order (T050
       taskProgress: volatile.taskProgress,
       workflowState: stable.workflowState,
       projectionSequence: 7,
-      v: 3,
+      v: 4,
     } as RehydrationDocument;
 
     const forwardJson = serializeRehydrationDocument(forwardDoc);
@@ -236,7 +238,7 @@ describe('rehydration document serializer — stable-before-volatile order (T050
 
   it('DocumentSerialization_ReorderedInput_ProducesIdenticalBytes', () => {
     const docA: RehydrationDocument = {
-      v: 3,
+      v: 4,
       projectionSequence: 42,
       workflowState: stable.workflowState,
       taskProgress: volatile.taskProgress,
@@ -259,7 +261,7 @@ describe('rehydration document serializer — stable-before-volatile order (T050
       taskProgress: volatile.taskProgress,
       workflowState: stable.workflowState,
       projectionSequence: 42,
-      v: 3,
+      v: 4,
     } as RehydrationDocument;
 
     expect(serializeRehydrationDocument(docA)).toBe(serializeRehydrationDocument(docB));
@@ -526,7 +528,7 @@ describe('RehydrationDocumentSchema v:3 envelope (T-01)', () => {
   it('RehydrationDocumentSchema_V3NullPlaybook_Parses', () => {
     // Minimum valid v:3 doc with phasePlaybook: null
     const v3Doc = {
-      v: 3,
+      v: 4,
       projectionSequence: 0,
       workflowState: minimalWorkflowState,
       ...minimalVolatileV3,
@@ -539,7 +541,7 @@ describe('RehydrationDocumentSchema v:3 envelope (T-01)', () => {
   it('RehydrationDocumentSchema_V3FullPlaybook_Parses', () => {
     // v:3 doc with a fully populated phasePlaybook
     const v3Doc = {
-      v: 3,
+      v: 4,
       projectionSequence: 5,
       workflowState: minimalWorkflowState,
       taskProgress: [],

--- a/servers/exarchos-mcp/src/projections/rehydration/schema.ts
+++ b/servers/exarchos-mcp/src/projections/rehydration/schema.ts
@@ -301,22 +301,53 @@ const VolatileSectionsSchemaV2 = z
 
 export type VolatileSections = z.infer<typeof VolatileSectionsSchema>;
 
-// ─── v:3 Top-Level Envelope ───────────────────────────────────────────────────
+// ─── v:4 Top-Level Envelope ───────────────────────────────────────────────────
 
 /**
- * Top-level rehydration document envelope — v:3 (T-01, rehydration-machinery-refactor).
+ * Top-level rehydration document envelope — v:4 (#1359 / PR4 T12,
+ * projection-drift fix).
  *
- * Breaking changes vs v:2:
- * - `v: 3` literal (was `v: 2`)
- * - `behavioralGuidance` removed from stable sections (was vestigial)
- * - `phasePlaybook` added to volatile sections (nullable; composed live at
- *   handler time by T-20; null until then)
+ * Breaking changes vs v:3:
+ * - `v: 4` literal (was `v: 3`)
+ * - `taskProgress[].status` aligned with canonical `TaskSchema.status`
+ *   vocabulary (`pending|in_progress|complete|failed`). Pre-#1359 the
+ *   reducer renamed `'complete' → 'completed'` and
+ *   `'in_progress' → 'assigned'`, which let agents reading the rehydration
+ *   document re-dispatch already-complete work because their comparison
+ *   against canonical `tasks[].status` never matched.
  *
- * Read-side compatibility: v:2 snapshots route through
- * {@link RehydrationDocumentSchemaV2} (T-03 upgrade path); v:1 snapshots
- * route through {@link RehydrationDocumentSchemaV1}.
+ * The on-disk shape is identical between v:3 and v:4 (the schema widens
+ * `status` to `z.string()` so the structural envelope hasn't changed); the
+ * version bump reflects a *vocabulary* contract change and lets
+ * `loadRehydrationDocument` route v:3 documents through the
+ * `upgradeRehydrationDocumentV3toV4` rename pass.
+ *
+ * Read-side compatibility chain: v:1 → v:2 → v:3 → v:4. Each upgrader is
+ * pure (no I/O) and exposed from `upgrade.ts`.
  */
 export const RehydrationDocumentSchema = z
+  .object({
+    v: z.literal(4),
+    projectionSequence: z.number().int().nonnegative(),
+  })
+  .merge(StableSectionsSchema)
+  .merge(VolatileSectionsSchema);
+
+/**
+ * Alias for the v:4 envelope inferred type.
+ * Prefer this name in new code for clarity.
+ */
+export type RehydrationDocumentV4 = z.infer<typeof RehydrationDocumentSchema>;
+
+/**
+ * v:3 envelope — read-back-only post-#1359 / PR4 T12. Used by
+ * `loadRehydrationDocument` to parse legacy snapshots before applying the
+ * v:3 → v:4 vocabulary rename. Mirrors the v:3 envelope frozen by T-01.
+ *
+ * Writers MUST NOT use this schema — emit v:4 directly via
+ * `RehydrationDocumentSchema`. Retirement criterion: on-disk v:3 doc count == 0.
+ */
+export const RehydrationDocumentSchemaV3 = z
   .object({
     v: z.literal(3),
     projectionSequence: z.number().int().nonnegative(),
@@ -324,23 +355,19 @@ export const RehydrationDocumentSchema = z
   .merge(StableSectionsSchema)
   .merge(VolatileSectionsSchema);
 
-/**
- * Alias for the v:3 envelope inferred type.
- * Prefer this name in new code for clarity.
- */
-export type RehydrationDocumentV3 = z.infer<typeof RehydrationDocumentSchema>;
+export type RehydrationDocumentV3 = z.infer<typeof RehydrationDocumentSchemaV3>;
 
 /**
- * Union of v:2 and v:3 envelope shapes — used as the public `RehydrationDocument`
- * type so that `upgrade.ts` (T-02) can continue to produce `RehydrationDocumentV2`
- * objects typed as `RehydrationDocument` until T-02 upgrades the function to
- * target v:3. Writers of new v:3 documents should use `RehydrationDocumentV3`
- * or constrain to `{ v: 3 }` explicitly.
+ * Union of v:3 and v:4 envelope shapes — used as the public
+ * `RehydrationDocument` type so call sites in `upgrade.ts` / `serialize.ts`
+ * can read either shape during the v:3 → v:4 migration window. Writers of
+ * new documents should use `RehydrationDocumentV4` or constrain to
+ * `{ v: 4 }` explicitly.
  *
- * @deprecated Prefer `RehydrationDocumentV3` for new code. This union will be
- * narrowed to v:3-only once T-02 migrates `upgrade.ts`.
+ * @deprecated Prefer `RehydrationDocumentV4` for new code. This union will be
+ * narrowed to v:4-only once on-disk v:3 doc count == 0.
  */
-export type RehydrationDocument = RehydrationDocumentV3 | RehydrationDocumentV2;
+export type RehydrationDocument = RehydrationDocumentV4 | RehydrationDocumentV3;
 
 // ─── v:2 Envelope (read-back-only) ───────────────────────────────────────────
 

--- a/servers/exarchos-mcp/src/projections/rehydration/serialize.test.ts
+++ b/servers/exarchos-mcp/src/projections/rehydration/serialize.test.ts
@@ -40,7 +40,7 @@ const minimalV2Stable = {
 };
 
 describe('loadRehydrationDocument (T3, #1246 + T-03, rehydration-machinery-refactor)', () => {
-  it('loadRehydrationDocument_V2Document_ReturnsV3Shape', () => {
+  it('loadRehydrationDocument_V2Document_ReturnsLatestShape', () => {
     // T-03 RED: v:2 doc should be upgraded to v:3 on load.
     const v2Input = {
       v: 2,
@@ -71,7 +71,7 @@ describe('loadRehydrationDocument (T3, #1246 + T-03, rehydration-machinery-refac
     const result = loadRehydrationDocument(v2Input);
 
     // Upgraded to v:3.
-    expect(result.v).toBe(3);
+    expect(result.v).toBe(4);
     expect(result.projectionSequence).toBe(7);
     expect(result.latestHandoff?.eventRef.sequence).toBe(100);
     expect(result.recentHandoffs?.[0]?.eventRef.sequence).toBe(100);
@@ -86,7 +86,7 @@ describe('loadRehydrationDocument (T3, #1246 + T-03, rehydration-machinery-refac
     expect(Object.prototype.hasOwnProperty.call(result, 'behavioralGuidance')).toBe(false);
   });
 
-  it('loadRehydrationDocument_V1Document_ReturnsV3Shape', () => {
+  it('loadRehydrationDocument_V1Document_ReturnsLatestShape', () => {
     // T-03 RED: v:1 doc should chain through v:2 → v:3 on load.
     const v1Input = {
       v: 1,
@@ -119,7 +119,7 @@ describe('loadRehydrationDocument (T3, #1246 + T-03, rehydration-machinery-refac
     const result = loadRehydrationDocument(v1Input);
 
     // Chained all the way to v:3.
-    expect(result.v).toBe(3);
+    expect(result.v).toBe(4);
 
     // No `id` leaks anywhere on eventRef.
     expect(result.latestHandoff?.eventRef).toEqual({
@@ -147,10 +147,10 @@ describe('loadRehydrationDocument (T3, #1246 + T-03, rehydration-machinery-refac
     expect(Object.prototype.hasOwnProperty.call(result, 'behavioralGuidance')).toBe(false);
   });
 
-  it('loadRehydrationDocument_V3Document_NativePassThrough', () => {
-    // T-03 RED: v:3 doc should pass through without any upgrade applied.
-    const v3Input = {
-      v: 3,
+  it('loadRehydrationDocument_V4Document_NativePassThrough', () => {
+    // Native pass-through for the latest envelope (v:4 post #1359 / PR4 T12).
+    const v4Input = {
+      v: 4,
       projectionSequence: 42,
       ...minimalWorkflowState,
       taskProgress: [],
@@ -161,10 +161,10 @@ describe('loadRehydrationDocument (T3, #1246 + T-03, rehydration-machinery-refac
       phasePlaybook: null,
     };
 
-    const result = loadRehydrationDocument(v3Input);
+    const result = loadRehydrationDocument(v4Input);
 
-    // Native pass-through: v:3 shape preserved verbatim.
-    expect(result.v).toBe(3);
+    // Native pass-through: v:4 shape preserved verbatim.
+    expect(result.v).toBe(4);
     expect(result.projectionSequence).toBe(42);
     expect(result.phasePlaybook).toBeNull();
     expect(result.blockers).toEqual([]);
@@ -174,7 +174,7 @@ describe('loadRehydrationDocument (T3, #1246 + T-03, rehydration-machinery-refac
   });
 
   it('loadRehydrationDocument_InvalidEnvelope_ThrowsInvalidEnvelopeError', () => {
-    // Neither v:1 nor v:2 nor v:3 — typed error (no silent fallback).
+    // None of v:1 / v:2 / v:3 / v:4 — typed error (no silent fallback).
     const garbage = { v: 99, projectionSequence: 0, ...minimalV2Stable };
 
     expect(() => loadRehydrationDocument(garbage)).toThrow(InvalidEnvelopeError);
@@ -218,7 +218,7 @@ describe('STABLE_KEYS (T-05, rehydration-machinery-refactor)', () => {
     // produce identical prefix bytes. Verifies that serializeRehydrationDocument
     // is field-order-disciplined for the v:3 stable section.
     const baseDoc = {
-      v: 3 as const,
+      v: 4 as const,
       projectionSequence: 10,
       workflowState: {
         featureId: 'feature-alpha',

--- a/servers/exarchos-mcp/src/projections/rehydration/serialize.ts
+++ b/servers/exarchos-mcp/src/projections/rehydration/serialize.ts
@@ -22,11 +22,12 @@ import {
   RehydrationDocumentSchema,
   RehydrationDocumentSchemaV1,
   RehydrationDocumentSchemaV2,
+  RehydrationDocumentSchemaV3,
   StableSectionsSchema,
   VolatileSectionsSchema,
   WorkflowStateSchema,
   type RehydrationDocument,
-  type RehydrationDocumentV3,
+  type RehydrationDocumentV4,
 } from './schema.js';
 import {
   InvalidEnvelopeError,
@@ -117,10 +118,17 @@ export function serializeRehydrationDocument(doc: RehydrationDocument): string {
     projectionSequence: doc.projectionSequence,
   };
 
-  // v:2 has behavioralGuidance in stable sections; v:3 does not.
-  if (doc.v === 2) {
+  // v:2 had behavioralGuidance in stable sections; v:3 and v:4 do not.
+  // The public `RehydrationDocument` union is now v:3 | v:4 so the
+  // behavioralGuidance branch is unreachable through the static type
+  // surface. The runtime check below guards callers that pass a freshly
+  // parsed v:2 envelope through this serializer (e.g. migration tooling
+  // that operates on `unknown` payloads — see CodeRabbit on PR #1178)
+  // without forcing the type union to widen back to v:2.
+  const docAsRecord = doc as Record<string, unknown>;
+  if (docAsRecord['v'] === 2 && docAsRecord['behavioralGuidance']) {
     ordered['behavioralGuidance'] = reorder(
-      doc.behavioralGuidance,
+      docAsRecord['behavioralGuidance'] as Record<string, unknown>,
       BEHAVIORAL_GUIDANCE_KEYS,
     );
   }
@@ -142,7 +150,12 @@ export function serializeRehydrationDocument(doc: RehydrationDocument): string {
  * Defined once at module scope so the compiled probe is shared across calls.
  */
 const EnvelopeVersionProbe = z.object({
-  v: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+  v: z.union([
+    z.literal(1),
+    z.literal(2),
+    z.literal(3),
+    z.literal(4),
+  ]),
 });
 
 /**
@@ -164,14 +177,16 @@ const EnvelopeVersionProbe = z.object({
  * the only legitimate path that touches `RehydrationDocumentSchemaV1` and
  * `RehydrationDocumentSchemaV2`.
  */
-export function loadRehydrationDocument(raw: unknown): RehydrationDocumentV3 {
+export function loadRehydrationDocument(raw: unknown): RehydrationDocumentV4 {
   const probe = EnvelopeVersionProbe.safeParse(raw);
   if (!probe.success) {
     throw new InvalidEnvelopeError(probe.error);
   }
   switch (probe.data.v) {
-    case 3:
+    case 4:
       return RehydrationDocumentSchema.parse(raw);
+    case 3:
+      return upgradeRehydrationDocument(RehydrationDocumentSchemaV3.parse(raw));
     case 2:
       return upgradeRehydrationDocument(RehydrationDocumentSchemaV2.parse(raw));
     case 1:

--- a/servers/exarchos-mcp/src/projections/rehydration/upgrade.test.ts
+++ b/servers/exarchos-mcp/src/projections/rehydration/upgrade.test.ts
@@ -25,6 +25,8 @@ import {
   upgradeHandoffEntryV1toV2,
   upgradeRehydrationDocumentV1toV2,
   upgradeRehydrationDocumentV2toV3,
+  upgradeRehydrationDocumentV3toV4,
+  upgradeRehydrationDocument,
   HandoffEntryUpgradeError,
 } from './upgrade.js';
 import {
@@ -33,6 +35,7 @@ import {
   RehydrationDocumentSchema,
   RehydrationDocumentSchemaV1,
   RehydrationDocumentSchemaV2,
+  RehydrationDocumentSchemaV3,
 } from './schema.js';
 
 const minimalStable = {
@@ -321,8 +324,10 @@ describe('upgradeRehydrationDocumentV2toV3 (T-02, rehydration-machinery-refactor
     // phasePlaybook seeded null (composed at handler time, not folded from events).
     expect(v3Doc.phasePlaybook).toBeNull();
 
-    // The v:3 schema validates the result.
-    expect(RehydrationDocumentSchema.safeParse(v3Doc).success).toBe(true);
+    // The v:3 schema validates the result. Post #1359 / PR4 T12 the
+    // top-level RehydrationDocumentSchema is v:4, so the intermediate v:3
+    // shape validates against the frozen RehydrationDocumentSchemaV3.
+    expect(RehydrationDocumentSchemaV3.safeParse(v3Doc).success).toBe(true);
   });
 
   it('upgradeRehydrationDocumentV2toV3_PreservesWorkflowStateProjectionSequenceAndVolatileFields', () => {
@@ -426,7 +431,7 @@ describe('upgradeRehydrationDocumentV2toV3 (T-02, rehydration-machinery-refactor
 
     fc.assert(
       fc.property(v2DocArb, (v2Doc) => {
-        const result = RehydrationDocumentSchema.safeParse(
+        const result = RehydrationDocumentSchemaV3.safeParse(
           upgradeRehydrationDocumentV2toV3(v2Doc),
         );
         return result.success;
@@ -470,9 +475,11 @@ describe('upgradeRehydrationDocumentV2toV3 (T-02, rehydration-machinery-refactor
     expect(v2Doc.v).toBe(2);
     expect(RehydrationDocumentSchemaV2.safeParse(v2Doc).success).toBe(true);
 
-    // v:2 → v:3 chain produces a valid v:3 document.
+    // v:2 → v:3 chain produces a valid v:3 document. Post #1359 / PR4 T12
+    // the top-level schema is v:4; the intermediate v:3 shape validates
+    // against the frozen RehydrationDocumentSchemaV3.
     expect(v3Doc.v).toBe(3);
-    expect(RehydrationDocumentSchema.safeParse(v3Doc).success).toBe(true);
+    expect(RehydrationDocumentSchemaV3.safeParse(v3Doc).success).toBe(true);
 
     // behavioralGuidance is absent from the v:3 result.
     expect(Object.prototype.hasOwnProperty.call(v3Doc, 'behavioralGuidance')).toBe(false);
@@ -486,5 +493,72 @@ describe('upgradeRehydrationDocumentV2toV3 (T-02, rehydration-machinery-refactor
     // latestHandoff preserved through the chain (upgraded from v:1 entry).
     expect(v3Doc.latestHandoff?.context).toBe('chain latest');
     expect(v3Doc.latestHandoff?.eventRef.sequence).toBe(3);
+  });
+});
+
+// ─── #1359 / PR4 T12 — v:3 → v:4 taskProgress vocabulary rename ─────────────
+
+describe('upgradeRehydrationDocumentV3toV4 (#1359 / PR4 T12)', () => {
+  it('UpgradeV3ToV4_TaskProgressCompleted_RenamesToComplete', () => {
+    // GIVEN: a valid v:3 document carrying the pre-#1359 task-progress
+    // vocabulary (`'completed'` / `'assigned'`).
+    const v3Doc = RehydrationDocumentSchemaV3.parse({
+      v: 3,
+      projectionSequence: 9,
+      workflowState: {
+        featureId: 'feat-1359',
+        phase: 'delegate',
+        workflowType: 'feature',
+      },
+      taskProgress: [
+        { id: 'T001', status: 'completed' },
+        { id: 'T002', status: 'assigned' },
+        { id: 'T003', status: 'failed' },
+        { id: 'T004', status: 'pending' },
+      ],
+      decisions: [],
+      artifacts: {},
+      blockers: [],
+      recentHandoffs: [],
+      phasePlaybook: null,
+    });
+
+    // WHEN: we upgrade to v:4
+    const v4Doc = upgradeRehydrationDocumentV3toV4(v3Doc);
+
+    // THEN: vocabulary is renamed to canonical TaskSchema.status values.
+    expect(v4Doc.v).toBe(4);
+    const byId = new Map(v4Doc.taskProgress.map((t) => [t.id, t.status]));
+    expect(byId.get('T001')).toBe('complete');     // was 'completed'
+    expect(byId.get('T002')).toBe('in_progress');  // was 'assigned'
+    expect(byId.get('T003')).toBe('failed');       // unchanged
+    expect(byId.get('T004')).toBe('pending');      // unchanged
+
+    // AND: the upgraded doc passes the v:4 schema.
+    expect(RehydrationDocumentSchema.safeParse(v4Doc).success).toBe(true);
+
+    // AND: non-task fields are preserved verbatim.
+    expect(v4Doc.projectionSequence).toBe(9);
+    expect(v4Doc.workflowState).toEqual(v3Doc.workflowState);
+    expect(v4Doc.phasePlaybook).toBeNull();
+  });
+
+  it('UpgradeChain_FromV1OrV2_TerminatesAtV4', () => {
+    // The full upgrade chain (v:1 → v:4) must produce a v:4-shaped document.
+    const v1Doc = RehydrationDocumentSchemaV1.parse({
+      v: 1,
+      projectionSequence: 1,
+      behavioralGuidance: { skill: 's', skillRef: 'sr' },
+      workflowState: { featureId: 'f', phase: 'p', workflowType: 'feature' },
+      taskProgress: [{ id: 'T1', status: 'completed' }],
+      decisions: [],
+      artifacts: {},
+      blockers: [],
+    });
+
+    const latest = upgradeRehydrationDocument(v1Doc);
+    expect(latest.v).toBe(4);
+    expect(latest.taskProgress[0]?.status).toBe('complete');
+    expect(RehydrationDocumentSchema.safeParse(latest).success).toBe(true);
   });
 });

--- a/servers/exarchos-mcp/src/projections/rehydration/upgrade.ts
+++ b/servers/exarchos-mcp/src/projections/rehydration/upgrade.ts
@@ -28,6 +28,7 @@ import type {
   RehydrationDocument,
   RehydrationDocumentV2,
   RehydrationDocumentV3,
+  RehydrationDocumentV4,
 } from './schema.js';
 
 /**
@@ -42,14 +43,14 @@ export class HandoffEntryUpgradeError extends Error {
 }
 
 /**
- * Envelope-routing failure: the input has none of `v: 1` / `v: 2` / `v: 3`.
- * Raised by `loadRehydrationDocument` so callers see typed corruption, not a
- * silently-substituted empty doc.
+ * Envelope-routing failure: the input has none of `v: 1` / `v: 2` / `v: 3` /
+ * `v: 4`. Raised by `loadRehydrationDocument` so callers see typed
+ * corruption, not a silently-substituted empty doc.
  */
 export class InvalidEnvelopeError extends Error {
   constructor(zodError: z.ZodError) {
     super(
-      `Rehydration envelope has none of v:1 / v:2 / v:3 shape: ${zodError.message}`,
+      `Rehydration envelope has none of v:1 / v:2 / v:3 / v:4 shape: ${zodError.message}`,
     );
     this.name = 'InvalidEnvelopeError';
   }
@@ -186,25 +187,66 @@ export function upgradeRehydrationDocumentV2toV3(
 }
 
 /**
- * Upgrade any versioned rehydration document to the latest (v:3) shape.
+ * Upgrade a v:3 rehydration document to v:4 (#1359 / PR4 T12,
+ * projection-drift fix).
+ *
+ * Pure vocabulary rename on `taskProgress[].status`:
+ *   - `'completed' → 'complete'`     (canonical TaskSchema vocabulary)
+ *   - `'assigned'  → 'in_progress'`  (canonical TaskSchema vocabulary)
+ *
+ * All other v:3 fields (`workflowState`, `projectionSequence`, every other
+ * volatile section, `phasePlaybook`) are preserved verbatim. The schema
+ * widens `status` to `z.string()` so the structural shape is unchanged —
+ * the version bump exists to signal that a v:3 reader cannot reliably
+ * substring-compare against canonical `tasks[].status` whereas a v:4
+ * reader can.
+ */
+export function upgradeRehydrationDocumentV3toV4(
+  doc: RehydrationDocumentV3,
+): RehydrationDocumentV4 {
+  const renameStatus = (raw: string): string => {
+    if (raw === 'completed') return 'complete';
+    if (raw === 'assigned') return 'in_progress';
+    return raw;
+  };
+  return {
+    ...doc,
+    v: 4,
+    taskProgress: doc.taskProgress.map((entry) => ({
+      ...entry,
+      status: renameStatus(entry.status),
+    })),
+  };
+}
+
+/**
+ * Upgrade any versioned rehydration document to the latest (v:4) shape.
  *
  * Routes through the version chain:
  *   v:1 → v:2  (upgradeRehydrationDocumentV1toV2)
  *   v:2 → v:3  (upgradeRehydrationDocumentV2toV3)
+ *   v:3 → v:4  (upgradeRehydrationDocumentV3toV4, #1359 / PR4)
  *
- * Returns a `RehydrationDocumentV3`. Only the read entry point
- * (`loadRehydrationDocument` in `serialize.ts`, T-03) should call this;
- * writers always emit v:3 directly.
+ * Returns a `RehydrationDocumentV4`. Only the read entry point
+ * (`loadRehydrationDocument` in `serialize.ts`) should call this; writers
+ * always emit v:4 directly.
  */
 export function upgradeRehydrationDocument(
-  doc: RehydrationDocumentV1 | RehydrationDocument,
-): RehydrationDocumentV3 {
+  doc: RehydrationDocumentV1 | RehydrationDocumentV2 | RehydrationDocument,
+): RehydrationDocumentV4 {
   if (doc.v === 1) {
-    return upgradeRehydrationDocumentV2toV3(upgradeRehydrationDocumentV1toV2(doc));
+    return upgradeRehydrationDocumentV3toV4(
+      upgradeRehydrationDocumentV2toV3(upgradeRehydrationDocumentV1toV2(doc)),
+    );
   }
   if (doc.v === 2) {
-    return upgradeRehydrationDocumentV2toV3(doc);
+    return upgradeRehydrationDocumentV3toV4(
+      upgradeRehydrationDocumentV2toV3(doc),
+    );
   }
-  // v:3 — already at latest.
+  if (doc.v === 3) {
+    return upgradeRehydrationDocumentV3toV4(doc);
+  }
+  // v:4 — already at latest.
   return doc;
 }

--- a/servers/exarchos-mcp/src/projections/shared/task-status-fold.test.ts
+++ b/servers/exarchos-mcp/src/projections/shared/task-status-fold.test.ts
@@ -37,6 +37,15 @@ describe('normalizeTaskStatus', () => {
     expect(normalizeTaskStatus('completed')).toBe('complete');
   });
 
+  it('NormalizeTaskStatus_LegacyAssigned_MapsToInProgress', () => {
+    // Pre-#1359 corpus emits `state.patched { patch: { tasks: [{status: "assigned"}] } }`.
+    // The legacy `'assigned'` literal must promote to `'in_progress'`,
+    // not silently downgrade to `'pending'` (which would re-dispatch
+    // work already in flight). Mirrors `upgradeRehydrationDocumentV3toV4`'s
+    // `'assigned' → 'in_progress'` rename (#1359 / PR4 T12).
+    expect(normalizeTaskStatus('assigned')).toBe('in_progress');
+  });
+
   it('NormalizeTaskStatus_UnknownValue_FallsBackToPending', () => {
     expect(normalizeTaskStatus('mystery-status')).toBe('pending');
     expect(normalizeTaskStatus(undefined)).toBe('pending');

--- a/servers/exarchos-mcp/src/projections/shared/task-status-fold.test.ts
+++ b/servers/exarchos-mcp/src/projections/shared/task-status-fold.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Co-located tests for the shared monotonic task-status fold helper.
+ *
+ * Sentry follow-up on PR #1394 (`task-status-fold.ts:58`): the workflow-side
+ * `TaskStatusSchema` carries a `z.preprocess` mapping the legacy
+ * `'completed'` literal to the canonical `'complete'`, but
+ * `state.patched` events emitted by `handleSet` do NOT route their
+ * `input.updates` through that schema. Historical events with
+ * `status: 'completed'` therefore arrive at the projections unchanged.
+ * Without the same legacy-mapping inside `normalizeTaskStatus`, those
+ * tasks would silently downgrade to `pending`, breaking
+ * taskCount/completedCount and risking re-dispatch of finished work.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  extractPlanTasksFromPatch,
+  normalizeTaskStatus,
+  promoteStatus,
+  rankOf,
+} from './task-status-fold.js';
+
+describe('normalizeTaskStatus', () => {
+  it('NormalizeTaskStatus_CanonicalValues_RoundTrip', () => {
+    expect(normalizeTaskStatus('pending')).toBe('pending');
+    expect(normalizeTaskStatus('in_progress')).toBe('in_progress');
+    expect(normalizeTaskStatus('complete')).toBe('complete');
+    expect(normalizeTaskStatus('failed')).toBe('failed');
+  });
+
+  it('NormalizeTaskStatus_LegacyCompleted_MapsToComplete', () => {
+    // Pre-#1359 corpus emits `state.patched { patch: { tasks: [{status: "completed"}] } }`.
+    // The legacy literal must promote to the canonical `complete`, not
+    // silently downgrade to `pending` (which would re-dispatch finished
+    // work). Mirrors the `TaskStatusSchema` `z.preprocess` mapping.
+    expect(normalizeTaskStatus('completed')).toBe('complete');
+  });
+
+  it('NormalizeTaskStatus_UnknownValue_FallsBackToPending', () => {
+    expect(normalizeTaskStatus('mystery-status')).toBe('pending');
+    expect(normalizeTaskStatus(undefined)).toBe('pending');
+    expect(normalizeTaskStatus(null)).toBe('pending');
+    expect(normalizeTaskStatus(42)).toBe('pending');
+  });
+});
+
+describe('extractPlanTasksFromPatch (legacy status carrier)', () => {
+  it('ExtractPlanTasks_LegacyCompletedStatus_MapsToCanonicalComplete', () => {
+    // Simulates a pre-#1359 `state.patched` payload containing the
+    // legacy literal. The extracted task must surface the canonical
+    // `complete` so downstream rankOf/promoteStatus treats it as
+    // terminal.
+    const extracted = extractPlanTasksFromPatch({
+      patch: {
+        tasks: [
+          { id: 'T-001', status: 'completed' },
+          { id: 'T-002', status: 'complete' },
+          { id: 'T-003', status: 'in_progress' },
+        ],
+      },
+    });
+
+    expect(extracted).toEqual([
+      { id: 'T-001', status: 'complete' },
+      { id: 'T-002', status: 'complete' },
+      { id: 'T-003', status: 'in_progress' },
+    ]);
+  });
+});
+
+describe('promoteStatus + rankOf (monotonic ladder)', () => {
+  it('PromoteStatus_LegacyCompletedFold_MonotonicallyPromotesFromInProgress', () => {
+    // The historical projection scenario: an in_progress task is
+    // re-asserted via state.patched with the legacy `'completed'`.
+    // After normalization, promoteStatus must advance the entry to
+    // `complete` (rank 2 > rank 1).
+    const initial: Record<string, string> = { 'T-001': 'in_progress' };
+    const next = promoteStatus(initial, 'T-001', normalizeTaskStatus('completed'));
+    expect(next['T-001']).toBe('complete');
+    expect(rankOf(next['T-001'])).toBe(2);
+  });
+
+  it('PromoteStatus_TerminalNeverRegresses', () => {
+    // Once `complete`, a subsequent `pending` assertion must not
+    // regress the entry — the precedence ladder is monotonic.
+    const initial: Record<string, string> = { 'T-001': 'complete' };
+    const next = promoteStatus(initial, 'T-001', 'pending');
+    expect(next['T-001']).toBe('complete');
+  });
+});

--- a/servers/exarchos-mcp/src/projections/shared/task-status-fold.ts
+++ b/servers/exarchos-mcp/src/projections/shared/task-status-fold.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared monotonic task-status fold helper (#1359 / PR4 T13).
+ *
+ * Used by both the rehydration projection reducer
+ * (`projections/rehydration/reducer.ts`) and the pipeline view projection
+ * (`views/pipeline-view.ts`) so both surfaces compute taskCount /
+ * completedCount / per-id status from a single ranking table.
+ *
+ * Canonical vocabulary mirrors the workflow-side `TaskSchema.status` enum
+ * (`workflow/schemas.ts`): `pending | in_progress | complete | failed`.
+ *
+ * Monotonic promotion rule: a fold can ONLY advance an entry up the
+ * precedence ladder (pending → in_progress → complete/failed). It must NOT
+ * regress a terminal status back to pending (the planner stamps the plan
+ * repeatedly; events / later state.patched re-assertions must not undo
+ * execution truth). Per CR review 4178067854.
+ */
+
+/**
+ * Canonical task-progress status union — single source of truth for both
+ * projection reducers. Mirrors `TaskSchema.status` post-#1359.
+ */
+export type TaskStatus = 'pending' | 'in_progress' | 'complete' | 'failed';
+
+/**
+ * Status precedence ladder. Higher rank "wins" when promoting an entry.
+ * `complete` and `failed` are sibling terminal ranks (rank 2) — neither
+ * regresses to the other.
+ */
+export const STATUS_RANK: Readonly<Record<TaskStatus, number>> = {
+  pending: 0,
+  in_progress: 1,
+  complete: 2,
+  failed: 2,
+};
+
+/**
+ * Look up the rank of an arbitrary string status, defaulting to 0 for any
+ * value outside the canonical ladder so unknown statuses can never block a
+ * known promotion.
+ */
+export function rankOf(status: string): number {
+  return Object.prototype.hasOwnProperty.call(STATUS_RANK, status)
+    ? STATUS_RANK[status as TaskStatus]
+    : 0;
+}
+
+/**
+ * Normalize a `TaskSchema.status` value (or close approximation thereof)
+ * into the canonical TaskStatus surface. Anything not recognized falls
+ * back to `pending` — the safe default for plan-state assertion folds.
+ */
+export function normalizeTaskStatus(raw: unknown): TaskStatus {
+  if (raw === 'failed') return 'failed';
+  if (raw === 'complete') return 'complete';
+  if (raw === 'in_progress') return 'in_progress';
+  return 'pending';
+}
+
+/**
+ * Monotonically promote `tasksById[id]` to `nextStatus` if and only if
+ * `nextStatus` outranks the existing entry. Returns a new map; never
+ * mutates the input.
+ */
+export function promoteStatus(
+  tasksById: Readonly<Record<string, string>>,
+  id: string,
+  nextStatus: TaskStatus,
+): Record<string, string> {
+  const existing = tasksById[id];
+  if (existing === undefined) {
+    return { ...tasksById, [id]: nextStatus };
+  }
+  if (rankOf(nextStatus) > rankOf(existing)) {
+    return { ...tasksById, [id]: nextStatus };
+  }
+  return tasksById as Record<string, string>;
+}
+
+/**
+ * Extract `{id, status}[]` from a `state.patched` event's `data.patch.tasks`
+ * subtree, mapping each entry onto canonical TaskStatus. Returns
+ * `undefined` when the event has no actionable tasks subtree.
+ *
+ * The workflow-side `TaskSchema` carries many fields; we only consume id +
+ * status. Anything without a non-empty string `id` is skipped — the patch
+ * could carry an intentionally partial entry (e.g. only `title` updates)
+ * that we should not invent an id for.
+ */
+export interface ExtractedPlanTask {
+  readonly id: string;
+  readonly status: TaskStatus;
+}
+
+export function extractPlanTasksFromPatch(
+  data: { readonly [key: string]: unknown } | undefined,
+): readonly ExtractedPlanTask[] | undefined {
+  if (!data) return undefined;
+  const patch = data['patch'];
+  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+    return undefined;
+  }
+  const tasksRaw = (patch as Record<string, unknown>)['tasks'];
+  if (!Array.isArray(tasksRaw)) {
+    return undefined;
+  }
+
+  const out: ExtractedPlanTask[] = [];
+  for (const entry of tasksRaw) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const e = entry as Record<string, unknown>;
+    const id = typeof e['id'] === 'string' ? (e['id'] as string) : undefined;
+    if (!id) continue;
+    out.push({ id, status: normalizeTaskStatus(e['status']) });
+  }
+
+  return out.length > 0 ? out : undefined;
+}

--- a/servers/exarchos-mcp/src/projections/shared/task-status-fold.ts
+++ b/servers/exarchos-mcp/src/projections/shared/task-status-fold.ts
@@ -49,10 +49,19 @@ export function rankOf(status: string): number {
  * Normalize a `TaskSchema.status` value (or close approximation thereof)
  * into the canonical TaskStatus surface. Anything not recognized falls
  * back to `pending` — the safe default for plan-state assertion folds.
+ *
+ * The workflow-side `TaskStatusSchema` (`workflow/schemas.ts`) carries a
+ * `z.preprocess` that folds the legacy `'completed'` literal into the
+ * canonical `'complete'`. `state.patched` events emitted by `handleSet`
+ * do NOT route their `input.updates` through that schema, so historical
+ * events with `status: 'completed'` land in projections unchanged.
+ * Without the same mapping here, those tasks would silently downgrade
+ * to `pending`, breaking taskCount/completedCount and risking re-dispatch
+ * of already-finished work. Sentry follow-up on PR #1394.
  */
 export function normalizeTaskStatus(raw: unknown): TaskStatus {
   if (raw === 'failed') return 'failed';
-  if (raw === 'complete') return 'complete';
+  if (raw === 'complete' || raw === 'completed') return 'complete';
   if (raw === 'in_progress') return 'in_progress';
   return 'pending';
 }

--- a/servers/exarchos-mcp/src/projections/shared/task-status-fold.ts
+++ b/servers/exarchos-mcp/src/projections/shared/task-status-fold.ts
@@ -50,19 +50,25 @@ export function rankOf(status: string): number {
  * into the canonical TaskStatus surface. Anything not recognized falls
  * back to `pending` — the safe default for plan-state assertion folds.
  *
- * The workflow-side `TaskStatusSchema` (`workflow/schemas.ts`) carries a
- * `z.preprocess` that folds the legacy `'completed'` literal into the
- * canonical `'complete'`. `state.patched` events emitted by `handleSet`
- * do NOT route their `input.updates` through that schema, so historical
- * events with `status: 'completed'` land in projections unchanged.
- * Without the same mapping here, those tasks would silently downgrade
- * to `pending`, breaking taskCount/completedCount and risking re-dispatch
- * of already-finished work. Sentry follow-up on PR #1394.
+ * Legacy aliases (Sentry follow-ups on PR #1394) — `state.patched`
+ * events emitted by `handleSet` do NOT route their `input.updates`
+ * through `TaskStatusSchema`'s `z.preprocess`, so historical events with
+ * pre-#1359 vocabulary arrive at projections unchanged. The mappings
+ * below mirror `upgradeRehydrationDocumentV3toV4` (`projections/
+ * rehydration/upgrade.ts`) so the on-disk migration and the live event
+ * fold agree byte-for-byte on legacy → canonical:
+ *
+ *   - `'completed'` → `'complete'`     (matches `TaskStatusSchema` preprocess)
+ *   - `'assigned'`  → `'in_progress'`  (matches v3→v4 task vocabulary rename)
+ *
+ * Without these, tasks silently downgrade to `pending` (the
+ * unrecognized-value fallback), breaking taskCount / completedCount and
+ * risking re-dispatch of work already in flight or finished.
  */
 export function normalizeTaskStatus(raw: unknown): TaskStatus {
   if (raw === 'failed') return 'failed';
   if (raw === 'complete' || raw === 'completed') return 'complete';
-  if (raw === 'in_progress') return 'in_progress';
+  if (raw === 'in_progress' || raw === 'assigned') return 'in_progress';
   return 'pending';
 }
 

--- a/servers/exarchos-mcp/src/views/pipeline-view.test.ts
+++ b/servers/exarchos-mcp/src/views/pipeline-view.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Pipeline view projection — #1359 / PR4 T13 tests.
+ *
+ * Bug A of the #1359 projection-drift RCA: pre-#1359 the pipeline view only
+ * folded `task.assigned` / `task.completed` / `task.failed` and ignored
+ * `state.patched`. Callers that mutated tasks via `workflow.update({tasks})`
+ * without paired `task.*` events were invisible to `taskCount` /
+ * `completedCount` / `failedCount`. One observed session: 53 vs 67
+ * taskCount, 20 vs 56 completedCount.
+ *
+ * Fix: a `tasksById` map keyed by task id, monotonically promoted by both
+ * `state.patched` plan-task folds and dedicated `task.*` events using the
+ * shared `STATUS_RANK` ladder. Counters are derived from the map so all
+ * paths share a single source of truth.
+ */
+import { describe, it, expect } from 'vitest';
+import { pipelineProjection, type PipelineViewState } from './pipeline-view.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+
+/**
+ * Helper — build a minimal WorkflowEvent. Only `type` and `data` are
+ * load-bearing for the projection; the rest satisfy WorkflowEventBase.
+ */
+function makeEvent<T extends Record<string, unknown>>(
+  type: string,
+  data: T,
+  sequence: number,
+): WorkflowEvent {
+  return {
+    streamId: 'wf-pipe',
+    sequence,
+    timestamp: '2026-05-15T00:00:00.000Z',
+    type,
+    schemaVersion: '1.0',
+    data,
+  } as WorkflowEvent;
+}
+
+describe('pipelineProjection — state.patched fold (#1359 / PR4 T13)', () => {
+  it('PipelineProjection_StatePatchedCompleteTask_IncrementsCompletedCount', () => {
+    // GIVEN: a workflow.started event setting context, followed by a
+    // state.patched whose patch.tasks declares two tasks — one complete,
+    // one pending — with no paired task.* events. Pre-fix this scenario
+    // left taskCount === 0; post-fix the view folds state.patched.tasks
+    // through the monotonic STATUS_RANK helper and surfaces the canonical
+    // counters.
+    const initial = pipelineProjection.init();
+    const started = makeEvent(
+      'workflow.started',
+      { featureId: 'feat-1359', workflowType: 'feature' },
+      1,
+    );
+    const patched = makeEvent(
+      'state.patched',
+      {
+        featureId: 'feat-1359',
+        fields: ['tasks'],
+        patch: {
+          tasks: [
+            { id: 'T001', title: 'first', status: 'complete' },
+            { id: 'T002', title: 'second', status: 'pending' },
+          ],
+        },
+      },
+      2,
+    );
+
+    let view: PipelineViewState = pipelineProjection.apply(initial, started);
+    view = pipelineProjection.apply(view, patched);
+
+    // THEN: the counters reflect canonical state.
+    expect(view.taskCount).toBe(2);
+    expect(view.completedCount).toBe(1);
+    expect(view.failedCount).toBe(0);
+  });
+
+  it('PipelineProjection_StatePatchedThenTaskCompleted_DoesNotDoubleCount', () => {
+    // Monotonic-promotion invariant: a state.patched marking T001 as
+    // 'complete' followed by a redundant task.completed event for T001
+    // must produce completedCount === 1, NOT 2.
+    const initial = pipelineProjection.init();
+    const started = makeEvent(
+      'workflow.started',
+      { featureId: 'feat-mono', workflowType: 'feature' },
+      1,
+    );
+    const patched = makeEvent(
+      'state.patched',
+      {
+        featureId: 'feat-mono',
+        fields: ['tasks'],
+        patch: { tasks: [{ id: 'T001', status: 'complete' }] },
+      },
+      2,
+    );
+    const completed = makeEvent('task.completed', { taskId: 'T001' }, 3);
+
+    let view: PipelineViewState = pipelineProjection.apply(initial, started);
+    view = pipelineProjection.apply(view, patched);
+    view = pipelineProjection.apply(view, completed);
+
+    expect(view.taskCount).toBe(1);
+    expect(view.completedCount).toBe(1);
+  });
+
+  it('PipelineProjection_TaskFailedThenStatePatchedPending_DoesNotRegress', () => {
+    // task.failed promotes T001 to 'failed' (rank 2). A later
+    // state.patched re-asserting the plan with status='pending' must NOT
+    // regress the entry — plan-state stamps the full task list, events
+    // carry execution truth.
+    const initial = pipelineProjection.init();
+    const started = makeEvent(
+      'workflow.started',
+      { featureId: 'feat-regress', workflowType: 'feature' },
+      1,
+    );
+    const failed = makeEvent('task.failed', { taskId: 'T001' }, 2);
+    const patched = makeEvent(
+      'state.patched',
+      {
+        featureId: 'feat-regress',
+        fields: ['tasks'],
+        patch: { tasks: [{ id: 'T001', status: 'pending' }] },
+      },
+      3,
+    );
+
+    let view: PipelineViewState = pipelineProjection.apply(initial, started);
+    view = pipelineProjection.apply(view, failed);
+    view = pipelineProjection.apply(view, patched);
+
+    expect(view.taskCount).toBe(1);
+    expect(view.failedCount).toBe(1);
+  });
+});

--- a/servers/exarchos-mcp/src/views/pipeline-view.ts
+++ b/servers/exarchos-mcp/src/views/pipeline-view.ts
@@ -1,5 +1,10 @@
 import type { ViewProjection } from './materializer.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
+import {
+  extractPlanTasksFromPatch,
+  promoteStatus,
+  type TaskStatus,
+} from '../projections/shared/task-status-fold.js';
 
 // ─── View Name Constant ────────────────────────────────────────────────────
 
@@ -27,8 +32,40 @@ export interface PipelineViewState {
   taskCount: number;
   completedCount: number;
   failedCount: number;
+  /**
+   * Per-task canonical status keyed by task id (#1359 / PR4 T13). Both
+   * `state.patched` plan folds and dedicated `task.*` events route
+   * through this map so the three counters above derive from one
+   * monotonic source of truth. Vocabulary is canonical TaskSchema
+   * (`pending | in_progress | complete | failed`); legacy values from
+   * pre-#1359 snapshots are accepted but pass through `rankOf` which
+   * treats unrecognized vocabulary as rank 0.
+   */
+  tasksById: Record<string, string>;
   stackPositions: StackPosition[];
   hasMore: boolean;
+  /**
+   * ISO timestamp of the last folded event — used by handlers to expose
+   * `projectionAsOf` and `_meta.projectionLag` on the response envelope
+   * (#1359 / PR4 T14 + T15). Empty string when no event has been folded.
+   */
+  _asOf: string;
+}
+
+// ─── Internal: derive counters from tasksById ─────────────────────────────
+
+function deriveCounters(
+  tasksById: Readonly<Record<string, string>>,
+): { taskCount: number; completedCount: number; failedCount: number } {
+  let completedCount = 0;
+  let failedCount = 0;
+  let taskCount = 0;
+  for (const status of Object.values(tasksById)) {
+    taskCount += 1;
+    if (status === 'complete') completedCount += 1;
+    else if (status === 'failed') failedCount += 1;
+  }
+  return { taskCount, completedCount, failedCount };
 }
 
 // ─── Projection ────────────────────────────────────────────────────────────
@@ -41,11 +78,18 @@ export const pipelineProjection: ViewProjection<PipelineViewState> = {
     taskCount: 0,
     completedCount: 0,
     failedCount: 0,
+    tasksById: {},
     stackPositions: [],
     hasMore: false,
+    _asOf: '',
   }),
 
   apply: (view, event) => {
+    // Update _asOf for every event we touch (whether or not we fold it
+    // into other fields) so that `projectionAsOf` always reflects the
+    // most recent event observed by the materializer.
+    const nextAsOf = event.timestamp ?? view._asOf;
+
     switch (event.type) {
       case 'workflow.started': {
         const data = event.data as { featureId?: string; workflowType?: string } | undefined;
@@ -54,6 +98,7 @@ export const pipelineProjection: ViewProjection<PipelineViewState> = {
           featureId: data?.featureId ?? view.featureId,
           workflowType: data?.workflowType ?? view.workflowType,
           phase: 'started',
+          _asOf: nextAsOf,
         };
       }
 
@@ -68,26 +113,65 @@ export const pipelineProjection: ViewProjection<PipelineViewState> = {
           // Only set featureId if not already populated by workflow.started
           featureId: view.featureId || data?.featureId || view.featureId,
           phase: data?.to ?? view.phase,
+          _asOf: nextAsOf,
         };
       }
 
-      case 'task.assigned':
-        return {
-          ...view,
-          taskCount: view.taskCount + 1,
-        };
+      case 'state.patched': {
+        // #1359 / PR4 T13 — fold plan-task assertions into tasksById via
+        // the shared monotonic STATUS_RANK helper. Plan-state assertions
+        // can advance an entry up the ladder but never regress a terminal
+        // status (the planner stamps the full task list repeatedly; events
+        // carry execution truth).
+        const data = event.data as Record<string, unknown> | undefined;
+        const planTasks = extractPlanTasksFromPatch(data);
+        if (!planTasks) {
+          return { ...view, _asOf: nextAsOf };
+        }
+        let tasksById = view.tasksById;
+        for (const t of planTasks) {
+          tasksById = promoteStatus(tasksById, t.id, t.status);
+        }
+        const counters = deriveCounters(tasksById);
+        return { ...view, tasksById, ...counters, _asOf: nextAsOf };
+      }
 
-      case 'task.completed':
-        return {
-          ...view,
-          completedCount: view.completedCount + 1,
-        };
+      case 'task.assigned': {
+        // Canonical vocabulary post #1359: task.assigned → 'in_progress'.
+        const data = event.data as { taskId?: string } | undefined;
+        if (!data?.taskId) return { ...view, _asOf: nextAsOf };
+        const tasksById = promoteStatus(
+          view.tasksById,
+          data.taskId,
+          'in_progress' satisfies TaskStatus,
+        );
+        const counters = deriveCounters(tasksById);
+        return { ...view, tasksById, ...counters, _asOf: nextAsOf };
+      }
 
-      case 'task.failed':
-        return {
-          ...view,
-          failedCount: view.failedCount + 1,
-        };
+      case 'task.completed': {
+        const data = event.data as { taskId?: string } | undefined;
+        if (!data?.taskId) return { ...view, _asOf: nextAsOf };
+        const tasksById = promoteStatus(
+          view.tasksById,
+          data.taskId,
+          'complete' satisfies TaskStatus,
+        );
+        const counters = deriveCounters(tasksById);
+        return { ...view, tasksById, ...counters, _asOf: nextAsOf };
+      }
+
+      case 'task.failed': {
+        const data = event.data as { taskId?: string } | undefined;
+        if (!data?.taskId) return { ...view, _asOf: nextAsOf };
+        const tasksById = promoteStatus(
+          view.tasksById,
+          data.taskId,
+          'failed' satisfies TaskStatus,
+        );
+        const counters = deriveCounters(tasksById);
+        return { ...view, tasksById, ...counters, _asOf: nextAsOf };
+      }
 
       case 'stack.position-filled': {
         const data = event.data as {
@@ -96,7 +180,9 @@ export const pipelineProjection: ViewProjection<PipelineViewState> = {
           branch?: string;
           prUrl?: string;
         } | undefined;
-        if (data?.position === undefined || !data?.taskId) return view;
+        if (data?.position === undefined || !data?.taskId) {
+          return { ...view, _asOf: nextAsOf };
+        }
         const newPositions = [
           ...view.stackPositions,
           {
@@ -115,6 +201,7 @@ export const pipelineProjection: ViewProjection<PipelineViewState> = {
           ...view,
           stackPositions: boundedPositions,
           hasMore: view.hasMore || evicted,
+          _asOf: nextAsOf,
         };
       }
 

--- a/servers/exarchos-mcp/src/views/tools.pipeline.test.ts
+++ b/servers/exarchos-mcp/src/views/tools.pipeline.test.ts
@@ -1,0 +1,128 @@
+/**
+ * `handleViewPipeline` integration tests for #1359 / PR4 T14 + T15.
+ *
+ * Covers the response-envelope additions:
+ *   - `data.projectionAsOf` — ISO timestamp of the most-recent folded event
+ *     across the union of materialized streams.
+ *   - `_meta.projectionLag` — sparse millisecond delta surfaced only when
+ *     the projection is stale beyond PROJECTION_LAG_THRESHOLD_MS.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { EventStore } from '../event-store/store.js';
+import { handleViewPipeline, resetMaterializerCache } from './tools.js';
+
+let tempDir: string;
+let stateDir: string;
+let store: EventStore;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(path.join(tmpdir(), 'view-pipeline-pr4-'));
+  stateDir = tempDir;
+  store = new EventStore(tempDir);
+  resetMaterializerCache();
+});
+
+afterEach(async () => {
+  resetMaterializerCache();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('handleViewPipeline — projectionAsOf + projectionLag (#1359 / PR4)', () => {
+  it('ViewPipeline_FoldedEvents_ExposesProjectionAsOf', async () => {
+    const featureId = 'view-asof';
+    await store.append(featureId, {
+      type: 'workflow.started',
+      data: { featureId, workflowType: 'feature' },
+    });
+    await store.append(featureId, {
+      type: 'task.assigned',
+      data: { taskId: 'T1' },
+    });
+
+    const result = await handleViewPipeline(
+      { includeCompleted: true },
+      stateDir,
+      store,
+    );
+
+    expect(result.success).toBe(true);
+    const meta = result._meta as Record<string, unknown> | undefined;
+    expect(meta).toBeDefined();
+    expect(typeof meta?.projectionAsOf).toBe('string');
+    expect(Number.isFinite(Date.parse(meta!.projectionAsOf as string))).toBe(true);
+  });
+
+  it('ViewPipeline_StatePatchedCompleteTask_CountsViaTasksById', async () => {
+    // Bug A end-to-end: a state.patched without paired task.* events must
+    // still surface accurate counters because the view folds plan tasks
+    // through `tasksById`.
+    const featureId = 'view-state-patched';
+    await store.append(featureId, {
+      type: 'workflow.started',
+      data: { featureId, workflowType: 'feature' },
+    });
+    await store.append(featureId, {
+      type: 'state.patched',
+      data: {
+        featureId,
+        fields: ['tasks'],
+        patch: {
+          tasks: [
+            { id: 'A', status: 'complete' },
+            { id: 'B', status: 'pending' },
+            { id: 'C', status: 'complete' },
+          ],
+        },
+      },
+    });
+
+    const result = await handleViewPipeline(
+      { includeCompleted: true },
+      stateDir,
+      store,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      workflows: ReadonlyArray<{
+        featureId: string;
+        taskCount: number;
+        completedCount: number;
+      }>;
+    };
+    const ours = data.workflows.find((w) => w.featureId === featureId);
+    expect(ours).toBeDefined();
+    expect(ours!.taskCount).toBe(3);
+    expect(ours!.completedCount).toBe(2);
+  });
+
+  it('ViewPipeline_StaleProjection_ExposesMetaProjectionLag', async () => {
+    const featureId = 'view-lag';
+    await store.append(featureId, {
+      type: 'workflow.started',
+      data: { featureId, workflowType: 'feature' },
+    });
+
+    const futureMs = Date.now() + 60_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(futureMs));
+    try {
+      const result = await handleViewPipeline(
+        { includeCompleted: true },
+        stateDir,
+        store,
+      );
+      expect(result.success).toBe(true);
+      const meta = result._meta as Record<string, unknown> | undefined;
+      expect(meta).toBeDefined();
+      expect(typeof meta?.projectionLag).toBe('number');
+      expect(meta?.projectionLag as number).toBeGreaterThanOrEqual(5000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/views/tools.ts
+++ b/servers/exarchos-mcp/src/views/tools.ts
@@ -90,6 +90,7 @@ import { detectRegressions, emitRegressionEvents } from '../quality/regression-d
 import type { FailureTracker } from '../quality/regression-detector.js';
 import { computeAttribution, isValidDimension } from '../quality/attribution.js';
 import type { AttributionDimension } from '../quality/attribution.js';
+import { PROJECTION_LAG_THRESHOLD_MS } from '../projections/index.js';
 
 // ─── Helper: create a materializer with all projections registered ─────────
 
@@ -433,7 +434,36 @@ export async function handleViewPipeline(
     const end = args.limit !== undefined ? start + args.limit : undefined;
     const workflows = filtered.slice(start, end);
 
-    return { success: true, data: { workflows, total } };
+    // #1359 / PR4 T14 + T15 — derive `projectionAsOf` from the maximum
+    // `_asOf` timestamp across the materialized workflows (the most
+    // recent event observed across the union of streams). Surface
+    // `_meta.projectionLag` when the projection is stale beyond
+    // PROJECTION_LAG_THRESHOLD_MS. The field is sparse: a fresh
+    // projection omits it entirely so agents have a clear "no lag"
+    // signal vs. an explicit numeric delta.
+    let projectionAsOf: string | undefined;
+    for (const w of allWorkflows) {
+      if (w._asOf && (!projectionAsOf || w._asOf > projectionAsOf)) {
+        projectionAsOf = w._asOf;
+      }
+    }
+    let meta: Record<string, unknown> | undefined;
+    if (projectionAsOf !== undefined) {
+      meta = { projectionAsOf };
+      const asOfMs = Date.parse(projectionAsOf);
+      if (Number.isFinite(asOfMs)) {
+        const lag = Date.now() - asOfMs;
+        if (lag > PROJECTION_LAG_THRESHOLD_MS) {
+          meta = { ...meta, projectionLag: lag };
+        }
+      }
+    }
+
+    return {
+      success: true,
+      data: { workflows, total },
+      ...(meta ? { _meta: meta } : {}),
+    };
   } catch (err) {
     return {
       success: false,

--- a/servers/exarchos-mcp/src/workflow/rehydrate.test.ts
+++ b/servers/exarchos-mcp/src/workflow/rehydrate.test.ts
@@ -84,7 +84,7 @@ describe('handleRehydrate — happy path (T031, DR-5)', () => {
     const parsed = RehydrationDocumentSchema.safeParse(doc);
     expect(parsed.success).toBe(true);
 
-    expect(doc.v).toBe(3);
+    expect(doc.v).toBe(4);
     // Every seeded event is handled by the rehydration reducer, so
     // `projectionSequence` must match the count of events.
     expect(doc.projectionSequence).toBe(4);
@@ -96,8 +96,8 @@ describe('handleRehydrate — happy path (T031, DR-5)', () => {
     // per-task upsert contract through the handler.
     expect(doc.taskProgress).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: 'T001', status: 'completed' }),
-        expect.objectContaining({ id: 'T002', status: 'assigned' }),
+        expect.objectContaining({ id: 'T001', status: 'complete' }),
+        expect.objectContaining({ id: 'T002', status: 'in_progress' }),
       ]),
     );
   });
@@ -168,11 +168,12 @@ describe('handleRehydrate — happy path (T031, DR-5)', () => {
     expect(doc.workflowState.featureId).toBe(featureId);
     expect(doc.workflowState.phase).toBe('tdd');
 
-    // Tail folded state: T100 stays completed; T101 promoted assigned→completed
-    // by tail; T102 added-then-failed by tail.
+    // Tail folded state: T100 stays complete; T101 promoted in_progress →
+    // complete by tail; T102 added-then-failed by tail. Canonical
+    // vocabulary post #1359 / PR4 T11.
     const byId = new Map(doc.taskProgress.map((t) => [t.id, t.status]));
-    expect(byId.get('T100')).toBe('completed');
-    expect(byId.get('T101')).toBe('completed');
+    expect(byId.get('T100')).toBe('complete');
+    expect(byId.get('T101')).toBe('complete');
     expect(byId.get('T102')).toBe('failed');
   });
 
@@ -189,7 +190,7 @@ describe('handleRehydrate — happy path (T031, DR-5)', () => {
 
     expect(result.success).toBe(true);
     const doc = result.data as RehydrationDocument;
-    expect(doc.v).toBe(3);
+    expect(doc.v).toBe(4);
     expect(doc.projectionSequence).toBe(0);
     expect(doc.taskProgress).toEqual([]);
     expect(doc.blockers).toEqual([]);
@@ -414,7 +415,7 @@ describe('handleRehydrate — reducer throw degradation (T054, DR-18)', () => {
       // THEN (2): the returned `data` is a minimal fallback document seeded
       //   from the state-store — v:3, sequence 0, populated workflowState.
       const doc = result.data as RehydrationDocument;
-      expect(doc.v).toBe(3);
+      expect(doc.v).toBe(4);
       expect(doc.projectionSequence).toBe(0);
       expect(doc.workflowState.featureId).toBe(featureId);
       expect(doc.workflowState.workflowType).toBe('feature');
@@ -612,7 +613,7 @@ describe('handleRehydrate — event-stream-unavailable degradation (T056, DR-18)
     //   from the state store — v:3, projectionSequence 0, populated
     //   workflowState.
     const doc = result.data as RehydrationDocument;
-    expect(doc.v).toBe(3);
+    expect(doc.v).toBe(4);
     expect(doc.projectionSequence).toBe(0);
     expect(doc.workflowState.featureId).toBe(featureId);
     expect(doc.workflowState.workflowType).toBe('feature');
@@ -941,5 +942,85 @@ describe('handleRehydrate — degraded paths preserve phasePlaybook null (T-22)'
     const doc = result.data as RehydrationDocument;
     expect(doc.phasePlaybook).toBeNull();
     expect(RehydrationDocumentSchema.safeParse(doc).success).toBe(true);
+  });
+});
+
+// ─── #1359 / PR4 T14 + T15 — projectionAsOf + projectionLag ─────────────────
+
+describe('handleRehydrate — projectionAsOf + projectionLag (#1359 / PR4)', () => {
+  it('Rehydrate_FoldedEvents_ExposesProjectionAsOf', async () => {
+    const featureId = 'pr4-asof';
+    // Seed two events; their timestamps drive `projectionAsOf`.
+    await store.append(featureId, {
+      type: 'workflow.started',
+      data: { featureId, workflowType: 'feature' },
+    });
+    await store.append(featureId, {
+      type: 'task.assigned',
+      data: { taskId: 'T001' },
+    });
+
+    const result = await handleRehydrate(
+      { featureId },
+      { eventStore: store, stateDir },
+    );
+
+    expect(result.success).toBe(true);
+    const meta = result._meta as Record<string, unknown> | undefined;
+    expect(meta).toBeDefined();
+    expect(typeof meta?.projectionAsOf).toBe('string');
+    // Sanity: parses as an ISO timestamp.
+    expect(Number.isFinite(Date.parse(meta!.projectionAsOf as string))).toBe(true);
+  });
+
+  it('Rehydrate_StaleProjection_ExposesMetaProjectionLag', async () => {
+    const featureId = 'pr4-lag';
+    await store.append(featureId, {
+      type: 'workflow.started',
+      data: { featureId, workflowType: 'feature' },
+    });
+
+    // Freeze Date.now() to far in the future so the projection appears
+    // stale beyond the 5s threshold. `vi.useFakeTimers` + setSystemTime
+    // is the documented vitest path for this. We don't fake `setTimeout`
+    // etc. — only the wall clock.
+    const futureMs = Date.now() + 60_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(futureMs));
+    try {
+      const result = await handleRehydrate(
+        { featureId },
+        { eventStore: store, stateDir },
+      );
+      expect(result.success).toBe(true);
+      const meta = result._meta as Record<string, unknown> | undefined;
+      expect(meta).toBeDefined();
+      expect(typeof meta?.projectionLag).toBe('number');
+      expect(meta?.projectionLag as number).toBeGreaterThanOrEqual(5000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('Rehydrate_FreshProjection_OmitsProjectionLag', async () => {
+    const featureId = 'pr4-fresh';
+    await store.append(featureId, {
+      type: 'workflow.started',
+      data: { featureId, workflowType: 'feature' },
+    });
+
+    const result = await handleRehydrate(
+      { featureId },
+      { eventStore: store, stateDir },
+    );
+
+    expect(result.success).toBe(true);
+    const meta = result._meta as Record<string, unknown> | undefined;
+    // Fresh projection: either no _meta at all OR _meta without
+    // projectionLag. The sparse contract means agents can rely on the
+    // field's presence to indicate "stale" rather than reading a 0/null.
+    if (meta) {
+      expect(meta.projectionLag).toBeUndefined();
+    }
   });
 });

--- a/servers/exarchos-mcp/src/workflow/rehydrate.ts
+++ b/servers/exarchos-mcp/src/workflow/rehydrate.ts
@@ -43,13 +43,14 @@ import {
 import {
   RehydrationDocumentSchema,
   type RehydrationDocument,
-  type RehydrationDocumentV3,
+  type RehydrationDocumentV4,
 } from '../projections/rehydration/schema.js';
 import { loadRehydrationDocument } from '../projections/rehydration/serialize.js';
 import type { ProjectionReducer } from '../projections/types.js';
 import { composePhasePlaybook } from './playbooks.js';
 import { readStateFile } from './state-store.js';
 import { buildValidatedEvent } from '../event-store/event-factory.js';
+import { PROJECTION_LAG_THRESHOLD_MS } from '../projections/index.js';
 
 /** Input shape for the rehydrate handler. */
 export interface RehydrateArgs {
@@ -474,19 +475,31 @@ export async function handleRehydrate(
     });
   }
 
-  // Route v:1/v:2 snapshots through the upgrade chain so the in-memory
-  // document is always v:3 — handler-time `phasePlaybook` composition (T-20)
-  // assumes the v:3 envelope shape. Cold-start (no snapshot) seeds from the
-  // reducer's v:3 initial directly. Reducer.apply preserves v:3 by contract;
-  // the cast below pins that for the local variable.
-  let document: RehydrationDocumentV3 =
+  // Route v:1/v:2/v:3 snapshots through the upgrade chain so the in-memory
+  // document is always v:4 — handler-time `phasePlaybook` composition (T-20)
+  // and the #1359 canonical task-status vocabulary both assume the v:4
+  // envelope shape. Cold-start (no snapshot) seeds from the reducer's v:4
+  // initial directly. Reducer.apply preserves v:4 by contract; the cast
+  // below pins that for the local variable.
+  let document: RehydrationDocumentV4 =
     snapshot !== undefined
       ? loadRehydrationDocument(snapshot.state)
-      : (rehydrationReducer.initial as RehydrationDocumentV3);
+      : (rehydrationReducer.initial as RehydrationDocumentV4);
+
+  // Track the ISO timestamp of the last folded event so the handler can
+  // surface `projectionAsOf` on the response (#1359 / PR4 T14) and
+  // `_meta.projectionLag` when stale (T15). Snapshot.timestamp is the
+  // most-recent-event-baked-into-the-snapshot timestamp; tail events
+  // overwrite it on every successful fold.
+  let projectionAsOf: string | undefined =
+    snapshot !== undefined && typeof snapshot.timestamp === 'string'
+      ? snapshot.timestamp
+      : undefined;
 
   try {
     for (const ev of tailEvents) {
-      document = rehydrationReducer.apply(document, ev) as RehydrationDocumentV3;
+      document = rehydrationReducer.apply(document, ev) as RehydrationDocumentV4;
+      if (typeof ev.timestamp === 'string') projectionAsOf = ev.timestamp;
     }
   } catch (err) {
     // Log the underlying throwable BEFORE delegating so audit / oncall
@@ -592,10 +605,32 @@ export async function handleRehydrate(
     );
   }
 
-  // The composite `envelopeWrap` (workflow/composite.ts) layers `next_actions`,
-  // `_meta`, and `_perf` on top of this ToolResult at the tool boundary.
+  // #1359 / PR4 T14 + T15 — surface `projectionAsOf` and
+  // `_meta.projectionLag` so agents can detect a stale projection. The
+  // composite `envelopeWrap` (workflow/composite.ts) merges per-handler
+  // `_meta` with its own per-call diagnostics; passing `_meta` here lets
+  // the projection-lag signal flow through to the final envelope.
+  //
+  // We piggyback `projectionAsOf` onto `_meta` rather than the document
+  // body because RehydrationDocumentSchema's volatile section is strict
+  // and rejects unknown sibling keys (additional top-level fields would
+  // require a schema bump; envelope metadata is the existing surface for
+  // diagnostic side-channels — see ToolResult._meta in format.ts).
+  let meta: Record<string, unknown> | undefined;
+  if (projectionAsOf !== undefined) {
+    meta = { projectionAsOf };
+    const asOfMs = Date.parse(projectionAsOf);
+    if (Number.isFinite(asOfMs)) {
+      const lag = Date.now() - asOfMs;
+      if (lag > PROJECTION_LAG_THRESHOLD_MS) {
+        meta = { ...meta, projectionLag: lag };
+      }
+    }
+  }
+
   return {
     success: true,
     data: document,
+    ...(meta ? { _meta: meta } : {}),
   };
 }

--- a/servers/exarchos-mcp/tests/fixtures/load-bearing/rehydrate-demo.expected-document.json
+++ b/servers/exarchos-mcp/tests/fixtures/load-bearing/rehydrate-demo.expected-document.json
@@ -1,5 +1,5 @@
 {
-  "v": 3,
+  "v": 4,
   "projectionSequence": 7,
   "workflowState": {
     "featureId": "rehydrate-demo",
@@ -9,11 +9,11 @@
   "taskProgress": [
     {
       "id": "T001",
-      "status": "completed"
+      "status": "complete"
     },
     {
       "id": "T002",
-      "status": "completed"
+      "status": "complete"
     }
   ],
   "decisions": [],

--- a/tests/outcome/rehydrate-projection-drift.test.ts
+++ b/tests/outcome/rehydrate-projection-drift.test.ts
@@ -1,18 +1,13 @@
-// ─── T-017 — rehydrate / view.pipeline projection drift outcome (RED) ────
+// ─── T-017 — rehydrate / view.pipeline projection drift outcome (GREEN) ────
 //
 // Encodes the #1359 regression: `rehydrate.taskProgress` and
 // `view.pipeline.completedCount` projections undercount when task
 // statuses are mutated through `workflow.update({tasks: [...]})` WITHOUT
 // the paired `task.assigned` + `task.completed` event emission.
 //
-// Test choreography note (cross-wave):
-//
-//   Remains it.fails() after PR2 ships — flipped by #1359 in Wave 2.
-//
-// PR2 (wave1-fixes) intentionally does NOT remove this `it.fails`
-// annotation — the underlying projection contract change lands in
-// Wave 2 under #1359. The test stays RED across the Wave 1 boundary
-// to surface the next-wave work item for reviewers.
+// Flipped from `it.fails(...)` to `it(...)` in PR4 of the v2.10.0-preview.4
+// stack — atomic RED→GREEN flip alongside the projection fix
+// (rehydrate canonical vocabulary + pipeline view state.patched fold).
 
 import { describe, it, expect } from 'vitest';
 import * as fs from 'node:fs/promises';
@@ -36,8 +31,8 @@ interface TaskProgressEntry {
 }
 
 describe('rehydrate projection drift outcome (#1359)', () => {
-  // Remains it.fails() after PR2 ships — flipped by #1359 in Wave 2.
-  it.fails(
+  // Flipped to it() in #1359 PR4 (atomic RED→GREEN with the projection fix).
+  it(
     'Rehydrate_TaskProgress_TracksCanonicalTaskStatus',
     async () => {
       const stateDir = await fs.mkdtemp(


### PR DESCRIPTION
## Summary

`rehydrate.taskProgress` and `view.pipeline.completedCount/taskCount` diverged from canonical `tasks[].status` when callers mutated tasks via `workflow.update({tasks})` without paired `task.*` events. One observed session: 53 vs 67 taskCount, 20 vs 56 completedCount. An agent trusting \`rehydrate\` re-dispatched completed work.

**Two compounding bugs:**
1. Pipeline view did NOT fold `state.patched` — only `task.assigned` / `task.completed` / `task.failed`.
2. Rehydrate reducer normalized `'complete' → 'completed'`, diverging projection vocabulary from canonical `TaskSchema` vocabulary.

**Fix:** Pipeline view gains `tasksById` and folds `state.patched` with the same monotonic STATUS_RANK rule as the rehydrate reducer (shared helper at `projections/shared/task-status-fold.ts`). Rehydrate reducer surfaces canonical `pending | in_progress | complete | failed` vocabulary. `RehydrationDocumentSchema` bumps to `v: 4`; v:3 documents upgrade in-memory on read.

Both response shapes expose `_meta.projectionAsOf`; `_meta.projectionLag` surfaces when stale > 5s. `reconcile_state` gains a `projection-drift` check.

**Atomic flip:** removes the `it.fails` annotation from `tests/outcome/rehydrate-projection-drift.test.ts` in the **same commit** as the projection fix — the parked outcome test is now GREEN.

Closes #1359. Part of #1354 Wave 2.

## Changes

- `projections/shared/task-status-fold.ts` — NEW. `TaskStatus`, `STATUS_RANK`, `rankOf`, `promoteStatus`, `extractPlanTasksFromPatch`. Single source of truth shared by rehydrate reducer and pipeline view.
- `projections/rehydration/reducer.ts` — drop `'complete' → 'completed'` normalization; canonical vocabulary throughout.
- `projections/rehydration/schema.ts` — bump envelope to `v: literal(4)`; freeze `RehydrationDocumentSchemaV3` for read-back.
- `projections/rehydration/upgrade.ts` — `upgradeRehydrationDocumentV3toV4` renames `'completed' → 'complete'` AND `'assigned' → 'in_progress'`. Tested via `UpgradeV3ToV4_*` and `UpgradeChain_FromV1OrV2_TerminatesAtV4`.
- `projections/index.ts` — exports `PROJECTION_LAG_THRESHOLD_MS = 5000`.
- `views/pipeline-view.ts` — `tasksById` map; `state.patched` fold; counters derived from map.
- `views/tools.ts`, `workflow/rehydrate.ts` — surface `_meta.projectionAsOf` + `_meta.projectionLag`.
- `orchestrate/reconcile-state.ts` — new `projection-drift` check; compares canonical `tasks[].status` to pipeline view counters.
- `tests/outcome/rehydrate-projection-drift.test.ts` — \`it.fails\` removed (atomic RED→GREEN flip).
- `tests/fixtures/load-bearing/rehydrate-demo.expected-document.json` — v:3 → v:4, legitimate vocabulary rename.

## Test Plan

- [x] `npm run typecheck`
- [x] Outcome tier: 11/11 pass including the previously-parked `Rehydrate_TaskProgress_TracksCanonicalTaskStatus`
- [x] Scoped (projections + views + workflow + orchestrate): 461/461 pass
- [x] Full MCP suite: 6662/6685 pass — 23 pre-existing failures unchanged
- [x] `npm run build`

## Risk

- Projection schema v:3 → v:4 envelope bump. Upgrade path covered in `upgrade.test.ts`. Snapshot fixture updated in this PR.
- Vocabulary rename audit: \`grep\` for stray `'completed'`/`'assigned'` literals in non-test files is a DIM-5 watch flag — no blocking findings.

🤖 Stack: PR 4 of 4 (final). Base: PR 3 (\`feature/preview4-pr3-telemetry-split\`). After this lands, Waves 2 + 3 of #1354 are complete; remaining open: #1362 + #1365.

Co-authored by Claude Opus 4.7 (Exarchos orchestrator).