### PR TITLE
test(next-actions): unit-tier pin for #1374 detour wire

### DIFF
--- a/servers/exarchos-mcp/src/next-actions-from-result.test.ts
+++ b/servers/exarchos-mcp/src/next-actions-from-result.test.ts
@@ -13,6 +13,8 @@
 import { describe, it, expect } from 'vitest';
 import { nextActionsFromResult } from './next-actions-from-result.js';
 import type { ToolResult } from './format.js';
+import { rehydrationReducer } from './projections/rehydration/reducer.js';
+import type { WorkflowEvent } from './event-store/schemas.js';
 
 function ok(data: unknown): ToolResult {
   return { success: true, data };
@@ -158,5 +160,120 @@ describe('nextActionsFromResult — shape recognition', () => {
       }),
     );
     expect(actions).toEqual([]);
+  });
+});
+
+// ─── #1374 cross-boundary pin: reducer output → nextActionsFromResult ────────
+//
+// Contract source: test/process/saga-merge-detour.test.ts (process tier).
+//
+// The saga test drives a real MCP server through `task_complete` with
+// `result.worktreePath`, then asserts the rehydrate envelope's `next_actions`
+// surfaces `merge_orchestrate`. This unit-tier pin reproduces the SAME
+// contract one tier earlier — no spawn, no IPC — by composing the
+// rehydration reducer (the projection that folds `task.completed{worktreePath}`
+// into `phase: merge-pending`) with `nextActionsFromResult` (the helper that
+// reads the rehydration document's `workflowState` segment to compute the
+// outbound verbs). If the chain breaks at either the reducer's worktree-fold
+// or the result-reader's shape-2 extraction, this test fails before the
+// process-tier saga does — catching a #1208 / #1374-class regression at the
+// unit tier.
+//
+// Why both tests stay: the saga test pins the cross-process JSON contract
+// (MCP envelope shape, stderr/transport plumbing) which this test does not
+// cover; this test pins the in-process projection→reader composition which
+// the saga can only check end-to-end. They sandwich the chain.
+describe('nextActionsFromResult — #1374 cross-boundary pin (reducer ⇒ reader)', () => {
+  function makeEvent<T extends Record<string, unknown>>(
+    type: string,
+    data: T,
+    sequence: number,
+  ): WorkflowEvent {
+    return {
+      streamId: 'pin-1374',
+      sequence,
+      timestamp: '2026-05-15T00:00:00.000Z',
+      type,
+      schemaVersion: '1.0',
+      data,
+    } as WorkflowEvent;
+  }
+
+  it('NextActions_FromReducerProjectedRehydrationDoc_AfterWorktreeBearingTaskCompleted_SurfacesMergeOrchestrate', () => {
+    // GIVEN: a feature workflow folded through `workflow.started` →
+    // `workflow.transition(to=delegate)` → `task.assigned` →
+    // `task.completed{worktreePath}` — the exact event sequence the saga
+    // drives through MCP.
+    let doc = rehydrationReducer.apply(
+      rehydrationReducer.initial,
+      makeEvent(
+        'workflow.started',
+        { featureId: 'pin-1374', workflowType: 'feature' },
+        0,
+      ),
+    );
+    doc = rehydrationReducer.apply(
+      doc,
+      makeEvent('workflow.transition', { from: '', to: 'delegate' }, 1),
+    );
+    doc = rehydrationReducer.apply(
+      doc,
+      makeEvent('task.assigned', { taskId: '001', branch: 'feature/pin-1374-001' }, 2),
+    );
+    doc = rehydrationReducer.apply(
+      doc,
+      makeEvent(
+        'task.completed',
+        { taskId: '001', worktreePath: '/tmp/wt/001', worktree: '.worktrees/001' },
+        3,
+      ),
+    );
+
+    // THEN: the reducer has stamped the merge-pending detour on workflowState
+    expect(doc.workflowState.phase).toBe('merge-pending');
+    expect(doc.workflowState.mergeOrchestrator).toEqual({
+      taskId: '001',
+      phase: 'pending',
+    });
+
+    // WHEN: nextActionsFromResult reads the rehydration document as the
+    // composite tool's `result.data` payload (shape 2)
+    const actions = nextActionsFromResult({ success: true, data: doc });
+
+    // THEN: merge_orchestrate is surfaced with the canonical idempotency key
+    // `<featureId>:merge_orchestrate:<taskId>` — same contract the saga test
+    // (test/process/saga-merge-detour.test.ts) asserts on the live envelope.
+    const mo = actions.find((a) => a.verb === 'merge_orchestrate');
+    expect(mo).toBeDefined();
+    expect(mo?.idempotencyKey).toBe('pin-1374:merge_orchestrate:001');
+  });
+
+  it('NextActions_FromReducerProjectedDoc_TaskCompletedWithoutWorktree_DoesNotSurfaceMergeOrchestrate', () => {
+    // Negative case: no worktree association → reducer leaves phase in
+    // `delegate` → nextActionsFromResult must NOT surface merge_orchestrate.
+    // Pins the gate so a future regression that fires the detour on bare
+    // task.completed events is caught at the unit tier.
+    let doc = rehydrationReducer.apply(
+      rehydrationReducer.initial,
+      makeEvent(
+        'workflow.started',
+        { featureId: 'pin-1374-neg', workflowType: 'feature' },
+        0,
+      ),
+    );
+    doc = rehydrationReducer.apply(
+      doc,
+      makeEvent('workflow.transition', { from: '', to: 'delegate' }, 1),
+    );
+    doc = rehydrationReducer.apply(
+      doc,
+      makeEvent('task.completed', { taskId: '001' }, 2),
+    );
+
+    expect(doc.workflowState.phase).toBe('delegate');
+    expect(doc.workflowState.mergeOrchestrator).toBeUndefined();
+
+    const actions = nextActionsFromResult({ success: true, data: doc });
+    expect(actions.some((a) => a.verb === 'merge_orchestrate')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Refs #1374. Investigation found the auto-detour wire is already intact on the wave-0 integration branch (head `8ebb8d4c`, post #1394 canonical-tasks projection fix) — the saga test at `test/process/saga-merge-detour.test.ts` passes against the freshly built binary. **None** of the three hypotheses (a/b/c) from the design § Verified surfaces / #1374 reproduced. This PR adds a unit-tier pin instead so a future regression of the same class is caught one tier earlier.

## Changes

- New cross-boundary pin in `servers/exarchos-mcp/src/next-actions-from-result.test.ts` composing `rehydrationReducer` (folds `task.completed{worktreePath}` → `phase: merge-pending`) with `nextActionsFromResult` (reads the rehydration doc's `workflowState` segment to surface `merge_orchestrate`). Includes a positive (worktreePath present → verb surfaces with idempotency key `<featureId>:merge_orchestrate:<taskId>`) and negative (no worktree → no verb) case.
- No source changes — the chain is intact end-to-end.

## Test Plan

- [x] `npx vitest run --project process test/process/saga-merge-detour.test.ts` GREEN against current head (chain already wired)
- [x] New unit pin GREEN against unmodified source (12/12 tests in `next-actions-from-result.test.ts`)
- [x] Pin verified to catch regression class: short-circuiting the reducer's `eventDataHasWorktreeAssociation` predicate made the new test fail with `expected 'delegate' to be 'merge-pending'` — restoring restored GREEN
- [x] Full MCP server suite: 6698/6698 pass + 24 skipped
- [x] Full root suite: 762/762 pass + 6 skipped
- [x] `npm run typecheck` clean

## Diagnostic transcript

Per T1.2 the three suspect sites were instrumented with `console.error` (all removed before commit, `git diff | grep -c console.error` = 0). Stderr buffer dump from the saga test run:

```
[DIAG-1374-A] task.completed event.data keys: [ "taskId", "worktree", "worktreePath", "evidence", ... ]
[DIAG-1374-B] reducer fold task.completed: status=complete phase= wt=feature
              data.worktreePath=/tmp/exarchos-hermetic-.../git data.worktree=.worktrees/001-detour detourablePhase=true
[DIAG-1374-B-POST] folded → phase=merge-pending, mergeOrchestrator={ taskId, phase: 'pending' }
[DIAG-1374-C] nextActionsFromResult: data keys=[ "v", "projectionSequence", "workflowState", ... ]
              structuredContent? false phase=undefined workflowType=undefined ...
```

Site C's `phase=undefined` here is innocuous — that invocation is over the raw rehydration document; the shape-2 `workflowState` backfill runs immediately after and lifts the phase/workflowType/mergeOrchestrator into the computed `NextAction[]`. Most importantly, `structuredContent? false` confirms hypothesis (c) is not the failure mode on this head: the carrier still rides on `result.data`. Hypothesis (a) is refuted by Site A showing `worktreePath` in the emitted event; hypothesis (b) by Site B's POST line stamping `merge-pending`.

The "broken on current head" assumption in the plan/design was stale — likely written against an earlier wave-0 tip before #1394's projection-vocabulary fix landed. The unit pin nonetheless provides defense in depth so the next regression of this class fails at the unit tier rather than the saga tier.