### PR TITLE
test(outcome): backfill coverage for #1360/#1363/#1364

### DIFF
--- a/tests/outcome/_helpers/README.md
+++ b/tests/outcome/_helpers/README.md
@@ -251,3 +251,39 @@ examples when authoring new ones:
 Each was authored as `it.fails()` against the helpers documented above.
 When you land the fix for one, flip the annotation in the same PR as the
 source change.
+
+## Coverage matrix
+
+The table below maps each dogfood-finding regression that ships an
+outcome-tier test to its carrier file. Entries marked `n/a` indicate a
+regression whose reproduction is outside the Linux outcome tier's scope
+(typically Windows-specific behavior). Process-tier carriers are linked
+where the outcome assertion lives in `test/process/` instead of
+`tests/outcome/` — usually because the regression requires multi-step
+saga choreography rather than a single CLI/handler invocation.
+
+| Dogfood Finding | Outcome Test | Status |
+|---|---|---|
+| #1355 install-skills | [`install-skills.test.ts`](../install-skills.test.ts) | OK |
+| #1356 merge multi-worktree | [`merge-orchestrate-multiworktree.test.ts`](../merge-orchestrate-multiworktree.test.ts) | OK |
+| #1359 projection drift | [`rehydrate-projection-drift.test.ts`](../rehydrate-projection-drift.test.ts) | OK |
+| #1360 reserved-fields | [`reserved-fields-discoverability.test.ts`](../reserved-fields-discoverability.test.ts) | OK |
+| #1363 runbook | [`runbook-merge-orchestration.test.ts`](../runbook-merge-orchestration.test.ts) | OK |
+| #1364 telemetry split | [`telemetry-action-errors.test.ts`](../telemetry-action-errors.test.ts) | OK |
+| #1362 Windows preflight | n/a (Linux tier cannot reproduce) | — |
+| #1374 saga detour wire | [`test/process/saga-merge-detour.test.ts`](../../../test/process/saga-merge-detour.test.ts) (process tier) | OK |
+
+Notes:
+
+- #1362 is the Windows preflight regression. The Linux outcome tier is
+  intentionally out of scope — the bug only manifests under Windows path
+  semantics and process-launch behavior, which the Linux-only
+  `outcome-tests` CI job cannot reproduce. The Windows-side gating
+  belongs in a future Windows-CI surface (cf. the "No Windows CI for MCP
+  server" tracking line in the v2.x roadmap).
+- #1374 is a saga-shape regression. Its assertion lives in the process
+  tier (`test/process/saga-merge-detour.test.ts`) because reproducing it
+  requires orchestrating a multi-step delegation + merge-detour saga
+  rather than a single handler call — the process tier is the right
+  granularity for that shape, and the outcome tier is reserved for
+  single operator-visible CLI / handler invocations.

--- a/tests/outcome/reserved-fields-discoverability.test.ts
+++ b/tests/outcome/reserved-fields-discoverability.test.ts
@@ -1,0 +1,182 @@
+// ─── T3.1 — RESERVED_FIELD discoverability outcome (GREEN) ────────────────
+//
+// Encodes the #1360 fix shipped in commit 481e51c7 (PR #1392). The contract
+// being locked here has two distinct surfaces:
+//
+//   1. Discoverability — `exarchos_workflow.describe({actions:['update']})`
+//      surfaces a `reservedFields` block sourced from
+//      `RESERVED_FIELDS_DESCRIPTOR`. Callers learn the immutable boundary
+//      (and the alternate write paths, e.g. `transition` for `phase`)
+//      through describe instead of trial-and-error against the error
+//      envelope.
+//
+//   2. Structured error data — when `applyDotPath` rejects an update for a
+//      reserved key, the returned envelope carries an `error.data` block
+//      shaped `{rejectedPath, rule, alternateWritePath}`. Callers can
+//      pivot to the alternate path programmatically without parsing the
+//      error message.
+//
+// This is a backfill: the fix landed prior; the tests are GREEN against
+// current head. A future regression that strips either surface fails CI.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { EventStore } from '../../servers/exarchos-mcp/src/event-store/store.js';
+import {
+  handleInit,
+  handleUpdate,
+} from '../../servers/exarchos-mcp/src/workflow/tools.js';
+import { handleDescribe } from '../../servers/exarchos-mcp/src/describe/handler.js';
+import { TOOL_REGISTRY } from '../../servers/exarchos-mcp/src/registry.js';
+
+const workflowTool = TOOL_REGISTRY.find((t) => t.name === 'exarchos_workflow');
+
+describe('reserved-fields discoverability outcome (#1360)', () => {
+  it('Describe_UpdateAction_EnumeratesReservedFields', async () => {
+    expect(workflowTool).toBeDefined();
+    const result = await handleDescribe(
+      { actions: ['update'] },
+      workflowTool!.actions,
+    );
+    expect(result.success).toBe(true);
+
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('update');
+    const updateDesc = data.update as Record<string, unknown>;
+    expect(updateDesc).toHaveProperty('reservedFields');
+
+    const reservedFields = updateDesc.reservedFields as Record<string, unknown>;
+
+    // The descriptor surfaces four keys; the runtime guard and the doc
+    // surface derive from the same constant, so changing the descriptor
+    // changes the discoverability output. Each must be non-empty.
+    expect(reservedFields).toHaveProperty('topLevelImmutable');
+    expect(reservedFields).toHaveProperty('underscorePrefixRule');
+    expect(reservedFields).toHaveProperty('examples');
+    expect(reservedFields).toHaveProperty('alternateWritePaths');
+
+    const topLevel = reservedFields.topLevelImmutable as readonly string[];
+    expect(Array.isArray(topLevel)).toBe(true);
+    expect(topLevel.length).toBeGreaterThan(0);
+    expect(topLevel).toContain('phase');
+    expect(topLevel).toContain('workflowType');
+    expect(topLevel).toContain('featureId');
+
+    expect(typeof reservedFields.underscorePrefixRule).toBe('string');
+    expect((reservedFields.underscorePrefixRule as string).length).toBeGreaterThan(0);
+
+    const examples = reservedFields.examples as readonly string[];
+    expect(Array.isArray(examples)).toBe(true);
+    expect(examples.length).toBeGreaterThan(0);
+
+    const alternates = reservedFields.alternateWritePaths as Record<string, string>;
+    expect(typeof alternates).toBe('object');
+    expect(Object.keys(alternates).length).toBeGreaterThan(0);
+    // The canonical alternate for `phase` redirects to the `transition`
+    // action — this is the most operator-load-bearing entry in the map.
+    expect(alternates.phase).toMatch(/transition/);
+  });
+
+  it('Update_WithReservedTopLevelField_ReturnsStructuredErrorData', async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'outcome-reserved-fields-'),
+    );
+    try {
+      const eventStore = new EventStore(stateDir);
+      const featureId = 'outcome-1360-toplevel';
+
+      const initResult = await handleInit(
+        { featureId, workflowType: 'feature' },
+        stateDir,
+        eventStore,
+      );
+      expect(initResult.success).toBe(true);
+
+      // `workflowType` is top-level immutable. Routes through `applyDotPath`,
+      // which throws `RESERVED_FIELD` with structured data. (`phase` is
+      // intercepted earlier in `handleUpdate` with INVALID_INPUT, by design
+      // — phase has its own HSM-aware error path. We test the canonical
+      // RESERVED_FIELD branch via a different top-level immutable.)
+      const updateResult = await handleUpdate(
+        { featureId, updates: { workflowType: 'debug' } },
+        stateDir,
+        eventStore,
+      );
+
+      expect(updateResult.success).toBe(false);
+      expect(updateResult.error?.code).toBe('RESERVED_FIELD');
+
+      const errData = updateResult.error?.data as {
+        rejectedPath?: unknown;
+        rule?: unknown;
+        alternateWritePath?: unknown;
+      } | undefined;
+      expect(errData).toBeDefined();
+      expect(errData!.rejectedPath).toBe('workflowType');
+      expect(typeof errData!.rule).toBe('string');
+      expect((errData!.rule as string).length).toBeGreaterThan(0);
+      // alternateWritePath may be a populated string or null; both shapes
+      // are contract-compliant per `ReservedFieldErrorData`. For
+      // `workflowType` the descriptor provides a populated alternate.
+      const altPath = errData!.alternateWritePath;
+      expect(altPath === null || typeof altPath === 'string').toBe(true);
+      if (typeof altPath === 'string') {
+        expect(altPath.length).toBeGreaterThan(0);
+      }
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('Update_WithUnderscorePrefixedField_ReturnsStructuredErrorData', async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'outcome-reserved-fields-underscore-'),
+    );
+    try {
+      const eventStore = new EventStore(stateDir);
+      const featureId = 'outcome-1360-underscore';
+
+      const initResult = await handleInit(
+        { featureId, workflowType: 'feature' },
+        stateDir,
+        eventStore,
+      );
+      expect(initResult.success).toBe(true);
+
+      // Underscore-prefixed keys are reserved for projection / event-store
+      // metadata. The descriptor's `underscorePrefixRule` is surfaced as
+      // the `rule` text on the structured error, and the `^_.*` regex
+      // entry in `alternateWritePaths` provides the redirect to the
+      // typed-event surface.
+      const updateResult = await handleUpdate(
+        { featureId, updates: { _meta: 'x' } },
+        stateDir,
+        eventStore,
+      );
+
+      expect(updateResult.success).toBe(false);
+      expect(updateResult.error?.code).toBe('RESERVED_FIELD');
+
+      const errData = updateResult.error?.data as {
+        rejectedPath?: unknown;
+        rule?: unknown;
+        alternateWritePath?: unknown;
+      } | undefined;
+      expect(errData).toBeDefined();
+      expect(errData!.rejectedPath).toBe('_meta');
+      expect(typeof errData!.rule).toBe('string');
+      expect((errData!.rule as string).length).toBeGreaterThan(0);
+
+      const altPath = errData!.alternateWritePath;
+      expect(altPath === null || typeof altPath === 'string').toBe(true);
+      if (typeof altPath === 'string') {
+        expect(altPath.length).toBeGreaterThan(0);
+      }
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/outcome/runbook-merge-orchestration.test.ts
+++ b/tests/outcome/runbook-merge-orchestration.test.ts
@@ -1,0 +1,107 @@
+// ─── T3.2 — MERGE_ORCHESTRATION runbook outcome (GREEN) ───────────────────
+//
+// Encodes the #1363 fix shipped in commit c0a59a7e (PR #1391). The contract
+// being locked: `exarchos_orchestrate.runbook({phase: 'merge-pending'})`
+// returns the populated `merge-orchestration` runbook summary, where
+// previously the registry had no entry for the `merge-pending` phase and
+// the call returned `[]`.
+//
+// The runbook's canonical step sequence is (1) preflight dryRun → (2) real
+// merge → (3) HSM transition back to delegate. It auto-emits four events
+// covering the merge lifecycle: `merge.preflight`, `merge.executed`,
+// `merge.rollback`, and `workflow.transition`. List mode (no `id`)
+// returns the summary view shape `{id, phase, description, stepCount}`.
+//
+// Backfill — fix is already on head. A future regression that removes the
+// runbook or drops its auto-emits fails CI.
+
+import { describe, it, expect } from 'vitest';
+
+import { handleRunbook } from '../../servers/exarchos-mcp/src/runbooks/handler.js';
+
+interface RunbookSummary {
+  readonly id: string;
+  readonly phase: string;
+  readonly description: string;
+  readonly stepCount: number;
+}
+
+describe('MERGE_ORCHESTRATION runbook outcome (#1363)', () => {
+  it('Runbook_MergePendingPhase_ReturnsCanonicalFourEventSequence', async () => {
+    // ─── List mode summary ──────────────────────────────────────────────
+    const listResult = await handleRunbook({ phase: 'merge-pending' });
+    expect(listResult.success).toBe(true);
+
+    const summaries = listResult.data as readonly RunbookSummary[];
+    expect(Array.isArray(summaries)).toBe(true);
+    expect(summaries.length).toBeGreaterThan(0);
+
+    const mergeOrch = summaries.find((r) => r.id === 'merge-orchestration');
+    expect(mergeOrch).toBeDefined();
+    expect(mergeOrch!.phase).toBe('merge-pending');
+    expect(typeof mergeOrch!.description).toBe('string');
+    expect(mergeOrch!.description.length).toBeGreaterThan(0);
+    expect(mergeOrch!.stepCount).toBe(3);
+
+    // ─── Detail mode — canonical step + auto-emit sequence ──────────────
+    //
+    // The four-event canonical sequence covers the full merge lifecycle.
+    // Order on `autoEmits` is the declared emission order: preflight
+    // fires first (dryRun), then `merge.executed` after the real merge
+    // succeeds OR `merge.rollback` after it fails, then
+    // `workflow.transition` regardless of outcome.
+    const detailResult = await handleRunbook({ id: 'merge-orchestration' });
+    expect(detailResult.success).toBe(true);
+
+    const detail = detailResult.data as {
+      readonly id: string;
+      readonly phase: string;
+      readonly autoEmits: readonly string[];
+      readonly steps: ReadonlyArray<{
+        readonly seq: number;
+        readonly tool: string;
+        readonly action: string;
+      }>;
+    };
+    expect(detail.id).toBe('merge-orchestration');
+    expect(detail.phase).toBe('merge-pending');
+
+    // Auto-emits must cover the four lifecycle events.
+    expect(detail.autoEmits).toEqual(
+      expect.arrayContaining([
+        'merge.preflight',
+        'merge.executed',
+        'merge.rollback',
+        'workflow.transition',
+      ]),
+    );
+
+    // Step shape: preflight (orchestrate) → real merge (orchestrate) →
+    // HSM transition (workflow). Each step carries `seq` for operator
+    // traceability.
+    expect(detail.steps).toHaveLength(3);
+    expect(detail.steps[0].tool).toBe('exarchos_orchestrate');
+    expect(detail.steps[0].action).toBe('merge_orchestrate');
+    expect(detail.steps[1].tool).toBe('exarchos_orchestrate');
+    expect(detail.steps[1].action).toBe('merge_orchestrate');
+    expect(detail.steps[2].tool).toBe('exarchos_workflow');
+    expect(detail.steps[2].action).toBe('transition');
+  });
+
+  it('Runbook_OtherPhases_StillPopulated', async () => {
+    // Quick regression guard: other phases the registry serves must remain
+    // populated. If a refactor accidentally narrows the runbook registry
+    // to merge-pending only (or drops a phase), this catches it.
+    const phasesToCheck = ['delegate', 'review', 'synthesize'] as const;
+    for (const phase of phasesToCheck) {
+      const result = await handleRunbook({ phase });
+      expect(result.success).toBe(true);
+      const summaries = result.data as readonly RunbookSummary[];
+      expect(Array.isArray(summaries)).toBe(true);
+      expect(summaries.length).toBeGreaterThan(0);
+      for (const summary of summaries) {
+        expect(summary.phase).toBe(phase);
+      }
+    }
+  });
+});

--- a/tests/outcome/telemetry-action-errors.test.ts
+++ b/tests/outcome/telemetry-action-errors.test.ts
@@ -1,0 +1,200 @@
+// ─── T3.3 — Telemetry action/transport split outcome (GREEN) ──────────────
+//
+// Encodes the #1364 fix shipped in commit 53cb4e4d (PR #1393). Before the
+// fix, the telemetry view's `errors` counter conflated two failure modes:
+//   - Transport / protocol JS throws (the handler crashed)
+//   - Structured action-level failures (the handler returned a
+//     `{success:false, error:{code,…}}` envelope per the MCP contract)
+//
+// The fix splits them. `tool.errored` continues to fire on JS throws only;
+// `tool.action_errored` fires on structured failures and carries the
+// per-call `errorCode`. The telemetry projection folds them into separate
+// counters: `errors` (transport) and `actionErrors` /
+// `actionErrorBreakdown` (action-level, keyed by error code).
+//
+// This test exercises the contract end-to-end via the real `withTelemetry`
+// middleware against an `EventStore`-backed telemetry view, mirroring the
+// outcome-tier posture of asserting on what an operator would observe in
+// `view.telemetry` output.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { EventStore } from '../../servers/exarchos-mcp/src/event-store/store.js';
+import { withTelemetry } from '../../servers/exarchos-mcp/src/telemetry/middleware.js';
+import type { CoreHandler } from '../../servers/exarchos-mcp/src/telemetry/middleware.js';
+import { handleViewTelemetry } from '../../servers/exarchos-mcp/src/telemetry/tools.js';
+import {
+  handleInit,
+  handleUpdate,
+} from '../../servers/exarchos-mcp/src/workflow/tools.js';
+
+interface TelemetryToolEntry {
+  readonly tool: string;
+  readonly invocations: number;
+  readonly errors: number;
+  readonly actionErrors: number;
+  readonly actionErrorBreakdown: Readonly<Record<string, number>>;
+}
+
+interface TelemetryEnvelope {
+  readonly session: {
+    readonly start: string;
+    readonly totalInvocations: number;
+    readonly totalTokens: number;
+  };
+  readonly tools: readonly TelemetryToolEntry[];
+}
+
+describe('telemetry action/transport split outcome (#1364)', () => {
+  it('Telemetry_AfterStructuredFailure_IncrementsActionErrorsNotTransportErrors', async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'outcome-telemetry-split-'),
+    );
+    try {
+      const eventStore = new EventStore(stateDir);
+
+      // Initialise a real workflow so the subsequent failing update has
+      // genuine state to land against (the RESERVED_FIELD path requires
+      // an existing state file).
+      const featureId = 'outcome-1364-action';
+      const initResult = await handleInit(
+        { featureId, workflowType: 'feature' },
+        stateDir,
+        eventStore,
+      );
+      expect(initResult.success).toBe(true);
+
+      // Wrap the real `handleUpdate` with the telemetry middleware. The
+      // middleware emits `tool.completed` + `tool.action_errored` when
+      // the wrapped handler returns a structured failure envelope (post
+      // #1364) instead of throwing.
+      const toolName = 'exarchos_workflow';
+      const wrapped: CoreHandler = withTelemetry(
+        async (args) =>
+          handleUpdate(
+            args as { featureId: string; updates: Record<string, unknown> },
+            stateDir,
+            eventStore,
+          ),
+        toolName,
+        eventStore,
+      );
+
+      // Drive a reserved-field rejection — the structured failure path.
+      // `workflowType` is top-level immutable and routes through
+      // `applyDotPath`, yielding `RESERVED_FIELD`.
+      const failure = await wrapped({
+        featureId,
+        updates: { workflowType: 'debug' },
+      });
+      expect(failure.success).toBe(false);
+      expect(failure.error?.code).toBe('RESERVED_FIELD');
+
+      // Read telemetry. The MCP composite isn't running, so we hit the
+      // handler directly — same underlying projection over the same
+      // TELEMETRY_STREAM events.
+      const telemetryResult = await handleViewTelemetry({}, stateDir, eventStore);
+      expect(telemetryResult.success).toBe(true);
+
+      const envelope = telemetryResult.data as TelemetryEnvelope;
+      const entry = envelope.tools.find((t) => t.tool === toolName);
+      expect(entry).toBeDefined();
+      // Structured failure must increment actionErrors, NOT errors.
+      expect(entry!.actionErrors).toBeGreaterThanOrEqual(1);
+      expect(entry!.errors).toBe(0);
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('Telemetry_ActionErrorBreakdown_KeyedByErrorCode', async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'outcome-telemetry-breakdown-'),
+    );
+    try {
+      const eventStore = new EventStore(stateDir);
+
+      const featureId = 'outcome-1364-breakdown';
+      const initResult = await handleInit(
+        { featureId, workflowType: 'feature' },
+        stateDir,
+        eventStore,
+      );
+      expect(initResult.success).toBe(true);
+
+      const toolName = 'exarchos_workflow';
+      const wrapped: CoreHandler = withTelemetry(
+        async (args) =>
+          handleUpdate(
+            args as { featureId: string; updates: Record<string, unknown> },
+            stateDir,
+            eventStore,
+          ),
+        toolName,
+        eventStore,
+      );
+
+      const failure = await wrapped({
+        featureId,
+        updates: { workflowType: 'debug' },
+      });
+      expect(failure.success).toBe(false);
+      expect(failure.error?.code).toBe('RESERVED_FIELD');
+
+      const telemetryResult = await handleViewTelemetry({}, stateDir, eventStore);
+      expect(telemetryResult.success).toBe(true);
+
+      const envelope = telemetryResult.data as TelemetryEnvelope;
+      const entry = envelope.tools.find((t) => t.tool === toolName);
+      expect(entry).toBeDefined();
+      // The breakdown is keyed by the structured `error.code`, not by a
+      // generic "failed" label — that is the per-call diagnostic surface.
+      expect(entry!.actionErrorBreakdown).toBeDefined();
+      expect(entry!.actionErrorBreakdown['RESERVED_FIELD']).toBeGreaterThanOrEqual(1);
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('Telemetry_AfterJsThrow_IncrementsTransportErrors', async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'outcome-telemetry-throw-'),
+    );
+    try {
+      const eventStore = new EventStore(stateDir);
+
+      // A handler that throws raw — the transport / protocol failure
+      // mode. Mirrors the wrapper's `tool.errored` path; explicitly
+      // contrasted with the structured-failure path above so the split
+      // contract is exercised both ways.
+      const toolName = 'exarchos_orchestrate';
+      const throwingHandler: CoreHandler = async () => {
+        throw new Error('transport explode');
+      };
+      const wrapped: CoreHandler = withTelemetry(
+        throwingHandler,
+        toolName,
+        eventStore,
+      );
+
+      await expect(wrapped({})).rejects.toThrow('transport explode');
+
+      const telemetryResult = await handleViewTelemetry({}, stateDir, eventStore);
+      expect(telemetryResult.success).toBe(true);
+
+      const envelope = telemetryResult.data as TelemetryEnvelope;
+      const entry = envelope.tools.find((t) => t.tool === toolName);
+      expect(entry).toBeDefined();
+      // Transport failure must increment errors and NOT actionErrors —
+      // the JS throw never resolves the handler envelope, so no
+      // `tool.action_errored` companion event fires.
+      expect(entry!.errors).toBeGreaterThanOrEqual(1);
+      expect(entry!.actionErrors).toBe(0);
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the outcome-tier coverage gap for the three AOC-carrier dogfood findings whose fixes shipped in the 2026-05-15 polish bundle. Three new outcome tests + a coverage-matrix update in the helpers README.

## Changes

- `tests/outcome/reserved-fields-discoverability.test.ts` — #1360 contract
- `tests/outcome/runbook-merge-orchestration.test.ts` — #1363 contract
- `tests/outcome/telemetry-action-errors.test.ts` — #1364 split contract
- `tests/outcome/_helpers/README.md` — coverage matrix

## Test Plan

- [x] All three new tests pass against current head
- [x] `npm run test:outcome` aggregate green (19/19)
- [x] `npm run test:run` full suite green (762/762 + 6 skipped)
- [x] `npm run typecheck` clean
- [x] No production code touched

## Notes

Pure test backfill — no production changes. The three contracts being locked were fixed in commits c0a59a7e (#1363), 481e51c7 (#1360), 53cb4e4d (#1364) which all shipped in the polish bundle. These tests prevent future refactors from silently regressing them.

One contract-spec deviation from the task brief: the brief expected `handleUpdate({phase: '…'})` to yield `RESERVED_FIELD`, but the current handler intercepts `phase` earlier with `INVALID_INPUT` + a `suggestedFix` block pointing to the `transition` action — by design, since `phase` has an HSM-aware error path distinct from `applyDotPath`. The test instead exercises the canonical `RESERVED_FIELD` branch via `workflowType` (another top-level immutable that does route through `applyDotPath`), keeping the structured-data contract locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)