### PR TITLE
feat(merge-preflight): Windows ancestry-debug instrumentation (#1362 phase 1)

### DIFF
--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -2478,6 +2478,72 @@ describe('MergePreflightData', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  // ─── #1362 phase 1 — optional debug branch ────────────────────────────
+  //
+  // The Windows ancestry-mismatch instrumentation attaches a structured
+  // `debug` block to `merge.preflight` events when
+  // `EXARCHOS_PREFLIGHT_DEBUG=1` AND ancestry failed. The branch is
+  // `.optional()` so:
+  //   1. legacy events emitted without it remain parseable
+  //      (`MergePreflightData_WithoutDebugBlock_ValidatesAgainstSchema`).
+  //   2. new events carrying the full payload also parse
+  //      (`MergePreflightData_WithDebugBlock_ValidatesAgainstSchema`).
+  it('MergePreflightData_WithoutDebugBlock_ValidatesAgainstSchema', () => {
+    const result = MergePreflightData.safeParse({
+      taskId: 'T11',
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      passed: false,
+      ancestry: { passed: false, reason: 'ancestry', missing: ['main'] },
+      currentBranchProtection: { blocked: false },
+      worktree: { isMain: true, actual: '/repo', expected: '/repo' },
+      drift: {
+        clean: true,
+        uncommittedFiles: [],
+        indexStale: false,
+        detachedHead: false,
+      },
+      failureReasons: ['ancestry missing: main'],
+    });
+    expect(result.success, JSON.stringify(result)).toBe(true);
+  });
+
+  it('MergePreflightData_WithDebugBlock_ValidatesAgainstSchema', () => {
+    const result = MergePreflightData.safeParse({
+      taskId: 'T11',
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      passed: false,
+      ancestry: { passed: false, reason: 'ancestry', missing: ['main'] },
+      currentBranchProtection: { blocked: false },
+      worktree: { isMain: true, actual: '/repo', expected: '/repo' },
+      drift: {
+        clean: true,
+        uncommittedFiles: [],
+        indexStale: false,
+        detachedHead: false,
+      },
+      failureReasons: ['ancestry missing: main'],
+      debug: {
+        gitVersion: 'git version 2.45.1',
+        repoRoot: 'C:\\repos\\example',
+        worktreeList: 'worktree C:/repos/example\nHEAD a\nbranch refs/heads/main\n',
+        refsHeadsSource: { sha: 'a'.repeat(40), packed: false },
+        refsHeadsTarget: { sha: 'b'.repeat(40), packed: false },
+        mergeBaseCommand: ['git', 'merge-base', '--is-ancestor', 'main', 'feat/x'],
+        mergeBaseExitCode: 1,
+        mergeBaseStdout: '',
+        mergeBaseStderr: '',
+      },
+    });
+    expect(result.success, JSON.stringify(result)).toBe(true);
+    if (result.success) {
+      expect(result.data.debug?.gitVersion).toBe('git version 2.45.1');
+      expect(result.data.debug?.refsHeadsSource.packed).toBe(false);
+      expect(result.data.debug?.mergeBaseExitCode).toBe(1);
+    }
+  });
 });
 
 describe('MergeExecutedData', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -1128,6 +1128,32 @@ const MergePreflightDriftData = z.object({
   detachedHead: z.boolean(),
 });
 
+// #1362 phase 1 — Windows ancestry-mismatch instrumentation. Optional debug
+// payload attached to `merge.preflight` when `EXARCHOS_PREFLIGHT_DEBUG=1`
+// AND ancestry failed. Failure-only gating is deliberate (DIM-8 / event-store
+// growth); verbose sub-modes belong on a separate `=2` channel.
+//
+// Field shape mirrors the `PreflightDebug` TypeScript type in
+// `orchestrate/pure/merge-preflight.ts`. Phase-1 captures the minimal data
+// needed to disambiguate Windows ref-resolution and merge-base failures
+// from filesystem-layer worktree mis-detection; phase-2 may extend.
+const MergePreflightDebugRefData = z.object({
+  sha: z.string(),
+  packed: z.boolean(),
+});
+
+export const MergePreflightDebugData = z.object({
+  gitVersion: z.string(),
+  repoRoot: z.string(),
+  worktreeList: z.string(),
+  refsHeadsSource: MergePreflightDebugRefData,
+  refsHeadsTarget: MergePreflightDebugRefData,
+  mergeBaseCommand: z.array(z.string()),
+  mergeBaseExitCode: z.number().int(),
+  mergeBaseStdout: z.string(),
+  mergeBaseStderr: z.string(),
+});
+
 /**
  * merge.preflight — captures the outcome of the preflight gate run before a
  * candidate merge. Preflight failures DO NOT route through merge.rollback;
@@ -1153,6 +1179,9 @@ export const MergePreflightData = z.object({
   worktree: MergePreflightWorktreeData.optional(),
   drift: MergePreflightDriftData.optional(),
   failureReasons: z.array(z.string()).optional(),
+  // #1362 phase 1 — see MergePreflightDebugData. Optional so legacy events
+  // (and the common ancestry-passing case) remain parseable unchanged.
+  debug: MergePreflightDebugData.optional(),
 });
 
 /**

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.test.ts
@@ -37,7 +37,7 @@
 //       returns `{ success: false, error: { code: 'STATE_CONFLICT' } }`.
 // ────────────────────────────────────────────────────────────────────────────
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { EventStore } from '../event-store/store.js';
 import type { DispatchContext } from '../core/dispatch.js';
 
@@ -341,6 +341,134 @@ describe('handleMergeOrchestrate (T12 — preflight-fail abort)', () => {
     });
     expect(Array.isArray(emitted.data.failureReasons)).toBe(true);
     expect((emitted.data.failureReasons as string[])[0]).toMatch(/ancestry/);
+  });
+});
+
+// ─── #1362 phase 1 — preflight.debug event-wire ─────────────────────────────
+//
+// The helper at `pure/merge-preflight.ts` attaches an optional `debug` field
+// to `MergePreflightResult` when `EXARCHOS_PREFLIGHT_DEBUG=1 && !ancestry.passed`.
+// The schema at `event-store/schemas.ts:MergePreflightData.debug` declares an
+// optional `MergePreflightDebugData` branch. The handler is the missing link:
+// these tests assert that `preflight.debug`, when present on the helper's
+// return value, is threaded through to `event.data.debug` on the appended
+// `merge.preflight` event. Without this assertion the regression class
+// (helper produces debug, schema accepts debug, but handler silently drops
+// it) is invisible — `tests/outcome/preflight-debug.test.ts` only exercises
+// the pure helper's return value and never inspects the appended event.
+const FAILING_PREFLIGHT_WITH_DEBUG: MergePreflightResult = {
+  ...FAILING_PREFLIGHT,
+  debug: {
+    gitVersion: 'git version 2.45.0',
+    repoRoot: '/repo',
+    worktreeList: 'worktree /repo\nHEAD abc\nbranch refs/heads/main\n',
+    refsHeadsSource: { sha: 'c'.repeat(40), packed: false },
+    refsHeadsTarget: { sha: 'd'.repeat(40), packed: false },
+    mergeBaseCommand: ['git', 'merge-base', '--is-ancestor', 'main', 'feat/x'],
+    mergeBaseExitCode: 1,
+    mergeBaseStdout: '',
+    mergeBaseStderr: '',
+  },
+};
+
+describe('handleMergeOrchestrate (#1362 — preflight.debug event-wire)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('MergeOrchestrate_EnvSetAndAncestryFail_AppendsDebugBlockToEvent', async () => {
+    // The handler accepts a DI'd `preflight` adapter, so the helper's env-var
+    // gating is exercised separately (outcome test). Here we drive the handler
+    // with a result that *already* carries `debug` (the exact shape the helper
+    // produces under `EXARCHOS_PREFLIGHT_DEBUG=1 && !ancestry.passed`) and
+    // assert the handler propagates it into the appended event.
+    vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', '1');
+    const ctx = makeMockCtx();
+    const preflight = vi.fn().mockResolvedValue(FAILING_PREFLIGHT_WITH_DEBUG);
+    const executeMerge = vi.fn();
+    const persistState = vi.fn().mockResolvedValue(undefined);
+
+    await handleMergeOrchestrate(
+      {
+        featureId: 'feat-x',
+        sourceBranch: 'feat/x',
+        targetBranch: 'main',
+        taskId: 'T1362',
+        strategy: 'squash',
+        preflight,
+        executeMerge,
+        persistState,
+      },
+      ctx,
+    );
+
+    const appendMock = ctx.eventStore.append as ReturnType<typeof vi.fn>;
+    const preflightCalls = appendMock.mock.calls.filter(
+      (call) => (call[1] as { type?: string } | undefined)?.type === 'merge.preflight',
+    );
+    expect(preflightCalls).toHaveLength(1);
+    const [, emitted] = preflightCalls[0] as [string, { data: Record<string, unknown> }];
+
+    // Core assertion: handler threads `preflight.debug` into `event.data.debug`.
+    expect(emitted.data.debug).toBeDefined();
+    expect(emitted.data.debug).toEqual(FAILING_PREFLIGHT_WITH_DEBUG.debug);
+
+    // Shape sanity — every required PreflightDebug field is present so a
+    // schema validator at the read-side will accept the record.
+    const debug = emitted.data.debug as Record<string, unknown>;
+    expect(typeof debug.gitVersion).toBe('string');
+    expect(typeof debug.repoRoot).toBe('string');
+    expect(typeof debug.worktreeList).toBe('string');
+    expect(debug.refsHeadsSource).toMatchObject({
+      sha: expect.any(String),
+      packed: expect.any(Boolean),
+    });
+    expect(debug.refsHeadsTarget).toMatchObject({
+      sha: expect.any(String),
+      packed: expect.any(Boolean),
+    });
+    expect(Array.isArray(debug.mergeBaseCommand)).toBe(true);
+    expect(typeof debug.mergeBaseExitCode).toBe('number');
+    expect(typeof debug.mergeBaseStdout).toBe('string');
+    expect(typeof debug.mergeBaseStderr).toBe('string');
+  });
+
+  it('MergeOrchestrate_EnvUnsetAndAncestryFail_NoDebugBlockOnEvent', async () => {
+    // Symmetric case: when the helper does NOT attach `debug` (env unset or
+    // ancestry passed), the handler must omit `debug` from the event entirely
+    // — not stamp an empty object, not stamp `undefined` explicitly. The
+    // optional-spread pattern (matching `failureReasons`) is the contract.
+    vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', '');
+    const ctx = makeMockCtx();
+    const preflight = vi.fn().mockResolvedValue(FAILING_PREFLIGHT);
+    const executeMerge = vi.fn();
+    const persistState = vi.fn().mockResolvedValue(undefined);
+
+    await handleMergeOrchestrate(
+      {
+        featureId: 'feat-x',
+        sourceBranch: 'feat/x',
+        targetBranch: 'main',
+        taskId: 'T1362',
+        strategy: 'squash',
+        preflight,
+        executeMerge,
+        persistState,
+      },
+      ctx,
+    );
+
+    const appendMock = ctx.eventStore.append as ReturnType<typeof vi.fn>;
+    const preflightCalls = appendMock.mock.calls.filter(
+      (call) => (call[1] as { type?: string } | undefined)?.type === 'merge.preflight',
+    );
+    expect(preflightCalls).toHaveLength(1);
+    const [, emitted] = preflightCalls[0] as [string, { data: Record<string, unknown> }];
+    expect('debug' in emitted.data).toBe(false);
   });
 });
 

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
@@ -550,6 +550,13 @@ export async function handleMergeOrchestrate(
           ...(preflight.passed
             ? {}
             : { failureReasons: [describePreflightFailure(preflight)] }),
+          // #1362 phase 1 — thread the optional debug payload from the helper
+          // through to the event so phase-2 analysis can read the persisted
+          // ancestry-mismatch diagnostic. The helper only attaches `debug`
+          // when `EXARCHOS_PREFLIGHT_DEBUG=1 && !ancestry.passed`; same
+          // conditional-spread pattern as `failureReasons` above so passing
+          // events stay byte-identical to the pre-#1362 shape.
+          ...(preflight.debug !== undefined ? { debug: preflight.debug } : {}),
         },
       },
       appendOptionsPreflight,

--- a/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.test.ts
@@ -9,8 +9,13 @@
  *     propagation from the underlying guard.
  */
 
-import { describe, it, expect } from 'vitest';
-import { detectDrift, mergePreflight, type GitExec } from './merge-preflight.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  detectDrift,
+  mergePreflight,
+  gatherPreflightDebug,
+  type GitExec,
+} from './merge-preflight.js';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -396,5 +401,226 @@ describe('mergePreflight — failure paths (T07)', () => {
     expect(result.drift.clean).toBe(false);
     expect(result.drift.uncommittedFiles.length).toBeGreaterThan(0);
     expect(result.drift.uncommittedFiles).toEqual(['src/foo.ts', 'src/bar.ts']);
+  });
+});
+
+// ─── gatherPreflightDebug (#1362 phase 1) ───────────────────────────────────
+//
+// Phase-1 Windows preflight instrumentation. The helper is pure: every git
+// invocation goes through the injected `gitExec`. Fail-closed semantics —
+// individual git failures must NOT throw; the helper records a partial
+// payload so the on-failure debug attachment is best-effort. See plan T2.2.
+
+describe('gatherPreflightDebug (#1362)', () => {
+  it('gatherPreflightDebug_AllGitCallsSucceed_PopulatesAllFields', () => {
+    // Build a mock that returns canned outputs for every git invocation the
+    // helper should make. Field order in the type is the canonical reading
+    // order for an operator inspecting the debug block.
+    const gitExec = makeGitExec([
+      { args: ['--version'], stdout: 'git version 2.45.1\n', exitCode: 0 },
+      { args: ['rev-parse', '--show-toplevel'], stdout: '/repo\n', exitCode: 0 },
+      {
+        args: ['worktree', 'list', '--porcelain'],
+        stdout: 'worktree /repo\nHEAD aaaaaaa\nbranch refs/heads/main\n',
+        exitCode: 0,
+      },
+      // refs lookups: source + target. Use `for-each-ref` so we capture both
+      // SHA and whether the ref is packed in one go.
+      {
+        args: [
+          'for-each-ref',
+          '--format=%(objectname) %(if)%(refname)%(then)%(refname)%(end)',
+          'refs/heads/feat/x',
+        ],
+        stdout: 'aaaaaaa refs/heads/feat/x\n',
+        exitCode: 0,
+      },
+      {
+        args: [
+          'for-each-ref',
+          '--format=%(objectname) %(if)%(refname)%(then)%(refname)%(end)',
+          'refs/heads/main',
+        ],
+        stdout: 'bbbbbbb refs/heads/main\n',
+        exitCode: 0,
+      },
+      // packed-refs check via `cat-file -e <packed-ref>` or by `git
+      // packed-refs --print`. We use `packed-refs` lookup via grep-free
+      // mechanism: `git rev-parse --symbolic-full-name --verify
+      // refs/heads/X` doesn't tell us packed state. The implementation uses
+      // `git for-each-ref --format=%(packed)` semantics — but for simplicity
+      // the helper just calls `cat-file -e <sha>` per ref. Mock stubs match
+      // the implementation's actual call order below.
+      {
+        args: ['cat-file', '-e', 'aaaaaaa'],
+        stdout: '',
+        exitCode: 0,
+      },
+      {
+        args: ['cat-file', '-e', 'bbbbbbb'],
+        stdout: '',
+        exitCode: 0,
+      },
+      // merge-base --is-ancestor invocation — the same call that the
+      // ancestry guard ran. We re-run it here to capture stderr / exit code
+      // verbatim for the debug block.
+      {
+        args: ['merge-base', '--is-ancestor', 'main', 'feat/x'],
+        stdout: '',
+        exitCode: 1,
+      },
+    ]);
+
+    const debug = gatherPreflightDebug(gitExec, '/repo', 'feat/x', 'main');
+
+    expect(debug.gitVersion).toBe('git version 2.45.1');
+    expect(debug.repoRoot).toBe('/repo');
+    expect(debug.worktreeList).toContain('worktree /repo');
+    expect(debug.refsHeadsSource.sha).toBe('aaaaaaa');
+    expect(debug.refsHeadsTarget.sha).toBe('bbbbbbb');
+    expect(debug.refsHeadsSource.packed).toBe(false);
+    expect(debug.refsHeadsTarget.packed).toBe(false);
+    expect(debug.mergeBaseCommand).toEqual([
+      'git',
+      'merge-base',
+      '--is-ancestor',
+      'main',
+      'feat/x',
+    ]);
+    expect(debug.mergeBaseExitCode).toBe(1);
+    expect(typeof debug.mergeBaseStdout).toBe('string');
+    expect(typeof debug.mergeBaseStderr).toBe('string');
+  });
+
+  it('gatherPreflightDebug_GitVersionFails_ReturnsPartialBlock', () => {
+    // Drive the very first git call (--version) to fail. The helper must
+    // record an empty/default value for that field and continue — never
+    // throw. This is the fail-closed contract: an instrumentation helper
+    // that throws inside an already-failed preflight would mask the real
+    // failure.
+    const gitExec: GitExec = (_root, args) => {
+      if (args[0] === '--version') {
+        return { stdout: '', exitCode: 127 };
+      }
+      // Stubs for the remaining calls so the test does not throw on
+      // unexpected invocations.
+      if (args[0] === 'rev-parse') return { stdout: '/repo\n', exitCode: 0 };
+      if (args[0] === 'worktree') return { stdout: '', exitCode: 0 };
+      if (args[0] === 'for-each-ref') return { stdout: 'sha refs/heads/x\n', exitCode: 0 };
+      if (args[0] === 'cat-file') return { stdout: '', exitCode: 0 };
+      if (args[0] === 'merge-base') return { stdout: '', exitCode: 0 };
+      return { stdout: '', exitCode: 1 };
+    };
+
+    let debug: ReturnType<typeof gatherPreflightDebug>;
+    expect(() => {
+      debug = gatherPreflightDebug(gitExec, '/repo', 'feat/x', 'main');
+    }).not.toThrow();
+
+    expect(debug!.gitVersion).toBe('');
+    // Subsequent fields must still be populated from their successful calls.
+    expect(debug!.repoRoot).toBe('/repo');
+  });
+});
+
+// ─── mergePreflight env-var integration (#1362 phase 1) ─────────────────────
+
+describe('mergePreflight env-gated debug attachment (#1362)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  /** Build a gitExec stub that drives ancestry to fail (exit 1 on
+   * `merge-base --is-ancestor`) and stubs every other call mergePreflight
+   * + gatherPreflightDebug make. */
+  function makeAncestryFailingExec(): GitExec {
+    return (_root, args) => {
+      const a = args.join(' ');
+      if (a === 'merge-base --is-ancestor main feat/x') {
+        return { stdout: '', exitCode: 1 };
+      }
+      if (a === 'rev-parse --abbrev-ref HEAD') {
+        return { stdout: 'feat/x\n', exitCode: 0 };
+      }
+      if (a === 'status --porcelain') return { stdout: '', exitCode: 0 };
+      if (a === 'diff --cached --quiet') return { stdout: '', exitCode: 0 };
+      if (a === '--version') return { stdout: 'git version 2.45.1\n', exitCode: 0 };
+      if (a === 'rev-parse --show-toplevel') return { stdout: '/repo\n', exitCode: 0 };
+      if (a === 'worktree list --porcelain') return { stdout: '', exitCode: 0 };
+      if (args[0] === 'for-each-ref') {
+        return { stdout: 'sha refs/heads/x\n', exitCode: 0 };
+      }
+      if (args[0] === 'cat-file') return { stdout: '', exitCode: 0 };
+      throw new Error(`Unexpected gitExec call: git ${a}`);
+    };
+  }
+
+  /** Same as above but ancestry passes. */
+  function makeAncestryPassingExec(): GitExec {
+    return (_root, args) => {
+      const a = args.join(' ');
+      if (a === 'merge-base --is-ancestor main feat/x') {
+        return { stdout: '', exitCode: 0 };
+      }
+      if (a === 'rev-parse --abbrev-ref HEAD') {
+        return { stdout: 'feat/x\n', exitCode: 0 };
+      }
+      if (a === 'status --porcelain') return { stdout: '', exitCode: 0 };
+      if (a === 'diff --cached --quiet') return { stdout: '', exitCode: 0 };
+      if (a === '--version') return { stdout: 'git version 2.45.1\n', exitCode: 0 };
+      if (a === 'rev-parse --show-toplevel') return { stdout: '/repo\n', exitCode: 0 };
+      if (a === 'worktree list --porcelain') return { stdout: '', exitCode: 0 };
+      if (args[0] === 'for-each-ref') {
+        return { stdout: 'sha refs/heads/x\n', exitCode: 0 };
+      }
+      if (args[0] === 'cat-file') return { stdout: '', exitCode: 0 };
+      throw new Error(`Unexpected gitExec call: git ${a}`);
+    };
+  }
+
+  it('MergePreflight_EnvUnsetAndAncestryFail_NoDebugField', async () => {
+    vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', '');
+    const result = await mergePreflight({
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      gitExec: makeAncestryFailingExec(),
+      cwd: '/tmp/repo',
+    });
+
+    expect(result.ancestry.passed).toBe(false);
+    expect((result as Record<string, unknown>).debug).toBeUndefined();
+  });
+
+  it('MergePreflight_EnvSetAndAncestryPass_NoDebugField', async () => {
+    // Failure-only gating: even with the debug env set, a passing ancestry
+    // must NOT attach a debug block. DIM-8 sustainability — event-store
+    // growth concern.
+    vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', '1');
+    const result = await mergePreflight({
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      gitExec: makeAncestryPassingExec(),
+      cwd: '/tmp/repo',
+    });
+
+    expect(result.ancestry.passed).toBe(true);
+    expect((result as Record<string, unknown>).debug).toBeUndefined();
+  });
+
+  it('MergePreflight_EnvSetAndAncestryFail_AttachesDebugBlock', async () => {
+    vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', '1');
+    const result = await mergePreflight({
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      gitExec: makeAncestryFailingExec(),
+      cwd: '/tmp/repo',
+    });
+
+    expect(result.ancestry.passed).toBe(false);
+    const debug = (result as { debug?: Record<string, unknown> }).debug;
+    expect(debug).toBeDefined();
+    expect(debug!.gitVersion).toBe('git version 2.45.1');
+    expect(debug!.repoRoot).toBe('/repo');
+    expect(debug!.mergeBaseExitCode).toBe(1);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts
@@ -132,6 +132,141 @@ export interface MergePreflightResult {
   readonly currentBranchProtection: CurrentBranchProtectionResult;
   readonly worktree: WorktreeAssertionResult;
   readonly drift: DriftResult;
+  /**
+   * Optional debug payload populated only when `EXARCHOS_PREFLIGHT_DEBUG=1`
+   * is set AND ancestry fails. Phase-1 Windows ancestry-mismatch
+   * instrumentation (#1362). Failure-only gating is deliberate (DIM-8 /
+   * event-store growth — verbose sub-modes will land separately via
+   * `EXARCHOS_PREFLIGHT_DEBUG=2` if/when phase 2 needs them).
+   */
+  readonly debug?: PreflightDebug;
+}
+
+/**
+ * Structured diagnostic payload for the Phase-1 Windows ancestry-mismatch
+ * investigation (#1362). All fields are best-effort: individual git call
+ * failures degrade gracefully to empty strings / default values rather than
+ * throwing. Reasoning: a debug helper that throws inside an already-failed
+ * preflight would mask the underlying ancestry failure the operator is
+ * trying to diagnose.
+ *
+ * Field order is the canonical reading order for an operator inspecting an
+ * issue report — git version → repo root → worktree layout → ref state →
+ * the actual ancestry invocation that failed.
+ */
+export interface PreflightDebug {
+  /** Output of `git --version`, stripped of trailing newlines. */
+  readonly gitVersion: string;
+  /** Output of `git rev-parse --show-toplevel`, stripped of trailing newlines. */
+  readonly repoRoot: string;
+  /** Verbatim porcelain output of `git worktree list --porcelain`. */
+  readonly worktreeList: string;
+  /** SHA + packed-status of the source branch ref. */
+  readonly refsHeadsSource: { readonly sha: string; readonly packed: boolean };
+  /** SHA + packed-status of the target branch ref. */
+  readonly refsHeadsTarget: { readonly sha: string; readonly packed: boolean };
+  /** The exact argv used for `merge-base --is-ancestor`, including the
+   * leading `'git'` literal so the operator can copy-paste verbatim. */
+  readonly mergeBaseCommand: readonly string[];
+  /** Exit code returned by the `merge-base --is-ancestor` invocation. */
+  readonly mergeBaseExitCode: number;
+  /** Stdout captured from the `merge-base --is-ancestor` invocation. */
+  readonly mergeBaseStdout: string;
+  /** Stderr captured from the `merge-base --is-ancestor` invocation. The
+   * default `GitExec` shape collapses stderr into `stdout` on failure — this
+   * field is currently a duplicate of `mergeBaseStdout` for Windows-specific
+   * gitExec implementations that may split the streams. */
+  readonly mergeBaseStderr: string;
+}
+
+// ─── gatherPreflightDebug (#1362 phase 1) ───────────────────────────────────
+
+/**
+ * Collect the Phase-1 Windows ancestry-debug payload.
+ *
+ * Every git invocation goes through the injected `gitExec` so the helper
+ * stays pure and unit-testable. Each call is wrapped in fail-closed
+ * semantics — a non-zero exit (or thrown error from a misbehaving gitExec)
+ * collapses to an empty string / default value for that field, never
+ * throws. The on-failure debug attachment is best-effort by design.
+ *
+ * The `for-each-ref` ref inspection is structured as
+ * `{ sha, packed }` because a Windows-host investigation needs to
+ * distinguish "ref does not exist" from "ref exists but is packed and
+ * unreadable by some downstream tool." Phase-1 reports `packed: false`
+ * universally; phase-2 may upgrade the helper to use `git pack-refs
+ * --print` for genuine packed-ref discrimination.
+ */
+export function gatherPreflightDebug(
+  gitExec: GitExec,
+  repoRoot: string,
+  source: string,
+  target: string,
+): PreflightDebug {
+  const safe = (args: readonly string[]): { stdout: string; exitCode: number } => {
+    try {
+      return gitExec(repoRoot, args);
+    } catch {
+      return { stdout: '', exitCode: 1 };
+    }
+  };
+
+  const versionRes = safe(['--version']);
+  const gitVersion = versionRes.exitCode === 0 ? versionRes.stdout.trim() : '';
+
+  const toplevelRes = safe(['rev-parse', '--show-toplevel']);
+  const reportedRoot =
+    toplevelRes.exitCode === 0 ? toplevelRes.stdout.trim() : '';
+
+  const worktreeRes = safe(['worktree', 'list', '--porcelain']);
+  const worktreeList = worktreeRes.exitCode === 0 ? worktreeRes.stdout : '';
+
+  const refFor = (
+    branch: string,
+  ): { sha: string; packed: boolean } => {
+    const refRes = safe([
+      'for-each-ref',
+      '--format=%(objectname) %(if)%(refname)%(then)%(refname)%(end)',
+      `refs/heads/${branch}`,
+    ]);
+    const sha =
+      refRes.exitCode === 0 ? refRes.stdout.trim().split(/\s+/)[0] ?? '' : '';
+    // Phase-1: `cat-file -e <sha>` confirms the SHA is reachable; we treat a
+    // success as `packed: false` (the typical loose-ref case). Phase-2 will
+    // distinguish loose vs packed via `pack-refs --print`. If the ref lookup
+    // failed outright, leave `packed: false` and let `sha === ''` signal it.
+    if (sha !== '') {
+      safe(['cat-file', '-e', sha]);
+    }
+    return { sha, packed: false };
+  };
+
+  const refsHeadsSource = refFor(source);
+  const refsHeadsTarget = refFor(target);
+
+  const mergeBaseCommand: readonly string[] = [
+    'git',
+    'merge-base',
+    '--is-ancestor',
+    target,
+    source,
+  ];
+  const mbRes = safe(['merge-base', '--is-ancestor', target, source]);
+  // The default `GitExec` collapses stderr into stdout on failure (see
+  // `defaultGitExec` in merge-orchestrate.ts), so the two fields are the
+  // same string under that adapter. Windows-specific adapters that capture
+  // stderr separately can populate the two fields independently.
+  return {
+    gitVersion,
+    repoRoot: reportedRoot,
+    worktreeList,
+    refsHeadsSource,
+    refsHeadsTarget,
+    mergeBaseCommand,
+    mergeBaseExitCode: mbRes.exitCode,
+    mergeBaseStdout: mbRes.stdout,
+    mergeBaseStderr: mbRes.stdout,
+  };
 }
 
 /**
@@ -249,11 +384,31 @@ export async function mergePreflight(
     worktree.isMain &&
     drift.clean;
 
+  // Phase-1 Windows ancestry-debug instrumentation (#1362). Failure-only
+  // gating: only attach a debug block when the env var is explicitly set
+  // AND ancestry failed. DIM-8 sustainability — we do NOT pay event-store
+  // growth for passing preflights even when an operator turns the flag on.
+  // Verbose sub-modes (passing-preflight diagnostics) belong on a
+  // separate `EXARCHOS_PREFLIGHT_DEBUG=2` channel and are out of scope.
+  let debug: PreflightDebug | undefined;
+  if (
+    process.env.EXARCHOS_PREFLIGHT_DEBUG === '1' &&
+    !ancestry.passed
+  ) {
+    debug = gatherPreflightDebug(
+      args.gitExec,
+      repoRoot,
+      args.sourceBranch,
+      args.targetBranch,
+    );
+  }
+
   return {
     passed,
     ancestry,
     currentBranchProtection,
     worktree,
     drift,
+    ...(debug !== undefined ? { debug } : {}),
   };
 }

--- a/skills-src/merge-orchestrator/SKILL.md
+++ b/skills-src/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `{{MCP_PREFIX}}exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `{{MCP_PREFIX}}exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/skills/claude/merge-orchestrator/SKILL.md
+++ b/skills/claude/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/skills/codex/merge-orchestrator/SKILL.md
+++ b/skills/codex/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/skills/copilot/merge-orchestrator/SKILL.md
+++ b/skills/copilot/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/skills/cursor/merge-orchestrator/SKILL.md
+++ b/skills/cursor/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/skills/generic/merge-orchestrator/SKILL.md
+++ b/skills/generic/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/skills/opencode/merge-orchestrator/SKILL.md
+++ b/skills/opencode/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -2138,6 +2138,33 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set \`EXARCHOS_PREFLIGHT_DEBUG=1\` in the environment before invoking \`merge_orchestrate\` to attach a structured debug payload to \`merge.preflight\` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. \`EXARCHOS_PREFLIGHT_DEBUG=1\` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., \`ancestry.passed === false\`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future \`EXARCHOS_PREFLIGHT_DEBUG=2\` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| \`gitVersion\` | \`git --version\` | Differentiate behaviors across git releases. |
+| \`repoRoot\` | \`git rev-parse --show-toplevel\` | Distinguish symlinked or normalized vs raw repo paths. |
+| \`worktreeList\` | \`git worktree list --porcelain\` | Surface sibling worktree topology that could affect ref resolution. |
+| \`refsHeadsSource\` | \`git for-each-ref refs/heads/<source>\` | SHA + packed-state of the source branch ref. |
+| \`refsHeadsTarget\` | \`git for-each-ref refs/heads/<target>\` | SHA + packed-state of the target branch ref. |
+| \`mergeBaseCommand\` | constructed | Exact argv re-run by the helper, including \`'git'\` prefix — copy-pasteable for the operator. |
+| \`mergeBaseExitCode\` | rerun of \`git merge-base --is-ancestor <target> <source>\` | The exit code that drove the ancestry failure. |
+| \`mergeBaseStdout\` | same invocation | Captured stdout. |
+| \`mergeBaseStderr\` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full \`data.debug\` block to a new GitHub issue tagged with relevant scope labels (e.g., \`windows\`, \`merge-orchestrator\`, \`preflight\`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call \`mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
@@ -6756,6 +6783,33 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set \`EXARCHOS_PREFLIGHT_DEBUG=1\` in the environment before invoking \`merge_orchestrate\` to attach a structured debug payload to \`merge.preflight\` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. \`EXARCHOS_PREFLIGHT_DEBUG=1\` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., \`ancestry.passed === false\`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future \`EXARCHOS_PREFLIGHT_DEBUG=2\` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| \`gitVersion\` | \`git --version\` | Differentiate behaviors across git releases. |
+| \`repoRoot\` | \`git rev-parse --show-toplevel\` | Distinguish symlinked or normalized vs raw repo paths. |
+| \`worktreeList\` | \`git worktree list --porcelain\` | Surface sibling worktree topology that could affect ref resolution. |
+| \`refsHeadsSource\` | \`git for-each-ref refs/heads/<source>\` | SHA + packed-state of the source branch ref. |
+| \`refsHeadsTarget\` | \`git for-each-ref refs/heads/<target>\` | SHA + packed-state of the target branch ref. |
+| \`mergeBaseCommand\` | constructed | Exact argv re-run by the helper, including \`'git'\` prefix — copy-pasteable for the operator. |
+| \`mergeBaseExitCode\` | rerun of \`git merge-base --is-ancestor <target> <source>\` | The exit code that drove the ancestry failure. |
+| \`mergeBaseStdout\` | same invocation | Captured stdout. |
+| \`mergeBaseStderr\` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full \`data.debug\` block to a new GitHub issue tagged with relevant scope labels (e.g., \`windows\`, \`merge-orchestrator\`, \`preflight\`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
@@ -11365,6 +11419,33 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
+
+## Diagnostics
+
+Set \`EXARCHOS_PREFLIGHT_DEBUG=1\` in the environment before invoking \`merge_orchestrate\` to attach a structured debug payload to \`merge.preflight\` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. \`EXARCHOS_PREFLIGHT_DEBUG=1\` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., \`ancestry.passed === false\`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future \`EXARCHOS_PREFLIGHT_DEBUG=2\` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| \`gitVersion\` | \`git --version\` | Differentiate behaviors across git releases. |
+| \`repoRoot\` | \`git rev-parse --show-toplevel\` | Distinguish symlinked or normalized vs raw repo paths. |
+| \`worktreeList\` | \`git worktree list --porcelain\` | Surface sibling worktree topology that could affect ref resolution. |
+| \`refsHeadsSource\` | \`git for-each-ref refs/heads/<source>\` | SHA + packed-state of the source branch ref. |
+| \`refsHeadsTarget\` | \`git for-each-ref refs/heads/<target>\` | SHA + packed-state of the target branch ref. |
+| \`mergeBaseCommand\` | constructed | Exact argv re-run by the helper, including \`'git'\` prefix — copy-pasteable for the operator. |
+| \`mergeBaseExitCode\` | rerun of \`git merge-base --is-ancestor <target> <source>\` | The exit code that drove the ancestry failure. |
+| \`mergeBaseStdout\` | same invocation | Captured stdout. |
+| \`mergeBaseStderr\` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full \`data.debug\` block to a new GitHub issue tagged with relevant scope labels (e.g., \`windows\`, \`merge-orchestrator\`, \`preflight\`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
 
 ## Schema Discovery
 
@@ -15986,6 +16067,33 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set \`EXARCHOS_PREFLIGHT_DEBUG=1\` in the environment before invoking \`merge_orchestrate\` to attach a structured debug payload to \`merge.preflight\` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. \`EXARCHOS_PREFLIGHT_DEBUG=1\` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., \`ancestry.passed === false\`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future \`EXARCHOS_PREFLIGHT_DEBUG=2\` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| \`gitVersion\` | \`git --version\` | Differentiate behaviors across git releases. |
+| \`repoRoot\` | \`git rev-parse --show-toplevel\` | Distinguish symlinked or normalized vs raw repo paths. |
+| \`worktreeList\` | \`git worktree list --porcelain\` | Surface sibling worktree topology that could affect ref resolution. |
+| \`refsHeadsSource\` | \`git for-each-ref refs/heads/<source>\` | SHA + packed-state of the source branch ref. |
+| \`refsHeadsTarget\` | \`git for-each-ref refs/heads/<target>\` | SHA + packed-state of the target branch ref. |
+| \`mergeBaseCommand\` | constructed | Exact argv re-run by the helper, including \`'git'\` prefix — copy-pasteable for the operator. |
+| \`mergeBaseExitCode\` | rerun of \`git merge-base --is-ancestor <target> <source>\` | The exit code that drove the ancestry failure. |
+| \`mergeBaseStdout\` | same invocation | Captured stdout. |
+| \`mergeBaseStderr\` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full \`data.debug\` block to a new GitHub issue tagged with relevant scope labels (e.g., \`windows\`, \`merge-orchestrator\`, \`preflight\`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
@@ -20576,6 +20684,33 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
+
+## Diagnostics
+
+Set \`EXARCHOS_PREFLIGHT_DEBUG=1\` in the environment before invoking \`merge_orchestrate\` to attach a structured debug payload to \`merge.preflight\` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. \`EXARCHOS_PREFLIGHT_DEBUG=1\` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., \`ancestry.passed === false\`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future \`EXARCHOS_PREFLIGHT_DEBUG=2\` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| \`gitVersion\` | \`git --version\` | Differentiate behaviors across git releases. |
+| \`repoRoot\` | \`git rev-parse --show-toplevel\` | Distinguish symlinked or normalized vs raw repo paths. |
+| \`worktreeList\` | \`git worktree list --porcelain\` | Surface sibling worktree topology that could affect ref resolution. |
+| \`refsHeadsSource\` | \`git for-each-ref refs/heads/<source>\` | SHA + packed-state of the source branch ref. |
+| \`refsHeadsTarget\` | \`git for-each-ref refs/heads/<target>\` | SHA + packed-state of the target branch ref. |
+| \`mergeBaseCommand\` | constructed | Exact argv re-run by the helper, including \`'git'\` prefix — copy-pasteable for the operator. |
+| \`mergeBaseExitCode\` | rerun of \`git merge-base --is-ancestor <target> <source>\` | The exit code that drove the ancestry failure. |
+| \`mergeBaseStdout\` | same invocation | Captured stdout. |
+| \`mergeBaseStderr\` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full \`data.debug\` block to a new GitHub issue tagged with relevant scope labels (e.g., \`windows\`, \`merge-orchestrator\`, \`preflight\`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
 
 ## Schema Discovery
 
@@ -25194,6 +25329,33 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
+
+## Diagnostics
+
+Set \`EXARCHOS_PREFLIGHT_DEBUG=1\` in the environment before invoking \`merge_orchestrate\` to attach a structured debug payload to \`merge.preflight\` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. \`EXARCHOS_PREFLIGHT_DEBUG=1\` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., \`ancestry.passed === false\`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future \`EXARCHOS_PREFLIGHT_DEBUG=2\` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| \`gitVersion\` | \`git --version\` | Differentiate behaviors across git releases. |
+| \`repoRoot\` | \`git rev-parse --show-toplevel\` | Distinguish symlinked or normalized vs raw repo paths. |
+| \`worktreeList\` | \`git worktree list --porcelain\` | Surface sibling worktree topology that could affect ref resolution. |
+| \`refsHeadsSource\` | \`git for-each-ref refs/heads/<source>\` | SHA + packed-state of the source branch ref. |
+| \`refsHeadsTarget\` | \`git for-each-ref refs/heads/<target>\` | SHA + packed-state of the target branch ref. |
+| \`mergeBaseCommand\` | constructed | Exact argv re-run by the helper, including \`'git'\` prefix — copy-pasteable for the operator. |
+| \`mergeBaseExitCode\` | rerun of \`git merge-base --is-ancestor <target> <source>\` | The exit code that drove the ancestry failure. |
+| \`mergeBaseStdout\` | same invocation | Captured stdout. |
+| \`mergeBaseStderr\` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full \`data.debug\` block to a new GitHub issue tagged with relevant scope labels (e.g., \`windows\`, \`merge-orchestrator\`, \`preflight\`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
 
 ## Schema Discovery
 

--- a/tests/outcome/preflight-debug.test.ts
+++ b/tests/outcome/preflight-debug.test.ts
@@ -1,0 +1,128 @@
+// ─── PR2 / #1362 — Windows ancestry-debug instrumentation outcome ────────────
+//
+// Phase-1 instrumentation contract: when `EXARCHOS_PREFLIGHT_DEBUG=1` AND the
+// ancestry guard fails, `mergePreflight` must attach a structured `debug` block
+// to its result. When the env var is unset (or set but ancestry passes), no
+// debug block is attached — the gating is failure-only by design (DIM-8 /
+// event-store growth concern; see plan T2.x and the design "Symmetry decision"
+// note). Phase-2 may introduce verbose sub-modes via `EXARCHOS_PREFLIGHT_DEBUG=2`
+// separately.
+//
+// Linux-only test path: drives ancestry-failure by creating an orphan branch
+// (no merge-base with `main`), then invokes `mergePreflight` against a real
+// tmp git repo.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import * as path from 'node:path';
+
+import { withTmpGit } from './_helpers/tmp-git.js';
+import { mergePreflight } from '../../servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.js';
+import type { GitExec } from '../../servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.js';
+
+/** Default gitExec mirroring the handler's `defaultGitExec` (no throw, returns
+ * `{ stdout, exitCode }`). Inline here so the outcome test does not depend on
+ * the handler module's internal helper. */
+function liveGitExec(repoRoot: string, args: readonly string[]): {
+  stdout: string;
+  exitCode: number;
+} {
+  try {
+    const stdout = execFileSync('git', [...args], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err) {
+    const status = (err as { status?: number }).status;
+    const stdout = (err as { stdout?: string | Buffer }).stdout;
+    const message = typeof stdout === 'string' ? stdout : stdout?.toString('utf-8') ?? '';
+    return { stdout: message, exitCode: typeof status === 'number' ? status : 1 };
+  }
+}
+
+/** Set up an orphan source branch so `merge-base --is-ancestor main source`
+ * fails with exit 1 (ancestry-missing). Returns the path of the primary
+ * repo with the orphan branch checked in. */
+async function setupAncestryFailureTopology(repoPath: string): Promise<void> {
+  // The initial commit on `main` is empty (no tracked files). Create an orphan
+  // branch with no shared history, then commit a file so HEAD has a valid
+  // commit and `merge-base --is-ancestor main feature/orphan` returns exit 1
+  // (disjoint histories, no common ancestor).
+  execFileSync('git', ['-C', repoPath, 'checkout', '--orphan', 'feature/orphan'], {
+    stdio: 'pipe',
+  });
+  await fs.writeFile(path.join(repoPath, 'orphan.txt'), 'orphan\n');
+  execFileSync('git', ['-C', repoPath, 'add', 'orphan.txt'], { stdio: 'pipe' });
+  execFileSync('git', ['-C', repoPath, 'commit', '-m', 'orphan'], { stdio: 'pipe' });
+}
+
+describe('preflight debug payload (#1362 phase 1)', () => {
+  it('Preflight_DebugEnvUnset_NoDebugField', async () => {
+    await withTmpGit(async (repoPath) => {
+      await setupAncestryFailureTopology(repoPath);
+
+      // Snapshot + clear the env var so this test is hermetic regardless of
+      // whether the runner has it set.
+      const prior = process.env.EXARCHOS_PREFLIGHT_DEBUG;
+      delete process.env.EXARCHOS_PREFLIGHT_DEBUG;
+      try {
+        const gitExec: GitExec = (root, args) => liveGitExec(root, args);
+        const result = await mergePreflight({
+          sourceBranch: 'feature/orphan',
+          targetBranch: 'main',
+          gitExec,
+          cwd: repoPath,
+        });
+
+        // Ancestry must actually fail for this test to be meaningful.
+        expect(result.passed).toBe(false);
+        expect(result.ancestry.passed).toBe(false);
+
+        // No debug block when env var is unset.
+        expect((result as Record<string, unknown>).debug).toBeUndefined();
+      } finally {
+        if (prior !== undefined) process.env.EXARCHOS_PREFLIGHT_DEBUG = prior;
+      }
+    });
+  });
+
+  it('Preflight_DebugEnvSetAndAncestryFail_AttachesDebugBlock', async () => {
+    await withTmpGit(async (repoPath) => {
+      await setupAncestryFailureTopology(repoPath);
+
+      const prior = process.env.EXARCHOS_PREFLIGHT_DEBUG;
+      process.env.EXARCHOS_PREFLIGHT_DEBUG = '1';
+      try {
+        const gitExec: GitExec = (root, args) => liveGitExec(root, args);
+        const result = await mergePreflight({
+          sourceBranch: 'feature/orphan',
+          targetBranch: 'main',
+          gitExec,
+          cwd: repoPath,
+        });
+
+        expect(result.passed).toBe(false);
+        expect(result.ancestry.passed).toBe(false);
+
+        // Debug block MUST be attached and structurally complete.
+        const debug = (result as { debug?: Record<string, unknown> }).debug;
+        expect(debug).toBeDefined();
+        expect(typeof debug!.gitVersion).toBe('string');
+        expect(typeof debug!.repoRoot).toBe('string');
+        expect(typeof debug!.worktreeList).toBe('string');
+        expect(debug!.refsHeadsSource).toBeDefined();
+        expect(debug!.refsHeadsTarget).toBeDefined();
+        expect(Array.isArray(debug!.mergeBaseCommand)).toBe(true);
+        expect(typeof debug!.mergeBaseExitCode).toBe('number');
+        expect(typeof debug!.mergeBaseStdout).toBe('string');
+        expect(typeof debug!.mergeBaseStderr).toBe('string');
+      } finally {
+        if (prior === undefined) delete process.env.EXARCHOS_PREFLIGHT_DEBUG;
+        else process.env.EXARCHOS_PREFLIGHT_DEBUG = prior;
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase-1 of #1362. Env-gated debug payload on `merge.preflight` events when ancestry fails. Awaits one Windows-host event with the new payload before Phase 2 (root-cause fix).

## Changes

- `gatherPreflightDebug` pure helper (fail-closed on git failures)
- Optional `debug` branch on `MergePreflightData` zod schema (backwards compatible)
- `mergePreflight` reads `EXARCHOS_PREFLIGHT_DEBUG` and attaches debug on ancestry failure only (DIM-8 sustainability)
- New `## Diagnostics` section in `skills-src/merge-orchestrator/SKILL.md` + regenerated runtime variants

## Test Plan

- [x] `tests/outcome/preflight-debug.test.ts` covers env-gating contract
- [x] Unit tests cover helper fail-closed behavior
- [x] Schema test asserts backwards compatibility
- [x] `npm run skills:guard` clean
- [x] `npm run typecheck` + `npm run test:run` clean