### PR TITLE
feat(v2.10.0-preview.3): final close-out bundle (#1354)

### DIFF
--- a/docs/designs/2026-05-15-v2-10-0-preview-3-closeout.md
+++ b/docs/designs/2026-05-15-v2-10-0-preview-3-closeout.md
@@ -1,0 +1,153 @@
+# v2.10.0-preview.3 — Final close-out bundle
+
+**Feature ID:** `v2-10-0-preview-3-closeout`
+**Epic:** [#1354](https://github.com/lvlup-sw/exarchos/issues/1354) — v2.10.0-preview.3 Windows dogfood remediation
+**Milestone:** v2.10.0 — Agent Output Contract
+**Scope:** #1374 (Wave 0 follow-up regression), #1362 (Windows preflight instrumentation), outcome-tier completeness backfill for #1360/#1363/#1364
+**Date:** 2026-05-15 (reshaped 2026-05-15: PR3 #1365 pulled pending eval-suite redesign)
+**Branch:** `feature/v2-10-0-preview-3-closeout`
+
+## Problem
+
+Preview.3's epic #1354 enumerated 8 dogfood findings + 3 systemic gates + 4 Agent Output Contract (AOC) carrier-track items. Waves 0–2 plus most of Wave 3 have landed (#1369 carrier swap; #1388 data-safety substrate; the 2026-05-15 polish bundle closing #1359/#1360/#1363/#1364). Three items remain in this bundle before the epic can partially close:
+
+- **#1374 — saga-merge-detour regression.** `test/process/saga-merge-detour.test.ts` fails on the wave-0 head: `next_actions` is `[]` after a worktree-bearing `task.completed`, instead of surfacing `merge_orchestrate`. The skill contract at `skills-src/delegation/SKILL.md` §"Worktree-Bearing Tasks: Auto-Detour to merge-pending" mandates the verb. The auto-detour wire originally landed under #1208 is broken. Process-tier CI is blocking; the surface (next-action computer + rehydration projection) is the same one Wave 2 #1359 touched, so the regression likely shipped alongside the carrier swap or the projection vocabulary update.
+- **#1362 — Windows preflight false-positive instrumentation.** `merge_orchestrate` preflight reports `ancestry.passed: false` on Windows even when `git merge-base --is-ancestor` succeeds manually. Phase-1 ships the debug payload behind `EXARCHOS_PREFLIGHT_DEBUG=1`; root-cause fix waits for one Windows-host event with the new payload.
+- **Outcome-tier completeness.** The user's note on #1354: *"ensure we fully scaffolded all the planned outcome-tier tests."* The #1358 seed set (3 tests for #1355/#1356/#1359) is GREEN; the four open AOC carriers landed without paired outcome tests. Backfill #1360 / #1363 / #1364 with operator-visible behavior tests to complete the dogfood-finding coverage matrix.
+
+All three belong in one bundle because they share the same carrier surface: every fix either consumes or extends an `outputSchema` registered during Wave 0 (#1287/#1289). Closing them together preserves the carrier-Wave / dogfood-Wave interaction discipline the epic established.
+
+### #1365 deferred to eval-suite redesign
+
+The original preview.3 close-out included #1365 (eval-suite elevation steps 1+2 — versioned dataset baselines + HTML dashboard). During plan review we recognized that #1365's design is built on top of an eval architecture we now intend to replace. Insight: our `{{TOKEN}}` placeholders encode harness mechanics (tool names, command verbs, hook surfaces) — they do NOT change the behavioral intent of the skill. Evaluating each rendered SKILL.md with a live LLM is triple-counting the same behavior under different vocabularies. The right architecture is a two-tier split: Tier A objective harness-surface tests against a versioned harness manifest; Tier B runtime-agnostic behavioral evals on the dotnet/skills pattern (live LLM + pairwise judging + overfitting detection). Shipping #1365 steps 1+2 against the current format would mean migrating both immediately after the redesign lands. Pulled from this bundle. Redesign tracked separately by the seed doc at `docs/research/2026-05-15-eval-suite-redesign-seed.md` and a forthcoming `/exarchos:ideate` pass.
+
+## Verified surfaces
+
+### #1374 — auto-detour wire location
+
+The detour chain is three handlers:
+
+1. **`servers/exarchos-mcp/src/projections/rehydration/reducer.ts:290-377`** — folds `task.completed` events. When `event.data.worktreePath` is present (line 299), the reducer projects the workflow into `phase: 'merge-pending'` and seeds `mergeOrchestrator: { taskId, phase: 'pending' }`. Re-entrant: a re-folded event keys off the existing `mergeOrchestrator.taskId` (lines 350-376) so idempotency holds.
+2. **`servers/exarchos-mcp/src/next-actions-from-result.ts:74-93`** — extracts `phase`, `workflowType`, `featureId`, `mergeOrchestrator` from the rehydration document's `workflowState` segment (shape 2). The shape-2 fallback was the original #1208 fix.
+3. **`servers/exarchos-mcp/src/next-actions-computer.ts:114-143`** — when `phase === 'merge-pending'` and `mergeOrchestrator.phase ∉ EXCLUDED_MERGE_PHASES`, appends `{verb: 'merge_orchestrate', idempotencyKey: '<streamId>:merge_orchestrate:<taskId>'}` to `next_actions`.
+
+The failure mode is unknown without instrumentation but the three most likely fault lines are: (a) Wave 0's carrier swap moved the rehydrate payload from `result.data` to `result.structuredContent` and `nextActionsFromResult(result)` still reads `result.data`; (b) the `task_complete` orchestrate handler stopped converting `result.worktreePath` to the event's `data.worktreePath`; (c) the rehydration reducer's `extractWorktreePath` helper regressed during the #1359 vocabulary update. The implementer task starts with a single targeted run of the saga test against the current head plus a `console.log` at each of the three sites — the failure shape determines which fault line is real.
+
+### #1362 — preflight surface
+
+`servers/exarchos-mcp/src/orchestrate/dispatch-guard.ts:78` calls `gitExec(['merge-base', '--is-ancestor', upstream, integrationBranch])`. The pure helper `servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts` composes `validateBranchAncestry` + `detectDrift` + `assertCurrentBranchNotProtected` + `assertMainWorktree` and emits `merge.preflight` events. The debug-block injection point is the `merge.preflight` event payload schema — add an optional `debug?: PreflightDebug` field gated on `process.env.EXARCHOS_PREFLIGHT_DEBUG === '1'` AND `ancestry.passed === false`. The `PreflightDebug` shape: `{ gitVersion, repoRoot, worktreeList, refsHeadsSource: {sha, packed}, refsHeadsTarget: {sha, packed}, mergeBaseCommand, mergeBaseExitCode, mergeBaseStdout, mergeBaseStderr }`. Per INV-1, the debug payload lives on the event (event-sourced), not a side channel.
+
+### Outcome-tier helpers
+
+`tests/outcome/_helpers/` ships `withTmpHome` (HOME isolation), `withTmpGit` (repo init), `addSiblingWorktree` (multi-worktree topology). The three existing tests cover CLI-binary invocation (#1355), handler-direct (#1356, #1359). No new helpers needed. The four new tests reuse existing patterns:
+
+- `tests/outcome/reserved-fields-discoverability.test.ts` (#1360) — handler-direct: call `handleDescribe` + `handleUpdate` with a reserved field, assert structured error data + describe enumeration.
+- `tests/outcome/runbook-merge-orchestration.test.ts` (#1363) — handler-direct: call `handleRunbook({phase: 'merge-pending'})`, assert non-empty payload with the expected event-shape entries.
+- `tests/outcome/telemetry-action-errors.test.ts` (#1364) — saga-shape: drive a workflow into a structured-failure handler, assert `view telemetry` reports `actionErrors > 0` and `actionErrorBreakdown` carries the named error code.
+- `tests/outcome/saga-merge-detour.test.ts` (#1374) — atomic RED→GREEN flip alongside the wire fix. Co-shipped in PR1; not separate.
+
+## Design overview
+
+Three PRs, stacked bottom-up on `feature/v2-10-0-preview-3-closeout`. Each PR is independently mergeable but bottom-up squash preserves the narrative.
+
+| PR | Fix | Outcome test | Carrier? |
+|---|---|---|---|
+| PR1 | #1374 wire restoration | `tests/outcome/saga-merge-detour.test.ts` (atomic flip) | Reads existing `next_actions` |
+| PR2 | #1362 preflight debug payload (env-gated) | `tests/outcome/preflight-debug.test.ts` (Linux: env-var gating + payload shape) | Extends `merge.preflight` event schema |
+| PR3 | Outcome-tier completeness backfill | Three new tests (#1360 / #1363 / #1364) | n/a (read-only assertions) |
+
+Bottom-up merge sequence partially closes #1354 on PR3 merge (#1365 stays open pending eval-suite redesign). Each PR independently registers its outputSchema delta where applicable (only PR2 needs a new envelope field). Atomic RED→GREEN discipline preserved on PR1 (#1208 contract restoration) and elsewhere where the test pairs with a fix.
+
+### Cross-cutting carrier interaction
+
+Per the epic's carrier-Wave / dogfood-Wave interaction checklist (Wave 0 #1287 mandated): any new envelope field requires updating the registered `outputSchema`. PR2 is the only PR in this bundle that touches envelope shape. The `merge.preflight` event's `Envelope<T>` schema gains an optional `debug?: PreflightDebugSchema` branch. PR2 must register the schema delta in `servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts`'s `registeredOutputSchema` call.
+
+## Per-PR design
+
+### PR1 — #1374 saga-merge-detour wire restoration
+
+**Investigation step (mandatory before fix):** Run `npm run test:run -- test/process/saga-merge-detour.test.ts` against current main. Add `console.error` instrumentation at three sites — (a) the `task_complete` handler's event emission (does `data.worktreePath` actually carry?); (b) the rehydration reducer's worktreePath fold (does `phase` flip to `merge-pending`?); (c) `nextActionsFromResult`'s shape-2 read (does the post-Wave-0 envelope still expose `data` or has it migrated to `structuredContent`?). The failure point determines the fix surface — do not write a fix without first knowing where the chain breaks.
+
+**Anticipated fix (subject to investigation):** If hypothesis (a) — patch `servers/exarchos-mcp/src/orchestrate/task-complete.ts` to thread `result.worktreePath` into the emitted `task.completed` event's `data.worktreePath`. If hypothesis (b) — patch `servers/exarchos-mcp/src/projections/rehydration/reducer.ts`'s `extractWorktreePath` helper. If hypothesis (c) — patch `servers/exarchos-mcp/src/next-actions-from-result.ts` to also read `result.structuredContent.workflowState` when `result.data.workflowState` is empty.
+
+**Outcome test:** No new test needed — the existing `test/process/saga-merge-detour.test.ts` is the contract and is currently failing. Optionally add a unit-level pin in `next-actions-computer.test.ts` covering the exact post-fix path so a future regression is caught at the unit tier before the saga tier.
+
+**Acceptance:** `test/process/saga-merge-detour.test.ts` passes on the PR's head; no other process-tier test regresses; PR body links the diagnostic transcript showing which hypothesis was correct.
+
+### PR2 — #1362 Windows preflight instrumentation
+
+**Deltas:**
+
+1. Extend `servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts` with a `gatherPreflightDebug(gitExec, repoRoot, source, target): PreflightDebug` pure helper. Returns the debug block schema documented in §Verified surfaces. All git invocations through the injected `gitExec` — no direct shellouts.
+2. Modify `mergePreflight` so when `process.env.EXARCHOS_PREFLIGHT_DEBUG === '1'` AND `ancestry.passed === false`, the returned `PreflightResult` carries a `debug` field populated by `gatherPreflightDebug`.
+3. Extend the `merge.preflight` event payload schema (`servers/exarchos-mcp/src/event-schemas/merge.ts` or equivalent) with an optional `debug?: PreflightDebugSchema` branch. Register against the action's `outputSchema` so the carrier validates.
+4. Document `EXARCHOS_PREFLIGHT_DEBUG=1` in `skills-src/merge-orchestrator/SKILL.md` under a new "Diagnostics" section.
+5. Run `npm run build:skills` to regenerate per-runtime variants. CI `skills:guard` re-renders and fails on drift; this PR must include the regenerated `skills/` tree.
+
+**Outcome test (`tests/outcome/preflight-debug.test.ts`):** Linux-only. Drives the preflight handler twice — once with `EXARCHOS_PREFLIGHT_DEBUG` unset (assert no `debug` field), once with it set AND a forced ancestry failure (assert `debug` field is present and shape-matches the schema). Does NOT attempt to reproduce the Windows-specific bug — that's phase 2.
+
+**Acceptance:** Env-gated payload behaves as designed; no-op default; skill mentions the env var; carrier validation passes.
+
+### PR3 — Outcome-tier completeness backfill
+
+**Three new tests (each ~80-120 LOC, modeled on the existing seed tests):**
+
+- **`tests/outcome/reserved-fields-discoverability.test.ts` (#1360)** — handler-direct invocation of `handleDescribe({tools: ['exarchos_workflow'], actions: ['update']})` asserting `reservedFields` block presence + schema. Second `it()` block: call `handleUpdate` with a reserved field, assert `success: false` + `error.code === 'RESERVED_FIELD'` + `error.data.rejectedPath` + `error.data.rule` + `error.data.alternateWritePath` all populated.
+- **`tests/outcome/runbook-merge-orchestration.test.ts` (#1363)** — handler-direct invocation of `handleRunbook({phase: 'merge-pending'})`. Assert `success: true`, `data` is a non-empty array, the four-event canonical sequence (`merge.requested → merge.preflight → merge.executed → merge.completed`) is enumerated with correct event types.
+- **`tests/outcome/telemetry-action-errors.test.ts` (#1364)** — saga-shape: drive a workflow into a structured-failure handler (e.g., `workflow.update` with a reserved field, forcing a `RESERVED_FIELD` envelope error). Then call `handleViewTelemetry` and assert `actionErrors >= 1` AND `actionErrorBreakdown['RESERVED_FIELD'] >= 1` AND transport-tier `errors` counter stays at 0 (the split that landed in #1393).
+
+Each test is standard pass/fail (no `it.fails` — the production fixes already landed). The PR ships pure test code; no production changes.
+
+**Acceptance:** All three tests pass against current main; `npm run test:outcome` aggregate stays green; coverage matrix updated in `tests/outcome/_helpers/README.md`.
+
+## Axiom design constraints (DIM-1..DIM-8 applied)
+
+- **DIM-1 (Topology):** No new state stores, no new tools. Bundle extends an existing event schema (#1362). Single source of truth preserved: `outputSchema` registered in dispatch-core; reserved-fields rule lives in `workflow/schemas.ts:isReservedField`. ✅
+- **DIM-2 (Simplicity):** Each PR is a focused change. PR1 surgical fix, no refactoring; PR2 one new helper, one schema field; PR3 pure test code. No premature abstractions. ✅
+- **DIM-3 (Verification):** Atomic RED→GREEN flip on PR1 (saga test currently RED → GREEN after fix). PR2 outcome test asserts env-var gating shape. PR3 backfills coverage where unit/integration was thin. ✅
+- **DIM-4 (Hardening):** PR2's `gatherPreflightDebug` is fail-closed: if any git invocation fails, the helper returns a partial debug block with the failure recorded — does not crash the preflight. Env-var gating ensures the payload never ships in production by default. ✅
+- **DIM-5 (Observability):** PR2 is itself observability work — the debug block IS the observability surface. PR3 makes telemetry observable from outcome-tier. ✅
+- **DIM-6 (Coherence):** All three PRs share the carrier discipline established by Wave 0. Anywhere a new envelope field appears (PR2), it's registered against the `outputSchema`. The outcome-test pattern is consistent across PR1 and PR3. ✅
+- **DIM-7 (Resilience):** PR2's debug block degrades gracefully on git failures (DIM-4 above). PR1's fix should be the minimum delta needed to restore the contract — no opportunistic refactoring of the surrounding next-action surface. ✅
+- **DIM-8 (Sustainability):** Outcome-tier backfill creates durable contracts for the #1360/#1363/#1364 fixes so future refactors cannot silently regress them. ✅
+
+## Design invariants (INV-1..INV-6 verified)
+
+- **INV-1 (Event-sourcing integrity):** PR2's debug block lives on the `merge.preflight` event payload, not a side channel. No projection bypasses the event store. PR1's fix restores an event-sourced contract (`task.completed{worktreePath}` → reducer-folded merge-pending phase). ✅
+- **INV-2 (Facade equivalence):** No new tools or actions; all changes flow through the shared dispatch core. CLI/MCP parity preserved automatically. ✅
+- **INV-3 (Basileus-forward):** No `agent` verb usage; nothing in this bundle pre-empts Basileus reservations. ✅
+- **INV-4 (Platform-agnosticity):** PR2 itself is Windows-targeted instrumentation but the implementation is platform-agnostic — env-var read, git-command shellout, payload assembly are all cross-platform. PR3's outcome tests are Linux-only (existing tier convention). ✅
+- **INV-5a (Agent-first input):** PR2's `EXARCHOS_PREFLIGHT_DEBUG=1` is an env var (agent-friendly: set once, applies to all invocations) not a per-call flag. ✅
+- **INV-5b (Spec-aligned output contract):** PR2's debug block is in the registered event schema; PR3's outcome tests assert envelope-shape contracts surfaced by #1359/#1360/#1364 fixes. ✅
+- **INV-5c (Aspire-inspired verbs):** No new verbs introduced. `merge_orchestrate` (restored by PR1) was already in the verb catalog. ✅
+- **INV-5d (Action discriminator):** No discriminator changes; PR1 restores the existing discriminator path. ✅
+- **INV-6 (Workflow-agnosticism):** PR2's instrumentation is a behavior of the merge-orchestrator skill, not a workflow-specific feature. PR3's outcome tests target operator-visible behavior, not workflow types. ✅
+
+## Sequencing notes
+
+- **PR1 lands first.** The saga test is failing process-tier CI today; restoring the wire is the highest-priority unblock and has zero coupling to the other two PRs.
+- **PR2 lands second.** New schema field; doesn't depend on PR1. Carrier registration is the most fragile work in the bundle — land it early so any registration-time issue surfaces with maximum review attention.
+- **PR3 lands last.** Pure test code; landing it after PR1+PR2 means the outcome-tier sweep captures the final post-fix state. Partially closes #1354 on merge (#1365 stays open for the eval-suite redesign).
+
+## Out of scope (deferred to eval-suite redesign / v2.10.0 GA / v2.11)
+
+- **#1365 eval-suite elevation** — entire scope deferred to the eval-suite redesign. Context seed at `docs/research/2026-05-15-eval-suite-redesign-seed.md`. Will run a fresh `/exarchos:ideate` pass with the two-tier architecture (Tier A harness-surface tests + Tier B behavioral evals on the dotnet/skills pattern). The {{TOKEN}} placeholder system in `skills-src/` encodes harness mechanics, not behavior — building versioned-dataset/dashboard on top of the current eval format would burn the cost twice once the redesign lands.
+- **#1362 phase 2** — Windows root-cause fix. Awaits one Windows-host event with the new debug payload. Phase-2 issue to be filed once data lands.
+- **#1387, #1396, #1397** — eval follow-up issues. Commented to note the redesign; rescoped or superseded by the redesign as appropriate.
+- **Outcome-tier coverage for #1362 instrumentation IN ACTION** (i.e., reproducing the false-positive). Linux-only outcome tier cannot reproduce the Windows-specific bug; we only test the env-gated payload shape.
+- **Refactoring `next-actions-from-result.ts`** beyond what PR1's fix requires (e.g., #1238's Zod discriminated unions). Separate issue.
+
+## Acceptance criteria (epic-level)
+
+- [ ] PR1 — `test/process/saga-merge-detour.test.ts` passes.
+- [ ] PR2 — `EXARCHOS_PREFLIGHT_DEBUG=1` produces the debug block on ancestry-failed preflights; default behavior unchanged; event schema validates.
+- [ ] PR3 — Three new outcome tests pass against the post-fix state.
+- [ ] Carrier-Wave / dogfood-Wave checklist for this bundle is updated (`MergePreflightDebugData` added to the `MergePreflightData` event schema).
+- [ ] `#1354` epic body checkboxes flipped on each PR merge for #1374, #1362; epic partially closes on PR3 merge (#1365 stays open pending redesign).
+- [ ] Follow-up issue filed for #1362 phase 2 (Windows root cause; awaits debug-payload data from a Windows host).
+- [ ] Eval-suite redesign seed doc written (`docs/research/2026-05-15-eval-suite-redesign-seed.md`).
+
+## Open questions for plan-review
+
+1. Should PR2's `gatherPreflightDebug` also run when `ancestry.passed === true` for symmetry? Phase-1 issue scopes "only on failure" to keep the event store quiet; symmetry helps future Phase 2 root-cause analysis. (Recommendation locked at plan-review: failure-only, per DIM-8.)
+2. PR1 hypothesis — should the implementer be authorized to add `console.error` instrumentation temporarily, or must they reason from logs only? (Authorized at plan-review with mandatory removal in T1.3.)

--- a/docs/designs/2026-05-15-v2-10-0-preview-3-closeout.md
+++ b/docs/designs/2026-05-15-v2-10-0-preview-3-closeout.md
@@ -56,11 +56,13 @@ Three PRs, stacked bottom-up on `feature/v2-10-0-preview-3-closeout`. Each PR is
 | PR2 | #1362 preflight debug payload (env-gated) | `tests/outcome/preflight-debug.test.ts` (Linux: env-var gating + payload shape) | Extends `merge.preflight` event schema |
 | PR3 | Outcome-tier completeness backfill | Three new tests (#1360 / #1363 / #1364) | n/a (read-only assertions) |
 
-Bottom-up merge sequence partially closes #1354 on PR3 merge (#1365 stays open pending eval-suite redesign). Each PR independently registers its outputSchema delta where applicable (only PR2 needs a new envelope field). Atomic RED→GREEN discipline preserved on PR1 (#1208 contract restoration) and elsewhere where the test pairs with a fix.
+Bottom-up merge sequence partially closes #1354 on PR3 merge (#1365 stays open pending eval-suite redesign). PR2 is the only bundle PR that touches event-schema shape (the `merge.preflight` event's data schema gains an optional `debug` branch); PR1 and PR3 touch no schemas. Atomic RED→GREEN discipline preserved on PR1 (#1208 contract restoration) and elsewhere where the test pairs with a fix.
 
-### Cross-cutting carrier interaction
+### Cross-cutting carrier interaction (clarified at plan-review)
 
-Per the epic's carrier-Wave / dogfood-Wave interaction checklist (Wave 0 #1287 mandated): any new envelope field requires updating the registered `outputSchema`. PR2 is the only PR in this bundle that touches envelope shape. The `merge.preflight` event's `Envelope<T>` schema gains an optional `debug?: PreflightDebugSchema` branch. PR2 must register the schema delta in `servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts`'s `registeredOutputSchema` call.
+**The `merge.preflight` event schema and the `merge_orchestrate` action's registered `outputSchema` are decoupled.** The Wave 0 carrier swap (#1287) mandates that any envelope-shape change for an action with a typed `outputSchema` (e.g., `WorkflowUpdateOutputSchema` for `exarchos_workflow.update`) must update the registration. `merge_orchestrate` does NOT have a typed outputSchema — it registers `EnvelopeSchema(z.unknown())` at the dispatch layer (verified at `servers/exarchos-mcp/src/registry.ts`). The event payload schema (`MergePreflightData` in `event-store/schemas.ts:1146`) is the source-of-truth for `merge.preflight` event shape; it gains the optional `debug` branch and is enforced at event-store append time, not at the action's envelope boundary.
+
+**Authoritative integration point for PR2:** Extend `MergePreflightData` in `servers/exarchos-mcp/src/event-store/schemas.ts` with `debug: MergePreflightDebugData.optional()`. No `registeredOutputSchema` call in `merge-orchestrate.ts` needs updating. (A future PR that promotes `merge_orchestrate`'s action outputSchema from `EnvelopeSchema(z.unknown())` to a typed envelope WOULD need to thread the debug branch through that contract — but that's out of scope here.)
 
 ## Per-PR design
 

--- a/docs/plans/2026-05-15-v2-10-0-preview-3-closeout.md
+++ b/docs/plans/2026-05-15-v2-10-0-preview-3-closeout.md
@@ -252,7 +252,7 @@
 **Phase:** GREEN (against post-fix production code)
 
 1. Create `tests/outcome/runbook-merge-orchestration.test.ts` (Linux-only):
-   - `Runbook_MergePendingPhase_ReturnsCanonicalFourEventSequence` — call `handleRunbook({phase: 'merge-pending'})`, assert `success: true`, `data` is a non-empty array, the four-event canonical sequence (`merge.requested → merge.preflight → merge.executed → merge.completed`) appears in order with expected event types.
+   - `Runbook_MergePendingPhase_ReturnsCanonicalFourEventSequence` — call `handleRunbook({phase: 'merge-pending'})`, assert `success: true`, `data` is a non-empty array, the four-event canonical `autoEmits` sequence (`merge.preflight → merge.executed → merge.rollback → workflow.transition`) appears with expected event types. Source-of-truth: `runbooks/definitions.ts:636` lists exactly these four lifecycle events for the merge-pending phase. Assert exact length (4) so the test fails if extra emit events are added without updating this matrix.
    - `Runbook_OtherPhases_StillPopulated` — quick check that `task-completion`, `quality-evaluation`, `synthesis-flow` phases still return non-empty payloads (regression guard against the registry change).
 
 **File:** `tests/outcome/runbook-merge-orchestration.test.ts` (new).

--- a/docs/plans/2026-05-15-v2-10-0-preview-3-closeout.md
+++ b/docs/plans/2026-05-15-v2-10-0-preview-3-closeout.md
@@ -1,0 +1,336 @@
+# Plan — v2.10.0-preview.3 Final Close-out Bundle
+
+**Design:** [`docs/designs/2026-05-15-v2-10-0-preview-3-closeout.md`](../designs/2026-05-15-v2-10-0-preview-3-closeout.md)
+**Feature ID:** `v2-10-0-preview-3-closeout`
+**Branch:** `feature/v2-10-0-preview-3-closeout`
+**Epic:** [#1354](https://github.com/lvlup-sw/exarchos/issues/1354)
+
+## Iron Law Reminder
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST**
+
+- PR1 has a pre-existing RED test (`test/process/saga-merge-detour.test.ts`). No new RED needed; investigation step locates the fault then GREEN restores the wire.
+- PR2 is fresh implementation — full TDD cycle (RED → GREEN per task).
+- PR3 is pure test backfill against already-merged production fixes — tests are written GREEN against current head (the contracts are post-fix stable). Pattern: write expectation that matches current behavior; failure means contract drifted and is a real bug to file.
+
+## Task overview
+
+3 PRs, 17 tasks total. PR1 = 4 tasks. PR2 = 9 tasks. PR3 = 4 tasks.
+
+**Note (2026-05-15 reshape):** original plan had a fourth PR for #1365 eval-suite elevation (9 tasks). That PR was pulled pending an eval-suite redesign (see `docs/research/2026-05-15-eval-suite-redesign-seed.md`). The remaining bundle ships the dogfood-finding closes only.
+
+**Parallelism:** All three PRs can be dispatched concurrently to separate worktrees because they touch orthogonal files. Within a PR, tasks are largely sequential (each builds on the prior).
+
+| PR | Tasks | Sequential? | Worktree |
+|---|---|---|---|
+| PR1 — #1374 wire restoration | T1.1–T1.4 | Yes | `agent-pr1-1374` |
+| PR2 — #1362 preflight debug | T2.1–T2.9 | Yes within helper/schema/wire stages; partial parallelism possible | `agent-pr2-1362` |
+| PR3 — Outcome-tier backfill | T3.1–T3.4 (was T4.1–T4.4) | No — three independent tests | `agent-pr3-backfill` |
+
+**Merge order:** PR1 → PR2 → PR3 (bottom-up squash, partially closes #1354 on PR3 merge; #1365 stays open for the redesign).
+
+---
+
+## PR1 — #1374 saga-merge-detour wire restoration
+
+### Task 1.1: Capture baseline failure mode
+
+**Phase:** RED (pre-existing)
+
+1. Run failing test against `feature/v2-10-0-preview-3-closeout` head:
+   ```bash
+   npm run build
+   npm run test:run -- test/process/saga-merge-detour.test.ts
+   ```
+2. Record the exact assertion output (`expected [] to deeply equal ArrayContaining{…}`) and any preceding step failures in the saga transcript.
+
+**File touched:** None (read-only diagnostic).
+**Expected outcome:** Test confirmed RED; baseline output captured in PR description draft.
+**Dependencies:** None.
+**Parallelizable:** No.
+
+### Task 1.2: Locate the broken link in the detour chain
+
+**Phase:** RED → diagnostic
+
+1. Temporarily add `console.error` instrumentation at the three suspect sites (REMOVE before commit):
+   - `servers/exarchos-mcp/src/orchestrate/task-complete.ts` — log `event.data.worktreePath` immediately before event-store append.
+   - `servers/exarchos-mcp/src/projections/rehydration/reducer.ts:299` — log the input event payload + the post-fold `state.workflowState.phase` + `state.workflowState.mergeOrchestrator`.
+   - `servers/exarchos-mcp/src/next-actions-from-result.ts:74-93` — log `result.data` keys + `result.structuredContent` keys (if present) + the extracted shape-2 fields.
+2. Re-run `test/process/saga-merge-detour.test.ts` with `--reporter=verbose`.
+3. Identify which site shows the signal-drop (the hypothesis from §Verified-surfaces of the design that is real).
+
+**Files touched:** Three sites above (instrumentation only).
+**Expected outcome:** Implementer-recorded transcript naming the broken link. Three hypotheses from design § Verified surfaces / #1374:
+- (a) `task_complete` orchestrate handler not threading `result.worktreePath` to event.
+- (b) rehydration reducer `extractWorktreePath` regressed.
+- (c) Wave 0 carrier swap moved payload from `result.data` to `result.structuredContent` and `nextActionsFromResult` reads stale shape.
+
+**Dependencies:** T1.1.
+**Parallelizable:** No.
+
+### Task 1.3: Apply targeted fix to the broken link
+
+**Phase:** GREEN
+
+1. Remove the diagnostic `console.error` calls added in T1.2.
+2. Apply the minimum-delta fix to the site identified in T1.2:
+   - **If hypothesis (a):** patch `servers/exarchos-mcp/src/orchestrate/task-complete.ts` to thread `args.result?.worktreePath` into the emitted event's `data.worktreePath`. Mirror `data.worktree` handling if needed.
+   - **If hypothesis (b):** patch the `extractWorktreePath` helper at `servers/exarchos-mcp/src/projections/rehydration/reducer.ts` (around line 290–305) to handle the post-#1359 vocabulary correctly.
+   - **If hypothesis (c):** patch `servers/exarchos-mcp/src/next-actions-from-result.ts:44-95` to also read `result.structuredContent.workflowState` when `result.data.workflowState` is empty/missing. Keep `result.data` reads as primary for backwards compatibility with shape-1 payloads.
+3. Run `npm run test:run -- test/process/saga-merge-detour.test.ts` → must turn GREEN.
+4. Run `npm run test:run` (full suite) → no regressions.
+
+**Files touched:** One of the three above; minimum delta only.
+**Expected outcome:** Saga test passes; full suite green; PR description documents which hypothesis was correct.
+**Dependencies:** T1.2.
+**Parallelizable:** No.
+
+### Task 1.4: Add unit-tier pin
+
+**Phase:** GREEN (defensive)
+
+1. [RED] Add a unit-level regression test at `servers/exarchos-mcp/src/next-actions-from-result.test.ts` (or `task-complete.test.ts` / `projections/rehydration/reducer.test.ts` depending on T1.3 fix surface) covering the EXACT post-fix path identified in T1.3.
+2. Run the new unit test → confirm it pins the fix (GREEN after T1.3 fix; would-be RED before T1.3 fix).
+3. Add a code comment in the unit test referencing #1374 and the saga test as the contract source.
+
+**File:** `servers/exarchos-mcp/src/{next-actions-from-result,task-complete,projections/rehydration/reducer}.test.ts` (one of these per T1.3 outcome).
+**Expected outcome:** Unit test catches the regression class one tier earlier than the saga test.
+**Dependencies:** T1.3.
+**Parallelizable:** No.
+
+---
+
+## PR2 — #1362 Windows preflight debug payload
+
+### Task 2.1: Outcome test scaffold (RED)
+
+**Phase:** RED
+
+1. Create `tests/outcome/preflight-debug.test.ts` (Linux-only — pin via `vitest.config.ts` outcome project as existing tests do).
+2. Two `it()` blocks:
+   - `Preflight_DebugEnvUnset_NoDebugField` — call `mergePreflight` with a deliberately failing ancestry (e.g., orphan branch), assert returned result has no `debug` field.
+   - `Preflight_DebugEnvSetAndAncestryFail_AttachesDebugBlock` — set `process.env.EXARCHOS_PREFLIGHT_DEBUG = '1'` in a `vi.stubEnv` boundary, run same scenario, assert `result.debug` matches `PreflightDebugSchema` shape (`gitVersion`, `repoRoot`, `worktreeList`, `refsHeadsSource`, `refsHeadsTarget`, `mergeBaseCommand`, `mergeBaseExitCode`, `mergeBaseStdout`, `mergeBaseStderr`).
+
+**File:** `tests/outcome/preflight-debug.test.ts`.
+**Expected failure:** `gatherPreflightDebug` doesn't exist; `result.debug` is undefined.
+**Dependencies:** None.
+**Parallelizable:** Yes (with T2.2).
+
+### Task 2.2: Unit test scaffold for `gatherPreflightDebug` (RED)
+
+**Phase:** RED
+
+1. Append test cases to `servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.test.ts`:
+   - `gatherPreflightDebug_AllGitCallsSucceed_PopulatesAllFields` — inject a `gitExec` mock returning canned outputs for each invocation (`version`, `worktree list --porcelain`, `rev-parse --verify`, `merge-base --is-ancestor`); assert all 9 PreflightDebug fields are populated.
+   - `gatherPreflightDebug_GitVersionFails_ReturnsPartialBlock` — `git --version` mock returns non-zero exit; assert `gitVersion === ''` and remaining fields populate from subsequent calls; no throw.
+
+**File:** `servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.test.ts`.
+**Expected failure:** `gatherPreflightDebug` import resolves to undefined.
+**Dependencies:** None.
+**Parallelizable:** Yes (with T2.1).
+
+### Task 2.3: Implement `gatherPreflightDebug` (GREEN)
+
+**Phase:** GREEN
+
+1. In `servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts`:
+   - Define `PreflightDebug` type matching the design §Verified-surfaces / #1362 schema.
+   - Implement `gatherPreflightDebug(gitExec: GitExec, repoRoot: string, source: string, target: string): PreflightDebug`. Fail-closed on each git call (catch exit-code errors; record partial). No throws.
+2. Export `PreflightDebug` type.
+3. Re-run T2.2 unit tests → GREEN.
+
+**File:** `servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts`.
+**Expected outcome:** Helper passes its unit tests; pure function with injected gitExec.
+**Dependencies:** T2.2.
+**Parallelizable:** No.
+
+### Task 2.4: Extend `MergePreflightData` Zod schema (RED)
+
+**Phase:** RED
+
+1. Add test cases to `servers/exarchos-mcp/src/event-store/schemas.test.ts` (or similar — locate existing schema test file near `MergePreflightData` references):
+   - `MergePreflightData_WithoutDebugBlock_ValidatesAgainstSchema` (must still pass — backwards compatible).
+   - `MergePreflightData_WithDebugBlock_ValidatesAgainstSchema` — RED until schema is extended.
+2. Schema location confirmed: `servers/exarchos-mcp/src/event-store/schemas.ts:1146` (`MergePreflightData = z.object({ ... })`). Existing sub-schemas at L1102-L1130 (`MergePreflightAncestryData`, `MergePreflightCurrentBranchProtectionData`, `MergePreflightWorktreeData`, `MergePreflightDriftData`) — `PreflightDebugSchema` will join this group.
+
+**File:** `servers/exarchos-mcp/src/event-store/schemas.test.ts` (append cases — confirm file exists during impl).
+**Expected failure:** Schema's `.strict()` (if applied) rejects unknown `debug` key; or `.parse()` silently strips it depending on mode.
+**Dependencies:** T2.3 (needs `PreflightDebug` type exported).
+**Parallelizable:** No.
+
+### Task 2.5: Add optional debug branch to `MergePreflightData` (GREEN)
+
+**Phase:** GREEN
+
+1. In `servers/exarchos-mcp/src/event-store/schemas.ts`, near L1146:
+   - Define `MergePreflightDebugData = z.object({ gitVersion: z.string(), repoRoot: z.string(), worktreeList: z.string(), refsHeadsSource: z.object({sha: z.string(), packed: z.boolean()}), refsHeadsTarget: z.object({sha: z.string(), packed: z.boolean()}), mergeBaseCommand: z.array(z.string()), mergeBaseExitCode: z.number(), mergeBaseStdout: z.string(), mergeBaseStderr: z.string() })`.
+   - Add `debug: MergePreflightDebugData.optional()` to `MergePreflightData`.
+2. Re-run T2.4 → both cases GREEN.
+3. NOTE: No separate action-output registration needed — `merge.preflight` is appended to the event store directly (see `merge-orchestrate.ts:533`); the action that handles `merge_orchestrate` registers `outputSchema: EnvelopeSchema(z.unknown())` at the dispatch layer, NOT against this event schema. The event schema and the action's outputSchema are decoupled. Reviewer should verify this decoupling holds (the alternative would be a typed `EnvelopeSchema<MergeOrchestrateResult>` which is out of scope for preview.3).
+
+**File:** `servers/exarchos-mcp/src/event-store/schemas.ts`.
+**Expected outcome:** Schema accepts debug field; backwards compatible; event store appends validate.
+**Dependencies:** T2.4.
+**Parallelizable:** No.
+
+### Task 2.6: Unit test mergePreflight env-var integration (RED)
+
+**Phase:** RED
+
+1. Append to `servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.test.ts`:
+   - `MergePreflight_EnvUnsetAndAncestryFail_NoDebugField` — `vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', undefined)`, run mergePreflight with mocked ancestry failure, assert result has no `debug`.
+   - `MergePreflight_EnvSetAndAncestryPass_NoDebugField` — `vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', '1')`, run mergePreflight with ancestry passing, assert no `debug` (gating is ancestry-failure-only).
+   - `MergePreflight_EnvSetAndAncestryFail_AttachesDebugBlock` — `vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', '1')`, run mergePreflight with ancestry failure, assert `result.debug` matches `PreflightDebug` shape.
+
+**File:** `servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.test.ts`.
+**Expected failure:** mergePreflight doesn't read env yet.
+**Dependencies:** T2.3, T2.5.
+**Parallelizable:** No.
+
+### Task 2.7: Wire env-var read into mergePreflight (GREEN)
+
+**Phase:** GREEN
+
+1. In `mergePreflight` (same file): after computing `ancestry`, if `process.env.EXARCHOS_PREFLIGHT_DEBUG === '1' && !ancestry.passed`, call `gatherPreflightDebug(...)` and attach to returned result.
+2. Re-run T2.6 → all three cases GREEN.
+
+**File:** `servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts`.
+**Expected outcome:** Env-gated payload behaves correctly.
+**Dependencies:** T2.6.
+**Parallelizable:** No.
+
+### Task 2.8: Update skill doc + regenerate skills tree (GREEN)
+
+**Phase:** GREEN
+
+1. Add a `## Diagnostics` section to `skills-src/merge-orchestrator/SKILL.md` documenting:
+   - `EXARCHOS_PREFLIGHT_DEBUG=1` env var.
+   - When the debug block fires (ancestry failure only).
+   - The 9 fields it carries.
+   - The reporting workflow ("attach to a new issue tagged scope:windows").
+2. Run `npm run build:skills` to regenerate per-runtime variants under `skills/<runtime>/merge-orchestrator/`.
+3. Run `npm run skills:guard` to verify no drift.
+
+**Files:** `skills-src/merge-orchestrator/SKILL.md`, `skills/<runtime>/merge-orchestrator/**` (regenerated).
+**Expected outcome:** Source-of-truth + per-runtime variants both updated; CI guard passes.
+**Dependencies:** T2.7.
+**Parallelizable:** No.
+
+### Task 2.9: Confirm outcome test passes (GREEN)
+
+**Phase:** GREEN
+
+1. Run `npm run test:outcome -- tests/outcome/preflight-debug.test.ts` → must pass.
+2. Run `npm run test:run` (full suite) → no regressions.
+
+**Files:** None modified.
+**Expected outcome:** PR2 ships GREEN end-to-end.
+**Dependencies:** T2.7, T2.8.
+**Parallelizable:** No.
+
+---
+
+## PR3 — Outcome-tier completeness backfill
+
+### Task 3.1: Outcome test for #1360 RESERVED_FIELD discoverability
+
+**Phase:** GREEN (against post-fix production code)
+
+1. Create `tests/outcome/reserved-fields-discoverability.test.ts` (Linux-only):
+   - `Describe_UpdateAction_EnumeratesReservedFields` — call `handleDescribe({actions: ['update']})`, assert response contains a `reservedFields` block with `rule`, `topLevelImmutable`, `underscorePrefixed`, `examples`, `alternateWritePaths`.
+   - `Update_WithReservedTopLevelField_ReturnsStructuredErrorData` — initialise a feature workflow, call `handleUpdate` with `updates: {phase: 'something'}` (reserved), assert `success: false`, `error.code === 'RESERVED_FIELD'`, `error.data.rejectedPath === 'phase'`, `error.data.rule` populated, `error.data.alternateWritePath` is `transition` or `null`.
+   - `Update_WithUnderscorePrefixedField_ReturnsStructuredErrorData` — pass `updates: {_meta: 'x'}`, assert structured error data populated.
+
+**Files:** `tests/outcome/reserved-fields-discoverability.test.ts` (new).
+**Expected outcome:** GREEN against current head (the #1360 fix landed in the polish bundle).
+**Dependencies:** None.
+**Parallelizable:** Yes (with T3.2, T3.3, T3.4).
+
+### Task 3.2: Outcome test for #1363 MERGE_ORCHESTRATION runbook
+
+**Phase:** GREEN (against post-fix production code)
+
+1. Create `tests/outcome/runbook-merge-orchestration.test.ts` (Linux-only):
+   - `Runbook_MergePendingPhase_ReturnsCanonicalFourEventSequence` — call `handleRunbook({phase: 'merge-pending'})`, assert `success: true`, `data` is a non-empty array, the four-event canonical sequence (`merge.requested → merge.preflight → merge.executed → merge.completed`) appears in order with expected event types.
+   - `Runbook_OtherPhases_StillPopulated` — quick check that `task-completion`, `quality-evaluation`, `synthesis-flow` phases still return non-empty payloads (regression guard against the registry change).
+
+**File:** `tests/outcome/runbook-merge-orchestration.test.ts` (new).
+**Expected outcome:** GREEN against current head (the #1363 fix landed).
+**Dependencies:** None.
+**Parallelizable:** Yes (with T3.1, T3.3, T3.4).
+
+### Task 3.3: Outcome test for #1364 telemetry action-errors split
+
+**Phase:** GREEN (against post-fix production code)
+
+1. Create `tests/outcome/telemetry-action-errors.test.ts` (Linux-only):
+   - `Telemetry_AfterStructuredFailure_IncrementsActionErrorsNotTransportErrors` — initialise a feature workflow, drive an `update` with a reserved field (`{phase: 'x'}`) which now returns a structured failure envelope, call `handleViewTelemetry`, assert `actionErrors >= 1` AND transport `errors === 0`.
+   - `Telemetry_ActionErrorBreakdown_KeyedByErrorCode` — same scenario, assert `actionErrorBreakdown['RESERVED_FIELD'] >= 1`.
+   - `Telemetry_AfterJsThrow_IncrementsTransportErrors` — induce a JS throw (e.g., call an unknown action), assert transport `errors >= 1` AND `actionErrors === 0` for that call.
+
+**File:** `tests/outcome/telemetry-action-errors.test.ts` (new).
+**Expected outcome:** GREEN against current head (the #1364 fix landed).
+**Dependencies:** None.
+**Parallelizable:** Yes (with T3.1, T3.2, T3.4).
+
+### Task 3.4: Update outcome helpers README coverage matrix
+
+**Phase:** GREEN (documentation)
+
+1. Edit `tests/outcome/_helpers/README.md`:
+   - Add a "Coverage matrix" section listing all 8 dogfood findings + the 4 new AOC carriers, with a `✅/—` column indicating outcome-tier coverage.
+   - Cross-link each test file.
+   - Note which findings are out-of-scope for the Linux outcome tier (#1362 Windows reproduction).
+
+**File:** `tests/outcome/_helpers/README.md`.
+**Expected outcome:** Matrix accurate at the post-PR3 state.
+**Dependencies:** T3.1, T3.2, T3.3.
+**Parallelizable:** No (depends on the three test files existing).
+
+---
+
+## Parallelization summary
+
+```
+Wave 0: Dispatch three agents concurrently (one PR each)
+  ├ agent-pr1-1374:    T1.1 → T1.2 → T1.3 → T1.4
+  ├ agent-pr2-1362:    T2.1 ‖ T2.2 → T2.3 → T2.4 → T2.5 → T2.6 → T2.7 → T2.8 → T2.9
+  └ agent-pr3-backfill: (T3.1 ‖ T3.2 ‖ T3.3) → T3.4
+
+Wave 1: Merge bottom-up after all agents complete
+  PR1 squash-merge → PR2 squash-merge → PR3 squash-merge
+                                            └─ partially closes #1354
+                                              (#1365 stays open for the
+                                              eval-suite redesign)
+```
+
+**Coordination contracts between PRs:**
+- PR2's `MergePreflightDebugData` schema delta is self-contained in `event-store/schemas.ts`. No PR-to-PR dependency at the orchestrator level; each PR is self-contained.
+- PR1 must land before the saga test re-runs in the CI matrix for PR2-3 (otherwise they inherit RED). If PR1 fix takes long, the other PRs can still develop on top of `feature/v2-10-0-preview-3-closeout` by rebasing onto PR1's head once it lands.
+
+## Acceptance gates
+
+- [ ] All 17 tasks complete with passing tests.
+- [ ] `test/process/saga-merge-detour.test.ts` GREEN on PR1.
+- [ ] `tests/outcome/preflight-debug.test.ts` GREEN on PR2.
+- [ ] `tests/outcome/{reserved-fields-discoverability,runbook-merge-orchestration,telemetry-action-errors}.test.ts` all GREEN on PR3.
+- [ ] `npm run skills:guard` clean.
+- [ ] `npm run typecheck` clean across all three PRs.
+- [ ] `npm run test:run` (full suite) green at each merge step.
+- [ ] #1354 epic body checkboxes updated (#1374, #1362 ticked); epic partially closes on PR3 merge (#1365 stays open).
+- [ ] Follow-up issue filed for #1362 phase 2 (Windows root cause; awaits debug-payload data from a Windows host).
+- [ ] Eval-suite redesign seed doc written (`docs/research/2026-05-15-eval-suite-redesign-seed.md`).
+- [ ] Comment posted on #1365 / #1396 / #1397 noting the redesign direction.
+
+## Out of scope reminders
+
+- **#1365 eval-suite elevation** — entire scope deferred to eval-suite redesign. See seed doc.
+- Windows root-cause fix for #1362 (phase 2 — separate issue after Phase 1 data arrives).
+- Refactoring `next-actions-from-result.ts` beyond PR1's minimum delta.
+- Adding outcome-tier coverage that reproduces the Windows-specific preflight bug (Linux-only tier).
+
+## Open questions resurfaced from design (resolved at plan-review)
+
+1. `gatherPreflightDebug` symmetry — locked at **failure-only** (Phase 1). DIM-8 / event-store growth concern. Phase 2 may introduce `EXARCHOS_PREFLIGHT_DEBUG=2` verbose sub-mode.
+2. `console.error` instrumentation in T1.2 — **authorized** as temporary diagnostic; T1.3 mandates removal before commit. PR1 review must confirm no instrumentation slipped past T1.3.

--- a/docs/research/2026-05-15-eval-suite-redesign-seed.md
+++ b/docs/research/2026-05-15-eval-suite-redesign-seed.md
@@ -8,7 +8,7 @@
 
 ## TL;DR
 
-The eval suite needs a fundamental redesign, not just elevation. Our `{{TOKEN}}` placeholder system in `skills-src/` encodes **harness mechanics** (tool names, command verbs, hook surfaces), not behavioral intent. Today's runtime-agnostic JSONL trace-replay tier conflates two distinct concerns — *did the agent pick the right behavior?* and *did the harness substitution produce a runnable form?* — and as a result tests neither cleanly. Six of 18 skills are covered; the missing 11 include every operator-facing surface that ships PRs.
+The eval suite needs a fundamental redesign, not just elevation. Our `{{TOKEN}}` placeholder system in `skills-src/` encodes **harness mechanics** (tool names, command verbs, hook surfaces), not behavioral intent. Today's runtime-agnostic JSONL trace-replay tier conflates two distinct concerns — *did the agent pick the right behavior?* and *did the harness substitution produce a runnable form?* — and as a result tests neither cleanly. Six of 17 skills are covered (the `skills-src/` tree has 19 entries: 17 actual skill directories plus `_shared` (cross-skill helpers) and `SKILL_AUTHORING.md` (an authoring doc), both excluded from the skill count); the missing 11 include every operator-facing surface that ships PRs.
 
 Reshape into **two distinct suites**:
 
@@ -25,7 +25,7 @@ The 2026-05-13 Windows dogfood session surfaced 8 findings; every gate verified 
 
 During preview.3 plan-review three observations converged:
 
-1. **Catalog gap was bigger than expected.** Measuring against `skills-src/`: 6 of 18 skills have eval suites. The missing 11 include `synthesis` (PR creation), `shepherd` (CI review and merge), `merge-orchestrator` (heaviest skill at 12 KB), `cleanup`, `oneshot-workflow`, `workflow-state`. Filing #1397 surfaced this scale.
+1. **Catalog gap was bigger than expected.** Measuring against `skills-src/`: 6 of 17 actual skill directories have eval suites (the `skills-src/` listing contains 19 entries — 17 skill dirs plus `_shared` and `SKILL_AUTHORING.md` which are not skills). The missing 11 include `synthesis` (PR creation), `shepherd` (CI review and merge), `merge-orchestrator` (heaviest skill at 12 KB), `cleanup`, `oneshot-workflow`, `workflow-state`. Filing #1397 surfaced this scale.
 
 2. **`{{TOKEN}}` placeholders are harness mechanics.** Looking at `runtimes/<runtime>.yaml` substitutions, the tokens are tool names (`Edit` vs `apply_patch`), command verbs (`Bash` vs `shell`), hook surfaces, filesystem paths, permission rules. **The behavioral intent of a skill is unchanged across runtimes; only the harness-facing verbs change.** Evaluating each rendered SKILL.md with a live LLM is triple-counting the same behavior under different vocabularies — wasteful, and worse, it muddles "did the skill teach the right behavior?" with "did the harness substitution produce a runnable form?"
 
@@ -251,7 +251,7 @@ servers/exarchos-mcp/src/harness-surface/
 └ sync-command.ts            (fetches upstream catalog → lockfile diff)
 
 tests/harness-surface/
-├ <runtime>/<skill>.test.ts  (one per skill × runtime = ~108 tests for 18 skills × 6 runtimes)
+├ <runtime>/<skill>.test.ts  (one per skill × runtime = ~108 tests for 17 skills × 6 runtimes)
 ```
 
 CI integration: new workflow `.github/workflows/harness-surface.yml` runs on every PR. Fast (no LLM, no network); blocking on red.
@@ -368,7 +368,7 @@ A four-phase migration is plausible:
 **Phase 1 — Tier A foundation (Linux-only, no LLM cost):**
 - Build `harness-surface/` module.
 - Author manifests for all 6 runtimes (snapshot current catalogs).
-- Generate the ~108 tests (18 skills × 6 runtimes).
+- Generate the ~108 tests (17 skills × 6 runtimes).
 - Wire CI workflow.
 - Land on its own — gates rendering drift immediately.
 

--- a/docs/research/2026-05-15-eval-suite-redesign-seed.md
+++ b/docs/research/2026-05-15-eval-suite-redesign-seed.md
@@ -1,0 +1,465 @@
+# Eval-Suite Redesign — Context Seed for Next Ideation Pass
+
+**Status:** Pre-ideate seed. Captures the framing decided during preview.3 plan-review on 2026-05-15. Inputs for a future `/exarchos:ideate` workflow on the eval-suite redesign.
+**Author:** rsalus + Claude (preview.3 plan-review session)
+**Supersedes:** the original #1365 step-1+2 design (versioned datasets + HTML dashboard) — pulled from preview.3 because it builds on an architecture we now intend to replace.
+
+---
+
+## TL;DR
+
+The eval suite needs a fundamental redesign, not just elevation. Our `{{TOKEN}}` placeholder system in `skills-src/` encodes **harness mechanics** (tool names, command verbs, hook surfaces), not behavioral intent. Today's runtime-agnostic JSONL trace-replay tier conflates two distinct concerns — *did the agent pick the right behavior?* and *did the harness substitution produce a runnable form?* — and as a result tests neither cleanly. Six of 18 skills are covered; the missing 11 include every operator-facing surface that ships PRs.
+
+Reshape into **two distinct suites**:
+
+- **Tier A — Harness-surface tests** (objective, runtime-specific, no LLM): schema-validate each rendered `skills/<runtime>/<skill>/SKILL.md` against a versioned harness manifest (tools, commands, hooks, paths). Deterministic. Fast. Catches rendering drift across all 6 runtimes.
+- **Tier B — Behavioral evals** (runtime-agnostic, dotnet/skills pattern): one eval suite per skill, live LLM sessions, pairwise judging (with-skill vs baseline), overfitting detection. Measures behavioral *impact*, not just trace conformance.
+
+The trickiest design problem is **harness versioning** — each runtime ships catalog updates independently; the manifest needs to be pinned, drift-detectable, and bidirectional.
+
+---
+
+## Why now
+
+The 2026-05-13 Windows dogfood session surfaced 8 findings; every gate verified that the code matched the spec. Nothing verified that the spec matched reality. Wave 1 (#1358) introduced the outcome-tier to catch operator-visible behavior. The next thing to land was #1365 — eval-suite elevation steps 1–2 (versioned dataset baselines + HTML dashboard from CI), modeled on `github.com/dotnet/skills`.
+
+During preview.3 plan-review three observations converged:
+
+1. **Catalog gap was bigger than expected.** Measuring against `skills-src/`: 6 of 18 skills have eval suites. The missing 11 include `synthesis` (PR creation), `shepherd` (CI review and merge), `merge-orchestrator` (heaviest skill at 12 KB), `cleanup`, `oneshot-workflow`, `workflow-state`. Filing #1397 surfaced this scale.
+
+2. **`{{TOKEN}}` placeholders are harness mechanics.** Looking at `runtimes/<runtime>.yaml` substitutions, the tokens are tool names (`Edit` vs `apply_patch`), command verbs (`Bash` vs `shell`), hook surfaces, filesystem paths, permission rules. **The behavioral intent of a skill is unchanged across runtimes; only the harness-facing verbs change.** Evaluating each rendered SKILL.md with a live LLM is triple-counting the same behavior under different vocabularies — wasteful, and worse, it muddles "did the skill teach the right behavior?" with "did the harness substitution produce a runnable form?"
+
+3. **dotnet/skills doesn't have our templating problem.** Their skills are single-form: one `SKILL.md` per skill, ships to GitHub Copilot (and other runtimes via plugin manifests) unchanged. Their evals can test "the rendered prose" because there's only one rendering. We render to 6 runtimes from one source; our evals have to either test the abstract behavior (current approach, no rendering verification) or test all 6 renderings (six-fold cost). Neither is right.
+
+Shipping #1365 steps 1+2 against the current eval format means migrating both immediately after the redesign lands. Pull from preview.3, design the right thing once, ship it once.
+
+---
+
+## Current state inventory
+
+### What exists at HEAD (2026-05-15)
+
+**Eval data files:**
+```
+evals/
+├ <skill>/suite.json + datasets/{regression,capability,golden}.jsonl  (6 skills only)
+├ datasets/                  (does not exist yet — was the #1365 step 1 target)
+├ captured/                  (trace recordings — *.trace.jsonl)
+├ calibration/gold-standard.jsonl
+└ reliability/datasets/{regression,compaction-behavioral}.jsonl
+```
+
+**Runtime:** `servers/exarchos-mcp/src/evals/`
+- `harness.ts` — orchestrator; runs `runAll()` across suites.
+- `dataset-loader.ts` — JSONL parser, schema-validates each line against `EvalCaseSchema`.
+- `comparison.ts` — trace-comparison primitives.
+- `graders/` — assertion-grader implementations (tool-call, trace-pattern, exact-match, llm-rubric, llm-similarity).
+- `calibration-metrics.ts` + `calibration-split.ts` — grader agreement tracking.
+- `reporters/` — `cli-reporter.ts` + `ci-reporter.ts` (GitHub Actions `::error::` / `::notice::`).
+- `auto-triage.ts`, `deduplication.ts`, `trace-capture.ts` — meta machinery.
+- `run-evals-cli.ts` — stdin-JSON entrypoint, invoked by CI.
+
+**CI:** `.github/workflows/eval-gate.yml`
+- Triggers on `pull_request` with path-filter on `skills/`, `commands/`, `rules/`, `evals/`, `servers/exarchos-mcp/src/{workflow/playbooks.ts,cli-commands,orchestrate/prepare-delegation.ts,evals}`, the workflow file itself.
+- Two layers — `regression` (blocking exit code), `capability` (advisory; `continue-on-error: true`).
+- Runs `bun dist/evals/run-evals-cli.js` with `{ci: true, layer: <name>}` over stdin.
+- Self-hosted runner; `ANTHROPIC_API_KEY` secret; 15-minute timeout.
+- **No fork-PR security model.** **No daily schedule.** **No Pages publication.**
+
+### Skill catalog (18 source dirs)
+
+```
+WITH evals (6):     brainstorming, debug, delegation, implementation-planning,
+                    quality-review, refactor
+WITHOUT evals (11): cleanup, discovery, dogfood, git-worktrees, merge-orchestrator,
+                    oneshot-workflow, prune-workflows, shepherd, spec-review,
+                    synthesis, workflow-state
+```
+
+(`_shared` and `SKILL_AUTHORING.md` excluded as non-skills.)
+
+### Existing assertion types
+
+From the 6 live suites:
+
+- `tool-call` (correctness, required calls in trace)
+- `trace-pattern` (event-sequence match, ordered/unordered)
+- `exact-match` (artifact paths)
+- `llm-rubric` (LLM judge against a written rubric)
+- `llm-similarity` (LLM-judged similarity between actual and expected output)
+
+All assertions run against simulated traces in the JSONL `input.tool_calls + input.trace_events` segments — **not** against live LLM responses. The two `llm-*` types call the LLM for grading, not for behavior production.
+
+---
+
+## dotnet/skills implementation (verified from `github.com/dotnet/skills` 2026-05-15)
+
+### Architecture
+
+**Eval data:** `tests/<plugin>/<skill>/eval.yaml` (canonical) + `eval.vally.yaml` (Vally adapter). YAML, not JSONL. Each carries `scenarios` (or `stimuli`) with free-text `prompt`, an `assertions` array, and a `rubric` array.
+
+Example (`tests/dotnet-ai/mcp-csharp-create/eval.yaml`):
+
+```yaml
+scenarios:
+  - name: "Implement MCP tools with proper attributes and DI"
+    prompt: |
+      I have a new C# MCP server project. I need to implement a tool class that...
+    assertions:
+      - type: "output_matches"
+        pattern: "\\[McpServerTool[\\],\\(]"
+      - type: "output_matches"
+        pattern: "(AddHttpClient|HttpClient)"
+    rubric:
+      - "Shows a tool class with [McpServerTool] attributes"
+      - "Injects HttpClient via DI..."
+    timeout: 360
+```
+
+**Runner:** `eng/skill-validator/` — .NET CLI with `Evaluate/` package containing:
+- `AgentRunner.cs` — for each scenario, spins up a **live LLM session** with the skill loaded and the prompt as input. Captures response + metrics.
+- `Judge.cs` — sends captured response + rubric to an LLM judge (currently `claude-opus-4.6`). Returns per-rubric-item pass/fail with reasoning. **Denies all tool permissions during judging** (`onPermissionRequest` returns deny) — judging must be a pure LLM task with no file or tool side effects.
+- `PairwiseJudge.cs` — runs the scenario TWICE: with-skill and baseline-without-skill. Asks the judge which is better. **Position-swap bias mitigation: A-then-B and B-then-A, checks consistency.**
+- `OverfittingJudge.cs` — analyzes the skill content + eval cases together. Detects when an eval is testing the literal SKILL.md prose instead of the underlying behavior. Anti-cheat at the eval-design level. 48 KB skill-content cap (~12K tokens).
+- `Reporter.cs` + `SessionDatabase.cs` + `Statistics.cs` — persist runs, time-series, surface in dashboard.
+
+**CI:** `.github/workflows/evaluation.yml`
+- Multi-trigger: `pull_request`, `pull_request_target` (for fork security), `issue_comment` (`/evaluate` command, requires write-permission), `schedule: '0 0 * * *'` (daily).
+- PR-status job posts "success" (no skill changes) or "pending" (needs `/evaluate`) so required-check doesn't dangle.
+- **Fork security model is explicit and two-tier:** workflow YAML always loaded from `main`; validator binary built from `main` for forks, from PR branch for same-repo PRs; skill content checked out from the fork PR as untrusted data.
+- Model pinning: `MODEL: claude-opus-4.6`, `JUDGE_MODEL: claude-opus-4.6` as env vars.
+- Daily scheduled runs.
+
+**Dashboard:** `eng/dashboard/dashboard.html` + `dashboard.js` + `token-usage.js`. Generated by `generate-benchmark-data.ps1`. Published to GitHub Pages with 14-day retention via `DASHBOARD_RETENTION_DAYS: 14`.
+
+**Validator self-tests:** `eng/skill-validator/tests/Check/` + `tests/Evaluate/` — unit tests of the eval framework itself. Coverage includes `EvalDiscoveryTests`, `EvalSchemaTests`, `FailureIsolationTests`, `JudgeTests`, `OverfittingJudgeTests`, `AssertionsTests`, `ComparatorTests`.
+
+### Where dotnet/skills is ahead of us
+
+| Capability | dotnet/skills | exarchos |
+|---|---|---|
+| Live LLM session per case | ✅ Every scenario | ❌ Only `llm-*` assertion grading |
+| Pairwise judging (proof-of-skill vs baseline) | ✅ With position-swap bias mitigation | ❌ |
+| Overfitting detection | ✅ Dedicated judge | ❌ |
+| Versioned datasets | Implicit (PR YAML diffs) | ❌ (was #1365 step 1) |
+| HTML dashboard | ✅ Pages-published, 14-day retention | ❌ (was #1365 step 2) |
+| Daily scheduled runs | ✅ | ❌ |
+| Fork-PR security model | ✅ Two-tier | ❌ |
+| Self-tests of the framework | ✅ `eng/skill-validator/tests/` | Partial (`*.test.ts` co-located) |
+
+### Where exarchos has a harder problem
+
+| Dimension | dotnet/skills | exarchos |
+|---|---|---|
+| Multi-runtime templating | ❌ Single SKILL.md per skill | ✅ 6 runtime variants from `{{TOKEN}}` substitution |
+| Multi-tier composition | Test pyramid + eval | Unit / integration / process / outcome / eval |
+| Calibration mechanics | Implicit (judge consistency) | Explicit (`calibration-metrics.ts`) |
+| Trace-based assertion replay | Not used | Used everywhere |
+
+---
+
+## The `{{TOKEN}}` insight (sharpening)
+
+A representative substitution map (from `runtimes/<runtime>.yaml`):
+
+| Concept | claude | codex | copilot | cursor | opencode | generic |
+|---|---|---|---|---|---|---|
+| Edit a file | `Edit` | `apply_patch` | `editFile` | `edit_file` | `edit_file` | `<file_edit>` |
+| Run shell | `Bash` | `shell` | `terminal` | `run_terminal_cmd` | `bash` | `<shell>` |
+| Plugin path | `~/.claude/plugins/` | `~/.codex/plugins/` | `…` | `…` | `…` | `<plugin_dir>` |
+
+**Observation:** these are *injective renames* — Edit always becomes apply_patch in codex; Bash always becomes shell. They don't change *what* the agent does (modify a file, run a command); they only change *the verb used to express it*.
+
+**Implication:** an eval that says "the agent should edit a file when asked to fix a bug" tests the same behavior in all 6 runtimes. There's exactly one behavioral assertion to make. But there are 6 surface-level vocabulary checks to make — does the rendered prose reference the verb correctly in each runtime?
+
+**Right architecture:**
+
+1. **Tier A — Harness-surface tier.** For each rendered `skills/<runtime>/<skill>/SKILL.md`, schema-validate every harness-primitive reference against the runtime's declared catalog. Deterministic. Fast. Unit-tier speed. Catches the entire rendering-drift class without one LLM call.
+
+2. **Tier B — Behavioral tier.** Test against a single canonical rendering (probably `skills/claude/<skill>/SKILL.md` since that's the primary author target, or a designated "behavioral source" derived from `skills-src/<skill>/SKILL.md`). LLM-based, dotnet/skills pattern: live sessions + pairwise judging + overfitting detection. **One eval suite per behavioral skill, not per runtime.**
+
+---
+
+## Tier A — Harness-surface tests (proposed)
+
+### What the manifest looks like
+
+Extend `runtimes/<runtime>.yaml` with a harness-catalog block:
+
+```yaml
+# runtimes/claude.yaml
+name: claude
+harnessVersion: "claude-code@2.x"   # pinned version range
+harnessLockfile: claude-harness-2x.lock.json  # sibling file with exact catalog
+
+# In claude-harness-2x.lock.json:
+{
+  "harnessVersion": "claude-code@2.4.1",
+  "lockedAt": "2026-05-15T00:00:00Z",
+  "tools": [
+    { "name": "Edit", "description": "...", "params": [...] },
+    { "name": "Read", ... },
+    ...
+  ],
+  "commands": [
+    { "name": "/clear", ... },
+    { "name": "/help", ... },
+    ...
+  ],
+  "hooks": ["TaskCreate", "TaskUpdate", ...],
+  "permissions": {...},
+  "paths": {
+    "pluginDir": "~/.claude/plugins/",
+    "skillsDir": ".claude/skills/",
+    ...
+  }
+}
+```
+
+### What Tier A asserts
+
+For each `skills/<runtime>/<skill>/SKILL.md`:
+
+1. **Tool references resolve.** Every backticked `Tool` or `<tool>` reference matches an entry in the runtime's `tools[]`.
+2. **Command references resolve.** Every `/command` reference appears in `commands[]`.
+3. **Hook references resolve.** Every hook-name reference appears in `hooks[]`.
+4. **Path conventions hold.** Every `~/foo` or `.bar/baz` path matches the runtime's `paths[]` conventions.
+5. **No drift between source and rendered.** `npm run build:skills` produces output identical to what's committed (this is the existing `skills:guard` check; pair it with Tier A).
+
+### Bidirectional drift detection
+
+Tier A flags two failure modes:
+
+- **Skill references a token not in the manifest** — the substitution table is missing a verb; or the skill author hand-typed a verb that doesn't exist; or the harness deprecated something we still cite.
+- **Manifest declares a token no skill uses** — informational; surfaces "harness added something; should we be using it?" Doesn't fail CI by default.
+
+### Harness versioning protocol
+
+- Each runtime's `harnessLockfile` is the source of truth for the catalog AT a pinned version.
+- **Update path:** when upstream ships a new version, run a maintenance command (e.g., `npm run runtimes:sync claude`) that re-fetches the catalog and produces a diff. Authors review and merge.
+- **CI sync job (optional):** scheduled weekly to re-fetch upstream and open an automated PR if drift detected. Or manual-trigger only.
+- **Multiple harness versions:** support range pinning — e.g., `claude-code@2.x` validates against the latest 2.x catalog, but the lockfile records the exact version that was current at sync time. Major version bumps trigger explicit author review.
+
+### Where Tier A code lives
+
+```
+servers/exarchos-mcp/src/harness-surface/
+├ manifest-loader.ts         (loads runtime YAML + lockfile)
+├ skill-scanner.ts           (extracts harness-primitive references from SKILL.md)
+├ validator.ts               (cross-references scanner output against manifest)
+├ reporter.ts                (human-readable + CI annotation output)
+└ sync-command.ts            (fetches upstream catalog → lockfile diff)
+
+tests/harness-surface/
+├ <runtime>/<skill>.test.ts  (one per skill × runtime = ~108 tests for 18 skills × 6 runtimes)
+```
+
+CI integration: new workflow `.github/workflows/harness-surface.yml` runs on every PR. Fast (no LLM, no network); blocking on red.
+
+---
+
+## Tier B — Behavioral evals (proposed)
+
+### Pattern: dotnet/skills, adapted
+
+**Eval data file:** one YAML per skill at `evals/<skill>/eval.yaml` (replaces today's `suite.json + datasets/*.jsonl` split):
+
+```yaml
+name: synthesis
+description: Evaluates the synthesis skill (PR creation)
+type: capability
+config:
+  timeout: 6m
+scenarios:
+  - name: "Synthesize a feature PR with no test plan section"
+    prompt: |
+      I have a feature branch with one new file (feat.ts) and three new tests.
+      The user said to create the PR. Walk through synthesis.
+    graders:
+      - type: tool-call
+        config:
+          required:
+            - tool: exarchos_orchestrate
+              action: synthesize
+      - type: pairwise        # with-skill vs baseline-without-skill
+      - type: judge           # rubric-graded
+    rubric:
+      - "Notices missing test_plan section and either generates one or asks user"
+      - "Does not create a PR with empty body"
+      - "Mentions all three new test files in the PR body"
+  - name: "Refuse to synthesize from a dirty worktree"
+    prompt: |
+      I have uncommitted changes in two files and asked you to create the PR.
+    graders:
+      - type: tool-call
+        config:
+          forbidden:
+            - tool: exarchos_orchestrate
+              action: synthesize    # MUST NOT call synthesize on dirty tree
+      - type: judge
+    rubric:
+      - "Explicitly notices the dirty worktree"
+      - "Refuses to proceed and explains why"
+      - "Suggests either committing or stashing"
+```
+
+**Runner:** new TS module at `servers/exarchos-mcp/src/behavioral-evals/`:
+- `agent-runner.ts` — spins live LLM session with skill loaded, runs prompt, captures response + metrics. (Equivalent to dotnet's `AgentRunner.cs`.)
+- `judge.ts` — rubric-grading LLM call; permissions denied. (Equivalent to dotnet's `Judge.cs`.)
+- `pairwise-judge.ts` — runs scenario twice (with-skill, baseline), judges with A-then-B + B-then-A. (Equivalent to dotnet's `PairwiseJudge.cs`.)
+- `overfitting-judge.ts` — analyzes eval against skill content for over-tuning. (Equivalent to dotnet's `OverfittingJudge.cs`.)
+
+**Eval source:** for runtime-agnosticism, evals run against a designated canonical rendering — likely `skills/claude/<skill>/SKILL.md` since Claude is the primary author target. Alternative: a "behavioral source" pre-substitution form that strips harness verbs entirely (treats them as opaque tokens). First decision point for the next ideation pass.
+
+**Migration:** the 6 existing eval suites get rewritten to the new format. Trace-replay assertions don't carry over — Tier B is live-LLM only. Some of today's capability cases may collapse into a single richer scenario; others may split.
+
+---
+
+## Cross-cutting concerns
+
+### 1. Harness version migrations
+
+When a harness ships a new version with renamed or removed verbs:
+
+- Tier A's lockfile sync surfaces the diff.
+- Authors edit `runtimes/<runtime>.yaml`'s substitution map to point at the new verb.
+- `npm run build:skills` regenerates `skills/<runtime>/**`.
+- `skills:guard` passes; Tier A passes against the new lockfile.
+- Tier B is **unaffected** because it tests behavioral intent, not verb names.
+
+This is the key property: harness churn doesn't touch Tier B. Authoring effort is roughly O(skills) once, not O(skills × harness versions × runtimes).
+
+### 2. Multiple model evaluations
+
+dotnet/skills pins one model (`claude-opus-4.6`). For Tier B, we have a choice:
+
+- Pin one model (operating cost lowest; reflects production posture).
+- Run across a small panel (Opus + Sonnet + Haiku) and surface per-model pass rates (catches model regressions; ~3x cost).
+- Hybrid: pin one model in CI; run the panel weekly on a schedule.
+
+Recommendation: pin one in CI; panel weekly on schedule. Second decision point.
+
+### 3. Fork-PR security
+
+dotnet/skills' two-tier model is sophisticated and worth borrowing wholesale:
+
+- Workflow YAML always from `main` (enforced by `issue_comment` and `pull_request_target` trigger semantics).
+- Tier A binary built from `main` for forks, from PR branch for same-repo PRs.
+- Tier B binary same posture.
+- Skill content checked out from fork PR as untrusted data; never executed, only loaded as text.
+- Secret access (LLM API keys) gated by write-permission check.
+
+### 4. Existing 6 eval suites — migration plan
+
+Wave A (paired with Tier B framework): rewrite the 6 existing suites (`brainstorming`, `debug`, `delegation`, `implementation-planning`, `quality-review`, `refactor`) to the new `eval.yaml` format. Drop trace-replay; lift the rubric items into LLM-judged form.
+
+Wave B+C: the 11 missing skills get suites in the new format (this is the original #1397 scope, redirected).
+
+### 5. The captured-traces directory
+
+`evals/captured/*.trace.jsonl` exists today as a side-channel for behavior recording. Under the new architecture this is **unused for assertion purposes**. Keep it for diagnostic / offline analysis, or retire it. Decision point.
+
+---
+
+## Migration sequencing (rough)
+
+A four-phase migration is plausible:
+
+**Phase 1 — Tier A foundation (Linux-only, no LLM cost):**
+- Build `harness-surface/` module.
+- Author manifests for all 6 runtimes (snapshot current catalogs).
+- Generate the ~108 tests (18 skills × 6 runtimes).
+- Wire CI workflow.
+- Land on its own — gates rendering drift immediately.
+
+**Phase 2 — Tier B foundation (LLM cost begins):**
+- Build `behavioral-evals/` runner with `AgentRunner` + `Judge`.
+- Migrate ONE existing suite (probably `delegation` since it's the canonical workflow skill) to the new format as the proof-of-concept.
+- Wire CI workflow for Tier B; pin one model.
+
+**Phase 3 — Wave A migration:**
+- Migrate remaining 5 existing suites.
+- Add `PairwiseJudge` + `OverfittingJudge`.
+- Add HTML dashboard against new format.
+- Add fork-PR security model.
+
+**Phase 4 — Wave B+C catalog completion:**
+- Write Tier B suites for the 11 missing skills.
+- Add daily scheduled runs.
+- Pages publication of dashboard.
+
+Each phase is plausibly 1-2 weeks. Total 6-8 weeks of focused work; likely longer with interleaved review cycles. Target: v2.11 substrate, possibly slipping into v2.12.
+
+---
+
+## Open questions for the next ideate pass
+
+1. **Where does the behavioral source live?** Three options:
+   - (a) `skills/claude/<skill>/SKILL.md` as the canonical rendering (pins to Claude's vocabulary).
+   - (b) A new "behavioral-only" pre-substitution form (verb tokens explicit but unresolved).
+   - (c) Test against the AST/structured form of the skill (not prose).
+
+2. **Tier A scope decisions:**
+   - Strict matching vs fuzzy? (`Edit` vs `edit_file` — do we normalize first?)
+   - Mention vs invocation? (Does a backtick mention count, or only verb-pattern invocations?)
+   - Strict or advisory on the "manifest declares something no skill uses" direction?
+
+3. **Tier B graders:** which subset of dotnet/skills' judges to ship in phase 2?
+   - Minimum: `Judge` (rubric grading).
+   - Recommended: + `PairwiseJudge` (proof-of-skill).
+   - Stretch: + `OverfittingJudge` (anti-cheat).
+
+4. **Pairwise judging baseline definition:** what does "without skill" mean exactly?
+   - No SKILL.md loaded at all? (Tests skill presence vs absence.)
+   - SKILL.md loaded but rubric items stripped? (Tests guidance vs no guidance.)
+   - SKILL.md replaced with a generic "be helpful" prompt? (Tests skill-specific vs baseline guidance.)
+
+5. **Storage model for runs:** dotnet/skills uses `SessionDatabase.cs` (probably SQLite). We have the Marten event store. Do we record Tier B runs as events? Or use a separate sidecar SQLite?
+
+6. **Model pinning policy:** single-model CI + panel-weekly is the recommendation, but the panel composition needs to be decided (Opus+Sonnet+Haiku, or include open-weight models, or include older Claude versions for regression detection).
+
+7. **Migration semantics for the 6 existing suites:** strict 1:1 case mapping, or open license to redesign? Some current `llm-similarity` assertions don't make sense in a live-LLM world — they test if simulated output matches expected output; live LLM produces actual output, which is what's being graded.
+
+8. **Cost gating:** Tier B is genuinely expensive (live LLM per scenario × N scenarios × pairwise = 2N+ calls per skill). What's the cost ceiling per CI run? Per scheduled run? Where do we draw the line on which evals are blocking vs advisory?
+
+9. **Outcome-tier interaction:** today the outcome tier (`tests/outcome/*`) is binary-correctness; Tier B is behavioral; Tier A is rendering. Is the three-tier picture stable, or does Tier A subsume some current process-tier checks?
+
+10. **Calibration mechanics:** `calibration-metrics.ts` is bespoke. dotnet/skills uses judge-consistency as the calibration signal (when A↔B swap disagrees, the judge is uncalibrated). Keep our explicit calibration, replace it with judge-consistency, or run both?
+
+---
+
+## Cross-references
+
+### Existing issues touched by this redesign
+
+- **#1365** — original "eval-suite elevation (steps 1-2)" issue. Will be retargeted or superseded by the redesign epic. Don't close — measured data still useful.
+- **#1387** — calibration drift gate. Subsumed by Tier B's judge-consistency or supplemented by it. Re-scope.
+- **#1396** — cross-runtime smoke coverage. **Becomes Tier A directly.** This is essentially Tier A under a different name.
+- **#1397** — F5 catalog audit (11 missing skills). **Becomes Wave B+C of the migration** — add Tier B suites for the missing skills in the new format.
+
+All four should get a comment linking to this seed doc + the eventual design doc. Don't close; let the redesign supersede them with new tracking issues.
+
+### Related substrate
+
+- **`evals/captured/`** — trace recordings. Useful as a behavioral baseline for designing scenarios; retire as an assertion source.
+- **`servers/exarchos-mcp/src/evals/calibration-*`** — calibration machinery. May migrate to Tier B's judge stack.
+- **`runtimes/<runtime>.yaml`** — substitution maps. Tier A extends these with harness-catalog blocks.
+- **`skills-src/<skill>/SKILL.md`** — source-of-truth skill prose. Tier B's canonical rendering input.
+- **`skills/<runtime>/<skill>/SKILL.md`** — rendered variants. Tier A's validation target.
+
+### Documentation pointers
+
+- dotnet/skills repository: `github.com/dotnet/skills`
+- dotnet/skills validator: `eng/skill-validator/src/Evaluate/`
+- dotnet/skills CI: `.github/workflows/evaluation.yml`
+- exarchos current eval gate: `.github/workflows/eval-gate.yml`
+- exarchos current eval source: `servers/exarchos-mcp/src/evals/`
+
+---
+
+## Suggested next steps
+
+1. **Run `/exarchos:ideate`** on this seed doc when ready to start the redesign workflow. Inputs are this file + the open questions above. Expected output: design doc at `docs/designs/YYYY-MM-DD-eval-suite-redesign.md`.
+2. **File a tracking epic** before the ideate pass (or as its first artifact) — "epic: eval-suite redesign — two-tier architecture (harness-surface + behavioral)". Link #1365, #1387, #1396, #1397 as inputs.
+3. **Comment on #1365, #1396, #1397** with a pointer to this seed doc (already planned as part of the preview.3 reshape).
+4. **Target milestone:** v2.11.0 — Autonomous Orchestration, or v2.12.0 — Process Lifecycle Verbs, depending on the cost ceiling and time investment the team is willing to commit. Preview.3 close-out itself unblocks the path.

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -2478,6 +2478,72 @@ describe('MergePreflightData', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  // ─── #1362 phase 1 — optional debug branch ────────────────────────────
+  //
+  // The Windows ancestry-mismatch instrumentation attaches a structured
+  // `debug` block to `merge.preflight` events when
+  // `EXARCHOS_PREFLIGHT_DEBUG=1` AND ancestry failed. The branch is
+  // `.optional()` so:
+  //   1. legacy events emitted without it remain parseable
+  //      (`MergePreflightData_WithoutDebugBlock_ValidatesAgainstSchema`).
+  //   2. new events carrying the full payload also parse
+  //      (`MergePreflightData_WithDebugBlock_ValidatesAgainstSchema`).
+  it('MergePreflightData_WithoutDebugBlock_ValidatesAgainstSchema', () => {
+    const result = MergePreflightData.safeParse({
+      taskId: 'T11',
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      passed: false,
+      ancestry: { passed: false, reason: 'ancestry', missing: ['main'] },
+      currentBranchProtection: { blocked: false },
+      worktree: { isMain: true, actual: '/repo', expected: '/repo' },
+      drift: {
+        clean: true,
+        uncommittedFiles: [],
+        indexStale: false,
+        detachedHead: false,
+      },
+      failureReasons: ['ancestry missing: main'],
+    });
+    expect(result.success, JSON.stringify(result)).toBe(true);
+  });
+
+  it('MergePreflightData_WithDebugBlock_ValidatesAgainstSchema', () => {
+    const result = MergePreflightData.safeParse({
+      taskId: 'T11',
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      passed: false,
+      ancestry: { passed: false, reason: 'ancestry', missing: ['main'] },
+      currentBranchProtection: { blocked: false },
+      worktree: { isMain: true, actual: '/repo', expected: '/repo' },
+      drift: {
+        clean: true,
+        uncommittedFiles: [],
+        indexStale: false,
+        detachedHead: false,
+      },
+      failureReasons: ['ancestry missing: main'],
+      debug: {
+        gitVersion: 'git version 2.45.1',
+        repoRoot: 'C:\\repos\\example',
+        worktreeList: 'worktree C:/repos/example\nHEAD a\nbranch refs/heads/main\n',
+        refsHeadsSource: { sha: 'a'.repeat(40), packed: false },
+        refsHeadsTarget: { sha: 'b'.repeat(40), packed: false },
+        mergeBaseCommand: ['git', 'merge-base', '--is-ancestor', 'main', 'feat/x'],
+        mergeBaseExitCode: 1,
+        mergeBaseStdout: '',
+        mergeBaseStderr: '',
+      },
+    });
+    expect(result.success, JSON.stringify(result)).toBe(true);
+    if (result.success) {
+      expect(result.data.debug?.gitVersion).toBe('git version 2.45.1');
+      expect(result.data.debug?.refsHeadsSource.packed).toBe(false);
+      expect(result.data.debug?.mergeBaseExitCode).toBe(1);
+    }
+  });
 });
 
 describe('MergeExecutedData', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -1128,6 +1128,32 @@ const MergePreflightDriftData = z.object({
   detachedHead: z.boolean(),
 });
 
+// #1362 phase 1 — Windows ancestry-mismatch instrumentation. Optional debug
+// payload attached to `merge.preflight` when `EXARCHOS_PREFLIGHT_DEBUG=1`
+// AND ancestry failed. Failure-only gating is deliberate (DIM-8 / event-store
+// growth); verbose sub-modes belong on a separate `=2` channel.
+//
+// Field shape mirrors the `PreflightDebug` TypeScript type in
+// `orchestrate/pure/merge-preflight.ts`. Phase-1 captures the minimal data
+// needed to disambiguate Windows ref-resolution and merge-base failures
+// from filesystem-layer worktree mis-detection; phase-2 may extend.
+const MergePreflightDebugRefData = z.object({
+  sha: z.string(),
+  packed: z.boolean(),
+});
+
+export const MergePreflightDebugData = z.object({
+  gitVersion: z.string(),
+  repoRoot: z.string(),
+  worktreeList: z.string(),
+  refsHeadsSource: MergePreflightDebugRefData,
+  refsHeadsTarget: MergePreflightDebugRefData,
+  mergeBaseCommand: z.array(z.string()),
+  mergeBaseExitCode: z.number().int(),
+  mergeBaseStdout: z.string(),
+  mergeBaseStderr: z.string(),
+});
+
 /**
  * merge.preflight — captures the outcome of the preflight gate run before a
  * candidate merge. Preflight failures DO NOT route through merge.rollback;
@@ -1153,6 +1179,9 @@ export const MergePreflightData = z.object({
   worktree: MergePreflightWorktreeData.optional(),
   drift: MergePreflightDriftData.optional(),
   failureReasons: z.array(z.string()).optional(),
+  // #1362 phase 1 — see MergePreflightDebugData. Optional so legacy events
+  // (and the common ancestry-passing case) remain parseable unchanged.
+  debug: MergePreflightDebugData.optional(),
 });
 
 /**

--- a/servers/exarchos-mcp/src/next-actions-from-result.test.ts
+++ b/servers/exarchos-mcp/src/next-actions-from-result.test.ts
@@ -13,6 +13,8 @@
 import { describe, it, expect } from 'vitest';
 import { nextActionsFromResult } from './next-actions-from-result.js';
 import type { ToolResult } from './format.js';
+import { rehydrationReducer } from './projections/rehydration/reducer.js';
+import type { WorkflowEvent } from './event-store/schemas.js';
 
 function ok(data: unknown): ToolResult {
   return { success: true, data };
@@ -158,5 +160,120 @@ describe('nextActionsFromResult — shape recognition', () => {
       }),
     );
     expect(actions).toEqual([]);
+  });
+});
+
+// ─── #1374 cross-boundary pin: reducer output → nextActionsFromResult ────────
+//
+// Contract source: test/process/saga-merge-detour.test.ts (process tier).
+//
+// The saga test drives a real MCP server through `task_complete` with
+// `result.worktreePath`, then asserts the rehydrate envelope's `next_actions`
+// surfaces `merge_orchestrate`. This unit-tier pin reproduces the SAME
+// contract one tier earlier — no spawn, no IPC — by composing the
+// rehydration reducer (the projection that folds `task.completed{worktreePath}`
+// into `phase: merge-pending`) with `nextActionsFromResult` (the helper that
+// reads the rehydration document's `workflowState` segment to compute the
+// outbound verbs). If the chain breaks at either the reducer's worktree-fold
+// or the result-reader's shape-2 extraction, this test fails before the
+// process-tier saga does — catching a #1208 / #1374-class regression at the
+// unit tier.
+//
+// Why both tests stay: the saga test pins the cross-process JSON contract
+// (MCP envelope shape, stderr/transport plumbing) which this test does not
+// cover; this test pins the in-process projection→reader composition which
+// the saga can only check end-to-end. They sandwich the chain.
+describe('nextActionsFromResult — #1374 cross-boundary pin (reducer ⇒ reader)', () => {
+  function makeEvent<T extends Record<string, unknown>>(
+    type: string,
+    data: T,
+    sequence: number,
+  ): WorkflowEvent {
+    return {
+      streamId: 'pin-1374',
+      sequence,
+      timestamp: '2026-05-15T00:00:00.000Z',
+      type,
+      schemaVersion: '1.0',
+      data,
+    } as WorkflowEvent;
+  }
+
+  it('NextActions_FromReducerProjectedRehydrationDoc_AfterWorktreeBearingTaskCompleted_SurfacesMergeOrchestrate', () => {
+    // GIVEN: a feature workflow folded through `workflow.started` →
+    // `workflow.transition(to=delegate)` → `task.assigned` →
+    // `task.completed{worktreePath}` — the exact event sequence the saga
+    // drives through MCP.
+    let doc = rehydrationReducer.apply(
+      rehydrationReducer.initial,
+      makeEvent(
+        'workflow.started',
+        { featureId: 'pin-1374', workflowType: 'feature' },
+        0,
+      ),
+    );
+    doc = rehydrationReducer.apply(
+      doc,
+      makeEvent('workflow.transition', { from: '', to: 'delegate' }, 1),
+    );
+    doc = rehydrationReducer.apply(
+      doc,
+      makeEvent('task.assigned', { taskId: '001', branch: 'feature/pin-1374-001' }, 2),
+    );
+    doc = rehydrationReducer.apply(
+      doc,
+      makeEvent(
+        'task.completed',
+        { taskId: '001', worktreePath: '/tmp/wt/001', worktree: '.worktrees/001' },
+        3,
+      ),
+    );
+
+    // THEN: the reducer has stamped the merge-pending detour on workflowState
+    expect(doc.workflowState.phase).toBe('merge-pending');
+    expect(doc.workflowState.mergeOrchestrator).toEqual({
+      taskId: '001',
+      phase: 'pending',
+    });
+
+    // WHEN: nextActionsFromResult reads the rehydration document as the
+    // composite tool's `result.data` payload (shape 2)
+    const actions = nextActionsFromResult({ success: true, data: doc });
+
+    // THEN: merge_orchestrate is surfaced with the canonical idempotency key
+    // `<featureId>:merge_orchestrate:<taskId>` — same contract the saga test
+    // (test/process/saga-merge-detour.test.ts) asserts on the live envelope.
+    const mo = actions.find((a) => a.verb === 'merge_orchestrate');
+    expect(mo).toBeDefined();
+    expect(mo?.idempotencyKey).toBe('pin-1374:merge_orchestrate:001');
+  });
+
+  it('NextActions_FromReducerProjectedDoc_TaskCompletedWithoutWorktree_DoesNotSurfaceMergeOrchestrate', () => {
+    // Negative case: no worktree association → reducer leaves phase in
+    // `delegate` → nextActionsFromResult must NOT surface merge_orchestrate.
+    // Pins the gate so a future regression that fires the detour on bare
+    // task.completed events is caught at the unit tier.
+    let doc = rehydrationReducer.apply(
+      rehydrationReducer.initial,
+      makeEvent(
+        'workflow.started',
+        { featureId: 'pin-1374-neg', workflowType: 'feature' },
+        0,
+      ),
+    );
+    doc = rehydrationReducer.apply(
+      doc,
+      makeEvent('workflow.transition', { from: '', to: 'delegate' }, 1),
+    );
+    doc = rehydrationReducer.apply(
+      doc,
+      makeEvent('task.completed', { taskId: '001' }, 2),
+    );
+
+    expect(doc.workflowState.phase).toBe('delegate');
+    expect(doc.workflowState.mergeOrchestrator).toBeUndefined();
+
+    const actions = nextActionsFromResult({ success: true, data: doc });
+    expect(actions.some((a) => a.verb === 'merge_orchestrate')).toBe(false);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.test.ts
@@ -37,7 +37,7 @@
 //       returns `{ success: false, error: { code: 'STATE_CONFLICT' } }`.
 // ────────────────────────────────────────────────────────────────────────────
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { EventStore } from '../event-store/store.js';
 import type { DispatchContext } from '../core/dispatch.js';
 
@@ -341,6 +341,134 @@ describe('handleMergeOrchestrate (T12 — preflight-fail abort)', () => {
     });
     expect(Array.isArray(emitted.data.failureReasons)).toBe(true);
     expect((emitted.data.failureReasons as string[])[0]).toMatch(/ancestry/);
+  });
+});
+
+// ─── #1362 phase 1 — preflight.debug event-wire ─────────────────────────────
+//
+// The helper at `pure/merge-preflight.ts` attaches an optional `debug` field
+// to `MergePreflightResult` when `EXARCHOS_PREFLIGHT_DEBUG=1 && !ancestry.passed`.
+// The schema at `event-store/schemas.ts:MergePreflightData.debug` declares an
+// optional `MergePreflightDebugData` branch. The handler is the missing link:
+// these tests assert that `preflight.debug`, when present on the helper's
+// return value, is threaded through to `event.data.debug` on the appended
+// `merge.preflight` event. Without this assertion the regression class
+// (helper produces debug, schema accepts debug, but handler silently drops
+// it) is invisible — `tests/outcome/preflight-debug.test.ts` only exercises
+// the pure helper's return value and never inspects the appended event.
+const FAILING_PREFLIGHT_WITH_DEBUG: MergePreflightResult = {
+  ...FAILING_PREFLIGHT,
+  debug: {
+    gitVersion: 'git version 2.45.0',
+    repoRoot: '/repo',
+    worktreeList: 'worktree /repo\nHEAD abc\nbranch refs/heads/main\n',
+    refsHeadsSource: { sha: 'c'.repeat(40), packed: false },
+    refsHeadsTarget: { sha: 'd'.repeat(40), packed: false },
+    mergeBaseCommand: ['git', 'merge-base', '--is-ancestor', 'main', 'feat/x'],
+    mergeBaseExitCode: 1,
+    mergeBaseStdout: '',
+    mergeBaseStderr: '',
+  },
+};
+
+describe('handleMergeOrchestrate (#1362 — preflight.debug event-wire)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('MergeOrchestrate_EnvSetAndAncestryFail_AppendsDebugBlockToEvent', async () => {
+    // The handler accepts a DI'd `preflight` adapter, so the helper's env-var
+    // gating is exercised separately (outcome test). Here we drive the handler
+    // with a result that *already* carries `debug` (the exact shape the helper
+    // produces under `EXARCHOS_PREFLIGHT_DEBUG=1 && !ancestry.passed`) and
+    // assert the handler propagates it into the appended event.
+    vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', '1');
+    const ctx = makeMockCtx();
+    const preflight = vi.fn().mockResolvedValue(FAILING_PREFLIGHT_WITH_DEBUG);
+    const executeMerge = vi.fn();
+    const persistState = vi.fn().mockResolvedValue(undefined);
+
+    await handleMergeOrchestrate(
+      {
+        featureId: 'feat-x',
+        sourceBranch: 'feat/x',
+        targetBranch: 'main',
+        taskId: 'T1362',
+        strategy: 'squash',
+        preflight,
+        executeMerge,
+        persistState,
+      },
+      ctx,
+    );
+
+    const appendMock = ctx.eventStore.append as ReturnType<typeof vi.fn>;
+    const preflightCalls = appendMock.mock.calls.filter(
+      (call) => (call[1] as { type?: string } | undefined)?.type === 'merge.preflight',
+    );
+    expect(preflightCalls).toHaveLength(1);
+    const [, emitted] = preflightCalls[0] as [string, { data: Record<string, unknown> }];
+
+    // Core assertion: handler threads `preflight.debug` into `event.data.debug`.
+    expect(emitted.data.debug).toBeDefined();
+    expect(emitted.data.debug).toEqual(FAILING_PREFLIGHT_WITH_DEBUG.debug);
+
+    // Shape sanity — every required PreflightDebug field is present so a
+    // schema validator at the read-side will accept the record.
+    const debug = emitted.data.debug as Record<string, unknown>;
+    expect(typeof debug.gitVersion).toBe('string');
+    expect(typeof debug.repoRoot).toBe('string');
+    expect(typeof debug.worktreeList).toBe('string');
+    expect(debug.refsHeadsSource).toMatchObject({
+      sha: expect.any(String),
+      packed: expect.any(Boolean),
+    });
+    expect(debug.refsHeadsTarget).toMatchObject({
+      sha: expect.any(String),
+      packed: expect.any(Boolean),
+    });
+    expect(Array.isArray(debug.mergeBaseCommand)).toBe(true);
+    expect(typeof debug.mergeBaseExitCode).toBe('number');
+    expect(typeof debug.mergeBaseStdout).toBe('string');
+    expect(typeof debug.mergeBaseStderr).toBe('string');
+  });
+
+  it('MergeOrchestrate_EnvUnsetAndAncestryFail_NoDebugBlockOnEvent', async () => {
+    // Symmetric case: when the helper does NOT attach `debug` (env unset or
+    // ancestry passed), the handler must omit `debug` from the event entirely
+    // — not stamp an empty object, not stamp `undefined` explicitly. The
+    // optional-spread pattern (matching `failureReasons`) is the contract.
+    vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', '');
+    const ctx = makeMockCtx();
+    const preflight = vi.fn().mockResolvedValue(FAILING_PREFLIGHT);
+    const executeMerge = vi.fn();
+    const persistState = vi.fn().mockResolvedValue(undefined);
+
+    await handleMergeOrchestrate(
+      {
+        featureId: 'feat-x',
+        sourceBranch: 'feat/x',
+        targetBranch: 'main',
+        taskId: 'T1362',
+        strategy: 'squash',
+        preflight,
+        executeMerge,
+        persistState,
+      },
+      ctx,
+    );
+
+    const appendMock = ctx.eventStore.append as ReturnType<typeof vi.fn>;
+    const preflightCalls = appendMock.mock.calls.filter(
+      (call) => (call[1] as { type?: string } | undefined)?.type === 'merge.preflight',
+    );
+    expect(preflightCalls).toHaveLength(1);
+    const [, emitted] = preflightCalls[0] as [string, { data: Record<string, unknown> }];
+    expect('debug' in emitted.data).toBe(false);
   });
 });
 

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.test.ts
@@ -470,6 +470,56 @@ describe('handleMergeOrchestrate (#1362 — preflight.debug event-wire)', () => 
     const [, emitted] = preflightCalls[0] as [string, { data: Record<string, unknown> }];
     expect('debug' in emitted.data).toBe(false);
   });
+
+  it('MergeOrchestrate_PassingAncestryWithDebugInjected_DoesNotPersistDebug', async () => {
+    // Defense-in-depth at the event-sourcing boundary (INV-1). The helper's
+    // contract is "only attach `debug` when ancestry FAILED" — but the handler
+    // accepts a DI'd `preflight` adapter, so a test fixture (or a future code
+    // path) could synthesize a `PreflightResult` with `debug` set on a PASSING
+    // preflight. The handler MUST NOT persist that debug into the event;
+    // otherwise we'd leak diagnostic payloads onto passing-preflight events
+    // and pollute the event store. The wire condition gates on BOTH the
+    // presence of debug AND `ancestry.passed === false`.
+    vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', '1');
+    const passingWithDebug: MergePreflightResult = {
+      ...PASSING_PREFLIGHT,
+      debug: FAILING_PREFLIGHT_WITH_DEBUG.debug,
+    };
+    const ctx = makeMockCtx();
+    const preflight = vi.fn().mockResolvedValue(passingWithDebug);
+    const executeMerge = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        phase: 'completed' as const,
+        mergeSha: MERGE_SHA,
+        rollbackSha: ROLLBACK_SHA,
+      },
+    });
+    const persistState = vi.fn().mockResolvedValue(undefined);
+
+    await handleMergeOrchestrate(
+      {
+        featureId: 'feat-x',
+        sourceBranch: 'feat/x',
+        targetBranch: 'main',
+        taskId: 'T1362-passing',
+        strategy: 'squash',
+        preflight,
+        executeMerge,
+        persistState,
+      },
+      ctx,
+    );
+
+    const appendMock = ctx.eventStore.append as ReturnType<typeof vi.fn>;
+    const preflightCalls = appendMock.mock.calls.filter(
+      (call) => (call[1] as { type?: string } | undefined)?.type === 'merge.preflight',
+    );
+    expect(preflightCalls).toHaveLength(1);
+    const [, emitted] = preflightCalls[0] as [string, { data: Record<string, unknown> }];
+    // Passing preflight + debug-injected → handler MUST drop debug.
+    expect('debug' in emitted.data).toBe(false);
+  });
 });
 
 describe('handleMergeOrchestrate (T13 — dry-run path)', () => {

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
@@ -201,21 +201,26 @@ function defaultGitExec(repoRoot: string, args: readonly string[]): GitExecResul
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    return { stdout, exitCode: 0 };
+    return { stdout, stderr: '', exitCode: 0 };
   } catch (err) {
-    // Surface git's stderr (merge conflicts, ref errors) in the returned
-    // stdout so the preflight failure surfaces the actual cause rather than
-    // an opaque exit code.
+    // Capture stderr separately so #1362 phase-1 diagnostics can read the
+    // actual git error output (e.g., for `merge-base --is-ancestor` exit
+    // codes != 0/1 indicating a real failure vs the documented "non-ancestor"
+    // signal). Also fold stderr into stdout for backwards-compat with
+    // existing callers that read `stdout` as the failure-message channel.
     const status = (err as { status?: number }).status;
-    const stderr = (err as { stderr?: string | Buffer }).stderr;
-    const stdout = (err as { stdout?: string | Buffer }).stdout;
-    const message = [
-      typeof stdout === 'string' ? stdout : stdout?.toString('utf-8') ?? '',
-      typeof stderr === 'string' ? stderr : stderr?.toString('utf-8') ?? '',
-    ]
-      .filter(Boolean)
-      .join('\n');
-    return { stdout: message, exitCode: typeof status === 'number' ? status : 1 };
+    const rawStderr = (err as { stderr?: string | Buffer }).stderr;
+    const rawStdout = (err as { stdout?: string | Buffer }).stdout;
+    const stderr =
+      typeof rawStderr === 'string' ? rawStderr : rawStderr?.toString('utf-8') ?? '';
+    const stdoutOnly =
+      typeof rawStdout === 'string' ? rawStdout : rawStdout?.toString('utf-8') ?? '';
+    const message = [stdoutOnly, stderr].filter(Boolean).join('\n');
+    return {
+      stdout: message,
+      stderr,
+      exitCode: typeof status === 'number' ? status : 1,
+    };
   }
 }
 
@@ -553,10 +558,15 @@ export async function handleMergeOrchestrate(
           // #1362 phase 1 — thread the optional debug payload from the helper
           // through to the event so phase-2 analysis can read the persisted
           // ancestry-mismatch diagnostic. The helper only attaches `debug`
-          // when `EXARCHOS_PREFLIGHT_DEBUG=1 && !ancestry.passed`; same
-          // conditional-spread pattern as `failureReasons` above so passing
-          // events stay byte-identical to the pre-#1362 shape.
-          ...(preflight.debug !== undefined ? { debug: preflight.debug } : {}),
+          // when `EXARCHOS_PREFLIGHT_DEBUG=1 && !ancestry.passed`; we double-
+          // gate here on `ancestry.passed === false` so a future code path
+          // (or a test fixture) that constructs a `PreflightResult` with
+          // `debug` set on a PASSING preflight cannot leak the diagnostic
+          // into a passing-preflight event. Defense-in-depth at the event-
+          // sourcing boundary (INV-1).
+          ...(preflight.debug !== undefined && preflight.ancestry?.passed === false
+            ? { debug: preflight.debug }
+            : {}),
         },
       },
       appendOptionsPreflight,

--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
@@ -550,6 +550,13 @@ export async function handleMergeOrchestrate(
           ...(preflight.passed
             ? {}
             : { failureReasons: [describePreflightFailure(preflight)] }),
+          // #1362 phase 1 — thread the optional debug payload from the helper
+          // through to the event so phase-2 analysis can read the persisted
+          // ancestry-mismatch diagnostic. The helper only attaches `debug`
+          // when `EXARCHOS_PREFLIGHT_DEBUG=1 && !ancestry.passed`; same
+          // conditional-spread pattern as `failureReasons` above so passing
+          // events stay byte-identical to the pre-#1362 shape.
+          ...(preflight.debug !== undefined ? { debug: preflight.debug } : {}),
         },
       },
       appendOptionsPreflight,

--- a/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.test.ts
@@ -9,8 +9,13 @@
  *     propagation from the underlying guard.
  */
 
-import { describe, it, expect } from 'vitest';
-import { detectDrift, mergePreflight, type GitExec } from './merge-preflight.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  detectDrift,
+  mergePreflight,
+  gatherPreflightDebug,
+  type GitExec,
+} from './merge-preflight.js';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -396,5 +401,226 @@ describe('mergePreflight — failure paths (T07)', () => {
     expect(result.drift.clean).toBe(false);
     expect(result.drift.uncommittedFiles.length).toBeGreaterThan(0);
     expect(result.drift.uncommittedFiles).toEqual(['src/foo.ts', 'src/bar.ts']);
+  });
+});
+
+// ─── gatherPreflightDebug (#1362 phase 1) ───────────────────────────────────
+//
+// Phase-1 Windows preflight instrumentation. The helper is pure: every git
+// invocation goes through the injected `gitExec`. Fail-closed semantics —
+// individual git failures must NOT throw; the helper records a partial
+// payload so the on-failure debug attachment is best-effort. See plan T2.2.
+
+describe('gatherPreflightDebug (#1362)', () => {
+  it('gatherPreflightDebug_AllGitCallsSucceed_PopulatesAllFields', () => {
+    // Build a mock that returns canned outputs for every git invocation the
+    // helper should make. Field order in the type is the canonical reading
+    // order for an operator inspecting the debug block.
+    const gitExec = makeGitExec([
+      { args: ['--version'], stdout: 'git version 2.45.1\n', exitCode: 0 },
+      { args: ['rev-parse', '--show-toplevel'], stdout: '/repo\n', exitCode: 0 },
+      {
+        args: ['worktree', 'list', '--porcelain'],
+        stdout: 'worktree /repo\nHEAD aaaaaaa\nbranch refs/heads/main\n',
+        exitCode: 0,
+      },
+      // refs lookups: source + target. Use `for-each-ref` so we capture both
+      // SHA and whether the ref is packed in one go.
+      {
+        args: [
+          'for-each-ref',
+          '--format=%(objectname) %(if)%(refname)%(then)%(refname)%(end)',
+          'refs/heads/feat/x',
+        ],
+        stdout: 'aaaaaaa refs/heads/feat/x\n',
+        exitCode: 0,
+      },
+      {
+        args: [
+          'for-each-ref',
+          '--format=%(objectname) %(if)%(refname)%(then)%(refname)%(end)',
+          'refs/heads/main',
+        ],
+        stdout: 'bbbbbbb refs/heads/main\n',
+        exitCode: 0,
+      },
+      // packed-refs check via `cat-file -e <packed-ref>` or by `git
+      // packed-refs --print`. We use `packed-refs` lookup via grep-free
+      // mechanism: `git rev-parse --symbolic-full-name --verify
+      // refs/heads/X` doesn't tell us packed state. The implementation uses
+      // `git for-each-ref --format=%(packed)` semantics — but for simplicity
+      // the helper just calls `cat-file -e <sha>` per ref. Mock stubs match
+      // the implementation's actual call order below.
+      {
+        args: ['cat-file', '-e', 'aaaaaaa'],
+        stdout: '',
+        exitCode: 0,
+      },
+      {
+        args: ['cat-file', '-e', 'bbbbbbb'],
+        stdout: '',
+        exitCode: 0,
+      },
+      // merge-base --is-ancestor invocation — the same call that the
+      // ancestry guard ran. We re-run it here to capture stderr / exit code
+      // verbatim for the debug block.
+      {
+        args: ['merge-base', '--is-ancestor', 'main', 'feat/x'],
+        stdout: '',
+        exitCode: 1,
+      },
+    ]);
+
+    const debug = gatherPreflightDebug(gitExec, '/repo', 'feat/x', 'main');
+
+    expect(debug.gitVersion).toBe('git version 2.45.1');
+    expect(debug.repoRoot).toBe('/repo');
+    expect(debug.worktreeList).toContain('worktree /repo');
+    expect(debug.refsHeadsSource.sha).toBe('aaaaaaa');
+    expect(debug.refsHeadsTarget.sha).toBe('bbbbbbb');
+    expect(debug.refsHeadsSource.packed).toBe(false);
+    expect(debug.refsHeadsTarget.packed).toBe(false);
+    expect(debug.mergeBaseCommand).toEqual([
+      'git',
+      'merge-base',
+      '--is-ancestor',
+      'main',
+      'feat/x',
+    ]);
+    expect(debug.mergeBaseExitCode).toBe(1);
+    expect(typeof debug.mergeBaseStdout).toBe('string');
+    expect(typeof debug.mergeBaseStderr).toBe('string');
+  });
+
+  it('gatherPreflightDebug_GitVersionFails_ReturnsPartialBlock', () => {
+    // Drive the very first git call (--version) to fail. The helper must
+    // record an empty/default value for that field and continue — never
+    // throw. This is the fail-closed contract: an instrumentation helper
+    // that throws inside an already-failed preflight would mask the real
+    // failure.
+    const gitExec: GitExec = (_root, args) => {
+      if (args[0] === '--version') {
+        return { stdout: '', exitCode: 127 };
+      }
+      // Stubs for the remaining calls so the test does not throw on
+      // unexpected invocations.
+      if (args[0] === 'rev-parse') return { stdout: '/repo\n', exitCode: 0 };
+      if (args[0] === 'worktree') return { stdout: '', exitCode: 0 };
+      if (args[0] === 'for-each-ref') return { stdout: 'sha refs/heads/x\n', exitCode: 0 };
+      if (args[0] === 'cat-file') return { stdout: '', exitCode: 0 };
+      if (args[0] === 'merge-base') return { stdout: '', exitCode: 0 };
+      return { stdout: '', exitCode: 1 };
+    };
+
+    let debug: ReturnType<typeof gatherPreflightDebug>;
+    expect(() => {
+      debug = gatherPreflightDebug(gitExec, '/repo', 'feat/x', 'main');
+    }).not.toThrow();
+
+    expect(debug!.gitVersion).toBe('');
+    // Subsequent fields must still be populated from their successful calls.
+    expect(debug!.repoRoot).toBe('/repo');
+  });
+});
+
+// ─── mergePreflight env-var integration (#1362 phase 1) ─────────────────────
+
+describe('mergePreflight env-gated debug attachment (#1362)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  /** Build a gitExec stub that drives ancestry to fail (exit 1 on
+   * `merge-base --is-ancestor`) and stubs every other call mergePreflight
+   * + gatherPreflightDebug make. */
+  function makeAncestryFailingExec(): GitExec {
+    return (_root, args) => {
+      const a = args.join(' ');
+      if (a === 'merge-base --is-ancestor main feat/x') {
+        return { stdout: '', exitCode: 1 };
+      }
+      if (a === 'rev-parse --abbrev-ref HEAD') {
+        return { stdout: 'feat/x\n', exitCode: 0 };
+      }
+      if (a === 'status --porcelain') return { stdout: '', exitCode: 0 };
+      if (a === 'diff --cached --quiet') return { stdout: '', exitCode: 0 };
+      if (a === '--version') return { stdout: 'git version 2.45.1\n', exitCode: 0 };
+      if (a === 'rev-parse --show-toplevel') return { stdout: '/repo\n', exitCode: 0 };
+      if (a === 'worktree list --porcelain') return { stdout: '', exitCode: 0 };
+      if (args[0] === 'for-each-ref') {
+        return { stdout: 'sha refs/heads/x\n', exitCode: 0 };
+      }
+      if (args[0] === 'cat-file') return { stdout: '', exitCode: 0 };
+      throw new Error(`Unexpected gitExec call: git ${a}`);
+    };
+  }
+
+  /** Same as above but ancestry passes. */
+  function makeAncestryPassingExec(): GitExec {
+    return (_root, args) => {
+      const a = args.join(' ');
+      if (a === 'merge-base --is-ancestor main feat/x') {
+        return { stdout: '', exitCode: 0 };
+      }
+      if (a === 'rev-parse --abbrev-ref HEAD') {
+        return { stdout: 'feat/x\n', exitCode: 0 };
+      }
+      if (a === 'status --porcelain') return { stdout: '', exitCode: 0 };
+      if (a === 'diff --cached --quiet') return { stdout: '', exitCode: 0 };
+      if (a === '--version') return { stdout: 'git version 2.45.1\n', exitCode: 0 };
+      if (a === 'rev-parse --show-toplevel') return { stdout: '/repo\n', exitCode: 0 };
+      if (a === 'worktree list --porcelain') return { stdout: '', exitCode: 0 };
+      if (args[0] === 'for-each-ref') {
+        return { stdout: 'sha refs/heads/x\n', exitCode: 0 };
+      }
+      if (args[0] === 'cat-file') return { stdout: '', exitCode: 0 };
+      throw new Error(`Unexpected gitExec call: git ${a}`);
+    };
+  }
+
+  it('MergePreflight_EnvUnsetAndAncestryFail_NoDebugField', async () => {
+    vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', '');
+    const result = await mergePreflight({
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      gitExec: makeAncestryFailingExec(),
+      cwd: '/tmp/repo',
+    });
+
+    expect(result.ancestry.passed).toBe(false);
+    expect((result as Record<string, unknown>).debug).toBeUndefined();
+  });
+
+  it('MergePreflight_EnvSetAndAncestryPass_NoDebugField', async () => {
+    // Failure-only gating: even with the debug env set, a passing ancestry
+    // must NOT attach a debug block. DIM-8 sustainability — event-store
+    // growth concern.
+    vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', '1');
+    const result = await mergePreflight({
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      gitExec: makeAncestryPassingExec(),
+      cwd: '/tmp/repo',
+    });
+
+    expect(result.ancestry.passed).toBe(true);
+    expect((result as Record<string, unknown>).debug).toBeUndefined();
+  });
+
+  it('MergePreflight_EnvSetAndAncestryFail_AttachesDebugBlock', async () => {
+    vi.stubEnv('EXARCHOS_PREFLIGHT_DEBUG', '1');
+    const result = await mergePreflight({
+      sourceBranch: 'feat/x',
+      targetBranch: 'main',
+      gitExec: makeAncestryFailingExec(),
+      cwd: '/tmp/repo',
+    });
+
+    expect(result.ancestry.passed).toBe(false);
+    const debug = (result as { debug?: Record<string, unknown> }).debug;
+    expect(debug).toBeDefined();
+    expect(debug!.gitVersion).toBe('git version 2.45.1');
+    expect(debug!.repoRoot).toBe('/repo');
+    expect(debug!.mergeBaseExitCode).toBe(1);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts
@@ -33,6 +33,16 @@ import {
 
 export interface GitExecResult {
   readonly stdout: string;
+  /**
+   * Captured stderr from the underlying git invocation. Optional: adapters
+   * that cannot separate stderr from stdout (e.g., a subprocess wrapper that
+   * merges descriptors) may omit it, in which case consumers should treat
+   * the absence as "not separately captured" rather than "definitely empty".
+   * The production `defaultGitExec` in merge-orchestrate.ts captures stderr
+   * separately on failure so phase-1 diagnostics can distinguish git's
+   * error output from any partial stdout.
+   */
+  readonly stderr?: string;
   readonly exitCode: number;
 }
 
@@ -203,11 +213,13 @@ export function gatherPreflightDebug(
   source: string,
   target: string,
 ): PreflightDebug {
-  const safe = (args: readonly string[]): { stdout: string; exitCode: number } => {
+  const safe = (
+    args: readonly string[],
+  ): { stdout: string; stderr?: string; exitCode: number } => {
     try {
       return gitExec(repoRoot, args);
     } catch {
-      return { stdout: '', exitCode: 1 };
+      return { stdout: '', stderr: '', exitCode: 1 };
     }
   };
 
@@ -252,10 +264,11 @@ export function gatherPreflightDebug(
     source,
   ];
   const mbRes = safe(['merge-base', '--is-ancestor', target, source]);
-  // The default `GitExec` collapses stderr into stdout on failure (see
-  // `defaultGitExec` in merge-orchestrate.ts), so the two fields are the
-  // same string under that adapter. Windows-specific adapters that capture
-  // stderr separately can populate the two fields independently.
+  // `mergeBaseStderr` reflects only what the adapter actually captured.
+  // Adapters that merge descriptors (so stderr lands in stdout) leave the
+  // field empty here; the canonical `defaultGitExec` in merge-orchestrate.ts
+  // captures stderr separately on failure so phase-2 diagnostics can
+  // distinguish merge-base's error output from any partial stdout.
   return {
     gitVersion,
     repoRoot: reportedRoot,
@@ -265,7 +278,7 @@ export function gatherPreflightDebug(
     mergeBaseCommand,
     mergeBaseExitCode: mbRes.exitCode,
     mergeBaseStdout: mbRes.stdout,
-    mergeBaseStderr: mbRes.stdout,
+    mergeBaseStderr: mbRes.stderr ?? '',
   };
 }
 

--- a/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts
+++ b/servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.ts
@@ -132,6 +132,141 @@ export interface MergePreflightResult {
   readonly currentBranchProtection: CurrentBranchProtectionResult;
   readonly worktree: WorktreeAssertionResult;
   readonly drift: DriftResult;
+  /**
+   * Optional debug payload populated only when `EXARCHOS_PREFLIGHT_DEBUG=1`
+   * is set AND ancestry fails. Phase-1 Windows ancestry-mismatch
+   * instrumentation (#1362). Failure-only gating is deliberate (DIM-8 /
+   * event-store growth — verbose sub-modes will land separately via
+   * `EXARCHOS_PREFLIGHT_DEBUG=2` if/when phase 2 needs them).
+   */
+  readonly debug?: PreflightDebug;
+}
+
+/**
+ * Structured diagnostic payload for the Phase-1 Windows ancestry-mismatch
+ * investigation (#1362). All fields are best-effort: individual git call
+ * failures degrade gracefully to empty strings / default values rather than
+ * throwing. Reasoning: a debug helper that throws inside an already-failed
+ * preflight would mask the underlying ancestry failure the operator is
+ * trying to diagnose.
+ *
+ * Field order is the canonical reading order for an operator inspecting an
+ * issue report — git version → repo root → worktree layout → ref state →
+ * the actual ancestry invocation that failed.
+ */
+export interface PreflightDebug {
+  /** Output of `git --version`, stripped of trailing newlines. */
+  readonly gitVersion: string;
+  /** Output of `git rev-parse --show-toplevel`, stripped of trailing newlines. */
+  readonly repoRoot: string;
+  /** Verbatim porcelain output of `git worktree list --porcelain`. */
+  readonly worktreeList: string;
+  /** SHA + packed-status of the source branch ref. */
+  readonly refsHeadsSource: { readonly sha: string; readonly packed: boolean };
+  /** SHA + packed-status of the target branch ref. */
+  readonly refsHeadsTarget: { readonly sha: string; readonly packed: boolean };
+  /** The exact argv used for `merge-base --is-ancestor`, including the
+   * leading `'git'` literal so the operator can copy-paste verbatim. */
+  readonly mergeBaseCommand: readonly string[];
+  /** Exit code returned by the `merge-base --is-ancestor` invocation. */
+  readonly mergeBaseExitCode: number;
+  /** Stdout captured from the `merge-base --is-ancestor` invocation. */
+  readonly mergeBaseStdout: string;
+  /** Stderr captured from the `merge-base --is-ancestor` invocation. The
+   * default `GitExec` shape collapses stderr into `stdout` on failure — this
+   * field is currently a duplicate of `mergeBaseStdout` for Windows-specific
+   * gitExec implementations that may split the streams. */
+  readonly mergeBaseStderr: string;
+}
+
+// ─── gatherPreflightDebug (#1362 phase 1) ───────────────────────────────────
+
+/**
+ * Collect the Phase-1 Windows ancestry-debug payload.
+ *
+ * Every git invocation goes through the injected `gitExec` so the helper
+ * stays pure and unit-testable. Each call is wrapped in fail-closed
+ * semantics — a non-zero exit (or thrown error from a misbehaving gitExec)
+ * collapses to an empty string / default value for that field, never
+ * throws. The on-failure debug attachment is best-effort by design.
+ *
+ * The `for-each-ref` ref inspection is structured as
+ * `{ sha, packed }` because a Windows-host investigation needs to
+ * distinguish "ref does not exist" from "ref exists but is packed and
+ * unreadable by some downstream tool." Phase-1 reports `packed: false`
+ * universally; phase-2 may upgrade the helper to use `git pack-refs
+ * --print` for genuine packed-ref discrimination.
+ */
+export function gatherPreflightDebug(
+  gitExec: GitExec,
+  repoRoot: string,
+  source: string,
+  target: string,
+): PreflightDebug {
+  const safe = (args: readonly string[]): { stdout: string; exitCode: number } => {
+    try {
+      return gitExec(repoRoot, args);
+    } catch {
+      return { stdout: '', exitCode: 1 };
+    }
+  };
+
+  const versionRes = safe(['--version']);
+  const gitVersion = versionRes.exitCode === 0 ? versionRes.stdout.trim() : '';
+
+  const toplevelRes = safe(['rev-parse', '--show-toplevel']);
+  const reportedRoot =
+    toplevelRes.exitCode === 0 ? toplevelRes.stdout.trim() : '';
+
+  const worktreeRes = safe(['worktree', 'list', '--porcelain']);
+  const worktreeList = worktreeRes.exitCode === 0 ? worktreeRes.stdout : '';
+
+  const refFor = (
+    branch: string,
+  ): { sha: string; packed: boolean } => {
+    const refRes = safe([
+      'for-each-ref',
+      '--format=%(objectname) %(if)%(refname)%(then)%(refname)%(end)',
+      `refs/heads/${branch}`,
+    ]);
+    const sha =
+      refRes.exitCode === 0 ? refRes.stdout.trim().split(/\s+/)[0] ?? '' : '';
+    // Phase-1: `cat-file -e <sha>` confirms the SHA is reachable; we treat a
+    // success as `packed: false` (the typical loose-ref case). Phase-2 will
+    // distinguish loose vs packed via `pack-refs --print`. If the ref lookup
+    // failed outright, leave `packed: false` and let `sha === ''` signal it.
+    if (sha !== '') {
+      safe(['cat-file', '-e', sha]);
+    }
+    return { sha, packed: false };
+  };
+
+  const refsHeadsSource = refFor(source);
+  const refsHeadsTarget = refFor(target);
+
+  const mergeBaseCommand: readonly string[] = [
+    'git',
+    'merge-base',
+    '--is-ancestor',
+    target,
+    source,
+  ];
+  const mbRes = safe(['merge-base', '--is-ancestor', target, source]);
+  // The default `GitExec` collapses stderr into stdout on failure (see
+  // `defaultGitExec` in merge-orchestrate.ts), so the two fields are the
+  // same string under that adapter. Windows-specific adapters that capture
+  // stderr separately can populate the two fields independently.
+  return {
+    gitVersion,
+    repoRoot: reportedRoot,
+    worktreeList,
+    refsHeadsSource,
+    refsHeadsTarget,
+    mergeBaseCommand,
+    mergeBaseExitCode: mbRes.exitCode,
+    mergeBaseStdout: mbRes.stdout,
+    mergeBaseStderr: mbRes.stdout,
+  };
 }
 
 /**
@@ -249,11 +384,31 @@ export async function mergePreflight(
     worktree.isMain &&
     drift.clean;
 
+  // Phase-1 Windows ancestry-debug instrumentation (#1362). Failure-only
+  // gating: only attach a debug block when the env var is explicitly set
+  // AND ancestry failed. DIM-8 sustainability — we do NOT pay event-store
+  // growth for passing preflights even when an operator turns the flag on.
+  // Verbose sub-modes (passing-preflight diagnostics) belong on a
+  // separate `EXARCHOS_PREFLIGHT_DEBUG=2` channel and are out of scope.
+  let debug: PreflightDebug | undefined;
+  if (
+    process.env.EXARCHOS_PREFLIGHT_DEBUG === '1' &&
+    !ancestry.passed
+  ) {
+    debug = gatherPreflightDebug(
+      args.gitExec,
+      repoRoot,
+      args.sourceBranch,
+      args.targetBranch,
+    );
+  }
+
   return {
     passed,
     ancestry,
     currentBranchProtection,
     worktree,
     drift,
+    ...(debug !== undefined ? { debug } : {}),
   };
 }

--- a/skills-src/merge-orchestrator/SKILL.md
+++ b/skills-src/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `{{MCP_PREFIX}}exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `{{MCP_PREFIX}}exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/skills/claude/merge-orchestrator/SKILL.md
+++ b/skills/claude/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/skills/codex/merge-orchestrator/SKILL.md
+++ b/skills/codex/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/skills/copilot/merge-orchestrator/SKILL.md
+++ b/skills/copilot/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/skills/cursor/merge-orchestrator/SKILL.md
+++ b/skills/cursor/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/skills/generic/merge-orchestrator/SKILL.md
+++ b/skills/generic/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/skills/opencode/merge-orchestrator/SKILL.md
+++ b/skills/opencode/merge-orchestrator/SKILL.md
@@ -163,6 +163,33 @@ Note: the `target-checked-out-elsewhere` early-abort path runs *before* the resu
 | Omit `--strategy` / `strategy:` field expecting a default | Strategy is required; supply `squash` / `merge` / `rebase` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set `EXARCHOS_PREFLIGHT_DEBUG=1` in the environment before invoking `merge_orchestrate` to attach a structured debug payload to `merge.preflight` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. `EXARCHOS_PREFLIGHT_DEBUG=1` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., `ancestry.passed === false`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future `EXARCHOS_PREFLIGHT_DEBUG=2` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| `gitVersion` | `git --version` | Differentiate behaviors across git releases. |
+| `repoRoot` | `git rev-parse --show-toplevel` | Distinguish symlinked or normalized vs raw repo paths. |
+| `worktreeList` | `git worktree list --porcelain` | Surface sibling worktree topology that could affect ref resolution. |
+| `refsHeadsSource` | `git for-each-ref refs/heads/<source>` | SHA + packed-state of the source branch ref. |
+| `refsHeadsTarget` | `git for-each-ref refs/heads/<target>` | SHA + packed-state of the target branch ref. |
+| `mergeBaseCommand` | constructed | Exact argv re-run by the helper, including `'git'` prefix — copy-pasteable for the operator. |
+| `mergeBaseExitCode` | rerun of `git merge-base --is-ancestor <target> <source>` | The exit code that drove the ancestry failure. |
+| `mergeBaseStdout` | same invocation | Captured stdout. |
+| `mergeBaseStderr` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full `data.debug` block to a new GitHub issue tagged with relevant scope labels (e.g., `windows`, `merge-orchestrator`, `preflight`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call `mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })`. Event payload shapes come from `mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })`.

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -2138,6 +2138,33 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set \`EXARCHOS_PREFLIGHT_DEBUG=1\` in the environment before invoking \`merge_orchestrate\` to attach a structured debug payload to \`merge.preflight\` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. \`EXARCHOS_PREFLIGHT_DEBUG=1\` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., \`ancestry.passed === false\`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future \`EXARCHOS_PREFLIGHT_DEBUG=2\` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| \`gitVersion\` | \`git --version\` | Differentiate behaviors across git releases. |
+| \`repoRoot\` | \`git rev-parse --show-toplevel\` | Distinguish symlinked or normalized vs raw repo paths. |
+| \`worktreeList\` | \`git worktree list --porcelain\` | Surface sibling worktree topology that could affect ref resolution. |
+| \`refsHeadsSource\` | \`git for-each-ref refs/heads/<source>\` | SHA + packed-state of the source branch ref. |
+| \`refsHeadsTarget\` | \`git for-each-ref refs/heads/<target>\` | SHA + packed-state of the target branch ref. |
+| \`mergeBaseCommand\` | constructed | Exact argv re-run by the helper, including \`'git'\` prefix — copy-pasteable for the operator. |
+| \`mergeBaseExitCode\` | rerun of \`git merge-base --is-ancestor <target> <source>\` | The exit code that drove the ancestry failure. |
+| \`mergeBaseStdout\` | same invocation | Captured stdout. |
+| \`mergeBaseStderr\` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full \`data.debug\` block to a new GitHub issue tagged with relevant scope labels (e.g., \`windows\`, \`merge-orchestrator\`, \`preflight\`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call \`mcp__plugin_exarchos_exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__plugin_exarchos_exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
@@ -6756,6 +6783,33 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set \`EXARCHOS_PREFLIGHT_DEBUG=1\` in the environment before invoking \`merge_orchestrate\` to attach a structured debug payload to \`merge.preflight\` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. \`EXARCHOS_PREFLIGHT_DEBUG=1\` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., \`ancestry.passed === false\`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future \`EXARCHOS_PREFLIGHT_DEBUG=2\` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| \`gitVersion\` | \`git --version\` | Differentiate behaviors across git releases. |
+| \`repoRoot\` | \`git rev-parse --show-toplevel\` | Distinguish symlinked or normalized vs raw repo paths. |
+| \`worktreeList\` | \`git worktree list --porcelain\` | Surface sibling worktree topology that could affect ref resolution. |
+| \`refsHeadsSource\` | \`git for-each-ref refs/heads/<source>\` | SHA + packed-state of the source branch ref. |
+| \`refsHeadsTarget\` | \`git for-each-ref refs/heads/<target>\` | SHA + packed-state of the target branch ref. |
+| \`mergeBaseCommand\` | constructed | Exact argv re-run by the helper, including \`'git'\` prefix — copy-pasteable for the operator. |
+| \`mergeBaseExitCode\` | rerun of \`git merge-base --is-ancestor <target> <source>\` | The exit code that drove the ancestry failure. |
+| \`mergeBaseStdout\` | same invocation | Captured stdout. |
+| \`mergeBaseStderr\` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full \`data.debug\` block to a new GitHub issue tagged with relevant scope labels (e.g., \`windows\`, \`merge-orchestrator\`, \`preflight\`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
@@ -11365,6 +11419,33 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
+
+## Diagnostics
+
+Set \`EXARCHOS_PREFLIGHT_DEBUG=1\` in the environment before invoking \`merge_orchestrate\` to attach a structured debug payload to \`merge.preflight\` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. \`EXARCHOS_PREFLIGHT_DEBUG=1\` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., \`ancestry.passed === false\`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future \`EXARCHOS_PREFLIGHT_DEBUG=2\` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| \`gitVersion\` | \`git --version\` | Differentiate behaviors across git releases. |
+| \`repoRoot\` | \`git rev-parse --show-toplevel\` | Distinguish symlinked or normalized vs raw repo paths. |
+| \`worktreeList\` | \`git worktree list --porcelain\` | Surface sibling worktree topology that could affect ref resolution. |
+| \`refsHeadsSource\` | \`git for-each-ref refs/heads/<source>\` | SHA + packed-state of the source branch ref. |
+| \`refsHeadsTarget\` | \`git for-each-ref refs/heads/<target>\` | SHA + packed-state of the target branch ref. |
+| \`mergeBaseCommand\` | constructed | Exact argv re-run by the helper, including \`'git'\` prefix — copy-pasteable for the operator. |
+| \`mergeBaseExitCode\` | rerun of \`git merge-base --is-ancestor <target> <source>\` | The exit code that drove the ancestry failure. |
+| \`mergeBaseStdout\` | same invocation | Captured stdout. |
+| \`mergeBaseStderr\` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full \`data.debug\` block to a new GitHub issue tagged with relevant scope labels (e.g., \`windows\`, \`merge-orchestrator\`, \`preflight\`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
 
 ## Schema Discovery
 
@@ -15986,6 +16067,33 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
 
+## Diagnostics
+
+Set \`EXARCHOS_PREFLIGHT_DEBUG=1\` in the environment before invoking \`merge_orchestrate\` to attach a structured debug payload to \`merge.preflight\` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. \`EXARCHOS_PREFLIGHT_DEBUG=1\` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., \`ancestry.passed === false\`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future \`EXARCHOS_PREFLIGHT_DEBUG=2\` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| \`gitVersion\` | \`git --version\` | Differentiate behaviors across git releases. |
+| \`repoRoot\` | \`git rev-parse --show-toplevel\` | Distinguish symlinked or normalized vs raw repo paths. |
+| \`worktreeList\` | \`git worktree list --porcelain\` | Surface sibling worktree topology that could affect ref resolution. |
+| \`refsHeadsSource\` | \`git for-each-ref refs/heads/<source>\` | SHA + packed-state of the source branch ref. |
+| \`refsHeadsTarget\` | \`git for-each-ref refs/heads/<target>\` | SHA + packed-state of the target branch ref. |
+| \`mergeBaseCommand\` | constructed | Exact argv re-run by the helper, including \`'git'\` prefix — copy-pasteable for the operator. |
+| \`mergeBaseExitCode\` | rerun of \`git merge-base --is-ancestor <target> <source>\` | The exit code that drove the ancestry failure. |
+| \`mergeBaseStdout\` | same invocation | Captured stdout. |
+| \`mergeBaseStderr\` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full \`data.debug\` block to a new GitHub issue tagged with relevant scope labels (e.g., \`windows\`, \`merge-orchestrator\`, \`preflight\`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
+
 ## Schema Discovery
 
 For the argument schema, call \`mcp__exarchos__exarchos_orchestrate({ action: "describe", actions: ["merge_orchestrate"] })\`. Event payload shapes come from \`mcp__exarchos__exarchos_event({ action: "describe", eventTypes: ["merge.preflight", "merge.requested", "merge.executed", "merge.rollback"] })\`.
@@ -20576,6 +20684,33 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
+
+## Diagnostics
+
+Set \`EXARCHOS_PREFLIGHT_DEBUG=1\` in the environment before invoking \`merge_orchestrate\` to attach a structured debug payload to \`merge.preflight\` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. \`EXARCHOS_PREFLIGHT_DEBUG=1\` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., \`ancestry.passed === false\`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future \`EXARCHOS_PREFLIGHT_DEBUG=2\` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| \`gitVersion\` | \`git --version\` | Differentiate behaviors across git releases. |
+| \`repoRoot\` | \`git rev-parse --show-toplevel\` | Distinguish symlinked or normalized vs raw repo paths. |
+| \`worktreeList\` | \`git worktree list --porcelain\` | Surface sibling worktree topology that could affect ref resolution. |
+| \`refsHeadsSource\` | \`git for-each-ref refs/heads/<source>\` | SHA + packed-state of the source branch ref. |
+| \`refsHeadsTarget\` | \`git for-each-ref refs/heads/<target>\` | SHA + packed-state of the target branch ref. |
+| \`mergeBaseCommand\` | constructed | Exact argv re-run by the helper, including \`'git'\` prefix — copy-pasteable for the operator. |
+| \`mergeBaseExitCode\` | rerun of \`git merge-base --is-ancestor <target> <source>\` | The exit code that drove the ancestry failure. |
+| \`mergeBaseStdout\` | same invocation | Captured stdout. |
+| \`mergeBaseStderr\` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full \`data.debug\` block to a new GitHub issue tagged with relevant scope labels (e.g., \`windows\`, \`merge-orchestrator\`, \`preflight\`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
 
 ## Schema Discovery
 
@@ -25194,6 +25329,33 @@ Note: the \`target-checked-out-elsewhere\` early-abort path runs *before* the re
 | Re-dispatch after \`reason: 'target-checked-out-elsewhere'\` without first freeing the sibling worktree | Remove or re-checkout the sibling worktree referenced by \`data.siblingWorktreePath\`, then re-dispatch |
 | Omit \`--strategy\` / \`strategy:\` field expecting a default | Strategy is required; supply \`squash\` / \`merge\` / \`rebase\` explicitly |
 | Invoke from a subagent worktree | Preflight refuses (main-worktree assertion); invoke from the main worktree |
+
+## Diagnostics
+
+Set \`EXARCHOS_PREFLIGHT_DEBUG=1\` in the environment before invoking \`merge_orchestrate\` to attach a structured debug payload to \`merge.preflight\` events. The payload is gated on **two** conditions, both of which must hold:
+
+1. \`EXARCHOS_PREFLIGHT_DEBUG=1\` is present in the orchestrator process environment.
+2. The preflight's ancestry guard failed (i.e., \`ancestry.passed === false\`).
+
+Passing preflights do **not** carry the debug payload even when the env var is set — the failure-only gating is deliberate (event-store growth concern). A future \`EXARCHOS_PREFLIGHT_DEBUG=2\` channel may add verbose / passing-preflight diagnostics; that is out of scope for phase 1.
+
+The debug block carries nine fields:
+
+| Field | Source | Purpose |
+|-------|--------|---------|
+| \`gitVersion\` | \`git --version\` | Differentiate behaviors across git releases. |
+| \`repoRoot\` | \`git rev-parse --show-toplevel\` | Distinguish symlinked or normalized vs raw repo paths. |
+| \`worktreeList\` | \`git worktree list --porcelain\` | Surface sibling worktree topology that could affect ref resolution. |
+| \`refsHeadsSource\` | \`git for-each-ref refs/heads/<source>\` | SHA + packed-state of the source branch ref. |
+| \`refsHeadsTarget\` | \`git for-each-ref refs/heads/<target>\` | SHA + packed-state of the target branch ref. |
+| \`mergeBaseCommand\` | constructed | Exact argv re-run by the helper, including \`'git'\` prefix — copy-pasteable for the operator. |
+| \`mergeBaseExitCode\` | rerun of \`git merge-base --is-ancestor <target> <source>\` | The exit code that drove the ancestry failure. |
+| \`mergeBaseStdout\` | same invocation | Captured stdout. |
+| \`mergeBaseStderr\` | same invocation | Captured stderr (collapsed into stdout under the default git adapter). |
+
+Fail-closed: any individual git invocation that fails inside the debug helper degrades to an empty string / default value for that field rather than throwing. The debug attachment must never mask the underlying preflight failure the operator is trying to investigate.
+
+**Reporting workflow.** When you capture a debug-bearing event, attach the full \`data.debug\` block to a new GitHub issue tagged with relevant scope labels (e.g., \`windows\`, \`merge-orchestrator\`, \`preflight\`). Phase-2 root-cause analysis depends on at least one real-host event with this payload.
 
 ## Schema Discovery
 

--- a/tests/outcome/_helpers/README.md
+++ b/tests/outcome/_helpers/README.md
@@ -270,17 +270,22 @@ saga choreography rather than a single CLI/handler invocation.
 | #1360 reserved-fields | [`reserved-fields-discoverability.test.ts`](../reserved-fields-discoverability.test.ts) | OK |
 | #1363 runbook | [`runbook-merge-orchestration.test.ts`](../runbook-merge-orchestration.test.ts) | OK |
 | #1364 telemetry split | [`telemetry-action-errors.test.ts`](../telemetry-action-errors.test.ts) | OK |
-| #1362 Windows preflight | n/a (Linux tier cannot reproduce) | — |
+| #1362 Windows preflight | [`preflight-debug.test.ts`](../preflight-debug.test.ts) (instrumentation only) | OK |
 | #1374 saga detour wire | [`test/process/saga-merge-detour.test.ts`](../../../test/process/saga-merge-detour.test.ts) (process tier) | OK |
 
 Notes:
 
-- #1362 is the Windows preflight regression. The Linux outcome tier is
-  intentionally out of scope — the bug only manifests under Windows path
-  semantics and process-launch behavior, which the Linux-only
-  `outcome-tests` CI job cannot reproduce. The Windows-side gating
-  belongs in a future Windows-CI surface (cf. the "No Windows CI for MCP
-  server" tracking line in the v2.x roadmap).
+- #1362 has two distinct concerns. The Linux outcome tier covers the
+  **instrumentation contract** for the Phase-1 debug payload —
+  `preflight-debug.test.ts` asserts that `EXARCHOS_PREFLIGHT_DEBUG=1` attaches
+  the structured debug block to `merge.preflight` events when ancestry fails,
+  and that the gate is no-op when the env var is unset or ancestry passes.
+  The Linux outcome tier is **out of scope for reproducing the Windows-
+  specific bug itself** (the ancestry false-positive only manifests under
+  Windows path semantics and process-launch behavior); reproduction belongs
+  in a future Windows-CI surface (cf. the "No Windows CI for MCP server"
+  tracking line in the v2.x roadmap). Phase-2 root-cause analysis awaits one
+  Windows-host event with the new payload.
 - #1374 is a saga-shape regression. Its assertion lives in the process
   tier (`test/process/saga-merge-detour.test.ts`) because reproducing it
   requires orchestrating a multi-step delegation + merge-detour saga

--- a/tests/outcome/_helpers/README.md
+++ b/tests/outcome/_helpers/README.md
@@ -251,3 +251,39 @@ examples when authoring new ones:
 Each was authored as `it.fails()` against the helpers documented above.
 When you land the fix for one, flip the annotation in the same PR as the
 source change.
+
+## Coverage matrix
+
+The table below maps each dogfood-finding regression that ships an
+outcome-tier test to its carrier file. Entries marked `n/a` indicate a
+regression whose reproduction is outside the Linux outcome tier's scope
+(typically Windows-specific behavior). Process-tier carriers are linked
+where the outcome assertion lives in `test/process/` instead of
+`tests/outcome/` — usually because the regression requires multi-step
+saga choreography rather than a single CLI/handler invocation.
+
+| Dogfood Finding | Outcome Test | Status |
+|---|---|---|
+| #1355 install-skills | [`install-skills.test.ts`](../install-skills.test.ts) | OK |
+| #1356 merge multi-worktree | [`merge-orchestrate-multiworktree.test.ts`](../merge-orchestrate-multiworktree.test.ts) | OK |
+| #1359 projection drift | [`rehydrate-projection-drift.test.ts`](../rehydrate-projection-drift.test.ts) | OK |
+| #1360 reserved-fields | [`reserved-fields-discoverability.test.ts`](../reserved-fields-discoverability.test.ts) | OK |
+| #1363 runbook | [`runbook-merge-orchestration.test.ts`](../runbook-merge-orchestration.test.ts) | OK |
+| #1364 telemetry split | [`telemetry-action-errors.test.ts`](../telemetry-action-errors.test.ts) | OK |
+| #1362 Windows preflight | n/a (Linux tier cannot reproduce) | — |
+| #1374 saga detour wire | [`test/process/saga-merge-detour.test.ts`](../../../test/process/saga-merge-detour.test.ts) (process tier) | OK |
+
+Notes:
+
+- #1362 is the Windows preflight regression. The Linux outcome tier is
+  intentionally out of scope — the bug only manifests under Windows path
+  semantics and process-launch behavior, which the Linux-only
+  `outcome-tests` CI job cannot reproduce. The Windows-side gating
+  belongs in a future Windows-CI surface (cf. the "No Windows CI for MCP
+  server" tracking line in the v2.x roadmap).
+- #1374 is a saga-shape regression. Its assertion lives in the process
+  tier (`test/process/saga-merge-detour.test.ts`) because reproducing it
+  requires orchestrating a multi-step delegation + merge-detour saga
+  rather than a single handler call — the process tier is the right
+  granularity for that shape, and the outcome tier is reserved for
+  single operator-visible CLI / handler invocations.

--- a/tests/outcome/preflight-debug.test.ts
+++ b/tests/outcome/preflight-debug.test.ts
@@ -1,0 +1,128 @@
+// ─── PR2 / #1362 — Windows ancestry-debug instrumentation outcome ────────────
+//
+// Phase-1 instrumentation contract: when `EXARCHOS_PREFLIGHT_DEBUG=1` AND the
+// ancestry guard fails, `mergePreflight` must attach a structured `debug` block
+// to its result. When the env var is unset (or set but ancestry passes), no
+// debug block is attached — the gating is failure-only by design (DIM-8 /
+// event-store growth concern; see plan T2.x and the design "Symmetry decision"
+// note). Phase-2 may introduce verbose sub-modes via `EXARCHOS_PREFLIGHT_DEBUG=2`
+// separately.
+//
+// Linux-only test path: drives ancestry-failure by creating an orphan branch
+// (no merge-base with `main`), then invokes `mergePreflight` against a real
+// tmp git repo.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import * as path from 'node:path';
+
+import { withTmpGit } from './_helpers/tmp-git.js';
+import { mergePreflight } from '../../servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.js';
+import type { GitExec } from '../../servers/exarchos-mcp/src/orchestrate/pure/merge-preflight.js';
+
+/** Default gitExec mirroring the handler's `defaultGitExec` (no throw, returns
+ * `{ stdout, exitCode }`). Inline here so the outcome test does not depend on
+ * the handler module's internal helper. */
+function liveGitExec(repoRoot: string, args: readonly string[]): {
+  stdout: string;
+  exitCode: number;
+} {
+  try {
+    const stdout = execFileSync('git', [...args], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err) {
+    const status = (err as { status?: number }).status;
+    const stdout = (err as { stdout?: string | Buffer }).stdout;
+    const message = typeof stdout === 'string' ? stdout : stdout?.toString('utf-8') ?? '';
+    return { stdout: message, exitCode: typeof status === 'number' ? status : 1 };
+  }
+}
+
+/** Set up an orphan source branch so `merge-base --is-ancestor main source`
+ * fails with exit 1 (ancestry-missing). Returns the path of the primary
+ * repo with the orphan branch checked in. */
+async function setupAncestryFailureTopology(repoPath: string): Promise<void> {
+  // The initial commit on `main` is empty (no tracked files). Create an orphan
+  // branch with no shared history, then commit a file so HEAD has a valid
+  // commit and `merge-base --is-ancestor main feature/orphan` returns exit 1
+  // (disjoint histories, no common ancestor).
+  execFileSync('git', ['-C', repoPath, 'checkout', '--orphan', 'feature/orphan'], {
+    stdio: 'pipe',
+  });
+  await fs.writeFile(path.join(repoPath, 'orphan.txt'), 'orphan\n');
+  execFileSync('git', ['-C', repoPath, 'add', 'orphan.txt'], { stdio: 'pipe' });
+  execFileSync('git', ['-C', repoPath, 'commit', '-m', 'orphan'], { stdio: 'pipe' });
+}
+
+describe('preflight debug payload (#1362 phase 1)', () => {
+  it('Preflight_DebugEnvUnset_NoDebugField', async () => {
+    await withTmpGit(async (repoPath) => {
+      await setupAncestryFailureTopology(repoPath);
+
+      // Snapshot + clear the env var so this test is hermetic regardless of
+      // whether the runner has it set.
+      const prior = process.env.EXARCHOS_PREFLIGHT_DEBUG;
+      delete process.env.EXARCHOS_PREFLIGHT_DEBUG;
+      try {
+        const gitExec: GitExec = (root, args) => liveGitExec(root, args);
+        const result = await mergePreflight({
+          sourceBranch: 'feature/orphan',
+          targetBranch: 'main',
+          gitExec,
+          cwd: repoPath,
+        });
+
+        // Ancestry must actually fail for this test to be meaningful.
+        expect(result.passed).toBe(false);
+        expect(result.ancestry.passed).toBe(false);
+
+        // No debug block when env var is unset.
+        expect((result as Record<string, unknown>).debug).toBeUndefined();
+      } finally {
+        if (prior !== undefined) process.env.EXARCHOS_PREFLIGHT_DEBUG = prior;
+      }
+    });
+  });
+
+  it('Preflight_DebugEnvSetAndAncestryFail_AttachesDebugBlock', async () => {
+    await withTmpGit(async (repoPath) => {
+      await setupAncestryFailureTopology(repoPath);
+
+      const prior = process.env.EXARCHOS_PREFLIGHT_DEBUG;
+      process.env.EXARCHOS_PREFLIGHT_DEBUG = '1';
+      try {
+        const gitExec: GitExec = (root, args) => liveGitExec(root, args);
+        const result = await mergePreflight({
+          sourceBranch: 'feature/orphan',
+          targetBranch: 'main',
+          gitExec,
+          cwd: repoPath,
+        });
+
+        expect(result.passed).toBe(false);
+        expect(result.ancestry.passed).toBe(false);
+
+        // Debug block MUST be attached and structurally complete.
+        const debug = (result as { debug?: Record<string, unknown> }).debug;
+        expect(debug).toBeDefined();
+        expect(typeof debug!.gitVersion).toBe('string');
+        expect(typeof debug!.repoRoot).toBe('string');
+        expect(typeof debug!.worktreeList).toBe('string');
+        expect(debug!.refsHeadsSource).toBeDefined();
+        expect(debug!.refsHeadsTarget).toBeDefined();
+        expect(Array.isArray(debug!.mergeBaseCommand)).toBe(true);
+        expect(typeof debug!.mergeBaseExitCode).toBe('number');
+        expect(typeof debug!.mergeBaseStdout).toBe('string');
+        expect(typeof debug!.mergeBaseStderr).toBe('string');
+      } finally {
+        if (prior === undefined) delete process.env.EXARCHOS_PREFLIGHT_DEBUG;
+        else process.env.EXARCHOS_PREFLIGHT_DEBUG = prior;
+      }
+    });
+  });
+});

--- a/tests/outcome/reserved-fields-discoverability.test.ts
+++ b/tests/outcome/reserved-fields-discoverability.test.ts
@@ -1,0 +1,182 @@
+// ─── T3.1 — RESERVED_FIELD discoverability outcome (GREEN) ────────────────
+//
+// Encodes the #1360 fix shipped in commit 481e51c7 (PR #1392). The contract
+// being locked here has two distinct surfaces:
+//
+//   1. Discoverability — `exarchos_workflow.describe({actions:['update']})`
+//      surfaces a `reservedFields` block sourced from
+//      `RESERVED_FIELDS_DESCRIPTOR`. Callers learn the immutable boundary
+//      (and the alternate write paths, e.g. `transition` for `phase`)
+//      through describe instead of trial-and-error against the error
+//      envelope.
+//
+//   2. Structured error data — when `applyDotPath` rejects an update for a
+//      reserved key, the returned envelope carries an `error.data` block
+//      shaped `{rejectedPath, rule, alternateWritePath}`. Callers can
+//      pivot to the alternate path programmatically without parsing the
+//      error message.
+//
+// This is a backfill: the fix landed prior; the tests are GREEN against
+// current head. A future regression that strips either surface fails CI.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { EventStore } from '../../servers/exarchos-mcp/src/event-store/store.js';
+import {
+  handleInit,
+  handleUpdate,
+} from '../../servers/exarchos-mcp/src/workflow/tools.js';
+import { handleDescribe } from '../../servers/exarchos-mcp/src/describe/handler.js';
+import { TOOL_REGISTRY } from '../../servers/exarchos-mcp/src/registry.js';
+
+const workflowTool = TOOL_REGISTRY.find((t) => t.name === 'exarchos_workflow');
+
+describe('reserved-fields discoverability outcome (#1360)', () => {
+  it('Describe_UpdateAction_EnumeratesReservedFields', async () => {
+    expect(workflowTool).toBeDefined();
+    const result = await handleDescribe(
+      { actions: ['update'] },
+      workflowTool!.actions,
+    );
+    expect(result.success).toBe(true);
+
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('update');
+    const updateDesc = data.update as Record<string, unknown>;
+    expect(updateDesc).toHaveProperty('reservedFields');
+
+    const reservedFields = updateDesc.reservedFields as Record<string, unknown>;
+
+    // The descriptor surfaces four keys; the runtime guard and the doc
+    // surface derive from the same constant, so changing the descriptor
+    // changes the discoverability output. Each must be non-empty.
+    expect(reservedFields).toHaveProperty('topLevelImmutable');
+    expect(reservedFields).toHaveProperty('underscorePrefixRule');
+    expect(reservedFields).toHaveProperty('examples');
+    expect(reservedFields).toHaveProperty('alternateWritePaths');
+
+    const topLevel = reservedFields.topLevelImmutable as readonly string[];
+    expect(Array.isArray(topLevel)).toBe(true);
+    expect(topLevel.length).toBeGreaterThan(0);
+    expect(topLevel).toContain('phase');
+    expect(topLevel).toContain('workflowType');
+    expect(topLevel).toContain('featureId');
+
+    expect(typeof reservedFields.underscorePrefixRule).toBe('string');
+    expect((reservedFields.underscorePrefixRule as string).length).toBeGreaterThan(0);
+
+    const examples = reservedFields.examples as readonly string[];
+    expect(Array.isArray(examples)).toBe(true);
+    expect(examples.length).toBeGreaterThan(0);
+
+    const alternates = reservedFields.alternateWritePaths as Record<string, string>;
+    expect(typeof alternates).toBe('object');
+    expect(Object.keys(alternates).length).toBeGreaterThan(0);
+    // The canonical alternate for `phase` redirects to the `transition`
+    // action — this is the most operator-load-bearing entry in the map.
+    expect(alternates.phase).toMatch(/transition/);
+  });
+
+  it('Update_WithReservedTopLevelField_ReturnsStructuredErrorData', async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'outcome-reserved-fields-'),
+    );
+    try {
+      const eventStore = new EventStore(stateDir);
+      const featureId = 'outcome-1360-toplevel';
+
+      const initResult = await handleInit(
+        { featureId, workflowType: 'feature' },
+        stateDir,
+        eventStore,
+      );
+      expect(initResult.success).toBe(true);
+
+      // `workflowType` is top-level immutable. Routes through `applyDotPath`,
+      // which throws `RESERVED_FIELD` with structured data. (`phase` is
+      // intercepted earlier in `handleUpdate` with INVALID_INPUT, by design
+      // — phase has its own HSM-aware error path. We test the canonical
+      // RESERVED_FIELD branch via a different top-level immutable.)
+      const updateResult = await handleUpdate(
+        { featureId, updates: { workflowType: 'debug' } },
+        stateDir,
+        eventStore,
+      );
+
+      expect(updateResult.success).toBe(false);
+      expect(updateResult.error?.code).toBe('RESERVED_FIELD');
+
+      const errData = updateResult.error?.data as {
+        rejectedPath?: unknown;
+        rule?: unknown;
+        alternateWritePath?: unknown;
+      } | undefined;
+      expect(errData).toBeDefined();
+      expect(errData!.rejectedPath).toBe('workflowType');
+      expect(typeof errData!.rule).toBe('string');
+      expect((errData!.rule as string).length).toBeGreaterThan(0);
+      // alternateWritePath may be a populated string or null; both shapes
+      // are contract-compliant per `ReservedFieldErrorData`. For
+      // `workflowType` the descriptor provides a populated alternate.
+      const altPath = errData!.alternateWritePath;
+      expect(altPath === null || typeof altPath === 'string').toBe(true);
+      if (typeof altPath === 'string') {
+        expect(altPath.length).toBeGreaterThan(0);
+      }
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('Update_WithUnderscorePrefixedField_ReturnsStructuredErrorData', async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'outcome-reserved-fields-underscore-'),
+    );
+    try {
+      const eventStore = new EventStore(stateDir);
+      const featureId = 'outcome-1360-underscore';
+
+      const initResult = await handleInit(
+        { featureId, workflowType: 'feature' },
+        stateDir,
+        eventStore,
+      );
+      expect(initResult.success).toBe(true);
+
+      // Underscore-prefixed keys are reserved for projection / event-store
+      // metadata. The descriptor's `underscorePrefixRule` is surfaced as
+      // the `rule` text on the structured error, and the `^_.*` regex
+      // entry in `alternateWritePaths` provides the redirect to the
+      // typed-event surface.
+      const updateResult = await handleUpdate(
+        { featureId, updates: { _meta: 'x' } },
+        stateDir,
+        eventStore,
+      );
+
+      expect(updateResult.success).toBe(false);
+      expect(updateResult.error?.code).toBe('RESERVED_FIELD');
+
+      const errData = updateResult.error?.data as {
+        rejectedPath?: unknown;
+        rule?: unknown;
+        alternateWritePath?: unknown;
+      } | undefined;
+      expect(errData).toBeDefined();
+      expect(errData!.rejectedPath).toBe('_meta');
+      expect(typeof errData!.rule).toBe('string');
+      expect((errData!.rule as string).length).toBeGreaterThan(0);
+
+      const altPath = errData!.alternateWritePath;
+      expect(altPath === null || typeof altPath === 'string').toBe(true);
+      if (typeof altPath === 'string') {
+        expect(altPath.length).toBeGreaterThan(0);
+      }
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/outcome/runbook-merge-orchestration.test.ts
+++ b/tests/outcome/runbook-merge-orchestration.test.ts
@@ -1,0 +1,107 @@
+// ─── T3.2 — MERGE_ORCHESTRATION runbook outcome (GREEN) ───────────────────
+//
+// Encodes the #1363 fix shipped in commit c0a59a7e (PR #1391). The contract
+// being locked: `exarchos_orchestrate.runbook({phase: 'merge-pending'})`
+// returns the populated `merge-orchestration` runbook summary, where
+// previously the registry had no entry for the `merge-pending` phase and
+// the call returned `[]`.
+//
+// The runbook's canonical step sequence is (1) preflight dryRun → (2) real
+// merge → (3) HSM transition back to delegate. It auto-emits four events
+// covering the merge lifecycle: `merge.preflight`, `merge.executed`,
+// `merge.rollback`, and `workflow.transition`. List mode (no `id`)
+// returns the summary view shape `{id, phase, description, stepCount}`.
+//
+// Backfill — fix is already on head. A future regression that removes the
+// runbook or drops its auto-emits fails CI.
+
+import { describe, it, expect } from 'vitest';
+
+import { handleRunbook } from '../../servers/exarchos-mcp/src/runbooks/handler.js';
+
+interface RunbookSummary {
+  readonly id: string;
+  readonly phase: string;
+  readonly description: string;
+  readonly stepCount: number;
+}
+
+describe('MERGE_ORCHESTRATION runbook outcome (#1363)', () => {
+  it('Runbook_MergePendingPhase_ReturnsCanonicalFourEventSequence', async () => {
+    // ─── List mode summary ──────────────────────────────────────────────
+    const listResult = await handleRunbook({ phase: 'merge-pending' });
+    expect(listResult.success).toBe(true);
+
+    const summaries = listResult.data as readonly RunbookSummary[];
+    expect(Array.isArray(summaries)).toBe(true);
+    expect(summaries.length).toBeGreaterThan(0);
+
+    const mergeOrch = summaries.find((r) => r.id === 'merge-orchestration');
+    expect(mergeOrch).toBeDefined();
+    expect(mergeOrch!.phase).toBe('merge-pending');
+    expect(typeof mergeOrch!.description).toBe('string');
+    expect(mergeOrch!.description.length).toBeGreaterThan(0);
+    expect(mergeOrch!.stepCount).toBe(3);
+
+    // ─── Detail mode — canonical step + auto-emit sequence ──────────────
+    //
+    // The four-event canonical sequence covers the full merge lifecycle.
+    // Order on `autoEmits` is the declared emission order: preflight
+    // fires first (dryRun), then `merge.executed` after the real merge
+    // succeeds OR `merge.rollback` after it fails, then
+    // `workflow.transition` regardless of outcome.
+    const detailResult = await handleRunbook({ id: 'merge-orchestration' });
+    expect(detailResult.success).toBe(true);
+
+    const detail = detailResult.data as {
+      readonly id: string;
+      readonly phase: string;
+      readonly autoEmits: readonly string[];
+      readonly steps: ReadonlyArray<{
+        readonly seq: number;
+        readonly tool: string;
+        readonly action: string;
+      }>;
+    };
+    expect(detail.id).toBe('merge-orchestration');
+    expect(detail.phase).toBe('merge-pending');
+
+    // Auto-emits must cover the four lifecycle events.
+    expect(detail.autoEmits).toEqual(
+      expect.arrayContaining([
+        'merge.preflight',
+        'merge.executed',
+        'merge.rollback',
+        'workflow.transition',
+      ]),
+    );
+
+    // Step shape: preflight (orchestrate) → real merge (orchestrate) →
+    // HSM transition (workflow). Each step carries `seq` for operator
+    // traceability.
+    expect(detail.steps).toHaveLength(3);
+    expect(detail.steps[0].tool).toBe('exarchos_orchestrate');
+    expect(detail.steps[0].action).toBe('merge_orchestrate');
+    expect(detail.steps[1].tool).toBe('exarchos_orchestrate');
+    expect(detail.steps[1].action).toBe('merge_orchestrate');
+    expect(detail.steps[2].tool).toBe('exarchos_workflow');
+    expect(detail.steps[2].action).toBe('transition');
+  });
+
+  it('Runbook_OtherPhases_StillPopulated', async () => {
+    // Quick regression guard: other phases the registry serves must remain
+    // populated. If a refactor accidentally narrows the runbook registry
+    // to merge-pending only (or drops a phase), this catches it.
+    const phasesToCheck = ['delegate', 'review', 'synthesize'] as const;
+    for (const phase of phasesToCheck) {
+      const result = await handleRunbook({ phase });
+      expect(result.success).toBe(true);
+      const summaries = result.data as readonly RunbookSummary[];
+      expect(Array.isArray(summaries)).toBe(true);
+      expect(summaries.length).toBeGreaterThan(0);
+      for (const summary of summaries) {
+        expect(summary.phase).toBe(phase);
+      }
+    }
+  });
+});

--- a/tests/outcome/runbook-merge-orchestration.test.ts
+++ b/tests/outcome/runbook-merge-orchestration.test.ts
@@ -66,7 +66,12 @@ describe('MERGE_ORCHESTRATION runbook outcome (#1363)', () => {
     expect(detail.id).toBe('merge-orchestration');
     expect(detail.phase).toBe('merge-pending');
 
-    // Auto-emits must cover the four lifecycle events.
+    // Auto-emits must cover EXACTLY the four lifecycle events — no extras.
+    // The runbook registry at `runbooks/definitions.ts` is the canonical
+    // source. arrayContaining alone would permit silent growth of the list
+    // (a real risk if a future change wires in additional emit events without
+    // updating this matrix); pin the count explicitly to catch that drift.
+    expect(detail.autoEmits).toHaveLength(4);
     expect(detail.autoEmits).toEqual(
       expect.arrayContaining([
         'merge.preflight',

--- a/tests/outcome/telemetry-action-errors.test.ts
+++ b/tests/outcome/telemetry-action-errors.test.ts
@@ -1,0 +1,200 @@
+// ─── T3.3 — Telemetry action/transport split outcome (GREEN) ──────────────
+//
+// Encodes the #1364 fix shipped in commit 53cb4e4d (PR #1393). Before the
+// fix, the telemetry view's `errors` counter conflated two failure modes:
+//   - Transport / protocol JS throws (the handler crashed)
+//   - Structured action-level failures (the handler returned a
+//     `{success:false, error:{code,…}}` envelope per the MCP contract)
+//
+// The fix splits them. `tool.errored` continues to fire on JS throws only;
+// `tool.action_errored` fires on structured failures and carries the
+// per-call `errorCode`. The telemetry projection folds them into separate
+// counters: `errors` (transport) and `actionErrors` /
+// `actionErrorBreakdown` (action-level, keyed by error code).
+//
+// This test exercises the contract end-to-end via the real `withTelemetry`
+// middleware against an `EventStore`-backed telemetry view, mirroring the
+// outcome-tier posture of asserting on what an operator would observe in
+// `view.telemetry` output.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { EventStore } from '../../servers/exarchos-mcp/src/event-store/store.js';
+import { withTelemetry } from '../../servers/exarchos-mcp/src/telemetry/middleware.js';
+import type { CoreHandler } from '../../servers/exarchos-mcp/src/telemetry/middleware.js';
+import { handleViewTelemetry } from '../../servers/exarchos-mcp/src/telemetry/tools.js';
+import {
+  handleInit,
+  handleUpdate,
+} from '../../servers/exarchos-mcp/src/workflow/tools.js';
+
+interface TelemetryToolEntry {
+  readonly tool: string;
+  readonly invocations: number;
+  readonly errors: number;
+  readonly actionErrors: number;
+  readonly actionErrorBreakdown: Readonly<Record<string, number>>;
+}
+
+interface TelemetryEnvelope {
+  readonly session: {
+    readonly start: string;
+    readonly totalInvocations: number;
+    readonly totalTokens: number;
+  };
+  readonly tools: readonly TelemetryToolEntry[];
+}
+
+describe('telemetry action/transport split outcome (#1364)', () => {
+  it('Telemetry_AfterStructuredFailure_IncrementsActionErrorsNotTransportErrors', async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'outcome-telemetry-split-'),
+    );
+    try {
+      const eventStore = new EventStore(stateDir);
+
+      // Initialise a real workflow so the subsequent failing update has
+      // genuine state to land against (the RESERVED_FIELD path requires
+      // an existing state file).
+      const featureId = 'outcome-1364-action';
+      const initResult = await handleInit(
+        { featureId, workflowType: 'feature' },
+        stateDir,
+        eventStore,
+      );
+      expect(initResult.success).toBe(true);
+
+      // Wrap the real `handleUpdate` with the telemetry middleware. The
+      // middleware emits `tool.completed` + `tool.action_errored` when
+      // the wrapped handler returns a structured failure envelope (post
+      // #1364) instead of throwing.
+      const toolName = 'exarchos_workflow';
+      const wrapped: CoreHandler = withTelemetry(
+        async (args) =>
+          handleUpdate(
+            args as { featureId: string; updates: Record<string, unknown> },
+            stateDir,
+            eventStore,
+          ),
+        toolName,
+        eventStore,
+      );
+
+      // Drive a reserved-field rejection — the structured failure path.
+      // `workflowType` is top-level immutable and routes through
+      // `applyDotPath`, yielding `RESERVED_FIELD`.
+      const failure = await wrapped({
+        featureId,
+        updates: { workflowType: 'debug' },
+      });
+      expect(failure.success).toBe(false);
+      expect(failure.error?.code).toBe('RESERVED_FIELD');
+
+      // Read telemetry. The MCP composite isn't running, so we hit the
+      // handler directly — same underlying projection over the same
+      // TELEMETRY_STREAM events.
+      const telemetryResult = await handleViewTelemetry({}, stateDir, eventStore);
+      expect(telemetryResult.success).toBe(true);
+
+      const envelope = telemetryResult.data as TelemetryEnvelope;
+      const entry = envelope.tools.find((t) => t.tool === toolName);
+      expect(entry).toBeDefined();
+      // Structured failure must increment actionErrors, NOT errors.
+      expect(entry!.actionErrors).toBeGreaterThanOrEqual(1);
+      expect(entry!.errors).toBe(0);
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('Telemetry_ActionErrorBreakdown_KeyedByErrorCode', async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'outcome-telemetry-breakdown-'),
+    );
+    try {
+      const eventStore = new EventStore(stateDir);
+
+      const featureId = 'outcome-1364-breakdown';
+      const initResult = await handleInit(
+        { featureId, workflowType: 'feature' },
+        stateDir,
+        eventStore,
+      );
+      expect(initResult.success).toBe(true);
+
+      const toolName = 'exarchos_workflow';
+      const wrapped: CoreHandler = withTelemetry(
+        async (args) =>
+          handleUpdate(
+            args as { featureId: string; updates: Record<string, unknown> },
+            stateDir,
+            eventStore,
+          ),
+        toolName,
+        eventStore,
+      );
+
+      const failure = await wrapped({
+        featureId,
+        updates: { workflowType: 'debug' },
+      });
+      expect(failure.success).toBe(false);
+      expect(failure.error?.code).toBe('RESERVED_FIELD');
+
+      const telemetryResult = await handleViewTelemetry({}, stateDir, eventStore);
+      expect(telemetryResult.success).toBe(true);
+
+      const envelope = telemetryResult.data as TelemetryEnvelope;
+      const entry = envelope.tools.find((t) => t.tool === toolName);
+      expect(entry).toBeDefined();
+      // The breakdown is keyed by the structured `error.code`, not by a
+      // generic "failed" label — that is the per-call diagnostic surface.
+      expect(entry!.actionErrorBreakdown).toBeDefined();
+      expect(entry!.actionErrorBreakdown['RESERVED_FIELD']).toBeGreaterThanOrEqual(1);
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('Telemetry_AfterJsThrow_IncrementsTransportErrors', async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'outcome-telemetry-throw-'),
+    );
+    try {
+      const eventStore = new EventStore(stateDir);
+
+      // A handler that throws raw — the transport / protocol failure
+      // mode. Mirrors the wrapper's `tool.errored` path; explicitly
+      // contrasted with the structured-failure path above so the split
+      // contract is exercised both ways.
+      const toolName = 'exarchos_orchestrate';
+      const throwingHandler: CoreHandler = async () => {
+        throw new Error('transport explode');
+      };
+      const wrapped: CoreHandler = withTelemetry(
+        throwingHandler,
+        toolName,
+        eventStore,
+      );
+
+      await expect(wrapped({})).rejects.toThrow('transport explode');
+
+      const telemetryResult = await handleViewTelemetry({}, stateDir, eventStore);
+      expect(telemetryResult.success).toBe(true);
+
+      const envelope = telemetryResult.data as TelemetryEnvelope;
+      const entry = envelope.tools.find((t) => t.tool === toolName);
+      expect(entry).toBeDefined();
+      // Transport failure must increment errors and NOT actionErrors —
+      // the JS throw never resolves the handler envelope, so no
+      // `tool.action_errored` companion event fires.
+      expect(entry!.errors).toBeGreaterThanOrEqual(1);
+      expect(entry!.actionErrors).toBe(0);
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Final close-out bundle for the v2.10.0-preview.3 dogfood remediation epic ([#1354](https://github.com/lvlup-sw/exarchos/issues/1354)). Closes three remaining items via three squashed sub-PRs:

- **[#1398](https://github.com/lvlup-sw/exarchos/pull/1398)** — `#1374` saga-merge-detour unit-tier pin. Investigation found the wire was already restored upstream by #1394; this PR ships a defensive cross-boundary pin so future regressions of the same class fail at unit-tier instead of the saga tier.
- **[#1400](https://github.com/lvlup-sw/exarchos/pull/1400)** — `#1362` Windows ancestry-preflight phase-1 instrumentation. Env-gated debug payload (`EXARCHOS_PREFLIGHT_DEBUG=1`) on `merge.preflight` events when ancestry fails. Captures git version, repo root, worktree list, packed-ref status, and `merge-base` invocation output for phase-2 root-cause analysis from a Windows host.
- **[#1399](https://github.com/lvlup-sw/exarchos/pull/1399)** — Outcome-tier completeness backfill for `#1360` / `#1363` / `#1364`. Three new operator-visible behavior tests + coverage matrix in the helpers README.

Also: design doc, plan, and eval-suite-redesign seed committed (~954 LOC of structured artifacts, separate commit).

## Changes

- **Production code:** `merge-preflight.ts` (+155 LOC `gatherPreflightDebug` helper), `merge-orchestrate.ts` (+7 LOC event-data spread fix per review), `event-store/schemas.ts` (+29 LOC `MergePreflightDebugData` optional branch), `skills-src/merge-orchestrator/SKILL.md` + 6 regenerated runtime variants (Diagnostics section).
- **Test code:** new `tests/outcome/{preflight-debug,reserved-fields-discoverability,runbook-merge-orchestration,telemetry-action-errors}.test.ts` (637 LOC); appended cases to `next-actions-from-result.test.ts`, `merge-orchestrate.test.ts`, `merge-preflight.test.ts`, `event-store/schemas.test.ts` (~430 LOC).
- **Docs:** design + plan + eval-redesign seed (~954 LOC).

## Test Plan

- [x] All 17 plan tasks accounted for in 3 sub-PR commits + 1 fixer commit (`48d1c8e4`)
- [x] MCP server suite: 6704 pass / 25 skipped / 0 fail
- [x] Root suite: 762 pass / 6 skipped / 0 fail
- [x] Outcome tier: 19/19 pass (was 16; +3 new tests)
- [x] `test/process/saga-merge-detour.test.ts` GREEN (#1374 contract holds)
- [x] `npm run typecheck` clean across both projects
- [x] `npm run skills:guard` clean (per-runtime SKILL.md variants symmetric across 6 runtimes)
- [x] CI Gate green on all 3 sub-PRs
- [x] All Binary Matrix targets green (linux-x64, linux-arm64, darwin-x64, darwin-arm64, windows-x64)

## Review

Two-stage review dispatched to subagents during the workflow:

- **Spec compliance** ([`exarchos:exarchos-reviewer`](spec-review)) — verified two implementer-flagged deviations:
  - PR1 no-fix outcome (saga test already GREEN on integration head post-#1394 canonical-tasks projection fix)
  - PR3 reserved-fields pivot from `phase` → `workflowType` (preserves contract intent — `phase` has HSM-aware early-intercept at `tools.ts:1003`)
  - PR3 runbook `autoEmits` detail-mode contract (matches source-of-truth at `runbooks/definitions.ts:636`)
- **Quality** ([`exarchos:exarchos-reviewer`](quality-review)) — 0 catalog findings across 6 dimensions (error-handling, type-safety, test-quality, code-hygiene, structural-complexity, resilience). Companion plugins (axiom, impeccable) not installed in environment.

**Initial verdict:** NEEDS_FIXES with 1 HIGH (PR2 event-store append omitted `debug` field — helper produced, schema accepted, persistence dropped). Fixer dispatched, landed `48d1c8e4` (7-line conditional spread mirroring `failureReasons` + paired handler-tier tests). **Post-fix verdict:** APPROVED (0 HIGH, 0 MEDIUM, 2 LOW informational).

## Epic close-out

Closes via this PR's merge:

- `#1354` — Wave 0/1/2/3 bundle complete (Wave 3 partially: #1362 phase-1 + #1374 + #1360/#1363/#1364 outcome backfill ship here; #1365 deferred)
- `#1374` — saga-merge-detour regression (unit-tier pin only — no production fix needed; #1394 already restored the wire)
- `#1362` — Windows preflight phase-1 instrumentation (phase-2 awaits Windows-host data)

Stays open (intentional, per redesign decision):

- `#1365` — eval-suite elevation. Pulled from this bundle pending a full eval-suite redesign. Insight: `{{TOKEN}}` placeholders encode harness mechanics, not behavior — shipping the current step 1+2 plan on top of an architecture we intend to replace would burn the cost twice. Two-tier architecture proposal (Tier A harness-surface tests + Tier B behavioral evals on the dotnet/skills pattern) seeded at `docs/research/2026-05-15-eval-suite-redesign-seed.md` with 10 open questions for the next `/exarchos:ideate` pass.
- `#1387` / `#1396` / `#1397` — eval follow-ups. Commented with redesign direction; will be retargeted or superseded once the redesign produces a tracking epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)