### PR TITLE
fix(merge-orchestrate): resolve repoRoot from git top-level, not cwd

### DIFF
--- a/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
+++ b/servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
@@ -390,7 +390,27 @@ export async function handleMergeOrchestrate(
   // when the caller's cwd traverses a symlinked segment (a common case on
   // macOS where /var → /private/var, or developer-symlinked checkouts).
   // realpathSync requires the path to exist; fall back to resolve() if not.
-  const repoRoot = normalizePath(args.repoRoot ?? process.cwd());
+  //
+  // When `repoRoot` is not supplied, derive it from `git rev-parse
+  // --show-toplevel` rather than `process.cwd()`. The cwd may be a subdir
+  // of the repo (test runners frequently invoke vitest from
+  // `servers/exarchos-mcp/` — a sub-package), in which case the
+  // `git worktree list --porcelain` output (which emits the canonical
+  // top-level path) would never equal cwd and the main worktree itself
+  // would be misidentified as a sibling holding the target branch.
+  // Falling back to cwd preserves the previous behavior when not inside
+  // any git repo (rare; surfaces as a clean preflight skip rather than a
+  // spurious abort).
+  let derivedRoot = args.repoRoot;
+  if (derivedRoot === undefined) {
+    const topLevel = gitExec(process.cwd(), ['rev-parse', '--show-toplevel']);
+    if (topLevel.exitCode === 0) {
+      derivedRoot = topLevel.stdout.trim();
+    } else {
+      derivedRoot = process.cwd();
+    }
+  }
+  const repoRoot = normalizePath(derivedRoot);
   const worktreeListResult = gitExec(repoRoot, ['worktree', 'list', '--porcelain']);
   if (worktreeListResult.exitCode === 0) {
     const targetRef = `refs/heads/${args.targetBranch}`;


### PR DESCRIPTION
## Summary
- Hotfix: 26 MCP-server tests across 9 files (`merge-orchestrate.*`) shipped red to `main` with the `v2.10.0-preview.3` close-out bundle (#1401), blocking the release.
- Root cause: the `targetWorktreeAvailability` preflight added in #1356 compares `git worktree list --porcelain` output (canonical repo top-level) against `repoRoot`, which defaulted to `process.cwd()`. When called from a repo subdir (e.g. vitest running in `servers/exarchos-mcp/`), the main worktree gets misidentified as a "sibling holding the target" and the handler aborts with `target-checked-out-elsewhere` before any DI'd preflight/executor mock runs.
- Fix: when `repoRoot` isn't supplied, derive it from `git rev-parse --show-toplevel` via the injectable `gitExec`. Falls back to `process.cwd()` only when not in any git repo.

## Changes
- `servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts` — derive `repoRoot` from `git rev-parse --show-toplevel` (single, surgical change).

## Test Plan
- [x] `npx vitest run src/orchestrate/merge-orchestrate.test.ts` — 15/15 pass (was 14/15 fail).
- [x] Full MCP-server suite (`cd servers/exarchos-mcp && npm run test:run`) — **6710 pass / 22 skipped / 0 fail** (was 26 fail).
- [x] Root suite (`npm run test:run`) — **762 pass / 6 skipped** (unchanged).
- [x] `npm run typecheck` — clean.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)