### PR TITLE
refactor(next-actions): Zod discriminated unions + fail-closed safeParse (#1238)

### DIFF
--- a/servers/exarchos-mcp/src/next-actions-from-result.test.ts
+++ b/servers/exarchos-mcp/src/next-actions-from-result.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   nextActionsFromResult,
+  nextActionsLogger,
   ResultDataSchema,
 } from './next-actions-from-result.js';
 import type { ToolResult } from './format.js';
@@ -216,7 +217,9 @@ describe('nextActionsFromResult — shape recognition', () => {
       let warnSpy: ReturnType<typeof vi.spyOn>;
 
       beforeEach(() => {
-        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        warnSpy = vi
+          .spyOn(nextActionsLogger, 'warn')
+          .mockImplementation(() => undefined as never);
       });
 
       afterEach(() => {
@@ -248,8 +251,8 @@ describe('nextActionsFromResult — shape recognition', () => {
       // Legitimate no-actions path: error envelope. Must NOT log a warning —
       // only malformed-success payloads warn.
       const warnSpy = vi
-        .spyOn(console, 'warn')
-        .mockImplementation(() => undefined);
+        .spyOn(nextActionsLogger, 'warn')
+        .mockImplementation(() => undefined as never);
       try {
         const result: ToolResult = {
           success: false,
@@ -266,8 +269,8 @@ describe('nextActionsFromResult — shape recognition', () => {
       // Legitimate no-actions path: success envelope with null/non-object
       // data (describe / list / status actions). Must NOT warn.
       const warnSpy = vi
-        .spyOn(console, 'warn')
-        .mockImplementation(() => undefined);
+        .spyOn(nextActionsLogger, 'warn')
+        .mockImplementation(() => undefined as never);
       try {
         expect(nextActionsFromResult(ok(null))).toEqual([]);
         expect(nextActionsFromResult(ok(undefined))).toEqual([]);

--- a/servers/exarchos-mcp/src/next-actions-from-result.test.ts
+++ b/servers/exarchos-mcp/src/next-actions-from-result.test.ts
@@ -10,8 +10,11 @@
 // Pre-fix only shape 1 was extracted, so rehydrate envelopes always returned
 // `next_actions: []` even when the merge-pending detour was active. These
 // tests pin shape 2 + the merge_orchestrate surfacing branch.
-import { describe, it, expect } from 'vitest';
-import { nextActionsFromResult } from './next-actions-from-result.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  nextActionsFromResult,
+  ResultDataSchema,
+} from './next-actions-from-result.js';
 import type { ToolResult } from './format.js';
 import { rehydrationReducer } from './projections/rehydration/reducer.js';
 import type { WorkflowEvent } from './event-store/schemas.js';
@@ -147,6 +150,133 @@ describe('nextActionsFromResult — shape recognition', () => {
     expect(actions.some((a) => a.verb === 'merge_orchestrate')).toBe(true);
     const mo = actions.find((a) => a.verb === 'merge_orchestrate');
     expect(mo?.idempotencyKey).toBe('top-level-mo:merge_orchestrate:099');
+  });
+
+  // ─── #1238 ResultDataSchema discriminated union coverage ──────────────────
+  //
+  // The parser body previously used `Record<string, unknown>` casts and inline
+  // `typeof` guards. #1238 replaces that with a Zod union of two shapes plus
+  // a fail-closed `safeParse` boundary. These tests pin both shapes plus the
+  // malformed → warn-and-[] case.
+
+  describe('#1238 ResultDataSchema discriminated union', () => {
+    it('NextActionsFromResult_WorkflowHandlerPayload_ParsesShapeOne', () => {
+      // Shape 1 — top-level phase + workflowType (+ optional featureId /
+      // mergeOrchestrator). Parses via ShapeOneSchema in the union.
+      const parsed = ResultDataSchema.safeParse({
+        phase: 'merge-pending',
+        workflowType: 'feature',
+        featureId: 'shape-one',
+        mergeOrchestrator: { taskId: '007', phase: 'pending' },
+      });
+      expect(parsed.success).toBe(true);
+
+      const actions = nextActionsFromResult(
+        ok({
+          phase: 'merge-pending',
+          workflowType: 'feature',
+          featureId: 'shape-one',
+          mergeOrchestrator: { taskId: '007', phase: 'pending' },
+        }),
+      );
+      const mo = actions.find((a) => a.verb === 'merge_orchestrate');
+      expect(mo).toBeDefined();
+      expect(mo?.idempotencyKey).toBe('shape-one:merge_orchestrate:007');
+    });
+
+    it('NextActionsFromResult_RehydrationDocument_ParsesShapeTwo', () => {
+      // Shape 2 — `{ workflowState: { phase, workflowType, featureId,
+      // mergeOrchestrator } }`. Parses via ShapeTwoSchema in the union.
+      const parsed = ResultDataSchema.safeParse({
+        workflowState: {
+          featureId: 'shape-two',
+          phase: 'merge-pending',
+          workflowType: 'feature',
+          mergeOrchestrator: { taskId: '042', phase: 'pending' },
+        },
+      });
+      expect(parsed.success).toBe(true);
+
+      const actions = nextActionsFromResult(
+        ok({
+          workflowState: {
+            featureId: 'shape-two',
+            phase: 'merge-pending',
+            workflowType: 'feature',
+            mergeOrchestrator: { taskId: '042', phase: 'pending' },
+          },
+        }),
+      );
+      const mo = actions.find((a) => a.verb === 'merge_orchestrate');
+      expect(mo).toBeDefined();
+      expect(mo?.idempotencyKey).toBe('shape-two:merge_orchestrate:042');
+    });
+
+    describe('NextActionsFromResult_MalformedPayload_FailsClosed', () => {
+      let warnSpy: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      });
+
+      afterEach(() => {
+        warnSpy.mockRestore();
+      });
+
+      it('returns [] and warns on a payload matching neither shape', () => {
+        // Payload that doesn't satisfy ShapeOneSchema (no string phase /
+        // workflowType at top level) AND doesn't satisfy ShapeTwoSchema
+        // (workflowState missing required featureId string). This must
+        // fail-closed: return [] AND log a warning so the malformed payload
+        // is surfaced rather than silently swallowed.
+        const actions = nextActionsFromResult(
+          ok({
+            phase: 42, // wrong type for ShapeOne
+            workflowState: {
+              // missing required `featureId`, wrong type on `phase`
+              phase: false,
+              workflowType: 'feature',
+            },
+          }),
+        );
+        expect(actions).toEqual([]);
+        expect(warnSpy).toHaveBeenCalled();
+      });
+    });
+
+    it('NextActionsFromResult_NonSuccessResult_ReturnsEmptyArray', () => {
+      // Legitimate no-actions path: error envelope. Must NOT log a warning —
+      // only malformed-success payloads warn.
+      const warnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+      try {
+        const result: ToolResult = {
+          success: false,
+          error: { code: 'X', message: 'no' },
+        };
+        expect(nextActionsFromResult(result)).toEqual([]);
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('NextActionsFromResult_NullData_ReturnsEmptyArray', () => {
+      // Legitimate no-actions path: success envelope with null/non-object
+      // data (describe / list / status actions). Must NOT warn.
+      const warnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+      try {
+        expect(nextActionsFromResult(ok(null))).toEqual([]);
+        expect(nextActionsFromResult(ok(undefined))).toEqual([]);
+        expect(nextActionsFromResult(ok('string-payload'))).toEqual([]);
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
   });
 
   it('returns [] for unknown workflowType in shape 2', () => {

--- a/servers/exarchos-mcp/src/next-actions-from-result.ts
+++ b/servers/exarchos-mcp/src/next-actions-from-result.ts
@@ -13,10 +13,56 @@
 // are possible and must not poison the envelope. Invoked at most once per
 // composite call.
 
+import { z } from 'zod';
 import type { ToolResult } from './format.js';
 import type { NextAction } from './next-action.js';
 import { computeNextActions } from './next-actions-computer.js';
+import {
+  RehydrationMergeOrchestratorSchema,
+  WorkflowStateSchema,
+} from './projections/rehydration/schema.js';
 import { getHSMDefinition } from './workflow/state-machine.js';
+
+// ─── #1238 ResultDataSchema discriminated union ─────────────────────────────
+//
+// The parser body previously used `Record<string, unknown>` casts and inline
+// `typeof` guards to dig phase / workflowType / featureId / mergeOrchestrator
+// out of `result.data`. #1238 replaces that with a Zod union of two shapes so
+// the contract is declarative and a malformed payload fails closed rather
+// than silently degrading.
+//
+// `.passthrough()` keeps unknown sibling fields (handler payloads carry many
+// extra fields — taskProgress, decisions, etc.) — we only validate the
+// fields this helper reads.
+
+/** Shape 1 — handler payload (`handleInit` / `handleGet` / `handleSet`). */
+export const ShapeOneSchema = z
+  .object({
+    phase: z.string(),
+    workflowType: z.string(),
+    featureId: z.string().optional(),
+    mergeOrchestrator: RehydrationMergeOrchestratorSchema.optional(),
+  })
+  .passthrough();
+
+/** Shape 2 — rehydration document (`handleRehydrate`). */
+export const ShapeTwoSchema = z
+  .object({
+    workflowState: WorkflowStateSchema,
+  })
+  .passthrough();
+
+/**
+ * Discriminated by structure: ShapeOne carries top-level `phase` /
+ * `workflowType`; ShapeTwo nests them inside `workflowState`. A payload that
+ * matches both (a handler payload that also carries a `workflowState`
+ * sibling) parses as ShapeOne by virtue of union order — the top-level
+ * extraction is preserved and the workflowState segment is read for
+ * `mergeOrchestrator` backfill via a separate ShapeTwo parse downstream.
+ */
+export const ResultDataSchema = z.union([ShapeOneSchema, ShapeTwoSchema]);
+
+export type ResultData = z.infer<typeof ResultDataSchema>;
 
 /**
  * Extract workflow state from a successful `ToolResult` and compute the

--- a/servers/exarchos-mcp/src/next-actions-from-result.ts
+++ b/servers/exarchos-mcp/src/next-actions-from-result.ts
@@ -88,53 +88,55 @@ export type ResultData = z.infer<typeof ResultDataSchema>;
  * `merge_orchestrate` surfacing branch.
  */
 export function nextActionsFromResult(result: ToolResult): readonly NextAction[] {
+  // Legitimate no-actions paths — describe/list/status actions, error
+  // envelopes, view composites. These MUST NOT warn: they're expected to be
+  // empty.
   if (!result.success) return [];
   const data = result.data;
-  if (data === null || typeof data !== 'object') return [];
+  if (data === null || data === undefined || typeof data !== 'object') return [];
 
-  const dataRecord = data as Record<string, unknown>;
-  // Shape 1 — workflow-handler payload.
-  let phase = typeof dataRecord.phase === 'string' ? dataRecord.phase : undefined;
-  let workflowType =
-    typeof dataRecord.workflowType === 'string' ? dataRecord.workflowType : undefined;
-  let featureId =
-    typeof dataRecord.featureId === 'string' ? dataRecord.featureId : undefined;
-  let mergeOrchestrator: { taskId?: string; phase?: string } | undefined;
-  if (
-    typeof dataRecord.mergeOrchestrator === 'object' &&
-    dataRecord.mergeOrchestrator !== null
-  ) {
-    const mo = dataRecord.mergeOrchestrator as Record<string, unknown>;
-    mergeOrchestrator = {
-      ...(typeof mo.taskId === 'string' ? { taskId: mo.taskId } : {}),
-      ...(typeof mo.phase === 'string' ? { phase: mo.phase } : {}),
-    };
+  // Fail-closed parse boundary (#1238). A success payload that's a non-null
+  // object but matches NEITHER shape is malformed — warn so the contract
+  // violation is surfaced rather than silently degrading to []. The two
+  // shapes are intentionally permissive (`.passthrough()`), so this only
+  // triggers on genuinely unexpected payloads (e.g. handler returned wrong
+  // types on phase / workflowType, or workflowState missing featureId).
+  const parsed = ResultDataSchema.safeParse(data);
+  if (!parsed.success) {
+    console.warn(
+      '[next-actions] malformed result.data — failed ResultDataSchema parse; returning [].',
+      { issues: parsed.error.issues },
+    );
+    return [];
   }
 
-  // Shape 2 — rehydration document. Backfill any field shape 1 did not
-  // populate. Read `mergeOrchestrator` regardless of whether shape 1 had
-  // phase/workflowType: handler payloads (shape 1) carry phase + workflowType
-  // at the top level but typically NOT mergeOrchestrator; that field lives on
-  // the workflowState segment. Without this backfill, a payload with both
-  // top-level phase + nested workflowState.mergeOrchestrator would drop the
-  // merge-orchestration context and miss `merge_orchestrate` in next_actions.
-  if (typeof dataRecord.workflowState === 'object' && dataRecord.workflowState !== null) {
-    const ws = dataRecord.workflowState as Record<string, unknown>;
-    if (!phase && typeof ws.phase === 'string') phase = ws.phase;
-    if (!workflowType && typeof ws.workflowType === 'string') {
-      workflowType = ws.workflowType;
-    }
-    if (!featureId && typeof ws.featureId === 'string') featureId = ws.featureId;
-    if (
-      mergeOrchestrator === undefined &&
-      typeof ws.mergeOrchestrator === 'object' &&
-      ws.mergeOrchestrator !== null
-    ) {
-      const mo = ws.mergeOrchestrator as Record<string, unknown>;
-      mergeOrchestrator = {
-        ...(typeof mo.taskId === 'string' ? { taskId: mo.taskId } : {}),
-        ...(typeof mo.phase === 'string' ? { phase: mo.phase } : {}),
-      };
+  // The union parses non-greedily on the first matching shape. To preserve
+  // the existing semantics — shape-1 fields take precedence; mergeOrchestrator
+  // backfilled from workflowState even when shape 1 supplies phase — read
+  // both shapes independently. Both safeParses are cheap (the data already
+  // matched at least one shape).
+  const shapeOne = ShapeOneSchema.safeParse(data);
+  const shapeTwo = ShapeTwoSchema.safeParse(data);
+
+  let phase: string | undefined;
+  let workflowType: string | undefined;
+  let featureId: string | undefined;
+  let mergeOrchestrator: { taskId?: string; phase?: string } | undefined;
+
+  if (shapeOne.success) {
+    phase = shapeOne.data.phase;
+    workflowType = shapeOne.data.workflowType;
+    featureId = shapeOne.data.featureId;
+    mergeOrchestrator = shapeOne.data.mergeOrchestrator;
+  }
+
+  if (shapeTwo.success) {
+    const ws = shapeTwo.data.workflowState;
+    if (!phase) phase = ws.phase;
+    if (!workflowType) workflowType = ws.workflowType;
+    if (!featureId) featureId = ws.featureId;
+    if (mergeOrchestrator === undefined && ws.mergeOrchestrator !== undefined) {
+      mergeOrchestrator = ws.mergeOrchestrator;
     }
   }
 

--- a/servers/exarchos-mcp/src/next-actions-from-result.ts
+++ b/servers/exarchos-mcp/src/next-actions-from-result.ts
@@ -15,6 +15,7 @@
 
 import { z } from 'zod';
 import type { ToolResult } from './format.js';
+import { logger } from './logger.js';
 import type { NextAction } from './next-action.js';
 import { computeNextActions } from './next-actions-computer.js';
 import {
@@ -22,6 +23,13 @@ import {
   WorkflowStateSchema,
 } from './projections/rehydration/schema.js';
 import { getHSMDefinition } from './workflow/state-machine.js';
+
+/**
+ * Structured logger child for fail-closed parse warnings (#1238).
+ * Exported so unit tests can `vi.spyOn(nextActionsLogger, 'warn')` to assert
+ * the malformed-payload fail-closed branch.
+ */
+export const nextActionsLogger = logger.child({ subsystem: 'next-actions' });
 
 // ─── #1238 ResultDataSchema discriminated union ─────────────────────────────
 //
@@ -53,16 +61,24 @@ export const ShapeTwoSchema = z
   .passthrough();
 
 /**
- * Discriminated by structure: ShapeOne carries top-level `phase` /
- * `workflowType`; ShapeTwo nests them inside `workflowState`. A payload that
- * matches both (a handler payload that also carries a `workflowState`
- * sibling) parses as ShapeOne by virtue of union order — the top-level
- * extraction is preserved and the workflowState segment is read for
- * `mergeOrchestrator` backfill via a separate ShapeTwo parse downstream.
+ * The two recognised workflow-context payload shapes. A success-envelope
+ * payload that carries a discriminator key but fails this union is treated
+ * as malformed (warn + `[]`) at the fail-closed boundary in
+ * `nextActionsFromResult`. Payloads without any discriminator key are
+ * non-workflow responses (event-store / view composite / describe) and are
+ * not parsed against this schema at all.
  */
 export const ResultDataSchema = z.union([ShapeOneSchema, ShapeTwoSchema]);
 
 export type ResultData = z.infer<typeof ResultDataSchema>;
+
+/**
+ * Discriminator keys that indicate a payload is *attempting* to carry
+ * workflow context (even if the types are wrong). Used to distinguish a
+ * legitimate non-workflow payload (silent `[]`) from a malformed workflow
+ * payload (warn + `[]`).
+ */
+const CONTEXT_DISCRIMINATOR_KEYS = ['phase', 'workflowType', 'workflowState'] as const;
 
 /**
  * Extract workflow state from a successful `ToolResult` and compute the
@@ -95,17 +111,28 @@ export function nextActionsFromResult(result: ToolResult): readonly NextAction[]
   const data = result.data;
   if (data === null || data === undefined || typeof data !== 'object') return [];
 
-  // Fail-closed parse boundary (#1238). A success payload that's a non-null
-  // object but matches NEITHER shape is malformed — warn so the contract
-  // violation is surfaced rather than silently degrading to []. The two
-  // shapes are intentionally permissive (`.passthrough()`), so this only
-  // triggers on genuinely unexpected payloads (e.g. handler returned wrong
-  // types on phase / workflowType, or workflowState missing featureId).
+  // Fail-closed parse boundary (#1238). Three cases:
+  //
+  //   1. Payload carries none of the workflow-context discriminator keys
+  //      (phase / workflowType / workflowState). It's an event-store /
+  //      view-composite / describe response — return [] silently.
+  //   2. Payload carries at least one discriminator key but ResultDataSchema
+  //      rejects it — malformed (wrong types, missing required nested
+  //      fields). Warn and return [].
+  //   3. Payload parses as ShapeOne, ShapeTwo, or both — proceed.
+  //
+  // `Reflect.has` is the structural attempt-detector; it does not introspect
+  // value types (that's the schema's job).
+  const attemptedContext = CONTEXT_DISCRIMINATOR_KEYS.some((k) =>
+    Reflect.has(data, k),
+  );
+  if (!attemptedContext) return [];
+
   const parsed = ResultDataSchema.safeParse(data);
   if (!parsed.success) {
-    console.warn(
-      '[next-actions] malformed result.data — failed ResultDataSchema parse; returning [].',
+    nextActionsLogger.warn(
       { issues: parsed.error.issues },
+      'malformed result.data — failed ResultDataSchema parse; returning [].',
     );
     return [];
   }


### PR DESCRIPTION
## Summary

Wave A PR 1 of the v2.10.0-preview.4 feature-freeze bundle. Closes #1238.

Replaces `Record<string, unknown>` casts + inline `typeof` guards in `next-actions-from-result.ts` with a Zod discriminated union (`ShapeOneSchema | ShapeTwoSchema`) consumed via `safeParse()`. Fail-closed on malformed workflow payloads (warns via pino child logger, returns `[]`); preserves the no-actions case for non-success / null-data inputs.

This is the contract enforcement point for the `next_actions` surface across all four composite tools — per axiom DIM-3 (contracts) and #1109 Constraint 2 (MCP parity).

## Changes

**Production (`servers/exarchos-mcp/src/next-actions-from-result.ts`, +159/-44):**
- `ShapeOneSchema = z.object({ phase, workflowType, featureId?, mergeOrchestrator? }).passthrough()` — workflow-handler payload shape.
- `ShapeTwoSchema = z.object({ workflowState: WorkflowStateSchema }).passthrough()` — rehydration document shape.
- `ResultDataSchema = z.union([ShapeOneSchema, ShapeTwoSchema])`.
- Parser uses `safeParse()` with a `Reflect.has`-based attempt discriminator on `phase|workflowType|workflowState`; non-workflow payloads silently return `[]`; malformed workflow payloads warn via `nextActionsLogger` (pino child) and return `[]`.
- One pre-flight `typeof data !== 'object'` guard remains at the helper entry to satisfy TypeScript narrowing on `unknown` (cannot be removed; `Reflect.has` throws on null).

**Test (`next-actions-from-result.test.ts`, +137/-2):**
- `NextActionsFromResult_WorkflowHandlerPayload_ParsesShapeOne`
- `NextActionsFromResult_RehydrationDocument_ParsesShapeTwo`
- `NextActionsFromResult_MalformedPayload_FailsClosed`
- `NextActionsFromResult_NonSuccessResult_ReturnsEmptyArray`
- `NextActionsFromResult_NullData_ReturnsEmptyArray`

## Test Plan

- [x] Root `npm run typecheck` clean.
- [x] Root `npm run test:run` clean (762 passed).
- [x] MCP-server `npm run test:run` clean for the touched files; 26 pre-existing failures in `merge-orchestrate.*.test.ts` reproduce on `origin/main` — unrelated to this PR (flagged for separate triage).
- [x] `npm run skills:guard` clean.
- [x] Test count delta: 12 → 17 in this file (+5).

## Commits

- `5eafecd5` test(next-actions): RED — ShapeOne/ShapeTwo/malformed coverage
- `1e6e2349` feat(next-actions): GREEN — define ResultDataSchema discriminated union
- `9702093a` feat(next-actions): GREEN — fail-closed safeParse replaces Record casts
- `4432cf96` refactor(next-actions): REFACTOR — remove Record casts + inline typeof guards

## Scope discipline

- Touched only `next-actions-from-result.{ts,test.ts}`.
- One scope-justified addition: pino `nextActionsLogger` child exported from the same file (required by the project's `NoConsoleInProduction_SourceFilesClean` lint gate; allows test spies via `vi.spyOn`).

Part of [#1088](https://github.com/lvlup-sw/exarchos/issues/1088) v3.0.0 P2 Agent Output Contract epic. Wave A of the [v2.10.0-preview.4 feature-freeze design](../blob/main/docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)