### PR TITLE
feat(architecture): machine-readable invariants + vocabulary lint + ideate first-turn surfacing (#1260)

### DIFF
--- a/commands/ideate.md
+++ b/commands/ideate.md
@@ -29,6 +29,12 @@ Follow the brainstorming skill: `@skills/brainstorming/SKILL.md`
 
 ## Process
 
+### Phase 0: Constraints (first turn)
+
+Before the clarifying questions, load the machine-readable invariants catalog at `docs/architecture/invariants.md` and surface a **Constraints** section naming the invariants and dimensions relevant to the proposal. For a CLI-shaped or agent-surface proposal, this typically includes `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), and `DIM-1` (topology). For an event-store or projection proposal, surface `INV-1` plus `DIM-1` / `DIM-3`. The brainstorming skill's "Constraint anchoring" subsection describes the selection rules.
+
+Emit the Constraints section *before* Phase 1 so the clarifying questions can probe the proposal against the load-bearing invariants instead of re-discovering them mid-design.
+
 ### Phase 1: Understanding
 Ask clarifying questions (one at a time):
 1. What problem are we solving?

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -1,0 +1,319 @@
+---
+title: Exarchos Architectural Invariants
+description: >
+  Machine-readable catalog of architectural invariants (INV-*) and axiom
+  dimensions (DIM-*) consumed by /ideate, the design-invariants skill,
+  and the vocabulary-lint scanner. Source of truth for the invariant
+  vocabulary in the Exarchos repo.
+schema-version: 1
+invariants:
+  - id: INV-1
+    dimension: event-sourcing-integrity
+    applies-to:
+      - event-store
+      - projections
+      - reducers
+      - workflow-state
+    summary: >
+      The append-only event log is the source of truth. Every read-model is a
+      left-fold; state mutations are events, not in-place updates. Reducers must
+      be pure, deterministic, and structurally share state. Stores that hold
+      derived state across calls must be projections over events, never
+      in-memory side databases.
+    references:
+      - .claude/skills/design-invariants/references/INV-1-event-sourcing.md
+      - .claude/skills/design-invariants/SKILL.md
+      - docs/architecture/projections.md
+
+  - id: INV-2
+    dimension: facade-equivalence
+    applies-to:
+      - cli-adapter
+      - mcp-adapter
+      - dispatch-core
+      - parity-tests
+    summary: >
+      CLI and MCP are both facades over a single functional dispatch core. For
+      any verb, the same DispatchContext + arguments must produce the same
+      ToolResult. Adapters carry zero behavior — only presentation. Post-#1266,
+      every action also registers a Zod outputSchema so parity is schema-checked
+      in addition to byte-checked.
+    references:
+      - .claude/skills/design-invariants/references/INV-2-facade-equivalence.md
+      - .claude/skills/design-invariants/SKILL.md
+      - docs/designs/2026-05-07-milestone-16-mcp-alignment.md
+
+  - id: INV-3
+    dimension: basileus-forward
+    applies-to:
+      - capabilities-resolver
+      - runtime-yaml
+      - mcp-transport
+      - sideband-daemon
+    summary: >
+      No design decision presumes MCP is local-only. Workflow and Ontology
+      channels have independent client lifecycles, handshake-authoritative
+      capability resolution, and .exarchos.yml-only configuration. Workspace
+      discovery prefers the MCP roots capability over cwd heuristics
+      (post-#1269).
+    references:
+      - .claude/skills/design-invariants/references/INV-3-basileus-forward.md
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: INV-4
+    dimension: platform-agnosticity
+    applies-to:
+      - skills-src
+      - runtimes
+      - skills-renderer
+      - commands
+    summary: >
+      Skills, rules, and workflows must not couple to any single harness. Six
+      runtimes are first-class (Claude Code, Codex, Copilot, Cursor, OpenCode,
+      generic). Runtime-specific text is tokenized via {{TOKEN}} placeholders or
+      guarded via <!-- requires:* --> blocks. Source-of-truth edits go to
+      skills-src/; skills/<runtime>/** is generated.
+    references:
+      - .claude/skills/design-invariants/references/INV-4-platform-agnosticity.md
+      - .claude/skills/design-invariants/SKILL.md
+      - skills-src/SKILL_AUTHORING.md
+
+  - id: INV-5a
+    dimension: input-ergonomics
+    applies-to:
+      - mcp-registry
+      - tool-schemas
+      - cli-flags
+    summary: >
+      Tool inputs are constrained at the schema level (enum, regex, format), not
+      via prose hints. Every tool description states when NOT to use the tool
+      with a pointer to the alternative. Visible tool count stays under 15.
+      Static reference content is exposed as MCP Resources, not tools.
+    references:
+      - .claude/skills/design-invariants/references/INV-5a-input-ergonomics.md
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: INV-5b
+    dimension: output-contract
+    applies-to:
+      - format.ts
+      - tool-results
+      - registered-output-schemas
+      - error-envelopes
+    summary: >
+      Every successful ToolResult carries machine-actionable affordance hints —
+      next_actions, _meta, _perf. Errors carry validTargets, expectedShape,
+      suggestedFix. Post-#1266, the carrier is structuredContent with a
+      registered outputSchema per action; long-running ops use Tasks (SEP-1686)
+      not NDJSON.
+    references:
+      - .claude/skills/design-invariants/references/INV-5b-output-contract.md
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: INV-5c
+    dimension: aspire-verbs
+    applies-to:
+      - cli-commands
+      - composite-tools
+      - process-lifecycle
+    summary: >
+      Exarchos CLI design borrows deliberately from Aspire — queryable,
+      dry-run-capable, JSON-explicit control-plane verbs. Agents query state;
+      they don't drive scripts. ps / describe / wait / export are observation
+      verbs; mutating verbs default to --dry-run.
+    references:
+      - .claude/skills/design-invariants/references/INV-5c-aspire-verbs.md
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: INV-5d
+    dimension: action-discriminator
+    applies-to:
+      - mcp-registry
+      - composite-tools
+      - tool-annotations
+    summary: >
+      Exarchos exposes 4 visible composite tools, each with an action
+      discriminator (exarchos_workflow, exarchos_event, exarchos_orchestrate,
+      exarchos_view). The visible tool count stays under 15; per-action
+      annotations (destructiveHint / readOnlyHint / idempotentHint /
+      openWorldHint) live on CompositeAction post-#1268.
+    references:
+      - .claude/skills/design-invariants/references/INV-5d-action-discriminator.md
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: INV-6
+    dimension: workflow-agnosticism
+    applies-to:
+      - skills-src
+      - playbooks
+      - skill-frontmatter
+    summary: >
+      Skills describe behaviors; playbooks describe workflows. A behavior-skill
+      describes triggers in workflow-neutral terms (verb names, idempotency
+      keys), not workflow stages or branch prefixes. Workflow-specific skills
+      must declare metadata.workflow-type: <type> in frontmatter.
+    references:
+      - .claude/skills/design-invariants/references/INV-6-workflow-agnosticism.md
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-1
+    dimension: topology
+    applies-to:
+      - module-boundaries
+      - dependency-direction
+      - state-ownership
+    summary: >
+      Topology dimension from axiom — module boundaries, layering, dependency
+      direction, ambient/shared-mutable state. Adapter-local mutable caches,
+      lazy fallback singletons, and side databases are topology smells that
+      frequently overlap with INV-1 / INV-2 violations.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-2
+    dimension: observability
+    applies-to:
+      - logging
+      - telemetry
+      - error-paths
+    summary: >
+      Observability dimension from axiom — silent catches, missing log context,
+      degradation paths that swallow signals. Frequently overlaps INV-1 when a
+      reducer apply catches and continues instead of triggering the
+      reducer-throw degradation path.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-3
+    dimension: contracts
+    applies-to:
+      - schemas
+      - event-types
+      - tool-output
+    summary: >
+      Contracts dimension from axiom — schema-runtime drift, type-assertion
+      safety, breaking field renames without versioning. Overlaps INV-1 when an
+      event field is removed but still read, and INV-5b when output shape
+      changes without an envelope version bump.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-4
+    dimension: test-fidelity
+    applies-to:
+      - test-suites
+      - mocks
+      - fixtures
+    summary: >
+      Test-fidelity dimension from axiom — mock overuse, fixture drift, tests
+      that pass against fakes but would fail in production. The TDD-task and
+      static-analysis gates compose with this dimension to catch
+      blast-radius regressions.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-5
+    dimension: vestigial-code
+    applies-to:
+      - dead-paths
+      - unused-exports
+      - legacy-flags
+    summary: >
+      Vestigial-code dimension from axiom — dead code, unused exports, legacy
+      feature flags that no longer gate behavior. Cleanup work that intersects
+      INV-2 (legacy adapter paths) or INV-5d (legacy top-level tools that
+      should collapse into composite actions).
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-6
+    dimension: solid-coupling
+    applies-to:
+      - module-design
+      - inheritance
+      - composition
+    summary: >
+      SOLID / coupling dimension from axiom — generic dependency direction,
+      single-responsibility violations, inheritance vs composition mismatches.
+      Axiom-owned; design-invariants defers here for generic SOLID findings.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-7
+    dimension: error-handling
+    applies-to:
+      - error-paths
+      - retry-logic
+      - degradation
+    summary: >
+      Error-handling dimension from axiom — silent fallbacks, retry storms,
+      degradation without telemetry. Often co-occurs with DIM-2 observability;
+      design-invariants intersects when a fallback creates a degraded EventStore
+      (INV-1) or hides parity divergence (INV-2).
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-8
+    dimension: ai-prose-tells
+    applies-to:
+      - documentation
+      - skill-bodies
+      - command-text
+    summary: >
+      AI-prose-tells dimension from axiom — telltale AI-generated prose
+      patterns (em-dashes that flatten clauses, padding adjectives, hedge
+      phrases). Owned by axiom:humanize; design-invariants does not duplicate
+      the check.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: basileus-boundary
+    dimension: cross-product-coordination
+    applies-to:
+      - basileus-exarchos-coordination
+      - ontology-mcp-server
+      - cross-tier-mediation
+    summary: >
+      Boundary discipline between Exarchos and Basileus. AgentHost ↔ Sandbox
+      calls must route through ControlPlane (Basileus INV-1). Cross-product
+      coordination uses the Ontology MCP Server (intent_register) rather than
+      bespoke RPC. Strategos.Contracts via TypeSpec governs schema.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+      - basileus/docs/adrs/2026-04-18-exarchos-basileus-coordination.md
+---
+
+# Exarchos Architectural Invariants
+
+Machine-readable catalog of the architectural invariants that govern Exarchos design and review. The YAML frontmatter above is the **source of truth** for tooling — the `/ideate` command, the `design-invariants` skill, and the `vocabulary-lint` scanner all consume the same shape.
+
+This file pairs with the prose reference content under [`.claude/skills/design-invariants/references/`](../../.claude/skills/design-invariants/references/). The frontmatter `summary` field is the short version; the linked reference files carry the full prose, severity guides, worked examples, and external grounding.
+
+## Schema
+
+Each entry in `invariants:` carries:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `id` | string | Stable identifier — `INV-1`..`INV-6`, sub-disciplines like `INV-5a`, axiom dimensions like `DIM-1`, plus cross-product entries (`basileus-boundary`). |
+| `dimension` | string | Short human-readable category name. |
+| `applies-to` | string[] | Surface areas (modules, file globs, capability domains) where the invariant is load-bearing. |
+| `summary` | string | One-to-two-sentence statement of the invariant. |
+| `references` | string[] | Pointers to source files where the invariant is detailed in prose. |
+
+## Vocabulary
+
+The vocabulary-lint scanner (`servers/exarchos-mcp/src/architecture/vocabulary-lint.ts`, exposed via `npm run lint:invariants`) walks `docs/`, `skills-src/`, and `commands/` for tokens matching `/\b(INV-\d+[a-d]?|DIM-\d+)\b/` and cross-checks against the IDs declared here. Unknown references surface as findings; the lint is advisory in initial rollout.
+
+## Consumers
+
+- `/exarchos:ideate` — surfaces relevant invariants as Constraints during Phase 1, before the clarifying questions.
+- `design-invariants` skill — audits design proposals against INV-1..INV-6.
+- `vocabulary-lint` — flags references to invariant IDs not registered here.
+- Future: `#1275` MCP Resources — expose this catalog as `resources/exarchos-invariants` once Resources land.
+
+## See also
+
+- [`docs/architecture/projections.md`](projections.md) — projection layer specifics.
+- [`docs/architecture/runtime.md`](runtime.md) — runtime / capability resolution.
+- [`.claude/skills/design-invariants/SKILL.md`](../../.claude/skills/design-invariants/SKILL.md) — operational skill that consumes this catalog.

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -303,11 +303,11 @@ Each entry in `invariants:` carries:
 
 ## Vocabulary
 
-The vocabulary-lint scanner (`servers/exarchos-mcp/src/architecture/vocabulary-lint.ts`, exposed via `npm run lint:invariants`) walks `docs/`, `skills-src/`, and `commands/` for tokens matching `/\b(INV-\d+[a-d]?|DIM-\d+)\b/` and cross-checks against the IDs declared here. Unknown references surface as findings; the lint is advisory in initial rollout.
+The vocabulary-lint scanner (`servers/exarchos-mcp/src/architecture/vocabulary-lint.ts`, exposed via `npm run lint:invariants`) walks `docs/`, `skills-src/`, and `commands/` for tokens matching `/\b(INV-\d+[a-d]?|DIM-\d+)\b/` and cross-checks against the IDs declared here. Unknown references surface as findings; the vocabulary lint is enforcing (exits non-zero on findings).
 
 ## Consumers
 
-- `/exarchos:ideate` — surfaces relevant invariants as Constraints during Phase 1, before the clarifying questions.
+- `/exarchos:ideate` — surfaces relevant invariants as Constraints during Phase 0 (before Phase 1), before the clarifying questions.
 - `design-invariants` skill — audits design proposals against INV-1..INV-6.
 - `vocabulary-lint` — flags references to invariant IDs not registered here.
 - Future: `#1275` MCP Resources — expose this catalog as `resources/exarchos-invariants` once Resources land.

--- a/docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml
+++ b/docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml
@@ -1,0 +1,56 @@
+# Sidecar for docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.md
+# Conforms to DesignSidecarV1 (servers/exarchos-mcp/src/orchestrate/sidecar-schemas.ts).
+# Backfilled per #1298 / T16.
+
+schema: design.v1
+
+sections:
+  problem: { present: true }
+  scope-and-grouping: { present: true }
+  wave-a-output-contract-completion: { present: true }
+  wave-b-correlation-event-topology: { present: true }
+  wave-c-tasks-dispatch-core: { present: true }
+  wave-d-authoring-substrate: { present: true }
+  sequencing: { present: true }
+  conformance-design-invariants: { present: true }
+  conformance-axiom-dimensions: { present: true }
+  risks-and-mitigations: { present: true }
+  acceptance-criteria: { present: true }
+  out-of-scope: { present: true }
+  references: { present: true }
+
+# Each issue in the bundle is modeled as a Design Requirement (DR). The
+# `id` is the literal GitHub issue number prefixed with `DR-` so DR ids
+# remain stable across the milestone.
+drs:
+  - { id: DR-1238, title: 'next_actions Zod discriminated unions', section: 'Wave A — Output Contract Completion' }
+  - { id: DR-1262, title: 'output-token quality hint via next_actions', section: 'Wave A — Output Contract Completion' }
+  - { id: DR-1290, title: 'Roots-based workspace discovery', section: 'Wave A — Output Contract Completion' }
+  - { id: DR-1274, title: 'Elicitation form mode for INVALID_INPUT', section: 'Wave A — Output Contract Completion' }
+  - { id: DR-1291, title: 'three-field correlation (operationId + correlationId + causationId)', section: 'Wave B — Correlation + Event Topology' }
+  - { id: DR-1261, title: 'dispatch.preflight + stash.detected events', section: 'Wave B — Correlation + Event Topology' }
+  - { id: DR-1272, title: 'EventSourcedTaskStore (TaskStore as projection)', section: 'Wave B — Correlation + Event Topology' }
+  - { id: DR-1273, title: 'Tasks (SEP-1686) dispatch-core integration', section: 'Wave C — Tasks Dispatch-Core' }
+  - { id: DR-1260, title: 'machine-readable invariants consumed by /ideate', section: 'Wave D — Authoring Substrate' }
+  - { id: DR-1298, title: 'designs/plans machine-readable sidecar', section: 'Wave D — Authoring Substrate' }
+  - { id: DR-1244, title: 'markdown-aware handoff lint at handleCheckpoint', section: 'Wave D — Authoring Substrate' }
+
+acceptance:
+  - { id: A-1238, references: [DR-1238] }
+  - { id: A-1262, references: [DR-1262] }
+  - { id: A-1290, references: [DR-1290] }
+  - { id: A-1274, references: [DR-1274] }
+  - { id: A-1291, references: [DR-1291] }
+  - { id: A-1261, references: [DR-1261] }
+  - { id: A-1272, references: [DR-1272] }
+  - { id: A-1273, references: [DR-1273] }
+  - { id: A-1260, references: [DR-1260] }
+  - { id: A-1298, references: [DR-1298] }
+  - { id: A-1244, references: [DR-1244] }
+  # Cross-cutting all-PR gates per the design's "All 11 PRs" acceptance block.
+  - { id: A-ALL-TYPECHECK, references: [DR-1238, DR-1262, DR-1290, DR-1274, DR-1291, DR-1261, DR-1272, DR-1273, DR-1260, DR-1298, DR-1244] }
+
+options:
+  # The design's "Scope and grouping" table evaluates 4 cohesive waves +
+  # 4 alternatives table per wave. Surface only the wave-count here.
+  count: 4

--- a/docs/plans/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml
+++ b/docs/plans/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml
@@ -1,0 +1,235 @@
+# Sidecar for docs/plans/2026-05-15-v2-10-0-preview-4-feature-freeze.md
+# Conforms to PlanSidecarV1 (servers/exarchos-mcp/src/orchestrate/sidecar-schemas.ts).
+# Backfilled per #1298 / T16. Mirrors the 36-task RED/GREEN/REFACTOR map.
+
+schema: plan.v1
+
+tasks:
+  # ─── Wave A · PR A1 — #1238 next_actions Zod discriminated unions ──────────
+  - id: T01
+    phase: RED
+    description: Author failing tests for ShapeOne, ShapeTwo, and ResultDataSchema discriminated union
+    files: [servers/exarchos-mcp/src/next-actions-from-result.test.ts]
+  - id: T02
+    phase: GREEN
+    description: Replace Record casts with safeParse against ResultDataSchema; fail-closed
+    files: [servers/exarchos-mcp/src/next-actions-from-result.ts]
+
+  # ─── Wave A · PR A2 — #1262 output-token quality hint ──────────────────────
+  - id: T03
+    phase: RED
+    description: Register `output_tokens_high` quality-hint type in the catalog
+    files: [servers/exarchos-mcp/src/telemetry/quality-hints.test.ts]
+  - id: T04
+    phase: GREEN
+    description: Threshold-crossing detection in telemetry projection emits hint via next_actions
+    files: [servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts, servers/exarchos-mcp/src/telemetry/telemetry-projection.ts]
+  - id: T05
+    phase: REFACTOR
+    description: Wire configurable threshold via CapabilityResolver and verify CLI/MCP envelope parity
+    files: [servers/exarchos-mcp/src/cli/envelope-parity.test.ts]
+
+  # ─── Wave A · PR A3 — #1290 Roots-based workspace discovery ────────────────
+  - id: T06
+    phase: RED
+    description: CapabilityResolver snapshots client.capabilities.roots at handshake
+    files: [servers/exarchos-mcp/src/capability/capability-resolver.test.ts, servers/exarchos-mcp/src/capability/capability-resolver.ts]
+  - id: T07
+    phase: GREEN
+    description: Roots-based inference with cache + signature scan + multi-match validTargets
+    files: [servers/exarchos-mcp/src/workspace/discovery.test.ts, servers/exarchos-mcp/src/workspace/discovery.ts, servers/exarchos-mcp/src/mcp/notifications.ts]
+  - id: T08
+    phase: REFACTOR
+    description: Wire discovery.resolveWorkspace into dispatch when featureId omitted
+    files: [tests/outcome/roots-discovery-dispatch.test.ts]
+
+  # ─── Wave A · PR A4 — #1274 Elicitation form mode ──────────────────────────
+  - id: T09
+    phase: RED
+    description: Derive elicitation sub-schema via .pick(); resolver snapshots capability
+    files: [servers/exarchos-mcp/src/capability/elicitation.test.ts, servers/exarchos-mcp/src/capability/elicitation.ts]
+  - id: T10
+    phase: GREEN
+    description: Dispatch missing-required-param sends elicitation/create + emits events with operationId
+    files: [servers/exarchos-mcp/src/dispatch/elicitation-dispatch.test.ts, servers/exarchos-mcp/src/dispatch/index.ts, servers/exarchos-mcp/src/event-store/schemas.ts]
+
+  # ─── Wave D · PR D1 — #1260 invariants doc ─────────────────────────────────
+  - id: T11
+    phase: RED
+    description: Loader parses invariants frontmatter into typed records
+    files: [servers/exarchos-mcp/src/architecture/invariants-loader.test.ts, servers/exarchos-mcp/src/architecture/invariants-loader.ts, docs/architecture/invariants.md]
+  - id: T12
+    phase: GREEN
+    description: Vocabulary lint scans markdown for unknown INV-N references
+    files: [servers/exarchos-mcp/src/architecture/vocabulary-lint.test.ts, servers/exarchos-mcp/src/architecture/vocabulary-lint.ts]
+  - id: T13
+    phase: REFACTOR
+    description: /ideate command + brainstorming skill surface invariants on first turn
+    files: [commands/ideate.md, skills-src/brainstorming/SKILL.md]
+
+  # ─── Wave D · PR D2 — #1298 designs/plans sidecar (this PR) ────────────────
+  - id: T14
+    phase: RED
+    description: Sidecar schemas (design.v1, plan.v1) with literal version + RED/GREEN/REFACTOR enum
+    files: [servers/exarchos-mcp/src/orchestrate/sidecar-schemas.test.ts, servers/exarchos-mcp/src/orchestrate/sidecar-schemas.ts]
+  - id: T15
+    phase: GREEN
+    description: Four authoring gates consume sidecar; regex fallback emits deprecation warning
+    files:
+      - servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
+      - servers/exarchos-mcp/src/orchestrate/sidecar-lookup.ts
+      - servers/exarchos-mcp/src/orchestrate/design-completeness.ts
+      - servers/exarchos-mcp/src/orchestrate/plan-coverage.ts
+      - servers/exarchos-mcp/src/orchestrate/provenance-chain.ts
+      - servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+  - id: T16
+    phase: GREEN
+    description: Backfill sidecar yml for the preview.4 design and plan
+    files:
+      - docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml
+      - docs/plans/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml
+
+  # ─── Wave D · PR D3 — #1244 handoff lint ───────────────────────────────────
+  - id: T17
+    phase: GREEN
+    description: handleCheckpoint runs prose lint on handoff fields with soft/hard-fail config
+    files: [servers/exarchos-mcp/src/workflow/checkpoint-handler.test.ts, servers/exarchos-mcp/src/workflow/checkpoint-handler.ts]
+
+  # ─── Wave B · PR B1 — #1291 three-field correlation ────────────────────────
+  - id: T18
+    phase: RED
+    description: DispatchContext mints operationId/correlationId/causationId at dispatch entry
+    files: [servers/exarchos-mcp/src/dispatch/dispatch-context.test.ts, servers/exarchos-mcp/src/dispatch/dispatch-context.ts]
+  - id: T19
+    phase: GREEN
+    description: Thread DispatchContext through every event emit site; widen EventBase _meta
+    files: [servers/exarchos-mcp/src/dispatch/composer.ts, servers/exarchos-mcp/src/event-store/append.ts]
+  - id: T20
+    phase: GREEN
+    description: Register three-field _meta extension on action outputSchemas
+    files: [servers/exarchos-mcp/src/mcp/output-schema-meta.test.ts, servers/exarchos-mcp/src/mcp/output-schema-base.ts]
+  - id: T21
+    phase: REFACTOR
+    description: Full-suite blast-radius sweep; widen tests that asserted absence of new fields
+    files: [tests/outcome/correlation-threading.test.ts]
+
+  # ─── Wave B · PR B2 — #1261 dispatch.preflight + stash.detected ────────────
+  - id: T22
+    phase: RED
+    description: Event schemas for dispatch.preflight (per-guard outcome) and stash.detected
+    files: [servers/exarchos-mcp/src/event-store/schemas.test.ts, servers/exarchos-mcp/src/event-store/schemas.ts]
+  - id: T23
+    phase: GREEN
+    description: dispatch-guard emits preflight per guard; stash-detection probe emits stash.detected
+    files: [servers/exarchos-mcp/src/dispatch/dispatch-guard.test.ts, servers/exarchos-mcp/src/dispatch/dispatch-guard.ts]
+
+  # ─── Wave B · PR B3 — #1272 EventSourcedTaskStore ──────────────────────────
+  - id: T24
+    phase: RED
+    description: task.* event schemas (created, polled, result, cancelled) carry three-field _meta
+    files: [servers/exarchos-mcp/src/event-store/task-events.test.ts, servers/exarchos-mcp/src/event-store/task-events.ts]
+  - id: T25
+    phase: GREEN
+    description: EventSourcedTaskStore implements SDK TaskStore via projection over task events
+    files: [servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts, servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts]
+  - id: T26
+    phase: GREEN
+    description: TTL-bounded projection expires tasks past expiresAt on next read
+    files: [servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts]
+  - id: T27
+    phase: REFACTOR
+    description: Remove InMemoryTaskStore from production wiring; keep only in test fixtures
+    files: [servers/exarchos-mcp/src/composition/index.ts]
+
+  # ─── Wave C · PR C1 — Dispatch-core Tasks-augmented path ───────────────────
+  - id: T28
+    phase: RED
+    description: Dispatch core branches one-shot vs Tasks-augmented based on options.task
+    files: [servers/exarchos-mcp/src/dispatch/dispatch-core.test.ts, servers/exarchos-mcp/src/dispatch/dispatch-core.ts]
+  - id: T29
+    phase: GREEN
+    description: Task lifecycle event emission from dispatch core (created/polled/result)
+    files: [tests/outcome/tasks-dispatch-lifecycle.test.ts]
+
+  # ─── Wave C · PR C2 — MCP adapter tasks/* methods ──────────────────────────
+  - id: T30
+    phase: RED
+    description: tools/call accepts task augmentation and returns CreateTaskResult shape
+    files: [servers/exarchos-mcp/src/mcp/tools-call-handler.test.ts, servers/exarchos-mcp/src/mcp/tools-call-handler.ts]
+  - id: T31
+    phase: GREEN
+    description: MCP methods tasks/get, tasks/result, tasks/cancel route through dispatch-core
+    files: [servers/exarchos-mcp/src/mcp/tasks-methods.test.ts, servers/exarchos-mcp/src/mcp/tasks-methods.ts]
+  - id: T32
+    phase: REFACTOR
+    description: taskSupport optional capability gating; fall back to one-shot for non-Task clients
+    files: [servers/exarchos-mcp/src/capability/task-support.test.ts, servers/exarchos-mcp/src/capability/task-support.ts]
+
+  # ─── Wave C · PR C3 — CLI --follow integration ─────────────────────────────
+  - id: T33
+    phase: RED
+    description: --follow polling loop renders task transitions to stdout
+    files: [servers/exarchos-mcp/src/cli/follow-loop.test.ts, servers/exarchos-mcp/src/cli/follow-loop.ts]
+  - id: T34
+    phase: GREEN
+    description: SIGINT during --follow cancels via task.cancelled with operationId parity
+    files: [servers/exarchos-mcp/src/cli/follow-loop.ts]
+
+  # ─── Cross-cutting — version bump + outcome sweep ──────────────────────────
+  - id: T35
+    phase: GREEN
+    description: Bump version to 2.10.0-preview.4; refresh lockfile; add CHANGELOG entry
+    files: [package.json, servers/exarchos-mcp/package.json, CHANGELOG.md]
+  - id: T36
+    phase: REFACTOR
+    description: Full outcome-tier sweep on main; address any cross-wave regression
+    files: [tests/outcome]
+
+coverage:
+  DR-1238: [T01, T02]
+  DR-1262: [T03, T04, T05]
+  DR-1290: [T06, T07, T08]
+  DR-1274: [T09, T10]
+  DR-1260: [T11, T12, T13]
+  DR-1298: [T14, T15, T16]
+  DR-1244: [T17]
+  DR-1291: [T18, T19, T20, T21]
+  DR-1261: [T22, T23]
+  DR-1272: [T24, T25, T26, T27]
+  DR-1273: [T28, T29, T30, T31, T32, T33, T34]
+
+provenance:
+  - { taskId: T01, dr: DR-1238 }
+  - { taskId: T02, dr: DR-1238 }
+  - { taskId: T03, dr: DR-1262 }
+  - { taskId: T04, dr: DR-1262 }
+  - { taskId: T05, dr: DR-1262 }
+  - { taskId: T06, dr: DR-1290 }
+  - { taskId: T07, dr: DR-1290 }
+  - { taskId: T08, dr: DR-1290 }
+  - { taskId: T09, dr: DR-1274 }
+  - { taskId: T10, dr: DR-1274 }
+  - { taskId: T11, dr: DR-1260 }
+  - { taskId: T12, dr: DR-1260 }
+  - { taskId: T13, dr: DR-1260 }
+  - { taskId: T14, dr: DR-1298 }
+  - { taskId: T15, dr: DR-1298 }
+  - { taskId: T16, dr: DR-1298 }
+  - { taskId: T17, dr: DR-1244 }
+  - { taskId: T18, dr: DR-1291 }
+  - { taskId: T19, dr: DR-1291 }
+  - { taskId: T20, dr: DR-1291 }
+  - { taskId: T21, dr: DR-1291 }
+  - { taskId: T22, dr: DR-1261 }
+  - { taskId: T23, dr: DR-1261 }
+  - { taskId: T24, dr: DR-1272 }
+  - { taskId: T25, dr: DR-1272 }
+  - { taskId: T26, dr: DR-1272 }
+  - { taskId: T27, dr: DR-1272 }
+  - { taskId: T28, dr: DR-1273 }
+  - { taskId: T29, dr: DR-1273 }
+  - { taskId: T30, dr: DR-1273 }
+  - { taskId: T31, dr: DR-1273 }
+  - { taskId: T32, dr: DR-1273 }
+  - { taskId: T33, dr: DR-1273 }
+  - { taskId: T34, dr: DR-1273 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "generate:agents": "tsx servers/exarchos-mcp/src/agents/generate-agents.ts",
     "build:skills": "npm run generate:agents && node dist/build-skills.js",
     "lint:inv6": "node scripts/lint-inv6.mjs skills-src/",
+    "lint:invariants": "tsx servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts",
     "skills:guard": "node dist/skills-guard.js && (npm run lint:inv6 || true)",
     "prepare": "tsc",
     "bench": "cd servers/exarchos-mcp && npx vitest bench",

--- a/servers/exarchos-mcp/package-lock.json
+++ b/servers/exarchos-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lvlup-sw/exarchos-mcp",
-  "version": "2.10.0-preview.2",
+  "version": "2.10.0-preview.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lvlup-sw/exarchos-mcp",
-      "version": "2.10.0-preview.2",
+      "version": "2.10.0-preview.3",
       "hasInstallScript": true,
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { loadInvariants, type InvariantEntry } from './invariants-loader.js';
 
@@ -75,5 +77,40 @@ describe('invariants-loader', () => {
     // INV-5a references should point at the design-invariants skill reference file.
     const hasInv5aRef = inv5a!.references.some((r) => r.includes('INV-5a'));
     expect(hasInv5aRef).toBe(true);
+  });
+
+  it('InvariantsLoader_DuplicateIds_ThrowsWithIdInMessage', () => {
+    // Construct a frontmatter fixture with two entries sharing the same id
+    // (`INV-1`). The loader must reject this at load time so a silent
+    // duplicate cannot shadow the legitimate entry.
+    const fixture = `---
+invariants:
+  - id: INV-1
+    dimension: event-sourcing integrity
+    applies-to:
+      - servers/exarchos-mcp/src/event-store
+    summary: First copy of INV-1.
+    references:
+      - docs/architecture/invariants.md
+  - id: INV-1
+    dimension: duplicate
+    applies-to:
+      - servers/exarchos-mcp/src/event-store
+    summary: Second copy of INV-1 — should be rejected.
+    references:
+      - docs/architecture/invariants.md
+---
+
+# Fixture
+`;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'invariants-dup-'));
+    const tmpFile = path.join(tmpDir, 'invariants.md');
+    fs.writeFileSync(tmpFile, fixture, 'utf8');
+    try {
+      expect(() => loadInvariants(tmpFile)).toThrow(/INV-1/);
+      expect(() => loadInvariants(tmpFile)).toThrow(/Duplicate invariant ID/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { loadInvariants, type InvariantEntry } from './invariants-loader.js';
+
+/**
+ * Repo root resolution: invariants-loader.test.ts lives at
+ *   servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
+ * Repo root is four directories up from this file.
+ */
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const INVARIANTS_DOC = path.join(REPO_ROOT, 'docs/architecture/invariants.md');
+
+const REQUIRED_INVARIANT_IDS = [
+  'INV-1',
+  'INV-2',
+  'INV-3',
+  'INV-4',
+  'INV-5a',
+  'INV-5b',
+  'INV-5c',
+  'INV-5d',
+  'INV-6',
+] as const;
+
+const REQUIRED_DIMENSION_IDS = [
+  'DIM-1',
+  'DIM-2',
+  'DIM-3',
+  'DIM-4',
+  'DIM-5',
+  'DIM-6',
+  'DIM-7',
+  'DIM-8',
+] as const;
+
+describe('invariants-loader', () => {
+  it('Invariants_StructuredFrontmatter_ParsesAllRequiredFields', () => {
+    const entries = loadInvariants(INVARIANTS_DOC);
+    expect(entries.length).toBeGreaterThan(0);
+
+    const ids = entries.map((e) => e.id);
+
+    // All required INV-* and DIM-* must be present.
+    for (const id of REQUIRED_INVARIANT_IDS) {
+      expect(ids).toContain(id);
+    }
+    for (const id of REQUIRED_DIMENSION_IDS) {
+      expect(ids).toContain(id);
+    }
+
+    // Basileus boundary entry must be present.
+    expect(ids).toContain('basileus-boundary');
+
+    // Each entry must carry the required fields.
+    for (const entry of entries) {
+      expect(typeof entry.id).toBe('string');
+      expect(entry.id.length).toBeGreaterThan(0);
+      expect(typeof entry.dimension).toBe('string');
+      expect(Array.isArray(entry.appliesTo)).toBe(true);
+      expect(entry.appliesTo.length).toBeGreaterThan(0);
+      expect(typeof entry.summary).toBe('string');
+      expect(entry.summary.length).toBeGreaterThan(0);
+      expect(Array.isArray(entry.references)).toBe(true);
+      expect(entry.references.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('Invariants_TypedEntries_HaveStableShape', () => {
+    const entries = loadInvariants(INVARIANTS_DOC);
+    const inv5a = entries.find((e: InvariantEntry) => e.id === 'INV-5a');
+    expect(inv5a).toBeDefined();
+    expect(inv5a!.dimension.toLowerCase()).toContain('input');
+    // INV-5a references should point at the design-invariants skill reference file.
+    const hasInv5aRef = inv5a!.references.some((r) => r.includes('INV-5a'));
+    expect(hasInv5aRef).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.ts
@@ -1,0 +1,110 @@
+/**
+ * Loader for the machine-readable invariants catalog at
+ * `docs/architecture/invariants.md` (issue #1260).
+ *
+ * The frontmatter is the source of truth; this module parses it into a typed
+ * `InvariantEntry[]` for consumption by `/ideate` first-turn surfacing, the
+ * vocabulary-lint scanner, and the design-invariants skill.
+ *
+ * Implementation note: we use `gray-matter` (already a devDependency of the
+ * MCP server) which sits on top of `js-yaml`. The loader is intentionally
+ * tolerant — unknown fields are preserved on `raw` but typed accessors map
+ * the documented shape.
+ */
+import fs from 'node:fs';
+import matter from 'gray-matter';
+
+export interface InvariantEntry {
+  /** Stable identifier — e.g. "INV-1", "INV-5a", "DIM-1", "basileus-boundary". */
+  id: string;
+  /** Short human-readable category name. */
+  dimension: string;
+  /** Surface areas (modules, file globs, capability domains) the invariant covers. */
+  appliesTo: string[];
+  /** One-to-two-sentence statement of the invariant. */
+  summary: string;
+  /** Pointers to source files where the invariant is detailed in prose. */
+  references: string[];
+  /** The raw parsed entry for fields not yet promoted to the typed shape. */
+  raw: Record<string, unknown>;
+}
+
+interface RawInvariantEntry {
+  id?: unknown;
+  dimension?: unknown;
+  'applies-to'?: unknown;
+  summary?: unknown;
+  references?: unknown;
+  [key: string]: unknown;
+}
+
+interface RawFrontmatter {
+  invariants?: unknown;
+  [key: string]: unknown;
+}
+
+function asStringArray(value: unknown, field: string, id: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(
+      `invariants-loader: entry "${id}" field "${field}" must be an array, got ${typeof value}`,
+    );
+  }
+  return value.map((v, i) => {
+    if (typeof v !== 'string') {
+      throw new Error(
+        `invariants-loader: entry "${id}" field "${field}"[${i}] must be a string`,
+      );
+    }
+    return v;
+  });
+}
+
+function asString(value: unknown, field: string, id: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(
+      `invariants-loader: entry "${id}" field "${field}" must be a string, got ${typeof value}`,
+    );
+  }
+  // Collapse YAML folded-scalar whitespace so consumers get clean prose.
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function parseEntry(raw: RawInvariantEntry): InvariantEntry {
+  if (typeof raw.id !== 'string' || raw.id.length === 0) {
+    throw new Error('invariants-loader: entry is missing required field "id"');
+  }
+  const id = raw.id;
+  return {
+    id,
+    dimension: asString(raw.dimension, 'dimension', id),
+    appliesTo: asStringArray(raw['applies-to'], 'applies-to', id),
+    summary: asString(raw.summary, 'summary', id),
+    references: asStringArray(raw.references, 'references', id),
+    raw: { ...raw },
+  };
+}
+
+/**
+ * Load and parse the invariants catalog from the given Markdown file.
+ *
+ * @param filePath Absolute path to `docs/architecture/invariants.md`.
+ */
+export function loadInvariants(filePath: string): InvariantEntry[] {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const parsed = matter(source);
+  const data = parsed.data as RawFrontmatter;
+  if (!Array.isArray(data.invariants)) {
+    throw new Error(
+      `invariants-loader: ${filePath} frontmatter must declare an "invariants:" array`,
+    );
+  }
+  return (data.invariants as RawInvariantEntry[]).map(parseEntry);
+}
+
+/**
+ * Convenience: return the set of valid invariant IDs (for vocabulary-lint
+ * cross-check).
+ */
+export function loadInvariantIds(filePath: string): Set<string> {
+  return new Set(loadInvariants(filePath).map((e) => e.id));
+}

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.ts
@@ -98,7 +98,18 @@ export function loadInvariants(filePath: string): InvariantEntry[] {
       `invariants-loader: ${filePath} frontmatter must declare an "invariants:" array`,
     );
   }
-  return (data.invariants as RawInvariantEntry[]).map(parseEntry);
+  const entries = (data.invariants as RawInvariantEntry[]).map(parseEntry);
+  // Reject duplicate IDs at load time — IDs are the catalog's primary key and
+  // must be unique. A silent duplicate would shadow the earlier entry and
+  // corrupt vocabulary-lint / ideate Constraint surfacing.
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (seen.has(entry.id)) {
+      throw new Error(`Duplicate invariant ID: ${entry.id}`);
+    }
+    seen.add(entry.id);
+  }
+  return entries;
 }
 
 /**

--- a/servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts
+++ b/servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts
@@ -2,18 +2,22 @@
 /**
  * CLI wrapper for `vocabulary-lint`. Exits 1 if any findings, 0 otherwise.
  * Wired into the root `package.json` as `npm run lint:invariants`.
+ *
+ * Uses `process.stdout.write` rather than `console.log` so the
+ * NoConsoleInProduction guard in `src/logger.test.ts` stays clean — CLI
+ * entry points are still production code under that test's scan.
  */
 import { scanRepoDefaults } from './vocabulary-lint.js';
 
 const findings = scanRepoDefaults();
 
 if (findings.length === 0) {
-  console.log('vocabulary-lint: 0 findings (clean)');
+  process.stdout.write('vocabulary-lint: 0 findings (clean)\n');
   process.exit(0);
 }
 
 for (const f of findings) {
-  console.log(`${f.file}:${f.line} ${f.kind} ${f.token}`);
+  process.stdout.write(`${f.file}:${f.line} ${f.kind} ${f.token}\n`);
 }
-console.log(`\nvocabulary-lint: ${findings.length} finding(s)`);
+process.stdout.write(`\nvocabulary-lint: ${findings.length} finding(s)\n`);
 process.exit(1);

--- a/servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts
+++ b/servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+/**
+ * CLI wrapper for `vocabulary-lint`. Exits 1 if any findings, 0 otherwise.
+ * Wired into the root `package.json` as `npm run lint:invariants`.
+ */
+import { scanRepoDefaults } from './vocabulary-lint.js';
+
+const findings = scanRepoDefaults();
+
+if (findings.length === 0) {
+  console.log('vocabulary-lint: 0 findings (clean)');
+  process.exit(0);
+}
+
+for (const f of findings) {
+  console.log(`${f.file}:${f.line} ${f.kind} ${f.token}`);
+}
+console.log(`\nvocabulary-lint: ${findings.length} finding(s)`);
+process.exit(1);

--- a/servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts
+++ b/servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 /**
- * CLI wrapper for `vocabulary-lint`. Exits 1 if any findings, 0 otherwise.
+ * CLI wrapper for `vocabulary-lint`. Sets exitCode 1 if any findings, 0 otherwise.
  * Wired into the root `package.json` as `npm run lint:invariants`.
  *
  * Uses `process.stdout.write` rather than `console.log` so the
  * NoConsoleInProduction guard in `src/logger.test.ts` stays clean — CLI
  * entry points are still production code under that test's scan.
+ *
+ * Uses `process.exitCode = N` (rather than `process.exit(N)`) so buffered
+ * stdout writes flush completely before the process terminates — see
+ * https://nodejs.org/api/process.html#processexitcode_1. With `process.exit`,
+ * piped output can be truncated when the consumer drains slowly.
  */
 import { scanRepoDefaults } from './vocabulary-lint.js';
 
@@ -13,11 +18,11 @@ const findings = scanRepoDefaults();
 
 if (findings.length === 0) {
   process.stdout.write('vocabulary-lint: 0 findings (clean)\n');
-  process.exit(0);
+  process.exitCode = 0;
+} else {
+  for (const f of findings) {
+    process.stdout.write(`${f.file}:${f.line} ${f.kind} ${f.token}\n`);
+  }
+  process.stdout.write(`vocabulary-lint: ${findings.length} finding(s)\n`);
+  process.exitCode = 1;
 }
-
-for (const f of findings) {
-  process.stdout.write(`${f.file}:${f.line} ${f.kind} ${f.token}\n`);
-}
-process.stdout.write(`\nvocabulary-lint: ${findings.length} finding(s)\n`);
-process.exit(1);

--- a/servers/exarchos-mcp/src/architecture/vocabulary-lint.test.ts
+++ b/servers/exarchos-mcp/src/architecture/vocabulary-lint.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { scanFile, scanPaths } from './vocabulary-lint.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const INVARIANTS_DOC = path.join(REPO_ROOT, 'docs/architecture/invariants.md');
+
+describe('vocabulary-lint', () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocab-lint-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('VocabularyLint_UnknownInvariantReference_Fails', () => {
+    const fixture = path.join(tmpDir, 'unknown-ref.md');
+    fs.writeFileSync(
+      fixture,
+      'Some prose referencing INV-99 which does not exist.\n',
+    );
+    const findings = scanFile(fixture, { invariantsDoc: INVARIANTS_DOC });
+    expect(findings.length).toBeGreaterThan(0);
+    const inv99 = findings.find((f) => f.token === 'INV-99');
+    expect(inv99).toBeDefined();
+    expect(inv99!.kind).toBe('unknown-invariant');
+  });
+
+  it('VocabularyLint_KnownInvariantReference_Passes', () => {
+    const fixture = path.join(tmpDir, 'known-ref.md');
+    fs.writeFileSync(
+      fixture,
+      'Some prose referencing INV-1 which is documented.\n',
+    );
+    const findings = scanFile(fixture, { invariantsDoc: INVARIANTS_DOC });
+    expect(findings).toEqual([]);
+  });
+
+  it('VocabularyLint_MultipleFileScan_AggregatesFindings', () => {
+    const subDir = path.join(tmpDir, 'multi');
+    fs.mkdirSync(subDir, { recursive: true });
+    fs.writeFileSync(path.join(subDir, 'a.md'), 'Prose with INV-1 and INV-77.\n');
+    fs.writeFileSync(path.join(subDir, 'b.md'), 'Prose with DIM-3 and DIM-42.\n');
+    const findings = scanPaths([subDir], { invariantsDoc: INVARIANTS_DOC });
+    expect(findings.length).toBe(2);
+    const tokens = findings.map((f) => f.token).sort();
+    expect(tokens).toEqual(['DIM-42', 'INV-77']);
+    // Each finding carries file + line.
+    for (const f of findings) {
+      expect(typeof f.file).toBe('string');
+      expect(typeof f.line).toBe('number');
+      expect(f.line).toBeGreaterThan(0);
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/architecture/vocabulary-lint.ts
+++ b/servers/exarchos-mcp/src/architecture/vocabulary-lint.ts
@@ -1,0 +1,169 @@
+/**
+ * Vocabulary-lint scanner for invariant references (issue #1260).
+ *
+ * Walks markdown files under the given roots, finds tokens matching
+ * `/\b(INV-\d+[a-d]?|DIM-\d+)\b/`, and cross-checks them against the IDs
+ * declared in `docs/architecture/invariants.md`. Unknown references are
+ * returned as findings.
+ *
+ * Designed to be a thin library that the `npm run lint:invariants` CLI
+ * wrapper can call.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadInvariantIds } from './invariants-loader.js';
+
+export interface VocabularyFinding {
+  file: string;
+  line: number;
+  token: string;
+  kind: 'unknown-invariant';
+}
+
+export interface ScanOptions {
+  /**
+   * Absolute path to the invariants catalog markdown file. Defaults to
+   * `<repoRoot>/docs/architecture/invariants.md`.
+   */
+  invariantsDoc?: string;
+  /** Skip these directory names while walking. */
+  skipDirs?: string[];
+}
+
+const TOKEN_RE = /\b(INV-\d+[a-d]?|DIM-\d+)\b/g;
+const DEFAULT_SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  '.next',
+  'coverage',
+]);
+
+/**
+ * Resolve the repository root from this module's location.
+ *
+ * src/architecture/vocabulary-lint.ts → repo root is four levels up.
+ */
+function resolveRepoRoot(): string {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(__dirname, '../../../..');
+}
+
+function defaultInvariantsDoc(): string {
+  return path.join(resolveRepoRoot(), 'docs/architecture/invariants.md');
+}
+
+/**
+ * Scan a single file for unknown invariant references.
+ */
+export function scanFile(
+  file: string,
+  options: ScanOptions = {},
+): VocabularyFinding[] {
+  const docPath = options.invariantsDoc ?? defaultInvariantsDoc();
+  const knownIds = loadInvariantIds(docPath);
+  return scanFileWithKnown(file, knownIds);
+}
+
+function scanFileWithKnown(
+  file: string,
+  knownIds: Set<string>,
+): VocabularyFinding[] {
+  const text = fs.readFileSync(file, 'utf8');
+  const findings: VocabularyFinding[] = [];
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    TOKEN_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    const seen = new Set<string>();
+    while ((match = TOKEN_RE.exec(line)) !== null) {
+      const token = match[1]!;
+      if (knownIds.has(token)) continue;
+      // De-dup within a line so a token repeated on the same line is one
+      // finding (line:token uniqueness).
+      const key = token;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      findings.push({
+        file,
+        line: i + 1,
+        token,
+        kind: 'unknown-invariant',
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Walk one or more paths (files or directories) and scan every markdown file
+ * (`*.md`) for unknown invariant references. Aggregates findings across files.
+ */
+export function scanPaths(
+  paths: string[],
+  options: ScanOptions = {},
+): VocabularyFinding[] {
+  const docPath = options.invariantsDoc ?? defaultInvariantsDoc();
+  const knownIds = loadInvariantIds(docPath);
+  const skipDirs = new Set([
+    ...DEFAULT_SKIP_DIRS,
+    ...(options.skipDirs ?? []),
+  ]);
+  const findings: VocabularyFinding[] = [];
+  for (const root of paths) {
+    if (!fs.existsSync(root)) continue;
+    const stat = fs.statSync(root);
+    if (stat.isFile()) {
+      if (root.endsWith('.md')) {
+        findings.push(...scanFileWithKnown(root, knownIds));
+      }
+      continue;
+    }
+    if (stat.isDirectory()) {
+      walkDirectory(root, skipDirs, (file) => {
+        findings.push(...scanFileWithKnown(file, knownIds));
+      });
+    }
+  }
+  return findings;
+}
+
+function walkDirectory(
+  root: string,
+  skipDirs: Set<string>,
+  visit: (file: string) => void,
+): void {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (skipDirs.has(entry.name)) continue;
+      walkDirectory(full, skipDirs, visit);
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      visit(full);
+    }
+  }
+}
+
+/**
+ * Default scan: walks `docs/`, `skills-src/`, and `commands/` from the repo
+ * root and returns aggregated findings. The exclusion list intentionally
+ * omits `skills/<runtime>/` (generated content — drift in source surfaces
+ * through `skills:guard`).
+ */
+export function scanRepoDefaults(
+  options: ScanOptions = {},
+): VocabularyFinding[] {
+  const root = resolveRepoRoot();
+  return scanPaths(
+    [
+      path.join(root, 'docs'),
+      path.join(root, 'skills-src'),
+      path.join(root, 'commands'),
+    ],
+    options,
+  );
+}

--- a/servers/exarchos-mcp/src/commands/ideate-loader.test.ts
+++ b/servers/exarchos-mcp/src/commands/ideate-loader.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadInvariants } from '../architecture/invariants-loader.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const IDEATE_COMMAND = path.join(REPO_ROOT, 'commands/ideate.md');
+const BRAINSTORMING_SKILL = path.join(
+  REPO_ROOT,
+  'skills-src/brainstorming/SKILL.md',
+);
+const INVARIANTS_DOC = path.join(REPO_ROOT, 'docs/architecture/invariants.md');
+
+describe('ideate first-turn invariant surfacing (#1260)', () => {
+  it('Ideate_FirstTurn_LoadsInvariantsDoc', () => {
+    const ideate = fs.readFileSync(IDEATE_COMMAND, 'utf8');
+    const skill = fs.readFileSync(BRAINSTORMING_SKILL, 'utf8');
+
+    // The /ideate command itself must reference docs/architecture/invariants.md
+    // so the agent knows to consult the invariants catalog on first turn.
+    expect(ideate).toContain('docs/architecture/invariants.md');
+
+    // The brainstorming skill body must guide surfacing of relevant invariants
+    // (and reference the invariants doc explicitly).
+    expect(skill).toContain('docs/architecture/invariants.md');
+    expect(skill.toLowerCase()).toContain('constraint anchoring');
+  });
+
+  it('Ideate_FirstTurn_SurfacesRelevantInvariants', () => {
+    // The contract: for a CLI-design proposal, the surfaced section should
+    // include the invariants that govern CLI / agent-first surface design —
+    // INV-5a (input ergonomics), INV-5c (Aspire verbs), DIM-1 (topology).
+    //
+    // Modeled as: those IDs must be declared in the invariants catalog AND
+    // they must be the IDs the /ideate workflow points the agent at for
+    // CLI-shaped proposals. We assert (a) the catalog has them, and (b) the
+    // brainstorming skill prose names them as canonical anchors so a CLI
+    // proposal is guaranteed to surface them.
+    const entries = loadInvariants(INVARIANTS_DOC);
+    const ids = new Set(entries.map((e) => e.id));
+    expect(ids.has('INV-5a')).toBe(true);
+    expect(ids.has('INV-5c')).toBe(true);
+    expect(ids.has('DIM-1')).toBe(true);
+
+    const skill = fs.readFileSync(BRAINSTORMING_SKILL, 'utf8');
+    // Skill must enumerate at least INV-5a, INV-5c, DIM-1 as CLI-design anchors.
+    expect(skill).toMatch(/INV-5a/);
+    expect(skill).toMatch(/INV-5c/);
+    expect(skill).toMatch(/DIM-1/);
+  });
+});

--- a/servers/exarchos-mcp/src/config/exarchos-config-schema.test.ts
+++ b/servers/exarchos-mcp/src/config/exarchos-config-schema.test.ts
@@ -79,4 +79,51 @@ describe('ExarchosConfigSchema', () => {
     const result = ExarchosConfigSchema.safeParse({ test: '' });
     expect(result.success).toBe(false);
   });
+
+  // ─── #1244: handoffLint config block ───────────────────────────────────
+  //
+  // `handoffLint.hardFail` toggles whether `handleCheckpoint` blocks the
+  // dispatch when the prose-lint finds AI-padded handoff text. Defaults
+  // (field absent / hardFail absent) keep the soft-warning behaviour
+  // unchanged for pre-#1244 callers.
+
+  it('schema_HandoffLintHardFailTrue_Validates', () => {
+    const result = ExarchosConfigSchema.safeParse({
+      handoffLint: { hardFail: true },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.handoffLint?.hardFail).toBe(true);
+    }
+  });
+
+  it('schema_HandoffLintHardFailFalse_Validates', () => {
+    const result = ExarchosConfigSchema.safeParse({
+      handoffLint: { hardFail: false },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.handoffLint?.hardFail).toBe(false);
+    }
+  });
+
+  it('schema_HandoffLintAbsent_Validates', () => {
+    // The handoffLint block is optional — pre-#1244 configs (without
+    // any handoffLint key) must continue to validate.
+    const result = ExarchosConfigSchema.safeParse({ test: 'bun test' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.handoffLint).toBeUndefined();
+    }
+  });
+
+  it('schema_HandoffLintUnknownField_Rejected', () => {
+    // `.strict()` on the nested schema rejects typos so an operator
+    // that writes `handoffLint: { hardfail: true }` (lowercase) sees a
+    // validation error instead of a silently-ignored field.
+    const result = ExarchosConfigSchema.safeParse({
+      handoffLint: { hardfail: true },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/servers/exarchos-mcp/src/config/exarchos-config-schema.ts
+++ b/servers/exarchos-mcp/src/config/exarchos-config-schema.ts
@@ -18,11 +18,30 @@ const safeCommand = z
   .min(1, 'must not be empty or whitespace-only')
   .regex(SAFE_COMMAND_REGEX, 'contains disallowed shell metacharacters');
 
+// #1244 — markdown-aware handoff lint switch.
+//
+// `handleCheckpoint` runs a prose-lint over the dispatch handoff payload
+// (DR-1244). By default the lint is advisory: findings surface as a
+// soft warning on the response envelope and the checkpoint event is
+// still appended. Setting `handoffLint.hardFail: true` flips the gate
+// to a blocking rejection — `INVALID_INPUT` is returned BEFORE any
+// event is appended, so retries don't duplicate.
+//
+// The opt-in default keeps backward compatibility for existing
+// `.exarchos.yml` files: configs that don't declare `handoffLint`
+// continue to soft-warn, which is the v2.10 default behaviour.
+const HandoffLintConfigSchema = z
+  .object({
+    hardFail: z.boolean().optional(),
+  })
+  .strict();
+
 export const ExarchosConfigSchema = z
   .object({
     test: safeCommand.optional(),
     typecheck: safeCommand.optional(),
     install: safeCommand.optional(),
+    handoffLint: HandoffLintConfigSchema.optional(),
   })
   .strict();
 

--- a/servers/exarchos-mcp/src/orchestrate/design-completeness.ts
+++ b/servers/exarchos-mcp/src/orchestrate/design-completeness.ts
@@ -11,6 +11,8 @@ import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { emitGateEvent } from './gate-utils.js';
 import { handleDesignCompleteness as runDesignCompleteness } from './pure/design-completeness.js';
+import { loadDesignSidecar } from './sidecar-lookup.js';
+import type { DesignSidecarV1 } from './sidecar-schemas.js';
 
 // ─── Handler ────────────────────────────────────────────────────────────────
 
@@ -32,20 +34,30 @@ export async function handleDesignCompleteness(
   // (matches storage/lifecycle.ts, cli-commands/{assemble-context,subagent-context,gates}).
   const stateFile = args.stateFile ?? `${stateDir}/${streamId}.state.json`;
 
-  // 2. Call pure TypeScript implementation
+  // 2. Prefer the sidecar (T15) when present + conformant; otherwise fall
+  // back to the existing regex-scrape path with a deprecation warning
+  // logged inside `loadDesignSidecar`. The regex branch is scheduled for
+  // removal in v2.11 (#1298 follow-up tracking issue).
   let parsed;
-  try {
-    parsed = runDesignCompleteness({
-      stateFile,
-      designFile: args.designPath,
-      docsDir: 'docs/designs',
-    });
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    return {
-      success: false,
-      error: { code: 'DESIGN_CHECK_ERROR', message: `Design completeness check failed: ${message}` },
-    };
+  let source: 'sidecar' | 'regex' = 'regex';
+  const sidecar = args.designPath ? loadDesignSidecar(args.designPath) : null;
+  if (sidecar) {
+    parsed = evaluateDesignSidecar(sidecar);
+    source = 'sidecar';
+  } else {
+    try {
+      parsed = runDesignCompleteness({
+        stateFile,
+        designFile: args.designPath,
+        docsDir: 'docs/designs',
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        error: { code: 'DESIGN_CHECK_ERROR', message: `Design completeness check failed: ${message}` },
+      };
+    }
   }
 
   // 3. Emit gate.executed event
@@ -67,6 +79,76 @@ export async function handleDesignCompleteness(
   // 4. Return result
   return {
     success: true,
-    data: parsed,
+    data: { ...parsed, source },
+  };
+}
+
+// ─── Sidecar evaluation ─────────────────────────────────────────────────────
+
+/**
+ * Evaluate a `DesignSidecarV1` against the same five checks the regex
+ * branch performs, but using the structured input directly:
+ *   1. (implicit) design doc exists — guaranteed when sidecar is present.
+ *   2. Required sections present — each declared section in `sections`
+ *      must have `present: true`.
+ *   3. Multiple options — `options.count >= 2`.
+ *   4. (skipped — state-file path already verified by the loader call site).
+ *   5. Acceptance criteria — every DR in `drs` must be referenced by at
+ *      least one entry in `acceptance` (advisory finding).
+ */
+function evaluateDesignSidecar(sidecar: DesignSidecarV1): {
+  passed: boolean;
+  advisory: boolean;
+  findings: string[];
+  checkCount: number;
+  passCount: number;
+  failCount: number;
+} {
+  const findings: string[] = [];
+  let passCount = 0;
+  let failCount = 0;
+
+  // Sections: every declared section must report `present: true`.
+  const missingSections = Object.entries(sidecar.sections)
+    .filter(([, v]) => !v.present)
+    .map(([k]) => k);
+  if (missingSections.length === 0) {
+    passCount++;
+  } else {
+    failCount++;
+    findings.push(`Required sections missing: ${missingSections.join(', ')}`);
+  }
+
+  // Multiple options: optional in the schema; if absent, treat as not-checked.
+  if (sidecar.options) {
+    if (sidecar.options.count >= 2) {
+      passCount++;
+    } else {
+      failCount++;
+      findings.push(`Found ${sidecar.options.count} option(s), expected at least 2`);
+    }
+  }
+
+  // Acceptance criteria — every DR referenced at least once (advisory).
+  const referenced = new Set<string>();
+  for (const a of sidecar.acceptance) {
+    for (const ref of a.references) referenced.add(ref);
+  }
+  const drsMissingAcceptance = sidecar.drs
+    .map((dr) => dr.id)
+    .filter((id) => !referenced.has(id));
+  if (drsMissingAcceptance.length > 0) {
+    findings.push(
+      `Advisory: DR entries missing acceptance criteria: ${drsMissingAcceptance.join(', ')}`,
+    );
+  }
+
+  return {
+    passed: failCount === 0,
+    advisory: true,
+    findings,
+    checkCount: passCount + failCount,
+    passCount,
+    failCount,
   };
 }

--- a/servers/exarchos-mcp/src/orchestrate/plan-coverage.ts
+++ b/servers/exarchos-mcp/src/orchestrate/plan-coverage.ts
@@ -9,6 +9,8 @@ import { readFile } from 'node:fs/promises';
 import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { emitGateEvent } from './gate-utils.js';
+import { loadDesignSidecar, loadPlanSidecar } from './sidecar-lookup.js';
+import type { DesignSidecarV1, PlanSidecarV1 } from './sidecar-schemas.js';
 
 // ─── Result Types ──────────────────────────────────────────────────────────
 
@@ -694,6 +696,28 @@ export async function handlePlanCoverage(
     };
   }
 
+  // Prefer the sidecars (T15) when both are present + conformant. The
+  // sidecar branch reads `coverage` directly without ever scraping
+  // markdown. When either side is missing, fall back to the existing
+  // regex-scrape path with a deprecation warning logged inside the
+  // sidecar-lookup helper.
+  const designSidecar = loadDesignSidecar(args.designPath);
+  const planSidecar = loadPlanSidecar(args.planPath);
+  if (designSidecar && planSidecar) {
+    const result = evaluatePlanCoverageFromSidecars(designSidecar, planSidecar);
+    try {
+      await emitGateEvent(eventStore, args.featureId, 'plan-coverage', 'planning', result.passed, {
+        dimension: 'D1',
+        phase: 'plan',
+        covered: result.coverage.covered,
+        gaps: result.coverage.gaps,
+        deferred: result.coverage.deferred,
+        totalSections: result.coverage.total,
+      });
+    } catch { /* fire-and-forget */ }
+    return { success: true, data: { ...result, source: 'sidecar' as const } };
+  }
+
   // Read files
   let designContent: string;
   let planContent: string;
@@ -754,5 +778,63 @@ export async function handlePlanCoverage(
     });
   } catch { /* fire-and-forget */ }
 
-  return { success: true, data: result };
+  return { success: true, data: { ...result, source: 'regex' as const } };
+}
+
+// ─── Sidecar evaluation ─────────────────────────────────────────────────────
+
+/**
+ * Compute plan-coverage from the structured sidecars. Each DR id from the
+ * design sidecar's `drs[]` is checked against the plan sidecar's `coverage`
+ * map. A DR with no covering tasks is a gap; everything else is covered.
+ *
+ * Deferred is treated as a no-op for sidecar-driven inputs (the structured
+ * shape has no equivalent of the "Deferred" cell in the markdown
+ * traceability table — designs that want to defer should omit the DR from
+ * the sidecar).
+ */
+function evaluatePlanCoverageFromSidecars(
+  design: DesignSidecarV1,
+  plan: PlanSidecarV1,
+): {
+  passed: boolean;
+  coverage: { covered: number; gaps: number; deferred: number; total: number };
+  report: string;
+  gapSections: readonly string[];
+} {
+  const gapSections: string[] = [];
+  let covered = 0;
+  let gaps = 0;
+
+  for (const dr of design.drs) {
+    const coveringTasks = plan.coverage[dr.id];
+    if (coveringTasks && coveringTasks.length > 0) {
+      covered++;
+    } else {
+      gaps++;
+      gapSections.push(dr.id);
+    }
+  }
+
+  const total = design.drs.length;
+  const passed = gaps === 0;
+  const reportLines = [
+    '## Plan Coverage Report (sidecar)',
+    '',
+    `- DRs total: ${total}`,
+    `- Covered: ${covered}`,
+    `- Gaps: ${gaps}`,
+  ];
+  if (gapSections.length > 0) {
+    reportLines.push('', '### Gaps');
+    for (const id of gapSections) reportLines.push(`- ${id}`);
+  }
+  reportLines.push('', passed ? `**Result: PASS** (${covered}/${total} DRs covered)` : `**Result: FAIL** (${gaps}/${total} gaps)`);
+
+  return {
+    passed,
+    coverage: { covered, gaps, deferred: 0, total },
+    report: reportLines.join('\n'),
+    gapSections,
+  };
 }

--- a/servers/exarchos-mcp/src/orchestrate/provenance-chain.ts
+++ b/servers/exarchos-mcp/src/orchestrate/provenance-chain.ts
@@ -9,6 +9,8 @@ import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { emitGateEvent } from './gate-utils.js';
 import { verifyProvenanceChain } from './pure/provenance-chain.js';
+import { loadDesignSidecar, loadPlanSidecar } from './sidecar-lookup.js';
+import type { DesignSidecarV1, PlanSidecarV1 } from './sidecar-schemas.js';
 
 // ─── Result Types ──────────────────────────────────────────────────────────
 
@@ -66,6 +68,27 @@ export async function handleProvenanceChain(
     };
   }
 
+  // Prefer the sidecars (T15) when both are present + conformant.
+  const designSidecar = loadDesignSidecar(args.designPath);
+  const planSidecar = loadPlanSidecar(args.planPath);
+  if (designSidecar && planSidecar) {
+    const sidecarResult = evaluateProvenanceFromSidecars(designSidecar, planSidecar);
+    try {
+      await emitGateEvent(eventStore, args.featureId, 'provenance-chain', 'planning', sidecarResult.passed, {
+        dimension: 'D1',
+        phase: 'plan',
+        requirements: sidecarResult.coverage.requirements,
+        covered: sidecarResult.coverage.covered,
+        gaps: sidecarResult.coverage.gaps,
+        orphanRefs: sidecarResult.coverage.orphanRefs,
+      });
+    } catch { /* fire-and-forget */ }
+    return {
+      success: true,
+      data: { ...sidecarResult, source: 'sidecar' as const },
+    };
+  }
+
   // Call pure TypeScript implementation
   const tsResult = verifyProvenanceChain({
     designFile: args.designPath,
@@ -110,5 +133,52 @@ export async function handleProvenanceChain(
     report: tsResult.output,
   };
 
-  return { success: true, data: result };
+  return { success: true, data: { ...result, source: 'regex' as const } };
+}
+
+// ─── Sidecar evaluation ─────────────────────────────────────────────────────
+
+/**
+ * Verify the design-to-plan provenance chain from the structured sidecars.
+ *
+ * A DR is "covered" when at least one `provenance` entry in the plan
+ * sidecar references it. An "orphan reference" is a plan provenance entry
+ * pointing at a DR id that does not appear in the design sidecar's `drs`.
+ */
+function evaluateProvenanceFromSidecars(
+  design: DesignSidecarV1,
+  plan: PlanSidecarV1,
+): {
+  passed: boolean;
+  coverage: { requirements: number; covered: number; gaps: number; orphanRefs: number };
+  report: string;
+} {
+  const drIds = new Set(design.drs.map((d) => d.id));
+  const provenanceDrs = new Set(plan.provenance.map((p) => p.dr));
+  let covered = 0;
+  const missing: string[] = [];
+  for (const dr of drIds) {
+    if (provenanceDrs.has(dr)) covered++;
+    else missing.push(dr);
+  }
+  const orphanRefs = [...provenanceDrs].filter((d) => !drIds.has(d));
+  const requirements = drIds.size;
+  const gaps = missing.length;
+  const passed = gaps === 0 && orphanRefs.length === 0;
+  const report = [
+    '## Provenance Chain Report (sidecar)',
+    '',
+    `- Requirements: ${requirements}`,
+    `- Covered: ${covered}`,
+    `- Gaps: ${gaps}${gaps > 0 ? ` (${missing.join(', ')})` : ''}`,
+    `- Orphan provenance refs: ${orphanRefs.length}${orphanRefs.length > 0 ? ` (${orphanRefs.join(', ')})` : ''}`,
+    '',
+    passed ? '**Result: PASS**' : '**Result: FAIL**',
+  ].join('\n');
+
+  return {
+    passed,
+    coverage: { requirements, covered, gaps, orphanRefs: orphanRefs.length },
+    report,
+  };
 }

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-backfill.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-backfill.test.ts
@@ -1,0 +1,41 @@
+// ─── Sidecar Backfill Validation (T16, #1298) ────────────────────────────────
+//
+// Ensures the hand-authored sidecars for the v2.10.0-preview.4 feature-freeze
+// design and plan parse cleanly under DesignSidecarV1 / PlanSidecarV1. Any
+// drift between the YAML and the schema is caught at test time, not in the
+// gate runtime.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse } from 'yaml';
+
+import { DesignSidecarV1, PlanSidecarV1 } from './sidecar-schemas.js';
+
+// Resolve relative to repo root from this test file's location:
+// servers/exarchos-mcp/src/orchestrate/<this> → ../../../../docs/...
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+
+describe('SidecarBackfill_Preview4', () => {
+  it('DesignSidecar_ParsesUnderDesignV1', () => {
+    const docPath = resolve(REPO_ROOT, 'docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml');
+    const raw = readFileSync(docPath, 'utf-8');
+    const parsed = DesignSidecarV1.safeParse(parse(raw));
+    if (!parsed.success) {
+      // Surface the first issue clearly when the test fails.
+      throw new Error(`Design sidecar invalid: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+    }
+    expect(parsed.success).toBe(true);
+  });
+
+  it('PlanSidecar_ParsesUnderPlanV1', () => {
+    const docPath = resolve(REPO_ROOT, 'docs/plans/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml');
+    const raw = readFileSync(docPath, 'utf-8');
+    const parsed = PlanSidecarV1.safeParse(parse(raw));
+    if (!parsed.success) {
+      throw new Error(`Plan sidecar invalid: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+    }
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-backfill.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-backfill.test.ts
@@ -8,13 +8,19 @@
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parse } from 'yaml';
 
 import { DesignSidecarV1, PlanSidecarV1 } from './sidecar-schemas.js';
 
 // Resolve relative to repo root from this test file's location:
 // servers/exarchos-mcp/src/orchestrate/<this> → ../../../../docs/...
+// `__dirname` is not defined under strict ESM/NodeNext; derive it from
+// `import.meta.url` so the test works regardless of vitest's CJS-compat
+// shim (CodeRabbit B3 on PR #1406).
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
 
 describe('SidecarBackfill_Preview4', () => {

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
@@ -1,0 +1,325 @@
+// ─── Sidecar Consumption Tests (T15, #1298) ──────────────────────────────────
+//
+// Cross-gate behaviour: each of the four authoring gates must consume the
+// machine-readable `<doc>.sidecar.yml` when present, and fall back to the
+// existing regex-scrape path with a deprecation warning when absent.
+//
+// These tests anchor that contract end-to-end against real on-disk fixtures
+// (no mocks) so the wiring between the handler, the sidecar-lookup helper,
+// and the underlying pure functions is exercised once per gate.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import type { EventStore } from '../event-store/store.js';
+
+import { handleDesignCompleteness } from './design-completeness.js';
+import { handlePlanCoverage } from './plan-coverage.js';
+import { handleProvenanceChain } from './provenance-chain.js';
+import { handleTaskDecomposition } from './task-decomposition.js';
+import { orchestrateLogger } from '../logger.js';
+
+// ─── Test scaffolding ───────────────────────────────────────────────────────
+
+const mockAppend = vi.fn();
+const mockQuery = vi.fn();
+const mockStore = {
+  append: mockAppend,
+  query: mockQuery,
+} as unknown as EventStore;
+
+let workDir: string;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'sidecar-consumption-'));
+  mockAppend.mockResolvedValue({
+    streamId: 'feat',
+    sequence: 1,
+    type: 'gate.executed',
+    timestamp: new Date().toISOString(),
+  });
+  mockQuery.mockResolvedValue([]);
+  // The deprecation message is emitted via pino (`orchestrateLogger.warn`)
+  // to stay inside the no-console-in-production policy (#1119).
+  warnSpy = vi.spyOn(orchestrateLogger, 'warn').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  if (existsSync(workDir)) {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+/** Concatenate all spied logger.warn invocations into one searchable string. */
+function collectWarnMessages(): string {
+  return warnSpy.mock.calls
+    .flatMap((call) => call.map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg))))
+    .join('\n');
+}
+
+// ─── Fixture helpers ────────────────────────────────────────────────────────
+
+function writeConformantDesignMarkdown(designPath: string): void {
+  // Conforms to existing regex-scrape expectations so the fallback path passes.
+  const content = `# Sample Design
+
+## Problem Statement
+Stuff.
+
+## Requirements
+- DR-1: Foo
+
+  - Given: X
+  - When: Y
+  - Then: Z
+
+## Chosen Approach
+Some prose.
+
+### Option 1
+A.
+
+### Option 2
+B.
+
+## Technical Design
+### Section A
+Detail.
+
+## Integration Points
+Stuff.
+
+## Testing Strategy
+Stuff.
+
+## Open Questions
+None.
+`;
+  writeFileSync(designPath, content, 'utf-8');
+}
+
+function writeConformantPlanMarkdown(planPath: string): void {
+  const content = `# Plan
+
+## Tasks
+
+### Task T-01: First task title with Section A and substantial description text
+
+**Goal:** Implement DR-1 with a description that comfortably exceeds ten words for the structural check.
+
+**Files:** \`src/a.ts\`, \`src/a.test.ts\`
+
+**Tests:** [RED] First_Test_Name
+
+**Dependencies:** none
+
+**Parallelizable:** No
+
+### Task T-02: Acceptance test task covering DR-1
+
+**Goal:** Provide acceptance coverage with at least ten descriptive words to satisfy the structural validator.
+
+**Test Layer:** acceptance
+
+**Implements:** DR-1
+
+**Files:** \`src/a.acceptance.test.ts\`
+
+**Tests:** [RED] Second_Test_Name
+
+**Dependencies:** T-01
+
+**Parallelizable:** No
+`;
+  writeFileSync(planPath, content, 'utf-8');
+}
+
+function writeDesignSidecar(designPath: string): void {
+  const yaml = `schema: design.v1
+sections:
+  problem: { present: true }
+  approaches: { present: true }
+drs:
+  - { id: DR-1, title: Foo, section: Wave A }
+acceptance:
+  - { id: A-1, references: [DR-1] }
+options:
+  count: 2
+`;
+  writeFileSync(`${designPath}.sidecar.yml`, yaml, 'utf-8');
+}
+
+function writePlanSidecar(planPath: string): void {
+  const yaml = `schema: plan.v1
+tasks:
+  - id: T-01
+    phase: RED
+    description: First failing test that anchors the contract before any production code lands
+    files: [src/a.test.ts]
+  - id: T-02
+    phase: GREEN
+    description: Minimal implementation turning the RED test green without overreach
+    files: [src/a.ts]
+coverage:
+  DR-1: [T-01, T-02]
+provenance:
+  - { taskId: T-01, dr: DR-1 }
+  - { taskId: T-02, dr: DR-1 }
+`;
+  writeFileSync(`${planPath}.sidecar.yml`, yaml, 'utf-8');
+}
+
+// ─── design-completeness ─────────────────────────────────────────────────────
+
+describe('CheckDesignCompleteness', () => {
+  it('SidecarPresent_UsesStructuredInput', async () => {
+    const designDir = join(workDir, 'designs');
+    mkdirSync(designDir, { recursive: true });
+    const designPath = join(designDir, '2026-05-15-fixture.md');
+    writeConformantDesignMarkdown(designPath);
+    writeDesignSidecar(designPath);
+
+    const stateDir = join(workDir, 'state');
+    mkdirSync(stateDir, { recursive: true });
+    const stateFile = join(stateDir, 'feat.state.json');
+    writeFileSync(stateFile, JSON.stringify({ artifacts: { design: designPath } }), 'utf-8');
+
+    const result = await handleDesignCompleteness(
+      { featureId: 'feat', stateFile, designPath },
+      stateDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { passed: boolean; source?: string; findings: readonly string[] };
+      expect(data.passed).toBe(true);
+      // Structured-input branch surfaces a `source: 'sidecar'` signal in the result.
+      expect(data.source).toBe('sidecar');
+    }
+    // Deprecation warning must NOT fire when sidecar is present.
+    expect(collectWarnMessages()).not.toContain('[DEPRECATION] sidecar missing');
+  });
+
+  it('NoSidecar_FallsBackToRegexWithDeprecationLog', async () => {
+    const designDir = join(workDir, 'designs');
+    mkdirSync(designDir, { recursive: true });
+    const designPath = join(designDir, '2026-05-15-fixture.md');
+    writeConformantDesignMarkdown(designPath);
+    // No sidecar written.
+
+    const stateDir = join(workDir, 'state');
+    mkdirSync(stateDir, { recursive: true });
+    const stateFile = join(stateDir, 'feat.state.json');
+    writeFileSync(stateFile, JSON.stringify({ artifacts: { design: designPath } }), 'utf-8');
+
+    const result = await handleDesignCompleteness(
+      { featureId: 'feat', stateFile, designPath },
+      stateDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { source?: string };
+      expect(data.source).toBe('regex');
+    }
+    const allWarns = collectWarnMessages();
+    expect(allWarns).toContain('[DEPRECATION]');
+    expect(allWarns).toContain(designPath);
+  });
+});
+
+// ─── plan-coverage ──────────────────────────────────────────────────────────
+
+describe('CheckPlanCoverage', () => {
+  it('SidecarPresent_VerifiesDrCoverageStructurally', async () => {
+    const designDir = join(workDir, 'designs');
+    mkdirSync(designDir, { recursive: true });
+    const designPath = join(designDir, '2026-05-15-fixture.md');
+    writeConformantDesignMarkdown(designPath);
+    writeDesignSidecar(designPath);
+
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-fixture.md');
+    writeConformantPlanMarkdown(planPath);
+    writePlanSidecar(planPath);
+
+    const result = await handlePlanCoverage(
+      { featureId: 'feat', designPath, planPath },
+      workDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { passed: boolean; source?: string };
+      expect(data.source).toBe('sidecar');
+      expect(data.passed).toBe(true);
+    }
+    expect(collectWarnMessages()).not.toContain('[DEPRECATION] sidecar missing');
+  });
+});
+
+// ─── provenance-chain ───────────────────────────────────────────────────────
+
+describe('CheckProvenanceChain', () => {
+  it('SidecarPresent_VerifiesDrsStructurally', async () => {
+    const designDir = join(workDir, 'designs');
+    mkdirSync(designDir, { recursive: true });
+    const designPath = join(designDir, '2026-05-15-fixture.md');
+    writeConformantDesignMarkdown(designPath);
+    writeDesignSidecar(designPath);
+
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-fixture.md');
+    writeConformantPlanMarkdown(planPath);
+    writePlanSidecar(planPath);
+
+    const result = await handleProvenanceChain(
+      { featureId: 'feat', designPath, planPath },
+      workDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { passed: boolean; source?: string };
+      expect(data.source).toBe('sidecar');
+      expect(data.passed).toBe(true);
+    }
+  });
+});
+
+// ─── task-decomposition ─────────────────────────────────────────────────────
+
+describe('CheckTaskDecomposition', () => {
+  it('SidecarPresent_VerifiesTasksStructurally', async () => {
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-fixture.md');
+    writeConformantPlanMarkdown(planPath);
+    writePlanSidecar(planPath);
+
+    const result = await handleTaskDecomposition(
+      { featureId: 'feat', planPath },
+      workDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { passed: boolean; source?: string; totalTasks: number };
+      expect(data.source).toBe('sidecar');
+      expect(data.passed).toBe(true);
+      expect(data.totalTasks).toBe(2);
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
@@ -174,7 +174,7 @@ tasks:
     files: [src/a.test.ts]
   - id: T-02
     phase: GREEN
-    description: Minimal implementation turning the RED test green without overreach
+    description: Minimal implementation turning the RED test green without overreaching the contract boundary established earlier
     files: [src/a.ts]
 coverage:
   DR-1: [T-01, T-02]

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
@@ -395,6 +395,92 @@ describe('CheckTaskDecomposition', () => {
     }
   });
 
+  // C1 (#1298, CodeRabbit third pass): sidecar word-count threshold drifted
+  // from the regex path (>= 5 words) while the regex path requires > 10
+  // (i.e. 11+). Unify on the regex behaviour so a task with 6–10 words is
+  // rejected via the sidecar path too — the schema alone is not enough.
+  it('SidecarTaskDescriptionShort_RejectedConsistent', async () => {
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-short-desc.md');
+
+    // Markdown task graph is conformant for DAG / parallel-safety checks
+    // (no cycles, no shared files among parallelizable tasks). The sidecar
+    // descriptions, however, are 7 and 8 words — above the legacy `>= 5`
+    // threshold, below the regex-path `> 10` threshold. These tasks must
+    // be reported as needing rework.
+    const markdown = `# Plan
+
+## Tasks
+
+### Task T-01: First task with conformant markdown description body
+
+**Goal:** First task with enough descriptive words for the structural validator to pass cleanly.
+
+**Files:** \`src/a.ts\`
+
+**Tests:** [RED] First_Test
+
+**Dependencies:** none
+
+**Parallelizable:** No
+
+### Task T-02: Second task with conformant markdown description body
+
+**Goal:** Second task with enough descriptive words for the structural validator to pass cleanly.
+
+**Files:** \`src/b.ts\`
+
+**Tests:** [RED] Second_Test
+
+**Dependencies:** T-01
+
+**Parallelizable:** No
+`;
+    writeFileSync(planPath, markdown, 'utf-8');
+
+    const shortDescSidecar = `schema: plan.v1
+tasks:
+  - id: T-01
+    phase: RED
+    description: Seven word description that exceeds five words
+    files: [src/a.ts]
+  - id: T-02
+    phase: GREEN
+    description: Eight word description that still fails eleven threshold
+    files: [src/b.ts]
+coverage:
+  DR-1: [T-01, T-02]
+provenance:
+  - { taskId: T-01, dr: DR-1 }
+  - { taskId: T-02, dr: DR-1 }
+`;
+    writeFileSync(sidecarPathForTest(planPath), shortDescSidecar, 'utf-8');
+
+    const result = await handleTaskDecomposition(
+      { featureId: 'feat', planPath },
+      workDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as {
+        passed: boolean;
+        needsRework: number;
+        wellDecomposed: number;
+        totalTasks: number;
+        source?: string;
+      };
+      expect(data.source).toBe('sidecar');
+      // Both tasks should be flagged as needing rework — 7 and 8 words
+      // are below the unified 11-word threshold.
+      expect(data.needsRework).toBe(2);
+      expect(data.wellDecomposed).toBe(0);
+      expect(data.passed).toBe(false);
+    }
+  });
+
   it('SidecarPresentWithFileConflict_ReportsParallelUnsafe', async () => {
     const planDir = join(workDir, 'plans');
     mkdirSync(planDir, { recursive: true });

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
@@ -333,4 +333,122 @@ describe('CheckTaskDecomposition', () => {
       expect(data.totalTasks).toBe(2);
     }
   });
+
+  // B2 (#1406): sidecar fixture covers structural shape (count + per-task
+  // description/files). DAG cycles and file conflicts are NOT encoded in
+  // the plan.v1 schema today, so the sidecar branch MUST still run those
+  // checks against the markdown task graph. Anchor that contract.
+  it('SidecarPresentWithDagCycle_ReportsDagInvalid', async () => {
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-cycle.md');
+
+    // Sidecar shape is conformant (two well-described tasks with files),
+    // but the markdown task graph has T-01 ↔ T-02 mutual dependency.
+    const cyclicMarkdown = `# Plan
+
+## Tasks
+
+### Task T-01: First cyclic task with enough words for the description check
+
+**Goal:** Describe task one with enough descriptive words for the structural validator.
+
+**Files:** \`src/a.ts\`
+
+**Tests:** [RED] First_Test
+
+**Dependencies:** T-02
+
+**Parallelizable:** No
+
+### Task T-02: Second cyclic task with enough descriptive words for the structural check
+
+**Goal:** Describe task two with enough descriptive words to clear the structural validator.
+
+**Files:** \`src/b.ts\`
+
+**Tests:** [RED] Second_Test
+
+**Dependencies:** T-01
+
+**Parallelizable:** No
+`;
+    writeFileSync(planPath, cyclicMarkdown, 'utf-8');
+    writePlanSidecar(planPath);
+
+    const result = await handleTaskDecomposition(
+      { featureId: 'feat', planPath },
+      workDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as {
+        passed: boolean;
+        dagValid: boolean;
+        source?: string;
+      };
+      expect(data.source).toBe('sidecar');
+      expect(data.dagValid).toBe(false);
+      expect(data.passed).toBe(false);
+    }
+  });
+
+  it('SidecarPresentWithFileConflict_ReportsParallelUnsafe', async () => {
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-conflict.md');
+
+    // Two parallelizable tasks declaring the same file → conflict in the
+    // parallel-safety check. Sidecar shape is otherwise conformant.
+    const conflictMarkdown = `# Plan
+
+## Tasks
+
+### Task T-01: First parallel task with sufficient descriptive words for the validator
+
+**Goal:** First task with enough descriptive words for the structural validator to pass.
+
+**Files:** \`src/shared.ts\`
+
+**Tests:** [RED] First_Test
+
+**Dependencies:** none
+
+**Parallelizable:** Yes
+
+### Task T-02: Second parallel task touching the same shared source file as task one
+
+**Goal:** Second task with enough descriptive words for the structural validator to pass.
+
+**Files:** \`src/shared.ts\`
+
+**Tests:** [RED] Second_Test
+
+**Dependencies:** none
+
+**Parallelizable:** Yes
+`;
+    writeFileSync(planPath, conflictMarkdown, 'utf-8');
+    writePlanSidecar(planPath);
+
+    const result = await handleTaskDecomposition(
+      { featureId: 'feat', planPath },
+      workDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as {
+        passed: boolean;
+        parallelSafe: boolean;
+        source?: string;
+      };
+      expect(data.source).toBe('sidecar');
+      expect(data.parallelSafe).toBe(false);
+      expect(data.passed).toBe(false);
+    }
+  });
 });

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
@@ -139,6 +139,17 @@ function writeConformantPlanMarkdown(planPath: string): void {
   writeFileSync(planPath, content, 'utf-8');
 }
 
+/**
+ * Resolve the on-disk sidecar path for a `.md` doc using the canonical
+ * `<base>.sidecar.yml` convention (B1 fix on PR #1406). Tests write
+ * sidecars to this path so the lookup helper actually resolves them.
+ */
+function sidecarPathForTest(docPath: string): string {
+  return docPath.endsWith('.md')
+    ? `${docPath.slice(0, -3)}.sidecar.yml`
+    : `${docPath}.sidecar.yml`;
+}
+
 function writeDesignSidecar(designPath: string): void {
   const yaml = `schema: design.v1
 sections:
@@ -151,7 +162,7 @@ acceptance:
 options:
   count: 2
 `;
-  writeFileSync(`${designPath}.sidecar.yml`, yaml, 'utf-8');
+  writeFileSync(sidecarPathForTest(designPath), yaml, 'utf-8');
 }
 
 function writePlanSidecar(planPath: string): void {
@@ -171,7 +182,7 @@ provenance:
   - { taskId: T-01, dr: DR-1 }
   - { taskId: T-02, dr: DR-1 }
 `;
-  writeFileSync(`${planPath}.sidecar.yml`, yaml, 'utf-8');
+  writeFileSync(sidecarPathForTest(planPath), yaml, 'utf-8');
 }
 
 // ─── design-completeness ─────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
@@ -481,6 +481,42 @@ provenance:
     }
   });
 
+  // C2 (#1406, CodeRabbit third pass): sidecar-mode missing empty-block
+  // guard. When the sidecar exists but the markdown has zero `### Task XX:`
+  // blocks, the regex path fast-fails — but the sidecar path silently lets
+  // DAG/safety run on an empty graph and may pass. Sidecar structure alone
+  // is insufficient; the markdown task graph must exist for DAG checks to
+  // mean anything.
+  it('SidecarPresentEmptyMarkdownTasks_FailsFast', async () => {
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-empty-md.md');
+
+    // Markdown has prose but no `### Task` blocks. Sidecar is fully
+    // populated and conformant — without the guard, this used to pass.
+    const emptyMarkdown = `# Plan
+
+## Tasks
+
+Prose without any task headers — DAG / parallel-safety would run on an
+empty graph and trivially pass.
+`;
+    writeFileSync(planPath, emptyMarkdown, 'utf-8');
+    writePlanSidecar(planPath);
+
+    const result = await handleTaskDecomposition(
+      { featureId: 'feat', planPath },
+      workDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe('NO_PLAN_TASKS');
+      expect(result.error.message).toContain(planPath);
+    }
+  });
+
   it('SidecarPresentWithFileConflict_ReportsParallelUnsafe', async () => {
     const planDir = join(workDir, 'plans');
     mkdirSync(planDir, { recursive: true });

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-lookup.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-lookup.test.ts
@@ -1,0 +1,33 @@
+// ─── Sidecar Lookup — path-resolution tests (B1, #1406) ──────────────────────
+//
+// Anchors `sidecarPathFor`'s canonical convention: `<base>.sidecar.yml`
+// next to the markdown, NOT `<base>.md.sidecar.yml`. The bug caught by
+// CodeRabbit on PR #1406 was that the helper appended `.sidecar.yml` to
+// the verbatim doc path, so for a `.md` input the sidecar lookup never
+// resolved on disk and every gate silently fell back to regex.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+
+import { sidecarPathFor } from './sidecar-lookup.js';
+
+describe('SidecarPathFor', () => {
+  it('MarkdownInput_StripsMdAndAppendsSidecarYml', () => {
+    expect(sidecarPathFor('foo.md')).toBe('foo.sidecar.yml');
+  });
+
+  it('NonMarkdownInput_AppendsSidecarYml', () => {
+    expect(sidecarPathFor('foo')).toBe('foo.sidecar.yml');
+  });
+
+  it('PathWithDirectories_StripsTrailingMdOnly', () => {
+    expect(sidecarPathFor('docs/designs/2026-05-15-feature.md')).toBe(
+      'docs/designs/2026-05-15-feature.sidecar.yml',
+    );
+  });
+
+  it('NonMdExtension_IsPreservedVerbatim', () => {
+    // Only a trailing `.md` is stripped; other extensions stay as-is.
+    expect(sidecarPathFor('foo.markdown')).toBe('foo.markdown.sidecar.yml');
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-lookup.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-lookup.ts
@@ -30,12 +30,17 @@ import {
 export const REGEX_REMOVAL_TRACKING_ISSUE = '#1407';
 
 /**
- * Compute the conventional sidecar path for a doc: `<doc>.sidecar.yml`.
- * The doc path itself is preserved verbatim, including its `.md` suffix —
- * sidecars are always `<doc>.md.sidecar.yml` next to the markdown.
+ * Compute the conventional sidecar path for a doc: `<base>.sidecar.yml`.
+ *
+ * A trailing `.md` extension on `docPath` is stripped before appending
+ * `.sidecar.yml` so the on-disk convention matches the sidecars shipped
+ * alongside the docs (`docs/designs/foo.md` →
+ * `docs/designs/foo.sidecar.yml`). Inputs without a `.md` suffix have
+ * `.sidecar.yml` appended verbatim.
  */
 export function sidecarPathFor(docPath: string): string {
-  return `${docPath}.sidecar.yml`;
+  const base = docPath.endsWith('.md') ? docPath.slice(0, -3) : docPath;
+  return `${base}.sidecar.yml`;
 }
 
 /**

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-lookup.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-lookup.ts
@@ -1,0 +1,123 @@
+// ─── Sidecar Lookup Helper (#1298) ───────────────────────────────────────────
+//
+// Locates `<doc>.sidecar.yml` next to a design or plan markdown file and
+// parses it via the relevant Zod schema. When the sidecar is missing or
+// fails to parse cleanly, returns `null` and emits the canonical deprecation
+// warning via `console.warn` so the calling gate can fall back to the
+// regex-scrape path.
+//
+// Removal of the regex-fallback branch is scheduled for v2.11 — tracking
+// issue placeholder is surfaced in the warning so it can be patched at
+// merge time.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { existsSync, readFileSync } from 'node:fs';
+import { parse as parseYaml } from 'yaml';
+import type { z } from 'zod';
+
+import { orchestrateLogger } from '../logger.js';
+import {
+  DesignSidecarV1,
+  PlanSidecarV1,
+  type DesignSidecarV1 as DesignSidecarV1Type,
+  type PlanSidecarV1 as PlanSidecarV1Type,
+} from './sidecar-schemas.js';
+
+/**
+ * GitHub issue tracking removal of the regex-fallback branch in v2.11.
+ * Filed alongside #1298 (v2.10.0-preview.4 PR D2).
+ */
+export const REGEX_REMOVAL_TRACKING_ISSUE = '#1407';
+
+/**
+ * Compute the conventional sidecar path for a doc: `<doc>.sidecar.yml`.
+ * The doc path itself is preserved verbatim, including its `.md` suffix —
+ * sidecars are always `<doc>.md.sidecar.yml` next to the markdown.
+ */
+export function sidecarPathFor(docPath: string): string {
+  return `${docPath}.sidecar.yml`;
+}
+
+/**
+ * Build the canonical deprecation warning string. Surfaced both via pino
+ * (`orchestrateLogger.warn`) for operator-visible logs and returned to
+ * callers/tests so the gate response can include the same text.
+ */
+export function buildDeprecationMessage(docPath: string): string {
+  return (
+    `[DEPRECATION] sidecar missing for ${docPath}; if pre-v2.10.0-preview.4, ` +
+    `grandfathered; otherwise regenerate via npm run sidecar:emit. Regex ` +
+    `fallback scheduled for removal in v2.11. Tracking: ${REGEX_REMOVAL_TRACKING_ISSUE}`
+  );
+}
+
+/**
+ * Emit the canonical deprecation warning. Pre-v2.10.0-preview.4 docs are
+ * grandfathered; older docs SHOULD log but are not load-bearing.
+ *
+ * Goes through `orchestrateLogger` (pino subsystem='orchestrate') so we
+ * stay inside the project's no-console-in-production policy (#1119);
+ * tests spy on the logger instance directly.
+ */
+function logDeprecation(docPath: string): void {
+  orchestrateLogger.warn({ docPath, gate: 'sidecar-lookup' }, buildDeprecationMessage(docPath));
+}
+
+/**
+ * Internal: load + schema-validate a sidecar of the requested shape.
+ */
+function loadSidecar<T extends z.ZodTypeAny>(
+  docPath: string,
+  schema: T,
+): z.infer<T> | null {
+  const sidecarPath = sidecarPathFor(docPath);
+  if (!existsSync(sidecarPath)) {
+    logDeprecation(docPath);
+    return null;
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(sidecarPath, 'utf-8');
+  } catch {
+    logDeprecation(docPath);
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch {
+    // Malformed YAML — fall back to regex with deprecation log.
+    logDeprecation(docPath);
+    return null;
+  }
+
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    logDeprecation(docPath);
+    return null;
+  }
+
+  return result.data;
+}
+
+/**
+ * Load the `<design>.sidecar.yml` next to `designPath`. Returns the parsed
+ * `DesignSidecarV1` when available + conformant, or `null` (logging a
+ * deprecation warning) when missing, unreadable, malformed, or
+ * non-conformant.
+ */
+export function loadDesignSidecar(designPath: string): DesignSidecarV1Type | null {
+  return loadSidecar(designPath, DesignSidecarV1);
+}
+
+/**
+ * Load the `<plan>.sidecar.yml` next to `planPath`. Returns the parsed
+ * `PlanSidecarV1` when available + conformant, or `null` (logging a
+ * deprecation warning) when missing, unreadable, malformed, or
+ * non-conformant.
+ */
+export function loadPlanSidecar(planPath: string): PlanSidecarV1Type | null {
+  return loadSidecar(planPath, PlanSidecarV1);
+}

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-schemas.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-schemas.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  AcceptanceCriterionSchema,
   DesignSidecarV1,
   PlanSidecarV1,
 } from './sidecar-schemas.js';
@@ -91,6 +92,35 @@ describe('SidecarSchema_MismatchedSchemaVersion', () => {
       provenance: [],
     };
     const parsed = PlanSidecarV1.safeParse(doc);
+    expect(parsed.success).toBe(false);
+  });
+});
+
+// B4 (#1406): AcceptanceCriterionSchema must require at least one
+// non-empty DR reference. Empty arrays and empty strings used to slip
+// through, masking content gaps in hand-authored sidecars.
+describe('SidecarSchema_AcceptanceCriterion', () => {
+  it('AcceptsConformantEntry', () => {
+    const parsed = AcceptanceCriterionSchema.safeParse({
+      id: 'A-1',
+      references: ['DR-1'],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('EmptyReferences_Rejected', () => {
+    const parsed = AcceptanceCriterionSchema.safeParse({
+      id: 'A-1',
+      references: [],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('EmptyReferenceString_Rejected', () => {
+    const parsed = AcceptanceCriterionSchema.safeParse({
+      id: 'A-1',
+      references: [''],
+    });
     expect(parsed.success).toBe(false);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-schemas.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-schemas.test.ts
@@ -1,0 +1,96 @@
+// ─── Sidecar Schemas — RED tests (T14, #1298) ────────────────────────────────
+//
+// These tests anchor the design.v1 and plan.v1 sidecar contracts. Gates
+// consume the parsed sidecar instead of regex-scraping the markdown when
+// the sidecar is present (see T15).
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import {
+  DesignSidecarV1,
+  PlanSidecarV1,
+} from './sidecar-schemas.js';
+
+describe('SidecarSchema_DesignV1', () => {
+  it('AcceptsConformantDoc', () => {
+    const doc = {
+      schema: 'design.v1',
+      sections: {
+        problem: { present: true },
+        approaches: { present: true },
+      },
+      drs: [
+        { id: 'DR-1', title: 'Zod unions', section: 'Wave A' },
+        { id: 'DR-2', title: 'Quality hint', section: 'Wave A' },
+      ],
+      acceptance: [
+        { id: 'A-1', references: ['DR-1'] },
+        { id: 'A-2', references: ['DR-1', 'DR-2'] },
+      ],
+      options: { count: 3 },
+    };
+
+    const parsed = DesignSidecarV1.safeParse(doc);
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe('SidecarSchema_PlanV1', () => {
+  it('AcceptsConformantDoc', () => {
+    const doc = {
+      schema: 'plan.v1',
+      tasks: [
+        { id: 'T01', phase: 'RED', description: 'Author the failing test', files: ['a.test.ts'] },
+        { id: 'T02', phase: 'GREEN', description: 'Implement minimal pass', files: ['a.ts'] },
+        { id: 'T03', phase: 'REFACTOR', description: 'Tidy', files: ['a.ts'] },
+      ],
+      coverage: {
+        'DR-1': ['T01', 'T02'],
+        'DR-2': ['T03'],
+      },
+      provenance: [
+        { taskId: 'T01', dr: 'DR-1' },
+        { taskId: 'T02', dr: 'DR-1' },
+        { taskId: 'T03', dr: 'DR-2' },
+      ],
+    };
+
+    const parsed = PlanSidecarV1.safeParse(doc);
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe('SidecarSchema_MismatchedSchemaVersion', () => {
+  it('Rejected for design when schema is wrong literal', () => {
+    const doc = {
+      schema: 'design.v2', // not the literal
+      sections: {},
+      drs: [],
+      acceptance: [],
+    };
+    const parsed = DesignSidecarV1.safeParse(doc);
+    expect(parsed.success).toBe(false);
+  });
+
+  it('Rejected for plan when schema is wrong literal', () => {
+    const doc = {
+      schema: 'plan.v0',
+      tasks: [],
+      coverage: {},
+      provenance: [],
+    };
+    const parsed = PlanSidecarV1.safeParse(doc);
+    expect(parsed.success).toBe(false);
+  });
+
+  it('Rejected when phase is outside the RED/GREEN/REFACTOR enum', () => {
+    const doc = {
+      schema: 'plan.v1',
+      tasks: [{ id: 'T01', phase: 'BLUE', description: 'x', files: [] }],
+      coverage: {},
+      provenance: [],
+    };
+    const parsed = PlanSidecarV1.safeParse(doc);
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-schemas.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-schemas.ts
@@ -1,0 +1,84 @@
+// ─── Sidecar Schemas (design.v1, plan.v1) — #1298 ────────────────────────────
+//
+// Machine-readable sidecar contracts consumed by the four authoring gates
+// (`check_design_completeness`, `check_plan_coverage`, `check_provenance_chain`,
+// `check_task_decomposition`). When a `<doc>.sidecar.yml` is present next to
+// the markdown, gates parse it via these schemas and operate on structured
+// input. When absent, gates fall back to the existing regex-scrape branch
+// with a deprecation warning (scheduled for removal in v2.11).
+//
+// Schema-version is a literal (`design.v1` / `plan.v1`) so mismatched-version
+// docs reject cleanly via `safeParse(...).success === false`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { z } from 'zod';
+
+// ─── Design.v1 ──────────────────────────────────────────────────────────────
+
+/**
+ * A single design requirement, identified by its DR-N id with a title and the
+ * design section it appears under.
+ */
+export const DesignRequirementSchema = z.object({
+  id: z.string().min(1),
+  title: z.string(),
+  section: z.string(),
+});
+
+/**
+ * An acceptance criterion entry, identified by id, references one or more DRs.
+ */
+export const AcceptanceCriterionSchema = z.object({
+  id: z.string().min(1),
+  references: z.array(z.string()),
+});
+
+/**
+ * Per-section presence flag. Gates that scan markdown for "is section X
+ * present?" now read this directly. Extra section-specific scalars (like
+ * `options.count`) live at the top-level alongside `sections`.
+ */
+export const DesignSectionEntrySchema = z.object({
+  present: z.boolean(),
+});
+
+export const DesignSidecarV1 = z.object({
+  schema: z.literal('design.v1'),
+  sections: z.record(z.string(), DesignSectionEntrySchema),
+  drs: z.array(DesignRequirementSchema),
+  acceptance: z.array(AcceptanceCriterionSchema),
+  options: z
+    .object({
+      count: z.number().int().nonnegative(),
+    })
+    .optional(),
+});
+
+export type DesignSidecarV1 = z.infer<typeof DesignSidecarV1>;
+
+// ─── Plan.v1 ────────────────────────────────────────────────────────────────
+
+export const PlanTaskPhaseSchema = z.enum(['RED', 'GREEN', 'REFACTOR']);
+export type PlanTaskPhase = z.infer<typeof PlanTaskPhaseSchema>;
+
+export const PlanTaskEntrySchema = z.object({
+  id: z.string().min(1),
+  phase: PlanTaskPhaseSchema,
+  description: z.string(),
+  files: z.array(z.string()),
+});
+
+export const PlanProvenanceEntrySchema = z.object({
+  taskId: z.string().min(1),
+  dr: z.string().min(1),
+});
+
+export const PlanSidecarV1 = z.object({
+  schema: z.literal('plan.v1'),
+  tasks: z.array(PlanTaskEntrySchema),
+  // Maps DR id → task ids that cover that requirement.
+  coverage: z.record(z.string(), z.array(z.string())),
+  provenance: z.array(PlanProvenanceEntrySchema),
+});
+
+export type PlanSidecarV1 = z.infer<typeof PlanSidecarV1>;

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-schemas.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-schemas.ts
@@ -26,11 +26,14 @@ export const DesignRequirementSchema = z.object({
 });
 
 /**
- * An acceptance criterion entry, identified by id, references one or more DRs.
+ * An acceptance criterion entry, identified by id, references one or more
+ * DRs. The "one or more" half of that contract is enforced here (B4 fix
+ * on PR #1406): empty arrays and empty-string references used to slip
+ * through, masking content gaps in hand-authored sidecars.
  */
 export const AcceptanceCriterionSchema = z.object({
   id: z.string().min(1),
-  references: z.array(z.string()),
+  references: z.array(z.string().min(1)).min(1),
 });
 
 /**

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -696,6 +696,22 @@ export async function handleTaskDecomposition(
   if (planSidecar) {
     const blocks = parseTaskBlocks(planContent);
 
+    // C2 fix (#1406 third pass): empty-block guard. Even with a populated
+    // sidecar, DAG / parallel-safety only mean anything when the markdown
+    // task graph exists. Without this guard, a sidecar-present plan whose
+    // markdown lost its `### Task` headers used to silently pass via an
+    // empty-graph DAG. Emit the same `NO_PLAN_TASKS` shape as the regex
+    // path so downstream consumers don't have to special-case the source.
+    if (blocks.length === 0) {
+      return {
+        success: false,
+        error: {
+          code: 'NO_PLAN_TASKS',
+          message: `No '### Task' headers found in plan file: ${args.planPath}`,
+        },
+      };
+    }
+
     // DAG validation against the markdown-declared dependency graph.
     const dagTasks: DagTask[] = blocks.map((b) => ({
       id: b.id,
@@ -732,10 +748,14 @@ export async function handleTaskDecomposition(
   const blocks = parseTaskBlocks(planContent);
 
   if (blocks.length === 0) {
+    // C2 fix (#1406 third pass): unify empty-plan error code with the
+    // sidecar branch above (and with `plan-coverage.ts`, which already
+    // uses `NO_PLAN_TASKS`). Previously this path emitted `SCRIPT_ERROR`,
+    // forcing downstream consumers to special-case the source.
     return {
       success: false,
       error: {
-        code: 'SCRIPT_ERROR',
+        code: 'NO_PLAN_TASKS',
         message: `No '### Task' headers found in plan file: ${args.planPath}`,
       },
     };

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -12,6 +12,8 @@ import { readFile } from 'node:fs/promises';
 import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { emitGateEvent } from './gate-utils.js';
+import { loadPlanSidecar } from './sidecar-lookup.js';
+import type { PlanSidecarV1 } from './sidecar-schemas.js';
 
 // ─── Types ───────────────────────────────────────────────────────────────
 
@@ -671,6 +673,22 @@ export async function handleTaskDecomposition(
     };
   }
 
+  // Prefer the sidecar (T15) when present + conformant.
+  const planSidecar = loadPlanSidecar(args.planPath);
+  if (planSidecar) {
+    const sidecarResult = evaluateTaskDecompositionFromSidecar(planSidecar);
+    try {
+      await emitGateEvent(eventStore, args.featureId, 'task-decomposition', 'planning', sidecarResult.passed, {
+        dimension: 'D5',
+        phase: 'plan',
+        wellDecomposed: sidecarResult.wellDecomposed,
+        needsRework: sidecarResult.needsRework,
+        totalTasks: sidecarResult.totalTasks,
+      });
+    } catch { /* fire-and-forget */ }
+    return { success: true, data: { ...sidecarResult, source: 'sidecar' as const } };
+  }
+
   // Read plan file
   let planContent: string;
   try {
@@ -818,5 +836,66 @@ export async function handleTaskDecomposition(
     report,
   };
 
-  return { success: true, data: result };
+  return { success: true, data: { ...result, source: 'regex' as const } };
+}
+
+// ─── Sidecar evaluation ─────────────────────────────────────────────────────
+
+/**
+ * Validate task decomposition from the structured plan sidecar. Each task
+ * is checked for: non-empty description (>= 5 words), at least one declared
+ * file, and a phase from the RED/GREEN/REFACTOR enum (already enforced by
+ * the schema).
+ *
+ * Parallel safety + dependency DAG are no-ops in the sidecar path for now
+ * — both inputs are absent from the v1 shape (deps/parallel flags would
+ * widen the contract). Future schema revisions can add them.
+ */
+function evaluateTaskDecompositionFromSidecar(plan: PlanSidecarV1): {
+  passed: boolean;
+  wellDecomposed: number;
+  needsRework: number;
+  totalTasks: number;
+  dagValid: boolean;
+  parallelSafe: boolean;
+  report: string;
+} {
+  let wellDecomposed = 0;
+  let needsRework = 0;
+  const rows: string[] = [];
+
+  for (const task of plan.tasks) {
+    const descWords = task.description.trim().split(/\s+/).filter((w) => w.length > 0).length;
+    const hasDescription = descWords >= 5;
+    const hasFiles = task.files.length > 0;
+    const status = hasDescription && hasFiles ? 'PASS' : 'FAIL';
+    if (status === 'PASS') wellDecomposed++;
+    else needsRework++;
+    rows.push(`| ${task.id} | ${task.phase} | ${descWords} words | ${task.files.length} files | ${status} |`);
+  }
+
+  const totalTasks = plan.tasks.length;
+  const passed = needsRework === 0;
+  const report = [
+    '## Task Decomposition Report (sidecar)',
+    '',
+    '| Task | Phase | Description | Files | Status |',
+    '|------|-------|-------------|-------|--------|',
+    ...rows,
+    '',
+    `- Well-decomposed: ${wellDecomposed}/${totalTasks}`,
+    `- Needs rework: ${needsRework}/${totalTasks}`,
+    '',
+    passed ? '**Result: PASS**' : `**Result: FAIL** — ${needsRework} tasks need rework`,
+  ].join('\n');
+
+  return {
+    passed,
+    wellDecomposed,
+    needsRework,
+    totalTasks,
+    dagValid: true,
+    parallelSafe: true,
+    report,
+  };
 }

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -673,21 +673,11 @@ export async function handleTaskDecomposition(
     };
   }
 
-  // Prefer the sidecar (T15) when present + conformant.
+  // Prefer the sidecar (T15) when present + conformant for structural
+  // scoring. DAG and parallel-safety still derive from the markdown task
+  // graph, since the plan.v1 schema does not encode deps/parallel flags
+  // (B2 fix on PR #1406: prevent sidecar from bypassing those checks).
   const planSidecar = loadPlanSidecar(args.planPath);
-  if (planSidecar) {
-    const sidecarResult = evaluateTaskDecompositionFromSidecar(planSidecar);
-    try {
-      await emitGateEvent(eventStore, args.featureId, 'task-decomposition', 'planning', sidecarResult.passed, {
-        dimension: 'D5',
-        phase: 'plan',
-        wellDecomposed: sidecarResult.wellDecomposed,
-        needsRework: sidecarResult.needsRework,
-        totalTasks: sidecarResult.totalTasks,
-      });
-    } catch { /* fire-and-forget */ }
-    return { success: true, data: { ...sidecarResult, source: 'sidecar' as const } };
-  }
 
   // Read plan file
   let planContent: string;
@@ -701,6 +691,41 @@ export async function handleTaskDecomposition(
         message: err instanceof Error ? err.message : String(err),
       },
     };
+  }
+
+  if (planSidecar) {
+    const blocks = parseTaskBlocks(planContent);
+
+    // DAG validation against the markdown-declared dependency graph.
+    const dagTasks: DagTask[] = blocks.map((b) => ({
+      id: b.id,
+      deps: extractDependencies(b.content),
+    }));
+    const dagResult = validateDependencyDAG(dagTasks);
+
+    // Parallel safety from `**Parallelizable:** Yes` + declared files.
+    const parallelTasks: ParallelTask[] = blocks.map((b) => ({
+      id: b.id,
+      isParallel: isParallelizable(b.content),
+      files: extractFiles(b.content),
+    }));
+    const safetyResult = checkParallelSafety(parallelTasks);
+
+    const sidecarResult = evaluateTaskDecompositionFromSidecar(
+      planSidecar,
+      dagResult,
+      safetyResult,
+    );
+    try {
+      await emitGateEvent(eventStore, args.featureId, 'task-decomposition', 'planning', sidecarResult.passed, {
+        dimension: 'D5',
+        phase: 'plan',
+        wellDecomposed: sidecarResult.wellDecomposed,
+        needsRework: sidecarResult.needsRework,
+        totalTasks: sidecarResult.totalTasks,
+      });
+    } catch { /* fire-and-forget */ }
+    return { success: true, data: { ...sidecarResult, source: 'sidecar' as const } };
   }
 
   // Parse task blocks
@@ -847,11 +872,17 @@ export async function handleTaskDecomposition(
  * file, and a phase from the RED/GREEN/REFACTOR enum (already enforced by
  * the schema).
  *
- * Parallel safety + dependency DAG are no-ops in the sidecar path for now
- * — both inputs are absent from the v1 shape (deps/parallel flags would
- * widen the contract). Future schema revisions can add them.
+ * DAG validity and parallel safety are NOT encoded in plan.v1 today, so
+ * they are passed in by the caller after running the existing pure
+ * helpers against the markdown task graph (B2 fix on PR #1406:
+ * `dagValid: true, parallelSafe: true` previously hard-coded here let
+ * cyclic / file-conflicting plans pass any time a sidecar existed).
  */
-function evaluateTaskDecompositionFromSidecar(plan: PlanSidecarV1): {
+function evaluateTaskDecompositionFromSidecar(
+  plan: PlanSidecarV1,
+  dagResult: DagValidationResult,
+  safetyResult: ParallelSafetyResult,
+): {
   passed: boolean;
   wellDecomposed: number;
   needsRework: number;
@@ -875,8 +906,10 @@ function evaluateTaskDecompositionFromSidecar(plan: PlanSidecarV1): {
   }
 
   const totalTasks = plan.tasks.length;
-  const passed = needsRework === 0;
-  const report = [
+  const passed =
+    needsRework === 0 && dagResult.valid && safetyResult.safe;
+
+  const reportLines: string[] = [
     '## Task Decomposition Report (sidecar)',
     '',
     '| Task | Phase | Description | Files | Status |',
@@ -885,17 +918,31 @@ function evaluateTaskDecompositionFromSidecar(plan: PlanSidecarV1): {
     '',
     `- Well-decomposed: ${wellDecomposed}/${totalTasks}`,
     `- Needs rework: ${needsRework}/${totalTasks}`,
+    `- Dependency: ${dagResult.valid ? 'valid DAG' : `CYCLE DETECTED: ${dagResult.cyclePath ?? 'unknown'}`}`,
+    `- Parallel safety: ${safetyResult.safe ? 'clean' : `${safetyResult.conflicts.length} conflict(s)`}`,
     '',
-    passed ? '**Result: PASS**' : `**Result: FAIL** — ${needsRework} tasks need rework`,
-  ].join('\n');
+  ];
+
+  if (!safetyResult.safe) {
+    for (const conflict of safetyResult.conflicts) {
+      reportLines.push(`- ${conflict}`);
+    }
+    reportLines.push('');
+  }
+
+  reportLines.push(
+    passed
+      ? '**Result: PASS**'
+      : `**Result: FAIL** — ${needsRework} tasks need rework`,
+  );
 
   return {
     passed,
     wellDecomposed,
     needsRework,
     totalTasks,
-    dagValid: true,
-    parallelSafe: true,
-    report,
+    dagValid: dagResult.valid,
+    parallelSafe: safetyResult.safe,
+    report: reportLines.join('\n'),
   };
 }

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -868,9 +868,10 @@ export async function handleTaskDecomposition(
 
 /**
  * Validate task decomposition from the structured plan sidecar. Each task
- * is checked for: non-empty description (>= 5 words), at least one declared
- * file, and a phase from the RED/GREEN/REFACTOR enum (already enforced by
- * the schema).
+ * is checked for: non-empty description (> 10 words, matching the regex
+ * path's threshold for consistency — C1 fix on PR #1406 third pass), at
+ * least one declared file, and a phase from the RED/GREEN/REFACTOR enum
+ * (already enforced by the schema).
  *
  * DAG validity and parallel safety are NOT encoded in plan.v1 today, so
  * they are passed in by the caller after running the existing pure
@@ -897,7 +898,12 @@ function evaluateTaskDecompositionFromSidecar(
 
   for (const task of plan.tasks) {
     const descWords = task.description.trim().split(/\s+/).filter((w) => w.length > 0).length;
-    const hasDescription = descWords >= 5;
+    // C1 fix (#1406 third pass): match the regex-path threshold of > 10
+    // words. Previously this used `>= 5`, letting 5–10-word descriptions
+    // pass the sidecar branch while the regex branch rejected them. The
+    // 11-word threshold is authoritative (older, exercised by every
+    // existing plan).
+    const hasDescription = descWords > 10;
     const hasFiles = task.files.length > 0;
     const status = hasDescription && hasFiles ? 'PASS' : 'FAIL';
     if (status === 'PASS') wellDecomposed++;

--- a/servers/exarchos-mcp/src/workflow/handoff-lint.test.ts
+++ b/servers/exarchos-mcp/src/workflow/handoff-lint.test.ts
@@ -1,0 +1,91 @@
+// ─── #1244: markdown-aware handoff lint at handleCheckpoint ────────────────
+//
+// `lintHandoff` is a thin wrapper over the canonical prose-lint
+// (`projections/rehydration/prose-lint.ts`) that scans all three text
+// fields of a `CheckpointHandoffSchema` payload — `context`, `nextSteps`,
+// `suggestions` — and tags each finding with the field it originated in.
+//
+// The wrapper does NOT duplicate the lint catalog; it only fans out
+// per-field and annotates the per-finding `source` so the downstream
+// checkpoint handler (and human readers) can localize the offending text.
+//
+// Scope: unit-tier helper. The integration-tier behavior (soft-warning
+// vs hard-fail at `handleCheckpoint`) is covered in `tools.test.ts` so
+// the wrapper can stay free of state-file / event-store wiring.
+
+import { describe, it, expect } from 'vitest';
+import { lintHandoff } from './handoff-lint.js';
+
+describe('lintHandoff (#1244)', () => {
+  it('HandoffLint_CleanHandoff_NoFindings', () => {
+    // GIVEN: a handoff payload with prose that contains none of the
+    // catalogued AI-writing tells.
+    const handoff = {
+      context: 'Implemented the parser. Tests pass. Ready for review.',
+      nextSteps: ['Add docs entry', 'Cut release notes'],
+      suggestions: ['Pin the parser version on the consumer side'],
+    };
+
+    // WHEN: the wrapper lints the payload.
+    const findings = lintHandoff(handoff);
+
+    // THEN: zero findings — clean prose flows through untouched.
+    expect(findings).toEqual([]);
+  });
+
+  it('HandoffLint_ScansAllThreeFields_AnnotatesSourceField', () => {
+    // GIVEN: a handoff with at least one prose-lint tell in each of the
+    // three text fields. We use `delve` (ai-vocabulary), `tapestry`
+    // (ai-vocabulary), and `leverage` (ai-vocabulary) so the pattern
+    // catalog flags one finding per field.
+    const handoff = {
+      context: 'We delve into the parser internals.',
+      nextSteps: ['Examine the rich tapestry of edge cases.'],
+      suggestions: ['Leverage the existing reducer hook.'],
+    };
+
+    // WHEN: the wrapper lints the payload.
+    const findings = lintHandoff(handoff);
+
+    // THEN: at least one finding per field, each tagged with its
+    // originating `source`. The wrapper's only job is to fan out and
+    // annotate; the pattern-detection logic stays in prose-lint.
+    const sources = findings.map((f) => f.source);
+    expect(sources).toContain('context');
+    expect(sources).toContain('nextSteps');
+    expect(sources).toContain('suggestions');
+  });
+
+  it('HandoffLint_PreservesProseLintShape_PatternLineExcerpt', () => {
+    // GIVEN: a handoff whose `context` triggers a single prose-lint
+    // pattern (`delve`).
+    const handoff = { context: 'We delve into the design.' };
+
+    // WHEN: the wrapper lints the payload.
+    const findings = lintHandoff(handoff);
+
+    // THEN: each finding carries the full prose-lint shape plus the
+    // `source` annotation. The wrapper must NOT reshape or summarize
+    // the underlying `pattern` / `line` / `excerpt` fields — downstream
+    // consumers (event hints, hard-fail data block) rely on them.
+    expect(findings.length).toBeGreaterThanOrEqual(1);
+    const first = findings[0]!;
+    expect(first.pattern).toBe('ai-vocabulary:delve');
+    expect(typeof first.line).toBe('number');
+    expect(typeof first.excerpt).toBe('string');
+    expect(first.source).toBe('context');
+  });
+
+  it('HandoffLint_EmptyHandoff_NoFindings', () => {
+    // GIVEN: an empty handoff payload — none of the optional fields set.
+    // This is the common case for pre-#1240 callers that omit handoff.
+    const handoff = {};
+
+    // WHEN: the wrapper lints the payload.
+    const findings = lintHandoff(handoff);
+
+    // THEN: zero findings; the wrapper short-circuits on absent fields
+    // rather than feeding empty strings into prose-lint.
+    expect(findings).toEqual([]);
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/handoff-lint.ts
+++ b/servers/exarchos-mcp/src/workflow/handoff-lint.ts
@@ -1,0 +1,86 @@
+/**
+ * #1244 — markdown-aware handoff lint at `handleCheckpoint`.
+ *
+ * Thin fan-out over `lintProse` (the canonical prose-lint at
+ * `projections/rehydration/prose-lint.ts`). Scans each of the three
+ * text-bearing fields of a `CheckpointHandoffSchema` payload —
+ * `context`, `nextSteps`, `suggestions` — and tags every finding with
+ * the field it originated in so the checkpoint handler (and the human
+ * reading the warning) can localize the offending text.
+ *
+ * Design notes:
+ *
+ *   1. **No duplicate catalog.** The pattern set lives in `prose-lint.ts`
+ *      (DR-13 / T048). This wrapper imports `lintProse` directly; any
+ *      future drift between "what the rehydration template lints" and
+ *      "what the handoff dispatch lints" would be a footgun, so the
+ *      single source of truth is enforced by import, not convention.
+ *
+ *   2. **Per-field fan-out.** `nextSteps` and `suggestions` are arrays
+ *      of short strings (DIM-7 caps each at 256 bytes). We lint each
+ *      string independently rather than joining them first — joining
+ *      would let the em-dash-chain pattern's `minHits: 3` rule mask a
+ *      single-line AI-tell that the operator could otherwise see and
+ *      fix.
+ *
+ *   3. **Short-circuit on empty.** Empty `context` / undefined arrays
+ *      yield zero findings without entering the lint loop. Pre-#1240
+ *      callers that omit `handoff` entirely (it's optional on
+ *      `CheckpointInputSchema`) also pass through cleanly.
+ */
+
+import { lintProse, type Violation } from '../projections/rehydration/prose-lint.js';
+
+/**
+ * A prose-lint violation annotated with the handoff field it came from.
+ * Inherits the full `Violation` shape (`pattern`, `line`, `excerpt`) so
+ * downstream consumers — the soft-warning event hint, the hard-fail
+ * `data` block — see the same fields they would from a direct
+ * `lintProse` call.
+ */
+export interface HandoffLintFinding extends Violation {
+  /** Which handoff field produced this finding. */
+  readonly source: 'context' | 'nextSteps' | 'suggestions';
+}
+
+/**
+ * Handoff payload shape accepted by the lint. Mirrors
+ * `CheckpointHandoffSchema` structurally but is declared inline so the
+ * helper has no cross-module dependency on the dispatch schema — keeps
+ * this file unit-testable without dragging in the workflow surface.
+ */
+export interface HandoffLintInput {
+  readonly context?: string;
+  readonly nextSteps?: readonly string[];
+  readonly suggestions?: readonly string[];
+}
+
+export function lintHandoff(handoff: HandoffLintInput): HandoffLintFinding[] {
+  const findings: HandoffLintFinding[] = [];
+
+  if (handoff.context && handoff.context.length > 0) {
+    for (const v of lintProse(handoff.context)) {
+      findings.push({ ...v, source: 'context' });
+    }
+  }
+
+  if (handoff.nextSteps) {
+    for (const step of handoff.nextSteps) {
+      if (!step || step.length === 0) continue;
+      for (const v of lintProse(step)) {
+        findings.push({ ...v, source: 'nextSteps' });
+      }
+    }
+  }
+
+  if (handoff.suggestions) {
+    for (const s of handoff.suggestions) {
+      if (!s || s.length === 0) continue;
+      for (const v of lintProse(s)) {
+        findings.push({ ...v, source: 'suggestions' });
+      }
+    }
+  }
+
+  return findings;
+}

--- a/servers/exarchos-mcp/src/workflow/tools.test.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.test.ts
@@ -543,3 +543,212 @@ describe('HandleCheckpoint_PhasePlaybook (T-23, rehydration-machinery-refactor)'
     }
   });
 });
+
+// ─── #1244: markdown-aware handoff lint at handleCheckpoint ────────────────
+//
+// `handleCheckpoint` runs `lintHandoff` over the dispatch `handoff` payload
+// at the handler boundary. The pattern catalog is the same one the
+// rehydration template lint uses (DR-13 / T048), but it now gates
+// per-dispatch prose: agents that mirror AI-slop back through the
+// handoff fields see a structured warning (soft-fail, default) or a
+// structured rejection (hard-fail, opt-in via `.exarchos.yml`).
+//
+// Both modes leave the integrity of the dispatch event stream intact:
+//   - Soft-fail: the checkpoint event is appended exactly as before, with
+//     findings surfaced on `data.handoffLintFindings` and a human-readable
+//     entry on `warnings`. The counter resets normally.
+//   - Hard-fail: the handler returns `INVALID_INPUT` BEFORE any event is
+//     appended; `data.findings` carries the structured violations and the
+//     event store is untouched, so the operator can fix the prose and
+//     retry without scrubbing a partial write.
+//
+// These tests pin the contract at the dispatch boundary. The unit-tier
+// fan-out behavior (per-field source annotation, prose-lint shape
+// preservation) lives in `handoff-lint.test.ts`.
+
+describe('HandleCheckpoint_HandoffLint (#1244)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    // Un-mock `./tools.js` so this suite hits real `handleInit` and
+    // `handleCheckpoint`; the file-level mock above stubs them for
+    // envelope-conformance assertions only.
+    vi.doUnmock('./tools.js');
+    vi.resetModules();
+
+    tempDir = await mkdtemp(path.join(tmpdir(), 'checkpoint-handoff-lint-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('HandleCheckpoint_AiPaddedContext_EmitsWarning', async () => {
+    // GIVEN: a feature initialized in `ideate`, and a checkpoint
+    // dispatch whose `handoff.context` contains catalogued AI tells
+    // (`delve`, `tapestry`, `leverage` — all from `ai-vocabulary`).
+    const { handleInit, handleCheckpoint } = await import('./tools.js');
+    const store = new EventStore(tempDir);
+    const featureId = 'wf-1244-soft';
+
+    const init = await handleInit(
+      { featureId, workflowType: 'feature' },
+      tempDir,
+      store,
+    );
+    expect(init.success).toBe(true);
+
+    // WHEN: handleCheckpoint runs with a soft-fail handoff (default
+    // config — no `.exarchos.yml` written, no override passed).
+    const result = await handleCheckpoint(
+      {
+        featureId,
+        handoff: {
+          context: 'We delve into the rich tapestry of edge cases and leverage the parser.',
+        },
+      },
+      tempDir,
+      store,
+    );
+
+    // THEN: the call succeeds (soft-fail does NOT block writes),
+    // findings surface on `data.handoffLintFindings`, and the
+    // human-readable summary is on `warnings`. The checkpoint event
+    // was still appended to the stream so the dispatch counter
+    // reflects reality on the operator's next read.
+    expect(result.success).toBe(true);
+    const data = result.data as { handoffLintFindings?: unknown[] };
+    expect(Array.isArray(data.handoffLintFindings)).toBe(true);
+    expect((data.handoffLintFindings as unknown[]).length).toBeGreaterThanOrEqual(1);
+    expect(Array.isArray(result.warnings)).toBe(true);
+    expect((result.warnings ?? []).some((w) => w.includes('handoff'))).toBe(true);
+
+    // AND: the `workflow.checkpoint` event was appended — soft-fail is
+    // advisory, not blocking.
+    const events = await store.query(featureId, { type: 'workflow.checkpoint' });
+    expect(events.length).toBe(1);
+  });
+
+  it('HandleCheckpoint_CleanHandoff_NoWarning', async () => {
+    // GIVEN: a clean handoff with no catalogued AI tells.
+    const { handleInit, handleCheckpoint } = await import('./tools.js');
+    const store = new EventStore(tempDir);
+    const featureId = 'wf-1244-clean';
+
+    const init = await handleInit(
+      { featureId, workflowType: 'feature' },
+      tempDir,
+      store,
+    );
+    expect(init.success).toBe(true);
+
+    // WHEN: handleCheckpoint runs with prose that the catalog ignores.
+    const result = await handleCheckpoint(
+      {
+        featureId,
+        handoff: {
+          context: 'Implemented the parser. Tests pass. Ready for review.',
+          nextSteps: ['Add docs entry'],
+          suggestions: ['Pin parser version'],
+        },
+      },
+      tempDir,
+      store,
+    );
+
+    // THEN: success with no findings and no handoff-lint warnings.
+    // The data envelope must NOT carry `handoffLintFindings` for clean
+    // input (the field's presence is itself a signal).
+    expect(result.success).toBe(true);
+    const data = result.data as { handoffLintFindings?: unknown[] };
+    expect(data.handoffLintFindings).toBeUndefined();
+    const handoffWarnings = (result.warnings ?? []).filter((w) => w.includes('handoff'));
+    expect(handoffWarnings).toEqual([]);
+  });
+
+  it('HandoffLint_ScansAllThreeFields_FindingsCoverEachSource', async () => {
+    // GIVEN: a handoff with at least one AI tell in each of context,
+    // nextSteps, suggestions. This duplicates the unit-tier coverage at
+    // the integration tier because the dispatch handler is the
+    // contract surface — the wrapper is private to the handler.
+    const { handleInit, handleCheckpoint } = await import('./tools.js');
+    const store = new EventStore(tempDir);
+    const featureId = 'wf-1244-allfields';
+
+    const init = await handleInit(
+      { featureId, workflowType: 'feature' },
+      tempDir,
+      store,
+    );
+    expect(init.success).toBe(true);
+
+    // WHEN: handleCheckpoint lints a handoff that triggers tells in
+    // every field.
+    const result = await handleCheckpoint(
+      {
+        featureId,
+        handoff: {
+          context: 'Delve into the parser internals.',
+          nextSteps: ['Examine the rich tapestry of edge cases.'],
+          suggestions: ['Leverage the existing reducer hook.'],
+        },
+      },
+      tempDir,
+      store,
+    );
+
+    // THEN: findings include one finding from each source field —
+    // the handler does NOT short-circuit after the first field.
+    expect(result.success).toBe(true);
+    const findings = (result.data as { handoffLintFindings?: { source: string }[] })
+      .handoffLintFindings ?? [];
+    const sources = findings.map((f) => f.source);
+    expect(sources).toContain('context');
+    expect(sources).toContain('nextSteps');
+    expect(sources).toContain('suggestions');
+  });
+
+  it('HandleCheckpoint_HardFailConfig_BlocksWrite', async () => {
+    // GIVEN: a feature initialized in `ideate`, and a hard-fail
+    // override (`handoffLint: { hardFail: true }`) passed in via the
+    // injection seam. The production wiring loads this from
+    // `.exarchos.yml`; the test passes it directly so the failure
+    // path is exercised without yaml fixture plumbing.
+    const { handleInit, handleCheckpoint } = await import('./tools.js');
+    const store = new EventStore(tempDir);
+    const featureId = 'wf-1244-hard';
+
+    const init = await handleInit(
+      { featureId, workflowType: 'feature' },
+      tempDir,
+      store,
+    );
+    expect(init.success).toBe(true);
+
+    // WHEN: handleCheckpoint runs with hard-fail + an AI-padded
+    // handoff. The 4th positional argument injects the config so the
+    // test does not depend on `.exarchos.yml` resolution.
+    const result = await handleCheckpoint(
+      {
+        featureId,
+        handoff: { context: 'Delve into the rich tapestry of complexity.' },
+      },
+      tempDir,
+      store,
+      { handoffLint: { hardFail: true } },
+    );
+
+    // THEN: the call rejects with INVALID_INPUT, the structured
+    // findings are on `data.findings`, and NO checkpoint event was
+    // appended — the event store is untouched so retries don't
+    // duplicate.
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+    const data = result.data as { findings?: unknown[] };
+    expect(Array.isArray(data?.findings)).toBe(true);
+    expect((data!.findings as unknown[]).length).toBeGreaterThanOrEqual(1);
+
+    const events = await store.query(featureId, { type: 'workflow.checkpoint' });
+    expect(events.length).toBe(0);
+  });
+});

--- a/servers/exarchos-mcp/src/workflow/tools.ts
+++ b/servers/exarchos-mcp/src/workflow/tools.ts
@@ -35,6 +35,7 @@ import { workflowLogger } from '../logger.js';
 import { getHSMDefinition, isBuiltInWorkflowType, getValidTransitions } from './state-machine.js';
 import { hsmTransitionGuard } from './hsm-transition-guard.js';
 import { getPlaybook, composePhasePlaybook } from './playbooks.js';
+import { lintHandoff, type HandoffLintFinding } from './handoff-lint.js';
 import { getRequiredReviews } from './review-contract.js';
 import { type ToolResult } from '../format.js';
 import { createHash } from 'node:crypto';
@@ -1266,10 +1267,27 @@ function levenshtein(a: string, b: string): number {
 
 // ─── handleCheckpoint ──────────────────────────────────────────────────────
 
+/**
+ * Optional knobs threaded into `handleCheckpoint` that are not part of
+ * the dispatch input itself. Today only `handoffLint` is wired (#1244);
+ * future per-call overrides for things like staleness or counter reset
+ * policy can join the same struct without re-shaping the signature.
+ *
+ * The production wiring source-of-truth is `.exarchos.yml`'s
+ * `handoffLint.hardFail` flag (DR-1244). Tests pass this directly so
+ * the hard-fail path can be exercised without yaml-fixture plumbing.
+ */
+export interface HandleCheckpointOptions {
+  readonly handoffLint?: {
+    readonly hardFail?: boolean;
+  };
+}
+
 export async function handleCheckpoint(
   input: CheckpointInput,
   stateDir: string,
   eventStore: EventStore | null,
+  options?: HandleCheckpointOptions,
 ): Promise<ToolResult> {
   // T4 (#1240) — validate the dispatch payload at the handler boundary
   // before any state-file I/O or event emission. The MCP tool registration
@@ -1294,6 +1312,39 @@ export async function handleCheckpoint(
     };
   }
   const validated = parsed.data;
+
+  // #1244 — markdown-aware handoff lint. Runs over the validated payload
+  // BEFORE any state-file read or event-store write so the hard-fail
+  // path leaves the event stream untouched on rejection. The lint is
+  // a no-op when `handoff` is absent (pre-#1240 callers) — `lintHandoff`
+  // short-circuits on each empty field, so the cost is a few array
+  // existence checks for the legacy shape.
+  //
+  // Soft-fail (default): findings surface on `data.handoffLintFindings`
+  // and a human-readable summary lands on `warnings`. The checkpoint
+  // event is still appended — the lint is advisory, not blocking.
+  //
+  // Hard-fail (`options.handoffLint.hardFail === true`, mirrored from
+  // `.exarchos.yml`'s `handoffLint.hardFail`): the call rejects with
+  // `INVALID_INPUT` and `data.findings` carries the structured
+  // violations. No event is appended, so the operator can fix the
+  // prose and retry without scrubbing a partial write.
+  let handoffLintFindings: HandoffLintFinding[] = [];
+  if (validated.handoff) {
+    handoffLintFindings = lintHandoff(validated.handoff);
+    if (handoffLintFindings.length > 0 && options?.handoffLint?.hardFail === true) {
+      return {
+        success: false,
+        error: {
+          code: ErrorCode.INVALID_INPUT,
+          message: `Handoff prose failed lint (${handoffLintFindings.length} finding${
+            handoffLintFindings.length === 1 ? '' : 's'
+          }); see data.findings for details`,
+        },
+        data: { findings: handoffLintFindings },
+      };
+    }
+  }
 
   const stateFile = path.join(stateDir, `${input.featureId}.state.json`);
 
@@ -1550,6 +1601,25 @@ export async function handleCheckpoint(
     state.phase,
   );
 
+  // #1244 — soft-fail surfacing. Findings are only attached when
+  // non-empty so the field's *presence* on the data envelope is itself
+  // the signal to the caller. Clean handoffs produce no field, no
+  // warnings entry; this keeps the response payload small for the
+  // happy path. The summary on `warnings` carries a count + the
+  // distinct source fields so operators see the shape without
+  // unmarshalling `data.handoffLintFindings`.
+  const handoffWarnings: string[] = [];
+  if (handoffLintFindings.length > 0) {
+    const sources = Array.from(
+      new Set(handoffLintFindings.map((f) => f.source)),
+    ).sort();
+    handoffWarnings.push(
+      `handoff prose lint: ${handoffLintFindings.length} finding${
+        handoffLintFindings.length === 1 ? '' : 's'
+      } across ${sources.join(', ')}`,
+    );
+  }
+
   return {
     success: true,
     data: {
@@ -1563,7 +1633,12 @@ export async function handleCheckpoint(
       // v:3 envelope schema requires the field's presence, not just
       // truthiness. (#1082 sidecar field deleted in v2.11 substrate cut.)
       phasePlaybook,
+      // #1244: only attach the findings array when non-empty so the
+      // happy path stays slim and the field's presence is itself a
+      // self-describing signal.
+      ...(handoffLintFindings.length > 0 && { handoffLintFindings }),
     },
+    ...(handoffWarnings.length > 0 && { warnings: handoffWarnings }),
     _meta: buildCheckpointMeta(mutableState._checkpoint as WorkflowState['_checkpoint']),
   };
 }

--- a/skills-src/brainstorming/SKILL.md
+++ b/skills-src/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills-src/brainstorming/SKILL.md
+++ b/skills-src/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/skills/claude/brainstorming/SKILL.md
+++ b/skills/claude/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills/claude/brainstorming/SKILL.md
+++ b/skills/claude/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/skills/codex/brainstorming/SKILL.md
+++ b/skills/codex/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills/codex/brainstorming/SKILL.md
+++ b/skills/codex/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/skills/copilot/brainstorming/SKILL.md
+++ b/skills/copilot/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills/copilot/brainstorming/SKILL.md
+++ b/skills/copilot/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/skills/cursor/brainstorming/SKILL.md
+++ b/skills/cursor/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills/cursor/brainstorming/SKILL.md
+++ b/skills/cursor/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/skills/generic/brainstorming/SKILL.md
+++ b/skills/generic/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills/generic/brainstorming/SKILL.md
+++ b/skills/generic/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/skills/opencode/brainstorming/SKILL.md
+++ b/skills/opencode/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills/opencode/brainstorming/SKILL.md
+++ b/skills/opencode/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/test/migration/__fixtures__/brainstorming-baseline.md
+++ b/test/migration/__fixtures__/brainstorming-baseline.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/test/migration/__fixtures__/brainstorming-baseline.md
+++ b/test/migration/__fixtures__/brainstorming-baseline.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -48,7 +48,7 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 **Emit format (before Phase 1 questions):**
 
-\`\`\`
+\`\`\`markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:
@@ -4771,7 +4771,7 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 **Emit format (before Phase 1 questions):**
 
-\`\`\`
+\`\`\`markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:
@@ -9447,7 +9447,7 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 **Emit format (before Phase 1 questions):**
 
-\`\`\`
+\`\`\`markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:
@@ -14115,7 +14115,7 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 **Emit format (before Phase 1 questions):**
 
-\`\`\`
+\`\`\`markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:
@@ -18793,7 +18793,7 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 **Emit format (before Phase 1 questions):**
 
-\`\`\`
+\`\`\`markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:
@@ -23442,7 +23442,7 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 **Emit format (before Phase 1 questions):**
 
-\`\`\`
+\`\`\`markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -30,6 +30,37 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load \`docs/architecture/invariants.md\` — the machine-readable catalog of \`INV-*\` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and \`DIM-*\` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | \`INV-5a\` (input ergonomics), \`INV-5b\` (output contract), \`INV-5c\` (Aspire-style verbs), \`INV-5d\` (action discriminator), \`DIM-1\` (topology) |
+| Event store / projection / workflow state | \`INV-1\` (event-sourcing integrity), \`INV-2\` (facade equivalence — if the projection feeds both adapters), \`DIM-1\`, \`DIM-3\` (contracts) |
+| Skills / commands / runtime authoring | \`INV-4\` (platform-agnosticity), \`INV-6\` (workflow-agnosticism), \`DIM-8\` (AI-prose-tells) |
+| Basileus or cross-product coordination | \`INV-3\` (basileus-forward), \`basileus-boundary\` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+\`\`\`
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+\`\`\`
+
+The \`summary\` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.
@@ -4722,6 +4753,37 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load \`docs/architecture/invariants.md\` — the machine-readable catalog of \`INV-*\` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and \`DIM-*\` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | \`INV-5a\` (input ergonomics), \`INV-5b\` (output contract), \`INV-5c\` (Aspire-style verbs), \`INV-5d\` (action discriminator), \`DIM-1\` (topology) |
+| Event store / projection / workflow state | \`INV-1\` (event-sourcing integrity), \`INV-2\` (facade equivalence — if the projection feeds both adapters), \`DIM-1\`, \`DIM-3\` (contracts) |
+| Skills / commands / runtime authoring | \`INV-4\` (platform-agnosticity), \`INV-6\` (workflow-agnosticism), \`DIM-8\` (AI-prose-tells) |
+| Basileus or cross-product coordination | \`INV-3\` (basileus-forward), \`basileus-boundary\` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+\`\`\`
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+\`\`\`
+
+The \`summary\` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.
@@ -9367,6 +9429,37 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load \`docs/architecture/invariants.md\` — the machine-readable catalog of \`INV-*\` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and \`DIM-*\` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | \`INV-5a\` (input ergonomics), \`INV-5b\` (output contract), \`INV-5c\` (Aspire-style verbs), \`INV-5d\` (action discriminator), \`DIM-1\` (topology) |
+| Event store / projection / workflow state | \`INV-1\` (event-sourcing integrity), \`INV-2\` (facade equivalence — if the projection feeds both adapters), \`DIM-1\`, \`DIM-3\` (contracts) |
+| Skills / commands / runtime authoring | \`INV-4\` (platform-agnosticity), \`INV-6\` (workflow-agnosticism), \`DIM-8\` (AI-prose-tells) |
+| Basileus or cross-product coordination | \`INV-3\` (basileus-forward), \`basileus-boundary\` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+\`\`\`
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+\`\`\`
+
+The \`summary\` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.
@@ -14003,6 +14096,37 @@ Activate this skill when:
 For a complete worked example, see \`references/worked-example.md\`.
 
 ## Three-Phase Process
+
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load \`docs/architecture/invariants.md\` — the machine-readable catalog of \`INV-*\` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and \`DIM-*\` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | \`INV-5a\` (input ergonomics), \`INV-5b\` (output contract), \`INV-5c\` (Aspire-style verbs), \`INV-5d\` (action discriminator), \`DIM-1\` (topology) |
+| Event store / projection / workflow state | \`INV-1\` (event-sourcing integrity), \`INV-2\` (facade equivalence — if the projection feeds both adapters), \`DIM-1\`, \`DIM-3\` (contracts) |
+| Skills / commands / runtime authoring | \`INV-4\` (platform-agnosticity), \`INV-6\` (workflow-agnosticism), \`DIM-8\` (AI-prose-tells) |
+| Basileus or cross-product coordination | \`INV-3\` (basileus-forward), \`basileus-boundary\` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+\`\`\`
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+\`\`\`
+
+The \`summary\` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
 
 ### Phase 1: Understanding
 
@@ -18651,6 +18775,37 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load \`docs/architecture/invariants.md\` — the machine-readable catalog of \`INV-*\` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and \`DIM-*\` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | \`INV-5a\` (input ergonomics), \`INV-5b\` (output contract), \`INV-5c\` (Aspire-style verbs), \`INV-5d\` (action discriminator), \`DIM-1\` (topology) |
+| Event store / projection / workflow state | \`INV-1\` (event-sourcing integrity), \`INV-2\` (facade equivalence — if the projection feeds both adapters), \`DIM-1\`, \`DIM-3\` (contracts) |
+| Skills / commands / runtime authoring | \`INV-4\` (platform-agnosticity), \`INV-6\` (workflow-agnosticism), \`DIM-8\` (AI-prose-tells) |
+| Basileus or cross-product coordination | \`INV-3\` (basileus-forward), \`basileus-boundary\` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+\`\`\`
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+\`\`\`
+
+The \`summary\` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.
@@ -23268,6 +23423,37 @@ Activate this skill when:
 For a complete worked example, see \`references/worked-example.md\`.
 
 ## Three-Phase Process
+
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load \`docs/architecture/invariants.md\` — the machine-readable catalog of \`INV-*\` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and \`DIM-*\` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | \`INV-5a\` (input ergonomics), \`INV-5b\` (output contract), \`INV-5c\` (Aspire-style verbs), \`INV-5d\` (action discriminator), \`DIM-1\` (topology) |
+| Event store / projection / workflow state | \`INV-1\` (event-sourcing integrity), \`INV-2\` (facade equivalence — if the projection feeds both adapters), \`DIM-1\`, \`DIM-3\` (contracts) |
+| Skills / commands / runtime authoring | \`INV-4\` (platform-agnosticity), \`INV-6\` (workflow-agnosticism), \`DIM-8\` (AI-prose-tells) |
+| Basileus or cross-product coordination | \`INV-3\` (basileus-forward), \`basileus-boundary\` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+\`\`\`
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+\`\`\`
+
+The \`summary\` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
 
 ### Phase 1: Understanding
 


### PR DESCRIPTION
## Summary

Wave D PR 1 of the v2.10.0-preview.4 feature-freeze bundle. Closes #1260.

Extracts the project's design invariants (INV-1..INV-6 including INV-5a/b/c/d), axiom dimensions (DIM-1..DIM-8), and the basileus boundary into a single machine-readable file (`docs/architecture/invariants.md`) with structured YAML frontmatter. Wires `/exarchos:ideate` (command + brainstorming skill) to load the file on first turn and surface relevant entries as a "Constraint anchoring" section before Phase 1 questions. Adds a vocabulary-lint scanner that fails on undefined invariant references.

Eliminates the repeating "design proposal goes config-file-centric / human-first / overlaps-basileus → user redirects against named frameworks" cycle documented in `docs/contexts/2026-05-07-insights-friction-discovery.md` (friction F2).

## Changes

**Production (`servers/exarchos-mcp/src/architecture/`, ~300 LOC):**
- `invariants-loader.ts` — parses `docs/architecture/invariants.md` frontmatter into typed `InvariantEntry[]`.
- `vocabulary-lint.ts` — scans markdown under `docs/`, `skills-src/`, `commands/` for `INV-N[a-d]?` / `DIM-N` references; cross-checks against the loaded catalog; returns `{file, line, token, kind}` findings.
- CLI wrapper invoked via `npm run lint:invariants` (uses `tsx`, exits 1 on findings).

**Doc (`docs/architecture/invariants.md`, 319 LOC):**
- 18-entry catalog: INV-1 (event-sourcing), INV-2 (facade equivalence), INV-3 (basileus-forward), INV-4 (platform-agnosticity), INV-5a/b/c/d (input/output/Aspire-verbs/action-discriminator), INV-6 (workflow-agnosticism), DIM-1..DIM-8, basileus-boundary.
- Each entry: `id`, `dimension`, `applies-to[]`, `summary` (1-2 sentences from existing `.claude/skills/design-invariants/`), `references[]` to source files.

**Commands + skill (`commands/ideate.md`, `skills-src/brainstorming/SKILL.md` + 6 regenerated runtime variants):**
- `commands/ideate.md` Phase 0 loads `docs/architecture/invariants.md` and emits a Constraint section before Phase 1.
- `skills-src/brainstorming/SKILL.md` "Constraint anchoring" subsection added.

**Test (3 files, ~190 LOC):**
- `invariants-loader.test.ts` — 2 tests covering full catalog parse.
- `vocabulary-lint.test.ts` — 3 tests covering known/unknown/multi-file aggregation.
- `ideate-loader.test.ts` — 2 tests covering first-turn prompt template + CLI-design-fixture invariant relevance.

## Test Plan

- [x] Root `npm run typecheck` clean.
- [x] Root `npm run test:run` clean (762 passed / 6 skipped, 91 files).
- [x] MCP-server `npm run test:run` for touched files clean; 26 pre-existing failures in `merge-orchestrate.*.test.ts` reproduce on `origin/main` — unrelated.
- [x] `npm run skills:guard` clean.
- [x] `npm run lint:invariants` clean for the new file.
- [x] New tests added: 7 (T11 ×2, T12 ×3, T13 ×2).

## Follow-up surfaced (NOT in scope here)

`npm run lint:invariants` finds **10 `INV-5` references in existing docs** — the umbrella `INV-5` is intentionally NOT registered in the catalog (only the sub-disciplines INV-5a/b/c/d are). Two options for follow-up:

- Add `INV-5` as an umbrella entry pointing at INV-5a..d as its children.
- Migrate the 10 references to specific sub-disciplines (INV-5a..d).

Locations:
- `docs/designs/2026-05-09-v2-10-0-preview-1-substrate-stabilization.md` L139, L169
- `docs/plans/2026-05-08-durable-event-store-substrate-p8-review-fixes.md` L16
- `docs/research/2026-05-07-design-invariants-skill.md` L3, L161, L254, L269, L317, L318, L345

Recommend filing a follow-up issue; not blocking this PR.

## Commits

- `779562e5` test(architecture): RED — invariants-loader contract
- `47558ab0` feat(architecture): GREEN — invariants.md + invariants-loader.ts
- `d80ad8b7` test(architecture): RED — vocabulary lint coverage
- `dfb949e1` feat(architecture): GREEN — vocabulary-lint scanner + CLI
- `d76dd0ca` test(commands): RED — ideate first-turn invariant surfacing
- `ef89fb0c` feat(commands): GREEN — wire ideate.md + brainstorming skill to invariants
- `d124aa22` docs(skills): regenerate brainstorming SKILL per-runtime variants
- `e7d9c64c` fix(architecture): use process.stdout in lint CLI; update migration baselines

Part of [#1088](https://github.com/lvlup-sw/exarchos/issues/1088) v3.0.0 P2 Agent Output Contract epic. Wave D root of the [v2.10.0-preview.4 feature-freeze design](../blob/main/docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)