### PR TITLE
feat(mcp): Elicitation form mode for INVALID_INPUT (#1274)

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -437,7 +437,11 @@ describe('EventTypes', () => {
     // #1290: bumped 105 → 106 to include `workspace.resolved`, emitted
     // by `workspace/discovery.ts` on roots-based or cwd-walk featureId
     // inference at the dispatch boundary.
-    expect(EventTypes).toHaveLength(106);
+    // #1274: bumped 106 → 108 to include `elicitation.requested` +
+    // `elicitation.fulfilled`, emitted by the dispatch elicitation
+    // hand-off on the per-operation pseudo-stream
+    // `elicitation/<operationId>`.
+    expect(EventTypes).toHaveLength(108);
   });
 
   it('should include workflow-level types', () => {

--- a/servers/exarchos-mcp/src/capabilities/elicitation.test.ts
+++ b/servers/exarchos-mcp/src/capabilities/elicitation.test.ts
@@ -1,0 +1,46 @@
+// ─── #1274 — Elicitation sub-schema derivation tests ─────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { deriveElicitationSchema } from './elicitation.js';
+
+describe('deriveElicitationSchema (#1274)', () => {
+  it('ElicitationSchema_DerivedViaPick_MatchesInputSchema', () => {
+    // Given a Zod input schema with `featureId` and `target`, calling
+    // `deriveElicitationSchema(schema, 'target')` should return a JSON
+    // Schema with only the `target` field — matching what
+    // `schema.pick({target: true})` would produce.
+    const inputSchema = z.object({
+      featureId: z.string(),
+      target: z.string(),
+    });
+
+    const derived = deriveElicitationSchema(inputSchema, 'target') as Record<string, unknown>;
+    const expected = (() => {
+      // Use the same internal adapter so the comparison pins the actual
+      // wire shape that callers will see (draft-2020-12, etc.).
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { zodToJsonSchema } = require('../adapters/json-schema.js');
+      return zodToJsonSchema(inputSchema.pick({ target: true }));
+    })();
+
+    // Shape comparison: the derived schema must declare the `target`
+    // property and only the `target` property.
+    expect(derived.type).toBe('object');
+    const properties = derived.properties as Record<string, unknown>;
+    expect(Object.keys(properties)).toEqual(['target']);
+    // And the JSON Schema must match a fresh pick().toJSONSchema()
+    // exactly — `deriveElicitationSchema` is just `pick + zodToJsonSchema`.
+    expect(derived).toEqual(expected);
+  });
+
+  it('ElicitationSchema_DerivationIdempotent', () => {
+    const inputSchema = z.object({
+      featureId: z.string(),
+      target: z.string(),
+    });
+    const a = deriveElicitationSchema(inputSchema, 'featureId');
+    const b = deriveElicitationSchema(inputSchema, 'featureId');
+    expect(a).toEqual(b);
+  });
+});

--- a/servers/exarchos-mcp/src/capabilities/elicitation.test.ts
+++ b/servers/exarchos-mcp/src/capabilities/elicitation.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import { deriveElicitationSchema } from './elicitation.js';
+import { zodToJsonSchema } from '../adapters/json-schema.js';
 
 describe('deriveElicitationSchema (#1274)', () => {
   it('ElicitationSchema_DerivedViaPick_MatchesInputSchema', () => {
@@ -16,13 +17,9 @@ describe('deriveElicitationSchema (#1274)', () => {
     });
 
     const derived = deriveElicitationSchema(inputSchema, 'target') as Record<string, unknown>;
-    const expected = (() => {
-      // Use the same internal adapter so the comparison pins the actual
-      // wire shape that callers will see (draft-2020-12, etc.).
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { zodToJsonSchema } = require('../adapters/json-schema.js');
-      return zodToJsonSchema(inputSchema.pick({ target: true }));
-    })();
+    // Use the same internal adapter so the comparison pins the actual
+    // wire shape that callers will see (draft-2020-12, etc.).
+    const expected = zodToJsonSchema(inputSchema.pick({ target: true })) as Record<string, unknown>;
 
     // Shape comparison: the derived schema must declare the `target`
     // property and only the `target` property.

--- a/servers/exarchos-mcp/src/capabilities/elicitation.ts
+++ b/servers/exarchos-mcp/src/capabilities/elicitation.ts
@@ -1,0 +1,44 @@
+// ─── #1274 — Elicitation sub-schema derivation ───────────────────────────────
+//
+// When dispatch detects a missing required parameter on a payload, and the
+// client has declared the MCP `elicitation` capability, the server may
+// round-trip an `elicitation/create` request asking the client to supply
+// just that one field. To stay aligned with the action's own input schema
+// (so the elicited value passes the same .strict() validation that fired
+// the missing-param branch in the first place), we derive the sub-schema
+// directly from the action schema by `.pick({field: true})` and convert
+// to JSON Schema via the existing draft-2020-12 adapter.
+//
+// Keeping the derivation collocated with the resolver lets it consume the
+// adapter without dragging the elicitation MCP method module into the
+// capabilities layer, which would create an unwanted cycle:
+//   capabilities -> mcp -> dispatch -> capabilities.
+
+import type { z } from 'zod';
+import { zodToJsonSchema } from '../adapters/json-schema.js';
+
+/**
+ * Derive a JSON Schema describing only `field` of the given Zod input
+ * schema. Equivalent to `zodToJsonSchema(inputSchema.pick({[field]: true}))`
+ * but kept as a thin helper so call sites stay declarative and the
+ * dependency on the adapter lives in one place.
+ *
+ * Idempotent: repeated calls with the same arguments return structurally
+ * equal JSON Schemas. Throws if `field` is not declared on `inputSchema`
+ * — propagated from `pick()` so the caller (dispatch's missing-param
+ * branch) surfaces a precise error instead of silently producing an
+ * empty schema.
+ */
+export function deriveElicitationSchema<T extends z.ZodObject>(
+  inputSchema: T,
+  field: string,
+): ReturnType<typeof zodToJsonSchema> {
+  // `pick` keys are `{[k]: true}` literal-truthy. The Zod v4 typing is
+  // strict on the shape; casting via `Record<string, true>` keeps the
+  // helper generic across action schemas without leaking inferred-key
+  // type complexity into callers.
+  const picked = (inputSchema as unknown as {
+    pick(mask: Record<string, true>): z.ZodObject;
+  }).pick({ [field]: true });
+  return zodToJsonSchema(picked);
+}

--- a/servers/exarchos-mcp/src/capabilities/resolver.test.ts
+++ b/servers/exarchos-mcp/src/capabilities/resolver.test.ts
@@ -178,6 +178,30 @@ describe('CapabilityResolver Roots handshake snapshot (#1290)', () => {
   });
 });
 
+// ─── #1274 — Elicitation capability snapshot (handshake-driven) ───────────
+
+describe('CapabilityResolver Elicitation handshake snapshot (#1274)', () => {
+  it('CapabilityResolver_ElicitationDeclared_Snapshots', () => {
+    const resolver = createInMemoryResolver([]);
+    expect(resolver.isElicitationDeclared()).toBe(false);
+    // Per the MCP spec, the `elicitation` capability is signaled by the
+    // client as `capabilities.elicitation: {}` — the presence of the
+    // object (any shape) is the declaration.
+    resolver.snapshot({ capabilities: { elicitation: {} } });
+    expect(resolver.isElicitationDeclared()).toBe(true);
+  });
+
+  it('CapabilityResolver_NoElicitation_ReturnsFalse', () => {
+    const resolver = createInMemoryResolver([]);
+    // No snapshot or snapshot without the elicitation capability → false.
+    expect(resolver.isElicitationDeclared()).toBe(false);
+    resolver.snapshot({ capabilities: { sampling: {} } });
+    expect(resolver.isElicitationDeclared()).toBe(false);
+    resolver.snapshot({ capabilities: { roots: { listChanged: true } } });
+    expect(resolver.isElicitationDeclared()).toBe(false);
+  });
+});
+
 // ─── #1262 — quality-hint threshold (config-resolver path) ─────────────────
 
 describe('getQualityHintThreshold (#1262)', () => {

--- a/servers/exarchos-mcp/src/capabilities/resolver.ts
+++ b/servers/exarchos-mcp/src/capabilities/resolver.ts
@@ -28,6 +28,13 @@ import { capabilitiesForPosture } from './posture-mapping.js';
 export interface ClientHandshake {
   readonly capabilities?: {
     readonly roots?: { readonly listChanged?: boolean };
+    /**
+     * Per the MCP spec (#1274), the `elicitation` capability is signaled by
+     * the client as `capabilities.elicitation: {}` — the presence of the
+     * object (any shape, including the empty object) is the declaration
+     * the resolver treats as authoritative.
+     */
+    readonly elicitation?: object;
     readonly [k: string]: unknown;
   };
 }
@@ -58,6 +65,13 @@ export interface CapabilityResolver {
   /** True when the snapshot recorded `capabilities.roots.listChanged === true`. */
   isRootsDeclared(): boolean;
   /**
+   * True when the snapshot recorded a `capabilities.elicitation` object
+   * (any shape — presence is the gate, per MCP spec #1274). Consumed by
+   * dispatch to decide whether missing-required-param paths route through
+   * `elicitation/create` or fall back to INVALID_INPUT.
+   */
+  isElicitationDeclared(): boolean;
+  /**
    * Return the cached roots list, or `undefined` when the cache is cold
    * (either never populated or freshly invalidated via
    * {@link invalidateRootsCache}). Synchronous: workspace discovery is
@@ -83,6 +97,7 @@ export function createInMemoryResolver(
 ): CapabilityResolver {
   const set = new Set(capabilities);
   let clientRootsDeclared = false;
+  let clientElicitationDeclared = false;
   let cachedRoots: readonly CachedRoot[] | undefined;
   return {
     has(capability) {
@@ -93,9 +108,18 @@ export function createInMemoryResolver(
     },
     snapshot(handshake) {
       clientRootsDeclared = handshake.capabilities?.roots?.listChanged === true;
+      // #1274 — `capabilities.elicitation` is presence-gated: the spec
+      // says `{}` is a valid declaration, so we record true whenever the
+      // field is a non-null object regardless of shape.
+      const elicitation = handshake.capabilities?.elicitation;
+      clientElicitationDeclared =
+        elicitation !== undefined && elicitation !== null && typeof elicitation === 'object';
     },
     isRootsDeclared() {
       return clientRootsDeclared;
+    },
+    isElicitationDeclared() {
+      return clientElicitationDeclared;
     },
     getCachedRoots() {
       return cachedRoots;

--- a/servers/exarchos-mcp/src/core/dispatch.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.ts
@@ -9,6 +9,7 @@ import type { ChannelEmitter } from '../channel/emitter.js';
 import type { CapabilityResolver } from '../capabilities/resolver.js';
 import type { StorageBackend } from '../storage/backend.js';
 import type { RootsClient } from '../workspace/discovery.js';
+import type { ElicitationClient } from '../dispatch/elicitation-dispatch.js';
 import { hasCustomToolHandlers, getCustomToolActionHandler, getFullRegistry } from '../registry.js';
 import {
   formatValidationError,
@@ -94,6 +95,53 @@ export interface DispatchContext {
    * absent — exercised in tests that inject a workspace fixture path.
    */
   readonly cwd?: string;
+  /**
+   * MCP `elicitation/create` adapter (#1274). When the client declares
+   * the `elicitation` capability via the initialize handshake (recorded
+   * on the {@link CapabilityResolver}), dispatch routes missing-required-
+   * param branches through this adapter to ask the client for the
+   * missing field instead of returning INVALID_INPUT outright. Resolution
+   * priority: explicit > roots > cwd > elicitation > INVALID_INPUT
+   * (elicitation is the last resort before INVALID_INPUT because it
+   * requires a transport round-trip).
+   *
+   * Optional — CLI / direct-call contexts omit it and dispatch falls
+   * back to the legacy INVALID_INPUT contract.
+   */
+  readonly elicitationClient?: ElicitationClient;
+}
+
+// ─── #1274 — Missing-required-field extractor ──────────────────────────────
+//
+// Used by the elicitation hand-off in `dispatch()` to decide whether a Zod
+// validation failure represents a single missing required parameter (the
+// case elicitation is designed to handle) or some other structural error
+// (multiple missing fields, wrong type, .strict() typo rejection, etc.).
+//
+// We elicit ONLY when exactly one top-level required field is missing —
+// multi-field elicitation would compose poorly with the per-action
+// validation contract (the client would have to round-trip once per
+// field, and partial fulfillment leaves the audit trail ambiguous).
+// Future iterations can extend this surface; the conservative single-field
+// gate is the v2.10 contract.
+
+function extractSingleMissingRequiredField(
+  error: import('zod').z.ZodError,
+): string | undefined {
+  // Zod v4's missing-required-key error surfaces with `code: 'invalid_type'`
+  // and `expected: 'string' | 'number' | …` on the leaf-most issue (the
+  // input was `undefined` for the field). We accept the issue when:
+  //   - exactly one issue is reported, AND
+  //   - the issue path is a single top-level key (string), AND
+  //   - the issue code is 'invalid_type' (Zod's universal "missing" code).
+  const issues = error.issues;
+  if (issues.length !== 1) return undefined;
+  const only = issues[0];
+  if (only.code !== 'invalid_type') return undefined;
+  if (only.path.length !== 1) return undefined;
+  const key = only.path[0];
+  if (typeof key !== 'string') return undefined;
+  return key;
 }
 
 // ─── T04: Server-side Read-only Action Allowlist (Issue #1192) ─────────────
@@ -491,11 +539,16 @@ export async function dispatch(
     let { action: _action, ...rest } = args;
 
     // ─── #1290 — Roots-based featureId inference ─────────────────────────
-    // Resolution priority: explicit > roots > cwd. If the caller already
-    // supplied a `featureId`, we leave it alone. Otherwise, if the client
-    // declared the MCP roots capability (snapshotted on the resolver via
-    // the initialize handshake), call `resolveWorkspace` to attempt
-    // inference from the cached roots list or a cwd-walk fallback.
+    // Resolution priority (load-bearing for missing-required-param paths):
+    //   explicit > roots > cwd > elicitation > INVALID_INPUT.
+    // Elicitation is the LAST resort before INVALID_INPUT because it
+    // requires a transport round-trip; roots + cwd inference are
+    // round-trip-free and so take precedence (#1274). If the caller
+    // already supplied a `featureId`, we leave it alone. Otherwise, if
+    // the client declared the MCP roots capability (snapshotted on the
+    // resolver via the initialize handshake), call `resolveWorkspace`
+    // to attempt inference from the cached roots list or a cwd-walk
+    // fallback.
     //
     // Multi-match returns a structured INVALID_INPUT here so the caller
     // can disambiguate; zero-match falls through to the existing per-
@@ -571,7 +624,55 @@ export async function dispatch(
             );
           })()
         : rest;
-    const parsed = matchingAction.schema.safeParse(cleanedRest);
+    let parsed = matchingAction.schema.safeParse(cleanedRest);
+
+    // ─── #1274 — Elicitation hand-off on missing required param ──────────
+    // If validation failed because exactly one required field is missing
+    // AND the client declared the MCP `elicitation` capability AND an
+    // elicitation client adapter is wired into the context, route through
+    // the elicitation hand-off and retry the validation with the elicited
+    // value spliced into the payload. This is the LAST resort before
+    // INVALID_INPUT — round-trip-free inference paths (explicit/roots/cwd)
+    // have already executed by the time we get here.
+    if (
+      !parsed.success &&
+      ctx.capabilityResolver?.isElicitationDeclared() === true &&
+      ctx.elicitationClient !== undefined
+    ) {
+      const missingField = extractSingleMissingRequiredField(parsed.error);
+      if (missingField !== undefined) {
+        const actionSchema = matchingAction.schema as unknown as import('zod').z.ZodObject;
+        try {
+          const { performElicitation } = await import(
+            '../dispatch/elicitation-dispatch.js'
+          );
+          const operationId = `${tool}-${actionName}-${Date.now()}-${Math.random()
+            .toString(36)
+            .slice(2, 10)}`;
+          const elicitation = await performElicitation({
+            inputSchema: actionSchema,
+            missingField,
+            client: ctx.elicitationClient,
+            eventStore: ctx.eventStore,
+            operationId,
+          });
+          if (elicitation.fulfilled) {
+            const retried = matchingAction.schema.safeParse({
+              ...cleanedRest,
+              [missingField]: elicitation.value,
+            });
+            if (retried.success) {
+              parsed = retried;
+            }
+          }
+        } catch {
+          // Elicitation is a best-effort hand-off; transport failures
+          // must not mask the legacy INVALID_INPUT envelope. Fall through
+          // to the validation-failure return below.
+        }
+      }
+    }
+
     if (!parsed.success) {
       const context = `${tool}/${actionName}`;
       return {

--- a/servers/exarchos-mcp/src/dispatch/elicitation-dispatch.test.ts
+++ b/servers/exarchos-mcp/src/dispatch/elicitation-dispatch.test.ts
@@ -1,0 +1,145 @@
+// ─── #1274 — Dispatch missing-required-param elicitation tests ──────────────
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { z } from 'zod';
+import { EventStore } from '../event-store/store.js';
+import { createInMemoryResolver } from '../capabilities/resolver.js';
+import {
+  performElicitation,
+  type ElicitationClient,
+} from './elicitation-dispatch.js';
+import { dispatch, stubCompositeHandler } from '../core/dispatch.js';
+
+describe('elicitation-dispatch (#1274)', () => {
+  let tmpDir: string;
+  let eventStore: EventStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'elicit-dispatch-test-'));
+    eventStore = new EventStore(tmpDir);
+    await eventStore.initialize();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it('Dispatch_MissingRequiredParamWithElicitation_SendsElicitationCreate', async () => {
+    // Client declares the elicitation capability; dispatch routes missing
+    // required params through the elicitation hand-off and the resulting
+    // request carries a `.pick()`-derived schema for the missing field.
+    const inputSchema = z.object({
+      featureId: z.string(),
+      target: z.string(),
+    });
+
+    let captured:
+      | {
+          field: string;
+          schema: Record<string, unknown>;
+        }
+      | undefined;
+    const client: ElicitationClient = {
+      async create({ field, schema }) {
+        captured = { field, schema };
+        return { value: 'elicited-feature' };
+      },
+    };
+
+    const result = await performElicitation({
+      inputSchema,
+      missingField: 'featureId',
+      client,
+      eventStore,
+      operationId: 'op-1',
+    });
+
+    expect(result.fulfilled).toBe(true);
+    expect(result.value).toBe('elicited-feature');
+    expect(captured).toBeDefined();
+    expect(captured!.field).toBe('featureId');
+    // Schema must be `.pick({featureId: true})` shape — single property.
+    const props = captured!.schema.properties as Record<string, unknown>;
+    expect(Object.keys(props)).toEqual(['featureId']);
+  });
+
+  it('Dispatch_MissingRequiredParamNoCapability_ReturnsInvalidInputFallback', async () => {
+    // Without elicitation capability on the resolver, dispatch must NOT
+    // attempt the hand-off — the existing INVALID_INPUT contract from
+    // per-action Zod validation remains the user-visible envelope.
+    const resolver = createInMemoryResolver([]);
+    expect(resolver.isElicitationDeclared()).toBe(false);
+
+    // Stub the composite so we can prove no handler is invoked.
+    let handlerCalled = false;
+    const restore = stubCompositeHandler('exarchos_workflow', async () => {
+      handlerCalled = true;
+      return { success: true, data: {} };
+    });
+
+    try {
+      // `get` requires `featureId`; we omit it. With no elicitation
+      // capability, the per-action validator surfaces INVALID_INPUT and
+      // dispatch never reaches the (stubbed) handler.
+      const result = await dispatch(
+        'exarchos_workflow',
+        { action: 'get' },
+        {
+          stateDir: tmpDir,
+          eventStore,
+          enableTelemetry: false,
+          capabilityResolver: resolver,
+        },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error?.code).toBe('INVALID_INPUT');
+      expect(handlerCalled).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it('Elicitation_RequestedAndFulfilled_EmitEventsWithOperationId', async () => {
+    // Both events emit through the event store and share the same
+    // operationId so downstream queries can correlate request/response.
+    const inputSchema = z.object({
+      featureId: z.string(),
+    });
+    const client: ElicitationClient = {
+      async create() {
+        return { value: 'feature-x' };
+      },
+    };
+
+    await performElicitation({
+      inputSchema,
+      missingField: 'featureId',
+      client,
+      eventStore,
+      operationId: 'op-correlated',
+    });
+
+    // Query the event store for both events. Elicitation events live on
+    // the per-operation pseudo-stream `elicitation/<operationId>` so the
+    // query is bounded and deterministic.
+    const events = await eventStore.query('elicitation/op-correlated');
+    const requested = events.find((e) => e.type === 'elicitation.requested');
+    const fulfilled = events.find((e) => e.type === 'elicitation.fulfilled');
+
+    expect(requested).toBeDefined();
+    expect(fulfilled).toBeDefined();
+
+    const requestedData = requested!.data as { operationId: string; field: string };
+    const fulfilledData = fulfilled!.data as { operationId: string; field: string };
+
+    expect(requestedData.operationId).toBe('op-correlated');
+    expect(fulfilledData.operationId).toBe('op-correlated');
+    expect(requestedData.operationId).toBe(fulfilledData.operationId);
+    expect(requestedData.field).toBe('featureId');
+    expect(fulfilledData.field).toBe('featureId');
+  });
+});

--- a/servers/exarchos-mcp/src/dispatch/elicitation-dispatch.ts
+++ b/servers/exarchos-mcp/src/dispatch/elicitation-dispatch.ts
@@ -1,0 +1,121 @@
+// ─── #1274 — Dispatch missing-required-param elicitation hand-off ────────────
+//
+// When the dispatch boundary detects a missing required parameter on a
+// payload, AND the client has declared the MCP `elicitation` capability,
+// dispatch routes the missing-param branch through this module instead of
+// returning INVALID_INPUT outright. The hand-off:
+//
+//   1. Derives a JSON Schema fragment for ONLY the missing field via
+//      `capabilities/elicitation.ts → deriveElicitationSchema`.
+//   2. Emits `elicitation.requested` (operationId, field, schema) on the
+//      per-operation pseudo-stream `elicitation/<operationId>` so audit
+//      queries can correlate request/response.
+//   3. Calls the transport's `elicitation/create` method via the injected
+//      {@link ElicitationClient} adapter (thin wrapper in
+//      `mcp/elicitation-method.ts`).
+//   4. Emits `elicitation.fulfilled` (operationId, field, value).
+//   5. Returns the elicited value so dispatch can retry the action with
+//      the now-complete payload.
+//
+// Resolution priority is documented in `core/dispatch.ts`:
+// explicit > roots > cwd > elicitation > INVALID_INPUT.
+
+import type { z } from 'zod';
+import type { EventStore } from '../event-store/store.js';
+import { deriveElicitationSchema } from '../capabilities/elicitation.js';
+
+/**
+ * Minimal `elicitation/create` surface consumed by {@link performElicitation}.
+ * The MCP SDK's full `ElicitRequestFormParamsSchema` carries more fields
+ * (message, mode, _meta, task ttl, etc.); we accept only the load-bearing
+ * subset so callers can swap in a thin transport adapter or a test fixture
+ * without dragging the SDK type graph into dispatch.
+ *
+ * The adapter is responsible for shaping the wire-level form-mode params
+ * (mode: 'form', message, requestedSchema) and translating the client's
+ * ElicitResult back into a `{value}` shape — keeping that translation
+ * outside this module keeps the dispatch helper transport-agnostic and
+ * testable without a live MCP transport.
+ */
+export interface ElicitationClient {
+  create(input: {
+    readonly field: string;
+    readonly schema: Record<string, unknown>;
+  }): Promise<{ readonly value: unknown }>;
+}
+
+/**
+ * Result of a single elicitation round-trip. `fulfilled: false` indicates
+ * the client declined or returned no value — dispatch should fall back to
+ * the legacy INVALID_INPUT contract rather than retrying.
+ */
+export interface ElicitationResult {
+  readonly fulfilled: boolean;
+  readonly value: unknown;
+}
+
+export interface PerformElicitationOpts {
+  /** Zod schema for the full action input — used to pick the missing field. */
+  readonly inputSchema: z.ZodObject;
+  /** The field name that triggered the missing-param branch. */
+  readonly missingField: string;
+  /** Transport adapter for `elicitation/create`. */
+  readonly client: ElicitationClient;
+  /** Event store used to record `elicitation.{requested,fulfilled}`. */
+  readonly eventStore: EventStore;
+  /**
+   * Operation correlation id — same value lands in both `requested` and
+   * `fulfilled` events so audit queries can pair the round-trip.
+   */
+  readonly operationId: string;
+}
+
+/**
+ * Perform the elicitation hand-off and return the elicited value.
+ *
+ * Emits `elicitation.requested` BEFORE the round-trip fires (durable
+ * intent; mirrors the Wave B two-event-split contract for non-idempotent
+ * side effects) and `elicitation.fulfilled` AFTER the client responds.
+ * Both events land on the per-operation pseudo-stream
+ * `elicitation/<operationId>`.
+ *
+ * Callers (notably `core/dispatch.ts`) are responsible for re-running the
+ * Zod validation pass after splicing the elicited value back into the
+ * payload — this helper produces the value; it does not retry the action.
+ */
+export async function performElicitation(
+  opts: PerformElicitationOpts,
+): Promise<ElicitationResult> {
+  const { inputSchema, missingField, client, eventStore, operationId } = opts;
+  const streamId = `elicitation/${operationId}`;
+  const schema = deriveElicitationSchema(inputSchema, missingField) as Record<
+    string,
+    unknown
+  >;
+
+  // (1) Durable intent: emit BEFORE the side effect. If the transport
+  // round-trip fails after this point, the audit trail still records the
+  // server's intent to elicit, matching the Wave B two-event-split
+  // contract for non-idempotent operations.
+  await eventStore.append(streamId, {
+    type: 'elicitation.requested',
+    data: { operationId, field: missingField, schema },
+  });
+
+  // (2) Round-trip to the client. The adapter is responsible for the
+  // wire-level form-mode params (mode: 'form', message, requestedSchema).
+  const response = await client.create({ field: missingField, schema });
+
+  // (3) Audit-trail: pair the request with its response, even when the
+  // returned value is `undefined` (so post-hoc queries can still detect
+  // "the round-trip completed").
+  await eventStore.append(streamId, {
+    type: 'elicitation.fulfilled',
+    data: { operationId, field: missingField, value: response.value },
+  });
+
+  return {
+    fulfilled: response.value !== undefined,
+    value: response.value,
+  };
+}

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -503,7 +503,17 @@ describe('EventTypes', () => {
     // Previous (84 → 90): six durable event-store substrate types (#1259 T02/T03/T04).
     // Previous (105 → 106): workspace.resolved (#1290 — roots-based workspace
     //   discovery; emitted by `src/workspace/discovery.ts`).
-    expect(EventTypes).toHaveLength(106);
+    // Bumped 106 → 108: elicitation.requested + elicitation.fulfilled
+    // (#1274 — elicitation form mode for missing-required-param hand-off
+    //   in the dispatch boundary).
+    expect(EventTypes).toHaveLength(108);
+  });
+
+  it('EventTypes_IncludesElicitation', () => {
+    // #1274 — both events carry the elicitation request/response on a
+    // per-operation pseudo-stream so dispatch can correlate by operationId.
+    expect(EventTypes).toContain('elicitation.requested');
+    expect(EventTypes).toContain('elicitation.fulfilled');
   });
 
   it('EventTypes_IncludesSessionTagged', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -146,6 +146,14 @@ export const EventTypes = [
   // queries can distinguish handshake-driven resolutions from cwd inference.
   // Not emitted on multi-match (no single featureId to attribute) or zero-match.
   'workspace.resolved',
+  // #1274 — dispatch elicitation hand-off (form mode). Emitted on a
+  // per-operation pseudo-stream (`elicitation/<operationId>`) so audit
+  // queries can correlate the request/response round-trip without
+  // contaminating the per-feature event log. `requested` lands BEFORE the
+  // `elicitation/create` MCP round-trip fires; `fulfilled` lands AFTER the
+  // client returns a value.
+  'elicitation.requested',
+  'elicitation.fulfilled',
 ] as const;
 
 export type EventType = typeof EventTypes[number];
@@ -412,6 +420,10 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   // #1290 — auto-emitted by the workspace discovery resolver on the
   // dispatch boundary. See EventTypes registration above.
   'workspace.resolved': 'auto',
+  // #1274 — dispatch elicitation hand-off. Auto-emitted by the dispatch
+  // boundary on the per-operation pseudo-stream.
+  'elicitation.requested': 'auto',
+  'elicitation.fulfilled': 'auto',
 };
 
 // ─── Base Event Schema ──────────────────────────────────────────────────────
@@ -1573,6 +1585,38 @@ export const WorkspaceResolvedData = z.object({
   featureId: z.string().min(1),
 });
 
+// ─── Dispatch elicitation hand-off (#1274) ──────────────────────────────────
+
+/**
+ * Emitted by `dispatch/elicitation-dispatch.ts` BEFORE the
+ * `elicitation/create` MCP round-trip fires. `operationId` correlates the
+ * request with its matching `elicitation.fulfilled`; `field` is the missing
+ * required parameter the server is asking the client to supply; `schema`
+ * is the JSON Schema fragment derived via `.pick({field: true})`.
+ *
+ * `schema` is intentionally typed as `Record<string, unknown>` (rather
+ * than a tight JSONSchema7 zod shape) because the wire shape depends on
+ * the action schema's surface and we don't want the audit-trail validator
+ * to drift every time a new action's field gets elicited.
+ */
+export const ElicitationRequestedData = z.object({
+  operationId: z.string().min(1),
+  field: z.string().min(1),
+  schema: z.record(z.string(), z.unknown()),
+});
+
+/**
+ * Emitted by `dispatch/elicitation-dispatch.ts` AFTER the client returns a
+ * value through `elicitation/create`. `operationId` matches the request;
+ * `value` is the elicited value (typed `unknown` since the schema is
+ * caller-supplied and JSON-shaped).
+ */
+export const ElicitationFulfilledData = z.object({
+  operationId: z.string().min(1),
+  field: z.string().min(1),
+  value: z.unknown(),
+});
+
 // ─── Event Data Schemas Map ─────────────────────────────────────────────────
 
 export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
@@ -1741,6 +1785,10 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
 
   // #1290 — workspace discovery resolution
   'workspace.resolved': WorkspaceResolvedData,
+
+  // #1274 — dispatch elicitation hand-off
+  'elicitation.requested': ElicitationRequestedData,
+  'elicitation.fulfilled': ElicitationFulfilledData,
 };
 
 // ─── TypeScript Types ───────────────────────────────────────────────────────
@@ -1844,6 +1892,10 @@ export type WorktreeRemoveExecuted = z.infer<typeof WorktreeRemoveExecutedData>;
 // #1290 — workspace discovery
 export type WorkspaceResolved = z.infer<typeof WorkspaceResolvedData>;
 
+// #1274 — dispatch elicitation hand-off
+export type ElicitationRequested = z.infer<typeof ElicitationRequestedData>;
+export type ElicitationFulfilled = z.infer<typeof ElicitationFulfilledData>;
+
 // ─── Event Data Map ─────────────────────────────────────────────────────────
 
 export type EventDataMap = {
@@ -1943,6 +1995,9 @@ export type EventDataMap = {
   'worktree.remove.executed': WorktreeRemoveExecuted;
   // #1290 — workspace discovery
   'workspace.resolved': WorkspaceResolved;
+  // #1274 — dispatch elicitation hand-off
+  'elicitation.requested': ElicitationRequested;
+  'elicitation.fulfilled': ElicitationFulfilled;
 };
 
 // ─── Event Catalog Serialization ────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/mcp/elicitation-method.ts
+++ b/servers/exarchos-mcp/src/mcp/elicitation-method.ts
@@ -1,0 +1,62 @@
+// ─── #1274 — MCP `elicitation/create` transport adapter ──────────────────────
+//
+// Thin wrapper that adapts the MCP SDK Server's `elicitation/create`
+// request to the {@link ElicitationClient} surface consumed by
+// `dispatch/elicitation-dispatch.ts`. Keeping the adapter in `mcp/` (next
+// to `mcp/notifications.ts`) preserves the layering rule that dispatch
+// depends only on transport-agnostic types — the SDK is imported HERE
+// rather than from dispatch.
+//
+// The form-mode `requestedSchema` shape demanded by the spec is narrower
+// than a generic JSON Schema (only a fixed set of primitive types and
+// constructs are allowed; see MCP `ElicitRequestFormParamsSchema`). The
+// dispatch helper produces the schema via `.pick({field: true})` on the
+// action schema, which for `featureId` / similar string fields will fall
+// inside the spec-permitted subset; surfaces that pick a more complex
+// nested field will need an explicit shaping pass at this adapter (out
+// of scope for #1274).
+
+import type { ElicitationClient } from '../dispatch/elicitation-dispatch.js';
+
+/**
+ * Minimal server surface this adapter consumes from the MCP SDK. We
+ * structural-type only the `elicitInput` method so test fixtures can
+ * inject a stub without spinning up a transport. The real
+ * `@modelcontextprotocol/sdk` `Server` exports a compatible signature.
+ */
+export interface ElicitationSdkServer {
+  elicitInput(params: {
+    mode: 'form';
+    message: string;
+    requestedSchema: Record<string, unknown>;
+  }): Promise<{ action: string; content?: Record<string, unknown> }>;
+}
+
+/**
+ * Build an {@link ElicitationClient} backed by the MCP SDK Server's
+ * `elicitation/create` method. Translates dispatch's `{field, schema}`
+ * surface into the form-mode params and the SDK's `ElicitResult` shape
+ * back into `{value}` so dispatch stays transport-agnostic.
+ *
+ * The `action: 'accept'` branch returns `content[field]`; everything
+ * else (`reject`, `cancel`, undefined content) returns `{value: undefined}`
+ * so the caller treats the round-trip as un-fulfilled and falls back to
+ * the legacy INVALID_INPUT envelope.
+ */
+export function createElicitationClient(
+  server: ElicitationSdkServer,
+): ElicitationClient {
+  return {
+    async create({ field, schema }) {
+      const result = await server.elicitInput({
+        mode: 'form',
+        message: `The server needs you to supply "${field}".`,
+        requestedSchema: schema,
+      });
+      if (result.action !== 'accept' || result.content === undefined) {
+        return { value: undefined };
+      }
+      return { value: result.content[field] };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Wave A PR 4 (tail) of the v2.10.0-preview.4 feature-freeze bundle. Closes #1274. Stacks on PR #1410.

When `dispatch()` finds a single missing required parameter AND the client declared the `elicitation` capability at handshake, derives the field's sub-schema via Zod `.pick({field: true})` + `z.toJSONSchema`, sends `elicitation/create`, awaits the response, and retries dispatch with the elicited value. Clients without the capability fall back to the existing `INVALID_INPUT` path.

Resolution priority in dispatch is now: `explicit > roots > cwd > elicitation > INVALID_INPUT`. Elicitation is the last resort before INVALID_INPUT because it requires a transport round-trip.

Elicitation schemas are **derived, not hand-written** (DIM-3 contract integrity).

## Changes

**Production (~370 LOC, 7 files):**
- `capabilities/resolver.ts` (extended) — `isElicitationDeclared(): boolean` snapshot.
- `capabilities/elicitation.ts` (new) — `deriveElicitationSchema(schema, field)` via Zod `.pick()` + in-house `json-schema.ts` adapter. No new top-level deps (existing adapter wraps Zod v4 native `z.toJSONSchema`).
- `dispatch/elicitation-dispatch.ts` (new, 112 LOC) — hand-off function: send `elicitation/create`, emit `elicitation.requested`, await response, emit `elicitation.fulfilled`, return elicited value.
- `mcp/elicitation-method.ts` (new, 58 LOC) — thin wrapper around MCP SDK's `elicitation/create`.
- `core/dispatch.ts` (extended ~78 LOC) — `DispatchContext` field for elicitation client; `extractSingleMissingRequiredField` extractor; retry branch after elicitation fulfillment; updated priority comment.
- `event-store/schemas.ts` (+55 LOC) — `elicitation.requested {operationId, field, schema}` and `elicitation.fulfilled {operationId, field, value}` events, registered in EVENT_TYPES (105→108) and EVENT_DATA_SCHEMAS.

**Test (~230 LOC):**
- `resolver.test.ts` — capability snapshot ×2.
- `elicitation.test.ts` — schema derivation ×2 (via `.pick`; idempotent).
- `elicitation-dispatch.test.ts` — capability-on / capability-off / event-emission ×3.
- `event-store/schemas.test.ts` — EventTypes count + elicitation-events-present.

## Test Plan

- [x] Root `npm run typecheck` clean.
- [x] Root `npm run test:run` clean (762 passed).
- [x] MCP-server `npm run test:run`: 6723 passed; pre-existing 26 merge-orchestrate failures unchanged.
- [x] `npm run skills:guard` clean.

## Commits

- `5a458261` test(capabilities): RED — elicitation capability snapshot + derived schema
- `d12fb24d` feat(capabilities): GREEN — isElicitationDeclared + deriveElicitationSchema
- `d99fc7bc` test(dispatch): RED — elicitation hand-off + fallback + events
- `9b2f8cde` feat(events): GREEN — elicitation.requested + elicitation.fulfilled
- `d07c0568` feat(dispatch): GREEN — capability-gated elicitation in missing-param path

## Notable design decisions

- Elicitation events emit on per-operation pseudo-stream `elicitation/<operationId>` to keep the audit trail correlatable without polluting per-feature stream logs.
- `extractSingleMissingRequiredField` scoped to single missing top-level required field; multi-field elicitation is deferred (partial fulfillment composes poorly with Zod `.strict()` contract).
- No new top-level deps — reused existing `adapters/json-schema.ts` over Zod v4's native `z.toJSONSchema`.

## Pre-existing observation (NOT introduced here)

MCP `tsc --noEmit` shows one pre-existing error on `dispatch.ts` `validTargets` mapping (line shifted from 526→579 by added lines; same root cause). Surfaces for separate triage.

Part of [#1088](https://github.com/lvlup-sw/exarchos/issues/1088) v3.0.0 P2 Agent Output Contract epic. Wave A tail of the [v2.10.0-preview.4 feature-freeze design](../blob/main/docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)