### PR TITLE
feat(mcp): Roots-based workspace discovery — capability-gated featureId inference (#1290)

### DIFF
--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -431,7 +431,10 @@ describe('EventTypes', () => {
     // PR3/T7 (#1364): bumped 103 → 104 to include `tool.action_errored`,
     // which splits structured action-level failures off of `tool.errored`
     // (transport/protocol failures only).
-    expect(EventTypes).toHaveLength(104);
+    // #1262: bumped 104 → 105 to include `turn.completed`, which carries
+    // the per-turn output-token sample the `output_tokens_high` quality
+    // hint fires on (see `telemetry/quality-hints.ts`).
+    expect(EventTypes).toHaveLength(105);
   });
 
   it('should include workflow-level types', () => {

--- a/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/event-store/schemas.test.ts
@@ -434,7 +434,10 @@ describe('EventTypes', () => {
     // #1262: bumped 104 → 105 to include `turn.completed`, which carries
     // the per-turn output-token sample the `output_tokens_high` quality
     // hint fires on (see `telemetry/quality-hints.ts`).
-    expect(EventTypes).toHaveLength(105);
+    // #1290: bumped 105 → 106 to include `workspace.resolved`, emitted
+    // by `workspace/discovery.ts` on roots-based or cwd-walk featureId
+    // inference at the dispatch boundary.
+    expect(EventTypes).toHaveLength(106);
   });
 
   it('should include workflow-level types', () => {

--- a/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/workflow/index.test.ts
@@ -47,6 +47,16 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
       },
     ),
     connect: vi.fn().mockResolvedValue(undefined),
+    // #1290 — createMcpServer wires `oninitialized` + `setNotificationHandler`
+    // for the roots/list_changed capability snapshot. The real McpServer
+    // exposes these via `.server` (the underlying SDK Server instance).
+    // The mock mirrors that surface so the production code path doesn't
+    // throw "Cannot set properties of undefined" when running under vitest.
+    server: {
+      oninitialized: null,
+      getClientCapabilities: vi.fn().mockReturnValue({}),
+      setNotificationHandler: vi.fn(),
+    },
   })),
 }));
 

--- a/servers/exarchos-mcp/src/adapters/mcp.test.ts
+++ b/servers/exarchos-mcp/src/adapters/mcp.test.ts
@@ -638,6 +638,61 @@ describe('createMcpServer', () => {
     spy.mockRestore();
   });
 
+  it('CreateMcpServer_OninitializedFires_CallsCapabilityResolverSnapshot', async () => {
+    // Sentry HIGH #1423: pre-fix the MCP wiring never called
+    // `capabilityResolver.snapshot()` on the initialize handshake, so
+    // `isRootsDeclared()` stayed `false` and roots-based discovery was
+    // dead code. Pin the oninitialized → snapshot bridge.
+    const { createMcpServer } = await import('./mcp.js');
+    const resolver = createInMemoryResolver(['mcp:exarchos:readonly']);
+    const snapshotSpy = vi.spyOn(resolver, 'snapshot');
+    const ctxWithResolver: DispatchContext = { ...ctx, capabilityResolver: resolver };
+
+    const server = createMcpServer(ctxWithResolver);
+
+    // The wiring registers an `oninitialized` callback on the underlying
+    // low-level Server. Direct invocation simulates the post-handshake
+    // moment without needing a transport.
+    expect(typeof server.server.oninitialized).toBe('function');
+    server.server.oninitialized?.();
+
+    expect(snapshotSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('CreateMcpServer_RootsListChangedNotificationHandler_IsRegistered', async () => {
+    // Sentry HIGH #1423 + CodeRabbit MAJOR #1423: the `roots/list_changed`
+    // notification handler was defined in mcp/notifications.ts but never
+    // registered. Spy on the underlying Server's setNotificationHandler
+    // call pattern via a Server.prototype intercept so a fresh
+    // createMcpServer call surfaces the registration.
+    const { Server } = await import('@modelcontextprotocol/sdk/server/index.js');
+    const setNotifSpy = vi.spyOn(Server.prototype, 'setNotificationHandler');
+    try {
+      const { createMcpServer } = await import('./mcp.js');
+      const resolver = createInMemoryResolver(['mcp:exarchos:readonly']);
+      createMcpServer({ ...ctx, capabilityResolver: resolver });
+      // At least one setNotificationHandler call must reference the
+      // roots/list_changed schema — the registration anchor.
+      const calledWithRootsListChanged = setNotifSpy.mock.calls.some((call) => {
+        const schema = call[0] as { shape?: { method?: { value?: string } } };
+        return schema?.shape?.method?.value === 'notifications/roots/list_changed';
+      });
+      expect(calledWithRootsListChanged).toBe(true);
+    } finally {
+      setNotifSpy.mockRestore();
+    }
+  });
+
+  it('CreateMcpServer_NoCapabilityResolver_SkipsHandshakeWiring', async () => {
+    // Defensive: if the caller supplies no capabilityResolver (today only
+    // hypothetical, but the field is optional on DispatchContext), the
+    // handshake wiring must skip cleanly rather than throw on
+    // `resolver.snapshot()` against undefined.
+    const { createMcpServer } = await import('./mcp.js');
+    const server = createMcpServer({ ...ctx, capabilityResolver: undefined });
+    expect(server.server.oninitialized).toBeUndefined();
+  });
+
   it('CreateMcpServer_SlimRegistration_UsesSlimDescriptions', async () => {
     // Arrange: create context with slimRegistration enabled
     const slimCtx: DispatchContext = { ...ctx, slimRegistration: true };

--- a/servers/exarchos-mcp/src/adapters/mcp.ts
+++ b/servers/exarchos-mcp/src/adapters/mcp.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { RootsListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
 import {
   getFullRegistry,
   buildRegistrationSchema,
@@ -10,7 +11,10 @@ import { toEnvelope } from '../format.js';
 import type { Envelope, ErrorEnvelope } from '../format.js';
 import { dispatch } from '../core/dispatch.js';
 import type { DispatchContext } from '../core/dispatch.js';
+import { handleRootsListChanged } from '../mcp/notifications.js';
+import type { RootsClient } from '../workspace/discovery.js';
 import { EnvelopeSchema } from '../schemas/envelope.js';
+import { logger } from '../logger.js';
 
 // ─── D.4: LCD outputSchema advertised to MCP clients ────────────────────────
 //
@@ -185,6 +189,61 @@ export function createMcpServer(ctx: DispatchContext): McpServer {
     },
   );
 
+  // ─── #1290 — Roots-based workspace discovery wiring (Sentry HIGH #1423) ──
+  // The capability resolver is constructed up in index.ts / context.ts but
+  // the MCP handshake observers — initialize callback + roots/list_changed
+  // notification handler + RootsClient adapter — must be wired here, after
+  // the McpServer is constructed, because they all depend on
+  // `server.server` (the underlying low-level Server instance).
+  //
+  // Pre-fix, none of these were wired: `resolver.snapshot()` was never
+  // called, so `isRootsDeclared()` stayed `false` forever and the
+  // dispatch-side check at dispatch.ts:504 always fell back to cwd-walk.
+  // `ctx.rootsClient` was never set, so even if isRootsDeclared() had
+  // flipped, the discovery branch would have skipped roots entirely.
+  // The notification handler defined in mcp/notifications.ts was unused.
+  //
+  // The augmented `dispatchCtx` below threads the rootsClient adapter
+  // through to dispatch; the resolver snapshot fires on the client's
+  // `initialized` notification (fully-handshaken state).
+  const rootsClient: RootsClient = {
+    list: async () => {
+      const result = await server.server.listRoots();
+      return result.roots.map((r) => ({ uri: r.uri }));
+    },
+  };
+  const dispatchCtx: DispatchContext = { ...ctx, rootsClient };
+
+  if (ctx.capabilityResolver !== undefined) {
+    const resolver = ctx.capabilityResolver;
+    server.server.oninitialized = () => {
+      try {
+        const capabilities = server.server.getClientCapabilities();
+        resolver.snapshot({ capabilities });
+      } catch (err) {
+        // Snapshot must never throw out of an MCP lifecycle hook —
+        // failure here only degrades discovery to the cwd-walk fallback.
+        logger.child({ subsystem: 'mcp-handshake' }).warn(
+          { error: err instanceof Error ? err.message : String(err) },
+          'capability resolver snapshot failed during MCP initialize',
+        );
+      }
+    };
+    server.server.setNotificationHandler(
+      RootsListChangedNotificationSchema,
+      async () => {
+        try {
+          handleRootsListChanged(resolver);
+        } catch (err) {
+          logger.child({ subsystem: 'mcp-handshake' }).warn(
+            { error: err instanceof Error ? err.message : String(err) },
+            'roots/list_changed handler failed; cache may be stale',
+          );
+        }
+      },
+    );
+  }
+
   for (const tool of getFullRegistry()) {
     // Tier model — INTENTIONAL asymmetry between MCP and CLI surfaces.
     //
@@ -214,7 +273,7 @@ export function createMcpServer(ctx: DispatchContext): McpServer {
     const mcpHandler = async (args: Record<string, unknown>) => {
       let env: Envelope<unknown> | ErrorEnvelope;
       try {
-        const result = await dispatch(toolName, args, ctx);
+        const result = await dispatch(toolName, args, dispatchCtx);
         env = toEnvelope(result);
       } catch (error) {
         env = toEnvelope({

--- a/servers/exarchos-mcp/src/capabilities/resolver.test.ts
+++ b/servers/exarchos-mcp/src/capabilities/resolver.test.ts
@@ -4,6 +4,9 @@ import {
   resolveEffectiveCapabilities,
   resolvePosture,
   ANTHROPIC_NATIVE_CACHING,
+  getQualityHintThreshold,
+  DEFAULT_OUTPUT_TOKEN_THRESHOLD_FRACTION,
+  OUTPUT_TOKENS_PER_TURN_CAP,
 } from './resolver.js';
 import type { Capability } from '../agents/capabilities.js';
 
@@ -133,5 +136,31 @@ describe('resolvePosture (T33, DR-6)', () => {
     // Handshake-declared cap (here happens to overlap fs:read; assert the
     // overlap doesn't suppress posture caps).
     expect(effective.has('fs:read')).toBe(true);
+  });
+});
+
+// ─── #1262 — quality-hint threshold (config-resolver path) ─────────────────
+
+describe('getQualityHintThreshold (#1262)', () => {
+  it('ConfigResolver_OutputTokenThreshold_ReadsExarchosYml', () => {
+    // `.exarchos.yml` carries `qualityHints.outputTokenThreshold: 0.6` —
+    // the resolver returns the token-count value derived from that
+    // fraction.
+    const config = { qualityHints: { outputTokenThreshold: 0.6 } };
+    const tokens = getQualityHintThreshold('output_tokens', config);
+    expect(tokens).toBe(OUTPUT_TOKENS_PER_TURN_CAP * 0.6);
+  });
+
+  it('ConfigResolver_OutputTokenThreshold_DefaultsTo80Percent', () => {
+    // No `qualityHints` key — falls back to the default fraction.
+    const tokens = getQualityHintThreshold('output_tokens', {});
+    expect(DEFAULT_OUTPUT_TOKEN_THRESHOLD_FRACTION).toBe(0.8);
+    expect(tokens).toBe(OUTPUT_TOKENS_PER_TURN_CAP * 0.8);
+  });
+
+  it('ConfigResolver_OutputTokenThreshold_UndefinedConfig_UsesDefault', () => {
+    // No config at all — same default.
+    const tokens = getQualityHintThreshold('output_tokens', undefined);
+    expect(tokens).toBe(OUTPUT_TOKENS_PER_TURN_CAP * 0.8);
   });
 });

--- a/servers/exarchos-mcp/src/capabilities/resolver.test.ts
+++ b/servers/exarchos-mcp/src/capabilities/resolver.test.ts
@@ -139,6 +139,45 @@ describe('resolvePosture (T33, DR-6)', () => {
   });
 });
 
+// ─── #1290 — Roots capability snapshot (handshake-driven) ─────────────────
+
+describe('CapabilityResolver Roots handshake snapshot (#1290)', () => {
+  it('CapabilityResolver_HandshakeRootsTrue_Snapshots', () => {
+    const resolver = createInMemoryResolver([]);
+    expect(resolver.isRootsDeclared()).toBe(false);
+    resolver.snapshot({ capabilities: { roots: { listChanged: true } } });
+    expect(resolver.isRootsDeclared()).toBe(true);
+  });
+
+  it('CapabilityResolver_NoRoots_ReturnsFalse', () => {
+    const resolver = createInMemoryResolver([]);
+    // No snapshot or snapshot without roots capability → false.
+    expect(resolver.isRootsDeclared()).toBe(false);
+    resolver.snapshot({ capabilities: { sampling: {} } });
+    expect(resolver.isRootsDeclared()).toBe(false);
+    resolver.snapshot({ capabilities: { roots: {} } });
+    // `roots` present but no `listChanged: true` → also false, per the
+    // MCP capability shape contract. Snapshot is the load-bearing source.
+    expect(resolver.isRootsDeclared()).toBe(false);
+  });
+
+  it('CapabilityResolver_RootsCache_LifecycleIsTriState', () => {
+    const resolver = createInMemoryResolver([]);
+    // Initially: cache miss.
+    expect(resolver.getCachedRoots()).toBeUndefined();
+
+    // Populate cache.
+    resolver.setCachedRoots([{ uri: 'file:///a' }, { uri: 'file:///b' }]);
+    const cached = resolver.getCachedRoots();
+    expect(cached).toBeDefined();
+    expect(cached!.length).toBe(2);
+
+    // Invalidate → cache miss again.
+    resolver.invalidateRootsCache();
+    expect(resolver.getCachedRoots()).toBeUndefined();
+  });
+});
+
 // ─── #1262 — quality-hint threshold (config-resolver path) ─────────────────
 
 describe('getQualityHintThreshold (#1262)', () => {

--- a/servers/exarchos-mcp/src/capabilities/resolver.ts
+++ b/servers/exarchos-mcp/src/capabilities/resolver.ts
@@ -13,21 +13,98 @@ import type { Capability } from '../agents/capabilities.js';
 import type { AgentPosture } from '../agents/spec.js';
 import { capabilitiesForPosture } from './posture-mapping.js';
 
+/**
+ * Minimal slice of the MCP initialize handshake consumed by
+ * {@link CapabilityResolver.snapshot}. The full handshake carries more
+ * fields (protocol version, client info, etc.) — we accept a structural
+ * shape so callers can pass the raw handshake without import gymnastics.
+ *
+ * Per the MCP spec, the `roots` capability is signaled by the client as
+ * `capabilities.roots: { listChanged: true }` when it both supports the
+ * `roots/list` request and will emit `notifications/roots/list_changed`
+ * on root-set mutations. The resolver treats `listChanged === true` as
+ * the authoritative declaration (#1290).
+ */
+export interface ClientHandshake {
+  readonly capabilities?: {
+    readonly roots?: { readonly listChanged?: boolean };
+    readonly [k: string]: unknown;
+  };
+}
+
+/**
+ * Cached entry from `roots/list`. Kept structurally minimal (`uri`) so
+ * downstream workspace discovery doesn't pull the MCP SDK Roots shape
+ * transitively. Tests can construct fixtures without spinning up a
+ * transport. The MCP spec carries an optional `name` field on each root
+ * which we ignore — only the URI is load-bearing for path matching.
+ */
+export interface CachedRoot {
+  readonly uri: string;
+}
+
 export interface CapabilityResolver {
   has(capability: string): boolean;
   list(): readonly string[];
+
+  // ─── #1290 Roots capability snapshot ──────────────────────────────────
+  /**
+   * Snapshot the client's initialize handshake. After this call,
+   * {@link isRootsDeclared} reflects whether the client supports the
+   * `roots` capability. Calling snapshot a second time replaces the
+   * prior snapshot wholesale — the latest handshake wins.
+   */
+  snapshot(handshake: ClientHandshake): void;
+  /** True when the snapshot recorded `capabilities.roots.listChanged === true`. */
+  isRootsDeclared(): boolean;
+  /**
+   * Return the cached roots list, or `undefined` when the cache is cold
+   * (either never populated or freshly invalidated via
+   * {@link invalidateRootsCache}). Synchronous: workspace discovery is
+   * expected to populate the cache lazily before calling.
+   */
+  getCachedRoots(): readonly CachedRoot[] | undefined;
+  /**
+   * Populate the cache with the result of a `roots/list` call. The
+   * resolver stores its own copy so downstream mutations of the input
+   * array don't desync the cache.
+   */
+  setCachedRoots(roots: readonly CachedRoot[]): void;
+  /**
+   * Drop the cached roots list. Wired to the MCP `roots/list_changed`
+   * notification handler — the next call to {@link getCachedRoots}
+   * returns `undefined` and forces a refetch.
+   */
+  invalidateRootsCache(): void;
 }
 
 export function createInMemoryResolver(
   capabilities: Iterable<string>,
 ): CapabilityResolver {
   const set = new Set(capabilities);
+  let clientRootsDeclared = false;
+  let cachedRoots: readonly CachedRoot[] | undefined;
   return {
     has(capability) {
       return set.has(capability);
     },
     list() {
       return [...set];
+    },
+    snapshot(handshake) {
+      clientRootsDeclared = handshake.capabilities?.roots?.listChanged === true;
+    },
+    isRootsDeclared() {
+      return clientRootsDeclared;
+    },
+    getCachedRoots() {
+      return cachedRoots;
+    },
+    setCachedRoots(roots) {
+      cachedRoots = roots.map((r) => ({ uri: r.uri }));
+    },
+    invalidateRootsCache() {
+      cachedRoots = undefined;
     },
   };
 }

--- a/servers/exarchos-mcp/src/capabilities/resolver.ts
+++ b/servers/exarchos-mcp/src/capabilities/resolver.ts
@@ -93,6 +93,12 @@ export function createInMemoryResolver(
     },
     snapshot(handshake) {
       clientRootsDeclared = handshake.capabilities?.roots?.listChanged === true;
+      // CodeRabbit MAJOR #1423: roots/list cache is handshake-scoped — any
+      // cached roots from a prior handshake belong to a different client
+      // session and must not carry over. Clearing here forces the first
+      // `getCachedRoots()` after a new handshake to return `undefined`, so
+      // the workspace resolver re-fetches via the new client's roots/list.
+      cachedRoots = undefined;
     },
     isRootsDeclared() {
       return clientRootsDeclared;

--- a/servers/exarchos-mcp/src/capabilities/resolver.ts
+++ b/servers/exarchos-mcp/src/capabilities/resolver.ts
@@ -34,6 +34,63 @@ export function createInMemoryResolver(
 
 export const ANTHROPIC_NATIVE_CACHING = 'anthropic_native_caching' as const;
 
+// ─── #1262 Quality-hint threshold resolver ──────────────────────────────────
+
+/**
+ * Per-turn output-token cap (matches the upper bound that Anthropic's
+ * sampling layer permits today). The `output_tokens_high` quality hint
+ * fires when a turn's `outputTokens` exceeds
+ * `cap * outputTokenThreshold`. Surfaced as a constant so tests can pin
+ * the multiplication and the cap can be bumped centrally if the model
+ * surface changes.
+ */
+export const OUTPUT_TOKENS_PER_TURN_CAP = 32000;
+
+/**
+ * Default threshold fraction (`0.8` = 80% of `OUTPUT_TOKENS_PER_TURN_CAP`).
+ * Overridden by `.exarchos.yml` → `qualityHints.outputTokenThreshold`.
+ */
+export const DEFAULT_OUTPUT_TOKEN_THRESHOLD_FRACTION = 0.8;
+
+/**
+ * Slice of `.exarchos.yml` consumed by {@link getQualityHintThreshold}.
+ * We accept a structurally-typed shape (rather than importing the full
+ * `ExarchosConfig` Zod type) to avoid a circular import between the
+ * resolver and the config schema and to keep the resolver consumable from
+ * tests without spinning up a config loader.
+ */
+export interface QualityHintsConfig {
+  readonly qualityHints?: {
+    readonly outputTokenThreshold?: number;
+  };
+}
+
+/**
+ * Return the absolute token threshold (in tokens) for a named quality
+ * hint, derived from the `.exarchos.yml` configuration when supplied or
+ * the resolver default otherwise.
+ *
+ * Currently only `'output_tokens'` is supported — the function returns
+ * `cap * fraction` where `fraction` is either the configured value or
+ * {@link DEFAULT_OUTPUT_TOKEN_THRESHOLD_FRACTION}. Unknown names return
+ * the default product so callers never see `NaN`/`undefined` when a new
+ * hint id is referenced before its threshold lands.
+ */
+export function getQualityHintThreshold(
+  name: 'output_tokens' | (string & {}),
+  config?: QualityHintsConfig,
+): number {
+  const fraction =
+    config?.qualityHints?.outputTokenThreshold ?? DEFAULT_OUTPUT_TOKEN_THRESHOLD_FRACTION;
+  if (name === 'output_tokens') {
+    return OUTPUT_TOKENS_PER_TURN_CAP * fraction;
+  }
+  // Unknown hint name — fall back to the same product so callers get a
+  // numeric value rather than `undefined`. Future hint families can fan
+  // out into a per-name switch here.
+  return OUTPUT_TOKENS_PER_TURN_CAP * fraction;
+}
+
 /**
  * Capabilities in the `mcp:exarchos` family. The resolver treats this family
  * as a tiered set: a single tier wins (handshake authoritative) rather than

--- a/servers/exarchos-mcp/src/cli/envelope-parity.test.ts
+++ b/servers/exarchos-mcp/src/cli/envelope-parity.test.ts
@@ -1,0 +1,71 @@
+// ─── CLI ↔ MCP envelope parity for output-tokens-high hint (#1262) ─────────
+//
+// PR A2 / T05 — confirm the rendered hint payload is byte-identical whether
+// the envelope is built on the MCP arm or the CLI arm. Both arms share
+// `toEnvelope` (see `format.ts`), so parity falls out from a single render
+// helper rather than two divergent serializers. This test pins that fact:
+// if a future refactor ever splits the formatter, the test will catch the
+// drift before the rendered hint silently diverges between agents reading
+// the MCP arm and humans reading the CLI arm.
+//
+// The fixture builds a synthetic ToolResult that mirrors a
+// composite-envelopeWrap return value with `next_actions` carrying the
+// `output_tokens_high` checkpoint hint. We then serialise it through
+// `toEnvelope` twice (the function is pure; the doubled call simulates the
+// two arms threading the same payload) and assert the JSON output is
+// identical byte-for-byte. The same approach can be extended to richer
+// fixtures as more quality hints land.
+
+import { describe, it, expect } from 'vitest';
+import { toEnvelope, type ToolResult } from '../format.js';
+import { computeOutputTokenHints, telemetryProjection } from '../telemetry/telemetry-projection.js';
+
+describe('EnvelopeParity_OutputTokensHigh (#1262)', () => {
+  it('Envelope_OutputTokensHighHint_CLIAndMCPIdentical', () => {
+    // Build a telemetry view that crosses the threshold once.
+    let view = telemetryProjection.init();
+    view = telemetryProjection.apply(view, {
+      streamId: 'telemetry',
+      sequence: 1,
+      timestamp: '2026-05-15T00:00:00.000Z',
+      type: 'turn.completed' as unknown as ReturnType<typeof telemetryProjection.apply> extends unknown ? never : never,
+      schemaVersion: '1.0',
+      data: { turnId: 'parity-1', outputTokens: 30000 },
+    } as Parameters<typeof telemetryProjection.apply>[1]);
+
+    const hints = computeOutputTokenHints(view, 25600);
+    expect(hints).toHaveLength(1);
+
+    // Lift the hint into a next_actions[] entry the way the envelope wrap
+    // point would. The shape mirrors NextAction (verb + reason).
+    const next_actions = hints.map(h => ({
+      verb: h.verb,
+      reason: h.reason,
+    }));
+
+    const result: ToolResult = {
+      success: true,
+      data: { phase: 'merge-pending', workflowType: 'feature' },
+      next_actions,
+      _perf: { ms: 1, bytes: 0, tokens: 0 },
+    };
+
+    // Both arms call the same `toEnvelope` — render twice, compare bytes.
+    const cliEnvelope = toEnvelope(result);
+    const mcpEnvelope = toEnvelope(result);
+
+    const cliJson = JSON.stringify(cliEnvelope);
+    const mcpJson = JSON.stringify(mcpEnvelope);
+
+    expect(cliJson).toBe(mcpJson);
+
+    // Sanity-check the hint payload survives the wrap.
+    const parsed = JSON.parse(cliJson) as {
+      next_actions?: ReadonlyArray<{ verb?: string; reason?: string }>;
+    };
+    expect(parsed.next_actions).toBeDefined();
+    expect(parsed.next_actions).toHaveLength(1);
+    expect(parsed.next_actions?.[0].verb).toBe('checkpoint');
+    expect(parsed.next_actions?.[0].reason).toMatch(/output tokens/i);
+  });
+});

--- a/servers/exarchos-mcp/src/config/exarchos-config-schema.ts
+++ b/servers/exarchos-mcp/src/config/exarchos-config-schema.ts
@@ -18,11 +18,28 @@ const safeCommand = z
   .min(1, 'must not be empty or whitespace-only')
   .regex(SAFE_COMMAND_REGEX, 'contains disallowed shell metacharacters');
 
+// #1262 — quality-hint thresholds.
+//
+// `qualityHints.outputTokenThreshold` is a fraction in (0, 1] that the
+// telemetry projection multiplies by the per-turn output-token cap (see
+// `capabilities/resolver.ts` `OUTPUT_TOKENS_PER_TURN_CAP`) to derive the
+// absolute token count above which an `output_tokens_high` checkpoint hint
+// is surfaced via `next_actions`. Default fraction is 0.8 when the field
+// is omitted; the config schema is `.strict()` so unknown fields are
+// rejected, hence the explicit nested key.
+const QualityHintsSchema = z
+  .object({
+    outputTokenThreshold: z.number().gt(0).lte(1).optional(),
+  })
+  .strict()
+  .optional();
+
 export const ExarchosConfigSchema = z
   .object({
     test: safeCommand.optional(),
     typecheck: safeCommand.optional(),
     install: safeCommand.optional(),
+    qualityHints: QualityHintsSchema,
   })
   .strict();
 

--- a/servers/exarchos-mcp/src/core/dispatch.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.ts
@@ -1,4 +1,5 @@
 import type { ToolResult } from '../format.js';
+import { logger } from '../logger.js';
 import type { EventStore } from '../event-store/store.js';
 import type { ExarchosConfig } from '../config/define.js';
 import type { ResolvedProjectConfig } from '../config/resolve.js';
@@ -201,6 +202,23 @@ export const READ_ONLY_ACTIONS = {
 } as const;
 
 export type ReadOnlyActionsMap = typeof READ_ONLY_ACTIONS;
+
+/**
+ * Actions that never consume a `featureId` (Sentry MEDIUM #1423).
+ *
+ * The roots-based workspace-discovery branch in `dispatch()` skips its
+ * synchronous filesystem walk for actions in this set so high-frequency
+ * introspection calls (catalog reads, runbook fetches, agent-spec
+ * lookups) don't pay the discovery cost. Adding an action here is a
+ * "this surface MUST NOT ever take a featureId" assertion — pair the
+ * addition with a registry-side check that the action's schema does not
+ * declare a `featureId` field.
+ */
+const NO_WORKSPACE_RESOLUTION_ACTIONS: ReadonlySet<string> = new Set([
+  'describe',
+  'runbook',
+  'agent_spec',
+]);
 
 /**
  * Apply the readonly capability gate. Returns a structured CAPABILITY_DENIED
@@ -501,7 +519,19 @@ export async function dispatch(
     // can disambiguate; zero-match falls through to the existing per-
     // action Zod validation, which surfaces the legacy "featureId is
     // required" envelope unchanged.
-    if (rest.featureId === undefined && ctx.capabilityResolver !== undefined) {
+    //
+    // Sentry MEDIUM #1423: actions that never consume workspace context
+    // (`describe`/`runbook`/`agent_spec` — pure introspection on the
+    // registry / catalogs) skip the discovery call entirely. Pre-fix
+    // these high-frequency informational calls each triggered a
+    // synchronous cwd-walk on miss, adding measurable latency to the
+    // dispatch hot path. The skip list is conservative: anything that
+    // *might* take a featureId stays in the discovery branch.
+    if (
+      rest.featureId === undefined
+      && ctx.capabilityResolver !== undefined
+      && !NO_WORKSPACE_RESOLUTION_ACTIONS.has(actionName)
+    ) {
       try {
         const { resolveWorkspace } = await import('../workspace/discovery.js');
         const resolution = await resolveWorkspace({
@@ -523,16 +553,33 @@ export async function dispatch(
                 message:
                   `${tool}/${actionName}: multiple workspaces matched MCP roots; ` +
                   'supply an explicit featureId to disambiguate.',
-                validTargets: resolution.validTargets,
+                // CodeRabbit CRITICAL #1423: `ToolResult.error.validTargets`
+                // expects `readonly (string | ValidTransitionTarget)[]`, but
+                // workspace resolution returns
+                // `readonly { featureId, path }[]`. Surface the featureIds
+                // (the disambiguator the caller actually supplies) so the
+                // envelope satisfies the contract.
+                validTargets: resolution.validTargets?.map((t) => t.featureId),
               },
             };
           }
         }
-      } catch {
+      } catch (err) {
         // Discovery is a best-effort inference hook — a failure must not
         // mask the legacy validation contract. Fall through to the
         // existing schema check; callers see the standard "featureId
-        // is required" envelope.
+        // is required" envelope. CodeRabbit MINOR #1423: silent catches
+        // violate the project's observability standard. Surface via the
+        // workspace-discovery logger child so the failure is auditable
+        // without changing the user-facing fallback.
+        logger.child({ subsystem: 'workspace-discovery' }).warn(
+          {
+            tool,
+            action: actionName,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          'workspace inference failed; falling back to legacy featureId validation',
+        );
       }
     }
 

--- a/servers/exarchos-mcp/src/core/dispatch.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.ts
@@ -8,6 +8,7 @@ import type { Outbox } from '../sync/outbox.js';
 import type { ChannelEmitter } from '../channel/emitter.js';
 import type { CapabilityResolver } from '../capabilities/resolver.js';
 import type { StorageBackend } from '../storage/backend.js';
+import type { RootsClient } from '../workspace/discovery.js';
 import { hasCustomToolHandlers, getCustomToolActionHandler, getFullRegistry } from '../registry.js';
 import {
   formatValidationError,
@@ -74,6 +75,25 @@ export interface DispatchContext {
    * is no JSONL fallback any more.
    */
   readonly storage?: StorageBackend;
+  /**
+   * MCP roots-list adapter (#1290). When the client declares the
+   * `roots` capability via the initialize handshake (recorded on the
+   * {@link CapabilityResolver}), dispatch calls this adapter to fetch
+   * the workspace roots for boundary-level `featureId` inference. The
+   * resolver caches the result; `notifications/roots/list_changed`
+   * invalidates the cache via `mcp/notifications.ts`.
+   *
+   * Optional — CLI / direct-call contexts omit it and dispatch falls
+   * back to the cwd-walk branch inside `resolveWorkspace`.
+   */
+  readonly rootsClient?: RootsClient;
+  /**
+   * Working directory threaded through dispatch so the cwd-walk fallback
+   * in {@link resolveWorkspace} (#1290) has a deterministic starting
+   * point that the caller controls. Defaults to `process.cwd()` when
+   * absent — exercised in tests that inject a workspace fixture path.
+   */
+  readonly cwd?: string;
 }
 
 // ─── T04: Server-side Read-only Action Allowlist (Issue #1192) ─────────────
@@ -468,7 +488,54 @@ export async function dispatch(
       };
     }
 
-    const { action: _action, ...rest } = args;
+    let { action: _action, ...rest } = args;
+
+    // ─── #1290 — Roots-based featureId inference ─────────────────────────
+    // Resolution priority: explicit > roots > cwd. If the caller already
+    // supplied a `featureId`, we leave it alone. Otherwise, if the client
+    // declared the MCP roots capability (snapshotted on the resolver via
+    // the initialize handshake), call `resolveWorkspace` to attempt
+    // inference from the cached roots list or a cwd-walk fallback.
+    //
+    // Multi-match returns a structured INVALID_INPUT here so the caller
+    // can disambiguate; zero-match falls through to the existing per-
+    // action Zod validation, which surfaces the legacy "featureId is
+    // required" envelope unchanged.
+    if (rest.featureId === undefined && ctx.capabilityResolver !== undefined) {
+      try {
+        const { resolveWorkspace } = await import('../workspace/discovery.js');
+        const resolution = await resolveWorkspace({
+          resolver: ctx.capabilityResolver,
+          rootsClient: ctx.rootsClient,
+          cwd: ctx.cwd ?? process.cwd(),
+          eventStore: ctx.eventStore,
+        });
+        if (resolution !== undefined) {
+          if (resolution.success) {
+            rest = { ...rest, featureId: resolution.featureId };
+          } else {
+            // Multi-match. Surface the structured INVALID_INPUT so the
+            // caller can pick the intended target.
+            return {
+              success: false,
+              error: {
+                code: resolution.code,
+                message:
+                  `${tool}/${actionName}: multiple workspaces matched MCP roots; ` +
+                  'supply an explicit featureId to disambiguate.',
+                validTargets: resolution.validTargets,
+              },
+            };
+          }
+        }
+      } catch {
+        // Discovery is a best-effort inference hook — a failure must not
+        // mask the legacy validation contract. Fall through to the
+        // existing schema check; callers see the standard "featureId
+        // is required" envelope.
+      }
+    }
+
     // Tolerant Dispatch (#1188): the MCP SDK validates against the flattened
     // parent schema (buildRegistrationSchema) and applies sibling-action
     // defaults (e.g. `nativeIsolation` from prepare_delegation, `outputFormat`

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -484,9 +484,12 @@ describe('EventTypes', () => {
   });
 
   it('EventTypes_HasExpectedCount', () => {
-    // Bumped from 103 → 104 with PR3/T7 (#1364): `tool.action_errored`
-    // splits structured action-level failures out from `tool.errored`
-    // (which now counts transport/protocol failures only).
+    // Bumped from 104 → 105 with #1262: `turn.completed` carries the
+    // per-turn output-token sample the `output_tokens_high` quality hint
+    // fires on (see `telemetry/quality-hints.ts`).
+    // Previous (103 → 104): PR3/T7 (#1364) `tool.action_errored` splits
+    // structured action-level failures out from `tool.errored` (which now
+    // counts transport/protocol failures only).
     // Previous (93 → 103): Wave B (#1342) 5×{requested,executed} two-event
     // split schemas for non-idempotent VCS handlers (B1–B5):
     //   pr.create.requested, pr.create.executed,
@@ -498,7 +501,7 @@ describe('EventTypes', () => {
     // Previous (92): migration.workflow_type_unknown (Wave 1, R-1 Marten #1313).
     // Previous (91): session.machinery_consumed (T-11, rehydration-machinery-refactor).
     // Previous (84 → 90): six durable event-store substrate types (#1259 T02/T03/T04).
-    expect(EventTypes).toHaveLength(104);
+    expect(EventTypes).toHaveLength(105);
   });
 
   it('EventTypes_IncludesSessionTagged', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -501,7 +501,9 @@ describe('EventTypes', () => {
     // Previous (92): migration.workflow_type_unknown (Wave 1, R-1 Marten #1313).
     // Previous (91): session.machinery_consumed (T-11, rehydration-machinery-refactor).
     // Previous (84 → 90): six durable event-store substrate types (#1259 T02/T03/T04).
-    expect(EventTypes).toHaveLength(105);
+    // Previous (105 → 106): workspace.resolved (#1290 — roots-based workspace
+    //   discovery; emitted by `src/workspace/discovery.ts`).
+    expect(EventTypes).toHaveLength(106);
   });
 
   it('EventTypes_IncludesSessionTagged', () => {

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -140,6 +140,12 @@ export const EventTypes = [
   // B5: remove-worktree
   'worktree.remove.requested',
   'worktree.remove.executed',
+  // #1290 — emitted by `resolveWorkspace` (servers/exarchos-mcp/src/workspace/
+  // discovery.ts) when the dispatch boundary resolves a missing `featureId`
+  // from MCP roots or via the cwd-walk fallback. Records the source so audit
+  // queries can distinguish handshake-driven resolutions from cwd inference.
+  // Not emitted on multi-match (no single featureId to attribute) or zero-match.
+  'workspace.resolved',
 ] as const;
 
 export type EventType = typeof EventTypes[number];
@@ -402,6 +408,10 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   'branch.delete.executed': 'auto',
   'worktree.remove.requested': 'auto',
   'worktree.remove.executed': 'auto',
+
+  // #1290 — auto-emitted by the workspace discovery resolver on the
+  // dispatch boundary. See EventTypes registration above.
+  'workspace.resolved': 'auto',
 };
 
 // ─── Base Event Schema ──────────────────────────────────────────────────────
@@ -1547,6 +1557,22 @@ export const MigrationWorkflowTypeUnknownData = z.object({
   streamId: z.string().min(1).describe('Affected stream / featureId'),
 });
 
+// ─── Workspace discovery (#1290) ────────────────────────────────────────────
+
+/**
+ * Emitted by `resolveWorkspace` when the dispatch boundary resolves a
+ * missing `featureId` from a single matching MCP root or via the cwd-walk
+ * fallback. `source` records which branch produced the resolution so
+ * audit queries can distinguish handshake-driven inference from cwd
+ * inference. `path` is the absolute workspace root (the directory
+ * containing `.exarchos.yml` or `docs/workflow-state/<id>.state.json`).
+ */
+export const WorkspaceResolvedData = z.object({
+  source: z.enum(['roots', 'cwd']),
+  path: z.string().min(1),
+  featureId: z.string().min(1),
+});
+
 // ─── Event Data Schemas Map ─────────────────────────────────────────────────
 
 export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
@@ -1712,6 +1738,9 @@ export const EVENT_DATA_SCHEMAS: Partial<Record<EventType, z.ZodSchema>> = {
   'branch.delete.executed': BranchDeleteExecutedData,
   'worktree.remove.requested': WorktreeRemoveRequestedData,
   'worktree.remove.executed': WorktreeRemoveExecutedData,
+
+  // #1290 — workspace discovery resolution
+  'workspace.resolved': WorkspaceResolvedData,
 };
 
 // ─── TypeScript Types ───────────────────────────────────────────────────────
@@ -1812,6 +1841,9 @@ export type BranchDeleteExecuted = z.infer<typeof BranchDeleteExecutedData>;
 export type WorktreeRemoveRequested = z.infer<typeof WorktreeRemoveRequestedData>;
 export type WorktreeRemoveExecuted = z.infer<typeof WorktreeRemoveExecutedData>;
 
+// #1290 — workspace discovery
+export type WorkspaceResolved = z.infer<typeof WorkspaceResolvedData>;
+
 // ─── Event Data Map ─────────────────────────────────────────────────────────
 
 export type EventDataMap = {
@@ -1909,6 +1941,8 @@ export type EventDataMap = {
   'branch.delete.executed': BranchDeleteExecuted;
   'worktree.remove.requested': WorktreeRemoveRequested;
   'worktree.remove.executed': WorktreeRemoveExecuted;
+  // #1290 — workspace discovery
+  'workspace.resolved': WorkspaceResolved;
 };
 
 // ─── Event Catalog Serialization ────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -37,6 +37,11 @@ export const EventTypes = [
   // PREFLIGHT_FAILED, RESERVED_FIELD, etc.) so `view telemetry` can report
   // them instead of silently rolling them up as completions.
   'tool.action_errored',
+  // #1262 — per-turn output-token sample emitted by the telemetry middleware
+  // when an agent turn completes. The `output_tokens_high` quality hint
+  // (catalog: `telemetry/quality-hints.ts`) fires off this stream when a
+  // turn's `outputTokens` crosses the configured threshold.
+  'turn.completed',
   'benchmark.completed',
   'team.spawned',
   'team.task.assigned',
@@ -253,6 +258,8 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   'tool.errored': 'auto',
   // PR3/T7 (#1364) — see EventTypes registration above.
   'tool.action_errored': 'auto',
+  // #1262 — auto-emitted by telemetry middleware on agent-turn boundary.
+  'turn.completed': 'auto',
   'quality.hint.generated': 'auto',
   'quality.refinement.suggested': 'auto',
   'stack.position-filled': 'auto',

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -1569,7 +1569,19 @@ export const MigrationWorkflowTypeUnknownData = z.object({
  */
 export const WorkspaceResolvedData = z.object({
   source: z.enum(['roots', 'cwd']),
-  path: z.string().min(1),
+  // CodeRabbit MINOR #1423: docstring above declares `path` as the
+  // absolute workspace root; pre-fix the schema only required `min(1)`
+  // so a relative path could slip past validation. Refine to accept
+  // either a POSIX absolute path (`/foo/bar`) or a Windows absolute
+  // path (`C:\foo`) — both shipped surfaces use `path.resolve()` so
+  // either form may legitimately appear depending on host platform.
+  path: z
+    .string()
+    .min(1)
+    .refine(
+      (p) => path.posix.isAbsolute(p) || path.win32.isAbsolute(p),
+      { message: 'path must be absolute (POSIX or Windows)' },
+    ),
   featureId: z.string().min(1),
 });
 

--- a/servers/exarchos-mcp/src/mcp/notifications.test.ts
+++ b/servers/exarchos-mcp/src/mcp/notifications.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { createInMemoryResolver } from '../capabilities/resolver.js';
+import { handleRootsListChanged } from './notifications.js';
+
+describe('handleRootsListChanged (#1290)', () => {
+  it('Notifications_RootsListChanged_InvalidatesCache', () => {
+    const resolver = createInMemoryResolver([]);
+    resolver.setCachedRoots([{ uri: 'file:///a' }]);
+    expect(resolver.getCachedRoots()).toBeDefined();
+
+    handleRootsListChanged(resolver);
+
+    expect(resolver.getCachedRoots()).toBeUndefined();
+  });
+
+  it('Notifications_RootsListChangedOnColdCache_IsNoOp', () => {
+    const resolver = createInMemoryResolver([]);
+    // Cold cache — invalidation should be safe.
+    expect(() => handleRootsListChanged(resolver)).not.toThrow();
+    expect(resolver.getCachedRoots()).toBeUndefined();
+  });
+});

--- a/servers/exarchos-mcp/src/mcp/notifications.ts
+++ b/servers/exarchos-mcp/src/mcp/notifications.ts
@@ -1,0 +1,28 @@
+// ─── #1290 — MCP notification handlers ───────────────────────────────────────
+//
+// Minimal wiring layer for client-emitted notifications that affect
+// server-side state. Today the surface is single-purpose
+// (`notifications/roots/list_changed` invalidates the resolver's roots
+// cache so the next `resolveWorkspace` call refetches). New
+// notifications should be added here as discrete handler functions
+// so the transport adapter can register them by name; we deliberately
+// avoid a generic dispatcher object to keep the contract grep-able.
+
+import type { CapabilityResolver } from '../capabilities/resolver.js';
+
+/**
+ * Handle a `notifications/roots/list_changed` event from the MCP client.
+ *
+ * The roots set is cached on the {@link CapabilityResolver} after the
+ * first `roots/list` round-trip (see `workspace/discovery.ts`). When
+ * the client mutates its root set (workspace add/remove in the IDE, for
+ * example), it emits `notifications/roots/list_changed`; calling this
+ * function from the transport adapter drops the cache so the next
+ * discovery call sees the fresh list.
+ *
+ * Idempotent: invoking it on a cold cache is a no-op. Safe to call
+ * unconditionally from the transport layer's notification dispatcher.
+ */
+export function handleRootsListChanged(resolver: CapabilityResolver): void {
+  resolver.invalidateRootsCache();
+}

--- a/servers/exarchos-mcp/src/telemetry/quality-hints.test.ts
+++ b/servers/exarchos-mcp/src/telemetry/quality-hints.test.ts
@@ -1,0 +1,50 @@
+// ─── Quality-hint catalog tests (#1262) ─────────────────────────────────────
+//
+// PR A2 / T03: A catalog of structured quality-hint *types* keyed by a stable
+// identifier (e.g. `output_tokens_high`). Each entry declares:
+//
+//   - `verb` — the NextAction verb to surface (e.g. `checkpoint`).
+//   - `reasonTemplate` — a printf-style template populated by the projection.
+//
+// The projection looks up a hint by id and uses the template to build the
+// `next_actions[].reason` string. Keeping the catalog separate from the
+// projection means the verb/template can evolve without touching the
+// threshold-detection logic, and the parity tests can reason about hint
+// payloads without instantiating the full projection state.
+
+import { describe, it, expect } from 'vitest';
+import {
+  getQualityHintTypes,
+  getQualityHintType,
+  type QualityHintType,
+} from './quality-hints.js';
+
+describe('QualityHintCatalog', () => {
+  it('QualityHint_OutputTokensHighType_RegisteredInCatalog', () => {
+    const types = getQualityHintTypes();
+    const hint = types['output_tokens_high'];
+    expect(hint).toBeDefined();
+    expect(hint.verb).toBe('checkpoint');
+    expect(typeof hint.reasonTemplate).toBe('string');
+    expect(hint.reasonTemplate.length).toBeGreaterThan(0);
+  });
+
+  it('QualityHint_GetByName_ReturnsTypedEntry', () => {
+    const hint: QualityHintType | undefined = getQualityHintType('output_tokens_high');
+    expect(hint).toBeDefined();
+    expect(hint?.verb).toBe('checkpoint');
+  });
+
+  it('QualityHint_GetByName_UnknownReturnsUndefined', () => {
+    const hint = getQualityHintType('does_not_exist');
+    expect(hint).toBeUndefined();
+  });
+
+  it('QualityHint_OutputTokensHighType_ReasonTemplateReferencesTokens', () => {
+    const hint = getQualityHintType('output_tokens_high');
+    expect(hint).toBeDefined();
+    // The template should mention "output tokens" so the rendered reason
+    // is comprehensible to the agent reading the hint.
+    expect(hint!.reasonTemplate.toLowerCase()).toMatch(/output tokens/);
+  });
+});

--- a/servers/exarchos-mcp/src/telemetry/quality-hints.ts
+++ b/servers/exarchos-mcp/src/telemetry/quality-hints.ts
@@ -1,0 +1,72 @@
+// ─── Quality-hint catalog (#1262) ────────────────────────────────────────────
+//
+// PR A2 / T03 — Output-token quality-hint catalog.
+//
+// A small, declarative table of hint *types* keyed by a stable identifier
+// (e.g. `output_tokens_high`). Each entry describes:
+//
+//   - `verb` — the NextAction verb to surface to callers (currently
+//     `checkpoint`; other verbs may be added as hints are introduced).
+//   - `reasonTemplate` — a printf-style template populated by the projection
+//     when it emits the hint. Tokens like `{tokens}` and `{threshold}` are
+//     substituted at render time by the projection's hint-builder; the
+//     catalog itself does no rendering.
+//
+// Keeping the catalog separate from the telemetry projection lets the
+// verb/template evolve without touching the threshold-detection logic, and
+// lets envelope-parity tests reason about hint payloads in isolation.
+
+export interface QualityHintType {
+  /** Stable identifier (snake_case). Used by the projection to look the hint up. */
+  readonly id: string;
+  /** NextAction verb to surface when the hint fires. */
+  readonly verb: string;
+  /**
+   * Printf-style template populated at render time. Recognised tokens:
+   *
+   *   - `{tokens}` — the actual per-turn output-token sum that crossed.
+   *   - `{threshold}` — the threshold value (in tokens) that was crossed.
+   */
+  readonly reasonTemplate: string;
+}
+
+const CATALOG: Readonly<Record<string, QualityHintType>> = Object.freeze({
+  output_tokens_high: Object.freeze({
+    id: 'output_tokens_high',
+    verb: 'checkpoint',
+    reasonTemplate:
+      'Per-turn output tokens ({tokens}) crossed quality threshold ({threshold}); consider a checkpoint before continuing.',
+  }),
+});
+
+/**
+ * Return the registered quality-hint types keyed by their stable identifier.
+ * The returned object is frozen — callers must treat it as readonly.
+ */
+export function getQualityHintTypes(): Readonly<Record<string, QualityHintType>> {
+  return CATALOG;
+}
+
+/**
+ * Look up a single quality-hint type by id. Returns `undefined` for unknown
+ * ids so callers can branch on registration state without throwing.
+ */
+export function getQualityHintType(id: string): QualityHintType | undefined {
+  return CATALOG[id];
+}
+
+/**
+ * Render a quality-hint's `reasonTemplate` into a human-readable string by
+ * substituting `{token}` placeholders with the supplied values. Unknown
+ * placeholders are left intact so the missing data is visible rather than
+ * silently dropped.
+ */
+export function renderQualityHintReason(
+  hint: QualityHintType,
+  values: Readonly<Record<string, string | number>>,
+): string {
+  return hint.reasonTemplate.replace(/\{(\w+)\}/g, (match, key: string) => {
+    const v = values[key];
+    return v === undefined ? match : String(v);
+  });
+}

--- a/servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts
+++ b/servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import type { WorkflowEvent } from '../event-store/schemas.js';
-import { telemetryProjection, TELEMETRY_VIEW, initToolMetrics } from './telemetry-projection.js';
+import {
+  telemetryProjection,
+  TELEMETRY_VIEW,
+  initToolMetrics,
+  computeOutputTokenHints,
+} from './telemetry-projection.js';
 import type { TelemetryViewState, ToolMetrics } from './telemetry-projection.js';
 
 describe('TelemetryProjection', () => {
@@ -450,5 +455,71 @@ describe('TelemetryProjection_ActionErrored_AggregatesByTool', () => {
     // No completed events folded — invocations stays 0.
     expect(state.tools['fresh_tool'].invocations).toBe(0);
     expect(state.tools['fresh_tool'].errors).toBe(0);
+  });
+});
+
+// ─── #1262 — per-turn output-token tracking + hint emission ────────────────
+
+describe('TelemetryProjection_OutputTokenHint', () => {
+  it('TelemetryProjection_ThresholdCrossed_EmitsHint', () => {
+    // Synthetic telemetry: a single `turn.completed` event carrying a
+    // per-turn output-token sum above the threshold.
+    let state = telemetryProjection.init();
+    state = telemetryProjection.apply(
+      state,
+      makeEvent('turn.completed', { turnId: 't1', outputTokens: 30000 }),
+    );
+
+    // The projection records each turn's output tokens.
+    expect(state.turns).toHaveLength(1);
+    expect(state.turns[0]).toEqual({ turnId: 't1', outputTokens: 30000 });
+
+    // computeOutputTokenHints surfaces a NextAction-shaped checkpoint hint
+    // when a turn crosses the threshold (passed in tokens).
+    const hints = computeOutputTokenHints(state, 25600);
+    expect(hints).toHaveLength(1);
+    expect(hints[0].verb).toBe('checkpoint');
+    expect(hints[0].reason).toMatch(/output tokens/i);
+  });
+
+  it('TelemetryProjection_BelowThreshold_NoHint', () => {
+    let state = telemetryProjection.init();
+    state = telemetryProjection.apply(
+      state,
+      makeEvent('turn.completed', { turnId: 't1', outputTokens: 10000 }),
+    );
+
+    expect(state.turns).toHaveLength(1);
+    const hints = computeOutputTokenHints(state, 25600);
+    expect(hints).toHaveLength(0);
+  });
+
+  it('TelemetryProjection_TurnCompleted_NonNumericOutputTokens_IgnoresEvent', () => {
+    const state = telemetryProjection.init();
+    const result = telemetryProjection.apply(
+      state,
+      makeEvent('turn.completed', { turnId: 't1', outputTokens: 'garbage' }),
+    );
+    expect(result).toBe(state);
+  });
+
+  it('TelemetryProjection_MultipleTurns_OnlyOneCrosses_EmitsOneHint', () => {
+    let state = telemetryProjection.init();
+    state = telemetryProjection.apply(
+      state,
+      makeEvent('turn.completed', { turnId: 't1', outputTokens: 5000 }),
+    );
+    state = telemetryProjection.apply(
+      state,
+      makeEvent('turn.completed', { turnId: 't2', outputTokens: 30000 }),
+    );
+    state = telemetryProjection.apply(
+      state,
+      makeEvent('turn.completed', { turnId: 't3', outputTokens: 8000 }),
+    );
+
+    const hints = computeOutputTokenHints(state, 25600);
+    expect(hints).toHaveLength(1);
+    expect(hints[0].verb).toBe('checkpoint');
   });
 });

--- a/servers/exarchos-mcp/src/telemetry/telemetry-projection.ts
+++ b/servers/exarchos-mcp/src/telemetry/telemetry-projection.ts
@@ -1,6 +1,11 @@
 import type { ViewProjection } from '../views/materializer.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
 import { percentile } from './percentile.js';
+import {
+  getQualityHintType,
+  renderQualityHintReason,
+  type QualityHintType,
+} from './quality-hints.js';
 
 // ─── View Name Constant ────────────────────────────────────────────────────
 
@@ -33,6 +38,19 @@ export interface ToolMetrics {
   readonly actionErrorBreakdown: Readonly<Record<string, number>>;
 }
 
+// ─── Per-Turn Output-Token Record (#1262) ──────────────────────────────────
+
+/**
+ * A single agent turn's output-token sum. The projection folds
+ * `turn.completed` events into `view.turns` so quality-hint generators can
+ * detect threshold crossings without scanning the raw event stream a second
+ * time.
+ */
+export interface TurnRecord {
+  readonly turnId: string;
+  readonly outputTokens: number;
+}
+
 // ─── Telemetry View State ──────────────────────────────────────────────────
 
 export interface TelemetryViewState {
@@ -41,6 +59,12 @@ export interface TelemetryViewState {
   readonly totalInvocations: number;
   readonly totalTokens: number;
   readonly windowSize: number;
+  /**
+   * Per-turn output-token records (#1262). Capped at `windowSize` like the
+   * rolling per-tool arrays so a long-running session doesn't grow the view
+   * state unbounded.
+   */
+  readonly turns: readonly TurnRecord[];
 }
 
 // ─── Factory for Empty ToolMetrics ─────────────────────────────────────────
@@ -84,6 +108,7 @@ export const telemetryProjection: ViewProjection<TelemetryViewState> = {
     totalInvocations: 0,
     totalTokens: 0,
     windowSize: DEFAULT_WINDOW_SIZE,
+    turns: [],
   }),
 
   apply: (view, event) => {
@@ -189,8 +214,86 @@ export const telemetryProjection: ViewProjection<TelemetryViewState> = {
         };
       }
 
+      // #1262 — per-turn output-token tracking. Folded into a capped
+      // rolling list (`view.turns`) so quality-hint generators can detect
+      // threshold crossings without re-scanning the raw event stream.
+      // `turn.completed` payloads must carry a string `turnId` and a
+      // numeric `outputTokens`; anything else is ignored (matches the
+      // tool.completed/tool.errored guard pattern).
+      case 'turn.completed': {
+        const tcData = event.data as { turnId?: unknown; outputTokens?: unknown } | undefined;
+        if (
+          !tcData
+          || typeof tcData.turnId !== 'string'
+          || typeof tcData.outputTokens !== 'number'
+        ) {
+          return view;
+        }
+        const turnId = tcData.turnId;
+        const outputTokens = tcData.outputTokens;
+
+        const next = [...view.turns, { turnId, outputTokens }];
+        const turns = next.length <= view.windowSize
+          ? next
+          : next.slice(next.length - view.windowSize);
+
+        return {
+          ...view,
+          turns,
+        };
+      }
+
       default:
         return view;
     }
   },
 };
+
+// ─── #1262 Quality-Hint Generation ─────────────────────────────────────────
+
+/**
+ * A NextAction-shaped hint surfaced when a per-turn output-token sum crosses
+ * the configured threshold. The shape is intentionally a subset of
+ * `NextAction` (verb + reason) so the envelope formatter can lift it
+ * directly into `next_actions[]` without translation.
+ */
+export interface OutputTokenHint {
+  readonly verb: string;
+  readonly reason: string;
+  readonly hintType: string;
+}
+
+/**
+ * Compute output-token quality hints for the given telemetry view state.
+ *
+ * Walks `view.turns` and emits one hint per turn whose `outputTokens`
+ * strictly exceeds the supplied threshold. The threshold is supplied
+ * explicitly (rather than read from a constant) so callers — typically the
+ * envelope wrap point — can pull the value from `.exarchos.yml` via the
+ * config resolver (T05).
+ *
+ * Returns `[]` when the catalog entry is missing (defensive) or no turn
+ * crosses the threshold.
+ */
+export function computeOutputTokenHints(
+  view: TelemetryViewState,
+  thresholdTokens: number,
+): readonly OutputTokenHint[] {
+  const hintType: QualityHintType | undefined = getQualityHintType('output_tokens_high');
+  if (!hintType) return [];
+
+  const hints: OutputTokenHint[] = [];
+  for (const turn of view.turns) {
+    if (turn.outputTokens > thresholdTokens) {
+      hints.push({
+        verb: hintType.verb,
+        reason: renderQualityHintReason(hintType, {
+          tokens: turn.outputTokens,
+          threshold: thresholdTokens,
+        }),
+        hintType: hintType.id,
+      });
+    }
+  }
+  return hints;
+}

--- a/servers/exarchos-mcp/src/telemetry/tools.ts
+++ b/servers/exarchos-mcp/src/telemetry/tools.ts
@@ -4,10 +4,18 @@ import { z } from 'zod';
 import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { getOrCreateMaterializer } from '../views/tools.js';
-import { TELEMETRY_VIEW } from './telemetry-projection.js';
+import {
+  TELEMETRY_VIEW,
+  computeOutputTokenHints,
+} from './telemetry-projection.js';
 import type { TelemetryViewState, ToolMetrics } from './telemetry-projection.js';
 import { TELEMETRY_STREAM } from './constants.js';
 import { generateHints } from './hints.js';
+import {
+  getQualityHintThreshold,
+  type QualityHintsConfig,
+} from '../capabilities/resolver.js';
+import type { NextAction } from '../next-action.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -62,6 +70,7 @@ export async function handleViewTelemetry(
   args: unknown,
   stateDir: string,
   eventStore: EventStore,
+  config?: QualityHintsConfig,
 ): Promise<ToolResult> {
   const parseResult = ViewTelemetryArgsSchema.safeParse(args);
   if (!parseResult.success) {
@@ -118,6 +127,19 @@ export async function handleViewTelemetry(
     // Generate hints
     const hints = generateHints(view);
 
+    // #1262 — compute output-token quality hints and surface them via
+    // `next_actions[]` so the envelope-wrap boundary lifts them onto the
+    // outgoing payload alongside any HSM-derived verbs. Each hint becomes
+    // one `NextAction` entry with `verb: 'checkpoint'`. The threshold is
+    // resolved from `.exarchos.yml` → `qualityHints.outputTokenThreshold`
+    // (default 80% of the per-turn cap).
+    const threshold = getQualityHintThreshold('output_tokens', config);
+    const tokenHints = computeOutputTokenHints(view, threshold);
+    const nextActions: readonly NextAction[] = tokenHints.map((h) => ({
+      verb: h.verb,
+      reason: h.reason,
+    }));
+
     return {
       success: true,
       data: {
@@ -129,6 +151,7 @@ export async function handleViewTelemetry(
         tools: toolEntries,
         hints,
       },
+      ...(nextActions.length > 0 ? { next_actions: nextActions } : {}),
     };
   } catch (err) {
     return {

--- a/servers/exarchos-mcp/src/views/composite.output-token-hint.test.ts
+++ b/servers/exarchos-mcp/src/views/composite.output-token-hint.test.ts
@@ -1,0 +1,91 @@
+// ─── End-to-end test: output_tokens_high hint surfaces in next_actions ─────
+//
+// PR A2 follow-up (#1262). The catalog + projection + threshold resolver
+// landed in the parent commits; this test pins the *end-to-end* contract:
+//
+//   1. Per-turn `turn.completed` events with `outputTokens` above threshold
+//      are appended to the telemetry stream.
+//   2. The composite `exarchos_view` `telemetry` action dispatches through
+//      `handleView`, which calls `envelopeWrap`.
+//   3. The returned envelope's `next_actions[]` contains a single entry
+//      with `verb: 'checkpoint'` and a `reason` mentioning output tokens.
+//
+// And the below-threshold mirror: no such entry.
+//
+// The test exercises real envelope wrapping (no vi.mock of the wrap helper)
+// so a future refactor that breaks the wire cannot pass this test by
+// accident.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { DispatchContext } from '../core/dispatch.js';
+import { EventStore } from '../event-store/store.js';
+import { handleView } from './composite.js';
+
+interface MaybeEnvelope {
+  success?: boolean;
+  next_actions?: ReadonlyArray<{ verb?: string; reason?: string }>;
+}
+
+async function emitTurn(
+  store: EventStore,
+  sequence: number,
+  turnId: string,
+  outputTokens: number,
+): Promise<void> {
+  await store.append('telemetry', {
+    type: 'turn.completed',
+    data: { turnId, outputTokens },
+  });
+  // sequence param is unused — append returns its own sequence; kept for
+  // call-site readability of the test scenario.
+  void sequence;
+}
+
+describe('CompositeViewTelemetry_OutputTokenHint_EndToEnd (#1262)', () => {
+  let stateDir: string;
+  let ctx: DispatchContext;
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'output-token-hint-e2e-'));
+    ctx = {
+      stateDir,
+      eventStore: new EventStore(stateDir),
+      enableTelemetry: false,
+    };
+  });
+
+  afterEach(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it('CompositeViewTelemetry_AboveThreshold_HintInNextActions', async () => {
+    // 30000 > default threshold (32000 * 0.8 = 25600) → hint fires.
+    await emitTurn(ctx.eventStore, 1, 'e2e-above-1', 30000);
+
+    const result = (await handleView({ action: 'telemetry' }, ctx)) as MaybeEnvelope;
+    expect(result.success).toBe(true);
+    expect(Array.isArray(result.next_actions)).toBe(true);
+
+    const hintEntries = (result.next_actions ?? []).filter(
+      (a) => a.verb === 'checkpoint',
+    );
+    expect(hintEntries).toHaveLength(1);
+    expect(hintEntries[0].reason).toMatch(/output tokens/i);
+  });
+
+  it('CompositeViewTelemetry_BelowThreshold_NoHint', async () => {
+    // 10000 < 25600 → no hint.
+    await emitTurn(ctx.eventStore, 1, 'e2e-below-1', 10000);
+
+    const result = (await handleView({ action: 'telemetry' }, ctx)) as MaybeEnvelope;
+    expect(result.success).toBe(true);
+
+    const hintEntries = (result.next_actions ?? []).filter(
+      (a) => a.verb === 'checkpoint',
+    );
+    expect(hintEntries).toHaveLength(0);
+  });
+});

--- a/servers/exarchos-mcp/src/views/composite.test.ts
+++ b/servers/exarchos-mcp/src/views/composite.test.ts
@@ -247,6 +247,11 @@ describe('handleView', () => {
         { compact: true, tool: 'workflow_get' },
         STATE_DIR,
         CTX.eventStore,
+        // #1262 — `ctx.config` is threaded through so the
+        // `qualityHints.outputTokenThreshold` setting reaches the hint
+        // generator. The test CTX above doesn't populate config, so
+        // `undefined` is the expected fourth argument.
+        undefined,
       );
     });
   });

--- a/servers/exarchos-mcp/src/views/composite.ts
+++ b/servers/exarchos-mcp/src/views/composite.ts
@@ -56,7 +56,14 @@ function envelopeWrap(result: ToolResult, startedAt: number): ToolResult {
 
   const meta = (result._meta ?? {}) as Record<string, unknown>;
   const perf = result._perf ?? { ms: Date.now() - startedAt };
-  const nextActions = nextActionsFromResult(result);
+  // #1262 — handlers may pre-populate `result.next_actions` with telemetry-
+  // derived hints (e.g. the `output_tokens_high` checkpoint hint surfaced
+  // by `handleViewTelemetry`). Merge those with the HSM-derived verbs
+  // from `nextActionsFromResult` so the envelope carries both rather than
+  // the wrap silently dropping one source.
+  const hsmActions = nextActionsFromResult(result);
+  const handlerActions = result.next_actions ?? [];
+  const nextActions = [...handlerActions, ...hsmActions];
   return wrapWithPassthrough(result, wrap(result.data, meta, perf, nextActions));
 }
 
@@ -146,6 +153,12 @@ export async function handleView(
           },
           stateDir,
           eventStore,
+          // #1262 — thread the resolved `.exarchos.yml` so
+          // `qualityHints.outputTokenThreshold` flows into the hint
+          // generator. Cast is the same shape both types declare; the
+          // resolver only reads the `qualityHints.outputTokenThreshold`
+          // slice (see `QualityHintsConfig`).
+          ctx.config as unknown as Parameters<typeof handleViewTelemetry>[3],
         ),
         startedAt,
       );

--- a/servers/exarchos-mcp/src/workspace/discovery.test.ts
+++ b/servers/exarchos-mcp/src/workspace/discovery.test.ts
@@ -1,0 +1,363 @@
+// ─── #1290 — Roots-based workspace discovery ─────────────────────────────────
+//
+// RED → GREEN coverage for `resolveWorkspace` and the pure
+// `isExarchosWorkspace` detector. Discovery priority is `explicit > roots
+// > cwd` — these tests pin the roots + cwd branches; the explicit branch
+// is exercised at the dispatch boundary (see tests/outcome/).
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { EventStore } from '../event-store/store.js';
+import { createInMemoryResolver } from '../capabilities/resolver.js';
+import type { RootsClient } from './discovery.js';
+import { resolveWorkspace, isExarchosWorkspace } from './discovery.js';
+
+async function mktemp(prefix: string): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), `discovery-${prefix}-`));
+}
+
+async function seedExarchosWorkspace(root: string, featureId: string): Promise<void> {
+  // `.exarchos.yml` is the canonical workspace signature. Empty file is
+  // sufficient — the loader is not invoked here.
+  await fs.writeFile(path.join(root, '.exarchos.yml'), '', 'utf8');
+  await fs.mkdir(path.join(root, 'docs', 'workflow-state'), { recursive: true });
+  await fs.writeFile(
+    path.join(root, 'docs', 'workflow-state', `${featureId}.state.json`),
+    JSON.stringify({ featureId, workflowType: 'feature' }),
+    'utf8',
+  );
+}
+
+function fileUriFor(p: string): string {
+  // path.posix.normalize keeps the leading separator on Linux; on Windows
+  // `pathToFileURL` from node:url is the cleaner construct but we already
+  // operate on absolute POSIX-style temp paths.
+  return `file://${p}`;
+}
+
+describe('isExarchosWorkspace detector (#1290)', () => {
+  it('IsExarchosWorkspace_ExarchosYmlPresent_ReturnsTrue', async () => {
+    const dir = await mktemp('iexa-yml');
+    try {
+      await fs.writeFile(path.join(dir, '.exarchos.yml'), '', 'utf8');
+      expect(isExarchosWorkspace(dir)).toBe(true);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('IsExarchosWorkspace_StateFilePresent_ReturnsTrue', async () => {
+    const dir = await mktemp('iexa-state');
+    try {
+      await fs.mkdir(path.join(dir, 'docs', 'workflow-state'), { recursive: true });
+      await fs.writeFile(
+        path.join(dir, 'docs', 'workflow-state', 'feat.state.json'),
+        '{}',
+        'utf8',
+      );
+      expect(isExarchosWorkspace(dir)).toBe(true);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('IsExarchosWorkspace_PlainDir_ReturnsFalse', async () => {
+    const dir = await mktemp('iexa-plain');
+    try {
+      expect(isExarchosWorkspace(dir)).toBe(false);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('resolveWorkspace roots branch (#1290)', () => {
+  it('WorkspaceDiscovery_OneRootsMatch_ResolvesAndEmitsEvent', async () => {
+    const tmp = await mktemp('one-root');
+    try {
+      const root = path.join(tmp, 'project');
+      await fs.mkdir(root, { recursive: true });
+      await seedExarchosWorkspace(root, 'feat-alpha');
+
+      const resolver = createInMemoryResolver([]);
+      resolver.snapshot({ capabilities: { roots: { listChanged: true } } });
+
+      const rootsClient: RootsClient = {
+        async list() {
+          return [{ uri: fileUriFor(root) }];
+        },
+      };
+
+      const stateDir = await mktemp('one-root-state');
+      const eventStore = new EventStore(stateDir);
+      await eventStore.initialize();
+
+      const result = await resolveWorkspace({
+        resolver,
+        rootsClient,
+        cwd: tmp,
+        eventStore,
+      });
+
+      expect(result).toBeDefined();
+      expect(result!.success).toBe(true);
+      expect(result!.source).toBe('roots');
+      expect(result!.featureId).toBe('feat-alpha');
+      expect(result!.path).toBe(root);
+
+      // `workspace.resolved` event landed on the resolved featureId's stream.
+      const events = await eventStore.query('feat-alpha');
+      const evt = events.find((e) => e.type === 'workspace.resolved');
+      expect(evt).toBeDefined();
+      const data = evt!.data as { source?: string; featureId?: string; path?: string };
+      expect(data.source).toBe('roots');
+      expect(data.featureId).toBe('feat-alpha');
+      expect(data.path).toBe(root);
+
+      await fs.rm(stateDir, { recursive: true, force: true });
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('WorkspaceDiscovery_ZeroRootsMatch_FallsBackToCwdWalk', async () => {
+    const tmp = await mktemp('zero-root');
+    try {
+      // Roots contain a non-exarchos dir.
+      const unrelated = path.join(tmp, 'unrelated');
+      await fs.mkdir(unrelated, { recursive: true });
+
+      // cwd is itself an exarchos workspace.
+      const cwd = path.join(tmp, 'project');
+      await fs.mkdir(cwd, { recursive: true });
+      await seedExarchosWorkspace(cwd, 'feat-cwd');
+
+      const resolver = createInMemoryResolver([]);
+      resolver.snapshot({ capabilities: { roots: { listChanged: true } } });
+
+      const rootsClient: RootsClient = {
+        async list() {
+          return [{ uri: fileUriFor(unrelated) }];
+        },
+      };
+
+      const stateDir = await mktemp('zero-root-state');
+      const eventStore = new EventStore(stateDir);
+      await eventStore.initialize();
+
+      const result = await resolveWorkspace({
+        resolver,
+        rootsClient,
+        cwd,
+        eventStore,
+      });
+
+      expect(result).toBeDefined();
+      expect(result!.success).toBe(true);
+      expect(result!.source).toBe('cwd');
+      expect(result!.featureId).toBe('feat-cwd');
+      expect(result!.path).toBe(cwd);
+
+      const events = await eventStore.query('feat-cwd');
+      const evt = events.find((e) => e.type === 'workspace.resolved');
+      expect(evt).toBeDefined();
+      expect((evt!.data as { source?: string }).source).toBe('cwd');
+
+      await fs.rm(stateDir, { recursive: true, force: true });
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('WorkspaceDiscovery_ZeroRootsAndCwdMiss_ReturnsUndefined', async () => {
+    const tmp = await mktemp('all-miss');
+    try {
+      const cwd = path.join(tmp, 'nothing');
+      await fs.mkdir(cwd, { recursive: true });
+
+      const resolver = createInMemoryResolver([]);
+      resolver.snapshot({ capabilities: { roots: { listChanged: true } } });
+
+      const rootsClient: RootsClient = {
+        async list() {
+          return [];
+        },
+      };
+
+      const stateDir = await mktemp('all-miss-state');
+      const eventStore = new EventStore(stateDir);
+      await eventStore.initialize();
+
+      const result = await resolveWorkspace({
+        resolver,
+        rootsClient,
+        cwd,
+        eventStore,
+      });
+
+      expect(result).toBeUndefined();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('WorkspaceDiscovery_MultipleRootsMatch_ReturnsInvalidInputWithValidTargets', async () => {
+    const tmp = await mktemp('multi');
+    try {
+      const a = path.join(tmp, 'a');
+      const b = path.join(tmp, 'b');
+      await fs.mkdir(a, { recursive: true });
+      await fs.mkdir(b, { recursive: true });
+      await seedExarchosWorkspace(a, 'feat-a');
+      await seedExarchosWorkspace(b, 'feat-b');
+
+      const resolver = createInMemoryResolver([]);
+      resolver.snapshot({ capabilities: { roots: { listChanged: true } } });
+
+      const rootsClient: RootsClient = {
+        async list() {
+          return [{ uri: fileUriFor(a) }, { uri: fileUriFor(b) }];
+        },
+      };
+
+      const stateDir = await mktemp('multi-state');
+      const eventStore = new EventStore(stateDir);
+      await eventStore.initialize();
+
+      const result = await resolveWorkspace({
+        resolver,
+        rootsClient,
+        cwd: tmp,
+        eventStore,
+      });
+
+      expect(result).toBeDefined();
+      expect(result!.success).toBe(false);
+      expect(result!.code).toBe('INVALID_INPUT');
+      expect(result!.validTargets).toBeDefined();
+      expect(result!.validTargets!.length).toBe(2);
+
+      const paths = result!.validTargets!.map((t) => t.path).sort();
+      expect(paths).toEqual([a, b].sort());
+
+      // No event emitted on multi-match — there is no single featureId to
+      // attribute the resolution to.
+      const a_events = await eventStore.query('feat-a');
+      const b_events = await eventStore.query('feat-b');
+      const resolved = [...a_events, ...b_events].filter(
+        (e) => e.type === 'workspace.resolved',
+      );
+      expect(resolved.length).toBe(0);
+
+      await fs.rm(stateDir, { recursive: true, force: true });
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('WorkspaceDiscovery_RootsListChangedDuringDispatch_InvalidatesCache', async () => {
+    const tmp = await mktemp('cache');
+    try {
+      const initial = path.join(tmp, 'initial');
+      const next = path.join(tmp, 'next');
+      await fs.mkdir(initial, { recursive: true });
+      await fs.mkdir(next, { recursive: true });
+      await seedExarchosWorkspace(initial, 'feat-initial');
+      await seedExarchosWorkspace(next, 'feat-next');
+
+      const resolver = createInMemoryResolver([]);
+      resolver.snapshot({ capabilities: { roots: { listChanged: true } } });
+
+      let fetchCount = 0;
+      let nextList: { uri: string }[] = [{ uri: fileUriFor(initial) }];
+      const rootsClient: RootsClient = {
+        async list() {
+          fetchCount += 1;
+          return nextList;
+        },
+      };
+
+      const stateDir = await mktemp('cache-state');
+      const eventStore = new EventStore(stateDir);
+      await eventStore.initialize();
+
+      // First call: cache miss → fetch.
+      const r1 = await resolveWorkspace({ resolver, rootsClient, cwd: tmp, eventStore });
+      expect(r1?.success).toBe(true);
+      expect(r1?.featureId).toBe('feat-initial');
+      expect(fetchCount).toBe(1);
+
+      // Second call: cache hit → no additional fetch. Even if the
+      // underlying fixture changes the rootsClient response, the cached
+      // entry must win until invalidation.
+      nextList = [{ uri: fileUriFor(next) }];
+      const r2 = await resolveWorkspace({ resolver, rootsClient, cwd: tmp, eventStore });
+      expect(r2?.success).toBe(true);
+      expect(r2?.featureId).toBe('feat-initial');
+      expect(fetchCount).toBe(1);
+
+      // Simulate `roots/list_changed` notification → cache invalidated.
+      resolver.invalidateRootsCache();
+
+      const r3 = await resolveWorkspace({ resolver, rootsClient, cwd: tmp, eventStore });
+      expect(r3?.success).toBe(true);
+      expect(r3?.featureId).toBe('feat-next');
+      expect(fetchCount).toBe(2);
+
+      await fs.rm(stateDir, { recursive: true, force: true });
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('WorkspaceDiscovery_RootsDeclaredFalse_SkipsRootsBranchEntirely', async () => {
+    const tmp = await mktemp('no-decl');
+    try {
+      const cwd = path.join(tmp, 'project');
+      await fs.mkdir(cwd, { recursive: true });
+      await seedExarchosWorkspace(cwd, 'feat-cwdonly');
+
+      const resolver = createInMemoryResolver([]);
+      // Note: NO snapshot call → isRootsDeclared() is false.
+
+      let fetchCount = 0;
+      const rootsClient: RootsClient = {
+        async list() {
+          fetchCount += 1;
+          return [{ uri: fileUriFor(cwd) }];
+        },
+      };
+
+      const stateDir = await mktemp('no-decl-state');
+      const eventStore = new EventStore(stateDir);
+      await eventStore.initialize();
+
+      const result = await resolveWorkspace({
+        resolver,
+        rootsClient,
+        cwd,
+        eventStore,
+      });
+
+      // Resolution falls back to cwd-walk. rootsClient is never called.
+      expect(result).toBeDefined();
+      expect(result!.success).toBe(true);
+      expect(result!.source).toBe('cwd');
+      expect(result!.featureId).toBe('feat-cwdonly');
+      expect(fetchCount).toBe(0);
+
+      await fs.rm(stateDir, { recursive: true, force: true });
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// Suppress unused-import warning for `fileURLToPath` if linter rules trip;
+// retained for parity with future URI normalisation tests.
+void fileURLToPath;

--- a/servers/exarchos-mcp/src/workspace/discovery.ts
+++ b/servers/exarchos-mcp/src/workspace/discovery.ts
@@ -23,6 +23,10 @@
 import * as fs from 'node:fs/promises';
 import * as fsSync from 'node:fs';
 import * as path from 'node:path';
+
+import { logger } from '../logger.js';
+
+const discoveryLogger = logger.child({ subsystem: 'workspace-discovery' });
 import { fileURLToPath } from 'node:url';
 
 import type { CapabilityResolver } from '../capabilities/resolver.js';
@@ -196,8 +200,20 @@ async function emitResolved(
       type: 'workspace.resolved',
       data,
     });
-  } catch {
-    // Swallow — discovery is a read-side audit hook, not a write barrier.
+  } catch (err) {
+    // Discovery is a read-side audit hook, not a write barrier — never
+    // fail discovery on an emission error (idempotency conflicts on
+    // replay, transient backend hiccups, etc.). CodeRabbit MINOR #1423:
+    // surface via the workspace-discovery logger child so the missed
+    // audit trail is observable instead of silently swallowed.
+    discoveryLogger.warn(
+      {
+        featureId: data.featureId,
+        source: data.source,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      'workspace.resolved emission failed; discovery proceeded without audit trail',
+    );
   }
 }
 

--- a/servers/exarchos-mcp/src/workspace/discovery.ts
+++ b/servers/exarchos-mcp/src/workspace/discovery.ts
@@ -1,0 +1,287 @@
+// ─── #1290 — Roots-based workspace discovery ─────────────────────────────────
+//
+// Resolution priority for a missing `featureId` at the dispatch boundary:
+//
+//     explicit > roots > cwd
+//
+// The dispatch path (see `core/dispatch.ts`) only invokes
+// `resolveWorkspace` when the caller's payload omits `featureId`; an
+// explicitly-supplied id always wins. When the client has declared the
+// `roots` capability via `notifications/roots/list_changed`, the
+// resolver inspects each root for an Exarchos workspace signature
+// (`.exarchos.yml` or a state file under `docs/workflow-state/`). A
+// single match returns the resolution; multiple matches return an
+// `INVALID_INPUT` shape with `validTargets` so the caller can disambig-
+// uate; zero matches falls back to a cwd-walk.
+//
+// The roots list is cached on the supplied {@link CapabilityResolver}.
+// MCP clients emit `notifications/roots/list_changed` when the
+// workspace boundary mutates; the `mcp/notifications.ts` handler
+// calls `resolver.invalidateRootsCache()` so the next discovery call
+// re-fetches.
+
+import * as fs from 'node:fs/promises';
+import * as fsSync from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { CapabilityResolver } from '../capabilities/resolver.js';
+import type { EventStore } from '../event-store/store.js';
+
+// ─── Public types ───────────────────────────────────────────────────────────
+
+/**
+ * Minimal `roots/list` surface consumed by {@link resolveWorkspace}. The
+ * MCP SDK's full `RootsResult` carries more metadata; we accept only the
+ * `uri` field so callers can pass a thin adapter or a test fixture
+ * without dragging the SDK's type graph into discovery.
+ */
+export interface RootsClient {
+  list(): Promise<readonly { uri: string }[]>;
+}
+
+/**
+ * Discriminated-union return type for `resolveWorkspace`.
+ *
+ *   - `{success: true, source, featureId, path}` — single match (roots or cwd).
+ *   - `{success: false, code: 'INVALID_INPUT', validTargets}` — multi-match;
+ *     the caller must disambiguate by supplying an explicit `featureId`.
+ *
+ * Zero-match (no roots hit and no cwd hit) returns `undefined` from
+ * `resolveWorkspace` rather than a success+empty shape so the dispatch
+ * boundary can distinguish "discovery silently produced nothing" from
+ * "discovery found multiple candidates."
+ */
+export type WorkspaceResolution =
+  | {
+      readonly success: true;
+      readonly source: 'roots' | 'cwd';
+      readonly featureId: string;
+      readonly path: string;
+    }
+  | {
+      readonly success: false;
+      readonly code: 'INVALID_INPUT';
+      readonly validTargets: readonly { readonly featureId: string; readonly path: string }[];
+    };
+
+export interface ResolveWorkspaceOpts {
+  /** Optional explicit featureId. When provided, discovery short-circuits. */
+  readonly featureId?: string;
+  /** Capability resolver carrying the handshake-derived roots flag + cache. */
+  readonly resolver: CapabilityResolver;
+  /** Roots client adapter. Omitted callers force the cwd-walk branch. */
+  readonly rootsClient?: RootsClient;
+  /** Working directory for the cwd-walk fallback. */
+  readonly cwd: string;
+  /** Event store used to emit `workspace.resolved` on single-match. */
+  readonly eventStore: EventStore;
+}
+
+// ─── Pure detector ──────────────────────────────────────────────────────────
+
+/**
+ * Synchronous workspace detector. Returns `true` when `dir` carries an
+ * Exarchos workspace signature: either a `.exarchos.yml` file at the
+ * root, or at least one `<id>.state.json` under
+ * `docs/workflow-state/`. Exported so unit tests can pin the contract
+ * independently of `resolveWorkspace`'s integration surface.
+ */
+export function isExarchosWorkspace(dir: string): boolean {
+  // The detector is sync because discovery walks N roots in a tight
+  // loop and we don't want N promise round-trips per call. Errors are
+  // swallowed silently — a missing root or unreadable workflow-state
+  // dir is "not a workspace," not a hard failure.
+  try {
+    if (fsSync.existsSync(path.join(dir, '.exarchos.yml'))) return true;
+  } catch {
+    // fall through
+  }
+  try {
+    const wfDir = path.join(dir, 'docs', 'workflow-state');
+    if (!fsSync.existsSync(wfDir)) return false;
+    const entries = fsSync.readdirSync(wfDir);
+    return entries.some((e) => e.endsWith('.state.json'));
+  } catch {
+    return false;
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Convert a `file://` URI to an absolute filesystem path. Falls back to
+ * a literal interpretation when the URI is not a `file:` scheme — the
+ * caller is responsible for filtering out non-file roots ahead of
+ * detector dispatch.
+ */
+function uriToPath(uri: string): string | undefined {
+  try {
+    if (uri.startsWith('file://')) {
+      return fileURLToPath(uri);
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Find a `featureId` inside a known-good workspace directory. Picks the
+ * lexically-first `*.state.json` under `docs/workflow-state/` so the
+ * result is deterministic across calls. Returns `undefined` when the
+ * workspace has `.exarchos.yml` but no state files yet.
+ */
+async function deriveFeatureId(workspace: string): Promise<string | undefined> {
+  const wfDir = path.join(workspace, 'docs', 'workflow-state');
+  let entries: string[];
+  try {
+    entries = await fs.readdir(wfDir);
+  } catch {
+    return undefined;
+  }
+  const stateFiles = entries
+    .filter((e) => e.endsWith('.state.json'))
+    .sort();
+  if (stateFiles.length === 0) return undefined;
+  return stateFiles[0].replace(/\.state\.json$/, '');
+}
+
+/**
+ * Read-through cache: returns the cached roots list, or fetches via
+ * `rootsClient.list()` and stores the result on the resolver before
+ * returning. The cache is invalidated by the MCP notifications handler
+ * (`mcp/notifications.ts`) on `roots/list_changed`.
+ */
+async function getOrFetchRoots(
+  resolver: CapabilityResolver,
+  rootsClient: RootsClient,
+): Promise<readonly { uri: string }[]> {
+  const cached = resolver.getCachedRoots();
+  if (cached !== undefined) return cached;
+  const fetched = await rootsClient.list();
+  resolver.setCachedRoots(fetched);
+  return fetched;
+}
+
+/**
+ * Walk from `cwd` upward looking for an Exarchos workspace signature.
+ * Stops at the first hit (deepest wins) or when the parent equals the
+ * current directory (filesystem root). Returns `undefined` on miss.
+ */
+function cwdWalk(cwd: string): string | undefined {
+  let cur = path.resolve(cwd);
+  // Bound the walk so a pathological symlink loop or a /-mounted cwd
+  // doesn't spin. 64 iterations is far above the deepest realistic
+  // workspace nesting (basileus → exarchos has been our worst case
+  // and lives 3 levels deep).
+  for (let i = 0; i < 64; i++) {
+    if (isExarchosWorkspace(cur)) return cur;
+    const parent = path.dirname(cur);
+    if (parent === cur) return undefined;
+    cur = parent;
+  }
+  return undefined;
+}
+
+async function emitResolved(
+  eventStore: EventStore,
+  data: { source: 'roots' | 'cwd'; path: string; featureId: string },
+): Promise<void> {
+  // Emit best-effort: observability emission must never fail discovery.
+  // The handler logs through the event store's own error surface if the
+  // append fails for non-fatal reasons (idempotency conflict, etc.).
+  try {
+    await eventStore.append(data.featureId, {
+      type: 'workspace.resolved',
+      data,
+    });
+  } catch {
+    // Swallow — discovery is a read-side audit hook, not a write barrier.
+  }
+}
+
+// ─── Main entry point ───────────────────────────────────────────────────────
+
+/**
+ * Resolve a workspace + `featureId` for a dispatch payload that did not
+ * supply one. See module header for the priority chain and event
+ * emission semantics.
+ *
+ * Returns:
+ *   - `WorkspaceResolution & {success: true}` on single-match (roots or cwd).
+ *   - `WorkspaceResolution & {success: false}` on multi-match (multiple roots
+ *     contain workspaces). The dispatch boundary surfaces this as an
+ *     `INVALID_INPUT` envelope so the caller can disambiguate.
+ *   - `undefined` on full miss (no roots match, no cwd-walk hit). Callers
+ *     should fall through to the existing `INVALID_INPUT: featureId is
+ *     required` envelope.
+ */
+export async function resolveWorkspace(
+  opts: ResolveWorkspaceOpts,
+): Promise<WorkspaceResolution | undefined> {
+  const { resolver, rootsClient, cwd, eventStore } = opts;
+
+  // Explicit featureId short-circuits — the dispatch boundary should
+  // have filtered this case out before calling, but the guard keeps
+  // the contract symmetric for direct callers and avoids surprising
+  // event emissions when the caller already has authoritative state.
+  if (opts.featureId !== undefined && opts.featureId.length > 0) {
+    return undefined;
+  }
+
+  // Branch 1: Roots-based inference (only when the client declared roots
+  // AND we have a client adapter to fetch them through).
+  if (resolver.isRootsDeclared() && rootsClient !== undefined) {
+    const roots = await getOrFetchRoots(resolver, rootsClient);
+    const matches: { featureId: string; path: string }[] = [];
+
+    for (const root of roots) {
+      const rootPath = uriToPath(root.uri);
+      if (rootPath === undefined) continue;
+      if (!isExarchosWorkspace(rootPath)) continue;
+      const featureId = await deriveFeatureId(rootPath);
+      if (featureId === undefined) continue;
+      matches.push({ featureId, path: rootPath });
+    }
+
+    if (matches.length === 1) {
+      const m = matches[0];
+      await emitResolved(eventStore, {
+        source: 'roots',
+        path: m.path,
+        featureId: m.featureId,
+      });
+      return {
+        success: true,
+        source: 'roots',
+        featureId: m.featureId,
+        path: m.path,
+      };
+    }
+
+    if (matches.length > 1) {
+      return {
+        success: false,
+        code: 'INVALID_INPUT',
+        validTargets: matches.map((m) => ({ featureId: m.featureId, path: m.path })),
+      };
+    }
+    // Zero match in roots → fall through to cwd-walk.
+  }
+
+  // Branch 2: cwd-walk fallback. The walk is bounded; on miss we return
+  // undefined and let the caller surface the existing `featureId is
+  // required` envelope.
+  const cwdHit = cwdWalk(cwd);
+  if (cwdHit === undefined) return undefined;
+  const featureId = await deriveFeatureId(cwdHit);
+  if (featureId === undefined) return undefined;
+
+  await emitResolved(eventStore, {
+    source: 'cwd',
+    path: cwdHit,
+    featureId,
+  });
+  return { success: true, source: 'cwd', featureId, path: cwdHit };
+}

--- a/tests/outcome/roots-discovery-dispatch.test.ts
+++ b/tests/outcome/roots-discovery-dispatch.test.ts
@@ -1,0 +1,102 @@
+// ─── T08 (#1290) — Roots-based dispatch-boundary discovery (outcome) ────────
+//
+// End-to-end pin for the dispatch-boundary integration: a caller dispatches
+// `exarchos_workflow.get` with NO `featureId`, the client has declared the
+// MCP roots capability, and a single root contains an Exarchos workspace.
+// Dispatch resolves the featureId from the root before per-action schema
+// validation, so the call lands as if the caller had supplied it
+// explicitly — instead of returning the legacy `INVALID_INPUT: featureId
+// is required` envelope.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { EventStore } from '../../servers/exarchos-mcp/src/event-store/store.js';
+import { handleInit } from '../../servers/exarchos-mcp/src/workflow/tools.js';
+import { dispatch } from '../../servers/exarchos-mcp/src/core/dispatch.js';
+import { createInMemoryResolver } from '../../servers/exarchos-mcp/src/capabilities/resolver.js';
+import type { RootsClient } from '../../servers/exarchos-mcp/src/workspace/discovery.js';
+
+async function mktemp(label: string): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), `outcome-1290-${label}-`));
+}
+
+function fileUriFor(p: string): string {
+  return `file://${p}`;
+}
+
+describe('Roots-based dispatch boundary discovery (#1290)', () => {
+  it('Dispatch_MissingFeatureIdWithRootsCapability_ResolvesAutomatically', async () => {
+    const workspace = await mktemp('workspace');
+    const stateDir = path.join(workspace, 'docs', 'workflow-state');
+    await fs.mkdir(stateDir, { recursive: true });
+    // `.exarchos.yml` marks the workspace; the state file below carries
+    // the resolvable featureId.
+    await fs.writeFile(path.join(workspace, '.exarchos.yml'), '', 'utf8');
+
+    const featureId = 'outcome-1290-roots';
+    try {
+      // Initialize a real workflow so dispatch can succeed end-to-end.
+      const eventStore = new EventStore(stateDir);
+      await eventStore.initialize();
+      const initResult = await handleInit(
+        { featureId, workflowType: 'feature' },
+        stateDir,
+        eventStore,
+      );
+      expect(initResult.success).toBe(true);
+
+      // Build the dispatch context with a roots-declaring resolver and
+      // a single-root client adapter pointing at the workspace.
+      const resolver = createInMemoryResolver([]);
+      resolver.snapshot({ capabilities: { roots: { listChanged: true } } });
+
+      const rootsClient: RootsClient = {
+        async list() {
+          return [{ uri: fileUriFor(workspace) }];
+        },
+      };
+
+      // Dispatch with NO featureId in the args. The legacy contract
+      // produced INVALID_INPUT here; the new contract must resolve via
+      // roots and succeed.
+      const result = await dispatch(
+        'exarchos_workflow',
+        { action: 'get' },
+        {
+          stateDir,
+          eventStore,
+          enableTelemetry: false,
+          capabilityResolver: resolver,
+          rootsClient,
+          cwd: workspace,
+        },
+      );
+
+      // Either the call succeeds outright (workflow exists, get returns
+      // state), or it succeeds at the dispatch boundary and any further
+      // failure is unrelated to featureId resolution. The contract we
+      // pin here is: dispatch did NOT return `INVALID_INPUT: featureId
+      // is required`.
+      if (!result.success) {
+        const code = result.error?.code;
+        const msg = result.error?.message ?? '';
+        expect(code === 'INVALID_INPUT' && /featureId/i.test(msg)).toBe(false);
+      } else {
+        // Success path: handler observed the resolved featureId.
+        expect(result.success).toBe(true);
+      }
+
+      // `workspace.resolved` event landed on the resolved stream with
+      // source='roots' so audit queries can trace the inference.
+      const events = await eventStore.query(featureId);
+      const resolved = events.find((e) => e.type === 'workspace.resolved');
+      expect(resolved).toBeDefined();
+      expect((resolved!.data as { source?: string }).source).toBe('roots');
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Wave A PR 3 (stacks on A2). Closes #1290.

When `featureId` is omitted AND client declared `roots: { listChanged: true }` at handshake, calls `roots/list` (cached per-handshake, invalidated on `roots/list_changed`), scans each root for `.exarchos.yml` / `docs/workflow-state/*.state.json`. Emits `workspace.resolved` event. Resolution priority: `explicit > roots > cwd > INVALID_INPUT`.

## Changes
- `capabilities/resolver.ts` — `isRootsDeclared()` + tri-state roots cache.
- `workspace/discovery.ts` (new) — `resolveWorkspace()` with roots-aware discovery + event emission.
- `mcp/notifications.ts` (new) — `roots/list_changed` cache invalidation.
- `event-store/schemas.ts` — `workspace.resolved` event type.
- `core/dispatch.ts` — wire workspace discovery into dispatch boundary.
- Outcome test: `tests/outcome/roots-discovery-dispatch.test.ts`.

## Test Plan
- [x] Root typecheck + test:run clean
- [x] MCP-server scoped tests clean (10 new tests across resolver/discovery/notifications/outcome)
- [x] skills:guard clean

Part of [#1088](https://github.com/lvlup-sw/exarchos/issues/1088). Stacks on #1422 (A2).