### PR TITLE
feat(architecture): machine-readable invariants + vocabulary lint + /ideate first-turn surfacing (#1260)

### DIFF
--- a/commands/ideate.md
+++ b/commands/ideate.md
@@ -29,6 +29,12 @@ Follow the brainstorming skill: `@skills/brainstorming/SKILL.md`
 
 ## Process
 
+### Phase 0: Constraints (first turn)
+
+Before the clarifying questions, load the machine-readable invariants catalog at `docs/architecture/invariants.md` and surface a **Constraints** section naming the invariants and dimensions relevant to the proposal. For a CLI-shaped or agent-surface proposal, this typically includes `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), and `DIM-1` (topology). For an event-store or projection proposal, surface `INV-1` plus `DIM-1` / `DIM-3`. The brainstorming skill's "Constraint anchoring" subsection describes the selection rules.
+
+Emit the Constraints section *before* Phase 1 so the clarifying questions can probe the proposal against the load-bearing invariants instead of re-discovering them mid-design.
+
 ### Phase 1: Understanding
 Ask clarifying questions (one at a time):
 1. What problem are we solving?

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -1,0 +1,319 @@
+---
+title: Exarchos Architectural Invariants
+description: >
+  Machine-readable catalog of architectural invariants (INV-*) and axiom
+  dimensions (DIM-*) consumed by /ideate, the design-invariants skill,
+  and the vocabulary-lint scanner. Source of truth for the invariant
+  vocabulary in the Exarchos repo.
+schema-version: 1
+invariants:
+  - id: INV-1
+    dimension: event-sourcing-integrity
+    applies-to:
+      - event-store
+      - projections
+      - reducers
+      - workflow-state
+    summary: >
+      The append-only event log is the source of truth. Every read-model is a
+      left-fold; state mutations are events, not in-place updates. Reducers must
+      be pure, deterministic, and structurally share state. Stores that hold
+      derived state across calls must be projections over events, never
+      in-memory side databases.
+    references:
+      - .claude/skills/design-invariants/references/INV-1-event-sourcing.md
+      - .claude/skills/design-invariants/SKILL.md
+      - docs/architecture/projections.md
+
+  - id: INV-2
+    dimension: facade-equivalence
+    applies-to:
+      - cli-adapter
+      - mcp-adapter
+      - dispatch-core
+      - parity-tests
+    summary: >
+      CLI and MCP are both facades over a single functional dispatch core. For
+      any verb, the same DispatchContext + arguments must produce the same
+      ToolResult. Adapters carry zero behavior — only presentation. Post-#1266,
+      every action also registers a Zod outputSchema so parity is schema-checked
+      in addition to byte-checked.
+    references:
+      - .claude/skills/design-invariants/references/INV-2-facade-equivalence.md
+      - .claude/skills/design-invariants/SKILL.md
+      - docs/designs/2026-05-07-milestone-16-mcp-alignment.md
+
+  - id: INV-3
+    dimension: basileus-forward
+    applies-to:
+      - capabilities-resolver
+      - runtime-yaml
+      - mcp-transport
+      - sideband-daemon
+    summary: >
+      No design decision presumes MCP is local-only. Workflow and Ontology
+      channels have independent client lifecycles, handshake-authoritative
+      capability resolution, and .exarchos.yml-only configuration. Workspace
+      discovery prefers the MCP roots capability over cwd heuristics
+      (post-#1269).
+    references:
+      - .claude/skills/design-invariants/references/INV-3-basileus-forward.md
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: INV-4
+    dimension: platform-agnosticity
+    applies-to:
+      - skills-src
+      - runtimes
+      - skills-renderer
+      - commands
+    summary: >
+      Skills, rules, and workflows must not couple to any single harness. Six
+      runtimes are first-class (Claude Code, Codex, Copilot, Cursor, OpenCode,
+      generic). Runtime-specific text is tokenized via {{TOKEN}} placeholders or
+      guarded via <!-- requires:* --> blocks. Source-of-truth edits go to
+      skills-src/; skills/<runtime>/** is generated.
+    references:
+      - .claude/skills/design-invariants/references/INV-4-platform-agnosticity.md
+      - .claude/skills/design-invariants/SKILL.md
+      - skills-src/SKILL_AUTHORING.md
+
+  - id: INV-5a
+    dimension: input-ergonomics
+    applies-to:
+      - mcp-registry
+      - tool-schemas
+      - cli-flags
+    summary: >
+      Tool inputs are constrained at the schema level (enum, regex, format), not
+      via prose hints. Every tool description states when NOT to use the tool
+      with a pointer to the alternative. Visible tool count stays under 15.
+      Static reference content is exposed as MCP Resources, not tools.
+    references:
+      - .claude/skills/design-invariants/references/INV-5a-input-ergonomics.md
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: INV-5b
+    dimension: output-contract
+    applies-to:
+      - format.ts
+      - tool-results
+      - registered-output-schemas
+      - error-envelopes
+    summary: >
+      Every successful ToolResult carries machine-actionable affordance hints —
+      next_actions, _meta, _perf. Errors carry validTargets, expectedShape,
+      suggestedFix. Post-#1266, the carrier is structuredContent with a
+      registered outputSchema per action; long-running ops use Tasks (SEP-1686)
+      not NDJSON.
+    references:
+      - .claude/skills/design-invariants/references/INV-5b-output-contract.md
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: INV-5c
+    dimension: aspire-verbs
+    applies-to:
+      - cli-commands
+      - composite-tools
+      - process-lifecycle
+    summary: >
+      Exarchos CLI design borrows deliberately from Aspire — queryable,
+      dry-run-capable, JSON-explicit control-plane verbs. Agents query state;
+      they don't drive scripts. ps / describe / wait / export are observation
+      verbs; mutating verbs default to --dry-run.
+    references:
+      - .claude/skills/design-invariants/references/INV-5c-aspire-verbs.md
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: INV-5d
+    dimension: action-discriminator
+    applies-to:
+      - mcp-registry
+      - composite-tools
+      - tool-annotations
+    summary: >
+      Exarchos exposes 4 visible composite tools, each with an action
+      discriminator (exarchos_workflow, exarchos_event, exarchos_orchestrate,
+      exarchos_view). The visible tool count stays under 15; per-action
+      annotations (destructiveHint / readOnlyHint / idempotentHint /
+      openWorldHint) live on CompositeAction post-#1268.
+    references:
+      - .claude/skills/design-invariants/references/INV-5d-action-discriminator.md
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: INV-6
+    dimension: workflow-agnosticism
+    applies-to:
+      - skills-src
+      - playbooks
+      - skill-frontmatter
+    summary: >
+      Skills describe behaviors; playbooks describe workflows. A behavior-skill
+      describes triggers in workflow-neutral terms (verb names, idempotency
+      keys), not workflow stages or branch prefixes. Workflow-specific skills
+      must declare metadata.workflow-type: <type> in frontmatter.
+    references:
+      - .claude/skills/design-invariants/references/INV-6-workflow-agnosticism.md
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-1
+    dimension: topology
+    applies-to:
+      - module-boundaries
+      - dependency-direction
+      - state-ownership
+    summary: >
+      Topology dimension from axiom — module boundaries, layering, dependency
+      direction, ambient/shared-mutable state. Adapter-local mutable caches,
+      lazy fallback singletons, and side databases are topology smells that
+      frequently overlap with INV-1 / INV-2 violations.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-2
+    dimension: observability
+    applies-to:
+      - logging
+      - telemetry
+      - error-paths
+    summary: >
+      Observability dimension from axiom — silent catches, missing log context,
+      degradation paths that swallow signals. Frequently overlaps INV-1 when a
+      reducer apply catches and continues instead of triggering the
+      reducer-throw degradation path.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-3
+    dimension: contracts
+    applies-to:
+      - schemas
+      - event-types
+      - tool-output
+    summary: >
+      Contracts dimension from axiom — schema-runtime drift, type-assertion
+      safety, breaking field renames without versioning. Overlaps INV-1 when an
+      event field is removed but still read, and INV-5b when output shape
+      changes without an envelope version bump.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-4
+    dimension: test-fidelity
+    applies-to:
+      - test-suites
+      - mocks
+      - fixtures
+    summary: >
+      Test-fidelity dimension from axiom — mock overuse, fixture drift, tests
+      that pass against fakes but would fail in production. The TDD-task and
+      static-analysis gates compose with this dimension to catch
+      blast-radius regressions.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-5
+    dimension: vestigial-code
+    applies-to:
+      - dead-paths
+      - unused-exports
+      - legacy-flags
+    summary: >
+      Vestigial-code dimension from axiom — dead code, unused exports, legacy
+      feature flags that no longer gate behavior. Cleanup work that intersects
+      INV-2 (legacy adapter paths) or INV-5d (legacy top-level tools that
+      should collapse into composite actions).
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-6
+    dimension: solid-coupling
+    applies-to:
+      - module-design
+      - inheritance
+      - composition
+    summary: >
+      SOLID / coupling dimension from axiom — generic dependency direction,
+      single-responsibility violations, inheritance vs composition mismatches.
+      Axiom-owned; design-invariants defers here for generic SOLID findings.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-7
+    dimension: error-handling
+    applies-to:
+      - error-paths
+      - retry-logic
+      - degradation
+    summary: >
+      Error-handling dimension from axiom — silent fallbacks, retry storms,
+      degradation without telemetry. Often co-occurs with DIM-2 observability;
+      design-invariants intersects when a fallback creates a degraded EventStore
+      (INV-1) or hides parity divergence (INV-2).
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: DIM-8
+    dimension: ai-prose-tells
+    applies-to:
+      - documentation
+      - skill-bodies
+      - command-text
+    summary: >
+      AI-prose-tells dimension from axiom — telltale AI-generated prose
+      patterns (em-dashes that flatten clauses, padding adjectives, hedge
+      phrases). Owned by axiom:humanize; design-invariants does not duplicate
+      the check.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+
+  - id: basileus-boundary
+    dimension: cross-product-coordination
+    applies-to:
+      - basileus-exarchos-coordination
+      - ontology-mcp-server
+      - cross-tier-mediation
+    summary: >
+      Boundary discipline between Exarchos and Basileus. AgentHost ↔ Sandbox
+      calls must route through ControlPlane (Basileus INV-1). Cross-product
+      coordination uses the Ontology MCP Server (intent_register) rather than
+      bespoke RPC. Strategos.Contracts via TypeSpec governs schema.
+    references:
+      - .claude/skills/design-invariants/SKILL.md
+      - basileus/docs/adrs/2026-04-18-exarchos-basileus-coordination.md
+---
+
+# Exarchos Architectural Invariants
+
+Machine-readable catalog of the architectural invariants that govern Exarchos design and review. The YAML frontmatter above is the **source of truth** for tooling — the `/ideate` command, the `design-invariants` skill, and the `vocabulary-lint` scanner all consume the same shape.
+
+This file pairs with the prose reference content under [`.claude/skills/design-invariants/references/`](../../.claude/skills/design-invariants/references/). The frontmatter `summary` field is the short version; the linked reference files carry the full prose, severity guides, worked examples, and external grounding.
+
+## Schema
+
+Each entry in `invariants:` carries:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `id` | string | Stable identifier — `INV-1`..`INV-6`, sub-disciplines like `INV-5a`, axiom dimensions like `DIM-1`, plus cross-product entries (`basileus-boundary`). |
+| `dimension` | string | Short human-readable category name. |
+| `applies-to` | string[] | Surface areas (modules, file globs, capability domains) where the invariant is load-bearing. |
+| `summary` | string | One-to-two-sentence statement of the invariant. |
+| `references` | string[] | Pointers to source files where the invariant is detailed in prose. |
+
+## Vocabulary
+
+The vocabulary-lint scanner (`servers/exarchos-mcp/src/architecture/vocabulary-lint.ts`, exposed via `npm run lint:invariants`) walks `docs/`, `skills-src/`, and `commands/` for tokens matching `/\b(INV-\d+[a-d]?|DIM-\d+)\b/` and cross-checks against the IDs declared here. Unknown references surface as findings; the lint is advisory in initial rollout.
+
+## Consumers
+
+- `/exarchos:ideate` — surfaces relevant invariants as Constraints during Phase 1, before the clarifying questions.
+- `design-invariants` skill — audits design proposals against INV-1..INV-6.
+- `vocabulary-lint` — flags references to invariant IDs not registered here.
+- Future: `#1275` MCP Resources — expose this catalog as `resources/exarchos-invariants` once Resources land.
+
+## See also
+
+- [`docs/architecture/projections.md`](projections.md) — projection layer specifics.
+- [`docs/architecture/runtime.md`](runtime.md) — runtime / capability resolution.
+- [`.claude/skills/design-invariants/SKILL.md`](../../.claude/skills/design-invariants/SKILL.md) — operational skill that consumes this catalog.

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -303,11 +303,11 @@ Each entry in `invariants:` carries:
 
 ## Vocabulary
 
-The vocabulary-lint scanner (`servers/exarchos-mcp/src/architecture/vocabulary-lint.ts`, exposed via `npm run lint:invariants`) walks `docs/`, `skills-src/`, and `commands/` for tokens matching `/\b(INV-\d+[a-d]?|DIM-\d+)\b/` and cross-checks against the IDs declared here. Unknown references surface as findings; the lint is advisory in initial rollout.
+The vocabulary-lint scanner (`servers/exarchos-mcp/src/architecture/vocabulary-lint.ts`, exposed via `npm run lint:invariants`) walks `docs/`, `skills-src/`, and `commands/` for tokens matching `/\b(INV-\d+[a-d]?|DIM-\d+)\b/` and cross-checks against the IDs declared here. Unknown references surface as findings; the vocabulary lint is enforcing (exits non-zero on findings).
 
 ## Consumers
 
-- `/exarchos:ideate` — surfaces relevant invariants as Constraints during Phase 1, before the clarifying questions.
+- `/exarchos:ideate` — surfaces relevant invariants as Constraints during Phase 0 (before Phase 1), before the clarifying questions.
 - `design-invariants` skill — audits design proposals against INV-1..INV-6.
 - `vocabulary-lint` — flags references to invariant IDs not registered here.
 - Future: `#1275` MCP Resources — expose this catalog as `resources/exarchos-invariants` once Resources land.

--- a/docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml
+++ b/docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml
@@ -1,0 +1,56 @@
+# Sidecar for docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.md
+# Conforms to DesignSidecarV1 (servers/exarchos-mcp/src/orchestrate/sidecar-schemas.ts).
+# Backfilled per #1298 / T16.
+
+schema: design.v1
+
+sections:
+  problem: { present: true }
+  scope-and-grouping: { present: true }
+  wave-a-output-contract-completion: { present: true }
+  wave-b-correlation-event-topology: { present: true }
+  wave-c-tasks-dispatch-core: { present: true }
+  wave-d-authoring-substrate: { present: true }
+  sequencing: { present: true }
+  conformance-design-invariants: { present: true }
+  conformance-axiom-dimensions: { present: true }
+  risks-and-mitigations: { present: true }
+  acceptance-criteria: { present: true }
+  out-of-scope: { present: true }
+  references: { present: true }
+
+# Each issue in the bundle is modeled as a Design Requirement (DR). The
+# `id` is the literal GitHub issue number prefixed with `DR-` so DR ids
+# remain stable across the milestone.
+drs:
+  - { id: DR-1238, title: 'next_actions Zod discriminated unions', section: 'Wave A — Output Contract Completion' }
+  - { id: DR-1262, title: 'output-token quality hint via next_actions', section: 'Wave A — Output Contract Completion' }
+  - { id: DR-1290, title: 'Roots-based workspace discovery', section: 'Wave A — Output Contract Completion' }
+  - { id: DR-1274, title: 'Elicitation form mode for INVALID_INPUT', section: 'Wave A — Output Contract Completion' }
+  - { id: DR-1291, title: 'three-field correlation (operationId + correlationId + causationId)', section: 'Wave B — Correlation + Event Topology' }
+  - { id: DR-1261, title: 'dispatch.preflight + stash.detected events', section: 'Wave B — Correlation + Event Topology' }
+  - { id: DR-1272, title: 'EventSourcedTaskStore (TaskStore as projection)', section: 'Wave B — Correlation + Event Topology' }
+  - { id: DR-1273, title: 'Tasks (SEP-1686) dispatch-core integration', section: 'Wave C — Tasks Dispatch-Core' }
+  - { id: DR-1260, title: 'machine-readable invariants consumed by /ideate', section: 'Wave D — Authoring Substrate' }
+  - { id: DR-1298, title: 'designs/plans machine-readable sidecar', section: 'Wave D — Authoring Substrate' }
+  - { id: DR-1244, title: 'markdown-aware handoff lint at handleCheckpoint', section: 'Wave D — Authoring Substrate' }
+
+acceptance:
+  - { id: A-1238, references: [DR-1238] }
+  - { id: A-1262, references: [DR-1262] }
+  - { id: A-1290, references: [DR-1290] }
+  - { id: A-1274, references: [DR-1274] }
+  - { id: A-1291, references: [DR-1291] }
+  - { id: A-1261, references: [DR-1261] }
+  - { id: A-1272, references: [DR-1272] }
+  - { id: A-1273, references: [DR-1273] }
+  - { id: A-1260, references: [DR-1260] }
+  - { id: A-1298, references: [DR-1298] }
+  - { id: A-1244, references: [DR-1244] }
+  # Cross-cutting all-PR gates per the design's "All 11 PRs" acceptance block.
+  - { id: A-ALL-TYPECHECK, references: [DR-1238, DR-1262, DR-1290, DR-1274, DR-1291, DR-1261, DR-1272, DR-1273, DR-1260, DR-1298, DR-1244] }
+
+options:
+  # The design's "Scope and grouping" table evaluates 4 cohesive waves +
+  # 4 alternatives table per wave. Surface only the wave-count here.
+  count: 4

--- a/docs/plans/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml
+++ b/docs/plans/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml
@@ -1,0 +1,235 @@
+# Sidecar for docs/plans/2026-05-15-v2-10-0-preview-4-feature-freeze.md
+# Conforms to PlanSidecarV1 (servers/exarchos-mcp/src/orchestrate/sidecar-schemas.ts).
+# Backfilled per #1298 / T16. Mirrors the 36-task RED/GREEN/REFACTOR map.
+
+schema: plan.v1
+
+tasks:
+  # ─── Wave A · PR A1 — #1238 next_actions Zod discriminated unions ──────────
+  - id: T01
+    phase: RED
+    description: Author failing tests for ShapeOne, ShapeTwo, and ResultDataSchema discriminated union
+    files: [servers/exarchos-mcp/src/next-actions-from-result.test.ts]
+  - id: T02
+    phase: GREEN
+    description: Replace Record casts with safeParse against ResultDataSchema; fail-closed
+    files: [servers/exarchos-mcp/src/next-actions-from-result.ts]
+
+  # ─── Wave A · PR A2 — #1262 output-token quality hint ──────────────────────
+  - id: T03
+    phase: RED
+    description: Register `output_tokens_high` quality-hint type in the catalog
+    files: [servers/exarchos-mcp/src/telemetry/quality-hints.test.ts]
+  - id: T04
+    phase: GREEN
+    description: Threshold-crossing detection in telemetry projection emits hint via next_actions
+    files: [servers/exarchos-mcp/src/telemetry/telemetry-projection.test.ts, servers/exarchos-mcp/src/telemetry/telemetry-projection.ts]
+  - id: T05
+    phase: REFACTOR
+    description: Wire configurable threshold via CapabilityResolver and verify CLI/MCP envelope parity
+    files: [servers/exarchos-mcp/src/cli/envelope-parity.test.ts]
+
+  # ─── Wave A · PR A3 — #1290 Roots-based workspace discovery ────────────────
+  - id: T06
+    phase: RED
+    description: CapabilityResolver snapshots client.capabilities.roots at handshake
+    files: [servers/exarchos-mcp/src/capability/capability-resolver.test.ts, servers/exarchos-mcp/src/capability/capability-resolver.ts]
+  - id: T07
+    phase: GREEN
+    description: Roots-based inference with cache + signature scan + multi-match validTargets
+    files: [servers/exarchos-mcp/src/workspace/discovery.test.ts, servers/exarchos-mcp/src/workspace/discovery.ts, servers/exarchos-mcp/src/mcp/notifications.ts]
+  - id: T08
+    phase: REFACTOR
+    description: Wire discovery.resolveWorkspace into dispatch when featureId omitted
+    files: [tests/outcome/roots-discovery-dispatch.test.ts]
+
+  # ─── Wave A · PR A4 — #1274 Elicitation form mode ──────────────────────────
+  - id: T09
+    phase: RED
+    description: Derive elicitation sub-schema via .pick(); resolver snapshots capability
+    files: [servers/exarchos-mcp/src/capability/elicitation.test.ts, servers/exarchos-mcp/src/capability/elicitation.ts]
+  - id: T10
+    phase: GREEN
+    description: Dispatch missing-required-param sends elicitation/create + emits events with operationId
+    files: [servers/exarchos-mcp/src/dispatch/elicitation-dispatch.test.ts, servers/exarchos-mcp/src/dispatch/index.ts, servers/exarchos-mcp/src/event-store/schemas.ts]
+
+  # ─── Wave D · PR D1 — #1260 invariants doc ─────────────────────────────────
+  - id: T11
+    phase: RED
+    description: Loader parses invariants frontmatter into typed records
+    files: [servers/exarchos-mcp/src/architecture/invariants-loader.test.ts, servers/exarchos-mcp/src/architecture/invariants-loader.ts, docs/architecture/invariants.md]
+  - id: T12
+    phase: GREEN
+    description: Vocabulary lint scans markdown for unknown INV-N references
+    files: [servers/exarchos-mcp/src/architecture/vocabulary-lint.test.ts, servers/exarchos-mcp/src/architecture/vocabulary-lint.ts]
+  - id: T13
+    phase: REFACTOR
+    description: /ideate command + brainstorming skill surface invariants on first turn
+    files: [commands/ideate.md, skills-src/brainstorming/SKILL.md]
+
+  # ─── Wave D · PR D2 — #1298 designs/plans sidecar (this PR) ────────────────
+  - id: T14
+    phase: RED
+    description: Sidecar schemas (design.v1, plan.v1) with literal version + RED/GREEN/REFACTOR enum
+    files: [servers/exarchos-mcp/src/orchestrate/sidecar-schemas.test.ts, servers/exarchos-mcp/src/orchestrate/sidecar-schemas.ts]
+  - id: T15
+    phase: GREEN
+    description: Four authoring gates consume sidecar; regex fallback emits deprecation warning
+    files:
+      - servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
+      - servers/exarchos-mcp/src/orchestrate/sidecar-lookup.ts
+      - servers/exarchos-mcp/src/orchestrate/design-completeness.ts
+      - servers/exarchos-mcp/src/orchestrate/plan-coverage.ts
+      - servers/exarchos-mcp/src/orchestrate/provenance-chain.ts
+      - servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+  - id: T16
+    phase: GREEN
+    description: Backfill sidecar yml for the preview.4 design and plan
+    files:
+      - docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml
+      - docs/plans/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml
+
+  # ─── Wave D · PR D3 — #1244 handoff lint ───────────────────────────────────
+  - id: T17
+    phase: GREEN
+    description: handleCheckpoint runs prose lint on handoff fields with soft/hard-fail config
+    files: [servers/exarchos-mcp/src/workflow/checkpoint-handler.test.ts, servers/exarchos-mcp/src/workflow/checkpoint-handler.ts]
+
+  # ─── Wave B · PR B1 — #1291 three-field correlation ────────────────────────
+  - id: T18
+    phase: RED
+    description: DispatchContext mints operationId/correlationId/causationId at dispatch entry
+    files: [servers/exarchos-mcp/src/dispatch/dispatch-context.test.ts, servers/exarchos-mcp/src/dispatch/dispatch-context.ts]
+  - id: T19
+    phase: GREEN
+    description: Thread DispatchContext through every event emit site; widen EventBase _meta
+    files: [servers/exarchos-mcp/src/dispatch/composer.ts, servers/exarchos-mcp/src/event-store/append.ts]
+  - id: T20
+    phase: GREEN
+    description: Register three-field _meta extension on action outputSchemas
+    files: [servers/exarchos-mcp/src/mcp/output-schema-meta.test.ts, servers/exarchos-mcp/src/mcp/output-schema-base.ts]
+  - id: T21
+    phase: REFACTOR
+    description: Full-suite blast-radius sweep; widen tests that asserted absence of new fields
+    files: [tests/outcome/correlation-threading.test.ts]
+
+  # ─── Wave B · PR B2 — #1261 dispatch.preflight + stash.detected ────────────
+  - id: T22
+    phase: RED
+    description: Event schemas for dispatch.preflight (per-guard outcome) and stash.detected
+    files: [servers/exarchos-mcp/src/event-store/schemas.test.ts, servers/exarchos-mcp/src/event-store/schemas.ts]
+  - id: T23
+    phase: GREEN
+    description: dispatch-guard emits preflight per guard; stash-detection probe emits stash.detected
+    files: [servers/exarchos-mcp/src/dispatch/dispatch-guard.test.ts, servers/exarchos-mcp/src/dispatch/dispatch-guard.ts]
+
+  # ─── Wave B · PR B3 — #1272 EventSourcedTaskStore ──────────────────────────
+  - id: T24
+    phase: RED
+    description: task.* event schemas (created, polled, result, cancelled) carry three-field _meta
+    files: [servers/exarchos-mcp/src/event-store/task-events.test.ts, servers/exarchos-mcp/src/event-store/task-events.ts]
+  - id: T25
+    phase: GREEN
+    description: EventSourcedTaskStore implements SDK TaskStore via projection over task events
+    files: [servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts, servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts]
+  - id: T26
+    phase: GREEN
+    description: TTL-bounded projection expires tasks past expiresAt on next read
+    files: [servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts]
+  - id: T27
+    phase: REFACTOR
+    description: Remove InMemoryTaskStore from production wiring; keep only in test fixtures
+    files: [servers/exarchos-mcp/src/composition/index.ts]
+
+  # ─── Wave C · PR C1 — Dispatch-core Tasks-augmented path ───────────────────
+  - id: T28
+    phase: RED
+    description: Dispatch core branches one-shot vs Tasks-augmented based on options.task
+    files: [servers/exarchos-mcp/src/dispatch/dispatch-core.test.ts, servers/exarchos-mcp/src/dispatch/dispatch-core.ts]
+  - id: T29
+    phase: GREEN
+    description: Task lifecycle event emission from dispatch core (created/polled/result)
+    files: [tests/outcome/tasks-dispatch-lifecycle.test.ts]
+
+  # ─── Wave C · PR C2 — MCP adapter tasks/* methods ──────────────────────────
+  - id: T30
+    phase: RED
+    description: tools/call accepts task augmentation and returns CreateTaskResult shape
+    files: [servers/exarchos-mcp/src/mcp/tools-call-handler.test.ts, servers/exarchos-mcp/src/mcp/tools-call-handler.ts]
+  - id: T31
+    phase: GREEN
+    description: MCP methods tasks/get, tasks/result, tasks/cancel route through dispatch-core
+    files: [servers/exarchos-mcp/src/mcp/tasks-methods.test.ts, servers/exarchos-mcp/src/mcp/tasks-methods.ts]
+  - id: T32
+    phase: REFACTOR
+    description: taskSupport optional capability gating; fall back to one-shot for non-Task clients
+    files: [servers/exarchos-mcp/src/capability/task-support.test.ts, servers/exarchos-mcp/src/capability/task-support.ts]
+
+  # ─── Wave C · PR C3 — CLI --follow integration ─────────────────────────────
+  - id: T33
+    phase: RED
+    description: --follow polling loop renders task transitions to stdout
+    files: [servers/exarchos-mcp/src/cli/follow-loop.test.ts, servers/exarchos-mcp/src/cli/follow-loop.ts]
+  - id: T34
+    phase: GREEN
+    description: SIGINT during --follow cancels via task.cancelled with operationId parity
+    files: [servers/exarchos-mcp/src/cli/follow-loop.ts]
+
+  # ─── Cross-cutting — version bump + outcome sweep ──────────────────────────
+  - id: T35
+    phase: GREEN
+    description: Bump version to 2.10.0-preview.4; refresh lockfile; add CHANGELOG entry
+    files: [package.json, servers/exarchos-mcp/package.json, CHANGELOG.md]
+  - id: T36
+    phase: REFACTOR
+    description: Full outcome-tier sweep on main; address any cross-wave regression
+    files: [tests/outcome]
+
+coverage:
+  DR-1238: [T01, T02]
+  DR-1262: [T03, T04, T05]
+  DR-1290: [T06, T07, T08]
+  DR-1274: [T09, T10]
+  DR-1260: [T11, T12, T13]
+  DR-1298: [T14, T15, T16]
+  DR-1244: [T17]
+  DR-1291: [T18, T19, T20, T21]
+  DR-1261: [T22, T23]
+  DR-1272: [T24, T25, T26, T27]
+  DR-1273: [T28, T29, T30, T31, T32, T33, T34]
+
+provenance:
+  - { taskId: T01, dr: DR-1238 }
+  - { taskId: T02, dr: DR-1238 }
+  - { taskId: T03, dr: DR-1262 }
+  - { taskId: T04, dr: DR-1262 }
+  - { taskId: T05, dr: DR-1262 }
+  - { taskId: T06, dr: DR-1290 }
+  - { taskId: T07, dr: DR-1290 }
+  - { taskId: T08, dr: DR-1290 }
+  - { taskId: T09, dr: DR-1274 }
+  - { taskId: T10, dr: DR-1274 }
+  - { taskId: T11, dr: DR-1260 }
+  - { taskId: T12, dr: DR-1260 }
+  - { taskId: T13, dr: DR-1260 }
+  - { taskId: T14, dr: DR-1298 }
+  - { taskId: T15, dr: DR-1298 }
+  - { taskId: T16, dr: DR-1298 }
+  - { taskId: T17, dr: DR-1244 }
+  - { taskId: T18, dr: DR-1291 }
+  - { taskId: T19, dr: DR-1291 }
+  - { taskId: T20, dr: DR-1291 }
+  - { taskId: T21, dr: DR-1291 }
+  - { taskId: T22, dr: DR-1261 }
+  - { taskId: T23, dr: DR-1261 }
+  - { taskId: T24, dr: DR-1272 }
+  - { taskId: T25, dr: DR-1272 }
+  - { taskId: T26, dr: DR-1272 }
+  - { taskId: T27, dr: DR-1272 }
+  - { taskId: T28, dr: DR-1273 }
+  - { taskId: T29, dr: DR-1273 }
+  - { taskId: T30, dr: DR-1273 }
+  - { taskId: T31, dr: DR-1273 }
+  - { taskId: T32, dr: DR-1273 }
+  - { taskId: T33, dr: DR-1273 }
+  - { taskId: T34, dr: DR-1273 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "generate:agents": "tsx servers/exarchos-mcp/src/agents/generate-agents.ts",
     "build:skills": "npm run generate:agents && node dist/build-skills.js",
     "lint:inv6": "node scripts/lint-inv6.mjs skills-src/",
+    "lint:invariants": "tsx servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts",
     "skills:guard": "node dist/skills-guard.js && (npm run lint:inv6 || true)",
     "prepare": "tsc",
     "bench": "cd servers/exarchos-mcp && npx vitest bench",

--- a/servers/exarchos-mcp/package-lock.json
+++ b/servers/exarchos-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lvlup-sw/exarchos-mcp",
-  "version": "2.10.0-preview.2",
+  "version": "2.10.0-preview.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lvlup-sw/exarchos-mcp",
-      "version": "2.10.0-preview.2",
+      "version": "2.10.0-preview.3",
       "hasInstallScript": true,
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { loadInvariants, type InvariantEntry } from './invariants-loader.js';
 
@@ -75,5 +77,40 @@ describe('invariants-loader', () => {
     // INV-5a references should point at the design-invariants skill reference file.
     const hasInv5aRef = inv5a!.references.some((r) => r.includes('INV-5a'));
     expect(hasInv5aRef).toBe(true);
+  });
+
+  it('InvariantsLoader_DuplicateIds_ThrowsWithIdInMessage', () => {
+    // Construct a frontmatter fixture with two entries sharing the same id
+    // (`INV-1`). The loader must reject this at load time so a silent
+    // duplicate cannot shadow the legitimate entry.
+    const fixture = `---
+invariants:
+  - id: INV-1
+    dimension: event-sourcing integrity
+    applies-to:
+      - servers/exarchos-mcp/src/event-store
+    summary: First copy of INV-1.
+    references:
+      - docs/architecture/invariants.md
+  - id: INV-1
+    dimension: duplicate
+    applies-to:
+      - servers/exarchos-mcp/src/event-store
+    summary: Second copy of INV-1 — should be rejected.
+    references:
+      - docs/architecture/invariants.md
+---
+
+# Fixture
+`;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'invariants-dup-'));
+    const tmpFile = path.join(tmpDir, 'invariants.md');
+    fs.writeFileSync(tmpFile, fixture, 'utf8');
+    try {
+      expect(() => loadInvariants(tmpFile)).toThrow(/INV-1/);
+      expect(() => loadInvariants(tmpFile)).toThrow(/Duplicate invariant ID/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { loadInvariants, type InvariantEntry } from './invariants-loader.js';
+
+/**
+ * Repo root resolution: invariants-loader.test.ts lives at
+ *   servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
+ * Repo root is four directories up from this file.
+ */
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const INVARIANTS_DOC = path.join(REPO_ROOT, 'docs/architecture/invariants.md');
+
+const REQUIRED_INVARIANT_IDS = [
+  'INV-1',
+  'INV-2',
+  'INV-3',
+  'INV-4',
+  'INV-5a',
+  'INV-5b',
+  'INV-5c',
+  'INV-5d',
+  'INV-6',
+] as const;
+
+const REQUIRED_DIMENSION_IDS = [
+  'DIM-1',
+  'DIM-2',
+  'DIM-3',
+  'DIM-4',
+  'DIM-5',
+  'DIM-6',
+  'DIM-7',
+  'DIM-8',
+] as const;
+
+describe('invariants-loader', () => {
+  it('Invariants_StructuredFrontmatter_ParsesAllRequiredFields', () => {
+    const entries = loadInvariants(INVARIANTS_DOC);
+    expect(entries.length).toBeGreaterThan(0);
+
+    const ids = entries.map((e) => e.id);
+
+    // All required INV-* and DIM-* must be present.
+    for (const id of REQUIRED_INVARIANT_IDS) {
+      expect(ids).toContain(id);
+    }
+    for (const id of REQUIRED_DIMENSION_IDS) {
+      expect(ids).toContain(id);
+    }
+
+    // Basileus boundary entry must be present.
+    expect(ids).toContain('basileus-boundary');
+
+    // Each entry must carry the required fields.
+    for (const entry of entries) {
+      expect(typeof entry.id).toBe('string');
+      expect(entry.id.length).toBeGreaterThan(0);
+      expect(typeof entry.dimension).toBe('string');
+      expect(Array.isArray(entry.appliesTo)).toBe(true);
+      expect(entry.appliesTo.length).toBeGreaterThan(0);
+      expect(typeof entry.summary).toBe('string');
+      expect(entry.summary.length).toBeGreaterThan(0);
+      expect(Array.isArray(entry.references)).toBe(true);
+      expect(entry.references.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('Invariants_TypedEntries_HaveStableShape', () => {
+    const entries = loadInvariants(INVARIANTS_DOC);
+    const inv5a = entries.find((e: InvariantEntry) => e.id === 'INV-5a');
+    expect(inv5a).toBeDefined();
+    expect(inv5a!.dimension.toLowerCase()).toContain('input');
+    // INV-5a references should point at the design-invariants skill reference file.
+    const hasInv5aRef = inv5a!.references.some((r) => r.includes('INV-5a'));
+    expect(hasInv5aRef).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.ts
@@ -1,0 +1,110 @@
+/**
+ * Loader for the machine-readable invariants catalog at
+ * `docs/architecture/invariants.md` (issue #1260).
+ *
+ * The frontmatter is the source of truth; this module parses it into a typed
+ * `InvariantEntry[]` for consumption by `/ideate` first-turn surfacing, the
+ * vocabulary-lint scanner, and the design-invariants skill.
+ *
+ * Implementation note: we use `gray-matter` (already a devDependency of the
+ * MCP server) which sits on top of `js-yaml`. The loader is intentionally
+ * tolerant — unknown fields are preserved on `raw` but typed accessors map
+ * the documented shape.
+ */
+import fs from 'node:fs';
+import matter from 'gray-matter';
+
+export interface InvariantEntry {
+  /** Stable identifier — e.g. "INV-1", "INV-5a", "DIM-1", "basileus-boundary". */
+  id: string;
+  /** Short human-readable category name. */
+  dimension: string;
+  /** Surface areas (modules, file globs, capability domains) the invariant covers. */
+  appliesTo: string[];
+  /** One-to-two-sentence statement of the invariant. */
+  summary: string;
+  /** Pointers to source files where the invariant is detailed in prose. */
+  references: string[];
+  /** The raw parsed entry for fields not yet promoted to the typed shape. */
+  raw: Record<string, unknown>;
+}
+
+interface RawInvariantEntry {
+  id?: unknown;
+  dimension?: unknown;
+  'applies-to'?: unknown;
+  summary?: unknown;
+  references?: unknown;
+  [key: string]: unknown;
+}
+
+interface RawFrontmatter {
+  invariants?: unknown;
+  [key: string]: unknown;
+}
+
+function asStringArray(value: unknown, field: string, id: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(
+      `invariants-loader: entry "${id}" field "${field}" must be an array, got ${typeof value}`,
+    );
+  }
+  return value.map((v, i) => {
+    if (typeof v !== 'string') {
+      throw new Error(
+        `invariants-loader: entry "${id}" field "${field}"[${i}] must be a string`,
+      );
+    }
+    return v;
+  });
+}
+
+function asString(value: unknown, field: string, id: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(
+      `invariants-loader: entry "${id}" field "${field}" must be a string, got ${typeof value}`,
+    );
+  }
+  // Collapse YAML folded-scalar whitespace so consumers get clean prose.
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function parseEntry(raw: RawInvariantEntry): InvariantEntry {
+  if (typeof raw.id !== 'string' || raw.id.length === 0) {
+    throw new Error('invariants-loader: entry is missing required field "id"');
+  }
+  const id = raw.id;
+  return {
+    id,
+    dimension: asString(raw.dimension, 'dimension', id),
+    appliesTo: asStringArray(raw['applies-to'], 'applies-to', id),
+    summary: asString(raw.summary, 'summary', id),
+    references: asStringArray(raw.references, 'references', id),
+    raw: { ...raw },
+  };
+}
+
+/**
+ * Load and parse the invariants catalog from the given Markdown file.
+ *
+ * @param filePath Absolute path to `docs/architecture/invariants.md`.
+ */
+export function loadInvariants(filePath: string): InvariantEntry[] {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const parsed = matter(source);
+  const data = parsed.data as RawFrontmatter;
+  if (!Array.isArray(data.invariants)) {
+    throw new Error(
+      `invariants-loader: ${filePath} frontmatter must declare an "invariants:" array`,
+    );
+  }
+  return (data.invariants as RawInvariantEntry[]).map(parseEntry);
+}
+
+/**
+ * Convenience: return the set of valid invariant IDs (for vocabulary-lint
+ * cross-check).
+ */
+export function loadInvariantIds(filePath: string): Set<string> {
+  return new Set(loadInvariants(filePath).map((e) => e.id));
+}

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.ts
@@ -98,7 +98,18 @@ export function loadInvariants(filePath: string): InvariantEntry[] {
       `invariants-loader: ${filePath} frontmatter must declare an "invariants:" array`,
     );
   }
-  return (data.invariants as RawInvariantEntry[]).map(parseEntry);
+  const entries = (data.invariants as RawInvariantEntry[]).map(parseEntry);
+  // Reject duplicate IDs at load time — IDs are the catalog's primary key and
+  // must be unique. A silent duplicate would shadow the earlier entry and
+  // corrupt vocabulary-lint / ideate Constraint surfacing.
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (seen.has(entry.id)) {
+      throw new Error(`Duplicate invariant ID: ${entry.id}`);
+    }
+    seen.add(entry.id);
+  }
+  return entries;
 }
 
 /**

--- a/servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts
+++ b/servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts
@@ -2,18 +2,22 @@
 /**
  * CLI wrapper for `vocabulary-lint`. Exits 1 if any findings, 0 otherwise.
  * Wired into the root `package.json` as `npm run lint:invariants`.
+ *
+ * Uses `process.stdout.write` rather than `console.log` so the
+ * NoConsoleInProduction guard in `src/logger.test.ts` stays clean — CLI
+ * entry points are still production code under that test's scan.
  */
 import { scanRepoDefaults } from './vocabulary-lint.js';
 
 const findings = scanRepoDefaults();
 
 if (findings.length === 0) {
-  console.log('vocabulary-lint: 0 findings (clean)');
+  process.stdout.write('vocabulary-lint: 0 findings (clean)\n');
   process.exit(0);
 }
 
 for (const f of findings) {
-  console.log(`${f.file}:${f.line} ${f.kind} ${f.token}`);
+  process.stdout.write(`${f.file}:${f.line} ${f.kind} ${f.token}\n`);
 }
-console.log(`\nvocabulary-lint: ${findings.length} finding(s)`);
+process.stdout.write(`\nvocabulary-lint: ${findings.length} finding(s)\n`);
 process.exit(1);

--- a/servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts
+++ b/servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+/**
+ * CLI wrapper for `vocabulary-lint`. Exits 1 if any findings, 0 otherwise.
+ * Wired into the root `package.json` as `npm run lint:invariants`.
+ */
+import { scanRepoDefaults } from './vocabulary-lint.js';
+
+const findings = scanRepoDefaults();
+
+if (findings.length === 0) {
+  console.log('vocabulary-lint: 0 findings (clean)');
+  process.exit(0);
+}
+
+for (const f of findings) {
+  console.log(`${f.file}:${f.line} ${f.kind} ${f.token}`);
+}
+console.log(`\nvocabulary-lint: ${findings.length} finding(s)`);
+process.exit(1);

--- a/servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts
+++ b/servers/exarchos-mcp/src/architecture/vocabulary-lint-cli.ts
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 /**
- * CLI wrapper for `vocabulary-lint`. Exits 1 if any findings, 0 otherwise.
+ * CLI wrapper for `vocabulary-lint`. Sets exitCode 1 if any findings, 0 otherwise.
  * Wired into the root `package.json` as `npm run lint:invariants`.
  *
  * Uses `process.stdout.write` rather than `console.log` so the
  * NoConsoleInProduction guard in `src/logger.test.ts` stays clean — CLI
  * entry points are still production code under that test's scan.
+ *
+ * Uses `process.exitCode = N` (rather than `process.exit(N)`) so buffered
+ * stdout writes flush completely before the process terminates — see
+ * https://nodejs.org/api/process.html#processexitcode_1. With `process.exit`,
+ * piped output can be truncated when the consumer drains slowly.
  */
 import { scanRepoDefaults } from './vocabulary-lint.js';
 
@@ -13,11 +18,11 @@ const findings = scanRepoDefaults();
 
 if (findings.length === 0) {
   process.stdout.write('vocabulary-lint: 0 findings (clean)\n');
-  process.exit(0);
+  process.exitCode = 0;
+} else {
+  for (const f of findings) {
+    process.stdout.write(`${f.file}:${f.line} ${f.kind} ${f.token}\n`);
+  }
+  process.stdout.write(`vocabulary-lint: ${findings.length} finding(s)\n`);
+  process.exitCode = 1;
 }
-
-for (const f of findings) {
-  process.stdout.write(`${f.file}:${f.line} ${f.kind} ${f.token}\n`);
-}
-process.stdout.write(`\nvocabulary-lint: ${findings.length} finding(s)\n`);
-process.exit(1);

--- a/servers/exarchos-mcp/src/architecture/vocabulary-lint.test.ts
+++ b/servers/exarchos-mcp/src/architecture/vocabulary-lint.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { scanFile, scanPaths } from './vocabulary-lint.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const INVARIANTS_DOC = path.join(REPO_ROOT, 'docs/architecture/invariants.md');
+
+describe('vocabulary-lint', () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vocab-lint-'));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('VocabularyLint_UnknownInvariantReference_Fails', () => {
+    const fixture = path.join(tmpDir, 'unknown-ref.md');
+    fs.writeFileSync(
+      fixture,
+      'Some prose referencing INV-99 which does not exist.\n',
+    );
+    const findings = scanFile(fixture, { invariantsDoc: INVARIANTS_DOC });
+    expect(findings.length).toBeGreaterThan(0);
+    const inv99 = findings.find((f) => f.token === 'INV-99');
+    expect(inv99).toBeDefined();
+    expect(inv99!.kind).toBe('unknown-invariant');
+  });
+
+  it('VocabularyLint_KnownInvariantReference_Passes', () => {
+    const fixture = path.join(tmpDir, 'known-ref.md');
+    fs.writeFileSync(
+      fixture,
+      'Some prose referencing INV-1 which is documented.\n',
+    );
+    const findings = scanFile(fixture, { invariantsDoc: INVARIANTS_DOC });
+    expect(findings).toEqual([]);
+  });
+
+  it('VocabularyLint_MultipleFileScan_AggregatesFindings', () => {
+    const subDir = path.join(tmpDir, 'multi');
+    fs.mkdirSync(subDir, { recursive: true });
+    fs.writeFileSync(path.join(subDir, 'a.md'), 'Prose with INV-1 and INV-77.\n');
+    fs.writeFileSync(path.join(subDir, 'b.md'), 'Prose with DIM-3 and DIM-42.\n');
+    const findings = scanPaths([subDir], { invariantsDoc: INVARIANTS_DOC });
+    expect(findings.length).toBe(2);
+    const tokens = findings.map((f) => f.token).sort();
+    expect(tokens).toEqual(['DIM-42', 'INV-77']);
+    // Each finding carries file + line.
+    for (const f of findings) {
+      expect(typeof f.file).toBe('string');
+      expect(typeof f.line).toBe('number');
+      expect(f.line).toBeGreaterThan(0);
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/architecture/vocabulary-lint.ts
+++ b/servers/exarchos-mcp/src/architecture/vocabulary-lint.ts
@@ -1,0 +1,169 @@
+/**
+ * Vocabulary-lint scanner for invariant references (issue #1260).
+ *
+ * Walks markdown files under the given roots, finds tokens matching
+ * `/\b(INV-\d+[a-d]?|DIM-\d+)\b/`, and cross-checks them against the IDs
+ * declared in `docs/architecture/invariants.md`. Unknown references are
+ * returned as findings.
+ *
+ * Designed to be a thin library that the `npm run lint:invariants` CLI
+ * wrapper can call.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadInvariantIds } from './invariants-loader.js';
+
+export interface VocabularyFinding {
+  file: string;
+  line: number;
+  token: string;
+  kind: 'unknown-invariant';
+}
+
+export interface ScanOptions {
+  /**
+   * Absolute path to the invariants catalog markdown file. Defaults to
+   * `<repoRoot>/docs/architecture/invariants.md`.
+   */
+  invariantsDoc?: string;
+  /** Skip these directory names while walking. */
+  skipDirs?: string[];
+}
+
+const TOKEN_RE = /\b(INV-\d+[a-d]?|DIM-\d+)\b/g;
+const DEFAULT_SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  '.next',
+  'coverage',
+]);
+
+/**
+ * Resolve the repository root from this module's location.
+ *
+ * src/architecture/vocabulary-lint.ts → repo root is four levels up.
+ */
+function resolveRepoRoot(): string {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(__dirname, '../../../..');
+}
+
+function defaultInvariantsDoc(): string {
+  return path.join(resolveRepoRoot(), 'docs/architecture/invariants.md');
+}
+
+/**
+ * Scan a single file for unknown invariant references.
+ */
+export function scanFile(
+  file: string,
+  options: ScanOptions = {},
+): VocabularyFinding[] {
+  const docPath = options.invariantsDoc ?? defaultInvariantsDoc();
+  const knownIds = loadInvariantIds(docPath);
+  return scanFileWithKnown(file, knownIds);
+}
+
+function scanFileWithKnown(
+  file: string,
+  knownIds: Set<string>,
+): VocabularyFinding[] {
+  const text = fs.readFileSync(file, 'utf8');
+  const findings: VocabularyFinding[] = [];
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    TOKEN_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    const seen = new Set<string>();
+    while ((match = TOKEN_RE.exec(line)) !== null) {
+      const token = match[1]!;
+      if (knownIds.has(token)) continue;
+      // De-dup within a line so a token repeated on the same line is one
+      // finding (line:token uniqueness).
+      const key = token;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      findings.push({
+        file,
+        line: i + 1,
+        token,
+        kind: 'unknown-invariant',
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Walk one or more paths (files or directories) and scan every markdown file
+ * (`*.md`) for unknown invariant references. Aggregates findings across files.
+ */
+export function scanPaths(
+  paths: string[],
+  options: ScanOptions = {},
+): VocabularyFinding[] {
+  const docPath = options.invariantsDoc ?? defaultInvariantsDoc();
+  const knownIds = loadInvariantIds(docPath);
+  const skipDirs = new Set([
+    ...DEFAULT_SKIP_DIRS,
+    ...(options.skipDirs ?? []),
+  ]);
+  const findings: VocabularyFinding[] = [];
+  for (const root of paths) {
+    if (!fs.existsSync(root)) continue;
+    const stat = fs.statSync(root);
+    if (stat.isFile()) {
+      if (root.endsWith('.md')) {
+        findings.push(...scanFileWithKnown(root, knownIds));
+      }
+      continue;
+    }
+    if (stat.isDirectory()) {
+      walkDirectory(root, skipDirs, (file) => {
+        findings.push(...scanFileWithKnown(file, knownIds));
+      });
+    }
+  }
+  return findings;
+}
+
+function walkDirectory(
+  root: string,
+  skipDirs: Set<string>,
+  visit: (file: string) => void,
+): void {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (skipDirs.has(entry.name)) continue;
+      walkDirectory(full, skipDirs, visit);
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      visit(full);
+    }
+  }
+}
+
+/**
+ * Default scan: walks `docs/`, `skills-src/`, and `commands/` from the repo
+ * root and returns aggregated findings. The exclusion list intentionally
+ * omits `skills/<runtime>/` (generated content — drift in source surfaces
+ * through `skills:guard`).
+ */
+export function scanRepoDefaults(
+  options: ScanOptions = {},
+): VocabularyFinding[] {
+  const root = resolveRepoRoot();
+  return scanPaths(
+    [
+      path.join(root, 'docs'),
+      path.join(root, 'skills-src'),
+      path.join(root, 'commands'),
+    ],
+    options,
+  );
+}

--- a/servers/exarchos-mcp/src/commands/ideate-loader.test.ts
+++ b/servers/exarchos-mcp/src/commands/ideate-loader.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadInvariants } from '../architecture/invariants-loader.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const IDEATE_COMMAND = path.join(REPO_ROOT, 'commands/ideate.md');
+const BRAINSTORMING_SKILL = path.join(
+  REPO_ROOT,
+  'skills-src/brainstorming/SKILL.md',
+);
+const INVARIANTS_DOC = path.join(REPO_ROOT, 'docs/architecture/invariants.md');
+
+describe('ideate first-turn invariant surfacing (#1260)', () => {
+  it('Ideate_FirstTurn_LoadsInvariantsDoc', () => {
+    const ideate = fs.readFileSync(IDEATE_COMMAND, 'utf8');
+    const skill = fs.readFileSync(BRAINSTORMING_SKILL, 'utf8');
+
+    // The /ideate command itself must reference docs/architecture/invariants.md
+    // so the agent knows to consult the invariants catalog on first turn.
+    expect(ideate).toContain('docs/architecture/invariants.md');
+
+    // The brainstorming skill body must guide surfacing of relevant invariants
+    // (and reference the invariants doc explicitly).
+    expect(skill).toContain('docs/architecture/invariants.md');
+    expect(skill.toLowerCase()).toContain('constraint anchoring');
+  });
+
+  it('Ideate_FirstTurn_SurfacesRelevantInvariants', () => {
+    // The contract: for a CLI-design proposal, the surfaced section should
+    // include the invariants that govern CLI / agent-first surface design —
+    // INV-5a (input ergonomics), INV-5c (Aspire verbs), DIM-1 (topology).
+    //
+    // Modeled as: those IDs must be declared in the invariants catalog AND
+    // they must be the IDs the /ideate workflow points the agent at for
+    // CLI-shaped proposals. We assert (a) the catalog has them, and (b) the
+    // brainstorming skill prose names them as canonical anchors so a CLI
+    // proposal is guaranteed to surface them.
+    const entries = loadInvariants(INVARIANTS_DOC);
+    const ids = new Set(entries.map((e) => e.id));
+    expect(ids.has('INV-5a')).toBe(true);
+    expect(ids.has('INV-5c')).toBe(true);
+    expect(ids.has('DIM-1')).toBe(true);
+
+    const skill = fs.readFileSync(BRAINSTORMING_SKILL, 'utf8');
+    // Skill must enumerate at least INV-5a, INV-5c, DIM-1 as CLI-design anchors.
+    expect(skill).toMatch(/INV-5a/);
+    expect(skill).toMatch(/INV-5c/);
+    expect(skill).toMatch(/DIM-1/);
+  });
+});

--- a/servers/exarchos-mcp/src/next-actions-from-result.test.ts
+++ b/servers/exarchos-mcp/src/next-actions-from-result.test.ts
@@ -10,8 +10,12 @@
 // Pre-fix only shape 1 was extracted, so rehydrate envelopes always returned
 // `next_actions: []` even when the merge-pending detour was active. These
 // tests pin shape 2 + the merge_orchestrate surfacing branch.
-import { describe, it, expect } from 'vitest';
-import { nextActionsFromResult } from './next-actions-from-result.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  nextActionsFromResult,
+  nextActionsLogger,
+  ResultDataSchema,
+} from './next-actions-from-result.js';
 import type { ToolResult } from './format.js';
 import { rehydrationReducer } from './projections/rehydration/reducer.js';
 import type { WorkflowEvent } from './event-store/schemas.js';
@@ -147,6 +151,135 @@ describe('nextActionsFromResult — shape recognition', () => {
     expect(actions.some((a) => a.verb === 'merge_orchestrate')).toBe(true);
     const mo = actions.find((a) => a.verb === 'merge_orchestrate');
     expect(mo?.idempotencyKey).toBe('top-level-mo:merge_orchestrate:099');
+  });
+
+  // ─── #1238 ResultDataSchema discriminated union coverage ──────────────────
+  //
+  // The parser body previously used `Record<string, unknown>` casts and inline
+  // `typeof` guards. #1238 replaces that with a Zod union of two shapes plus
+  // a fail-closed `safeParse` boundary. These tests pin both shapes plus the
+  // malformed → warn-and-[] case.
+
+  describe('#1238 ResultDataSchema discriminated union', () => {
+    it('NextActionsFromResult_WorkflowHandlerPayload_ParsesShapeOne', () => {
+      // Shape 1 — top-level phase + workflowType (+ optional featureId /
+      // mergeOrchestrator). Parses via ShapeOneSchema in the union.
+      const parsed = ResultDataSchema.safeParse({
+        phase: 'merge-pending',
+        workflowType: 'feature',
+        featureId: 'shape-one',
+        mergeOrchestrator: { taskId: '007', phase: 'pending' },
+      });
+      expect(parsed.success).toBe(true);
+
+      const actions = nextActionsFromResult(
+        ok({
+          phase: 'merge-pending',
+          workflowType: 'feature',
+          featureId: 'shape-one',
+          mergeOrchestrator: { taskId: '007', phase: 'pending' },
+        }),
+      );
+      const mo = actions.find((a) => a.verb === 'merge_orchestrate');
+      expect(mo).toBeDefined();
+      expect(mo?.idempotencyKey).toBe('shape-one:merge_orchestrate:007');
+    });
+
+    it('NextActionsFromResult_RehydrationDocument_ParsesShapeTwo', () => {
+      // Shape 2 — `{ workflowState: { phase, workflowType, featureId,
+      // mergeOrchestrator } }`. Parses via ShapeTwoSchema in the union.
+      const parsed = ResultDataSchema.safeParse({
+        workflowState: {
+          featureId: 'shape-two',
+          phase: 'merge-pending',
+          workflowType: 'feature',
+          mergeOrchestrator: { taskId: '042', phase: 'pending' },
+        },
+      });
+      expect(parsed.success).toBe(true);
+
+      const actions = nextActionsFromResult(
+        ok({
+          workflowState: {
+            featureId: 'shape-two',
+            phase: 'merge-pending',
+            workflowType: 'feature',
+            mergeOrchestrator: { taskId: '042', phase: 'pending' },
+          },
+        }),
+      );
+      const mo = actions.find((a) => a.verb === 'merge_orchestrate');
+      expect(mo).toBeDefined();
+      expect(mo?.idempotencyKey).toBe('shape-two:merge_orchestrate:042');
+    });
+
+    describe('NextActionsFromResult_MalformedPayload_FailsClosed', () => {
+      let warnSpy: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        warnSpy = vi
+          .spyOn(nextActionsLogger, 'warn')
+          .mockImplementation(() => undefined as never);
+      });
+
+      afterEach(() => {
+        warnSpy.mockRestore();
+      });
+
+      it('returns [] and warns on a payload matching neither shape', () => {
+        // Payload that doesn't satisfy ShapeOneSchema (no string phase /
+        // workflowType at top level) AND doesn't satisfy ShapeTwoSchema
+        // (workflowState missing required featureId string). This must
+        // fail-closed: return [] AND log a warning so the malformed payload
+        // is surfaced rather than silently swallowed.
+        const actions = nextActionsFromResult(
+          ok({
+            phase: 42, // wrong type for ShapeOne
+            workflowState: {
+              // missing required `featureId`, wrong type on `phase`
+              phase: false,
+              workflowType: 'feature',
+            },
+          }),
+        );
+        expect(actions).toEqual([]);
+        expect(warnSpy).toHaveBeenCalled();
+      });
+    });
+
+    it('NextActionsFromResult_NonSuccessResult_ReturnsEmptyArray', () => {
+      // Legitimate no-actions path: error envelope. Must NOT log a warning —
+      // only malformed-success payloads warn.
+      const warnSpy = vi
+        .spyOn(nextActionsLogger, 'warn')
+        .mockImplementation(() => undefined as never);
+      try {
+        const result: ToolResult = {
+          success: false,
+          error: { code: 'X', message: 'no' },
+        };
+        expect(nextActionsFromResult(result)).toEqual([]);
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('NextActionsFromResult_NullData_ReturnsEmptyArray', () => {
+      // Legitimate no-actions path: success envelope with null/non-object
+      // data (describe / list / status actions). Must NOT warn.
+      const warnSpy = vi
+        .spyOn(nextActionsLogger, 'warn')
+        .mockImplementation(() => undefined as never);
+      try {
+        expect(nextActionsFromResult(ok(null))).toEqual([]);
+        expect(nextActionsFromResult(ok(undefined))).toEqual([]);
+        expect(nextActionsFromResult(ok('string-payload'))).toEqual([]);
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
   });
 
   it('returns [] for unknown workflowType in shape 2', () => {

--- a/servers/exarchos-mcp/src/next-actions-from-result.ts
+++ b/servers/exarchos-mcp/src/next-actions-from-result.ts
@@ -13,10 +13,72 @@
 // are possible and must not poison the envelope. Invoked at most once per
 // composite call.
 
+import { z } from 'zod';
 import type { ToolResult } from './format.js';
+import { logger } from './logger.js';
 import type { NextAction } from './next-action.js';
 import { computeNextActions } from './next-actions-computer.js';
+import {
+  RehydrationMergeOrchestratorSchema,
+  WorkflowStateSchema,
+} from './projections/rehydration/schema.js';
 import { getHSMDefinition } from './workflow/state-machine.js';
+
+/**
+ * Structured logger child for fail-closed parse warnings (#1238).
+ * Exported so unit tests can `vi.spyOn(nextActionsLogger, 'warn')` to assert
+ * the malformed-payload fail-closed branch.
+ */
+export const nextActionsLogger = logger.child({ subsystem: 'next-actions' });
+
+// ─── #1238 ResultDataSchema discriminated union ─────────────────────────────
+//
+// The parser body previously used `Record<string, unknown>` casts and inline
+// `typeof` guards to dig phase / workflowType / featureId / mergeOrchestrator
+// out of `result.data`. #1238 replaces that with a Zod union of two shapes so
+// the contract is declarative and a malformed payload fails closed rather
+// than silently degrading.
+//
+// `.passthrough()` keeps unknown sibling fields (handler payloads carry many
+// extra fields — taskProgress, decisions, etc.) — we only validate the
+// fields this helper reads.
+
+/** Shape 1 — handler payload (`handleInit` / `handleGet` / `handleSet`). */
+export const ShapeOneSchema = z
+  .object({
+    phase: z.string(),
+    workflowType: z.string(),
+    featureId: z.string().optional(),
+    mergeOrchestrator: RehydrationMergeOrchestratorSchema.optional(),
+  })
+  .passthrough();
+
+/** Shape 2 — rehydration document (`handleRehydrate`). */
+export const ShapeTwoSchema = z
+  .object({
+    workflowState: WorkflowStateSchema,
+  })
+  .passthrough();
+
+/**
+ * The two recognised workflow-context payload shapes. A success-envelope
+ * payload that carries a discriminator key but fails this union is treated
+ * as malformed (warn + `[]`) at the fail-closed boundary in
+ * `nextActionsFromResult`. Payloads without any discriminator key are
+ * non-workflow responses (event-store / view composite / describe) and are
+ * not parsed against this schema at all.
+ */
+export const ResultDataSchema = z.union([ShapeOneSchema, ShapeTwoSchema]);
+
+export type ResultData = z.infer<typeof ResultDataSchema>;
+
+/**
+ * Discriminator keys that indicate a payload is *attempting* to carry
+ * workflow context (even if the types are wrong). Used to distinguish a
+ * legitimate non-workflow payload (silent `[]`) from a malformed workflow
+ * payload (warn + `[]`).
+ */
+const CONTEXT_DISCRIMINATOR_KEYS = ['phase', 'workflowType', 'workflowState'] as const;
 
 /**
  * Extract workflow state from a successful `ToolResult` and compute the
@@ -42,53 +104,66 @@ import { getHSMDefinition } from './workflow/state-machine.js';
  * `merge_orchestrate` surfacing branch.
  */
 export function nextActionsFromResult(result: ToolResult): readonly NextAction[] {
+  // Legitimate no-actions paths — describe/list/status actions, error
+  // envelopes, view composites. These MUST NOT warn: they're expected to be
+  // empty.
   if (!result.success) return [];
   const data = result.data;
-  if (data === null || typeof data !== 'object') return [];
+  if (data === null || data === undefined || typeof data !== 'object') return [];
 
-  const dataRecord = data as Record<string, unknown>;
-  // Shape 1 — workflow-handler payload.
-  let phase = typeof dataRecord.phase === 'string' ? dataRecord.phase : undefined;
-  let workflowType =
-    typeof dataRecord.workflowType === 'string' ? dataRecord.workflowType : undefined;
-  let featureId =
-    typeof dataRecord.featureId === 'string' ? dataRecord.featureId : undefined;
-  let mergeOrchestrator: { taskId?: string; phase?: string } | undefined;
-  if (
-    typeof dataRecord.mergeOrchestrator === 'object' &&
-    dataRecord.mergeOrchestrator !== null
-  ) {
-    const mo = dataRecord.mergeOrchestrator as Record<string, unknown>;
-    mergeOrchestrator = {
-      ...(typeof mo.taskId === 'string' ? { taskId: mo.taskId } : {}),
-      ...(typeof mo.phase === 'string' ? { phase: mo.phase } : {}),
-    };
+  // Fail-closed parse boundary (#1238). Three cases:
+  //
+  //   1. Payload carries none of the workflow-context discriminator keys
+  //      (phase / workflowType / workflowState). It's an event-store /
+  //      view-composite / describe response — return [] silently.
+  //   2. Payload carries at least one discriminator key but ResultDataSchema
+  //      rejects it — malformed (wrong types, missing required nested
+  //      fields). Warn and return [].
+  //   3. Payload parses as ShapeOne, ShapeTwo, or both — proceed.
+  //
+  // `Reflect.has` is the structural attempt-detector; it does not introspect
+  // value types (that's the schema's job).
+  const attemptedContext = CONTEXT_DISCRIMINATOR_KEYS.some((k) =>
+    Reflect.has(data, k),
+  );
+  if (!attemptedContext) return [];
+
+  const parsed = ResultDataSchema.safeParse(data);
+  if (!parsed.success) {
+    nextActionsLogger.warn(
+      { issues: parsed.error.issues },
+      'malformed result.data — failed ResultDataSchema parse; returning [].',
+    );
+    return [];
   }
 
-  // Shape 2 — rehydration document. Backfill any field shape 1 did not
-  // populate. Read `mergeOrchestrator` regardless of whether shape 1 had
-  // phase/workflowType: handler payloads (shape 1) carry phase + workflowType
-  // at the top level but typically NOT mergeOrchestrator; that field lives on
-  // the workflowState segment. Without this backfill, a payload with both
-  // top-level phase + nested workflowState.mergeOrchestrator would drop the
-  // merge-orchestration context and miss `merge_orchestrate` in next_actions.
-  if (typeof dataRecord.workflowState === 'object' && dataRecord.workflowState !== null) {
-    const ws = dataRecord.workflowState as Record<string, unknown>;
-    if (!phase && typeof ws.phase === 'string') phase = ws.phase;
-    if (!workflowType && typeof ws.workflowType === 'string') {
-      workflowType = ws.workflowType;
-    }
-    if (!featureId && typeof ws.featureId === 'string') featureId = ws.featureId;
-    if (
-      mergeOrchestrator === undefined &&
-      typeof ws.mergeOrchestrator === 'object' &&
-      ws.mergeOrchestrator !== null
-    ) {
-      const mo = ws.mergeOrchestrator as Record<string, unknown>;
-      mergeOrchestrator = {
-        ...(typeof mo.taskId === 'string' ? { taskId: mo.taskId } : {}),
-        ...(typeof mo.phase === 'string' ? { phase: mo.phase } : {}),
-      };
+  // The union parses non-greedily on the first matching shape. To preserve
+  // the existing semantics — shape-1 fields take precedence; mergeOrchestrator
+  // backfilled from workflowState even when shape 1 supplies phase — read
+  // both shapes independently. Both safeParses are cheap (the data already
+  // matched at least one shape).
+  const shapeOne = ShapeOneSchema.safeParse(data);
+  const shapeTwo = ShapeTwoSchema.safeParse(data);
+
+  let phase: string | undefined;
+  let workflowType: string | undefined;
+  let featureId: string | undefined;
+  let mergeOrchestrator: { taskId?: string; phase?: string } | undefined;
+
+  if (shapeOne.success) {
+    phase = shapeOne.data.phase;
+    workflowType = shapeOne.data.workflowType;
+    featureId = shapeOne.data.featureId;
+    mergeOrchestrator = shapeOne.data.mergeOrchestrator;
+  }
+
+  if (shapeTwo.success) {
+    const ws = shapeTwo.data.workflowState;
+    if (!phase) phase = ws.phase;
+    if (!workflowType) workflowType = ws.workflowType;
+    if (!featureId) featureId = ws.featureId;
+    if (mergeOrchestrator === undefined && ws.mergeOrchestrator !== undefined) {
+      mergeOrchestrator = ws.mergeOrchestrator;
     }
   }
 

--- a/servers/exarchos-mcp/src/orchestrate/design-completeness.ts
+++ b/servers/exarchos-mcp/src/orchestrate/design-completeness.ts
@@ -108,15 +108,25 @@ function evaluateDesignSidecar(sidecar: DesignSidecarV1): {
   let passCount = 0;
   let failCount = 0;
 
-  // Sections: every declared section must report `present: true`.
-  const missingSections = Object.entries(sidecar.sections)
-    .filter(([, v]) => !v.present)
-    .map(([k]) => k);
-  if (missingSections.length === 0) {
-    passCount++;
-  } else {
+  // Sections: every declared section must report `present: true`. CodeRabbit
+  // MAJOR #1425 r2: `sections: {}` previously passed the gate because the
+  // missingSections.filter() returned an empty array — vacuously "every
+  // section is present." Treat an empty sections map as a fail, mirroring
+  // the legacy regex path's "no design sections found" failure.
+  const sectionEntries = Object.entries(sidecar.sections);
+  if (sectionEntries.length === 0) {
     failCount++;
-    findings.push(`Required sections missing: ${missingSections.join(', ')}`);
+    findings.push('No design sections declared in sidecar');
+  } else {
+    const missingSections = sectionEntries
+      .filter(([, v]) => !v.present)
+      .map(([k]) => k);
+    if (missingSections.length === 0) {
+      passCount++;
+    } else {
+      failCount++;
+      findings.push(`Required sections missing: ${missingSections.join(', ')}`);
+    }
   }
 
   // Multiple options: optional in the schema; if absent, treat as not-checked.

--- a/servers/exarchos-mcp/src/orchestrate/design-completeness.ts
+++ b/servers/exarchos-mcp/src/orchestrate/design-completeness.ts
@@ -11,6 +11,8 @@ import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { emitGateEvent } from './gate-utils.js';
 import { handleDesignCompleteness as runDesignCompleteness } from './pure/design-completeness.js';
+import { loadDesignSidecar } from './sidecar-lookup.js';
+import type { DesignSidecarV1 } from './sidecar-schemas.js';
 
 // ─── Handler ────────────────────────────────────────────────────────────────
 
@@ -32,20 +34,30 @@ export async function handleDesignCompleteness(
   // (matches storage/lifecycle.ts, cli-commands/{assemble-context,subagent-context,gates}).
   const stateFile = args.stateFile ?? `${stateDir}/${streamId}.state.json`;
 
-  // 2. Call pure TypeScript implementation
+  // 2. Prefer the sidecar (T15) when present + conformant; otherwise fall
+  // back to the existing regex-scrape path with a deprecation warning
+  // logged inside `loadDesignSidecar`. The regex branch is scheduled for
+  // removal in v2.11 (#1298 follow-up tracking issue).
   let parsed;
-  try {
-    parsed = runDesignCompleteness({
-      stateFile,
-      designFile: args.designPath,
-      docsDir: 'docs/designs',
-    });
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    return {
-      success: false,
-      error: { code: 'DESIGN_CHECK_ERROR', message: `Design completeness check failed: ${message}` },
-    };
+  let source: 'sidecar' | 'regex' = 'regex';
+  const sidecar = args.designPath ? loadDesignSidecar(args.designPath) : null;
+  if (sidecar) {
+    parsed = evaluateDesignSidecar(sidecar);
+    source = 'sidecar';
+  } else {
+    try {
+      parsed = runDesignCompleteness({
+        stateFile,
+        designFile: args.designPath,
+        docsDir: 'docs/designs',
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        error: { code: 'DESIGN_CHECK_ERROR', message: `Design completeness check failed: ${message}` },
+      };
+    }
   }
 
   // 3. Emit gate.executed event
@@ -67,6 +79,76 @@ export async function handleDesignCompleteness(
   // 4. Return result
   return {
     success: true,
-    data: parsed,
+    data: { ...parsed, source },
+  };
+}
+
+// ─── Sidecar evaluation ─────────────────────────────────────────────────────
+
+/**
+ * Evaluate a `DesignSidecarV1` against the same five checks the regex
+ * branch performs, but using the structured input directly:
+ *   1. (implicit) design doc exists — guaranteed when sidecar is present.
+ *   2. Required sections present — each declared section in `sections`
+ *      must have `present: true`.
+ *   3. Multiple options — `options.count >= 2`.
+ *   4. (skipped — state-file path already verified by the loader call site).
+ *   5. Acceptance criteria — every DR in `drs` must be referenced by at
+ *      least one entry in `acceptance` (advisory finding).
+ */
+function evaluateDesignSidecar(sidecar: DesignSidecarV1): {
+  passed: boolean;
+  advisory: boolean;
+  findings: string[];
+  checkCount: number;
+  passCount: number;
+  failCount: number;
+} {
+  const findings: string[] = [];
+  let passCount = 0;
+  let failCount = 0;
+
+  // Sections: every declared section must report `present: true`.
+  const missingSections = Object.entries(sidecar.sections)
+    .filter(([, v]) => !v.present)
+    .map(([k]) => k);
+  if (missingSections.length === 0) {
+    passCount++;
+  } else {
+    failCount++;
+    findings.push(`Required sections missing: ${missingSections.join(', ')}`);
+  }
+
+  // Multiple options: optional in the schema; if absent, treat as not-checked.
+  if (sidecar.options) {
+    if (sidecar.options.count >= 2) {
+      passCount++;
+    } else {
+      failCount++;
+      findings.push(`Found ${sidecar.options.count} option(s), expected at least 2`);
+    }
+  }
+
+  // Acceptance criteria — every DR referenced at least once (advisory).
+  const referenced = new Set<string>();
+  for (const a of sidecar.acceptance) {
+    for (const ref of a.references) referenced.add(ref);
+  }
+  const drsMissingAcceptance = sidecar.drs
+    .map((dr) => dr.id)
+    .filter((id) => !referenced.has(id));
+  if (drsMissingAcceptance.length > 0) {
+    findings.push(
+      `Advisory: DR entries missing acceptance criteria: ${drsMissingAcceptance.join(', ')}`,
+    );
+  }
+
+  return {
+    passed: failCount === 0,
+    advisory: true,
+    findings,
+    checkCount: passCount + failCount,
+    passCount,
+    failCount,
   };
 }

--- a/servers/exarchos-mcp/src/orchestrate/plan-coverage.ts
+++ b/servers/exarchos-mcp/src/orchestrate/plan-coverage.ts
@@ -704,6 +704,23 @@ export async function handlePlanCoverage(
   const designSidecar = loadDesignSidecar(args.designPath);
   const planSidecar = loadPlanSidecar(args.planPath);
   if (designSidecar && planSidecar) {
+    // Sentry #1425 — parity with the legacy `NO_DESIGN_SECTIONS` branch
+    // (above). An empty `drs[]` would otherwise produce
+    // `total=0, gaps=0, passed=true`, silently passing a design with no
+    // requirements at all. Reject up front with the same error code so
+    // sidecar and regex paths converge on this contract.
+    if (designSidecar.drs.length === 0) {
+      return {
+        success: false,
+        error: {
+          code: 'NO_DESIGN_SECTIONS',
+          message:
+            'design.v1 sidecar contains no design requirements (drs is empty). ' +
+            "Expected at least one DR entry — equivalent to the legacy regex path's " +
+            'missing-design-sections check.',
+        },
+      };
+    }
     const result = evaluatePlanCoverageFromSidecars(designSidecar, planSidecar);
     try {
       await emitGateEvent(eventStore, args.featureId, 'plan-coverage', 'planning', result.passed, {

--- a/servers/exarchos-mcp/src/orchestrate/plan-coverage.ts
+++ b/servers/exarchos-mcp/src/orchestrate/plan-coverage.ts
@@ -721,6 +721,21 @@ export async function handlePlanCoverage(
         },
       };
     }
+    // CodeRabbit MAJOR #1425 r2: parity short-circuit for an empty plan
+    // tasks list. The legacy regex path detects "no tasks" via the
+    // markdown task-block scan; the sidecar path needs the same gate or
+    // a plan that declares zero tasks would silently pass.
+    if (planSidecar.tasks.length === 0) {
+      return {
+        success: false,
+        error: {
+          code: 'NO_PLAN_TASKS',
+          message:
+            'plan.v1 sidecar contains no tasks (tasks is empty). Expected at ' +
+            'least one task entry to cross-reference against design.drs.',
+        },
+      };
+    }
     const result = evaluatePlanCoverageFromSidecars(designSidecar, planSidecar);
     try {
       await emitGateEvent(eventStore, args.featureId, 'plan-coverage', 'planning', result.passed, {
@@ -820,12 +835,26 @@ function evaluatePlanCoverageFromSidecars(
   gapSections: readonly string[];
 } {
   const gapSections: string[] = [];
+  const unknownTaskRefs: string[] = [];
   let covered = 0;
   let gaps = 0;
 
+  // CodeRabbit MAJOR #1425 r2: cross-reference each coverage[] entry against
+  // the declared plan.tasks. A `coverage[DR-1] = ['T-99']` where T-99 is not
+  // in plan.tasks previously marked DR-1 as covered, since the only check
+  // was list-non-empty. Treat any task ID that doesn't appear in plan.tasks
+  // as if it weren't covering — same outcome the legacy regex path produces
+  // when a plan's traceability table references a non-existent task.
+  const knownTaskIds = new Set(plan.tasks.map((t) => t.id));
+
   for (const dr of design.drs) {
-    const coveringTasks = plan.coverage[dr.id];
-    if (coveringTasks && coveringTasks.length > 0) {
+    const coveringTasks = plan.coverage[dr.id] ?? [];
+    const validCoveringTasks = coveringTasks.filter((id) => {
+      if (knownTaskIds.has(id)) return true;
+      unknownTaskRefs.push(`${dr.id} → ${id}`);
+      return false;
+    });
+    if (validCoveringTasks.length > 0) {
       covered++;
     } else {
       gaps++;
@@ -845,6 +874,10 @@ function evaluatePlanCoverageFromSidecars(
   if (gapSections.length > 0) {
     reportLines.push('', '### Gaps');
     for (const id of gapSections) reportLines.push(`- ${id}`);
+  }
+  if (unknownTaskRefs.length > 0) {
+    reportLines.push('', '### Coverage entries referencing unknown task IDs');
+    for (const ref of unknownTaskRefs) reportLines.push(`- ${ref}`);
   }
   reportLines.push('', passed ? `**Result: PASS** (${covered}/${total} DRs covered)` : `**Result: FAIL** (${gaps}/${total} gaps)`);
 

--- a/servers/exarchos-mcp/src/orchestrate/plan-coverage.ts
+++ b/servers/exarchos-mcp/src/orchestrate/plan-coverage.ts
@@ -9,6 +9,8 @@ import { readFile } from 'node:fs/promises';
 import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { emitGateEvent } from './gate-utils.js';
+import { loadDesignSidecar, loadPlanSidecar } from './sidecar-lookup.js';
+import type { DesignSidecarV1, PlanSidecarV1 } from './sidecar-schemas.js';
 
 // ─── Result Types ──────────────────────────────────────────────────────────
 
@@ -694,6 +696,28 @@ export async function handlePlanCoverage(
     };
   }
 
+  // Prefer the sidecars (T15) when both are present + conformant. The
+  // sidecar branch reads `coverage` directly without ever scraping
+  // markdown. When either side is missing, fall back to the existing
+  // regex-scrape path with a deprecation warning logged inside the
+  // sidecar-lookup helper.
+  const designSidecar = loadDesignSidecar(args.designPath);
+  const planSidecar = loadPlanSidecar(args.planPath);
+  if (designSidecar && planSidecar) {
+    const result = evaluatePlanCoverageFromSidecars(designSidecar, planSidecar);
+    try {
+      await emitGateEvent(eventStore, args.featureId, 'plan-coverage', 'planning', result.passed, {
+        dimension: 'D1',
+        phase: 'plan',
+        covered: result.coverage.covered,
+        gaps: result.coverage.gaps,
+        deferred: result.coverage.deferred,
+        totalSections: result.coverage.total,
+      });
+    } catch { /* fire-and-forget */ }
+    return { success: true, data: { ...result, source: 'sidecar' as const } };
+  }
+
   // Read files
   let designContent: string;
   let planContent: string;
@@ -754,5 +778,63 @@ export async function handlePlanCoverage(
     });
   } catch { /* fire-and-forget */ }
 
-  return { success: true, data: result };
+  return { success: true, data: { ...result, source: 'regex' as const } };
+}
+
+// ─── Sidecar evaluation ─────────────────────────────────────────────────────
+
+/**
+ * Compute plan-coverage from the structured sidecars. Each DR id from the
+ * design sidecar's `drs[]` is checked against the plan sidecar's `coverage`
+ * map. A DR with no covering tasks is a gap; everything else is covered.
+ *
+ * Deferred is treated as a no-op for sidecar-driven inputs (the structured
+ * shape has no equivalent of the "Deferred" cell in the markdown
+ * traceability table — designs that want to defer should omit the DR from
+ * the sidecar).
+ */
+function evaluatePlanCoverageFromSidecars(
+  design: DesignSidecarV1,
+  plan: PlanSidecarV1,
+): {
+  passed: boolean;
+  coverage: { covered: number; gaps: number; deferred: number; total: number };
+  report: string;
+  gapSections: readonly string[];
+} {
+  const gapSections: string[] = [];
+  let covered = 0;
+  let gaps = 0;
+
+  for (const dr of design.drs) {
+    const coveringTasks = plan.coverage[dr.id];
+    if (coveringTasks && coveringTasks.length > 0) {
+      covered++;
+    } else {
+      gaps++;
+      gapSections.push(dr.id);
+    }
+  }
+
+  const total = design.drs.length;
+  const passed = gaps === 0;
+  const reportLines = [
+    '## Plan Coverage Report (sidecar)',
+    '',
+    `- DRs total: ${total}`,
+    `- Covered: ${covered}`,
+    `- Gaps: ${gaps}`,
+  ];
+  if (gapSections.length > 0) {
+    reportLines.push('', '### Gaps');
+    for (const id of gapSections) reportLines.push(`- ${id}`);
+  }
+  reportLines.push('', passed ? `**Result: PASS** (${covered}/${total} DRs covered)` : `**Result: FAIL** (${gaps}/${total} gaps)`);
+
+  return {
+    passed,
+    coverage: { covered, gaps, deferred: 0, total },
+    report: reportLines.join('\n'),
+    gapSections,
+  };
 }

--- a/servers/exarchos-mcp/src/orchestrate/provenance-chain.ts
+++ b/servers/exarchos-mcp/src/orchestrate/provenance-chain.ts
@@ -9,6 +9,8 @@ import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { emitGateEvent } from './gate-utils.js';
 import { verifyProvenanceChain } from './pure/provenance-chain.js';
+import { loadDesignSidecar, loadPlanSidecar } from './sidecar-lookup.js';
+import type { DesignSidecarV1, PlanSidecarV1 } from './sidecar-schemas.js';
 
 // ─── Result Types ──────────────────────────────────────────────────────────
 
@@ -66,6 +68,27 @@ export async function handleProvenanceChain(
     };
   }
 
+  // Prefer the sidecars (T15) when both are present + conformant.
+  const designSidecar = loadDesignSidecar(args.designPath);
+  const planSidecar = loadPlanSidecar(args.planPath);
+  if (designSidecar && planSidecar) {
+    const sidecarResult = evaluateProvenanceFromSidecars(designSidecar, planSidecar);
+    try {
+      await emitGateEvent(eventStore, args.featureId, 'provenance-chain', 'planning', sidecarResult.passed, {
+        dimension: 'D1',
+        phase: 'plan',
+        requirements: sidecarResult.coverage.requirements,
+        covered: sidecarResult.coverage.covered,
+        gaps: sidecarResult.coverage.gaps,
+        orphanRefs: sidecarResult.coverage.orphanRefs,
+      });
+    } catch { /* fire-and-forget */ }
+    return {
+      success: true,
+      data: { ...sidecarResult, source: 'sidecar' as const },
+    };
+  }
+
   // Call pure TypeScript implementation
   const tsResult = verifyProvenanceChain({
     designFile: args.designPath,
@@ -110,5 +133,52 @@ export async function handleProvenanceChain(
     report: tsResult.output,
   };
 
-  return { success: true, data: result };
+  return { success: true, data: { ...result, source: 'regex' as const } };
+}
+
+// ─── Sidecar evaluation ─────────────────────────────────────────────────────
+
+/**
+ * Verify the design-to-plan provenance chain from the structured sidecars.
+ *
+ * A DR is "covered" when at least one `provenance` entry in the plan
+ * sidecar references it. An "orphan reference" is a plan provenance entry
+ * pointing at a DR id that does not appear in the design sidecar's `drs`.
+ */
+function evaluateProvenanceFromSidecars(
+  design: DesignSidecarV1,
+  plan: PlanSidecarV1,
+): {
+  passed: boolean;
+  coverage: { requirements: number; covered: number; gaps: number; orphanRefs: number };
+  report: string;
+} {
+  const drIds = new Set(design.drs.map((d) => d.id));
+  const provenanceDrs = new Set(plan.provenance.map((p) => p.dr));
+  let covered = 0;
+  const missing: string[] = [];
+  for (const dr of drIds) {
+    if (provenanceDrs.has(dr)) covered++;
+    else missing.push(dr);
+  }
+  const orphanRefs = [...provenanceDrs].filter((d) => !drIds.has(d));
+  const requirements = drIds.size;
+  const gaps = missing.length;
+  const passed = gaps === 0 && orphanRefs.length === 0;
+  const report = [
+    '## Provenance Chain Report (sidecar)',
+    '',
+    `- Requirements: ${requirements}`,
+    `- Covered: ${covered}`,
+    `- Gaps: ${gaps}${gaps > 0 ? ` (${missing.join(', ')})` : ''}`,
+    `- Orphan provenance refs: ${orphanRefs.length}${orphanRefs.length > 0 ? ` (${orphanRefs.join(', ')})` : ''}`,
+    '',
+    passed ? '**Result: PASS**' : '**Result: FAIL**',
+  ].join('\n');
+
+  return {
+    passed,
+    coverage: { requirements, covered, gaps, orphanRefs: orphanRefs.length },
+    report,
+  };
 }

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-backfill.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-backfill.test.ts
@@ -8,14 +8,21 @@
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parse } from 'yaml';
 
 import { DesignSidecarV1, PlanSidecarV1 } from './sidecar-schemas.js';
 
+// CodeRabbit MAJOR #1425 r2: `__dirname` is undefined under NodeNext/ESM
+// (the project's resolution mode — see CLAUDE.md). Use the ESM-safe
+// `import.meta.url` → `fileURLToPath(...)` → `dirname()` chain so the
+// REPO_ROOT constant resolves correctly in both ts-node and the
+// vitest runner.
+//
 // Resolve relative to repo root from this test file's location:
 // servers/exarchos-mcp/src/orchestrate/<this> → ../../../../docs/...
-const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
 
 describe('SidecarBackfill_Preview4', () => {
   it('DesignSidecar_ParsesUnderDesignV1', () => {

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-backfill.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-backfill.test.ts
@@ -1,0 +1,41 @@
+// ─── Sidecar Backfill Validation (T16, #1298) ────────────────────────────────
+//
+// Ensures the hand-authored sidecars for the v2.10.0-preview.4 feature-freeze
+// design and plan parse cleanly under DesignSidecarV1 / PlanSidecarV1. Any
+// drift between the YAML and the schema is caught at test time, not in the
+// gate runtime.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse } from 'yaml';
+
+import { DesignSidecarV1, PlanSidecarV1 } from './sidecar-schemas.js';
+
+// Resolve relative to repo root from this test file's location:
+// servers/exarchos-mcp/src/orchestrate/<this> → ../../../../docs/...
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+
+describe('SidecarBackfill_Preview4', () => {
+  it('DesignSidecar_ParsesUnderDesignV1', () => {
+    const docPath = resolve(REPO_ROOT, 'docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml');
+    const raw = readFileSync(docPath, 'utf-8');
+    const parsed = DesignSidecarV1.safeParse(parse(raw));
+    if (!parsed.success) {
+      // Surface the first issue clearly when the test fails.
+      throw new Error(`Design sidecar invalid: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+    }
+    expect(parsed.success).toBe(true);
+  });
+
+  it('PlanSidecar_ParsesUnderPlanV1', () => {
+    const docPath = resolve(REPO_ROOT, 'docs/plans/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml');
+    const raw = readFileSync(docPath, 'utf-8');
+    const parsed = PlanSidecarV1.safeParse(parse(raw));
+    if (!parsed.success) {
+      throw new Error(`Plan sidecar invalid: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+    }
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
@@ -1,0 +1,325 @@
+// ─── Sidecar Consumption Tests (T15, #1298) ──────────────────────────────────
+//
+// Cross-gate behaviour: each of the four authoring gates must consume the
+// machine-readable `<doc>.sidecar.yml` when present, and fall back to the
+// existing regex-scrape path with a deprecation warning when absent.
+//
+// These tests anchor that contract end-to-end against real on-disk fixtures
+// (no mocks) so the wiring between the handler, the sidecar-lookup helper,
+// and the underlying pure functions is exercised once per gate.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import type { EventStore } from '../event-store/store.js';
+
+import { handleDesignCompleteness } from './design-completeness.js';
+import { handlePlanCoverage } from './plan-coverage.js';
+import { handleProvenanceChain } from './provenance-chain.js';
+import { handleTaskDecomposition } from './task-decomposition.js';
+import { orchestrateLogger } from '../logger.js';
+
+// ─── Test scaffolding ───────────────────────────────────────────────────────
+
+const mockAppend = vi.fn();
+const mockQuery = vi.fn();
+const mockStore = {
+  append: mockAppend,
+  query: mockQuery,
+} as unknown as EventStore;
+
+let workDir: string;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'sidecar-consumption-'));
+  mockAppend.mockResolvedValue({
+    streamId: 'feat',
+    sequence: 1,
+    type: 'gate.executed',
+    timestamp: new Date().toISOString(),
+  });
+  mockQuery.mockResolvedValue([]);
+  // The deprecation message is emitted via pino (`orchestrateLogger.warn`)
+  // to stay inside the no-console-in-production policy (#1119).
+  warnSpy = vi.spyOn(orchestrateLogger, 'warn').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  if (existsSync(workDir)) {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+/** Concatenate all spied logger.warn invocations into one searchable string. */
+function collectWarnMessages(): string {
+  return warnSpy.mock.calls
+    .flatMap((call) => call.map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg))))
+    .join('\n');
+}
+
+// ─── Fixture helpers ────────────────────────────────────────────────────────
+
+function writeConformantDesignMarkdown(designPath: string): void {
+  // Conforms to existing regex-scrape expectations so the fallback path passes.
+  const content = `# Sample Design
+
+## Problem Statement
+Stuff.
+
+## Requirements
+- DR-1: Foo
+
+  - Given: X
+  - When: Y
+  - Then: Z
+
+## Chosen Approach
+Some prose.
+
+### Option 1
+A.
+
+### Option 2
+B.
+
+## Technical Design
+### Section A
+Detail.
+
+## Integration Points
+Stuff.
+
+## Testing Strategy
+Stuff.
+
+## Open Questions
+None.
+`;
+  writeFileSync(designPath, content, 'utf-8');
+}
+
+function writeConformantPlanMarkdown(planPath: string): void {
+  const content = `# Plan
+
+## Tasks
+
+### Task T-01: First task title with Section A and substantial description text
+
+**Goal:** Implement DR-1 with a description that comfortably exceeds ten words for the structural check.
+
+**Files:** \`src/a.ts\`, \`src/a.test.ts\`
+
+**Tests:** [RED] First_Test_Name
+
+**Dependencies:** none
+
+**Parallelizable:** No
+
+### Task T-02: Acceptance test task covering DR-1
+
+**Goal:** Provide acceptance coverage with at least ten descriptive words to satisfy the structural validator.
+
+**Test Layer:** acceptance
+
+**Implements:** DR-1
+
+**Files:** \`src/a.acceptance.test.ts\`
+
+**Tests:** [RED] Second_Test_Name
+
+**Dependencies:** T-01
+
+**Parallelizable:** No
+`;
+  writeFileSync(planPath, content, 'utf-8');
+}
+
+function writeDesignSidecar(designPath: string): void {
+  const yaml = `schema: design.v1
+sections:
+  problem: { present: true }
+  approaches: { present: true }
+drs:
+  - { id: DR-1, title: Foo, section: Wave A }
+acceptance:
+  - { id: A-1, references: [DR-1] }
+options:
+  count: 2
+`;
+  writeFileSync(`${designPath}.sidecar.yml`, yaml, 'utf-8');
+}
+
+function writePlanSidecar(planPath: string): void {
+  const yaml = `schema: plan.v1
+tasks:
+  - id: T-01
+    phase: RED
+    description: First failing test that anchors the contract before any production code lands
+    files: [src/a.test.ts]
+  - id: T-02
+    phase: GREEN
+    description: Minimal implementation turning the RED test green without overreach
+    files: [src/a.ts]
+coverage:
+  DR-1: [T-01, T-02]
+provenance:
+  - { taskId: T-01, dr: DR-1 }
+  - { taskId: T-02, dr: DR-1 }
+`;
+  writeFileSync(`${planPath}.sidecar.yml`, yaml, 'utf-8');
+}
+
+// ─── design-completeness ─────────────────────────────────────────────────────
+
+describe('CheckDesignCompleteness', () => {
+  it('SidecarPresent_UsesStructuredInput', async () => {
+    const designDir = join(workDir, 'designs');
+    mkdirSync(designDir, { recursive: true });
+    const designPath = join(designDir, '2026-05-15-fixture.md');
+    writeConformantDesignMarkdown(designPath);
+    writeDesignSidecar(designPath);
+
+    const stateDir = join(workDir, 'state');
+    mkdirSync(stateDir, { recursive: true });
+    const stateFile = join(stateDir, 'feat.state.json');
+    writeFileSync(stateFile, JSON.stringify({ artifacts: { design: designPath } }), 'utf-8');
+
+    const result = await handleDesignCompleteness(
+      { featureId: 'feat', stateFile, designPath },
+      stateDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { passed: boolean; source?: string; findings: readonly string[] };
+      expect(data.passed).toBe(true);
+      // Structured-input branch surfaces a `source: 'sidecar'` signal in the result.
+      expect(data.source).toBe('sidecar');
+    }
+    // Deprecation warning must NOT fire when sidecar is present.
+    expect(collectWarnMessages()).not.toContain('[DEPRECATION] sidecar missing');
+  });
+
+  it('NoSidecar_FallsBackToRegexWithDeprecationLog', async () => {
+    const designDir = join(workDir, 'designs');
+    mkdirSync(designDir, { recursive: true });
+    const designPath = join(designDir, '2026-05-15-fixture.md');
+    writeConformantDesignMarkdown(designPath);
+    // No sidecar written.
+
+    const stateDir = join(workDir, 'state');
+    mkdirSync(stateDir, { recursive: true });
+    const stateFile = join(stateDir, 'feat.state.json');
+    writeFileSync(stateFile, JSON.stringify({ artifacts: { design: designPath } }), 'utf-8');
+
+    const result = await handleDesignCompleteness(
+      { featureId: 'feat', stateFile, designPath },
+      stateDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { source?: string };
+      expect(data.source).toBe('regex');
+    }
+    const allWarns = collectWarnMessages();
+    expect(allWarns).toContain('[DEPRECATION]');
+    expect(allWarns).toContain(designPath);
+  });
+});
+
+// ─── plan-coverage ──────────────────────────────────────────────────────────
+
+describe('CheckPlanCoverage', () => {
+  it('SidecarPresent_VerifiesDrCoverageStructurally', async () => {
+    const designDir = join(workDir, 'designs');
+    mkdirSync(designDir, { recursive: true });
+    const designPath = join(designDir, '2026-05-15-fixture.md');
+    writeConformantDesignMarkdown(designPath);
+    writeDesignSidecar(designPath);
+
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-fixture.md');
+    writeConformantPlanMarkdown(planPath);
+    writePlanSidecar(planPath);
+
+    const result = await handlePlanCoverage(
+      { featureId: 'feat', designPath, planPath },
+      workDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { passed: boolean; source?: string };
+      expect(data.source).toBe('sidecar');
+      expect(data.passed).toBe(true);
+    }
+    expect(collectWarnMessages()).not.toContain('[DEPRECATION] sidecar missing');
+  });
+});
+
+// ─── provenance-chain ───────────────────────────────────────────────────────
+
+describe('CheckProvenanceChain', () => {
+  it('SidecarPresent_VerifiesDrsStructurally', async () => {
+    const designDir = join(workDir, 'designs');
+    mkdirSync(designDir, { recursive: true });
+    const designPath = join(designDir, '2026-05-15-fixture.md');
+    writeConformantDesignMarkdown(designPath);
+    writeDesignSidecar(designPath);
+
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-fixture.md');
+    writeConformantPlanMarkdown(planPath);
+    writePlanSidecar(planPath);
+
+    const result = await handleProvenanceChain(
+      { featureId: 'feat', designPath, planPath },
+      workDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { passed: boolean; source?: string };
+      expect(data.source).toBe('sidecar');
+      expect(data.passed).toBe(true);
+    }
+  });
+});
+
+// ─── task-decomposition ─────────────────────────────────────────────────────
+
+describe('CheckTaskDecomposition', () => {
+  it('SidecarPresent_VerifiesTasksStructurally', async () => {
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-fixture.md');
+    writeConformantPlanMarkdown(planPath);
+    writePlanSidecar(planPath);
+
+    const result = await handleTaskDecomposition(
+      { featureId: 'feat', planPath },
+      workDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { passed: boolean; source?: string; totalTasks: number };
+      expect(data.source).toBe('sidecar');
+      expect(data.passed).toBe(true);
+      expect(data.totalTasks).toBe(2);
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-consumption.test.ts
@@ -155,15 +155,19 @@ options:
 }
 
 function writePlanSidecar(planPath: string): void {
+  // Descriptions include [RED]/Method_Scenario_Outcome markers to satisfy the
+  // sidecar task-decomposition gate's test-marker requirement, mirroring the
+  // markdown body convention (`**Tests:** [RED] First_Test_Name`) the legacy
+  // regex path validates.
   const yaml = `schema: plan.v1
 tasks:
   - id: T-01
     phase: RED
-    description: First failing test that anchors the contract before any production code lands
+    description: "[RED] First_Test_Name — failing test that anchors the contract before any production code lands"
     files: [src/a.test.ts]
   - id: T-02
     phase: GREEN
-    description: Minimal implementation turning the RED test green without overreach
+    description: "Minimal implementation turning the [RED] Second_Test_Name green without overreach beyond the contract"
     files: [src/a.ts]
 coverage:
   DR-1: [T-01, T-02]
@@ -321,5 +325,162 @@ describe('CheckTaskDecomposition', () => {
       expect(data.passed).toBe(true);
       expect(data.totalTasks).toBe(2);
     }
+  });
+
+  it('SidecarTaskDecomposition_DescriptionUnderTenWords_FailsLikeLegacy', async () => {
+    // Sentry #1425 HIGH: pre-fix the sidecar gate accepted any description
+    // >= 5 words. Legacy `validateTaskStructure` requires > 10. Drift was a
+    // silent regression in decomposition quality. Pin both branches to the
+    // same threshold.
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-fixture.md');
+    writeConformantPlanMarkdown(planPath);
+    const shortDescSidecar = `schema: plan.v1
+tasks:
+  - id: T-01
+    phase: RED
+    description: "[RED] Short_Test_Name only six words here"
+    files: [src/a.test.ts]
+coverage:
+  DR-1: [T-01]
+provenance:
+  - { taskId: T-01, dr: DR-1 }
+`;
+    writeFileSync(`${planPath}.sidecar.yml`, shortDescSidecar, 'utf-8');
+
+    const result = await handleTaskDecomposition(
+      { featureId: 'feat', planPath },
+      workDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { passed: boolean; source?: string; needsRework: number };
+      expect(data.source).toBe('sidecar');
+      expect(data.passed).toBe(false);
+      expect(data.needsRework).toBeGreaterThan(0);
+    }
+  });
+
+  it('SidecarTaskDecomposition_DescriptionMissingTestMarker_FailsLikeLegacy', async () => {
+    // Sentry #1425 HIGH: pre-fix the sidecar gate omitted the test-marker
+    // check entirely. A task could claim `phase: RED` with a description
+    // containing no test method name. Legacy `validateTaskStructure`
+    // requires at least one `[RED]` token or `Method_Scenario_Outcome`
+    // triple in the block body.
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-fixture.md');
+    writeConformantPlanMarkdown(planPath);
+    const noMarkerSidecar = `schema: plan.v1
+tasks:
+  - id: T-01
+    phase: RED
+    description: "A perfectly long description that comfortably exceeds ten words but has no test markers anywhere"
+    files: [src/a.test.ts]
+coverage:
+  DR-1: [T-01]
+provenance:
+  - { taskId: T-01, dr: DR-1 }
+`;
+    writeFileSync(`${planPath}.sidecar.yml`, noMarkerSidecar, 'utf-8');
+
+    const result = await handleTaskDecomposition(
+      { featureId: 'feat', planPath },
+      workDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const data = result.data as { passed: boolean; source?: string; needsRework: number };
+      expect(data.source).toBe('sidecar');
+      expect(data.passed).toBe(false);
+      expect(data.needsRework).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ─── #1425 follow-ups: empty-drs + log-once dedup ───────────────────────────
+
+describe('CheckPlanCoverage — sidecar parity follow-ups', () => {
+  it('SidecarPlanCoverage_EmptyDrsArray_FailsClosedWithNoDesignSections', async () => {
+    // Sentry #1425 MEDIUM: pre-fix an empty `drs[]` from a malformed design
+    // sidecar yielded `total=0, gaps=0, passed=true` — silently passing a
+    // design with zero requirements. Legacy regex path returns
+    // `NO_DESIGN_SECTIONS` for the equivalent input. Sidecar path must
+    // match the same error code.
+    const designDir = join(workDir, 'designs');
+    mkdirSync(designDir, { recursive: true });
+    const designPath = join(designDir, '2026-05-15-fixture.md');
+    writeConformantDesignMarkdown(designPath);
+    const emptyDrsSidecar = `schema: design.v1
+sections: {}
+drs: []
+acceptance: []
+`;
+    writeFileSync(`${designPath}.sidecar.yml`, emptyDrsSidecar, 'utf-8');
+
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-fixture.md');
+    writeConformantPlanMarkdown(planPath);
+    writePlanSidecar(planPath);
+
+    const result = await handlePlanCoverage(
+      { featureId: 'feat', designPath, planPath },
+      workDir,
+      mockStore,
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.code).toBe('NO_DESIGN_SECTIONS');
+    }
+  });
+});
+
+describe('SidecarLookup — log-once dedup', () => {
+  it('SidecarMissing_AcrossMultipleGates_LogsDeprecationOncePerDocPath', async () => {
+    // Sentry #1425 LOW: pre-fix the deprecation warning fired once per
+    // (gate × missing-file) combination — 4+ duplicate lines per check for
+    // a workflow without sidecars. Per-process dedup collapses repeats.
+    const { __resetDeprecationLog } = await import('./sidecar-lookup.js');
+    __resetDeprecationLog();
+
+    const designDir = join(workDir, 'designs');
+    mkdirSync(designDir, { recursive: true });
+    const designPath = join(designDir, '2026-05-15-dedup.md');
+    writeConformantDesignMarkdown(designPath);
+
+    const planDir = join(workDir, 'plans');
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, '2026-05-15-dedup.md');
+    writeConformantPlanMarkdown(planPath);
+
+    // Hit four gates back-to-back with NO sidecars on disk. The legacy regex
+    // path runs each time and the missing-sidecar warning would fire on
+    // every call without dedup. We assert the warn count for each unique
+    // docPath stays at exactly 1.
+    await handleDesignCompleteness({ featureId: 'feat', designPath }, workDir, mockStore);
+    await handlePlanCoverage({ featureId: 'feat', designPath, planPath }, workDir, mockStore);
+    await handleProvenanceChain({ featureId: 'feat', designPath, planPath }, workDir, mockStore);
+    await handleTaskDecomposition({ featureId: 'feat', planPath }, workDir, mockStore);
+
+    const designWarnHits = warnSpy.mock.calls.filter((call) =>
+      call.some(
+        (arg) => typeof arg === 'object' && arg !== null && (arg as { docPath?: string }).docPath === designPath,
+      ),
+    ).length;
+    const planWarnHits = warnSpy.mock.calls.filter((call) =>
+      call.some(
+        (arg) => typeof arg === 'object' && arg !== null && (arg as { docPath?: string }).docPath === planPath,
+      ),
+    ).length;
+
+    expect(designWarnHits).toBe(1);
+    expect(planWarnHits).toBe(1);
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-lookup.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-lookup.ts
@@ -52,14 +52,44 @@ export function buildDeprecationMessage(docPath: string): string {
 }
 
 /**
+ * Per-process log-once dedup for deprecation warnings (Sentry #1425 LOW).
+ *
+ * Multiple gates (plan-coverage, provenance-chain, task-decomposition,
+ * design-completeness) load the same sidecar pair (`<design>.sidecar.yml` +
+ * `<plan>.sidecar.yml`) sequentially during a single gate-check pass. Pre-fix
+ * the warning fired once per (gate × missing-file) combination — typically
+ * 6+ duplicate lines in CI for a workflow that hasn't generated sidecars yet.
+ * Now each unique docPath warns at most once for the lifetime of the process.
+ *
+ * The Set is module-scoped; tests reset it via `__resetDeprecationLog`.
+ * Keying by `docPath` alone (not by failure-mode) is intentional: the emitted
+ * message and remediation are identical for every miss path (missing /
+ * unreadable / malformed YAML / non-conformant), so any one warn per file is
+ * the right signal — collapsing the rest is pure noise reduction.
+ */
+const loggedDocPaths = new Set<string>();
+
+/**
+ * Test-only: clear the log-once cache so each test starts from a clean slate.
+ * Production code MUST NOT call this — silencing prod dedup defeats the
+ * Sentry #1425 noise-reduction guarantee.
+ */
+export function __resetDeprecationLog(): void {
+  loggedDocPaths.clear();
+}
+
+/**
  * Emit the canonical deprecation warning. Pre-v2.10.0-preview.4 docs are
  * grandfathered; older docs SHOULD log but are not load-bearing.
  *
  * Goes through `orchestrateLogger` (pino subsystem='orchestrate') so we
  * stay inside the project's no-console-in-production policy (#1119);
- * tests spy on the logger instance directly.
+ * tests spy on the logger instance directly. Deduped per-process by
+ * `loggedDocPaths` (see above).
  */
 function logDeprecation(docPath: string): void {
+  if (loggedDocPaths.has(docPath)) return;
+  loggedDocPaths.add(docPath);
   orchestrateLogger.warn({ docPath, gate: 'sidecar-lookup' }, buildDeprecationMessage(docPath));
 }
 

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-lookup.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-lookup.ts
@@ -1,0 +1,123 @@
+// ─── Sidecar Lookup Helper (#1298) ───────────────────────────────────────────
+//
+// Locates `<doc>.sidecar.yml` next to a design or plan markdown file and
+// parses it via the relevant Zod schema. When the sidecar is missing or
+// fails to parse cleanly, returns `null` and emits the canonical deprecation
+// warning via `console.warn` so the calling gate can fall back to the
+// regex-scrape path.
+//
+// Removal of the regex-fallback branch is scheduled for v2.11 — tracking
+// issue placeholder is surfaced in the warning so it can be patched at
+// merge time.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { existsSync, readFileSync } from 'node:fs';
+import { parse as parseYaml } from 'yaml';
+import type { z } from 'zod';
+
+import { orchestrateLogger } from '../logger.js';
+import {
+  DesignSidecarV1,
+  PlanSidecarV1,
+  type DesignSidecarV1 as DesignSidecarV1Type,
+  type PlanSidecarV1 as PlanSidecarV1Type,
+} from './sidecar-schemas.js';
+
+/**
+ * GitHub issue tracking removal of the regex-fallback branch in v2.11.
+ * Filed alongside #1298 (v2.10.0-preview.4 PR D2).
+ */
+export const REGEX_REMOVAL_TRACKING_ISSUE = '#1407';
+
+/**
+ * Compute the conventional sidecar path for a doc: `<doc>.sidecar.yml`.
+ * The doc path itself is preserved verbatim, including its `.md` suffix —
+ * sidecars are always `<doc>.md.sidecar.yml` next to the markdown.
+ */
+export function sidecarPathFor(docPath: string): string {
+  return `${docPath}.sidecar.yml`;
+}
+
+/**
+ * Build the canonical deprecation warning string. Surfaced both via pino
+ * (`orchestrateLogger.warn`) for operator-visible logs and returned to
+ * callers/tests so the gate response can include the same text.
+ */
+export function buildDeprecationMessage(docPath: string): string {
+  return (
+    `[DEPRECATION] sidecar missing for ${docPath}; if pre-v2.10.0-preview.4, ` +
+    `grandfathered; otherwise regenerate via npm run sidecar:emit. Regex ` +
+    `fallback scheduled for removal in v2.11. Tracking: ${REGEX_REMOVAL_TRACKING_ISSUE}`
+  );
+}
+
+/**
+ * Emit the canonical deprecation warning. Pre-v2.10.0-preview.4 docs are
+ * grandfathered; older docs SHOULD log but are not load-bearing.
+ *
+ * Goes through `orchestrateLogger` (pino subsystem='orchestrate') so we
+ * stay inside the project's no-console-in-production policy (#1119);
+ * tests spy on the logger instance directly.
+ */
+function logDeprecation(docPath: string): void {
+  orchestrateLogger.warn({ docPath, gate: 'sidecar-lookup' }, buildDeprecationMessage(docPath));
+}
+
+/**
+ * Internal: load + schema-validate a sidecar of the requested shape.
+ */
+function loadSidecar<T extends z.ZodTypeAny>(
+  docPath: string,
+  schema: T,
+): z.infer<T> | null {
+  const sidecarPath = sidecarPathFor(docPath);
+  if (!existsSync(sidecarPath)) {
+    logDeprecation(docPath);
+    return null;
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(sidecarPath, 'utf-8');
+  } catch {
+    logDeprecation(docPath);
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch {
+    // Malformed YAML — fall back to regex with deprecation log.
+    logDeprecation(docPath);
+    return null;
+  }
+
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    logDeprecation(docPath);
+    return null;
+  }
+
+  return result.data;
+}
+
+/**
+ * Load the `<design>.sidecar.yml` next to `designPath`. Returns the parsed
+ * `DesignSidecarV1` when available + conformant, or `null` (logging a
+ * deprecation warning) when missing, unreadable, malformed, or
+ * non-conformant.
+ */
+export function loadDesignSidecar(designPath: string): DesignSidecarV1Type | null {
+  return loadSidecar(designPath, DesignSidecarV1);
+}
+
+/**
+ * Load the `<plan>.sidecar.yml` next to `planPath`. Returns the parsed
+ * `PlanSidecarV1` when available + conformant, or `null` (logging a
+ * deprecation warning) when missing, unreadable, malformed, or
+ * non-conformant.
+ */
+export function loadPlanSidecar(planPath: string): PlanSidecarV1Type | null {
+  return loadSidecar(planPath, PlanSidecarV1);
+}

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-schemas.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-schemas.test.ts
@@ -1,0 +1,96 @@
+// ─── Sidecar Schemas — RED tests (T14, #1298) ────────────────────────────────
+//
+// These tests anchor the design.v1 and plan.v1 sidecar contracts. Gates
+// consume the parsed sidecar instead of regex-scraping the markdown when
+// the sidecar is present (see T15).
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import {
+  DesignSidecarV1,
+  PlanSidecarV1,
+} from './sidecar-schemas.js';
+
+describe('SidecarSchema_DesignV1', () => {
+  it('AcceptsConformantDoc', () => {
+    const doc = {
+      schema: 'design.v1',
+      sections: {
+        problem: { present: true },
+        approaches: { present: true },
+      },
+      drs: [
+        { id: 'DR-1', title: 'Zod unions', section: 'Wave A' },
+        { id: 'DR-2', title: 'Quality hint', section: 'Wave A' },
+      ],
+      acceptance: [
+        { id: 'A-1', references: ['DR-1'] },
+        { id: 'A-2', references: ['DR-1', 'DR-2'] },
+      ],
+      options: { count: 3 },
+    };
+
+    const parsed = DesignSidecarV1.safeParse(doc);
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe('SidecarSchema_PlanV1', () => {
+  it('AcceptsConformantDoc', () => {
+    const doc = {
+      schema: 'plan.v1',
+      tasks: [
+        { id: 'T01', phase: 'RED', description: 'Author the failing test', files: ['a.test.ts'] },
+        { id: 'T02', phase: 'GREEN', description: 'Implement minimal pass', files: ['a.ts'] },
+        { id: 'T03', phase: 'REFACTOR', description: 'Tidy', files: ['a.ts'] },
+      ],
+      coverage: {
+        'DR-1': ['T01', 'T02'],
+        'DR-2': ['T03'],
+      },
+      provenance: [
+        { taskId: 'T01', dr: 'DR-1' },
+        { taskId: 'T02', dr: 'DR-1' },
+        { taskId: 'T03', dr: 'DR-2' },
+      ],
+    };
+
+    const parsed = PlanSidecarV1.safeParse(doc);
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe('SidecarSchema_MismatchedSchemaVersion', () => {
+  it('Rejected for design when schema is wrong literal', () => {
+    const doc = {
+      schema: 'design.v2', // not the literal
+      sections: {},
+      drs: [],
+      acceptance: [],
+    };
+    const parsed = DesignSidecarV1.safeParse(doc);
+    expect(parsed.success).toBe(false);
+  });
+
+  it('Rejected for plan when schema is wrong literal', () => {
+    const doc = {
+      schema: 'plan.v0',
+      tasks: [],
+      coverage: {},
+      provenance: [],
+    };
+    const parsed = PlanSidecarV1.safeParse(doc);
+    expect(parsed.success).toBe(false);
+  });
+
+  it('Rejected when phase is outside the RED/GREEN/REFACTOR enum', () => {
+    const doc = {
+      schema: 'plan.v1',
+      tasks: [{ id: 'T01', phase: 'BLUE', description: 'x', files: [] }],
+      coverage: {},
+      provenance: [],
+    };
+    const parsed = PlanSidecarV1.safeParse(doc);
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/sidecar-schemas.ts
+++ b/servers/exarchos-mcp/src/orchestrate/sidecar-schemas.ts
@@ -1,0 +1,84 @@
+// ─── Sidecar Schemas (design.v1, plan.v1) — #1298 ────────────────────────────
+//
+// Machine-readable sidecar contracts consumed by the four authoring gates
+// (`check_design_completeness`, `check_plan_coverage`, `check_provenance_chain`,
+// `check_task_decomposition`). When a `<doc>.sidecar.yml` is present next to
+// the markdown, gates parse it via these schemas and operate on structured
+// input. When absent, gates fall back to the existing regex-scrape branch
+// with a deprecation warning (scheduled for removal in v2.11).
+//
+// Schema-version is a literal (`design.v1` / `plan.v1`) so mismatched-version
+// docs reject cleanly via `safeParse(...).success === false`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { z } from 'zod';
+
+// ─── Design.v1 ──────────────────────────────────────────────────────────────
+
+/**
+ * A single design requirement, identified by its DR-N id with a title and the
+ * design section it appears under.
+ */
+export const DesignRequirementSchema = z.object({
+  id: z.string().min(1),
+  title: z.string(),
+  section: z.string(),
+});
+
+/**
+ * An acceptance criterion entry, identified by id, references one or more DRs.
+ */
+export const AcceptanceCriterionSchema = z.object({
+  id: z.string().min(1),
+  references: z.array(z.string()),
+});
+
+/**
+ * Per-section presence flag. Gates that scan markdown for "is section X
+ * present?" now read this directly. Extra section-specific scalars (like
+ * `options.count`) live at the top-level alongside `sections`.
+ */
+export const DesignSectionEntrySchema = z.object({
+  present: z.boolean(),
+});
+
+export const DesignSidecarV1 = z.object({
+  schema: z.literal('design.v1'),
+  sections: z.record(z.string(), DesignSectionEntrySchema),
+  drs: z.array(DesignRequirementSchema),
+  acceptance: z.array(AcceptanceCriterionSchema),
+  options: z
+    .object({
+      count: z.number().int().nonnegative(),
+    })
+    .optional(),
+});
+
+export type DesignSidecarV1 = z.infer<typeof DesignSidecarV1>;
+
+// ─── Plan.v1 ────────────────────────────────────────────────────────────────
+
+export const PlanTaskPhaseSchema = z.enum(['RED', 'GREEN', 'REFACTOR']);
+export type PlanTaskPhase = z.infer<typeof PlanTaskPhaseSchema>;
+
+export const PlanTaskEntrySchema = z.object({
+  id: z.string().min(1),
+  phase: PlanTaskPhaseSchema,
+  description: z.string(),
+  files: z.array(z.string()),
+});
+
+export const PlanProvenanceEntrySchema = z.object({
+  taskId: z.string().min(1),
+  dr: z.string().min(1),
+});
+
+export const PlanSidecarV1 = z.object({
+  schema: z.literal('plan.v1'),
+  tasks: z.array(PlanTaskEntrySchema),
+  // Maps DR id → task ids that cover that requirement.
+  coverage: z.record(z.string(), z.array(z.string())),
+  provenance: z.array(PlanProvenanceEntrySchema),
+});
+
+export type PlanSidecarV1 = z.infer<typeof PlanSidecarV1>;

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -843,13 +843,21 @@ export async function handleTaskDecomposition(
 
 /**
  * Validate task decomposition from the structured plan sidecar. Each task
- * is checked for: non-empty description (>= 5 words), at least one declared
- * file, and a phase from the RED/GREEN/REFACTOR enum (already enforced by
- * the schema).
+ * is checked against the same rules as the legacy `validateTaskStructure`
+ * regex path so the sidecar route does not silently weaken the gate
+ * (CodeRabbit #1425 — Sentry HIGH):
  *
- * Parallel safety + dependency DAG are no-ops in the sidecar path for now
- * — both inputs are absent from the v1 shape (deps/parallel flags would
- * widen the contract). Future schema revisions can add them.
+ *   - description word count > 10 (matches legacy `descriptionWordCount > 10`)
+ *   - at least one declared file
+ *   - at least one test marker in the description: either a `[RED]` token or
+ *     a `Method_Scenario_Outcome` PascalCase triple — the same patterns the
+ *     legacy `validateTaskStructure` body scans for. The sidecar's `phase`
+ *     enum (RED/GREEN/REFACTOR) is necessary but not sufficient: a `RED`
+ *     phase claim without an actual test name in the description is exactly
+ *     the kind of low-quality decomposition the legacy gate rejected.
+ *
+ * Parallel safety + dependency DAG remain no-ops in the sidecar path — both
+ * inputs are absent from the v1 shape. Future schema revisions can add them.
  */
 function evaluateTaskDecompositionFromSidecar(plan: PlanSidecarV1): {
   passed: boolean;
@@ -864,14 +872,25 @@ function evaluateTaskDecompositionFromSidecar(plan: PlanSidecarV1): {
   let needsRework = 0;
   const rows: string[] = [];
 
+  // Mirror the legacy regex pair from `validateTaskStructure` so the two
+  // paths converge on the same definition of "test marker."
+  const redPattern = /\[RED\]/g;
+  const msoPattern = /[A-Z][a-zA-Z]+_[A-Z][a-zA-Z]+_[A-Z][a-zA-Z]+/g;
+
   for (const task of plan.tasks) {
     const descWords = task.description.trim().split(/\s+/).filter((w) => w.length > 0).length;
-    const hasDescription = descWords >= 5;
+    const hasDescription = descWords > 10;
     const hasFiles = task.files.length > 0;
-    const status = hasDescription && hasFiles ? 'PASS' : 'FAIL';
+    const redMatches = task.description.match(redPattern) ?? [];
+    const msoMatches = task.description.match(msoPattern) ?? [];
+    const testCount = redMatches.length + msoMatches.length;
+    const hasTests = testCount > 0;
+    const status = hasDescription && hasFiles && hasTests ? 'PASS' : 'FAIL';
     if (status === 'PASS') wellDecomposed++;
     else needsRework++;
-    rows.push(`| ${task.id} | ${task.phase} | ${descWords} words | ${task.files.length} files | ${status} |`);
+    rows.push(
+      `| ${task.id} | ${task.phase} | ${descWords} words | ${task.files.length} files | ${testCount} tests | ${status} |`,
+    );
   }
 
   const totalTasks = plan.tasks.length;
@@ -879,8 +898,8 @@ function evaluateTaskDecompositionFromSidecar(plan: PlanSidecarV1): {
   const report = [
     '## Task Decomposition Report (sidecar)',
     '',
-    '| Task | Phase | Description | Files | Status |',
-    '|------|-------|-------------|-------|--------|',
+    '| Task | Phase | Description | Files | Tests | Status |',
+    '|------|-------|-------------|-------|-------|--------|',
     ...rows,
     '',
     `- Well-decomposed: ${wellDecomposed}/${totalTasks}`,

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -12,6 +12,8 @@ import { readFile } from 'node:fs/promises';
 import type { ToolResult } from '../format.js';
 import type { EventStore } from '../event-store/store.js';
 import { emitGateEvent } from './gate-utils.js';
+import { loadPlanSidecar } from './sidecar-lookup.js';
+import type { PlanSidecarV1 } from './sidecar-schemas.js';
 
 // ─── Types ───────────────────────────────────────────────────────────────
 
@@ -671,6 +673,22 @@ export async function handleTaskDecomposition(
     };
   }
 
+  // Prefer the sidecar (T15) when present + conformant.
+  const planSidecar = loadPlanSidecar(args.planPath);
+  if (planSidecar) {
+    const sidecarResult = evaluateTaskDecompositionFromSidecar(planSidecar);
+    try {
+      await emitGateEvent(eventStore, args.featureId, 'task-decomposition', 'planning', sidecarResult.passed, {
+        dimension: 'D5',
+        phase: 'plan',
+        wellDecomposed: sidecarResult.wellDecomposed,
+        needsRework: sidecarResult.needsRework,
+        totalTasks: sidecarResult.totalTasks,
+      });
+    } catch { /* fire-and-forget */ }
+    return { success: true, data: { ...sidecarResult, source: 'sidecar' as const } };
+  }
+
   // Read plan file
   let planContent: string;
   try {
@@ -818,5 +836,66 @@ export async function handleTaskDecomposition(
     report,
   };
 
-  return { success: true, data: result };
+  return { success: true, data: { ...result, source: 'regex' as const } };
+}
+
+// ─── Sidecar evaluation ─────────────────────────────────────────────────────
+
+/**
+ * Validate task decomposition from the structured plan sidecar. Each task
+ * is checked for: non-empty description (>= 5 words), at least one declared
+ * file, and a phase from the RED/GREEN/REFACTOR enum (already enforced by
+ * the schema).
+ *
+ * Parallel safety + dependency DAG are no-ops in the sidecar path for now
+ * — both inputs are absent from the v1 shape (deps/parallel flags would
+ * widen the contract). Future schema revisions can add them.
+ */
+function evaluateTaskDecompositionFromSidecar(plan: PlanSidecarV1): {
+  passed: boolean;
+  wellDecomposed: number;
+  needsRework: number;
+  totalTasks: number;
+  dagValid: boolean;
+  parallelSafe: boolean;
+  report: string;
+} {
+  let wellDecomposed = 0;
+  let needsRework = 0;
+  const rows: string[] = [];
+
+  for (const task of plan.tasks) {
+    const descWords = task.description.trim().split(/\s+/).filter((w) => w.length > 0).length;
+    const hasDescription = descWords >= 5;
+    const hasFiles = task.files.length > 0;
+    const status = hasDescription && hasFiles ? 'PASS' : 'FAIL';
+    if (status === 'PASS') wellDecomposed++;
+    else needsRework++;
+    rows.push(`| ${task.id} | ${task.phase} | ${descWords} words | ${task.files.length} files | ${status} |`);
+  }
+
+  const totalTasks = plan.tasks.length;
+  const passed = needsRework === 0;
+  const report = [
+    '## Task Decomposition Report (sidecar)',
+    '',
+    '| Task | Phase | Description | Files | Status |',
+    '|------|-------|-------------|-------|--------|',
+    ...rows,
+    '',
+    `- Well-decomposed: ${wellDecomposed}/${totalTasks}`,
+    `- Needs rework: ${needsRework}/${totalTasks}`,
+    '',
+    passed ? '**Result: PASS**' : `**Result: FAIL** — ${needsRework} tasks need rework`,
+  ].join('\n');
+
+  return {
+    passed,
+    wellDecomposed,
+    needsRework,
+    totalTasks,
+    dagValid: true,
+    parallelSafe: true,
+    report,
+  };
 }

--- a/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
+++ b/servers/exarchos-mcp/src/orchestrate/task-decomposition.ts
@@ -673,20 +673,66 @@ export async function handleTaskDecomposition(
     };
   }
 
-  // Prefer the sidecar (T15) when present + conformant.
+  // Prefer the sidecar (T15) when present + conformant. CodeRabbit MAJOR
+  // #1425 r2: the sidecar v1 schema doesn't carry `deps[]` or parallel
+  // flags, so a sidecar-only evaluation would hardcode `dagValid: true`
+  // and `parallelSafe: true` — letting a plan with a dependency cycle or
+  // two parallel tasks targeting the same file pass the gate silently.
+  // Keep the markdown-derived DAG + parallel-safety checks running in
+  // the sidecar flow until the sidecar schema can carry that data.
   const planSidecar = loadPlanSidecar(args.planPath);
   if (planSidecar) {
     const sidecarResult = evaluateTaskDecompositionFromSidecar(planSidecar);
+    // Read the same markdown to derive deps + parallel flags. If the read
+    // fails or the markdown is unparseable, fall back to the sidecar's
+    // no-op assumption (clearly marked in the report) so the sidecar
+    // flow still produces a result — but flag the degraded mode.
+    let dagResult: DagValidationResult = { valid: true };
+    let safetyResult: ParallelSafetyResult = { safe: true, conflicts: [] };
+    let degraded = false;
     try {
-      await emitGateEvent(eventStore, args.featureId, 'task-decomposition', 'planning', sidecarResult.passed, {
+      const planContent = await readFile(args.planPath, 'utf-8');
+      const blocks = parseTaskBlocks(planContent);
+      if (blocks.length > 0) {
+        const dagTasks: DagTask[] = blocks.map((b) => ({
+          id: b.id,
+          deps: extractDependencies(b.content),
+        }));
+        dagResult = validateDependencyDAG(dagTasks);
+        const parallelTasks: ParallelTask[] = blocks.map((b) => ({
+          id: b.id,
+          isParallel: isParallelizable(b.content),
+          files: extractFiles(b.content),
+        }));
+        safetyResult = checkParallelSafety(parallelTasks);
+      } else {
+        degraded = true;
+      }
+    } catch {
+      degraded = true;
+    }
+    const combinedPassed = sidecarResult.passed && dagResult.valid && safetyResult.safe;
+    const combined = {
+      ...sidecarResult,
+      passed: combinedPassed,
+      dagValid: dagResult.valid,
+      parallelSafe: safetyResult.safe,
+      report:
+        sidecarResult.report +
+        (degraded
+          ? '\n\n*Note: DAG + parallel-safety checks degraded — markdown unreadable. dagValid/parallelSafe defaulted to true.*'
+          : `\n\n### Dependency Analysis\n- DAG valid: ${dagResult.valid}\n- Parallel-safe: ${safetyResult.safe}`),
+    };
+    try {
+      await emitGateEvent(eventStore, args.featureId, 'task-decomposition', 'planning', combined.passed, {
         dimension: 'D5',
         phase: 'plan',
-        wellDecomposed: sidecarResult.wellDecomposed,
-        needsRework: sidecarResult.needsRework,
-        totalTasks: sidecarResult.totalTasks,
+        wellDecomposed: combined.wellDecomposed,
+        needsRework: combined.needsRework,
+        totalTasks: combined.totalTasks,
       });
     } catch { /* fire-and-forget */ }
-    return { success: true, data: { ...sidecarResult, source: 'sidecar' as const } };
+    return { success: true, data: { ...combined, source: 'sidecar' as const } };
   }
 
   // Read plan file

--- a/skills-src/brainstorming/SKILL.md
+++ b/skills-src/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills-src/brainstorming/SKILL.md
+++ b/skills-src/brainstorming/SKILL.md
@@ -25,7 +25,7 @@ Activate this skill when:
 
 For a complete worked example, see `references/worked-example.md`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 

--- a/skills-src/brainstorming/SKILL.md
+++ b/skills-src/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/skills/claude/brainstorming/SKILL.md
+++ b/skills/claude/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills/claude/brainstorming/SKILL.md
+++ b/skills/claude/brainstorming/SKILL.md
@@ -25,7 +25,7 @@ Activate this skill when:
 
 For a complete worked example, see `references/worked-example.md`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 

--- a/skills/claude/brainstorming/SKILL.md
+++ b/skills/claude/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/skills/codex/brainstorming/SKILL.md
+++ b/skills/codex/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills/codex/brainstorming/SKILL.md
+++ b/skills/codex/brainstorming/SKILL.md
@@ -25,7 +25,7 @@ Activate this skill when:
 
 For a complete worked example, see `references/worked-example.md`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 

--- a/skills/codex/brainstorming/SKILL.md
+++ b/skills/codex/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/skills/copilot/brainstorming/SKILL.md
+++ b/skills/copilot/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills/copilot/brainstorming/SKILL.md
+++ b/skills/copilot/brainstorming/SKILL.md
@@ -25,7 +25,7 @@ Activate this skill when:
 
 For a complete worked example, see `references/worked-example.md`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 

--- a/skills/copilot/brainstorming/SKILL.md
+++ b/skills/copilot/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/skills/cursor/brainstorming/SKILL.md
+++ b/skills/cursor/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills/cursor/brainstorming/SKILL.md
+++ b/skills/cursor/brainstorming/SKILL.md
@@ -25,7 +25,7 @@ Activate this skill when:
 
 For a complete worked example, see `references/worked-example.md`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 

--- a/skills/cursor/brainstorming/SKILL.md
+++ b/skills/cursor/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/skills/generic/brainstorming/SKILL.md
+++ b/skills/generic/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills/generic/brainstorming/SKILL.md
+++ b/skills/generic/brainstorming/SKILL.md
@@ -25,7 +25,7 @@ Activate this skill when:
 
 For a complete worked example, see `references/worked-example.md`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 

--- a/skills/generic/brainstorming/SKILL.md
+++ b/skills/generic/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/skills/opencode/brainstorming/SKILL.md
+++ b/skills/opencode/brainstorming/SKILL.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/skills/opencode/brainstorming/SKILL.md
+++ b/skills/opencode/brainstorming/SKILL.md
@@ -25,7 +25,7 @@ Activate this skill when:
 
 For a complete worked example, see `references/worked-example.md`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 

--- a/skills/opencode/brainstorming/SKILL.md
+++ b/skills/opencode/brainstorming/SKILL.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/test/migration/__fixtures__/brainstorming-baseline.md
+++ b/test/migration/__fixtures__/brainstorming-baseline.md
@@ -27,6 +27,37 @@ For a complete worked example, see `references/worked-example.md`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load `docs/architecture/invariants.md` — the machine-readable catalog of `INV-*` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and `DIM-*` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | `INV-5a` (input ergonomics), `INV-5b` (output contract), `INV-5c` (Aspire-style verbs), `INV-5d` (action discriminator), `DIM-1` (topology) |
+| Event store / projection / workflow state | `INV-1` (event-sourcing integrity), `INV-2` (facade equivalence — if the projection feeds both adapters), `DIM-1`, `DIM-3` (contracts) |
+| Skills / commands / runtime authoring | `INV-4` (platform-agnosticity), `INV-6` (workflow-agnosticism), `DIM-8` (AI-prose-tells) |
+| Basileus or cross-product coordination | `INV-3` (basileus-forward), `basileus-boundary` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+```
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+```
+
+The `summary` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.

--- a/test/migration/__fixtures__/brainstorming-baseline.md
+++ b/test/migration/__fixtures__/brainstorming-baseline.md
@@ -25,7 +25,7 @@ Activate this skill when:
 
 For a complete worked example, see `references/worked-example.md`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 

--- a/test/migration/__fixtures__/brainstorming-baseline.md
+++ b/test/migration/__fixtures__/brainstorming-baseline.md
@@ -45,7 +45,7 @@ For a complete worked example, see `references/worked-example.md`.
 
 **Emit format (before Phase 1 questions):**
 
-```
+```markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -28,7 +28,7 @@ Activate this skill when:
 
 For a complete worked example, see \`references/worked-example.md\`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 
@@ -4751,7 +4751,7 @@ Activate this skill when:
 
 For a complete worked example, see \`references/worked-example.md\`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 
@@ -9427,7 +9427,7 @@ Activate this skill when:
 
 For a complete worked example, see \`references/worked-example.md\`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 
@@ -14095,7 +14095,7 @@ Activate this skill when:
 
 For a complete worked example, see \`references/worked-example.md\`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 
@@ -18773,7 +18773,7 @@ Activate this skill when:
 
 For a complete worked example, see \`references/worked-example.md\`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 
@@ -23422,7 +23422,7 @@ Activate this skill when:
 
 For a complete worked example, see \`references/worked-example.md\`.
 
-## Three-Phase Process
+## Four-Phase Process
 
 ### Phase 0: Constraint anchoring (first turn, before Phase 1)
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -48,7 +48,7 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 **Emit format (before Phase 1 questions):**
 
-\`\`\`
+\`\`\`markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:
@@ -4771,7 +4771,7 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 **Emit format (before Phase 1 questions):**
 
-\`\`\`
+\`\`\`markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:
@@ -9447,7 +9447,7 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 **Emit format (before Phase 1 questions):**
 
-\`\`\`
+\`\`\`markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:
@@ -14115,7 +14115,7 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 **Emit format (before Phase 1 questions):**
 
-\`\`\`
+\`\`\`markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:
@@ -18793,7 +18793,7 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 **Emit format (before Phase 1 questions):**
 
-\`\`\`
+\`\`\`markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:
@@ -23442,7 +23442,7 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 **Emit format (before Phase 1 questions):**
 
-\`\`\`
+\`\`\`markdown
 ## Constraints
 
 Anchored to docs/architecture/invariants.md:

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -30,6 +30,37 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load \`docs/architecture/invariants.md\` — the machine-readable catalog of \`INV-*\` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and \`DIM-*\` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | \`INV-5a\` (input ergonomics), \`INV-5b\` (output contract), \`INV-5c\` (Aspire-style verbs), \`INV-5d\` (action discriminator), \`DIM-1\` (topology) |
+| Event store / projection / workflow state | \`INV-1\` (event-sourcing integrity), \`INV-2\` (facade equivalence — if the projection feeds both adapters), \`DIM-1\`, \`DIM-3\` (contracts) |
+| Skills / commands / runtime authoring | \`INV-4\` (platform-agnosticity), \`INV-6\` (workflow-agnosticism), \`DIM-8\` (AI-prose-tells) |
+| Basileus or cross-product coordination | \`INV-3\` (basileus-forward), \`basileus-boundary\` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+\`\`\`
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+\`\`\`
+
+The \`summary\` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.
@@ -4722,6 +4753,37 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load \`docs/architecture/invariants.md\` — the machine-readable catalog of \`INV-*\` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and \`DIM-*\` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | \`INV-5a\` (input ergonomics), \`INV-5b\` (output contract), \`INV-5c\` (Aspire-style verbs), \`INV-5d\` (action discriminator), \`DIM-1\` (topology) |
+| Event store / projection / workflow state | \`INV-1\` (event-sourcing integrity), \`INV-2\` (facade equivalence — if the projection feeds both adapters), \`DIM-1\`, \`DIM-3\` (contracts) |
+| Skills / commands / runtime authoring | \`INV-4\` (platform-agnosticity), \`INV-6\` (workflow-agnosticism), \`DIM-8\` (AI-prose-tells) |
+| Basileus or cross-product coordination | \`INV-3\` (basileus-forward), \`basileus-boundary\` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+\`\`\`
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+\`\`\`
+
+The \`summary\` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.
@@ -9367,6 +9429,37 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load \`docs/architecture/invariants.md\` — the machine-readable catalog of \`INV-*\` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and \`DIM-*\` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | \`INV-5a\` (input ergonomics), \`INV-5b\` (output contract), \`INV-5c\` (Aspire-style verbs), \`INV-5d\` (action discriminator), \`DIM-1\` (topology) |
+| Event store / projection / workflow state | \`INV-1\` (event-sourcing integrity), \`INV-2\` (facade equivalence — if the projection feeds both adapters), \`DIM-1\`, \`DIM-3\` (contracts) |
+| Skills / commands / runtime authoring | \`INV-4\` (platform-agnosticity), \`INV-6\` (workflow-agnosticism), \`DIM-8\` (AI-prose-tells) |
+| Basileus or cross-product coordination | \`INV-3\` (basileus-forward), \`basileus-boundary\` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+\`\`\`
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+\`\`\`
+
+The \`summary\` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.
@@ -14003,6 +14096,37 @@ Activate this skill when:
 For a complete worked example, see \`references/worked-example.md\`.
 
 ## Three-Phase Process
+
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load \`docs/architecture/invariants.md\` — the machine-readable catalog of \`INV-*\` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and \`DIM-*\` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | \`INV-5a\` (input ergonomics), \`INV-5b\` (output contract), \`INV-5c\` (Aspire-style verbs), \`INV-5d\` (action discriminator), \`DIM-1\` (topology) |
+| Event store / projection / workflow state | \`INV-1\` (event-sourcing integrity), \`INV-2\` (facade equivalence — if the projection feeds both adapters), \`DIM-1\`, \`DIM-3\` (contracts) |
+| Skills / commands / runtime authoring | \`INV-4\` (platform-agnosticity), \`INV-6\` (workflow-agnosticism), \`DIM-8\` (AI-prose-tells) |
+| Basileus or cross-product coordination | \`INV-3\` (basileus-forward), \`basileus-boundary\` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+\`\`\`
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+\`\`\`
+
+The \`summary\` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
 
 ### Phase 1: Understanding
 
@@ -18651,6 +18775,37 @@ For a complete worked example, see \`references/worked-example.md\`.
 
 ## Three-Phase Process
 
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load \`docs/architecture/invariants.md\` — the machine-readable catalog of \`INV-*\` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and \`DIM-*\` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | \`INV-5a\` (input ergonomics), \`INV-5b\` (output contract), \`INV-5c\` (Aspire-style verbs), \`INV-5d\` (action discriminator), \`DIM-1\` (topology) |
+| Event store / projection / workflow state | \`INV-1\` (event-sourcing integrity), \`INV-2\` (facade equivalence — if the projection feeds both adapters), \`DIM-1\`, \`DIM-3\` (contracts) |
+| Skills / commands / runtime authoring | \`INV-4\` (platform-agnosticity), \`INV-6\` (workflow-agnosticism), \`DIM-8\` (AI-prose-tells) |
+| Basileus or cross-product coordination | \`INV-3\` (basileus-forward), \`basileus-boundary\` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+\`\`\`
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+\`\`\`
+
+The \`summary\` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
+
 ### Phase 1: Understanding
 
 **Goal:** Deeply understand the problem before proposing solutions.
@@ -23268,6 +23423,37 @@ Activate this skill when:
 For a complete worked example, see \`references/worked-example.md\`.
 
 ## Three-Phase Process
+
+### Phase 0: Constraint anchoring (first turn, before Phase 1)
+
+**Goal:** Surface the architectural invariants and axiom dimensions relevant to the proposal *before* the clarifying questions, so the design is anchored to load-bearing constraints from the first turn.
+
+**Source of truth:** Load \`docs/architecture/invariants.md\` — the machine-readable catalog of \`INV-*\` invariants (event-sourcing integrity, facade equivalence, basileus-forward, platform-agnosticity, agent-first input/output/verbs/discriminator, workflow-agnosticism) and \`DIM-*\` axiom dimensions (topology, observability, contracts, test-fidelity, vestigial-code, SOLID/coupling, error-handling, AI-prose-tells).
+
+**Selection rules — which invariants to surface as Constraints:**
+
+| Proposal shape | Anchor invariants (minimum) |
+|---|---|
+| CLI command / agent surface / new MCP action | \`INV-5a\` (input ergonomics), \`INV-5b\` (output contract), \`INV-5c\` (Aspire-style verbs), \`INV-5d\` (action discriminator), \`DIM-1\` (topology) |
+| Event store / projection / workflow state | \`INV-1\` (event-sourcing integrity), \`INV-2\` (facade equivalence — if the projection feeds both adapters), \`DIM-1\`, \`DIM-3\` (contracts) |
+| Skills / commands / runtime authoring | \`INV-4\` (platform-agnosticity), \`INV-6\` (workflow-agnosticism), \`DIM-8\` (AI-prose-tells) |
+| Basileus or cross-product coordination | \`INV-3\` (basileus-forward), \`basileus-boundary\` |
+| Multi-surface design (most non-trivial proposals) | Union of the above rows that apply |
+
+**Emit format (before Phase 1 questions):**
+
+\`\`\`
+## Constraints
+
+Anchored to docs/architecture/invariants.md:
+- INV-5a: <one-sentence summary from the catalog>
+- INV-5c: <one-sentence summary from the catalog>
+- DIM-1: <one-sentence summary from the catalog>
+
+(Probe Phase 1 questions against these.)
+\`\`\`
+
+The \`summary\` field of each catalog entry is the canonical one-sentence form — reuse it verbatim so the surfaced Constraints stay in sync with the catalog as it evolves.
 
 ### Phase 1: Understanding
 


### PR DESCRIPTION
## Summary

Wave D PR 1 (root). Closes #1260.

Extracts INV-1..INV-6 (incl. INV-5a/b/c/d), DIM-1..DIM-8, basileus-boundary into `docs/architecture/invariants.md` with structured YAML frontmatter. Wires `/exarchos:ideate` Phase 0 to load the file and emit a Constraint anchoring section before Phase 1.

Eliminates the "design proposal goes config-file-centric / human-first → user redirects against named frameworks" cycle (friction F2 from `docs/contexts/2026-05-07-insights-friction-discovery.md`).

## Changes
- `docs/architecture/invariants.md` (new, 319 LOC) — 18 entries with `id`, `dimension`, `applies-to`, `summary`, `references`.
- `servers/exarchos-mcp/src/architecture/invariants-loader.ts` (new) — frontmatter parser with duplicate-ID detection.
- `servers/exarchos-mcp/src/architecture/vocabulary-lint.ts` (new) — scans markdown for `INV-N` / `DIM-N` references.
- `vocabulary-lint-cli.ts` (new) — exposes via `npm run lint:invariants`.
- `commands/ideate.md` + `skills-src/brainstorming/SKILL.md` — load invariants on first turn.
- 6 regenerated per-runtime brainstorming SKILL variants.

## Test Plan
- [x] Root typecheck + test:run clean (762 passed)
- [x] MCP-server test:run clean for new files
- [x] skills:guard clean post-regenerate
- [x] `npm run lint:invariants` clean for the new file

## Known follow-up
- 10 existing-file `INV-5` umbrella references (without specific sub-discipline). Recommend separate issue: add INV-5 umbrella to catalog OR migrate to specific sub-disciplines.

Part of [#1088](https://github.com/lvlup-sw/exarchos/issues/1088).