### PR TITLE
feat(task-store): throttle task.polled emit (FINDING-3, #1438)

### DIFF
--- a/docs/designs/2026-05-16-event-sourced-task-store-high-trio.md
+++ b/docs/designs/2026-05-16-event-sourced-task-store-high-trio.md
@@ -1,0 +1,295 @@
+# Design — EventSourcedTaskStore HIGH-trio (FINDING-1/2/3)
+
+**Date:** 2026-05-16
+**Epic:** #1441 v2.10.0-preview.4 polish + post-bundle follow-ups
+**Source issue:** #1438 — `fix(task-store): EventSourcedTaskStore audit findings`
+**Audit:** `docs/research/2026-05-16-event-sourced-task-store-audit.md`
+**Scope:** Close all three HIGH-severity findings in one cohesive design; ship as three sequenceable PRs (FINDING-3 → FINDING-2 → FINDING-1, the recommended remediation order).
+
+## Problem
+
+The audit of `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts` named three HIGH-severity gaps where the implementation falls short of canonical event-sourcing patterns:
+
+- **FINDING-1 — No optimistic concurrency on writes.** Both `storeTaskResult` and `updateTaskStatus` follow `load → terminal-check → append` without an `expectedSequence` argument. Two concurrent callers (MCP `tasks/cancel` racing the wrapped handler's `task.result`, or two CLI processes against the same SQLite store) both pass the in-memory `isTerminal` check and both append. The stream ends with two terminal events; last-write-wins at the projection layer; the contract "Task results can only be stored once" is violated at the durable layer.
+
+- **FINDING-2 — Cache hits skip stream validation.** The class docstring (lines 30-37) claims "cache hits are validated against the projection sequence so a missed event invalidates the cache transparently." The code at `loadTask:399-400` does a straight cache return with no sequence check. Multi-process scenarios drift silently: Process A's cached `ProjectedTask` shadows Process B's `task.result` append until eviction.
+
+- **FINDING-3 — `task.polled` write amplification.** Every `getTask` read appends a `task.polled` event. At the 250ms CLI poll cadence × 10-minute task = ~2,400 events per task. The projection IGNORES `task.polled` (`projectTask:516-518`) — pure write amplification with no projection benefit. At 200 concurrent tasks this is ~480,000 writes per session for zero state-machine effect.
+
+All three are correctness debt that become load-bearing under INV-3 (basileus-forward: remote MCP servers serving Tasks). FINDING-3 is also an immediate operational concern and gates #1440 (Tasks adoption expansion — more callers = more poll-emit load).
+
+## Constraints
+
+- **The substrate already supports OCC.** `EventStore.append(stream, event, { expectedSequence })` (store.ts:320) throws `SequenceConflictError` (store.ts:46) on tail mismatch. `AtomicAppender.withSession` / `decide` (atomic-appender.ts:576) wrap the entire load-decide-append cycle. The TaskStore just does not thread it.
+- **INV-1 — events are truth.** Any fix must preserve the REPLAY acceptance test (`event-sourced-task-store.test.ts`) — projecting events into the same `ProjectedTask` shape regardless of how many writers contributed.
+- **INV-2 — facade equivalence.** CLI follow-loop (`cli/follow-loop.ts:SIGINT`) and MCP `tasks/cancel` (`mcp/tasks-methods.ts:cancel`) both flow through `taskStore.updateTaskStatus`. Whatever OCC threading lands must apply identically to both callers — no per-caller bypass.
+- **No background timers / periodic sweeps.** Per Marten W-1 + the existing TaskStore comments, the design is "fresh process, no daemon." Reapers run on read; the same discipline applies to any cache validation we add.
+- **Backward compatible event schema.** No breaking changes to the four `task.*` event payloads. The `task.polled` event semantics shift from "every read" to "throttled audit trail," but the event shape is unchanged — old events project identically.
+
+## Approach — Session-shaped OCC threading + tail-sequence cache validation + throttled poll emit
+
+The chosen approach (Approach B from `/exarchos:ideate` brainstorming) threads `expectedSequence` through the two write paths, validates cache entries via a new lightweight `EventStore.tailSequence(stream)` accessor, and throttles the `task.polled` emit by tracking `lastPolledAt` per task.
+
+Why session-shaped rather than full `AtomicAppender.withSession` registration: the TaskStore already has a pure `projectTask` fold function that IS effectively a reducer, and it already calls `EventStore.append` (not `AtomicAppender` directly). Threading `expectedSequence` through the existing call shape is the smaller refactor that captures 100% of the canonical-pattern benefit. A future hardening can promote `projectTask` to a registered `ProjectionReducer` and switch to `withSession`; this design does not block that future move.
+
+### Design — FINDING-3 (PR 1, recommended order — unblocks #1440)
+
+**Mechanism:** Track `lastPolledAt: number | undefined` per task. On `getTask`, only emit `task.polled` if `now - lastPolledAt >= TASK_POLLED_THROTTLE_MS` (default 5000ms). Update `lastPolledAt` after a successful emit attempt (regardless of swallow outcome — the throttle is per-process state, not per-stream truth).
+
+**Storage location:** A separate `private readonly lastPolledAt = new Map<string, number>()` map, NOT a field on `ProjectedTask`. Rationale: keep "projected from events" data (`ProjectedTask`) cleanly separate from "process-local rate-limit state" (`lastPolledAt`). The map is reset on process restart — acceptable because the first poll after restart emits, which is the only behavior anyone could reasonably expect.
+
+**Throttle constant:** Module-level constant `TASK_POLLED_THROTTLE_MS = 5_000`. Not a constructor option in this PR — keeps the API stable. If a future caller needs to tune, the constructor signature can grow then.
+
+**REPLAY impact:** None. `projectTask` already ignores `task.polled`; the projection is unaffected. Existing REPLAY test still passes.
+
+**Cleanup:** `lastPolledAt` entries should also be removed when a task is reaped (TTL expiry). Add to `reapExpired` and to the per-key delete in `getTask`/`getTaskResult`.
+
+**Acceptance test:** Two new tests:
+1. Rate test: call `getTask` 20 times in a tight loop, verify the stream has exactly 1 or 2 `task.polled` events (not 20).
+2. Window test: call `getTask`, advance clock by 5001ms (injectable clock), call again, verify two `task.polled` events.
+
+**Why first:** Smallest blast radius, unblocks #1440 adoption expansion, observable wins (20× write reduction at default poll cadence), and the other two findings benefit from the reduced event-stream length when they incrementally re-fold (FINDING-2) or replay-check on conflict (FINDING-1).
+
+### Design — FINDING-2 (PR 2)
+
+**New substrate surface:** `EventStore.tailSequence(streamId: string): Promise<number>` — returns 0 for empty streams, else the highest sequence on the stream. Delegates to the existing `readSequenceHighWaterMark` on the SQLite backend (already used internally by `AtomicAppender` at three sites). One-line method; no new SQL.
+
+**ProjectedTask additions:**
+```ts
+interface ProjectedTask {
+  task: Task;
+  request: Request;
+  requestId: RequestId;
+  result?: Result;
+  expiresAt?: number;
+  /** Tail sequence at last fold — used to invalidate the cache when the stream advances. */
+  lastReadSequence: number;
+}
+```
+
+**loadTask rewrite:**
+```ts
+private async loadTask(taskId: string): Promise<ProjectedTask | undefined> {
+  const cached = this.tasks.get(taskId);
+  if (cached) {
+    const tail = await this.store.tailSequence(taskStream(taskId));
+    if (tail === cached.lastReadSequence) return cached; // cache valid
+    // Cache stale — incrementally fold the events newer than what we projected last time.
+    const delta = await this.store.query(taskStream(taskId), { fromSequence: cached.lastReadSequence + 1 });
+    if (delta.length === 0) {
+      // Tail moved but query returned nothing (e.g., transient ordering); fall through to full refold.
+      return this.fullRefold(taskId);
+    }
+    const refolded = projectTaskIncremental(cached, delta);
+    refolded.lastReadSequence = tail;
+    this.tasks.set(taskId, refolded);
+    return refolded;
+  }
+  return this.fullRefold(taskId);
+}
+
+private async fullRefold(taskId: string): Promise<ProjectedTask | undefined> {
+  const events = await this.store.query(taskStream(taskId));
+  if (events.length === 0) return undefined;
+  const projected = projectTask(taskId, events);
+  if (!projected) return undefined;
+  projected.lastReadSequence = events[events.length - 1].sequence;
+  this.tasks.set(taskId, projected);
+  return projected;
+}
+```
+
+**Incremental fold:** A new `projectTaskIncremental(cached, deltaEvents)` function takes a `ProjectedTask` + delta and applies only the new events. Same `switch (event.type)` body as `projectTask`'s post-`task.created` branch; reuses the existing logic. The `task.created` event is by construction not in the delta (sequence 1 is already cached).
+
+**Query API check:** `EventStore.query(streamId, { fromSequence })` already supports a `fromSequence` option (used by other consumers — verify in plan phase; fallback is in-memory filter on full query result).
+
+**Acceptance tests:**
+1. Multi-process simulation: instantiate TWO `EventSourcedTaskStore` instances backed by the SAME `EventStore`. A calls `createTask` + `getTask` (warming cache). B calls `storeTaskResult` directly on the underlying store. A's next `getTask` returns the result — proving cache validation works.
+2. Concurrent same-process: two interleaved write+read sequences against one store instance — confirms incremental fold preserves projection correctness vs. full refold.
+3. REPLAY: existing acceptance test still passes (cache-cold path unchanged in shape).
+
+**Docstring fix:** Update the class docstring (currently lines 30-37) to accurately describe the new behavior — the prose dimension finding (DIM-8) closes when prose matches code.
+
+### Design — FINDING-1 (PR 3)
+
+**OCC threading:** With FINDING-2 in place, `ProjectedTask` carries `lastReadSequence`. Both write paths capture it and pass to `append`:
+
+```ts
+async storeTaskResult(taskId, status, result, _sessionId): Promise<void> {
+  return this.commitWithOcc(taskId, 'storeTaskResult', async (stored) => {
+    if (isTerminal(stored.task.status)) {
+      throw new Error(`Cannot store result for task ${taskId} in terminal status...`);
+    }
+    return {
+      event: { type: 'task.result', timestamp: new Date().toISOString(), data: {...} },
+      mutate: (s) => { s.result = result; s.task = {...s.task, status, lastUpdatedAt: ...}; ... },
+    };
+  });
+}
+```
+
+**`commitWithOcc` helper (private):**
+```ts
+private async commitWithOcc(
+  taskId: string,
+  opName: string,
+  decide: (stored: ProjectedTask) => Promise<{ event: EventInput | null; mutate: (s: ProjectedTask) => void }>,
+  maxRetries = 3,
+): Promise<void> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const stored = await this.loadTask(taskId);
+    if (!stored) throw new Error(`Task with ID ${taskId} not found`);
+    const { event, mutate } = await decide(stored);
+    if (event === null) { mutate(stored); return; }
+    try {
+      await this.store.append(taskStream(taskId), event, { expectedSequence: stored.lastReadSequence });
+      mutate(stored);
+      stored.lastReadSequence += 1;
+      return;
+    } catch (err) {
+      if (err instanceof SequenceConflictError && attempt < maxRetries) {
+        this.tasks.delete(taskId); // force full refold next iteration
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new ConcurrencyError({ streamId: taskStream(taskId), operationId: opName, ... });
+}
+```
+
+**Retry budget:** 3 attempts (matches the design's R-2 retry conventions for non-idempotent decisions). Past the budget, surface as `ConcurrencyError` — the MCP boundary maps this to JSON-RPC `-32004` (matching the existing `wrap()` convention in `mcp/wrap.ts`).
+
+**Terminal-conflict semantics:** If a retry re-folds and sees terminal status, the existing in-method throw fires ("Cannot store result for task X in terminal status..."). This is correct: the other writer won, the operation is no longer valid, the error message is honest about why.
+
+**Cancellation race scenario (the load-bearing case):**
+- T0: handler is wrapped; MCP `tasks/cancel` arrives; wrapped handler's `task.result` emission also arrives.
+- T1: both call `loadTask` → both see `lastReadSequence = N`, status='working'.
+- T2: `tasks/cancel` calls `updateTaskStatus('cancelled')` → `append` with `expectedSequence: N` → succeeds; sequence becomes N+1.
+- T3: wrapped handler calls `storeTaskResult('completed')` → `append` with `expectedSequence: N` → `SequenceConflictError` → catch → invalidate cache → re-fold → status='cancelled' → terminal-check throws "Cannot store result for task X in terminal status 'cancelled'". This is the correct outcome — the cancel wins, the late result is rejected with an honest message.
+
+**Acceptance tests:**
+1. Concurrent write race: two `Promise.all` calls to `updateTaskStatus` on the same task with conflicting target statuses; verify exactly one wins, the other surfaces `ConcurrencyError` or the terminal-check error after retry.
+2. Cancel-vs-result race: above scenario as a test.
+3. Single-writer happy path: existing tests pass unchanged.
+4. Multi-process: two store instances, interleaved writes; verify last-write-wins is no longer possible (the loser throws).
+
+**MCP boundary mapping:** `ConcurrencyError` already has a handler in `mcp/wrap.ts` (audit grep above) — confirm in plan phase; no new boundary code needed in this design.
+
+## Substrate additions
+
+The design adds exactly one new public method:
+
+**`EventStore.tailSequence(streamId: string): Promise<number>`**
+- Returns the highest sequence number on `streamId`, or 0 if the stream is empty.
+- Implementation: thin wrapper over `backend.readSequenceHighWaterMark(streamId)`. The backend already exposes this for `AtomicAppender`'s internal use.
+- Zero impact on existing callers; pure addition.
+- Test: empty stream → 0; populated stream → matches `query(stream)[-1].sequence`.
+
+No other substrate changes. The `expectedSequence` option on `EventStore.append` is already there. `SequenceConflictError` already exists. `ConcurrencyError` already maps at the MCP boundary.
+
+## Conformance check
+
+### /design-invariants (INV-1..INV-6)
+
+| Invariant | Before | After | Notes |
+|---|---|---|---|
+| **INV-1 event-sourcing integrity** | ⚠ WATCH — cache shadows authoritative state | ✅ — cache validated against tail; OCC prevents stream divergence | F-2 + F-1 directly. The throttled `task.polled` does not affect projection state (no handler in `projectTask`). |
+| **INV-2 facade equivalence** | ✅ | ✅ preserved | `commitWithOcc` wraps both write paths identically; no per-caller bypass. |
+| **INV-3 basileus-forward** | ⚠ at-correctness | ✅ | Multi-writer correctness now load-bearing-safe; remote MCP federation can land without revisiting this surface. |
+| **INV-4 platform-agnosticity** | ✅ | ✅ | No platform-specific code; pure TS over the existing `EventStore` API. |
+| **INV-5a–d** | N/A | N/A | TaskStore is not a CLI/Action surface. |
+| **INV-6 workflow-agnosticism** | ✅ | ✅ | Operates on `task-store/*` streams; agnostic to workflow type. |
+
+### /axiom:design (DIM-1..DIM-8)
+
+| Dimension | Before | After | Notes |
+|---|---|---|---|
+| **DIM-1 topology** | ⚠ dual source (cache + stream) | ✅ cache is a validated projection; stream is sole authority | `lastReadSequence` is the bridge. |
+| **DIM-2 observability** | ⚠ F-3 write amplification + silent swallow | ✅ — throttled emit reduces noise; conflict surfacing via typed errors | Logger.warn on `SequenceConflictError` retry exhaustion gives operational visibility (added in `commitWithOcc`). |
+| **DIM-3 contracts** | ⚠ docstring lies | ✅ docstring matches code | Class docstring updated in PR 2. |
+| **DIM-4 test fidelity** | ✅ REPLAY load-bearing; ⚠ no concurrency tests | ✅ — concurrency, race, multi-process tests added | Each PR ships its own acceptance test. |
+| **DIM-6 coupling** | ✅ EventStore-only | ✅ EventStore-only (tailSequence is a same-class addition) | No new substrate dependency. |
+| **DIM-7 error handling** | ⚠ silent F-3 swallow on every poll | ✅ — swallow rate reduced 20×; `commitWithOcc` surfaces typed errors | F-3 swallow remains for the throttled emit (still best-effort, but rate-limited). |
+| **DIM-8 prose** | ⚠ docstring/code drift | ✅ aligned | Audit closes the prose finding when PR 2 lands. |
+
+### Marten / Azure ES patterns
+
+| Pattern | Before | After |
+|---|---|---|
+| **Marten C-2 fetchForWriting** | ❌ | ✅ via `commitWithOcc` (same shape, EventStore-native) |
+| **Azure ES OCC** | ❌ | ✅ via `expectedSequence` threading |
+| **Azure ES snapshots** | ❌ | Still ❌ (deferred to FINDING-6 / future PR — out of scope here) |
+
+## Test plan
+
+**Per-PR acceptance tests** (each PR ships its own; below is the consolidated view):
+
+- **FINDING-3 (PR 1):**
+  - `getTask` rate test — 20 sequential reads emit ≤ 2 `task.polled` events.
+  - `getTask` window test — advancing injectable clock past throttle window emits next event.
+  - REPLAY test unchanged (projection ignores `task.polled` regardless of count).
+  - Reap clears `lastPolledAt` entries.
+
+- **FINDING-2 (PR 2):**
+  - Two-store multi-process simulation — Store A's cache invalidates when Store B writes.
+  - Incremental fold preserves projection vs. full refold (property test).
+  - REPLAY test unchanged (cold path still calls `fullRefold`).
+  - `EventStore.tailSequence` unit tests (empty stream, populated stream, after append).
+
+- **FINDING-1 (PR 3):**
+  - Concurrent `updateTaskStatus` race — exactly one wins.
+  - Cancel-vs-result race — cancel wins, late result rejected with terminal-status error.
+  - Retry budget exhaustion surfaces `ConcurrencyError`.
+  - Single-writer tests unchanged.
+  - MCP-boundary integration test — `ConcurrencyError` maps to JSON-RPC error envelope.
+
+**Existing tests to verify unbroken:**
+- `event-sourced-task-store.test.ts` (REPLAY acceptance)
+- `production-wiring.test.ts` (no `InMemoryTaskStore` regression)
+- `tasks-augmented.test.ts` (wrapped handler flow)
+- All `cli/follow-loop` SIGINT tests
+
+## Migration / backward compatibility
+
+- **Event schemas:** unchanged. Existing `task.*` events on disk project identically.
+- **`task.polled` semantics:** shifts from "every read" to "throttled trace." A consumer that counted `task.polled` events to infer poll cadence would see a different signal post-fix — but no such consumer exists today (audit confirmed: projection ignores; no view query counts them).
+- **MCP error surface:** new `-32004` (ConcurrencyError) responses possible from `tasks/cancel`, `tasks/get` (via wrapped handler conflicts). Existing MCP boundary already handles this error class.
+- **CLI:** no behavioral change at single-writer (the dominant case). Multi-writer correctness improves silently.
+- **Tests:** `event-sourced-task-store.test.ts` REPLAY tests still pass — the shape of `ProjectedTask` gains one field (`lastReadSequence`) which the test fixtures need to ignore via partial matching (or the test simply asserts on the public `task: Task` field).
+
+## Out of scope
+
+- **FINDING-4** (TTL reaper coverage on `createTask`) — separate PR, MEDIUM severity.
+- **FINDING-5** (cursor stability via sorted createdAt) — separate PR, MEDIUM severity.
+- **FINDING-6** (paginated hydration) — separate PR; partially relieved by FINDING-3's amplification fix.
+- **FINDING-7** (projection coercion logging) — separate PR, LOW.
+- **FINDING-8** (requestId persistence) — separate PR, LOW.
+- **Snapshot substrate** (Azure ES snapshot pattern) — deferred to a v3.x rewrite when remote MCP scenarios are routine.
+- **`projectTask` promotion to a registered `ProjectionReducer`** — incremental future move; this design does not block it.
+- **Constructor knob for throttle window** — add when a caller needs it; default 5_000ms ships hardcoded.
+
+## Sequencing & PR shape
+
+Three PRs in audit-recommended order:
+
+1. **PR 1 — `fix(task-store): throttle task.polled emit (FINDING-3)`** (~1 day) — smallest, unblocks #1440, observable win, no API change.
+2. **PR 2 — `fix(task-store): validate cache against stream tail (FINDING-2)`** (~2 days) — adds `EventStore.tailSequence`, adds `lastReadSequence` to `ProjectedTask`, rewrites `loadTask`. Closes DIM-8 docstring lie.
+3. **PR 3 — `fix(task-store): thread expectedSequence through writes (FINDING-1)`** (~2 days) — adds `commitWithOcc`, rewrites `storeTaskResult` + `updateTaskStatus`. Depends on PR 2's `lastReadSequence`.
+
+Each PR is independently mergeable on top of the previous; each ships its own tests; each closes a discrete finding in #1438.
+
+## References
+
+- Audit: `docs/research/2026-05-16-event-sourced-task-store-audit.md`
+- Bundle audit: `docs/research/2026-05-16-v2-10-0-preview-4-bundle-audit.md`
+- Issue: #1438 — `fix(task-store): EventSourcedTaskStore audit findings`
+- Epic: #1441 — v2.10.0-preview.4 polish + post-bundle follow-ups
+- Original feature: PR #1430, Issue #1272
+- Post-merge fix: PR #1435 (REPLAY drift + pollInterval validity)
+- Marten lessons: `docs/research/2026-05-08-marten-event-store-lessons.md` §C-1, C-2, C-5
+- Azure ES pattern: https://learn.microsoft.com/azure/architecture/patterns/event-sourcing
+- Substrate: `servers/exarchos-mcp/src/event-store/atomic-appender.ts` (withSession, decide, AppendOptions)
+- Substrate: `servers/exarchos-mcp/src/event-store/store.ts:46` (SequenceConflictError), `store.ts:249` (append with expectedSequence)
+- Invariants: `.claude/skills/design-invariants/SKILL.md`
+- Backend quality dimensions: `axiom:backend-quality`

--- a/docs/plans/2026-05-16-event-sourced-task-store-high-trio.md
+++ b/docs/plans/2026-05-16-event-sourced-task-store-high-trio.md
@@ -1,0 +1,511 @@
+# Implementation Plan — EventSourcedTaskStore HIGH-trio
+
+**Date:** 2026-05-16
+**Design:** `docs/designs/2026-05-16-event-sourced-task-store-high-trio.md`
+**Source issue:** #1438 (HIGH findings F-1, F-2, F-3)
+**Workflow:** `task-store-high-trio`
+
+## Iron Law
+
+> NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
+
+## Branch / PR strategy
+
+Three stacked PRs, audit-recommended order (F-3 → F-2 → F-1):
+
+| PR | Branch | Base | Tasks | Est |
+|---|---|---|---|---|
+| PR 1 — F-3 throttle | `feature/task-store-finding-3` | `main` | T01–T06 | ~1 day |
+| PR 2 — F-2 cache validation | `feature/task-store-finding-2` | PR 1 | T07–T15 | ~2 days |
+| PR 3 — F-1 OCC threading | `feature/task-store-finding-1` | PR 2 | T16–T24 | ~2 days |
+
+Each PR is independently reviewable. Stack base relationship preserved per the memory note `feedback_stacked_pr_discipline.md`.
+
+## File map
+
+| Concern | File | Touch type |
+|---|---|---|
+| TaskStore impl | `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts` | Edit (all 3 PRs) |
+| TaskStore tests | `servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts` | Append (all 3 PRs) |
+| EventStore impl | `servers/exarchos-mcp/src/event-store/store.ts` | Edit (PR 2 only — add `tailSequence`) |
+| EventStore tests | `servers/exarchos-mcp/src/event-store/store.test.ts` | Append (PR 2 only) |
+| MCP boundary | `servers/exarchos-mcp/src/mcp/wrap.ts` | Verify only (no change expected — `ConcurrencyError` mapping should already exist) |
+
+---
+
+## PR 1 — FINDING-3 (Throttle `task.polled` emit)
+
+### Task T01: Rate-test — rapid reads emit at most one `task.polled`
+
+**Phase:** RED
+
+1. [RED] Write test: `getTask_RapidSequentialReads_EmitsAtMostOneTaskPolled`
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts`
+   - Setup: create task; advance injectable clock so `lastPolledAt` is reset; call `getTask` 20× in a tight loop.
+   - Assert: `eventStore.query('task-store/<id>')` filters to `task.polled` events → length is exactly 1.
+   - Expected failure: current impl emits 20 `task.polled` events.
+
+**Dependencies:** None
+**Parallelizable:** No (start of chain)
+
+---
+
+### Task T02: Implement throttle gate
+
+**Phase:** GREEN
+
+1. [GREEN] Add `TASK_POLLED_THROTTLE_MS = 5_000` module constant + `private readonly lastPolledAt = new Map<string, number>()` field.
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts`
+   - In `getTask`: before the existing `try { append('task.polled') }` block, compute `now = Date.now()`; `const last = this.lastPolledAt.get(taskId) ?? 0`; if `now - last < TASK_POLLED_THROTTLE_MS`, skip emit; else attempt emit and set `this.lastPolledAt.set(taskId, now)`.
+   - Keep the swallow `catch {}` — emit is still best-effort.
+
+2. Verify T01 passes.
+
+**Dependencies:** T01
+**Parallelizable:** No
+
+---
+
+### Task T03: Window-test — emit resumes after throttle window
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `getTask_AfterThrottleWindowElapses_EmitsSecondTaskPolled`
+   - Setup: create task; call `getTask`; advance injectable clock by `TASK_POLLED_THROTTLE_MS + 1`; call `getTask` again.
+   - Assert: exactly 2 `task.polled` events on the stream.
+   - Expected failure: passes already from T02 with a real clock — but the test asserts deterministic behavior, requiring an injectable clock. The TaskStore currently uses `Date.now()` directly. Test fails to set up cleanly.
+
+2. [GREEN] Refactor `getTask` to read clock via an injectable `nowMs: () => number` (constructor option, default `() => Date.now()`).
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts`
+   - Add `clock?: () => number` to constructor; store as `private readonly nowMs: () => number = options?.clock ?? Date.now.bind(Date)`.
+   - Use `this.nowMs()` in throttle gate.
+   - Note: existing `Date.now()` calls in `createTask`/`storeTaskResult`/etc. relate to TTL `expiresAt` — leave those alone to minimize blast radius (TTL is wall-clock; throttle is rate-limit). Document in inline comment.
+
+3. Verify T03 passes.
+
+**Dependencies:** T02
+**Parallelizable:** No
+
+---
+
+### Task T04: REPLAY test still passes
+
+**Phase:** RED (verification)
+
+1. [RED] Re-run existing `event-sourced-task-store.test.ts` REPLAY tests.
+   - Expected: pass without change. `projectTask` ignores `task.polled` regardless of count.
+   - If fails: throttle implementation accidentally affected projection — investigate.
+
+**Dependencies:** T02
+**Parallelizable:** With T03
+
+---
+
+### Task T05: `lastPolledAt` cleared on reap/expiry
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `getTask_ExpiredTaskReaped_LastPolledAtCleared`
+   - Setup: create task with short TTL; getTask (sets lastPolledAt); advance clock past TTL; call getTask (returns null, reaps).
+   - Assert: `lastPolledAt.has(taskId)` is false after the expired read.
+   - Expected failure: T02's `lastPolledAt` map is never cleaned up.
+
+2. [RED] Write test: `reapExpired_RemovesLastPolledAtForExpiredTasks`
+   - Setup: create N tasks; getTask each; advance clock; call listTasks (triggers reap).
+   - Assert: `lastPolledAt` map size matches `tasks` map size after reap.
+   - Expected failure: lastPolledAt entries leak.
+
+3. [GREEN] In `getTask` expired branch (line 175-178): also `this.lastPolledAt.delete(taskId)`.
+   - In `getTaskResult` expired branch (line 249-252): same.
+   - In `reapExpired`: same.
+
+4. Verify T05 tests pass.
+
+**Dependencies:** T03
+**Parallelizable:** No
+
+---
+
+### Task T06: PR 1 final scoped run + commit
+
+**Phase:** REFACTOR + validate
+
+1. Run scoped vitest: `cd servers/exarchos-mcp && npx vitest run src/task-store/`.
+2. Run typecheck: `cd servers/exarchos-mcp && npm run typecheck`.
+3. Update class-level docstring `## TTL` section to mention the throttled poll trace (one line).
+4. Commit `feat(task-store): throttle task.polled emit (FINDING-3, #1438)` — single commit per PR per repo convention.
+
+**Dependencies:** T05
+**Parallelizable:** No
+
+---
+
+## PR 2 — FINDING-2 (Cache validation + `EventStore.tailSequence`)
+
+### Task T07: `EventStore.tailSequence` — empty stream returns 0
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `tailSequence_EmptyStream_ReturnsZero`
+   - File: `servers/exarchos-mcp/src/event-store/store.test.ts` (append to existing)
+   - Setup: fresh EventStore; never written.
+   - Assert: `await store.tailSequence('some-stream')` === 0.
+   - Expected failure: method does not exist.
+
+2. [GREEN] Add `async tailSequence(streamId: string): Promise<number>` on `EventStore`.
+   - File: `servers/exarchos-mcp/src/event-store/store.ts`
+   - Implementation: delegate to backend via `const backend = await this.ensureBackend(); return backend.readSequenceHighWaterMark(streamId);`. Mirror how `AtomicAppender` reaches the backend.
+   - Verify `readSequenceHighWaterMark` returns 0 (not undefined) for missing streams; if it returns undefined, coerce with `?? 0`.
+
+3. Verify T07 passes.
+
+**Dependencies:** None (PR 2 root)
+**Parallelizable:** Yes — independent file from PR 1
+
+---
+
+### Task T08: `EventStore.tailSequence` — populated stream returns latest sequence
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `tailSequence_PopulatedStream_ReturnsHighestSequence`
+   - Setup: append 3 events to a stream.
+   - Assert: `tailSequence(stream)` equals `(await store.query(stream)).at(-1)!.sequence`.
+   - Expected failure: should pass after T07 if HWM logic is correct; if it fails the backend impl needs adjustment.
+
+2. [GREEN] (passes from T07 in expected case).
+
+**Dependencies:** T07
+**Parallelizable:** No
+
+---
+
+### Task T09: ProjectedTask carries `lastReadSequence`
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `loadTask_AfterInitialFold_RecordsTailSequenceOnProjectedTask`
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts`
+   - This test peeks at internals via a small accessor. Add a `getCachedProjection(taskId): ProjectedTask | undefined` test-only helper on the class (private method, but exported via a `_test` symbol pattern, OR cast via `(store as any).tasks.get(taskId)`).
+   - Setup: create task; call getTask; inspect cached projection.
+   - Assert: `cached.lastReadSequence === 1` (just the `task.created` event).
+   - Expected failure: `ProjectedTask` has no `lastReadSequence` field.
+
+2. [GREEN] Add `lastReadSequence: number` to `ProjectedTask` interface.
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts`
+   - In `loadTask`: after a successful `projectTask` call, set `projected.lastReadSequence = events[events.length - 1].sequence`.
+   - In `createTask`: set `lastReadSequence: 1` when constructing the cache entry (the `task.created` event was just appended at sequence 1 for a fresh stream).
+   - In `projectTask`: NO change — the function still returns `ProjectedTask` without `lastReadSequence`; the caller sets it. (Keep `projectTask` pure / sequence-unaware so it remains a fold function over event content.)
+   - Update fixture creation in REPLAY test if needed (likely just narrow types via partial matching).
+
+3. Verify T09 passes; verify existing REPLAY tests still pass.
+
+**Dependencies:** T08
+**Parallelizable:** No
+
+---
+
+### Task T10: `loadTask` cache hit re-validates via `tailSequence`
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `loadTask_CacheHitWithAdvancedStream_TriggersRefoldAndReturnsLatest`
+   - Setup: instantiate StoreA + StoreB backed by SAME `EventStore`. A.createTask → A.getTask (warms cache). Then `eventStore.append('task-store/<id>', { type: 'task.result', ... })` directly (simulating B's write). Then A.getTask again.
+   - Assert: A.getTask returns task with `status === 'completed'`.
+   - Expected failure: A returns cached `working` status.
+
+2. [GREEN] Rewrite `loadTask`:
+   ```ts
+   private async loadTask(taskId: string): Promise<ProjectedTask | undefined> {
+     const cached = this.tasks.get(taskId);
+     if (cached) {
+       const tail = await this.store.tailSequence(taskStream(taskId));
+       if (tail === cached.lastReadSequence) return cached;
+       return this.refoldDelta(taskId, cached, tail);
+     }
+     return this.fullRefold(taskId);
+   }
+
+   private async fullRefold(taskId: string): Promise<ProjectedTask | undefined> {
+     const events = await this.store.query(taskStream(taskId));
+     if (events.length === 0) return undefined;
+     const projected = projectTask(taskId, events);
+     if (!projected) return undefined;
+     projected.lastReadSequence = events[events.length - 1].sequence;
+     this.tasks.set(taskId, projected);
+     return projected;
+   }
+
+   private async refoldDelta(taskId: string, cached: ProjectedTask, tail: number): Promise<ProjectedTask | undefined> {
+     const delta = await this.store.query(taskStream(taskId), { fromSequence: cached.lastReadSequence + 1 });
+     if (delta.length === 0) return this.fullRefold(taskId); // tail moved but query empty — defensive
+     const next = projectTaskIncremental(cached, delta);
+     next.lastReadSequence = tail;
+     this.tasks.set(taskId, next);
+     return next;
+   }
+   ```
+
+3. Verify T10 passes.
+
+**Dependencies:** T09
+**Parallelizable:** No
+
+---
+
+### Task T11: Verify `query({ fromSequence })` supported
+
+**Phase:** RED (verification)
+
+1. [RED] Quick check: `grep -n "fromSequence" servers/exarchos-mcp/src/event-store/store.ts`.
+   - If supported on `query()`: proceed.
+   - If not: either (a) add a `fromSequence` option to `EventStore.query`, OR (b) fall back to full query + in-memory filter `events.filter(e => e.sequence > cached.lastReadSequence)`.
+   - Document the choice in a one-line comment in `refoldDelta`.
+
+2. [GREEN] If option (a) needed: add the `fromSequence` param to `EventStore.query` signature and thread to backend's `queryEvents` (which likely already supports it).
+
+**Dependencies:** T10
+**Parallelizable:** With T09 (different surface area)
+
+---
+
+### Task T12: `projectTaskIncremental` — incremental fold equals full refold
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `projectTaskIncremental_FromCachedToTail_MatchesFullRefold`
+   - Property-style test: build a stream by appending N random events (created, polled×k, cancelled or result); cache the projection at midpoint; apply delta; assert deep-equal to a full-refold from the same final stream.
+   - Expected failure: function does not exist.
+
+2. [GREEN] Add `projectTaskIncremental(cached: ProjectedTask, delta: readonly WorkflowEvent[]): ProjectedTask`.
+   - Pure function. Same `switch (event.type)` body as `projectTask`'s post-created loop (lines 482-520).
+   - Returns a fresh `ProjectedTask` (don't mutate `cached`); structuredClone or manual shallow-merge.
+
+3. Verify T12 passes.
+
+**Dependencies:** T10
+**Parallelizable:** No
+
+---
+
+### Task T13: Multi-process integration test
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `EventSourcedTaskStore_MultiProcessRace_CacheValidatesOnRead`
+   - Setup: SQLite-backed EventStore; two TaskStore instances on top. A.createTask + A.getTask (cache warm). B.storeTaskResult on same taskId. A.getTask.
+   - Assert: A observes the result.
+   - This re-asserts T10 at integration level. Expected to pass from T10 work.
+
+2. [GREEN] (passes from T10).
+
+**Dependencies:** T12
+**Parallelizable:** No
+
+---
+
+### Task T14: Update class docstring
+
+**Phase:** REFACTOR
+
+1. [REFACTOR] Edit the `## Cache semantics` section of the TaskStore class docstring (lines 30-37) to accurately describe:
+   - In-memory cache is a lazy projection;
+   - On every read, cache hits are validated against `EventStore.tailSequence`;
+   - When tail advanced, an incremental fold (`projectTaskIncremental`) brings the cache forward;
+   - Closes DIM-8 prose-vs-code finding.
+
+**Dependencies:** T13
+**Parallelizable:** No
+
+---
+
+### Task T15: PR 2 final scoped run + commit
+
+**Phase:** validate
+
+1. Run: `cd servers/exarchos-mcp && npx vitest run src/task-store/ src/event-store/store.test.ts`
+2. Run: `cd servers/exarchos-mcp && npm run typecheck`
+3. Commit `feat(task-store): validate cache against stream tail (FINDING-2, #1438)`.
+
+**Dependencies:** T14
+**Parallelizable:** No
+
+---
+
+## PR 3 — FINDING-1 (OCC threading via `expectedSequence`)
+
+### Task T16: Concurrent `storeTaskResult` race — exactly one succeeds
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `storeTaskResult_ConcurrentCallers_ExactlyOneSucceeds`
+   - Setup: create task; two TaskStore instances backed by the same EventStore (simulates two processes / two requests). Issue `Promise.all([A.storeTaskResult(id, 'completed', r1), B.storeTaskResult(id, 'failed', r2)])`.
+   - Assert: one promise resolves; the other rejects with an error that mentions "terminal status" OR a `ConcurrencyError`. The stream has exactly one `task.result` event.
+   - Expected failure: today both append; stream gets two `task.result`s; last-write-wins.
+
+2. [GREEN] Implement `commitWithOcc` helper + rewrite `storeTaskResult`.
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts`
+   - Helper signature per design §"Design — FINDING-1 (PR 3)".
+   - Catch `SequenceConflictError`; on catch: `this.tasks.delete(taskId)` (force refold); retry up to 3 times; past budget throw `ConcurrencyError` (import from `../event-store/concurrency-error.js`).
+   - Rewrite `storeTaskResult` to call `commitWithOcc(taskId, 'storeTaskResult', async (stored) => { /* terminal check; build event; mutate */ })`.
+
+3. Verify T16 passes.
+
+**Dependencies:** T15 (PR 2 — needs `lastReadSequence`)
+**Parallelizable:** No
+
+---
+
+### Task T17: Concurrent `updateTaskStatus` race
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `updateTaskStatus_ConcurrentCallersToConflictingStates_ExactlyOneSucceeds`
+   - Same setup as T16 but `updateTaskStatus(id, 'cancelled')` vs `updateTaskStatus(id, 'input_required')`.
+   - Assert: one wins; stream has one terminal-class state-change event (`task.cancelled`) or no event (input_required has no durable event today, only projection mutation — that's pre-existing behavior).
+   - Note: only `cancelled` writes an event today. Test should reflect this asymmetry.
+
+2. [GREEN] Rewrite `updateTaskStatus` via `commitWithOcc`. Cancellation branch writes event; other status transitions are projection-only (preserve existing behavior).
+   - Key subtlety: when no event is appended (non-cancel status change), `commitWithOcc` returns `event === null` and just mutates. This means there is no OCC protection for non-cancel transitions — but those don't change the durable stream, so the only correctness concern is "did we read stale state?" — which PR 2's cache validation already addresses.
+
+3. Verify T17 passes.
+
+**Dependencies:** T16
+**Parallelizable:** No
+
+---
+
+### Task T18: Cancel-vs-result race — cancel wins
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `cancelRacesResult_CancelArrivesFirst_LateResultRejectsWithTerminalError`
+   - Setup: A.updateTaskStatus(id, 'cancelled') and B.storeTaskResult(id, 'completed', r). Sequence so cancel commits first (e.g. await A first then call B).
+   - Assert: B throws an error whose message mentions "terminal status" — proves the retry refold saw the cancelled state and the terminal-check threw.
+
+2. [GREEN] (should pass from T16 + T17 work — the `commitWithOcc` retry path naturally re-fold + re-evaluates terminal check).
+
+3. If test fails: ensure terminal-check is INSIDE the `decide` closure (so it runs on every retry).
+
+**Dependencies:** T17
+**Parallelizable:** With T19 (different scenarios)
+
+---
+
+### Task T19: Retry budget exhaustion → ConcurrencyError
+
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `commitWithOcc_RetryBudgetExhausted_ThrowsConcurrencyError`
+   - Setup: mock EventStore.append to throw `SequenceConflictError` every time. Call `storeTaskResult`.
+   - Assert: throws `ConcurrencyError` after maxRetries+1 attempts.
+
+2. [GREEN] Ensure budget exhaustion throws `ConcurrencyError` with structured fields (`streamId`, `operationId`, `expectedVersion`, `actualVersion`). Use the existing `ConcurrencyError` constructor shape.
+
+3. Verify T19 passes.
+
+**Dependencies:** T17
+**Parallelizable:** With T18
+
+---
+
+### Task T20: MCP boundary maps ConcurrencyError correctly
+
+**Phase:** RED (verification)
+
+1. [RED] Inspect `servers/exarchos-mcp/src/mcp/wrap.ts`:
+   - Confirm there's a handler that maps `ConcurrencyError` → JSON-RPC error envelope (likely `-32004` or similar per existing convention).
+   - If missing: add a small handler block (one-line `instanceof` check). Document this as a follow-up if it's substantive.
+   - If present: write a smoke test that calls a `tasks/*` MCP method, forces a conflict, asserts the JSON-RPC error shape.
+
+2. [GREEN] If new mapping needed: implement it; otherwise no-op.
+
+**Dependencies:** T19
+**Parallelizable:** With T18
+
+---
+
+### Task T21: Logger.warn on retry exhaustion
+
+**Phase:** REFACTOR
+
+1. [REFACTOR] In `commitWithOcc` retry-exhaustion path: `logger.warn({ taskId, opName, attempts: maxRetries }, 'OCC retry budget exhausted')` before throwing.
+   - Use the existing logger import pattern from the file (likely none today — add minimally, or use console.warn if no logger is in scope).
+
+**Dependencies:** T19
+**Parallelizable:** With T20
+
+---
+
+### Task T22: Single-writer happy path tests unchanged
+
+**Phase:** RED (verification)
+
+1. [RED] Re-run full `event-sourced-task-store.test.ts` suite.
+2. Expect: all existing tests pass. If any fail, the `commitWithOcc` refactor changed semantics for the single-writer case — investigate.
+
+**Dependencies:** T20, T21
+**Parallelizable:** No
+
+---
+
+### Task T23: Documentation + remove obsolete comments
+
+**Phase:** REFACTOR
+
+1. [REFACTOR] Remove the now-stale inline comment in old `storeTaskResult` about "in-memory throw only catches sequential same-process double-write."
+2. Add a one-line comment on `commitWithOcc` explaining the retry budget rationale.
+
+**Dependencies:** T22
+**Parallelizable:** No
+
+---
+
+### Task T24: PR 3 final scoped run + commit
+
+**Phase:** validate
+
+1. Run: `cd servers/exarchos-mcp && npx vitest run src/task-store/ src/event-store/`
+2. Run: `cd servers/exarchos-mcp && npm run typecheck`
+3. Run full suite once: `cd servers/exarchos-mcp && npm run test:run` (per memory `feedback_tdd_gate_blast_radius.md` — high-blast tasks need full-suite check).
+4. Commit `feat(task-store): thread expectedSequence through writes (FINDING-1, #1438)`.
+
+**Dependencies:** T23
+**Parallelizable:** No
+
+---
+
+## Parallelization summary
+
+Within a PR: tasks are strictly sequential TDD chains.
+Across PRs:
+- **PR 1 ↔ PR 2 cross-PR parallelism is possible** (different code paths — PR 1 touches `getTask`'s emit, PR 2 touches `loadTask`'s cache logic). But the design ships them sequentially for review clarity and to keep the stack base relationships clean. **Recommend: sequential** to honor the memory `feedback_stacked_pr_discipline.md`.
+- PR 3 strictly depends on PR 2.
+
+If wall-clock matters more than review hygiene, an alternative dispatch is: T01–T06 (PR 1) in worktree A in parallel with T07–T15 (PR 2) in worktree B, then rebase B onto merged A; T16–T24 (PR 3) waits for both.
+
+## Dispatch notes for `/exarchos:delegate`
+
+- Each PR is a separate dispatch wave with its own worktree branched from main (PR 1) or from the preceding PR's branch (PR 2, PR 3).
+- Per memory `feedback_subagent_nested_worktrees.md`: prompts MUST include explicit `git checkout -B feature/task-store-finding-N <base-branch>` reset.
+- Per memory `feedback_worktree_npm_install.md`: agents must `cd servers/exarchos-mcp && npm install` before scoped test runs.
+- Per memory `feedback_orchestrator_task_assigned_emission.md`: emit `task.assigned` per dispatch so rehydration projection stays accurate.
+- Per memory `feedback_orchestrator_commit_before_dispatch.md`: commit design + plan to main before dispatching PR 1.
+
+## Acceptance summary
+
+When all 24 tasks complete:
+
+- [ ] FINDING-3: `task.polled` emit throttled to ≥5s interval; rate test green.
+- [ ] FINDING-2: cache validated via `EventStore.tailSequence`; multi-process race test green; class docstring accurate.
+- [ ] FINDING-1: OCC threaded via `expectedSequence`; cancel-vs-result race test green; `ConcurrencyError` mapped at MCP boundary.
+- [ ] Existing REPLAY + production-wiring tests still pass.
+- [ ] Three PRs merged in sequence (F-3 → F-2 → F-1).
+- [ ] Issue #1438 references the merged PRs; audit doc updated to mark F-1/F-2/F-3 as fixed.
+
+## References
+
+- Design: `docs/designs/2026-05-16-event-sourced-task-store-high-trio.md`
+- Audit: `docs/research/2026-05-16-event-sourced-task-store-audit.md`
+- Issue: #1438, Epic: #1441
+- Substrate: `servers/exarchos-mcp/src/event-store/store.ts` (append, SequenceConflictError), `atomic-appender.ts` (ConcurrencyError import path), `concurrency-error.ts`

--- a/docs/research/2026-05-16-event-sourced-task-store-audit.md
+++ b/docs/research/2026-05-16-event-sourced-task-store-audit.md
@@ -1,0 +1,255 @@
+# EventSourcedTaskStore Audit — #1272 Implementation Review
+
+**File audited:** `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts` (536 LOC)
+**Audit date:** 2026-05-16
+**Reference frameworks:** Marten patterns (`docs/research/2026-05-08-marten-event-store-lessons.md`), Azure Event Sourcing pattern (Microsoft Learn), design-invariants (INV-1..INV-6), axiom backend-quality (DIM-1..DIM-8), preview.4 design + #1273 acceptance criteria
+
+## Summary
+
+EventSourcedTaskStore (PR #1430, originally #1272) implements the MCP SDK's `TaskStore` interface as a projection over four `task.*` event types, satisfying INV-1's "event stream is truth" contract. The implementation ships a load-bearing REPLAY acceptance test (`event-sourced-task-store.test.ts`), defensive `pollInterval` normalization (post-#1435 fix), and proper INV-2 facade equivalence between the CLI follow-loop and the MCP `tasks/*` methods.
+
+However, eight findings — three HIGH, three MEDIUM, two LOW — name gaps where the implementation falls short of well-known event-sourcing patterns or makes claims in comments that the code does not honor. The most consequential are the absence of optimistic concurrency on writes (FINDING-1), the silent cache-staleness on multi-process scenarios (FINDING-2), and the `task.polled` write amplification at the design's 250ms CLI poll cadence (FINDING-3). The first two are correctness debt that becomes load-bearing for INV-3 basileus-forward / remote-MCP scenarios; the third is an immediate operational concern at any non-trivial workload.
+
+## Findings
+
+### FINDING-1 (HIGH) — No optimistic concurrency on writes
+
+**Where:** `storeTaskResult:205-242`, `updateTaskStatus:259-304`.
+
+**Pattern:** Both methods follow `load → isTerminal check → append`. The append does not pass an `expectedSequence` to the event store.
+
+**Failure mode:** Two concurrent callers (e.g., MCP `tasks/cancel` and the wrapped handler's `task.result` emission, or two CLI processes against the same SQLite store) both pass the `isTerminal(stored.task.status) === false` check; both proceed to `this.store.append(...)`; the stream now has two terminal events. `projectTask` folds them in arrival order — last-write-wins. The auditable contract "Task results can only be stored once" (line 217 error message) is violated at the stream layer; the in-memory `throw` only catches sequential same-process double-write.
+
+**Comparison to canonical patterns:**
+
+- **Marten C-2 `fetchForWriting`** (`docs/research/2026-05-08-marten-event-store-lessons.md` §51-74): the entire pattern Marten centralizes is "read the aggregate with its version → decide → commit with OCC; reject if stream tail advanced." This is the missing primitive here.
+- **Azure ES pattern** (`learn.microsoft.com/azure/architecture/patterns/event-sourcing` §Solution.4): *"Event stores address this scenario by using optimistic concurrency control and reject an append if the stream changed since it was read. Upon rejection, the handler reloads the entity, reevaluates, and retries."*
+
+**Substrate readiness:** Exarchos `AtomicAppender` already accepts `expectedSequence` (audit `atomic-appender.ts:145-155`). The TaskStore does not thread it.
+
+**Fix:** Capture stream tail in `loadTask` → pass through to `storeTaskResult`/`updateTaskStatus` → call `append` with `expectedSequence` → on `SequenceConflictError`, re-fold and re-evaluate (or surface as 409 Conflict at the MCP layer).
+
+**Severity rationale:** HIGH at multi-writer scale, LOW at single-CLI-process scale. INV-3 basileus-forward roadmap (remote MCP servers serving Tasks identically) makes multi-writer the eventual default — repay the debt before the federation lands.
+
+---
+
+### FINDING-2 (HIGH) — Cache hits skip stream validation
+
+**Where:** Class docstring lines 30-37 vs `loadTask:398-410`.
+
+**Pattern:** The class docstring claims:
+
+> "Cache misses fall through to a stream read; cache hits are validated against the projection sequence so a missed event invalidates the cache transparently."
+
+The implementation:
+
+```ts
+const cached = this.tasks.get(taskId);
+if (cached) return cached;
+```
+
+No sequence comparison. No re-fold. The comment is aspirational; the code is wrong.
+
+**Failure mode:** Process A holds a cached `ProjectedTask` for `taskId=X`. Process B (sibling CLI, second MCP server instance, replay tooling) appends a `task.result` event to `task-store/X`. Process A's next `getTask(X)` returns the stale cached state — the result is invisible until either the cache key is evicted (TTL, restart) or Process A explicitly calls `loadTask` after deleting the cache entry (no code path does this).
+
+**Failure scope:** Single-process scenarios are safe (only one writer mutates the cache). Multi-process scenarios — CLI + MCP server both wired to the same SQLite event store, or two MCP server instances during a hot-swap — drift silently.
+
+**Comparison to canonical patterns:**
+
+- **Azure ES Snapshots** (Microsoft Learn §Problems.7): *"A snapshot is a serialized representation of the entity's state at a specific point in its eventstream. To rehydrate the entity, load the most recent snapshot and replay only the events that occur after it."* This is the right model: cache the projection up to sequence N, then fold any events at sequence > N on read.
+
+**Fix:** Track `lastReadSequence` per cached entry. On `loadTask` cache hit: `const tail = await this.store.tailSequence(taskStream(taskId))`; if `tail > cached.lastReadSequence`, re-fold via `projectTask(query(taskStream(taskId), { fromSequence: cached.lastReadSequence + 1 }))` (incremental fold; cheaper than full rebuild).
+
+**Severity rationale:** HIGH because the comment is a falsehood — future readers will trust the docstring and build on the assumption. The implementation difficulty is moderate (the SQLite store already tracks tail sequences in the `sequences` table).
+
+---
+
+### FINDING-3 (HIGH) — `task.polled` write amplification
+
+**Where:** `getTask:172-203` — every successful read appends a `task.polled` event.
+
+**Workload model:**
+
+| Variable | Assumption |
+|---|---|
+| CLI poll cadence | 250ms (`cli.followPollIntervalMs` default) |
+| Task duration | 10 minutes (realistic for a workflow phase) |
+| Concurrent tasks per workflow | 1–20 |
+| Concurrent workflows | 1–10 |
+
+**Event count per task:** `task.created` × 1 + `task.polled` × 2,400 + `task.result` × 1 = ~2,402 events. With 200 concurrent tasks (max scenario) = **~480,000 events per session**.
+
+The `projectTask` projection at line 516-518 **ignores** `task.polled` entirely:
+
+```ts
+default:
+  // `task.polled` and unknown types are no-op for state projection.
+  break;
+```
+
+So this is pure write amplification: every poll incurs a write to disk, a sequence allocation, an outbox enqueue, a journal flush — for zero projection benefit.
+
+**Audit value:** The argued benefit (per comment lines 179-198) is "reconstruct the cadence + identity of every poll." This is high-fidelity but rarely valuable — for almost all debugging, you want to know *that* the client polled and *when it last polled*, not every individual poll timestamp.
+
+**Three remediation options:**
+
+| Option | Cost | Trade-off |
+|---|---|---|
+| **A** — Throttled emit: only emit `task.polled` when ≥N seconds since last (default N=10s) | Add a per-task `lastPolledAt` to cache | Loses sub-N-second cadence detail |
+| **B** — Aggregate on terminal: emit single `task.polled_summary {count, firstAt, lastAt, intervals: [...]}` on `task.result`/`task.cancelled` | Per-task counter + the terminal event handler | Per-poll detail lost; reconstruction loses ordering against other events between polls |
+| **C** — Don't emit at all | Delete the emit block | Audit cadence becomes inferable only from surrounding dispatch events |
+
+**Recommendation:** Option A with default N=5s. Preserves "the client is polling" visibility, keeps cadence-burst detail (any cluster shorter than 5s is still observable as N events within a window), and reduces write rate by ~20× at 250ms poll.
+
+**Issue compliance:** #1273 acceptance does not require per-poll emit. The cross-cutting "Task lifecycle fully reconstructable from `task.*` events" criterion is satisfied by `task.created` + `task.result`/`task.cancelled` alone.
+
+---
+
+### FINDING-4 (MEDIUM) — TTL reaper only sweeps on `listTasks`
+
+**Where:** `reapExpired:425-431` is called only from `listTasks:330`.
+
+**Pattern:** `getTask`/`getTaskResult` reap their own entry (line 175-178, 249-252). `createTask` adds an entry. Expired entries created via `createTask` and never read accumulate in `this.tasks` Map until `listTasks` is called.
+
+**Failure mode:** A long-running MCP server process that creates many tasks (e.g., one per subagent wave) but rarely calls `listTasks` (no consumer for paginated listing in production today — only used by `tasks/list` from the SDK) leaks memory at `O(tasks_created_since_last_listTasks)`.
+
+**Fix:** Either:
+- Periodic timer-based sweep (rejected: adds a background process to a fresh-process runtime; per Marten W-1)
+- Size-cap with eager reap when crossing a threshold (preferred): on `createTask`, if `this.tasks.size > MAX_CACHE_SIZE` (default 1,024), run `reapExpired` before adding
+
+**Severity rationale:** MEDIUM because today's adoption surface (2 CLI flags + opt-in MCP) won't hit the threshold; becomes HIGH when more tools opt into Tasks-augmented dispatch.
+
+---
+
+### FINDING-5 (MEDIUM) — `listTasks` cursor is unstable across processes
+
+**Where:** `listTasks:332` `const allTaskIds = Array.from(this.tasks.keys())`.
+
+**Pattern:** Map iteration order is insertion order. Insertion order depends on the order `hydrateFromEventStore` enumerates `task-store/*` streams, which is determined by the SQLite read backend's `listStreams()` implementation — undocumented stable across restarts, undocumented stable across schema migrations.
+
+**Failure mode:** Client pages through tasks during a server restart between page-fetches. Cursor `taskId-A` no longer at the same index in the rebuilt cache → `cursorIndex` returns a different position → page either skips or duplicates entries.
+
+**Comparison:** SDK contract for cursors does not mandate cross-process stability, but it's the kind of "works locally, fails in deployment" footgun that gets discovered by users, not tests.
+
+**Fix:** Sort by `task.createdAt` (deterministic from event timestamps) before computing the index. Cursor encodes `createdAt + taskId` to break ties.
+
+---
+
+### FINDING-6 (MEDIUM) — `hydrateFromEventStore` full enumeration per `listTasks`
+
+**Where:** `hydrateFromEventStore:368-389` runs on every `listTasks` call.
+
+**Pattern:** Comment claims `O(n_streams_total)` enumeration is cheap because the SQLite read backend caches the stream catalog. But the `loadTask` calls (line 384-388) issue a full per-stream `query` on every cache miss — `O(events_per_stream)` per cold task.
+
+**Workload:** 1,000 historical tasks, MCP server restart, first `listTasks` call: 1,000 stream queries, each folding the full event log (`task.created` + N×`task.polled` + terminal). At ~2,400 events per task, that's ~2.4M event reads on a single `listTasks` call before pagination can even start.
+
+**Fix:** Paginated hydration — load only the streams needed to fill the requested page. Anchor on the cursor: read the next `PAGE_SIZE + 1` streams sorted by stream-name, fold those, return; defer the rest.
+
+**Coupled to:** FINDING-3 (if `task.polled` amplification is fixed, this becomes proportionally less expensive).
+
+---
+
+### FINDING-7 (LOW) — `projectTask` silently coerces malformed `request`
+
+**Where:** `projectTask:455` `const request = (createdData['request'] ?? {}) as Request;`.
+
+**Pattern:** A `task.created` event missing the `request` field projects to a `Task` with empty `request: {}`. Same for malformed (non-object) values via the `?? {}` fallback and the `as Request` cast.
+
+**Failure mode:** A stream corrupted by a bad write (e.g., a pre-fix C2 snapshot that didn't validate `request`) projects to a syntactically valid but semantically empty task. SDK consumers that read `task.request` get `{}` and may follow code paths that assume the request shape is meaningful.
+
+**Fix:** Either tolerate-and-flag (warn via logger.warn on coerce, with stream id and event sequence) or be strict (`return undefined` so `loadTask` reports the task as missing, surfacing the corruption).
+
+---
+
+### FINDING-8 (LOW) — `requestId` synthesized as `replayed:${taskId}`
+
+**Where:** `projectTask:522-526`.
+
+**Pattern:** The comment acknowledges this is fine for in-memory consumers but breaks JSON-RPC correlation when a replayed task's result is sent over MCP.
+
+**Failure mode:** Not load-bearing for current flows (no consumer sends replayed-task results back to a client mid-poll). Future SSE/server-push semantics would expose this.
+
+**Fix:** Persist `requestId` on `task.created` event payload. Already partially supported by the SDK Request type; the `task.created` data shape just needs the field added to the Zod schema. Backward-compatible — old events without the field continue to project to the synthetic.
+
+---
+
+## Conformance Matrix
+
+### Design invariants (INV-1..INV-6)
+
+| Invariant | Verdict | Notes |
+|---|---|---|
+| **INV-1 event-sourcing integrity** | ⚠ WATCH | REPLAY proven by acceptance test; F-1 (no OCC) + F-2 (cache validation gap) leak in-memory authority in multi-writer scenarios |
+| **INV-2 facade equivalence** | ✅ | Same TaskStore consumed by CLI follow-loop and MCP `tasks/*`; cancellation flows through identical surface |
+| **INV-3 basileus-forward** | ✅ at-design / ⚠ at-correctness | Process-local design is correct; F-1 + F-2 will surface as bugs when remote-MCP federation lands |
+| **INV-4 platform-agnosticity** | ✅ | Pure TS; depends on EventStore + SDK types only |
+| **INV-5a input ergonomics** | ✅ | Defensive `pollInterval`/`ttl` coercion at boundary (post-#1435 fix) |
+| **INV-5b output contract** | N/A | Not an output-shaped surface |
+| **INV-5c Aspire verbs** | N/A | Not a new verb |
+| **INV-5d action discriminator** | N/A | Not a new action |
+| **INV-6 workflow-agnosticism** | ✅ | Operates on `task-store/*` streams; agnostic to workflow type |
+
+### Axiom backend-quality dimensions (DIM-1..DIM-8)
+
+| Dimension | Verdict | Notes |
+|---|---|---|
+| **DIM-1 topology** | ⚠ WATCH | `this.tasks` map + event stream are dual sources; docstring claims cache; code reads as authoritative |
+| **DIM-2 observability** | ⚠ | F-3 amplification; `try {} catch {}` swallows on `task.polled` emit; F-4 silent memory accumulation |
+| **DIM-3 contracts** | ✅ with caveats | Defensive pollInterval/ttl normalization good; F-7 silent projection coercion |
+| **DIM-4 test fidelity** | ✅ | REPLAY test is load-bearing; F-1 surface not covered by concurrency tests |
+| **DIM-5 dead code** | ✅ | Clean; no vestigial state |
+| **DIM-6 coupling** | ✅ | Clean dep on EventStore only; production-wiring test asserts no SDK `InMemoryTaskStore` |
+| **DIM-7 error handling** | ⚠ | Best-effort swallows are observability-blind; F-7 silent coercion |
+| **DIM-8 prose** | ⚠ | F-2: docstring at lines 30-37 makes a claim the code does not honor |
+
+### Marten patterns (`docs/research/2026-05-08-marten-event-store-lessons.md`)
+
+| Pattern | Status | Notes |
+|---|---|---|
+| **C-1 idempotency keys** | ❌ | `createTask` retry mid-network creates duplicate tasks; `task.polled` emit OK because no projection effect, but `task.result` retry double-writes terminal |
+| **C-2 `fetchForWriting`** | ❌ | Same OCC gap as F-1; the primitive Marten centralizes is exactly what's missing |
+| **C-3 three-field correlation** | ✅ | Carried via ALS stamping from #1291 |
+| **C-5 stream-type markers** | ❌ | `task-store/<id>` is a prefix convention, not a typed column on the streams table; R-1 still relevant |
+
+### Azure ES pattern (Microsoft Learn)
+
+| Principle | Status | Notes |
+|---|---|---|
+| Optimistic concurrency on stream changes | ❌ | F-1 |
+| Idempotent event handlers | ⚠ | Projection is idempotent (pure fold); but command handlers (`storeTaskResult`/`updateTaskStatus`) are not |
+| Tolerant deserialization | ✅ with caveats | `projectTask` defaults missing fields; F-7 may be too tolerant |
+| Event ordering via timestamps | ✅ | Per-event timestamp; sequence provided by event store |
+| Snapshots for large streams | ❌ | No snapshot mechanism; full fold on every cache miss (compounds with F-3 amplification) |
+
+## Recommended Remediation Order
+
+1. **FINDING-3** (poll write amplification) — immediate operational concern; ~1 day of work for Option A throttling
+2. **FINDING-2** (cache validation gap) — comment claims contract not honored; ~2 days for incremental fold
+3. **FINDING-1** (OCC on writes) — correctness debt; ~3 days to thread `expectedSequence` end-to-end; needed before INV-3 remote scenarios
+4. **FINDING-4** (cache reaper) — preventive; ~1 day for size-cap reap
+5. **FINDING-5** (cursor stability) — pre-emptive; ~½ day for sort-by-createdAt
+6. **FINDING-6** (hydration paging) — load-cap; ~2 days for cursor-anchored fold
+7. **FINDING-7** (projection coercion) — observability hygiene; ~½ day to add logger.warn
+8. **FINDING-8** (requestId persistence) — future-proofing; ~½ day to add to event schema
+
+**Total estimated effort:** ~10 days serialized; ~5 days with two-engineer split.
+
+## What Was Done Well
+
+- **REPLAY test is load-bearing** (`event-sourced-task-store.test.ts` exists and pins INV-1 acceptance). Found one substantive REPLAY bug (`pollInterval` drift on restart) and that became PR #1435 — the test caught it.
+- **Defensive normalization at boundaries** (PR #1435): `pollInterval` and `ttl` both validated at `extractTaskOptions` AND `createTask` for defense-in-depth.
+- **INV-2 facade equivalence** is genuine — `cli/follow-loop.ts:SIGINT` and `mcp/tasks-methods.ts:cancel` both route through `taskStore.updateTaskStatus(taskId, 'cancelled', ...)`. The implementation is one surface, two callers.
+- **Production-wiring test** (`task-store/production-wiring.test.ts`) asserts no SDK `InMemoryTaskStore` instances exist in production code paths — guards against accidental regression to the demo store.
+- **Per-task namespacing** (`task-store/<taskId>` streams) keeps task lifecycle disjoint from workflow lifecycle — cross-stream queries can pivot on either axis without entanglement.
+
+## Sources
+
+- File audited: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts`
+- Marten lessons: `docs/research/2026-05-08-marten-event-store-lessons.md`
+- Azure Event Sourcing pattern: `learn.microsoft.com/azure/architecture/patterns/event-sourcing`
+- Azure CQRS + Event Sourcing: `learn.microsoft.com/azure/architecture/patterns/cqrs#combine-the-event-sourcing-and-cqrs-patterns`
+- Issue #1272 acceptance + PR #1430
+- Post-merge fix PR #1435 (covers REPLAY drift + pollInterval validity + sequence deprecation)
+- Bundle design: `docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.md` Wave B §"#1272 EventSourcedTaskStore"
+- Backend quality dimensions: `axiom:backend-quality`
+- Design invariants: `.claude/skills/design-invariants/SKILL.md`

--- a/docs/research/2026-05-16-v2-10-0-preview-4-bundle-audit.md
+++ b/docs/research/2026-05-16-v2-10-0-preview-4-bundle-audit.md
@@ -1,0 +1,181 @@
+# v2.10.0-preview.4 Bundle Audit — What Landed vs Design Intent
+
+**Feature ID:** `preview4-bundle-audit`
+**Date:** 2026-05-16
+**Bundle:** PRs #1421–#1435 (between c3a55f44 preview.3 close-out and 77c9d77b HEAD)
+**Reference design:** [`docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.md`](../designs/2026-05-15-v2-10-0-preview-4-feature-freeze.md)
+**Reference plan:** [`docs/plans/2026-05-15-v2-10-0-preview-4-feature-freeze.md`](../plans/2026-05-15-v2-10-0-preview-4-feature-freeze.md)
+
+## TL;DR
+
+All 11 originating issues (#1238, #1244, #1260, #1261, #1262, #1272, #1273, #1274, #1290, #1291, #1298) are **closed**, and the substantive code+content for every wave (A/B/C/D) is on `main`. The bundle delivers the feature-freeze line as scoped.
+
+However, **four drift items** are worth surfacing:
+
+1. **PR-to-content attribution is misleading.** Because the bundle used stacked PR branches, four of the eleven issues (`#1262/PR1422`, `#1290/PR1423`, `#1261/PR1429`, `#1272/PR1430`) never produced their own squash commit on `main` — their content arrived via their parent's squash and is attributed in git log to the wrong PR number.
+2. **#1273 Wave C had a process incident.** PR #1432 (C2 MCP adapter) was squash-merged from a pre-CodeRabbit-fix snapshot; PR #1431 went structurally stale; PR #1435 was created post-hoc to replay the CodeRabbit-final fix delta. C1 (Tasks-augmented dispatch-core) never had its own attributed merge — the content rode in under PR #1433 (C3 `--follow`).
+3. **#1291 acceptance has two substantive un-met items** — no SQL-column storage layer for `correlation_id`/`causation_id`, and no telemetry-view filters for the three fields. The fields exist on the TS event-factory + envelope; storage and view filters are deferred (#1414 covers two MEDIUM gaps).
+4. **#1244 (handoff lint) had a documented design deviation** — the plan prescribed `_eventHints` payload, but `EventHintsPayload` is strictly typed; the PR shipped the existing `result.warnings` + `data.handoffLintFindings` pattern instead. Functionally equivalent, but not the surface the plan named.
+
+Plus a notable functional bug that almost shipped: **PR #1426 B1** (sidecar lookup returned `foo.md.sidecar.yml` instead of `foo.sidecar.yml`) would have made the entire #1298 sidecar gate path silently dead. Caught by CodeRabbit pre-merge.
+
+The version is still `2.10.0-preview.3` in both root `package.json` and `servers/exarchos-mcp/package.json`; no preview.4 CHANGELOG entry exists yet. The bundle is **merged but not released**.
+
+## Bundle Composition — What Actually Landed on Main
+
+Between `c3a55f44` (preview.3 close-out, 2026-05-16T02:02Z) and `77c9d77b` (HEAD, 2026-05-16T23:26Z), `main` received 13 commits. Nine of those are the preview.4 PR squashes plus the design+plan docs and one cleanup fix carried over from preview.3:
+
+| Commit | PR | Wave | Issue | Surface |
+|---|---|---|---|---|
+| `72bf1823` | #1404 | (preview.3 carry) | — | `fix(merge-orchestrate)`: repoRoot from git top-level |
+| `1e48212a` | (chore) | — | — | bump 2.10.0-preview.3 |
+| `77048483` | (direct) | — | — | `fix(cli)`: bare `exarchos` UNCAUGHT_EXCEPTION |
+| `74adbeda` | #1088 | bundle docs | — | preview.4 design + plan + 2 sidecars |
+| `af40ed18` | **#1425** | **D1** | **#1260** | machine-readable invariants + vocabulary lint + `/ideate` first-turn |
+| `99aacc4d` | **#1421** | **A1** | **#1238** | next-actions Zod discriminated unions + safeParse fail-closed |
+| `ff8a83a4` | **#1426** | **D2** | **#1298** | designs/plans machine-readable sidecar + 4 functional fixes |
+| `f7e70a11` | **#1427** | **D3** | **#1244** | markdown-aware handoff lint at `handleCheckpoint` |
+| `be4e5a50` | **#1428** | **B1** | **#1291** | three-field correlation + AsyncLocalStorage event threading |
+| `08f68ced` | **#1433** | **C3** | **#1273** | CLI `--follow` polling loop |
+| `1a2e8b12` | **#1424** | **A4** | **#1274** | Elicitation form mode for INVALID_INPUT |
+| `299b902a` | **#1432** | **C2** | **#1273** | `tasks/*` methods + `taskSupport` capability |
+| `77c9d77b` | **#1435** | **C1-fix** | **#1273** | pollInterval validity + `task.polled.sequence` deprecation |
+
+**Wave coverage summary:**
+
+| Wave | Theme | Issues | Status |
+|---|---|---|---|
+| **A** | Output contract completion | #1238 #1262 #1290 #1274 | All 4 landed |
+| **B** | Correlation + event topology | #1291 #1261 #1272 | All 3 landed (1261 + 1272 via #1428 squash) |
+| **C** | Tasks dispatch-core | #1273 | Landed; C1 + C2 + C3 + post-merge fix |
+| **D** | Authoring substrate | #1260 #1298 #1244 | All 3 landed |
+
+## Per-Wave Findings
+
+### Wave A — Output Contract Completion
+
+| Issue | Acceptance summary | Landed | Drift |
+|---|---|---|---|
+| **#1238** | `nextActionsFromResult` uses `safeParse` over discriminated union; fail-closed; no Record casts. | ✅ via PR #1421 (own squash) | None. |
+| **#1262** | `output_tokens_high` hint via `next_actions` on threshold crossing; CLI+MCP envelope parity; configurable via `.exarchos.yml`. | ✅ via #1421's squash (PR #1422 merged-but-not-as-own-commit) | Attribution: file `telemetry/quality-hints.ts` shows up in git blame under #1421's commit, not #1422. |
+| **#1290** | Roots capability snapshotted; one-match resolves with `workspace.resolved {source:'roots'}`; multi-match→`INVALID_INPUT`+`validTargets`; cache invalidates on `roots/list_changed`. | ✅ — file `servers/exarchos-mcp/src/workspace/discovery.ts` is in `main` | Attribution: git blame credits this file to **#1428** (Wave B PR1), not #1423. Content semantically intact (signature heuristic + tri-state cache + `roots/list_changed` invalidation present in the file's leading comment). |
+| **#1274** | Missing-required-param + `elicitation` declared → `elicitation/create` with `.pick()`-derived schema; events carry `operationId`. | ✅ via PR #1424 (own squash) | None. PR notes `roots > cwd > elicitation > INVALID_INPUT` resolution order, matching design. |
+
+**Wave A verdict: complete; one re-attribution oddity in the squash chain.**
+
+### Wave B — Correlation + Event Topology
+
+| Issue | Acceptance summary | Landed | Drift |
+|---|---|---|---|
+| **#1291** | `DispatchContext` three fields; thread through every event-emit site; **three new typed SQL columns** (`operation_id` `correlation_id` `causation_id`); telemetry views accept filters for all three; integration tests for inheritance + auto-dispatch + property collision. | ⚠️ partial | **Substantive drift:** TS fields exist (`event-factory.ts`, `atomic-appender.ts`, envelope `_meta`), but `git grep correlation_id\|causation_id` over `servers/exarchos-mcp/` returns 0 SQL columns. Telemetry views (`src/views/`) don't accept the three filters either. PR body explicitly documents two MEDIUM CodeRabbit gaps deferred to **#1414** (preserve inbound `_meta` for built-in tools + `batchAppend` cache-hit operationId preservation). |
+| **#1261** | `dispatch.preflight` per-guard + `stash.detected` events with three-field correlation. | ✅ — `event-store/schemas.ts` registers both event types; emitted from `prepare-delegation.ts` | Attribution: PR #1429's content arrived via #1428's squash. |
+| **#1272** | `EventSourcedTaskStore` projection over `task.*` events; lifecycle reconstructable from event stream; TTL; no `InMemoryTaskStore` in production. | ✅ — `task-store/event-sourced-task-store.ts` in `main`; `production-wiring.test.ts` asserts the SDK store is absent | Attribution: PR #1430's content arrived via #1428's squash (first appears at `be4e5a50`). |
+
+**Wave B verdict: feature-functional, but #1291 missed the storage-layer column model and the telemetry-filter wiring named in the issue's acceptance list. The two TODOs from CodeRabbit are tracked under #1414.**
+
+### Wave C — Tasks Dispatch-Core (#1273)
+
+The bundle's most operationally messy slice. Split into C1 / C2 / C3 per design; landed as:
+
+| Sub-PR | Surface | Status |
+|---|---|---|
+| **C1** Tasks-augmented dispatch core (`dispatch/tasks-augmented.ts`) | dispatch-core path returning `CreateTaskResult` | Landed — but no own attribution. First appears in `main` at `08f68ced` (PR **#1433**, C3) |
+| **C2** MCP adapter (`mcp/tasks-methods.ts`, `mcp/tools-call-handler.ts`) | `tasks/get` / `tasks/result` / `tasks/cancel`; `taskSupport: 'optional'` | Landed at `299b902a` (PR **#1432**), but from a **stale snapshot** that pre-dated CodeRabbit-final fixes on PR #1431 |
+| **C3** CLI `--follow` polling loop (`cli/follow-loop.ts`, `cli/follow-formatter.ts`) | in-process polling against `EventSourcedTaskStore`; SIGINT→cancel parity | Landed at `08f68ced` (PR **#1433**) |
+| **C1-fix** post-merge | pollInterval validity + `task.polled.sequence` deprecation + pollInterval REPLAY drift | Landed at `77c9d77b` (PR **#1435**) |
+
+**Process incident (documented in PR #1435 body):**
+
+> PR #1432 (#1273 C2) was squash-merged at 23:06 UTC from a branch snapshot that pre-dated the CodeRabbit-final fixes that landed on PR #1431. PR #1431 is now structurally stale — its diff vs main would *remove* the C2 files it doesn't yet contain. This PR ports just the CodeRabbit fix delta forward to a clean branch off `main`.
+
+The three fixes #1435 had to replay are non-trivial:
+
+1. **pollInterval validity contract alignment** — `0` / negatives / NaN / Infinity / fractional floats could slip past the dispatch boundary and silently fail the durable `TaskCreatedData.pollInterval` schema inside the best-effort emit.
+2. **`task.polled.data.sequence` deprecation** — canonical ordering moved to envelope atomic `.sequence`; payload field is redundant.
+3. **pollInterval REPLAY drift** — pre-fix, a process restart silently reverted every task to the 1000ms default because cadence was only in the in-memory projection.
+
+The REPLAY drift in particular is an **INV-1 violation** (event-sourcing integrity) that almost shipped. If this had escaped review, every restart would have silently re-defaulted Task cadence — a behavior change invisible to clients but breaking the "projection rebuilt from stream alone" guarantee that #1272 is supposed to enforce.
+
+**Acceptance criteria status (#1273):**
+
+| Criterion | Status |
+|---|---|
+| Dispatch core Tasks-augmented path returns `CreateTaskResult` | ✅ |
+| MCP adapter wires `tools/call+task` → dispatch core; `tasks/get`/`tasks/result`/`tasks/cancel` resolve via `EventSourcedTaskStore` | ✅ |
+| CLI adapter `--follow` consumes the same `EventSourcedTaskStore` | ✅ |
+| `--format json --follow` emits NDJSON matching registered `outputSchema` per transition | ⚠️ not verified in this audit; PR #1433 body mentions transition formatter but not the NDJSON schema parity test |
+| Parity test (same dispatch through both adapters → identical content per transition) | ⚠️ PR #1433 says "INV-2 facade equivalence" via shared `updateTaskStatus` call, but the byte-identical-per-transition test named in the issue is not called out |
+| `taskSupport: 'optional'` — clients without Tasks support get one-shot | ✅ |
+| First adoption: `exarchos_view --follow workflow` + `--follow shepherd` | ✅ |
+
+**Wave C verdict: feature-functional and shipped; process scar from the stale snapshot is documented and remediated by #1435; two acceptance items (NDJSON outputSchema parity per transition, byte-equal cross-adapter parity test) would benefit from spot-check verification.**
+
+### Wave D — Authoring Substrate
+
+| Issue | Acceptance summary | Landed | Drift |
+|---|---|---|---|
+| **#1260** | `docs/architecture/invariants.md` with structured frontmatter; `/ideate` first-turn loads + surfaces; vocabulary lint fails CI on undefined `INV-N`/`DIM-N` references. | ✅ via PR #1425 (own squash) — 18 entries, 319 LOC; `vocabulary-lint-cli.ts`; `npm run lint:invariants` | Known follow-up in PR body: 10 existing-file `INV-5` umbrella references without specific sub-discipline. Recommended as a separate issue. |
+| **#1298** | Design + plan sidecars; 4 gates consume sidecar when present; regex fallback with deprecation log; tracking issue filed in same PR. | ✅ via PR #1426 (own squash) — backfill sidecars exist for the preview.4 design + plan; regex-fallback removal tracked under **#1407** | **Functional bug caught in review:** B1 — `sidecar-lookup.ts` originally returned `foo.md.sidecar.yml` (mismatch with shipped `foo.sidecar.yml` filenames). Without the fix, the sidecar branch never fired. Also B2 (DAG check stub), B3 (ESM `__dirname`), B4 (`min(1)` references). All four caught and fixed before merge by CodeRabbit. |
+| **#1244** | Run `prose-lint.ts` on `handoff.context/nextSteps/suggestions` at `handleCheckpoint`; soft-fail default; hard-fail opt-in via `.exarchos.yml`. | ✅ via PR #1427 (own squash) — `workflow/handoff-lint.ts`; `handoffLint.hardFail?: boolean` config | **Documented design deviation:** plan prescribed `_eventHints: [{kind:'handoff_lint_warning', findings}]` but `EventHintsPayload` is strictly typed; PR shipped existing canonical soft-warning pattern (`result.warnings` + `data.handoffLintFindings`). Functionally equivalent; surface-named deviation explicit in PR body. |
+
+**Wave D verdict: complete; one functional bug pre-empted by review (PR #1426 B1), one explicit plan-vs-implementation surface deviation (PR #1427 handoff lint payload shape).**
+
+## Cross-Cutting Observations
+
+### 1. Stacked-PR attribution drift
+
+The bundle used per-wave integration branches (`feature/preview4-wave-{a,b,c,d}`) with stacked sub-branches. When a stack-base PR squash-merged to `main`, its squash collapsed every stacked child's content into a single commit attributed to the base PR. Consequence: four issues have no own squash commit on `main`:
+
+- **#1262** → content in #1421's squash (or #1428's; first-appearance of `telemetry/quality-hints.ts` warrants verification)
+- **#1290** → `workspace/discovery.ts` first appears at #1428's squash
+- **#1261** → first appears at #1428's squash
+- **#1272** → first appears at #1428's squash
+
+This is not a functional issue, but it makes `git blame`/`git log -- <file>` confusing for anyone trying to trace why a feature exists.
+
+### 2. The #1431 / #1432 / #1435 stale-snapshot incident
+
+PR #1432 was merged from a branch snapshot that pre-dated three CodeRabbit-final fixes on PR #1431. PR #1431 went structurally stale (its diff vs main would *remove* C2 files), and PR #1435 had to be created to replay the fix delta on a clean branch off main. The three fixes covered a real INV-1 violation (pollInterval REPLAY drift). This is a workflow hazard worth memorializing — the [stale-worktree-after-external-push](../../README.md) memory feedback applies, and the stacked-PR discipline memory may need an additional clause: **never squash-merge from a stale snapshot when a sibling PR has post-review fixes pending.**
+
+### 3. Sequencing drift vs design
+
+Design said: "Wave A and Wave D run in parallel; Wave B serial after A+D; Wave C serial after B." Actual merge order: D1 → A1 → D2 → D3 → **B1** → **C3** → **A4** → **C2** → C1-fix. Two minor deviations:
+
+- **A4 (#1424)** merged *after* B1 — Wave A was not fully closed before Wave B started.
+- **C3 (#1433)** merged *before* C2 (#1432) — same wave, but reverse the design's "split internally" order.
+
+Neither caused a regression. Sequencing was looser than the design's strict serialization, but disjoint surfaces made it safe.
+
+### 4. Version not yet bumped
+
+Both `package.json` and `servers/exarchos-mcp/package.json` are still `2.10.0-preview.3`. No CHANGELOG entry for preview.4 exists yet. The bundle is **merged-but-not-released**. The design's RC-readiness assertions (no new API surface, no new event types, no new MCP capabilities post-preview.4) are now operative; the version bump + CHANGELOG entry + tag are the remaining steps.
+
+### 5. Conformance the design promised
+
+The design declared PASS or PASS(+) on all 9 INV checks and all 8 DIM checks, with one DIM-5 WATCH (regex-fallback removal scheduled v2.11). The landed code substantiates:
+
+- **INV-1**: ✅ task lifecycle reconstructable from stream (`EventSourcedTaskStore` + #1435 REPLAY fix close the loop)
+- **INV-2**: ✅ shared `updateTaskStatus` between CLI SIGINT and MCP `tasks/cancel`
+- **INV-5a**: ✅ Roots eliminates "guess featureId"; Elicitation eliminates "trial-and-error which param"; invariants doc surfaces on `/ideate` first turn
+- **INV-5b**: ⚠️ partial — three-field correlation does register in envelope `_meta`, but the storage column + telemetry filter halves of the contract are not landed
+- **DIM-3**: ✅ Zod discriminated union (#1238); `.pick()`-derived elicitation schemas (#1274); sidecar IS the contract (#1298); invariants doc structured frontmatter (#1260)
+- **DIM-5 WATCH**: ✅ regex-fallback deprecation log present; removal tracked under **#1407**
+
+## Recommendations
+
+1. **Cut the preview.4 release.** Bump `package.json` + `servers/exarchos-mcp/package.json`, write the CHANGELOG entry, tag, run the release workflow. Until this happens, the design's RC-readiness assertions are inert.
+2. **Close out #1414** before RC1. The two MEDIUM CodeRabbit gaps from #1428 (preserve inbound `_meta`, `batchAppend` cache-hit operationId preservation) are the load-bearing pieces missing from #1291's contract.
+3. **Decide whether the SQL columns + telemetry filters from #1291's acceptance are RC-eligible or v2.11.** The acceptance was specific ("Three new typed columns on the events table — `operation_id`, `correlation_id`, `causation_id`. Indexed for telemetry-view queries"). Today's TS-only implementation leaves the wire-format primitive in place but the persistent index is missing. If they're deferred, file a follow-up and amend the design.
+4. **Verify the two #1273 acceptance items** that this audit could not confirm: `--format json --follow` NDJSON-per-transition matches the registered outputSchema, and the byte-equal cross-adapter parity test exists for Tasks (not just for one-shot envelopes).
+5. **Codify the stacked-PR squash hazard.** Add a clause to the stacked-PR discipline feedback: **before squash-merging the bottom of a stack, confirm no sibling PR has post-review fixes pending against the same branch snapshot.** The #1431 / #1432 / #1435 incident is the canonical example.
+6. **(Optional) Resolve the attribution drift for the four stacked PRs.** No functional impact, but `git blame` users will be confused. If the attribution is preserved in PR labels / closing-issue references, that's adequate; if it isn't, consider a documentation note in the CHANGELOG entry.
+
+## Sources
+
+- Design: `docs/designs/2026-05-15-v2-10-0-preview-4-feature-freeze.md`
+- Plan: `docs/plans/2026-05-15-v2-10-0-preview-4-feature-freeze.md`
+- Plan sidecar: `docs/plans/2026-05-15-v2-10-0-preview-4-feature-freeze.sidecar.yml`
+- Issues: #1088 (epic), #1238 #1244 #1260 #1261 #1262 #1272 #1273 #1274 #1290 #1291 #1298
+- PRs: #1421 #1422 #1423 #1424 #1425 #1426 #1427 #1428 #1429 #1430 #1432 #1433 #1435
+- Preview.3 close-out: PR #1401 (squash `c3a55f44`)
+- Follow-ups filed against the bundle: **#1407** (regex-fallback removal, v2.11), **#1414** (two #1291 MEDIUM gaps)

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -224,6 +224,164 @@ describe('EventSourcedTaskStore (#1272)', () => {
     expect(ids).toEqual([t1.taskId, t2.taskId].sort());
   });
 
+  it('getTask_RapidSequentialReads_EmitsAtMostOneTaskPolled', async () => {
+    // FINDING-3 (#1438, PR 1): the SDK's `tasks/poll` and the CLI
+    // `--follow` loop call `getTask` at the task's `pollInterval`
+    // cadence (default 250ms in many flows). Without a throttle the
+    // store appends one `task.polled` event per call, causing severe
+    // write amplification on the durable stream. The throttle gate
+    // collapses bursts within a 5-second window down to a single emit.
+    const task = await store.createTask(
+      { ttl: 60_000 },
+      'req-throttle',
+      sampleRequest,
+    );
+
+    // Burst of 20 reads within the throttle window — only the first
+    // should emit `task.polled`.
+    for (let i = 0; i < 20; i++) {
+      await store.getTask(task.taskId);
+    }
+
+    const events = await eventStore.query(`task-store/${task.taskId}`);
+    const polled = events.filter((e) => e.type === 'task.polled');
+    expect(polled).toHaveLength(1);
+  });
+
+  it('getTask_AfterThrottleWindowElapses_EmitsSecondTaskPolled', async () => {
+    // FINDING-3 (#1438, PR 1): once the throttle window has elapsed,
+    // a subsequent `getTask` MUST emit a fresh `task.polled` so that
+    // long-running polls remain observable. Determinism requires an
+    // injectable clock — the production default is `Date.now()` and
+    // the throttle constant is 5_000ms, so a real-clock test would be
+    // flaky and slow.
+    let now = 1_000_000;
+    const clock = () => now;
+    const throttleStore = new EventSourcedTaskStore(eventStore, { clock });
+
+    const task = await throttleStore.createTask(
+      { ttl: 60_000 },
+      'req-window',
+      sampleRequest,
+    );
+
+    // First read inside the window — emits.
+    await throttleStore.getTask(task.taskId);
+
+    // Advance past the throttle window — second read emits again.
+    now += 5_001;
+    await throttleStore.getTask(task.taskId);
+
+    const events = await eventStore.query(`task-store/${task.taskId}`);
+    const polled = events.filter((e) => e.type === 'task.polled');
+    expect(polled).toHaveLength(2);
+  });
+
+  it('getTask_ExpiredTaskReaped_LastPolledAtCleared', async () => {
+    // FINDING-3 (#1438): the `lastPolledAt` map must not leak entries
+    // for tasks that have been reaped on expiry. We assert via the
+    // observable effect — recreating a fresh task in the SAME store
+    // with the same id after expiry is contrived, so instead we use
+    // the test-only `getLastPolledAtSize` helper (added below) AND
+    // verify that re-arming the throttle after manual reap re-emits.
+    vi.useFakeTimers();
+    try {
+      const task = await store.createTask(
+        { ttl: 5_000 },
+        'req-reap',
+        sampleRequest,
+      );
+      // Prime the throttle.
+      expect(await store.getTask(task.taskId)).not.toBeNull();
+      expect(
+        (store as unknown as { lastPolledAt: Map<string, number> })
+          .lastPolledAt.size,
+      ).toBe(1);
+
+      // Advance past TTL — next getTask returns null and reaps cache.
+      vi.setSystemTime(Date.now() + 10_000);
+      expect(await store.getTask(task.taskId)).toBeNull();
+
+      // The throttle map entry MUST be cleaned up alongside the cache.
+      expect(
+        (store as unknown as { lastPolledAt: Map<string, number> })
+          .lastPolledAt.size,
+      ).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('getTaskResult_ExpiredTaskReaped_LastPolledAtCleared', async () => {
+    // FINDING-3 (#1438): the `getTaskResult` expired branch also reaps
+    // the cache and must drop the throttle entry symmetrically with
+    // `getTask`.
+    vi.useFakeTimers();
+    try {
+      const task = await store.createTask(
+        { ttl: 5_000 },
+        'req-reap-result',
+        sampleRequest,
+      );
+      // Prime the throttle by polling once.
+      await store.getTask(task.taskId);
+      expect(
+        (store as unknown as { lastPolledAt: Map<string, number> })
+          .lastPolledAt.size,
+      ).toBe(1);
+
+      vi.setSystemTime(Date.now() + 10_000);
+      await expect(store.getTaskResult(task.taskId)).rejects.toThrow(
+        /not found/,
+      );
+
+      expect(
+        (store as unknown as { lastPolledAt: Map<string, number> })
+          .lastPolledAt.size,
+      ).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reapExpired_RemovesLastPolledAtForExpiredTasks', async () => {
+    // FINDING-3 (#1438): the `listTasks` reap path (which calls
+    // `reapExpired`) must also evict matching `lastPolledAt` entries.
+    vi.useFakeTimers();
+    try {
+      const a = await store.createTask({ ttl: 5_000 }, 'r-a', sampleRequest);
+      const b = await store.createTask({ ttl: 5_000 }, 'r-b', sampleRequest);
+      const c = await store.createTask({ ttl: null }, 'r-c', sampleRequest);
+
+      // Prime the throttle for all three tasks.
+      await store.getTask(a.taskId);
+      await store.getTask(b.taskId);
+      await store.getTask(c.taskId);
+      expect(
+        (store as unknown as { lastPolledAt: Map<string, number> })
+          .lastPolledAt.size,
+      ).toBe(3);
+
+      // Advance past TTL of a + b only.
+      vi.setSystemTime(Date.now() + 10_000);
+
+      // listTasks triggers reapExpired.
+      const { tasks } = await store.listTasks();
+      const ids = tasks.map((t) => t.taskId).sort();
+      expect(ids).toEqual([c.taskId].sort());
+
+      // Only the unlimited-TTL task's entry should remain in
+      // `lastPolledAt` after reap.
+      const lastPolledAt = (
+        store as unknown as { lastPolledAt: Map<string, number> }
+      ).lastPolledAt;
+      expect(lastPolledAt.size).toBe(1);
+      expect(lastPolledAt.has(c.taskId)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('EventSourcedTaskStore_ListTasks_HydratesFromEventStoreOnColdStart', async () => {
     // CR PR #1432: cold-start listTasks must enumerate durable
     // `task-store/*` streams rather than silently returning an empty

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -42,7 +42,10 @@
  * `task.created` event. Expired tasks are reaped on read (`getTask` /
  * `getTaskResult` / `listTasks`) — no background timers, no extra
  * substrate state. `ttl === null` means unlimited lifetime (per the
- * SDK contract).
+ * SDK contract). The per-task `task.polled` emit (FINDING-3, #1438) is
+ * throttled to one event per `TASK_POLLED_THROTTLE_MS` window via an
+ * in-memory `lastPolledAt` map that is cleaned up alongside the cache
+ * on reap.
  */
 import { randomBytes } from 'node:crypto';
 import type {
@@ -89,6 +92,31 @@ function taskStream(taskId: string): string {
   return `task-store/${taskId}`;
 }
 
+/**
+ * FINDING-3 (#1438): throttle window for `task.polled` emit. The CLI
+ * `--follow` loop and the SDK `tasks/poll` flow drive `getTask` at the
+ * task's `pollInterval` cadence (often 250ms), which without throttling
+ * appends one `task.polled` event per call and severely amplifies the
+ * durable stream. A 5-second window collapses tight bursts to a single
+ * emit while still preserving observability of long-running polls.
+ */
+const TASK_POLLED_THROTTLE_MS = 5_000;
+
+/**
+ * Optional constructor options for `EventSourcedTaskStore`.
+ *
+ * `clock` is the rate-limit clock for the FINDING-3 throttle gate.
+ * Production callers omit it (defaults to `Date.now()`); tests inject a
+ * counter-style function to make the throttle behavior deterministic.
+ * NOTE: TTL/`expiresAt` math elsewhere in the class intentionally keeps
+ * reading `Date.now()` directly — TTL is wall-clock semantics, throttle
+ * is rate-limit semantics, and conflating them in one knob would muddy
+ * blast radius.
+ */
+export interface EventSourcedTaskStoreOptions {
+  clock?: () => number;
+}
+
 export class EventSourcedTaskStore implements TaskStore {
   private readonly store: EventStore;
 
@@ -98,8 +126,24 @@ export class EventSourcedTaskStore implements TaskStore {
    */
   private readonly tasks = new Map<string, ProjectedTask>();
 
-  constructor(eventStore: EventStore) {
+  /**
+   * FINDING-3 (#1438): per-task wall-clock timestamp of the last
+   * `task.polled` emit. Used by the throttle gate in `getTask`. Cleared
+   * when the task expires (read-time reap) or is otherwise reaped to
+   * avoid unbounded growth.
+   */
+  private readonly lastPolledAt = new Map<string, number>();
+
+  /**
+   * FINDING-3 (#1438): injectable clock used ONLY by the `task.polled`
+   * throttle gate. Defaults to `Date.now()`. See
+   * `EventSourcedTaskStoreOptions.clock` for why this is scoped narrowly.
+   */
+  private readonly nowMs: () => number;
+
+  constructor(eventStore: EventStore, options?: EventSourcedTaskStoreOptions) {
     this.store = eventStore;
+    this.nowMs = options?.clock ?? Date.now.bind(Date);
   }
 
   // ─── SDK TaskStore interface ────────────────────────────────────────────
@@ -174,6 +218,9 @@ export class EventSourcedTaskStore implements TaskStore {
     if (!stored) return null;
     if (this.isExpired(stored)) {
       this.tasks.delete(taskId);
+      // FINDING-3 (#1438): keep the throttle map in lockstep with the
+      // cache so reaped tasks don't leave dangling rate-limit entries.
+      this.lastPolledAt.delete(taskId);
       return null;
     }
     // ─── #1273 / T29 — Emit task.polled on every successful read ──────────
@@ -190,14 +237,27 @@ export class EventSourcedTaskStore implements TaskStore {
     // a transient I/O blip. The projection itself is unaffected (no
     // `task.polled` handler in `projectTask` — it is a pure observability
     // event, not a state transition).
-    try {
-      await this.store.append(taskStream(taskId), {
-        type: 'task.polled',
-        timestamp: new Date().toISOString(),
-        data: { taskId },
-      });
-    } catch {
-      // best-effort
+    //
+    // FINDING-3 throttle gate (#1438): collapse bursts of `getTask`
+    // calls within `TASK_POLLED_THROTTLE_MS` down to a single emit.
+    // Uses an injectable clock (`this.nowMs`) for the rate-limit
+    // decision so tests can advance time deterministically; TTL and
+    // event-timestamp wall-clock reads elsewhere intentionally remain
+    // on `Date.now()` (TTL is wall-clock semantics, throttle is
+    // rate-limit semantics — keep them disjoint).
+    const now = this.nowMs();
+    const last = this.lastPolledAt.get(taskId) ?? 0;
+    if (now - last >= TASK_POLLED_THROTTLE_MS) {
+      try {
+        await this.store.append(taskStream(taskId), {
+          type: 'task.polled',
+          timestamp: new Date().toISOString(),
+          data: { taskId },
+        });
+        this.lastPolledAt.set(taskId, now);
+      } catch {
+        // best-effort
+      }
     }
     return { ...stored.task };
   }
@@ -248,6 +308,8 @@ export class EventSourcedTaskStore implements TaskStore {
     }
     if (this.isExpired(stored)) {
       this.tasks.delete(taskId);
+      // FINDING-3 (#1438): symmetric with getTask's reap branch.
+      this.lastPolledAt.delete(taskId);
       throw new Error(`Task with ID ${taskId} not found`);
     }
     if (stored.result === undefined) {
@@ -426,6 +488,9 @@ export class EventSourcedTaskStore implements TaskStore {
     for (const [taskId, stored] of this.tasks) {
       if (this.isExpired(stored)) {
         this.tasks.delete(taskId);
+        // FINDING-3 (#1438): drop the matching throttle entry so the
+        // `lastPolledAt` map stays bounded by live tasks.
+        this.lastPolledAt.delete(taskId);
       }
     }
   }


### PR DESCRIPTION
## Summary

PR 1 of 3 addressing the HIGH-severity findings from the EventSourcedTaskStore audit (#1438, epic #1441). Closes **FINDING-3** — `task.polled` write amplification.

Every `getTask` previously appended a `task.polled` event. At the default CLI poll cadence (250ms) × a 10-minute task = ~2,400 events per task, all of which the projection IGNORES (pure write amplification). This PR throttles the emit to ≥5s spacing per task, reducing write rate ~20× at default poll cadence.

Companion PRs (stacked):
- **PR 2** — FINDING-2 cache validation via new `EventStore.tailSequence` (pending)
- **PR 3** — FINDING-1 OCC threading via `expectedSequence` (pending)

## Changes

- `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts`
  - Added `TASK_POLLED_THROTTLE_MS = 5_000` module constant
  - Added `lastPolledAt: Map<string, number>` rate-limit state (process-local, not projected)
  - Added optional `clock` constructor option for deterministic tests (defaults to `Date.now`)
  - `getTask` skips emit when `now - lastPolledAt[id] < TASK_POLLED_THROTTLE_MS`
  - `lastPolledAt` cleaned up in three eviction paths: `getTask` expired branch, `getTaskResult` expired branch, `reapExpired` loop
  - Class docstring `## TTL` section updated to describe throttled poll trace
- `servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts`
  - 5 new tests covering rate, window, and three cleanup branches
- Bundled docs from the planning phase:
  - `docs/research/2026-05-16-event-sourced-task-store-audit.md` — the audit that surfaced these findings
  - `docs/research/2026-05-16-v2-10-0-preview-4-bundle-audit.md` — parent bundle audit
  - `docs/designs/2026-05-16-event-sourced-task-store-high-trio.md` — design for the three-PR stack
  - `docs/plans/2026-05-16-event-sourced-task-store-high-trio.md` — TDD task plan (24 tasks)

## Test Plan

- [x] `npx vitest run src/task-store/` — 16 passed, 0 failed
- [x] `npx tsc --noEmit` (MCP server) — exit 0
- [x] REPLAY acceptance tests still pass (projection ignores `task.polled` regardless of count)
- [x] Cross-cutting smoke: `tasks-augmented.test.ts`, `task-support.test.ts`, `tasks-methods.test.ts`, `tools-call-handler.test.ts`, `dispatch.test.ts`, `tests/outcome/tasks-dispatch-lifecycle.test.ts` all green

## Invariant / dimension conformance

- INV-1 (event-sourcing integrity): ✅ preserved — projection unchanged; throttled emit is a sampled trace
- INV-2 (facade equivalence): ✅ — single store, single behavior
- DIM-2 (observability): ✅ — write amplification reduced 20×; swallow path still best-effort but rate-limited
- DIM-7 (error handling): ✅ — emit still best-effort; cleanup paths add no new error surface

Refs: #1438, #1441, #1272 (original feature), #1430 (original PR), #1435 (post-merge follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)