### PR TITLE
feat(task-store): validate cache against stream tail (FINDING-2, #1438)

### DIFF
--- a/servers/exarchos-mcp/src/event-store/store.test.ts
+++ b/servers/exarchos-mcp/src/event-store/store.test.ts
@@ -954,3 +954,42 @@ describe('EventStore appendValidated', () => {
   // dual-write (`writeOutbox` / `setOutbox`) were removed in Phase 2
   // along with the JSONL primary substrate.
 });
+
+// ─── FINDING-2 (#1438, PR 2) — tailSequence accessor ────────────────────────
+
+describe('EventStore.tailSequence', () => {
+  it('tailSequence_EmptyStream_ReturnsZero', async () => {
+    // FINDING-2 (#1438): `tailSequence` is the one-line wrapper over the
+    // backend high-water-mark accessor that `EventSourcedTaskStore` will
+    // use to validate cache hits against the durable stream tail. For a
+    // stream that has never been written, the contract returns 0 (NOT
+    // undefined) so callers can use `tail === cached.lastReadSequence`
+    // as a clean equality check without separate undefined-handling.
+    const store = new EventStore(tempDir);
+    await store.initialize();
+
+    const tail = await store.tailSequence('never-written');
+    expect(tail).toBe(0);
+  });
+
+  it('tailSequence_PopulatedStream_ReturnsHighestSequence', async () => {
+    // FINDING-2 (#1438): for a populated stream, `tailSequence` returns
+    // the sequence of the most-recently-appended event — equivalent to
+    // `(await query(stream)).at(-1).sequence`. AtomicAppender uses the
+    // same accessor internally to compute the next sequence; this is the
+    // public surface that exposes the value without forcing callers to
+    // re-query the whole stream.
+    const store = new EventStore(tempDir);
+    await store.initialize();
+    const streamId = 'populated-stream';
+
+    await store.append(streamId, { type: 'workflow.started' });
+    await store.append(streamId, { type: 'task.assigned' });
+    await store.append(streamId, { type: 'workflow.transition' });
+
+    const events = await store.query(streamId);
+    const tail = await store.tailSequence(streamId);
+    expect(tail).toBe(events.at(-1)!.sequence);
+    expect(tail).toBe(3);
+  });
+});

--- a/servers/exarchos-mcp/src/event-store/store.ts
+++ b/servers/exarchos-mcp/src/event-store/store.ts
@@ -604,6 +604,20 @@ export class EventStore {
   }
 
   /**
+   * Return the highest sequence persisted on `streamId`, or 0 when the
+   * stream is empty / has never been written. Mirrors the semantics of
+   * `StorageBackend.getSequence` (and the SqliteBackend
+   * `readSequenceHighWaterMark` accessor `AtomicAppender` uses
+   * internally) — the public surface lets cache-validating consumers
+   * (notably `EventSourcedTaskStore.loadTask`, FINDING-2 #1438) compare
+   * a stale `lastReadSequence` against the live stream tail without
+   * having to re-query the entire event list.
+   */
+  async tailSequence(streamId: string): Promise<number> {
+    return this.getReadBackend().getSequence(streamId);
+  }
+
+  /**
    * Register a stream in the typed-stream registry (Marten R-1, #1313).
    * Idempotent: re-calling for the same streamId leaves the registry row
    * untouched. The workflow_type column is immutable post-insert — a CI

--- a/servers/exarchos-mcp/src/logger.ts
+++ b/servers/exarchos-mcp/src/logger.ts
@@ -20,3 +20,4 @@ export const viewLogger = logger.child({ subsystem: 'views' });
 export const syncLogger = logger.child({ subsystem: 'sync' });
 export const telemetryLogger = logger.child({ subsystem: 'telemetry' });
 export const orchestrateLogger = logger.child({ subsystem: 'orchestrate' });
+export const taskStoreLogger = logger.child({ subsystem: 'task-store' });

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -455,10 +455,15 @@ describe('EventSourcedTaskStore (#1272)', () => {
     // the same events (duplicate work; defensive fullRefold may fire on
     // an empty delta).
     //
-    // The test drives the symptom directly: after a refold, the cache's
-    // `lastReadSequence` MUST equal the current `EventStore.tailSequence`
-    // for that stream, so a subsequent cache check is a true hit (no
-    // unnecessary query).
+    // CodeRabbit r3253913164 follow-up: the original shape of this test
+    // appended once BEFORE the read, so pre-read tail and applied-delta
+    // tail collapsed onto the same value — a buggy impl that stamped
+    // the pre-read tail would still pass. To genuinely exercise the
+    // race we spy on `eventStore.query` and inject an append the FIRST
+    // time the store under test queries this stream. That append lands
+    // AFTER `tailSequence()` was sampled inside `loadTask` but BEFORE
+    // the original `query()` returns — exactly the interleaving the
+    // CodeRabbit fix guards against.
     const storeA = new EventSourcedTaskStore(eventStore);
     const task = await storeA.createTask(
       { ttl: 60_000 },
@@ -467,24 +472,67 @@ describe('EventSourcedTaskStore (#1272)', () => {
     );
     await storeA.getTask(task.taskId); // warm cache
 
-    // External append (simulated sibling writer).
-    await eventStore.append(`task-store/${task.taskId}`, {
+    const stream = `task-store/${task.taskId}`;
+
+    // Pre-read external append — moves the tail past the cache so
+    // `loadTask` enters the `refoldDelta` branch (tail > cached
+    // lastReadSequence at the `tailSequence()` check).
+    await eventStore.append(stream, {
       type: 'task.cancelled',
       timestamp: new Date().toISOString(),
-      data: { taskId: task.taskId, reason: 'stamp-from-delta' },
+      data: { taskId: task.taskId, reason: 'pre-read-append' },
     });
 
-    // First read after external append triggers refoldDelta.
-    await storeA.getTask(task.taskId);
+    // Spy on `query`: the first time the store reads THIS stream,
+    // perform a concurrent append BEFORE delegating to the original
+    // query. The injected event lands between `tailSequence()` (already
+    // returned earlier in `loadTask`) and the body of `query()`, so the
+    // returned `delta` contains a sequence strictly greater than the
+    // pre-read tail. A buggy impl stamping `pre-read tail` would
+    // record an under-value; the correct impl (stamp from
+    // `delta[-1].sequence`) records the higher value.
+    const origQuery = eventStore.query.bind(eventStore);
+    let injected = false;
+    const querySpy = vi
+      .spyOn(eventStore, 'query')
+      .mockImplementation(async (streamId, filters) => {
+        if (!injected && streamId === stream) {
+          injected = true;
+          await eventStore.append(streamId, {
+            // `task.polled` is projection-no-op (no state transition);
+            // it advances the sequence without further perturbing the
+            // projected `task` and keeps the test focused on the
+            // sequence-stamping invariant.
+            type: 'task.polled',
+            timestamp: new Date().toISOString(),
+            data: { taskId: task.taskId },
+          });
+        }
+        return origQuery(streamId, filters);
+      });
 
-    const tail = await eventStore.tailSequence(`task-store/${task.taskId}`);
-    const cached = (
-      storeA as unknown as {
-        tasks: Map<string, { lastReadSequence: number }>;
-      }
-    ).tasks.get(task.taskId);
-    expect(cached).toBeDefined();
-    expect(cached!.lastReadSequence).toBe(tail);
+    try {
+      await storeA.getTask(task.taskId);
+
+      // The spy must have fired exactly once on the stream under test.
+      expect(injected).toBe(true);
+
+      const tail = await eventStore.tailSequence(stream);
+      const cached = (
+        storeA as unknown as {
+          tasks: Map<string, { lastReadSequence: number }>;
+        }
+      ).tasks.get(task.taskId);
+      expect(cached).toBeDefined();
+      // The cache MUST reflect the highest sequence actually folded —
+      // i.e., the injected event's sequence, which is past the pre-read
+      // tail. Equality with the post-read `tailSequence()` proves the
+      // invariant: a subsequent `loadTask` for the same task will be a
+      // true cache hit, not a redundant re-query.
+      expect(cached!.lastReadSequence).toBe(tail);
+    } finally {
+      querySpy.mockRestore();
+    }
   });
 
   it('projectTaskIncremental_FromCachedToTail_MatchesFullRefold', async () => {

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -794,6 +794,72 @@ describe('EventSourcedTaskStore (#1272)', () => {
     expect(after?.statusMessage).toBeUndefined();
   });
 
+  it('projectTaskIncremental_DropsStaleStatusMessage_OnExternalTerminalEvent', async () => {
+    // CodeRabbit r3253923003: the bug specific to the incremental
+    // fold path. Setup the exact divergence the comment names:
+    //
+    //   1. Process A stamps a projection-only `statusMessage` via
+    //      `updateTaskStatus(id, 'input_required', 'Need confirm')`.
+    //      No durable event is emitted — A's cache holds the prompt;
+    //      the durable stream does not.
+    //   2. Process B writes the terminal `task.result` event (no
+    //      `statusMessage` field on the event).
+    //   3. Process A's next read enters `loadTask` → `refoldDelta` →
+    //      `projectTaskIncremental(cached, [task.result])`.
+    //
+    // Pre-fix, the incremental fold spread `...cached.task` into the
+    // terminal-state shape, preserving A's stale projection-only
+    // `statusMessage`. A fresh-process replayer (`projectTask` on the
+    // same stream) projects the terminal task with NO `statusMessage`
+    // — the two folds diverge on exactly the value of `statusMessage`.
+    // INV-1 cross-process consistency violated.
+    //
+    // Post-fix: both folds project `statusMessage: undefined`.
+    const storeA = new EventSourcedTaskStore(eventStore);
+    const storeB = new EventSourcedTaskStore(eventStore);
+    const task = await storeA.createTask(
+      { ttl: 60_000 },
+      'req-incremental-clear',
+      sampleRequest,
+    );
+
+    // (1) A stamps a projection-only `statusMessage`. After this,
+    // A's cache reflects status=input_required + statusMessage; the
+    // durable stream still contains only `task.created`.
+    await storeA.updateTaskStatus(
+      task.taskId,
+      'input_required',
+      'Need confirmation',
+    );
+    expect((await storeA.getTask(task.taskId))?.statusMessage).toBe(
+      'Need confirmation',
+    );
+
+    // (2) B drives the terminal transition through its own public API
+    // (cache miss → fullRefold → OCC append) so a real `task.result`
+    // event lands on the durable stream. Note that B's projection
+    // never sees A's projection-only `input_required` mutation —
+    // realistic multi-process shape.
+    await storeB.storeTaskResult(task.taskId, 'completed', {
+      content: [{ type: 'text', text: 'done' }],
+    });
+
+    // (3) A's next read MUST take the incremental-fold path: the
+    // cache is warm at the pre-terminal sequence, and the new
+    // terminal event is the only delta. The `getTask` reaper-and-poll
+    // dance plus the throttled `task.polled` emit do NOT mutate
+    // `statusMessage`, so any leak is attributable to the fold itself.
+    const aView = await storeA.getTask(task.taskId);
+    expect(aView?.status).toBe('completed');
+    expect(aView?.statusMessage).toBeUndefined();
+
+    // A fresh replayer projecting from events alone agrees.
+    const replayer = new EventSourcedTaskStore(eventStore);
+    const replayerView = await replayer.getTask(task.taskId);
+    expect(replayerView?.status).toBe('completed');
+    expect(replayerView?.statusMessage).toBeUndefined();
+  });
+
   // ─── FINDING-1 (#1438, PR 3) — OCC threading via expectedSequence ─────────
   //
   // The fix invariant: two concurrent writers on the same task stream MUST

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -546,6 +546,274 @@ describe('EventSourcedTaskStore (#1272)', () => {
     });
   });
 
+  // ─── FINDING-1 (#1438, PR 3) — OCC threading via expectedSequence ─────────
+  //
+  // The fix invariant: two concurrent writers on the same task stream MUST
+  // resolve deterministically. One commits, the other gets either a
+  // terminal-status error (after retry refold sees the winner's terminal
+  // event) or a `ConcurrencyError` (after exhausting the retry budget).
+  // Last-write-wins at the durable layer is no longer possible — exactly
+  // one `task.result` / `task.cancelled` event lands on the stream per
+  // intended outcome.
+  //
+  // Race scenarios covered:
+  //   T16 — `storeTaskResult` × `storeTaskResult` (this block)
+  //   T17 — `updateTaskStatus` × `updateTaskStatus` (cancellation race)
+  //   T18 — cancel-arrives-first vs late result (terminal-status throw)
+  //   T19 — retry budget exhaustion surfaces `ConcurrencyError`
+
+  it('storeTaskResult_ConcurrentCallers_ExactlyOneSucceeds', async () => {
+    // Two TaskStore instances on the SAME EventStore — simulates two
+    // processes (CLI + MCP server, two MCP instances) or two interleaved
+    // requests that both passed their in-memory `isTerminal` check before
+    // either committed. Pre-fix: both `append` calls would succeed; the
+    // stream would contain two `task.result` events; the projection would
+    // last-write-win silently. Post-fix: `commitWithOcc` threads
+    // `expectedSequence: stored.lastReadSequence` so the second writer
+    // hits `SequenceConflictError`; on retry refold the loser sees the
+    // winner's terminal status and the in-decide-closure terminal-check
+    // throws "Cannot store result ... in terminal status".
+    const storeA = new EventSourcedTaskStore(eventStore);
+    const storeB = new EventSourcedTaskStore(eventStore);
+
+    const task = await storeA.createTask(
+      { ttl: 60_000 },
+      'req-occ-1',
+      sampleRequest,
+    );
+
+    // Force both stores' caches to be warmed at the SAME lastReadSequence
+    // before the race so they each see the pre-race tail.
+    await storeA.getTask(task.taskId);
+    await storeB.getTask(task.taskId);
+
+    const r1 = { content: [{ type: 'text', text: 'from-A' }] };
+    const r2 = { content: [{ type: 'text', text: 'from-B' }] };
+
+    const results = await Promise.allSettled([
+      storeA.storeTaskResult(task.taskId, 'completed', r1),
+      storeB.storeTaskResult(task.taskId, 'failed', r2),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+
+    // The rejection must be either a terminal-status error (loser retried,
+    // re-folded, saw the winner's terminal event) or a ConcurrencyError
+    // (budget exhausted in the OCC retry loop).
+    const rejectedReason = (rejected[0] as PromiseRejectedResult).reason;
+    const message: string =
+      rejectedReason instanceof Error
+        ? rejectedReason.message
+        : String(rejectedReason);
+    expect(message).toMatch(/terminal status|ConcurrencyError|tail advanced/);
+
+    // The stream MUST contain exactly one `task.result` event — the
+    // winner's append. Last-write-wins at the durable layer is now
+    // impossible.
+    const events = await eventStore.query(`task-store/${task.taskId}`);
+    const resultEvents = events.filter((e) => e.type === 'task.result');
+    expect(resultEvents).toHaveLength(1);
+  });
+
+  it('updateTaskStatus_ConcurrentCallersToConflictingStates_ExactlyOneSucceeds', async () => {
+    // Cancellation race: two writers both call `updateTaskStatus(..., 'cancelled')`.
+    // Cancellation is the only `updateTaskStatus` transition that writes
+    // a durable event (line 375 of event-sourced-task-store.ts), so it's
+    // the case where OCC enforcement is observable on the stream.
+    // Non-cancel transitions (working ↔ input_required) are projection-
+    // only and intentionally retain pre-PR-3 semantics — that asymmetry
+    // is documented inline on `commitWithOcc`.
+    const storeA = new EventSourcedTaskStore(eventStore);
+    const storeB = new EventSourcedTaskStore(eventStore);
+
+    const task = await storeA.createTask(
+      { ttl: 60_000 },
+      'req-occ-cancel',
+      sampleRequest,
+    );
+
+    // Both stores warm their cache at the same lastReadSequence.
+    await storeA.getTask(task.taskId);
+    await storeB.getTask(task.taskId);
+
+    const results = await Promise.allSettled([
+      storeA.updateTaskStatus(task.taskId, 'cancelled', 'reason-A'),
+      storeB.updateTaskStatus(task.taskId, 'cancelled', 'reason-B'),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+
+    const reason = (rejected[0] as PromiseRejectedResult).reason;
+    const message: string =
+      reason instanceof Error ? reason.message : String(reason);
+    // After the loser refolds, it sees `cancelled` (terminal) and the
+    // `updateTaskStatus` terminal-check throws ("Cannot update task ...
+    // from terminal status 'cancelled'"). If the retry budget were
+    // exhausted instead we would see "tail advanced" from ConcurrencyError.
+    expect(message).toMatch(/terminal status|tail advanced/);
+
+    // Stream MUST contain exactly one `task.cancelled` event — duplicate
+    // cancellations are not appended.
+    const events = await eventStore.query(`task-store/${task.taskId}`);
+    const cancelEvents = events.filter((e) => e.type === 'task.cancelled');
+    expect(cancelEvents).toHaveLength(1);
+  });
+
+  it('cancelRacesResult_CancelArrivesFirst_LateResultRejectsWithTerminalError', async () => {
+    // Sequenced race: cancel commits first, late `storeTaskResult` arrives
+    // afterwards with a cached projection that still says `working`. The
+    // OCC retry path MUST refold, see the `cancelled` status, and have
+    // the terminal-check in `storeTaskResult`'s decide closure throw.
+    // This is the load-bearing scenario from the design's
+    // §"Cancellation race scenario" — MCP `tasks/cancel` racing a
+    // wrapped handler's `task.result`.
+    const storeA = new EventSourcedTaskStore(eventStore);
+    const storeB = new EventSourcedTaskStore(eventStore);
+
+    const task = await storeA.createTask(
+      { ttl: 60_000 },
+      'req-cancel-wins',
+      sampleRequest,
+    );
+
+    // B warms its cache BEFORE A cancels, so B's `lastReadSequence` is
+    // stale when it tries to write the result. This matches the
+    // production scenario where the wrapped handler read state at the
+    // start of its work and only commits its result later.
+    await storeB.getTask(task.taskId);
+
+    // A cancels and the commit lands first (await sequences this).
+    await storeA.updateTaskStatus(task.taskId, 'cancelled', 'race-test');
+
+    // B tries to record a late completion. The decide closure's
+    // terminal-check throws on the first retry (after the cache refold
+    // surfaces the cancelled status).
+    await expect(
+      storeB.storeTaskResult(task.taskId, 'completed', {
+        content: [{ type: 'text', text: 'late' }],
+      }),
+    ).rejects.toThrow(/terminal status/);
+
+    // Exactly one terminal-class event on the stream — the cancel.
+    const events = await eventStore.query(`task-store/${task.taskId}`);
+    const resultEvents = events.filter((e) => e.type === 'task.result');
+    const cancelEvents = events.filter((e) => e.type === 'task.cancelled');
+    expect(resultEvents).toHaveLength(0);
+    expect(cancelEvents).toHaveLength(1);
+  });
+
+  it('commitWithOcc_RetryBudgetExhausted_ThrowsConcurrencyError', async () => {
+    // Force `EventStore.append` to throw `SequenceConflictError` on every
+    // attempt. After `maxRetries + 1` attempts (default budget = 3 ⇒ 4
+    // total), `commitWithOcc` must surface a `ConcurrencyError` with
+    // structured fields (streamId, reducerId='task-store', operationId,
+    // expectedVersion, actualVersion).
+    const task = await store.createTask(
+      { ttl: 60_000 },
+      'req-budget-exhausted',
+      sampleRequest,
+    );
+    await store.getTask(task.taskId); // warm cache
+
+    const { SequenceConflictError } = await import('../event-store/store.js');
+    const { ConcurrencyError } = await import(
+      '../event-store/concurrency-error.js'
+    );
+
+    // Silence the warning emitted on budget exhaustion to keep test
+    // output clean — the warning IS the observability surface we want,
+    // but for this test we only care that the throw shape is correct.
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    // Track attempt count to confirm the budget walk.
+    let attempts = 0;
+    const appendSpy = vi
+      .spyOn(eventStore, 'append')
+      .mockImplementation(async () => {
+        attempts += 1;
+        // The actual numbers don't matter — only the type does.
+        throw new SequenceConflictError(1, 99);
+      });
+
+    try {
+      await expect(
+        store.storeTaskResult(task.taskId, 'completed', {
+          content: [{ type: 'text', text: 'will-never-commit' }],
+        }),
+      ).rejects.toBeInstanceOf(ConcurrencyError);
+
+      // 3 retries + the initial attempt = 4 total append calls.
+      expect(attempts).toBe(4);
+      // Warning emitted exactly once on budget exhaustion.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      appendSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('commitWithOcc_ConcurrencyErrorFlowsToMcpEnvelope_CONCURRENCY_CONFLICT', async () => {
+    // T20 — integration smoke that the typed `ConcurrencyError` raised
+    // by `commitWithOcc` after budget exhaustion deserializes into the
+    // canonical MCP `CONCURRENCY_CONFLICT` envelope via `wrapError`. The
+    // mapping itself is unit-tested in `format.test.ts`; this test proves
+    // the wiring is intact end-to-end from the task-store layer.
+    const task = await store.createTask(
+      { ttl: 60_000 },
+      'req-mcp-envelope',
+      sampleRequest,
+    );
+    await store.getTask(task.taskId);
+
+    const { SequenceConflictError } = await import('../event-store/store.js');
+    const { wrapError } = await import('../format.js');
+
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const appendSpy = vi
+      .spyOn(eventStore, 'append')
+      .mockImplementation(async () => {
+        throw new SequenceConflictError(1, 99);
+      });
+
+    try {
+      let caught: unknown;
+      try {
+        await store.storeTaskResult(task.taskId, 'completed', {
+          content: [{ type: 'text', text: 'will-fail' }],
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeDefined();
+
+      const envelope = wrapError(caught);
+      expect(envelope.success).toBe(false);
+      // ErrorEnvelope is a union; narrow by `success: false` branch.
+      if (envelope.success === false) {
+        expect(envelope.error.code).toBe('CONCURRENCY_CONFLICT');
+        const errBody = envelope.error as { streamId?: string; reducerId?: string; operationId?: string };
+        expect(errBody.streamId).toBe(`task-store/${task.taskId}`);
+        expect(errBody.reducerId).toBe('task-store');
+        expect(errBody.operationId).toBe('storeTaskResult');
+        expect(envelope._meta.retryable).toBe(true);
+      }
+    } finally {
+      appendSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
   it('EventSourcedTaskStore_ListTasks_HydratesFromEventStoreOnColdStart', async () => {
     // CR PR #1432: cold-start listTasks must enumerate durable
     // `task-store/*` streams rather than silently returning an empty

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -639,6 +639,113 @@ describe('EventSourcedTaskStore (#1272)', () => {
     }
   });
 
+  // ─── CodeRabbit follow-ups on #1444 — statusMessage hygiene + INV-1 ──────
+
+  it('updateTaskStatus_CompletedFailed_RejectedWithStoreTaskResultGuidance', async () => {
+    // CodeRabbit r3253903306: `updateTaskStatus(id, 'completed' | 'failed')`
+    // pre-fix slipped through the projection-only fallback — the
+    // status flip lived in this process's cache and disappeared on
+    // replay or in any sibling process (no `task.result` event was
+    // emitted), violating INV-1.
+    //
+    // The guard fires BEFORE `commitWithOcc` so the rejection is
+    // observable directly on the call, without forging a doomed
+    // round-trip through the OCC loop. The error message explicitly
+    // names `storeTaskResult` so callers can resolve the contract
+    // violation without spelunking through internals.
+    const task = await store.createTask(
+      { ttl: 60_000 },
+      'req-guard',
+      sampleRequest,
+    );
+
+    for (const terminal of ['completed', 'failed'] as const) {
+      await expect(
+        store.updateTaskStatus(task.taskId, terminal),
+      ).rejects.toThrow(/storeTaskResult/);
+    }
+
+    // The task's durable stream contains ONLY `task.created` (+
+    // optional `task.polled` from the warm read inside createTask's
+    // immediate use). No `task.result` was forged behind the caller's
+    // back: the rejection prevents any cache mutation too.
+    const events = await eventStore.query(`task-store/${task.taskId}`);
+    expect(events.filter((e) => e.type === 'task.result')).toHaveLength(0);
+
+    // The projected state is unchanged — still `working`.
+    expect((await store.getTask(task.taskId))?.status).toBe('working');
+  });
+
+  it('storeTaskResult_DropsStaleStatusMessage_AlignedWithReplayProjection', async () => {
+    // CodeRabbit r3253903305: pre-fix, a task that passed through
+    // `updateTaskStatus(id, 'input_required', 'Please confirm X')` and
+    // then `storeTaskResult(id, 'completed', result)` would carry the
+    // stale `'Please confirm X'` `statusMessage` into the terminal
+    // state. The durable `task.result` event has no statusMessage
+    // field, so a replaying reader would project the task with NO
+    // `statusMessage` — writer cache and replayer diverge.
+    //
+    // Post-fix both sides agree (writer drops the prior message; the
+    // projection never had it to begin with).
+    const task = await store.createTask(
+      { ttl: 60_000 },
+      'req-stale-msg',
+      sampleRequest,
+    );
+    await store.updateTaskStatus(
+      task.taskId,
+      'input_required',
+      'Please confirm X',
+    );
+
+    // Sanity: the prompt is visible on the projected task.
+    expect((await store.getTask(task.taskId))?.statusMessage).toBe(
+      'Please confirm X',
+    );
+
+    await store.storeTaskResult(task.taskId, 'completed', {
+      content: [{ type: 'text', text: 'done' }],
+    });
+
+    // Writer cache observation — no stale prompt.
+    const writerView = await store.getTask(task.taskId);
+    expect(writerView?.status).toBe('completed');
+    expect(writerView?.statusMessage).toBeUndefined();
+
+    // Replayer observation — a fresh store on the same durable stream
+    // MUST project the same shape.
+    const replayer = new EventSourcedTaskStore(eventStore);
+    const replayerView = await replayer.getTask(task.taskId);
+    expect(replayerView?.status).toBe('completed');
+    expect(replayerView?.statusMessage).toBeUndefined();
+  });
+
+  it('updateTaskStatus_WithoutMessage_ClearsPriorMessage', async () => {
+    // CodeRabbit r3253903305: the SDK's `Task.statusMessage` reflects
+    // the *latest* status update. A return-to-`working` after an
+    // `input_required` prompt should drop the prompt — otherwise
+    // callers see a stale prompt-string attached to a working task.
+    //
+    // Note: non-cancel `updateTaskStatus` transitions are
+    // projection-only (no durable event) by design; this test
+    // therefore verifies the WRITER-side cache only. There is no
+    // cross-process consistency to assert here — replayers never see
+    // the `input_required` transition in the first place — but the
+    // in-process hygiene is still a correctness bug worth pinning.
+    const task = await store.createTask(
+      { ttl: 60_000 },
+      'req-clear-msg',
+      sampleRequest,
+    );
+    await store.updateTaskStatus(task.taskId, 'input_required', 'Need input');
+    expect((await store.getTask(task.taskId))?.statusMessage).toBe('Need input');
+
+    await store.updateTaskStatus(task.taskId, 'working');
+    const after = await store.getTask(task.taskId);
+    expect(after?.status).toBe('working');
+    expect(after?.statusMessage).toBeUndefined();
+  });
+
   // ─── FINDING-1 (#1438, PR 3) — OCC threading via expectedSequence ─────────
   //
   // The fix invariant: two concurrent writers on the same task stream MUST

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -444,6 +444,48 @@ describe('EventSourcedTaskStore (#1272)', () => {
     expect(afterBWrite?.status).toBe('completed');
   });
 
+  it('refoldDelta_StampsLastReadSequenceFromAppliedDelta_NotPreReadTail', async () => {
+    // CodeRabbit #1444: `lastReadSequence` MUST reflect the highest
+    // sequence actually applied from the delta — NOT the tail captured
+    // before `query(sinceSequence)`. Events can land between
+    // `tailSequence()` and `query()`, so `delta` may include sequences
+    // greater than the pre-read tail. Stamping the pre-read tail under-
+    // records progress and causes the next read to re-query and re-fold
+    // the same events (duplicate work; defensive fullRefold may fire on
+    // an empty delta).
+    //
+    // The test drives the symptom directly: after a refold, the cache's
+    // `lastReadSequence` MUST equal the current `EventStore.tailSequence`
+    // for that stream, so a subsequent cache check is a true hit (no
+    // unnecessary query).
+    const storeA = new EventSourcedTaskStore(eventStore);
+    const task = await storeA.createTask(
+      { ttl: 60_000 },
+      'req-stamp-from-delta',
+      sampleRequest,
+    );
+    await storeA.getTask(task.taskId); // warm cache
+
+    // External append (simulated sibling writer).
+    await eventStore.append(`task-store/${task.taskId}`, {
+      type: 'task.cancelled',
+      timestamp: new Date().toISOString(),
+      data: { taskId: task.taskId, reason: 'stamp-from-delta' },
+    });
+
+    // First read after external append triggers refoldDelta.
+    await storeA.getTask(task.taskId);
+
+    const tail = await eventStore.tailSequence(`task-store/${task.taskId}`);
+    const cached = (
+      storeA as unknown as {
+        tasks: Map<string, { lastReadSequence: number }>;
+      }
+    ).tasks.get(task.taskId);
+    expect(cached).toBeDefined();
+    expect(cached!.lastReadSequence).toBe(tail);
+  });
+
   it('projectTaskIncremental_FromCachedToTail_MatchesFullRefold', async () => {
     // FINDING-2 (#1438, PR 2): incremental fold from a cached projection
     // MUST be observationally equivalent to a full refold of the same

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -27,6 +27,7 @@ import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
 import { EventStore } from '../event-store/store.js';
+import { taskStoreLogger } from '../logger.js';
 import { EventSourcedTaskStore } from './event-sourced-task-store.js';
 
 describe('EventSourcedTaskStore (#1272)', () => {
@@ -588,6 +589,56 @@ describe('EventSourcedTaskStore (#1272)', () => {
     });
   });
 
+  it('terminalTransition_ExpiresAtConsistent_AcrossWriterAndReplayer', async () => {
+    // CodeRabbit follow-up on #1444: pre-fix, the writer's `mutate`
+    // closure bumped `expiresAt` to `Date.now() + ttl` on a terminal
+    // transition, but `projectTask` / `projectTaskIncremental` left
+    // `expiresAt` at the original `createdAt + ttl`. A replaying
+    // sibling process would therefore consider a task expired while
+    // the writer's local cache still considered it live (or vice
+    // versa) — the exact divergence INV-1 forbids.
+    //
+    // Setup: TTL = 1000ms. Create task at T0, advance the clock 500ms
+    // BEFORE writing the terminal event so `event.timestamp + ttl`
+    // strictly exceeds `createdAt + ttl`. Then advance the clock to a
+    // wall-clock moment that is past the pre-fix expiry but inside the
+    // post-fix expiry — both writer (storeA) and a fresh replayer
+    // (storeB) MUST observe the task as live.
+    vi.useFakeTimers();
+    try {
+      const T0 = 1_700_000_000_000;
+      vi.setSystemTime(T0);
+
+      const storeA = new EventSourcedTaskStore(eventStore);
+      const task = await storeA.createTask(
+        { ttl: 1_000 },
+        'req-expires-at',
+        sampleRequest,
+      );
+
+      vi.setSystemTime(T0 + 500);
+      await storeA.storeTaskResult(task.taskId, 'completed', {
+        content: [{ type: 'text', text: 'done' }],
+      });
+
+      // At T0 + 1_200: past pre-fix expiry (T0 + 1_000), inside
+      // post-fix expiry (T0 + 500 + 1_000 = T0 + 1_500).
+      vi.setSystemTime(T0 + 1_200);
+
+      const storeB = new EventSourcedTaskStore(eventStore);
+      expect(await storeA.getTask(task.taskId)).not.toBeNull();
+      expect(await storeB.getTask(task.taskId)).not.toBeNull();
+
+      // Both observers MUST agree the task is expired past the
+      // post-fix expiry (T0 + 1_500).
+      vi.setSystemTime(T0 + 1_600);
+      expect(await storeA.getTask(task.taskId)).toBeNull();
+      expect(await storeB.getTask(task.taskId)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // ─── FINDING-1 (#1438, PR 3) — OCC threading via expectedSequence ─────────
   //
   // The fix invariant: two concurrent writers on the same task stream MUST
@@ -774,7 +825,7 @@ describe('EventSourcedTaskStore (#1272)', () => {
     // output clean — the warning IS the observability surface we want,
     // but for this test we only care that the throw shape is correct.
     const warnSpy = vi
-      .spyOn(console, 'warn')
+      .spyOn(taskStoreLogger, 'warn')
       .mockImplementation(() => undefined);
     // Track attempt count to confirm the budget walk.
     let attempts = 0;
@@ -820,7 +871,7 @@ describe('EventSourcedTaskStore (#1272)', () => {
     const { wrapError } = await import('../format.js');
 
     const warnSpy = vi
-      .spyOn(console, 'warn')
+      .spyOn(taskStoreLogger, 'warn')
       .mockImplementation(() => undefined);
     const appendSpy = vi
       .spyOn(eventStore, 'append')

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -382,6 +382,170 @@ describe('EventSourcedTaskStore (#1272)', () => {
     }
   });
 
+  it('loadTask_AfterInitialFold_RecordsTailSequence', async () => {
+    // FINDING-2 (#1438, PR 2): `ProjectedTask` now carries
+    // `lastReadSequence` so cache-hit branches in `loadTask` can compare
+    // against the live stream tail. After a successful `createTask` the
+    // only persisted event is `task.created` at sequence 1, so the
+    // cached projection's `lastReadSequence` MUST equal 1.
+    //
+    // Test peeks at the private `tasks` map via a `unknown` cast — same
+    // pattern PR 1's throttle tests use for `lastPolledAt` inspection.
+    const task = await store.createTask(
+      { ttl: 60_000 },
+      'req-tail-seq',
+      sampleRequest,
+    );
+
+    const cached = (
+      store as unknown as { tasks: Map<string, { lastReadSequence: number }> }
+    ).tasks.get(task.taskId);
+    expect(cached).toBeDefined();
+    expect(cached!.lastReadSequence).toBe(1);
+  });
+
+  it('loadTask_CacheHitWithAdvancedStream_TriggersRefoldAndReturnsLatest', async () => {
+    // FINDING-2 (#1438, PR 2): the in-memory `tasks` map is a CACHE, not
+    // authoritative state. Two TaskStore instances backed by the SAME
+    // `EventStore` represent the multi-process scenario (CLI + MCP
+    // server sharing a SQLite store, or two MCP server instances during
+    // a hot-swap). When B writes a terminal event after A has warmed its
+    // cache, A's next `getTask` MUST observe the new state — which
+    // requires re-validating the cache against the live stream tail
+    // (`EventStore.tailSequence`) on every read and incrementally
+    // re-folding the delta.
+    const storeA = new EventSourcedTaskStore(eventStore);
+
+    const task = await storeA.createTask(
+      { ttl: 60_000 },
+      'req-multi-A',
+      sampleRequest,
+    );
+
+    // A warms its cache.
+    const beforeBWrite = await storeA.getTask(task.taskId);
+    expect(beforeBWrite?.status).toBe('working');
+
+    // B (simulated by a direct event-store append — the durable substrate
+    // is the same one A is reading from) writes a terminal `task.result`.
+    await eventStore.append(`task-store/${task.taskId}`, {
+      type: 'task.result',
+      timestamp: new Date().toISOString(),
+      data: {
+        taskId: task.taskId,
+        status: 'completed',
+        result: { content: [{ type: 'text', text: 'from-B' }] },
+      },
+    });
+
+    // A's next read MUST observe the terminal status — the cache hit is
+    // invalidated by `tailSequence` advancing past `lastReadSequence`.
+    const afterBWrite = await storeA.getTask(task.taskId);
+    expect(afterBWrite?.status).toBe('completed');
+  });
+
+  it('projectTaskIncremental_FromCachedToTail_MatchesFullRefold', async () => {
+    // FINDING-2 (#1438, PR 2): incremental fold from a cached projection
+    // MUST be observationally equivalent to a full refold of the same
+    // final stream. This is the load-bearing invariant — if it ever
+    // diverged, the cache-validation path would silently corrupt
+    // projections.
+    //
+    // The test exercises a mixed stream (created + polled + cancelled)
+    // by driving it through two TaskStore instances on the same
+    // EventStore: storeA warms its cache mid-stream, storeB (a fresh
+    // instance) does a full cold refold of the final state. Their
+    // resulting `task` objects MUST be deep-equal.
+    const storeA = new EventSourcedTaskStore(eventStore);
+
+    // Build the stream. After createTask, the cache holds the
+    // `task.created` event at sequence 1.
+    const task = await storeA.createTask(
+      { ttl: 60_000 },
+      'req-incremental',
+      sampleRequest,
+    );
+
+    // First read warms storeA's cache (also emits one throttled
+    // `task.polled` at sequence 2).
+    await storeA.getTask(task.taskId);
+
+    // Append the terminal event directly via the event store — same
+    // mechanism the multi-process scenario uses. storeA's cache is now
+    // stale (`tail > lastReadSequence`).
+    await eventStore.append(`task-store/${task.taskId}`, {
+      type: 'task.cancelled',
+      timestamp: new Date().toISOString(),
+      data: {
+        taskId: task.taskId,
+        reason: 'incremental-fold-test',
+      },
+    });
+
+    // storeA's next read goes through the incremental fold path
+    // (cache hit + tail moved → `refoldDelta` → `projectTaskIncremental`).
+    const aTask = await storeA.getTask(task.taskId);
+
+    // A fresh storeB does a full cold refold via `fullRefold`.
+    const storeB = new EventSourcedTaskStore(eventStore);
+    const bTask = await storeB.getTask(task.taskId);
+
+    // Both paths converge on the same projected `task`. The throttled
+    // `task.polled` emit on B's read may bump sequences differently but
+    // does not affect `status` / `statusMessage` projection state.
+    expect(aTask?.status).toBe('cancelled');
+    expect(bTask?.status).toBe('cancelled');
+    expect(aTask?.statusMessage).toBe('incremental-fold-test');
+    expect(bTask?.statusMessage).toBe('incremental-fold-test');
+    expect(aTask?.taskId).toBe(bTask?.taskId);
+    expect(aTask?.ttl).toBe(bTask?.ttl);
+    expect(aTask?.pollInterval).toBe(bTask?.pollInterval);
+    // The `lastUpdatedAt` timestamp comes from the terminal event's
+    // timestamp in both paths, so it should match exactly.
+    expect(aTask?.lastUpdatedAt).toBe(bTask?.lastUpdatedAt);
+  });
+
+  it('EventSourcedTaskStore_MultiProcessRace_CacheValidatesOnRead', async () => {
+    // FINDING-2 (#1438, PR 2): integration-style assertion of the
+    // multi-process race. Two `EventSourcedTaskStore` instances share a
+    // single SQLite-backed `EventStore` — exactly the topology of:
+    //   - CLI + MCP server on the same `stateDir`
+    //   - Two MCP server instances during a hot-swap
+    //   - Test runners that spawn the store from multiple harnesses
+    //
+    // The fix invariant: A's read MUST observe B's terminal write, no
+    // matter how warm A's cache is. T10 covered the same scenario at
+    // unit level via a direct `eventStore.append`; this test re-asserts
+    // through the second store's public API to prove the path works
+    // end-to-end against the same durable substrate.
+    const storeA = new EventSourcedTaskStore(eventStore);
+    const storeB = new EventSourcedTaskStore(eventStore);
+
+    const task = await storeA.createTask(
+      { ttl: 60_000 },
+      'req-mp-race',
+      sampleRequest,
+    );
+
+    // A warms its cache.
+    expect((await storeA.getTask(task.taskId))?.status).toBe('working');
+
+    // B writes the terminal result through its own public API. Note: B
+    // first does its own `loadTask` (cache miss → full refold), which
+    // is the realistic shape for a second process picking up the task.
+    await storeB.storeTaskResult(task.taskId, 'completed', {
+      content: [{ type: 'text', text: 'from-storeB' }],
+    });
+
+    // A's next read MUST surface the terminal status.
+    const observed = await storeA.getTask(task.taskId);
+    expect(observed?.status).toBe('completed');
+    const observedResult = await storeA.getTaskResult(task.taskId);
+    expect(observedResult).toEqual({
+      content: [{ type: 'text', text: 'from-storeB' }],
+    });
+  });
+
   it('EventSourcedTaskStore_ListTasks_HydratesFromEventStoreOnColdStart', async () => {
     // CR PR #1432: cold-start listTasks must enumerate durable
     // `task-store/*` streams rather than silently returning an empty

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -660,7 +660,7 @@ export class EventSourcedTaskStore implements TaskStore {
   private async refoldDelta(
     taskId: string,
     cached: ProjectedTask,
-    tail: number,
+    _tail: number,
   ): Promise<ProjectedTask | undefined> {
     const delta = await this.store.query(taskStream(taskId), {
       sinceSequence: cached.lastReadSequence,
@@ -670,7 +670,12 @@ export class EventSourcedTaskStore implements TaskStore {
     // back to a full refold so we never return a known-stale projection.
     if (delta.length === 0) return this.fullRefold(taskId);
     const next = projectTaskIncremental(cached, delta);
-    next.lastReadSequence = tail;
+    // Stamp from the LAST sequence actually applied — not the pre-read
+    // tail captured before query(). Events can land between tailSequence()
+    // and query(sinceSequence), so delta may include sequences > tail;
+    // recording `tail` would under-stamp and cause duplicate refolds on
+    // the next read. (CodeRabbit #1444.)
+    next.lastReadSequence = delta[delta.length - 1]!.sequence;
     this.tasks.set(taskId, next);
     return next;
   }

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -76,6 +76,7 @@ import { isTerminal } from '@modelcontextprotocol/sdk/experimental/tasks/interfa
 import { EventStore, SequenceConflictError } from '../event-store/store.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
 import { ConcurrencyError } from '../event-store/concurrency-error.js';
+import { taskStoreLogger } from '../logger.js';
 
 /**
  * Per-task projected lifecycle state. The shape carries everything
@@ -232,7 +233,11 @@ export class EventSourcedTaskStore implements TaskStore {
       task,
       request,
       requestId,
-      expiresAt: ttl !== null ? Date.now() + ttl : undefined,
+      // Bind `expiresAt` to the event timestamp (not `Date.now()`) so the
+      // writer's in-memory cache matches what a replaying reader process
+      // computes via `projectTask` / `projectTaskIncremental`. Otherwise
+      // two processes folding the same stream could disagree on expiry.
+      expiresAt: ttl !== null ? Date.parse(createdAt) + ttl : undefined,
       // FINDING-2 (#1438): the `task.created` event we just appended is
       // the only event on a fresh stream, so the cached projection's
       // last-read tail is sequence 1. Subsequent appends (`task.polled`,
@@ -330,8 +335,11 @@ export class EventSourcedTaskStore implements TaskStore {
             lastUpdatedAt: now,
           };
           // TTL resets from terminal transition (matches SDK semantics).
+          // Use the event's ISO timestamp — not `Date.now()` — so the
+          // writer's cache stays in lockstep with the projection a
+          // sibling process computes when it replays the same event.
           if (s.task.ttl !== null) {
-            s.expiresAt = Date.now() + s.task.ttl;
+            s.expiresAt = Date.parse(now) + s.task.ttl;
           }
         },
       };
@@ -381,8 +389,10 @@ export class EventSourcedTaskStore implements TaskStore {
           lastUpdatedAt: now,
           ...(statusMessage !== undefined ? { statusMessage } : {}),
         };
+        // See `storeTaskResult` for why this binds to the event ISO
+        // timestamp rather than `Date.now()`.
         if (isTerminal(status) && s.task.ttl !== null) {
-          s.expiresAt = Date.now() + s.task.ttl;
+          s.expiresAt = Date.parse(now) + s.task.ttl;
         }
       };
       // The `cancelled` transition gets its own durable event so audit
@@ -552,8 +562,9 @@ export class EventSourcedTaskStore implements TaskStore {
     // visibility (DIM-2) before throwing because budget exhaustion is a
     // notable event — it implies sustained write contention on this
     // specific task stream.
-    console.warn(
-      `[task-store] OCC retry budget exhausted: taskId=${taskId} op=${opName} attempts=${maxRetries + 1}`,
+    taskStoreLogger.warn(
+      { taskId, op: opName, attempts: maxRetries + 1 },
+      'OCC retry budget exhausted',
     );
     throw new ConcurrencyError({
       streamId: taskStream(taskId),
@@ -751,7 +762,7 @@ function projectTask(
       : 1000;
 
   const createdAt = created.timestamp;
-  const expiresAt = ttl !== null ? Date.parse(createdAt) + ttl : undefined;
+  let expiresAt = ttl !== null ? Date.parse(createdAt) + ttl : undefined;
 
   let task: Task = {
     taskId,
@@ -782,6 +793,15 @@ function projectTask(
           if (data['result'] !== undefined) {
             result = data['result'] as Result;
           }
+          // Mirror the writer's mutate closure (`storeTaskResult` /
+          // `updateTaskStatus`): a terminal transition resets TTL from
+          // the event's wall-clock timestamp. Without this bump, a
+          // sibling process replaying the stream would see the original
+          // created-time expiry while the writer's local cache has the
+          // post-terminal value — they would then disagree on `isExpired`.
+          if (ttl !== null) {
+            expiresAt = Date.parse(event.timestamp) + ttl;
+          }
         }
         break;
       }
@@ -795,6 +815,9 @@ function projectTask(
             ? { statusMessage: data['reason'] }
             : {}),
         };
+        if (ttl !== null) {
+          expiresAt = Date.parse(event.timestamp) + ttl;
+        }
         break;
       }
       default:
@@ -860,6 +883,11 @@ function projectTaskIncremental(
           if (data['result'] !== undefined) {
             result = data['result'] as Result;
           }
+          // Terminal-transition TTL bump — see `projectTask` for the
+          // why. The two folds must stay observationally equivalent.
+          if (task.ttl !== null) {
+            expiresAt = Date.parse(event.timestamp) + task.ttl;
+          }
         }
         break;
       }
@@ -873,6 +901,9 @@ function projectTaskIncremental(
             ? { statusMessage: data['reason'] }
             : {}),
         };
+        if (task.ttl !== null) {
+          expiresAt = Date.parse(event.timestamp) + task.ttl;
+        }
         break;
       }
       default:

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -329,8 +329,23 @@ export class EventSourcedTaskStore implements TaskStore {
         },
         mutate: (s: ProjectedTask) => {
           s.result = result;
+          // CodeRabbit r3253903305 (#1444): drop any prior
+          // `statusMessage` (typically a stale `input_required` prompt)
+          // — `storeTaskResult` is a terminal transition with an
+          // explicit result, so the prior diagnostic no longer applies.
+          // Equally important: the projection a sibling process
+          // computes from the durable stream NEVER sets `statusMessage`
+          // for `task.result` (no field carries it), so without this
+          // explicit clear the writer's cache would diverge from
+          // replayers — the same INV-1 cross-process inconsistency the
+          // `expiresAt` bump above also guards against.
+          const {
+            statusMessage: _staleStatusMessage,
+            ...taskWithoutStatusMessage
+          } = s.task;
+          void _staleStatusMessage;
           s.task = {
-            ...s.task,
+            ...taskWithoutStatusMessage,
             status,
             lastUpdatedAt: now,
           };
@@ -369,6 +384,20 @@ export class EventSourcedTaskStore implements TaskStore {
     statusMessage?: string,
     _sessionId?: string,
   ): Promise<void> {
+    // CodeRabbit r3253903306 (#1444): `completed` / `failed` carry a
+    // result payload and only have a faithful representation as a
+    // durable `task.result` event via `storeTaskResult`. Allowing them
+    // here would route through the `event: null` projection-only
+    // fallback below — the transition would live in this process's
+    // cache and disappear on replay or in any sibling process,
+    // violating INV-1 (event-sourcing integrity). We reject loudly
+    // BEFORE entering `commitWithOcc` so callers see the contract
+    // violation directly rather than as a post-hoc divergence.
+    if (status === 'completed' || status === 'failed') {
+      throw new Error(
+        `Cannot transition task ${taskId} to '${status}' via updateTaskStatus — terminal '${status}' carries a result payload and requires a durable task.result event. Use storeTaskResult() instead.`,
+      );
+    }
     // FINDING-1 (#1438, PR 3): route through `commitWithOcc`. The
     // cancellation branch returns a durable `task.cancelled` event and
     // gets full OCC enforcement; non-cancel transitions return
@@ -383,8 +412,22 @@ export class EventSourcedTaskStore implements TaskStore {
       }
       const now = new Date().toISOString();
       const mutate = (s: ProjectedTask) => {
+        // CodeRabbit r3253903305 (#1444): explicitly drop the prior
+        // `statusMessage` before re-assigning. The SDK Task contract
+        // treats `statusMessage` as "the latest status update", so a
+        // transition that doesn't carry a message MUST clear stale
+        // text — otherwise an `input_required` prompt persists across
+        // a return to `working`, and (for cancellation) the projection
+        // a replayer computes from the durable `task.cancelled` event
+        // would diverge from the writer's cache (the event only carries
+        // `reason`, never the pre-cancel diagnostic).
+        const {
+          statusMessage: _staleStatusMessage,
+          ...taskWithoutStatusMessage
+        } = s.task;
+        void _staleStatusMessage;
         s.task = {
-          ...s.task,
+          ...taskWithoutStatusMessage,
           status,
           lastUpdatedAt: now,
           ...(statusMessage !== undefined ? { statusMessage } : {}),

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -29,12 +29,25 @@
  *
  * ## Cache semantics
  *
- * The in-memory map (`this.tasks`) is a **cache**, not authoritative
- * state. On every read we MAY rebuild it from the event store; the
- * acceptance test exercises exactly this by appending events directly
- * and instantiating a fresh store. Cache misses fall through to a
- * stream read; cache hits are validated against the projection
- * sequence so a missed event invalidates the cache transparently.
+ * The in-memory map (`this.tasks`) is a **lazy projection cache**, not
+ * authoritative state. The durable stream is the source of truth — the
+ * cache is rebuilt lazily on miss and validated against the stream on
+ * every hit.
+ *
+ *   - **Cache miss** → `fullRefold` queries the entire `task-store/<id>`
+ *     stream, folds it via `projectTask`, stamps `lastReadSequence` to
+ *     the tail event's sequence, and caches the result.
+ *   - **Cache hit** → `loadTask` calls `EventStore.tailSequence(stream)`
+ *     and compares against the cached `lastReadSequence`. If they match,
+ *     the cached projection is returned verbatim. If the tail has
+ *     advanced (a sibling process / instance appended `task.result` or
+ *     `task.cancelled` since we cached), `refoldDelta` queries only the
+ *     events newer than `lastReadSequence` (`sinceSequence` is exclusive
+ *     in the backend) and applies them via `projectTaskIncremental`.
+ *
+ * This closes FINDING-2 (#1438) — multi-process scenarios (CLI + MCP
+ * server on the same `stateDir`, hot-swap, two MCP instances) no longer
+ * drift silently: the prose here now matches the code (closes DIM-8).
  *
  * ## TTL
  *
@@ -77,6 +90,17 @@ interface ProjectedTask {
   result?: Result;
   /** Wall-clock expiration; undefined when ttl is null (unlimited). */
   expiresAt?: number;
+  /**
+   * FINDING-2 (#1438, PR 2): tail sequence at the last successful fold.
+   * `loadTask` compares this against `EventStore.tailSequence(stream)` on
+   * every cache hit; when the tail has advanced (a sibling process /
+   * instance appended `task.result` / `task.cancelled` since we cached),
+   * we incrementally re-fold the delta via `projectTaskIncremental`.
+   * `projectTask` itself remains sequence-unaware (pure fold over event
+   * content); the caller is responsible for stamping this field after a
+   * successful projection.
+   */
+  lastReadSequence: number;
 }
 
 /**
@@ -208,6 +232,12 @@ export class EventSourcedTaskStore implements TaskStore {
       request,
       requestId,
       expiresAt: ttl !== null ? Date.now() + ttl : undefined,
+      // FINDING-2 (#1438): the `task.created` event we just appended is
+      // the only event on a fresh stream, so the cached projection's
+      // last-read tail is sequence 1. Subsequent appends (`task.polled`,
+      // `task.result`, `task.cancelled`) bump this via the cache-hit
+      // path in `loadTask` after each successful fold.
+      lastReadSequence: 1,
     });
 
     return task;
@@ -458,17 +488,69 @@ export class EventSourcedTaskStore implements TaskStore {
    * Returns `undefined` (not throw) when the task has never existed.
    */
   private async loadTask(taskId: string): Promise<ProjectedTask | undefined> {
+    // FINDING-2 (#1438, PR 2): cache hits MUST be validated against the
+    // live stream tail before being returned. The pre-PR-2 implementation
+    // returned the cached projection unconditionally, which let a sibling
+    // process's `task.result` / `task.cancelled` shadow the cached
+    // `working` status indefinitely (silent drift). The design here is:
+    //   1. Cache hit + tail matches  → return cached.
+    //   2. Cache hit + tail moved    → incremental fold of the delta
+    //      (`sinceSequence: cached.lastReadSequence` is exclusive in the
+    //      backend query, so we get exactly the events newer than what
+    //      we already folded).
+    //   3. Cache miss                → full refold from the stream.
     const cached = this.tasks.get(taskId);
-    if (cached) return cached;
+    if (cached) {
+      const tail = await this.store.tailSequence(taskStream(taskId));
+      if (tail === cached.lastReadSequence) return cached;
+      return this.refoldDelta(taskId, cached, tail);
+    }
+    return this.fullRefold(taskId);
+  }
 
+  /**
+   * FINDING-2 (#1438): cold-path refold — query the entire stream and
+   * project from scratch. Used on cache miss and as a defensive fallback
+   * when the tail advanced but the delta query came back empty (e.g.,
+   * transient ordering between `tailSequence` and the next `query` call
+   * against the same backend).
+   */
+  private async fullRefold(taskId: string): Promise<ProjectedTask | undefined> {
     const events = await this.store.query(taskStream(taskId));
     if (events.length === 0) return undefined;
-
     const projected = projectTask(taskId, events);
     if (!projected) return undefined;
+    const full: ProjectedTask = {
+      ...projected,
+      lastReadSequence: events[events.length - 1].sequence,
+    };
+    this.tasks.set(taskId, full);
+    return full;
+  }
 
-    this.tasks.set(taskId, projected);
-    return projected;
+  /**
+   * FINDING-2 (#1438): incremental refold from a cached projection. The
+   * substrate's `EventStore.query` exposes a `sinceSequence` (exclusive)
+   * filter — passing `cached.lastReadSequence` returns exactly the
+   * delta. No `fromSequence` API exists; `sinceSequence`'s exclusive
+   * semantics give us the right shape directly (no off-by-one).
+   */
+  private async refoldDelta(
+    taskId: string,
+    cached: ProjectedTask,
+    tail: number,
+  ): Promise<ProjectedTask | undefined> {
+    const delta = await this.store.query(taskStream(taskId), {
+      sinceSequence: cached.lastReadSequence,
+    });
+    // Defensive: if tail moved but the delta query came back empty
+    // (rare — would require a backend-internal ordering anomaly), fall
+    // back to a full refold so we never return a known-stale projection.
+    if (delta.length === 0) return this.fullRefold(taskId);
+    const next = projectTaskIncremental(cached, delta);
+    next.lastReadSequence = tail;
+    this.tasks.set(taskId, next);
+    return next;
   }
 
   /**
@@ -504,11 +586,21 @@ export class EventSourcedTaskStore implements TaskStore {
  * Returns `undefined` when the stream is empty or malformed (no
  * `task.created`). This is the function the REPLAY acceptance test in
  * `event-sourced-task-store.test.ts` validates end-to-end.
+ *
+ * FINDING-2 (#1438, PR 2) note: this function is intentionally
+ * sequence-unaware — it folds over event *content* and returns a
+ * `ProjectedTask`-minus-`lastReadSequence`. The caller stamps the
+ * `lastReadSequence` field from `events.at(-1).sequence` (or the
+ * `EventStore.tailSequence` value, depending on whether the caller is
+ * doing a full refold or an incremental fold). Keeping the fold pure
+ * lets `projectTaskIncremental` reuse the same per-event switch logic
+ * without conflating projection semantics with cache-validation
+ * bookkeeping.
  */
 function projectTask(
   taskId: string,
   events: readonly WorkflowEvent[],
-): ProjectedTask | undefined {
+): Omit<ProjectedTask, 'lastReadSequence'> | undefined {
   // The first event must be `task.created`; everything else folds on top.
   const created = events.find((e) => e.type === 'task.created');
   if (!created) return undefined;
@@ -596,5 +688,79 @@ function projectTask(
     requestId,
     result,
     expiresAt,
+  };
+}
+
+/**
+ * FINDING-2 (#1438, PR 2): incremental fold from a cached projection.
+ *
+ * Given a previously-cached `ProjectedTask` and a `delta` of events
+ * that arrived AFTER the cached `lastReadSequence`, returns a fresh
+ * `ProjectedTask` reflecting the combined state. The `task.created`
+ * event by construction lives at sequence 1 and is therefore never in
+ * the delta (the cache always carries at least the created-state); the
+ * switch body below mirrors `projectTask`'s post-created loop exactly
+ * — same handlers for `task.result`, `task.cancelled`, and the no-op
+ * default for `task.polled` / unknown.
+ *
+ * Pure function — no I/O, no clock reads. Does NOT mutate `cached`.
+ * The caller is responsible for stamping the new `lastReadSequence`
+ * (typically `EventStore.tailSequence(stream)` at the moment of read).
+ */
+function projectTaskIncremental(
+  cached: ProjectedTask,
+  delta: readonly WorkflowEvent[],
+): ProjectedTask {
+  let task: Task = { ...cached.task };
+  let result: Result | undefined = cached.result;
+  let expiresAt: number | undefined = cached.expiresAt;
+
+  for (const event of delta) {
+    switch (event.type) {
+      case 'task.result': {
+        const data = (event.data ?? {}) as Record<string, unknown>;
+        const status = data['status'];
+        if (
+          status === 'completed' ||
+          status === 'failed' ||
+          status === 'cancelled'
+        ) {
+          task = {
+            ...task,
+            status,
+            lastUpdatedAt: event.timestamp,
+          };
+          if (data['result'] !== undefined) {
+            result = data['result'] as Result;
+          }
+        }
+        break;
+      }
+      case 'task.cancelled': {
+        const data = (event.data ?? {}) as Record<string, unknown>;
+        task = {
+          ...task,
+          status: 'cancelled',
+          lastUpdatedAt: event.timestamp,
+          ...(typeof data['reason'] === 'string'
+            ? { statusMessage: data['reason'] }
+            : {}),
+        };
+        break;
+      }
+      default:
+        // `task.polled` and unknown types are no-op for state projection
+        // — same as `projectTask`. Keep both branches in lockstep.
+        break;
+    }
+  }
+
+  return {
+    task,
+    request: cached.request,
+    requestId: cached.requestId,
+    result,
+    expiresAt,
+    lastReadSequence: cached.lastReadSequence,
   };
 }

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -828,8 +828,21 @@ function projectTask(
           status === 'failed' ||
           status === 'cancelled'
         ) {
+          // Defensive statusMessage clear — kept in lockstep with
+          // `projectTaskIncremental`. In a well-formed stream a
+          // `task.cancelled` would never precede a `task.result`
+          // (writer-side OCC enforces single-terminal-event), so the
+          // local `task` shouldn't carry statusMessage here; the
+          // explicit clear keeps the fold robust against
+          // hand-appended or out-of-order streams and prevents the
+          // two folds from drifting structurally.
+          const {
+            statusMessage: _staleStatusMessage,
+            ...taskWithoutStatusMessage
+          } = task;
+          void _staleStatusMessage;
           task = {
-            ...task,
+            ...taskWithoutStatusMessage,
             status,
             lastUpdatedAt: event.timestamp,
           };
@@ -850,8 +863,15 @@ function projectTask(
       }
       case 'task.cancelled': {
         const data = (event.data ?? {}) as Record<string, unknown>;
+        // Same hygiene as the incremental fold: clear before
+        // optionally re-setting from `reason`.
+        const {
+          statusMessage: _staleStatusMessage,
+          ...taskWithoutStatusMessage
+        } = task;
+        void _staleStatusMessage;
         task = {
-          ...task,
+          ...taskWithoutStatusMessage,
           status: 'cancelled',
           lastUpdatedAt: event.timestamp,
           ...(typeof data['reason'] === 'string'
@@ -918,8 +938,23 @@ function projectTaskIncremental(
           status === 'failed' ||
           status === 'cancelled'
         ) {
+          // CodeRabbit r3253923003 (#1444): drop any stale
+          // projection-only `statusMessage` carried on `cached.task`
+          // (e.g. an `input_required` prompt set on this process via
+          // `updateTaskStatus`, which never emits a durable event).
+          // The `task.result` event has no statusMessage field, so a
+          // fresh-process replayer (`projectTask` on the same stream)
+          // produces a terminal task with NO `statusMessage` — without
+          // this explicit clear, the incremental fold path would
+          // diverge from the full-refold path on exactly this case,
+          // violating INV-1 cross-process consistency.
+          const {
+            statusMessage: _staleStatusMessage,
+            ...taskWithoutStatusMessage
+          } = task;
+          void _staleStatusMessage;
           task = {
-            ...task,
+            ...taskWithoutStatusMessage,
             status,
             lastUpdatedAt: event.timestamp,
           };
@@ -936,8 +971,17 @@ function projectTaskIncremental(
       }
       case 'task.cancelled': {
         const data = (event.data ?? {}) as Record<string, unknown>;
+        // Same statusMessage-hygiene as `task.result`: clear any stale
+        // value before optionally setting from the event's `reason`.
+        // Cancellation may carry a fresh diagnostic; absent that, the
+        // prior projection-only prompt MUST not leak through.
+        const {
+          statusMessage: _staleStatusMessage,
+          ...taskWithoutStatusMessage
+        } = task;
+        void _staleStatusMessage;
         task = {
-          ...task,
+          ...taskWithoutStatusMessage,
           status: 'cancelled',
           lastUpdatedAt: event.timestamp,
           ...(typeof data['reason'] === 'string'

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -73,8 +73,9 @@ import type {
 } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
 import { isTerminal } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
 
-import { EventStore } from '../event-store/store.js';
+import { EventStore, SequenceConflictError } from '../event-store/store.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
+import { ConcurrencyError } from '../event-store/concurrency-error.js';
 
 /**
  * Per-task projected lifecycle state. The shape carries everything
@@ -298,37 +299,43 @@ export class EventSourcedTaskStore implements TaskStore {
     result: Result,
     _sessionId?: string,
   ): Promise<void> {
-    const stored = await this.loadTask(taskId);
-    if (!stored) {
-      throw new Error(`Task with ID ${taskId} not found`);
-    }
-    if (isTerminal(stored.task.status)) {
-      throw new Error(
-        `Cannot store result for task ${taskId} in terminal status '${stored.task.status}'. Task results can only be stored once.`,
-      );
-    }
-
-    const now = new Date().toISOString();
-    await this.store.append(taskStream(taskId), {
-      type: 'task.result',
-      timestamp: now,
-      data: {
-        taskId,
-        status,
-        result,
-      },
+    // FINDING-1 (#1438, PR 3): route the read→decide→append through
+    // `commitWithOcc` so the durable layer enforces single-writer
+    // semantics via `expectedSequence`. The terminal-check fires INSIDE
+    // the decide closure so each retry re-evaluates against a freshly
+    // refolded projection (a concurrent winner's `task.result` /
+    // `task.cancelled` becomes visible on the next attempt).
+    return this.commitWithOcc(taskId, 'storeTaskResult', async (stored) => {
+      if (isTerminal(stored.task.status)) {
+        throw new Error(
+          `Cannot store result for task ${taskId} in terminal status '${stored.task.status}'. Task results can only be stored once.`,
+        );
+      }
+      const now = new Date().toISOString();
+      return {
+        event: {
+          type: 'task.result',
+          timestamp: now,
+          data: {
+            taskId,
+            status,
+            result,
+          },
+        },
+        mutate: (s: ProjectedTask) => {
+          s.result = result;
+          s.task = {
+            ...s.task,
+            status,
+            lastUpdatedAt: now,
+          };
+          // TTL resets from terminal transition (matches SDK semantics).
+          if (s.task.ttl !== null) {
+            s.expiresAt = Date.now() + s.task.ttl;
+          }
+        },
+      };
     });
-
-    stored.result = result;
-    stored.task = {
-      ...stored.task,
-      status,
-      lastUpdatedAt: now,
-    };
-    // TTL resets from terminal transition (matches SDK semantics).
-    if (stored.task.ttl !== null) {
-      stored.expiresAt = Date.now() + stored.task.ttl;
-    }
   }
 
   async getTaskResult(taskId: string, _sessionId?: string): Promise<Result> {
@@ -354,45 +361,51 @@ export class EventSourcedTaskStore implements TaskStore {
     statusMessage?: string,
     _sessionId?: string,
   ): Promise<void> {
-    const stored = await this.loadTask(taskId);
-    if (!stored) {
-      throw new Error(`Task with ID ${taskId} not found`);
-    }
-    if (isTerminal(stored.task.status)) {
-      throw new Error(
-        `Cannot update task ${taskId} from terminal status '${stored.task.status}' to '${status}'. Terminal states (completed, failed, cancelled) cannot transition to other states.`,
-      );
-    }
-
-    const now = new Date().toISOString();
-
-    // The `cancelled` transition gets its own durable event so audit
-    // can attribute the cancellation reason cleanly. Other status
-    // transitions (working ↔ input_required) don't have a dedicated
-    // event yet; they live only in the projection's
-    // `lastUpdatedAt`/`statusMessage` until a downstream consumer
-    // requires durable visibility.
-    if (status === 'cancelled') {
-      await this.store.append(taskStream(taskId), {
-        type: 'task.cancelled',
-        timestamp: now,
-        data: {
-          taskId,
-          reason: statusMessage ?? 'unspecified',
-        },
-      });
-    }
-
-    stored.task = {
-      ...stored.task,
-      status,
-      lastUpdatedAt: now,
-      ...(statusMessage !== undefined ? { statusMessage } : {}),
-    };
-
-    if (isTerminal(status) && stored.task.ttl !== null) {
-      stored.expiresAt = Date.now() + stored.task.ttl;
-    }
+    // FINDING-1 (#1438, PR 3): route through `commitWithOcc`. The
+    // cancellation branch returns a durable `task.cancelled` event and
+    // gets full OCC enforcement; non-cancel transitions return
+    // `event: null` (projection-only) and retain pre-PR-3 semantics —
+    // see the inline note on `commitWithOcc` for why this asymmetry is
+    // intentional (no durable event ⇒ no `expectedSequence` to enforce).
+    return this.commitWithOcc(taskId, 'updateTaskStatus', async (stored) => {
+      if (isTerminal(stored.task.status)) {
+        throw new Error(
+          `Cannot update task ${taskId} from terminal status '${stored.task.status}' to '${status}'. Terminal states (completed, failed, cancelled) cannot transition to other states.`,
+        );
+      }
+      const now = new Date().toISOString();
+      const mutate = (s: ProjectedTask) => {
+        s.task = {
+          ...s.task,
+          status,
+          lastUpdatedAt: now,
+          ...(statusMessage !== undefined ? { statusMessage } : {}),
+        };
+        if (isTerminal(status) && s.task.ttl !== null) {
+          s.expiresAt = Date.now() + s.task.ttl;
+        }
+      };
+      // The `cancelled` transition gets its own durable event so audit
+      // can attribute the cancellation reason cleanly. Other status
+      // transitions (working ↔ input_required) don't have a dedicated
+      // event yet; they live only in the projection's
+      // `lastUpdatedAt`/`statusMessage` until a downstream consumer
+      // requires durable visibility.
+      if (status === 'cancelled') {
+        return {
+          event: {
+            type: 'task.cancelled',
+            timestamp: now,
+            data: {
+              taskId,
+              reason: statusMessage ?? 'unspecified',
+            },
+          },
+          mutate,
+        };
+      }
+      return { event: null, mutate };
+    });
   }
 
   async listTasks(
@@ -441,6 +454,115 @@ export class EventSourcedTaskStore implements TaskStore {
   }
 
   // ─── Internals ─────────────────────────────────────────────────────────
+
+  /**
+   * FINDING-1 (#1438, PR 3): optimistic-concurrency write helper.
+   *
+   * The single entry point for every state-mutating durable write. Wraps
+   * the canonical read→decide→append pattern with `expectedSequence`
+   * enforcement so a sibling writer's commit between our read and our
+   * append surfaces as `SequenceConflictError` rather than silent
+   * last-write-wins on the stream.
+   *
+   * Flow per attempt:
+   *   1. `loadTask` — picks up the latest projection via PR 2's
+   *      cache-validation path (full refold on miss, incremental fold on
+   *      stale cache).
+   *   2. `decide(stored)` — the caller's pure decision function. Returns
+   *      either:
+   *        - `{ event, mutate }` — durable event to append + mutation to
+   *          apply to the cached projection on success.
+   *        - `{ event: null, mutate }` — projection-only update (no
+   *          durable event; no OCC enforcement). Used for `updateTaskStatus`
+   *          transitions that don't carry their own event today.
+   *   3. `store.append(..., { expectedSequence: stored.lastReadSequence })`
+   *      — on conflict the backend throws `SequenceConflictError`; we
+   *      invalidate the cache and loop. The decide closure MUST be
+   *      idempotent w.r.t. its own throws (e.g. terminal-status check)
+   *      because retries re-invoke it against the latest projection.
+   *
+   * Retry budget is 3 (mirrors the R-2 design's `withStateRetry`
+   * convention for non-idempotent decisions). Past the budget we surface
+   * a `ConcurrencyError` — the `mcp/format.ts::wrapError` boundary maps
+   * this to `CONCURRENCY_CONFLICT` (validTargets: ['retry']) for MCP
+   * callers, and the workflow `withStateRetry` middleware already
+   * recognises the type at the inner layer (`workflow/state-retry.ts:59`).
+   */
+  private async commitWithOcc(
+    taskId: string,
+    opName: string,
+    decide: (
+      stored: ProjectedTask,
+    ) => Promise<{
+      event:
+        | (Partial<Omit<WorkflowEvent, 'sequence' | 'streamId'>> & {
+            type: string;
+          })
+        | null;
+      mutate: (s: ProjectedTask) => void;
+    }>,
+    maxRetries = 3,
+  ): Promise<void> {
+    let lastConflict: SequenceConflictError | undefined;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const stored = await this.loadTask(taskId);
+      if (!stored) {
+        throw new Error(`Task with ID ${taskId} not found`);
+      }
+      const { event, mutate } = await decide(stored);
+      if (event === null) {
+        // Projection-only update: no durable event to append, no
+        // expectedSequence to enforce. The caller has opted into the
+        // pre-PR-3 semantics for this code path (e.g. non-cancel
+        // `updateTaskStatus` transitions). PR 2's cache-validation in
+        // `loadTask` already gives this branch read-time freshness; the
+        // remaining "stale decision" risk is unchanged from the prior
+        // implementation.
+        mutate(stored);
+        return;
+      }
+      try {
+        await this.store.append(taskStream(taskId), event, {
+          expectedSequence: stored.lastReadSequence,
+        });
+        mutate(stored);
+        stored.lastReadSequence += 1;
+        return;
+      } catch (err) {
+        if (err instanceof SequenceConflictError) {
+          // Force a full refold next iteration: the cached
+          // `lastReadSequence` is provably stale, and we want the next
+          // `loadTask` to re-query from scratch (rather than walk through
+          // the cache-hit-plus-tail-validation path with the now-known-
+          // wrong sequence number).
+          lastConflict = err;
+          this.tasks.delete(taskId);
+          if (attempt < maxRetries) continue;
+          // Fall through to the post-loop ConcurrencyError on the final
+          // attempt so the boundary sees the typed envelope, not the raw
+          // `SequenceConflictError`.
+          break;
+        }
+        throw err;
+      }
+    }
+    // Retry budget exhausted — surface as a structured `ConcurrencyError`
+    // so the MCP boundary (`format.ts::wrapError`) emits the canonical
+    // `CONCURRENCY_CONFLICT` envelope. We log a warning for operational
+    // visibility (DIM-2) before throwing because budget exhaustion is a
+    // notable event — it implies sustained write contention on this
+    // specific task stream.
+    console.warn(
+      `[task-store] OCC retry budget exhausted: taskId=${taskId} op=${opName} attempts=${maxRetries + 1}`,
+    );
+    throw new ConcurrencyError({
+      streamId: taskStream(taskId),
+      reducerId: 'task-store',
+      expectedVersion: lastConflict?.expected ?? -1,
+      actualVersion: lastConflict?.actual ?? -1,
+      operationId: opName,
+    });
+  }
 
   /**
    * Enumerate `task-store/*` streams from the event store and load


### PR DESCRIPTION
## Summary

PR 2 of 3 addressing HIGH-severity findings from #1438 (epic #1441). **Closes FINDING-2** — cache hits skip stream validation.

The class docstring claimed cache hits were validated against the projection sequence "so a missed event invalidates the cache transparently." The code did a straight cache return. Multi-process scenarios (CLI + MCP server sharing a SQLite store; two MCP server instances during hot-swap) drift silently when a sibling appends `task.result`/`task.cancelled` — Process A's cached `ProjectedTask` shadows the new event until eviction.

This PR ships:
1. New `EventStore.tailSequence(streamId)` substrate accessor (one-line wrapper over `getReadBackend().getSequence`).
2. New `lastReadSequence: number` field on `ProjectedTask`, set after every fold.
3. `loadTask` cache hits query `tailSequence`; if advanced, incrementally re-fold via new `projectTaskIncremental` (uses `query({ sinceSequence })`, exclusive).
4. Class docstring rewritten to describe what the code now does (closes DIM-8 prose-vs-code finding).

Stacked behind merged PR #1443 (FINDING-3 throttle). PR 3 for FINDING-1 (OCC threading) follows.

## Changes

- `servers/exarchos-mcp/src/event-store/store.ts` — adds `tailSequence(streamId): Promise<number>`. Delegates to `getReadBackend().getSequence(streamId)` (matches the `listStreams()` pattern at line 602; works against both `SqliteBackend` and `InMemoryBackend`).
- `servers/exarchos-mcp/src/event-store/store.test.ts` — 2 new tests: empty stream returns 0; populated stream returns highest sequence.
- `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts`:
  - Adds `lastReadSequence: number` to `ProjectedTask` (required field).
  - Narrows `projectTask` return type to `Omit<ProjectedTask, 'lastReadSequence'>` so the pure fold stays sequence-unaware; the caller stamps `lastReadSequence`.
  - Splits `loadTask` into cache-validation + `fullRefold` + `refoldDelta`.
  - Adds `projectTaskIncremental(cached, delta)` — sibling of `projectTask`, same `switch (event.type)` body for non-`task.created` events.
  - Rewrites the `## Cache semantics` docstring to match the implementation.
- `servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts` — 4 new tests: `lastReadSequence` recorded after fold; cache hit triggers refold when stream advances; `projectTaskIncremental` matches full refold (property-style); multi-process race.

## Test Plan

- [x] `npx vitest run src/task-store/ src/event-store/store.test.ts` — 72 passed, 0 failed (3 files)
- [x] `npx tsc --noEmit` (MCP server) — exit 0
- [x] Existing REPLAY tests still pass (the cold-path projection is unchanged; only the cache-hit path gained validation)
- [x] Production-wiring test unchanged

## Deviations from design

- Design pseudocode used `query({ fromSequence })`; the actual `EventStore.query` API uses `sinceSequence` (exclusive). Implementation uses `sinceSequence: cached.lastReadSequence` directly — yields the desired delta without off-by-one math. Documented inline in `refoldDelta`.
- `tailSequence` delegates to `getReadBackend().getSequence` (already on the `StorageBackend` interface) instead of the SqliteBackend-specific `readSequenceHighWaterMark` path. Same 0-for-empty semantics; works across both backends; matches the existing `listStreams()` delegation pattern at `store.ts:602`.
- Made `projectTask`'s return type `Omit<ProjectedTask, 'lastReadSequence'>` rather than mutating the fold function. Keeps `projectTask` pure / sequence-unaware as the design required; the caller (`fullRefold` / `createTask`) owns the `lastReadSequence` stamp.

## Invariant / dimension conformance

- INV-1 (event-sourcing integrity): ✅ — cache is now a validated projection; stream is sole authority
- INV-3 (basileus-forward): ✅ — multi-writer correctness for remote MCP scenarios
- DIM-1 (topology): ✅ — cache + stream are now bridged by `lastReadSequence`
- DIM-3 (contracts): ✅ — docstring matches behavior
- DIM-8 (prose): ✅ — docstring claims are now true

Refs: #1438, #1441, #1443 (PR 1 in stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)