### PR TITLE
feat(task-store): thread expectedSequence through writes (FINDING-1, #1438)

### DIFF
--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -546,6 +546,274 @@ describe('EventSourcedTaskStore (#1272)', () => {
     });
   });
 
+  // ─── FINDING-1 (#1438, PR 3) — OCC threading via expectedSequence ─────────
+  //
+  // The fix invariant: two concurrent writers on the same task stream MUST
+  // resolve deterministically. One commits, the other gets either a
+  // terminal-status error (after retry refold sees the winner's terminal
+  // event) or a `ConcurrencyError` (after exhausting the retry budget).
+  // Last-write-wins at the durable layer is no longer possible — exactly
+  // one `task.result` / `task.cancelled` event lands on the stream per
+  // intended outcome.
+  //
+  // Race scenarios covered:
+  //   T16 — `storeTaskResult` × `storeTaskResult` (this block)
+  //   T17 — `updateTaskStatus` × `updateTaskStatus` (cancellation race)
+  //   T18 — cancel-arrives-first vs late result (terminal-status throw)
+  //   T19 — retry budget exhaustion surfaces `ConcurrencyError`
+
+  it('storeTaskResult_ConcurrentCallers_ExactlyOneSucceeds', async () => {
+    // Two TaskStore instances on the SAME EventStore — simulates two
+    // processes (CLI + MCP server, two MCP instances) or two interleaved
+    // requests that both passed their in-memory `isTerminal` check before
+    // either committed. Pre-fix: both `append` calls would succeed; the
+    // stream would contain two `task.result` events; the projection would
+    // last-write-win silently. Post-fix: `commitWithOcc` threads
+    // `expectedSequence: stored.lastReadSequence` so the second writer
+    // hits `SequenceConflictError`; on retry refold the loser sees the
+    // winner's terminal status and the in-decide-closure terminal-check
+    // throws "Cannot store result ... in terminal status".
+    const storeA = new EventSourcedTaskStore(eventStore);
+    const storeB = new EventSourcedTaskStore(eventStore);
+
+    const task = await storeA.createTask(
+      { ttl: 60_000 },
+      'req-occ-1',
+      sampleRequest,
+    );
+
+    // Force both stores' caches to be warmed at the SAME lastReadSequence
+    // before the race so they each see the pre-race tail.
+    await storeA.getTask(task.taskId);
+    await storeB.getTask(task.taskId);
+
+    const r1 = { content: [{ type: 'text', text: 'from-A' }] };
+    const r2 = { content: [{ type: 'text', text: 'from-B' }] };
+
+    const results = await Promise.allSettled([
+      storeA.storeTaskResult(task.taskId, 'completed', r1),
+      storeB.storeTaskResult(task.taskId, 'failed', r2),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+
+    // The rejection must be either a terminal-status error (loser retried,
+    // re-folded, saw the winner's terminal event) or a ConcurrencyError
+    // (budget exhausted in the OCC retry loop).
+    const rejectedReason = (rejected[0] as PromiseRejectedResult).reason;
+    const message: string =
+      rejectedReason instanceof Error
+        ? rejectedReason.message
+        : String(rejectedReason);
+    expect(message).toMatch(/terminal status|ConcurrencyError|tail advanced/);
+
+    // The stream MUST contain exactly one `task.result` event — the
+    // winner's append. Last-write-wins at the durable layer is now
+    // impossible.
+    const events = await eventStore.query(`task-store/${task.taskId}`);
+    const resultEvents = events.filter((e) => e.type === 'task.result');
+    expect(resultEvents).toHaveLength(1);
+  });
+
+  it('updateTaskStatus_ConcurrentCallersToConflictingStates_ExactlyOneSucceeds', async () => {
+    // Cancellation race: two writers both call `updateTaskStatus(..., 'cancelled')`.
+    // Cancellation is the only `updateTaskStatus` transition that writes
+    // a durable event (line 375 of event-sourced-task-store.ts), so it's
+    // the case where OCC enforcement is observable on the stream.
+    // Non-cancel transitions (working ↔ input_required) are projection-
+    // only and intentionally retain pre-PR-3 semantics — that asymmetry
+    // is documented inline on `commitWithOcc`.
+    const storeA = new EventSourcedTaskStore(eventStore);
+    const storeB = new EventSourcedTaskStore(eventStore);
+
+    const task = await storeA.createTask(
+      { ttl: 60_000 },
+      'req-occ-cancel',
+      sampleRequest,
+    );
+
+    // Both stores warm their cache at the same lastReadSequence.
+    await storeA.getTask(task.taskId);
+    await storeB.getTask(task.taskId);
+
+    const results = await Promise.allSettled([
+      storeA.updateTaskStatus(task.taskId, 'cancelled', 'reason-A'),
+      storeB.updateTaskStatus(task.taskId, 'cancelled', 'reason-B'),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+
+    const reason = (rejected[0] as PromiseRejectedResult).reason;
+    const message: string =
+      reason instanceof Error ? reason.message : String(reason);
+    // After the loser refolds, it sees `cancelled` (terminal) and the
+    // `updateTaskStatus` terminal-check throws ("Cannot update task ...
+    // from terminal status 'cancelled'"). If the retry budget were
+    // exhausted instead we would see "tail advanced" from ConcurrencyError.
+    expect(message).toMatch(/terminal status|tail advanced/);
+
+    // Stream MUST contain exactly one `task.cancelled` event — duplicate
+    // cancellations are not appended.
+    const events = await eventStore.query(`task-store/${task.taskId}`);
+    const cancelEvents = events.filter((e) => e.type === 'task.cancelled');
+    expect(cancelEvents).toHaveLength(1);
+  });
+
+  it('cancelRacesResult_CancelArrivesFirst_LateResultRejectsWithTerminalError', async () => {
+    // Sequenced race: cancel commits first, late `storeTaskResult` arrives
+    // afterwards with a cached projection that still says `working`. The
+    // OCC retry path MUST refold, see the `cancelled` status, and have
+    // the terminal-check in `storeTaskResult`'s decide closure throw.
+    // This is the load-bearing scenario from the design's
+    // §"Cancellation race scenario" — MCP `tasks/cancel` racing a
+    // wrapped handler's `task.result`.
+    const storeA = new EventSourcedTaskStore(eventStore);
+    const storeB = new EventSourcedTaskStore(eventStore);
+
+    const task = await storeA.createTask(
+      { ttl: 60_000 },
+      'req-cancel-wins',
+      sampleRequest,
+    );
+
+    // B warms its cache BEFORE A cancels, so B's `lastReadSequence` is
+    // stale when it tries to write the result. This matches the
+    // production scenario where the wrapped handler read state at the
+    // start of its work and only commits its result later.
+    await storeB.getTask(task.taskId);
+
+    // A cancels and the commit lands first (await sequences this).
+    await storeA.updateTaskStatus(task.taskId, 'cancelled', 'race-test');
+
+    // B tries to record a late completion. The decide closure's
+    // terminal-check throws on the first retry (after the cache refold
+    // surfaces the cancelled status).
+    await expect(
+      storeB.storeTaskResult(task.taskId, 'completed', {
+        content: [{ type: 'text', text: 'late' }],
+      }),
+    ).rejects.toThrow(/terminal status/);
+
+    // Exactly one terminal-class event on the stream — the cancel.
+    const events = await eventStore.query(`task-store/${task.taskId}`);
+    const resultEvents = events.filter((e) => e.type === 'task.result');
+    const cancelEvents = events.filter((e) => e.type === 'task.cancelled');
+    expect(resultEvents).toHaveLength(0);
+    expect(cancelEvents).toHaveLength(1);
+  });
+
+  it('commitWithOcc_RetryBudgetExhausted_ThrowsConcurrencyError', async () => {
+    // Force `EventStore.append` to throw `SequenceConflictError` on every
+    // attempt. After `maxRetries + 1` attempts (default budget = 3 ⇒ 4
+    // total), `commitWithOcc` must surface a `ConcurrencyError` with
+    // structured fields (streamId, reducerId='task-store', operationId,
+    // expectedVersion, actualVersion).
+    const task = await store.createTask(
+      { ttl: 60_000 },
+      'req-budget-exhausted',
+      sampleRequest,
+    );
+    await store.getTask(task.taskId); // warm cache
+
+    const { SequenceConflictError } = await import('../event-store/store.js');
+    const { ConcurrencyError } = await import(
+      '../event-store/concurrency-error.js'
+    );
+
+    // Silence the warning emitted on budget exhaustion to keep test
+    // output clean — the warning IS the observability surface we want,
+    // but for this test we only care that the throw shape is correct.
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    // Track attempt count to confirm the budget walk.
+    let attempts = 0;
+    const appendSpy = vi
+      .spyOn(eventStore, 'append')
+      .mockImplementation(async () => {
+        attempts += 1;
+        // The actual numbers don't matter — only the type does.
+        throw new SequenceConflictError(1, 99);
+      });
+
+    try {
+      await expect(
+        store.storeTaskResult(task.taskId, 'completed', {
+          content: [{ type: 'text', text: 'will-never-commit' }],
+        }),
+      ).rejects.toBeInstanceOf(ConcurrencyError);
+
+      // 3 retries + the initial attempt = 4 total append calls.
+      expect(attempts).toBe(4);
+      // Warning emitted exactly once on budget exhaustion.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      appendSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('commitWithOcc_ConcurrencyErrorFlowsToMcpEnvelope_CONCURRENCY_CONFLICT', async () => {
+    // T20 — integration smoke that the typed `ConcurrencyError` raised
+    // by `commitWithOcc` after budget exhaustion deserializes into the
+    // canonical MCP `CONCURRENCY_CONFLICT` envelope via `wrapError`. The
+    // mapping itself is unit-tested in `format.test.ts`; this test proves
+    // the wiring is intact end-to-end from the task-store layer.
+    const task = await store.createTask(
+      { ttl: 60_000 },
+      'req-mcp-envelope',
+      sampleRequest,
+    );
+    await store.getTask(task.taskId);
+
+    const { SequenceConflictError } = await import('../event-store/store.js');
+    const { wrapError } = await import('../format.js');
+
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const appendSpy = vi
+      .spyOn(eventStore, 'append')
+      .mockImplementation(async () => {
+        throw new SequenceConflictError(1, 99);
+      });
+
+    try {
+      let caught: unknown;
+      try {
+        await store.storeTaskResult(task.taskId, 'completed', {
+          content: [{ type: 'text', text: 'will-fail' }],
+        });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeDefined();
+
+      const envelope = wrapError(caught);
+      expect(envelope.success).toBe(false);
+      // ErrorEnvelope is a union; narrow by `success: false` branch.
+      if (envelope.success === false) {
+        expect(envelope.error.code).toBe('CONCURRENCY_CONFLICT');
+        const errBody = envelope.error as { streamId?: string; reducerId?: string; operationId?: string };
+        expect(errBody.streamId).toBe(`task-store/${task.taskId}`);
+        expect(errBody.reducerId).toBe('task-store');
+        expect(errBody.operationId).toBe('storeTaskResult');
+        expect(envelope._meta.retryable).toBe(true);
+      }
+    } finally {
+      appendSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
   it('EventSourcedTaskStore_ListTasks_HydratesFromEventStoreOnColdStart', async () => {
     // CR PR #1432: cold-start listTasks must enumerate durable
     // `task-store/*` streams rather than silently returning an empty

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -73,8 +73,9 @@ import type {
 } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
 import { isTerminal } from '@modelcontextprotocol/sdk/experimental/tasks/interfaces.js';
 
-import { EventStore } from '../event-store/store.js';
+import { EventStore, SequenceConflictError } from '../event-store/store.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
+import { ConcurrencyError } from '../event-store/concurrency-error.js';
 
 /**
  * Per-task projected lifecycle state. The shape carries everything
@@ -298,37 +299,43 @@ export class EventSourcedTaskStore implements TaskStore {
     result: Result,
     _sessionId?: string,
   ): Promise<void> {
-    const stored = await this.loadTask(taskId);
-    if (!stored) {
-      throw new Error(`Task with ID ${taskId} not found`);
-    }
-    if (isTerminal(stored.task.status)) {
-      throw new Error(
-        `Cannot store result for task ${taskId} in terminal status '${stored.task.status}'. Task results can only be stored once.`,
-      );
-    }
-
-    const now = new Date().toISOString();
-    await this.store.append(taskStream(taskId), {
-      type: 'task.result',
-      timestamp: now,
-      data: {
-        taskId,
-        status,
-        result,
-      },
+    // FINDING-1 (#1438, PR 3): route the read→decide→append through
+    // `commitWithOcc` so the durable layer enforces single-writer
+    // semantics via `expectedSequence`. The terminal-check fires INSIDE
+    // the decide closure so each retry re-evaluates against a freshly
+    // refolded projection (a concurrent winner's `task.result` /
+    // `task.cancelled` becomes visible on the next attempt).
+    return this.commitWithOcc(taskId, 'storeTaskResult', async (stored) => {
+      if (isTerminal(stored.task.status)) {
+        throw new Error(
+          `Cannot store result for task ${taskId} in terminal status '${stored.task.status}'. Task results can only be stored once.`,
+        );
+      }
+      const now = new Date().toISOString();
+      return {
+        event: {
+          type: 'task.result',
+          timestamp: now,
+          data: {
+            taskId,
+            status,
+            result,
+          },
+        },
+        mutate: (s: ProjectedTask) => {
+          s.result = result;
+          s.task = {
+            ...s.task,
+            status,
+            lastUpdatedAt: now,
+          };
+          // TTL resets from terminal transition (matches SDK semantics).
+          if (s.task.ttl !== null) {
+            s.expiresAt = Date.now() + s.task.ttl;
+          }
+        },
+      };
     });
-
-    stored.result = result;
-    stored.task = {
-      ...stored.task,
-      status,
-      lastUpdatedAt: now,
-    };
-    // TTL resets from terminal transition (matches SDK semantics).
-    if (stored.task.ttl !== null) {
-      stored.expiresAt = Date.now() + stored.task.ttl;
-    }
   }
 
   async getTaskResult(taskId: string, _sessionId?: string): Promise<Result> {
@@ -354,45 +361,51 @@ export class EventSourcedTaskStore implements TaskStore {
     statusMessage?: string,
     _sessionId?: string,
   ): Promise<void> {
-    const stored = await this.loadTask(taskId);
-    if (!stored) {
-      throw new Error(`Task with ID ${taskId} not found`);
-    }
-    if (isTerminal(stored.task.status)) {
-      throw new Error(
-        `Cannot update task ${taskId} from terminal status '${stored.task.status}' to '${status}'. Terminal states (completed, failed, cancelled) cannot transition to other states.`,
-      );
-    }
-
-    const now = new Date().toISOString();
-
-    // The `cancelled` transition gets its own durable event so audit
-    // can attribute the cancellation reason cleanly. Other status
-    // transitions (working ↔ input_required) don't have a dedicated
-    // event yet; they live only in the projection's
-    // `lastUpdatedAt`/`statusMessage` until a downstream consumer
-    // requires durable visibility.
-    if (status === 'cancelled') {
-      await this.store.append(taskStream(taskId), {
-        type: 'task.cancelled',
-        timestamp: now,
-        data: {
-          taskId,
-          reason: statusMessage ?? 'unspecified',
-        },
-      });
-    }
-
-    stored.task = {
-      ...stored.task,
-      status,
-      lastUpdatedAt: now,
-      ...(statusMessage !== undefined ? { statusMessage } : {}),
-    };
-
-    if (isTerminal(status) && stored.task.ttl !== null) {
-      stored.expiresAt = Date.now() + stored.task.ttl;
-    }
+    // FINDING-1 (#1438, PR 3): route through `commitWithOcc`. The
+    // cancellation branch returns a durable `task.cancelled` event and
+    // gets full OCC enforcement; non-cancel transitions return
+    // `event: null` (projection-only) and retain pre-PR-3 semantics —
+    // see the inline note on `commitWithOcc` for why this asymmetry is
+    // intentional (no durable event ⇒ no `expectedSequence` to enforce).
+    return this.commitWithOcc(taskId, 'updateTaskStatus', async (stored) => {
+      if (isTerminal(stored.task.status)) {
+        throw new Error(
+          `Cannot update task ${taskId} from terminal status '${stored.task.status}' to '${status}'. Terminal states (completed, failed, cancelled) cannot transition to other states.`,
+        );
+      }
+      const now = new Date().toISOString();
+      const mutate = (s: ProjectedTask) => {
+        s.task = {
+          ...s.task,
+          status,
+          lastUpdatedAt: now,
+          ...(statusMessage !== undefined ? { statusMessage } : {}),
+        };
+        if (isTerminal(status) && s.task.ttl !== null) {
+          s.expiresAt = Date.now() + s.task.ttl;
+        }
+      };
+      // The `cancelled` transition gets its own durable event so audit
+      // can attribute the cancellation reason cleanly. Other status
+      // transitions (working ↔ input_required) don't have a dedicated
+      // event yet; they live only in the projection's
+      // `lastUpdatedAt`/`statusMessage` until a downstream consumer
+      // requires durable visibility.
+      if (status === 'cancelled') {
+        return {
+          event: {
+            type: 'task.cancelled',
+            timestamp: now,
+            data: {
+              taskId,
+              reason: statusMessage ?? 'unspecified',
+            },
+          },
+          mutate,
+        };
+      }
+      return { event: null, mutate };
+    });
   }
 
   async listTasks(
@@ -441,6 +454,115 @@ export class EventSourcedTaskStore implements TaskStore {
   }
 
   // ─── Internals ─────────────────────────────────────────────────────────
+
+  /**
+   * FINDING-1 (#1438, PR 3): optimistic-concurrency write helper.
+   *
+   * The single entry point for every state-mutating durable write. Wraps
+   * the canonical read→decide→append pattern with `expectedSequence`
+   * enforcement so a sibling writer's commit between our read and our
+   * append surfaces as `SequenceConflictError` rather than silent
+   * last-write-wins on the stream.
+   *
+   * Flow per attempt:
+   *   1. `loadTask` — picks up the latest projection via PR 2's
+   *      cache-validation path (full refold on miss, incremental fold on
+   *      stale cache).
+   *   2. `decide(stored)` — the caller's pure decision function. Returns
+   *      either:
+   *        - `{ event, mutate }` — durable event to append + mutation to
+   *          apply to the cached projection on success.
+   *        - `{ event: null, mutate }` — projection-only update (no
+   *          durable event; no OCC enforcement). Used for `updateTaskStatus`
+   *          transitions that don't carry their own event today.
+   *   3. `store.append(..., { expectedSequence: stored.lastReadSequence })`
+   *      — on conflict the backend throws `SequenceConflictError`; we
+   *      invalidate the cache and loop. The decide closure MUST be
+   *      idempotent w.r.t. its own throws (e.g. terminal-status check)
+   *      because retries re-invoke it against the latest projection.
+   *
+   * Retry budget is 3 (mirrors the R-2 design's `withStateRetry`
+   * convention for non-idempotent decisions). Past the budget we surface
+   * a `ConcurrencyError` — the `mcp/format.ts::wrapError` boundary maps
+   * this to `CONCURRENCY_CONFLICT` (validTargets: ['retry']) for MCP
+   * callers, and the workflow `withStateRetry` middleware already
+   * recognises the type at the inner layer (`workflow/state-retry.ts:59`).
+   */
+  private async commitWithOcc(
+    taskId: string,
+    opName: string,
+    decide: (
+      stored: ProjectedTask,
+    ) => Promise<{
+      event:
+        | (Partial<Omit<WorkflowEvent, 'sequence' | 'streamId'>> & {
+            type: string;
+          })
+        | null;
+      mutate: (s: ProjectedTask) => void;
+    }>,
+    maxRetries = 3,
+  ): Promise<void> {
+    let lastConflict: SequenceConflictError | undefined;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const stored = await this.loadTask(taskId);
+      if (!stored) {
+        throw new Error(`Task with ID ${taskId} not found`);
+      }
+      const { event, mutate } = await decide(stored);
+      if (event === null) {
+        // Projection-only update: no durable event to append, no
+        // expectedSequence to enforce. The caller has opted into the
+        // pre-PR-3 semantics for this code path (e.g. non-cancel
+        // `updateTaskStatus` transitions). PR 2's cache-validation in
+        // `loadTask` already gives this branch read-time freshness; the
+        // remaining "stale decision" risk is unchanged from the prior
+        // implementation.
+        mutate(stored);
+        return;
+      }
+      try {
+        await this.store.append(taskStream(taskId), event, {
+          expectedSequence: stored.lastReadSequence,
+        });
+        mutate(stored);
+        stored.lastReadSequence += 1;
+        return;
+      } catch (err) {
+        if (err instanceof SequenceConflictError) {
+          // Force a full refold next iteration: the cached
+          // `lastReadSequence` is provably stale, and we want the next
+          // `loadTask` to re-query from scratch (rather than walk through
+          // the cache-hit-plus-tail-validation path with the now-known-
+          // wrong sequence number).
+          lastConflict = err;
+          this.tasks.delete(taskId);
+          if (attempt < maxRetries) continue;
+          // Fall through to the post-loop ConcurrencyError on the final
+          // attempt so the boundary sees the typed envelope, not the raw
+          // `SequenceConflictError`.
+          break;
+        }
+        throw err;
+      }
+    }
+    // Retry budget exhausted — surface as a structured `ConcurrencyError`
+    // so the MCP boundary (`format.ts::wrapError`) emits the canonical
+    // `CONCURRENCY_CONFLICT` envelope. We log a warning for operational
+    // visibility (DIM-2) before throwing because budget exhaustion is a
+    // notable event — it implies sustained write contention on this
+    // specific task stream.
+    console.warn(
+      `[task-store] OCC retry budget exhausted: taskId=${taskId} op=${opName} attempts=${maxRetries + 1}`,
+    );
+    throw new ConcurrencyError({
+      streamId: taskStream(taskId),
+      reducerId: 'task-store',
+      expectedVersion: lastConflict?.expected ?? -1,
+      actualVersion: lastConflict?.actual ?? -1,
+      operationId: opName,
+    });
+  }
 
   /**
    * Enumerate `task-store/*` streams from the event store and load


### PR DESCRIPTION
## Summary

**Final PR of the 3-PR stack** addressing HIGH-severity findings from #1438 (epic #1441). Closes **FINDING-1** — no optimistic concurrency on writes.

Both `storeTaskResult` and `updateTaskStatus` previously followed `load → terminal-check → append` without an `expectedSequence` argument. Two concurrent callers (MCP `tasks/cancel` racing the wrapped handler's `task.result`, or two CLI processes against the same SQLite store) both passed the in-memory `isTerminal` check and both appended. The stream ended with two terminal events; last-write-wins at the projection layer; the "Task results can only be stored once" contract was violated at the durable layer.

Stack:
- ✅ **PR 1** #1443 — FINDING-3 throttle (merged)
- 🟡 **PR 2** #1444 — FINDING-2 cache validation (open, auto-merge enabled — this PR targets it)
- **PR 3** (this) — FINDING-1 OCC threading

## Changes

- `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts`:
  - New `commitWithOcc(taskId, opName, decide, maxRetries=3)` private helper. Captures `stored.lastReadSequence` (added by PR 2), passes `expectedSequence` to `EventStore.append`. On `SequenceConflictError`: invalidates cache, refolds via `loadTask`, re-runs the decide closure (which re-evaluates terminal checks). On budget exhaustion: throws `ConcurrencyError` with structured fields.
  - `storeTaskResult` rewritten to use `commitWithOcc`. Terminal check runs inside the decide closure, so retries see the refolded state.
  - `updateTaskStatus` rewritten via `commitWithOcc`. Cancellation branch returns a `task.cancelled` event; non-cancel transitions return `{event: null, mutate}` — projection-only (preserves pre-existing semantics where non-cancel statuses don't write durable events).
  - `console.warn` on retry budget exhaustion before throwing (observability).
- `servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts` — 5 new tests covering concurrent races, cancel-vs-result race, retry budget exhaustion, and the full envelope path through `format.ts::wrapError`.

## Cancellation race scenario (the load-bearing case)

- T0: MCP `tasks/cancel` arrives; wrapped handler's `task.result` emission also arrives.
- T1: both call `loadTask` → both see `lastReadSequence = N`, status `working`.
- T2: `tasks/cancel` calls `updateTaskStatus('cancelled')` → `append` with `expectedSequence: N` → succeeds; sequence becomes N+1.
- T3: wrapped handler calls `storeTaskResult('completed')` → `append` with `expectedSequence: N` → `SequenceConflictError` → caught → cache invalidated → refold → status is `cancelled` → terminal-check throws "Cannot store result for task X in terminal status 'cancelled'".

Late result rejected with an honest error. Cancel wins. No silent last-write-wins.

## Test Plan

- [x] Scoped: `npx vitest run src/task-store/ src/event-store/` — 564 passed, 0 failed (40 files)
- [x] Full suite: `npm run test:run` (root) — 762 passed, 6 skipped, 0 failed (91 files)
- [x] Typecheck: `npx tsc --noEmit` — clean
- [x] MCP envelope smoke test confirms `ConcurrencyError → CONCURRENCY_CONFLICT` via existing `format.ts::wrapError` (no new boundary code needed)

## Deviations from design

- **Fixed a loop fall-through bug in the design's pseudocode.** The design's `commitWithOcc` had `if (err instanceof SequenceConflictError && attempt < maxRetries) continue; throw err;` — on the final attempt the `continue` guard fails and the catch falls through to `throw err`, surfacing `SequenceConflictError` directly instead of the post-loop `ConcurrencyError`. Implementation catches `SequenceConflictError` unconditionally inside the loop and only falls through (`break`) on the final attempt, so the post-loop `ConcurrencyError` always wraps the typed boundary error. The T19 test (`commitWithOcc_RetryBudgetExhausted_ThrowsConcurrencyError`) caught this — without the fix the test would have failed.
- **MCP boundary mapping lives in `src/format.ts::wrapError`, not `src/mcp/wrap.ts` (file does not exist).** The audit-doc reference to `wrap()` was forward-correct but pointed at the wrong filename. The existing `format.ts:342` maps `ConcurrencyError → CONCURRENCY_CONFLICT` envelope with `_meta.retryable: true`. The new smoke test asserts the envelope shape end-to-end.
- T23's stale-comment removal was a no-op — the comment the plan referenced wasn't actually present in the source.

## Invariant / dimension conformance

- INV-1 (event-sourcing integrity): ✅ — OCC prevents stream divergence
- INV-3 (basileus-forward): ✅ — multi-writer correctness loaded-bearing-safe; remote MCP federation can land without revisiting
- DIM-1 (topology): ✅ — `lastReadSequence` (PR 2) + `expectedSequence` (this PR) bridge cache and stream
- DIM-2 (observability): ✅ — typed errors surface; retry exhaustion logged
- DIM-4 (test fidelity): ✅ — concurrency tests added; existing 11 + PR-1's 5 + PR-2's 4 all still green
- DIM-7 (error handling): ✅ — typed `ConcurrencyError` surfaces at MCP boundary; no silent last-write-wins

Closes the audit's HIGH-trio. Per the audit doc, this also satisfies Marten C-2 (`fetchForWriting`) and Azure ES OCC patterns — both were ❌ before this stack and are ✅ after.

Refs: #1438, #1441, #1443 (PR 1 merged), #1444 (PR 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)