### PR TITLE
feat(correlation): wire consumer side of correlation tuple filters (#1448 items 2-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to Exarchos are documented in this file. Organized by semver
   - `materializeFiltered` cache-bypass helper prevents cache contamination across filtered/unfiltered calls on the same view.
   - Closes the [#1291](https://github.com/lvlup-sw/exarchos/issues/1291) acceptance criteria (storage layer + telemetry filters + three end-to-end integration tests) that PR [#1428](https://github.com/lvlup-sw/exarchos/pull/1428) deferred. Closes [#1414](https://github.com/lvlup-sw/exarchos/issues/1414) (regression coverage proves the inline fix from #1428's post-merge hardening).
 
+- Correlation consumer wiring ([#1448](https://github.com/lvlup-sw/exarchos/issues/1448))
+  - `deriveCorrelationFilters` helper in `views/tools.ts` — inside an active `runWithDispatchContext` scope, defaults `correlationId` to the active dispatch's correlationId when no filter args are supplied; explicit args always win. Emits `source: 'ctx-default'` debug log on the inferred path. Replaces six inline filter-spread blocks across the six telemetry view handlers.
+  - CLI flags `--operation-id` / `--correlation-id` / `--causation-id` on all six telemetry view subcommands. Auto-generated from each action's Zod schema in `registry.ts` via `addFlagsFromSchema`; 20 regression-pin tests (full subcommand × flag matrix + introspection sweep + end-to-end smoke through real dispatch).
+  - `cacheBypasses` counter on `ViewMaterializer.getCacheStats()` plus `correlationFilteredQueries` counter on `SqliteBackend.getStats()` — close the two DIM-2 LOW findings from PR [#1447](https://github.com/lvlup-sw/exarchos/pull/1447)'s axiom audit (silent index regression + invisible cache-bypass).
+  - `docs/runbooks/correlation-filters.md` — operator + agent reference covering the three IDs, filter selection rule, MCP + CLI examples, and the AsyncLocalStorage default. Linked from `README.md` in the agent-first architecture section.
+  - T17 acceptance test: inline TODO replaced with permanent design rationale. No production auto-dispatch handler exists (both CLI and MCP adapters are one-shot); T17's manual `mintDispatchContext` synthesis models the correct caller-driven path at the substrate boundary, not a workaround. Companion CLI roundtrip test pins `next_actions` field integrity through the one-shot pipeline.
+  - Closes [#1448](https://github.com/lvlup-sw/exarchos/issues/1448) items 2-5 (item 1 = [#1446](https://github.com/lvlup-sw/exarchos/issues/1446) separately tracked).
+
 ## [2.10.0-preview.2] - 2026-05-11
 
 ### Marten primitives + post-DR-4 cleanup (#1312, #1340, #1313, #1284, #1304, #1314, #1341)

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Exarchos ships as a single binary (`exarchos`) with an `mcp` subcommand. Claude 
 
 All four tools support lazy schema loading via `describe`. At startup, only slim descriptions and action enums are registered. Full schemas load on demand.
 
+`exarchos_view`'s telemetry actions accept correlation filter args — `operationId`, `correlationId`, `causationId` — so an agent can scope telemetry to the active workflow. Inside an active dispatch context, the filter auto-defaults to the chain anchor; explicit args always win. See [`docs/runbooks/correlation-filters.md`](docs/runbooks/correlation-filters.md) for the surface.
+
 Every tool input is a Zod-validated discriminated union keyed on `action`. The same `dispatch()` function backs both the MCP transport and the CLI, so `exarchos workflow get --featureId my-feature` from a terminal returns the same result the agent gets.
 
 Structured input over natural language and strict schema validation over loose parsing. One binary with the same behavior whether an agent or a human is driving it.

--- a/docs/designs/2026-05-16-correlation-consumer-wiring.md
+++ b/docs/designs/2026-05-16-correlation-consumer-wiring.md
@@ -1,0 +1,102 @@
+# Correlation Consumer Wiring (#1448)
+
+**Status:** Draft → in-progress
+**Stacked on:** PR #1447 (`feature/correlation-indexed-columns`)
+**Closes:** #1448 (items 2-5; item 1 = #1446 separately tracked)
+**Branch:** `feature/correlation-consumer-wiring`
+
+## Problem
+
+PR #1447 landed the correlation substrate — indexed columns, backend-aware filter API, 6 view actions accept filter args. The *substrate* is wired. The *consumer side* is not:
+
+- Agents inside a dispatch context must manually thread the correlation tuple into every telemetry call.
+- T17 acceptance test synthesizes the second dispatch boundary instead of going through the `next_actions` auto-dispatch handler.
+- The filter surface has no narrative documentation and no CLI flags.
+- The indexed-path and cache-bypass branches have no telemetry — silent regressions would be invisible.
+
+## Approach
+
+Single bundled PR stacked on #1447 covering all four consumer-side concerns. Items are independently shippable but cluster around one user-facing theme ("filter ergonomics work"); one PR avoids 4× shepherding overhead.
+
+### Item 2 — AsyncLocalStorage default for `current_correlation`
+
+**Behavior:**
+- When *none* of `operationId`/`correlationId`/`causationId` are supplied AND a dispatch context is active → default `correlationId` to `getDispatchContext().correlationId`.
+- When *any* filter arg is supplied → explicit-wins; no default injection.
+
+**Why `correlationId`, not `operationId` or `causationId`:** correlationId is the chain-stable anchor — the "workflow scope" view. operationId would scope to the current dispatch boundary only (too narrow); causationId is one-hop (irrelevant for scoping).
+
+**Implementation:**
+- Extract helper `deriveCorrelationFilters(args): ViewQueryFilters` colocated with `ViewQueryFilters` interface in `views/tools.ts`.
+- Replace the 6 inline spread blocks (lines 596-600, 648-652, 749-752, 854-857, 926-929, and `telemetry/tools.ts` 110-113) with a single call to the helper.
+- Helper reads `getDispatchContext()` only when *all three* args are undefined.
+
+**Observability:** Helper emits a `logger.debug` line `{ source: 'ctx-default' | 'explicit' | 'none' }` so operators can tell which path the filter came from.
+
+### Item 3 — T17 integration via real `next_actions` handler
+
+**Investigation required:** locate the `next_actions` auto-dispatch executor. Candidates from grep: `next-actions-from-result.ts` (computes, doesn't dispatch), `views/composite.ts` (envelope wrap), `cli-commands/checkpoint.ts`. The actual auto-dispatch path may be in the CLI or test driver rather than a production handler.
+
+**Two outcomes:**
+1. If a production auto-dispatch handler exists → rewrite T17 to drive through it.
+2. If not (auto-dispatch is caller-driven) → write the test against the *minimal* caller path that callers in production use, and document that the orchestration loop is the integration surface.
+
+### Item 4 — Docs runbook + CLI flag wiring
+
+**New runbook:** `docs/runbooks/correlation-filters.md`
+- Three IDs: operation (dispatch boundary), correlation (chain anchor), causation (one-hop upstream)
+- Filter selection rule: workflow scoping vs cross-workflow rollups
+- MCP call example: `exarchos_view telemetry { correlationId: 'cor-x' }`
+- CLI call example: `exarchos view telemetry --correlation-id cor-x`
+- Note on AsyncLocalStorage default (Item 2)
+
+**CLI flags:** Wire `--operation-id`, `--correlation-id`, `--causation-id` to the 6 telemetry view subcommands in `adapters/cli.ts`. Flag names are kebab-case of the arg keys (INV-5d).
+
+**README:** One paragraph in the observability section linking to the runbook.
+
+### Item 5 — Observability for indexed-path + cache-bypass
+
+**Indexed-path hit counter:** Add `correlationFilteredQueries` counter to `SqliteBackend`. Increment at both filter-clause sites (`queryEvents` L1258-1268 and `queryEventsByType` L1353-1363). Expose via a getter for telemetry/test inspection.
+
+**Cache-bypass counter:** Add `cacheBypasses` counter to `ViewMaterializer` (alongside `cacheHits`/`cacheMisses` at L75-76). Increment from `materializeFiltered` in `views/tools.ts` via a new `materializer.recordBypass()` method. Include `bypasses` in the existing stats getter at L269-274 (so the thrashing-detection payload surfaces it).
+
+## Design invariants check (`/design-invariants`)
+
+| Invariant | Status | Note |
+|-----------|--------|------|
+| **INV-1** event-sourcing integrity | ✓ | All changes are read-side or in-memory measurement. Counters are NOT events; they are aggregates with a getter. No payload mutation. |
+| **INV-2** facade equivalence | ✓ | CLI facade (Item 4) gets the same defaulting behavior because flag-parsed args flow through the same `deriveCorrelationFilters` helper. |
+| **INV-3** basileus-forward | n/a | No cross-tier mediation introduced. AsyncLocalStorage is local-process. |
+| **INV-4** platform-agnosticity | ✓ | Item 4 covers MCP and CLI surfaces symmetrically. Runbook documents both. |
+| **INV-5a** input ergonomics | ✓ | Item 2 IS the input-ergonomics improvement. Explicit-wins preserves caller intent. |
+| **INV-5b** spec-aligned output | ✓ | `exarchos_view describe` already surfaces the three filter fields; Item 2 default is documented in field description. |
+| **INV-5c** Aspire-inspired verbs | n/a | No new verbs introduced. |
+| **INV-5d** action discriminator | ✓ | CLI flags are kebab-case of arg keys (no new discriminator surface). |
+| **INV-6** workflow-agnosticism | ✓ | Skills/playbooks unchanged. |
+
+## Axiom design constraints (`/axiom:design`)
+
+| Dimension | Application |
+|-----------|-------------|
+| **DIM-1** correctness | Item 2 explicit-args-win rule, test-pinned (3 paths: none-supplied-no-ctx, none-supplied-with-ctx, any-supplied-with-ctx). |
+| **DIM-2** observability | Item 5 IS the DIM-2 fix. Both counters exposed via stats getters; debug logs on the ctx-default branch. |
+| **DIM-3** context economy | Single `deriveCorrelationFilters` helper replaces 6 inline spread blocks. Runbook is skimmable (what/when/how structure, not narrative). |
+| **DIM-4** operational resilience | Counters are simple integers, no overflow concern at production rates. AsyncLocalStorage failure mode = no default (degrades gracefully). |
+| **DIM-5** dependency direction | Helper colocated with `ViewQueryFilters`; no new cross-module edges. |
+| **DIM-6** SOLID compliance | Single responsibility for `deriveCorrelationFilters`; open for extension (additional default sources) without modifying handlers. |
+| **DIM-7** reproducibility / determinism | Runbook examples must be runnable verbatim. CLI flags deterministic from arg names. |
+| **DIM-8** test integrity | Item 3 closes the T17 substrate-only hole. Per-item unit tests cover the explicit-wins rule and the bypass-counter assertion. |
+
+## Acceptance criteria
+
+- [ ] **Item 2:** Calling any of the 6 filter-aware view actions inside `runWithDispatchContext(ctx, ...)` with no filter args returns events scoped to `ctx.correlationId`. Passing any explicit filter arg disables the default.
+- [ ] **Item 3:** T17 either drives through a production auto-dispatch handler OR documents (with a code reference) why such a handler does not exist; in the latter case, T17's inline TODO is updated with a permanent justification.
+- [ ] **Item 4:** `docs/runbooks/correlation-filters.md` exists with the four required sections. `exarchos view telemetry --correlation-id cor-x` filters telemetry correctly end-to-end. README has a link to the runbook.
+- [ ] **Item 5:** `SqliteBackend.getStats()` exposes `correlationFilteredQueries`. `ViewMaterializer.getStats()` returns `cacheBypasses`. Counters increment in the integration paths.
+
+## Out of scope
+
+- #1446 (10 other view actions in `TOOL_REGISTRY`) — separately tracked.
+- Cross-tier correlation propagation (basileus / remote MCP) — INV-3 deferred.
+- Filter-aware materializer cache keying (rejected in #1447 design for INV-1 reasons).
+- SSE / push subscriptions for filtered streams (#1440 Opp 5).

--- a/docs/plans/2026-05-16-correlation-consumer-wiring.md
+++ b/docs/plans/2026-05-16-correlation-consumer-wiring.md
@@ -1,0 +1,281 @@
+# Implementation Plan — Correlation Consumer Wiring (#1448)
+
+**Design:** [`docs/designs/2026-05-16-correlation-consumer-wiring.md`](../designs/2026-05-16-correlation-consumer-wiring.md)
+**Feature ID:** `refactor-correlation-consumer-wiring`
+**Issue:** [#1448](https://github.com/lvlup-sw/exarchos/issues/1448) (items 2-5; item 1 = #1446 separately tracked)
+**Stacked on:** PR #1447 (`feature/correlation-indexed-columns`)
+**Branch:** `feature/correlation-consumer-wiring`
+**Date:** 2026-05-16
+**Total tasks:** 9, organized into 4 waves
+
+## Iron Law
+
+> NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST.
+>
+> Every task that modifies production behavior begins with a RED test (assert the new behavior; assert it fails for the right reason). GREEN is the minimum production change to flip RED green. REFACTOR is optional — only if duplication or cohesion suffers.
+
+## Wave overview
+
+| Wave | Theme | Tasks | Parallel? | Depends on |
+|---|---|---|---|---|
+| 1 | Item 5 counters + Item 3 investigation | 1-3 | Yes (all 3 parallel — no shared files) | — |
+| 2 | Item 2 — AsyncLocalStorage default | 4-5 | Sequential chain (helper → handler refactor) | — (parallel with Wave 1) |
+| 3 | Item 4 — CLI flags + runbook + README | 6-8 | Two parallel groups (flag wiring vs docs) | Wave 2 (helper exists for CLI to reuse) |
+| 4 | Item 3 — T17 rewrite | 9 | — | Wave 1 Task 3 outcome |
+
+Branch strategy: subagent worktrees branch from `feature/correlation-consumer-wiring` (per `feedback_subagent_nested_worktrees`). Each task lands on the integration branch before the next dependent wave begins.
+
+**Critical:** Waves 1 + 2 + 3 must not race for `views/tools.ts`. Wave 1 Task 1 touches `views/tools.ts` (the `materializeFiltered` call site). Wave 2 Tasks 4-5 also touch `views/tools.ts` (the 6 inline spread blocks). **Serialize:** Wave 1 Task 1 → Wave 2 Tasks 4-5. Wave 1 Tasks 2-3 can run parallel with anything.
+
+---
+
+## Wave 1 — Item 5 counters + Item 3 investigation
+
+### Task 1: `cacheBypasses` counter in `ViewMaterializer`
+
+**Phase:** RED → GREEN
+
+1. **[RED]** Write test in `servers/exarchos-mcp/src/views/materializer.test.ts`:
+   - `Materializer_recordBypass_IncrementsCacheBypassesCounter`
+   - Construct a materializer, call `materializer.recordBypass()` 3 times, assert `materializer.getStats().bypasses === 3`. Also assert `hits` and `misses` are untouched.
+   - Expected: RED — `recordBypass` method does not exist; `bypasses` is not in stats.
+
+2. **[GREEN]** In `servers/exarchos-mcp/src/views/materializer.ts`:
+   - Add `private cacheBypasses = 0;` next to `cacheHits` / `cacheMisses` (L75-76).
+   - Add `recordBypass(): void { this.cacheBypasses++; }` method.
+   - Extend `getStats()` (L269-274) to return `bypasses: this.cacheBypasses` and include it in the total denominator for `bypassRate`.
+
+3. **[REFACTOR]** Wire the call site: in `servers/exarchos-mcp/src/views/tools.ts`, `materializeFiltered` (L221-235), call `materializer.recordBypass()` after `getProjection` succeeds, before the fold loop. **Coordination:** this is the only `views/tools.ts` touch in Wave 1; Wave 2 must serialize after this lands.
+
+4. **[GREEN]** Update the test to assert end-to-end: call `materializeFiltered(materializer, viewName, [])` and verify `getStats().bypasses === 1`.
+
+**Files:** `views/materializer.ts`, `views/materializer.test.ts`, `views/tools.ts` (`materializeFiltered` call only)
+**Dependencies:** None
+**Parallelizable:** With Tasks 2-3 (different files except for the small `views/tools.ts` touch). Wave 2 Tasks 4-5 must wait on this.
+
+---
+
+### Task 2: `correlationFilteredQueries` counter in `SqliteBackend`
+
+**Phase:** RED → GREEN
+
+1. **[RED]** Write test in `servers/exarchos-mcp/src/storage/sqlite-backend.test.ts`:
+   - `Sqlite_queryEvents_WithCorrelationFilter_IncrementsIndexedPathCounter`
+   - Initialize a `SqliteBackend`, insert a few events, call `backend.queryEvents(streamId, { correlationId: 'x' })` 3 times and `backend.queryEvents(streamId, {})` once (no filter). Assert `backend.getStats().correlationFilteredQueries === 3`.
+   - Also: `Sqlite_queryEventsByType_WithCorrelationFilter_IncrementsIndexedPathCounter` mirrors the same pattern via `queryEventsByType`.
+   - Expected: RED — counter does not exist.
+
+2. **[GREEN]** In `servers/exarchos-mcp/src/storage/sqlite-backend.ts`:
+   - Add `private correlationFilteredQueries = 0;` to the `SqliteBackend` class fields.
+   - In `queryEvents` (L1258-1268 filter-clause block) and `queryEventsByType` (L1353-1363 filter-clause block), increment when any of the three correlation filter fields is supplied. **Important:** increment once per query, not per clause appended (otherwise a query with all three filters would triple-count).
+   - Extend `getStats()` (or add one if it doesn't exist — check the class API) to return `correlationFilteredQueries`.
+
+3. **[REFACTOR]** Inspect: does `SqliteBackend` already expose a stats getter? If not, add one that returns at least `{ correlationFilteredQueries }`. Match the shape of the existing `ViewMaterializer.getStats()` for consistency.
+
+**Files:** `storage/sqlite-backend.ts`, `storage/sqlite-backend.test.ts`
+**Dependencies:** None
+**Parallelizable:** Yes (no overlap with Tasks 1, 3, or Wave 2/3/4).
+
+---
+
+### Task 3: Investigation — does a production `next_actions` auto-dispatch handler exist?
+
+**Phase:** Investigation (no production code change in this task; outcome feeds Task 9).
+
+1. **[INVESTIGATE]** Trace from a `ToolResult` carrying `next_actions: [...]` to wherever the dispatcher *executes* one of those actions in production (NOT in a test driver). Candidates to inspect:
+   - `servers/exarchos-mcp/src/next-actions-from-result.ts` (already known: computes only).
+   - `servers/exarchos-mcp/src/views/composite.ts` (envelope wrap).
+   - `servers/exarchos-mcp/src/adapters/cli.ts` (CLI driver).
+   - `servers/exarchos-mcp/src/cli-commands/checkpoint.ts` (orchestrator loop?).
+   - Grep `next_actions` callsites that are NOT field assignments — i.e., reads that feed a dispatcher call.
+
+2. **[DECISION]** Two outcomes:
+   - **(A) Production handler exists** — record file path + entry function in the task result. Task 9 then drives T17 through it.
+   - **(B) No production handler; auto-dispatch is caller-driven** (orchestrator harness or CLI loop reads `next_actions` and dispatches one-shot). Record evidence (the grep results, the orchestrator file paths, the abstraction boundary). Task 9 then becomes a documentation-only update to T17's inline TODO with a permanent justification + reference to where production auto-dispatch *would* live if added.
+
+3. **[OUTPUT]** Write the investigation result as the task's `evidence` field. Subsequent task (Task 9) reads this to choose its approach.
+
+**Files:** read-only investigation
+**Dependencies:** None
+**Parallelizable:** Yes (read-only).
+
+---
+
+## Wave 2 — Item 2: AsyncLocalStorage default for `current_correlation`
+
+### Task 4: `deriveCorrelationFilters` helper
+
+**Phase:** RED → GREEN
+
+1. **[RED]** Write test in `servers/exarchos-mcp/src/views/tools.test.ts` (or a new `deriveCorrelationFilters.test.ts` colocated with the helper):
+   - `DeriveCorrelationFilters_ExplicitArgs_PassesThroughUnchanged` — supply `{ correlationId: 'cor-x' }`, no dispatch context active, assert returned `{ correlationId: 'cor-x' }`.
+   - `DeriveCorrelationFilters_NoArgsNoContext_ReturnsEmpty` — supply `{}`, no dispatch context active, assert `{}`.
+   - `DeriveCorrelationFilters_NoArgsWithContext_DefaultsCorrelationId` — supply `{}` inside `runWithDispatchContext({ operationId, correlationId: 'ctx-cor', causationId }, ...)`, assert returned `{ correlationId: 'ctx-cor' }`.
+   - `DeriveCorrelationFilters_AnyExplicitArg_DoesNotDefault` — supply `{ operationId: 'op-x' }` inside `runWithDispatchContext(...)`, assert returned `{ operationId: 'op-x' }` — NO `correlationId` injection.
+   - `DeriveCorrelationFilters_NoArgsWithContext_LogsCtxDefault` — verify debug log line emitted with `{ source: 'ctx-default' }` (spy on `logger.debug`).
+
+2. **[GREEN]** Add to `servers/exarchos-mcp/src/views/tools.ts` (next to `ViewQueryFilters` interface, L167-184):
+   ```typescript
+   export function deriveCorrelationFilters(args: {
+     operationId?: string;
+     correlationId?: string;
+     causationId?: string;
+   }): ViewQueryFilters {
+     const explicit: ViewQueryFilters = {
+       ...(args.operationId !== undefined ? { operationId: args.operationId } : {}),
+       ...(args.correlationId !== undefined ? { correlationId: args.correlationId } : {}),
+       ...(args.causationId !== undefined ? { causationId: args.causationId } : {}),
+     };
+     if (Object.keys(explicit).length > 0) {
+       return explicit;
+     }
+     const ctx = getDispatchContext();
+     if (ctx) {
+       logger.debug({ source: 'ctx-default', correlationId: ctx.correlationId }, 'deriveCorrelationFilters: defaulted to active dispatch context');
+       return { correlationId: ctx.correlationId };
+     }
+     return {};
+   }
+   ```
+   - Import `getDispatchContext` from `'../dispatch/dispatch-context.js'`.
+
+**Files:** `views/tools.ts`, `views/tools.test.ts` (or new test file)
+**Dependencies:** None (parallel with Wave 1)
+**Parallelizable:** Can run parallel with Wave 1, but Task 5 (handler refactor) MUST serialize after Wave 1 Task 1 to avoid `views/tools.ts` conflicts.
+
+---
+
+### Task 5: Refactor the 6 handlers + telemetry handler to use `deriveCorrelationFilters`
+
+**Phase:** GREEN-only (Task 4's helper already covers the behavior; this is mechanical substitution).
+
+1. **[RED-OPTIONAL]** Add one integration test that exercises the end-to-end ctx-default path through a handler:
+   - `HandleViewTelemetry_NoArgsInsideDispatch_DefaultsToCtxCorrelationId`
+   - Set up an EventStore with events stamped under correlation `cor-X`. Wrap a call to `handleViewTelemetry({}, ...)` in `runWithDispatchContext({ correlationId: 'cor-X', ... }, ...)`. Assert the returned telemetry filters out events that don't match cor-X.
+   - Mirror once for one other handler (e.g., `handleViewCodeQuality`) to pin the cross-handler invariance.
+
+2. **[GREEN]** Replace the inline filter-spread blocks at 6 sites with `const correlationFilters = deriveCorrelationFilters(args);`:
+   - `views/tools.ts:596-600` (`handleViewDelegationTimeline`)
+   - `views/tools.ts:648-652` (`handleViewCodeQuality`)
+   - `views/tools.ts:749-752` (`handleViewEvalResults`)
+   - `views/tools.ts:854-857` (`handleViewQualityCorrelation`)
+   - `views/tools.ts:926-929` (`handleViewQualityAttribution`)
+   - `telemetry/tools.ts:110-113` (`handleViewTelemetry`)
+   - Each becomes a single line. The rest of each handler (the `hasCorrelationFilters(correlationFilters)` branch, `materializeFiltered` call, etc.) is unchanged.
+
+3. **[GREEN]** Re-run full suite — no test should regress; the existing 6 handler tests pass identically (explicit-args-win means existing callers see no change).
+
+**Files:** `views/tools.ts` (6 inline blocks), `telemetry/tools.ts` (1 inline block), one integration test file
+**Dependencies:** Task 4 (helper exists). Serialize with Wave 1 Task 1.
+**Parallelizable:** No (single-author refactor).
+
+---
+
+## Wave 3 — Item 4: CLI flags + runbook + README
+
+### Task 6: Wire `--operation-id` / `--correlation-id` / `--causation-id` CLI flags
+
+**Phase:** RED → GREEN
+
+1. **[INVESTIGATE]** In `servers/exarchos-mcp/src/adapters/cli.ts` (1148 lines), locate the subcommand wiring for the 6 telemetry view actions. Identify the flag-definition surface (likely a Commander or yargs invocation; or a manual `process.argv` parse). Record the pattern in the task's working notes.
+
+2. **[RED]** Add CLI flag-parsing tests (file likely exists — search for `cli.test.ts` or similar):
+   - `Cli_ViewTelemetry_CorrelationIdFlag_ProducesArg` — invoke the CLI with `view telemetry --correlation-id cor-x`, assert the parsed args object contains `correlationId: 'cor-x'`.
+   - Mirror for `--operation-id` and `--causation-id`.
+   - Mirror for one other telemetry action (e.g., `delegation_timeline`) to pin the flag is wired symmetrically.
+
+3. **[GREEN]** Add the three flag definitions to each of the 6 telemetry view subcommands. Use kebab-case flag names → camelCase arg keys.
+
+4. **[GREEN]** Run an end-to-end smoke: spin up an in-process EventStore with a stamped event, invoke the CLI's `view telemetry --correlation-id cor-x`, assert the output is filtered. This exercises both the flag parser AND the `deriveCorrelationFilters` helper from Task 4 (explicit-args-win path).
+
+**Files:** `adapters/cli.ts`, `adapters/cli.test.ts` (or equivalent)
+**Dependencies:** Task 4 (helper) — Task 6's smoke test confirms the integration. Strictly speaking, CLI flag parsing doesn't need the helper; but the end-to-end smoke does.
+**Parallelizable:** With Tasks 7-8 (different files).
+
+---
+
+### Task 7: Runbook — `docs/runbooks/correlation-filters.md`
+
+**Phase:** Documentation (no production code).
+
+1. Create `docs/runbooks/correlation-filters.md` covering:
+   - **What:** definitions of the three IDs (operation = dispatch boundary, correlation = chain anchor, causation = one-hop upstream).
+   - **When:** filter selection rule (workflow scoping with `correlationId`; cross-workflow rollup = no filter; one-hop tracing = `causationId`).
+   - **How (MCP):** example call `exarchos_view telemetry { correlationId: 'cor-x' }` with sample response shape.
+   - **How (CLI):** example `exarchos view telemetry --correlation-id cor-x` with sample output.
+   - **AsyncLocalStorage default:** brief note that inside an active dispatch, omitting all three filters auto-defaults `correlationId` to the active dispatch's correlationId. Link to `dispatch-context.ts` for the primitive.
+
+2. **Verification:** All command examples must be copy-pasteable and produce a valid response shape against the current API. Author runs each example manually before committing.
+
+**Files:** `docs/runbooks/correlation-filters.md` (new)
+**Dependencies:** None for content. Reference to AsyncLocalStorage section is accurate once Task 4-5 land.
+**Parallelizable:** With Task 6, 8.
+
+---
+
+### Task 8: README — add observability section link to runbook
+
+**Phase:** Documentation.
+
+1. In `README.md`, find the "Observability" or equivalent section. Add a brief paragraph (2-3 sentences) explaining that telemetry view actions support correlation filters and link to `docs/runbooks/correlation-filters.md`.
+
+2. If no observability section exists, place under the closest relevant section (likely the MCP server feature list or telemetry mention).
+
+**Files:** `README.md`
+**Dependencies:** Task 7 (runbook must exist at the linked path).
+**Parallelizable:** With Task 6 (different files).
+
+---
+
+## Wave 4 — Item 3: T17 rewrite
+
+### Task 9: Convert T17 based on Task 3 outcome
+
+**Phase:** Depends on Task 3 evidence.
+
+**Branch A (production auto-dispatch handler exists):**
+
+1. **[RED]** Update `T17_CausationChain_AutoDispatch_FromNextActionsHint_CarriesCausationIdReferencingUpstreamEvent` in `correlation-acceptance.test.ts`:
+   - Remove the `mintDispatchContext` synthesis of the second boundary.
+   - Construct a `ToolResult` that the production handler treats as the trigger (carrying `next_actions` hint with the parent eventId as causation).
+   - Invoke the production handler.
+   - Assert the resulting child dispatch's events carry `causationId === parentEventId` and `correlationId === parentCorrelationId`.
+
+2. **[GREEN-IF-RED]** If the test goes RED, the production handler is the genuine causation-threading bug. Fix the handler to thread `causationId` from the upstream event id into the child `mintDispatchContext` call.
+
+**Branch B (no production auto-dispatch handler):**
+
+1. Replace the T17 inline TODO at the test's describe block with a permanent justification:
+   - State that auto-dispatch is caller-driven in the current architecture (orchestrator harness, CLI loop, or test driver) and therefore the test's `mintDispatchContext` synthesis IS the integration surface.
+   - Reference the investigation evidence from Task 3 by file path.
+   - Link to a (new, optional) issue for "production-side `next_actions` auto-dispatch handler" if one is justified architecturally.
+
+2. Add a smaller test that DOES cover what we can: simulate the caller path (the orchestrator's `next_actions` consumption code, if present at all) and assert `causationId` threading there.
+
+**Files:** `__tests__/correlation-acceptance.test.ts`; possibly the auto-dispatch handler source file under Branch A.
+**Dependencies:** Task 3 evidence.
+**Parallelizable:** No (depends on Wave 1 Task 3).
+
+---
+
+## Validation gates (post-task)
+
+After each task lands on the integration branch, the orchestrator runs:
+
+- `check_tdd_compliance` — verifies the RED commit landed before the GREEN commit (Tasks 1, 2, 4, 5, 6, 9 branch A).
+- `check_static_analysis` — typecheck + lint clean.
+- Co-located test suite passes for the touched files.
+
+Before final synthesis (PR creation):
+
+- `cd servers/exarchos-mcp && npm run test:run` — full project sweep.
+- `npm run typecheck` — root typecheck.
+- Verify `feature/correlation-consumer-wiring` rebases cleanly on `feature/correlation-indexed-columns` (no drift from PR #1447).
+
+## PR shape
+
+Single squash merge of `feature/correlation-consumer-wiring` → `feature/correlation-indexed-columns`. When PR #1447 merges to `main`, GitHub auto-retargets this PR to `main`.
+
+Title: `feat(correlation): wire consumer side of correlation tuple filters (#1448)`
+
+Closes #1448 (items 2-5).

--- a/docs/runbooks/correlation-filters.md
+++ b/docs/runbooks/correlation-filters.md
@@ -1,0 +1,117 @@
+# Correlation Filters
+
+Reference for `operationId`, `correlationId`, and `causationId` filter args on the six telemetry view actions.
+
+---
+
+## What are the three IDs?
+
+| ID | Scope | Notes |
+|----|-------|-------|
+| `correlationId` | Chain-stable — survives across dispatch boundaries unchanged | The anchor for "this entire workflow." When a chain root is minted, `correlationId` self-binds to `operationId`. |
+| `operationId` | Single dispatch boundary crossing | A fresh UUID is minted on every `dispatch()` call. Idempotent retries reuse the same value via `AppendOptions.idempotencyKey`. |
+| `causationId` | One hop only | The upstream event id that triggered the current event. Undefined for chain roots. |
+
+Source of truth: `servers/exarchos-mcp/src/dispatch/dispatch-context.ts`.
+
+---
+
+## When to filter
+
+| Goal | Filter by |
+|------|-----------|
+| Telemetry scoped to one whole workflow (across dispatch boundaries) | `correlationId` |
+| Telemetry for one specific dispatch call only | `operationId` |
+| Trace what caused a specific event one hop back | `causationId` |
+| Cross-workflow rollups (e.g., all gate pass rates last week) | No filter |
+
+---
+
+## How — MCP
+
+```
+exarchos_view({
+  view: "telemetry",
+  correlationId: "cor-workflow-7a3f"
+})
+```
+
+Successful response shape (abbreviated):
+
+```json
+{
+  "success": true,
+  "data": {
+    "session": {
+      "start": "2026-05-16T10:00:00.000Z",
+      "totalInvocations": 42,
+      "totalTokens": 18300
+    },
+    "tools": [
+      { "tool": "exarchos_workflow", "invocations": 12, "errors": 0 }
+    ],
+    "hints": []
+  }
+}
+```
+
+The response reflects only events whose `correlationId` matches the supplied value.
+
+---
+
+## How — CLI
+
+```bash
+exarchos view telemetry --correlation-id cor-workflow-7a3f
+```
+
+Filter by `operationId`:
+
+```bash
+exarchos view telemetry --operation-id op-a1b2c3d4
+```
+
+Filter by `causationId`:
+
+```bash
+exarchos view telemetry --causation-id evt-upstream-99
+```
+
+Terminal output shows the same `session` + `tools` structure as the MCP response, rendered as a table.
+
+> Note: the `--operation-id`, `--correlation-id`, and `--causation-id` flags are wired in `adapters/cli.ts` (Task 6, #1448 item 4). This runbook documents the stable contract.
+
+---
+
+## AsyncLocalStorage default
+
+When an agent runs inside a `runWithDispatchContext` scope and calls a telemetry view action **without supplying any filter arg**, the helper `deriveCorrelationFilters` (in `views/tools.ts`) automatically defaults `correlationId` to the active dispatch context's `correlationId`.
+
+This is the ergonomic "show me telemetry for the workflow I'm currently in" behavior — no manual threading required.
+
+Rules:
+
+- **Explicit args always win.** Supplying any of `operationId`, `correlationId`, or `causationId` disables the default entirely.
+- **No active context → no default.** An uncovered call site returns an unfiltered result.
+- **Observable.** The default path emits a debug log entry: `{ source: 'ctx-default', correlationId: '...' }`. Explicit args emit `{ source: 'explicit' }`. No-filter emits `{ source: 'none' }`.
+
+---
+
+## Supported view actions
+
+All six actions accept the same three filter args:
+
+| Action | Description |
+|--------|-------------|
+| `telemetry` | Aggregated per-tool metrics and token usage |
+| `delegation_timeline` | Subagent dispatch timeline |
+| `code_quality` | Quality gate pass rates and regressions |
+| `eval_results` | Eval suite outcomes and calibration records |
+| `quality_correlation` | Gate-to-skill correlation signals |
+| `quality_attribution` | Finding attribution by skill |
+
+---
+
+## Out of scope
+
+Cross-tier correlation propagation (basileus / remote MCP) is deferred per INV-3 of the correlation consumer wiring design. The ten other view actions (`pipeline`, `tasks`, and others in `TOOL_REGISTRY`) do not yet accept correlation filters; they are tracked under #1446.

--- a/servers/exarchos-mcp/src/__tests__/correlation-acceptance.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/correlation-acceptance.test.ts
@@ -163,16 +163,34 @@ describe('#1291 acceptance — correlation propagation across a wave', () => {
 // ─── Task 17 ───────────────────────────────────────────────────────────────
 
 describe('#1291 acceptance — causation chain across auto-dispatch', () => {
-  // Coverage scope: this test is SUBSTRATE-ONLY. It pins that the storage
-  // + filter substrate correctly carries causationId across two dispatch
-  // boundaries. It does NOT exercise the orchestrator's next_actions
-  // auto-dispatch handler — the second dispatch is synthesized manually
-  // here rather than triggered by the orchestrator following a hint.
+  // T17 — substrate-only by design.
   //
-  // A future integration test should wire the actual auto-dispatch path
-  // (orchestrator.process_next_actions → mintDispatchContext + run) so
-  // the causationId thread is verified end-to-end through the handler
-  // layer. Tracked as a follow-up under #1437/#1441 review backlog.
+  // T17 verifies the storage substrate's ability to carry `causationId`
+  // across two dispatch boundaries. The second dispatch is synthesized
+  // manually via `mintDispatchContext` + `runWithDispatchContext` because
+  // NO PRODUCTION AUTO-DISPATCH HANDLER EXISTS to drive a follow-up from a
+  // `ToolResult.next_actions[]` hint. Both `adapters/cli.ts`
+  // (lines 557-596) and `adapters/mcp.ts` (lines 354-389) are strictly
+  // one-shot: they dispatch once, return the envelope, and exit. No code in
+  // `servers/exarchos-mcp/src/` reads `result.next_actions` and invokes a
+  // follow-up dispatcher.
+  //
+  // The HATEOAS follow-up pattern is documented as aspirational at
+  // `dispatch/dispatch-context.ts:12-19` but unimplemented. The
+  // orchestrator / agent harness (Claude Code itself, for the agent-loop
+  // use case) is the consumer of `next_actions`; T17's manual synthesis
+  // models that caller-driven path AT THE SUBSTRATE BOUNDARY.
+  //
+  // If a production auto-dispatch handler is ever added (e.g., a tight
+  // orchestration loop inside the MCP server), extend this file with a
+  // parallel `T17_Integration_*` variant — the substrate test below
+  // remains load-bearing and distinct.
+  //
+  // See `docs/plans/2026-05-16-correlation-consumer-wiring.md` Wave 1
+  // Task 3 investigation (Branch B) for the search evidence; the
+  // companion field-integrity regression guard for the one-shot pipeline
+  // lives in `src/adapters/cli-format.test.ts` under
+  // `Cli_OneShotDispatch_PreservesNextActionsField`.
   it('AutoDispatch_FromNextActionsHint_CarriesCausationIdReferencingUpstreamEvent', async () => {
     // Phase 1 — upstream dispatch. Emit an event; capture its
     // eventId. This event is the "upstream" that a `next_actions` hint

--- a/servers/exarchos-mcp/src/adapters/cli-format.test.ts
+++ b/servers/exarchos-mcp/src/adapters/cli-format.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { prettyPrint, printError, toCliResult } from './cli-format.js';
 import { toEnvelope } from '../format.js';
-import type { ToolResult } from '../format.js';
+import type { Envelope, ToolResult } from '../format.js';
+import type { NextAction } from '../next-action.js';
 
 describe('prettyPrint', () => {
   let stdoutSpy: ReturnType<typeof vi.spyOn>;
@@ -314,6 +315,70 @@ describe('toCliResult', () => {
 
     const stdoutOutput = stdoutSpy.mock.calls.map(c => c[0]).join('');
     expect(stdoutOutput).toBe(JSON.stringify(env, null, 2) + '\n');
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  // ─── #1448 item 3 — next_actions field integrity through one-shot dispatch ─
+  //
+  // Regression guard pinning that `next_actions` survives the one-shot
+  // dispatch pipeline (`toEnvelope` → `toCliResult` → JSON on stdout). The
+  // T3 investigation (Branch B, see
+  // `docs/plans/2026-05-16-correlation-consumer-wiring.md` Wave 1 Task 3)
+  // established that NO production auto-dispatch handler exists; the
+  // CLI / MCP adapter is the one-shot exit point and the caller
+  // (orchestrator / agent harness) is the next_actions consumer. This
+  // test pins the field-integrity contract at the caller boundary so
+  // future refactors of `emitResult` / `toCliResult` / `toEnvelope`
+  // cannot silently drop the hints. It is NOT an integration test of
+  // auto-dispatch (which doesn't exist) — assertions are limited to
+  // field presence and shape, not behavior.
+  it('Cli_OneShotDispatch_PreservesNextActionsField', () => {
+    const actions: NextAction[] = [
+      {
+        verb: 'merge_orchestrate',
+        reason: 'worktree-bearing task.completed auto-detour',
+        idempotencyKey: 'p2-detour:merge_orchestrate:001',
+      },
+      {
+        verb: 'advance_phase',
+        reason: 'gate passed',
+        validTargets: ['delegate'],
+        hint: 'orchestrator may auto-advance',
+      },
+    ];
+    const source = {
+      success: true,
+      data: { phase: 'plan' },
+      next_actions: actions,
+      _meta: { featureId: 'feat-1' },
+      _perf: { ms: 7, bytes: 32, tokens: 8 },
+    } as unknown as ToolResult;
+
+    const env = toEnvelope(source);
+    // Stage 1 — envelope boundary preserves the hints intact (the same
+    // contract `toEnvelope_SuccessWithNextActions_PreservesAffordances`
+    // pins, repeated here so a failure isolates which seam regressed).
+    expect(env.success).toBe(true);
+    if (env.success) {
+      expect((env as Envelope<unknown>).next_actions).toEqual(actions);
+    }
+
+    toCliResult(env, 'json');
+
+    // Stage 2 — the one-shot CLI emit path writes the JSON envelope to
+    // stdout with `next_actions` carried verbatim. Parse the actual
+    // byte-output rather than re-inspecting `env` so the assertion pins
+    // the on-the-wire contract a caller sees.
+    const stdoutOutput = stdoutSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stdoutOutput).toBe(JSON.stringify(env, null, 2) + '\n');
+    const parsed = JSON.parse(stdoutOutput.trim()) as {
+      success: boolean;
+      next_actions: NextAction[];
+    };
+    expect(parsed.success).toBe(true);
+    expect(parsed.next_actions).toEqual(actions);
+    // No stderr writes on the one-shot success path — diagnostics roll
+    // into the envelope under json mode.
     expect(stderrSpy).not.toHaveBeenCalled();
   });
 

--- a/servers/exarchos-mcp/src/adapters/cli.correlation-flags.test.ts
+++ b/servers/exarchos-mcp/src/adapters/cli.correlation-flags.test.ts
@@ -1,0 +1,316 @@
+// Wave 3 Task 6 (#1448 item 4) — CLI surface for correlation filters.
+//
+// PR #1447 added `operationId / correlationId / causationId` to the Zod
+// schemas of all 6 telemetry view actions (`telemetry`,
+// `delegation_timeline`, `code_quality`, `eval_results`,
+// `quality_correlation`, `quality_attribution`). The CLI layer in
+// `adapters/cli.ts` generates flags from each action's schema via
+// `addFlagsFromSchema` (schema-to-flags.ts), which kebab-cases optional
+// string fields. That means the three filter flags should already be
+// reachable from the command line — but no test pinned that contract,
+// so a future schema refactor (e.g. moving correlation fields into a
+// `.merge(...)` mixin or wrapping them in a transform) could silently
+// drop the CLI surface without any test failure.
+//
+// These tests lock the surface in three layers:
+//   1. Per-subcommand-per-flag dispatch-args assertions (18 tests:
+//      3 flags × 6 subcommands) — the strongest cross-layer guarantee
+//      short of subprocess invocation.
+//   2. A Commander-program introspection sweep — fails fast and with a
+//      clearer message if the flags vanish from the option list.
+//   3. One end-to-end smoke that runs the CLI parse with the real
+//      dispatch + a real in-process EventStore and asserts the response
+//      reflects the correlation filter. This is the cross-layer
+//      assertion the task plan calls for: flag → handler → helper →
+//      EventStore filter, end to end.
+//
+// INV-4 (platform-agnosticity): the CLI surface must mirror the MCP
+// surface. INV-5d (action discriminator): the flag names are the
+// kebab-case of the camelCase arg keys.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ToolResult } from '../format.js';
+import type { DispatchContext } from '../core/dispatch.js';
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+// Default mock for the unit tests below. The end-to-end smoke test in the
+// last describe block UN-mocks dispatch (vi.doUnmock) so it can exercise
+// the real handler chain against a real EventStore.
+vi.mock('../core/dispatch.js', () => ({
+  dispatch: vi.fn<(tool: string, args: Record<string, unknown>, ctx: unknown) => Promise<ToolResult>>(
+    async () => ({ success: true, data: { mocked: true } }),
+  ),
+}));
+
+// Mirror the cli.test.ts mock — avoids real stdout side effects from the
+// pretty/table paths while letting --json still emit the envelope for any
+// assertion that wants to inspect stdout.
+vi.mock('./cli-format.js', () => ({
+  prettyPrint: vi.fn(),
+  printError: vi.fn(),
+  toCliResult: vi.fn((env: unknown, format: string) => {
+    if (format === 'json') {
+      process.stdout.write(JSON.stringify(env, null, 2) + '\n');
+    }
+  }),
+}));
+
+import { buildCli } from './cli.js';
+import { dispatch } from '../core/dispatch.js';
+
+function createTestContext(): DispatchContext {
+  return {
+    stateDir: '/tmp/test-state',
+    eventStore: {} as DispatchContext['eventStore'],
+    enableTelemetry: false,
+  };
+}
+
+// The 6 telemetry view subcommands PR #1447 wired correlation filters on.
+// The CLI alias for `exarchos_view` is `vw`.
+const VIEW_SUBCOMMANDS = [
+  'telemetry',
+  'delegation_timeline',
+  'code_quality',
+  'eval_results',
+  'quality_correlation',
+  'quality_attribution',
+] as const;
+
+// Three kebab→camel flag pairs. INV-5d: the flag name MUST be the
+// kebab-case of the arg key so the MCP and CLI surfaces are 1:1.
+const CORRELATION_FLAGS: ReadonlyArray<{
+  flag: `--${string}`;
+  argKey: 'operationId' | 'correlationId' | 'causationId';
+  value: string;
+}> = [
+  { flag: '--operation-id', argKey: 'operationId', value: 'op-xyz' },
+  { flag: '--correlation-id', argKey: 'correlationId', value: 'cor-abc' },
+  { flag: '--causation-id', argKey: 'causationId', value: 'cau-def' },
+];
+
+// ─── Layer 1: Per-subcommand × per-flag dispatch-args wiring ────────────────
+
+describe('CLI correlation filter flags — dispatch-args wiring (#1448 item 4)', () => {
+  let ctx: DispatchContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = createTestContext();
+  });
+
+  for (const subcommand of VIEW_SUBCOMMANDS) {
+    for (const { flag, argKey, value } of CORRELATION_FLAGS) {
+      // PascalCase test name embeds both axes so a CI failure points
+      // directly at the broken cell (subcommand × flag).
+      const subcommandPascal = subcommand
+        .split('_')
+        .map((s) => s[0].toUpperCase() + s.slice(1))
+        .join('');
+      const argKeyPascal = argKey[0].toUpperCase() + argKey.slice(1);
+
+      it(`Cli_View${subcommandPascal}_${argKeyPascal}Flag_ProducesCamelCaseArg`, async () => {
+        const program = buildCli(ctx);
+
+        await program.parseAsync([
+          'node',
+          'exarchos',
+          'vw',
+          subcommand,
+          flag,
+          value,
+          '--json',
+        ]);
+
+        // Assert the auto-generated kebab→camel coercion produced the
+        // exact arg key the MCP-side handler reads (INV-4 facade
+        // equivalence + INV-5d action discriminator). If anyone ever
+        // removes the correlation fields from the schemas, or breaks
+        // the `addFlagsFromSchema` auto-derivation for optional strings,
+        // dispatch would either not be called or be called without
+        // `argKey`, and this assertion would fail.
+        expect(dispatch).toHaveBeenCalledWith(
+          'exarchos_view',
+          expect.objectContaining({
+            action: subcommand,
+            [argKey]: value,
+          }),
+          ctx,
+        );
+      });
+    }
+  }
+});
+
+// ─── Layer 2: Commander introspection sweep ─────────────────────────────────
+//
+// A safety net for diagnosing why the dispatch-args tests above would fail:
+// if the option simply isn't registered on the Commander subcommand at all,
+// `parseAsync` would emit an `unknown option` Commander error (not call
+// dispatch), and the layer-1 message could be confusing ("expected
+// dispatch to have been called"). This layer asserts on the option list
+// directly so the failure says exactly what's missing.
+
+describe('CLI correlation filter flags — Commander option registration', () => {
+  it('Cli_AllViewSubcommands_RegisterAllThreeCorrelationFlags', () => {
+    const program = buildCli(createTestContext());
+    const viewCmd = program.commands.find((c) => c.name() === 'vw');
+    expect(viewCmd).toBeDefined();
+
+    const missing: string[] = [];
+
+    for (const subcommand of VIEW_SUBCOMMANDS) {
+      const subCmd = viewCmd!.commands.find((c) => c.name() === subcommand);
+      if (!subCmd) {
+        missing.push(`${subcommand} (subcommand not registered)`);
+        continue;
+      }
+      const optionFlags = subCmd.options.map((o) => o.flags);
+
+      for (const { flag } of CORRELATION_FLAGS) {
+        if (!optionFlags.some((f) => f.includes(flag))) {
+          missing.push(`${subcommand}: missing ${flag}`);
+        }
+      }
+    }
+
+    // Empty array → all 6 subcommands × 3 flags are registered. Non-empty
+    // array surfaces every cell that's broken so the operator doesn't have
+    // to re-run after each fix.
+    expect(missing).toEqual([]);
+  });
+});
+
+// ─── Layer 3: End-to-end smoke (CLI → handler → helper → EventStore) ────────
+//
+// Exercises the FULL chain — `parseAsync` on the real Commander program,
+// real `dispatch`, real `handleViewTelemetry`, real `EventStore` — to
+// confirm the flag's value actually scopes the returned rollup. The unit
+// tests above prove the arg makes it to `dispatch`; this confirms the
+// handler honors it.
+
+describe('CLI correlation filter — end-to-end smoke', () => {
+  let tmpDir: string;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutChunks: string[];
+
+  beforeEach(async () => {
+    // Clear the per-file dispatch mock for this block; we want the REAL
+    // dispatch implementation here.
+    vi.doUnmock('../core/dispatch.js');
+    vi.resetModules();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'exarchos-cli-corr-flag-'));
+    stdoutChunks = [];
+    stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: unknown) => {
+        stdoutChunks.push(String(chunk));
+        return true;
+      });
+  });
+
+  afterEach(async () => {
+    stdoutSpy.mockRestore();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+    // Restore the per-file mock for the next describe block. Vitest
+    // executes describe blocks in source order within a file, but a
+    // beforeEach reset keeps things deterministic regardless.
+    vi.doMock('../core/dispatch.js', async () => {
+      const real = await vi.importActual<typeof import('../core/dispatch.js')>(
+        '../core/dispatch.js',
+      );
+      return real;
+    });
+  });
+
+  it('CliVwTelemetry_CorrelationIdFlag_FiltersTelemetryEventsEndToEnd', async () => {
+    // Late imports so the `vi.doUnmock` above takes effect for this
+    // module subtree. Without re-import, the mocked `dispatch` would
+    // still be wired into the `buildCli` action callback.
+    const { buildCli: buildCliReal } = await import('./cli.js');
+    const { EventStore } = await import('../event-store/store.js');
+
+    const store = new EventStore(tmpDir);
+    const TELEMETRY_STREAM = 'telemetry';
+
+    // GIVEN: one tool.completed event stamped cor-X, one stamped cor-Y.
+    // Pre-Task-5 (or pre-#1437) a no-filter call would fold both.
+    await store.append(TELEMETRY_STREAM, {
+      streamId: TELEMETRY_STREAM,
+      sequence: 1,
+      timestamp: new Date().toISOString(),
+      type: 'tool.completed',
+      operationId: 'op-X',
+      correlationId: 'cor-X',
+      data: {
+        tool: 'tool_X',
+        durationMs: 10,
+        responseBytes: 100,
+        tokenEstimate: 25,
+      },
+      schemaVersion: '1.0',
+    });
+    await store.append(TELEMETRY_STREAM, {
+      streamId: TELEMETRY_STREAM,
+      sequence: 2,
+      timestamp: new Date().toISOString(),
+      type: 'tool.completed',
+      operationId: 'op-Y',
+      correlationId: 'cor-Y',
+      data: {
+        tool: 'tool_Y',
+        durationMs: 50,
+        responseBytes: 500,
+        tokenEstimate: 200,
+      },
+      schemaVersion: '1.0',
+    });
+
+    const ctx: DispatchContext = {
+      stateDir: tmpDir,
+      eventStore: store,
+      enableTelemetry: false,
+    };
+
+    // WHEN: the user runs `exarchos vw telemetry --correlation-id cor-X`.
+    const program = buildCliReal(ctx);
+    await program.parseAsync([
+      'node',
+      'exarchos',
+      'vw',
+      'telemetry',
+      '--correlation-id',
+      'cor-X',
+      '--json',
+    ]);
+
+    // THEN: the envelope on stdout reflects only the cor-X event. We
+    // pluck the JSON envelope, walk down to `data.tools`, and assert
+    // tool_Y was excluded — proving the CLI flag's value reached the
+    // EventStore-side filter.
+    const joined = stdoutChunks.join('');
+    expect(joined).toContain('"success": true');
+
+    // The envelope is pretty-printed JSON; locate the top-level object
+    // by trimming. There may be extra whitespace/newlines around it.
+    const trimmed = joined.trim();
+    const envelope = JSON.parse(trimmed) as {
+      success: boolean;
+      data?: {
+        tools?: Array<{ tool: string; invocations: number }>;
+        session?: { totalInvocations: number };
+      };
+    };
+
+    expect(envelope.success).toBe(true);
+    expect(envelope.data).toBeDefined();
+    const tools = envelope.data!.tools ?? [];
+    // Cross-layer assertion: ONLY tool_X must be present.
+    expect(tools.map((t) => t.tool)).toEqual(['tool_X']);
+    expect(envelope.data!.session?.totalInvocations).toBe(1);
+  });
+});

--- a/servers/exarchos-mcp/src/storage/sqlite-backend.test.ts
+++ b/servers/exarchos-mcp/src/storage/sqlite-backend.test.ts
@@ -1329,3 +1329,70 @@ describe('SqliteBackend queryEvents correlation filters (Wave 4 / #1437)', () =>
     expect(results.every((e) => e.correlationId === 'cor-X')).toBe(true);
   });
 });
+
+// ─── #1448 (Wave 1 / Task 2) — correlationFilteredQueries counter ───────────
+//
+// PR #1447 added the indexed-WHERE fast path on (operation_id, correlation_id,
+// causation_id), but nothing currently distinguishes "indexed-path hit" from
+// "fell back to post-fetch filter" at runtime. The counter below is the
+// observability surface that closes the DIM-2 LOW finding from #1447's audit:
+// a silent index regression (schema change drops the column, future
+// WHERE-builder edit forgets the clause) would otherwise produce correct
+// answers via full-scan, invisible until users notice latency.
+//
+// Counting rule: ONE increment per query, regardless of how many of the three
+// correlation filter fields are supplied. A query with all three filters counts
+// as 1.
+
+describe('SqliteBackend correlationFilteredQueries counter (#1448 Task 2)', () => {
+  let backend: SqliteBackend;
+
+  beforeEach(() => {
+    backend = new SqliteBackend(':memory:');
+    backend.initialize();
+
+    // Seed a couple of stamped events so the queries below have something to
+    // scan past. The counter is independent of result-set size — it advances
+    // whenever the filter-clause block runs, not when rows match.
+    for (let i = 1; i <= 3; i++) {
+      backend.appendEvent('test-stream', makeEvent({
+        streamId: 'test-stream',
+        sequence: i,
+        type: 'workflow.started',
+        operationId: 'op-x',
+        correlationId: 'cor-x',
+        causationId: 'cau-x',
+      }));
+    }
+  });
+
+  afterEach(() => {
+    backend.close();
+  });
+
+  it('Sqlite_queryEvents_WithCorrelationFilter_IncrementsIndexedPathCounter', () => {
+    backend.queryEvents('test-stream', { correlationId: 'cor-x' });
+    backend.queryEvents('test-stream', { operationId: 'op-x' });
+    backend.queryEvents('test-stream', { causationId: 'cau-x' });
+    backend.queryEvents('test-stream', {}); // no correlation filter — must NOT increment
+
+    expect(backend.getStats().correlationFilteredQueries).toBe(3);
+  });
+
+  it('Sqlite_queryEventsByType_WithCorrelationFilter_IncrementsIndexedPathCounter', () => {
+    backend.queryEventsByType('workflow.started', 'test-stream', { correlationId: 'cor-x' });
+    backend.queryEventsByType('workflow.started', 'test-stream', {}); // no filter
+
+    expect(backend.getStats().correlationFilteredQueries).toBe(1);
+  });
+
+  it('Sqlite_queryEvents_WithMultipleFilters_CountsOncePerQuery', () => {
+    backend.queryEvents('test-stream', {
+      operationId: 'op-x',
+      correlationId: 'cor-x',
+      causationId: 'cau-x',
+    });
+
+    expect(backend.getStats().correlationFilteredQueries).toBe(1);
+  });
+});

--- a/servers/exarchos-mcp/src/storage/sqlite-backend.ts
+++ b/servers/exarchos-mcp/src/storage/sqlite-backend.ts
@@ -321,6 +321,21 @@ export class SqliteBackend implements StorageBackend {
   private queryStmtCache: Map<string, Statement> = new Map();
 
   /**
+   * Counter for queries that exercised the indexed-WHERE fast path on the
+   * V6 correlation columns (operation_id, correlation_id, causation_id).
+   *
+   * Incremented ONCE per query when any of the three correlation filter
+   * fields is supplied — NOT once per clause appended, so a caller passing
+   * all three filters still counts as 1.
+   *
+   * Exposed via {@link getStats}. Closes the DIM-2 LOW finding from PR
+   * #1447's axiom audit (#1448 item 5): without this counter a silent
+   * index regression would produce correct answers via full-scan and stay
+   * invisible until users notice the latency.
+   */
+  private correlationFilteredQueries = 0;
+
+  /**
    * Clock used for outbox retry-eligibility checks. Injectable so tests can
    * advance time without sleeping for real-world backoff windows
    * (`Math.pow(2, attempts) * 1000` ms — up to 32 s before dead-lettering).
@@ -1255,6 +1270,17 @@ export class SqliteBackend implements StorageBackend {
     // SQL string as the cache key, so adding/omitting these clauses
     // produces distinct cache entries automatically — no manual cache
     // bookkeeping required.
+    //
+    // #1448 item 5 — bump the correlationFilteredQueries counter once per
+    // query (not once per clause) so silent index regressions surface via
+    // `getStats()` rather than via user-visible latency.
+    if (
+      filters?.operationId !== undefined ||
+      filters?.correlationId !== undefined ||
+      filters?.causationId !== undefined
+    ) {
+      this.correlationFilteredQueries++;
+    }
     if (filters?.operationId !== undefined) {
       conditions.push('operation_id = ?');
       params.push(filters.operationId);
@@ -1313,6 +1339,22 @@ export class SqliteBackend implements StorageBackend {
   }
 
   /**
+   * Backend observability counters. Currently exposes
+   * `correlationFilteredQueries` — the number of {@link queryEvents} /
+   * {@link queryEventsByType} invocations that supplied at least one of the
+   * three correlation filter fields and therefore exercised the V6 indexed
+   * fast path. Counted once per query, regardless of how many of the three
+   * filter fields were supplied.
+   *
+   * Shape mirrors `ViewMaterializer.getStats()` (a plain numeric counter
+   * object) so callers can compose per-subsystem stat snapshots without a
+   * shared metrics interface.
+   */
+  getStats(): { correlationFilteredQueries: number } {
+    return { correlationFilteredQueries: this.correlationFilteredQueries };
+  }
+
+  /**
    * Cross-stream query reducer (DR-3). Reduces over the events table for a
    * single event type whose streamId is `streamPrefix` (parent stream) OR a
    * namespaced descendant `<streamPrefix>/<segment>`. SQL clause matches the
@@ -1350,6 +1392,15 @@ export class SqliteBackend implements StorageBackend {
     // WHERE clauses against the V6 columns; the (correlation_id, sequence)
     // index makes the common cross-stream telemetry lookup ("all events in
     // workflow X of type Y") O(log n + matches).
+    //
+    // #1448 item 5 — same once-per-query counter as queryEvents.
+    if (
+      filters?.operationId !== undefined ||
+      filters?.correlationId !== undefined ||
+      filters?.causationId !== undefined
+    ) {
+      this.correlationFilteredQueries++;
+    }
     if (filters?.operationId !== undefined) {
       conditions.push('operation_id = ?');
       params.push(filters.operationId);

--- a/servers/exarchos-mcp/src/telemetry/tools.ts
+++ b/servers/exarchos-mcp/src/telemetry/tools.ts
@@ -7,6 +7,7 @@ import {
   getOrCreateMaterializer,
   materializeFiltered,
   hasCorrelationFilters,
+  deriveCorrelationFilters,
 } from '../views/tools.js';
 import {
   TELEMETRY_VIEW,
@@ -107,11 +108,7 @@ export async function handleViewTelemetry(
     // Filtered queries bypass the materializer cache (see ViewQueryFilters
     // doc in views/tools.ts) so an unfiltered call before or after is not
     // contaminated by the filtered fold.
-    const correlationFilters = {
-      ...(validated.operationId !== undefined ? { operationId: validated.operationId } : {}),
-      ...(validated.correlationId !== undefined ? { correlationId: validated.correlationId } : {}),
-      ...(validated.causationId !== undefined ? { causationId: validated.causationId } : {}),
-    };
+    const correlationFilters = deriveCorrelationFilters(validated);
     const filtered = hasCorrelationFilters(correlationFilters);
     let view: TelemetryViewState;
     if (filtered) {

--- a/servers/exarchos-mcp/src/views/derive-correlation-filters.test.ts
+++ b/servers/exarchos-mcp/src/views/derive-correlation-filters.test.ts
@@ -1,0 +1,72 @@
+// Wave 2 (#1448, item 2) — deriveCorrelationFilters helper.
+//
+// Pins the explicit-args-win + AsyncLocalStorage-default contract for the
+// telemetry view handlers. The helper centralises the inline filter spread
+// block that currently appears in 6 handlers (Task 5 will refactor each
+// handler to call this helper). The default branch (no args + active
+// dispatch context) lets agents get auto-scoped telemetry without manually
+// threading the correlation tuple back into every view call.
+
+import { describe, it, expect, vi } from 'vitest';
+import { deriveCorrelationFilters } from './tools.js';
+import {
+  runWithDispatchContext,
+  mintDispatchContext,
+} from '../dispatch/dispatch-context.js';
+import { logger } from '../logger.js';
+
+describe('deriveCorrelationFilters', () => {
+  it('DeriveCorrelationFilters_ExplicitArgs_PassesThroughUnchanged', () => {
+    expect(deriveCorrelationFilters({ correlationId: 'cor-x' })).toEqual({
+      correlationId: 'cor-x',
+    });
+    expect(deriveCorrelationFilters({ operationId: 'op-x' })).toEqual({
+      operationId: 'op-x',
+    });
+    expect(deriveCorrelationFilters({ causationId: 'cau-x' })).toEqual({
+      causationId: 'cau-x',
+    });
+    expect(
+      deriveCorrelationFilters({
+        operationId: 'op',
+        correlationId: 'cor',
+        causationId: 'cau',
+      }),
+    ).toEqual({ operationId: 'op', correlationId: 'cor', causationId: 'cau' });
+  });
+
+  it('DeriveCorrelationFilters_NoArgsNoContext_ReturnsEmpty', () => {
+    expect(deriveCorrelationFilters({})).toEqual({});
+  });
+
+  it('DeriveCorrelationFilters_NoArgsWithContext_DefaultsCorrelationId', () => {
+    const ctx = mintDispatchContext({ correlationId: 'ctx-cor-1' });
+    const result = runWithDispatchContext(ctx, () =>
+      deriveCorrelationFilters({}),
+    );
+    expect(result).toEqual({ correlationId: 'ctx-cor-1' });
+  });
+
+  it('DeriveCorrelationFilters_AnyExplicitArg_DoesNotDefault', () => {
+    const ctx = mintDispatchContext({ correlationId: 'ctx-cor-1' });
+    const result = runWithDispatchContext(ctx, () =>
+      deriveCorrelationFilters({ operationId: 'op-explicit' }),
+    );
+    expect(result).toEqual({ operationId: 'op-explicit' });
+    expect(result).not.toHaveProperty('correlationId');
+  });
+
+  it('DeriveCorrelationFilters_NoArgsWithContext_LogsCtxDefault', () => {
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    const ctx = mintDispatchContext({ correlationId: 'ctx-cor-x' });
+    runWithDispatchContext(ctx, () => deriveCorrelationFilters({}));
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'ctx-default',
+        correlationId: 'ctx-cor-x',
+      }),
+      expect.stringContaining('deriveCorrelationFilters'),
+    );
+    debugSpy.mockRestore();
+  });
+});

--- a/servers/exarchos-mcp/src/views/materializer.test.ts
+++ b/servers/exarchos-mcp/src/views/materializer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { ViewMaterializer, type ViewProjection } from './materializer.js';
+import { materializeFiltered } from './tools.js';
 import type { WorkflowEvent } from '../event-store/schemas.js';
 import {
   workflowStateProjection,
@@ -689,5 +690,44 @@ describe('ViewMaterializer Cache Stats', () => {
     expect(warnSpy).toHaveBeenCalledTimes(2);
 
     warnSpy.mockRestore();
+  });
+});
+
+// ─── Cache Bypass Counter (#1448 item 5) ──────────────────────────────────
+
+describe('ViewMaterializer Cache Bypass Counter', () => {
+  const VIEW_NAME = 'counter';
+
+  it('Materializer_recordBypass_IncrementsCacheBypassesCounter', () => {
+    const materializer = new ViewMaterializer();
+
+    materializer.recordBypass();
+    materializer.recordBypass();
+    materializer.recordBypass();
+
+    const stats = materializer.getCacheStats();
+    expect(stats.bypasses).toBe(3);
+    // No leak into hit/miss counters.
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+  });
+
+  it('materializeFiltered_OnEachCall_IncrementsBypassesCounter', () => {
+    const materializer = new ViewMaterializer();
+    materializer.register(VIEW_NAME, counterProjection);
+
+    // Single call with no events — bypasses counter should still tick.
+    materializeFiltered<number>(materializer, VIEW_NAME, []);
+
+    expect(materializer.getCacheStats().bypasses).toBe(1);
+
+    // A second call increments by one again; hits/misses untouched.
+    materializeFiltered<number>(materializer, VIEW_NAME, [
+      makeEvent(1, 'stream-a'),
+    ]);
+    const stats = materializer.getCacheStats();
+    expect(stats.bypasses).toBe(2);
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
   });
 });

--- a/servers/exarchos-mcp/src/views/materializer.test.ts
+++ b/servers/exarchos-mcp/src/views/materializer.test.ts
@@ -594,7 +594,7 @@ describe('ViewMaterializer Cache Stats', () => {
 
     const stats = materializer.getCacheStats();
 
-    expect(stats).toEqual({ hits: 0, misses: 0, size: 0, missRate: 0 });
+    expect(stats).toEqual({ hits: 0, misses: 0, size: 0, missRate: 0, bypasses: 0 });
   });
 
   it('getCacheStats_AfterHitsAndMisses_TracksCorrectly', () => {

--- a/servers/exarchos-mcp/src/views/materializer.ts
+++ b/servers/exarchos-mcp/src/views/materializer.ts
@@ -74,6 +74,12 @@ export class ViewMaterializer {
   // Cache hit/miss counters
   private cacheHits = 0;
   private cacheMisses = 0;
+  // Cache-bypass counter (#1448 item 5 / PR #1447 DIM-2 audit). Incremented by
+  // `materializeFiltered` in `views/tools.ts`, which skips the LRU cache entirely
+  // for correlation-filtered queries. Tracked on a separate axis from hits/misses
+  // so the existing hit-rate calculation stays well-defined; otherwise a healthy
+  // hitRate could mask thousands of invisible bypass calls.
+  private cacheBypasses = 0;
 
   // Thrashing detection sliding window
   private readonly thrashingWindowSize: number;
@@ -264,15 +270,34 @@ export class ViewMaterializer {
 
   /**
    * Return cumulative cache statistics for monitoring and diagnostics.
+   *
+   * `bypasses` counts calls to `materializeFiltered` (correlation-filtered
+   * queries that skip the LRU cache entirely). It is reported alongside hits
+   * and misses but is NOT folded into the missRate denominator — bypasses are
+   * an orthogonal axis, not a cache outcome.
    */
-  getCacheStats(): { hits: number; misses: number; size: number; missRate: number } {
+  getCacheStats(): { hits: number; misses: number; size: number; missRate: number; bypasses: number } {
     const total = this.cacheHits + this.cacheMisses;
     return {
       hits: this.cacheHits,
       misses: this.cacheMisses,
       size: this.states.size,
       missRate: total > 0 ? this.cacheMisses / total : 0,
+      bypasses: this.cacheBypasses,
     };
+  }
+
+  /**
+   * Record a cache bypass (called by `materializeFiltered` in `views/tools.ts`).
+   * Increments the `bypasses` counter exposed via `getCacheStats()`.
+   *
+   * Cache-bypass paths skip the LRU entirely, so without this counter their
+   * traffic is invisible to hit/miss telemetry — `cacheHits=950, cacheMisses=50`
+   * could look healthy while 5,000 filtered calls bypassed silently (PR #1447
+   * DIM-2 audit finding).
+   */
+  recordBypass(): void {
+    this.cacheBypasses++;
   }
 
   /**

--- a/servers/exarchos-mcp/src/views/tools.ctx-default.test.ts
+++ b/servers/exarchos-mcp/src/views/tools.ctx-default.test.ts
@@ -1,0 +1,222 @@
+// Wave 2 (#1448, item 2) — AsyncLocalStorage ctx-default integration tests.
+//
+// `deriveCorrelationFilters` (Task 4) is exercised in isolation by
+// `derive-correlation-filters.test.ts`. These tests pin the same behavior
+// end-to-end through real handlers AFTER Task 5 substitutes the inline
+// spread blocks at the 6 sites. The handler tests in `handlers.test.ts`
+// already pin the explicit-args-win path; these add the ctx-default path
+// (no args + active dispatch context) and an explicit-wins regression
+// guard inside an active context.
+//
+// RED today because the 6 inline spread blocks ignore `getDispatchContext`
+// — the handler returns the unfiltered roll-up (which folds in cor-Y too)
+// rather than scoping to the active context's correlationId. After
+// Task 5's substitution, the helper's ctx-default branch kicks in and
+// these go GREEN.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { handleViewCodeQuality, resetMaterializerCache } from './tools.js';
+import { handleViewTelemetry } from '../telemetry/tools.js';
+import { EventStore } from '../event-store/store.js';
+import {
+  mintDispatchContext,
+  runWithDispatchContext,
+} from '../dispatch/dispatch-context.js';
+
+describe('Wave 2 — handlers honor AsyncLocalStorage ctx-default (#1448)', () => {
+  let tmpDir: string;
+  let store: EventStore;
+
+  beforeEach(async () => {
+    resetMaterializerCache();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'exarchos-ctx-default-'));
+    store = new EventStore(tmpDir);
+  });
+
+  afterEach(async () => {
+    resetMaterializerCache();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('HandleViewCodeQuality_NoArgsInsideDispatch_DefaultsToCtxCorrelationId', async () => {
+    const streamId = 'ctx-cq-wf';
+
+    // GIVEN: two gate.executed events, one stamped cor-X and one stamped
+    // cor-Y. Pre-ctx-default, a no-args call would fold both into the view.
+    await store.append(streamId, {
+      streamId,
+      sequence: 1,
+      timestamp: new Date().toISOString(),
+      type: 'gate.executed',
+      operationId: 'op-X',
+      correlationId: 'cor-X',
+      data: {
+        gateName: 'typecheck',
+        layer: 'build',
+        passed: true,
+        duration: 100,
+        details: { skill: 'delegation' },
+      },
+      schemaVersion: '1.0',
+    });
+    await store.append(streamId, {
+      streamId,
+      sequence: 2,
+      timestamp: new Date().toISOString(),
+      type: 'gate.executed',
+      operationId: 'op-Y',
+      correlationId: 'cor-Y',
+      data: {
+        gateName: 'lint',
+        layer: 'build',
+        passed: true,
+        duration: 200,
+        details: { skill: 'synthesis' },
+      },
+      schemaVersion: '1.0',
+    });
+
+    // WHEN: handler is invoked with NO correlation args, inside an active
+    // dispatch scope whose correlationId is cor-X.
+    const ctx = mintDispatchContext({ correlationId: 'cor-X' });
+    const result = await runWithDispatchContext(ctx, () =>
+      handleViewCodeQuality({ workflowId: streamId }, tmpDir, store),
+    );
+
+    // THEN: the view folds only the cor-X event. The cor-Y gate ('lint',
+    // skill 'synthesis') must be absent because the helper defaulted
+    // correlationId from the active context.
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const gates = data.gates as Record<string, unknown>;
+    expect(gates).toHaveProperty('typecheck');
+    expect(gates).not.toHaveProperty('lint');
+    const skills = data.skills as Record<string, unknown>;
+    expect(skills).toHaveProperty('delegation');
+    expect(skills).not.toHaveProperty('synthesis');
+  });
+
+  it('HandleViewTelemetry_NoArgsInsideDispatch_DefaultsToCtxCorrelationId', async () => {
+    // Cross-handler invariance: the telemetry handler in telemetry/tools.ts
+    // walks a different code path (direct store.query rather than
+    // queryDeltaEvents) but the helper substitution must yield the same
+    // ctx-default behavior.
+    const TELEMETRY_STREAM_NAME = 'telemetry';
+
+    await store.append(TELEMETRY_STREAM_NAME, {
+      streamId: TELEMETRY_STREAM_NAME,
+      sequence: 1,
+      timestamp: new Date().toISOString(),
+      type: 'tool.completed',
+      operationId: 'op-X',
+      correlationId: 'cor-X',
+      data: {
+        tool: 'tool_X',
+        durationMs: 10,
+        responseBytes: 100,
+        tokenEstimate: 25,
+      },
+      schemaVersion: '1.0',
+    });
+    await store.append(TELEMETRY_STREAM_NAME, {
+      streamId: TELEMETRY_STREAM_NAME,
+      sequence: 2,
+      timestamp: new Date().toISOString(),
+      type: 'tool.completed',
+      operationId: 'op-Y',
+      correlationId: 'cor-Y',
+      data: {
+        tool: 'tool_Y',
+        durationMs: 50,
+        responseBytes: 500,
+        tokenEstimate: 200,
+      },
+      schemaVersion: '1.0',
+    });
+
+    const ctx = mintDispatchContext({ correlationId: 'cor-X' });
+    const result = await runWithDispatchContext(ctx, () =>
+      handleViewTelemetry({}, tmpDir, store),
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      session: { totalInvocations: number; totalTokens: number };
+      tools: Array<{ tool: string; invocations: number }>;
+    };
+    // Only tool_X (stamped cor-X) is rolled up; tool_Y must be absent.
+    expect(data.tools).toHaveLength(1);
+    expect(data.tools[0].tool).toBe('tool_X');
+    expect(data.session.totalInvocations).toBe(1);
+  });
+
+  it('HandleViewCodeQuality_ExplicitOperationIdInsideDispatch_DoesNotInheritCorrelation', async () => {
+    // Regression guard for explicit-wins: when the caller supplies any
+    // correlation arg, the active dispatch context's correlationId MUST
+    // NOT be merged in. Otherwise the helper would silently AND-filter
+    // a caller-supplied operationId with the ctx correlationId, and any
+    // event matching the operationId but NOT the ctx correlationId would
+    // be wrongly dropped.
+    const streamId = 'ctx-explicit-wf';
+
+    // cor-X event with operationId op-irrelevant (should NOT appear)
+    await store.append(streamId, {
+      streamId,
+      sequence: 1,
+      timestamp: new Date().toISOString(),
+      type: 'gate.executed',
+      operationId: 'op-irrelevant',
+      correlationId: 'cor-X',
+      data: {
+        gateName: 'lint',
+        layer: 'build',
+        passed: true,
+        duration: 100,
+        details: { skill: 'synthesis' },
+      },
+      schemaVersion: '1.0',
+    });
+    // explicit-target event: op-explicit-z, stamped with a DIFFERENT
+    // correlationId (cor-Z) than the active dispatch ctx (cor-X). It must
+    // still appear because the explicit operationId disables the
+    // ctx-default branch.
+    await store.append(streamId, {
+      streamId,
+      sequence: 2,
+      timestamp: new Date().toISOString(),
+      type: 'gate.executed',
+      operationId: 'op-explicit-z',
+      correlationId: 'cor-Z',
+      data: {
+        gateName: 'typecheck',
+        layer: 'build',
+        passed: true,
+        duration: 200,
+        details: { skill: 'delegation' },
+      },
+      schemaVersion: '1.0',
+    });
+
+    const ctx = mintDispatchContext({ correlationId: 'cor-X' });
+    const result = await runWithDispatchContext(ctx, () =>
+      handleViewCodeQuality(
+        { workflowId: streamId, operationId: 'op-explicit-z' },
+        tmpDir,
+        store,
+      ),
+    );
+
+    // The op-explicit-z event (typecheck/delegation, cor-Z) must appear;
+    // the cor-X event (lint/synthesis, op-irrelevant) must NOT.
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    const gates = data.gates as Record<string, unknown>;
+    expect(gates).toHaveProperty('typecheck');
+    expect(gates).not.toHaveProperty('lint');
+    const skills = data.skills as Record<string, unknown>;
+    expect(skills).toHaveProperty('delegation');
+    expect(skills).not.toHaveProperty('synthesis');
+  });
+});

--- a/servers/exarchos-mcp/src/views/tools.ts
+++ b/servers/exarchos-mcp/src/views/tools.ts
@@ -635,11 +635,7 @@ export async function handleViewDelegationTimeline(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const correlationFilters: ViewQueryFilters = {
-      ...(args.operationId !== undefined ? { operationId: args.operationId } : {}),
-      ...(args.correlationId !== undefined ? { correlationId: args.correlationId } : {}),
-      ...(args.causationId !== undefined ? { causationId: args.causationId } : {}),
-    };
+    const correlationFilters = deriveCorrelationFilters(args);
     const filtered = hasCorrelationFilters(correlationFilters);
     const events = await queryDeltaEvents(store, materializer, streamId, DELEGATION_TIMELINE_VIEW, correlationFilters);
     // Wave 5 (#1437) — under a correlation filter, fold a fresh projection
@@ -687,11 +683,7 @@ export async function handleViewCodeQuality(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const correlationFilters: ViewQueryFilters = {
-      ...(args.operationId !== undefined ? { operationId: args.operationId } : {}),
-      ...(args.correlationId !== undefined ? { correlationId: args.correlationId } : {}),
-      ...(args.causationId !== undefined ? { causationId: args.causationId } : {}),
-    };
+    const correlationFilters = deriveCorrelationFilters(args);
     const correlationFiltered = hasCorrelationFilters(correlationFilters);
     const events = await queryDeltaEvents(store, materializer, streamId, CODE_QUALITY_VIEW, correlationFilters);
     // Wave 5 (#1437) — under a correlation filter, fold a fresh projection
@@ -788,11 +780,7 @@ export async function handleViewEvalResults(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const correlationFilters: ViewQueryFilters = {
-      ...(args.operationId !== undefined ? { operationId: args.operationId } : {}),
-      ...(args.correlationId !== undefined ? { correlationId: args.correlationId } : {}),
-      ...(args.causationId !== undefined ? { causationId: args.causationId } : {}),
-    };
+    const correlationFilters = deriveCorrelationFilters(args);
     const correlationFiltered = hasCorrelationFilters(correlationFilters);
     const events = await queryDeltaEvents(store, materializer, streamId, EVAL_RESULTS_VIEW, correlationFilters);
     // Wave 5 (#1437) — under a correlation filter, fold a fresh projection
@@ -893,11 +881,7 @@ export async function handleViewQualityCorrelation(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const correlationFilters: ViewQueryFilters = {
-      ...(args.operationId !== undefined ? { operationId: args.operationId } : {}),
-      ...(args.correlationId !== undefined ? { correlationId: args.correlationId } : {}),
-      ...(args.causationId !== undefined ? { causationId: args.causationId } : {}),
-    };
+    const correlationFilters = deriveCorrelationFilters(args);
     const correlationFiltered = hasCorrelationFilters(correlationFilters);
 
     const cqEvents = await queryDeltaEvents(store, materializer, streamId, CODE_QUALITY_VIEW, correlationFilters);
@@ -965,11 +949,7 @@ export async function handleViewQualityAttribution(
     const materializer = getOrCreateMaterializer(stateDir);
     const streamId = args.workflowId ?? 'default';
 
-    const correlationFilters: ViewQueryFilters = {
-      ...(args.operationId !== undefined ? { operationId: args.operationId } : {}),
-      ...(args.correlationId !== undefined ? { correlationId: args.correlationId } : {}),
-      ...(args.causationId !== undefined ? { causationId: args.causationId } : {}),
-    };
+    const correlationFilters = deriveCorrelationFilters(args);
     const correlationFiltered = hasCorrelationFilters(correlationFilters);
 
     const cqEvents = await queryDeltaEvents(store, materializer, streamId, CODE_QUALITY_VIEW, correlationFilters);

--- a/servers/exarchos-mcp/src/views/tools.ts
+++ b/servers/exarchos-mcp/src/views/tools.ts
@@ -6,6 +6,7 @@ import { pickFields, type ToolResult } from '../format.js';
 import { logger } from '../logger.js';
 import { TERMINAL_PHASES } from '../workflow/terminal-phases.js';
 import { isFeatureStream } from '../core/infra-streams.js';
+import { getDispatchContext } from '../dispatch/dispatch-context.js';
 import { ViewMaterializer } from './materializer.js';
 import { SnapshotStore } from './snapshot-store.js';
 import {
@@ -181,6 +182,42 @@ export function hasCorrelationFilters(filters?: ViewQueryFilters): boolean {
     filters.correlationId !== undefined ||
     filters.causationId !== undefined
   );
+}
+
+/**
+ * Wave 2 (#1448) — AsyncLocalStorage-aware default for correlation filters.
+ *
+ * Returns the explicit args verbatim if any are supplied (explicit-wins).
+ * Otherwise, if a dispatch context is active, defaults `correlationId` to
+ * the active dispatch's correlationId — the chain-stable anchor for the
+ * current workflow scope. If no args AND no active context, returns empty.
+ *
+ * The default makes "show me telemetry for the workflow I'm in" Just Work
+ * inside an agent dispatch without requiring the agent to thread the
+ * correlation tuple back into every telemetry call.
+ */
+export function deriveCorrelationFilters(args: {
+  operationId?: string;
+  correlationId?: string;
+  causationId?: string;
+}): ViewQueryFilters {
+  const explicit: ViewQueryFilters = {
+    ...(args.operationId !== undefined ? { operationId: args.operationId } : {}),
+    ...(args.correlationId !== undefined ? { correlationId: args.correlationId } : {}),
+    ...(args.causationId !== undefined ? { causationId: args.causationId } : {}),
+  };
+  if (Object.keys(explicit).length > 0) {
+    return explicit;
+  }
+  const ctx = getDispatchContext();
+  if (ctx) {
+    logger.debug(
+      { source: 'ctx-default', correlationId: ctx.correlationId },
+      'deriveCorrelationFilters: defaulted correlationId from active dispatch context',
+    );
+    return { correlationId: ctx.correlationId };
+  }
+  return {};
 }
 
 /** @internal Exported for CLI commands and testing */

--- a/servers/exarchos-mcp/src/views/tools.ts
+++ b/servers/exarchos-mcp/src/views/tools.ts
@@ -227,6 +227,11 @@ export function materializeFiltered<T>(
   if (!projection) {
     throw new Error(`No projection registered for view: ${viewName}`);
   }
+  // #1448 item 5: record the bypass on every successful call so the
+  // correlation-filtered traffic is visible alongside the LRU hit/miss stats.
+  // Without this, a healthy hitRate can mask thousands of cache-skipping calls
+  // (PR #1447 DIM-2 audit).
+  materializer.recordBypass();
   let view = projection.init();
   for (const event of events) {
     view = projection.apply(view, event);


### PR DESCRIPTION
## Summary

Stacked on [PR #1447](https://github.com/lvlup-sw/exarchos/pull/1447) (the substrate landing). Closes [#1448](https://github.com/lvlup-sw/exarchos/issues/1448) items 2-5 — the four consumer-side follow-ups that close the gap between *"substrate ready"* and *"feature ergonomic."* Item 1 (#1446) is separately tracked.

Applies `/design-invariants` (INV-1..6) and `/axiom:design` (DIM-1..8) at the design level (see [`docs/designs/2026-05-16-correlation-consumer-wiring.md`](docs/designs/2026-05-16-correlation-consumer-wiring.md)). 9 tasks across 4 waves, all TDD where applicable.

When PR #1447 merges to `main`, GitHub auto-retargets this PR to `main`.

## Changes

### Item 2 — AsyncLocalStorage default for `correlationId`

- New helper `deriveCorrelationFilters(args)` in `servers/exarchos-mcp/src/views/tools.ts` — returns explicit args verbatim when any filter arg is supplied (explicit-wins), otherwise defaults `correlationId` to `getDispatchContext()?.correlationId` when a dispatch context is active. Emits a `source: 'ctx-default'` debug log on the inferred path so operators can tell which way the filter came from.
- Six handlers refactored to call the helper (`handleViewDelegationTimeline`, `handleViewCodeQuality`, `handleViewEvalResults`, `handleViewQualityCorrelation`, `handleViewQualityAttribution`, `handleViewTelemetry`). Each handler's 5-line spread block becomes a one-liner; existing tests pass unchanged because explicit-wins preserves the prior contract.
- 5 unit tests in `derive-correlation-filters.test.ts` pin the 4 paths + ctx-default debug log; 3 integration tests in `tools.ctx-default.test.ts` pin the end-to-end ctx-default behavior through real handlers.

### Item 3 — T17 permanent justification + `next_actions` roundtrip guard

- Wave 1 Task 3 investigation discovered **no production auto-dispatch handler exists** — both `adapters/cli.ts:557-596` and `adapters/mcp.ts:354-389` are strictly one-shot. The HATEOAS pattern is documented as aspirational in `dispatch-context.ts:12-19` but unimplemented.
- T17's manual `mintDispatchContext` synthesis is therefore the **correct caller-driven model**, not a workaround. Inline TODO replaced with permanent design rationale citing the search evidence and pointing to where a future integration variant should live if HATEOAS auto-dispatch is ever implemented.
- Companion test `Cli_OneShotDispatch_PreservesNextActionsField` in `adapters/cli-format.test.ts` pins `next_actions` field integrity through the one-shot pipeline (envelope + on-the-wire JSON). Passed first run — regression guard, not bug-find.

### Item 4 — Runbook + README link + CLI flag verification

- New runbook [`docs/runbooks/correlation-filters.md`](docs/runbooks/correlation-filters.md) (117 lines) — operator + agent reference covering the three IDs, filter selection rule, MCP + CLI examples, and the AsyncLocalStorage default.
- README observability paragraph (2 sentences) linking the runbook from the agent-first architecture section.
- **CLI flag discovery (Task 6):** The three flags (`--operation-id`/`--correlation-id`/`--causation-id`) were already live on all 6 telemetry view subcommands via schema-driven auto-generation (`addFlagsFromSchema` reads each action's Zod schema in `registry.ts`; PR #1447 added the fields, which made the flags reachable). The issue's framing ("flags need wiring") was a false negative from grepping `cli.ts` directly. Closed by 20 regression-pin tests in `adapters/cli.correlation-flags.test.ts` (full 6×3 subcommand × flag matrix + introspection sweep + end-to-end smoke through real dispatch). RED verified by reversible mutation (delete fields → 5 tests fail → restore).

### Item 5 — Observability for indexed-path + cache-bypass

- `cacheBypasses` counter on `ViewMaterializer` with `recordBypass()` method; surfaces in the existing `getCacheStats()` alongside `hits`/`misses`. Wired from `views/tools.ts:materializeFiltered`. Closes the "5,000 filtered calls invisible to cache stats" DIM-2 finding.
- `correlationFilteredQueries` counter on `SqliteBackend` with new `getStats()` getter. Increments **once per query** (not per clause) at both filter-clause sites (`queryEvents` and `queryEventsByType`). Closes the "silent index regression invisible until users notice latency" DIM-2 finding.

## Design invariants & axiom dimensions

Detailed tables in [`docs/designs/2026-05-16-correlation-consumer-wiring.md`](docs/designs/2026-05-16-correlation-consumer-wiring.md). Highlights:

- **INV-1** event-source integrity ✓ — counters are in-memory aggregates with getters, NOT events. No payload mutation.
- **INV-2** facade equivalence ✓ — CLI flags symmetric with MCP surface via schema-driven generation.
- **INV-4** platform-agnosticity ✓ — runbook covers both MCP and CLI.
- **INV-5a/b/d** ✓ — input ergonomics is the whole point; explicit-wins preserves caller intent; CLI flags are kebab-case of arg keys.
- **DIM-1** correctness — explicit-args-win test-pinned (3 paths covered).
- **DIM-2** observability — both counters are the whole point of Item 5.
- **DIM-3** context economy — single helper consolidates 6 inline spread blocks.
- **DIM-8** test integrity — closes the T17 substrate-only hole with permanent justification.

## Test Plan

- [x] `derive-correlation-filters.test.ts` — 5 tests pin helper's 4 paths + ctx-default debug log
- [x] `tools.ctx-default.test.ts` — 3 integration tests pin end-to-end ctx-default through real handlers
- [x] `materializer.test.ts` — `recordBypass` + `materializeFiltered` integration on `cacheBypasses` counter
- [x] `sqlite-backend.test.ts` — 3 tests for `correlationFilteredQueries` (per-query counting, both filter sites, multi-filter dedup)
- [x] `cli.correlation-flags.test.ts` — 20 regression-pin tests (6×3 subcommand × flag matrix + introspection sweep + end-to-end smoke)
- [x] `cli-format.test.ts` — `Cli_OneShotDispatch_PreservesNextActionsField` regression guard on `next_actions` field integrity
- [x] **Full MCP sweep:** `cd servers/exarchos-mcp && npm run test:run` → **6981 passed | 22 skipped | 0 failed** (542 test files)
- [x] **Typecheck:** `npm run typecheck` → clean
- [x] **TDD discipline preserved:** 6 RED commits visible in history for behavior-changing tasks; 3 doc/test-only tasks (T3 investigation, T6 regression-pin, T7+T8 docs) have RED-equivalent reversible verification or are documentation.

## Wave map

| Wave | Tasks | Outcome |
|------|-------|---------|
| 1 (parallel) | T1 `cacheBypasses` counter · T2 indexed-path counter · T3 `next_actions` investigation | All green; T3 returned Branch B (no handler) |
| 2 (sequential) | T4 helper · T5 6-handler refactor | All green |
| 3 (parallel groups) | T6 CLI flags · T7 runbook · T8 README link | T6 found flags already live (regression-pin); T7+T8 docs |
| 4 | T9 T17 rewrite | Branch B from T3 → permanent justification + roundtrip guard |

## Out of scope

- [#1446](https://github.com/lvlup-sw/exarchos/issues/1446) (10 other view actions registered in TOOL_REGISTRY) — separately tracked.
- Cross-tier correlation propagation (basileus / remote MCP) — INV-3 deferred to v3+ roadmap.
- Filter-aware materializer cache keying — rejected in PR #1447 design for INV-1 reasons; `materializeFiltered` cache-bypass is the correctness-preserving alternative.
- Production auto-dispatch handler for `next_actions[]` — would be a separate epic (HATEOAS in `dispatch-context.ts` is aspirational).

Closes #1448.