### PR TITLE
feat(preview-4): substrate hygiene bundle — views layer + task-store F-4..F-8 (#1441)

### DIFF
--- a/docs/designs/2026-05-17-preview-4-substrate-hygiene.md
+++ b/docs/designs/2026-05-17-preview-4-substrate-hygiene.md
@@ -71,7 +71,7 @@ Trade-offs vs alternatives:
 - *(Separate (createdAt, taskId, streamId) index table)* — rejected for now: adds a second source of truth that must stay consistent with the event log. Re-evaluable in v2.11 if the lookahead approach degrades under load.
 - *(Sort by sequence # of task.created in the dispatched stream)* — rejected: harder to compute, and the audit doc already prefers `createdAt`.
 
-**Event-store query surface** — this design assumes `EventStore.queryEvents` supports a `(streamPrefix='task-store/', eventType='task.created', createdAtFrom, limit)` filter. Wave T implementation must verify this against the V6 schema and, if missing, file a sub-issue for the minimal extension (NOT widen scope inside this bundle).
+**Event-store query surface** — this design assumes `EventStore.queryByType` supports a `(streamPrefix='task-store/', eventType='task.created', createdAtFrom, limit)` filter. Wave T implementation must verify this against the V6 schema and, if missing, file a sub-issue for the minimal extension (NOT widen scope inside this bundle).
 
 ## F-8 disposition (requestId)
 
@@ -92,7 +92,7 @@ The hardening philosophy invited reconsidering the audit-aligned "keep the fallb
 | `servers/exarchos-mcp/src/registry.ts` | T1 — add 3 viewActions entries | V |
 | `servers/exarchos-mcp/src/views/materializer.ts` | T2 — sentinel-skip in stream iterator | V |
 | `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts` | T4/T5/T6/T7/T8 | T |
-| `servers/exarchos-mcp/src/event-store/store.ts` (or sqlite-backend) | T7 — verify `queryEvents` accepts `(streamPrefix, eventType, createdAtFrom)` | T |
+| `servers/exarchos-mcp/src/event-store/store.ts` (or sqlite-backend) | T7 — verify `queryByType` accepts `(streamPrefix, eventType, createdAtFrom)` | T |
 | `servers/exarchos-mcp/src/__tests__/...` co-located | regression tests per task | both |
 
 No schema migration. No event payload changes for existing events. No CLI surface changes (T1 schemas auto-emit flags via `addFlagsFromSchema` per memory note `project_cli_schema_driven_flags`).
@@ -140,7 +140,7 @@ No dimension regresses.
 - **F-7 coerce-and-warn log noise**: if many existing streams contain malformed `request` payloads, the warn may fire repeatedly. *Mitigation*: include streamId in the log so it's deduplicable; if noise becomes operational, downgrade to debug or sample 1/N. Land as `warn` and observe.
 - **F-6 cursor lookahead under-shoots tie-break churn**: if many `task.created` events share a millisecond timestamp, lookahead=8 may leave gaps. *Mitigation*: lookahead is configurable; integration tests assert lookahead=8 is sufficient at expected creation rates. If observed in the wild, raise.
 - **T2 sentinel-skip hides a legitimate `__`-prefixed stream**: the only known sentinel is `__migration__`. *Mitigation*: log at debug level when a `__`-prefixed stream is skipped; explicit allowlist (`__migration__`) reviewable in v2.11 if other sentinels emerge.
-- **Event-store query surface assumption**: T7's cursor mechanism assumes `queryEvents` supports `(streamPrefix, eventType, createdAtFrom)` filter triple. *Mitigation*: T7 implementation verifies this first; on miss, files a 1-line `EventStore.queryEvents` extension issue and falls back to existing query + post-filter (degrades to today's behavior for the cold-start path only).
+- **Event-store query surface assumption**: T7's cursor mechanism assumes `queryByType` supports `(streamPrefix, eventType, createdAtFrom)` filter triple. *Mitigation*: T7 implementation verifies this first; on miss, files a 1-line `EventStore.queryByType` extension issue and falls back to existing query + post-filter (degrades to today's behavior for the cold-start path only).
 
 ## Acceptance
 

--- a/docs/designs/2026-05-17-preview-4-substrate-hygiene.md
+++ b/docs/designs/2026-05-17-preview-4-substrate-hygiene.md
@@ -1,0 +1,172 @@
+# Design — v2.10.0-preview.4 substrate hygiene bundle (RC1-ready)
+
+> **Status:** Draft
+> **Author:** @rsalus
+> **Date:** 2026-05-17
+> **Epic:** #1441 — v2.10.0-preview.4 polish + post-bundle follow-ups
+> **Closes:** #1446 (residue), #1434, #1448 (hygiene), #1438 FINDING-4..8
+> **Philosophy:** Audit + INV-aligned hardening (F-5+F-6 co-design as one subsystem; F-8 explicitly considered + rejected for hardening)
+
+---
+
+## Context
+
+The v2.10.0-preview.4 bundle landed two substrates: the EventSourcedTaskStore (#1430) and the correlation-tuple indexed columns + telemetry filters (#1447 + #1449). Both received post-merge audits identifying follow-up findings; all HIGH-severity TaskStore correctness issues (#1443/#1444/#1445) and the consumer-side correlation wiring (#1449) have landed.
+
+The remaining open follow-ups span two subsystems but share a single coherence theme: **close the post-#1430+#1447 audit follow-ups before v2.10.0-RC1**. Two of the open items also affect the live operator surface — #1434 crashes the `exarchos_view pipeline` action on any repo with a `__migration__` sentinel stream (every upgraded repo), and the 3 unregistered view actions silently bypass DR-5 schema validation at dispatch. Both are RC1-visible.
+
+This bundle groups the work into one design surface because:
+
+- All findings are MEDIUM/LOW severity (no HIGH-class correctness gap remains);
+- All ship together cleanly against the same RC1 sequencing decision;
+- Each finding is small enough to be a wave within one PR rather than a standalone landing;
+- The user accepted the multi-subsystem blast-radius tradeoff explicitly during ideation.
+
+The audit recommendations (`docs/research/2026-05-16-event-sourced-task-store-audit.md` and the #1434/#1446 issue bodies) are taken as the floor. F-5 + F-6 receive INV-aligned hardening as one co-designed "cursor + hydration" subsystem; F-8 is explicitly evaluated for hardening and the audit-aligned answer retained with documented rationale.
+
+## Decision
+
+Ship a single feature branch `feature/preview-4-substrate-hygiene` containing two parallel-safe waves of work mapped to the eight findings:
+
+**Wave V (views layer, parallel-safe):**
+
+- T1 — Register `session_provenance`, `provenance`, `ideate_readiness` in `TOOL_REGISTRY.viewActions` (#1446 residue). Mirror the Wave 5 pattern from `registry.ts:2731–2784`. Each schema is a `z.object({...})` derived from the composite handler's existing arg shape, with `CORRELATION_TUPLE_FILTER_SHAPE` included for the two that touch the event store.
+- T2 — Add an internal-sentinel skip to `ViewMaterializer`'s stream iterator: streams whose `streamId.startsWith('__')` are excluded from snapshot/load (option (a) from #1434). Narrower than relaxing `SAFE_ID_PATTERN`; preserves the kebab-only constraint for user-facing featureIds.
+- T3 — Hygiene close: add resolution comment to #1448 confirming items 2–5 landed via PR #1449, update epic #1441 checklist.
+
+**Wave T (task-store layer):**
+
+- T4 — Size-cap reap on `createTask` when `this.tasks.size > 1024` (F-4 verbatim).
+- T5 — `logger.warn` on the `(createdData['request'] ?? {}) as Request` coerce site in `projectTask:455`, including streamId + event sequence (F-7 verbatim).
+- T6 — Persist `requestId` on the `task.created` event payload going forward. Fallback synthesizer `replayed:${taskId}` retained for existing events (F-8 audit-aligned, see §F-8 disposition below).
+- **T7+T8 co-designed — Cursor + Hydration subsystem (F-5 + F-6)**: see §Subsystem design.
+
+Sequencing within the branch: Wave V tasks are parallel-safe (touch different files). Wave T tasks T4/T5/T6 are parallel-safe; T7+T8 are sequential and depend on each other's design contract.
+
+## Subsystem design — Cursor + Hydration (F-5 + F-6)
+
+Today `listTasks` reads `Array.from(this.tasks.values())` in Map insertion order, then paginates. Insertion order is set by `hydrateFromEventStore` enumeration order on cold start and by `createTask` insertion sequence afterward — neither stable across processes, and `hydrateFromEventStore` enumerates every `task-store/*` stream on every `listTasks` call.
+
+The co-designed surface introduces one rule and one mechanism:
+
+**Sort rule** — tasks are ordered by `(createdAt ASC, taskId ASC)`. `createdAt` is deterministic from the `task.created` event timestamp; `taskId` is the tie-break for events with identical timestamps (possible on fast paths). The cursor encodes the sort key:
+
+```ts
+type ListTasksCursor = {
+  readonly createdAt: string;   // ISO-8601 from the last task on the prior page
+  readonly taskId: string;      // tie-break
+};
+// Wire format: base64url(JSON.stringify(cursor))
+```
+
+**Hydration mechanism** — `hydrateFromEventStore` becomes cursor-anchored and incremental:
+
+1. On a `listTasks` call, query the event store for `task.created` events with `createdAt >= cursor.createdAt` (or all if no cursor), capped at `limit + lookahead` (lookahead is small, e.g., 8, to absorb tie-break churn).
+2. For each `task.created` event in the page, hydrate the per-task projection from `task-store/{taskId}` if not already cached in `this.tasks`. Skip already-cached tasks.
+3. Apply the sort rule to the union of (newly hydrated) + (cached) tasks within the page window, slice to `limit`, emit `nextCursor` from the last item.
+
+Trade-offs vs alternatives:
+
+- *(LRU cache of projections only)* — rejected: doesn't fix the O(N) enumeration; only caches what's already loaded.
+- *(Separate (createdAt, taskId, streamId) index table)* — rejected for now: adds a second source of truth that must stay consistent with the event log. Re-evaluable in v2.11 if the lookahead approach degrades under load.
+- *(Sort by sequence # of task.created in the dispatched stream)* — rejected: harder to compute, and the audit doc already prefers `createdAt`.
+
+**Event-store query surface** — this design assumes `EventStore.queryEvents` supports a `(streamPrefix='task-store/', eventType='task.created', createdAtFrom, limit)` filter. Wave T implementation must verify this against the V6 schema and, if missing, file a sub-issue for the minimal extension (NOT widen scope inside this bundle).
+
+## F-8 disposition (requestId)
+
+The hardening philosophy invited reconsidering the audit-aligned "keep the fallback synthesizer" answer. Evaluation:
+
+| Option | INV-1 status | Operational cost | Benefit |
+|---|---|---|---|
+| (A) Audit-aligned: add `requestId` to new `task.created` events; keep synthesizer for old | Compliant | None | Forward-clean; back-fill is read-only |
+| (B) Compensating event: emit `task.requestIdHydrated` for each existing task | Compliant | N new events (one per existing task) | Removes synthesizer wart |
+| (C) Mutate existing `task.created` rows in DR sweep | **Violates INV-1** | Migration risk | Rejected on principle |
+
+**Decision: (A).** The synthesizer is read-side only (no event payload is written from the synthetic value); its presence is a 1-line projection branch. Option (B) produces an operationally meaningful N-event footprint to remove a 1-line branch — not worth it. The audit-aligned answer survives INV-aligned re-evaluation. Documented here so future audits don't relitigate.
+
+## Components touched
+
+| File | Why | Wave |
+|---|---|---|
+| `servers/exarchos-mcp/src/registry.ts` | T1 — add 3 viewActions entries | V |
+| `servers/exarchos-mcp/src/views/materializer.ts` | T2 — sentinel-skip in stream iterator | V |
+| `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts` | T4/T5/T6/T7/T8 | T |
+| `servers/exarchos-mcp/src/event-store/store.ts` (or sqlite-backend) | T7 — verify `queryEvents` accepts `(streamPrefix, eventType, createdAtFrom)` | T |
+| `servers/exarchos-mcp/src/__tests__/...` co-located | regression tests per task | both |
+
+No schema migration. No event payload changes for existing events. No CLI surface changes (T1 schemas auto-emit flags via `addFlagsFromSchema` per memory note `project_cli_schema_driven_flags`).
+
+## Design invariants (#1109 catalog)
+
+| Invariant | Status | Note |
+|---|---|---|
+| **INV-1** event-sourcing integrity | ✓ Preserved | No event mutation. F-8 fallback is read-side; F-6 hydration anchors on event timestamps. Cursor is a read-side construct. |
+| **INV-2** facade equivalence over shared dispatch core | ✓ Preserved | T1 brings 3 actions under the standard dispatch validation path; net+ for facade symmetry. |
+| **INV-3** basileus-forward | ✓ Preserved | Multi-process correctness (cursor stability across restarts) is exactly the F-5 fix. Removes a basileus-blocker. |
+| **INV-4** platform-agnosticity | ✓ Preserved | All changes are storage-backend-agnostic. Materializer sentinel-skip is filesystem-symmetric. |
+| **INV-5a** input ergonomics | ✓ Preserved | Cursor is opaque to callers; default limit unchanged. T1 makes 3 actions schema-validatable (input contract honesty). |
+| **INV-5b** spec-aligned output contract | ✓ Preserved | `nextCursor` field shape unchanged externally; internal encoding shifts. Envelope shape preserved. |
+| **INV-5c** Aspire-inspired control-plane verbs | n/a | No new verbs. |
+| **INV-5d** action discriminator pattern | ✓ Preserved | T1's 3 actions retain their existing discriminator strings. |
+| **INV-6** workflow-agnosticism | ✓ Preserved | No skill/playbook changes. |
+
+## Axiom dimensions (DIM-1..8)
+
+| Dimension | Status | Note |
+|---|---|---|
+| **DIM-1** topology / cohesion | ↑ Improved | Cursor + hydration co-designed reduces "dual sources of truth" smell flagged in audit (in-memory Map vs event stream). |
+| **DIM-2** observability | ↑ Improved | F-7 coerce-and-warn closes a silent fold-time hazard. T1 surfaces 3 actions in `describe()`. |
+| **DIM-3** context economy | ↑ Improved | Cursor + hydration reduces per-`listTasks` O(N) stream scan. |
+| **DIM-4** complexity budget | → Neutral | Each task is small. Cursor sort+lookahead adds modest complexity; offset by removing per-call full enumeration. |
+| **DIM-5** dependency direction | ✓ Preserved | views→event-store, task-store→event-store. No cycles introduced. |
+| **DIM-6** testability | ↑ Improved | Stable cursor enables deterministic pagination tests across restarts; F-5/F-6 was previously test-fragile. |
+| **DIM-7** lifecycle | ↑ Improved | F-4 size-cap reap removes the "unread tasks never reaped" hazard. |
+| **DIM-8** contract honesty | ↑ Improved | T1 closes the DR-5 schema validation gap for 3 actions; #1446 issue body is explicit: "input is cast (rest as {...}) at the composite layer but never Zod-parsed at runtime." |
+
+No dimension regresses.
+
+## Out of scope
+
+- T17 `next_actions` real-handler integration (already closed via #1449's "no production auto-dispatch handler exists" investigation — replaced with permanent justification + roundtrip guard).
+- Cross-tier correlation propagation (basileus / remote MCP — INV-3 deferred to v3+ roadmap).
+- Filter-aware materializer cache keying (rejected in PR #1447 design).
+- TaskStore: any reopening of FINDING-1/2/3 (already landed in #1443/#1444/#1445).
+- `_eventHints.missing` auto-emit audit (#1395) — separate bundle.
+- Invariant content audit (#1370 + #1439) — separate bundle.
+
+## Risks
+
+- **F-7 coerce-and-warn log noise**: if many existing streams contain malformed `request` payloads, the warn may fire repeatedly. *Mitigation*: include streamId in the log so it's deduplicable; if noise becomes operational, downgrade to debug or sample 1/N. Land as `warn` and observe.
+- **F-6 cursor lookahead under-shoots tie-break churn**: if many `task.created` events share a millisecond timestamp, lookahead=8 may leave gaps. *Mitigation*: lookahead is configurable; integration tests assert lookahead=8 is sufficient at expected creation rates. If observed in the wild, raise.
+- **T2 sentinel-skip hides a legitimate `__`-prefixed stream**: the only known sentinel is `__migration__`. *Mitigation*: log at debug level when a `__`-prefixed stream is skipped; explicit allowlist (`__migration__`) reviewable in v2.11 if other sentinels emerge.
+- **Event-store query surface assumption**: T7's cursor mechanism assumes `queryEvents` supports `(streamPrefix, eventType, createdAtFrom)` filter triple. *Mitigation*: T7 implementation verifies this first; on miss, files a 1-line `EventStore.queryEvents` extension issue and falls back to existing query + post-filter (degrades to today's behavior for the cold-start path only).
+
+## Acceptance
+
+- [ ] #1446 residue closed: `session_provenance`, `provenance`, `ideate_readiness` registered; `exarchos_view describe` exposes all 17 dispatched actions; per-action dispatch validation fires for each.
+- [ ] #1434 closed: `exarchos_view pipeline` succeeds on a repo with a `__migration__` stream; sentinel-skip covered by a regression test.
+- [ ] #1448 closed: resolution comment posted confirming items 2–5 landed via PR #1449; epic checklist updated.
+- [ ] #1438 F-4 closed: `tasks.size > 1024` triggers reap on `createTask`; regression test.
+- [ ] #1438 F-5 closed: cursor stable across process restarts; cross-process pagination test.
+- [ ] #1438 F-6 closed: `listTasks` performs O(page) stream queries, not O(total tasks); benchmark or counter assertion.
+- [ ] #1438 F-7 closed: `projectTask` malformed-request path emits a warn with streamId + sequence; coverage test.
+- [ ] #1438 F-8 closed: new `task.created` events include `requestId`; old events fall back to synthetic; coverage test.
+- [ ] Full MCP server suite passes: `cd servers/exarchos-mcp && npm run test:run`.
+- [ ] Typecheck clean: `npm run typecheck`.
+
+## Decision log
+
+- **2026-05-17** — Bundle scope reframed mid-ideation: PR #1449 landed #1448 items 2–5 between epic-writing and design-writing. Original Bundle A reduced to #1446 residue + #1434 + #1448 hygiene; combined with TaskStore F-4..8 per user direction.
+- **2026-05-17** — F-8 evaluated for compensating-event hardening (Option B); rejected on operational footprint vs benefit. Audit-aligned answer retained.
+- **2026-05-17** — F-5 + F-6 co-designed as one cursor + hydration subsystem per hardening philosophy; separate `(createdAt, taskId, streamId)` index table rejected as second source of truth (re-evaluable in v2.11).
+
+## References
+
+- Epic: #1441
+- TaskStore audit: `docs/research/2026-05-16-event-sourced-task-store-audit.md`
+- Bundle audit: `docs/research/2026-05-16-v2-10-0-preview-4-bundle-audit.md`
+- Prior correlation design: `docs/designs/2026-05-16-correlation-indexed-columns.md`
+- Prior correlation consumer wiring: `docs/designs/2026-05-16-correlation-consumer-wiring.md`
+- PR #1449 (closes #1448 items 2–5)
+- PR #1443/#1444/#1445 (closed #1438 F-1/F-2/F-3)

--- a/docs/designs/2026-05-17-preview-4-substrate-hygiene.md
+++ b/docs/designs/2026-05-17-preview-4-substrate-hygiene.md
@@ -161,6 +161,17 @@ No dimension regresses.
 - **2026-05-17** — F-8 evaluated for compensating-event hardening (Option B); rejected on operational footprint vs benefit. Audit-aligned answer retained.
 - **2026-05-17** — F-5 + F-6 co-designed as one cursor + hydration subsystem per hardening philosophy; separate `(createdAt, taskId, streamId)` index table rejected as second source of truth (re-evaluable in v2.11).
 
+## Event vocabulary note
+
+This design references `task.created`, `task.polled`, `task.result`, and `task.cancelled`. These are the **SDK task-store lifecycle events** (see `@modelcontextprotocol/sdk/experimental/tasks/interfaces.ts:TaskStore`), declared at `servers/exarchos-mcp/src/event-store/schemas.ts:172-185` with an explicit comment block distinguishing them from the workflow-orchestration `task.assigned`/`task.claimed`/`task.progressed`/`task.completed`/`task.failed` family (declared earlier in the same file at lines 10-14).
+
+These are **two distinct event domains** in this codebase:
+
+- Task-store events back the `EventSourcedTaskStore` in `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts` — they durably record the SDK protocol's task lifecycle (create → poll → result/cancel).
+- Workflow events back the orchestrator's workflow lifecycle (`task.assigned` when a subagent claims a workflow task, `task.completed` when its result lands, etc.).
+
+Renaming `task.created` to `task.assigned` in this design would create doc–code divergence: the code emits `task.created` to the `task-store/{taskId}` stream, the V5→V6 schema migration backfills `task.created` rows, and `EventStore.queryByType('task.created', ...)` is the literal API call in `hydrateFromEventStore`. The design intentionally uses the same vocabulary as the code.
+
 ## References
 
 - Epic: #1441

--- a/docs/designs/2026-05-17-preview-4-substrate-hygiene.md
+++ b/docs/designs/2026-05-17-preview-4-substrate-hygiene.md
@@ -71,7 +71,7 @@ Trade-offs vs alternatives:
 - *(Separate (createdAt, taskId, streamId) index table)* — rejected for now: adds a second source of truth that must stay consistent with the event log. Re-evaluable in v2.11 if the lookahead approach degrades under load.
 - *(Sort by sequence # of task.created in the dispatched stream)* — rejected: harder to compute, and the audit doc already prefers `createdAt`.
 
-**Event-store query surface** — this design assumes `EventStore.queryByType` supports a `(streamPrefix='task-store/', eventType='task.created', createdAtFrom, limit)` filter. Wave T implementation must verify this against the V6 schema and, if missing, file a sub-issue for the minimal extension (NOT widen scope inside this bundle).
+**Event-store query surface** — this design assumes the call `EventStore.queryByType('task.created', { streamPrefix: 'task-store/', since, limit })` is available (signature: `queryByType(eventType, filters)` where `filters` is `QueryFilters & { streamPrefix?: string }`; see `servers/exarchos-mcp/src/event-store/store.ts:526`). Wave T implementation must verify this against the V6 schema and, if missing, file a sub-issue for the minimal extension (NOT widen scope inside this bundle).
 
 ## F-8 disposition (requestId)
 
@@ -92,7 +92,7 @@ The hardening philosophy invited reconsidering the audit-aligned "keep the fallb
 | `servers/exarchos-mcp/src/registry.ts` | T1 — add 3 viewActions entries | V |
 | `servers/exarchos-mcp/src/views/materializer.ts` | T2 — sentinel-skip in stream iterator | V |
 | `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts` | T4/T5/T6/T7/T8 | T |
-| `servers/exarchos-mcp/src/event-store/store.ts` (or sqlite-backend) | T7 — verify `queryByType` accepts `(streamPrefix, eventType, createdAtFrom)` | T |
+| `servers/exarchos-mcp/src/event-store/store.ts` (or sqlite-backend) | T7 — verify `queryByType(eventType, { streamPrefix, since, limit })` is wired through to `SqliteBackend` | T |
 | `servers/exarchos-mcp/src/__tests__/...` co-located | regression tests per task | both |
 
 No schema migration. No event payload changes for existing events. No CLI surface changes (T1 schemas auto-emit flags via `addFlagsFromSchema` per memory note `project_cli_schema_driven_flags`).
@@ -140,7 +140,7 @@ No dimension regresses.
 - **F-7 coerce-and-warn log noise**: if many existing streams contain malformed `request` payloads, the warn may fire repeatedly. *Mitigation*: include streamId in the log so it's deduplicable; if noise becomes operational, downgrade to debug or sample 1/N. Land as `warn` and observe.
 - **F-6 cursor lookahead under-shoots tie-break churn**: if many `task.created` events share a millisecond timestamp, lookahead=8 may leave gaps. *Mitigation*: lookahead is configurable; integration tests assert lookahead=8 is sufficient at expected creation rates. If observed in the wild, raise.
 - **T2 sentinel-skip hides a legitimate `__`-prefixed stream**: the only known sentinel is `__migration__`. *Mitigation*: log at debug level when a `__`-prefixed stream is skipped; explicit allowlist (`__migration__`) reviewable in v2.11 if other sentinels emerge.
-- **Event-store query surface assumption**: T7's cursor mechanism assumes `queryByType` supports `(streamPrefix, eventType, createdAtFrom)` filter triple. *Mitigation*: T7 implementation verifies this first; on miss, files a 1-line `EventStore.queryByType` extension issue and falls back to existing query + post-filter (degrades to today's behavior for the cold-start path only).
+- **Event-store query surface assumption**: T7's cursor mechanism assumes the call shape `EventStore.queryByType(eventType, { streamPrefix, since, limit })` is available. *Mitigation*: T7 implementation verifies this first; on miss, files a 1-line `EventStore.queryByType` extension issue and falls back to existing query + post-filter (degrades to today's behavior for the cold-start path only).
 
 ## Acceptance
 

--- a/docs/plans/2026-05-17-preview-4-substrate-hygiene.md
+++ b/docs/plans/2026-05-17-preview-4-substrate-hygiene.md
@@ -236,6 +236,10 @@ Before opening the integration PR:
 - T2 sentinel hides legit `__`-prefixed stream — mitigation: debug log on skip
 - T8 queryByType surface — mitigation: PRECHECK + fallback path
 
+## Event vocabulary
+
+`task.created` / `task.polled` / `task.result` / `task.cancelled` are the **SDK task-store lifecycle events** (declared at `servers/exarchos-mcp/src/event-store/schemas.ts:172-185`) — distinct from the workflow-orchestration `task.assigned` / `task.claimed` / `task.progressed` / `task.completed` / `task.failed` family (lines 10-14 of the same file). See the design doc's "Event vocabulary note" section for the full rationale on why this plan uses the same vocabulary as the code.
+
 ## References
 
 - Design: `docs/designs/2026-05-17-preview-4-substrate-hygiene.md`

--- a/docs/plans/2026-05-17-preview-4-substrate-hygiene.md
+++ b/docs/plans/2026-05-17-preview-4-substrate-hygiene.md
@@ -186,14 +186,14 @@ Branch convention: each task lands on `task/<feature>-<id>` and merges into `fea
 **Closes:** #1438 F-6 (hydration half of the cursor + hydration co-design)
 **Phase:** PRECHECK → RED → GREEN → REFACTOR
 
-1. **[PRECHECK]** Verify `EventStore.queryEvents` supports `(streamPrefix, eventType, createdAtFrom, limit)` filter triple.
-   - File: read `servers/exarchos-mcp/src/event-store/store.ts` + `storage/sqlite-backend.ts` `queryEvents` signature.
+1. **[PRECHECK]** Verify `EventStore.queryByType` supports `(streamPrefix, eventType, createdAtFrom, limit)` filter triple.
+   - File: read `servers/exarchos-mcp/src/event-store/store.ts` + `storage/sqlite-backend.ts` `queryByType` signature.
    - On match: proceed.
    - On miss: file a 1-line issue for the minimal extension; T8 falls back to "query all + post-filter" for cold-start only (degrades to today's behavior on the slow path). Document chosen path in the PR.
 
 2. **[RED]** Write test: `ListTasks_OnColdStartWithLimit10_QueriesOnePageOfStreams`
    - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts`
-   - Setup: seed 100 `task.created` events. Wrap `EventStore.queryEvents` with a counter. Cold-start instance and call `listTasks({ limit: 10 })`.
+   - Setup: seed 100 `task.created` events. Wrap `EventStore.queryByType` with a counter. Cold-start instance and call `listTasks({ limit: 10 })`.
    - Asserts: counter ≤ `limit + lookahead` (i.e., ≤ 18 with lookahead=8); not 100.
    - Companion test: `ListTasks_OnWarmCallAfterColdHydration_DoesNotReQueryAlreadyHydratedTasks` — call `listTasks` twice; second call queries only for newly-created tasks since the first.
    - Expected failure: today `hydrateFromEventStore` enumerates all streams.
@@ -234,7 +234,7 @@ Before opening the integration PR:
 - F-7 coerce-warn noise — mitigation: streamId in log payload
 - F-6 lookahead under-shoot — mitigation: lookahead configurable; test asserts 8 sufficient
 - T2 sentinel hides legit `__`-prefixed stream — mitigation: debug log on skip
-- T8 queryEvents surface — mitigation: PRECHECK + fallback path
+- T8 queryByType surface — mitigation: PRECHECK + fallback path
 
 ## References
 

--- a/docs/plans/2026-05-17-preview-4-substrate-hygiene.md
+++ b/docs/plans/2026-05-17-preview-4-substrate-hygiene.md
@@ -1,0 +1,243 @@
+# Implementation Plan — v2.10.0-preview.4 substrate hygiene bundle
+
+> **Design:** `docs/designs/2026-05-17-preview-4-substrate-hygiene.md`
+> **Date:** 2026-05-17
+> **Integration branch:** `feature/preview-4-substrate-hygiene`
+> **Closes:** #1446 (residue), #1434, #1448 (hygiene), #1438 F-4..F-8
+> **Iron Law:** No production code without a failing test first.
+
+---
+
+## Wave map
+
+| Wave | Tasks | Parallelizable | Notes |
+|---|---|---|---|
+| **V** (views layer) | T1, T2, T3 | T1 ∥ T2 (different files); T3 last | Wave V is parallel-safe with Wave T |
+| **T** (task-store) | T4, T5, T6, T7, T8 | T4 ∥ T5 ∥ T6 ∥ T7; T8 depends on T7 | Five tasks, only T8→T7 has a hard edge |
+
+Branch convention: each task lands on `task/<feature>-<id>` and merges into `feature/preview-4-substrate-hygiene`. Final integration → one PR to `main`.
+
+---
+
+## Wave V — Views layer
+
+### Task T1: Register 3 unregistered view actions in `TOOL_REGISTRY`
+
+**Closes:** #1446 residue
+**Phase:** RED → GREEN → REFACTOR
+
+1. **[RED]** Write three tests pinning the full DR-5 acceptance:
+   - Test A — `TOOL_REGISTRY_viewActions_IncludesSessionProvenanceProvenanceAndIdeateReadiness`
+     - File: `servers/exarchos-mcp/src/registry.test.ts` (extend existing suite)
+     - Asserts: `TOOL_REGISTRY.exarchos_view.actions.find(a => a.name === 'session_provenance')` is defined, schema is `z.object`, and `provenance` + `ideate_readiness` likewise. For each, where the underlying handler queries the event store, asserts `CORRELATION_TUPLE_FILTER_SHAPE` keys (`operationId`, `correlationId`, `causationId`) are present in the action's schema shape.
+   - Test B — `ExarchosViewDescribe_ListsAllSeventeenDispatchedActions`
+     - File: `servers/exarchos-mcp/src/views/composite.envelope.test.ts` (extend) or new `describe.coverage.test.ts`
+     - Asserts: invoking `exarchos_view {action: 'describe'}` returns an action list whose `name` set is a superset of all 17 dispatched action names (collected from `composite.ts` switch cases excluding `describe`). Pins the registry-vs-dispatch parity contract.
+   - Test C — `ExarchosViewDispatch_OnInvalidArgsForNewlyRegisteredAction_ReturnsZodValidationError`
+     - File: `servers/exarchos-mcp/src/core/dispatch.test.ts` (extend) or co-located
+     - Asserts: dispatching `session_provenance` (and `provenance`, `ideate_readiness`) with a Zod-invalid arg shape returns a structured validation error envelope — same path that fired for Wave 5 actions post-#1437.
+   - Expected failure: today all three actions are absent from `viewActions`, so describe under-lists them and dispatch's per-action Zod validation at `core/dispatch.ts:801` silently skips.
+
+2. **[GREEN]** Implement
+   - File: `servers/exarchos-mcp/src/registry.ts`
+   - Add 3 entries to `viewActions: readonly ToolAction[]`, mirroring the Wave 5 pattern from `eval_results` / `quality_correlation` / `quality_attribution`. Each entry: `name`, `description`, `schema` (derived from composite handler signature in `views/composite.ts`), `phases`, `roles`, `outputSchema: EnvelopeSchema(z.unknown())`, `annotations: READ_ONLY_LOCAL`. Include `CORRELATION_TUPLE_FILTER_SHAPE` where the underlying view queries the event store.
+
+3. **[REFACTOR]** None expected; the existing pattern is the target shape.
+
+**Dependencies:** None
+**Parallelizable:** Yes (with T2..T7)
+
+---
+
+### Task T2: Skip `__`-prefixed sentinel streams in `ViewMaterializer`
+
+**Closes:** #1434
+**Phase:** RED → GREEN → REFACTOR
+
+1. **[RED]** Write test: `ViewMaterializer_IteratesStreams_SkipsDunderPrefixedSentinels`
+   - File: `servers/exarchos-mcp/src/views/materializer.test.ts` (extend) or new `materializer.sentinel-skip.test.ts`
+   - Setup: event store seeded with two streams — `my-feature` (user-facing) and `__migration__` (sentinel). Call the materializer's stream iteration path (whichever method drives `pipeline` view aggregation).
+   - Asserts: `my-feature` is materialized; `__migration__` is NOT passed to `SnapshotStore.getSnapshotPath`; no `Invalid streamId` error thrown.
+   - Companion integration test: `ExarchosView_Pipeline_DoesNotCrashOnMigrationStream` — drives through `exarchos_view {action: 'pipeline'}` end-to-end with a `__migration__` stream present; asserts envelope success.
+   - Expected failure: today the validator throws; today's pipeline view crashes.
+
+2. **[GREEN]** Implement
+   - File: `servers/exarchos-mcp/src/views/materializer.ts`
+   - At the stream-iteration site, add a `if (streamId.startsWith('__')) continue;` (or equivalent filter). Add a `logger.debug({ streamId }, 'ViewMaterializer: skipping sentinel stream')` so operators can see it.
+
+3. **[REFACTOR]** Extract to a named predicate if used in multiple sites: `const isInternalSentinelStream = (id: string) => id.startsWith('__')`.
+
+**Dependencies:** None
+**Parallelizable:** Yes
+
+---
+
+### Task T3: Hygiene close `#1448`
+
+**Closes:** #1448 (issue closure only — no code)
+**Phase:** No-code task; ordering only
+
+1. **[VERIFY]** Confirm items 2–5 landed via PR #1449 by running `git log --oneline --all -- servers/exarchos-mcp/src/views/tools.ts | grep '#1448'`. Expect commits `5c3c1826`, `cc9343e3`, `c69ad5c0`, `1ccc41f1`, and `3288cf7d`.
+2. **[ACT]** Post resolution comment on #1448: "Items 2–5 landed via PR #1449 (merged 2026-05-17). Item 1 (#1446) tracked separately; residue closed in this bundle." Close issue.
+3. **[ACT]** Update epic #1441 checklist to reflect #1446 + #1434 + #1448 closure once the bundle PR merges.
+
+**Dependencies:** Bundle PR merge (T3 fires post-merge, not in the PR itself)
+**Parallelizable:** n/a (no code)
+
+---
+
+## Wave T — Task-store layer
+
+### Task T4: Size-cap reap on `createTask`
+
+**Closes:** #1438 F-4
+**Phase:** RED → GREEN → REFACTOR
+
+1. **[RED]** Write test: `CreateTask_WhenMapExceeds1024Entries_TriggersExpiredReap`
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts`
+   - Setup: create 1024 tasks with TTLs that have already expired (mock clock or short TTL + advance). Then call `createTask` once more. Assert: `this.tasks.size` post-call ≤ 1024 (the new task plus survivors), expired entries gone.
+   - Companion test: `CreateTask_WhenMapUnder1024_DoesNotReap` — assert no reap activity for sizes ≤ 1024 (asserts via a spy on the reap method).
+   - Expected failure: today `createTask` never calls `reapExpired`; map grows unbounded.
+
+2. **[GREEN]** Implement
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts`
+   - In `createTask`, after the `task.created` event append, add: `if (this.tasks.size > 1024) this.reapExpired();`
+   - Optional: extract `1024` to a `SIZE_CAP_REAP_THRESHOLD` const at module top.
+
+3. **[REFACTOR]** None expected.
+
+**Dependencies:** None
+**Parallelizable:** Yes (with T5, T6, T7)
+
+---
+
+### Task T5: Coerce-and-warn on `projectTask` malformed `request`
+
+**Closes:** #1438 F-7
+**Phase:** RED → GREEN → REFACTOR
+
+1. **[RED]** Write test: `ProjectTask_WhenRequestPayloadMalformed_LogsWarnWithStreamIdAndSequence`
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts`
+   - Setup: seed `task.created` event whose `request` field is `null` / missing / non-object. Replay via the projection.
+   - Asserts: `logger.warn` called once with payload containing `streamId` and event `sequence`; projection still returns a coerced Task (tolerate-and-flag).
+   - Expected failure: today the coerce is silent.
+
+2. **[GREEN]** Implement
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts`
+   - At `projectTask:455` (the `createdData['request'] ?? {}`): branch on whether `createdData['request']` is missing or non-object; if so, call `logger.warn({ streamId, sequence: event.sequence, requestType: typeof createdData['request'] }, 'projectTask: coerced malformed request payload')`. Behavior unchanged on the happy path.
+
+3. **[REFACTOR]** If similar coerce sites exist for other fields, file a follow-up but do not expand scope here.
+
+**Dependencies:** None
+**Parallelizable:** Yes
+
+---
+
+### Task T6: Persist `requestId` on `task.created` event payload
+
+**Closes:** #1438 F-8
+**Phase:** RED → GREEN → REFACTOR
+
+1. **[RED]** Write test: `CreateTask_AppendsTaskCreatedEvent_IncludesRequestIdInPayload`
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts`
+   - Setup: call `createTask({ ..., requestId: 'req-abc' })`. Inspect the appended `task.created` event payload.
+   - Asserts: `event.data.requestId === 'req-abc'`. Companion test: `ProjectTask_ReplaysTaskCreated_WithoutRequestIdField_FallsBackToSyntheticReplayedPrefix` — replay an old-shape event lacking `requestId`; assert projection returns `requestId: 'replayed:${taskId}'`.
+   - Expected failure: today `requestId` is not written to event payload.
+
+2. **[GREEN]** Implement
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts`
+   - At the `task.created` emission site in `createTask`, add `requestId` to the event `data` object. Update the typed payload schema (if `task.created` has a Zod schema in `events/` or similar — verify location during implementation).
+   - In `projectTask`, read `createdData['requestId']` first; fall back to `replayed:${taskId}` if missing.
+
+3. **[REFACTOR]** None expected.
+
+**Dependencies:** None
+**Parallelizable:** Yes
+
+---
+
+### Task T7: Stable cursor — sort `listTasks` by `(createdAt ASC, taskId ASC)`
+
+**Closes:** #1438 F-5 (cursor half of the cursor + hydration co-design)
+**Phase:** RED → GREEN → REFACTOR
+
+1. **[RED]** Write test: `ListTasks_AcrossSimulatedRestart_PaginatesStablyWithCursor`
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts`
+   - Setup: seed N=20 `task.created` events with deterministic but **unsorted** insertion order (e.g., createdAt timestamps interleaved). Create instance A, page through with `limit=5`, capture cursors per page. Destroy instance A. Create instance B against the same event store. Page through with the same cursors.
+   - Asserts: instance B returns the same task order as instance A. Tasks across all pages are unique and totalled to N.
+   - Companion test: `ListTasks_TieBreakOnIdenticalCreatedAt_OrdersByTaskIdAsc` — two `task.created` events with identical timestamps; assert `taskId` ASC ordering.
+   - Expected failure: today sort is Map insertion order → instance B sees a different sequence.
+
+2. **[GREEN]** Implement
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts`
+   - In `listTasks`, after hydration: `Array.from(this.tasks.values()).sort((a, b) => a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : a.taskId < b.taskId ? -1 : a.taskId > b.taskId ? 1 : 0)`.
+   - Cursor encoding: `base64url(JSON.stringify({ createdAt, taskId }))` for the last task in the page.
+   - Cursor decode + offset: skip past tasks `<=` the cursor (lexicographic on `(createdAt, taskId)` tuple).
+
+3. **[REFACTOR]** Extract cursor encode/decode helpers if useful; document the cursor shape in a top-of-file comment.
+
+**Dependencies:** None
+**Parallelizable:** Yes (with T1..T6); T8 depends on T7
+
+---
+
+### Task T8: Cursor-anchored incremental hydration
+
+**Closes:** #1438 F-6 (hydration half of the cursor + hydration co-design)
+**Phase:** PRECHECK → RED → GREEN → REFACTOR
+
+1. **[PRECHECK]** Verify `EventStore.queryEvents` supports `(streamPrefix, eventType, createdAtFrom, limit)` filter triple.
+   - File: read `servers/exarchos-mcp/src/event-store/store.ts` + `storage/sqlite-backend.ts` `queryEvents` signature.
+   - On match: proceed.
+   - On miss: file a 1-line issue for the minimal extension; T8 falls back to "query all + post-filter" for cold-start only (degrades to today's behavior on the slow path). Document chosen path in the PR.
+
+2. **[RED]** Write test: `ListTasks_OnColdStartWithLimit10_QueriesOnePageOfStreams`
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts`
+   - Setup: seed 100 `task.created` events. Wrap `EventStore.queryEvents` with a counter. Cold-start instance and call `listTasks({ limit: 10 })`.
+   - Asserts: counter ≤ `limit + lookahead` (i.e., ≤ 18 with lookahead=8); not 100.
+   - Companion test: `ListTasks_OnWarmCallAfterColdHydration_DoesNotReQueryAlreadyHydratedTasks` — call `listTasks` twice; second call queries only for newly-created tasks since the first.
+   - Expected failure: today `hydrateFromEventStore` enumerates all streams.
+
+3. **[GREEN]** Implement
+   - File: `servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts`
+   - Replace `hydrateFromEventStore`'s full enumeration with: query `task.created` events with `(streamPrefix='task-store/', eventType='task.created', createdAtFrom=cursor.createdAt OR undefined, limit=limit+lookahead)`. For each event in result, hydrate the per-task projection if `this.tasks` doesn't already have it. Skip cached.
+   - Set `lookahead = 8` as a module-level const.
+
+4. **[REFACTOR]** Document the lookahead choice + tie-break interaction in a top-of-file comment.
+
+**Dependencies:** T7 (cursor sort + encoding)
+**Parallelizable:** No (sequential after T7)
+
+---
+
+## Pre-PR gates
+
+Before opening the integration PR:
+
+- [ ] `cd servers/exarchos-mcp && npm run test:run` — full suite passes
+- [ ] `npm run typecheck` — clean (root + servers/exarchos-mcp)
+- [ ] `npm run build` — clean
+- [ ] Manual smoke: `exarchos_view {action: 'pipeline'}` on a repo with `__migration__` stream
+- [ ] Manual smoke: `exarchos_view {action: 'session_provenance'}` invokes Zod-validated dispatch
+- [ ] Benchmark: `listTasks` cold-start query count for 100 seeded tasks (counter assertion, see T8)
+
+## Out of scope
+
+- T17 `next_actions` real-handler integration (closed via #1449)
+- Cross-tier correlation propagation (basileus / remote MCP — INV-3, v3+)
+- Filter-aware materializer cache keying (rejected in #1447 design)
+- Reopening F-1/F-2/F-3 (#1443/#1444/#1445)
+- #1395 auto-emit audit; #1370 + #1439 invariant audit — separate bundles
+
+## Risks (carried from design)
+
+- F-7 coerce-warn noise — mitigation: streamId in log payload
+- F-6 lookahead under-shoot — mitigation: lookahead configurable; test asserts 8 sufficient
+- T2 sentinel hides legit `__`-prefixed stream — mitigation: debug log on skip
+- T8 queryEvents surface — mitigation: PRECHECK + fallback path
+
+## References
+
+- Design: `docs/designs/2026-05-17-preview-4-substrate-hygiene.md`
+- Epic: #1441
+- TaskStore audit: `docs/research/2026-05-16-event-sourced-task-store-audit.md`

--- a/docs/plans/2026-05-17-preview-4-substrate-hygiene.md
+++ b/docs/plans/2026-05-17-preview-4-substrate-hygiene.md
@@ -186,8 +186,8 @@ Branch convention: each task lands on `task/<feature>-<id>` and merges into `fea
 **Closes:** #1438 F-6 (hydration half of the cursor + hydration co-design)
 **Phase:** PRECHECK → RED → GREEN → REFACTOR
 
-1. **[PRECHECK]** Verify `EventStore.queryByType` supports `(streamPrefix, eventType, createdAtFrom, limit)` filter triple.
-   - File: read `servers/exarchos-mcp/src/event-store/store.ts` + `storage/sqlite-backend.ts` `queryByType` signature.
+1. **[PRECHECK]** Verify the call shape `EventStore.queryByType('task.created', { streamPrefix: 'task-store/', since, limit })` resolves through to `SqliteBackend.queryEventsByType`. Signature contract: `queryByType(eventType: string, filters?: QueryFilters & { streamPrefix?: string })`.
+   - File: read `servers/exarchos-mcp/src/event-store/store.ts:526` + `storage/sqlite-backend.ts` to confirm the `since` + `streamPrefix` pair is honored.
    - On match: proceed.
    - On miss: file a 1-line issue for the minimal extension; T8 falls back to "query all + post-filter" for cold-start only (degrades to today's behavior on the slow path). Document chosen path in the PR.
 
@@ -234,7 +234,7 @@ Before opening the integration PR:
 - F-7 coerce-warn noise — mitigation: streamId in log payload
 - F-6 lookahead under-shoot — mitigation: lookahead configurable; test asserts 8 sufficient
 - T2 sentinel hides legit `__`-prefixed stream — mitigation: debug log on skip
-- T8 queryByType surface — mitigation: PRECHECK + fallback path
+- T8 `queryByType(eventType, { streamPrefix, since, limit })` surface — mitigation: PRECHECK + fallback path
 
 ## Event vocabulary
 

--- a/servers/exarchos-mcp/src/core/dispatch.test.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.test.ts
@@ -1313,4 +1313,59 @@ describe('dispatch', () => {
     expect(typeof meta!.operationId).toBe('string');
     expect(meta!.operationId as string).toMatch(UUID_RE);
   });
+
+  // T1 (#1446 residue) — DR-5 dispatch validation for the three view
+  // actions that were dispatched through `views/composite.ts` but missing
+  // from `TOOL_REGISTRY.viewActions`. Before T1, dispatching with bad args
+  // returned the generic "unknown action" error from dispatch.ts:650-657
+  // (action not in registry), so callers could not distinguish "the action
+  // doesn't exist" from "the action exists but the args are malformed".
+  // After T1, the same path that fires for Wave 5 actions post-#1437 must
+  // also fire here: the action is found, the per-action schema rejects the
+  // malformed input, and the envelope carries the Zod issue path (the field
+  // name the caller got wrong).
+  describe('T1 — DR-5 dispatch validation for newly registered view actions', () => {
+    const NEWLY_REGISTERED_VIEW_ACTIONS = [
+      'session_provenance',
+      'provenance',
+      'ideate_readiness',
+    ] as const;
+
+    for (const action of NEWLY_REGISTERED_VIEW_ACTIONS) {
+      it(`ExarchosViewDispatch_OnInvalidArgsForNewlyRegisteredAction_ReturnsZodValidationError_${action}`, async () => {
+        const { dispatch } = await import('./dispatch.js');
+
+        // workflowId is declared as `z.string().optional()` on every one of
+        // the three new schemas, so passing a number triggers a `z.string`
+        // type-mismatch — the canonical post-T1 Zod surface, distinct from
+        // the pre-T1 "unknown action" surface.
+        const result = await dispatch(
+          'exarchos_view',
+          { action, workflowId: 123 },
+          { stateDir: tmpDir, eventStore, enableTelemetry: false },
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.error?.code).toBe('INVALID_INPUT');
+
+        const message = result.error?.message ?? '';
+        // Post-T1: Zod validation fires. The message MUST reference the
+        // offending field path (`workflowId`) — that's the discriminator
+        // between the per-action validation envelope and the registry's
+        // "unknown action" envelope. Pre-T1 the message reads:
+        //   `exarchos_view: unknown action "<action>". Valid actions: ...`
+        // which contains the action name but never the field name.
+        expect(
+          message,
+          `Expected Zod validation to reject 'workflowId: 123' for action ` +
+            `'${action}'. Got: ${message}`,
+        ).toMatch(/workflowId/);
+        expect(
+          message,
+          `Expected '${action}' to be a registered action (post-T1). ` +
+            `Got "unknown action" envelope: ${message}`,
+        ).not.toMatch(/unknown action/i);
+      });
+    }
+  });
 });

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -1789,6 +1789,16 @@ export const TaskCreatedData = z.object({
   // the field continue to project (back-compat with pre-fix
   // `task.created` payloads).
   pollInterval: z.number().int().positive().optional(),
+  // FINDING-8 (#1438, T6): persist the JSON-RPC `requestId` so REPLAY
+  // recovers the original outbound correlation id verbatim instead of
+  // having to synthesize `replayed:${taskId}`. Optional because
+  // historical `task.created` events emitted before this fix do NOT
+  // carry the field — the synthesizer in `projectTask` remains the
+  // load-bearing back-compat fallback for those events (INV-1: events
+  // are immutable, so old events stay shaped as they were when written).
+  // SDK `RequestId` is `string | number` (JSON-RPC envelope), so we
+  // mirror that union here rather than narrowing to string.
+  requestId: z.union([z.string(), z.number()]).optional(),
 });
 
 /**

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -742,6 +742,90 @@ describe('TOOL_REGISTRY', () => {
       });
       expect(result.success).toBe(true);
     });
+
+    // T1 (#1446 residue) — register the three view actions that are
+    // dispatched through `views/composite.ts` today but were never added to
+    // `TOOL_REGISTRY.viewActions`. Without the registry entry, per-action
+    // Zod validation at `core/dispatch.ts:801` is silently skipped and
+    // `exarchos_view describe` under-lists the dispatched surface.
+    it('TOOL_REGISTRY_viewActions_IncludesSessionProvenanceProvenanceAndIdeateReadiness', () => {
+      const viewComposite = findComposite('exarchos_view');
+      expect(viewComposite).toBeDefined();
+
+      // ── session_provenance ────────────────────────────────────────────
+      // Handler: `handleViewSessionProvenance(args, stateDir)` —
+      // accepts `{ sessionId?, workflowId?, metric? }`. Does NOT receive
+      // the event store, so the correlation-tuple filter shape is
+      // intentionally absent here.
+      const sessionProvenance = viewComposite!.actions.find(
+        (a) => a.name === 'session_provenance',
+      );
+      expect(sessionProvenance, 'session_provenance must be registered').toBeDefined();
+      expect(
+        sessionProvenance!.schema instanceof z.ZodObject,
+        'session_provenance.schema must be a ZodObject',
+      ).toBe(true);
+      const sessionProvenanceShape = (
+        sessionProvenance!.schema as z.ZodObject
+      ).shape;
+      // Accepts the args the composite handler routes today.
+      const sessionProvenanceParse = sessionProvenance!.schema.safeParse({
+        sessionId: 'sess-abc',
+        workflowId: 'wf-1',
+        metric: 'cost',
+      });
+      expect(sessionProvenanceParse.success).toBe(true);
+      // No event-store query => no correlation-tuple slots.
+      expect(sessionProvenanceShape).not.toHaveProperty('operationId');
+      expect(sessionProvenanceShape).not.toHaveProperty('correlationId');
+      expect(sessionProvenanceShape).not.toHaveProperty('causationId');
+
+      // ── provenance ────────────────────────────────────────────────────
+      // Handler: `handleViewProvenance(args, stateDir, eventStore)` — queries
+      // the event store via `queryDeltaEvents`, so the correlation-tuple
+      // filter shape MUST be present so DR-5 dispatch validation surfaces
+      // those slots through `describe` (parity with the Wave 5 actions
+      // registered post-#1437).
+      const provenance = viewComposite!.actions.find(
+        (a) => a.name === 'provenance',
+      );
+      expect(provenance, 'provenance must be registered').toBeDefined();
+      expect(
+        provenance!.schema instanceof z.ZodObject,
+        'provenance.schema must be a ZodObject',
+      ).toBe(true);
+      const provenanceShape = (provenance!.schema as z.ZodObject).shape;
+      expect(provenanceShape).toHaveProperty('operationId');
+      expect(provenanceShape).toHaveProperty('correlationId');
+      expect(provenanceShape).toHaveProperty('causationId');
+      expect(
+        provenance!.schema.safeParse({ workflowId: 'wf-1' }).success,
+      ).toBe(true);
+
+      // ── ideate_readiness ──────────────────────────────────────────────
+      // Handler: `handleViewIdeateReadiness(args, stateDir, eventStore)` —
+      // queries the event store; same DR-5 correlation-tuple contract.
+      const ideateReadiness = viewComposite!.actions.find(
+        (a) => a.name === 'ideate_readiness',
+      );
+      expect(
+        ideateReadiness,
+        'ideate_readiness must be registered',
+      ).toBeDefined();
+      expect(
+        ideateReadiness!.schema instanceof z.ZodObject,
+        'ideate_readiness.schema must be a ZodObject',
+      ).toBe(true);
+      const ideateReadinessShape = (
+        ideateReadiness!.schema as z.ZodObject
+      ).shape;
+      expect(ideateReadinessShape).toHaveProperty('operationId');
+      expect(ideateReadinessShape).toHaveProperty('correlationId');
+      expect(ideateReadinessShape).toHaveProperty('causationId');
+      expect(
+        ideateReadiness!.schema.safeParse({ workflowId: 'wf-1' }).success,
+      ).toBe(true);
+    });
   });
 
   describe('schema validation', () => {

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -2593,7 +2593,7 @@ export const TOOL_REGISTRY: readonly CompositeTool[] = [
     description: 'CQRS materialized views — pipeline, tasks, workflow status, stack, and telemetry',
     actions: viewActions,
     cli: { alias: 'vw' },
-    slimDescription: 'CQRS materialized views for pipeline, tasks, and telemetry. Use describe(actions) for schemas.\n\nActions: pipeline, tasks, workflow_status, stack_status, stack_place, telemetry, team_performance, delegation_timeline, code_quality, eval_results, quality_correlation, quality_attribution, quality_hints, delegation_readiness, synthesis_readiness, shepherd_status, convergence',
+    slimDescription: 'CQRS materialized views for pipeline, tasks, and telemetry. Use describe(actions) for schemas.\n\nActions: pipeline, tasks, workflow_status, stack_status, stack_place, telemetry, team_performance, delegation_timeline, code_quality, eval_results, quality_correlation, quality_attribution, quality_hints, delegation_readiness, synthesis_readiness, shepherd_status, convergence, session_provenance, provenance, ideate_readiness',
   },
   {
     name: 'exarchos_sync',

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -2446,6 +2446,62 @@ const viewActions: readonly ToolAction[] = [
     outputSchema: EnvelopeSchema(z.unknown()),
     annotations: READ_ONLY_LOCAL,
   },
+  // T1 (#1446 residue) — three view actions dispatched through
+  // `views/composite.ts` but previously absent from TOOL_REGISTRY.viewActions.
+  // Without the registry entry, per-action Zod validation at
+  // `core/dispatch.ts:801` is silently skipped (DR-5 hole) and
+  // `exarchos_view describe` cannot surface their schemas. Registering them
+  // here closes both gaps. Schemas mirror the args the composite.ts handlers
+  // route today (see `views/composite.ts` cases for each action).
+  {
+    name: 'session_provenance',
+    description: 'Per-session provenance roll-up (tokens, tools, cost attribution) — query by sessionId or workflowId, optionally narrowed by metric',
+    schema: z.object({
+      sessionId: z.string().optional(),
+      workflowId: z.string().optional(),
+      metric: z.string().optional(),
+      // No correlation-tuple filter slots: the underlying handler
+      // (`handleViewSessionProvenance`) does not receive the event store.
+      // The session-provenance projection reads `stateDir` only, so there
+      // is no event-store query for the tuple filters to scope.
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_ANY,
+    outputSchema: EnvelopeSchema(z.unknown()),
+    annotations: READ_ONLY_LOCAL,
+  },
+  {
+    name: 'provenance',
+    description: 'Design-to-task provenance: per-requirement coverage and orphan-task detection from the design.linked / task.assigned event chain',
+    schema: z.object({
+      workflowId: z.string().optional(),
+      // Underlying handler (`handleViewProvenance`) queries the event store
+      // via `queryDeltaEvents`, so the correlation-tuple filter surface
+      // mirrors the Wave 5 (#1437) telemetry-view contract — slots are
+      // optional and pass through the cache-bypassing filtered fold path
+      // when present.
+      ...CORRELATION_TUPLE_FILTER_SHAPE,
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_ANY,
+    outputSchema: EnvelopeSchema(z.unknown()),
+    annotations: READ_ONLY_LOCAL,
+  },
+  {
+    name: 'ideate_readiness',
+    description: 'Check ideate-phase readiness: design artifact presence and the gates that gate transition to plan',
+    schema: z.object({
+      workflowId: z.string().optional(),
+      // Underlying handler (`handleViewIdeateReadiness`) queries the event
+      // store via `queryDeltaEvents`; correlation-tuple filter surface
+      // mirrors the Wave 5 (#1437) contract.
+      ...CORRELATION_TUPLE_FILTER_SHAPE,
+    }),
+    phases: ALL_PHASES,
+    roles: ROLE_ANY,
+    outputSchema: EnvelopeSchema(z.unknown()),
+    annotations: READ_ONLY_LOCAL,
+  },
   {
     name: 'synthesis_readiness',
     description: 'Check synthesis readiness: task completion, reviews, tests, and typecheck status',

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -1538,4 +1538,138 @@ describe('EventSourcedTaskStore (#1272)', () => {
       vi.useRealTimers();
     }
   });
+
+  it('ListTasks_OnColdStartWithLimit10_QueriesOnePageOfStreams', async () => {
+    // FINDING-6 (#1438, T8): cursor-anchored incremental hydration.
+    //
+    // Pre-fix: `hydrateFromEventStore` enumerates EVERY `task-store/*`
+    // stream on every `listTasks` call and folds each via `loadTask`.
+    // With N historical tasks that is N per-stream `eventStore.query`
+    // calls before pagination even begins — a cold-start `listTasks`
+    // over 100 historical tasks paid 100 stream queries to return 10.
+    //
+    // Post-fix: hydration queries the event store ONCE via
+    // `queryByType('task.created', { streamPrefix, since, limit })`
+    // with `limit = PAGE_SIZE + LOOKAHEAD = 18`. Per-task projection
+    // folds only run for the (at most 18) events that came back. The
+    // upper bound on per-stream `query` calls is therefore
+    // `PAGE_SIZE + LOOKAHEAD`, not the total stream count.
+    //
+    // Repro: seed 100 task.created events through the durable substrate
+    // (bypassing the in-memory cache so the new store truly cold-starts),
+    // then spy `eventStore.query` and call `listTasks()`. Pre-fix the
+    // spy fires 100 times; post-fix it fires ≤ 18.
+    const N = 100;
+    const baseTimeMs = Date.parse('2026-03-01T00:00:00.000Z');
+    for (let i = 0; i < N; i++) {
+      const taskId = `task-cold-${String(i).padStart(4, '0')}`;
+      const createdAt = new Date(baseTimeMs + i * 1000).toISOString();
+      await eventStore.append(`task-store/${taskId}`, {
+        type: 'task.created',
+        timestamp: createdAt,
+        data: {
+          taskId,
+          ttl: null,
+          request: sampleRequest,
+        },
+      });
+    }
+
+    // Cold-start instance: fresh store backed by the same event store,
+    // so `this.tasks` is empty and every `listTasks` entry requires
+    // hydration from durable events.
+    const coldStore = new EventSourcedTaskStore(eventStore);
+    const querySpy = vi.spyOn(eventStore, 'query');
+
+    try {
+      const { tasks, nextCursor } = await coldStore.listTasks();
+
+      // Sanity: page 1 returns exactly PAGE_SIZE=10 entries and exposes
+      // a cursor (more pages follow). Sorted by createdAt ASC, the page
+      // is the first 10 inserts.
+      expect(tasks).toHaveLength(10);
+      expect(nextCursor).toBeDefined();
+
+      // The load-bearing assertion: cold-start hydration MUST NOT walk
+      // every durable stream. With PAGE_SIZE=10 and LOOKAHEAD=8 the
+      // upper bound on per-stream `eventStore.query` invocations is 18.
+      // Pre-fix this spy fires 100 times.
+      const LOOKAHEAD = 8;
+      const PAGE_SIZE = 10;
+      expect(querySpy.mock.calls.length).toBeLessThanOrEqual(
+        PAGE_SIZE + LOOKAHEAD,
+      );
+      // Lower bound: hydration MUST have hit at least the page-sized
+      // number of streams (10) to fold each task's projection. Anything
+      // below that would mean the implementation skipped real work and
+      // the listing would be incomplete.
+      expect(querySpy.mock.calls.length).toBeGreaterThanOrEqual(PAGE_SIZE);
+    } finally {
+      querySpy.mockRestore();
+    }
+  });
+
+  it('ListTasks_OnWarmCallAfterColdHydration_DoesNotReQueryAlreadyHydratedTasks', async () => {
+    // FINDING-6 (#1438, T8): incremental hydration anchored on the
+    // cursor's `createdAt`. After a cold-start `listTasks()` has
+    // hydrated page 1, calling `listTasks(cursor)` must NOT re-fold
+    // every durable stream — only the unhydrated tasks past the cursor
+    // (bounded by `PAGE_SIZE + LOOKAHEAD = 18` events).
+    //
+    // Pre-fix: every call re-enumerates all 100 streams and the cache-
+    // hit branch in `loadTask` (after cold-start) still incurs a
+    // `tailSequence` round-trip per stream, plus a `query` on any that
+    // were appended to since cache-stamp. The per-call overhead scales
+    // linearly with TOTAL durable tasks.
+    //
+    // Post-fix: the warm call's `query` count is bounded by the page
+    // worth of new folds, not the total durable count.
+    const N = 100;
+    const baseTimeMs = Date.parse('2026-04-01T00:00:00.000Z');
+    for (let i = 0; i < N; i++) {
+      const taskId = `task-warm-${String(i).padStart(4, '0')}`;
+      const createdAt = new Date(baseTimeMs + i * 1000).toISOString();
+      await eventStore.append(`task-store/${taskId}`, {
+        type: 'task.created',
+        timestamp: createdAt,
+        data: {
+          taskId,
+          ttl: null,
+          request: sampleRequest,
+        },
+      });
+    }
+
+    const coldStore = new EventSourcedTaskStore(eventStore);
+
+    // Cold call (hydrates page 1). We don't constrain its query count
+    // here — Test A covers that. We DO need the returned cursor so the
+    // warm call has an anchor.
+    const cold = await coldStore.listTasks();
+    expect(cold.tasks).toHaveLength(10);
+    expect(cold.nextCursor).toBeDefined();
+
+    // Now spy on `query` for the warm call only.
+    const querySpy = vi.spyOn(eventStore, 'query');
+    try {
+      const { tasks } = await coldStore.listTasks(cold.nextCursor);
+
+      // Sanity: the warm page returns the next 10 entries (and they
+      // differ from page 1).
+      expect(tasks).toHaveLength(10);
+
+      // Load-bearing assertion: the warm call's per-stream query count
+      // is much less than N. Concretely, an incremental-hydration impl
+      // does NOT re-fold any of the page-1 tasks (they are already
+      // cached); it folds only the new page's worth (≤ PAGE_SIZE +
+      // LOOKAHEAD = 18). Pre-fix this spy fires ~100 times.
+      const LOOKAHEAD = 8;
+      const PAGE_SIZE = 10;
+      expect(querySpy.mock.calls.length).toBeLessThanOrEqual(
+        PAGE_SIZE + LOOKAHEAD,
+      );
+    } finally {
+      querySpy.mockRestore();
+    }
+  });
 });

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -1143,4 +1143,101 @@ describe('EventSourcedTaskStore (#1272)', () => {
     const ids = tasks.map((t) => t.taskId).sort();
     expect(ids).toEqual([t1.taskId, t2.taskId].sort());
   });
+
+  it('CreateTask_WhenMapExceeds1024Entries_TriggersExpiredReap', async () => {
+    // FINDING-4 (#1438, T4): the TTL reaper (`reapExpired`) used to fire
+    // only on `listTasks`. Tasks created via `createTask` and never read
+    // accumulated in `this.tasks` indefinitely. The size-cap fix invokes
+    // `reapExpired` from `createTask` once the cache crosses
+    // `SIZE_CAP_REAP_THRESHOLD = 1024` so an unbounded creator workload
+    // cannot starve the reap path.
+    //
+    // Setup: create 1024 tasks with short TTLs, advance the wall clock
+    // past their expiry, then create one more — the 1025th create must
+    // trigger reap and drop every expired entry. The post-call cache
+    // size is `1` (only the survivor task).
+    vi.useFakeTimers();
+    try {
+      const SHORT_TTL = 5_000;
+      // Create exactly 1024 short-TTL tasks. After this loop the cache
+      // size is 1024 (== threshold, not yet over), so reap must NOT
+      // have fired yet — assert via the spy below.
+      const reapSpy = vi.spyOn(
+        store as unknown as { reapExpired: () => void },
+        'reapExpired',
+      );
+      try {
+        for (let i = 0; i < 1024; i++) {
+          await store.createTask(
+            { ttl: SHORT_TTL },
+            `req-${i}`,
+            sampleRequest,
+          );
+        }
+        // Pre-1025th create: no reap triggered (size is exactly 1024,
+        // not strictly greater than threshold).
+        expect(reapSpy).not.toHaveBeenCalled();
+        expect(
+          (store as unknown as { tasks: Map<string, unknown> }).tasks.size,
+        ).toBe(1024);
+
+        // Advance wall clock past every TTL so the first 1024 are all
+        // expired by the time the 1025th create's reap runs.
+        vi.setSystemTime(Date.now() + SHORT_TTL * 2);
+
+        // The 1025th create pushes size to 1025 > 1024 and must invoke
+        // `reapExpired`, sweeping all 1024 expired entries.
+        const survivor = await store.createTask(
+          { ttl: null },
+          'req-survivor',
+          sampleRequest,
+        );
+
+        expect(reapSpy).toHaveBeenCalledTimes(1);
+        const finalSize = (
+          store as unknown as { tasks: Map<string, unknown> }
+        ).tasks.size;
+        // Post-reap: only the survivor (unlimited TTL, just created)
+        // remains. Expired entries are gone; bound is well under 1024.
+        expect(finalSize).toBe(1);
+        expect(
+          (store as unknown as { tasks: Map<string, unknown> }).tasks.has(
+            survivor.taskId,
+          ),
+        ).toBe(true);
+      } finally {
+        reapSpy.mockRestore();
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('CreateTask_WhenMapUnder1024_DoesNotReap', async () => {
+    // FINDING-4 (#1438, T4): the size-cap reap is gated strictly on
+    // `this.tasks.size > SIZE_CAP_REAP_THRESHOLD`. Below the threshold,
+    // `createTask` MUST NOT invoke `reapExpired` — paying the O(n)
+    // sweep cost on every create at small cache sizes would regress
+    // hot-path performance for the common workload.
+    const reapSpy = vi.spyOn(
+      store as unknown as { reapExpired: () => void },
+      'reapExpired',
+    );
+    try {
+      // 100 creates, none expired, all under threshold.
+      for (let i = 0; i < 100; i++) {
+        await store.createTask(
+          { ttl: 60_000 },
+          `req-under-${i}`,
+          sampleRequest,
+        );
+      }
+      expect(reapSpy).not.toHaveBeenCalled();
+      expect(
+        (store as unknown as { tasks: Map<string, unknown> }).tasks.size,
+      ).toBe(100);
+    } finally {
+      reapSpy.mockRestore();
+    }
+  });
 });

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -1128,6 +1128,98 @@ describe('EventSourcedTaskStore (#1272)', () => {
     }
   });
 
+  it('ProjectTask_WhenRequestPayloadMalformed_LogsWarnWithStreamIdAndSequence', async () => {
+    // FINDING-7 (#1438, T5): `projectTask` previously coerced a missing /
+    // null / non-object `request` to `{}` silently via `?? {}`. This hid
+    // corrupt event payloads from operators. The fix is tolerate-and-flag:
+    // still produce a coerced empty-object Request, but emit a structured
+    // `logger.warn` carrying the `streamId` and event `sequence` so the
+    // corrupt record is locatable. Behavior on the happy path (a
+    // well-formed `request` object) is unchanged — no warning.
+    const taskId = 'malformed-request-task';
+    const streamId = `task-store/${taskId}`;
+    const now = new Date().toISOString();
+
+    // Seed a malformed `task.created` event directly via the event store
+    // (bypassing the public createTask API, which always supplies a
+    // well-formed `request`). `request: null` is the canonical malformed
+    // case — schema-permissive enough to land in the durable stream, but
+    // not a real `Request` object.
+    await eventStore.append(streamId, {
+      type: 'task.created',
+      timestamp: now,
+      data: {
+        taskId,
+        ttl: 60_000,
+        request: null,
+      },
+    });
+
+    const warnSpy = vi
+      .spyOn(taskStoreLogger, 'warn')
+      .mockImplementation(() => undefined);
+
+    try {
+      // Replay via a fresh store — forces `projectTask` to fold the
+      // seeded events from scratch.
+      const replayStore = new EventSourcedTaskStore(eventStore);
+      const replayed = await replayStore.getTask(taskId);
+
+      // Tolerate-and-flag: projection still returns a coerced Task with
+      // an empty-object request — DO NOT throw.
+      expect(replayed).not.toBeNull();
+      expect(replayed?.taskId).toBe(taskId);
+
+      // Exactly one warn for the malformed coerce branch (we filter out
+      // any unrelated warnings, e.g. throttle-gate or OCC noise, by
+      // matching on the coerce message shape).
+      const coerceCalls = warnSpy.mock.calls.filter((call) => {
+        const msg = call[1];
+        return typeof msg === 'string' && /malformed request/i.test(msg);
+      });
+      expect(coerceCalls).toHaveLength(1);
+
+      // First-arg object payload MUST carry the locator fields so the
+      // operator can find the corrupt event.
+      const payload = coerceCalls[0]![0] as Record<string, unknown>;
+      expect(payload.streamId).toBe(streamId);
+      expect(typeof payload.sequence).toBe('number');
+      expect(payload.sequence).toBeGreaterThanOrEqual(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('ProjectTask_WhenRequestPayloadWellFormed_DoesNotWarn', async () => {
+    // Happy-path companion to the FINDING-7 (#1438, T5) test above. A
+    // well-formed `request` object MUST NOT trigger the coerce-and-warn
+    // branch — only missing / null / non-object payloads do.
+    const warnSpy = vi
+      .spyOn(taskStoreLogger, 'warn')
+      .mockImplementation(() => undefined);
+
+    try {
+      const task = await store.createTask(
+        { ttl: 60_000 },
+        'req-happy',
+        sampleRequest,
+      );
+
+      // Force a refold via a fresh store so `projectTask` runs.
+      const replayStore = new EventSourcedTaskStore(eventStore);
+      const replayed = await replayStore.getTask(task.taskId);
+      expect(replayed).not.toBeNull();
+
+      const coerceCalls = warnSpy.mock.calls.filter((call) => {
+        const msg = call[1];
+        return typeof msg === 'string' && /malformed request/i.test(msg);
+      });
+      expect(coerceCalls).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('EventSourcedTaskStore_ListTasks_HydratesFromEventStoreOnColdStart', async () => {
     // CR PR #1432: cold-start listTasks must enumerate durable
     // `task-store/*` streams rather than silently returning an empty

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -1399,6 +1399,53 @@ describe('EventSourcedTaskStore (#1272)', () => {
     }
   });
 
+  it('CreateTask_AboveThresholdWithNoExpiredEntries_AmortizesReapByGrowthDelta', async () => {
+    // FINDING-4 amortization (CodeRabbit on PR #1450): the original T4
+    // gate fired `reapExpired()` on EVERY create above the threshold,
+    // even when no entries were expired (steady-state pathological
+    // case). The amortization gate runs the sweep only when
+    // `tasks.size - lastReapSize >= REAP_GROWTH_DELTA (64)`.
+    //
+    // Setup: fill to 1025 entries (one above threshold) — first sweep
+    // fires immediately. Then create 200 MORE entries with long TTL
+    // (none expire). The sweep should run only on the boundary creates
+    // where growth-since-last-reap reaches 64 — i.e., roughly 200 / 64
+    // = ~3 additional invocations, NOT 200 (one per create as the
+    // pre-amortization gate would do).
+    const reapSpy = vi.spyOn(
+      store as unknown as { reapExpired: () => void },
+      'reapExpired',
+    );
+    try {
+      // Phase 1: cross the threshold. Single reap on the 1025th create.
+      for (let i = 0; i < 1025; i++) {
+        await store.createTask(
+          { ttl: 60_000 },
+          `req-cross-${i}`,
+          sampleRequest,
+        );
+      }
+      // After Phase 1 there should be exactly one sweep recorded.
+      expect(reapSpy).toHaveBeenCalledTimes(1);
+
+      // Phase 2: 200 more creates with NO expired entries. Without
+      // amortization this would be 200 additional sweeps. With
+      // amortization (delta=64) it should be ≤ ceil(200 / 64) = 4.
+      reapSpy.mockClear();
+      for (let i = 0; i < 200; i++) {
+        await store.createTask(
+          { ttl: 60_000 },
+          `req-amort-${i}`,
+          sampleRequest,
+        );
+      }
+      expect(reapSpy.mock.calls.length).toBeGreaterThan(0);
+      expect(reapSpy.mock.calls.length).toBeLessThanOrEqual(4);
+    } finally {
+      reapSpy.mockRestore();
+    }
+  });
+
   it('ListTasks_AcrossSimulatedRestart_PaginatesStablyWithCursor', async () => {
     // FINDING-5 (#1438, T7): cursor pagination MUST be stable across
     // process restarts. The pre-fix implementation paginated by Map

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -1305,6 +1305,72 @@ describe('EventSourcedTaskStore (#1272)', () => {
     }
   });
 
+  it('CreateTask_AppendsTaskCreatedEvent_IncludesRequestIdInPayload', async () => {
+    // FINDING-8 (#1438, T6): the audit-aligned fix for the
+    // `replayed:${taskId}` synthesizer is to persist `requestId` on new
+    // `task.created` events so a fresh-process replayer recovers the
+    // original JSON-RPC correlation id verbatim — the synthesizer stays
+    // as a strict backward-compat fallback for historical events that
+    // pre-date this fix (INV-1: events are immutable, so we cannot
+    // retroactively stamp old events; the synthesizer remains the
+    // only sound answer for them).
+    const task = await store.createTask(
+      { ttl: 60_000 },
+      'req-abc',
+      sampleRequest,
+    );
+
+    const events = await eventStore.query(`task-store/${task.taskId}`);
+    const created = events.find((e) => e.type === 'task.created');
+    expect(created).toBeDefined();
+    const data = (created!.data ?? {}) as Record<string, unknown>;
+    expect(data['requestId']).toBe('req-abc');
+  });
+
+  it('ProjectTask_ReplaysTaskCreated_WithoutRequestIdField_FallsBackToSyntheticReplayedPrefix', async () => {
+    // FINDING-8 (#1438, T6): historical `task.created` events emitted
+    // before the requestId-persistence fix do NOT carry a `requestId`
+    // field in `data`. The synthesizer (`replayed:${taskId}`) is the
+    // load-bearing backward-compat fallback for those events — we
+    // intentionally KEEP it (per the design's F-8 disposition: removing
+    // it would require INV-1-violating event mutation OR an
+    // operationally-meaningful sweep that the design rejected).
+    const taskId = 'old-event-no-requestid';
+    const streamId = `task-store/${taskId}`;
+    const now = new Date().toISOString();
+
+    // Seed an old-shape `task.created` event directly: no `requestId`
+    // field. The schema permits this (the new field is optional for
+    // exactly this back-compat reason).
+    await eventStore.append(streamId, {
+      type: 'task.created',
+      timestamp: now,
+      data: {
+        taskId,
+        ttl: 60_000,
+        request: sampleRequest,
+      },
+    });
+
+    // Force a fresh-process replay via a new store so projectTask folds
+    // the seeded event from scratch.
+    const replayStore = new EventSourcedTaskStore(eventStore);
+    const replayed = await replayStore.getTask(taskId);
+    expect(replayed).not.toBeNull();
+
+    // Inspect the projected entry's `requestId` — the public Task
+    // surface does not carry it, but the internal `tasks` cache holds
+    // the ProjectedTask which does. The synthesizer fallback MUST be
+    // exactly `replayed:${taskId}` for these old events.
+    const cached = (
+      replayStore as unknown as {
+        tasks: Map<string, { requestId: string }>;
+      }
+    ).tasks.get(taskId);
+    expect(cached).toBeDefined();
+    expect(cached!.requestId).toBe(`replayed:${taskId}`);
+  });
+
   it('CreateTask_WhenMapUnder1024_DoesNotReap', async () => {
     // FINDING-4 (#1438, T4): the size-cap reap is gated strictly on
     // `this.tasks.size > SIZE_CAP_REAP_THRESHOLD`. Below the threshold,

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.test.ts
@@ -1332,4 +1332,144 @@ describe('EventSourcedTaskStore (#1272)', () => {
       reapSpy.mockRestore();
     }
   });
+
+  it('ListTasks_AcrossSimulatedRestart_PaginatesStablyWithCursor', async () => {
+    // FINDING-5 (#1438, T7): cursor pagination MUST be stable across
+    // process restarts. The pre-fix implementation paginated by Map
+    // insertion order — set by `hydrateFromEventStore` on cold start
+    // and by `createTask` afterward. Neither establishes a content-
+    // derived sort key. For backends whose `listStreams` happens to be
+    // lex-sorted (SQLite) the pre-fix code accidentally appears stable
+    // ONLY when taskId lex order coincides with creation order; for
+    // every other relationship (and for the memory backend, which
+    // preserves insertion order) two instances disagree on pagination.
+    //
+    // The fix sorts by (createdAt ASC, taskId ASC) — `createdAt` is
+    // deterministic from the durable `task.created` event timestamp,
+    // and `taskId` is the tie-break for events with identical
+    // timestamps. The cursor wire format is opaque
+    // (base64url(JSON.stringify({createdAt, taskId}))) so consumers
+    // cannot accidentally couple to internal representation.
+    //
+    // Repro setup: seed 25 task.created events such that taskId lex
+    // order is the REVERSE of createdAt order. This forces the
+    // assertion to fail under the pre-fix Map-insertion-order
+    // implementation (which produces lex(taskId) order on SQLite cold
+    // start) and pass under the (createdAt ASC, taskId ASC) sort.
+    const N = 25;
+    const baseTimeMs = Date.parse('2026-01-01T00:00:00.000Z');
+
+    // taskIds: pad with 4-digit slot index, but invert (N-1-slot) into
+    // the taskId so taskId lex order is REVERSE of slot order. Slot
+    // also determines createdAt — slot 0 has the EARLIEST createdAt.
+    // Expected sort: ascending slot (== ascending createdAt) →
+    // taskIds in DESCENDING lex order. Insert in slot order so the
+    // memory-backend / Map-insertion path also disagrees with sort.
+    for (let slot = 0; slot < N; slot++) {
+      const inverted = N - 1 - slot; // taskId tag descends as slot ascends
+      const taskId = `task-${String(inverted).padStart(4, '0')}`;
+      const createdAt = new Date(baseTimeMs + slot * 1000).toISOString();
+      await eventStore.append(`task-store/${taskId}`, {
+        type: 'task.created',
+        timestamp: createdAt,
+        data: {
+          taskId,
+          ttl: null,
+          request: sampleRequest,
+        },
+      });
+    }
+
+    // Expected sort: by createdAt ASC. Slot index drives createdAt, so
+    // slot 0 (with taskId `task-00${N-1}`) comes first. That means
+    // taskIds appear in DESCENDING lex order — the OPPOSITE of what
+    // a pre-fix listStreams-driven implementation produces on SQLite.
+    const expectedOrder = Array.from({ length: N }, (_, slot) =>
+      `task-${String(N - 1 - slot).padStart(4, '0')}`,
+    );
+
+    // Instance A: page through the durable event store.
+    const instanceA = new EventSourcedTaskStore(eventStore);
+    const aPages: string[][] = [];
+    const aCursors: Array<string | undefined> = [];
+    let cursor: string | undefined;
+    do {
+      const page = await instanceA.listTasks(cursor);
+      aPages.push(page.tasks.map((t) => t.taskId));
+      aCursors.push(page.nextCursor);
+      cursor = page.nextCursor;
+    } while (cursor !== undefined);
+
+    // Sanity: A enumerates exactly N unique tasks in sorted order.
+    const aAll = aPages.flat();
+    expect(aAll).toHaveLength(N);
+    expect(new Set(aAll).size).toBe(N);
+    expect(aAll).toEqual(expectedOrder);
+
+    // Instance B: a fresh store against the same event store, replaying
+    // each of A's cursors as the input to the next listTasks. B's
+    // sequence MUST equal A's sequence — that is the cross-process
+    // pagination-stability contract.
+    const instanceB = new EventSourcedTaskStore(eventStore);
+    // Page 1 (no cursor).
+    const bPage1 = await instanceB.listTasks();
+    expect(bPage1.tasks.map((t) => t.taskId)).toEqual(aPages[0]);
+    // The cursor B emits at the end of page 1 MUST equal A's page-1
+    // cursor — that's the byte-level invariant of an opaque cursor.
+    expect(bPage1.nextCursor).toEqual(aCursors[0]);
+    // Feed A's cursor (not B's) into B for subsequent pages so we are
+    // testing the exact contract: A's cursor used by B yields A's
+    // next page.
+    for (let i = 1; i < aPages.length; i++) {
+      const bPage = await instanceB.listTasks(aCursors[i - 1]);
+      expect(bPage.tasks.map((t) => t.taskId)).toEqual(aPages[i]);
+      expect(bPage.nextCursor).toEqual(aCursors[i]);
+    }
+  });
+
+  it('ListTasks_TieBreakOnIdenticalCreatedAt_OrdersByTaskIdAsc', async () => {
+    // FINDING-5 (#1438, T7): when two `task.created` events share an
+    // identical ISO timestamp (two tasks created within the same
+    // millisecond), the sort tie-break MUST be taskId ASC. Without a
+    // stable secondary key the relative order falls through to Map
+    // insertion order, which is exactly the cross-process
+    // inconsistency T7 closes.
+    //
+    // Force-the-bug setup: drive enough back-to-back `createTask`
+    // calls under a frozen clock so every `task.created.timestamp`
+    // is byte-identical. `createTask` generates RANDOM 32-char hex
+    // taskIds and appends to `this.tasks` in call order, so the
+    // probability that Map insertion order coincidentally equals
+    // taskId-lex order across N=10 entries is essentially zero
+    // (10! permutations, only 1 matches). Pre-fix `listTasks`
+    // returns Map iteration order (an arbitrary permutation);
+    // post-fix returns the unique permutation sorted by taskId ASC.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(Date.parse('2026-02-15T12:00:00.000Z'));
+
+      const N = 10;
+      const createdTaskIds: string[] = [];
+      for (let i = 0; i < N; i++) {
+        const t = await store.createTask(
+          { ttl: null },
+          `req-tie-${i}`,
+          sampleRequest,
+        );
+        createdTaskIds.push(t.taskId);
+      }
+      // Sanity: all N timestamps tied at the frozen wall-clock.
+
+      const { tasks } = await store.listTasks();
+      const observed = tasks.map((t) => t.taskId);
+
+      // Contract: with identical createdAt across all entries, the
+      // result MUST be sorted by taskId ASC — a pure function of the
+      // taskIds, no insertion-order influence.
+      const expected = [...createdTaskIds].sort();
+      expect(observed).toEqual(expected);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -227,6 +227,15 @@ export class EventSourcedTaskStore implements TaskStore {
         ttl,
         request,
         pollInterval,
+        // FINDING-8 (#1438, T6): persist the JSON-RPC `requestId` so a
+        // replaying process recovers the original outbound correlation
+        // id verbatim. Pre-fix, the value lived only in this in-memory
+        // entry and was lost across process restarts — `projectTask`
+        // had to synthesize `replayed:${taskId}` for every fold. With
+        // this field on new events the synthesizer becomes a strict
+        // backward-compat fallback for historical (pre-T6) events
+        // rather than a routine code path.
+        requestId,
         // `createdBy` is left to upstream stamping (DispatchContext via
         // AsyncLocalStorage — see B1) when the call is inside a
         // dispatch boundary. The schema permits the field as optional.
@@ -940,11 +949,22 @@ function projectTask(
     }
   }
 
-  // requestId is not durably persisted (the SDK uses it only for
-  // outbound JSON-RPC correlation, which a replayed task doesn't have).
-  // We synthesize a sentinel so the projected shape is still a valid
-  // `ProjectedTask` for in-memory consumers.
-  const requestId: RequestId = `replayed:${taskId}`;
+  // FINDING-8 (#1438, T6): prefer the persisted `requestId` from the
+  // `task.created` event payload — new events carry it verbatim so a
+  // replaying process recovers the original JSON-RPC correlation id.
+  // Historical events emitted before the persistence fix do NOT have
+  // the field; they fall back to the `replayed:${taskId}` synthesizer
+  // below. KEEP THE FALLBACK: per the F-8 design disposition, the
+  // synthesizer is read-side-only and load-bearing for old events —
+  // removing it would require INV-1-violating event mutation (events
+  // are immutable). The SDK `RequestId` is `string | number`, so we
+  // accept either shape from the payload.
+  const persistedRequestId = createdData['requestId'];
+  const requestId: RequestId =
+    typeof persistedRequestId === 'string' ||
+    typeof persistedRequestId === 'number'
+      ? persistedRequestId
+      : `replayed:${taskId}`;
 
   return {
     task,

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -142,6 +142,49 @@ const TASK_POLLED_THROTTLE_MS = 5_000;
 const SIZE_CAP_REAP_THRESHOLD = 1024;
 
 /**
+ * FINDING-5 (#1438, T7): `listTasks` cursor — opaque, base64url-encoded
+ * JSON of the `(createdAt, taskId)` tuple of the LAST entry on the
+ * prior page. Anchoring on `(createdAt, taskId)` instead of Map
+ * insertion order is what makes pagination stable across process
+ * restarts and across multiple instances pointed at the same event
+ * store. See the `listTasks` body for the sort + offset implementation
+ * that consumes this shape.
+ */
+interface ListTasksCursor {
+  readonly createdAt: string;
+  readonly taskId: string;
+}
+
+function encodeListTasksCursor(c: ListTasksCursor): string {
+  return Buffer.from(JSON.stringify(c), 'utf8').toString('base64url');
+}
+
+function decodeListTasksCursor(s: string): ListTasksCursor {
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(s, 'base64url').toString('utf8'),
+    ) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'createdAt' in parsed &&
+      'taskId' in parsed &&
+      typeof (parsed as Record<string, unknown>)['createdAt'] === 'string' &&
+      typeof (parsed as Record<string, unknown>)['taskId'] === 'string'
+    ) {
+      return parsed as ListTasksCursor;
+    }
+    throw new Error('Invalid cursor: missing or malformed fields');
+  } catch (err) {
+    // Preserve the legacy `Invalid cursor: ...` prefix that the prior
+    // taskId-indexOf path produced. Callers (and downstream MCP error
+    // wrappers) match on this string shape.
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid cursor: ${detail}`);
+  }
+}
+
+/**
  * Optional constructor options for `EventSourcedTaskStore`.
  *
  * `clock` is the rate-limit clock for the FINDING-3 throttle gate.
@@ -511,21 +554,48 @@ export class EventSourcedTaskStore implements TaskStore {
     // Reap expired entries first so listings stay consistent with reads.
     this.reapExpired();
 
-    const allTaskIds = Array.from(this.tasks.keys());
-    let startIndex = 0;
-    if (cursor) {
-      const cursorIndex = allTaskIds.indexOf(cursor);
-      if (cursorIndex >= 0) {
-        startIndex = cursorIndex + 1;
-      } else {
-        throw new Error(`Invalid cursor: ${cursor}`);
-      }
-    }
-    const pageIds = allTaskIds.slice(startIndex, startIndex + PAGE_SIZE);
-    const tasks = pageIds.map((id) => ({ ...this.tasks.get(id)!.task }));
+    // FINDING-5 (#1438, T7): sort by `(createdAt ASC, taskId ASC)`
+    // BEFORE pagination. Map insertion order is set by
+    // `hydrateFromEventStore` (backend-listing order) on cold start and
+    // by `createTask` afterward — neither is content-derived nor stable
+    // across processes. Sorting by the event's durable `createdAt`
+    // (with `taskId` as the tie-break for sub-millisecond ties) gives
+    // every instance an identical, deterministic enumeration.
+    const sorted = Array.from(this.tasks.values()).sort((a, b) => {
+      if (a.task.createdAt < b.task.createdAt) return -1;
+      if (a.task.createdAt > b.task.createdAt) return 1;
+      if (a.task.taskId < b.task.taskId) return -1;
+      if (a.task.taskId > b.task.taskId) return 1;
+      return 0;
+    });
+
+    // FINDING-5 (#1438, T7): cursor-anchored offset. The decoded cursor
+    // is the `(createdAt, taskId)` tuple of the LAST entry on the prior
+    // page; we keep entries strictly greater than that tuple under the
+    // same lex ordering as the sort.
+    const cursorObj = cursor ? decodeListTasksCursor(cursor) : undefined;
+    const afterCursor = cursorObj
+      ? sorted.filter(
+          (p) =>
+            p.task.createdAt > cursorObj.createdAt ||
+            (p.task.createdAt === cursorObj.createdAt &&
+              p.task.taskId > cursorObj.taskId),
+        )
+      : sorted;
+
+    const page = afterCursor.slice(0, PAGE_SIZE);
+    const tasks = page.map((p) => ({ ...p.task }));
+    // `nextCursor` is emitted only when there is at least one more
+    // entry past this page — i.e., the page is full AND something
+    // followed it in `afterCursor`. Encoding the LAST entry's
+    // `(createdAt, taskId)` lets the next call resume exactly past
+    // it.
     const nextCursor =
-      startIndex + PAGE_SIZE < allTaskIds.length
-        ? pageIds[pageIds.length - 1]
+      page.length === PAGE_SIZE && afterCursor.length > PAGE_SIZE
+        ? encodeListTasksCursor({
+            createdAt: page[page.length - 1].task.createdAt,
+            taskId: page[page.length - 1].task.taskId,
+          })
         : undefined;
     return { tasks, nextCursor };
   }

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -790,7 +790,34 @@ function projectTask(
   const rawTtl = createdData['ttl'];
   const ttl: Task['ttl'] =
     typeof rawTtl === 'number' && Number.isFinite(rawTtl) ? rawTtl : null;
-  const request = (createdData['request'] ?? {}) as Request;
+  // FINDING-7 (#1438, T5): tolerate-and-flag malformed `request` payloads.
+  // The pre-fix `?? {}` coerce silently masked corrupt event payloads
+  // (missing field, `null`, non-object, array). We still coerce to an
+  // empty-object `Request` so REPLAY stays robust against historical
+  // bad data, but we emit a structured `logger.warn` carrying the
+  // `streamId` and the offending event's `sequence` so operators can
+  // locate and audit the corrupt record. Behavior is unchanged on the
+  // happy path (a real object payload bypasses the warn branch).
+  let request: Request;
+  const rawRequest = createdData['request'];
+  if (
+    rawRequest === undefined ||
+    rawRequest === null ||
+    typeof rawRequest !== 'object' ||
+    Array.isArray(rawRequest)
+  ) {
+    taskStoreLogger.warn(
+      {
+        streamId: taskStream(taskId),
+        sequence: created.sequence,
+        requestType: rawRequest === null ? 'null' : typeof rawRequest,
+      },
+      'projectTask: coerced malformed request payload',
+    );
+    request = {} as Request;
+  } else {
+    request = rawRequest as Request;
+  }
   // CodeRabbit MAJOR #1431 follow-up: replay the persisted pollInterval
   // so a process restart preserves the caller-supplied cadence. Older
   // events without the field (and any payload whose value fails the

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -129,6 +129,19 @@ function taskStream(taskId: string): string {
 const TASK_POLLED_THROTTLE_MS = 5_000;
 
 /**
+ * FINDING-4 (#1438): size-cap threshold for the TTL reap path. The
+ * read-time reaper (`reapExpired`) used to fire ONLY from `listTasks`
+ * — tasks created via `createTask` and never read accumulated in the
+ * in-memory cache indefinitely. To bound the cache without adding a
+ * background timer, `createTask` invokes `reapExpired` once the cache
+ * strictly exceeds this threshold. The bound is intentionally generous
+ * (steady-state worst case is `2 * threshold` immediately before the
+ * sweep) so the hot path stays O(1) at small sizes; the O(n) sweep
+ * cost is amortized across `threshold` creates between sweeps.
+ */
+const SIZE_CAP_REAP_THRESHOLD = 1024;
+
+/**
  * Optional constructor options for `EventSourcedTaskStore`.
  *
  * `clock` is the rate-limit clock for the FINDING-3 throttle gate.
@@ -245,6 +258,17 @@ export class EventSourcedTaskStore implements TaskStore {
       // path in `loadTask` after each successful fold.
       lastReadSequence: 1,
     });
+
+    // FINDING-4 (#1438): size-cap reap. Without this, a creator-only
+    // workload (no `listTasks` reads) lets `this.tasks` grow unbounded
+    // — the read-time reaper only fires from `listTasks`. Sweep here
+    // when the cache crosses the threshold so expired entries cannot
+    // accumulate silently. The strict `>` keeps the gate idempotent
+    // at the boundary: at exactly `threshold` entries we have NOT yet
+    // paid the sweep cost; the 1025th create is what triggers it.
+    if (this.tasks.size > SIZE_CAP_REAP_THRESHOLD) {
+      this.reapExpired();
+    }
 
     return task;
   }

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -59,6 +59,35 @@
  * throttled to one event per `TASK_POLLED_THROTTLE_MS` window via an
  * in-memory `lastPolledAt` map that is cleaned up alongside the cache
  * on reap.
+ *
+ * ## listTasks ordering + cursor wire format (FINDING-5, #1438 T7)
+ *
+ * Pagination sorts by `(createdAt ASC, taskId ASC)`. `createdAt` is
+ * the `task.created` event's ISO timestamp — deterministic and
+ * present on every entry in the cache. `taskId` is the tie-break for
+ * two events sharing a millisecond (a real race when two consumers
+ * race against the same store at high QPS). Neither key depends on
+ * Map insertion order, so the enumeration is identical across
+ * processes, restarts, and replicas pointed at the same event store
+ * — the prerequisite for the cursor contract below.
+ *
+ * The cursor is an OPAQUE string: callers MUST treat it as a
+ * round-trip blob and MUST NOT parse it. Internally:
+ *
+ *   cursor = base64url(JSON.stringify({ createdAt, taskId }))
+ *
+ * where `createdAt` and `taskId` are the values of the LAST entry on
+ * the page just returned. Decoding skips past every entry whose
+ * `(createdAt, taskId)` tuple is `<=` the cursor under the same lex
+ * ordering as the sort. `nextCursor` is only emitted when there is at
+ * least one entry past the current page.
+ *
+ * Hydration (`hydrateFromEventStore`) currently enumerates ALL
+ * `task-store/*` streams on every `listTasks` call. T8 (#1438 F-6)
+ * will replace this with cursor-anchored incremental hydration that
+ * folds only the streams created since the cursor — at which point
+ * the cursor's `createdAt` field becomes load-bearing for the
+ * hydration filter as well, not just for sort + offset.
  */
 import { randomBytes } from 'node:crypto';
 import type {

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -175,6 +175,16 @@ const TASK_POLLED_THROTTLE_MS = 5_000;
 const SIZE_CAP_REAP_THRESHOLD = 1024;
 
 /**
+ * FINDING-4 amortization: above `SIZE_CAP_REAP_THRESHOLD`, only re-run
+ * the reap when `tasks.size` has grown by this many entries since the
+ * previous reap. Bounds the post-threshold worst case to 1 sweep per
+ * `REAP_GROWTH_DELTA` creates instead of 1 sweep per create — the
+ * latter is the path CodeRabbit flagged on #1450 when every create
+ * above the threshold finds no expired entries to reap.
+ */
+const REAP_GROWTH_DELTA = 64;
+
+/**
  * FINDING-5 (#1438, T7): `listTasks` cursor — opaque, base64url-encoded
  * JSON of the `(createdAt, taskId)` tuple of the LAST entry on the
  * prior page. Anchoring on `(createdAt, taskId)` instead of Map
@@ -302,6 +312,15 @@ export class EventSourcedTaskStore implements TaskStore {
    */
   private readonly nowMs: () => number;
 
+  /**
+   * FINDING-4 amortization: tracks `tasks.size` immediately after the
+   * most recent `reapExpired()` call from `createTask`. Used by the
+   * `REAP_GROWTH_DELTA` gate to avoid re-running the sweep on every
+   * create above `SIZE_CAP_REAP_THRESHOLD` when no entries are
+   * actually expired. See the comment block at that const for context.
+   */
+  private lastReapSize = 0;
+
   constructor(eventStore: EventStore, options?: EventSourcedTaskStoreOptions) {
     this.store = eventStore;
     this.nowMs = options?.clock ?? Date.now.bind(Date);
@@ -397,8 +416,19 @@ export class EventSourcedTaskStore implements TaskStore {
     // accumulate silently. The strict `>` keeps the gate idempotent
     // at the boundary: at exactly `threshold` entries we have NOT yet
     // paid the sweep cost; the 1025th create is what triggers it.
-    if (this.tasks.size > SIZE_CAP_REAP_THRESHOLD) {
+    //
+    // Amortized: once size > threshold, only sweep when growth since
+    // last reap >= REAP_GROWTH_DELTA. Otherwise a steady stream of
+    // creates above the threshold with NO expired entries would run
+    // reapExpired() on every call for zero benefit. This bounds the
+    // reap cost to 1 / REAP_GROWTH_DELTA per create.
+    const sizeAfterInsert = this.tasks.size;
+    if (
+      sizeAfterInsert > SIZE_CAP_REAP_THRESHOLD &&
+      sizeAfterInsert - this.lastReapSize >= REAP_GROWTH_DELTA
+    ) {
       this.reapExpired();
+      this.lastReapSize = this.tasks.size;
     }
 
     return task;

--- a/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
+++ b/servers/exarchos-mcp/src/task-store/event-sourced-task-store.ts
@@ -82,12 +82,16 @@
  * ordering as the sort. `nextCursor` is only emitted when there is at
  * least one entry past the current page.
  *
- * Hydration (`hydrateFromEventStore`) currently enumerates ALL
- * `task-store/*` streams on every `listTasks` call. T8 (#1438 F-6)
- * will replace this with cursor-anchored incremental hydration that
- * folds only the streams created since the cursor — at which point
- * the cursor's `createdAt` field becomes load-bearing for the
- * hydration filter as well, not just for sort + offset.
+ * Hydration (`hydrateFromEventStore`) is cursor-anchored and
+ * incremental (FINDING-6, #1438 T8). Each `listTasks` call issues one
+ * `EventStore.queryByType('task.created', ...)` round-trip filtered to
+ * the `task-store/` prefix, anchored at `cursor.createdAt`
+ * (`undefined` on cold-start), and capped at `PAGE_SIZE + LOOKAHEAD`.
+ * Per-task projection folds only run for events that aren't already
+ * cached, so steady-state cost is `O(new tasks since prior page)`
+ * rather than `O(total durable tasks)`. The cursor's `createdAt`
+ * field is therefore load-bearing for the hydration filter AND for
+ * sort + offset.
  */
 import { randomBytes } from 'node:crypto';
 import type {
@@ -144,7 +148,7 @@ function generateTaskId(): string {
 }
 
 function taskStream(taskId: string): string {
-  return `task-store/${taskId}`;
+  return `${TASK_STREAM_PREFIX}${taskId}`;
 }
 
 /**
@@ -183,6 +187,52 @@ interface ListTasksCursor {
   readonly createdAt: string;
   readonly taskId: string;
 }
+
+/**
+ * FINDING-5 (#1438, T7): page size for `listTasks` pagination. Module-
+ * level so T8's hydration query can stay aligned with the cursor wire
+ * format — the hydration window is bounded by `PAGE_SIZE + LOOKAHEAD`,
+ * not by the total durable task count.
+ */
+const PAGE_SIZE = 10;
+
+/**
+ * FINDING-6 (#1438, T8): lookahead window on the cursor-anchored
+ * hydration query. Each `listTasks` call queries the event store for at
+ * most `PAGE_SIZE + LOOKAHEAD` `task.created` events anchored on the
+ * cursor's `createdAt` (or from the beginning when no cursor is
+ * supplied). The lookahead absorbs tie-break churn for events that
+ * share a millisecond timestamp — the substrate orders by
+ * `(timestamp, streamId, sequence)` so events with identical
+ * timestamps fall through to `streamId` lex order; without the
+ * lookahead the page slice could miss a same-millisecond sibling that
+ * sorts after the page boundary by `taskId` but before by `streamId`.
+ *
+ * Concrete bound on pre-fix vs. post-fix work: with N durable tasks
+ * pre-fix hydration paid N `eventStore.query` calls per `listTasks`
+ * call (one full-refold per stream). Post-fix it pays at most
+ * `PAGE_SIZE + LOOKAHEAD = 18` per-task `query` calls plus one
+ * `queryByType` round-trip, regardless of N. The 8-entry lookahead
+ * also pre-warms the cache for the next page (overlap of 1 between
+ * consecutive query windows means page-2's hydration usually folds
+ * only the genuinely new entries past page-1's tail).
+ *
+ * Configurability: the constant is module-private today. If
+ * production telemetry shows tie-break churn exceeds 8 at observed
+ * creation rates, raise the bound and re-run the cross-process
+ * pagination acceptance tests (`ListTasks_AcrossSimulatedRestart_*`,
+ * `ListTasks_TieBreakOnIdenticalCreatedAt_*`).
+ */
+const LOOKAHEAD = 8;
+
+/**
+ * FINDING-6 (#1438, T8): the namespaced stream prefix for per-task
+ * lifecycle streams. Kept as a module-level const so `taskStream()`
+ * (the writer side) and `hydrateFromEventStore` (the reader side) use
+ * the exact same string — a divergence would silently break the
+ * cross-stream `queryByType` prefix filter.
+ */
+const TASK_STREAM_PREFIX = 'task-store/';
 
 function encodeListTasksCursor(c: ListTasksCursor): string {
   return Buffer.from(JSON.stringify(c), 'utf8').toString('base64url');
@@ -570,6 +620,13 @@ export class EventSourcedTaskStore implements TaskStore {
     cursor?: string,
     _sessionId?: string,
   ): Promise<{ tasks: Task[]; nextCursor?: string }> {
+    // FINDING-6 (#1438, T8): decode the cursor BEFORE hydration so the
+    // hydration query can be anchored on `cursor.createdAt`. This
+    // collapses the per-call hydration cost from `O(total durable
+    // tasks)` to `O(PAGE_SIZE + LOOKAHEAD)` — see
+    // `hydrateFromEventStore`'s doc for the full rationale.
+    const cursorObj = cursor ? decodeListTasksCursor(cursor) : undefined;
+
     // ─── Cold-start hydration (#1272 / CR PR #1432) ───────────────────────
     // The in-memory cache (`this.tasks`) is not authoritative; on a
     // freshly-constructed instance it is empty even if durable
@@ -578,17 +635,16 @@ export class EventSourcedTaskStore implements TaskStore {
     // new process, which violates the SDK `TaskStore` contract and
     // INV-1 (event-sourcing integrity — state derives from events).
     //
-    // The EventStore exposes `listStreams()` (delegated to the read
-    // backend), so we enumerate the `task-store/` prefix and fold each
-    // matching stream via `loadTask()`. After hydration completes once,
-    // subsequent `listTasks` calls re-use the warmed cache plus any
-    // streams created since (we re-enumerate every call — it is cheap
-    // relative to event-folding, and keeps the listing consistent with
-    // concurrent `createTask` writes from other processes sharing the
-    // same SQLite event store).
-    await this.hydrateFromEventStore();
+    // FINDING-6 (#1438, T8): hydration is now cursor-anchored. On
+    // cold-start (`cursorObj === undefined`) the query window is the
+    // first `PAGE_SIZE + LOOKAHEAD` `task.created` events under the
+    // `task-store/` prefix. On subsequent paginated calls it is the
+    // same window anchored at `cursor.createdAt` — same `inclusive`
+    // semantic the `since` filter exposes — so same-millisecond
+    // siblings of the prior-page tail are not silently dropped. The
+    // cursor-offset filter below discards the already-paged entry.
+    await this.hydrateFromEventStore(cursorObj?.createdAt);
 
-    const PAGE_SIZE = 10;
     // Reap expired entries first so listings stay consistent with reads.
     this.reapExpired();
 
@@ -611,7 +667,6 @@ export class EventSourcedTaskStore implements TaskStore {
     // is the `(createdAt, taskId)` tuple of the LAST entry on the prior
     // page; we keep entries strictly greater than that tuple under the
     // same lex ordering as the sort.
-    const cursorObj = cursor ? decodeListTasksCursor(cursor) : undefined;
     const afterCursor = cursorObj
       ? sorted.filter(
           (p) =>
@@ -751,40 +806,88 @@ export class EventSourcedTaskStore implements TaskStore {
   }
 
   /**
-   * Enumerate `task-store/*` streams from the event store and load
-   * any that aren't already cached. Used by `listTasks` to make
-   * cold-start enumeration replay-safe (INV-1).
+   * FINDING-6 (#1438, T8): cursor-anchored incremental hydration.
    *
-   * The EventStore's `listStreams()` is in-memory after backend init
-   * (the SQLite read backend caches the stream catalog) so the per-call
-   * overhead is bounded by `O(n_streams_total)`; the actual `loadTask`
-   * fold only runs on cache misses, so steady-state cost is O(new tasks
-   * since last call).
+   * Pre-T8 this method enumerated EVERY `task-store/*` stream via
+   * `EventStore.listStreams()` and folded each via `loadTask()` — N
+   * per-stream queries per `listTasks` call, where N is the total
+   * number of durable tasks the substrate has ever seen. With 1,000
+   * historical tasks post-restart, every `listTasks` paid 1,000
+   * `EventStore.query` round-trips before pagination even began.
+   *
+   * Post-T8 this is bounded by `PAGE_SIZE + LOOKAHEAD = 18` regardless
+   * of N. The implementation:
+   *
+   *   1. Query the event store ONCE for `task.created` events under the
+   *      `task-store/` prefix, anchored at `sinceCreatedAt` (the cursor's
+   *      timestamp; `undefined` on cold-start = no time filter).
+   *   2. Cap the result at `PAGE_SIZE + LOOKAHEAD` events. The lookahead
+   *      absorbs tie-break churn at the page boundary AND pre-warms the
+   *      cache by one window-overlap for the next page.
+   *   3. For each event, extract the taskId from the envelope `streamId`
+   *      and skip if already cached. Otherwise call `loadTask` to fold
+   *      that single stream — same exact code path the pre-T8 hot path
+   *      used, so REPLAY semantics (INV-1) are unchanged.
+   *
+   * `since` filter semantics: the backend SQL is `timestamp >= ?` (see
+   * `SqliteBackend.queryEventsByType`). Inclusive `since` is REQUIRED:
+   * when the cursor anchors mid-tie (multiple events at the same
+   * millisecond), an exclusive filter would silently skip same-
+   * millisecond siblings that follow the cursor entry under the
+   * `(createdAt ASC, taskId ASC)` sort. The cursor-offset filter in
+   * `listTasks` discards the already-paged entry without losing its
+   * timestamp-tied siblings.
+   *
+   * Correctness fence: any `task.created` event whose `createdAt` is
+   * `>= sinceCreatedAt` and falls within the substrate's natural
+   * `(timestamp, streamId, sequence)` ordering's first
+   * `PAGE_SIZE + LOOKAHEAD` matches is hydrated. Events past that
+   * window are picked up by the next page's query (anchored on the new
+   * cursor) — they are NOT silently dropped. The known under-shoot
+   * case is documented in the design (`#1438 F-6`): when more than
+   * `LOOKAHEAD` events share a single millisecond AND the cursor lands
+   * inside that tie cluster, the page can be short. Per the design
+   * risk register the mitigation is to raise `LOOKAHEAD`.
    *
    * Failures during a per-stream load are swallowed: one malformed
-   * stream MUST NOT block enumeration of healthy ones. The next
-   * targeted `getTask(taskId)` will surface the underlying error.
+   * stream MUST NOT block enumeration of healthy ones (same contract
+   * as the pre-T8 enumeration). The next targeted `getTask(taskId)`
+   * will surface the underlying error.
    */
-  private async hydrateFromEventStore(): Promise<void> {
-    const prefix = 'task-store/';
-    let allStreams: string[];
+  private async hydrateFromEventStore(sinceCreatedAt?: string): Promise<void> {
+    // Build the filter shape that `EventStore.queryByType` consumes.
+    // `since` is the inclusive ISO-timestamp lower bound (see method
+    // doc above for the inclusive-vs-exclusive rationale). `limit`
+    // caps the per-call query window at `PAGE_SIZE + LOOKAHEAD`.
+    let events: readonly WorkflowEvent[];
     try {
-      allStreams = this.store.listStreams();
+      events = await this.store.queryByType('task.created', {
+        streamPrefix: TASK_STREAM_PREFIX.replace(/\/$/, ''),
+        ...(sinceCreatedAt !== undefined ? { since: sinceCreatedAt } : {}),
+        limit: PAGE_SIZE + LOOKAHEAD,
+      });
     } catch {
-      // If the backend can't enumerate streams, fall back to whatever
-      // is already cached — this preserves the prior behavior for any
-      // exotic backend that doesn't implement `listStreams`.
+      // If the backend cannot service the cross-stream query (exotic
+      // test fixture without `queryByType` support, or a transient
+      // backend error), fall back to whatever is already cached — same
+      // best-effort contract as the pre-T8 `listStreams` catch branch.
       return;
     }
-    const taskStreams = allStreams.filter((s) => s.startsWith(prefix));
-    for (const streamId of taskStreams) {
-      const taskId = streamId.slice(prefix.length);
+
+    for (const event of events) {
+      // The envelope `streamId` is canonical (`task-store/<taskId>`).
+      // Extracting the taskId from it — rather than reaching into
+      // `event.data` — keeps this loop independent of any schema
+      // drift on the `task.created` data shape.
+      const streamId = event.streamId;
+      if (!streamId.startsWith(TASK_STREAM_PREFIX)) continue;
+      const taskId = streamId.slice(TASK_STREAM_PREFIX.length);
       if (taskId.length === 0) continue;
       if (this.tasks.has(taskId)) continue;
       try {
         await this.loadTask(taskId);
       } catch {
-        // best-effort — see docstring
+        // best-effort — see method doc
       }
     }
   }

--- a/servers/exarchos-mcp/src/views/describe.coverage.test.ts
+++ b/servers/exarchos-mcp/src/views/describe.coverage.test.ts
@@ -16,9 +16,10 @@
 // adding a new view action to composite.ts without registering it surfaces
 // here immediately.
 
-import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { DispatchContext } from '../core/dispatch.js';
 import { EventStore } from '../event-store/store.js';
@@ -28,22 +29,54 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Parse `views/composite.ts` and return every action name handled by a
- * `case 'xxx':` arm in the `handleView` switch. Excludes `describe` (the
- * introspection action itself — there's no requirement to introspect the
- * introspector) and the `default` arm (not a dispatched action).
+ * `case 'xxx':` arm inside the `handleView` switch (NOT case arms anywhere
+ * else in the file — `composite.ts` includes other helper switches whose
+ * cases must not pollute the action surface). Excludes `describe` (the
+ * introspection action itself).
+ *
+ * The regex first isolates the `handleView` body up to its closing brace,
+ * then locates the `switch (action) {...}` block within it, then collects
+ * `case '...':` literals from that block only. Tightened in response to a
+ * CodeRabbit nit on #1450 — the previous loose `[a-z_]+` regex against the
+ * full file could have picked up unrelated case arms.
  */
 function collectDispatchedActionNames(): string[] {
   const source = readFileSync(resolve(__dirname, 'composite.ts'), 'utf-8');
-  const matches = source.matchAll(/case '([a-z_]+)':/g);
+  // Anchor on `switch (action) {` opening through the switch's `default:`
+  // arm — `default:` inside a switch is a deterministic terminator that
+  // doesn't collide with inner block close braces. Falling back to a body-
+  // wide regex would risk picking up case arms from helper switches
+  // declared elsewhere in the same file.
+  const switchMatch = source.match(
+    /export\s+async\s+function\s+handleView[\s\S]*?switch\s*\(\s*action\s*\)\s*\{([\s\S]*?)default\s*:/,
+  );
+  if (!switchMatch || switchMatch[1] === undefined) {
+    throw new Error(
+      'collectDispatchedActionNames: could not locate handleView action switch (or its default arm) in views/composite.ts',
+    );
+  }
+  const switchBody = switchMatch[1];
+  const matches = switchBody.matchAll(/case\s+'([^']+)'\s*:/g);
   const names = new Set<string>();
   for (const m of matches) {
-    if (m[1] === 'describe') continue;
-    names.add(m[1]);
+    const name = m[1];
+    if (name === undefined || name === 'describe') continue;
+    names.add(name);
   }
   return [...names].sort();
 }
 
 describe('ExarchosViewDescribe — registry-vs-dispatch parity (T1, #1446 residue)', () => {
+  let tempStateDir: string;
+
+  beforeEach(() => {
+    tempStateDir = mkdtempSync(join(tmpdir(), 'exarchos-describe-coverage-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempStateDir, { recursive: true, force: true });
+  });
+
   it('ExarchosViewDescribe_ListsAllSeventeenDispatchedActions', async () => {
     const dispatched = collectDispatchedActionNames();
 
@@ -56,8 +89,8 @@ describe('ExarchosViewDescribe — registry-vs-dispatch parity (T1, #1446 residu
     expect(dispatched).toContain('ideate_readiness');
 
     const ctx: DispatchContext = {
-      stateDir: '/tmp/test-describe-coverage',
-      eventStore: new EventStore('/tmp/test-describe-coverage'),
+      stateDir: tempStateDir,
+      eventStore: new EventStore(tempStateDir),
       enableTelemetry: false,
     };
 

--- a/servers/exarchos-mcp/src/views/describe.coverage.test.ts
+++ b/servers/exarchos-mcp/src/views/describe.coverage.test.ts
@@ -1,0 +1,94 @@
+// ─── T1 (#1446 residue) — Describe coverage parity ──────────────────────────
+//
+// Pins the registry-vs-dispatch parity contract for `exarchos_view`. Every
+// action dispatched through `views/composite.ts` MUST be registered in
+// `TOOL_REGISTRY.viewActions`. Without this parity:
+//   1. Per-action Zod validation at `core/dispatch.ts:801` is silently
+//      skipped for the unregistered action (DR-5 hole).
+//   2. `exarchos_view describe` cannot surface the action's schema — the
+//      handler reads schemas from the registry, so unregistered actions
+//      are invisible to introspection.
+//
+// The test parses `composite.ts` to collect the dispatched action names from
+// the switch statement (the dispatched-surface source of truth), then calls
+// `exarchos_view { action: 'describe', actions: [<all>] }` and asserts each
+// dispatched name resolves to a describe entry. The dynamic discovery means
+// adding a new view action to composite.ts without registering it surfaces
+// here immediately.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { DispatchContext } from '../core/dispatch.js';
+import { EventStore } from '../event-store/store.js';
+import { handleView } from './composite.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Parse `views/composite.ts` and return every action name handled by a
+ * `case 'xxx':` arm in the `handleView` switch. Excludes `describe` (the
+ * introspection action itself — there's no requirement to introspect the
+ * introspector) and the `default` arm (not a dispatched action).
+ */
+function collectDispatchedActionNames(): string[] {
+  const source = readFileSync(resolve(__dirname, 'composite.ts'), 'utf-8');
+  const matches = source.matchAll(/case '([a-z_]+)':/g);
+  const names = new Set<string>();
+  for (const m of matches) {
+    if (m[1] === 'describe') continue;
+    names.add(m[1]);
+  }
+  return [...names].sort();
+}
+
+describe('ExarchosViewDescribe — registry-vs-dispatch parity (T1, #1446 residue)', () => {
+  it('ExarchosViewDescribe_ListsAllSeventeenDispatchedActions', async () => {
+    const dispatched = collectDispatchedActionNames();
+
+    // Sanity: composite.ts must dispatch at least the three actions T1 is
+    // closing residue on, plus the broader Wave 5 set. If this collapses to
+    // zero, the regex needs an update — fail loudly rather than silently.
+    expect(dispatched.length).toBeGreaterThan(0);
+    expect(dispatched).toContain('session_provenance');
+    expect(dispatched).toContain('provenance');
+    expect(dispatched).toContain('ideate_readiness');
+
+    const ctx: DispatchContext = {
+      stateDir: '/tmp/test-describe-coverage',
+      eventStore: new EventStore('/tmp/test-describe-coverage'),
+      enableTelemetry: false,
+    };
+
+    // Drive the public introspection surface end-to-end. `handleDescribe`
+    // returns UNKNOWN_ACTION on the first unregistered name in `args.actions`,
+    // so a single missing entry fails this assertion with a clear message
+    // naming the offending action.
+    const result = await handleView(
+      { action: 'describe', actions: dispatched },
+      ctx,
+    );
+
+    expect(
+      result.success,
+      `describe(actions=[${dispatched.join(',')}]) must succeed; ` +
+        `got error: ${JSON.stringify(result.error ?? {})}`,
+    ).toBe(true);
+
+    const data = result.data as Record<string, unknown>;
+    const describedNames = Object.keys(data);
+
+    // Every dispatched name MUST appear as a key in describe's response.
+    // Superset assertion (rather than equality) so additions to the
+    // registry don't break this test — the contract is "registry covers
+    // dispatched surface", not "they are identical sets".
+    for (const name of dispatched) {
+      expect(
+        describedNames,
+        `Registry is missing dispatched view action '${name}'. ` +
+          `Add it to TOOL_REGISTRY.viewActions in src/registry.ts.`,
+      ).toContain(name);
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/views/materializer.sentinel-skip.test.ts
+++ b/servers/exarchos-mcp/src/views/materializer.sentinel-skip.test.ts
@@ -1,0 +1,178 @@
+/**
+ * T2 — sentinel-stream skip in `ViewMaterializer` (closes #1434).
+ *
+ * Today `exarchos_view {action: 'pipeline'}` crashes on a clean install when a
+ * `__migration__` stream exists in the event store, because
+ * `SnapshotStore.getSnapshotPath` rejects any streamId that does not match the
+ * kebab-only `SAFE_ID_PATTERN = /^[a-z0-9-]+$/`. The event store legitimately
+ * writes progress events to `__`-prefixed sentinel streams (e.g. the v5→v6
+ * backfill in `migrateV5ToV6`), and the pipeline view's stream-iteration path
+ * forwards every discovered streamId into `materialize`, which then tries to
+ * persist a snapshot.
+ *
+ * Fix (#1434 option a): skip `__`-prefixed sentinel streams at the materializer
+ * level. Narrower than relaxing `SAFE_ID_PATTERN` (option b — explicitly
+ * rejected); preserves the kebab-only constraint for user-facing featureIds.
+ *
+ * Test A pins the unit-level guarantee: `materialize` must NOT pass a
+ * `__`-prefixed streamId to `SnapshotStore.save` (the call site that
+ * transitively invokes `getSnapshotPath`).
+ *
+ * Test B pins the end-to-end UX bug: `handleViewPipeline` must return a
+ * success envelope when a `__migration__` stream is present alongside a
+ * normal user-facing stream.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { ViewMaterializer, type ViewProjection } from './materializer.js';
+import type { WorkflowEvent } from '../event-store/schemas.js';
+import { EventStore } from '../event-store/store.js';
+import { handleViewPipeline, resetMaterializerCache } from './tools.js';
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+const counterProjection: ViewProjection<number> = {
+  init: () => 0,
+  apply: (view: number, _event: WorkflowEvent) => view + 1,
+};
+
+function makeEvent(sequence: number, streamId: string): WorkflowEvent {
+  return {
+    streamId,
+    sequence,
+    timestamp: new Date().toISOString(),
+    type: 'workflow.started',
+    schemaVersion: '1.0',
+    data: {},
+  } as WorkflowEvent;
+}
+
+// ─── Test A — Unit: materializer skips __-prefixed streams ──────────────────
+
+describe('ViewMaterializer_IteratesStreams_SkipsDunderPrefixedSentinels', () => {
+  const VIEW_NAME = 'counter';
+
+  it('does not pass __-prefixed streamIds into SnapshotStore.save', () => {
+    const snapshotStore = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    // snapshotInterval=1 forces a save attempt on every event so the
+    // assertion below is sensitive — without the sentinel guard,
+    // `materialize('__migration__', …)` would invoke `save`, which (via
+    // `getSnapshotPath`) throws `Invalid streamId: "__migration__"`.
+    const materializer = new ViewMaterializer({
+      snapshotStore,
+      snapshotInterval: 1,
+    });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    // User-facing stream — the normal happy path.
+    materializer.materialize('my-feature', VIEW_NAME, [
+      makeEvent(1, 'my-feature'),
+    ]);
+
+    // Sentinel stream — must not crash, must not save, must not touch cache.
+    expect(() =>
+      materializer.materialize('__migration__', VIEW_NAME, [
+        makeEvent(1, '__migration__'),
+      ]),
+    ).not.toThrow();
+
+    // `save` was called for the user stream …
+    expect(snapshotStore.save).toHaveBeenCalledWith(
+      'my-feature',
+      VIEW_NAME,
+      expect.anything(),
+      expect.any(Number),
+    );
+    // … and NEVER for `__migration__`.
+    const sentinelCall = snapshotStore.save.mock.calls.find(
+      (c) => c[0] === '__migration__',
+    );
+    expect(sentinelCall).toBeUndefined();
+
+    // No state cached for the sentinel — it was skipped entirely.
+    expect(materializer.getState('__migration__', VIEW_NAME)).toBeUndefined();
+    // User stream cached normally.
+    expect(materializer.getState('my-feature', VIEW_NAME)).toBeDefined();
+  });
+
+  it('loadFromSnapshot returns false for __-prefixed streams without touching the snapshot store', async () => {
+    const snapshotStore = {
+      save: vi.fn().mockResolvedValue(undefined),
+      load: vi.fn().mockResolvedValue({
+        view: 1,
+        highWaterMark: 1,
+        savedAt: '2026-05-17T00:00:00Z',
+        schemaVersion: '1.0',
+      }),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    const materializer = new ViewMaterializer({ snapshotStore });
+    materializer.register(VIEW_NAME, counterProjection);
+
+    const loaded = await materializer.loadFromSnapshot('__migration__', VIEW_NAME);
+
+    expect(loaded).toBe(false);
+    // load was never called — the sentinel was rejected before reaching the
+    // store, so the validator inside `getSnapshotPath` can never fire.
+    expect(snapshotStore.load).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Test B — Integration: pipeline view survives a __migration__ stream ───
+
+describe('ExarchosView_Pipeline_DoesNotCrashOnMigrationStream', () => {
+  let tempDir: string;
+  let stateDir: string;
+  let store: EventStore;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'view-pipeline-t2-'));
+    stateDir = tempDir;
+    store = new EventStore(tempDir);
+    resetMaterializerCache();
+  });
+
+  afterEach(async () => {
+    resetMaterializerCache();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns a success envelope when __migration__ exists alongside a normal stream', async () => {
+    const featureId = 'my-feature';
+    await store.append(featureId, {
+      type: 'workflow.started',
+      data: { featureId, workflowType: 'feature' },
+    });
+
+    // Seed an event on the internal `__migration__` stream — the real
+    // backfill in `migrateV5ToV6` writes progress events here. The event
+    // schema only requires `streamId.min(1).max(100)`, so this is a faithful
+    // reproduction of the production crash.
+    await store.append('__migration__', {
+      type: 'state.patched',
+      data: { featureId: '__migration__', fields: [], patch: {} },
+    });
+
+    const result = await handleViewPipeline(
+      { includeCompleted: true },
+      stateDir,
+      store,
+    );
+
+    expect(result.success).toBe(true);
+    // The known crash signature was `VIEW_ERROR: Invalid streamId: "__migration__"`.
+    // Pin the absence explicitly so a future regression that returns
+    // `{success:false}` with this message is caught even if a different
+    // assertion masks it.
+    if (!result.success) {
+      expect(result.error?.message).not.toContain('Invalid streamId');
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/views/materializer.ts
+++ b/servers/exarchos-mcp/src/views/materializer.ts
@@ -36,6 +36,23 @@ const DEFAULT_SNAPSHOT_INTERVAL = 50;
 const DEFAULT_MAX_CACHE_ENTRIES = 100;
 const DEFAULT_THRASHING_WINDOW_SIZE = 100;
 
+// ─── Internal Sentinel Streams (#1434) ─────────────────────────────────────
+//
+// The event store writes progress events to `__`-prefixed sentinel streams
+// (e.g. `__migration__` from `migrateV5ToV6`). These are intentionally
+// outside the user-facing kebab-only featureId vocabulary, but the pipeline
+// view's stream-iteration path forwards every discovered streamId into
+// `materialize`, which transitively reaches `SnapshotStore.getSnapshotPath`
+// — and that enforces `SAFE_ID_PATTERN = /^[a-z0-9-]+$/`, crashing the view
+// with `VIEW_ERROR: Invalid streamId: "__migration__"` on any clean install
+// that has run a schema migration.
+//
+// Skipping at this layer is narrower than relaxing `SAFE_ID_PATTERN` (option
+// (b) in #1434, explicitly rejected); the kebab-only constraint is the
+// right shape for user-facing featureIds and we don't want a future caller
+// to accidentally name a snapshot file `..` or `subdir/foo`.
+const isInternalSentinelStream = (id: string): boolean => id.startsWith('__');
+
 /** Read EXARCHOS_MAX_CACHE_ENTRIES from env, falling back to default on invalid/missing. */
 function parseEnvMaxCacheEntries(): number {
   const raw = process.env.EXARCHOS_MAX_CACHE_ENTRIES;
@@ -124,6 +141,19 @@ export class ViewMaterializer {
     const projection = this.projections.get(viewName);
     if (!projection) {
       throw new Error(`No projection registered for view: ${viewName}`);
+    }
+
+    // #1434 — skip `__`-prefixed sentinel streams (e.g. `__migration__`) so
+    // they never reach `SnapshotStore.getSnapshotPath`, whose `SAFE_ID_PATTERN`
+    // rejects underscores and crashes the pipeline view. Returning
+    // `projection.init()` keeps the caller's iteration loop happy without
+    // polluting the LRU cache or persisting a snapshot for the sentinel.
+    if (isInternalSentinelStream(streamId)) {
+      viewLogger.debug(
+        { streamId, viewName },
+        'ViewMaterializer: skipping sentinel stream',
+      );
+      return projection.init() as T;
     }
 
     const stateKey = `${viewName}:${streamId}`;
@@ -223,6 +253,16 @@ export class ViewMaterializer {
    * Falls back to default init state if snapshot is missing or corrupt.
    */
   async loadFromSnapshot(streamId: string, viewName: string): Promise<boolean> {
+    // #1434 — sentinel streams never have a meaningful snapshot to load and
+    // would otherwise trip `SnapshotStore.getSnapshotPath`'s kebab-only
+    // validator. Short-circuit before touching the backend/snapshotStore.
+    if (isInternalSentinelStream(streamId)) {
+      viewLogger.debug(
+        { streamId, viewName },
+        'ViewMaterializer: skipping snapshot load for sentinel stream',
+      );
+      return false;
+    }
     // Prefer backend view cache when available
     if (this.backend) {
       const cached = this.backend.getViewCache(streamId, viewName);


### PR DESCRIPTION
## Summary

Bundles the remaining v2.10.0-preview.4 polish work into one feature against epic #1441: closes the 3 view-action TOOL_REGISTRY residue from #1446, the `__migration__` stream crash in #1434, the #1448 consumer-side wiring hygiene, and the 5 TaskStore audit follow-ups #1438 F-4..F-8.

Philosophy: **Audit + INV-aligned hardening** (selected during ideation). F-5 + F-6 co-designed as one cursor + hydration subsystem; F-8 evaluated for hardening and audit-aligned answer retained with documented rationale (see design doc §"F-8 disposition").

## Changes

### Views layer

- **T1 / #1446 residue** — register `session_provenance`, `provenance`, `ideate_readiness` in `TOOL_REGISTRY.viewActions`. Closes the DR-5 dispatch validation gap and the `exarchos_view describe` blind spot. Pinned by 3 RED tests: registry shape, describe coverage parity (17 dispatched actions), and Zod rejection on invalid args.
- **T2 / #1434** — `ViewMaterializer.materialize` and `loadFromSnapshot` now skip `__`-prefixed sentinel streams. Stops the `Invalid streamId: "__migration__"` crash on `exarchos_view pipeline`. `SAFE_ID_PATTERN` in `snapshot-store.ts` is preserved (option (a) per the issue).

### TaskStore layer (`EventSourcedTaskStore`)

- **T4 / F-4** — size-cap TTL reap on `createTask` when `this.tasks.size > 1024`. Closes the "expired entries accumulate until listTasks fires" hazard.
- **T5 / F-7** — `projectTask` malformed-`request` coerce branch now emits `taskStoreLogger.warn` with `streamId` and event `sequence`. Tolerate-and-flag preserved; happy path unchanged.
- **T6 / F-8** — `requestId` persisted on `task.created` event payload (new optional Zod field in `event-store/schemas.ts`); projection reads payload first, falls back to `replayed:${taskId}` synthesizer for old events. INV-1 preserved — no event mutation.
- **T7 / F-5** — `listTasks` sorts by `(createdAt ASC, taskId ASC)` (deterministic across process restarts); cursor wire format is `base64url(JSON.stringify({createdAt, taskId}))`. Cross-process pagination stability pinned by RED test that destroys + recreates the store instance against the same event-store.
- **T8 / F-6** — `hydrateFromEventStore` rewritten as cursor-anchored single-page query: `EventStore.queryByType('task.created', {streamPrefix: 'task-store', since, limit: PAGE_SIZE + LOOKAHEAD})`. Cold-start query count drops from O(total tasks) to ≤ 18 (PAGE_SIZE=10 + LOOKAHEAD=8). PRECHECK confirmed the EventStore API already supports the filter triple — no API extension needed.

### Hygiene

- **T3 / #1448** — post-merge issue closure with resolution comment (items 2–5 already landed in PR #1449; epic #1441 checklist update).

## Design invariants & axiom dimensions

Detailed conformance tables in [`docs/designs/2026-05-17-preview-4-substrate-hygiene.md`](docs/designs/2026-05-17-preview-4-substrate-hygiene.md).

- **INV-1** event-sourcing integrity ✓ — F-8 fallback is read-side only; F-6 anchors on event timestamps; no payload mutation.
- **INV-2** facade equivalence ✓ — T1 brings 3 actions under DR-5 dispatch validation; CLI auto-emits via `addFlagsFromSchema`.
- **INV-3** basileus-forward ✓ — cross-process cursor stability (F-5) removes a multi-writer blocker.
- **INV-5a/b/d** ✓ — cursor is opaque to callers; envelope shape `{ tasks, nextCursor? }` preserved.
- **DIM-1** topology — F-5+F-6 co-design reduces "dual sources of truth" smell.
- **DIM-2** observability — F-7 closes silent fold-time hazard; T1 surfaces 3 actions in `describe()`.
- **DIM-3** context economy — cursor-anchored hydration: O(page) vs O(total).
- **DIM-7** lifecycle — F-4 size-cap reap removes "unread tasks never reaped" hazard.
- **DIM-8** contract honesty — DR-5 validation gap closed.

## Test Plan

- [x] **MCP server suite:** `cd servers/exarchos-mcp && npm run test:run` → **6999 passed | 22 skipped | 0 failed** (548 test files)
- [x] **Root suite:** `npm run test:run` → 762 passed | 6 skipped (91 files)
- [x] **Typecheck:** `npm run typecheck` → clean
- [x] **Two-stage review:** spec-review APPROVED (0 HIGH, 3 MEDIUM advisory); quality-review APPROVED (0 HIGH, 0 MEDIUM, 4 LOW advisory)
- [x] **TDD discipline:** 8 RED commits visible in history precede their GREEN counterparts
- [x] Manual smoke: `exarchos_view {action: 'pipeline'}` against repo with `__migration__` stream (verified via integration test in `materializer.sentinel-skip.test.ts`)

### Tests added (16)

- 3 registry / describe / dispatch-validation tests (T1)
- 3 sentinel-skip tests (T2: unit × 2 + pipeline integration)
- 2 size-cap reap tests (T4: at/under threshold)
- 2 coerce-warn tests (T5: malformed/well-formed)
- 2 requestId persistence tests (T6: new payload / old fallback)
- 2 cursor stability tests (T7: cross-process + tie-break)
- 2 cursor-anchored hydration tests (T8: cold-start count / warm no-requery)

## Closes

- #1446 (residue — 3 unregistered view actions)
- #1434 (pipeline view __migration__ crash)
- #1438 (FINDING-4..F-8 — all 5 remaining MEDIUM/LOW TaskStore audit items)
- #1448 (consumer-side correlation wiring — items 2–5 closed previously by PR #1449; this PR closes the issue hygiene)

Parent epic: #1441 (v2.10.0-preview.4 polish + post-bundle follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)