### PR TITLE
feat(preview-4): substrate realization bundle (#1436, #1440 Op 1/2/4, #1451)

### DIFF
--- a/docs/designs/2026-05-17-preview-4-substrate-realization.md
+++ b/docs/designs/2026-05-17-preview-4-substrate-realization.md
@@ -35,7 +35,7 @@ Five unrealized opportunities are catalogued in #1440. This design scopes three 
 
 ### 4.1 — #1436 Elicitation form-mode E2E smoketest
 
-**Surface:** new test file `servers/exarchos-mcp/src/__tests__/outcome/elicitation-roundtrip.test.ts`.
+**Surface:** new test file `servers/exarchos-mcp/src/__tests__/integration/elicitation-roundtrip.test.ts`.
 
 The test wires an in-process MCP client + server pair using the SDK's `InMemoryTransport` (already used by `tools-call-handler.test.ts` and `tasks-methods.test.ts`). Three paths:
 
@@ -210,7 +210,7 @@ Applied recursively to this bundle:
 
 ## 8. Acceptance criteria
 
-- [ ] **#1436 closed:** `servers/exarchos-mcp/src/__tests__/outcome/elicitation-roundtrip.test.ts` passes with three paths (accept / decline / capability-absent). Each path asserts envelope outcome AND event-store emissions.
+- [ ] **#1436 closed:** `servers/exarchos-mcp/src/__tests__/integration/elicitation-roundtrip.test.ts` passes with three paths (accept / decline / capability-absent). Each path asserts envelope outcome AND event-store emissions.
 - [ ] **#1440 Op 1 closed:** `view pipeline` / `view convergence` / `view delegation_timeline` accept `--follow`; CLI-follow test covers each; idempotency audit recorded in PR description.
 - [ ] **#1440 Op 2 closed:** `DispatchHints` interface added to `registry.ts`; four actions annotated (`merge`, `synthesize`, `cleanup`, `rehydrate`); `describe` projects `dispatch` field; describe-coverage test asserts.
 - [ ] **#1440 Op 4 closed:** `retry_with_task` verb added to next-actions discriminator schema; hint emitted from dispatch boundary when (elapsed > threshold) AND (`taskSuitable: true`) AND (`task: { ttl }` not threaded); unit + integration tests cover positive + 3 negative paths.

--- a/docs/designs/2026-05-17-preview-4-substrate-realization.md
+++ b/docs/designs/2026-05-17-preview-4-substrate-realization.md
@@ -1,0 +1,243 @@
+# Design — v2.10.0-preview.4 Substrate Realization
+
+> **Status:** Design
+> **Author:** @rsalus
+> **Opened:** 2026-05-17
+> **Bundle:** Closes #1436 + #1440 (partial: Op 1 + Op 2 + Op 4)
+> **Parent epic:** #1441 — v2.10.0-preview.4 polish + post-bundle follow-ups
+> **Predecessor design:** `docs/designs/2026-05-17-preview-4-substrate-hygiene.md` (#1450)
+
+## 1. Context
+
+The v2.10.0-preview.4 bundle (PRs #1421–#1435) landed two substrates whose realized utility is currently narrower than the infrastructure justifies:
+
+- **Elicitation form-mode** (PR #1424) shipped the round-trip plumbing through `core/dispatch.ts:811-855` and wired `createElicitationClient` against SDK 1.29 `server.elicitInput` in `adapters/mcp.ts:266`. The CodeRabbit MAJOR finding caught a "wired-but-not-invoked" class of failure (the gate always failed `elicitationClient !== undefined`). The fix landed pre-merge, but **no integration test verifies the path actually fires end-to-end against a real MCP client.** (#1436)
+- **Tasks dispatch-core** (PR #1273, split C1/C2/C3) shipped the shared dispatch surface between CLI `--follow` and MCP `tasks/*` methods, with INV-2 facade equivalence verified and `EventSourcedTaskStore` projection proven via REPLAY test. **The substrate is correct.** The realized utility is three production callsites: `view workflow_status --follow`, `view shepherd_status --follow`, and the MCP `tools/call` `task: { ttl }` opt-in. (#1440 — 5 unrealized opportunities)
+
+The companion hygiene wave (#1450, 2026-05-18) closed the substrate's correctness debt. This bundle closes the **realization debt**: moving substrate from "shipped and correct" to "actually used and verified end-to-end."
+
+Five unrealized opportunities are catalogued in #1440. This design scopes three of them (Op 1, Op 2, Op 4) plus the elicitation E2E gap (#1436). Op 3 (workflow verb wiring) and Op 5 (SSE) are deferred to dedicated designs — rationale in §7.
+
+## 2. Goals
+
+- **Verification:** prove the elicitation form-mode round-trip works end-to-end against a real MCP client, with three paths covered (accept / decline / capability-absent).
+- **Realization:** expand `--follow` to three more long-running view actions, surface a `taskSuitable` annotation through `view describe`, and emit a `retry_with_task` `next_actions` hint when a task-suitable one-shot crosses a duration threshold.
+- **Conformance:** every addition must pass `/design-invariants` (INV-1..INV-6) and `/axiom:design` (DIM-1..DIM-8); the bundle is explicitly a recursive application of both skills.
+
+## 3. Non-goals
+
+- Workflow verb wiring (Op 3 — `merge_orchestrate`, `synthesize`, `cleanup` through Tasks-augmented dispatch). Deferred: this has per-verb cancellation semantics that deserve dedicated design.
+- SSE/server-push fallback (Op 5). Deferred per #1440 acceptance criteria: gated on a client that needs it.
+- Rehydration-report optimization spike (#1395 Spike). Out of bundle theme.
+- Any change to the existing `taskCapabilityGate` at `core/dispatch.ts:927-954`. The annotation is **advisory and discovery-only**; the gate continues to be the binding opt-in.
+
+## 4. Component designs
+
+### 4.1 — #1436 Elicitation form-mode E2E smoketest
+
+**Surface:** new test file `servers/exarchos-mcp/src/__tests__/outcome/elicitation-roundtrip.test.ts`.
+
+The test wires an in-process MCP client + server pair using the SDK's `InMemoryTransport` (already used by `tools-call-handler.test.ts` and `tasks-methods.test.ts`). Three paths:
+
+1. **Accept path.** Client declares `capabilities.elicitation: {}` at handshake. Server is invoked with `tools/call` for an action that has a required field omitted from the input. Assert: server sends `elicitation/create` form-mode request to the client; client responds with `action: 'accept'` and the field value; dispatch retries with the spliced value and returns a success envelope. Query the per-operation stream `elicitation/<operationId>`: assert both `elicitation.requested` and `elicitation.fulfilled` events present. Assert `operationId` is shared with the dispatch's parent envelope `_meta.operationId` (closes the trust boundary for cross-stream correlation).
+
+2. **Decline path.** Client returns `action: 'reject'`. Assert: server emits `elicitation.declined` (the typed event added during the CodeRabbit MEDIUM fix at `dispatch/elicitation-dispatch.ts:122-126`); dispatch falls back to `INVALID_INPUT` envelope; no retry attempted.
+
+3. **Capability-absent path.** Client does NOT declare `elicitation` capability. Server skips the elicitation branch entirely (gate at `dispatch.ts:814` short-circuits because `elicitationClient` is undefined for that client); dispatch returns the legacy `INVALID_INPUT` envelope on the missing field. Assert: no events on any `elicitation/*` stream.
+
+Each path asserts **both** the envelope outcome AND the event-store emissions. This is the INV-1 closure: event-stream truth and envelope truth must agree, end-to-end.
+
+**Test target action.** The test needs an action with at least one required field that's worth eliciting. Candidates: `exarchos_workflow init` (`featureId` required). The test fixture's seeded workflow ID must not collide; use a unique per-test featureId.
+
+### 4.2 — #1440 Op 1: `--follow` expansion to additional view actions
+
+**Surface:** `adapters/cli.ts:236-238` — the `isViewFollow` predicate.
+
+Current:
+
+```typescript
+const isViewFollow =
+  tool.name === 'exarchos_view' &&
+  (action.name === 'workflow_status' || action.name === 'shepherd_status');
+```
+
+Expansion targets (from #1440 §"Opportunity 1"):
+
+- `view pipeline` — paginated list of active workflows; useful to watch as workflows arrive/complete
+- `view convergence` — D1-D5 gate convergence; useful during a synthesis push
+- `view delegation_timeline` — bottleneck detection in flight
+
+Predicate becomes a set membership check against a registry-driven constant:
+
+```typescript
+const VIEW_FOLLOW_ACTIONS = new Set([
+  'workflow_status',
+  'shepherd_status',
+  'pipeline',
+  'convergence',
+  'delegation_timeline',
+]);
+const isViewFollow = tool.name === 'exarchos_view' && VIEW_FOLLOW_ACTIONS.has(action.name);
+```
+
+**Invariant constraint:** each underlying handler must be **idempotent for repeated polls** — calling the action N times in a row with the same args must return monotonically-current state without write side effects. The three existing follow-able actions already meet this; we audit the three new ones during implementation. Any handler that doesn't (e.g., one that emits a `*.polled` event itself) must be hardened first.
+
+**Test:** one `cli-follow.test.ts` case per new action verifying NDJSON frames are emitted and the underlying handler is read-only.
+
+### 4.3 — #1440 Op 2: `taskSuitable` action annotation + describe projection
+
+**Issue framing:** `cli.taskSuitable: true` annotation, projected into `exarchos_view describe`.
+
+**Refined placement (INV-2 + INV-4 + DIM-2):** the issue's `cli.` prefix is a misnomer. The Tasks dispatch-core is **shared** between CLI and MCP (INV-2). The annotation is *action-behavior metadata* (this action is long-running and benefits from Tasks-augmented dispatch), not CLI presentation. The right home is a sibling-level optional field on the `ToolAction` interface, not under `CliActionHints`.
+
+**Surface changes:**
+
+```typescript
+// servers/exarchos-mcp/src/registry.ts
+export interface DispatchHints {
+  /**
+   * Advisory marker: this action is long-running and benefits from
+   * Tasks-augmented dispatch. Surfaced via `exarchos_view describe` so
+   * clients can enumerate. The actual opt-in gate remains
+   * `taskAugmented && ctx.taskStore && taskCapabilityGate` at
+   * core/dispatch.ts:927-954. Clients are not required to honor this
+   * marker; the gate is binding.
+   */
+  readonly taskSuitable?: boolean;
+  /**
+   * Suggested TTL for Tasks-augmented dispatch, in ms. Surfaced
+   * alongside `taskSuitable` so clients have a sensible default to
+   * thread when they opt in.
+   */
+  readonly taskTtlSuggestionMs?: number;
+}
+
+export interface ToolAction {
+  // ... existing fields ...
+  readonly dispatch?: DispatchHints;
+}
+```
+
+Initial annotation targets (from #1440 §"Opportunity 2"):
+
+- `exarchos_orchestrate merge` — multi-step git merge orchestration
+- `exarchos_workflow synthesize` — PR creation flow
+- `exarchos_workflow cleanup` — post-merge cleanup
+- `exarchos_workflow rehydrate` — full state rebuild
+
+For each: `dispatch: { taskSuitable: true, taskTtlSuggestionMs: 60_000 }`. The TTL suggestion is a sensible default; clients may override.
+
+**Describe projection.** Extend `describe/handler.ts:113-149` to include `dispatch` in the per-action result when present:
+
+```typescript
+...(action.dispatch ? { dispatch: action.dispatch } : {}),
+```
+
+The shape mirrors existing optional fields (`autoEmits`, `deprecated`, `outputSchema`). Test in `describe/handler.test.ts` (and `views/describe.coverage.test.ts`): assert the four target actions surface `dispatch.taskSuitable: true`.
+
+**Naming rationale.** `dispatch` (not `cli` or `tasks`) because the annotation is dispatch-layer metadata; `tasks` would be too narrow (a future `streaming: true` annotation belongs in the same block); `cli` violates INV-2/INV-4.
+
+### 4.4 — #1440 Op 4: `retry_with_task` next-actions hint
+
+**Surface:** `next-actions-computer.ts` + `next-actions-from-result.ts` — the next-actions surface.
+
+**Trigger condition.** When a task-suitable action (Op 2 annotation `dispatch.taskSuitable === true`) is invoked **without** the `task: { ttl }` augmentation, AND the dispatch's elapsed time exceeds a threshold, emit a `next_actions` hint of shape:
+
+```typescript
+{
+  verb: 'retry_with_task',
+  reason: `this action took ${elapsedMs}ms; consider Tasks-augmented dispatch for live progress`,
+  ttl_suggestion_ms: action.dispatch.taskTtlSuggestionMs ?? 60_000,
+}
+```
+
+**Threshold.** Default 10_000 ms (10s), matching the issue's example. Configurable via `.exarchos.yml` under `dispatch.retryWithTaskHintThresholdMs` for project-level tuning.
+
+**Where it fires.** The hint computation runs at the dispatch boundary — `core/dispatch.ts`, after the action handler returns its `ToolResult` and BEFORE `nextActionsFromResult` runs. The hint is **prepended** to whatever the result-derived hints are, because it's a meta-hint about dispatch shape, not about the result's domain content.
+
+**Idempotency.** If the caller already used `task: { ttl }`, the hint is not emitted (would be tautological). If the action is not `taskSuitable`, the hint is not emitted (no value to add).
+
+**INV-5b conformance.** The `verb: 'retry_with_task'` is a new entry in the next-actions vocabulary. It must be added to the spec-aligned discriminator schema, not free-form prose. Check `next-actions-from-result.ts:122` for the existing discriminator pattern; extend it.
+
+**Aspire-inspired (INV-5c).** `retry_with_task` is the right verb — it names the action the caller should take (`retry`) plus the augmentation that would help (`with_task`). Compare with existing verbs like `merge_orchestrate`, which name a control-plane action plus its subject. Vocabulary stays consistent.
+
+**Test:**
+- Unit test in `next-actions-computer.test.ts`: assert the hint is emitted when elapsed > threshold AND `taskSuitable: true` AND `task: { ttl }` was not threaded.
+- Negative tests: (a) hint not emitted when elapsed < threshold; (b) hint not emitted when `taskSuitable: false`; (c) hint not emitted when `task: { ttl }` was threaded.
+- Integration test in `core/dispatch.test.ts`: full path with a slow action (simulated via `vi.useFakeTimers`).
+
+## 5. /design-invariants conformance check
+
+Applied recursively to this bundle:
+
+| Invariant | Bundle impact | Disposition |
+|---|---|---|
+| **INV-1** (event-sourcing integrity) | #1436 asserts both envelope AND event-store truth for all three paths. Op 1 expansion preserves: each new follow-able action's underlying handler is read-only on repeated polls. Op 2 + Op 4 add no new event types. | ✅ Conforms |
+| **INV-2** (facade equivalence) | Op 1: `--follow` is CLI-side; MCP gets equivalent behavior via `tasks/get` polling against the same handler. Op 2: annotation lives on action metadata (registry.ts), projected by both CLI doctor and MCP describe — same source. Op 4: hint emits from dispatch boundary, which both facades cross. | ✅ Conforms (this is precisely why Op 2 doesn't live under `cli.`) |
+| **INV-3** (basileus-forward) | All four items are local-only. No remote substrate surface added. The `taskSuitable` annotation does NOT promise remote-Tasks support; it stays advisory for local dispatch. | ✅ Conforms |
+| **INV-4** (platform-agnosticity) | None of the changes assume Claude Code as runtime. `taskSuitable` is a generic MCP-spec-aligned annotation; `--follow` works in any MCP-compatible CLI; `retry_with_task` is a generic next-actions verb. | ✅ Conforms |
+| **INV-5a** (input ergonomics) | `task: { ttl }` augmentation remains optional and backward-compatible. The `retry_with_task` hint teaches agents the augmentation surface through use, lowering discovery cost. | ✅ Conforms (improves) |
+| **INV-5b** (spec-aligned output) | `retry_with_task` is a new entry in the next-actions discriminator. It must extend the existing schema, not invent a parallel structure. `dispatch.taskSuitable` surfaces via existing `describe` output's slot pattern. | ✅ Conforms (with implementation discipline) |
+| **INV-5c** (Aspire-inspired control verbs) | `retry_with_task` follows the `verb_subject` pattern (`merge_orchestrate`, `task_create`, `next_action`). No new control surface; uses existing `next_actions` hint envelope. | ✅ Conforms |
+| **INV-5d** (action discriminator) | No new actions added. `retry_with_task` is a hint verb, not a tool action — discriminator pattern unaffected. | ✅ Conforms (no impact) |
+| **INV-6** (workflow-agnosticism) | All four items live below the workflow playbook layer. Op 2's initial annotations include workflow verbs (`synthesize`, `cleanup`, `rehydrate`) but only as instances of dispatch metadata — playbooks still drive phase transitions. | ✅ Conforms |
+
+**No invariant violations.** One implementation-discipline note (INV-5b): the `retry_with_task` verb must be added to the next-actions discriminator schema, not threaded as free-form prose. This is a TDD task gate — RED test asserts the discriminator validates `retry_with_task` before GREEN code emits it.
+
+## 6. /axiom:design conformance check (DIM-1..DIM-8)
+
+| Dimension | Bundle treatment |
+|---|---|
+| **DIM-1** (cohesion / coupling) | Each component touches one seam: #1436 → test harness; Op 1 → `isViewFollow` predicate; Op 2 → registry interface + describe handler; Op 4 → dispatch boundary + next-actions computer. No cross-seam coupling introduced. |
+| **DIM-2** (boundaries / direction) | The `dispatch` annotation block lives on the action descriptor (where action metadata belongs), not under `cli.` (where presentation lives) — this is the design's most important boundary call. Op 4's hint emission lives at the dispatch boundary, downstream of action handlers (correct direction). |
+| **DIM-3** (resource / lifecycle) | Op 4's hint is informational only — zero lifecycle impact. Op 1's `--follow` reuses existing `cli/follow-loop.ts` lifecycle (already C3-SIGINT-aware). No new resources acquired. |
+| **DIM-4** (error handling) | #1436's decline-path verifies the `elicitation.declined` event lands AND the dispatch falls back to `INVALID_INPUT` — error path is exercised. No new error envelopes added; existing patterns reused. |
+| **DIM-5** (concurrency) | Op 1's three new follow-able view actions must be **read-only on repeated polls** — this is the concurrency hazard. Each gets an idempotency audit during implementation; any handler that emits a `*.polled` event itself must be hardened with FINDING-3 throttle (already shipped) BEFORE landing follow support. |
+| **DIM-6** (performance) | Op 4's hint emission adds an `elapsed > threshold` check per dispatch — O(1), zero allocation. Op 1's `--follow` is opt-in; no impact when not used. Op 2's annotation adds one field per action descriptor — negligible. |
+| **DIM-7** (testability) | #1436 is *literally* a testability improvement — fills the verification gap from PR #1424. Op 4 is testable via fake timers (vi.useFakeTimers) without real elapsed time. Op 1 uses the existing `cli-follow.test.ts` harness. Op 2 has straightforward describe-projection tests. |
+| **DIM-8** (observability) | Op 4's hint surface is observable via envelope `_meta`. #1436 asserts event-store emissions exist (closes a verification gap = observability gap). Op 2's annotation is observable via `view describe`. No new opaque surface. |
+
+**One DIM-5 risk noted:** Op 1's idempotency audit is non-trivial for `pipeline` / `convergence` / `delegation_timeline`. The implementation plan must include a "audit handler idempotency" task BEFORE the predicate expansion task, so we don't ship a `--follow` flag that pollutes the event store on every poll.
+
+## 7. Deferrals + rationale
+
+| Deferred | Where to | Why |
+|---|---|---|
+| #1440 Op 3 (workflow verb wiring) | Dedicated design | Per-verb cancellation semantics differ (`merge_orchestrate` mid-rebase ≠ `cleanup` mid-branch-delete). Each verb deserves its own design + risk envelope. Folding into this bundle would dilute review and inflate blast radius. |
+| #1440 Op 5 (SSE/server-push) | Future design, gated on demand | Per #1440 acceptance criteria: "implementation gated on a client that needs it." No such client exists today. Polling cost is real but not RC1-blocking. |
+| #1395 (rehydration spike) | Separate ideate cycle | Different bundle theme (observability vs. realization). Spike scope (live user think-aloud sessions) doesn't fit the implementation rhythm of this bundle. |
+| #1370 + #1439 (invariants audits) | Dedicated ideate cycle | Audit work is research-doc-first, then targeted edits; different cadence from feature/test work. Better as their own bundle. |
+
+## 8. Acceptance criteria
+
+- [ ] **#1436 closed:** `servers/exarchos-mcp/src/__tests__/outcome/elicitation-roundtrip.test.ts` passes with three paths (accept / decline / capability-absent). Each path asserts envelope outcome AND event-store emissions.
+- [ ] **#1440 Op 1 closed:** `view pipeline` / `view convergence` / `view delegation_timeline` accept `--follow`; CLI-follow test covers each; idempotency audit recorded in PR description.
+- [ ] **#1440 Op 2 closed:** `DispatchHints` interface added to `registry.ts`; four actions annotated (`merge`, `synthesize`, `cleanup`, `rehydrate`); `describe` projects `dispatch` field; describe-coverage test asserts.
+- [ ] **#1440 Op 4 closed:** `retry_with_task` verb added to next-actions discriminator schema; hint emitted from dispatch boundary when (elapsed > threshold) AND (`taskSuitable: true`) AND (`task: { ttl }` not threaded); unit + integration tests cover positive + 3 negative paths.
+- [ ] No regression in existing `--follow` parity (CLI vs MCP byte-identical per transition).
+- [ ] No new event types added (DIM-8 + INV-1 discipline).
+- [ ] All `/design-invariants` and `/axiom:design` checks in §5 + §6 pass at PR review time.
+
+## 9. Out of scope (explicit)
+
+- Op 3 (workflow verb wiring): `merge_orchestrate`, `synthesize`, `cleanup` through Tasks-augmented dispatch. See §7.
+- Op 5 (SSE fallback). See §7.
+- Changing the binding `taskCapabilityGate` at `core/dispatch.ts:927-954`. The annotation is advisory and discovery-only.
+- Renaming any existing CLI flags or MCP method names.
+- Migration tooling for the `dispatch` annotation (it's optional; existing actions stay valid without it).
+
+## 10. References
+
+- Epic: [#1441](https://github.com/lvlup-sw/exarchos/issues/1441) — preview.4 polish + post-bundle follow-ups
+- Sub-issues: [#1436](https://github.com/lvlup-sw/exarchos/issues/1436), [#1440](https://github.com/lvlup-sw/exarchos/issues/1440)
+- Predecessor design: `docs/designs/2026-05-17-preview-4-substrate-hygiene.md` (#1450)
+- Invariants catalog: `docs/architecture/invariants.md`
+- Bundle audit: `docs/research/2026-05-16-v2-10-0-preview-4-bundle-audit.md`
+- Relevant code:
+  - `servers/exarchos-mcp/src/core/dispatch.ts:811-855` (elicitation gate)
+  - `servers/exarchos-mcp/src/core/dispatch.ts:927-954` (taskCapabilityGate)
+  - `servers/exarchos-mcp/src/adapters/cli.ts:236-238` (isViewFollow)
+  - `servers/exarchos-mcp/src/adapters/mcp.ts:266` (createElicitationClient)
+  - `servers/exarchos-mcp/src/registry.ts:45-72` (ActionAnnotations + ToolAction)
+  - `servers/exarchos-mcp/src/describe/handler.ts:113-149` (action describe projection)
+  - `servers/exarchos-mcp/src/next-actions-from-result.ts:122` (next-actions discriminator)

--- a/docs/designs/2026-05-17-preview-4-substrate-realization.md
+++ b/docs/designs/2026-05-17-preview-4-substrate-realization.md
@@ -151,7 +151,7 @@ The shape mirrors existing optional fields (`autoEmits`, `deprecated`, `outputSc
 }
 ```
 
-**Threshold.** Default 10_000 ms (10s), matching the issue's example. Configurable via `.exarchos.yml` under `dispatch.retryWithTaskHintThresholdMs` for project-level tuning.
+**Threshold.** Hardcoded to 10_000 ms (10s) for this bundle. Config wiring at `.exarchos.yml` (`dispatch.retryWithTaskHintThresholdMs`) is deferred to a follow-up — see `dispatch.ts:1011` TODO.
 
 **Where it fires.** The hint computation runs at the dispatch boundary — `core/dispatch.ts`, after the action handler returns its `ToolResult` and BEFORE `nextActionsFromResult` runs. The hint is **prepended** to whatever the result-derived hints are, because it's a meta-hint about dispatch shape, not about the result's domain content.
 

--- a/docs/plans/2026-05-17-preview-4-substrate-realization.md
+++ b/docs/plans/2026-05-17-preview-4-substrate-realization.md
@@ -1,0 +1,303 @@
+# Implementation Plan — Preview.4 Substrate Realization
+
+> **Design:** `docs/designs/2026-05-17-preview-4-substrate-realization.md`
+> **Closes:** #1436 + #1440 (Op 1 + Op 2 + Op 4)
+> **Defers:** #1440 Op 3 (workflow verb wiring), Op 5 (SSE)
+> **Iron law:** No production code without a failing test first.
+
+## Task overview
+
+12 tasks, organized into 2 waves with 4 parallel streams.
+
+**Wave 0 — Prereqs (sequential, foundation).** Quick prerequisites that unblock parallel work. Two tasks: idempotency audit (T1) and `DispatchHints` interface (T2). T2 blocks T7, T9, T10.
+
+**Wave 1 — Parallel streams.**
+- Stream A — Elicitation E2E (#1436): T3, T4, T5, T6.
+- Stream B — `--follow` expansion (#1440 Op 1): T7.
+- Stream C — Op 2 describe + annotations (#1440 Op 2): T8, T9.
+- Stream D — Op 4 hint (#1440 Op 4): T10, T11, T12.
+
+**PR boundary.** Two PRs:
+- **PR-A** — Stream A only (#1436). Smaller, focused, ships first.
+- **PR-B** — Streams B + C + D (#1440 Op 1+2+4 bundle).
+
+## Task list
+
+### Task 1: Audit handler idempotency for new `--follow` view actions
+
+**Phase:** [Audit only — no test or code change]
+
+Verify that `view pipeline`, `view convergence`, `view delegation_timeline` handlers are **read-only on repeated polls** — no `*.polled` event emission, no state writes, no race-prone cache invalidation. Document findings in a short audit note appended to the PR-B description (or inline in a code comment on `cli.ts`'s `VIEW_FOLLOW_ACTIONS` set).
+
+For each handler:
+
+1. Read the handler entry point (`servers/exarchos-mcp/src/views/pipeline-view.ts`, `convergence-view.ts`, `delegation-timeline-view.ts` if exists, or wherever each routes).
+2. Grep for `eventStore.append`, `emit`, `mutate`, `cache.set`, or any write surface.
+3. If any handler emits a `*.polled` event, the FINDING-3 throttle pattern (already shipped for `task.polled`) must be retrofitted BEFORE landing follow support — file a follow-up issue and pull this handler out of the bundle.
+
+**Deliverable:** audit note attached to PR-B describing each handler's idempotency status. If all three are clean, the predicate refactor (T7) proceeds. If any are dirty, T7 ships with the dirty handlers removed from the set.
+
+**Dependencies:** None.
+**Parallelizable:** Yes (Wave 0).
+**Branch:** `feat/preview-4-realization-audit` (or merged inline with T7's branch).
+
+---
+
+### Task 2: Add `DispatchHints` interface to `ToolAction`
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. **[RED]** Add test in `servers/exarchos-mcp/src/registry.test.ts`:
+   - `ToolAction_DispatchHintsShape_OptionalTaskSuitableField` — assert an action descriptor with `dispatch: { taskSuitable: true, taskTtlSuggestionMs: 60000 }` satisfies the `ToolAction` type and is preserved on the registry export.
+   - Expected failure: `dispatch` is not a known field on `ToolAction`; TypeScript compile error.
+
+2. **[GREEN]** Add `DispatchHints` interface and `dispatch?: DispatchHints` field to `ToolAction` in `servers/exarchos-mcp/src/registry.ts`:
+   - `DispatchHints` has `taskSuitable?: boolean` and `taskTtlSuggestionMs?: number`.
+   - Place adjacent to `CliActionHints` for visual grouping.
+   - Field is optional; no existing actions need annotation yet.
+
+3. **[REFACTOR]** Add a JSDoc block citing the design's INV-2 rationale (why `dispatch.`, not `cli.`).
+
+**Dependencies:** None.
+**Parallelizable:** Yes (Wave 0). **Blocks:** T7 (predicate refactor doesn't use it but field convention should land first), T9 (annotations), T10 (hint reads `taskSuitable`).
+**Branch:** `feat/preview-4-realization-dispatch-hints` (merged into PR-B base branch).
+
+---
+
+### Task 3: Elicitation E2E test harness — InMemoryTransport fixture
+
+**Phase:** [GREEN — fixture setup]
+
+Build the shared test infrastructure for #1436. Not a test itself — a helper that T4/T5/T6 consume.
+
+1. **[GREEN]** Create `servers/exarchos-mcp/src/__tests__/integration/elicitation-roundtrip.fixture.ts`:
+   - Export `createElicitationTestPair({ clientCapabilities, elicitInputHandler })` returning `{ client, server, eventStore, cleanup }`.
+   - Wire `InMemoryTransport` (pattern from `cli-parity.test.ts`).
+   - `clientCapabilities` controls whether `elicitation: {}` is declared.
+   - `elicitInputHandler` is the test's mock — receives the form-mode params, returns `{ action: 'accept'|'reject'|'cancel', content?: Record<string,unknown> }`.
+   - EventStore wiring: SQLite in-memory, fresh per test.
+
+2. Quick sanity test in the same file (one test): `createElicitationTestPair_DefaultArgs_HandshakeSucceeds`.
+
+**Dependencies:** None.
+**Parallelizable:** Yes (Wave 1, Stream A entry point).
+**Branch:** `feat/preview-4-realization-elicitation-e2e` (PR-A).
+
+---
+
+### Task 4: Elicitation E2E — accept path
+
+**Phase:** RED → GREEN
+
+1. **[RED]** Add test in `elicitation-roundtrip.test.ts` (new file at `src/__tests__/integration/`):
+   - `ElicitationRoundtrip_AcceptPath_EnvelopeSuccessAndEventsLanded`.
+   - Setup via fixture (T3). Client declares `elicitation: {}`. Mock `elicitInputHandler` returns `{ action: 'accept', content: { featureId: 'test-id' } }`.
+   - Invoke `tools/call` for `exarchos_workflow init` with `featureId` omitted.
+   - Assert: envelope is `success: true` (workflow created).
+   - Assert: events on stream `elicitation/<operationId>`: both `elicitation.requested` AND `elicitation.fulfilled` present.
+   - Assert: `result._meta.operationId` matches the elicitation stream's operation prefix (cross-stream correlation closed).
+   - Expected outcome: PASS on first run if substrate is correct; FAIL if PR #1424 + CodeRabbit fix has any residual gap.
+
+**Dependencies:** T3.
+**Parallelizable:** Yes (Stream A, parallel with T5, T6).
+**Branch:** Same as T3 (`feat/preview-4-realization-elicitation-e2e`).
+
+---
+
+### Task 5: Elicitation E2E — decline path
+
+**Phase:** RED → GREEN
+
+1. **[RED]** Add test in `elicitation-roundtrip.test.ts`:
+   - `ElicitationRoundtrip_DeclinePath_InvalidInputEnvelopeAndDeclinedEventLanded`.
+   - Mock `elicitInputHandler` returns `{ action: 'reject' }`.
+   - Assert: envelope is `success: false` with `error.code: 'INVALID_INPUT'`.
+   - Assert: event on stream `elicitation/<operationId>`: `elicitation.declined` present (typed event from `elicitation-dispatch.ts:122-126`).
+   - Assert: NO retry attempted (the underlying action handler is called at most once).
+   - Expected outcome: PASS on first run if substrate is correct.
+
+**Dependencies:** T3.
+**Parallelizable:** Yes (Stream A, parallel with T4, T6).
+**Branch:** Same as T3.
+
+---
+
+### Task 6: Elicitation E2E — capability-absent path
+
+**Phase:** RED → GREEN
+
+1. **[RED]** Add test in `elicitation-roundtrip.test.ts`:
+   - `ElicitationRoundtrip_CapabilityAbsent_LegacyInvalidInputAndNoElicitationEvents`.
+   - Client does NOT declare `elicitation` capability.
+   - Invoke `tools/call` for `exarchos_workflow init` with `featureId` omitted.
+   - Assert: envelope is `success: false` with `error.code: 'INVALID_INPUT'` (legacy path).
+   - Assert: NO events on ANY `elicitation/*` stream.
+   - Assert: `elicitInputHandler` was never invoked.
+   - Expected outcome: PASS on first run.
+
+**Dependencies:** T3.
+**Parallelizable:** Yes (Stream A, parallel with T4, T5).
+**Branch:** Same as T3.
+
+---
+
+### Task 7: `--follow` expansion to 3 view actions
+
+**Phase:** RED → GREEN → REFACTOR
+
+1. **[RED]** Add tests in `servers/exarchos-mcp/src/cli/follow-loop.test.ts` (or new `cli-follow-expansion.test.ts` if existing file gets unwieldy):
+   - `CliFollow_PipelineAction_EmitsNdjsonFrames`.
+   - `CliFollow_ConvergenceAction_EmitsNdjsonFrames`.
+   - `CliFollow_DelegationTimelineAction_EmitsNdjsonFrames`.
+   - Each: invoke CLI with `view <action> --follow`; assert NDJSON frames stream; assert no `*.polled` events emitted (idempotency cross-check).
+   - Expected failure: `isViewFollow` predicate rejects each new action; `--follow` flag not registered.
+
+2. **[GREEN]** Refactor `adapters/cli.ts:236-238`:
+   - Replace inline predicate with `VIEW_FOLLOW_ACTIONS` set containing `workflow_status`, `shepherd_status`, `pipeline`, `convergence`, `delegation_timeline`.
+   - Update the action-name routing at `cli.ts:405` (currently a ternary) to route via the set as well.
+   - Apply the audit results from T1: if any of the 3 new actions is non-idempotent, exclude from the set and file a follow-up.
+
+3. **[REFACTOR]** Extract `VIEW_FOLLOW_ACTIONS` to a top-level module constant with a JSDoc comment citing INV-2 (CLI `--follow` and MCP `tasks/get` polling produce byte-equivalent transitions).
+
+**Dependencies:** T1 (audit must complete before set expansion).
+**Parallelizable:** Yes (Stream B, parallel with Streams C, D).
+**Branch:** `feat/preview-4-realization-follow-expansion` (PR-B sub-branch).
+
+---
+
+### Task 8: Project `dispatch` field through `describe` handler
+
+**Phase:** RED → GREEN
+
+1. **[RED]** Add test in `servers/exarchos-mcp/src/describe/handler.test.ts` (or `views/describe.coverage.test.ts` — locate during implementation):
+   - `DescribeHandler_ActionWithDispatchHints_ProjectsDispatchField`.
+   - Setup: fixture action with `dispatch: { taskSuitable: true, taskTtlSuggestionMs: 60000 }`.
+   - Invoke `describe({ actions: ['<fixture-action>'] })`.
+   - Assert: result has `dispatch: { taskSuitable: true, taskTtlSuggestionMs: 60000 }`.
+   - `DescribeHandler_ActionWithoutDispatchHints_OmitsDispatchField` — assert field is absent when annotation not set.
+   - Expected failure: handler at `describe/handler.ts:113-149` does not project the field.
+
+2. **[GREEN]** Extend `describe/handler.ts:113-149` action result construction:
+   - Add `...(action.dispatch ? { dispatch: action.dispatch } : {})` alongside existing optional spreads (autoEmits, deprecated, outputSchema).
+
+**Dependencies:** T2 (`DispatchHints` interface must exist).
+**Parallelizable:** Yes (Stream C, parallel with B, D).
+**Branch:** `feat/preview-4-realization-describe-dispatch` (PR-B sub-branch).
+
+---
+
+### Task 9: Annotate 4 target actions with `dispatch.taskSuitable`
+
+**Phase:** RED → GREEN
+
+1. **[RED]** Add test in `registry.test.ts`:
+   - `Registry_TaskSuitableAnnotations_FourActionsMarked`.
+   - Assert: `exarchos_orchestrate merge`, `exarchos_workflow synthesize`, `exarchos_workflow cleanup`, `exarchos_workflow rehydrate` each surface `dispatch.taskSuitable: true` AND `dispatch.taskTtlSuggestionMs: 60000`.
+   - Expected failure: none of these actions has a `dispatch` annotation yet.
+
+2. **[GREEN]** Add `dispatch: { taskSuitable: true, taskTtlSuggestionMs: 60_000 }` to each of the 4 action descriptors in `registry.ts`.
+
+**Dependencies:** T2 (`DispatchHints` interface), T8 (projection — needed if test asserts via describe).
+**Parallelizable:** Yes (Stream C, after T8).
+**Branch:** Same as T8.
+
+---
+
+### Task 10: Add `retry_with_task` verb to next-actions discriminator schema
+
+**Phase:** RED → GREEN
+
+1. **[RED]** Add test in `servers/exarchos-mcp/src/next-actions-from-result.test.ts` (or wherever the discriminator validation lives):
+   - `NextActionsDiscriminator_RetryWithTaskVerb_Validates`.
+   - Assert: a next-action object of shape `{ verb: 'retry_with_task', reason: '...', ttl_suggestion_ms: 60000 }` passes the discriminator schema.
+   - Expected failure: verb is not in the discriminator union.
+
+2. **[GREEN]** Extend the discriminator schema at `next-actions-from-result.ts:122` (or wherever the union is defined — locate during implementation) to include `retry_with_task` with `ttl_suggestion_ms: number` as the additional payload field.
+
+**Dependencies:** T2 (annotation must exist so the verb has somewhere to point).
+**Parallelizable:** Yes (Stream D, parallel with B, C).
+**Branch:** `feat/preview-4-realization-retry-with-task-hint` (PR-B sub-branch).
+
+---
+
+### Task 11: Emit `retry_with_task` hint from dispatch boundary
+
+**Phase:** RED → GREEN
+
+1. **[RED]** Add unit test in `next-actions-computer.test.ts` (or `core/dispatch.test.ts` — locate based on where hint composition lives):
+   - `RetryWithTaskHint_TaskSuitableActionWithoutTaskTtlExceededThreshold_PrependsHint` (positive path).
+   - Use `vi.useFakeTimers()` to simulate elapsed > threshold (default 10_000 ms).
+   - Assert: `result._meta.next_actions[0].verb === 'retry_with_task'`.
+   - Assert: `next_actions[0].ttl_suggestion_ms === 60_000` (from `dispatch.taskTtlSuggestionMs`).
+   - Expected failure: no hint emission rule exists yet.
+
+2. **[GREEN]** Add hint emission rule at the dispatch boundary in `core/dispatch.ts`, **after** the action handler returns but **before** `nextActionsFromResult` runs:
+   - Compute `elapsedMs` from a start timestamp captured at dispatch entry.
+   - Read `action.dispatch?.taskSuitable` from the registry.
+   - Detect whether `task: { ttl }` was threaded (existing logic at `dispatch.ts:526`).
+   - If (`taskSuitable === true`) AND (no `task: { ttl }`) AND (`elapsedMs > threshold`), construct the `retry_with_task` next-action object and prepend to `result._meta.next_actions`.
+   - Threshold: read from `config.dispatch.retryWithTaskHintThresholdMs` if present, else `10_000`.
+
+**Dependencies:** T9 (`merge`/`synthesize`/`cleanup`/`rehydrate` are annotated; test fixture uses one of them), T10 (discriminator accepts the verb).
+**Parallelizable:** Sequential with T10 + T9.
+**Branch:** Same as T10.
+
+---
+
+### Task 12: Negative-path coverage + integration test for `retry_with_task`
+
+**Phase:** RED → GREEN
+
+1. **[RED]** Add three negative tests in the same file as T11:
+   - `RetryWithTaskHint_ElapsedBelowThreshold_HintNotEmitted` — fake timer to 9_999 ms.
+   - `RetryWithTaskHint_ActionNotTaskSuitable_HintNotEmitted` — invoke a non-annotated action.
+   - `RetryWithTaskHint_TaskTtlAlreadyThreaded_HintNotEmitted` — invoke with `task: { ttl: 60_000 }`.
+   - Expected outcome: each must show the hint is NOT in `next_actions[0]`.
+
+2. **[RED]** Add integration test in `core/dispatch.test.ts`:
+   - `Dispatch_SlowTaskSuitableAction_EmitsRetryWithTaskHintInMeta`.
+   - End-to-end: dispatch `merge_orchestrate` (or similar long-running annotated action) with a simulated handler that takes > 10s.
+   - Assert: returned envelope's `_meta.next_actions` contains `retry_with_task` as the first entry.
+
+3. **[GREEN]** Verify negative paths pass without code change (the emission rule from T11 should already short-circuit correctly). If not, tighten the rule.
+
+**Dependencies:** T11.
+**Parallelizable:** Sequential with T11.
+**Branch:** Same as T10/T11.
+
+---
+
+## Wave + PR mapping
+
+```
+PR-A (#1436 only):                  PR-B (#1440 Op 1 + Op 2 + Op 4):
+  T3 → T4, T5, T6 (parallel)          Wave 0:
+                                        T1 (audit) — parallelizable
+                                        T2 (DispatchHints type)
+                                      Wave 1:
+                                        Stream B: T7
+                                        Stream C: T8 → T9
+                                        Stream D: T10 → T11 → T12
+                                      (Streams B, C, D parallel after Wave 0)
+```
+
+**Estimated PR sizes:**
+- PR-A: 1 fixture file + 1 test file with 3 cases. Probably 250-400 LOC. Single review pass expected.
+- PR-B: ~6 files touched (registry.ts, describe/handler.ts, adapters/cli.ts, core/dispatch.ts, next-actions-from-result.ts, plus tests). Probably 600-900 LOC. Reviewable but at the upper bound — consider stacking PR-B as 3 smaller PRs (per stream) if review feedback signals it.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| T1 audit finds a non-idempotent handler | Exclude that handler from the `VIEW_FOLLOW_ACTIONS` set; file follow-up issue; do NOT block the bundle. |
+| T4/T5/T6 fail on first run (substrate gap) | This IS the test value. File a hot-fix sub-issue; do not paper over. |
+| T11 hint emission has unexpected interaction with `nextActionsFromResult` ordering | Hint is prepended at dispatch boundary; integration test in T12 catches ordering regressions. |
+| T9 annotations affect existing review/audit gates | None of the 4 actions currently has `dispatch` field; addition is additive and optional. Existing tests pass unchanged. |
+| Stream B/C/D parallel work conflicts on `registry.ts` | T7, T8, T9, T10 touch different sections of `registry.ts` (or none of them — T7 touches `cli.ts`, T10 touches `next-actions-from-result.ts`). Only T2 + T9 touch the same file; T9 depends on T2 sequentially. Low conflict risk. |
+
+## Out of scope (explicit, mirrors design §9)
+
+- #1440 Op 3 (workflow verb wiring through Tasks-augmented dispatch).
+- #1440 Op 5 (SSE/server-push).
+- Any change to the binding `taskCapabilityGate` at `core/dispatch.ts:927-954`.
+- Migration tooling for the `dispatch` annotation (purely additive).

--- a/servers/exarchos-mcp/src/__tests__/integration/elicitation-roundtrip.fixture.ts
+++ b/servers/exarchos-mcp/src/__tests__/integration/elicitation-roundtrip.fixture.ts
@@ -225,8 +225,22 @@ export async function createElicitationTestPair(
   const cleanup = async (): Promise<void> => {
     try {
       await client.close();
-    } catch {
-      /* ignore — close-after-close is a no-op semantically */
+    } catch (err) {
+      // The SDK / InMemoryTransport surface a few benign signals during
+      // teardown (e.g., double-close after a test path that already closed
+      // the client; pending request rejection when the transport tears down
+      // mid-flight). Those are idempotent / expected. Anything else is a
+      // real teardown failure and must surface — silently swallowing it
+      // masks resource leaks and substrate regressions.
+      const message = err instanceof Error ? err.message : String(err);
+      const isBenign =
+        /already closed/i.test(message) ||
+        /not connected/i.test(message) ||
+        /transport.*closed/i.test(message) ||
+        /connection closed/i.test(message);
+      if (!isBenign) {
+        throw err;
+      }
     }
     await fs.rm(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   };

--- a/servers/exarchos-mcp/src/__tests__/integration/elicitation-roundtrip.fixture.ts
+++ b/servers/exarchos-mcp/src/__tests__/integration/elicitation-roundtrip.fixture.ts
@@ -1,0 +1,240 @@
+// ─── T3 / #1436 — Elicitation form-mode E2E fixture ─────────────────────────
+//
+// Shared test infrastructure for the three elicitation-roundtrip path tests
+// (accept / decline / capability-absent — T4, T5, T6). Wires an in-process
+// MCP client + server pair via the SDK's `InMemoryTransport`, matching the
+// pattern already established by `cli-parity.test.ts` and
+// `tools-list.test.ts`. The fixture is intentionally narrow: it owns the
+// transport/lifecycle wiring AND the event-store substrate, so each path
+// test can focus on the round-trip semantics.
+//
+// Per design `docs/designs/2026-05-17-preview-4-substrate-realization.md`
+// §4.1, the fixture closes the verification gap from PR #1424: the
+// elicitation form-mode plumbing landed but no test exercised the full path
+// against a real MCP client. T4/T5/T6 consume this fixture to cover all
+// three paths.
+//
+// Implementation notes:
+//
+//   • The fresh EventStore lives under a temp directory (mirroring the
+//     existing integration-test convention — `EventStore` is SQLite-backed
+//     and a per-test temp directory gives us isolation without a special
+//     in-memory mode).
+//
+//   • The `capabilityResolver` is wired into the dispatch context so the
+//     server's `oninitialized` hook (`adapters/mcp.ts:298-326`) snapshots
+//     the client's declared capabilities. Without this resolver, the
+//     dispatch-side gate at `core/dispatch.ts:813` would never observe
+//     `isElicitationDeclared() === true` and the elicitation branch would
+//     stay dark even with the SDK plumbing fully wired.
+//
+//   • When the caller provides `clientCapabilities.elicitation`, the client
+//     registers a `setRequestHandler(ElicitRequestSchema, …)` that forwards
+//     to the caller's `elicitInputHandler`. When the caller omits the
+//     capability, the handler is NOT registered — this mirrors how real
+//     clients that don't support elicitation simply don't advertise it.
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createMcpServer } from '../../adapters/mcp.js';
+import { createInMemoryResolver } from '../../capabilities/resolver.js';
+import type { DispatchContext } from '../../core/dispatch.js';
+import { EventStore } from '../../event-store/store.js';
+
+// ─── Public surface ────────────────────────────────────────────────────────
+
+/**
+ * MCP form-mode elicitation request parameters as the test's mock handler
+ * receives them from the SDK. Mirrors `ElicitRequestFormParamsSchema` (see
+ * `@modelcontextprotocol/sdk/types.d.ts` line 4966) but narrowed to the
+ * fields the dispatcher actually surfaces — keeps the test-author surface
+ * compact without dragging the SDK's full discriminated-union shape into
+ * fixture consumers.
+ *
+ * `requestedSchema` is the dispatcher's `.pick({<field>: true})` shape
+ * (a Record-shaped JSON Schema fragment); fixture consumers can inspect
+ * `requestedSchema.properties` to confirm which field is being elicited.
+ */
+export interface ElicitInputParams {
+  readonly message: string;
+  readonly mode?: 'form';
+  readonly requestedSchema: Record<string, unknown>;
+}
+
+/**
+ * Mock-client response shape — what the test's `elicitInputHandler` returns
+ * to fulfill (or decline) the server's elicitation request. Mirrors the
+ * SDK's `ElicitResultSchema` (`@modelcontextprotocol/sdk/types.d.ts:5381`):
+ *
+ *   • `action: 'accept'` + `content` — supplies the field value(s). The
+ *     dispatcher reads `content[<missingField>]` after the round-trip.
+ *   • `action: 'decline'` / `'cancel'` — the dispatch helper treats both
+ *     as un-fulfilled and emits `elicitation.declined` rather than
+ *     `elicitation.fulfilled` (see `dispatch/elicitation-dispatch.ts:122-126`).
+ */
+export interface ElicitInputResult {
+  readonly action: 'accept' | 'decline' | 'cancel';
+  readonly content?: Record<string, unknown>;
+}
+
+/**
+ * Caller-supplied client capabilities. When `elicitation` is present (even
+ * as `{}`), the resolver snapshots it during the initialize handshake and
+ * the dispatch-side gate opens. When absent, the dispatcher falls back to
+ * the legacy INVALID_INPUT path on missing required fields.
+ */
+export interface ElicitationTestPairOpts {
+  /** Capabilities the test client advertises during the initialize handshake. */
+  readonly clientCapabilities?: {
+    readonly elicitation?: Record<string, never>;
+  };
+  /**
+   * Mock handler that stands in for the user / agent fulfilling the form.
+   * Required only when `clientCapabilities.elicitation` is declared. If
+   * omitted while elicitation IS declared, the fixture wires a default
+   * handler that returns `{ action: 'decline' }` so unmocked tests fail
+   * loudly rather than silently round-tripping.
+   */
+  readonly elicitInputHandler?: (
+    params: ElicitInputParams,
+  ) => Promise<ElicitInputResult>;
+}
+
+/**
+ * Wired in-process MCP pair plus the substrate the server is bound to.
+ * Consumers exercise the round-trip via `client.callTool(...)`, then assert
+ * envelope outcome via the returned `structuredContent` AND event-store
+ * truth via `eventStore.query('elicitation/<operationId>')`.
+ */
+export interface ElicitationTestPair {
+  readonly client: Client;
+  readonly server: Server;
+  readonly eventStore: EventStore;
+  readonly cleanup: () => Promise<void>;
+}
+
+// ─── Fixture factory ───────────────────────────────────────────────────────
+
+/**
+ * Build an in-process MCP client + server pair that exercises the
+ * elicitation form-mode round-trip end-to-end. The server is the same
+ * `createMcpServer(ctx)` production carrier consumed by `index.ts`, so
+ * the path under test is the production path; only the transport is
+ * substituted (`InMemoryTransport` instead of stdio/HTTP).
+ *
+ * The returned `server` is the low-level `Server` (SDK type) accessed via
+ * `McpServer.server` — convenient for tests that want to inspect or stub
+ * lifecycle hooks. The `eventStore` is fresh per call; queries against
+ * `elicitation/<operationId>` streams will contain only events emitted by
+ * the test under inspection.
+ *
+ * Always call `cleanup()` in `afterEach` (closes the client, drops the
+ * temp directory). Failing to do so leaks the SQLite handle and the temp
+ * directory, which compounds across the test suite.
+ */
+export async function createElicitationTestPair(
+  opts: ElicitationTestPairOpts,
+): Promise<ElicitationTestPair> {
+  // EventStore substrate — fresh SQLite per call, lives under a temp
+  // directory. Matches the convention in `tools-list.test.ts` and
+  // `cli-parity.test.ts` (the integration suite's idiom for per-test
+  // isolation; `EventStore` does not currently expose an explicit
+  // `:memory:` mode).
+  const tmpDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'elicitation-roundtrip-test-'),
+  );
+  const eventStore = new EventStore(tmpDir);
+  await eventStore.initialize();
+
+  // CapabilityResolver wiring — the dispatch-side elicitation gate at
+  // `core/dispatch.ts:813` reads `ctx.capabilityResolver?.isElicitationDeclared()`.
+  // Without a resolver on the dispatch context, that branch can never open
+  // even if the client declares the capability. `createMcpServer` wires
+  // `server.oninitialized` to snapshot the client's capabilities into the
+  // resolver during the initialize handshake (see `adapters/mcp.ts:298-326`).
+  const capabilityResolver = createInMemoryResolver([]);
+
+  const ctx: DispatchContext = {
+    stateDir: tmpDir,
+    eventStore,
+    enableTelemetry: false,
+    capabilityResolver,
+  };
+
+  const mcpServer = createMcpServer(ctx);
+
+  // Transport pair — both halves of an in-memory channel. The server
+  // attaches first via `connect(serverTransport)`, then the client
+  // attaches to its half; the SDK runs the initialize handshake during
+  // `client.connect(...)` so the capability snapshot fires before the
+  // first `tools/call` lands.
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  // Build the client with the caller's declared capabilities. The
+  // capability shape (`elicitation: {}` vs absent) determines whether the
+  // server's elicitation branch lights up — that's the discriminator the
+  // T4 / T5 / T6 path tests pivot on.
+  const client = new Client(
+    { name: 'elicitation-roundtrip-test', version: '1.0.0' },
+    { capabilities: opts.clientCapabilities ?? {} },
+  );
+
+  // Client-side elicitation handler wiring. When the caller declared
+  // `elicitation: {}`, attach a `setRequestHandler(ElicitRequestSchema, …)`
+  // that forwards to the test's mock. When the caller did NOT declare
+  // elicitation, DO NOT register a handler — this mirrors real clients
+  // that don't support elicitation simply not advertising it (and the
+  // server's dispatch-side gate stays closed regardless of any client
+  // handler).
+  if (opts.clientCapabilities?.elicitation !== undefined) {
+    // Default to a `decline` response when the caller omits a handler so
+    // an unmocked test fails loudly (envelope is `INVALID_INPUT` + the
+    // `elicitation.declined` event lands) rather than hanging on an
+    // un-resolved transport request.
+    const handler =
+      opts.elicitInputHandler ?? (async () => ({ action: 'decline' as const }));
+
+    client.setRequestHandler(ElicitRequestSchema, async (request) => {
+      // The SDK validates incoming requests against the union of
+      // form-mode + URL-mode params; the dispatcher only emits form-mode
+      // today, so we narrow without runtime checks here (a mismatch
+      // would be a substrate bug T4/T5/T6 should catch).
+      const params = request.params as unknown as ElicitInputParams;
+      const result = await handler(params);
+      // `ElicitResultSchema` accepts `accept | decline | cancel`. The
+      // structural cast is necessary because the SDK's result shape is
+      // discriminated on `action` and not all branches carry `content`.
+      return {
+        action: result.action,
+        ...(result.content !== undefined ? { content: result.content } : {}),
+      } as Awaited<ReturnType<Parameters<Client['setRequestHandler']>[1]>>;
+    });
+  }
+
+  await Promise.all([
+    mcpServer.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  const cleanup = async (): Promise<void> => {
+    try {
+      await client.close();
+    } catch {
+      /* ignore — close-after-close is a no-op semantically */
+    }
+    await fs.rm(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  };
+
+  return {
+    client,
+    server: mcpServer.server,
+    eventStore,
+    cleanup,
+  };
+}

--- a/servers/exarchos-mcp/src/__tests__/integration/elicitation-roundtrip.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/integration/elicitation-roundtrip.test.ts
@@ -8,7 +8,7 @@
 //
 // Design: `docs/designs/2026-05-17-preview-4-substrate-realization.md` §4.1.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createElicitationTestPair } from './elicitation-roundtrip.fixture.js';
 
 describe('#1436 — elicitation-roundtrip fixture smoke', () => {
@@ -22,6 +22,239 @@ describe('#1436 — elicitation-roundtrip fixture smoke', () => {
     try {
       const { tools } = await pair.client.listTools();
       expect(tools.length).toBeGreaterThan(0);
+    } finally {
+      await pair.cleanup();
+    }
+  });
+});
+
+// ─── T4 / #1436 — Accept path ─────────────────────────────────────────────
+//
+// Client declares `capabilities.elicitation: {}` at handshake; the server's
+// dispatch boundary detects the missing `featureId` on `exarchos_workflow
+// init`, routes through the elicitation hand-off, the test's mock handler
+// returns `action: 'accept'` with a valid `featureId`, and dispatch retries
+// the validation with the spliced value. Closes the verification gap from
+// PR #1424 by asserting BOTH the envelope outcome AND the event-store
+// truth (`elicitation.requested` + `elicitation.fulfilled` on the
+// per-operation stream, sharing the dispatch's `_meta.operationId`).
+//
+// Substrate is believed correct after PR #1424 + CodeRabbit fix; this test
+// SHOULD pass on first run.
+describe('#1436 — elicitation-roundtrip accept path', () => {
+  it('ElicitationRoundtrip_AcceptPath_EnvelopeSuccessAndEventsLanded', async () => {
+    // Random suffix avoids collisions with any same-test re-runs sharing
+    // the substrate (the EventStore is per-test, but the workflow.started
+    // event's featureId is what dispatch-side stream-naming keys on, so
+    // a unique id keeps audit-trail noise out of subsequent assertions).
+    const featureId = `test-accept-${Math.random().toString(36).slice(2, 10)}`;
+
+    const elicitInputHandler = vi.fn(async () => ({
+      action: 'accept' as const,
+      content: { featureId },
+    }));
+
+    const pair = await createElicitationTestPair({
+      clientCapabilities: { elicitation: {} },
+      elicitInputHandler,
+    });
+
+    try {
+      // `featureId` is OMITTED — the schema requires it, so dispatch will
+      // detect the single-missing-required-field condition and route
+      // through `performElicitation`. `workflowType` IS supplied so the
+      // missing-field count is exactly one (the `extractSingleMissing-
+      // RequiredField` gate at `dispatch.ts:151` only fires for exactly
+      // one missing required field).
+      const result = (await pair.client.callTool({
+        name: 'exarchos_workflow',
+        arguments: { action: 'init', workflowType: 'feature' },
+      })) as {
+        structuredContent?: {
+          success?: boolean;
+          _meta?: { operationId?: string };
+        };
+      };
+
+      // Envelope: success — workflow created via the elicitation hand-off.
+      expect(result.structuredContent).toBeDefined();
+      expect(result.structuredContent?.success).toBe(true);
+
+      // Mock handler should have been invoked exactly once (the
+      // elicitation hand-off is a single round-trip; no retry loop).
+      expect(elicitInputHandler).toHaveBeenCalledTimes(1);
+
+      // Event-store truth — both lifecycle events land on the per-operation
+      // pseudo-stream `elicitation/<operationId>`. The operationId on the
+      // envelope's `_meta` must match the prefix used to name the stream
+      // (Sentry MEDIUM #1428 cross-stream correlation contract).
+      const operationId = result.structuredContent?._meta?.operationId;
+      expect(operationId).toBeDefined();
+      expect(typeof operationId).toBe('string');
+
+      const events = await pair.eventStore.query(
+        `elicitation/${operationId}`,
+      );
+      const eventTypes = events.map((e) => e.type);
+      expect(eventTypes).toContain('elicitation.requested');
+      expect(eventTypes).toContain('elicitation.fulfilled');
+    } finally {
+      await pair.cleanup();
+    }
+  });
+});
+
+// ─── T5 / #1436 — Decline path ────────────────────────────────────────────
+//
+// Client declares elicitation but the mock handler returns `decline`. The
+// dispatch hand-off emits `elicitation.declined` (the typed-event split
+// from CodeRabbit MEDIUM #1424 at `dispatch/elicitation-dispatch.ts:122-126`)
+// and falls back to the legacy INVALID_INPUT envelope rather than retrying.
+//
+// The decline path also verifies that the underlying `init` handler is NOT
+// invoked twice: the elicitation gate runs to its un-fulfilled terminal
+// state without splicing a value and re-validating, so no `workflow.started`
+// event lands for the test's would-be featureId. We don't have a clean spy
+// surface on the registry-resolved handler from the test, so we use the
+// event-store as the indirect witness — no `workflow.*` events should
+// appear for `test-decline-*` ids.
+describe('#1436 — elicitation-roundtrip decline path', () => {
+  it('ElicitationRoundtrip_DeclinePath_InvalidInputEnvelopeAndDeclinedEventLanded', async () => {
+    const featureId = `test-decline-${Math.random().toString(36).slice(2, 10)}`;
+
+    const elicitInputHandler = vi.fn(async () => ({
+      action: 'decline' as const,
+    }));
+
+    const pair = await createElicitationTestPair({
+      clientCapabilities: { elicitation: {} },
+      elicitInputHandler,
+    });
+
+    try {
+      const result = (await pair.client.callTool({
+        name: 'exarchos_workflow',
+        arguments: { action: 'init', workflowType: 'feature' },
+      })) as {
+        structuredContent?: {
+          success?: boolean;
+          error?: { code?: string };
+          _meta?: { operationId?: string };
+        };
+      };
+
+      // Envelope: legacy INVALID_INPUT — the elicitation gate detected the
+      // decline and fell through to the validation-failure return at
+      // `core/dispatch.ts:859-862`.
+      expect(result.structuredContent).toBeDefined();
+      expect(result.structuredContent?.success).toBe(false);
+      expect(result.structuredContent?.error?.code).toBe('INVALID_INPUT');
+
+      // The mock handler was invoked once — the elicitation round-trip
+      // happened but the client refused to supply a value. No retry.
+      expect(elicitInputHandler).toHaveBeenCalledTimes(1);
+
+      // Event-store truth — the typed `elicitation.declined` event lands
+      // on the per-operation stream. This is the CodeRabbit MEDIUM fix:
+      // pre-fix the decline path emitted `elicitation.fulfilled` with an
+      // undefined value, making audit consumers unable to discriminate a
+      // genuine refusal from a value-shape error.
+      const operationId = result.structuredContent?._meta?.operationId;
+      expect(operationId).toBeDefined();
+
+      const events = await pair.eventStore.query(
+        `elicitation/${operationId}`,
+      );
+      const eventTypes = events.map((e) => e.type);
+      expect(eventTypes).toContain('elicitation.requested');
+      expect(eventTypes).toContain('elicitation.declined');
+      // And NO `elicitation.fulfilled` — these are mutually exclusive
+      // terminal states per the dispatch helper's contract.
+      expect(eventTypes).not.toContain('elicitation.fulfilled');
+
+      // No-retry assertion via the event store: the init handler is the
+      // emitter of `workflow.started`, so if it ran on a decline we'd see
+      // an event for the test's featureId. Query the workflow stream and
+      // confirm absence. (The featureId never made it past validation in
+      // the decline path, but a buggy retry-on-decline would surface here.)
+      const wfEvents = await pair.eventStore.query(featureId);
+      expect(wfEvents.length).toBe(0);
+    } finally {
+      await pair.cleanup();
+    }
+  });
+});
+
+// ─── T6 / #1436 — Capability-absent path ──────────────────────────────────
+//
+// Client does NOT declare the `elicitation` capability. The dispatch-side
+// gate at `core/dispatch.ts:813-815` short-circuits because
+// `ctx.capabilityResolver.isElicitationDeclared()` returns false; the
+// elicitation hand-off is skipped entirely and dispatch returns the
+// legacy INVALID_INPUT envelope on the missing required field.
+//
+// Critical assertions:
+//   • NO events on any `elicitation/*` stream (the substrate does not
+//     attempt the round-trip).
+//   • The mock handler we registered is never invoked (the SDK never
+//     sends an `elicitation/create` request because the client lacks
+//     the capability declaration).
+describe('#1436 — elicitation-roundtrip capability-absent path', () => {
+  it('ElicitationRoundtrip_CapabilityAbsent_LegacyInvalidInputAndNoElicitationEvents', async () => {
+    // No `clientCapabilities.elicitation` → resolver records
+    // `isElicitationDeclared() === false`. Per the fixture contract, the
+    // client-side `setRequestHandler(ElicitRequestSchema, …)` is NOT
+    // registered when the capability is absent — matching real clients
+    // that don't support elicitation.
+    //
+    // We still pass an `elicitInputHandler` so we can assert it was never
+    // called (the SDK won't deliver an `elicitation/create` request
+    // without the capability declaration, so the handler is effectively
+    // dead code — exactly what we want to verify).
+    const elicitInputHandler = vi.fn(async () => ({
+      action: 'accept' as const,
+      content: { featureId: 'test-capability-absent-handler-should-not-fire' },
+    }));
+
+    const pair = await createElicitationTestPair({
+      // No clientCapabilities → no elicitation capability declared.
+      elicitInputHandler,
+    });
+
+    try {
+      const result = (await pair.client.callTool({
+        name: 'exarchos_workflow',
+        arguments: { action: 'init', workflowType: 'feature' },
+      })) as {
+        structuredContent?: {
+          success?: boolean;
+          error?: { code?: string };
+        };
+      };
+
+      // Envelope: legacy INVALID_INPUT — exactly the pre-#1274 behavior
+      // for a missing required field. The elicitation gate is dark.
+      expect(result.structuredContent).toBeDefined();
+      expect(result.structuredContent?.success).toBe(false);
+      expect(result.structuredContent?.error?.code).toBe('INVALID_INPUT');
+
+      // The mock handler is unreachable because no `setRequestHandler` is
+      // registered on the client (per fixture contract when elicitation
+      // capability is absent). Even if it were registered, the server
+      // never issues `elicitation/create` because the capability gate
+      // is closed dispatch-side.
+      expect(elicitInputHandler).not.toHaveBeenCalled();
+
+      // No `elicitation/*` stream activity at all — the round-trip was
+      // never attempted, so `elicitation.requested` was never emitted.
+      // This is the INV-1 closure for the capability-absent path:
+      // event-stream truth (no events) and envelope truth (legacy
+      // INVALID_INPUT) agree, end-to-end.
+      const allStreams = pair.eventStore.listStreams();
+      const elicitationStreams = allStreams.filter((s) =>
+        s.startsWith('elicitation/'),
+      );
+      expect(elicitationStreams).toEqual([]);
     } finally {
       await pair.cleanup();
     }

--- a/servers/exarchos-mcp/src/__tests__/integration/elicitation-roundtrip.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/integration/elicitation-roundtrip.test.ts
@@ -1,0 +1,29 @@
+// ─── T3 / #1436 — Elicitation form-mode E2E fixture smoke test ──────────────
+//
+// Sanity-only test for the fixture itself. The accept / decline / capability-
+// absent path tests (T4 / T5 / T6) build on `createElicitationTestPair`, so a
+// failure here would cascade across the substrate-realization wave. This
+// test proves the wiring works end-to-end (handshake + tool registration)
+// before the path tests layer assertions on top.
+//
+// Design: `docs/designs/2026-05-17-preview-4-substrate-realization.md` §4.1.
+
+import { describe, it, expect } from 'vitest';
+import { createElicitationTestPair } from './elicitation-roundtrip.fixture.js';
+
+describe('#1436 — elicitation-roundtrip fixture smoke', () => {
+  it('CreateElicitationTestPair_DefaultArgs_HandshakeSucceeds', async () => {
+    // Default-args path: no client capabilities declared, no elicitation
+    // handler attached. Verifies the InMemoryTransport handshake completes
+    // and the server advertises a non-empty `tools/list` (matches the
+    // production registry shape — `exarchos_workflow`, `exarchos_event`,
+    // etc.). If this fails, T4 / T5 / T6 are blocked.
+    const pair = await createElicitationTestPair({});
+    try {
+      const { tools } = await pair.client.listTools();
+      expect(tools.length).toBeGreaterThan(0);
+    } finally {
+      await pair.cleanup();
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/__tests__/integration/elicitation-roundtrip.test.ts
+++ b/servers/exarchos-mcp/src/__tests__/integration/elicitation-roundtrip.test.ts
@@ -112,15 +112,25 @@ describe('#1436 — elicitation-roundtrip accept path', () => {
 // and falls back to the legacy INVALID_INPUT envelope rather than retrying.
 //
 // The decline path also verifies that the underlying `init` handler is NOT
-// invoked twice: the elicitation gate runs to its un-fulfilled terminal
-// state without splicing a value and re-validating, so no `workflow.started`
-// event lands for the test's would-be featureId. We don't have a clean spy
-// surface on the registry-resolved handler from the test, so we use the
-// event-store as the indirect witness — no `workflow.*` events should
-// appear for `test-decline-*` ids.
+// invoked: the elicitation gate runs to its un-fulfilled terminal state
+// without splicing a value and re-validating, so `workflow.started` is
+// never emitted. Because the fixture's EventStore is fresh per test, the
+// hermetic post-decline state contains ONLY the per-operation
+// `elicitation/<operationId>` stream — any other stream signals a bug
+// (e.g., a substrate that retried after decline, with any featureId).
 describe('#1436 — elicitation-roundtrip decline path', () => {
   it('ElicitationRoundtrip_DeclinePath_InvalidInputEnvelopeAndDeclinedEventLanded', async () => {
-    const featureId = `test-decline-${Math.random().toString(36).slice(2, 10)}`;
+    // NOTE: no featureId is supplied to the dispatch call (the entire point
+    // of the decline path is that the elicitation gate fires precisely
+    // because `featureId` is the missing required field). Per CodeRabbit C4,
+    // an earlier revision queried the event store for a randomly-generated
+    // `test-decline-*` featureId that was NEVER actually passed to dispatch
+    // — which made the "no retry" assertion trivially true (it would have
+    // passed even if a buggy substrate WAS retrying with some other
+    // featureId). The replacement assertion below targets the substrate's
+    // actual observable signal: workflow.started is the init handler's
+    // first emission, and the substrate is keyed on per-test EventStore,
+    // so a hermetic post-decline state has ZERO workflow streams.
 
     const elicitInputHandler = vi.fn(async () => ({
       action: 'decline' as const,
@@ -173,12 +183,23 @@ describe('#1436 — elicitation-roundtrip decline path', () => {
       expect(eventTypes).not.toContain('elicitation.fulfilled');
 
       // No-retry assertion via the event store: the init handler is the
-      // emitter of `workflow.started`, so if it ran on a decline we'd see
-      // an event for the test's featureId. Query the workflow stream and
-      // confirm absence. (The featureId never made it past validation in
-      // the decline path, but a buggy retry-on-decline would surface here.)
-      const wfEvents = await pair.eventStore.query(featureId);
-      expect(wfEvents.length).toBe(0);
+      // first (and only) emitter of `workflow.started` in this dispatch
+      // path. If the substrate buggily retried after the decline (with any
+      // featureId — synthesized, stale, or otherwise), a workflow stream
+      // would land on the per-test EventStore. The fixture's EventStore
+      // is fresh per call, so the post-decline hermetic state has ZERO
+      // workflow streams. Any non-elicitation stream is a bug.
+      //
+      // (Prior revision queried a random `test-decline-*` featureId that
+      // was never passed to dispatch — see CodeRabbit C4. That assertion
+      // was trivially satisfied because the queried id never appeared in
+      // any code path; the assertion below is provable: it fails if the
+      // substrate creates a workflow stream by any means.)
+      const allStreams = pair.eventStore.listStreams();
+      const workflowStreams = allStreams.filter(
+        (s) => !s.startsWith('elicitation/'),
+      );
+      expect(workflowStreams).toEqual([]);
     } finally {
       await pair.cleanup();
     }

--- a/servers/exarchos-mcp/src/adapters/cli.test.ts
+++ b/servers/exarchos-mcp/src/adapters/cli.test.ts
@@ -203,6 +203,63 @@ describe('buildCli', () => {
 
     stdoutSpy.mockRestore();
   });
+
+  // ─── #1440 Op 1 (T7): --follow expansion to additional view actions ──────
+  //
+  // The `isViewFollow` predicate currently inlines a two-arm disjunction
+  // over `workflow_status | shepherd_status`. Expansion adds three more
+  // pure ViewProjection-backed actions (`pipeline`, `convergence`,
+  // `delegation_timeline`) per the T1 orchestrator-inline idempotency
+  // audit. These tests pin that the `--follow` option is REGISTERED for
+  // each of the five actions through the Commander tree — they fail
+  // BEFORE expansion because the predicate rejects the new three, so the
+  // `actionCmd.option('--follow', ...)` registration call is skipped and
+  // the option simply doesn't exist on the command.
+
+  // Map (action.name in registry) → (CLI subcommand name, after action.cli.alias resolution).
+  // Only `pipeline` carries an alias (`ls`); the others register under their full name.
+  const FOLLOW_ACTION_CLI_NAMES: ReadonlyArray<{ readonly action: string; readonly cliName: string }> = [
+    { action: 'workflow_status', cliName: 'workflow_status' },
+    { action: 'shepherd_status', cliName: 'shepherd_status' },
+    { action: 'pipeline', cliName: 'ls' },
+    { action: 'convergence', cliName: 'convergence' },
+    { action: 'delegation_timeline', cliName: 'delegation_timeline' },
+  ];
+
+  for (const { action, cliName } of FOLLOW_ACTION_CLI_NAMES) {
+    it(`BuildCli_ViewFollow_${action}_RegistersFollowFlag`, () => {
+      // Arrange — locate the `vw <cliName>` subcommand via the Commander tree.
+      const program = buildCli(ctx);
+      const viewCmd = program.commands.find((c) => c.name() === 'vw');
+      expect(viewCmd, 'exarchos vw tool group not registered').toBeDefined();
+      const actionCmd = viewCmd?.commands.find((c) => c.name() === cliName);
+      expect(
+        actionCmd,
+        `exarchos vw ${cliName} subcommand not registered (action.name: ${action})`,
+      ).toBeDefined();
+
+      // Assert — the `--follow` option is present on the subcommand.
+      const optionFlags = actionCmd?.options.map((o) => o.flags) ?? [];
+      expect(
+        optionFlags.some((f) => f.includes('--follow')),
+        `exarchos vw ${cliName} must register --follow (action.name '${action}' belongs in VIEW_FOLLOW_ACTIONS)`,
+      ).toBe(true);
+    });
+  }
+
+  it('BuildCli_ViewFollow_NonFollowAction_DoesNotRegisterFollowFlag', () => {
+    // Negative control: `view tasks` is a one-shot detail view that the
+    // T7 expansion deliberately leaves out of `VIEW_FOLLOW_ACTIONS`. The
+    // predicate must continue to gate `--follow` registration to the
+    // members of the set — a stray addition (or a typo) should NOT
+    // silently register the flag on every view action.
+    const program = buildCli(ctx);
+    const viewCmd = program.commands.find((c) => c.name() === 'vw');
+    const tasksCmd = viewCmd?.commands.find((c) => c.name() === 'tasks');
+    expect(tasksCmd, 'exarchos vw tasks subcommand not registered').toBeDefined();
+    const optionFlags = tasksCmd?.options.map((o) => o.flags) ?? [];
+    expect(optionFlags.some((f) => f.includes('--follow'))).toBe(false);
+  });
 });
 
 // ─── Task 12: Schema Command ─────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/adapters/cli.ts
+++ b/servers/exarchos-mcp/src/adapters/cli.ts
@@ -17,6 +17,7 @@ import {
   VALIDATION_ERROR_CODE,
 } from './schema-to-flags.js';
 import { HandleMergeOrchestrateArgsSchema } from '../orchestrate/merge-orchestrate.js';
+import type { FollowSubcommand } from '../cli/follow-formatter.js';
 import { prettyPrint, printError, toCliResult } from './cli-format.js';
 // NOTE: `./schema-introspection.js` is intentionally NOT imported at the top
 // level. It pulls `zod-to-json-schema`, the state-machine topology serializer,
@@ -176,6 +177,40 @@ function resolvePackageVersion(): string {
 // ─── CLI Command Tree Generator ─────────────────────────────────────────────
 
 /**
+ * The set of `exarchos_view` action.names that the CLI exposes a `--follow`
+ * streaming mode for. Membership drives BOTH the predicate that registers
+ * the `--follow` Commander option (`buildCli` registration loop) and the
+ * dispatch ternary that maps `action.name` → `FollowSubcommand` label
+ * (the `subcommand` value threaded into `runFollowLoop`).
+ *
+ * Invariant (INV-2 — CLI `--follow` and MCP `tasks/get` polling produce
+ * byte-equivalent transitions): every member MUST be backed by a pure
+ * `ViewProjection` fold — no `eventStore.append`, no `emit`, no
+ * `*.polled` events. Repeated polls must be a no-op against the
+ * EventStore so the polling cadence under `--follow` (and the
+ * MCP-side `tasks/get` retry path) doesn't mutate the timeline they
+ * are observing.
+ *
+ * Audit (#1440 Op 1 / T1, orchestrator-inline 2026-05-17): all five
+ * underlying handlers verified pure folds — see `workflow-status-view.ts`,
+ * `shepherd-status-view.ts`, `pipeline-view.ts`, `convergence-view.ts`,
+ * `delegation-timeline-view.ts`. The source-file idempotency cross-check
+ * for the three NEW members lives in `cli/cli-follow-expansion.test.ts`
+ * so any future write-surface regression fails CI before landing.
+ *
+ * Keep this set in lockstep with the `FollowSubcommand` union in
+ * `cli/follow-formatter.ts` — the union's literal members must mirror
+ * this set exactly.
+ */
+export const VIEW_FOLLOW_ACTIONS: ReadonlySet<string> = new Set([
+  'workflow_status',
+  'shepherd_status',
+  'pipeline',
+  'convergence',
+  'delegation_timeline',
+]);
+
+/**
  * Builds a Commander program from the TOOL_REGISTRY.
  *
  * Each composite tool becomes a top-level command (with `exarchos_` prefix stripped),
@@ -225,17 +260,19 @@ export function buildCli(ctx: DispatchContext): Command {
         actionCmd.option('--follow', 'Stream events as NDJSON frames until the source closes');
       }
 
-      // T33 (#1273) / Wave C PR 3 — the `exarchos view workflow_status` and
-      // `exarchos view shepherd_status` actions gain a `--follow` flag that
-      // drives the dispatch-core `EventSourcedTaskStore` polling loop (see
-      // `cli/follow-loop.ts`). Like the event-query `--follow`, this flag is
-      // registered outside `addFlagsFromSchema` so the MCP tool schema for
-      // the underlying action stays one-shot — the Tasks-augmented branch
-      // for the MCP arm is gated by the SDK `task: { ttl }` request
-      // parameter, not by a tool-schema field (see C2).
+      // T33 (#1273) / Wave C PR 3 — the `exarchos view` actions listed in
+      // `VIEW_FOLLOW_ACTIONS` gain a `--follow` flag that drives the
+      // dispatch-core `EventSourcedTaskStore` polling loop (see
+      // `cli/follow-loop.ts`). #1440 Op 1 (T7) expanded the set from the
+      // original two-arm disjunction (workflow_status, shepherd_status) to
+      // include three more pure-projection view actions (pipeline,
+      // convergence, delegation_timeline). Like the event-query `--follow`,
+      // this flag is registered outside `addFlagsFromSchema` so the MCP
+      // tool schema for the underlying action stays one-shot — the
+      // Tasks-augmented branch for the MCP arm is gated by the SDK
+      // `task: { ttl }` request parameter, not by a tool-schema field (C2).
       const isViewFollow =
-        tool.name === 'exarchos_view' &&
-        (action.name === 'workflow_status' || action.name === 'shepherd_status');
+        tool.name === 'exarchos_view' && VIEW_FOLLOW_ACTIONS.has(action.name);
       if (isViewFollow) {
         actionCmd.option(
           '--follow',
@@ -401,8 +438,14 @@ export function buildCli(ctx: DispatchContext): Command {
 
           try {
             const { runFollowLoop } = await import('../cli/follow-loop.js');
-            const subcommand =
-              action.name === 'workflow_status' ? 'workflow_status' : 'shepherd_status';
+            // #1440 Op 1 (T7): the routing now flows directly from
+            // `action.name` since `VIEW_FOLLOW_ACTIONS` and the
+            // `FollowSubcommand` union are kept in lockstep — both
+            // describe the same five-element set. The cast is the
+            // bridge from the registry's `string` field to the
+            // narrower literal union; the `isViewFollow` guard above
+            // proves membership before we reach this point.
+            const subcommand = action.name as FollowSubcommand;
 
             // Dispatch the underlying action through the Tasks-augmented
             // path so the lifecycle is recorded in the same

--- a/servers/exarchos-mcp/src/cli/cli-follow-expansion.test.ts
+++ b/servers/exarchos-mcp/src/cli/cli-follow-expansion.test.ts
@@ -184,6 +184,14 @@ describe('view handlers — #1440 Op 1 idempotency cross-check (T1 audit)', () =
   const FORBIDDEN_PATTERNS: ReadonlyArray<string> = [
     'eventStore.append',
     '.polled',
+    // `.emit(` (method-call form, NOT the bare word) catches EventEmitter-
+    // style write surfaces while avoiding false-positives on the word
+    // 'emit' that legitimately appears in JSDoc/comments referencing the
+    // T1 audit. Per CodeRabbit C5: the per-handler docstring at the top of
+    // this file explicitly forbids `emit`, but the runtime guard above
+    // missed it — closing the gap so a future regression that introduces
+    // an event-emitter write on a poll path fails CI before review.
+    '.emit(',
   ];
 
   for (const filename of FOLLOW_TARGETS) {

--- a/servers/exarchos-mcp/src/cli/cli-follow-expansion.test.ts
+++ b/servers/exarchos-mcp/src/cli/cli-follow-expansion.test.ts
@@ -1,0 +1,201 @@
+/**
+ * cli-follow-expansion — `--follow` expansion to view {pipeline,convergence,delegation_timeline} (#1440 Op 1, T7).
+ *
+ * Pin two contracts independently from the broader `follow-loop.test.ts` to
+ * keep the diff focused:
+ *
+ *   1. `runFollowLoop` accepts the three new `FollowSubcommand` values and
+ *      emits NDJSON-shaped transition frames identical to the existing
+ *      workflow_status/shepherd_status entry points (only the prefix
+ *      bracket differs).
+ *   2. The underlying view handlers are pure projections — no
+ *      `eventStore.append`, no `emit`, no `*.polled` events. Cross-checks
+ *      the T1 idempotency audit at the source-file level so any future
+ *      handler edit that introduces a write surface fails this test
+ *      before it ships.
+ *
+ * INV-2: CLI `--follow` and MCP `tasks/get` polling produce byte-equivalent
+ * transitions. The TaskStore-polling substrate is shared with the
+ * workflow_status/shepherd_status path, so the rendering test below is
+ * the only new behavior to pin at this layer.
+ */
+import { describe, it, expect } from 'vitest';
+import { PassThrough } from 'node:stream';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Task } from '@modelcontextprotocol/sdk/types.js';
+
+import { runFollowLoop, type FollowTaskStore } from './follow-loop.js';
+
+const ISO_FIXED = '2026-05-17T00:00:00.000Z';
+
+// ─── Fixture builder (mirrors the scriptedStore in follow-loop.test.ts) ───
+
+function scriptedStore(taskId: string, script: ReadonlyArray<Task>): FollowTaskStore {
+  let cursor = 0;
+  return {
+    async getTask(id: string): Promise<Task | null> {
+      if (id !== taskId) return null;
+      const next = script[Math.min(cursor, script.length - 1)];
+      cursor += 1;
+      return { ...next };
+    },
+    async updateTaskStatus(): Promise<void> {
+      /* unused in expansion tests */
+    },
+  };
+}
+
+function drain(stream: PassThrough): string {
+  return stream.read()?.toString('utf8') ?? '';
+}
+
+// Resolve `__dirname` under ESM/NodeNext so the source-file idempotency
+// check below works regardless of vitest worker cwd.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('runFollowLoop — #1440 Op 1 expansion to additional view actions', () => {
+  it('CliFollow_PipelineAction_EmitsNdjsonFrames', async () => {
+    // Pipeline view is the paginated list of active workflows. Operators
+    // tail it during a synthesis push to watch workflows arrive/complete.
+    // Same TaskStore-polling substrate as workflow_status — the only
+    // observable diff is the `[pipeline]` bracket in the output line.
+    const taskId = 'task-pipeline-001';
+    const script: Task[] = [
+      { taskId, status: 'working', ttl: 60_000, createdAt: ISO_FIXED, lastUpdatedAt: ISO_FIXED },
+      {
+        taskId,
+        status: 'completed',
+        ttl: 60_000,
+        createdAt: ISO_FIXED,
+        lastUpdatedAt: '2026-05-17T00:00:01.000Z',
+      },
+    ];
+    const stdout = new PassThrough();
+    const store = scriptedStore(taskId, script);
+
+    const result = await runFollowLoop({
+      taskStore: store,
+      taskId,
+      pollIntervalMs: 1,
+      stdout,
+      subcommand: 'pipeline',
+    });
+
+    const text = drain(stdout);
+    expect(text).toContain('[pipeline]');
+    expect(text).toContain(taskId);
+    expect(text).toContain('completed');
+    expect(result.terminalStatus).toBe('completed');
+    expect(result.transitions).toBeGreaterThanOrEqual(2);
+  });
+
+  it('CliFollow_ConvergenceAction_EmitsNdjsonFrames', async () => {
+    // Convergence view surfaces D1-D5 gate convergence. Useful during a
+    // synthesis push to watch dimensions land sequentially.
+    const taskId = 'task-convergence-002';
+    const script: Task[] = [
+      {
+        taskId,
+        status: 'working',
+        ttl: 60_000,
+        createdAt: ISO_FIXED,
+        lastUpdatedAt: ISO_FIXED,
+        statusMessage: 'D1 pending',
+      },
+      {
+        taskId,
+        status: 'completed',
+        ttl: 60_000,
+        createdAt: ISO_FIXED,
+        lastUpdatedAt: '2026-05-17T00:00:02.000Z',
+        statusMessage: 'D1-D5 converged',
+      },
+    ];
+    const stdout = new PassThrough();
+    const store = scriptedStore(taskId, script);
+
+    const result = await runFollowLoop({
+      taskStore: store,
+      taskId,
+      pollIntervalMs: 1,
+      stdout,
+      subcommand: 'convergence',
+    });
+
+    const text = drain(stdout);
+    expect(text).toContain('[convergence]');
+    expect(text).toContain(taskId);
+    expect(text).toContain('D1-D5 converged');
+    expect(result.terminalStatus).toBe('completed');
+  });
+
+  it('CliFollow_DelegationTimelineAction_EmitsNdjsonFrames', async () => {
+    // Delegation timeline drives bottleneck detection in flight. Operators
+    // typically tail this during multi-agent dispatch waves.
+    const taskId = 'task-delegation-003';
+    const script: Task[] = [
+      { taskId, status: 'working', ttl: 60_000, createdAt: ISO_FIXED, lastUpdatedAt: ISO_FIXED },
+      {
+        taskId,
+        status: 'completed',
+        ttl: 60_000,
+        createdAt: ISO_FIXED,
+        lastUpdatedAt: '2026-05-17T00:00:03.000Z',
+      },
+    ];
+    const stdout = new PassThrough();
+    const store = scriptedStore(taskId, script);
+
+    const result = await runFollowLoop({
+      taskStore: store,
+      taskId,
+      pollIntervalMs: 1,
+      stdout,
+      subcommand: 'delegation_timeline',
+    });
+
+    const text = drain(stdout);
+    expect(text).toContain('[delegation_timeline]');
+    expect(text).toContain(taskId);
+    expect(text).toContain('completed');
+    expect(result.terminalStatus).toBe('completed');
+  });
+});
+
+describe('view handlers — #1440 Op 1 idempotency cross-check (T1 audit)', () => {
+  // Cross-check the orchestrator-inline T1 idempotency audit at the
+  // source-file level. The three new --follow targets MUST be pure
+  // `ViewProjection` folds — no `eventStore.append`, no `emit`, no
+  // `*.polled` events. If a future edit introduces a write surface this
+  // test fails BEFORE the per-handler test, surfacing the regression at
+  // the design-invariant level.
+  const VIEWS_DIR = path.resolve(__dirname, '..', 'views');
+  const FOLLOW_TARGETS = [
+    'pipeline-view.ts',
+    'convergence-view.ts',
+    'delegation-timeline-view.ts',
+  ];
+  // Strings that would indicate a write side-effect on a poll path. The
+  // patterns are conservative: any literal substring match here is
+  // enough to fail the test and trigger a manual review of the handler.
+  const FORBIDDEN_PATTERNS: ReadonlyArray<string> = [
+    'eventStore.append',
+    '.polled',
+  ];
+
+  for (const filename of FOLLOW_TARGETS) {
+    it(`ViewHandler_${filename}_NoWriteSurfacesOrPolledEvents`, () => {
+      const filePath = path.join(VIEWS_DIR, filename);
+      const source = fs.readFileSync(filePath, 'utf8');
+      for (const pattern of FORBIDDEN_PATTERNS) {
+        expect(
+          source.includes(pattern),
+          `${filename} must not contain '${pattern}' — the --follow polling path requires idempotent reads (T1 audit, INV-2)`,
+        ).toBe(false);
+      }
+    });
+  }
+});

--- a/servers/exarchos-mcp/src/cli/follow-formatter.ts
+++ b/servers/exarchos-mcp/src/cli/follow-formatter.ts
@@ -20,7 +20,18 @@
  */
 import type { Task } from '@modelcontextprotocol/sdk/types.js';
 
-export type FollowSubcommand = 'workflow_status' | 'shepherd_status';
+/**
+ * Widened in #1440 Op 1 (T7): the CLI `--follow` predicate now admits
+ * three additional view actions backed by pure `ViewProjection` folds.
+ * The formatter is unchanged — only the prefix bracket varies — and the
+ * union is kept in lockstep with `VIEW_FOLLOW_ACTIONS` in `adapters/cli.ts`.
+ */
+export type FollowSubcommand =
+  | 'workflow_status'
+  | 'shepherd_status'
+  | 'pipeline'
+  | 'convergence'
+  | 'delegation_timeline';
 
 export interface FollowTransition {
   readonly subcommand: FollowSubcommand;

--- a/servers/exarchos-mcp/src/core/dispatch.test.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.test.ts
@@ -1506,5 +1506,180 @@ describe('dispatch', () => {
         restore();
       }
     });
+
+    // ─── T12 — Negative paths ────────────────────────────────────────────
+    //
+    // The emission rule is conditional on three predicates ANDed together
+    // (taskSuitable && !taskAugmented && elapsedMs > threshold). Each
+    // negative test breaks exactly one predicate to pin the boundary.
+
+    it('RetryWithTaskHint_ElapsedBelowThreshold_HintNotEmitted', async () => {
+      // Arrange — same task-suitable action (`cleanup`), no `task: { ttl }`,
+      // but elapsed = 9_999 ms which is below the 10_000 ms threshold.
+      const { stubCompositeHandler, dispatch } = await import('./dispatch.js');
+      const stub = async (_args: Record<string, unknown>, _ctx: DispatchContext): Promise<ToolResult> => ({
+        success: true,
+        data: { ok: true },
+      });
+      const restore = stubCompositeHandler('exarchos_workflow', stub);
+
+      // 0 → 9_999: strictly below 10_000 (the rule uses `>` not `>=`, so
+      // even exactly 10_000 would still suppress the hint).
+      installClockSequence([0, 9_999]);
+
+      try {
+        const result = await dispatch(
+          'exarchos_workflow',
+          {
+            action: 'cleanup',
+            featureId: 'hint-below-threshold',
+            mergeVerified: true,
+          },
+          { stateDir: tmpDir, eventStore, enableTelemetry: false },
+        );
+
+        // Assert — no retry_with_task entry in next_actions (it may be
+        // absent or empty, but if present must not start with the hint).
+        expect(result.success).toBe(true);
+        const nextActions = (result as ToolResult & { next_actions?: readonly { verb: string }[] }).next_actions;
+        if (nextActions !== undefined && nextActions.length > 0) {
+          expect(nextActions[0].verb).not.toBe('retry_with_task');
+        }
+        // Stronger: no entry anywhere in the array is the hint verb.
+        const hasHint = (nextActions ?? []).some((n) => n.verb === 'retry_with_task');
+        expect(hasHint).toBe(false);
+      } finally {
+        restore();
+      }
+    });
+
+    it('RetryWithTaskHint_ActionNotTaskSuitable_HintNotEmitted', async () => {
+      // Arrange — `exarchos_view describe` is NOT annotated with
+      // `dispatch.taskSuitable` (read-only pure introspection over the
+      // registry). Even with a long elapsed time, the hint must not fire.
+      const { stubCompositeHandler, dispatch } = await import('./dispatch.js');
+      const stub = async (_args: Record<string, unknown>, _ctx: DispatchContext): Promise<ToolResult> => ({
+        success: true,
+        data: { ok: true, actions: [] },
+      });
+      const restore = stubCompositeHandler('exarchos_view', stub);
+
+      installClockSequence([0, 30_000]); // way above threshold
+
+      try {
+        const result = await dispatch(
+          'exarchos_view',
+          { action: 'describe', actions: ['cleanup'] },
+          { stateDir: tmpDir, eventStore, enableTelemetry: false },
+        );
+
+        expect(result.success).toBe(true);
+        const nextActions = (result as ToolResult & { next_actions?: readonly { verb: string }[] }).next_actions;
+        const hasHint = (nextActions ?? []).some((n) => n.verb === 'retry_with_task');
+        expect(hasHint).toBe(false);
+      } finally {
+        restore();
+      }
+    });
+
+    it('RetryWithTaskHint_TaskTtlAlreadyThreaded_HintNotEmitted', async () => {
+      // Arrange — caller threaded `task: { ttl: 60_000 }`, so the hint
+      // would be tautological. Even with elapsed > threshold and a
+      // task-suitable action, the emission must be suppressed.
+      //
+      // Note: the underlying `runTasksAugmented` path requires
+      // `ctx.taskStore` and capability gating to actually fire; without
+      // them (as here), `taskAugmented` is true but the call falls back
+      // to one-shot. The hint suppression must depend on `taskAugmented`
+      // (the caller's stated intent), NOT on whether the task path
+      // actually engaged — otherwise a fallback caller would receive a
+      // confusing hint to retry with the same TTL they already supplied.
+      const { stubCompositeHandler, dispatch } = await import('./dispatch.js');
+      const stub = async (_args: Record<string, unknown>, _ctx: DispatchContext): Promise<ToolResult> => ({
+        success: true,
+        data: { ok: true },
+      });
+      const restore = stubCompositeHandler('exarchos_workflow', stub);
+
+      installClockSequence([0, 30_000]); // above threshold
+
+      try {
+        const result = await dispatch(
+          'exarchos_workflow',
+          {
+            action: 'cleanup',
+            featureId: 'hint-task-threaded',
+            mergeVerified: true,
+            task: { ttl: 60_000 },
+          },
+          { stateDir: tmpDir, eventStore, enableTelemetry: false },
+        );
+
+        expect(result.success).toBe(true);
+        const nextActions = (result as ToolResult & { next_actions?: readonly { verb: string }[] }).next_actions;
+        const hasHint = (nextActions ?? []).some((n) => n.verb === 'retry_with_task');
+        expect(hasHint).toBe(false);
+      } finally {
+        restore();
+      }
+    });
+
+    // ─── T12 — Integration test ──────────────────────────────────────────
+    //
+    // End-to-end through the full dispatch flow (correlation context,
+    // built-in action validation, composite invocation, attachMeta) for
+    // a task-suitable annotated action. The composite handler is stubbed
+    // to short-circuit the real merge orchestration logic but the rest
+    // of the dispatch pipeline runs unchanged.
+
+    it('Dispatch_SlowTaskSuitableAction_EmitsRetryWithTaskHintInMeta', async () => {
+      // Arrange — stub `exarchos_orchestrate` so `merge_orchestrate`
+      // returns a minimal envelope without performing real VCS work.
+      // The boundary hint emission runs AFTER this stub returns.
+      const { stubCompositeHandler, dispatch } = await import('./dispatch.js');
+      const stub = async (_args: Record<string, unknown>, _ctx: DispatchContext): Promise<ToolResult> => ({
+        success: true,
+        data: { mergeSha: 'abc1234', strategy: 'squash' },
+        // Simulate a result that already has SOME workflow-derived hint;
+        // the boundary hint must be PREPENDED, not replace these.
+        next_actions: [
+          { verb: 'completed', reason: 'merge finished' },
+        ],
+      });
+      const restore = stubCompositeHandler('exarchos_orchestrate', stub);
+
+      // 0 → 12_500: well above 10s threshold.
+      installClockSequence([0, 12_500]);
+
+      try {
+        const result = await dispatch(
+          'exarchos_orchestrate',
+          {
+            action: 'merge_orchestrate',
+            featureId: 'integration-hint',
+            sourceBranch: 'feat/x',
+            targetBranch: 'main',
+            strategy: 'squash',
+          },
+          { stateDir: tmpDir, eventStore, enableTelemetry: false },
+        );
+
+        // Assert — envelope is successful, hint is FIRST in next_actions,
+        // existing handler-supplied hint is preserved after.
+        expect(result.success).toBe(true);
+        const nextActions = (result as ToolResult & { next_actions?: readonly { verb: string; ttl_suggestion_ms?: number }[] }).next_actions;
+        expect(nextActions).toBeDefined();
+        expect(nextActions!.length).toBe(2);
+        expect(nextActions![0].verb).toBe('retry_with_task');
+        expect(nextActions![0].ttl_suggestion_ms).toBe(60_000);
+        expect(nextActions![1].verb).toBe('completed');
+        // _meta correlation block must still be attached by attachMeta.
+        const meta = (result as ToolResult & { _meta?: Record<string, unknown> })._meta;
+        expect(meta).toBeDefined();
+        expect(typeof meta!.operationId).toBe('string');
+      } finally {
+        restore();
+      }
+    });
   });
 });

--- a/servers/exarchos-mcp/src/core/dispatch.test.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../registry.js';
 import type { CompositeTool } from '../registry.js';
 import type { DispatchContext } from './dispatch.js';
+import { extractSingleMissingRequiredField } from './dispatch.js';
 import { InMemoryBackend } from '../storage/memory-backend.js';
 import type { StorageBackend } from '../storage/backend.js';
 
@@ -1367,5 +1368,60 @@ describe('dispatch', () => {
         ).not.toMatch(/unknown action/i);
       });
     }
+  });
+
+  // ─── #1451 — extractSingleMissingRequiredField under Zod v4 ─────────────
+  //
+  // Zod v4 dropped the non-standard `received` property from
+  // `invalid_type` issues. The pre-fix narrowing required
+  // `issue.received === 'undefined'` (a Zod v3-only string signal), so under
+  // Zod v4 the helper rejected every missing-field issue and elicitation
+  // never fired. The dual-signal fix accepts either:
+  //   - `received === 'undefined'` (Zod v3 string signal), OR
+  //   - `received === undefined`   (property absent — Zod v4 shape).
+  // The `input !== undefined` check at the top of the helper still
+  // disambiguates wrong-type from missing-field, so the relaxed `received`
+  // gate cannot regress CodeRabbit CRITICAL #1424.
+  describe('extractSingleMissingRequiredField — Zod v4 issue shape (#1451)', () => {
+    it('ExtractSingleMissingRequiredField_ZodV4MissingFieldNoReceivedProperty_ReturnsKey', () => {
+      // Arrange — real Zod v4 parse of an empty payload against a single
+      // required string field. This grounds the test in the actual issue
+      // shape Zod v4 emits in production rather than a hand-rolled stub.
+      const schema = z.object({ featureId: z.string() });
+      const parsed = schema.safeParse({}, { reportInput: true });
+
+      expect(parsed.success).toBe(false);
+      if (parsed.success) return; // type-narrow for TS
+      // Sanity: Zod v4 omits `received` entirely on missing-field issues.
+      const issue = parsed.error.issues[0] as { received?: unknown };
+      expect('received' in issue).toBe(false);
+
+      // Act
+      const result = extractSingleMissingRequiredField(parsed.error);
+
+      // Assert — helper must return the missing key, not undefined.
+      expect(result).toBe('featureId');
+    });
+
+    it('ExtractSingleMissingRequiredField_ZodV4WrongTypeNumber_ReturnsUndefined', () => {
+      // Arrange — caller passed a number where a string was expected. In
+      // Zod v4 the issue shape includes `input: 42` (populated because of
+      // reportInput: true), and the `input !== undefined` guard at the top
+      // of the helper screens this out — never reaching the `received`
+      // gate. The helper must continue to refuse to elicit on wrong type.
+      const schema = z.object({ featureId: z.string() });
+      const parsed = schema.safeParse({ featureId: 42 }, { reportInput: true });
+
+      expect(parsed.success).toBe(false);
+      if (parsed.success) return;
+      const issue = parsed.error.issues[0] as { input?: unknown };
+      expect(issue.input).toBe(42);
+
+      // Act
+      const result = extractSingleMissingRequiredField(parsed.error);
+
+      // Assert — wrong-type must NOT be treated as missing.
+      expect(result).toBeUndefined();
+    });
   });
 });

--- a/servers/exarchos-mcp/src/core/dispatch.test.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.test.ts
@@ -1424,4 +1424,87 @@ describe('dispatch', () => {
       expect(result).toBeUndefined();
     });
   });
+
+  // ─── T11 (#1440 Op 4) — retry_with_task hint emission ─────────────────
+  //
+  // When a `dispatch.taskSuitable === true` action is invoked WITHOUT a
+  // `task: { ttl }` augmentation and the dispatch elapsed time exceeds
+  // the threshold (default 10_000 ms), the dispatch boundary prepends a
+  // `{ verb: 'retry_with_task', reason, ttl_suggestion_ms }` next-action
+  // to `result.next_actions`. This teaches callers the augmentation
+  // surface through use (design 2026-05-17-preview-4 §4.4).
+  //
+  // The annotation is sourced from the action's `dispatch.taskSuitable`
+  // and `dispatch.taskTtlSuggestionMs` fields in the registry. The
+  // canonical fixture is `exarchos_workflow.cleanup` which carries
+  // `dispatch: { taskSuitable: true, taskTtlSuggestionMs: 60_000 }`.
+  describe('retry_with_task hint (Preview-4 §4.4)', () => {
+    let dateNowSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+    afterEach(() => {
+      if (dateNowSpy) {
+        dateNowSpy.mockRestore();
+        dateNowSpy = undefined;
+      }
+    });
+
+    /**
+     * Install a `Date.now` spy that returns a deterministic sequence of
+     * timestamps. Used to drive the hint's elapsed-time check without
+     * actually waiting >10s. The dispatch core does not call `Date.now`
+     * anywhere else in its own body, so this spy only interacts with the
+     * hint emission path (plus any composite-level perf accounting,
+     * which is bypassed when we stub the composite handler directly).
+     */
+    function installClockSequence(values: readonly number[]): void {
+      let i = 0;
+      dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => {
+        const v = values[Math.min(i, values.length - 1)];
+        i++;
+        return v;
+      });
+    }
+
+    it('RetryWithTaskHint_TaskSuitableActionWithoutTaskTtlExceededThreshold_PrependsHint', async () => {
+      // Arrange — stub the workflow composite to short-circuit the real
+      // cleanup pipeline. The stub returns a minimal success envelope
+      // with no pre-existing next_actions so the assertion can focus on
+      // the boundary-injected hint.
+      const { stubCompositeHandler, dispatch } = await import('./dispatch.js');
+      const stub = async (_args: Record<string, unknown>, _ctx: DispatchContext): Promise<ToolResult> => ({
+        success: true,
+        data: { ok: true },
+      });
+      const restore = stubCompositeHandler('exarchos_workflow', stub);
+
+      // Drive Date.now: 0 at dispatch entry, 11_000 after handler
+      // returns. 11_000 > 10_000 threshold so the hint fires.
+      installClockSequence([0, 11_000]);
+
+      try {
+        const result = await dispatch(
+          'exarchos_workflow',
+          {
+            action: 'cleanup',
+            featureId: 'hint-test',
+            mergeVerified: true,
+          },
+          { stateDir: tmpDir, eventStore, enableTelemetry: false },
+        );
+
+        // Assert — the hint is the FIRST entry in next_actions.
+        expect(result.success).toBe(true);
+        const nextActions = (result as ToolResult & { next_actions?: readonly { verb: string; reason: string; ttl_suggestion_ms?: number }[] }).next_actions;
+        expect(nextActions).toBeDefined();
+        expect(nextActions!.length).toBeGreaterThanOrEqual(1);
+        const hint = nextActions![0];
+        expect(hint.verb).toBe('retry_with_task');
+        expect(hint.ttl_suggestion_ms).toBe(60_000);
+        expect(typeof hint.reason).toBe('string');
+        expect(hint.reason).toMatch(/11000ms|Tasks-augmented/);
+      } finally {
+        restore();
+      }
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/core/dispatch.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.ts
@@ -148,7 +148,7 @@ export interface DispatchContext {
 // Future iterations can extend this surface; the conservative single-field
 // gate is the v2.10 contract.
 
-function extractSingleMissingRequiredField(
+export function extractSingleMissingRequiredField(
   error: import('zod').z.ZodError,
 ): string | undefined {
   // Zod v4's missing-required-key error surfaces with `code: 'invalid_type'`
@@ -166,11 +166,21 @@ function extractSingleMissingRequiredField(
   //   - exactly one issue is reported, AND
   //   - the issue path is a single top-level key (string), AND
   //   - the issue code is 'invalid_type' (Zod's universal "missing" code), AND
-  //   - the issue's `input` is `undefined` AND the non-standard `received`
-  //     property is the string `'undefined'` (distinguishes a genuinely
-  //     missing field from a wrong-type field — elicitation only applies
-  //     to the former; the dual check defends against Zod versions that
-  //     populate one signal but not the other).
+  //   - the issue's `input` is `undefined` (the primary "field missing"
+  //     disambiguator across Zod v3 and v4 — populated by reportInput at
+  //     the call site; see comment at the safeParse site below). The
+  //     non-standard `received` property is *also* inspected as a
+  //     belt-and-suspenders signal, but its presence varies:
+  //       - Zod v3 populates `received: 'undefined'` (the string) for
+  //         missing fields.
+  //       - Zod v4 omits the `received` property entirely (Issue #1451 /
+  //         discovered via #1436 E2E smoketest). The runtime value of
+  //         `(issue as any).received` is therefore JS `undefined`.
+  //     Both signals are valid "missing field" indicators; we reject only
+  //     when `received` carries some OTHER value (a wrong-type indicator
+  //     like 'string' or 'number'). The `input !== undefined` guard above
+  //     is what actually keeps wrong-type errors from leaking into the
+  //     elicitation hand-off — CodeRabbit CRITICAL #1424 remains satisfied.
   const issues = error.issues;
   if (issues.length !== 1) return undefined;
   const only = issues[0];
@@ -179,10 +189,11 @@ function extractSingleMissingRequiredField(
   if (only.path.length !== 1) return undefined;
   const key = only.path[0];
   if (typeof key !== 'string') return undefined;
-  // Guard against wrong-type fields masquerading as missing. The `received`
-  // property is non-standard across Zod versions — narrow defensively.
+  // Dual-signal received-property gate (#1451). Accept absence (Zod v4)
+  // or the literal string 'undefined' (Zod v3); reject any other value
+  // (a wrong-type indicator).
   const received = (only as { received?: unknown }).received;
-  if (received !== 'undefined') return undefined;
+  if (received !== 'undefined' && received !== undefined) return undefined;
   return key;
 }
 

--- a/servers/exarchos-mcp/src/core/dispatch.ts
+++ b/servers/exarchos-mcp/src/core/dispatch.ts
@@ -11,7 +11,8 @@ import type { CapabilityResolver } from '../capabilities/resolver.js';
 import type { StorageBackend } from '../storage/backend.js';
 import type { RootsClient } from '../workspace/discovery.js';
 import type { ElicitationClient } from '../dispatch/elicitation-dispatch.js';
-import { hasCustomToolHandlers, getCustomToolActionHandler, getFullRegistry } from '../registry.js';
+import { hasCustomToolHandlers, getCustomToolActionHandler, getFullRegistry, findActionInRegistry } from '../registry.js';
+import type { NextAction } from '../next-action.js';
 import {
   formatValidationError,
   buildInvalidInput,
@@ -554,6 +555,14 @@ export async function dispatch(
     args = rest;
   }
 
+  // ─── T11 (#1440 Op 4, Preview-4 §4.4) — retry_with_task hint clock ──────
+  // Capture the dispatch-entry timestamp here so the emission rule at the
+  // post-handler boundary can compute elapsed wall-clock time. Anchored as
+  // early as possible (after `task: { ttl }` strip; before workspace
+  // resolution / schema validation / handler invocation) so the elapsed
+  // measurement covers the full dispatch round-trip the caller observes.
+  const dispatchStartTs = Date.now();
+
   // Lazy-loaded composite handler. Falls back to `undefined` when the tool
   // is not a built-in (e.g. custom tools registered via config).
   //
@@ -971,6 +980,48 @@ export async function dispatch(
   } else {
     result = await coreHandler(args);
   }
+
+  // ─── T11 (#1440 Op 4, Preview-4 §4.4) — retry_with_task hint emission ───
+  // After the handler returns its ToolResult, decide whether the caller
+  // should be advised to re-invoke this action under the Tasks-augmented
+  // dispatch path. Conditions (all must hold):
+  //
+  //   1. The action's registry annotation declares `dispatch.taskSuitable === true`.
+  //   2. The caller did NOT thread `task: { ttl }` (i.e., `taskAugmented === false`).
+  //   3. Elapsed wall-clock dispatch time exceeded the threshold (default 10_000 ms).
+  //
+  // When all three hold, prepend a `{ verb: 'retry_with_task', reason,
+  // ttl_suggestion_ms }` next-action to `result.next_actions`. The hint
+  // schema lives at `next-action.ts:92` (RetryWithTaskNextActionSchema).
+  //
+  // Prepended (not appended) because it is a meta-hint about dispatch
+  // *shape*, not about the result's domain content — callers reading the
+  // first hint to decide their next step see the augmentation suggestion
+  // before any result-derived workflow verbs.
+  //
+  // TODO(#1440 Op 4 follow-up): wire `config.dispatch.retryWithTaskHintThresholdMs`
+  // through `ExarchosConfig` so projects can tune the threshold without
+  // touching dispatch core. Hardcoded for now per design §4.4.
+  if (result.success && !taskAugmented) {
+    const actionName = typeof args.action === 'string' ? args.action : undefined;
+    if (actionName !== undefined) {
+      const action = findActionInRegistry(tool, actionName);
+      if (action?.dispatch?.taskSuitable === true) {
+        const elapsedMs = Date.now() - dispatchStartTs;
+        const RETRY_WITH_TASK_THRESHOLD_MS = 10_000;
+        if (elapsedMs > RETRY_WITH_TASK_THRESHOLD_MS) {
+          const hint: NextAction = {
+            verb: 'retry_with_task',
+            reason: `this action took ${elapsedMs}ms; consider Tasks-augmented dispatch for live progress`,
+            ttl_suggestion_ms: action.dispatch.taskTtlSuggestionMs ?? 60_000,
+          };
+          const existing: readonly NextAction[] = result.next_actions ?? [];
+          result = { ...result, next_actions: [hint, ...existing] };
+        }
+      }
+    }
+  }
+
   return attachMeta(result);
   } catch (error) {
     return attachMeta({

--- a/servers/exarchos-mcp/src/describe/handler.test.ts
+++ b/servers/exarchos-mcp/src/describe/handler.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
 import { handleDescribe, handleEventTypeDescribe, handleEventDescribe } from './handler.js';
 import { TOOL_REGISTRY } from '../registry.js';
+import type { ToolAction } from '../registry.js';
 
 const workflowTool = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow')!;
 const eventTool = TOOL_REGISTRY.find(t => t.name === 'exarchos_event')!;
@@ -51,6 +53,69 @@ describe('handleDescribe', () => {
     // autoEmits should be omitted entirely (not null, not empty array)
     expect(data.get.autoEmits).toBeUndefined();
     expect('autoEmits' in data.get).toBe(false);
+  });
+
+  // ─── T8 (#1440 Op 2, preview-4) — DispatchHints projection ───────────
+  //
+  // The `dispatch` slot is action-behavior metadata (sibling of autoEmits,
+  // deprecated, outputSchema) added by T2's `DispatchHints` interface
+  // (design §4.3). Describe MUST project the field through unchanged when
+  // present, and MUST omit the field entirely (not null, not empty
+  // object) when the action does not declare it — mirroring the existing
+  // optional-slot pattern in handler.ts:113-149.
+  it('DescribeHandler_ActionWithDispatchHints_ProjectsDispatchField', async () => {
+    const fixture: ToolAction = {
+      name: 'fixture_with_dispatch',
+      description: 'Test fixture with dispatch hints.',
+      schema: z.object({ featureId: z.string() }),
+      phases: new Set(['plan']),
+      roles: new Set(['lead']),
+      outputSchema: z.object({ success: z.boolean() }),
+      annotations: {
+        safety: 'local-mutation',
+        readOnly: false,
+        destructive: false,
+        idempotent: false,
+        openWorld: false,
+      },
+      dispatch: {
+        taskSuitable: true,
+        taskTtlSuggestionMs: 60_000,
+      },
+    };
+
+    const result = await handleDescribe({ actions: ['fixture_with_dispatch'] }, [fixture]);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, Record<string, unknown>>;
+    expect(data.fixture_with_dispatch.dispatch).toEqual({
+      taskSuitable: true,
+      taskTtlSuggestionMs: 60_000,
+    });
+  });
+
+  it('DescribeHandler_ActionWithoutDispatchHints_OmitsDispatchField', async () => {
+    const fixture: ToolAction = {
+      name: 'fixture_no_dispatch',
+      description: 'Test fixture without dispatch hints.',
+      schema: z.object({}),
+      phases: new Set(['ideate']),
+      roles: new Set(['any']),
+      outputSchema: z.object({ success: z.boolean() }),
+      annotations: {
+        safety: 'read-only',
+        readOnly: true,
+        destructive: false,
+        idempotent: true,
+        openWorld: false,
+      },
+    };
+
+    const result = await handleDescribe({ actions: ['fixture_no_dispatch'] }, [fixture]);
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, Record<string, unknown>>;
+    // dispatch should be omitted entirely (not null, not empty object)
+    expect(data.fixture_no_dispatch.dispatch).toBeUndefined();
+    expect('dispatch' in data.fixture_no_dispatch).toBe(false);
   });
 
   it('HandleDescribe_GateMetadata_IncludedWhenPresent', async () => {

--- a/servers/exarchos-mcp/src/describe/handler.ts
+++ b/servers/exarchos-mcp/src/describe/handler.ts
@@ -122,6 +122,12 @@ export async function handleDescribe(
         // description string. Surfaced unconditionally (not just when true)
         // so structurally-honest consumers can rely on the slot's presence.
         ...(action.deprecated ? { deprecated: true } : {}),
+        // T8 (#1440 Op 2, preview-4 design §4.3): project the `dispatch`
+        // DispatchHints slot so clients can enumerate task-suitable
+        // actions via `exarchos_view describe`. The slot is omitted
+        // entirely when the action does not declare it, mirroring the
+        // `autoEmits` / `deprecated` optional-field pattern above.
+        ...(action.dispatch ? { dispatch: action.dispatch } : {}),
         // Wave 0 / Task G.3 (#1287 + INV-5b, design §2.1 Approach C):
         // per-action `outputSchema` is surfaced as JSON Schema 2020-12
         // under `outputSchemaJson` so clients can introspect the precise

--- a/servers/exarchos-mcp/src/next-action.test.ts
+++ b/servers/exarchos-mcp/src/next-action.test.ts
@@ -11,4 +11,36 @@ describe('NextAction schema', () => {
     const result = NextAction.safeParse({ verb: '', reason: 'x' });
     expect(result.success).toBe(false);
   });
+
+  // ─── Preview-4 / T10 — `retry_with_task` verb (design §4.4, #1440 Op 4) ────
+  //
+  // The next-actions vocabulary gains a new verb `retry_with_task` that the
+  // dispatch boundary emits when a `taskSuitable: true` action is invoked
+  // without `task: { ttl }` and exceeds the duration threshold. INV-5b
+  // requires this verb to be a first-class entry in the discriminator schema
+  // (not free-form prose), so the schema validates its required payload
+  // shape: `ttl_suggestion_ms: number`.
+  //
+  // T10 lands the schema entry only; T11 will emit the verb from
+  // `core/dispatch.ts`, and T12 will add the integration coverage.
+
+  it('NextActionsDiscriminator_RetryWithTaskVerb_Validates', () => {
+    const result = NextAction.safeParse({
+      verb: 'retry_with_task',
+      reason: 'test reason',
+      ttl_suggestion_ms: 60_000,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('NextActionsDiscriminator_RetryWithTaskMissingTtl_Fails', () => {
+    // `retry_with_task` is the only verb whose payload requires
+    // `ttl_suggestion_ms`. The catch-all branch (any other verb string) does
+    // not, so this assertion specifically pins the verb-keyed branch.
+    const result = NextAction.safeParse({
+      verb: 'retry_with_task',
+      reason: 'x',
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/servers/exarchos-mcp/src/next-action.ts
+++ b/servers/exarchos-mcp/src/next-action.ts
@@ -1,16 +1,111 @@
 import { z } from 'zod';
 
-/** Schema for a suggested next action in a rehydration envelope (DR-8). */
-export const NextAction = z.object({
+// ─── Next-actions discriminator schema (DR-8 / Preview-4 §4.4 / #1440 Op 4) ─
+//
+// `NextAction` is a Zod union keyed on `verb`. Most verbs (HSM transition
+// names, `merge_orchestrate`, future control verbs) share the open base
+// shape — verb-specific payload fields are not required. The
+// `retry_with_task` verb (Preview-4 §4.4) carries a required
+// `ttl_suggestion_ms: number` field so callers know what Tasks-augmented
+// dispatch TTL to use when re-invoking. INV-5b requires that a new verb
+// like `retry_with_task` lands as a first-class entry in this schema
+// rather than as free-form prose.
+//
+// The union is *ordered*: the verb-specific branch (`retry_with_task`)
+// must be tried before the catch-all `BaseNextActionSchema`, because the
+// catch-all accepts any string verb and would otherwise short-circuit on
+// the first member. Zod's `z.union` walks members in order, so listing the
+// specific branch first preserves the discriminator contract.
+//
+// Adding a new verb-specific branch (T11+/future): append a new
+// `z.object({ verb: z.literal('your_verb'), ...payload }).strict()` to the
+// `verbBranches` list. The catch-all stays last.
+
+/**
+ * Shared fields every `NextAction` carries regardless of verb. Verb-specific
+ * branches extend this base.
+ *
+ * - `verb`: control-verb name, snake_case (`merge_orchestrate`,
+ *   `retry_with_task`, HSM target phase names like `plan`).
+ * - `reason`: free-form, human-readable rationale.
+ * - `validTargets`: optional list of canonical target identifiers.
+ * - `hint`: optional free-form prose for the caller.
+ * - `idempotencyKey`: empty strings rejected — empty keys would collapse
+ *   unrelated invocations onto the same de-dup slot (DR-MO-1).
+ */
+const baseFields = {
   verb: z.string().min(1),
   reason: z.string(),
   validTargets: z.array(z.string()).optional(),
   hint: z.string().optional(),
-  // T18 (DR-MO-1): action verbs that carry a side-effect (e.g.
-  // `merge_orchestrate`) include an idempotency key so callers can de-duplicate
-  // auto-triggered work across rehydrations of the same workflow state. Empty
-  // strings are rejected — an empty key collapses unrelated invocations.
   idempotencyKey: z.string().min(1).optional(),
+} as const;
+
+/**
+ * Verbs that have a dedicated, verb-specific branch with required-payload
+ * fields. The catch-all branch below explicitly excludes these so that a
+ * malformed verb-specific payload (e.g. `retry_with_task` without
+ * `ttl_suggestion_ms`) cannot quietly fall through to the open shape.
+ *
+ * When you add a new verb-specific branch, list its literal here too.
+ */
+const VERB_SPECIFIC_LITERALS = ['retry_with_task'] as const;
+
+/**
+ * Catch-all branch. Validates any verb whose payload is just the base
+ * shape — HSM transition names, `merge_orchestrate`, `checkpoint`, etc.
+ *
+ * The `verb` refinement explicitly rejects any literal that has a
+ * verb-specific branch above; otherwise Zod's `z.union` walks members in
+ * order, and a malformed `{ verb: 'retry_with_task', reason: '...' }` (no
+ * `ttl_suggestion_ms`) would fail the verb-specific branch and then
+ * silently parse against this catch-all, defeating the discriminator
+ * contract.
+ *
+ * Order matters: this MUST be the last member of the union so
+ * verb-specific branches above are matched first.
+ */
+const BaseNextActionSchema = z.object({
+  ...baseFields,
+  verb: baseFields.verb.refine(
+    (v) => !(VERB_SPECIFIC_LITERALS as readonly string[]).includes(v),
+    {
+      message:
+        'verb has a dedicated discriminator branch; payload must match that branch',
+    },
+  ),
 });
+
+/**
+ * `retry_with_task` branch (Preview-4 §4.4, #1440 Op 4).
+ *
+ * Emitted by the dispatch boundary when a `taskSuitable: true` action is
+ * invoked **without** the `task: { ttl }` augmentation and the elapsed
+ * dispatch time exceeds the threshold (default 10_000 ms). The verb
+ * suggests the caller re-invoke the same action with `task: { ttl:
+ * ttl_suggestion_ms }` to get live progress telemetry.
+ *
+ * `ttl_suggestion_ms` is REQUIRED — the whole point of the hint is to
+ * teach callers what TTL to thread back. The dispatch boundary sources it
+ * from `action.dispatch.taskTtlSuggestionMs ?? 60_000`.
+ */
+const RetryWithTaskNextActionSchema = z.object({
+  ...baseFields,
+  verb: z.literal('retry_with_task'),
+  ttl_suggestion_ms: z.number().int().positive(),
+});
+
+/**
+ * Schema for a suggested next action in a rehydration envelope (DR-8).
+ *
+ * Verb-keyed union. Adding a verb with a required-payload contract: prepend
+ * a `z.object({ verb: z.literal('...'), ... })` branch to the union *before*
+ * `BaseNextActionSchema`. Verbs that need only the base shape don't need a
+ * dedicated branch — they validate via the catch-all.
+ */
+export const NextAction = z.union([
+  RetryWithTaskNextActionSchema,
+  BaseNextActionSchema,
+]);
 
 export type NextAction = z.infer<typeof NextAction>;

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -2051,3 +2051,71 @@ describe('validateAction', () => {
     ).not.toThrow();
   });
 });
+
+// ─── Preview-4 / T2 — DispatchHints on ToolAction (#1440 Op 2) ─────────
+//
+// Adds an optional, action-descriptor-level `dispatch: DispatchHints`
+// block so future tasks (T8 describe projection, T9 annotations, T11
+// retry_with_task verb) can annotate which actions are long-running and
+// benefit from Tasks-augmented dispatch. Lives at the descriptor level
+// (sibling to `cli`, `gate`, `autoEmits`), not under `cli.`, because the
+// Tasks dispatch-core is shared between CLI and MCP facades (INV-2). See
+// design §4.3.
+//
+// This test asserts the shape only — no annotations on existing actions
+// land in T2; those are T9's job. The actual opt-in gate stays at
+// `core/dispatch.ts:927-954`; this marker is advisory.
+describe('ToolAction.dispatch - DispatchHints shape', () => {
+  it('ToolAction_DispatchHintsShape_OptionalTaskSuitableField', () => {
+    const action: ToolAction = {
+      name: 'longRunningExample',
+      description: 'Example long-running action for shape assertion.',
+      schema: z.object({ featureId: z.string() }),
+      phases: new Set(['plan']),
+      roles: new Set(['lead']),
+      outputSchema: z.object({ success: z.boolean() }),
+      annotations: {
+        safety: 'local-mutation',
+        readOnly: false,
+        destructive: false,
+        idempotent: false,
+        openWorld: false,
+      },
+      dispatch: {
+        taskSuitable: true,
+        taskTtlSuggestionMs: 60_000,
+      },
+    };
+
+    // Anchor the type-level assertion with a runtime check so the test
+    // also fails loudly under vitest if the field is dropped or renamed
+    // (TS-only tests get excluded from CI typecheck — see
+    // servers/exarchos-mcp/tsconfig.json's `**/*.test.ts` exclude).
+    expect(action.dispatch).toBeDefined();
+    expect(action.dispatch?.taskSuitable).toBe(true);
+    expect(action.dispatch?.taskTtlSuggestionMs).toBe(60_000);
+  });
+
+  it('ToolAction_DispatchHintsShape_FieldIsOptional', () => {
+    // Omitting `dispatch` must still satisfy `ToolAction`. This guards
+    // against the field being inadvertently promoted to required, which
+    // would force every existing action to annotate before T9 lands.
+    const actionNoDispatch: ToolAction = {
+      name: 'readOnlyExample',
+      description: 'Example read-only action without DispatchHints.',
+      schema: z.object({}),
+      phases: new Set(['ideate']),
+      roles: new Set(['any']),
+      outputSchema: z.object({ success: z.boolean() }),
+      annotations: {
+        safety: 'read-only',
+        readOnly: true,
+        destructive: false,
+        idempotent: true,
+        openWorld: false,
+      },
+    };
+
+    expect(actionNoDispatch.dispatch).toBeUndefined();
+  });
+});

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -2119,3 +2119,56 @@ describe('ToolAction.dispatch - DispatchHints shape', () => {
     expect(actionNoDispatch.dispatch).toBeUndefined();
   });
 });
+
+// ─── T9 (#1440 Op 2, preview-4 design §4.3) — Task-suitable annotations ──
+//
+// The four initial task-suitable targets from design §4.3:
+//   - `exarchos_orchestrate merge_orchestrate` (multi-step git merge)
+//   - `exarchos_orchestrate request_synthesize` — the registry-canonical
+//     name for the design's "synthesize" verb (PR creation flow flipped
+//     by emitting `synthesize.requested` to the choice-state guard).
+//     The design §4.3 callout lists "synthesize" as the logical verb;
+//     `request_synthesize` is its registry-name realization and lives
+//     under `exarchos_orchestrate` alongside the other gate verbs, NOT
+//     under `exarchos_workflow` (which only carries the HSM-level
+//     primitives `init`/`get`/`transition`/`update`/`cancel`/...).
+//   - `exarchos_workflow cleanup` (post-merge cleanup)
+//   - `exarchos_workflow rehydrate` (full state rebuild)
+//
+// Each must carry `dispatch: { taskSuitable: true,
+// taskTtlSuggestionMs: 60_000 }`. Annotations are advisory — the binding
+// opt-in gate stays at `core/dispatch.ts:927-954` — so this test only
+// pins the registry-side declaration, not behavior.
+describe('Registry — taskSuitable annotations (T9, #1440 Op 2)', () => {
+  it('Registry_TaskSuitableAnnotations_FourActionsMarked', () => {
+    const orchestrateTool = TOOL_REGISTRY.find(t => t.name === 'exarchos_orchestrate');
+    const workflowTool = TOOL_REGISTRY.find(t => t.name === 'exarchos_workflow');
+    expect(orchestrateTool, 'exarchos_orchestrate tool must exist').toBeDefined();
+    expect(workflowTool, 'exarchos_workflow tool must exist').toBeDefined();
+
+    const targets: Array<{ tool: 'exarchos_orchestrate' | 'exarchos_workflow'; action: string }> = [
+      { tool: 'exarchos_orchestrate', action: 'merge_orchestrate' },
+      { tool: 'exarchos_orchestrate', action: 'request_synthesize' },
+      { tool: 'exarchos_workflow', action: 'cleanup' },
+      { tool: 'exarchos_workflow', action: 'rehydrate' },
+    ];
+
+    for (const { tool, action } of targets) {
+      const composite = tool === 'exarchos_orchestrate' ? orchestrateTool! : workflowTool!;
+      const found = composite.actions.find(a => a.name === action);
+      expect(found, `${tool}.${action} must be registered`).toBeDefined();
+      expect(
+        found!.dispatch,
+        `${tool}.${action} must carry a DispatchHints block`,
+      ).toBeDefined();
+      expect(
+        found!.dispatch?.taskSuitable,
+        `${tool}.${action} must declare taskSuitable: true`,
+      ).toBe(true);
+      expect(
+        found!.dispatch?.taskTtlSuggestionMs,
+        `${tool}.${action} must declare taskTtlSuggestionMs: 60_000`,
+      ).toBe(60_000);
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -23,6 +23,39 @@ export interface CliToolHints {
   readonly group?: string;
 }
 
+/**
+ * Action-descriptor-level dispatch metadata (#1440 Op 2, preview-4 T2,
+ * design §4.3).
+ *
+ * Lives at the action-descriptor level (sibling to `cli`, `gate`,
+ * `autoEmits`) — NOT under `cli.` — because the Tasks dispatch-core is
+ * shared between the CLI and MCP facades (INV-2). Annotating under
+ * `cli.` would imply this is CLI-presentation metadata; it isn't. It's
+ * action-behavior metadata: "this action is long-running and benefits
+ * from Tasks-augmented dispatch."
+ *
+ * The block is intentionally extensible — a future `streaming: true`
+ * marker, for example, belongs here too. Hence the name `dispatch`
+ * (not `tasks`, which would be too narrow).
+ */
+export interface DispatchHints {
+  /**
+   * Advisory marker: this action is long-running and benefits from
+   * Tasks-augmented dispatch. Surfaced via `exarchos_view describe` so
+   * clients can enumerate. The actual opt-in gate remains
+   * `taskAugmented && ctx.taskStore && taskCapabilityGate` at
+   * core/dispatch.ts:927-954. Clients are not required to honor this
+   * marker; the gate is binding.
+   */
+  readonly taskSuitable?: boolean;
+  /**
+   * Suggested TTL for Tasks-augmented dispatch, in ms. Surfaced
+   * alongside `taskSuitable` so clients have a sensible default to
+   * thread when they opt in.
+   */
+  readonly taskTtlSuggestionMs?: number;
+}
+
 export interface GateMetadata {
   readonly blocking: boolean;
   readonly dimension?: string;
@@ -280,6 +313,15 @@ export interface ToolAction {
   readonly cli?: CliActionHints;
   readonly gate?: GateMetadata;
   readonly autoEmits?: readonly AutoEmission[];
+  /**
+   * Dispatch-layer metadata (#1440 Op 2, preview-4 T2, design §4.3).
+   * Sibling-level (not under `cli`) because the Tasks dispatch-core is
+   * shared between CLI and MCP facades (INV-2). Advisory only — the
+   * binding opt-in gate stays at `core/dispatch.ts:927-954`. Surfaced
+   * via `exarchos_view describe` so clients can enumerate
+   * task-suitable actions.
+   */
+  readonly dispatch?: DispatchHints;
   /**
    * DR-5: When true, the action can take multiple seconds to complete and
    * the CLI adapter should emit stderr heartbeats under `--json` so a long

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -1130,6 +1130,12 @@ const workflowActions: readonly ToolAction[] = [
     autoEmits: [
       { event: 'workflow.cleanup', condition: 'always' },
     ],
+    // T9 (#1440 Op 2, preview-4 design §4.3): post-merge cleanup is a
+    // long-running multi-step verb (merge verification, synthesis
+    // metadata backfill, review force-resolve, transition) that benefits
+    // from Tasks-augmented dispatch. The annotation is advisory — the
+    // binding opt-in gate stays at `core/dispatch.ts:927-954`.
+    dispatch: { taskSuitable: true, taskTtlSuggestionMs: 60_000 },
     outputSchema: EnvelopeSchema(z.unknown()),
     annotations: COMPENSABLE_LOCAL,
   },
@@ -1167,6 +1173,11 @@ const workflowActions: readonly ToolAction[] = [
         description: 'When rehydration succeeds (event-store emission failures are logged but do not fail the call — see rehydrate.ts).',
       },
     ],
+    // T9 (#1440 Op 2, preview-4 design §4.3): full state rebuild is a
+    // long-running projection fold (latest snapshot + every event since)
+    // that benefits from Tasks-augmented dispatch. Advisory — the
+    // binding opt-in gate stays at `core/dispatch.ts:927-954`.
+    dispatch: { taskSuitable: true, taskTtlSuggestionMs: 60_000 },
     outputSchema: EnvelopeSchema(z.unknown()),
     annotations: LOCAL_MUTATION_IDEMPOTENT,
   },
@@ -1643,6 +1654,12 @@ const orchestrateActions: readonly ToolAction[] = [
       { event: 'merge.executed', condition: 'conditional', description: 'When preflight passes and execute succeeds' },
       { event: 'merge.rollback', condition: 'conditional', description: 'When execute fails after a merge SHA was produced' },
     ],
+    // T9 (#1440 Op 2, preview-4 design §4.3): multi-step git merge
+    // orchestration (preflight → execute → optional rollback) is the
+    // canonical long-running verb and benefits from Tasks-augmented
+    // dispatch. Advisory — the binding opt-in gate stays at
+    // `core/dispatch.ts:927-954`.
+    dispatch: { taskSuitable: true, taskTtlSuggestionMs: 60_000 },
     outputSchema: EnvelopeSchema(z.unknown()),
     annotations: COMPENSABLE_REMOTE,
   },
@@ -2097,6 +2114,14 @@ const orchestrateActions: readonly ToolAction[] = [
     autoEmits: [
       { event: 'synthesize.requested', condition: 'always' },
     ],
+    // T9 (#1440 Op 2, preview-4 design §4.3): the registry-canonical
+    // name for the design's "synthesize" verb — PR creation flow flipped
+    // by emitting `synthesize.requested` to the choice-state guard.
+    // The synthesize phase itself is multi-step (branch staging, PR open,
+    // CI wait) so the verb that gates it benefits from Tasks-augmented
+    // dispatch. Advisory — the binding opt-in gate stays at
+    // `core/dispatch.ts:927-954`.
+    dispatch: { taskSuitable: true, taskTtlSuggestionMs: 60_000 },
     outputSchema: EnvelopeSchema(z.unknown()),
     annotations: LOCAL_MUTATION,
   },


### PR DESCRIPTION
## Summary

Realizes the v2.10.0-preview.4 substrate by closing 4 follow-ups under epic #1441: the elicitation form-mode E2E verification gap (#1436), three of five Tasks dispatch-core adoption opportunities (#1440 Op 1, Op 2, Op 4), and a HIGH-severity substrate bug (#1451) the new E2E test surfaced mid-bundle.

The bundle moves preview.4 substrate from "shipped and correct" to "actually used and verified end-to-end." Op 3 (workflow-verb wiring through Tasks-augmented dispatch) and Op 5 (SSE) remain deferred to dedicated designs per `docs/designs/2026-05-17-preview-4-substrate-realization.md` §7.

Discovery worth highlighting: #1436's smoketest immediately caught a wired-but-not-invoked class of failure — `dispatch.ts:184-185`'s over-strict `received !== 'undefined'` narrowing doesn't match Zod v4's actual issue shape, so elicitation form-mode was dead in production despite the PR #1424 substrate landing. Filed as #1451 and fixed in-bundle.

Closes #1436, #1451. Partially closes #1440 (Op 1, Op 2, Op 4 — Op 3 and Op 5 deferred). Tracked under epic #1441.

## Changes

**#1436 — Elicitation form-mode E2E smoketest** (`servers/exarchos-mcp/src/__tests__/integration/`)
- `elicitation-roundtrip.fixture.ts` — in-process MCP client+server pair wired via `InMemoryTransport`, with `CapabilityResolver` snapshotted by the SDK's `oninitialized` hook (mirrors production).
- `elicitation-roundtrip.test.ts` — three paths: **accept** (envelope success + `elicitation.requested` + `elicitation.fulfilled` events on per-operation stream + `_meta.operationId` cross-stream correlation), **decline** (`INVALID_INPUT` envelope + `elicitation.declined` event, no retry), **capability-absent** (legacy `INVALID_INPUT`, no `elicitation/*` streams).

**#1451 — Elicitation Zod v4 narrowing fix** (`servers/exarchos-mcp/src/core/dispatch.ts:178-199`)
- `extractSingleMissingRequiredField` accepts both `received === 'undefined'` (Zod v3 string signal) and `received === undefined` (Zod v4 omitted property). Regression test grounded in a real `z.object(...).safeParse({})` parse, not a hand-crafted issue.
- Without this, every elicitation candidate was rejected; T4 (accept) and T5 (decline) caught it; T6 (capability-absent) was GREEN because it never exercises the broken extraction.

**#1440 Op 1 — `--follow` expansion** (`servers/exarchos-mcp/src/adapters/cli.ts` + `cli/follow-formatter.ts`)
- `VIEW_FOLLOW_ACTIONS` set extracted as a top-level constant covering `workflow_status`, `shepherd_status`, `pipeline`, `convergence`, `delegation_timeline`. `FollowSubcommand` union widened in lockstep.
- Idempotency audit captured inline (orchestrator-verified): all three new view handlers are pure `ViewProjection` folds — no `eventStore.append`, no `*.polled` events. A source-file regression test asserts the invariant (`cli-follow-expansion.test.ts:175-200`).

**#1440 Op 2 — `DispatchHints` annotation + describe projection** (`registry.ts` + `describe/handler.ts`)
- New `DispatchHints` interface sibling-level to `CliActionHints` on `ToolAction` (placement honors INV-2: the dispatch-core is shared between CLI and MCP, so this is action metadata, not CLI presentation).
- `describe` handler projects the `dispatch` field through `view describe` output alongside `autoEmits`, `deprecated`, `outputSchema`.
- Four actions annotated with `dispatch: { taskSuitable: true, taskTtlSuggestionMs: 60_000 }`: `merge_orchestrate`, `request_synthesize`, `cleanup`, `rehydrate`. Note: the design's "synthesize under exarchos_workflow" was a name mismatch — the canonical synthesize-step dispatcher is `request_synthesize` under `exarchos_orchestrate`. Annotation lands on the actual registry entry.

**#1440 Op 4 — `retry_with_task` next-actions hint** (`next-action.ts` + `core/dispatch.ts`)
- New `retry_with_task` verb added to the next-actions discriminator — implemented as a verb-keyed `z.union` with a `refine`-based catch-all that rejects verb-specific literals (closes the silent-fall-through hole). Negative test pins missing-`ttl_suggestion_ms` rejection.
- Hint emission rule at dispatch boundary: when (`success && !taskAugmented && action.dispatch?.taskSuitable && elapsedMs > 10_000`), prepend `{ verb: 'retry_with_task', reason, ttl_suggestion_ms }` to `result.next_actions`. Prepended (not destructive) so prior handler-supplied hints survive.
- Threshold currently hardcoded to `10_000` with a TODO for follow-up config wiring (see "Known follow-ups" below).

## Test Plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:run` (root) — 762 passed / 6 skipped
- [x] `cd servers/exarchos-mcp && npm run test:run` — **7030 passed / 22 skipped / 0 failed**
- [x] Spec compliance review — APPROVED (0 HIGH, 0 MEDIUM, 3 LOW traceability notes)
- [x] Code quality review — APPROVED (0 HIGH, 0 MEDIUM, 9 LOW — 4 catalog false-positives + 5 minor style/observability nits)
- [x] No regressions in existing `--follow` parity for `workflow_status` / `shepherd_status`
- [x] No new event types added (preserves INV-1 + DIM-8 discipline)
- [x] No changes to the binding `taskCapabilityGate` at `core/dispatch.ts:927-954` — annotation is purely advisory; gate remains binding

## Known follow-ups (LOW, not blocking)

Suggested but deferred to a future doc-fix / polish PR:
1. Hoist `RETRY_WITH_TASK_THRESHOLD_MS` (currently inline at `dispatch.ts:1011`) to module scope and wire `config.dispatch.retryWithTaskHintThresholdMs` — open a dedicated tracking issue and update the TODO link.
2. Add a `logger.child({ subsystem: 'elicitation' }).warn(...)` to the silent catch at `dispatch.ts:869` to match the workspace-discovery observability pattern.
3. Update design `§4.3` and `§4.4` prose to use the canonical registry names (`request_synthesize` instead of `synthesize`) and `result.next_actions` (top-level, per `format.ts:66`) instead of `_meta.next_actions`.

## /design-invariants conformance

| Invariant | Disposition |
|---|---|
| INV-1 event-sourcing integrity | OK — E2E paths assert both envelope AND event-store truth |
| INV-2 facade equivalence | OK — `dispatch` annotation lives on `ToolAction` (sibling-level), not under `cli.`; hint emits at dispatch boundary (both facades cross it) |
| INV-3 basileus-forward | OK — no remote substrate added |
| INV-4 platform-agnosticity | OK — generic MCP annotations, no Claude-Code specifics |
| INV-5a input ergonomics | OK — `task: { ttl }` optional, hint teaches the augmentation surface |
| INV-5b spec-aligned output | OK — `retry_with_task` is a first-class discriminator branch with negative-test coverage |
| INV-5c Aspire control verbs | OK — `verb_subject` naming, no new control surface |
| INV-5d action discriminator | N/A — no new tool actions |
| INV-6 workflow-agnosticism | OK — dispatch metadata is below the playbook layer |

🤖 Generated with [Claude Code](https://claude.com/claude-code)