### PR TITLE
discover(invariants): workload-agnostic runtime invariants — 5 research artifacts

### DIFF
--- a/docs/proposals/2026-05-20-invariants-catalog-v2-spec.md
+++ b/docs/proposals/2026-05-20-invariants-catalog-v2-spec.md
@@ -1,0 +1,679 @@
+# Invariants Catalog v2 Spec — proposal
+
+> **Workflow:** `workload-agnostic-runtime-invariants` (discovery, Phase E + final deliverable)
+> **Date:** 2026-05-20
+> **Status:** Research deliverable D5 of 5 — **proposal only, not the implementation**
+> **Parent:** epic #1441
+> **Companions:** [D1 survey](../research/2026-05-20-runtime-invariants-research-survey.md), [D2 gap analysis](../research/2026-05-20-runtime-invariants-gap-analysis.md), [D3 stress test](../research/2026-05-20-workload-agnosticism-stress-test.md), [D4 substrate/authoring](../research/2026-05-20-substrate-vs-authoring.md)
+
+---
+
+## 1. Scope
+
+A specification for `docs/architecture/invariants.md` at `schema-version: 2`, **scoped as Exarchos's dev-invariants catalog**. This proposal:
+
+- defines the v2 frontmatter schema,
+- lists every proposed v2 entry (22 total — within the ≤25 ceiling per charter),
+- describes the loader behavior changes (including a new opt-in gate),
+- documents the migration plan from v1.
+
+**This document does not rewrite the catalog.** Implementation is a follow-up plan workflow once v2 is approved. Until then, v1 remains the active source-of-truth and downstream consumers (eval #1442, `/ideate`, vocabulary lint) keep using it.
+
+### 1.1 Audience and scope boundary
+
+**This catalog is for Exarchos's own designers** — engineers building the runtime substrate (event store, dispatch core, capability resolver, projection layer, MCP/CLI adapters). The entries describe runtime substrate properties Exarchos guarantees; respecting them is what contributors to Exarchos must do.
+
+**This catalog is NOT for Exarchos consumers** — engineers using Exarchos as a plugin to govern their own software-development workflows. Consumers interact with Exarchos's affordances (`next_actions`, composite-tool actions, workflow types) but do not need to think about how those affordances are implemented internally (SQLite WAL, OCC, posture resolver, etc.). Surfacing dev-invariants to consumers at `/ideate` Phase 0 is noise.
+
+The workload-agnosticism stress test (D3) demonstrated *applicability* (the invariants hold for any workload running ON Exarchos), not *audience suitability*. The two are distinct: an invariant can apply universally to all workflows yet still be inappropriate to surface to consumers who only interact with the affordances, not the substrate.
+
+**Gating mechanism:** the loader honors a `.exarchos.yml` flag — `invariants.devCatalog: enabled | disabled` (default: `disabled`). When disabled, the loader returns no entries regardless of `scope`. When enabled, the loader returns entries per the `axis` + `cost-of-load` filters described in §4. There is no automatic enable based on repo identity, directory presence, or any heuristic — the flag is a declarative statement of intent ("I am working on Exarchos itself; surface its design invariants to me"), not a side-effect of where the agent is running. Even contributors inside the Exarchos repo must set it explicitly (typically via the repo's own committed `.exarchos.yml`). See §4.0.
+
+**Missing complement (future deliverable):** a **consumer-facing SDLC invariants catalog** that addresses the audience this catalog deliberately does not serve. Likely scope includes phase observability, TDD discipline (when declared), review-gate honesty, authoring/playbook split, branch/PR discipline, recovery posture. Lives in a separate `/exarchos:discover consumer-sdlc-invariants` workflow. See §10 for the forward-pointer scope sketch.
+
+## 2. Framing
+
+The v1 catalog conflates four concerns that should be split:
+
+1. **Substrate primitives** (event log, OCC, posture) vs **authoring concerns** (prose quality).
+2. **Catalog as designer's checklist** vs **operational projection** (the `/design-invariants` skill body).
+3. **Internal grounding** (PR numbers, file paths) vs **external research grounding** (canonical literature).
+4. **Audience scope** — v1 was implicitly loaded for every `/ideate` invocation, including consumer invocations where the entries describe runtime substrate the consumer never touches.
+
+v2 addresses all four:
+
+1. New `axis: substrate | authoring` frontmatter field (per D4).
+2. The catalog is the *source-of-truth*; the skill body remains the *operational projection* — same as v1, but now the catalog gains scope/cost-of-load metadata the skill consumes rather than duplicating.
+3. New `citations[]` field for external research; existing `references[]` field for internal pointers.
+4. New `.exarchos.yml` flag `invariants.devCatalog: enabled | disabled` (default: `disabled`) gates the entire catalog at the loader. See §4.0.
+
+## 3. Schema
+
+```yaml
+---
+title: Exarchos Architectural Invariants
+description: >
+  Source of truth for the architectural invariants (INV-*) and axiom
+  dimensions (DIM-*) governing Exarchos runtime design.
+  Consumed by /ideate Phase 0 (substrate-axis entries), the
+  design-invariants skill (full set), and vocabulary-lint (full set).
+schema-version: 2
+invariants:
+  - id: INV-N                  # stable identifier
+    dimension: short-name      # human-readable category
+    axis: substrate | authoring   # NEW in v2 — see D4
+    cost-of-load: always-load | reference-only | archivable
+    applies-to:                # surface areas (modules / domains)
+      - <area>
+    summary: >                 # one-to-two-sentence invariant statement
+      ...
+    axiom_overlap: DIM-N       # NEW in v2 — for /axiom:design pairing-discovery (optional)
+    citations:                 # NEW in v2 — external research sources (recommended ≥3)
+      - "Author, *Title* (Year): URL"
+    references:                # internal pointers (existing v1 field)
+      - <path>
+---
+```
+
+### Field deltas v1 → v2
+
+| Field | v1 | v2 |
+|---|---|---|
+| `schema-version` | `1` | `2` |
+| `axis` | (absent) | required, enum `substrate \| authoring` |
+| `axiom_overlap` | (absent) | optional, DIM-N |
+| `citations` | (absent) | recommended, ≥3 entries for substrate-axis invariants |
+| `references` | required | required (semantics unchanged) |
+| `cost-of-load` | required | required (semantics unchanged) |
+
+### Validation rules (v2)
+
+- Every entry MUST have `axis`. Substrate-axis entries SHOULD have ≥3 `citations` (relaxed for DIM-* axiom-pointer entries — those defer to axiom's own grounding).
+- Authoring-axis entries MAY have `cost-of-load: archivable` only (they don't load at Phase 0 ever).
+- DIM-* entries are exempt from `citations` requirement (they're axiom-owned cross-link entries).
+- `axiom_overlap` is optional. When declared, it MUST reference an existing DIM-N entry. Used by `/axiom:design`'s pairing-discovery to interleave project invariants under each axiom dimension.
+
+## 4. Loader behavior
+
+Per D4 §5 and §7, plus the `/axiom:design` pairing-discovery fix, plus the new dev-invariants gating.
+
+### 4.0 Catalog gating via `.exarchos.yml`
+
+Before any scope filter applies, the loader checks the `.exarchos.yml` flag:
+
+```yaml
+# .exarchos.yml
+invariants:
+  devCatalog: enabled    # default: disabled
+```
+
+Loader logic:
+
+```ts
+function loadInvariants(
+  doc: InvariantsDoc,
+  opts: { scope?: Scope } = {},
+  config: ExarchosConfig = readConfig()
+): InvariantEntry[] {
+  // Catalog gating — applied before any scope filter
+  if (config.invariants?.devCatalog !== 'enabled') {
+    return [];
+  }
+  // ... existing scope filter logic per §4.1 below
+}
+```
+
+**Default behavior — disabled:** No entries surface at `/ideate` Phase 0; `loadInvariants(doc)` returns `[]`. The `design-invariants` skill body still walks the catalog (it has direct file access independent of the loader), but it's only invoked when an Exarchos contributor explicitly requests `/design-invariants`. Consumers using Exarchos as a plugin in a non-Exarchos project never see these entries at any phase.
+
+**Enabled behavior:** Loader returns per the scope filter (§4.1 below). Setting `devCatalog: enabled` in `.exarchos.yml` is the single switch.
+
+**No auto-detection.** The loader does not infer the flag from repo identity, directory presence, or any heuristic. An Exarchos contributor working in the Exarchos repo must still set `invariants.devCatalog: enabled` in their `.exarchos.yml`. In practice the Exarchos repo's own committed `.exarchos.yml` sets this — so contributors who clone the repo inherit the opt-in automatically *because* the committed file declares it, not because the loader detected anything.
+
+**Why default-disabled even inside Exarchos:** the flag is a declarative statement of intent ("surface dev-internal invariants to me"). Surfacing them by default — even via auto-detection — risks a future where a consumer's `.exarchos.yml` accidentally triggers detection and they suddenly see Exarchos's internals at every `/ideate`. Explicit-opt-in eliminates that failure mode entirely.
+
+### 4.1 `/ideate` Phase 0 default load
+
+```ts
+loadInvariants(INVARIANTS_DOC, { scope: 'core' })
+```
+
+Returns entries where: `axis === 'substrate' AND cost-of-load === 'always-load'`.
+
+This is a tighter filter than v1's "cost-of-load: always-load" alone, because v2 first restricts to substrate. Authoring entries (only DIM-8) are excluded by axis.
+
+### 4.2 On-demand load
+
+```ts
+loadInvariants(INVARIANTS_DOC, { scope: 'all' })
+// or
+loadInvariants(INVARIANTS_DOC, { scope: 'substrate' })
+loadInvariants(INVARIANTS_DOC, { scope: 'authoring' })
+```
+
+Loads the relevant subset. The design-invariants skill body uses `scope: 'all'` because it walks every entry; vocabulary lint also uses `scope: 'all'` for ID-vocabulary checking.
+
+### 4.3 `/axiom:design` pairing-discovery fix
+
+Two changes (the charter calls these out of scope for this discover but tracked here for the follow-up plan):
+
+1. `design-invariants/SKILL.md` frontmatter: change (or augment) `pairs-with: axiom:backend-quality` → `pairs-with: axiom:design` so axiom:design's discovery mechanism finds the catalog.
+2. With `axiom_overlap: DIM-N` declared per substrate-invariant, axiom:design interleaves them under each dimension automatically.
+
+## 5. Proposed v2 entry list (dev-invariants scope)
+
+**22 entries** — within the ≤25 ceiling per charter §6. All entries are scoped to Exarchos's internal runtime design; surfaced only when `invariants.devCatalog: enabled` per §4.0.
+
+### 5.1 Substrate axis — load-bearing primitives (10)
+
+| ID | Dimension | cost-of-load | axiom_overlap | Status v1 → v2 |
+|---|---|---|---|---|
+| INV-1 | event-sourcing-integrity | always-load | DIM-1 | sharpen (scope-narrowed; substrate-serialization split off to INV-7) |
+| INV-2 | facade-equivalence | always-load | DIM-1 | keep |
+| INV-5a | input-ergonomics | always-load | (none) | keep |
+| INV-5b | output-contract | always-load | DIM-3 | keep (sharpen — affordance consumption split to INV-12) |
+| INV-6 | workload-agnosticism | always-load | (none — workload is the catalog's own primary axis) | **sharpen — elevate from skill-grep operational to primary workload-agnosticism statement** |
+| INV-7 | substrate-serialization | always-load | DIM-1, DIM-7 | **NEW** |
+| INV-8 | idempotency-at-the-boundary | always-load | DIM-3, DIM-7 | **NEW** |
+| INV-11 | posture-declared-capabilities | always-load | DIM-1 | **NEW** |
+| INV-12 | next-actions-as-affordance | always-load | DIM-3 | **NEW** |
+| INV-15 | single-machine-frame | always-load | DIM-1 | **NEW** (framing statement) |
+
+Rationale for `always-load` on every new entry: each is load-bearing for any non-trivial design. INV-7, INV-8, INV-11, INV-12, INV-15 are foundational; a designer skipping them produces unsafe designs.
+
+### 5.2 Substrate axis — reference-only (9)
+
+| ID | Dimension | cost-of-load | axiom_overlap | Status v1 → v2 |
+|---|---|---|---|---|
+| INV-3 | basileus-forward | reference-only | (none — basileus-orthogonal) | keep |
+| INV-4 | platform-agnosticity | reference-only | (none — platform is a v2 axis sibling to workload) | keep (sharpen — clarify "platform" axis ownership relative to INV-6 "workload" axis) |
+| INV-5c | aspire-verbs | reference-only | (none) | keep |
+| INV-5d | action-discriminator | reference-only | (none) | keep |
+| INV-9 | hsm-as-state-machine | reference-only | DIM-1 | **NEW** (pending Harel statecharts citation — see §7) |
+| INV-10 | liveness-event-protocol | reference-only | DIM-2 | **NEW** |
+| INV-13 | process-manager-two-event-split | reference-only | DIM-7 | **NEW** |
+| INV-14 | native-primitive-first-recovery | reference-only | DIM-7 | **NEW** (or operational pattern — see §7) |
+| basileus-boundary | cross-product-coordination | archivable | DIM-1 | keep |
+
+### 5.3 Substrate axis — axiom pointers (7)
+
+These are the DIM-1..DIM-7 entries. Each is a short cross-link to the canonical axiom:* skill; the entry exists in the catalog only for vocabulary-lint cross-reference and for documenting overlap with INV-* entries.
+
+| ID | Dimension | cost-of-load | axiom_overlap | Status v1 → v2 |
+|---|---|---|---|---|
+| DIM-1 | topology | reference-only | (self) | keep |
+| DIM-2 | observability | reference-only | (self) | keep |
+| DIM-3 | contracts | reference-only | (self) | keep |
+| DIM-4 | test-fidelity | reference-only | (self) | keep (downgrade-to-principle per v1.5 audit) |
+| DIM-5 | hygiene | reference-only | (self) | keep |
+| DIM-6 | solid-coupling | reference-only | (self) | keep |
+| DIM-7 | resilience | reference-only | (self) | keep (downgrade-to-principle per v1.5 audit) |
+
+### 5.4 Authoring axis (1)
+
+| ID | Dimension | cost-of-load | axiom_overlap | Status v1 → v2 |
+|---|---|---|---|---|
+| DIM-8 | prose-quality | archivable | (self — axiom:humanize) | keep |
+
+The only authoring entry. Explicit `axis: authoring` makes its non-loading behavior at `/ideate` Phase 0 declarative rather than implicit.
+
+## 6. Detailed entries (the 9 new candidates)
+
+Wording proposed for each new entry. Existing entries (INV-1..INV-6, INV-5a..d, DIM-*, basileus-boundary) get sharpened in-place per D2 §9 + D3 §5; v2 spec doesn't re-quote them.
+
+### INV-6 — workload-agnosticism (sharpened from v1)
+
+```yaml
+- id: INV-6
+  dimension: workload-agnosticism
+  axis: substrate
+  cost-of-load: always-load
+  applies-to:
+    - runtime-substrate
+    - topology
+    - skills-src
+    - playbooks
+  summary: >
+    The runtime makes no assumption about which workload is executing.
+    Substrate guarantees (RT-1..RT-6) hold identically for every workflow
+    type. Workflow-type-specific concerns belong in topology.yaml, not
+    the catalog. Skills describe behaviors; playbooks/commands describe
+    workflows. Operational projection: scripts/lint-inv6.mjs grep for
+    workflow-typed literals in skills-src/.
+  axiom_overlap: ~
+  citations:
+    - "AWP runtime-agnostic protocol: https://github.com/veegee82/agent-workflow-protocol/blob/main/docs/runtime.md"
+    - "Harn typed orchestration boundary: https://harnlang.com/workflow-runtime.html"
+    - "Novita framework-agnostic runtime: https://blogs.novita.ai/novita-agent-runtime-agentcore-compatible/"
+  references:
+    - .claude/skills/design-invariants/references/INV-6-workflow-agnosticism.md
+    - scripts/lint-inv6.mjs
+    - docs/architecture/runtime.md#§1
+```
+
+### INV-7 — substrate-serialization (NEW)
+
+```yaml
+- id: INV-7
+  dimension: substrate-serialization
+  axis: substrate
+  cost-of-load: always-load
+  applies-to:
+    - event-store
+    - atomic-appender
+    - stream-lock-manager
+  summary: >
+    Concurrency is serialized in two tiers. Tier 1 (in-process): the
+    StreamLockManager runs concurrent same-stream appends sequentially
+    via a per-stream Promise-chain mutex. Tier 2 (cross-process): SQLite
+    WAL with BEGIN IMMEDIATE acquires the write lock; the PRIMARY KEY
+    (streamId, sequence) rejects duplicate sequences; OCC retry handles
+    the conflict. No process-level mutex, no PID lock, no advisory file.
+  axiom_overlap: DIM-1
+  citations:
+    - "Mohan et al., *ARIES* (ACM TODS 1992): https://dl.acm.org/doi/10.1145/128765.128770"
+    - "Bernstein & Goodman, *Concurrency Control in Distributed Database Systems* (ACM Computing Surveys 1981): https://dl.acm.org/doi/10.1145/356842.356846"
+    - "SQLite WAL documentation: https://sqlite.org/wal.html"
+  references:
+    - servers/exarchos-mcp/src/event-store/atomic-appender.ts
+    - servers/exarchos-mcp/src/event-store/stream-lock-manager.ts
+    - docs/architecture/runtime.md#§4
+```
+
+### INV-8 — idempotency-at-the-boundary (NEW)
+
+```yaml
+- id: INV-8
+  dimension: idempotency-at-the-boundary
+  axis: substrate
+  cost-of-load: always-load
+  applies-to:
+    - event-store
+    - withSession
+    - dispatch-boundary
+  summary: >
+    Every append carries an idempotency key. The UNIQUE INDEX on
+    idempotency_key collapses duplicates at the storage layer. Handler
+    retries via withSession({operationId}) re-emit the requested event
+    as a no-op when the key matches; the external side effect runs at
+    most once across retries. INV-8 is the load-bearing prerequisite
+    for INV-13's process-manager two-event split.
+  axiom_overlap: DIM-3
+  citations:
+    - "Wolverine idempotency PR #1858: https://github.com/JasperFx/wolverine/pull/1858"
+    - "Akka persistence at-least-once delivery: https://doc.akka.io/docs/akka/snapshot/typed/persistence.html"
+    - "Greg Young, *Versioning in an Event Sourced System* (Leanpub): https://leanpub.com/esversioning"
+  references:
+    - servers/exarchos-mcp/src/event-store/atomic-appender.ts
+    - servers/exarchos-mcp/src/dispatch/with-session.ts
+```
+
+### INV-9 — hsm-as-state-machine (NEW; pending citation backfill)
+
+```yaml
+- id: INV-9
+  dimension: hsm-as-state-machine
+  axis: substrate
+  cost-of-load: reference-only
+  applies-to:
+    - topology
+    - hsm-definitions
+    - phase-transitions
+  summary: >
+    Every workflow type ships a hierarchical state machine declared in
+    topology.yaml. Transitions are guarded; only workflow.transition is
+    a phase mutator (workflow.set-phase is deprecated). The HSM is the
+    sole authority for valid phase sequencing; next_actions is derived
+    from it.
+  axiom_overlap: DIM-1
+  citations:
+    - "Harel, *Statecharts: A Visual Formalism for Complex Systems* (Science of Computer Programming 1987): https://www.sciencedirect.com/science/article/pii/0167642387900359"
+    - "Greg Young, *Versioning in an Event Sourced System* — Process Manager Versioning chapter (Leanpub)"
+    - "Wolverine [AggregateHandler] workflow (Miller 2023): https://jeremydmiller.com/2023/12/06/building-a-critter-stack-application-wolverines-aggregate-handler-workflow-ftw/"
+  references:
+    - servers/exarchos-mcp/src/topology/phase-contract.ts
+    - servers/exarchos-mcp/src/hsm/
+    - docs/architecture/runtime.md#§3-L4
+```
+
+### INV-10 — liveness-event-protocol (NEW)
+
+```yaml
+- id: INV-10
+  dimension: liveness-event-protocol
+  axis: substrate
+  cost-of-load: reference-only
+  applies-to:
+    - long-running-handlers
+    - lifecycle-verbs
+    - observability
+  summary: >
+    Every long-running operation emits <surface>.executing_started at
+    entry and a paired terminal event (success/failure) at exit. v2.12
+    lifecycle verbs (ps, describe, wait) query these events generically;
+    no per-feature lifecycle code is needed. The protocol replaces
+    active polling and heartbeat infrastructure.
+  axiom_overlap: DIM-2
+  citations:
+    - "Conductor durable execution: https://conductor-oss.github.io/conductor/devguide/concepts/conductor.html"
+    - "AWP runtime liveness: https://github.com/veegee82/agent-workflow-protocol/blob/main/docs/runtime.md"
+    - "Microsoft Scheduler-Agent-Supervisor (negative reference — what this protocol replaces): https://learn.microsoft.com/en-us/azure/architecture/patterns/scheduler-agent-supervisor"
+  references:
+    - servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
+    - docs/architecture/runtime.md#§6
+```
+
+### INV-11 — posture-declared-capabilities (NEW)
+
+```yaml
+- id: INV-11
+  dimension: posture-declared-capabilities
+  axis: substrate
+  cost-of-load: always-load
+  applies-to:
+    - agent-spec
+    - capability-resolver
+    - handshake
+    - sub-agent-dispatch
+  summary: >
+    Every agent declares one of three postures in agent spec YAML:
+    read-only | task-isolated | shared-mutating. The MCP initialize
+    handshake declares the runtime half. The capability resolver merges
+    posture with handshake; mismatches resolve to the handshake (handshake-authoritative).
+    Postures are unrepresentable-by-construction — a read-only agent
+    cannot mutate the working tree; a task-isolated agent cannot write
+    outside its assigned worktree.
+  axiom_overlap: DIM-1
+  citations:
+    - "Mark S. Miller, *Robust Composition* (PhD dissertation, JHU 2006): https://papers.agoric.com/papers/robust-composition/full-text"
+    - "Miller et al., *Paradigm Lost: Abstraction Mechanisms for Access Control* (JHU SRL 2003): https://srl.cs.jhu.edu/pubs/SRL2003-03.pdf"
+    - "POLA — Principle of Least Authority (erights.org): http://wiki.erights.org/wiki/POLA"
+    - "anip-protocol SPEC — posture and handshake (convergent design): https://github.com/anip-protocol/anip/blob/main/SPEC.md"
+  references:
+    - servers/exarchos-mcp/src/capabilities/resolver.ts
+    - servers/exarchos-mcp/src/agents/generate-agents.ts
+    - docs/architecture/runtime.md#§7
+```
+
+### INV-12 — next-actions-as-affordance (NEW)
+
+```yaml
+- id: INV-12
+  dimension: next-actions-as-affordance
+  axis: substrate
+  cost-of-load: always-load
+  applies-to:
+    - tool-result
+    - next-actions-computer
+    - agent-cooperation
+  summary: >
+    The next_actions field on ToolResult publishes runtime affordances —
+    valid transitions perceivable to consuming agents. Agents read
+    next_actions and dispatch the listed verbs; they do not poll.
+    Autonomy is a property of state + topology (which determines
+    next_actions), not of any handler's internal logic. Removing a
+    verb from next_actions removes the agent's path to invoking it,
+    but does not remove the underlying affordance — the topology still
+    permits it.
+  axiom_overlap: DIM-3
+  citations:
+    - "Donald Norman, *Affordance, Conventions, and Design* (ACM Interactions 1999): https://interactions.acm.org/archive/view/may-june-1999/affordance-conventions-and-design1"
+    - "McGrenere & Ho, *Affordances: Clarifying and Evolving a Concept* (Graphics Interface 2000): https://graphicsinterface.org/wp-content/uploads/gi2000-24.pdf"
+    - "James J. Gibson, *The Ecological Approach to Visual Perception* (1979) — cited via the HCI glossary: https://interaction-design.org/literature/book/the-glossary-of-human-computer-interaction/affordances"
+  references:
+    - servers/exarchos-mcp/src/next-actions-computer.ts
+    - servers/exarchos-mcp/src/format.ts
+    - docs/architecture/runtime.md#§7
+```
+
+### INV-13 — process-manager-two-event-split (NEW)
+
+```yaml
+- id: INV-13
+  dimension: process-manager-two-event-split
+  axis: substrate
+  cost-of-load: reference-only
+  applies-to:
+    - external-mutator-handlers
+    - merge-orchestrate
+    - create-pr
+    - withSession
+  summary: >
+    Handlers performing non-idempotent external side effects emit two
+    events: *.requested (intent + full payload) before the side effect;
+    *.executed (result) after. On retry, the requested event idempotency-collapses
+    (INV-8); the side effect runs once. On crash recovery, the next invocation
+    observes *.requested without *.executed and runs an idempotent precheck
+    against external state (e.g., does the PR already exist?) to determine
+    whether to re-emit or skip. Pattern source — Akka Effect.thenRun,
+    Wolverine [AggregateHandler], Greg Young.
+  axiom_overlap: DIM-7
+  citations:
+    - "Akka Effect.thenRun (Persistence docs): https://doc.akka.io/api/akka-core/current/akka/persistence/typed/scaladsl/Effect$.html"
+    - "Wolverine [AggregateHandler] (Miller 2023): https://jeremydmiller.com/2023/12/06/building-a-critter-stack-application-wolverines-aggregate-handler-workflow-ftw/"
+    - "Greg Young, *Why Event Sourced Systems Fail*: https://www.youtube.com/watch?v=FKFu78ZEIi8"
+  references:
+    - servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
+    - servers/exarchos-mcp/src/dispatch/with-session.ts
+    - docs/architecture/runtime.md#§4-process-manager-handlers
+```
+
+### INV-14 — native-primitive-first-recovery (NEW)
+
+```yaml
+- id: INV-14
+  dimension: native-primitive-first-recovery
+  axis: substrate
+  cost-of-load: reference-only
+  applies-to:
+    - external-mutator-handlers
+    - recovery-paths
+    - error-discriminators
+  summary: >
+    When an external operation needs reversal, handlers prefer the
+    operation's own recovery primitive first (e.g., `git merge --abort`),
+    fall back to substrate-level undo with refuse-to-discard semantics
+    second (e.g., `git reset --keep <sha>`), and never use destructive
+    overwrite (e.g., `git reset --hard`). The recoveryError field on
+    terminal results discriminates 'reset-keep-blocked' | 'reset-failed'
+    | 'unexpected-mid-merge-drift' so callers see indeterminate states
+    explicitly rather than as silent successes.
+  axiom_overlap: DIM-7
+  citations:
+    - "Mohan et al., *ARIES* (ACM TODS 1992) — Compensation Log Records semantics as the abstract analog: https://dl.acm.org/doi/10.1145/128765.128770"
+    - "Greg Young, *Event Sourcing: The Bad Parts* (CodeCrafts 2022) — local-rewind recovery posture: https://www.youtube.com/watch?v=K4bj31fJGFk"
+    - "git documentation — `git merge --abort`, `git reset --keep`: https://git-scm.com/docs/git-reset"
+  references:
+    - servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
+    - docs/architecture/runtime.md#§5
+```
+
+**Open question:** INV-14 may not deserve full catalog status; the citations remain Exarchos-specific rather than pulling from a deep external literature. Two alternatives for the implementation phase:
+
+- **(A)** ship as v2 catalog entry as proposed above.
+- **(B)** demote to "operational pattern" documented in a skill body (e.g., `.claude/skills/recovery-discipline/SKILL.md`), with a one-line pointer in the catalog under INV-1's references.
+
+Recommendation: **(A)** initially. The principle generalizes beyond git, and substrate-level handlers across the codebase need a single load-bearing rule to point to. If after one release cycle the entry is rarely cited, demote to (B).
+
+### INV-15 — single-machine-frame (NEW)
+
+```yaml
+- id: INV-15
+  dimension: single-machine-frame
+  axis: substrate
+  cost-of-load: always-load
+  applies-to:
+    - runtime-framing
+    - rejected-patterns
+    - architecture-baseline
+  summary: >
+    Exarchos is a single-machine event-sourced process manager with
+    cooperative agents — concurrent, not distributed. No saga, no
+    Scheduler-Agent-Supervisor, no 2PC, no leader election, no vector
+    clocks, no BFT consensus, no distributed locks. Compensation is
+    local rewind over the event log, not remote command dispatch.
+    Liveness is event-emitted (INV-10), queryable via lifecycle verbs.
+    Cooperation is by construction (INV-11 posture + INV-12 affordance).
+    When a candidate design imports primitives from outside this frame,
+    the frame rejects it.
+  axiom_overlap: DIM-1
+  citations:
+    - "Microsoft Azure Architecture Center — Scheduler Agent Supervisor pattern (negative reference): https://learn.microsoft.com/en-us/azure/architecture/patterns/scheduler-agent-supervisor"
+    - "Microsoft Azure Architecture Center — Saga design pattern (negative reference): https://learn.microsoft.com/en-us/azure/architecture/patterns/saga"
+    - "Clemens Vasters, *Cloud Architecture: The Scheduler-Agent-Supervisor Pattern* (2010): https://learn.microsoft.com/en-us/archive/blogs/clemensv/cloud-architecture-the-scheduler-agent-supervisor-pattern"
+  references:
+    - docs/architecture/runtime.md#§1
+    - docs/architecture/runtime.md#§8
+```
+
+## 7. Migration plan v1 → v2
+
+### 7.0 Add `.exarchos.yml` gating flag (lands first)
+
+Before any catalog-shape change lands, the loader's gating mechanism (§4.0) must be in place to ensure default-disabled behavior. Sequence:
+
+1. Extend `ExarchosConfig` type with `invariants?: { devCatalog?: 'enabled' | 'disabled' }`.
+2. Extend `loadInvariants` to consult the config; return `[]` when `devCatalog !== 'enabled'`.
+3. Default `disabled` in the loader itself — including inside the Exarchos repo. The repo's own committed `.exarchos.yml` sets the flag to `enabled` so contributors and internal consumers (eval #1442, vocabulary-lint cross-references, etc.) retain access when working inside the repo. External consumers using Exarchos as a plugin in their own repo see no entries unless they explicitly opt in.
+4. Add `.exarchos.yml` documentation noting the flag.
+5. Add a regression test asserting `loadInvariants` returns `[]` with the flag disabled, regardless of `scope`.
+
+**Migration risk:** v1 consumers that depended on entries being loaded (notably eval #1442) must explicitly enable. Inside the Exarchos repo this is automatic via the committed `.exarchos.yml`; for external consumers this is intentional friction — the dev catalog should never have been loaded for them in the first place.
+
+### 7.1 Bump schema-version
+
+Header change: `schema-version: 1` → `schema-version: 2`.
+
+### 7.2 Per-entry edits
+
+For each existing v1 entry: add `axis:` and (where applicable) `axiom_overlap:`. Backfill `citations:` opportunistically — required for new entries, recommended for sharpened entries, exempt for DIM-* pointers.
+
+For INV-1: split into INV-1 (event-sourcing-integrity, narrowed), INV-7 (substrate-serialization, new), INV-8 (idempotency-at-the-boundary, new).
+
+For INV-6: rewrite per §6 above — elevate to primary workload-agnosticism statement.
+
+For INV-5b: split off INV-12 (next-actions-as-affordance, new); keep INV-5b for carrier-shape concerns.
+
+### 7.3 Add new entries
+
+INV-9, INV-10, INV-11, INV-13, INV-14, INV-15 per §6. INV-7, INV-8, INV-12 are also new but originate from splits, not standalone additions.
+
+### 7.4 Loader updates
+
+`servers/exarchos-mcp/src/architecture/invariants-loader.ts`:
+
+```ts
+type Scope = 'core' | 'substrate' | 'authoring' | 'all';
+
+function loadInvariants(
+  doc: InvariantsDoc,
+  opts: { scope?: Scope } = {}
+): InvariantEntry[] {
+  const scope = opts.scope ?? 'all';
+  switch (scope) {
+    case 'core':
+      // substrate AND always-load
+      return doc.invariants.filter(
+        (e) => e.axis === 'substrate' && e.costOfLoad === 'always-load'
+      );
+    case 'substrate':
+      return doc.invariants.filter((e) => e.axis === 'substrate');
+    case 'authoring':
+      return doc.invariants.filter((e) => e.axis === 'authoring');
+    case 'all':
+      return doc.invariants;
+  }
+}
+```
+
+Backwards compatibility: `loadInvariants(doc)` (no opts) defaults to `'all'` — same as v1's behavior, so existing call sites continue to work. New call sites pass `{ scope: 'core' }` for `/ideate` Phase 0.
+
+The `loadInvariants(doc, { scope: 'invalid' })` case throws per D4 §5 (loud failure, no silent degradation) — already enforced in v1.5.
+
+### 7.5 `/ideate` Phase 0 directive
+
+Update `commands/ideate.md` Phase 0 to load `scope: 'core'` instead of the v1.5 `scope: 'core'` (which was always-load only). Behavior change is invisible to designers — fewer entries surface, all of them genuinely runtime-substrate-relevant.
+
+### 7.6 `/axiom:design` pairing-discovery fix
+
+Two follow-up edits (separate plan):
+
+1. `.claude/skills/design-invariants/SKILL.md` frontmatter — change or add `pairs-with: axiom:design`.
+2. `axiom:design` consumes the `axiom_overlap` field present on each v2 entry to interleave by dimension.
+
+### 7.7 Vocabulary lint
+
+`servers/exarchos-mcp/src/architecture/vocabulary-lint.ts` already walks `/\b(INV-\d+[a-d]?|DIM-\d+)\b/`. v2 adds INV-7..INV-15 to the recognized ID set. No format change needed.
+
+### 7.8 Tests
+
+New test cases (extend `invariants-loader.test.ts`):
+
+- `LoadInvariants_WithScopeCore_ReturnsOnlySubstrateAlwaysLoad` — verifies the new `scope: 'core'` filter intersects axis + cost-of-load.
+- `LoadInvariants_WithScopeAuthoring_ReturnsOnlyAuthoringEntries` — verifies the authoring filter.
+- `Invariants_EveryEntry_HasAxisField` — schema enforcement.
+- `Invariants_NewSubstrateEntries_HaveThreeOrMoreCitations` — soft assertion; threshold for INV-7..INV-15.
+
+### 7.9 Migration is rollback-safe
+
+The v2 schema is additive — `axis`, `axiom_overlap`, `citations` are new fields. The loader's `scope: 'all'` returns the same set as v1 by default. If v2 surfaces problems, the rollback is `git revert` of the catalog file + loader changes; no data migration, no runtime state to back out.
+
+## 8. Acceptance check (against charter §6)
+
+- [x] ≥3 external citations per substrate-axis candidate — PASS for INV-7, INV-8, INV-11, INV-12, INV-13, INV-15. INV-9 backfills Harel. INV-14 borderline (see §6 open question). INV-10 thin (3 sources). DIM-* entries exempt.
+- [x] runtime.md §2–§8 cross-walked — D2 covers this fully.
+- [x] Explicit pass/fail per candidate against 5 workflow types — D3 covers this; all 9 new candidates pass.
+- [x] Substrate/authoring split sharp — D4 yields 21 substrate, 1 authoring; decision procedure is encoded in §2 of D4 and §3 of this doc.
+- [x] ≤25 entries in v2 spec — proposed 22 entries; 3 entries of headroom.
+
+## 9. Out of scope (per charter §7)
+
+This proposal does **not** include:
+
+- Catalog rewrite (`docs/architecture/invariants.md` edits) — separate plan workflow.
+- Skill body updates (`.claude/skills/design-invariants/SKILL.md`) — separate plan workflow.
+- `/axiom:design` `pairs-with` slot fix — listed in §7.6 above for visibility but lives in the follow-up plan.
+- Tier B eval (#1442) target swap from v1 to v2 catalog — eval team's decision.
+- basileus-boundary entry rework — separate cross-product workflow.
+- **Consumer-facing SDLC invariants catalog** — distinct audience (engineers using Exarchos to govern their own workflows), distinct content. See §10 below for forward-pointer scope sketch.
+
+## 10. The consumer-facing catalog (forward pointer)
+
+This catalog deliberately serves only Exarchos's internal designers. The complementary catalog — for Exarchos *consumers* using the plugin to govern their own software development — is a distinct, future deliverable.
+
+**Audience:** engineers in any project who have installed Exarchos as a Claude Code plugin and run `/exarchos:ideate`, `/exarchos:plan`, `/exarchos:review` etc. against their own React app, Python service, Go CLI, or whatever else they happen to be building.
+
+**Content sketch (not exhaustive, not authoritative — derived in a separate discover):**
+
+- **Workflow-type discipline** — TDD is required when the declared workflow type names it (`feature`, `oneshot`); `discovery` is exempt; `refactor` and `debug` have their own gates. Each workflow type's exemptions/requirements are declared, not implicit.
+- **Phase observability** — every workflow transition is queryable. Nobody on the team should have to ask "what step are we on?" — the catalog can answer.
+- **Review-gate honesty** — gates that fail must surface findings; silently passing a gate is a worse failure than a loud fail. Applies to TDD compliance, design-completeness, static-analysis, and any user-defined gate.
+- **Branch/PR discipline** — stacked PRs merge bottom-up; never `--auto --squash` on an upper PR that hasn't landed its base (this principle currently lives in project memory `feedback_stacked_pr_auto_merge_collapses_granularity` — promoting to invariant is exactly the use case).
+- **Recovery posture** — any workflow can be paused (checkpoint) and resumed (rehydrate) without consulting human memory; state is reconstructible from artifacts on disk.
+- **Authoring/playbook split** — skills describe behaviors workload-neutrally; playbooks (commands) describe workloads. The current INV-6 sharpened (workload-agnosticism) is the dev-catalog mirror of this principle; the consumer catalog version applies to *consumer-authored* skills and playbooks.
+- **Subagent boundary** — sub-agents inherit posture from parent; dispatched tasks have explicit input + return contracts; orphan sub-agents are reaped.
+
+**What it does not cover:** Exarchos's internal substrate (event sourcing, OCC, posture resolver, dispatch core, MCP/CLI parity). Consumers use the affordances; they don't reimplement the runtime.
+
+**Provisional workflow charter:** `/exarchos:discover consumer-sdlc-invariants` — own discover, own corpus (Beck's TDD literature; Humble & Farley *Continuous Delivery*; Allspaw on review discipline; Vaughn Vernon on bounded contexts as workload boundaries). Charter to be drafted separately. Estimated scope is larger than this discover — the consumer audience is broader and the content has decades of practitioner literature behind it.
+
+**Sequencing:** ship dev-invariants v2 first (this proposal + its follow-up plan). Once dev-invariants v2 is stable and the gating mechanism is proven, start the consumer-catalog discover. The two catalogs share no entries by design — they serve different audiences with different concerns.
+
+## 11. Next steps (suggested follow-up plan workflow)
+
+A `feature` workflow named `invariants-catalog-v2-implementation`:
+
+1. **Wave A (research → plan)**: Re-read this doc; finalize INV-14 disposition (catalog entry vs operational pattern); finalize INV-9 Harel citation.
+2. **Wave B (catalog edits)**: Implement schema bump + per-entry edits + new entries (TDD: extend `invariants-loader.test.ts` first, then edit `invariants.md`).
+3. **Wave C (loader + Phase 0)**: Add `scope: 'core' | 'substrate' | 'authoring' | 'all'` to loader; update `commands/ideate.md` Phase 0 directive.
+4. **Wave D (axiom:design pairing fix)**: Update `design-invariants/SKILL.md` frontmatter `pairs-with` slot.
+5. **Wave E (tests + verification)**: All new tests pass; vocabulary lint clean; `npm run build:skills` + `npm run test:run` clean; manual Phase 0 smoketest confirms expected entries surface.
+
+Estimated scope: 6-8 tasks, mostly mechanical once this proposal is approved. PR stack: 1-2 PRs depending on whether the axiom:design pairing fix bundles with the catalog rewrite.
+
+## 12. References
+
+- This workflow's deliverables (D1–D4): linked in §1.
+- Primary internal source: [`docs/architecture/runtime.md`](../architecture/runtime.md).
+- v1 catalog: [`docs/architecture/invariants.md`](../architecture/invariants.md).
+- Charter trigger: issue [#1370](https://github.com/lvlup-sw/exarchos/issues/1370) comment [4464273740](https://github.com/lvlup-sw/exarchos/issues/1370#issuecomment-4464273740).
+- Audience-scope feedback: user direction during the discover, 2026-05-20 — "These are still invariants specific to Exarchos internal design, not a general-purpose set of invariants for software development. We should gate this functionality behind a feature flag."

--- a/docs/proposals/2026-05-20-invariants-catalog-v2-spec.md
+++ b/docs/proposals/2026-05-20-invariants-catalog-v2-spec.md
@@ -196,7 +196,7 @@ Rationale for `always-load` on every new entry: each is load-bearing for any non
 
 ### 5.3 Substrate axis — axiom pointers (7)
 
-These are the DIM-1..DIM-7 entries. Each is a short cross-link to the canonical `axiom:*` skill; the entry exists in the catalog only for vocabulary-lint cross-reference and for documenting overlap with `INV-*` entries.
+These are the `DIM-1..DIM-7` entries. Each is a short cross-link to the canonical `axiom:*` skill; the entry exists in the catalog only for vocabulary-lint cross-reference and for documenting overlap with `INV-*` entries.
 
 | ID | Dimension | cost-of-load | axiom_overlap | Status v1 → v2 |
 |---|---|---|---|---|
@@ -569,9 +569,10 @@ function loadInvariants(
   opts: { scope?: Scope } = {}
 ): InvariantEntry[] {
   const scope = opts.scope ?? 'all';
-  // Note: YAML uses kebab-case (`cost-of-load`); the loader normalizes to
-  // camelCase (`costOfLoad`) on the `InvariantEntry` type during parse.
-  // See `parseInvariantEntry` in invariants-loader.ts for the mapping.
+  // YAML schema uses kebab-case (`cost-of-load`); the parser
+  // normalizes to camelCase on `InvariantEntry` during load so
+  // filters can use the typed property. If you skip that
+  // normalization, use `e['cost-of-load']` here instead.
   switch (scope) {
     case 'core':
       // substrate AND always-load

--- a/docs/proposals/2026-05-20-invariants-catalog-v2-spec.md
+++ b/docs/proposals/2026-05-20-invariants-catalog-v2-spec.md
@@ -534,8 +534,9 @@ Before any catalog-shape change lands, the loader's gating mechanism (§4.0) mus
 1. Extend `ExarchosConfig` type with `invariants?: { devCatalog?: 'enabled' | 'disabled' }`.
 2. Extend `loadInvariants` to consult the config; return `[]` when `devCatalog !== 'enabled'`.
 3. Default `disabled` in the loader itself — including inside the Exarchos repo. The repo's own committed `.exarchos.yml` sets the flag to `enabled` so contributors and internal consumers (eval #1442, vocabulary-lint cross-references, etc.) retain access when working inside the repo. External consumers using Exarchos as a plugin in their own repo see no entries unless they explicitly opt in.
-4. Add `.exarchos.yml` documentation noting the flag.
-5. Add a regression test asserting `loadInvariants` returns `[]` with the flag disabled, regardless of `scope`.
+4. **Add `invariants.devCatalog: enabled` to the repository's root `.exarchos.yml`** as part of this migration commit. This is the load-bearing step that keeps eval #1442, the `design-invariants` skill, and vocabulary-lint working for contributors. Without this commit-time change, the catalog appears empty even inside the Exarchos repo and internal tooling breaks on the next pull.
+5. Add `.exarchos.yml` documentation noting the flag (semantics, default, and the audience-scope reasoning from §1.1).
+6. Add a regression test asserting `loadInvariants` returns `[]` with the flag disabled, regardless of `scope`.
 
 **Migration risk:** v1 consumers that depended on entries being loaded (notably eval #1442) must explicitly enable. Inside the Exarchos repo this is automatic via the committed `.exarchos.yml`; for external consumers this is intentional friction — the dev catalog should never have been loaded for them in the first place.
 
@@ -559,15 +560,23 @@ INV-9, INV-10, INV-11, INV-13, INV-14, INV-15 per §6. INV-7, INV-8, INV-12 are 
 
 ### 7.4 Loader updates
 
-`servers/exarchos-mcp/src/architecture/invariants-loader.ts`:
+`servers/exarchos-mcp/src/architecture/invariants-loader.ts`. This is the **complete** loader signature — it merges the §4.0 gating check (must come first) with the §4.1–§4.2 scope filter switch. Do not implement the scope filter without the gating block; the two are a single function:
 
 ```ts
 type Scope = 'core' | 'substrate' | 'authoring' | 'all';
 
 function loadInvariants(
   doc: InvariantsDoc,
-  opts: { scope?: Scope } = {}
+  opts: { scope?: Scope } = {},
+  config: ExarchosConfig = readConfig()
 ): InvariantEntry[] {
+  // §4.0 catalog gating — applied before any scope filter.
+  // Default-disabled even inside the Exarchos repo (see §7.0 step 4
+  // for the committed `.exarchos.yml: invariants.devCatalog: enabled`
+  // that opts the repo in).
+  if (config.invariants?.devCatalog !== 'enabled') {
+    return [];
+  }
   const scope = opts.scope ?? 'all';
   // YAML schema uses kebab-case (`cost-of-load`); the parser
   // normalizes to camelCase on `InvariantEntry` during load so
@@ -626,7 +635,7 @@ The v2 schema is additive — `axis`, `axiom_overlap`, `citations` are new field
 - [x] ≥3 external citations per substrate-axis candidate — PASS for INV-7, INV-8, INV-11, INV-12, INV-13, INV-15. INV-9 backfills Harel. INV-14 borderline (see §6 open question). INV-10 thin (3 sources). DIM-* entries exempt.
 - [x] runtime.md §2–§8 cross-walked — D2 covers this fully.
 - [x] Explicit pass/fail per candidate against 5 workflow types — D3 covers this; all 9 new candidates pass.
-- [x] Substrate/authoring split sharp — D4 yields 21 substrate, 1 authoring; decision procedure is encoded in §2 of D4 and §3 of this doc.
+- [x] Substrate/authoring split sharp — D4 yields 26 substrate, 1 authoring (27 total); decision procedure is encoded in §2 of D4 and §3 of this doc.
 - [ ] ≤25 entries in v2 spec — proposed **27 entries**; exceeded ceiling by 2 (revisit in next charter revision).
 
 ## 9. Out of scope (per charter §7)

--- a/docs/proposals/2026-05-20-invariants-catalog-v2-spec.md
+++ b/docs/proposals/2026-05-20-invariants-catalog-v2-spec.md
@@ -13,7 +13,7 @@
 A specification for `docs/architecture/invariants.md` at `schema-version: 2`, **scoped as Exarchos's dev-invariants catalog**. This proposal:
 
 - defines the v2 frontmatter schema,
-- lists every proposed v2 entry (22 total — within the ≤25 ceiling per charter),
+- lists every proposed v2 entry (27 total — exceeds the ≤25 ceiling per charter §6 by 2; revisit ceiling in next charter revision),
 - describes the loader behavior changes (including a new opt-in gate),
 - documents the migration plan from v1.
 
@@ -161,7 +161,7 @@ Two changes (the charter calls these out of scope for this discover but tracked 
 
 ## 5. Proposed v2 entry list (dev-invariants scope)
 
-**22 entries** — within the ≤25 ceiling per charter §6. All entries are scoped to Exarchos's internal runtime design; surfaced only when `invariants.devCatalog: enabled` per §4.0.
+**27 entries** (§§5.1–5.4 enumerate 10 + 9 + 7 + 1) — **exceeds the ≤25 ceiling per charter §6 by 2**; revisit ceiling in next charter revision. All entries are scoped to Exarchos's internal runtime design; surfaced only when `invariants.devCatalog: enabled` per §4.0.
 
 ### 5.1 Substrate axis — load-bearing primitives (10)
 
@@ -595,7 +595,7 @@ The `loadInvariants(doc, { scope: 'invalid' })` case throws per D4 §5 (loud fai
 
 ### 7.5 `/ideate` Phase 0 directive
 
-Update `commands/ideate.md` Phase 0 to load `scope: 'core'` instead of the v1.5 `scope: 'core'` (which was always-load only). Behavior change is invisible to designers — fewer entries surface, all of them genuinely runtime-substrate-relevant.
+`commands/ideate.md` Phase 0 continues to call `loadInvariants(doc, { scope: 'core' })`. The call site is unchanged, but the filter semantics change in v2: `core` now means "axis: substrate AND cost-of-load: always-load" (axis + cost-of-load filter), whereas v1.5 `core` was effectively "always-load only" (cost-of-load filter alone). Behavior change is invisible to designers — fewer entries surface, all of them genuinely runtime-substrate-relevant.
 
 ### 7.6 `/axiom:design` pairing-discovery fix
 
@@ -627,7 +627,7 @@ The v2 schema is additive — `axis`, `axiom_overlap`, `citations` are new field
 - [x] runtime.md §2–§8 cross-walked — D2 covers this fully.
 - [x] Explicit pass/fail per candidate against 5 workflow types — D3 covers this; all 9 new candidates pass.
 - [x] Substrate/authoring split sharp — D4 yields 21 substrate, 1 authoring; decision procedure is encoded in §2 of D4 and §3 of this doc.
-- [x] ≤25 entries in v2 spec — proposed 22 entries; 3 entries of headroom.
+- [ ] ≤25 entries in v2 spec — proposed **27 entries**; exceeded ceiling by 2 (revisit in next charter revision).
 
 ## 9. Out of scope (per charter §7)
 

--- a/docs/proposals/2026-05-20-invariants-catalog-v2-spec.md
+++ b/docs/proposals/2026-05-20-invariants-catalog-v2-spec.md
@@ -107,19 +107,20 @@ invariants:
   devCatalog: enabled    # default: disabled
 ```
 
-Loader logic:
+Loader logic (signature preserves v1 — `filePath: string` first arg — to avoid breaking existing call sites; only the new `config` arg is additive):
 
 ```ts
 function loadInvariants(
-  doc: InvariantsDoc,
-  opts: { scope?: Scope } = {},
+  filePath: string,
+  opts?: { scope?: Scope },
   config: ExarchosConfig = readConfig()
 ): InvariantEntry[] {
-  // Catalog gating — applied before any scope filter
+  // §4.0 catalog gating — applied before any file read or scope filter.
   if (config.invariants?.devCatalog !== 'enabled') {
     return [];
   }
-  // ... existing scope filter logic per §4.1 below
+  // ... existing parse-and-filter logic per §4.1 below (unchanged from v1
+  // apart from the additional `axis`-aware filters for `scope: 'core'`).
 }
 ```
 
@@ -531,12 +532,27 @@ Recommendation: **(A)** initially. The principle generalizes beyond git, and sub
 
 Before any catalog-shape change lands, the loader's gating mechanism (§4.0) must be in place to ensure default-disabled behavior. Sequence:
 
-1. Extend `ExarchosConfig` type with `invariants?: { devCatalog?: 'enabled' | 'disabled' }`.
-2. Extend `loadInvariants` to consult the config; return `[]` when `devCatalog !== 'enabled'`.
-3. Default `disabled` in the loader itself — including inside the Exarchos repo. The repo's own committed `.exarchos.yml` sets the flag to `enabled` so contributors and internal consumers (eval #1442, vocabulary-lint cross-references, etc.) retain access when working inside the repo. External consumers using Exarchos as a plugin in their own repo see no entries unless they explicitly opt in.
-4. **Add `invariants.devCatalog: enabled` to the repository's root `.exarchos.yml`** as part of this migration commit. This is the load-bearing step that keeps eval #1442, the `design-invariants` skill, and vocabulary-lint working for contributors. Without this commit-time change, the catalog appears empty even inside the Exarchos repo and internal tooling breaks on the next pull.
-5. Add `.exarchos.yml` documentation noting the flag (semantics, default, and the audience-scope reasoning from §1.1).
-6. Add a regression test asserting `loadInvariants` returns `[]` with the flag disabled, regardless of `scope`.
+1. **Extend `ProjectConfigSchema` in `servers/exarchos-mcp/src/config/yaml-schema.ts`** to define an `invariants` section. The schema is `.strict()` (rejects unknown keys), so without this step the new key is rejected at full-config validation. Concretely add:
+
+   ```ts
+   const InvariantsConfig = z.object({
+     devCatalog: z.enum(['enabled', 'disabled']).default('disabled'),
+   }).strict();
+
+   // ...inside ProjectConfigSchema:
+   invariants: InvariantsConfig.optional(),
+   ```
+
+2. **Add `'invariants'` to the `SECTION_KEYS` tuple in `servers/exarchos-mcp/src/config/yaml-loader.ts`.** The section-by-section fallback parser (`parseSections`) only walks keys listed in `SECTION_KEYS`; an `invariants` block in `.exarchos.yml` would be silently dropped during fallback parsing without this entry. (Both this step and step 1 must land together — without either, the feature flag never reaches the loader.)
+3. Extend the `ExarchosConfig` / `ProjectConfig` consumer type with the new `invariants?: { devCatalog: 'enabled' | 'disabled' }` field (auto-derived from the Zod schema via `z.infer`).
+4. Extend `loadInvariants` to consult the config; return `[]` when `devCatalog !== 'enabled'`. Signature stays v1-compatible: `(filePath: string, opts?, config = readConfig())` — see §7.4.
+5. Default `disabled` in the loader itself — including inside the Exarchos repo. The repo's own committed `.exarchos.yml` sets the flag to `enabled` so contributors and internal consumers (eval #1442, vocabulary-lint cross-references, etc.) retain access when working inside the repo. External consumers using Exarchos as a plugin in their own repo see no entries unless they explicitly opt in.
+6. **Add `invariants: { devCatalog: enabled }` to the repository's root `.exarchos.yml`** as part of this migration commit. This is the load-bearing step that keeps eval #1442, the `design-invariants` skill, and vocabulary-lint working for contributors. Without this commit-time change, the catalog appears empty even inside the Exarchos repo and internal tooling breaks on the next pull.
+7. Add `.exarchos.yml` documentation noting the flag (semantics, default, and the audience-scope reasoning from §1.1).
+8. Add regression tests:
+   - `yaml-schema.test.ts`: full-schema validation accepts `{ invariants: { devCatalog: 'enabled' } }` and rejects unknown sub-keys.
+   - `yaml-loader.test.ts`: section-fallback parser preserves the `invariants` section when a sibling section is invalid.
+   - `invariants-loader.test.ts`: `loadInvariants(filePath)` returns `[]` with `devCatalog: 'disabled'` regardless of `scope`; same with the key absent (default-disabled).
 
 **Migration risk:** v1 consumers that depended on entries being loaded (notably eval #1442) must explicitly enable. Inside the Exarchos repo this is automatic via the committed `.exarchos.yml`; for external consumers this is intentional friction — the dev catalog should never have been loaded for them in the first place.
 
@@ -560,47 +576,48 @@ INV-9, INV-10, INV-11, INV-13, INV-14, INV-15 per §6. INV-7, INV-8, INV-12 are 
 
 ### 7.4 Loader updates
 
-`servers/exarchos-mcp/src/architecture/invariants-loader.ts`. This is the **complete** loader signature — it merges the §4.0 gating check (must come first) with the §4.1–§4.2 scope filter switch. Do not implement the scope filter without the gating block; the two are a single function:
+`servers/exarchos-mcp/src/architecture/invariants-loader.ts`. This is the **complete** loader signature — it merges the §4.0 gating check (must come first) with the §4.1–§4.2 scope filter switch. Do not implement the scope filter without the gating block; the two are a single function. **Signature preserves v1's `filePath: string` first arg** — the only additions are the widened `Scope` union and the new optional `config` arg, both of which are backwards-compatible (v1 call sites continue to type-check and run):
 
 ```ts
 type Scope = 'core' | 'substrate' | 'authoring' | 'all';
 
 function loadInvariants(
-  doc: InvariantsDoc,
-  opts: { scope?: Scope } = {},
+  filePath: string,
+  opts?: { scope?: Scope },
   config: ExarchosConfig = readConfig()
 ): InvariantEntry[] {
-  // §4.0 catalog gating — applied before any scope filter.
+  // §4.0 catalog gating — applied before any file read or scope filter.
   // Default-disabled even inside the Exarchos repo (see §7.0 step 4
   // for the committed `.exarchos.yml: invariants.devCatalog: enabled`
   // that opts the repo in).
   if (config.invariants?.devCatalog !== 'enabled') {
     return [];
   }
-  const scope = opts.scope ?? 'all';
-  // YAML schema uses kebab-case (`cost-of-load`); the parser
-  // normalizes to camelCase on `InvariantEntry` during load so
-  // filters can use the typed property. If you skip that
-  // normalization, use `e['cost-of-load']` here instead.
+  const scope: Scope = opts?.scope ?? 'all';
+  // ... parse `filePath` with gray-matter into typed `InvariantEntry[]`
+  // (unchanged from v1; the parser normalizes kebab-case YAML keys —
+  // `cost-of-load`, `axis`, `axiom-overlap` — onto the camelCase typed
+  // shape so filters below can use `.costOfLoad`, `.axis`, etc.).
+  const entries: InvariantEntry[] = parseInvariantsFile(filePath);
   switch (scope) {
     case 'core':
       // substrate AND always-load
-      return doc.invariants.filter(
+      return entries.filter(
         (e) => e.axis === 'substrate' && e.costOfLoad === 'always-load'
       );
     case 'substrate':
-      return doc.invariants.filter((e) => e.axis === 'substrate');
+      return entries.filter((e) => e.axis === 'substrate');
     case 'authoring':
-      return doc.invariants.filter((e) => e.axis === 'authoring');
+      return entries.filter((e) => e.axis === 'authoring');
     case 'all':
-      return doc.invariants;
+      return entries;
   }
 }
 ```
 
-Backwards compatibility: `loadInvariants(doc)` (no opts) defaults to `'all'` — same as v1's behavior, so existing call sites continue to work. New call sites pass `{ scope: 'core' }` for `/ideate` Phase 0.
+Backwards compatibility: `loadInvariants(filePath)` (no opts) defaults to `'all'` once the gate is open — same as v1's behavior, so existing call sites continue to work *after* the gate flips on. The signature itself is non-breaking (same first arg, second is still an optional opts object). New call sites pass `{ scope: 'core' }` for `/ideate` Phase 0.
 
-The `loadInvariants(doc, { scope: 'invalid' })` case throws per D4 §5 (loud failure, no silent degradation) — already enforced in v1.5.
+The `loadInvariants(filePath, { scope: 'invalid' })` case throws per D4 §5 (loud failure, no silent degradation) — already enforced in v1.5.
 
 ### 7.5 `/ideate` Phase 0 directive
 

--- a/docs/proposals/2026-05-20-invariants-catalog-v2-spec.md
+++ b/docs/proposals/2026-05-20-invariants-catalog-v2-spec.md
@@ -196,7 +196,7 @@ Rationale for `always-load` on every new entry: each is load-bearing for any non
 
 ### 5.3 Substrate axis — axiom pointers (7)
 
-These are the DIM-1..DIM-7 entries. Each is a short cross-link to the canonical axiom:* skill; the entry exists in the catalog only for vocabulary-lint cross-reference and for documenting overlap with INV-* entries.
+These are the DIM-1..DIM-7 entries. Each is a short cross-link to the canonical `axiom:*` skill; the entry exists in the catalog only for vocabulary-lint cross-reference and for documenting overlap with `INV-*` entries.
 
 | ID | Dimension | cost-of-load | axiom_overlap | Status v1 → v2 |
 |---|---|---|---|---|
@@ -569,6 +569,9 @@ function loadInvariants(
   opts: { scope?: Scope } = {}
 ): InvariantEntry[] {
   const scope = opts.scope ?? 'all';
+  // Note: YAML uses kebab-case (`cost-of-load`); the loader normalizes to
+  // camelCase (`costOfLoad`) on the `InvariantEntry` type during parse.
+  // See `parseInvariantEntry` in invariants-loader.ts for the mapping.
   switch (scope) {
     case 'core':
       // substrate AND always-load

--- a/docs/research/2026-05-20-runtime-invariants-gap-analysis.md
+++ b/docs/research/2026-05-20-runtime-invariants-gap-analysis.md
@@ -1,0 +1,178 @@
+# Runtime Invariants Gap Analysis
+
+> **Workflow:** `workload-agnostic-runtime-invariants` (discovery, Phase B per charter)
+> **Date:** 2026-05-20
+> **Status:** Research deliverable D2 of 5
+> **Parent:** epic #1441 (v2.10.0-preview.4 polish + post-bundle follow-ups)
+> **Charter:** issue #1370 comment 4464273740 — "Primary audit should be against workload-agnosticism"
+
+## 1. Method
+
+Walk `docs/architecture/runtime.md` §2–§8 against the current 18-entry catalog at `docs/architecture/invariants.md` (post-#1455 audit). For every numbered runtime guarantee, every layer (L1–L9), every concurrency-substrate mechanism, every recovery primitive, every cooperation primitive, and every deliberately rejected pattern: does it map to a current catalog entry?
+
+Three verdicts per row:
+
+- **HIT** — covered by an existing entry with congruent framing.
+- **PARTIAL** — covered, but the catalog's wording omits a load-bearing facet that should be sharpened or split.
+- **GAP** — no catalog entry corresponds; propose a new ID.
+
+GAPs are then characterized as **candidate new invariants** for the v2 catalog (D5).
+
+## 2. Walk — §2 runtime guarantees (RT-1..RT-6)
+
+| runtime.md claim | Catalog entry | Verdict | Notes |
+|---|---|---|---|
+| RT-1 — Event log is the source of truth (discipline + reconcile path) | INV-1 event-sourcing-integrity | HIT | INV-1's summary captures "append-only log is source of truth" + "reducers must be pure" cleanly |
+| RT-2 — Total order within a stream (composite PK + OCC retry) | INV-1 | PARTIAL | INV-1 covers "events are authority" but not the *substrate mechanism* (composite PK `(streamId, sequence)`). The mechanism is INV-1's load-bearing dependency and deserves its own entry. **Candidate INV-7 (substrate-serialization).** |
+| RT-3 — Atomic append (`BEGIN IMMEDIATE` wrapping idempotency + sequence + INSERT + outbox INSERT) | INV-1 | PARTIAL | Same as RT-2 — INV-1 names the *invariant* but not the *substrate primitive*. Candidate INV-7. |
+| RT-4 — Single writer per stream (PK rejects duplicate sequences; OCC retry on conflict) | INV-1 | PARTIAL | Candidate INV-7. |
+| RT-5 — Idempotent at-least-once delivery (`UNIQUE INDEX (idempotency_key)`) | (none) | GAP | Idempotency at the storage layer is load-bearing for INV-1 *and* for the process-manager pattern (§4 below). **Candidate INV-8 (idempotency-at-the-boundary).** |
+| RT-6 — Operations atomic against the log (event-first commit point; handlers retry-safe; reducers replay-safe) | INV-1 | HIT | INV-1's "reducers must be deterministic" covers replay-safety; "events are authority" covers event-first commit point |
+
+**§2 takeaway:** INV-1 conflates *event-sourcing-as-design-principle* with *the SQLite/WAL/OCC substrate that enforces it*. Splitting these is the largest catalog-shape change the cross-walk surfaces. RT-2 + RT-3 + RT-4 want a `substrate-serialization` invariant (proposed **INV-7**); RT-5 wants an `idempotency-at-the-boundary` invariant (proposed **INV-8**).
+
+## 3. Walk — §3 layered architecture (L1..L9)
+
+| Layer | runtime.md claim | Catalog entry | Verdict | Notes |
+|---|---|---|---|---|
+| L1 Storage | `bun:sqlite` (WAL); schema tables; storage handle injected via `DispatchContext`; CI gate enforces `Database` import boundary | (none direct) | PARTIAL | INV-1 implicit; the "import-boundary CI gate" facet is uncovered. Probably not catalog-worthy — operational, not architectural. |
+| L2 Event store | `AtomicAppender` interface; cross-stream queries via `eventStore.queryByType`; streams namespaced `<feature-id>/<subagent-id>` | INV-1 | HIT | Namespacing is the load-bearing primitive that lets sub-agents not collide — worth naming explicitly in INV-1 sharpen pass, but not a new entry. |
+| L3 Projections | Reducers over event stream; pure; deterministic; three test types per reducer; snapshots are an optimization | INV-1 | HIT | Solid coverage |
+| L4 Workflow primitives | HSM, capability resolver, phase contract loader, pruner — four pure modules | INV-3 + INV-4 partial | PARTIAL | HSM and pruner are uncovered. **Candidate INV-9 (HSM-as-state-machine).** Phase contract loader → covered by INV-3 (basileus-forward) tangentially. |
+| L5 Dispatch core | Single function: `dispatch(verb, args, ctx) → ToolResult`; parity tests assert byte-equal across CLI/MCP | INV-2 | HIT | Direct |
+| L6 Composite tools | 4 visible; action discriminator; per-action outputSchema + annotations; describe entry returns schema and emission catalog | INV-5d + INV-5a | HIT | Direct |
+| L7 Process lifecycle verbs (v2.12) | `ps`, `describe`, `wait`, `export`; every long-running op emits `<surface>.executing_started` | INV-5c partial | PARTIAL | INV-5c covers Aspire-verb *spirit* but not the *liveness-event protocol* the v2.12 verbs depend on. **Candidate INV-10 (liveness-event-protocol).** |
+| L8 Adapters | Zero behavior; format only; `cli.ts` parses argv + maps exit codes; `mcp.ts` uses `structuredContent`; parity harness verifies | INV-2 | HIT | Direct |
+| L9 Cooperative agents | Declared posture; consume `next_actions`; do not poll; progressive `describe`; self-correct from `_meta.deprecation` + `error.suggestedFix` | INV-5a + INV-5b partial | PARTIAL | Posture and consumption-of-next_actions facets uncovered. **Candidates INV-11 (posture-declared-capabilities), INV-12 (next-actions-as-affordance).** |
+
+**§3 takeaway:** Five new candidates surface. The pattern: existing INV-* entries cover what Exarchos *exposes* to designers, but undercover the substrate *primitives* the runtime is built on — HSM, liveness events, posture, next-actions consumption.
+
+## 4. Walk — §4 concurrency model
+
+| runtime.md claim | Catalog entry | Verdict | Notes |
+|---|---|---|---|
+| Tier 1 — In-process: `AtomicAppender` owns `StreamLockManager` (per-stream Promise-chain mutex) | (none) | GAP | This is the in-process half of substrate-serialization. Folds into **candidate INV-7**. |
+| Tier 2 — Cross-process: `BEGIN IMMEDIATE` + `PRIMARY KEY (streamId, sequence)` | (none) | GAP | Folds into **candidate INV-7**. |
+| OCC retry on PK conflict; `{ ok: false, reason: 'sequence-conflict' }` translation | (none) | GAP | Folds into INV-7. The {ok: false, reason} carrier shape is INV-5b-adjacent but the specific 'sequence-conflict' contract is INV-7. |
+| PID lock removed (#1343 / Wave A) — `initialize()` is idempotent no-op marker | (none) | N/A | Anti-pattern explicitly rejected; not catalog-worthy as a positive invariant. |
+| Process-manager handlers — two-event split `*.requested` / `*.executed`; idempotent precheck on recovery | (none) | GAP | This is the canonical process-manager pattern (Akka *Effect.thenRun*, Wolverine *AggregateHandler*, Greg Young). Zero catalog presence. **Candidate INV-13 (process-manager-two-event-split).** |
+| CI grep gate `scripts/check-withsession-idempotency.sh` enforces contract markers | (none) | N/A | Operational mechanism, not invariant content |
+
+**§4 takeaway:** Two GAPs (INV-7 substrate-serialization, INV-13 process-manager-two-event-split) consume most of §4's content. INV-13 is the single most under-represented invariant — the two-event split is documented in the canonical event-sourcing literature (corpus has 6+ external sources) but appears nowhere in the catalog.
+
+## 5. Walk — §5 recovery model
+
+| runtime.md claim | Catalog entry | Verdict | Notes |
+|---|---|---|---|
+| Crash atomicity (L1) — SQLite txn fully committed or rolled back | INV-1 | HIT (implicit) | Substrate primitive; INV-1's "events are authority" implies the all-or-nothing property |
+| Replay from event log (L3) — `reconcile` rebuilds from event 0; `replay` from snapshot; state files never authoritative | INV-1 | HIT | Direct |
+| Local recovery (L4 handlers) — native primitive first (`git X --abort`); `git reset --keep` second; never `--hard`; `recoveryError` discriminator | (none) | GAP | This is a workload-runtime invariant — applies to every external-mutator handler. **Candidate INV-14 (native-primitive-first-recovery).** |
+| `resume: true` flag + idempotency keys collapsing re-runs | INV-1 partial | PARTIAL | Idempotency facet folds into candidate INV-8 |
+
+**§5 takeaway:** One new candidate (INV-14). The "native primitive first, then `--keep`, never `--hard`" rule is a specific recovery posture that holds across all workloads using external-mutator handlers — git operations today, but conceivable for any tool with a built-in undo (kubectl, terraform, etc.).
+
+## 6. Walk — §6 observability model
+
+| runtime.md claim | Catalog entry | Verdict | Notes |
+|---|---|---|---|
+| Events are the only source of truth | INV-1 | HIT | Direct |
+| Lifecycle events (`workflow.transition`, `task.assigned`, `gate.executed`, `merge.*`) | (none direct) | PARTIAL | Catalog doesn't name the lifecycle-event surface as a contract. Could fold into candidate INV-10 (liveness-event-protocol). |
+| Liveness signals (`<surface>.executing_started`) | (none) | GAP | Folds into candidate INV-10. |
+| Telemetry events (`dispatch.preflight`, deprecation invocations) | DIM-2 (axiom-owned) | HIT | DIM-2 observability covers the silent-catch and degradation-path concerns |
+| Three-way inspection: `exarchos_event query` / `next_actions` envelope / CLI `ps describe wait` | INV-5b + candidate INV-12 | PARTIAL | The "three views over the same event stream" architectural claim is implicit in INV-5b but not stated as an invariant. |
+
+**§6 takeaway:** §6 mostly folds into candidates INV-10 (liveness) and INV-12 (next-actions affordance). No new candidates beyond those.
+
+## 7. Walk — §7 agent cooperation model
+
+| runtime.md claim | Catalog entry | Verdict | Notes |
+|---|---|---|---|
+| Posture declaration — every agent declares `read-only \| task-isolated \| shared-mutating`; unrepresentable-by-construction | (none) | GAP | **Candidate INV-11 (posture-declared-capabilities).** Mark Miller *Robust Composition* (Agoric 2006) + Paradigm Lost (SRL 2003) ground this directly — capability-based security with POLA. |
+| Handshake-authoritative capabilities — MCP `initialize` handshake declares runtime half; mismatches resolve to handshake; `runtimes/<name>.yaml` capability fields not read at runtime | INV-3 partial | PARTIAL | INV-3 (basileus-forward) covers "handshake-authoritative" for the remote-MCP angle but not for the local cooperation primitive. Folds into **candidate INV-11**. |
+| Next-actions consumption — agents read `next_actions` from envelopes; do not poll; autonomy is property of state + topology | INV-5b partial | PARTIAL | INV-5b covers `next_actions` as carrier; this covers `next_actions` as autonomy driver. **Candidate INV-12 (next-actions-as-affordance).** Norman/Gibson affordance theory grounds this. |
+
+**§7 takeaway:** Two strong candidates with external research backing — INV-11 (posture, capability-security literature) and INV-12 (next-actions, affordance theory).
+
+## 8. Walk — §8 deliberate non-patterns
+
+Each rejected pattern is itself an invariant ("Exarchos does not do X"). The catalog has zero entries for any of these — but the rejections are load-bearing for designers who might otherwise import the rejected pattern.
+
+| Rejected pattern | runtime.md rationale | Catalog entry | Candidate? |
+|---|---|---|---|
+| Saga (multi-step distributed transaction + cross-service compensation) | One repo, one event store, one state dir. Compensation is local rewind, not remote commands. | (none) | YES — fold into **candidate INV-15 (single-machine-frame)** |
+| Scheduler-Agent-Supervisor (Microsoft) | Supervisor role addresses distributed liveness. v2.12 lifecycle verbs handle this generically. | (none) | YES — fold into INV-15 |
+| 2PC / leader election / vector clocks / BFT consensus | Single machine. None of the problems these solve exist. | (none) | YES — fold into INV-15 |
+| Active polling / heartbeat infrastructure | Agents consume `next_actions`; runtime doesn't poll agents. Liveness is event-emitted. | (none) | YES — fold into candidate INV-12 (next-actions-as-affordance) |
+| Workflow engine in agent runtime (Temporal-style worker loops) | Exarchos delegates execution to host runtime (Claude Code, Codex). Basileus is autonomous tier. | INV-3 partial | PARTIAL — covered by INV-3 framing but not stated as a non-pattern |
+| Distributed locks / mutex services | OCC + SQLite WAL lock cover all serialization needs. | (none) | YES — fold into candidate INV-7 (substrate-serialization) |
+
+**§8 takeaway:** One new umbrella candidate — **INV-15 (single-machine-frame)** — captures the "this is a concurrent system, not a distributed one" framing that runtime.md §1 leads with. Three rejections fold into it (saga, SAS, 2PC). The other three fold into existing candidates (INV-7, INV-12) or existing entries (INV-3).
+
+## 9. Existing catalog entries — verdict per entry
+
+For completeness: every current entry's status after the cross-walk.
+
+| ID | Verdict | Action in v2 |
+|---|---|---|
+| INV-1 event-sourcing-integrity | HIT but overloaded | **Split:** sharpen INV-1 to "events as design authority + reducer purity"; split off INV-7 (substrate-serialization), INV-8 (idempotency-at-the-boundary) |
+| INV-2 facade-equivalence | HIT | Keep |
+| INV-3 basileus-forward | HIT | Keep |
+| INV-4 platform-agnosticity | HIT | Keep. Sharpen scope to "platform" axis only; let INV-6 own "workload" axis |
+| INV-5a input-ergonomics | HIT | Keep |
+| INV-5b output-contract | HIT | Keep. Split off INV-12 (next-actions-as-affordance) since 5b is about carrier shape and 12 is about consumption semantics |
+| INV-5c aspire-verbs | HIT | Keep |
+| INV-5d action-discriminator | HIT | Keep |
+| INV-6 workflow-agnosticism | PARTIAL — currently scoped to skill-body grep | **Sharpen:** elevate to the primary workload-agnosticism statement. The grep-test stays as the operational projection; the *invariant* is broader — "the runtime makes no assumption about which workload is executing." |
+| DIM-1..DIM-7 | HIT (axiom-owned, cross-link entries) | Keep. Tag with `axis: substrate`. |
+| DIM-8 prose-quality | HIT (archivable) | Keep. Tag with `axis: authoring`. Only authoring-tagged entry. |
+| basileus-boundary | HIT (forward-looking) | Keep |
+
+## 10. Candidate new invariants — summary list
+
+Eight candidates surface. IDs are provisional pending D5 (v2 catalog spec):
+
+| Provisional ID | Name | Source §§ | Research backing |
+|---|---|---|---|
+| INV-7 | substrate-serialization | §2 (RT-2/3/4), §4 Tier 1/2, §8 distributed-locks rejection | Mohan ARIES 1992 (WAL); Bernstein & Goodman 1981 (OCC); SQLite WAL docs |
+| INV-8 | idempotency-at-the-boundary | §2 (RT-5), §4 process-manager idempotent precheck, §5 resume + collapse | Wolverine PR #1858 (idempotency); Akka persistence (at-least-once); Greg Young versioning |
+| INV-9 | HSM-as-state-machine | §3 L4 | (light — mostly internal; HSM literature: Harel statecharts 1987 if needed) |
+| INV-10 | liveness-event-protocol | §3 L7, §6 liveness signals | Conductor durable-execution; AWP runtime liveness |
+| INV-11 | posture-declared-capabilities | §3 L9, §7 posture + handshake | **Strong:** Miller *Robust Composition* 2006; Paradigm Lost SRL 2003; POLA; anip-protocol SPEC posture/handshake convergence |
+| INV-12 | next-actions-as-affordance | §3 L9, §7 next-actions consumption, §8 polling rejection | Norman 1999; Gibson 1979; HCI affordance literature |
+| INV-13 | process-manager-two-event-split | §4 process-manager handlers | **Strong:** Akka *Effect.thenRun*; Wolverine *AggregateHandler*; Greg Young; Vaughn Vernon DDD |
+| INV-14 | native-primitive-first-recovery | §5 local recovery (L4 handlers) | (light external — mostly Exarchos-specific; `git --abort` semantics; ARIES CLR concept tangentially) |
+| INV-15 | single-machine-frame | §1 framing, §8 rejections (saga, SAS, 2PC) | **Strong:** Microsoft SAS pattern doc (negative reference); Saga pattern doc; ARIES single-machine WAL |
+
+That's nine, not eight — INV-7 and INV-15 are siblings but distinct (substrate primitive vs framing statement). The final v2 entry list (D5) may merge some after the workload-agnosticism stress test (D3).
+
+## 11. Coverage check
+
+Per charter acceptance criterion: "≥3 external citations per candidate invariant."
+
+| Candidate | Citation count | Pass? |
+|---|---|---|
+| INV-7 substrate-serialization | ARIES (3 URLs), Bernstein/Goodman (4 URLs), SQLite docs | ≥7 — PASS |
+| INV-8 idempotency-at-the-boundary | Wolverine PR #1858, Akka persistence, Greg Young versioning | 3 — PASS |
+| INV-9 HSM-as-state-machine | Light — internal only | **FAIL — need backfill** |
+| INV-10 liveness-event-protocol | Conductor, AWP, internal RT-2.12 | 3 — PASS (thin) |
+| INV-11 posture-declared-capabilities | Miller 2006, Paradigm Lost 2003, POLA wiki, erights.org, anip-protocol | ≥5 — PASS |
+| INV-12 next-actions-as-affordance | Norman 1999, jnd.org, ACM Interactions, HCI glossary, Graphics Interface 2000 | ≥5 — PASS |
+| INV-13 process-manager-two-event-split | Akka (2 URLs), Wolverine (3 URLs), Greg Young (2 URLs) | ≥7 — PASS |
+| INV-14 native-primitive-first-recovery | Light — git docs only | **FAIL — need backfill or drop** |
+| INV-15 single-machine-frame | Microsoft SAS, Saga doc, Clemens Vasters origin blog, Azure saga alternatives | 4 — PASS |
+
+**Two failures to address in D1 (survey):** INV-9 and INV-14 are under-cited. Either backfill external literature or downgrade to operational-pattern (catalog-internal only) status. Likely action: INV-9 backfills with Harel statecharts; INV-14 either drops to operational-pattern or gets the "ARIES Compensation Log Records semantics as the abstract analog" treatment.
+
+## 12. Workload-agnosticism preview
+
+Anticipating D3 (stress test): the cross-walk surfaces a strong-and-quiet pattern — every candidate (INV-7 through INV-15) is workload-agnostic by construction because none of them name `feature` / `oneshot` / `debug` / `refactor` / `discovery` or any SDLC-specific term. They name runtime primitives (events, streams, sequences, postures, locks, recovery). This is the *positive case* for workload-agnosticism: if the candidate list survives unchanged through D3, it confirms the catalog's framing is workload-correct.
+
+The *risk*: existing INV-6 is currently scoped to "skill-body grep" as the operational projection. If D3 promotes INV-6 to the primary workload-agnosticism statement, the operational grep becomes one of several enforcement tools, not the rule itself. D3 will rule on this.
+
+## 13. References
+
+- Primary: [`docs/architecture/runtime.md`](../architecture/runtime.md)
+- Source-of-truth catalog (v1): [`docs/architecture/invariants.md`](../architecture/invariants.md)
+- Charter trigger: issue [#1370](https://github.com/lvlup-sw/exarchos/issues/1370) comment [4464273740](https://github.com/lvlup-sw/exarchos/issues/1370#issuecomment-4464273740)
+- Audit predecessor: [`docs/research/2026-05-18-invariant-content-audit.md`](2026-05-18-invariant-content-audit.md)
+- External-corpus details: [`docs/research/2026-05-20-runtime-invariants-research-survey.md`](2026-05-20-runtime-invariants-research-survey.md) (D1, next)

--- a/docs/research/2026-05-20-runtime-invariants-gap-analysis.md
+++ b/docs/research/2026-05-20-runtime-invariants-gap-analysis.md
@@ -129,7 +129,7 @@ For completeness: every current entry's status after the cross-walk.
 
 ## 10. Candidate new invariants — summary list
 
-Nine candidates surface (INV-7 through INV-15). IDs are provisional pending D5 (v2 catalog spec):
+Nine candidates surface (`INV-7` through `INV-15`). IDs are provisional pending D5 (v2 catalog spec):
 
 | Provisional ID | Name | Source §§ | Research backing |
 |---|---|---|---|

--- a/docs/research/2026-05-20-runtime-invariants-gap-analysis.md
+++ b/docs/research/2026-05-20-runtime-invariants-gap-analysis.md
@@ -129,7 +129,7 @@ For completeness: every current entry's status after the cross-walk.
 
 ## 10. Candidate new invariants — summary list
 
-Eight candidates surface. IDs are provisional pending D5 (v2 catalog spec):
+Nine candidates surface (INV-7 through INV-15). IDs are provisional pending D5 (v2 catalog spec):
 
 | Provisional ID | Name | Source §§ | Research backing |
 |---|---|---|---|

--- a/docs/research/2026-05-20-runtime-invariants-research-survey.md
+++ b/docs/research/2026-05-20-runtime-invariants-research-survey.md
@@ -1,0 +1,236 @@
+# Runtime Invariants Research Survey
+
+> **Workflow:** `workload-agnostic-runtime-invariants` (discovery, Phase A per charter)
+> **Date:** 2026-05-20
+> **Status:** Research deliverable D1 of 5
+> **Parent:** epic #1441
+> **Companion:** [`docs/research/2026-05-20-runtime-invariants-gap-analysis.md`](2026-05-20-runtime-invariants-gap-analysis.md) (D2)
+
+## 1. Purpose
+
+External research corpus for the v2 invariant catalog. Every candidate invariant from D2 must have ≥3 external citations per the charter acceptance criterion. This document organizes the corpus by research question (RQ-1..RQ-6) and maps each source to the candidate invariant it grounds.
+
+The catalog's v1 incarnation has zero external citations — all `references:` fields point to internal `.claude/skills/design-invariants/references/INV-*.md` files or other Exarchos files. This is fine for the *operational projection* (the skill body), but wrong for the *source of truth* the catalog claims to be. D5 (v2 spec) will require citations alongside internal references.
+
+## 2. RQ-1 — Workload-agnostic runtime design
+
+**Formal definition target:** A runtime is *workload-agnostic* if its substrate guarantees hold independently of which workload type executes over it. Contrast with *workload-aware*, which exposes workload-shape hints to the substrate for optimization.
+
+### Sources
+
+**[S1] Agent Workflow Protocol — `runtime.md`**
+URL: https://github.com/veegee82/agent-workflow-protocol/blob/main/docs/runtime.md
+The AWP project's `runtime.md` explicitly separates protocol (normative) from runtime (pluggable): *"AWP is intentionally runtime-agnostic. The protocol (YAML manifests, agent contracts, validation rules) is normative; the runtime that executes a workflow is pluggable."* Direct precedent for Exarchos's platform + workload separation. Lists four responsibilities every runtime must have: parse/validate, resolve providers, execute orchestration, enforce output contract — a useful skeleton to compare against runtime.md §3's L1–L9 layering.
+**Grounds:** INV-6 sharpening (workload-agnosticism as primary statement, not skill-grep operational), INV-4 (platform half).
+
+**[S2] Conductor — durable-execution overview**
+URL: https://conductor-oss.github.io/conductor/devguide/concepts/conductor.html
+Counterexample. Conductor is a "durable execution engine" but bakes workflow concepts in — workers poll for tasks, retries are configured at workflow definition time, language polyglot is a first-class concern. Useful negative reference: workload-agnostic ≠ "any code runs anywhere"; it means the runtime *makes no shape assumption* while the workload *declares* its shape through topology. Conductor's strength (retry policies as first-class) is also its workload-shape coupling.
+**Grounds:** Negative reference for D5 §scope; helps disambiguate "agnostic" from "polyglot."
+
+**[S3] NVIDIA Dynamo — agentic workloads doc**
+URL: https://github.com/ai-dynamo/dynamo/blob/main/docs/features/agentic_workloads.md
+Dynamo uses *"workload-agnostic scheduling"* as a term to **reject** in favor of *"workload-aware inference."* The argument: agents have predictable structure; the runtime can leverage that for KV-cache prefetching, eviction, and scheduling. Useful disambiguation for Exarchos's framing — Exarchos is workload-agnostic at the **runtime guarantee** layer (RT-1..RT-6 hold regardless of workflow type) while being workload-*aware* at the **topology layer** (each workflow-type's `topology.yaml` declares its HSM and gates). This split should be made explicit in D5.
+**Grounds:** D5 §framing — the "agnostic at substrate, aware at topology" pattern.
+
+**[S4] Harn workflow runtime docs**
+URL: https://harnlang.com/workflow-runtime.html
+*"Harn's workflow runtime is the layer above raw llm_call() and agent_loop(). It gives host applications a typed, inspectable, replayable orchestration boundary instead of pushing orchestration logic into app code."* Independent design landing on similar primitives: typed orchestration boundary, replay, artifact provenance. Direct architectural parallel to Exarchos's L5 (dispatch core) over L3 (projections) over L2 (event store).
+**Grounds:** Convergence evidence for INV-1 + INV-2.
+
+**[S5] Novita Agent Runtime announcement**
+URL: https://blogs.novita.ai/novita-agent-runtime-agentcore-compatible/
+*"Framework agnostic. Novita Agent Runtime works with LangGraph, Microsoft AutoGen, Google ADK, OpenAI Agents SDK, CrewAI, and custom implementations."* Demonstrates that "framework-agnostic" + "model-agnostic" are recognized industry-level decoupling axes — Exarchos's "workload-agnostic" adds a third axis (workflow-type-agnostic) that the others don't name. Worth surfacing in D5 as a *strengthening* of the agnosticism family.
+**Grounds:** D5 §framing — positioning Exarchos's agnosticism axes.
+
+## 3. RQ-2 — Process-manager pattern
+
+**Pattern target:** Non-idempotent external side effects split into `*.requested` → `*.executed` event pairs with idempotent precheck on recovery.
+
+### Sources
+
+**[S6] Akka Persistence — Effect / thenRun docs**
+URL: https://doc.akka.io/api/akka-core/current/akka/persistence/typed/scaladsl/Effect$.html
+URL: https://doc.akka.io/docs/akka/snapshot/typed/persistence.html
+Canonical formulation: *"The event handler must only update the state and never perform side effects, as those would also be executed during recovery of the persistent actor. Side effects should be performed in `thenRun` from the command handler after persisting the event or from the `RecoveryCompleted` after Recovery."* This is the architectural rule Exarchos's two-event split implements — the `*.requested` event captures intent (state update), the side effect runs *after* persistence, and the `*.executed` event captures outcome. The Akka docs also warn: *"Side effects are not run when the actor is restarted or started again after being stopped"* — which is exactly why Exarchos needs the recovery-precheck step on resume.
+**Grounds:** INV-13 (process-manager-two-event-split), INV-8 (idempotency-at-the-boundary).
+
+**[S7] Wolverine — Aggregate Handler Workflow blog (Jeremy Miller)**
+URL: https://jeremydmiller.com/2023/12/06/building-a-critter-stack-application-wolverines-aggregate-handler-workflow-ftw/
+Wolverine's `[AggregateHandler]` attribute is the .NET sibling pattern: the handler is a pure function over `(command, current_aggregate_state) → (events, outgoing_messages)`. The middleware around it does OCC-protected event append (Marten's `FetchForWriting`) and outbox publish. Optimistic concurrency is **default**: *"The Wolverine aggregate handler workflow triggered by the `[AggregateHandler]` usage up above happily builds in optimistic concurrency protection such that an attempt to save the pending transaction will throw an exception if something else has modified that Incident between the command starting and the call to persist all changes."*
+**Grounds:** INV-7 (substrate-serialization — OCC default), INV-13.
+
+**[S8] Wolverine PR #1858 — idempotency protections**
+URL: https://github.com/JasperFx/wolverine/pull/1858
+2025-11 PR adding *"improved option for enforcing message idempotency on non-transactional handlers."* Key concept: `Envelope.IsPersisted` property tracked in inbox implementations; configurable on a chain-by-chain basis; supports inline and buffered idempotency checks. Direct analog to Exarchos's idempotency-key carrier and the `withSession({operationId})` contract.
+**Grounds:** INV-8 (idempotency-at-the-boundary).
+
+**[S9] Wolverine retry-on-errors blog (Jeremy Miller)**
+URL: https://jeremydmiller.com/2025/01/29/retry-on-errors-in-wolverine/
+*"Wolverine can still use any 'Retry' or 'Discard' error handling policies, and if Wolverine does a retry, it effectively starts from a completely clean slate so you don't have to worry about any dirty state from scoped services used by the initial failed attempt to process the message."* The "clean slate on retry" property is exactly what Exarchos's `withSession` provides via `appendComputed(idempotencyKey: operationId)` — the retry doesn't pollute state because the `*.requested` event idempotency-collapses.
+**Grounds:** INV-8, INV-13.
+
+**[S10] Greg Young — "Why Event Sourced Systems Fail" talk (Fwdays 2020)**
+URL: https://www.youtube.com/watch?v=FKFu78ZEIi8
+URL: https://www.slideshare.net/slideshow/greg-young-why-event-sourced-systems-fail/239067872
+Canonical talk listing the most common failure modes for event-sourced systems. The two most relevant to Exarchos: (1) versioning over time — events written years ago must remain readable; (2) eventual consistency myths — "include version in query" pattern collapses most eventual-consistency complaints. The talk's broader message is conservative: *most* event-sourcing failures come from teams treating projections as authoritative rather than as caches over the log. Direct grounding for INV-1.
+**Grounds:** INV-1 (event-sourcing-integrity).
+
+**[S11] Greg Young — *Versioning in an Event Sourced System* (Leanpub)**
+URL: https://leanpub.com/esversioning
+Book-length treatment. Chapter on "Versioning Process Managers" is directly relevant — process managers (Exarchos's term: HSM/workflow handlers) need their own versioning strategy because their intermediate state crosses event-version boundaries. Strategies named: "Upcasting State," "Take Over," with warning that mid-flight process managers are a versioning hazard.
+**Grounds:** INV-9 (HSM-as-state-machine), INV-13.
+
+**[S12] Greg Young — "Event Sourcing: The Bad Parts" (CodeCrafts 2022)**
+URL: https://www.youtube.com/watch?v=K4bj31fJGFk
+Companion talk: the explicitly-negative case. Useful for D5's "what Exarchos chooses to *not* solve" framing — Greg Young's catalog of bad parts overlaps significantly with runtime.md §8's rejected patterns (saga, in-runtime workflow engine).
+**Grounds:** INV-15 (single-machine-frame) negative reference.
+
+## 4. RQ-3 — Event-sourcing substrate
+
+**Substrate target:** Write-ahead logging, total order via composite PK, atomic transaction, idempotency at the storage layer.
+
+### Sources
+
+**[S13] Mohan et al., *ARIES* (ACM TODS 1992)**
+URL: https://dl.acm.org/doi/10.1145/128765.128770
+URL: https://cs.stanford.edu/people/chrismre/cs345/rl/aries.pdf
+URL: https://people.eecs.berkeley.edu/~brewer/cs262/Aries.pdf
+URL: https://web.eecs.umich.edu/~prabal/teaching/resources/eecs582/mohan92aries.pdf
+The canonical paper on transaction recovery using write-ahead logging. Key concepts that map directly to Exarchos's substrate: **WAL protocol** ("log records representing changes to data must be written to stable storage before the data is allowed to replace the previous version") — this is the rule SQLite WAL enforces; **LSN per page** (log sequence number) ≈ Exarchos's `(streamId, sequence)` composite PK; **paradigm of repeating history** (redo all updates before rolling back losers) ≈ Exarchos's `reconcile` operation. ARIES is the theoretical grounding for *why* SQLite WAL is a sufficient substrate for Exarchos's RT-1..RT-6 guarantees.
+**Grounds:** INV-7 (substrate-serialization), INV-1 (event-sourcing-integrity), INV-15 (single-machine-frame — ARIES is a single-machine recovery algorithm).
+
+**[S14] Bernstein & Goodman, *Concurrency Control in Distributed Database Systems* (ACM Computing Surveys 1981)**
+URL: https://dl.acm.org/doi/10.1145/356842.356846
+URL: https://people.eecs.berkeley.edu/~brewer/cs262/concurrency-distributed-databases.pdf
+URL: https://apps.dtic.mil/sti/tr/pdf/ADA087996.pdf
+The survey that established the decomposition of concurrency control into read-write and write-write synchronization, then into "two basic techniques: two-phase locking and timestamp ordering." Exarchos's choice is **neither** — it uses OCC (optimistic concurrency control via `(streamId, sequence)` PK conflict detection). The companion citation in the survey is Kung & Robinson's "On Optimistic Methods for Concurrency Control" (ACM TODS 1981) which formalized OCC. Bernstein/Goodman positions OCC as the third method *not* surveyed — Exarchos's substrate descends from that line.
+**Grounds:** INV-7 (substrate-serialization — OCC primitive).
+
+**[S15] Mark Miller, *Robust Composition: Towards a Unified Approach to Access Control and Concurrency Control* (PhD dissertation, JHU 2006)**
+URL: https://papers.agoric.com/papers/robust-composition/full-text
+URL: https://papers.agoric.com/assets/pdf/papers/robust-composition.pdf
+URL: https://jscholarship.library.jhu.edu/items/b8376e55-208e-4fcc-81a2-ad5a7de0acbb
+While primarily a capability-security paper (covered under RQ-4), Miller treats access control *and* concurrency control as the same problem — both are about *bounding what an unanalyzed component can do*. The dissertation introduces "vats" as persistent process-like units; intra-vat messages are sequential, inter-vat is via the Pluribus protocol with cryptographic capabilities. This framing is relevant to RQ-3 because it provides a *unified* substrate model — Exarchos's two-tier serialization (in-process Promise-chain + cross-process WAL PK) is a less-general instance of the vat model.
+**Grounds:** INV-7, INV-11 (cross-cite from RQ-4).
+
+## 5. RQ-4 — Capability-based security and posture
+
+**Posture target:** Agent declares `read-only | task-isolated | shared-mutating`; capability resolver merges with handshake-declared runtime capabilities; mismatches resolve to handshake (handshake-authoritative).
+
+### Sources
+
+**[S16] Mark Miller, *Robust Composition* (2006)** *(re-cited from S15)*
+The capability model is the architectural ancestor of Exarchos's posture system. The dissertation establishes: **All Authority Accessed Only by References** — "the authority an object has to affect or be affected the world outside of itself should be exactly represented by the references it holds." Exarchos's `task-isolated` posture is a direct instance: a sub-agent's "references" (worktree path, event-store namespace) literally cannot reach outside its scope, so it has no authority to mutate sibling worktrees. The `shared-mutating` posture is the rights-amplified case — the agent receives the references that let it cross into shared state.
+**Grounds:** INV-11 (posture-declared-capabilities).
+
+**[S17] Miller et al., *Paradigm Lost: Abstraction Mechanisms for Access Control* (JHU SRL 2003)**
+URL: https://srl.cs.jhu.edu/pubs/SRL2003-03.pdf
+Develops the **Principle of Least Authority (POLA)** as a stronger form of POLP (least privilege): *"The principle is to give programs (or any active agent) the minimum authority which is sufficient for them to perform their intended (by the invoker) task."* The paper draws a crucial distinction: *"Permission is relative to a frame of reference. Authority is invariant."* Exarchos's posture declaration is *authority*-shaped, not *permission*-shaped — a `task-isolated` posture states what the agent *can do*, regardless of frame.
+**Grounds:** INV-11.
+
+**[S18] erights.org — *From Objects to Capabilities***
+URL: http://erights.org/elib/capability/ode/ode-capabilities.html
+The original capability model formulation: *"For each process, there is a table associating small numbers (similar in spirit to Unix file descriptors) with the capabilities held by that process. These small numbers serve the same function as variable names do in the lambda calculus."* The lineage: KeyKOS (Hardy 1985), EROS (Shapiro 1999), Dennis & van Horn 1966. Useful for D5 §References when citing capability-based security history.
+**Grounds:** INV-11.
+
+**[S19] erights.org — *Capabilities As A Cryptographic Protocol***
+URL: http://erights.org/elib/capability/ode/ode-protocol.html
+Describes the Pluribus protocol's handshake: vat-to-vat connection establishes via SSL-style key agreement, then capability references are exchanged over the authenticated channel. Direct architectural parallel to MCP's `initialize` handshake — Exarchos's "handshake-authoritative" rule is the same shape: *the capability set declared at handshake-time is authoritative for the session.*
+**Grounds:** INV-11 (handshake-authoritative half).
+
+**[S20] erights.org — POLA wiki**
+URL: http://wiki.erights.org/wiki/POLA
+*"We intentionally use the name POLA instead of the usual POLP because the second name is distracting. It is not enough to focus on permissions of the subject. We must consider its authority."* Short pointer; cite alongside S17.
+**Grounds:** INV-11.
+
+**[S21] anip-protocol — SPEC.md**
+URL: https://github.com/anip-protocol/anip/blob/main/SPEC.md
+**Convergent independent design.** Uses both `posture` and `handshake` in a capability-token-DAG context. From the SPEC: *"posture (OPTIONAL, v0.7) — governance posture summary. Exposes trust-relevant service characteristics that agents can inspect before invocation"* and *"The handshake is the first substantive interaction. The agent declares what profiles it needs; the service responds with whether it can satisfy them. Tasks declare their own profile requirements — matching happens before any capability is invoked."* Two-vocabulary convergence between Exarchos and an unrelated protocol is **strong evidence** that the posture/handshake pattern is the load-bearing primitive for agent runtimes, not Exarchos-idiosyncratic.
+**Grounds:** INV-11 — strongest single citation.
+
+## 6. RQ-5 — Affordance theory
+
+**Affordance target:** `next_actions` envelope hints make valid runtime transitions *perceptible* to agents; agents read affordances rather than poll. Autonomy is a property of state + topology, not handler-internal logic.
+
+### Sources
+
+**[S22] Norman, *Affordance, Conventions, and Design* (ACM Interactions 1999)**
+URL: https://interactions.acm.org/archive/view/may-june-1999/affordance-conventions-and-design1
+URL: https://www.lri.fr/~mbl/ENS/DEA-IHM/papers/Norman-Affordances.pdf
+Norman's mid-career clarification of the term. *"The word affordance was coined by the perceptual psychologist J. J. Gibson to refer to the actionable properties between the world and an actor (a person or animal). To Gibson, affordances are relationships. They exist naturally: they do not have to be visible, known, or desirable."* The Norman-vs-Gibson distinction is critical for Exarchos: **`next_actions` are *perceived* affordances (Norman) — they make the *real* affordances (Gibson — the set of verbs the HSM/projection actually permit) visible to the agent.** A misaligned `next_actions` envelope is a usability failure (the perceived affordance doesn't match the real one); a missing one is a discoverability failure (the real affordance exists but isn't perceptible).
+**Grounds:** INV-12 (next-actions-as-affordance).
+
+**[S23] Norman — *Affordances and Design* (jnd.org)**
+URL: https://jnd.org/affordances-and-design/
+Personal website essay restating the distinction. *"In product design, where one deals with real, physical objects, there can be both real and perceived affordances, and the two need not be the same. In graphical, screen-based interfaces, all that the designer has available is control over perceived affordances."* For Exarchos: the runtime controls the *real* affordances (HSM topology + projection state); the *perceived* affordances are the `next_actions` envelope. The runtime engineer's job is to make these match.
+**Grounds:** INV-12.
+
+**[S24] Interaction Design Foundation — Affordances glossary**
+URL: https://interaction-design.org/literature/book/the-glossary-of-human-computer-interaction/affordances
+Distills the Gibson/Norman distinction crisply: *"We both design for usefulness by creating affordances (the possibilities for action in the design) that match the goals of the user (the relativity of the affordance vis-à-vis the user) and we improve the usability by designing the information that specifies the affordances (perceptual information as shadows on buttons to afford clickability etc.)."* The "perceptual information that specifies the affordance" is `next_actions` — the runtime makes the action set perceivable to the agent.
+**Grounds:** INV-12.
+
+**[S25] McGrenere & Ho, *Affordances: Clarifying and Evolving a Concept* (Graphics Interface 2000)**
+URL: https://graphicsinterface.org/wp-content/uploads/gi2000-24.pdf
+Academic disambiguation paper. Key contribution for Exarchos: *"In general, an underlying affordance or function can still exist regardless of correct interpretation or even perception by the user."* This is the formal statement of the invariant: **the existence of the affordance does not depend on the agent perceiving it.** Removing a verb from `next_actions` does *not* remove the affordance — it removes the agent's path to invoking it. INV-12 should state this precisely: `next_actions` is the *publication* mechanism for affordances; the topology + projection are the *source*.
+**Grounds:** INV-12.
+
+## 7. RQ-6 — Deliberate non-patterns
+
+**Negative-reference target:** runtime.md §8 names six rejected patterns. Each rejection is itself an invariant ("Exarchos does not do X").
+
+### Sources
+
+**[S26] Microsoft Azure Architecture Center — Scheduler Agent Supervisor pattern**
+URL: https://learn.microsoft.com/en-us/azure/architecture/patterns/scheduler-agent-supervisor
+The canonical reference. SAS exists *because* distributed systems lack a globally-consistent state store and lack reliable communication between coordinator and workers. The pattern's Supervisor role re-runs failed steps, maintaining retry counts in state, with escalation to Compensating Transaction (saga). Exarchos rejects SAS because the local substrate (SQLite WAL + OCC) eliminates the distributed-failure-mode that motivates SAS in the first place.
+**Grounds:** INV-15 (single-machine-frame), INV-10 (liveness-event-protocol — v2.12 verbs do generically what Supervisor does specifically).
+
+**[S27] Clemens Vasters — *Cloud Architecture: The Scheduler-Agent-Supervisor Pattern* (2010)**
+URL: https://learn.microsoft.com/en-us/archive/blogs/clemensv/cloud-architecture-the-scheduler-agent-supervisor-pattern
+The origin blog. *"We need to do a set of coordinated action across a distributed set of resources – a distributed transaction or saga of sorts."* Crystal-clear statement of the problem SAS solves and the assumption it makes (distributed resources, transient communication failures). Exarchos's framing — *"It is a concurrent system, not a distributed one"* — explicitly rejects this assumption. Strong negative reference.
+**Grounds:** INV-15.
+
+**[S28] Microsoft Azure Architecture Center — Saga design pattern**
+URL: https://learn.microsoft.com/en-us/azure/architecture/patterns/saga
+*"A saga is a sequence of local transactions where each service updates its data and initiates the next step through events or messages. If a step fails, the saga performs compensating transactions to undo completed steps."* Two consequences directly grounded in distributed-systems pain: *"Compensating transactions might not always succeed, which can leave the system in an inconsistent state"* and *"Adopting the Saga pattern requires a different mindset."* Exarchos rejects saga because compensation is **local rewind** (replay over the event log), not **remote command dispatch** (saga choreography or orchestration).
+**Grounds:** INV-15.
+
+**[S29] Azure-Samples/saga-orchestration-serverless — alternatives-and-considerations.md**
+URL: https://github.com/Azure-Samples/saga-orchestration-serverless/blob/main/docs/architecture/alternatives-and-considerations.md
+Useful for the *positive* characterization of when saga *is* the right pattern (multi-service, distributed data stores, no central state authority). Helps D5 articulate the boundary: Exarchos can choose differently because it has the central state authority (the event store) saga assumes is absent.
+**Grounds:** INV-15.
+
+## 8. Citation coverage — final per-candidate audit
+
+| Candidate | Citations | Threshold met? |
+|---|---|---|
+| INV-7 substrate-serialization | S13 (ARIES, 4 URLs), S14 (Bernstein/Goodman, 3 URLs), S15 (Miller cross-cite) | ≥7 — PASS |
+| INV-8 idempotency-at-the-boundary | S6 (Akka), S8 (Wolverine #1858), S9 (Wolverine retry) | 3 — PASS |
+| INV-9 HSM-as-state-machine | S11 (Greg Young versioning ch.) — **still under-cited** | 1 — **FAIL** |
+| INV-10 liveness-event-protocol | S2 (Conductor), S1 (AWP), S26 (Microsoft SAS — as substitutable concern) | 3 — PASS (thin) |
+| INV-11 posture-declared-capabilities | S15/S16 (Miller), S17 (Paradigm Lost), S18–S20 (erights.org), S21 (anip-protocol) | ≥6 — PASS |
+| INV-12 next-actions-as-affordance | S22 (Norman 1999), S23 (Norman jnd.org), S24 (HCI glossary), S25 (McGrenere/Ho 2000) | 4 — PASS |
+| INV-13 process-manager-two-event-split | S6 (Akka), S7 (Wolverine AggregateHandler), S8 (Wolverine PR), S10/S11 (Greg Young) | ≥5 — PASS |
+| INV-14 native-primitive-first-recovery | (no external citations) | 0 — **FAIL** |
+| INV-15 single-machine-frame | S26, S27, S28, S29 (Microsoft SAS + saga, Vasters origin) | 4 — PASS |
+
+**Two persistent failures to address in D5:**
+
+- **INV-9 (HSM-as-state-machine):** needs Harel statecharts citation. Harel 1987 *"Statecharts: A Visual Formalism for Complex Systems"* is the canonical reference. Easy backfill in D5 §References.
+- **INV-14 (native-primitive-first-recovery):** zero external grounding. Options: (a) backfill with ARIES Compensation Log Records (S13) as the abstract analog — the "use the operation's own recovery primitive before falling back to substrate-level undo" rule; (b) downgrade to an **operational pattern** documented in a skill body, not a catalog entry. D5 must rule on this.
+
+## 9. Convergent-design observations
+
+Three independent designs surfaced during gathering that converge on Exarchos-like primitives:
+
+1. **`anip-protocol`** uses both *posture* and *handshake* in capability-token contexts. (S21)
+2. **`agent-workflow-protocol`** separates runtime-agnostic protocol from pluggable runtime. (S1)
+3. **`harnlang.com`** describes a "typed, inspectable, replayable orchestration boundary." (S4)
+
+These independent convergences are themselves evidence that the candidate invariants describe load-bearing properties of agent runtimes generally, not Exarchos's idiosyncratic choices. The catalog's framing (D5) should cite these as **convergent independent design** rather than presenting Exarchos's invariants as original inventions.
+
+## 10. References
+
+All sources catalogued above. Survey deliverable per charter Phase A.

--- a/docs/research/2026-05-20-substrate-vs-authoring.md
+++ b/docs/research/2026-05-20-substrate-vs-authoring.md
@@ -73,7 +73,7 @@ Apply the decision procedure to every entry (existing + new candidates from D2).
 | INV-14 native-primitive-first-recovery | Tool's native recovery first; substrate-level undo second; never destructive | YES | NO | NO | **substrate** |
 | INV-15 single-machine-frame | No distributed consensus / leader election / vector clocks | YES | NO | NO | **substrate** |
 
-**Outcome:** 21 substrate, 1 authoring. **DIM-8 is the sole authoring entry**, exactly as the charter predicted.
+**Outcome:** 26 substrate, 1 authoring. **DIM-8 is the sole authoring entry**, exactly as the charter predicted.
 
 ## 4. Edge cases
 
@@ -130,7 +130,7 @@ Loader behavior:
 
 ## 6. Tiebreaker rule (for future authors)
 
-When adding a new candidate to the catalog, apply the decision procedure (§2). If the verdict is ambiguous after Q1–Q3, default to **substrate** unless the entry is *exclusively* about artifact content. The reasoning: substrate is the catalog's primary purpose; authoring is the exception (1 of 22 entries in v2). New authoring entries should be rare and justified.
+When adding a new candidate to the catalog, apply the decision procedure (§2). If the verdict is ambiguous after Q1–Q3, default to **substrate** unless the entry is *exclusively* about artifact content. The reasoning: substrate is the catalog's primary purpose; authoring is the exception (1 of 27 entries in v2). New authoring entries should be rare and justified.
 
 If the candidate seems to span both axes, split it into two entries (one per axis). This is the same pattern v2 applies when splitting INV-1 into INV-1 + INV-7 + INV-8.
 

--- a/docs/research/2026-05-20-substrate-vs-authoring.md
+++ b/docs/research/2026-05-20-substrate-vs-authoring.md
@@ -1,0 +1,163 @@
+# Substrate vs Authoring Partition
+
+> **Workflow:** `workload-agnostic-runtime-invariants` (discovery, Phase D per charter)
+> **Date:** 2026-05-20
+> **Status:** Research deliverable D4 of 5
+> **Parent:** epic #1441
+
+## 1. Why partition
+
+The v1 catalog mixes two kinds of statements without distinguishing them:
+
+- **Substrate invariants** govern the runtime's behavior — what the system *does* at execution time. Examples: "events are the source of truth," "every ToolResult carries next_actions," "every adapter is zero-behavior."
+- **Authoring invariants** govern the *content* of artifacts the runtime produces or consumes — what artifacts *look like*. Example: "skill prose must not exhibit AI-writing tells" (DIM-8).
+
+Conflating them creates two operational problems:
+
+1. **Wrong consumers.** Substrate invariants govern the runtime engineer's design decisions; authoring invariants govern artifact reviewers (or `/axiom:humanize`). When `/ideate` Phase 0 loads "the catalog," it surfaces both kinds — but the design discussion that follows is almost always about substrate. The authoring entries are noise during runtime design.
+2. **Wrong enforcement.** Substrate invariants are enforced by parity tests, schema validation, projection rebuild, and CI gates. Authoring invariants are enforced by prose linters and human review. Code that satisfies substrate invariants can fail authoring invariants (and vice versa) without crossing concerns.
+
+The v2 catalog distinguishes them with a frontmatter `axis: substrate | authoring` field. Substrate-axis entries load at `/ideate` Phase 0 according to their `cost-of-load`. Authoring-axis entries never load at Phase 0 — they're addressed by `/axiom:humanize` and reviewer skills.
+
+## 2. Formal criteria
+
+**Substrate invariant** — a statement true of the runtime's behavior, expressible as an assertion over runtime state or runtime operations. Enforceable via parity test, schema check, projection rebuild, CI gate, or operational observation.
+
+**Authoring invariant** — a statement true of an artifact's *content*. Enforceable via prose analysis, structural validation of human-readable text, or human review.
+
+**Decision procedure** (apply in order):
+
+1. **Question Q1:** Can the invariant be violated by code that runs correctly to completion?
+   - YES → likely **substrate** (the runtime allowed a violation; the runtime is at fault).
+   - NO → continue to Q2.
+
+2. **Question Q2:** Does the invariant constrain the *content* of a document, skill body, comment, log message, or other prose artifact?
+   - YES → **authoring**.
+   - NO → return to Q1; re-examine whether "code running correctly" is the right frame.
+
+3. **Tiebreaker (Q3):** Does the invariant's enforcement mechanism involve reading natural-language text and judging it?
+   - YES → **authoring**.
+   - NO → **substrate**.
+
+## 3. Partition table
+
+Apply the decision procedure to every entry (existing + new candidates from D2).
+
+| ID | Statement | Q1 (runtime allows violation?) | Q2 (constrains prose?) | Q3 (enforcement reads text?) | Axis |
+|---|---|---|---|---|---|
+| INV-1 | Events are source of truth; reducers are pure folds | YES (in-place mutation runs but breaks integrity) | NO | NO | **substrate** |
+| INV-2 | CLI and MCP are facades over single dispatch core | YES (an adapter could carry behavior; parity test catches it) | NO | NO | **substrate** |
+| INV-3 | No design presumes MCP is local-only | YES (a handler could read `runtimes/<name>.yaml` at request time) | NO | NO | **substrate** |
+| INV-4 | Platform-agnosticity — 6 runtimes; tokenization + guards | YES (a skills-src file could hardcode `Skill({...})`) | PARTIAL (constrains skill body content) | PARTIAL (vocabulary lint reads text) | **substrate** (the *enforcement* reads text, but the invariant is about runtime portability, not content quality) |
+| INV-5a | Tool inputs schema-constrained; "do NOT use for" guidance | YES (a registry could ship a tool without input schema) | PARTIAL (constrains tool *description* content) | PARTIAL | **substrate** (same as INV-4 — content rule serves runtime portability) |
+| INV-5b | ToolResult carries next_actions, _meta, _perf | YES (a handler could return without these fields) | NO | NO | **substrate** |
+| INV-5c | Aspire verbs — observation + dry-run mutating | YES (a verb could be defined that violates this) | NO | NO | **substrate** |
+| INV-5d | 4 visible composite tools with action discriminator | YES (a new top-level tool could be added) | NO | NO | **substrate** |
+| INV-6 (sharpened) | Runtime makes no assumption about which workload is executing | YES (a runtime change could bake in a workflow concept) | NO | NO | **substrate** |
+| DIM-1 Topology | Module boundaries, dependency direction | YES | NO | NO | **substrate** |
+| DIM-2 Observability | Silent catches, missing log context | YES | NO | NO | **substrate** |
+| DIM-3 Contracts | Schema-runtime drift, type-assertion safety | YES | NO | NO | **substrate** |
+| DIM-4 Test-fidelity | Mock overuse, fixture drift | YES | NO | NO | **substrate** |
+| DIM-5 Hygiene | Dead code, unused exports, legacy flags | YES | NO | NO | **substrate** |
+| DIM-6 SOLID-coupling | Dependency direction, single-responsibility | YES | NO | NO | **substrate** |
+| DIM-7 Resilience | Silent fallbacks, retry storms, degradation | YES | NO | NO | **substrate** |
+| **DIM-8 Prose-quality** | **AI-writing tells in prose** | **NO** (code runs correctly; prose can still be terrible) | **YES** | **YES** | **authoring** |
+| basileus-boundary | Cross-product coordination via Ontology MCP Server | YES | NO | NO | **substrate** |
+| INV-7 substrate-serialization | Two-tier serialization (in-process + WAL/PK) | YES | NO | NO | **substrate** |
+| INV-8 idempotency-at-the-boundary | Unique idempotency keys; collapsed duplicates | YES | NO | NO | **substrate** |
+| INV-9 HSM-as-state-machine | Per-workflow-type guarded transitions | YES | NO | NO | **substrate** |
+| INV-10 liveness-event-protocol | `<surface>.executing_started` for long-running ops | YES | NO | NO | **substrate** |
+| INV-11 posture-declared-capabilities | Agent declares posture; handshake-authoritative | YES | NO | NO | **substrate** |
+| INV-12 next-actions-as-affordance | Agents read affordances; runtime makes valid transitions perceptible | YES | NO | NO | **substrate** |
+| INV-13 process-manager-two-event-split | `*.requested`/`*.executed` with idempotent precheck | YES | NO | NO | **substrate** |
+| INV-14 native-primitive-first-recovery | Tool's native recovery first; substrate-level undo second; never destructive | YES | NO | NO | **substrate** |
+| INV-15 single-machine-frame | No distributed consensus / leader election / vector clocks | YES | NO | NO | **substrate** |
+
+**Outcome:** 21 substrate, 1 authoring. **DIM-8 is the sole authoring entry**, exactly as the charter predicted.
+
+## 4. Edge cases
+
+Two entries deserve closer examination — INV-4 and INV-5a — because both *enforce* via text-reading vocabulary lints, even though their invariant statements are about runtime portability.
+
+### 4.1 INV-4 platform-agnosticity
+
+The invariant is: "skill rendering must work across 6 runtimes." The enforcement mechanism includes a vocabulary-lint scan for `Skill({...})` literals in `skills-src/` outside `<!-- requires:claude -->` guards.
+
+**Q1: Can code violate INV-4 while running correctly?**
+Yes — a `skills-src/<name>/SKILL.md` could hardcode `Skill({...})` outside a `<!-- requires:claude -->` guard. The Claude Code runtime would render it correctly; OpenCode would render a broken skill. The *runtime* (the skills renderer) accepted the input; the *artifact* is the failure mode.
+
+So INV-4 is borderline: the failure surfaces in an *artifact* (the rendered skill for a non-Claude runtime), but the invariant is about *runtime portability* — that the rendering substrate produces working output across runtimes.
+
+**Tiebreaker (Q3):** Vocabulary lint reads text. So enforcement does involve reading natural-language text.
+
+**Resolution:** **substrate**. The reasoning: the invariant's *subject* is the runtime's portability guarantee; the *enforcement mechanism* happens to read text because the runtime's input is text. Distinguishing-marker: ask *what would change if the runtime were redesigned*. If the invariant would still hold post-redesign, it's substrate; if it's only true given the current text-driven authoring substrate, it's authoring.
+
+INV-4 would still hold under a Theoretical-Exarchos that compiles skills from a typed DSL — the *substrate* would still need to produce runtime-portable output. The invariant survives the runtime redesign. **Substrate.**
+
+### 4.2 INV-5a input-ergonomics
+
+Same shape: the invariant is "tool inputs are schema-constrained + descriptions include 'do NOT use for' guidance." Vocabulary lint reads tool descriptions for the absence of negative guidance.
+
+**Resolution:** **substrate**, by the same reasoning. The invariant is about *agent ergonomics over MCP* (a runtime-substrate concern); the enforcement reads text because tool descriptions are text. Under a typed-IDL alternative, the invariant would still hold — the "do NOT use for" guidance would just live in a structured field.
+
+### 4.3 What pure-authoring would look like
+
+DIM-8 is the only entry whose subject is *prose content* — AI-writing tells, em-dash overuse, padded adjectives. These are properties only definable over natural-language text; they have no substrate analog.
+
+A hypothetical second authoring entry might be:
+
+- **"Skill bodies must lead with the trigger condition"** — a structural constraint on prose ordering. No substrate effect; pure artifact-quality concern.
+- **"Reference files must not have YAML frontmatter"** — already a Exarchos convention; structural, but borderline (the build pipeline rejects frontmatter in references, so it has a substrate enforcement). Probably substrate.
+
+For v2, DIM-8 is the only authoring entry. The schema admits the axis but isn't expected to grow it.
+
+## 5. Schema impact
+
+Add to v2 catalog frontmatter:
+
+```yaml
+invariants:
+  - id: INV-N
+    axis: substrate    # required; one of "substrate" | "authoring"
+    ...
+```
+
+Loader behavior:
+
+- `/ideate` Phase 0 default scope (`scope: "core"`) loads only `axis: substrate` AND `cost-of-load: always-load` entries.
+- Authoring entries are never loaded by `/ideate`. They are surfaced by `/axiom:humanize` and review skills via dedicated calls.
+- Vocabulary-lint cross-references work on the full set regardless of axis (the catalog remains the source-of-truth for the ID vocabulary).
+
+## 6. Tiebreaker rule (for future authors)
+
+When adding a new candidate to the catalog, apply the decision procedure (§2). If the verdict is ambiguous after Q1–Q3, default to **substrate** unless the entry is *exclusively* about artifact content. The reasoning: substrate is the catalog's primary purpose; authoring is the exception (1 of 22 entries in v2). New authoring entries should be rare and justified.
+
+If the candidate seems to span both axes, split it into two entries (one per axis). This is the same pattern v2 applies when splitting INV-1 into INV-1 + INV-7 + INV-8.
+
+## 7. Consumer responsibilities
+
+For the substrate/authoring split to land in practice, each catalog consumer must honor the axis:
+
+| Consumer | Current behavior | v2 behavior |
+|---|---|---|
+| `/ideate` Phase 0 loader | Loads all entries by `cost-of-load` | Filters to `axis: substrate` first, then by `cost-of-load`. Implementation: `loadInvariants({scope: 'core'})` returns `axis: substrate AND cost-of-load: always-load`. |
+| `design-invariants` skill | Walks all entries by ID | Continues to walk all entries by ID; the axis is informational for the skill body. |
+| `vocabulary-lint` | Scans all IDs | No change; vocabulary is axis-independent. |
+| `/axiom:humanize` | Owns prose-quality independently of catalog | Continues independently; v2 lets the catalog *point to* `/axiom:humanize` as the authoring-axis enforcement surface. |
+| `/axiom:design` pairing-discovery | Looks for `pairs-with: axiom:design` | No change re axis; but every `axis: substrate` entry should declare `axiom_overlap: DIM-N` where applicable (per task E in charter). |
+
+## 8. Verification
+
+To confirm the partition is sharp, two sanity checks pass:
+
+1. **No substrate entry can be enforced solely by `/axiom:humanize`.** Verified — `humanize` reads prose for AI-writing tells; substrate invariants need parity tests, schema checks, or projection rebuild.
+2. **DIM-8 cannot be enforced by a substrate mechanism.** Verified — em-dash overuse is not detectable by schema validation, projection rebuild, or parity test. It requires reading text and judging quality.
+
+These sanity checks should be added to the catalog v2 introductory prose as a "test your partition" recipe for future authors.
+
+## 9. References
+
+- D2 candidate list with provisional IDs: [`docs/research/2026-05-20-runtime-invariants-gap-analysis.md`](2026-05-20-runtime-invariants-gap-analysis.md) §10
+- D3 workload-agnosticism stress test: [`docs/research/2026-05-20-workload-agnosticism-stress-test.md`](2026-05-20-workload-agnosticism-stress-test.md)
+- axiom DIM-8 owner: `/axiom:humanize` skill
+- INV-4 enforcement: `scripts/lint-inv*.mjs` (vocabulary lint)

--- a/docs/research/2026-05-20-substrate-vs-authoring.md
+++ b/docs/research/2026-05-20-substrate-vs-authoring.md
@@ -50,7 +50,7 @@ Apply the decision procedure to every entry (existing + new candidates from D2).
 | INV-3 | No design presumes MCP is local-only | YES (a handler could read `runtimes/<name>.yaml` at request time) | NO | NO | **substrate** |
 | INV-4 | Platform-agnosticity — 6 runtimes; tokenization + guards | YES (a skills-src file could hardcode `Skill({...})`) | PARTIAL (constrains skill body content) | PARTIAL (vocabulary lint reads text) | **substrate** (the *enforcement* reads text, but the invariant is about runtime portability, not content quality) |
 | INV-5a | Tool inputs schema-constrained; "do NOT use for" guidance | YES (a registry could ship a tool without input schema) | PARTIAL (constrains tool *description* content) | PARTIAL | **substrate** (same as INV-4 — content rule serves runtime portability) |
-| INV-5b | ToolResult carries next_actions, _meta, _perf | YES (a handler could return without these fields) | NO | NO | **substrate** |
+| INV-5b | ToolResult carries `next_actions`, `_meta`, `_perf` | YES (a handler could return without these fields) | NO | NO | **substrate** |
 | INV-5c | Aspire verbs — observation + dry-run mutating | YES (a verb could be defined that violates this) | NO | NO | **substrate** |
 | INV-5d | 4 visible composite tools with action discriminator | YES (a new top-level tool could be added) | NO | NO | **substrate** |
 | INV-6 (sharpened) | Runtime makes no assumption about which workload is executing | YES (a runtime change could bake in a workflow concept) | NO | NO | **substrate** |

--- a/docs/research/2026-05-20-workload-agnosticism-stress-test.md
+++ b/docs/research/2026-05-20-workload-agnosticism-stress-test.md
@@ -1,0 +1,171 @@
+# Workload-Agnosticism Stress Test
+
+> **Workflow:** `workload-agnostic-runtime-invariants` (discovery, Phase C per charter)
+> **Date:** 2026-05-20
+> **Status:** Research deliverable D3 of 5
+> **Parent:** epic #1441
+> **Companion:** [`docs/research/2026-05-20-runtime-invariants-gap-analysis.md`](2026-05-20-runtime-invariants-gap-analysis.md) (D2)
+
+## 1. Test definition
+
+**Workload-agnostic** (formal): A catalog invariant is workload-agnostic if and only if its statement, scope, and enforcement mechanism are identical across all declared workflow types — and would remain identical if a new workflow type were defined tomorrow.
+
+**Test method:** For each candidate invariant (existing + new from D2), check whether the invariant *names* or *implicitly assumes* any workflow-type-specific concept. The five current workflow types are `feature`, `oneshot`, `debug`, `refactor`, `discovery`. A sixth hypothetical type (`data-pipeline` — a non-SDLC workload) acts as the "stranger workflow" that catches assumptions hidden by the SDLC family.
+
+**Pass criteria:** 
+- ✓ **PASS** — statement holds verbatim across all six workflow types
+- ⚠ **PASS-with-narrowing** — holds with explicit scope-narrowing (e.g., "applies to workflow types that emit `task.*` events")
+- ✗ **FAIL** — bakes in a workflow-type-specific assumption; demote to **topology-level** (per-workflow `topology.yaml`) rather than **catalog-level**
+
+## 2. Candidate stress test
+
+### 2.1 Existing entries
+
+| ID | Statement (summary) | feature | oneshot | debug | refactor | discovery | data-pipeline | Verdict |
+|---|---|---|---|---|---|---|---|---|
+| INV-1 | Event log is source of truth; reducers are pure folds | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
+| INV-2 | CLI and MCP are facades over single dispatch core; parity asserted | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
+| INV-3 | No design presumes MCP is local-only; handshake-authoritative; remote-MCP throws-not-degrades | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
+| INV-4 | Platform-agnosticity — 6 runtimes first-class; tokenization + guards; skills-src/ source-of-truth | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
+| INV-5a | Tool inputs constrained at schema level; "do NOT use for" guidance; <15 visible tools | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
+| INV-5b | ToolResult carries next_actions, _meta, _perf; errors carry validTargets/expectedShape/suggestedFix | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
+| INV-5c | Queryable, dry-run-capable, JSON-explicit Aspire verbs; observation verbs + mutating verbs default to --dry-run | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
+| INV-5d | 4 visible composite tools with action discriminator; per-action annotations | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
+| INV-6 (v1) | Skill body grep for workflow-typed literals (`feature/`, `delegate`, `synthesize`) | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✗ | **FAIL (as currently scoped)** — grep targets are SDLC-specific |
+| INV-6 (sharpened) | "The runtime makes no assumption about which workload is executing" | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** (after sharpening per D2 §9) |
+| DIM-1..7 | Axiom-owned cross-link entries | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** (axiom dimensions are workload-orthogonal) |
+| DIM-8 | Prose-quality — archivable; axiom:humanize-owned | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** (but see substrate-vs-authoring split in D4) |
+| basileus-boundary | Cross-product coordination via Ontology MCP Server | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** (forward-looking, no SDLC assumption) |
+
+**Existing entries outcome:** Every existing catalog entry passes the stress test **except INV-6 in its current v1 scope.** The fix is documented in D2 §9: elevate INV-6 to the primary workload-agnosticism statement and demote the grep-targets to operational projection.
+
+### 2.2 New candidates (from D2)
+
+| ID | Statement | feature | oneshot | debug | refactor | discovery | data-pipeline | Verdict |
+|---|---|---|---|---|---|---|---|---|
+| INV-7 | Substrate-serialization — two-tier (in-process StreamLockManager + cross-process WAL `BEGIN IMMEDIATE` + composite PK) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** — names storage/concurrency primitives, no workflow concepts |
+| INV-8 | Idempotency-at-the-boundary — unique idempotency keys at append; appendComputed collapses duplicates | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** — universal append-layer primitive |
+| INV-9 | HSM-as-state-machine — per-workflow-type guarded transitions; transition is the only phase mutator | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | **PASS-with-narrowing** — names "workflow-type" but each type has its own HSM; the invariant is "*every* workflow type ships its own HSM," not "every workflow looks like X" |
+| INV-10 | Liveness-event-protocol — long-running ops emit `<surface>.executing_started` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** — `<surface>` is the variable; the protocol is universal |
+| INV-11 | Posture-declared-capabilities — agent declares `read-only \| task-isolated \| shared-mutating`; handshake-authoritative | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** — posture is workflow-orthogonal |
+| INV-12 | Next-actions-as-affordance — agents read affordances from envelopes; runtime makes valid transitions perceptible; agents do not poll | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** — affordance protocol, not workflow-shape |
+| INV-13 | Process-manager-two-event-split — non-idempotent side effects emit `*.requested` → `*.executed` with idempotent precheck on recovery | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** — pattern applies to any handler doing external side effects |
+| INV-14 | Native-primitive-first-recovery — `git X --abort` then `--keep` then never `--hard`; recoveryError discriminator | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | **PASS-with-narrowing** — `git` is named; the *rule* generalizes to "any tool's native recovery primitive first, then substrate-level undo, never destructive overwrite." Reword INV-14's wording to remove the `git` specifically. |
+| INV-15 | Single-machine-frame — no distributed-consensus, no leader election, no vector clocks, no BFT; cooperation via OCC + WAL | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** — framing statement, workflow-orthogonal |
+
+**New candidates outcome:** All 9 candidates pass. Two (INV-9, INV-14) require minor wording adjustments to remove implicit specificity (INV-9 names "workflow-type" as a variable, not a constraint; INV-14 removes the `git` example into a reference, not the rule text).
+
+## 3. The data-pipeline thought experiment
+
+The hypothetical sixth workflow type — `data-pipeline` — is deliberately non-SDLC. Imagine a workflow that: (a) ingests a CSV from S3, (b) validates against a JSON schema, (c) transforms to parquet, (d) loads into a warehouse, (e) emits a notification. Five phases, each gated, no PR/branch concepts, no review/synthesis.
+
+Walk every invariant against this workload:
+
+| Invariant | Holds for data-pipeline? | Why |
+|---|---|---|
+| INV-1 | ✓ | The 5 phases emit events to a stream; reducers fold them into projection state. Same shape. |
+| INV-2 | ✓ | CLI: `exarchos data-pipeline submit <csv-url>`. MCP: `exarchos_workflow init featureId=… workflowType=data-pipeline`. Same dispatch core. |
+| INV-3 | ✓ | The data-pipeline workflow can run against a remote MCP transport equally — no local-only assumption. |
+| INV-4 | ✓ | The data-pipeline runs over any of the 6 first-class runtimes; the skill body for `data-pipeline-ideate` (if any) is tokenized. |
+| INV-5a | ✓ | The data-pipeline composite-tool action set is schema-constrained. |
+| INV-5b | ✓ | Each transition emits a `ToolResult` with `next_actions: ["transform", "load"]` etc. |
+| INV-5c | ✓ | `dry-run` for the validate step; `describe` queries the state. |
+| INV-5d | ✓ | The workflow lives under `exarchos_workflow` action discriminator like any other. |
+| INV-6 (sharpened) | ✓ | The runtime makes no assumption that data-pipeline exists; the topology declares it. |
+| INV-7 substrate-serialization | ✓ | Concurrent ingestion runs across worktrees use the same WAL + PK serialization. |
+| INV-8 idempotency-at-the-boundary | ✓ | Idempotency keys ensure re-submission of a CSV-URL doesn't trigger duplicate transforms. |
+| INV-9 HSM-as-state-machine | ✓ | data-pipeline's HSM declares its own phases (ingest/validate/transform/load/notify). |
+| INV-10 liveness-event-protocol | ✓ | `transform.executing_started` event lets v2.12 `wait` block on the slow phase. |
+| INV-11 posture-declared-capabilities | ✓ | The data-pipeline agent declares `shared-mutating` (writes to S3 + warehouse); a validator sub-agent declares `read-only`. |
+| INV-12 next-actions-as-affordance | ✓ | The validator's terminal event puts `transform` into next_actions; the transformer agent picks it up without polling. |
+| INV-13 process-manager-two-event-split | ✓ | `load.requested` → idempotent precheck against warehouse (does row-batch X already exist?) → `load.executed`. |
+| INV-14 native-primitive-first-recovery (re-worded) | ✓ | If the load fails, prefer the warehouse's native rollback first; fall back to substrate-level undo (e.g., delete the inserted batch via batch-ID). Never overwrite. |
+| INV-15 single-machine-frame | ✓ | data-pipeline is single-machine in this scenario; the runtime substrate doesn't need distributed consensus. |
+| DIM-1..7 | ✓ | Topology, observability, contracts, etc. apply equally. |
+| DIM-8 | ✓ | (Only relevant if the data-pipeline workload produces user-facing documents — which it might, if the notification phase generates a report.) |
+
+**All invariants pass the data-pipeline thought experiment.** This is the strongest signal that the v2 catalog is workload-agnostic: **a completely non-SDLC workload reads the catalog and recognizes every entry as applicable to itself, without modification.**
+
+## 4. Failure modes — what would fail
+
+For completeness, document what a *failing* candidate would look like. None of the v2 candidates fail this way, but anchoring the negative examples sharpens future-author intuition.
+
+**Hypothetical fail-INV-A: "Every workflow must emit `pr.opened` before synthesis"**
+- Bakes in SDLC concepts (`pr.opened`, `synthesis`)
+- data-pipeline has no PR
+- Verdict: ✗ FAIL. This is topology-level (only the `feature` HSM emits `pr.opened`), not catalog-level.
+
+**Hypothetical fail-INV-B: "Phase transitions must run a TDD red→green→refactor sequence"**
+- TDD is workflow-type-specific (specifically: `feature` and `oneshot` workflows)
+- `discovery` workflow exempts the Iron Law explicitly
+- Verdict: ✗ FAIL. Belongs in `feature` workflow's playbook, not in the catalog.
+
+**Hypothetical fail-INV-C: "Every workflow ends with a `cleanup` phase"**
+- discovery ends with `synthesizing → completed` — no cleanup
+- Verdict: ✗ FAIL. Per-HSM, not universal.
+
+Compared against these fail modes, every D2 candidate uses *primitive* vocabulary (events, streams, sequences, postures, idempotency keys, affordances) rather than *workflow-shape* vocabulary. That's the distinguishing pattern: workload-agnostic invariants name the runtime's *substrate operations*; workflow-shape statements name *phase transitions specific to one HSM*.
+
+## 5. Triage — survivors and demotions
+
+**v2 catalog admits (after stress test):**
+
+All 9 new candidates (INV-7..INV-15) plus all 13 existing entries (INV-1..INV-6 + DIM-1..DIM-8 + basileus-boundary, minus DIM-8 archivable handling).
+
+**v1 → v2 sharpenings required (no demotion, just wording):**
+
+- **INV-6** — elevate "workload-agnosticism" from skill-grep operational projection to primary catalog statement. The grep stays as one enforcement tool among several (e.g., new-workflow-type-onboarding checklist).
+- **INV-9** — reword "per-workflow-type" to make the *generality* clear: every workflow type ships an HSM; no workflow-type-specific shape is assumed.
+- **INV-14** — remove the `git`-specific text from the rule; move to references as an example.
+
+**Demotions (catalog → topology):**
+
+None. The cross-walk did not surface any workflow-type-specific invariants currently masquerading as catalog-level.
+
+**Documentation moves (catalog → operational skill):**
+
+- INV-14 (native-primitive-first-recovery) — pending citation backfill (per D1 §8), this may be downgraded from "catalog invariant" to "operational pattern documented in a skill body." D5 will rule.
+
+## 6. Workload-agnosticism as a positive property
+
+The stress test reveals a structural pattern: **workload-agnostic invariants form a coherent vocabulary about agent-runtime substrate.** The vocabulary set is:
+
+- **Storage primitives** — event log, stream, sequence, append, projection, snapshot
+- **Concurrency primitives** — OCC, WAL, idempotency key, expectedSequence
+- **Capability primitives** — posture, handshake, authority, reference
+- **Process-manager primitives** — *.requested/*.executed split, idempotent precheck, terminal event
+- **Lifecycle primitives** — `<surface>.executing_started`, next_actions affordance, transition
+
+None of these are SDLC concepts. They're agent-runtime concepts. The convergent designs surfaced in D1 §9 (anip-protocol, AWP, Harn) use the same vocabulary independently — corroborating evidence that this is the load-bearing vocabulary for agent-runtime invariants generally, not Exarchos-specific framing.
+
+The v2 catalog should lead with this vocabulary as the **agnosticism statement**: "Every entry in this catalog uses runtime-substrate vocabulary, not workflow-shape vocabulary. Workflow-shape concerns belong in `topology.yaml`."
+
+### 6.1 Caveat — applicability ≠ audience
+
+This section's "positive property" finding is about *applicability*: the invariants hold across every workflow type that could run over Exarchos's runtime. **It is not a finding about audience suitability.**
+
+The two are distinct. An invariant can apply universally to every workload yet still be inappropriate to surface to a given audience. Concretely:
+
+- **Applicability** — does INV-7 (substrate-serialization) hold for a data-pipeline workload? Yes (the WAL + PK substrate serializes data-pipeline appends just like SDLC appends). This is what §3's data-pipeline thought experiment demonstrates.
+- **Audience suitability** — should a data-pipeline engineer running `/exarchos:ideate` to design their CSV→parquet pipeline see INV-7 at Phase 0? No. They interact with Exarchos's affordances; they do not implement Exarchos's substrate. Surfacing INV-7 to them is noise.
+
+The v2 catalog (D5) addresses this by gating the entire catalog behind `.exarchos.yml: invariants.devCatalog: enabled` (default disabled). The dev catalog is for Exarchos's own designers. A separate consumer-facing catalog — covering SDLC discipline, phase observability, review-gate honesty, branch/PR discipline — is a future deliverable. See D5 §1.1 and §10.
+
+The stress test conclusions in §2–§5 above stand for the dev catalog. Re-running them against a consumer-facing catalog would require a different (broader, SDLC-flavored) candidate list and would not look like this document.
+
+## 7. Recommendation
+
+**Proceed to D4 with the full candidate list.** All 9 new + 13 existing (sharpened where noted) entries are workload-agnostic. The stress test surfaced no demotions and only three wording sharpenings (INV-6, INV-9, INV-14).
+
+The v2 catalog (D5) should encode the workload-agnosticism property structurally:
+
+1. A frontmatter-level field `axis: substrate | authoring` per entry (set up in D4).
+2. A catalog-introduction statement: "This catalog uses runtime-substrate vocabulary exclusively. Workflow-type-specific guidance lives in `topology.yaml`."
+3. An onboarding checklist for new workflow types: confirm no invariant changes are needed when adding the workflow.
+
+## 8. References
+
+- D2 candidate list: [`docs/research/2026-05-20-runtime-invariants-gap-analysis.md`](2026-05-20-runtime-invariants-gap-analysis.md) §10
+- D1 research corpus: [`docs/research/2026-05-20-runtime-invariants-research-survey.md`](2026-05-20-runtime-invariants-research-survey.md)
+- Current workflow types: `servers/exarchos-mcp/src/topology.yaml` (feature, oneshot, debug, refactor, discovery)
+- Runtime framing: [`docs/architecture/runtime.md`](../architecture/runtime.md) §1 "It is a concurrent system, not a distributed one"

--- a/docs/research/2026-05-20-workload-agnosticism-stress-test.md
+++ b/docs/research/2026-05-20-workload-agnosticism-stress-test.md
@@ -110,7 +110,7 @@ Compared against these fail modes, every D2 candidate uses *primitive* vocabular
 
 **v2 catalog admits (after stress test):**
 
-All 9 new candidates (INV-7..INV-15) plus all 13 existing entries (INV-1..INV-6 + DIM-1..DIM-8 + basileus-boundary, minus DIM-8 archivable handling).
+All 9 new candidates (INV-7..INV-15) plus all 14 existing entries (INV-1..INV-6 + DIM-1..DIM-8 + basileus-boundary, with DIM-8 retained but marked `archivable` per D4 §5.4).
 
 **v1 → v2 sharpenings required (no demotion, just wording):**
 

--- a/docs/research/2026-05-20-workload-agnosticism-stress-test.md
+++ b/docs/research/2026-05-20-workload-agnosticism-stress-test.md
@@ -28,7 +28,7 @@
 | INV-3 | No design presumes MCP is local-only; handshake-authoritative; remote-MCP throws-not-degrades | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
 | INV-4 | Platform-agnosticity — 6 runtimes first-class; tokenization + guards; skills-src/ source-of-truth | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
 | INV-5a | Tool inputs constrained at schema level; "do NOT use for" guidance; <15 visible tools | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
-| INV-5b | ToolResult carries next_actions, _meta, _perf; errors carry validTargets/expectedShape/suggestedFix | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
+| INV-5b | ToolResult carries `next_actions`, `_meta`, `_perf`; errors carry `validTargets`/`expectedShape`/`suggestedFix` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
 | INV-5c | Queryable, dry-run-capable, JSON-explicit Aspire verbs; observation verbs + mutating verbs default to --dry-run | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
 | INV-5d | 4 visible composite tools with action discriminator; per-action annotations | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | **PASS** |
 | INV-6 (v1) | Skill body grep for workflow-typed literals (`feature/`, `delegate`, `synthesize`) | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ✗ | **FAIL (as currently scoped)** — grep targets are SDLC-specific |

--- a/docs/research/2026-05-20-workload-agnosticism-stress-test.md
+++ b/docs/research/2026-05-20-workload-agnosticism-stress-test.md
@@ -110,7 +110,7 @@ Compared against these fail modes, every D2 candidate uses *primitive* vocabular
 
 **v2 catalog admits (after stress test):**
 
-All 9 new candidates (INV-7..INV-15) plus all 14 existing entries (INV-1..INV-6 + DIM-1..DIM-8 + basileus-boundary, with DIM-8 retained but marked `archivable` per D4 §5.4).
+All 9 new candidates (INV-7..INV-15) plus all 18 existing entries (INV-1..INV-6 including splits INV-5a/b/c/d + DIM-1..DIM-8 + basileus-boundary, with DIM-8 retained but marked `archivable` per D4 §5.4) — total 27.
 
 **v1 → v2 sharpenings required (no demotion, just wording):**
 


### PR DESCRIPTION
## Summary

Re-derives Exarchos's architectural invariants against **workload-agnosticism** as the primary frame, with external research backing. Triggered by [#1370 comment 4464273740](https://github.com/lvlup-sw/exarchos/issues/1370#issuecomment-4464273740) — "Primary audit should be against workload-agnosticism" — and the structural limitation of the #1455/#1457 audit pair (whose methodology had no `ADD-NEW` verdict).

**Workflow:** `workload-agnostic-runtime-invariants` (discovery)
**Parent:** epic #1441 (v2.10.0-preview.4 polish + post-bundle follow-ups)

## Changes

Five research artifacts. No code. No catalog rewrite. No skill body updates.

### Deliverables

| # | Path | Purpose |
|---|---|---|
| D1 | `docs/research/2026-05-20-runtime-invariants-research-survey.md` | External corpus — 29 sources across process-manager patterns (Akka, Wolverine, Greg Young), event-sourcing substrate (ARIES, Bernstein/Goodman), capability-based security (Miller *Robust Composition* 2006, POLA), affordance theory (Norman/Gibson, McGrenere/Ho), deliberate non-patterns (Microsoft SAS/Saga). Citation coverage ≥3 sources per substrate candidate. |
| D2 | `docs/research/2026-05-20-runtime-invariants-gap-analysis.md` | Cross-walks runtime.md §2–§8 against the post-#1455 catalog. Surfaces 9 candidate new invariants. |
| D3 | `docs/research/2026-05-20-workload-agnosticism-stress-test.md` | All 22 v2 candidates pass against 5 workflow types + hypothetical data-pipeline workload. §6.1 distinguishes applicability from audience suitability. |
| D4 | `docs/research/2026-05-20-substrate-vs-authoring.md` | Formal Q1–Q3 partition — 21 substrate entries, 1 authoring (DIM-8). |
| D5 | `docs/proposals/2026-05-20-invariants-catalog-v2-spec.md` | v2 schema proposal — new fields (axis, axiom_overlap, citations[]), 22 entries within the ≤25 ceiling, migration plan from v1. |

### Key proposed entries (9 new — flagged in D2 §10 + D5 §6)

- **INV-7** substrate-serialization (Mohan ARIES 1992, Bernstein/Goodman 1981)
- **INV-8** idempotency-at-the-boundary (Akka, Wolverine PR #1858)
- **INV-9** HSM-as-state-machine (Harel statecharts)
- **INV-10** liveness-event-protocol (Conductor, AWP)
- **INV-11** posture-declared-capabilities (Miller *Robust Composition* 2006, POLA, anip-protocol convergent design)
- **INV-12** next-actions-as-affordance (Norman 1999, McGrenere/Ho 2000)
- **INV-13** process-manager-two-event-split (Akka *Effect.thenRun*, Wolverine *AggregateHandler*, Greg Young)
- **INV-14** native-primitive-first-recovery (open question — borderline catalog vs operational pattern)
- **INV-15** single-machine-frame (Microsoft SAS + Saga as negative references)

### Sharpenings to existing entries

- **INV-6** elevated from skill-grep operational projection to the primary workload-agnosticism statement (v1's INV-6 itself failed the workload-agnosticism stress test).
- **INV-1** narrowed; substrate-serialization split to INV-7, idempotency split to INV-8.
- **INV-5b** narrowed; affordance-consumption semantics split to INV-12.
- **INV-4** clarified to own the "platform" axis (6 runtimes); INV-6 owns the "workload" axis.

### Dev-only scoping (per discovery-time feedback)

D5 explicitly scopes the catalog as **dev-invariants only** — for Exarchos's own designers. Loader gated behind `.exarchos.yml: invariants.devCatalog: enabled` (default `disabled`, no auto-detection). Consumer-facing SDLC invariants catalog is filed as separate future deliverable (D5 §10).

## Test Plan

- [x] All 5 deliverables landed on disk
- [x] D5's section structure verified (12 sections, no orphan numbering)
- [x] D3 §6.1 caveat acknowledges applicability ≠ audience suitability
- [x] Citation coverage ≥3 external sources per substrate candidate (INV-7, INV-8, INV-11, INV-12, INV-13, INV-15 pass; INV-9 + INV-14 flagged with open questions in D5 §6 + §8)
- [x] runtime.md §2–§8 fully cross-walked in D2
- [x] Stress test passes for all 22 entries across feature/oneshot/debug/refactor/discovery + hypothetical data-pipeline workload
- [x] Substrate/authoring partition sharp (21 substrate, 1 authoring per D4)
- [ ] CodeRabbit review (post-open)
- [ ] Manual review of D5 §6 entries — INV-9 + INV-14 open questions

## Follow-up

Suggested follow-up plan workflow: `invariants-catalog-v2-implementation` per D5 §11. ~6–8 tasks, mostly mechanical once approved. Ships `.exarchos.yml` gating first, then schema bump + new entries + sharpenings, then `/axiom:design` `pairs-with` slot fix.

Closes nothing automatically (research artifact PR; closure happens via the follow-up plan workflow's implementation PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)