### PR TITLE
feat(invariants): v3 dev-catalog content + SDLC-* consumer catalog (#1466, #1467)

### DIFF
--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -5,10 +5,22 @@ description: >
   dimensions (DIM-*) consumed by /ideate, the check_invariant_conformance
   gate, and the vocabulary-lint scanner. Source of truth for the invariant
   vocabulary in the Exarchos repo.
-schema-version: 2
+schema-version: 3
 invariants:
   - id: INV-1
     dimension: event-sourcing-integrity
+    integrity-class: substrate
+    phase-affinity: [review]
+    severity:
+      default: blocking
+      by-workflow:
+        oneshot: advisory
+    enforcement:
+      mode: audit
+      audit-prompt: >
+        Does any read-model hold state across calls that is not a left-fold
+        over the event log? Flag in-place mutations, adapter-local mutable
+        caches, and side databases that bypass the append-only store.
     axis: substrate
     cost-of-load: always-load
     applies-to:
@@ -130,6 +142,16 @@ invariants:
 
   - id: INV-11
     dimension: posture-declared-capabilities
+    integrity-class: substrate
+    phase-affinity: [review]
+    enforcement:
+      mode: audit
+      audit-prompt: >
+        Is each agent's authority bounded by construction rather than by
+        convention? A read-only agent must be unable to mutate the working
+        tree; a task-isolated agent must be unable to write outside its
+        worktree. Flag a posture asserted in prose but not enforced at the
+        capability boundary.
     axis: substrate
     cost-of-load: always-load
     applies-to:
@@ -185,6 +207,15 @@ invariants:
 
   - id: INV-13
     dimension: process-manager-two-event-split
+    integrity-class: substrate
+    phase-affinity: [review]
+    enforcement:
+      mode: audit
+      audit-prompt: >
+        Does every non-idempotent external side effect emit a *.requested
+        intent before and a *.executed result after, so a crash between them
+        is recoverable by an idempotent precheck? Flag single-event external
+        mutators.
     axis: substrate
     cost-of-load: reference-only
     applies-to:
@@ -213,6 +244,15 @@ invariants:
 
   - id: INV-14
     dimension: native-primitive-first-recovery
+    integrity-class: substrate
+    phase-affinity: [review]
+    enforcement:
+      mode: audit
+      audit-prompt: >
+        On reversal, does the handler prefer the operation's own recovery
+        primitive, then a refuse-to-discard substrate undo, and never a
+        destructive overwrite? Flag any reset-hard-style path or a recovery
+        that can silently lose work.
     axis: substrate
     cost-of-load: reference-only
     applies-to:
@@ -266,6 +306,21 @@ invariants:
 
   - id: INV-2
     dimension: facade-equivalence
+    integrity-class: substrate
+    phase-affinity: [review]
+    severity:
+      default: advisory
+    enforcement:
+      # mode:audit, not check: a grep for "behavior in an adapter file" is a
+      # low-precision proxy that cannot prove parity and would false-positive
+      # on legitimate adapter code. Parity is proven by the parity-harness
+      # tests; the reviewer judges adapter discipline.
+      mode: audit
+      audit-prompt: >
+        Do the CLI and MCP adapters carry only presentation, with all behavior
+        in the shared dispatch core? Flag logic added to adapters/cli.ts or
+        adapters/mcp.ts beyond formatting, and any verb lacking a parity or
+        registered outputSchema guarantee.
     axis: substrate
     cost-of-load: always-load
     applies-to:
@@ -286,6 +341,15 @@ invariants:
 
   - id: INV-3
     dimension: basileus-forward
+    integrity-class: substrate
+    phase-affinity: [review]
+    enforcement:
+      mode: audit
+      audit-prompt: >
+        Does any decision presume the MCP transport is co-located with the
+        workflow process? Capability resolution must stay
+        handshake-authoritative and configuration .exarchos.yml-only, so the
+        same code path serves a remote channel without change.
     axis: substrate
     cost-of-load: reference-only
     applies-to:
@@ -308,6 +372,27 @@ invariants:
 
   - id: INV-4
     dimension: platform-agnosticity
+    integrity-class: substrate
+    phase-affinity: [review]
+    workflow-affinity: [feature, debug, refactor, oneshot]
+    severity:
+      default: blocking
+      by-workflow:
+        oneshot: advisory
+    enforcement:
+      # Diff-precise mode:check (issue #1466). Generated runtime variants under
+      # skills/<runtime>/** are build output of `npm run build:skills`; a diff
+      # touching any of them is a direct edit to generated output (source of
+      # truth is skills-src/). The `scope` combinator narrows the fileGlob to
+      # the generated tree; the grep fires on the hunk header so any touched
+      # generated file is flagged. skills-src/** is excluded by the glob.
+      mode: check
+      check:
+        scope:
+          fileGlob: "skills/**"
+        node:
+          kind: grep
+          pattern: "@@"
     axis: substrate
     cost-of-load: reference-only
     applies-to:
@@ -331,6 +416,17 @@ invariants:
 
   - id: INV-5a
     dimension: input-ergonomics
+    integrity-class: substrate
+    phase-affinity: [review]
+    enforcement:
+      # mode:audit, not check: the visible-tool-count is a whole-repo
+      # structural fact (a count over registry.ts), not a diff property the
+      # combinator evaluator can see. Judgment stays with the reviewer.
+      mode: audit
+      audit-prompt: >
+        Are tool inputs constrained at the schema level (enum, regex, format)
+        rather than by prose hints, does every tool state when NOT to use it,
+        and does the visible tool count stay under 15?
     axis: substrate
     cost-of-load: always-load
     applies-to:
@@ -393,6 +489,17 @@ invariants:
 
   - id: INV-5d
     dimension: action-discriminator
+    integrity-class: substrate
+    phase-affinity: [review]
+    enforcement:
+      # mode:audit, not check: the composite-tool count is a whole-repo
+      # structural fact, not a diff property. Judgment stays with the reviewer.
+      mode: audit
+      audit-prompt: >
+        Do the visible composite tools stay at four with action
+        discriminators, and do per-action annotations (destructive / readOnly
+        / idempotent / openWorld) ride on each action? Flag any new top-level
+        tool that should be an action.
     axis: substrate
     cost-of-load: reference-only
     applies-to:
@@ -413,6 +520,20 @@ invariants:
 
   - id: INV-6
     dimension: workload-agnosticism
+    integrity-class: substrate
+    phase-affinity: [review]
+    enforcement:
+      # mode:audit, not check: scripts/lint-inv6.mjs is a deliberately-advisory
+      # literal scan with a frontmatter-declaration escape hatch a diff-grep
+      # cannot replicate (legitimate prose in skills-src references workflow
+      # types). The judgment stays with the reviewer; the script remains the
+      # out-of-band advisory lint.
+      mode: audit
+      audit-prompt: >
+        Does any skill body encode workflow-typed branching or assume one
+        workflow type without declaring metadata.workflow-type? Substrate
+        guarantees must hold for every workflow type; workflow-specifics
+        belong in topology and playbooks.
     axis: substrate
     cost-of-load: always-load
     applies-to:
@@ -492,6 +613,9 @@ invariants:
 
   - id: DIM-4
     dimension: test-fidelity
+    # coverage-closure (DR-8): axiom-owned dimension, no Exarchos-specific
+    # specializing INV-*. Canonical check is /axiom:verify.
+    coverage: n/a
     axis: substrate
     cost-of-load: reference-only
     applies-to:
@@ -508,6 +632,9 @@ invariants:
 
   - id: DIM-5
     dimension: hygiene
+    # coverage-closure (DR-8): axiom-owned dimension. Canonical check is
+    # /axiom:distill.
+    coverage: n/a
     axis: substrate
     cost-of-load: reference-only
     applies-to:
@@ -525,6 +652,9 @@ invariants:
 
   - id: DIM-6
     dimension: solid-coupling
+    # coverage-closure (DR-8): axiom-owned dimension. Canonical check is
+    # /axiom:critique.
+    coverage: n/a
     axis: substrate
     cost-of-load: reference-only
     applies-to:
@@ -557,6 +687,10 @@ invariants:
 
   - id: DIM-8
     dimension: prose-quality
+    integrity-class: authoring
+    # coverage-closure (DR-8): axiom-owned authoring dimension. Canonical check
+    # is /axiom:humanize.
+    coverage: n/a
     axis: authoring
     cost-of-load: archivable
     applies-to:

--- a/docs/designs/2026-05-24-invariants-dev-catalog-v3-content.md
+++ b/docs/designs/2026-05-24-invariants-dev-catalog-v3-content.md
@@ -1,0 +1,120 @@
+# Design: Author v3 Dev-Catalog Content (make the machinery bite)
+
+> **Status:** Design — output of `/exarchos:ideate`, input to `/exarchos:plan`.
+> **Date:** 2026-05-24
+> **Issue:** [#1466](https://github.com/lvlup-sw/exarchos/issues/1466) (`type:bug`)
+> **Stacks on:** [PR #1465](https://github.com/lvlup-sw/exarchos/pull/1465) (`feature/invariants-projection-extensibility` — the v3 *machinery*)
+> **Parent design:** [`docs/designs/2026-05-23-invariants-projection-and-extensibility.md`](2026-05-23-invariants-projection-and-extensibility.md) (DR-1, §6 projection table)
+> **Sibling (separate workflow):** [#1467](https://github.com/lvlup-sw/exarchos/issues/1467) — consumer `SDLC-*` catalog, authored via its own `/exarchos:discover`.
+> **Catalog touched:** `docs/architecture/invariants.md` (schema-version `2 → 3`, dev layer only)
+
+## Constraints (Phase 0 — devCatalog: enabled)
+
+Anchored to `docs/architecture/invariants.md`. This is **content authoring against an already-built schema**, not new machinery, so the load-bearing invariants govern what the authored entries are *allowed to say*:
+
+- **INV-4 (declarative-only)** — *the* binding constraint. Every `mode: check` tree compiles to sandbox-free `grep|structural|heuristic` leaves under `all-of/any-of/not/scope`; the schema is `.strict()` at the DSL boundary, so any embedded `script`/`exec`/`code` field fails to parse. No check may *pretend* to prove a semantic property a grep can't see.
+- **INV-6 (workload-agnosticism)** — `workflow-affinity` and the severity-by-workflow downgrades are catalog *data*, not workflow-typed literals in the substrate. `scripts/lint-inv6.mjs` is itself the proven projection we reuse as INV-6's `mode: check`.
+- **INV-2 + INV-5b** — not authored, but the "verify the gate produces real findings" acceptance rides `check_invariant_conformance`'s CLI↔MCP parity; the fixture-diff verification must exercise both facades.
+- **INV-11 (POLA authority gradient)** — out of scope for #1466 (override-floor is the sdlc/user concern of #1467), but `integrity-class: substrate|authoring` on dev entries is the self-protection class we set here.
+- **INV-3 (basileus-forward)** — `mode: audit` prompts must not presume MCP-local execution.
+- **DIM-3 (contracts)** — the `schema-version 2 → 3` bump on the *live* catalog is the additive contract change; the loader back-compat test is the regression guard.
+- **DIM-4/5/6/8 (coverage-closure)** — acceptance requires the coverage-closure lint satisfied: each needs a specializing `INV-*` or an explicit `coverage: n/a`. These four are axiom-owned pointers, so the disposition here is `coverage: n/a` with the axiom-skill cross-reference (not minting Exarchos-specific INVs).
+
+**Bootstrap hazard (the defining design force).** The moment `invariants.md` reaches v3 with real `mode: check` trees, `check_invariant_conformance` evaluates those trees against *this PR's own diff* at review. The authored checks must not false-positive on the authoring diff. This dictates the **calibrate-on-HEAD rule** below and the choice of `mode: check` only for high-precision proxies.
+
+## Problem Statement
+
+PR #1465 shipped the v3 invariant *machinery* — multi-dimensional schema (`invariant-schema.ts`), the combinator DSL + evaluator, `check_invariant_conformance`, projection, and layered catalogs. But the live catalog `docs/architecture/invariants.md` is still authored at `schema-version: 2` with **zero v3 fields populated**. The gate therefore resolves an effectively-empty effective catalog and returns `APPROVED` trivially. The machinery exists and does nothing. This is the `type:bug`: the catalog content that makes the machinery bite was deferred out of #1465 by design, and is authored here.
+
+Two latent inconsistencies surface on inspection of the schema vs. the live file:
+
+1. **`axiom_overlap` key drift — deliberately left untouched.** The v3 schema (`invariant-schema.ts`) reads `axiom-overlap` (kebab-case), but the v2 loader (`invariants-loader.ts`) reads `axiom_overlap` (underscore) into `entry.axiomOverlap`, and the **coverage-closure lint depends on that v2 accessor**. Renaming the live catalog to kebab would silently break the one consumer that actually gates #1466 (coverage-closure would report DIM-1/2/3/7 as gaps). Since no #1466 acceptance criterion requires the kebab field to resolve, the catalog keeps `axiom_overlap` (underscore) **unchanged**. The schema/loader key-unification (have `invariant-schema.ts` accept underscore, or the loader emit kebab) is a *machinery* seam belonging to #1465's code surface, explicitly **out of #1466's content scope** — logged as Open Question #4 / follow-up, not done in this content PR.
+2. **Two severity scales:** the catalog entry `severity` is `{ default: blocking|advisory, by-workflow?, by-phase? }` (a review-dimension verdict), while the leaf-check `severity` in `check-catalog.ts` is `HIGH|MEDIUM|LOW`. Authoring must not conflate them — entries carry the blocking/advisory scale; leaf precision is a separate axis the evaluator maps.
+
+## Chosen Approach — B: Mechanize-where-precise, audit-the-rest (calibrated)
+
+Author `mode: check` only for invariants that *already possess* a high-precision operational projection (an existing lint or a structural fact with near-zero false-positive rate); author `mode: audit` for every invariant whose conformance is a genuine judgment call. Each `mode: check` tree must satisfy the **calibrate-on-HEAD rule**: it produces **zero findings against the current clean tree** before it is declared, so the only finding on any diff is an *introduced* violation (and the authoring PR's own review stays green except for the deliberately-seeded fixture).
+
+Rejected: **A (audit-first)** under-delivers against the bug — most invariants stay soft and the DSL is never exercised. **C (full mechanization)** authors greps that masquerade as semantic proofs, violating INV-4's spirit and guaranteeing review noise on legitimate future PRs.
+
+### Enforcement-mode assignment
+
+| Invariant | Mode | Leaf / projection | Why this mode |
+|---|---|---|---|
+| **INV-6** workload-agnosticism | `check` | reuse `scripts/lint-inv6.mjs` grep — workflow-typed literals in `skills-src/**` | Already a proven, enforcing lint; zero-FP today. |
+| **INV-5d** action-discriminator | `check` | `structural` — count of visible composite tools registered in `registry.ts` ≤ 4 (and total visible ≤ 15) | A countable structural fact, not a judgment. |
+| **INV-5a** input-ergonomics | `check` | `structural` — visible tool count < 15 (shares INV-5d's count) | Mechanical threshold. |
+| **INV-4** platform-agnosticity | `check` | `grep` — direct edits to generated `skills/<runtime>/**` (source-of-truth violation) | High-precision: any diff hunk under `skills/<runtime>/` that isn't a regen is a violation. |
+| **INV-2** facade-equivalence | `check` | `grep` (`scope`d) — behavior keywords appearing inside `adapters/{cli,mcp}.ts` beyond presentation | Heuristic proxy; **calibrated to zero on HEAD**, MEDIUM severity, advisory floor — flags suspicious adapter logic for human confirmation, does not claim to prove parity. |
+| **INV-1** event-sourcing-integrity | `audit` | `audit-prompt` | Reducer purity / "is this a drifting side database?" is judgment. |
+| **INV-11** posture / unrepresentable | `audit` | `audit-prompt` | Capability-resolution reasoning; not greppable. |
+| **INV-3** basileus-forward | `audit` | `audit-prompt` | "Does this presume MCP-local?" is judgment. |
+| **INV-13 / INV-14** process-manager / recovery | `audit` | `audit-prompt` | Two-event-split and recovery-primitive ordering are semantic. |
+
+INV-7/8/9/10/12/15 keep affinity + severity metadata but no enforcement block at launch (audit-prompt may be added incrementally; absence is valid). The acceptance bar (≥1 `check` ∧ ≥1 `audit`, both exercised) is met several times over.
+
+### Projection metadata (DR-5 §6 table)
+
+Every authored entry gains:
+
+- **`phase-affinity`** — enforcement-bearing substrate invariants get `[review]` (the gate phase); design-time invariants additionally get `[ideate, plan]` where they shape acceptance criteria.
+- **`workflow-affinity`** — code-axis invariants exclude `discover` (docs-only workflow → code invariants N/A); all keep `feature/debug/refactor/oneshot`.
+- **`severity`** — `default: blocking` for substrate invariants, with `by-workflow: { oneshot: advisory }` (the design's oneshot-downgrade) and `by-workflow: { discover: advisory }` where an invariant is retained but soft. INV-2's heuristic check is `default: advisory` (precision-limited proxy).
+- **`integrity-class`** — `substrate` for INV-1..INV-15; `authoring` for the DIM-8 prose-quality pointer.
+
+### Coverage-closure disposition (DR-8)
+
+`DIM-4` (test-fidelity), `DIM-5` (hygiene), `DIM-6` (solid-coupling), `DIM-8` (prose-quality) are axiom-owned dimensions with no Exarchos-specific specializing invariant. Per DR-8 each is marked **`coverage: n/a`** with a one-line cross-reference to its owning axiom skill (`/axiom:verify`, `/axiom:distill`, `/axiom:critique`, `/axiom:humanize`). DIM-1/2/3/7 are already covered by specializing INVs via `axiom-overlap` and need only the key-normalization. The coverage-closure lint (additive to `npm run lint:invariants`, shipped by #1465) must exit zero after authoring.
+
+## Requirements
+
+### CR-1: Schema bump + back-compat
+Bump `docs/architecture/invariants.md` frontmatter to `schema-version: 3`. **Do not** rename `axiom_overlap` (see Problem Statement #1 — coupling to coverage-closure). The existing loader back-compat fixture test stays green; add/extend a characterization asserting (a) the live catalog still parses under the v3 loader with zero errors, (b) v3 fields parse where authored, and (c) absent affinities resolve to all-phases/all-types.
+
+**Acceptance:** loader parses the v3 catalog with zero errors; back-compat test green; `schema-version: 3`; coverage-closure still green (proving the `axiom_overlap` accessor is intact).
+
+### CR-2: Author ≥1 `mode: check` + ≥1 `mode: audit`, exercised
+Author the enforcement blocks per the assignment table. Each `mode: check` tree calibrated to **zero findings on HEAD**. Add a fixture-diff test: a seeded violating diff makes `check_invariant_conformance` produce a real finding with the invariant id, and a clean diff returns `APPROVED` with a `gate.executed` event (INV-10 observability).
+
+**Acceptance:** ≥1 check and ≥1 audit authored and exercised against a fixture diff; clean-tree calibration verified; gate emits `gate.executed` on both paths.
+
+### CR-3: Projection metadata populated
+`phase-affinity`, `workflow-affinity`, `severity` authored per §DR-5 table. Verify projection excludes code invariants for `workflow-type=discover` and that `by-workflow: { oneshot: advisory }` downgrades resolve.
+
+**Acceptance:** a projection test over the live catalog confirms discover-exclusion and oneshot-downgrade.
+
+### CR-4: Coverage-closure satisfied
+DIM-4/5/6/8 marked `coverage: n/a` with axiom cross-reference; DIM-1/2/3/7 confirmed covered. `npm run lint:invariants` exits zero.
+
+**Acceptance:** coverage-closure lint green; `lint:invariants` byte-identical-or-cleaner than base; `skills:guard` exit 0.
+
+### CR-5: Verify the gate bites end-to-end (INV-2 parity)
+The fixture-diff verification runs through **both** the CLI and MCP adapters and asserts byte/schema-identical `ToolResult` (reuse `__tests__/parity-harness.ts`). This is the proof the authored content — not just the machinery — produces real findings on both facades.
+
+**Acceptance:** parity test green over `check_invariant_conformance` with the authored catalog; full MCP suite + root suite green; `tsc --noEmit` clean.
+
+## Integration Points
+
+- `docs/architecture/invariants.md` — the authored content (all CRs).
+- `servers/exarchos-mcp/src/architecture/invariant-schema.ts` — schema is the authoring target (read-only here; no code change expected unless an unforeseen field is needed).
+- `servers/exarchos-mcp/src/architecture/invariants-loader.ts` + its tests — back-compat characterization (CR-1).
+- `servers/exarchos-mcp/src/architecture/project-catalog.ts` + tests — projection assertions (CR-3).
+- `servers/exarchos-mcp/src/orchestrate/check-invariant-conformance.{ts,test.ts}` — fixture-diff exercise (CR-2/5).
+- `scripts/lint-inv6.mjs` — referenced as INV-6's `mode: check` projection (reuse, not rewrite).
+- `npm run lint:invariants` (vocabulary-lint + coverage-closure) — CR-4 gate.
+
+## Testing Strategy
+
+- **Back-compat:** v3-loader over the newly-bumped live catalog → zero parse errors; `axiom-overlap` resolves.
+- **Calibration:** each `mode: check` tree evaluated against clean HEAD → zero findings (the bootstrap-hazard guard).
+- **Fixture-diff bite:** seeded violation per authored check → finding with invariant id; clean diff → `APPROVED` + `gate.executed`.
+- **Projection:** discover excludes code invariants; oneshot downgrades to advisory.
+- **INV-2 parity:** gate through both adapters → identical `ToolResult`.
+- **Coverage-closure:** `lint:invariants` exits zero; DIM-4/5/6/8 `n/a` markers honored.
+
+## Open Questions (deferred to plan/implementation)
+
+1. **INV-2 heuristic-check precision.** The adapter-behavior grep is the one genuinely-heuristic `mode: check`. If calibration on HEAD can't reach zero findings without an over-broad `not(...)` exclusion list, demote INV-2 to `mode: audit` (Approach-B fallback) rather than ship a noisy check. Decide at implementation against the real tree.
+2. **Fixture-diff location.** Whether seeded violating diffs live as test fixtures under `check-invariant-conformance.test.ts` or as a small fixtures dir — a plan-time mechanical choice.
+3. **INV-5a/5d shared count leaf.** Whether the visible-tool-count structural leaf is authored once and referenced, or duplicated across INV-5a and INV-5d — the DSL has no cross-entry reference, so likely duplicated with a shared pattern constant; confirm at plan.
+4. **`axiom_overlap` key unification (out of #1466 scope).** The v3 schema reads `axiom-overlap` while the loader + coverage-closure read `axiom_overlap`. Unifying them is a one-line machinery change in #1465's surface (`invariant-schema.ts` or `invariants-loader.ts`), tracked as a small follow-up so `/axiom:design` pairing-discovery sees the v3 field. Not blocking #1466.

--- a/docs/designs/2026-05-24-sdlc-catalog-authoring.md
+++ b/docs/designs/2026-05-24-sdlc-catalog-authoring.md
@@ -1,0 +1,84 @@
+# Design: Author the SDLC-* Consumer Catalog + Close the sdlc-Layer Seam
+
+> **Status:** Design — output of `/exarchos:ideate`, input to `/exarchos:plan`.
+> **Date:** 2026-05-24
+> **Issue:** [#1467](https://github.com/lvlup-sw/exarchos/issues/1467)
+> **Research input:** [`docs/research/2026-05-24-sdlc-consumer-invariants.md`](../research/2026-05-24-sdlc-consumer-invariants.md)
+> **Stacks on:** #1466 (`feature/invariants-v3-content-and-sdlc`) → #1465 (machinery). **Merges as one combined PR.**
+> **Catalog:** adds the **sdlc layer** (new, plugin-bundled, default-on); dev catalog (`INV-*`) unchanged.
+
+## Constraints (Phase 0 — devCatalog: enabled)
+
+- **INV-11 (POLA authority gradient)** — `integrity-class: sdlc` ⇒ override-floor `advisory`: consumers tune `SDLC-*` down to advisory, never silently disable. The override-floor verification is the load-bearing acceptance test (DR-3).
+- **INV-1 (no drifting side store)** — the inline catalog is a module constant; `resolveEffectiveCatalog` stays a pure read-model with **zero file-IO** for the sdlc layer.
+- **INV-2 (facade-equivalence)** — the sdlc layer flows through the single `resolveEffectiveCatalog` core the gate + view + CLI already share; no second path.
+- **INV-6 (workload-agnosticism)** — every `SDLC-*` entry is workload-neutral (the research §3 audience-boundary test).
+- **INV-4 / INV-3** — baseline is all-audit (sandbox-free by construction); prompts are transport-neutral.
+- **DIM-3 (contracts)** — `resolveEffectiveCatalog`'s signature and the entry Zod schema are unchanged; the seam change is additive.
+
+## Problem Statement
+
+PR #1465 wired the sdlc layer as a hardcoded empty-array placeholder (`resolve-effective-catalog.ts:131`: *"sdlc catalog CONTENT is out of scope"*), and #1467's discovery scoped the content + audience boundary. This design ships the content. The packaging reality forces the mechanism: the MCP server runs as a **single-file binary** (`command: "exarchos"`), and the npm `files` list bundles `dist/bin`, `commands`, `skills` — **not `docs/`**. A catalog under `docs/` would be absent for plugin consumers, so a "default-on" catalog cannot be a `docs/` file read at runtime.
+
+## Chosen Approach — Inline TS module, schema-validated
+
+Author the `SDLC-*` baseline as a typed array in `servers/exarchos-mcp/src/architecture/sdlc-catalog.ts`, validated at module load through the **same** `InvariantEntryV3Schema` the dev loader uses (INV-4 `.strict()` enforcement guarantee preserved). The seam at `resolve-effective-catalog.ts:131` becomes `const sdlc = loadSdlcCatalog();` — a constant import, no `fs`, no `devCatalog`-style gate (sdlc ships **on**). Consumers still author *their own* catalogs as `.md`/`.yml` via `config.invariants.catalogs`; only Exarchos's shipped baseline is code.
+
+To avoid duplicating the loader's raw→typed projection, expose a pure `parseInvariantEntries(raw: unknown[]): InvariantEntry[]` from `invariants-loader.ts` (the existing internal `parseEntry` + `projectV3Fields`, minus file-IO and the devCatalog gate). Both the file loader and `sdlc-catalog.ts` call it — one parse path (INV-2 spirit), no drift.
+
+Rejected: a shipped `.md` data file (adds packaging entries + `EXARCHOS_PLUGIN_ROOT` path resolution + runtime disk-IO); a build-time `.md`→TS embed (adds a codegen step). Both carry more failure surface for no authoring benefit on a 5-entry shipped baseline.
+
+## Requirements
+
+### DR-1: Author the 5-entry `SDLC-*` baseline (all-audit)
+In `sdlc-catalog.ts`, author SDLC-1..5 per research §4, each with `integrity-class: sdlc`, `axis: substrate` (closest enum fit for "runtime conduct"; also yields the desired discovery-exclusion), `enforcement: { mode: audit, audit-prompt }`, `severity`, and `workflow-affinity` **excluding `discovery`** (see §below). Audit prompts are transport-neutral (INV-3) and workload-neutral (INV-6).
+
+| id | summary | severity | workflow-affinity |
+|---|---|---|---|
+| SDLC-1 phase-observability | long-running ops queryable; state reconstructible | advisory | feature, debug, refactor, oneshot |
+| SDLC-2 tdd-discipline | test-before-impl where declared; prompt **points at `check_tdd_compliance`** (no double-gate) | blocking; `by-workflow:{oneshot:advisory}` | feature, oneshot |
+| SDLC-3 review-gate-honesty | verdict reflects findings; no advisory-laundering of HIGH | blocking | feature, debug, refactor, oneshot |
+| SDLC-4 branch-pr-discipline | PR body has Summary/Changes/Test Plan; bottom-up stacked merge; no admin-merge bypass | blocking | feature, debug, refactor, oneshot |
+| SDLC-5 recovery-posture | pause/resume from on-disk state; native-primitive-first, no destructive overwrite | advisory | feature, debug, refactor, oneshot |
+
+**Acceptance:** `loadSdlcCatalog()` returns 5 schema-valid `InvariantEntry[]`; each `axis: substrate`, `integrity-class: sdlc`, `mode: audit`; a malformed inline entry fails at module load (fail-fast).
+
+**Discovery scoping note:** `projectCatalog` already excludes `axis: substrate` entries from `discovery` workflows. SDLC entries are `axis: substrate`, so all five are excluded from discovery automatically — consistent with their `workflow-affinity` (discovery is a docs-research workflow; SDLC conduct invariants target code-bearing workflows). This deliberately tightens research §4's SDLC-5 "all" to "exclude discovery" and needs **no machinery change**.
+
+### DR-2: Close the sdlc-layer seam
+Replace `resolve-effective-catalog.ts:131`'s `const sdlc: InvariantEntry[] = []` with `const sdlc = loadSdlcCatalog()`. No gate. `mergeCatalogs` already tags sdlc entries `integrity-class: sdlc`; the inline `integrity-class` is reaffirmed, not relied upon.
+
+**Acceptance:** with `devCatalog: disabled` (a consumer), `resolveEffectiveCatalog` at `phase=review, workflow=feature` returns the SDLC-* entries (dev layer empty, sdlc layer populated) — proving sdlc is default-on independent of the dev gate. Parity: the `invariants_effective` view + CLI `--json` surface the same SDLC entries (INV-2, reuse parity harness).
+
+### DR-3: Verify override-floor end-to-end (the INV-11 acceptance)
+A consumer `overrides: { SDLC-3: { severity: advisory } }` clamps SDLC-3 to advisory; `overrides: { SDLC-3: { enabled: false } }` is **refused** by the honored-disable filter (sdlc floor = advisory) — the entry survives and a warning is emitted, never a silent drop.
+
+**Acceptance:** a config-driven test (real `resolveEffectiveCatalog`, no DI double) proves both: severity-clamp honored; full-disable refused + warning surfaced.
+
+### DR-4: Update the consumer authoring guide
+`docs/guides/authoring-invariants.md` documents the shipped default-on `SDLC-*` baseline, the override-floor semantics (tune-to-advisory, not disable), and the dev/sdlc/user audience split (research §3).
+
+**Acceptance:** the guide names all five SDLC-* entries + a worked override example; no new `vocabulary-lint` findings (SDLC-* is outside the `INV-/DIM-` token regex, so it is lint-neutral).
+
+## Integration Points
+
+- `servers/exarchos-mcp/src/architecture/sdlc-catalog.ts` — **new**: inline catalog + `loadSdlcCatalog()` (DR-1).
+- `servers/exarchos-mcp/src/architecture/invariants-loader.ts` — expose `parseInvariantEntries(raw[])` (refactor, reused by the loader + sdlc-catalog).
+- `servers/exarchos-mcp/src/architecture/resolve-effective-catalog.ts` — close the seam (DR-2).
+- `docs/guides/authoring-invariants.md` — DR-4.
+- Tests: `sdlc-catalog.test.ts` (DR-1), `resolve-effective-catalog.test.ts` (DR-2/DR-3 default-on + override-floor).
+
+## Testing Strategy
+
+- **Catalog validity:** `loadSdlcCatalog()` → 5 entries, all `mode: audit`, `integrity-class: sdlc`; a malformed entry throws at load.
+- **Default-on isolation:** `devCatalog: disabled` still yields SDLC-* (the consumer scenario); `devCatalog: enabled` yields dev + sdlc.
+- **Override-floor:** severity-clamp honored; full-disable refused + warning (DR-3, config-driven).
+- **Discovery exclusion:** `workflow=discovery` projects zero SDLC-* entries.
+- **Parity:** gate + view return identical SDLC payload (reuse `__tests__/parity-harness.ts`).
+- **No regression:** full MCP + root suites; `tsc --noEmit`; `skills:guard`; `lint:invariants` (coverage-closure still green, no new findings).
+
+## Open Questions (deferred to plan/implementation)
+
+1. **`parseInvariantEntries` extraction shape** — whether to expose the batch parser or a single-entry `parseInvariantEntry`; mechanical, decided at plan against the existing `parseEntry` signature.
+2. **SDLC-2 ↔ `check_tdd_compliance` linkage** — the audit-prompt references the existing gate by name; confirm no projection wiring makes it double-fire at review.
+3. **`axis` semantics for sdlc** — `substrate` is the pragmatic enum fit; a future `axis: sdlc` value is a possible machinery refinement (out of scope here, logged).

--- a/docs/designs/2026-05-24-sdlc-catalog-authoring.md
+++ b/docs/designs/2026-05-24-sdlc-catalog-authoring.md
@@ -43,7 +43,7 @@ In `sdlc-catalog.ts`, author SDLC-1..5 per research §4, each with `integrity-cl
 
 **Acceptance:** `loadSdlcCatalog()` returns 5 schema-valid `InvariantEntry[]`; each `axis: substrate`, `integrity-class: sdlc`, `mode: audit`; a malformed inline entry fails at module load (fail-fast).
 
-**Discovery scoping note:** `projectCatalog` already excludes `axis: substrate` entries from `discovery` workflows. SDLC entries are `axis: substrate`, so all five are excluded from discovery automatically — consistent with their `workflow-affinity` (discovery is a docs-research workflow; SDLC conduct invariants target code-bearing workflows). This deliberately tightens research §4's SDLC-5 "all" to "exclude discovery" and needs **no machinery change**.
+**Discovery scoping note:** all five entries are excluded from discovery workflows via their `workflow-affinity` (the lists omit discovery; discovery is a docs-research workflow, SDLC conduct invariants target code-bearing ones). This tightens research §4's SDLC-5 "all" to "exclude discovery" and needs **no machinery change**. (`projectCatalog` also has an `axis: substrate` auto-exclusion branch, but it checks the token `'discover'` while the runtime workflow type is `'discovery'` — a latent #1465 token mismatch, logged as a follow-up; the `workflow-affinity` exclusion is the robust path and does not depend on that branch.)
 
 ### DR-2: Close the sdlc-layer seam
 Replace `resolve-effective-catalog.ts:131`'s `const sdlc: InvariantEntry[] = []` with `const sdlc = loadSdlcCatalog()`. No gate. `mergeCatalogs` already tags sdlc entries `integrity-class: sdlc`; the inline `integrity-class` is reaffirmed, not relied upon.

--- a/docs/guides/authoring-invariants.md
+++ b/docs/guides/authoring-invariants.md
@@ -13,7 +13,7 @@ by authoring a catalog file and listing it in `.exarchos.yml`.
 > [§0](#0-the-shipped-sdlc-baseline-default-on). Authoring your own `user`-tier
 > catalog is supported today; your entries merge on top of the SDLC baseline.
 
-## 0. The shipped SDLC-* baseline (default-on)
+## 0. The shipped SDLC baseline (default-on)
 
 Exarchos ships a small **consumer-facing** catalog that is **on by default** —
 you do not register or enable it. These `SDLC-*` invariants govern *how you run

--- a/docs/guides/authoring-invariants.md
+++ b/docs/guides/authoring-invariants.md
@@ -8,11 +8,35 @@ gate**. This is the same machinery Exarchos applies to itself; you plug into it
 by authoring a catalog file and listing it in `.exarchos.yml`.
 
 > **Status:** the v3 schema, loader, projection, and gate ship as of
-> [PR #1465](https://github.com/lvlup-sw/exarchos/pull/1465). Authoring your own
-> `user`-tier catalog is supported today. The Exarchos-shipped `SDLC-*` consumer
-> catalog (default-on baseline invariants) is a separate forthcoming deliverable
-> — until it lands, the sdlc layer is empty and only your `user` catalog and any
-> enabled dev catalog contribute.
+> [PR #1465](https://github.com/lvlup-sw/exarchos/pull/1465). The Exarchos-shipped
+> `SDLC-*` consumer catalog (the default-on baseline) ships as of #1467 — see
+> [§0](#0-the-shipped-sdlc-baseline-default-on). Authoring your own `user`-tier
+> catalog is supported today; your entries merge on top of the SDLC baseline.
+
+## 0. The shipped SDLC-* baseline (default-on)
+
+Exarchos ships a small **consumer-facing** catalog that is **on by default** —
+you do not register or enable it. These `SDLC-*` invariants govern *how you run
+your SDLC through Exarchos* (workflow conduct), not your application's
+architecture. They are workload-neutral: the same set applies to a React app, a
+Go CLI, or a Python service. All ship as `mode: audit` (the review subagent
+judges them; none is a mechanical diff check) with `integrity-class: sdlc`, so
+you can **tune any of them down to advisory but never silently disable** one
+(§4).
+
+| id | governs | default severity |
+|---|---|---|
+| `SDLC-1` phase-observability | long-running ops are queryable; state reconstructible from disk | advisory |
+| `SDLC-2` tdd-discipline | test-before-impl where the workflow declares it (feature, oneshot); defers to the `check_tdd_compliance` gate | blocking (oneshot ⇒ advisory) |
+| `SDLC-3` review-gate-honesty | the verdict reflects the findings; no advisory-laundering of a HIGH | blocking |
+| `SDLC-4` branch-pr-discipline | PR body has Summary/Changes/Test Plan; bottom-up stacked merge; no admin-merge bypass | blocking |
+| `SDLC-5` recovery-posture | pause/resume from on-disk state; native-primitive-first recovery, no destructive overwrite | advisory |
+
+They bite at **review** on code-bearing workflows (`feature`, `debug`,
+`refactor`, `oneshot`); a `discovery` (docs-only) workflow is exempt. The three
+audiences are distinct: **dev** (`INV-*`, Exarchos's own runtime substrate,
+`devCatalog`-gated, you never see it) → **sdlc** (`SDLC-*`, this baseline) →
+**user** (your own `U-*` entries, §2).
 
 ## 1. Register a catalog
 
@@ -126,8 +150,8 @@ Use `overrides` to adjust an invariant Exarchos ships, within its
 ```yaml
 invariants:
   overrides:
-    SDLC-3: { severity: advisory }   # downgrade
-    SDLC-7: { enabled: false }       # clamps to advisory if the floor forbids disable (you'll get a warning)
+    SDLC-3: { severity: advisory }   # downgrade review-gate-honesty to advisory
+    SDLC-4: { enabled: false }       # REFUSED — sdlc floor is advisory, so this clamps to advisory + emits a warning, not a silent disable
 ```
 
 You can add new ids (in your own namespace) freely; you can tune `sdlc`/`authoring`

--- a/docs/plans/2026-05-24-invariants-dev-catalog-v3-content.md
+++ b/docs/plans/2026-05-24-invariants-dev-catalog-v3-content.md
@@ -1,0 +1,203 @@
+# Implementation Plan: Author v3 Dev-Catalog Content (#1466)
+
+> **Design:** [`docs/designs/2026-05-24-invariants-dev-catalog-v3-content.md`](../designs/2026-05-24-invariants-dev-catalog-v3-content.md)
+> **Stacks on:** PR #1465 (`feature/invariants-projection-extensibility`)
+> **Iron law:** no catalog content lands without a failing test first (loader / projection / gate / lint).
+
+## Nature of this work
+
+The "production code" is **YAML content** in `docs/architecture/invariants.md`. TDD applies literally: each task writes a failing test (loader back-compat, fixture-diff bite, projection assertion, or coverage-closure lint) **first**, then authors the catalog content that turns it green. The machinery (schema, evaluator, gate, lint) is already shipped by #1465 and is read-only here.
+
+**Single-file contention:** nearly every task edits the one file `docs/architecture/invariants.md`. Worktree-parallel dispatch would collide on that file, so the content tasks run **sequentially on one branch**. Test files differ per task and could be authored in parallel, but since RED must precede the shared-file GREEN, the chain is serial. This is an honest constraint, not a missed parallelization.
+
+**Calibrate-on-HEAD rule (applies to every `mode: check` task):** after authoring a check tree, run `check_invariant_conformance` against the *current clean tree* and confirm **zero findings**. Only a deliberately-seeded fixture diff may produce a finding. This is the bootstrap-hazard guard.
+
+---
+
+### Task 1: Schema-version bump + v3 loader back-compat
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** CR-1
+
+1. [RED] Extend `servers/exarchos-mcp/src/architecture/invariants-loader.test.ts`
+   - Test: `loadInvariants_liveCatalogAtV3_parsesEveryEntryWithNoError`
+   - Test: `loadInvariants_entryWithoutAffinities_resolvesAllPhasesAllTypes`
+   - Expected failure: live catalog is `schema-version: 2`; the v3 assertion on the frontmatter version fails.
+
+2. [GREEN] Edit `docs/architecture/invariants.md` frontmatter: `schema-version: 2` → `3`. **No other change.** Do *not* rename `axiom_overlap` (design Problem-Statement #1).
+
+3. [REFACTOR] Confirm `npm run lint:invariants` coverage-closure still green (proves the `axiom_overlap` accessor is intact post-bump).
+
+**Dependencies:** None
+**Parallelizable:** No (touches the shared catalog file)
+
+---
+
+### Task 2: INV-6 `mode: check` (workflow-typed-literal grep)
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** CR-2 (check #1)
+
+1. [RED] Add to `servers/exarchos-mcp/src/orchestrate/check-invariant-conformance.test.ts`
+   - Test: `gate_diffWithWorkflowTypedLiteralInSkillsSrc_emitsInv6Finding`
+   - Test: `gate_cleanDiff_inv6ProducesNoFinding`
+   - Expected failure: INV-6 has no `enforcement` block, so no finding on the seeded violating diff.
+
+2. [GREEN] Author INV-6 `enforcement: { mode: check, check: <grep tree> }` in `invariants.md`, reusing the `scripts/lint-inv6.mjs` literal set (`feature/`, `featureId`, workflow-type names) scoped to `fileGlob: skills-src/**`. Use a `not(scope(...))` arm to exclude legitimate `featureId` field references if calibration requires.
+
+3. [REFACTOR] **Calibrate-on-HEAD:** run the gate on clean tree → assert zero INV-6 findings; tighten the pattern/`not` arm until green.
+
+**Dependencies:** Task 1
+**Parallelizable:** No
+
+---
+
+### Task 3: INV-5d + INV-5a `mode: check` (visible-tool-count structural)
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** CR-2 (check #2, #3)
+
+1. [RED] Add to `check-invariant-conformance.test.ts`
+   - Test: `gate_diffRegisteringFifthCompositeTool_emitsInv5dFinding`
+   - Test: `gate_cleanDiff_inv5dInv5aProduceNoFinding`
+   - Expected failure: no enforcement block on INV-5d/INV-5a.
+
+2. [GREEN] Author `structural` check leaves: INV-5d → composite-tool registration count > 4 in `registry.ts`; INV-5a → visible-tool count ≥ 15. Use a shared pattern constant duplicated across both entries (DSL has no cross-entry reference — design OQ #3).
+
+3. [REFACTOR] Calibrate-on-HEAD: current count is 4 composite / under 15 visible → zero findings.
+
+**Dependencies:** Task 1
+**Parallelizable:** No
+
+---
+
+### Task 4: INV-4 `mode: check` (generated-skills direct-edit grep)
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** CR-2 (check #4)
+
+1. [RED] Add to `check-invariant-conformance.test.ts`
+   - Test: `gate_diffEditingGeneratedSkillsRuntimeFile_emitsInv4Finding`
+   - Test: `gate_diffEditingSkillsSrcOnly_inv4ProducesNoFinding`
+   - Expected failure: no enforcement block on INV-4.
+
+2. [GREEN] Author `grep` check: hunk headers touching `skills/<runtime>/**` (generated output) flagged as a source-of-truth violation, scoped to exclude `skills-src/**`.
+
+3. [REFACTOR] Calibrate-on-HEAD (this PR touches no `skills/**` → zero findings).
+
+**Dependencies:** Task 1
+**Parallelizable:** No
+
+---
+
+### Task 5: INV-2 `mode: check` heuristic (adapter-carries-behavior) — with audit fallback
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** CR-2 (check #5), design OQ #1
+
+1. [RED] Add to `check-invariant-conformance.test.ts`
+   - Test: `gate_diffAddingLogicToCliAdapter_emitsInv2AdvisoryFinding`
+   - Expected failure: no enforcement block on INV-2.
+
+2. [GREEN] Author `grep` (scoped to `adapters/{cli,mcp}.ts`) for behavior keywords beyond presentation, `severity: { default: advisory }`. **Decision gate:** if calibration on HEAD cannot reach zero findings without an over-broad `not(...)` exclusion list, **demote INV-2 to `mode: audit`** (the Approach-B fallback) rather than ship a noisy check.
+
+3. [REFACTOR] Calibrate-on-HEAD; record the check-vs-audit decision in the task notes.
+
+**Dependencies:** Task 1
+**Parallelizable:** No
+
+---
+
+### Task 6: `mode: audit` prompts — INV-1 / INV-11 / INV-3 / INV-13 / INV-14
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** CR-2 (audit), DR-4
+
+1. [RED] Extend `servers/exarchos-mcp/src/architecture/audit-prompt.test.ts`
+   - Test: `renderAuditPrompt_inv11Authored_containsAuditPromptVerbatim`
+   - Test: `renderAuditPrompt_noMcpLocalPresumption_inv3PromptIsTransportNeutral` (INV-3 guard)
+   - Expected failure: no `audit-prompt` on these entries.
+
+2. [GREEN] Author `enforcement: { mode: audit, audit-prompt: "..." }` for INV-1 (reducer purity / side-database), INV-11 (unrepresentable-by-construction), INV-3 (no MCP-local presumption — transport-neutral phrasing), INV-13/14 (two-event-split / recovery-primitive ordering).
+
+3. [REFACTOR] Verify rendered prompt carries no `INV-*`-specific branching in the runner (INV-6 — runner stays workflow-agnostic).
+
+**Dependencies:** Task 1
+**Parallelizable:** No
+
+---
+
+### Task 7: Projection metadata — affinity + severity + integrity-class
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** CR-3, DR-5 §6 table
+
+1. [RED] Extend `servers/exarchos-mcp/src/architecture/project-catalog.test.ts`
+   - Test: `projectCatalog_workflowDiscoverPhaseReview_excludesCodeAxisInvariants`
+   - Test: `projectCatalog_workflowOneshot_downgradesSeverityToAdvisory`
+   - Expected failure: entries lack `workflow-affinity` / `severity.by-workflow`.
+
+2. [GREEN] Author per-entry `phase-affinity` (`[review]` for enforcement-bearing; `+[ideate,plan]` for design-time), `workflow-affinity` (code-axis excludes `discover`), `severity` (`default: blocking`, `by-workflow: { oneshot: advisory }`), `integrity-class` (`substrate` for INV-*, `authoring` for DIM-8). INV-2 keeps `default: advisory`.
+
+3. [REFACTOR] Spot-check the live-catalog projection snapshot for unintended exclusions.
+
+**Dependencies:** Tasks 2–6 (entries must exist before metadata is layered)
+**Parallelizable:** No
+
+---
+
+### Task 8: Coverage-closure — DIM-4/5/6/8 `coverage: n/a`
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** CR-4, DR-8
+
+1. [RED] Extend `servers/exarchos-mcp/src/architecture/vocabulary-lint.test.ts`
+   - Test: `coverageClosure_dim4Through8WithoutSpecializingInv_areExemptedByNaMarker`
+   - Expected failure: DIM-4/5/6/8 have neither a specializing INV nor an `n/a` marker → coverage-gap findings.
+
+2. [GREEN] Add `coverage: n/a` to DIM-4/5/6/8 entries in `invariants.md`, each with a one-line axiom cross-reference (`/axiom:verify`, `/axiom:distill`, `/axiom:critique`, `/axiom:humanize`). Confirm DIM-1/2/3/7 stay covered via existing `axiom_overlap`.
+
+3. [REFACTOR] `npm run lint:invariants` exits zero.
+
+**Dependencies:** Task 1
+**Parallelizable:** No
+
+---
+
+### Task 9: End-to-end gate bite + INV-2 facade parity
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** CR-5, INV-2/5b
+
+1. [RED] Add a parity test (reuse `servers/exarchos-mcp/src/__tests__/parity-harness.ts`)
+   - Test: `checkInvariantConformance_authoredCatalog_cliAndMcpReturnIdenticalToolResult`
+   - Test: `checkInvariantConformance_seededViolation_emitsGateExecutedWithInvariantId`
+   - Expected failure (pre-content) / regression guard (post-content).
+
+2. [GREEN] Content already authored (Tasks 2–7); this task verifies the authored catalog produces byte/schema-identical `ToolResult` across both adapters and that a clean diff returns `APPROVED` + a `gate.executed` event (INV-10).
+
+3. [REFACTOR] Full suites: `cd servers/exarchos-mcp && npm run test:run`; root `npm run test:run`; `npm run typecheck`; `npm run skills:guard`; `npm run lint:invariants`. All green.
+
+**Dependencies:** Tasks 1–8
+**Parallelizable:** No
+
+---
+
+## Execution order (single serial chain)
+
+```
+Task 1 (bump)
+  ├─▶ Task 2 (INV-6 check)
+  ├─▶ Task 3 (INV-5d/5a check)
+  ├─▶ Task 4 (INV-4 check)
+  ├─▶ Task 5 (INV-2 check/audit)
+  ├─▶ Task 6 (audit prompts)
+  └─▶ Task 8 (coverage-closure)
+            │
+            ▼
+        Task 7 (metadata — needs entries from 2–6)
+            │
+            ▼
+        Task 9 (e2e parity + suites)
+```
+
+Tasks 2–6 + 8 are *logically* independent but **serialized on the shared `invariants.md` file**. Task 7 layers metadata onto the authored entries; Task 9 is the final verification gate.
+
+## Definition of done (acceptance roll-up)
+
+- [ ] `invariants.md` at `schema-version: 3`; loader back-compat green; `axiom_overlap` untouched (CR-1).
+- [ ] ≥1 `mode: check` + ≥1 `mode: audit` authored and exercised by `check_invariant_conformance` against a fixture diff; every check calibrated to zero findings on HEAD (CR-2).
+- [ ] `phase-affinity` / `workflow-affinity` / `severity` / `integrity-class` populated; discover-exclusion + oneshot-downgrade proven (CR-3).
+- [ ] DIM-4/5/6/8 `coverage: n/a`; `lint:invariants` exits zero (CR-4).
+- [ ] INV-2 CLI↔MCP parity green; full MCP + root suites green; `tsc --noEmit` clean; `skills:guard` exit 0 (CR-5).

--- a/docs/plans/2026-05-24-sdlc-catalog-authoring.md
+++ b/docs/plans/2026-05-24-sdlc-catalog-authoring.md
@@ -1,0 +1,134 @@
+# Implementation Plan: SDLC-* Consumer Catalog + Close the sdlc Seam (#1467)
+
+> **Design:** [`docs/designs/2026-05-24-sdlc-catalog-authoring.md`](../designs/2026-05-24-sdlc-catalog-authoring.md)
+> **Branch:** `feature/invariants-v3-content-and-sdlc` (combined PR with #1466)
+> **Iron law:** no production code without a failing test first.
+
+## Nature of this work
+
+Mixed code + content + docs: a loader refactor, a new inline-catalog module, a one-line seam change, and a guide update. The 5 `SDLC-*` entries are typed data validated by the existing Zod schema. TDD applies to every code change; the guide (DR-4) is docs (no test, lint-checked).
+
+All tasks land on the single combined branch (no worktree fan-out): the seam change (`resolve-effective-catalog.ts`) and the new module (`sdlc-catalog.ts`) are separate files but chain by dependency, so execution is serial.
+
+---
+
+### Task 1: Expose `parseInvariantEntries` from the loader (refactor enabler)
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** Chosen-Approach (one parse path, INV-2 spirit)
+
+1. [RED] Add to `servers/exarchos-mcp/src/architecture/invariants-loader.test.ts`
+   - Test: `parseInvariantEntries_rawEntries_projectsTypedShapeWithV3Fields`
+   - Test: `parseInvariantEntries_duplicateIds_throws`
+   - Expected failure: `parseInvariantEntries` is not exported.
+
+2. [GREEN] Refactor `invariants-loader.ts`: extract the existing `data.invariants.map(parseEntry)` + duplicate-id guard into an exported pure `parseInvariantEntries(raw: unknown[]): InvariantEntry[]` (no file-IO, no schema-version guard, no devCatalog gate, no scope filter). `loadInvariants` calls it. Behavior unchanged for the file path.
+
+3. [REFACTOR] Confirm the full loader suite (43 tests) stays green — the extraction is behavior-preserving.
+
+**Dependencies:** None
+**Parallelizable:** No (shared file with later edits)
+
+---
+
+### Task 2: `sdlc-catalog.ts` — author the 5-entry baseline
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** DR-1
+
+1. [RED] New `servers/exarchos-mcp/src/architecture/sdlc-catalog.test.ts`
+   - Test: `loadSdlcCatalog_returnsFiveEntries_allAuditModeIntegritySdlc`
+   - Test: `loadSdlcCatalog_everyEntry_axisSubstrateWorkflowAffinityExcludesDiscovery`
+   - Test: `loadSdlcCatalog_malformedEntry_throwsAtLoad` (e.g. an embedded `script` key fails the `.strict()` enforcement schema)
+   - Expected failure: module does not exist.
+
+2. [GREEN] Author `sdlc-catalog.ts`: a raw-entry array (SDLC-1..5 per DR-1 table — `integrity-class: sdlc`, `axis: substrate`, `mode: audit` transport-neutral + workload-neutral prompts, `severity`, `workflow-affinity` excluding `discovery`; SDLC-2 prompt references `check_tdd_compliance`), and `loadSdlcCatalog()` = `parseInvariantEntries(RAW_SDLC_ENTRIES)` (Task 1), validated/fail-fast at module load.
+
+3. [REFACTOR] Verify prompts contain no MCP-local language (INV-3) and no workflow-typed branching assumptions (INV-6).
+
+**Dependencies:** Task 1
+**Parallelizable:** No
+
+---
+
+### Task 3: Close the sdlc-layer seam (default-on)
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** DR-2
+
+1. [RED] Add to `servers/exarchos-mcp/src/architecture/resolve-effective-catalog.test.ts`
+   - Test: `resolveEffectiveCatalog_devCatalogDisabled_stillReturnsSdlcEntries` (consumer scenario: dev layer empty, sdlc populated, default-on)
+   - Test: `resolveEffectiveCatalog_workflowDiscovery_excludesAllSdlcEntries`
+   - Expected failure: sdlc layer is the empty-array placeholder → zero SDLC entries.
+
+2. [GREEN] In `resolve-effective-catalog.ts:131`, replace `const sdlc: InvariantEntry[] = []` with `const sdlc = loadSdlcCatalog()`. No gate.
+
+3. [REFACTOR] Confirm `resolveEffectiveCatalog` stays pure (no fs added for the sdlc layer; INV-1).
+
+**Dependencies:** Task 2
+**Parallelizable:** No
+
+---
+
+### Task 4: Override-floor verification (the INV-11 acceptance)
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** DR-3
+
+1. [RED] Add to `resolve-effective-catalog.test.ts`
+   - Test: `resolveEffectiveCatalog_sdlc3SeverityOverrideAdvisory_clampHonored`
+   - Test: `resolveEffectiveCatalog_sdlc3EnabledFalse_refusedAndWarns` (floor=advisory → entry survives + warning, never silent drop)
+   - Expected failure (pre-seam) / regression guard (post-seam): without the sdlc layer there is no SDLC-3 to override.
+
+2. [GREEN] No new code expected — `applyOverrides` + the honored-disable filter already enforce the floor (delivered by #1465). This task proves it end-to-end against the real SDLC-3 entry. If a gap surfaces, fix minimally.
+
+3. [REFACTOR] Assert the warning text names SDLC-3 and the floor.
+
+**Dependencies:** Task 3
+**Parallelizable:** No
+
+---
+
+### Task 5: Parity — gate + view surface identical SDLC payload
+**Phase:** RED → GREEN → REFACTOR
+**Maps:** DR-2 (INV-2)
+
+1. [RED] Add a parity assertion (reuse `servers/exarchos-mcp/src/__tests__/parity-harness.ts` patterns) that the `invariants_effective` view / CLI `--json` and the gate's resolved catalog both contain the SDLC-* entries for a consumer context.
+   - Test: `invariantsEffective_consumerContext_surfacesSdlcEntries_cliMcpIdentical`
+   - Expected failure / regression guard.
+
+2. [GREEN] Content already wired (Task 3); this verifies byte/shape identity across facades.
+
+3. [REFACTOR] —
+
+**Dependencies:** Task 3
+**Parallelizable:** Yes (independent of Task 4)
+
+---
+
+### Task 6: Update the consumer authoring guide (DR-4) + full verification
+**Phase:** (docs — no RED) → verify
+
+1. [GREEN] Update `docs/guides/authoring-invariants.md`: replace the "sdlc layer is empty / forthcoming" status note with the shipped default-on `SDLC-*` baseline (all five named), the override-floor semantics (tune-to-advisory, not disable), and the dev/sdlc/user audience split (research §3) + a worked override example.
+
+2. [VERIFY] `cd servers/exarchos-mcp && npm run test:run`; root `npm run test:run`; root `npm run typecheck`; `npm run skills:guard`; `npm run lint:invariants` (coverage-closure still green, no new findings — SDLC-* is outside the INV-/DIM- token regex, lint-neutral).
+
+**Dependencies:** Tasks 1–5
+**Parallelizable:** No
+
+---
+
+## Execution order
+
+```
+Task 1 (expose parseInvariantEntries)
+   └─▶ Task 2 (sdlc-catalog.ts + 5 entries)
+          └─▶ Task 3 (close seam, default-on)
+                 ├─▶ Task 4 (override-floor verify)
+                 └─▶ Task 5 (facade parity)
+                        └─▶ Task 6 (guide + full suites)
+```
+
+## Definition of done (acceptance roll-up)
+
+- [ ] `loadSdlcCatalog()` → 5 schema-valid entries, all `mode: audit`, `integrity-class: sdlc`, `axis: substrate`; malformed entry fails at load (DR-1).
+- [ ] Seam closed: `devCatalog: disabled` consumer still gets SDLC-* (default-on); discovery excludes them (DR-2).
+- [ ] Override-floor: SDLC-3 severity-clamp honored; full-disable refused + warning (DR-3, INV-11).
+- [ ] Facade parity: gate + view identical SDLC payload (INV-2).
+- [ ] Guide updated; `lint:invariants` coverage-closure green + no new findings; full MCP + root suites green; `tsc --noEmit` clean; `skills:guard` exit 0 (DR-4).

--- a/docs/research/2026-05-24-sdlc-consumer-invariants.md
+++ b/docs/research/2026-05-24-sdlc-consumer-invariants.md
@@ -1,0 +1,103 @@
+# Research: The SDLC-* Consumer-Facing Invariants Catalog
+
+> **Status:** Discovery deliverable — output of `/exarchos:discover`, input to a follow-on `/exarchos:ideate`.
+> **Date:** 2026-05-24
+> **Issue:** [#1467](https://github.com/lvlup-sw/exarchos/issues/1467) (`type:docs` — scoping; has an implementation tail, see §5)
+> **Stacks on:** #1466 (`feature/invariants-dev-catalog-v3-content`) → #1465 (machinery)
+> **Mechanism delivered by:** [PR #1465](https://github.com/lvlup-sw/exarchos/pull/1465) (`integrity-class: sdlc`, layered merge, override-floor)
+> **Provenance:** v2 spec [§10](../proposals/2026-05-20-invariants-catalog-v2-spec.md); design [DR-6 + Open Question #2](../designs/2026-05-23-invariants-projection-and-extensibility.md)
+
+## 1. Research question
+
+PR #1465 built the **sdlc layer mechanism** but authored **zero** `SDLC-*` entries; the layer is a hardcoded empty-array placeholder. This discovery answers two questions before any catalog is authored:
+
+1. **What is the `SDLC-*` set** — which consumer-facing invariants ship default-on, and as `mode: check` vs `mode: audit`?
+2. **Where is the audience boundary** — what distinguishes a consumer SDLC invariant from (a) an Exarchos *dev* invariant (`INV-*`, `devCatalog`-gated) and (b) a consumer's *own* application invariant (`U-*`, user layer)?
+
+It does **not** author the catalog. The authoring + the code seam it requires are a follow-on `/exarchos:ideate` (§5).
+
+## 2. What the mechanism already provides (the constraints authoring must fit)
+
+From `catalog-merge.ts` and `resolve-effective-catalog.ts` (PR #1465):
+
+- **Three layers, merged in order** `dev → sdlc → user` (`mergeCatalogs`). The sdlc layer is tagged `integrity-class: sdlc`.
+- **Override floor.** `resolveFloor` derives a per-invariant floor from `integrity-class`; **sdlc defaults to `advisory`** — a consumer may downgrade an `SDLC-*` entry to advisory via `.exarchos.yml: invariants.overrides`, but the honored-disable filter refuses a full `enabled: false` unless the floor permits it. An entry may carry an explicit `override-floor: advisory | disable` to widen/narrow this. This is the POLA authority gradient (INV-11) realized for consumers: **tunable, never silently removable.**
+- **`SDLC-*` is a reserved namespace** (`RESERVED_USER_ID_PREFIXES`). A user catalog claiming an `SDLC-*` id fails with `ReservedNamespaceError`. So the shipped sdlc set owns that prefix; consumers extend with free-form/`U-*` ids.
+- **The seam is open.** `resolve-effective-catalog.ts:131` hardcodes `const sdlc: InvariantEntry[] = []` with the comment *"sdlc catalog CONTENT is out of scope for this task."* **Shipping the catalog requires closing this seam** (load a plugin-bundled catalog file into the sdlc layer) — a small code change, not pure docs (§5).
+- **Projection applies uniformly.** `SDLC-*` entries carry `phase-affinity` / `workflow-affinity` / `severity` / `enforcement` exactly as the dev `INV-*` entries do (the #1466 worked reference). The same `check_invariant_conformance` gate evaluates them.
+
+## 3. The audience boundary (the load-bearing distinction)
+
+Three concentric audiences, three id namespaces, three integrity classes:
+
+| Catalog | Audience | Governs | id prefix | default state |
+|---|---|---|---|---|
+| **dev** | Exarchos's own contributors | the Exarchos runtime substrate (event log, OCC, posture, dispatch parity) | `INV-*` / `DIM-*` | `devCatalog`-gated, **off** for consumers |
+| **sdlc** | *any* engineer using Exarchos as a plugin | **how they run their SDLC through Exarchos** — workflow conduct, not application code | `SDLC-*` | **default-on** |
+| **user** | a specific consumer project | *their own* application architecture | free-form / `U-*` | opt-in via `catalogs:` |
+
+The discriminator for an `SDLC-*` entry is: **it governs the consumer's conduct of a software-development workflow, enforceable through affordances Exarchos already exposes** (lifecycle events, review gates, the PR template, checkpoint/rehydrate, posture) — and it is **workload-neutral** (true for a React app, a Go CLI, a Python service alike).
+
+It is **not** an `SDLC-*` invariant if:
+- it describes Exarchos's *internal* substrate (that's dev/`INV-*`, and consumers never touch it — they use the affordances, they don't reimplement the runtime); or
+- it describes the *consumer's application* (that's their `U-*` user catalog — e.g. "all HTTP handlers validate input"; Exarchos has no opinion).
+
+**Relationship to dev `INV-*`:** several `SDLC-*` entries are the *consumer-facing mirror* of a substrate `INV-*`. INV-10 (liveness protocol) is substrate machinery; **SDLC phase-observability** is the consumer-visible guarantee that machinery affords. INV-14 (native-primitive recovery) is substrate; **SDLC recovery-posture** is the consumer's "my workflow is resumable from disk" guarantee. The mirror is intentional — same principle, different audience, different enforcement surface.
+
+## 4. Proposed `SDLC-*` set (default-on baseline)
+
+Five entries for the launch baseline, drawn from v2 spec §10 and the design's named candidates. Each lists its enforcement mode (mechanizable `check` vs judgment `audit`, applying #1466's calibration discipline — *only mechanize a high-precision, diff-visible proxy*), default severity, override-floor, and workflow-affinity.
+
+### SDLC-1 — Phase observability
+*Every long-running workflow operation is queryable; nobody asks "what step are we on?"* — the workflow emits lifecycle events and state is reconstructible.
+- **Mode:** `audit` (the consumer's workflow either emits via Exarchos affordances or it doesn't; a diff-grep can't judge "observable"). Mirrors substrate INV-10.
+- **Severity:** advisory · **floor:** advisory · **workflow-affinity:** all except `discovery`.
+
+### SDLC-2 — TDD discipline (when declared)
+*Test-before-implementation for workflow types that name it (`feature`, `oneshot`); `discovery` exempt; `debug`/`refactor` have their own gates.* The consumer-facing analogue of `check_tdd_compliance`.
+- **Mode:** `audit` at review (the RED-before-GREEN ordering is a commit-history property, not a single-diff property — the same reason #1466 kept judgment calls as audit). Candidate `check` only if a diff-visible proxy proves reliable.
+- **Severity:** blocking on `feature`/`oneshot`; **`by-workflow: { discovery: advisory }`** · **floor:** advisory · **workflow-affinity:** `feature`, `oneshot`.
+
+### SDLC-3 — Review-gate honesty
+*A gate that fails surfaces its findings; the verdict reflects them. No advisory-laundering of a HIGH finding; silently passing a gate is worse than a loud fail.*
+- **Mode:** `audit` (honesty is a judgment about the verdict↔findings relationship).
+- **Severity:** blocking · **floor:** advisory · **workflow-affinity:** all except `discovery`.
+- *Note:* this is the entry the design uses as the `override-floor` worked example (`SDLC-3` downgradable to advisory, not disable-able).
+
+### SDLC-4 — Branch / PR discipline
+*PR bodies carry the required sections (`## Summary` / `## Changes` / `## Test Plan`); stacked PRs merge bottom-up; no admin-merge bypassing review.*
+- **Mode:** **`check`** for the mechanizable half — a grep over the PR body for the required section headers is a high-precision, text-visible proxy (the one strong `check` candidate in the set). `audit` for the "no admin-merge bypass" half.
+- **Severity:** blocking · **floor:** advisory · **workflow-affinity:** all except `discovery`.
+- *Provenance:* promotes project memory `feedback_stacked_pr_auto_merge_collapses_granularity` + the PR-template CI rule to a first-class invariant.
+
+### SDLC-5 — Recovery posture
+*Any workflow pauses (checkpoint) and resumes (rehydrate) from on-disk state without consulting human memory; recovery prefers native primitives, never destructive overwrite.*
+- **Mode:** `audit`. Mirrors substrate INV-14 for the consumer.
+- **Severity:** advisory · **floor:** advisory · **workflow-affinity:** all.
+
+### Deferred candidates (named in §10, held back from the launch baseline)
+- **Authoring/playbook split** — the consumer-facing mirror of INV-6; defer until consumers actually author skills/playbooks (low signal at launch).
+- **Subagent boundary** — "sub-agents inherit posture; orphans are reaped" overlaps substrate INV-11 and is largely enforced by the runtime, not the consumer's conduct; defer.
+
+**Mode tally:** 1 `check` (SDLC-4 PR-section grep) + 5 `audit`-bearing — matching #1466's finding that, under INV-4's declarative-only constraint, *most* invariants are honestly judgment calls and only a few have a high-precision diff-visible proxy.
+
+## 5. What "shipping the catalog" actually requires (the implementation tail)
+
+The issue's acceptance has four items; only item 1 is this discovery. The rest is a follow-on `/exarchos:ideate` and is **not pure docs**:
+
+1. ✅ **This research artifact** — SDLC-* set + audience boundary (delivered here).
+2. ⏳ **Author the catalog file** — a plugin-bundled `SDLC-*` catalog (e.g. `catalogs/sdlc-invariants.md`, shipped in the plugin package), authored in the #1466 v3 shape.
+3. ⏳ **Close the loader seam** — replace `resolve-effective-catalog.ts:131`'s `const sdlc = []` with a loader that reads the bundled catalog **default-on** (no `devCatalog`-style gate; sdlc ships enabled). This is the one genuine code change.
+4. ⏳ **Verify override-floor end-to-end** — a test proving a consumer can downgrade `SDLC-3` to advisory but a full `enabled: false` is refused by the honored-disable filter (the floor holds).
+5. ⏳ **Update the consumer guide** — `docs/guides/authoring-invariants.md` to document the shipped baseline + how to override it.
+
+## 6. Open questions for the follow-on ideate
+
+1. **Catalog file location & packaging** — where the plugin bundles the sdlc catalog so the loader finds it both in-repo and when installed as a plugin (path resolution differs from the `repoRoot`-relative dev catalog).
+2. **Default-on vs gate** — confirm sdlc ships with *no* opt-in flag (unlike `devCatalog`). The override mechanism is the consumer's escape hatch, not a master switch — consistent with "default-on baseline."
+3. **SDLC-2 TDD enforcement surface** — whether the existing `check_tdd_compliance` gate is *reused* (SDLC-2 points at it) or re-expressed as catalog enforcement; avoid double-gating.
+4. **SDLC-4 check precision** — calibrate the PR-body-section grep against real PR bodies before declaring it `check` (the #1466 calibrate-on-HEAD discipline).
+
+## 7. Recommendation
+
+Proceed to a follow-on `/exarchos:ideate` scoped to **author the 5-entry `SDLC-*` baseline + close the loader seam (items 2–5 above)**, stacked on this branch. The audience boundary in §3 is the acceptance test for every candidate entry: *if it isn't workload-neutral consumer workflow-conduct enforceable through an existing Exarchos affordance, it doesn't belong in `SDLC-*`.*

--- a/servers/exarchos-mcp/src/architecture/dev-catalog-content.test.ts
+++ b/servers/exarchos-mcp/src/architecture/dev-catalog-content.test.ts
@@ -1,0 +1,293 @@
+// ─── Dev-catalog v3 content characterization (issue #1466) ──────────────────
+//
+// These tests assert the AUTHORED CONTENT of the live dev catalog at
+// `docs/architecture/invariants.md` — distinct from #1465's machinery tests
+// (loader, evaluator, projection) which inject synthetic entries. Here we load
+// the REAL catalog and assert the v3 fields authored onto real invariants:
+//   CR-1  schema-version 3 + back-compat
+//   CR-2  ≥1 mode:check + ≥1 mode:audit, each firing on a seeded diff and
+//         CALIBRATED to zero findings on a clean diff (bootstrap-hazard guard)
+//   CR-3  affinity + severity + integrity-class projection
+//   CR-6  audit prompts rendered verbatim
+//
+// The "calibrate on clean" guard here uses an empty / benign diff; the full
+// "zero findings on the actual HEAD diff" calibration is verified by the gate
+// run during implementation and the e2e parity test.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import matter from 'gray-matter';
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+import { loadInvariants, type InvariantEntry } from './invariants-loader.js';
+import { evaluateTree } from './check-evaluator.js';
+import { projectCatalog } from './project-catalog.js';
+import { renderAuditPrompt } from './audit-prompt.js';
+import { scanCoverageClosure } from './vocabulary-lint.js';
+import { EventStore } from '../event-store/store.js';
+import { handleCheckInvariantConformance } from '../orchestrate/check-invariant-conformance.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const INVARIANTS_DOC = path.join(REPO_ROOT, 'docs/architecture/invariants.md');
+const ENABLED_CONFIG = { invariants: { devCatalog: 'enabled' as const } };
+
+function loadCatalog(): InvariantEntry[] {
+  return loadInvariants(INVARIANTS_DOC, { scope: 'all' }, ENABLED_CONFIG);
+}
+
+function entry(id: string): InvariantEntry {
+  const e = loadCatalog().find((x) => x.id === id);
+  if (!e) throw new Error(`catalog entry ${id} not found`);
+  return e;
+}
+
+/** A unified diff hunk touching one file. */
+function diffFor(filePath: string, addedLines: string[]): string {
+  return [
+    `--- a/${filePath}`,
+    `+++ b/${filePath}`,
+    '@@ -1 +1,2 @@',
+    ...addedLines.map((l) => `+${l}`),
+  ].join('\n');
+}
+
+// ─── CR-1: schema bump + back-compat ─────────────────────────────────────────
+
+describe('dev-catalog v3 content — CR-1 schema bump', () => {
+  it('liveCatalog_declaresSchemaVersion3', () => {
+    const fm = matter(fs.readFileSync(INVARIANTS_DOC, 'utf8')).data as {
+      'schema-version'?: unknown;
+    };
+    expect(fm['schema-version']).toBe(3);
+  });
+
+  it('liveCatalog_loadsUnderV3LoaderWithNoError', () => {
+    expect(() => loadCatalog()).not.toThrow();
+    expect(loadCatalog().length).toBeGreaterThan(0);
+  });
+
+  it('liveCatalog_coverageClosureStaysGreen_axiomOverlapAccessorIntact', () => {
+    // Proves the axiom_overlap accessor (underscore) survived the bump — the
+    // coverage-closure lint depends on it; renaming to kebab would break it.
+    const gaps = scanCoverageClosure({
+      invariantsDoc: INVARIANTS_DOC,
+      config: ENABLED_CONFIG,
+    });
+    expect(gaps).toEqual([]);
+  });
+
+  it('entryWithoutAffinities_resolvesAllPhasesAllTypes', () => {
+    // An entry with no phase/workflow affinity must project for any context.
+    const noAffinity = loadCatalog().find(
+      (e) => e.phaseAffinity === undefined && e.workflowAffinity === undefined,
+    );
+    expect(noAffinity).toBeDefined();
+    const projected = projectCatalog([noAffinity!], {
+      phase: 'review',
+      workflowType: 'feature',
+    });
+    expect(projected).toHaveLength(1);
+  });
+});
+
+// ─── CR-2: mode:check enforcement, calibrated ────────────────────────────────
+
+describe('dev-catalog v3 content — CR-2 mode:check enforcement', () => {
+  it('atLeastOneCheckAndOneAudit_authored', () => {
+    const cat = loadCatalog();
+    const checks = cat.filter((e) => e.enforcement?.mode === 'check');
+    const audits = cat.filter((e) => e.enforcement?.mode === 'audit');
+    expect(checks.length).toBeGreaterThanOrEqual(1);
+    expect(audits.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // INV-4 is the lone precise mode:check. INV-6's operational projection
+  // (scripts/lint-inv6.mjs) is a deliberately-advisory literal scan with a
+  // frontmatter-declaration escape hatch a diff-grep cannot replicate, and
+  // INV-5a/5d tool-COUNT facts require the whole file, not a diff — so all
+  // three are mode:audit (Approach-B "audit the rest"). See CR-6 below.
+
+  it('inv4_editingGeneratedSkillsRuntimeFile_fires', () => {
+    const e = entry('INV-4');
+    expect(e.enforcement?.mode).toBe('check');
+    const violating = diffFor('skills/claude-code/brainstorming/SKILL.md', [
+      'direct edit to generated output',
+    ]);
+    const findings = evaluateTree(
+      (e.enforcement as { mode: 'check'; check: never }).check,
+      violating,
+    );
+    expect(findings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('inv4_editingSkillsSrcOnly_producesNoFinding', () => {
+    const e = entry('INV-4');
+    const clean = diffFor('skills-src/brainstorming/SKILL.md', [
+      'edit to source-of-truth is fine',
+    ]);
+    const findings = evaluateTree(
+      (e.enforcement as { mode: 'check'; check: never }).check,
+      clean,
+    );
+    expect(findings).toEqual([]);
+  });
+});
+
+// ─── CR-6: mode:audit prompts ────────────────────────────────────────────────
+
+describe('dev-catalog v3 content — CR-6 mode:audit', () => {
+  it('inv6_inv5a_inv5d_areAuditMode', () => {
+    // Demoted from check (Approach-B): not diff-precise. They contribute
+    // judgment prompts, never a programmatic check.
+    for (const id of ['INV-6', 'INV-5a', 'INV-5d']) {
+      expect(entry(id).enforcement?.mode).toBe('audit');
+    }
+  });
+
+  it('inv11_isAuditModeWithPrompt', () => {
+    const e = entry('INV-11');
+    expect(e.enforcement?.mode).toBe('audit');
+    const prompt = renderAuditPrompt([e]);
+    expect(prompt).toContain('INV-11');
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+
+  it('inv3_auditPrompt_isTransportNeutral', () => {
+    // INV-3 (basileus-forward) audit prompt must not presume MCP-local
+    // execution — no "locally"/"on this machine"-style language.
+    const e = entry('INV-3');
+    expect(e.enforcement?.mode).toBe('audit');
+    const promptText = (
+      e.enforcement as { mode: 'audit'; 'audit-prompt': string }
+    )['audit-prompt'].toLowerCase();
+    expect(promptText).not.toMatch(/mcp[- ]local|local-only|on this machine/);
+  });
+
+  it('renderedAuditPrompt_carriesNoPerInvariantBranching', () => {
+    // INV-6 guard: the renderer treats every audit invariant uniformly.
+    const cat = loadCatalog();
+    const audits = cat.filter((e) => e.enforcement?.mode === 'audit');
+    const prompt = renderAuditPrompt(audits);
+    for (const a of audits) expect(prompt).toContain(a.id);
+  });
+});
+
+// ─── CR-3: projection metadata ───────────────────────────────────────────────
+
+describe('dev-catalog v3 content — CR-3 projection', () => {
+  it('workflowDiscoverPhaseReview_excludesCodeAxisInvariants', () => {
+    const projected = projectCatalog(loadCatalog(), {
+      phase: 'review',
+      workflowType: 'discover',
+    });
+    // No substrate-axis (code) invariant survives a discover-workflow review.
+    expect(projected.every((e) => e.axis !== 'substrate')).toBe(true);
+  });
+
+  it('substrateInvariants_carryIntegrityClassSubstrate', () => {
+    const inv1 = entry('INV-1');
+    expect(inv1.integrityClass).toBe('substrate');
+  });
+
+  it('oneshotWorkflow_downgradesSeverityToAdvisory', () => {
+    // At least one enforcement-bearing invariant downgrades to advisory under
+    // the oneshot workflow (design DR-5 oneshot rule).
+    const downgraded = loadCatalog().filter(
+      (e) => e.severity?.['by-workflow']?.['oneshot'] === 'advisory',
+    );
+    expect(downgraded.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─── CR-5: end-to-end gate bite through the REAL production path ─────────────
+//
+// Drives handleCheckInvariantConformance with repoRoot=REPO_ROOT + the enabled
+// config and NO injected loader, so resolveEffectiveCatalog loads the AUTHORED
+// docs/architecture/invariants.md for real. Proves the authored content (not
+// just the machinery) produces a real finding on a violating diff and stays
+// APPROVED + emits gate.executed on a clean diff (calibrate-on-HEAD).
+
+describe('dev-catalog v3 content — CR-5 end-to-end gate bite', () => {
+  async function arm(): Promise<{ stateDir: string; eventStore: EventStore }> {
+    const stateDir = await mkdtemp(path.join(tmpdir(), 'inv1466-e2e-'));
+    const eventStore = new EventStore(stateDir);
+    await eventStore.initialize();
+    return { stateDir, eventStore };
+  }
+
+  it('seededGeneratedSkillsEdit_inv4Fires_NeedsFixesWithGateEvent', async () => {
+    const { stateDir, eventStore } = await arm();
+    try {
+      const violating = diffFor('skills/claude-code/brainstorming/SKILL.md', [
+        'a direct edit to generated output',
+      ]);
+      const result = await handleCheckInvariantConformance(
+        {
+          featureId: 'feat-1466-violating',
+          workflowType: 'feature',
+          phase: 'review',
+          diff: violating,
+          repoRoot: REPO_ROOT,
+          config: ENABLED_CONFIG,
+        },
+        stateDir,
+        eventStore,
+      );
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        verdict: string;
+        high: number;
+        findings: Array<{ dimension?: string }>;
+      };
+      expect(data.verdict).toBe('NEEDS_FIXES');
+      expect(data.high).toBeGreaterThanOrEqual(1);
+      expect(data.findings.some((f) => f.dimension === 'INV-4')).toBe(true);
+
+      const gates = await eventStore.query('feat-1466-violating', {
+        type: 'gate.executed',
+      });
+      expect(gates.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it('cleanDiff_approvedWithGateEvent', async () => {
+    const { stateDir, eventStore } = await arm();
+    try {
+      // A benign source edit (no skills/** path) trips no mode:check invariant.
+      const clean = diffFor('servers/exarchos-mcp/src/example.ts', [
+        'export const answer = 42;',
+      ]);
+      const result = await handleCheckInvariantConformance(
+        {
+          featureId: 'feat-1466-clean',
+          workflowType: 'feature',
+          phase: 'review',
+          diff: clean,
+          repoRoot: REPO_ROOT,
+          config: ENABLED_CONFIG,
+        },
+        stateDir,
+        eventStore,
+      );
+      expect(result.success).toBe(true);
+      const data = result.data as { verdict: string; high: number };
+      expect(data.verdict).toBe('APPROVED');
+      expect(data.high).toBe(0);
+
+      const gates = await eventStore.query('feat-1466-clean', {
+        type: 'gate.executed',
+      });
+      expect(gates.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
@@ -379,6 +379,18 @@ describe('invariants-loader', () => {
     expect(() => parseInvariantEntries(dup)).toThrow(/Duplicate invariant ID: SDLC-1/);
   });
 
+  it('parseInvariantEntries_nonObjectEntry_throwsIndexNamedError', () => {
+    // A null/primitive element must fail with a clear, index-named loader error
+    // rather than a generic TypeError deep in parseEntry. The dev/user layers
+    // surface this as a DR-9 degradation warning naming the catalog.
+    const bad = [
+      { id: 'SDLC-1', dimension: 'a', axis: 'substrate', 'cost-of-load': 'always-load', 'applies-to': ['x'], summary: 's', references: ['r'] },
+      null,
+    ];
+    expect(() => parseInvariantEntries(bad)).toThrow(/entry at index 1 must be an object/);
+    expect(() => parseInvariantEntries(['just-a-string'])).toThrow(/entry at index 0 must be an object/);
+  });
+
   it('Invariants_AfterSchemaV3Bump_EveryEntryHasAxisField', () => {
     // Read raw frontmatter to assert the schema-version bump (v3, issue #1466).
     const source = fs.readFileSync(INVARIANTS_DOC, 'utf8');

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import {
   loadCoreInvariants,
   loadInvariants,
+  parseInvariantEntries,
   type InvariantEntry,
 } from './invariants-loader.js';
 
@@ -344,6 +345,39 @@ describe('invariants-loader', () => {
   // (Wave D1) intersects with `cost-of-load`.
   //
   // Spec: docs/proposals/2026-05-20-invariants-catalog-v2-spec.md §3, §7.1
+
+  it('parseInvariantEntries_rawEntries_projectsTypedShapeWithV3Fields', () => {
+    // The pure raw[]→typed projection reused by both the file loader and the
+    // inline sdlc catalog (#1467). No file-IO, no devCatalog gate, no scope.
+    const raw = [
+      {
+        id: 'SDLC-1',
+        dimension: 'phase-observability',
+        axis: 'substrate',
+        'cost-of-load': 'always-load',
+        'integrity-class': 'sdlc',
+        'applies-to': ['workflow-lifecycle'],
+        summary: 'Long-running ops are queryable.',
+        references: ['docs/guides/authoring-invariants.md'],
+        'workflow-affinity': ['feature', 'oneshot'],
+        enforcement: { mode: 'audit', 'audit-prompt': 'Is every op queryable?' },
+      },
+    ];
+    const entries = parseInvariantEntries(raw);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe('SDLC-1');
+    expect(entries[0].integrityClass).toBe('sdlc');
+    expect(entries[0].workflowAffinity).toEqual(['feature', 'oneshot']);
+    expect(entries[0].enforcement?.mode).toBe('audit');
+  });
+
+  it('parseInvariantEntries_duplicateIds_throws', () => {
+    const dup = [
+      { id: 'SDLC-1', dimension: 'a', axis: 'substrate', 'cost-of-load': 'always-load', 'applies-to': ['x'], summary: 's', references: ['r'] },
+      { id: 'SDLC-1', dimension: 'b', axis: 'substrate', 'cost-of-load': 'always-load', 'applies-to': ['x'], summary: 's', references: ['r'] },
+    ];
+    expect(() => parseInvariantEntries(dup)).toThrow(/Duplicate invariant ID: SDLC-1/);
+  });
 
   it('Invariants_AfterSchemaV3Bump_EveryEntryHasAxisField', () => {
     // Read raw frontmatter to assert the schema-version bump (v3, issue #1466).

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
@@ -345,13 +345,13 @@ describe('invariants-loader', () => {
   //
   // Spec: docs/proposals/2026-05-20-invariants-catalog-v2-spec.md §3, §7.1
 
-  it('Invariants_AfterSchemaV2Bump_EveryEntryHasAxisField', () => {
-    // Read raw frontmatter to assert the schema-version bump.
+  it('Invariants_AfterSchemaV3Bump_EveryEntryHasAxisField', () => {
+    // Read raw frontmatter to assert the schema-version bump (v3, issue #1466).
     const source = fs.readFileSync(INVARIANTS_DOC, 'utf8');
     const frontmatterMatch = source.match(/^---\n([\s\S]*?)\n---/);
     expect(frontmatterMatch, 'invariants.md must have YAML frontmatter').not.toBeNull();
     const frontmatter = frontmatterMatch![1];
-    expect(frontmatter).toMatch(/^schema-version:\s*2\b/m);
+    expect(frontmatter).toMatch(/^schema-version:\s*3\b/m);
 
     // Every loaded entry must expose the typed `axis` field with one of
     // the two allowed values. Asserts the loader has promoted the new
@@ -1183,31 +1183,64 @@ invariants:
     }
   });
 
-  it('LoadInvariants_LiveV2Catalog_ZeroDiffUnderV3Loader', () => {
-    // Characterization guard: the REAL docs/architecture/invariants.md
-    // (still schema-version: 2) must load under the widened v3 loader with
-    // zero observable change. We assert STRUCTURAL parity — not an exact
-    // snapshot of churn-prone summary prose:
-    //   - it loads without error,
-    //   - every resolved entry keeps its v2 fields intact,
-    //   - no v3 field is spuriously populated (all undefined).
-    const entries = loadInvariants(INVARIANTS_DOC, undefined, ENABLED_CONFIG);
-    expect(entries.length).toBeGreaterThan(0);
-    for (const entry of entries) {
-      // v2 required fields are well-formed.
-      expect(typeof entry.id).toBe('string');
-      expect(entry.id.length).toBeGreaterThan(0);
-      expect(entry.axis === 'substrate' || entry.axis === 'authoring').toBe(true);
-      expect(['always-load', 'reference-only', 'archivable']).toContain(entry.costOfLoad);
-      expect(Array.isArray(entry.appliesTo)).toBe(true);
-      expect(typeof entry.summary).toBe('string');
-      // No v3 field is populated under the v2 catalog.
-      expect(entry.phaseAffinity).toBeUndefined();
-      expect(entry.workflowAffinity).toBeUndefined();
-      expect(entry.stateAffinity).toBeUndefined();
-      expect(entry.integrityClass).toBeUndefined();
-      expect(entry.severity).toBeUndefined();
-      expect(entry.enforcement).toBeUndefined();
+  it('LoadInvariants_V2FixtureCatalog_ZeroV3FieldsUnderV3Loader', () => {
+    // Back-compat contract (DR-1): a schema-version: 2 catalog with NO v3 keys
+    // loads under the widened v3 loader with every v3 field undefined.
+    //
+    // NOTE: the LIVE docs/architecture/invariants.md is now schema-version: 3
+    // and authors v3 fields (issue #1466 — see dev-catalog-content.test.ts).
+    // This guard therefore pins the v2 back-compat contract against a synthetic
+    // v2 fixture rather than the live file, so the contract stays asserted even
+    // though the live catalog has graduated to v3.
+    const v2Fixture = `---
+schema-version: 2
+invariants:
+  - id: INV-1
+    dimension: event-sourcing-integrity
+    axis: substrate
+    cost-of-load: always-load
+    applies-to:
+      - event-store
+    summary: A v2 entry that declares no v3 fields.
+    references:
+      - docs/architecture/invariants.md
+  - id: DIM-8
+    dimension: prose-quality
+    axis: authoring
+    cost-of-load: archivable
+    applies-to:
+      - documentation
+    summary: A v2 authoring-axis entry.
+    references:
+      - docs/architecture/invariants.md
+---
+
+# Fixture
+`;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'invariants-v2-'));
+    const tmpFile = path.join(tmpDir, 'invariants.md');
+    fs.writeFileSync(tmpFile, v2Fixture, 'utf8');
+    try {
+      const entries = loadInvariants(tmpFile, undefined, ENABLED_CONFIG);
+      expect(entries.length).toBeGreaterThan(0);
+      for (const entry of entries) {
+        // v2 required fields are well-formed.
+        expect(typeof entry.id).toBe('string');
+        expect(entry.id.length).toBeGreaterThan(0);
+        expect(entry.axis === 'substrate' || entry.axis === 'authoring').toBe(true);
+        expect(['always-load', 'reference-only', 'archivable']).toContain(entry.costOfLoad);
+        expect(Array.isArray(entry.appliesTo)).toBe(true);
+        expect(typeof entry.summary).toBe('string');
+        // No v3 field is populated under the v2 catalog.
+        expect(entry.phaseAffinity).toBeUndefined();
+        expect(entry.workflowAffinity).toBeUndefined();
+        expect(entry.stateAffinity).toBeUndefined();
+        expect(entry.integrityClass).toBeUndefined();
+        expect(entry.severity).toBeUndefined();
+        expect(entry.enforcement).toBeUndefined();
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.ts
@@ -344,7 +344,18 @@ export function parseInvariantEntries(rawEntries: unknown): InvariantEntry[] {
       'invariants-loader: parseInvariantEntries expects an array of entries',
     );
   }
-  const entries = (rawEntries as RawInvariantEntry[]).map(parseEntry);
+  // Guard each element before parseEntry so a null/primitive entry yields a
+  // clear, index-named loader error instead of a generic TypeError deep in the
+  // parser. For the disk/consumer layers this surfaces as a DR-9 degradation
+  // warning naming the catalog rather than an opaque crash.
+  const entries = rawEntries.map((raw, index) => {
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new Error(
+        `invariants-loader: entry at index ${index} must be an object`,
+      );
+    }
+    return parseEntry(raw as RawInvariantEntry);
+  });
   // Reject duplicate IDs — IDs are the catalog's primary key and must be
   // unique. A silent duplicate would shadow the earlier entry and corrupt
   // vocabulary-lint / ideate Constraint surfacing.

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.ts
@@ -326,6 +326,39 @@ function projectV3Fields(raw: RawInvariantEntry, entry: InvariantEntry): void {
 }
 
 /**
+ * Pure raw→typed projection for a list of catalog entries (no file-IO, no
+ * `schema-version` guard, no `devCatalog` gate, no scope filter). Validates and
+ * projects each raw entry via `parseEntry` (which enforces the v2 required
+ * fields and the v3 `.strict()` enforcement DSL, INV-4) and rejects duplicate
+ * ids — the same primary-key guarantee `loadInvariants` relies on.
+ *
+ * This is the single parse path shared by the file loader (`loadInvariants`)
+ * and the inline plugin-shipped sdlc catalog (`sdlc-catalog.ts`, #1467), so the
+ * two cannot drift (INV-2 spirit). Cross-entry `axiom_overlap` referential
+ * integrity stays in `loadInvariants` — it is meaningful only for the full
+ * INV-/DIM- catalog, not an arbitrary entry list.
+ */
+export function parseInvariantEntries(rawEntries: unknown): InvariantEntry[] {
+  if (!Array.isArray(rawEntries)) {
+    throw new Error(
+      'invariants-loader: parseInvariantEntries expects an array of entries',
+    );
+  }
+  const entries = (rawEntries as RawInvariantEntry[]).map(parseEntry);
+  // Reject duplicate IDs — IDs are the catalog's primary key and must be
+  // unique. A silent duplicate would shadow the earlier entry and corrupt
+  // vocabulary-lint / ideate Constraint surfacing.
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (seen.has(entry.id)) {
+      throw new Error(`Duplicate invariant ID: ${entry.id}`);
+    }
+    seen.add(entry.id);
+  }
+  return entries;
+}
+
+/**
  * Read the `invariants:` block from the closest `.exarchos.yml` walking up
  * from the catalog file. Returns `{}` when no file is found or when the
  * YAML lacks the `invariants` key — both cases collapse to default-disabled
@@ -460,17 +493,7 @@ export function loadInvariants(
       `invariants-loader: ${filePath} frontmatter must declare an "invariants:" array`,
     );
   }
-  const entries = (data.invariants as RawInvariantEntry[]).map(parseEntry);
-  // Reject duplicate IDs at load time — IDs are the catalog's primary key and
-  // must be unique. A silent duplicate would shadow the earlier entry and
-  // corrupt vocabulary-lint / ideate Constraint surfacing.
-  const seen = new Set<string>();
-  for (const entry of entries) {
-    if (seen.has(entry.id)) {
-      throw new Error(`Duplicate invariant ID: ${entry.id}`);
-    }
-    seen.add(entry.id);
-  }
+  const entries = parseInvariantEntries(data.invariants);
   // Referential integrity for `axiom_overlap` (PR #1459 CodeRabbit finding 1).
   // The format check in `parseEntry` only verifies the regex shape — a
   // reference that matches the shape (e.g. `DIM-99`) but does NOT point at

--- a/servers/exarchos-mcp/src/architecture/resolve-effective-catalog.test.ts
+++ b/servers/exarchos-mcp/src/architecture/resolve-effective-catalog.test.ts
@@ -339,13 +339,24 @@ describe('resolveEffectiveCatalog', () => {
   });
 
   it('ResolveEffectiveCatalog_WorkflowDiscovery_ExcludesAllSdlcEntries', () => {
-    const { entries } = resolveEffectiveCatalog({
-      repoRoot: fixture.repoRoot,
-      config: { invariants: { devCatalog: 'disabled' } },
-      phase: 'review',
-      workflowType: 'discovery',
-    });
-    expect(entries.filter((e) => e.id.startsWith('SDLC-'))).toHaveLength(0);
+    // The SDLC entries are excluded from a docs-only research workflow via
+    // their `workflow-affinity` (the lists omit discovery), NOT via the
+    // `projectCatalog` axis-substrate branch — that branch checks 'discover'
+    // while the runtime workflow type is 'discovery' (a latent #1465 token
+    // mismatch). Assert both spellings yield zero so the exclusion is robust
+    // regardless of which token a caller passes.
+    for (const workflowType of ['discovery', 'discover']) {
+      const { entries } = resolveEffectiveCatalog({
+        repoRoot: fixture.repoRoot,
+        config: { invariants: { devCatalog: 'disabled' } },
+        phase: 'review',
+        workflowType,
+      });
+      expect(
+        entries.filter((e) => e.id.startsWith('SDLC-')),
+        `SDLC entries must be excluded for workflowType='${workflowType}'`,
+      ).toHaveLength(0);
+    }
   });
 
   // ─── #1467 DR-3: override-floor (INV-11) end-to-end on a real SDLC entry ───

--- a/servers/exarchos-mcp/src/architecture/resolve-effective-catalog.test.ts
+++ b/servers/exarchos-mcp/src/architecture/resolve-effective-catalog.test.ts
@@ -313,4 +313,76 @@ describe('resolveEffectiveCatalog', () => {
     );
     expect(warning).toBeDefined();
   });
+
+  // ─── #1467: sdlc layer is default-on, independent of the dev gate ──────────
+
+  it('ResolveEffectiveCatalog_DevCatalogDisabled_StillReturnsSdlcEntries', () => {
+    // Consumer scenario: devCatalog NOT enabled ⇒ dev layer empty, but the
+    // shipped SDLC-* baseline still resolves (default-on, no gate).
+    const config: ExarchosConfig = {
+      invariants: { devCatalog: 'disabled' },
+    };
+    const { entries } = resolveEffectiveCatalog({
+      repoRoot: fixture.repoRoot,
+      config,
+      phase: 'review',
+      workflowType: 'feature',
+    });
+    const ids = entries.map((e) => e.id);
+    expect(ids).not.toContain('INV-1'); // dev layer gated off
+    expect(ids).toContain('SDLC-1'); // sdlc layer default-on
+    expect(ids).toContain('SDLC-3');
+    // Every sdlc entry is tagged integrity-class sdlc by the merge.
+    for (const e of entries.filter((x) => x.id.startsWith('SDLC-'))) {
+      expect(e.integrityClass).toBe('sdlc');
+    }
+  });
+
+  it('ResolveEffectiveCatalog_WorkflowDiscovery_ExcludesAllSdlcEntries', () => {
+    const { entries } = resolveEffectiveCatalog({
+      repoRoot: fixture.repoRoot,
+      config: { invariants: { devCatalog: 'disabled' } },
+      phase: 'review',
+      workflowType: 'discovery',
+    });
+    expect(entries.filter((e) => e.id.startsWith('SDLC-'))).toHaveLength(0);
+  });
+
+  // ─── #1467 DR-3: override-floor (INV-11) end-to-end on a real SDLC entry ───
+
+  it('ResolveEffectiveCatalog_Sdlc3SeverityOverrideAdvisory_ClampHonored', () => {
+    const { entries } = resolveEffectiveCatalog({
+      repoRoot: fixture.repoRoot,
+      config: {
+        invariants: {
+          devCatalog: 'disabled',
+          overrides: { 'SDLC-3': { severity: 'advisory' } },
+        },
+      },
+      phase: 'review',
+      workflowType: 'feature',
+    });
+    const sdlc3 = entries.find((e) => e.id === 'SDLC-3');
+    expect(sdlc3).toBeDefined();
+    expect(sdlc3?.severity?.default).toBe('advisory');
+  });
+
+  it('ResolveEffectiveCatalog_Sdlc3EnabledFalse_RefusedByFloorAndWarns', () => {
+    // sdlc floor = advisory ⇒ a full disable is REFUSED: the entry survives and
+    // a warning is emitted, never a silent drop (INV-11 authority gradient).
+    const { entries, warnings } = resolveEffectiveCatalog({
+      repoRoot: fixture.repoRoot,
+      config: {
+        invariants: {
+          devCatalog: 'disabled',
+          overrides: { 'SDLC-3': { enabled: false } },
+        },
+      },
+      phase: 'review',
+      workflowType: 'feature',
+    });
+    expect(entries.map((e) => e.id)).toContain('SDLC-3');
+    const warning = warnings.find((w) => w.includes('SDLC-3'));
+    expect(warning).toBeDefined();
+  });
 });

--- a/servers/exarchos-mcp/src/architecture/resolve-effective-catalog.ts
+++ b/servers/exarchos-mcp/src/architecture/resolve-effective-catalog.ts
@@ -118,10 +118,13 @@ export function resolveEffectiveCatalog(
   const repoRoot = ctx.repoRoot ?? defaultRepoRoot();
   const config = ctx.config;
 
-  // Degradation log shared by every layer. A load/parse failure in ANY layer
-  // is folded here (never thrown) so the gate, the view facade, and any future
-  // Resource degrade uniformly and surface the failure loudly as an advisory
-  // rather than aborting the whole resolution (INV-1 / DR-9).
+  // Degradation log for the EXTERNAL layers (dev catalog on disk, consumer
+  // `catalogs`). A load/parse failure in those is folded here (never thrown)
+  // so the gate, the view facade, and any future Resource degrade uniformly
+  // and surface the failure loudly as an advisory rather than aborting the
+  // whole resolution (INV-1 / DR-9). The built-in sdlc layer is compiled-in and
+  // validated at build time, so it deliberately fails fast at module load
+  // instead (see Layer 2).
   const loadWarnings: string[] = [];
 
   // ── Layer 1: dev catalog (gated by invariants.devCatalog) ──
@@ -154,20 +157,15 @@ export function resolveEffectiveCatalog(
   // (per-invariant floor = advisory for `integrity-class: sdlc`) is the
   // consumer's escape hatch, not a master switch.
   //
-  // Compiled-in and validated at build time, so a throw here would mean a
-  // corrupted binary — but the gate's never-abort contract applies to EVERY
-  // layer (INV-1 / DR-9), so we degrade to "no sdlc layer" with a visible
-  // warning rather than letting it crash the gate.
-  let sdlc: InvariantEntry[] = [];
-  try {
-    sdlc = loadSdlcCatalog();
-  } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
-    loadWarnings.push(
-      `Built-in SDLC invariant catalog failed to load and was skipped; ` +
-        `evaluated remaining layers only. Reason: ${reason}`,
-    );
-  }
+  // Unlike the disk/consumer layers, the sdlc catalog is compiled into the
+  // binary and validated at build time (`sdlc-catalog.test.ts`). It is parsed
+  // once at MODULE load (`sdlc-catalog.ts`), so it fails fast at server start
+  // by design: a parse failure can only mean a corrupted binary, which must
+  // surface loudly at boot — not silently drop the consumer's primary
+  // governance mid-review (that would be a worse INV-1 violation than a clean
+  // boot failure). A runtime try/catch here would be dead code anyway: the
+  // throw happens at import time, before this line can run.
+  const sdlc: InvariantEntry[] = loadSdlcCatalog();
 
   // ── Layer 3: user catalogs (paths from config.invariants.catalogs) ──
   //

--- a/servers/exarchos-mcp/src/architecture/resolve-effective-catalog.ts
+++ b/servers/exarchos-mcp/src/architecture/resolve-effective-catalog.ts
@@ -44,6 +44,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { ExarchosConfig } from '../config/exarchos-config-schema.js';
 import { loadInvariants, type InvariantEntry } from './invariants-loader.js';
+import { loadSdlcCatalog } from './sdlc-catalog.js';
 import {
   mergeCatalogs,
   applyOverrides,
@@ -145,11 +146,14 @@ export function resolveEffectiveCatalog(
     }
   }
 
-  // ── Layer 2: sdlc catalog (placeholder) ──
-  // The sdlc catalog CONTENT is out of scope for this task; the layer seam is
-  // wired with an empty array so `mergeCatalogs` still receives all three
-  // layers and the sdlc tagging path stays exercised once content lands.
-  const sdlc: InvariantEntry[] = [];
+  // ── Layer 2: sdlc catalog (default-on, plugin-shipped) ──
+  // The consumer-facing SDLC-* baseline (#1467). Inline-authored and compiled
+  // into the binary (the server ships as a single-file binary; docs/ is not in
+  // the plugin package), so it is present for every consumer with ZERO file-IO
+  // and NO `devCatalog`-style gate — sdlc ships enabled. The override mechanism
+  // (per-invariant floor = advisory for `integrity-class: sdlc`) is the
+  // consumer's escape hatch, not a master switch.
+  const sdlc: InvariantEntry[] = loadSdlcCatalog();
 
   // ── Layer 3: user catalogs (paths from config.invariants.catalogs) ──
   //

--- a/servers/exarchos-mcp/src/architecture/resolve-effective-catalog.ts
+++ b/servers/exarchos-mcp/src/architecture/resolve-effective-catalog.ts
@@ -21,9 +21,9 @@
  * ## Pipeline
  *
  *   load dev catalog (gated by `invariants.devCatalog`)
+ *     + sdlc layer (default-on, plugin-shipped SDLC-* baseline — #1467;
+ *       compiled into the binary, no gate, no file-IO)
  *     + load user `catalogs` from config
- *     + sdlc layer (placeholder — empty today; the sdlc catalog CONTENT is
- *       out of scope for this task, only the seam is wired)
  *   → mergeCatalogs (tags each layer's integrity-class)
  *   → applyOverrides (clamp each override to its invariant's floor)
  *   → drop honored-disabled entries (the final filter — see note below)

--- a/servers/exarchos-mcp/src/architecture/resolve-effective-catalog.ts
+++ b/servers/exarchos-mcp/src/architecture/resolve-effective-catalog.ts
@@ -153,7 +153,21 @@ export function resolveEffectiveCatalog(
   // and NO `devCatalog`-style gate — sdlc ships enabled. The override mechanism
   // (per-invariant floor = advisory for `integrity-class: sdlc`) is the
   // consumer's escape hatch, not a master switch.
-  const sdlc: InvariantEntry[] = loadSdlcCatalog();
+  //
+  // Compiled-in and validated at build time, so a throw here would mean a
+  // corrupted binary — but the gate's never-abort contract applies to EVERY
+  // layer (INV-1 / DR-9), so we degrade to "no sdlc layer" with a visible
+  // warning rather than letting it crash the gate.
+  let sdlc: InvariantEntry[] = [];
+  try {
+    sdlc = loadSdlcCatalog();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    loadWarnings.push(
+      `Built-in SDLC invariant catalog failed to load and was skipped; ` +
+        `evaluated remaining layers only. Reason: ${reason}`,
+    );
+  }
 
   // ── Layer 3: user catalogs (paths from config.invariants.catalogs) ──
   //

--- a/servers/exarchos-mcp/src/architecture/sdlc-catalog.test.ts
+++ b/servers/exarchos-mcp/src/architecture/sdlc-catalog.test.ts
@@ -1,0 +1,64 @@
+// ─── SDLC-* consumer catalog (issue #1467) ──────────────────────────────────
+//
+// The plugin-shipped, default-on consumer catalog. Authored inline (the MCP
+// server is a single-file binary; docs/ is not in the plugin package) and
+// validated through the SAME parseInvariantEntries path as the dev loader.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import { loadSdlcCatalog } from './sdlc-catalog.js';
+import { parseInvariantEntries } from './invariants-loader.js';
+
+describe('SDLC-* consumer catalog (#1467)', () => {
+  it('loadSdlcCatalog_returnsFiveEntries_allAuditModeIntegritySdlc', () => {
+    const entries = loadSdlcCatalog();
+    expect(entries).toHaveLength(5);
+    const ids = entries.map((e) => e.id).sort();
+    expect(ids).toEqual(['SDLC-1', 'SDLC-2', 'SDLC-3', 'SDLC-4', 'SDLC-5']);
+    for (const e of entries) {
+      expect(e.enforcement?.mode).toBe('audit');
+      expect(e.integrityClass).toBe('sdlc');
+    }
+  });
+
+  it('loadSdlcCatalog_everyEntry_axisSubstrateWorkflowAffinityExcludesDiscovery', () => {
+    for (const e of loadSdlcCatalog()) {
+      expect(e.axis).toBe('substrate');
+      expect(e.workflowAffinity).toBeDefined();
+      expect(e.workflowAffinity).not.toContain('discovery');
+    }
+  });
+
+  it('loadSdlcCatalog_auditPrompts_areTransportNeutral', () => {
+    // INV-3: no MCP-local presumption in any shipped audit prompt.
+    for (const e of loadSdlcCatalog()) {
+      const prompt = (
+        e.enforcement as { mode: 'audit'; 'audit-prompt': string }
+      )['audit-prompt'].toLowerCase();
+      expect(prompt).not.toMatch(/mcp[- ]local|local-only|on this machine/);
+    }
+  });
+
+  it('sdlcEntries_embeddedExecutable_failsStrictSchemaAtParse', () => {
+    // INV-4 sandbox guarantee: an SDLC entry with an embedded executable field
+    // is rejected by the .strict() enforcement DSL — proving the inline catalog
+    // is held to the same declarative-only bar as everything else.
+    const malformed = [
+      {
+        id: 'SDLC-9',
+        dimension: 'malformed',
+        axis: 'substrate',
+        'cost-of-load': 'always-load',
+        'integrity-class': 'sdlc',
+        'applies-to': ['x'],
+        summary: 's',
+        references: ['r'],
+        enforcement: {
+          mode: 'check',
+          check: { kind: 'grep', pattern: 'x', script: 'rm -rf /' },
+        },
+      },
+    ];
+    expect(() => parseInvariantEntries(malformed)).toThrow();
+  });
+});

--- a/servers/exarchos-mcp/src/architecture/sdlc-catalog.ts
+++ b/servers/exarchos-mcp/src/architecture/sdlc-catalog.ts
@@ -176,15 +176,17 @@ const RAW_SDLC_ENTRIES: ReadonlyArray<Record<string, unknown>> = [
  * at server start rather than mid-resolution). `mergeCatalogs` re-tags these
  * with `integrity-class: sdlc`; the inline class is the authoring intent.
  */
-const SDLC_CATALOG: InvariantEntry[] = parseInvariantEntries(
-  RAW_SDLC_ENTRIES as unknown[],
-);
+const SDLC_CATALOG: InvariantEntry[] = parseInvariantEntries(RAW_SDLC_ENTRIES);
 
 /**
  * Return the shipped, default-on SDLC-* consumer catalog. No `devCatalog`-style
  * gate — sdlc ships enabled; the override mechanism is the consumer's escape
  * hatch, not a master switch.
+ *
+ * Returns a fresh deep copy per call (matching `loadInvariants`'s re-parse
+ * semantics) so a downstream consumer cannot mutate the shared module-level
+ * singleton — INV-1: the catalog is an immutable source, not a drifting store.
  */
 export function loadSdlcCatalog(): InvariantEntry[] {
-  return SDLC_CATALOG;
+  return structuredClone(SDLC_CATALOG);
 }

--- a/servers/exarchos-mcp/src/architecture/sdlc-catalog.ts
+++ b/servers/exarchos-mcp/src/architecture/sdlc-catalog.ts
@@ -1,0 +1,190 @@
+/**
+ * SDLC-* consumer-facing invariants catalog (issue #1467, design DR-1/DR-2).
+ *
+ * The default-on baseline Exarchos ships *to consumers* — engineers using
+ * Exarchos as a plugin to govern their own SDLC. Distinct from the dev catalog
+ * (`docs/architecture/invariants.md`, `INV-*`, devCatalog-gated, never surfaced
+ * to consumers) and from a consumer's own `user`-layer catalog (`U-*`).
+ *
+ * ## Why inline (not a .md file)
+ *
+ * The MCP server ships as a single-file binary (`command: "exarchos"`); the npm
+ * package `files` list bundles `dist/bin`, `commands`, `skills` — NOT `docs/`.
+ * A catalog under `docs/` would be absent for plugin consumers, so a
+ * *default-on* catalog cannot be a `docs/` file read at runtime. Authoring the
+ * baseline as a typed constant compiled into the binary guarantees it is
+ * present wherever the server runs, with zero file-IO at resolve time (INV-1)
+ * and zero packaging/path-resolution risk. Consumers still author THEIR
+ * catalogs as `.md`/`.yml` via `.exarchos.yml: invariants.catalogs`.
+ *
+ * ## Shape & validation
+ *
+ * Entries are authored in the same frontmatter shape as the dev catalog and
+ * validated through the SAME `parseInvariantEntries` path (INV-2 spirit — one
+ * parse, no drift), so the v3 `.strict()` enforcement DSL (INV-4) and every
+ * typed-field projection apply identically. `loadSdlcCatalog()` fails fast at
+ * module load if any entry is malformed.
+ *
+ * ## Audience-boundary contract (research §3)
+ *
+ * Every entry is workload-neutral consumer workflow-CONDUCT enforceable through
+ * an affordance Exarchos already exposes (lifecycle events, review gates, the
+ * PR template, checkpoint/rehydrate, posture). All are `mode: audit`: the
+ * conformance gate evaluates a code diff, and SDLC conduct is a judgment about
+ * the workflow, not a diff property. `axis: substrate` is the closest enum fit
+ * for "runtime conduct" and yields the intended `discovery` exclusion (a
+ * docs-only research workflow does not bear these). `integrity-class: sdlc`
+ * gives the POLA override floor (INV-11): consumers tune entries down to
+ * advisory via `.exarchos.yml: invariants.overrides`, never silently disable.
+ */
+import { parseInvariantEntries, type InvariantEntry } from './invariants-loader.js';
+
+/** Workflow types the SDLC baseline governs — all code-bearing workflows; `discovery` (docs-only) excluded. */
+const CODE_BEARING_WORKFLOWS = ['feature', 'debug', 'refactor', 'oneshot'] as const;
+
+const GUIDE = 'docs/guides/authoring-invariants.md';
+
+/**
+ * The shipped baseline, authored in catalog-frontmatter shape. Kept as a plain
+ * array so it reads like the `.md` catalog and is validated by the shared
+ * parser rather than hand-built into the typed shape.
+ */
+const RAW_SDLC_ENTRIES: ReadonlyArray<Record<string, unknown>> = [
+  {
+    id: 'SDLC-1',
+    dimension: 'phase-observability',
+    axis: 'substrate',
+    'cost-of-load': 'always-load',
+    'integrity-class': 'sdlc',
+    'applies-to': ['workflow-lifecycle', 'long-running-operations'],
+    summary:
+      'Every long-running workflow operation is queryable and workflow state ' +
+      'is reconstructible — nobody on the team has to ask "what step are we on?".',
+    references: [GUIDE],
+    'phase-affinity': ['review'],
+    'workflow-affinity': [...CODE_BEARING_WORKFLOWS],
+    severity: { default: 'advisory' },
+    enforcement: {
+      mode: 'audit',
+      'audit-prompt':
+        'Does every long-running step in this workflow emit lifecycle events ' +
+        'so its progress and outcome are queryable after the fact, and is the ' +
+        "workflow's state reconstructible from on-disk artifacts rather than " +
+        'from anyone’s memory?',
+    },
+  },
+  {
+    id: 'SDLC-2',
+    dimension: 'tdd-discipline',
+    axis: 'substrate',
+    'cost-of-load': 'always-load',
+    'integrity-class': 'sdlc',
+    'applies-to': ['implementation-tasks', 'test-suites'],
+    summary:
+      'Test-before-implementation for workflow types that declare it (feature, ' +
+      'oneshot); discovery is exempt; debug and refactor have their own gates.',
+    references: [GUIDE],
+    'phase-affinity': ['review'],
+    'workflow-affinity': ['feature', 'oneshot'],
+    severity: { default: 'blocking', 'by-workflow': { oneshot: 'advisory' } },
+    enforcement: {
+      mode: 'audit',
+      // Points at the existing gate rather than re-expressing TDD as catalog
+      // enforcement — avoids double-gating (research OQ#3 / design DR-1).
+      'audit-prompt':
+        'For a workflow that declares TDD (feature, oneshot), was each unit of ' +
+        'production code preceded by a failing test? This mirrors the ' +
+        'check_tdd_compliance gate; defer to that gate where it runs and flag ' +
+        'only implementation that landed with no prior failing test.',
+    },
+  },
+  {
+    id: 'SDLC-3',
+    dimension: 'review-gate-honesty',
+    axis: 'substrate',
+    'cost-of-load': 'always-load',
+    'integrity-class': 'sdlc',
+    'applies-to': ['review-gates', 'verdicts'],
+    summary:
+      'A gate that fails surfaces its findings and the verdict reflects them. ' +
+      'No advisory-laundering of a HIGH finding; a silent pass is worse than a ' +
+      'loud fail.',
+    references: [GUIDE],
+    'phase-affinity': ['review'],
+    'workflow-affinity': [...CODE_BEARING_WORKFLOWS],
+    severity: { default: 'blocking' },
+    enforcement: {
+      mode: 'audit',
+      'audit-prompt':
+        'Does the review verdict faithfully reflect the findings — no HIGH ' +
+        'finding quietly downgraded to advisory, no gate reported as passing ' +
+        'while it had blocking findings? Flag any verdict that does not match ' +
+        'its underlying findings.',
+    },
+  },
+  {
+    id: 'SDLC-4',
+    dimension: 'branch-pr-discipline',
+    axis: 'substrate',
+    'cost-of-load': 'always-load',
+    'integrity-class': 'sdlc',
+    'applies-to': ['pull-requests', 'branch-topology', 'merge'],
+    summary:
+      'PR bodies carry the required sections (Summary / Changes / Test Plan); ' +
+      'stacked PRs merge bottom-up; no admin-merge that bypasses review.',
+    references: [GUIDE],
+    'phase-affinity': ['review'],
+    'workflow-affinity': [...CODE_BEARING_WORKFLOWS],
+    severity: { default: 'blocking' },
+    enforcement: {
+      mode: 'audit',
+      'audit-prompt':
+        'Does the PR body carry the required sections (Summary, Changes, Test ' +
+        'Plan), do stacked PRs merge bottom-up, and was review honoured rather ' +
+        'than bypassed by an admin merge? Flag any PR that skipped these.',
+    },
+  },
+  {
+    id: 'SDLC-5',
+    dimension: 'recovery-posture',
+    axis: 'substrate',
+    'cost-of-load': 'always-load',
+    'integrity-class': 'sdlc',
+    'applies-to': ['checkpoint', 'rehydrate', 'recovery-paths'],
+    summary:
+      'Any workflow can pause (checkpoint) and resume (rehydrate) from on-disk ' +
+      'state without consulting human memory; recovery prefers native ' +
+      'primitives and never destructively overwrites work.',
+    references: [GUIDE],
+    'phase-affinity': ['review'],
+    'workflow-affinity': [...CODE_BEARING_WORKFLOWS],
+    severity: { default: 'advisory' },
+    enforcement: {
+      mode: 'audit',
+      'audit-prompt':
+        'Can this workflow be paused and resumed purely from on-disk state, and ' +
+        'does any reversal prefer a native recovery primitive over a ' +
+        'destructive overwrite that could lose work? Flag recovery paths that ' +
+        'depend on unsaved context or that discard work irrecoverably.',
+    },
+  },
+];
+
+/**
+ * The validated SDLC-* baseline. Parsed once at module load via the shared
+ * `parseInvariantEntries` (fail-fast: a malformed entry throws here, surfacing
+ * at server start rather than mid-resolution). `mergeCatalogs` re-tags these
+ * with `integrity-class: sdlc`; the inline class is the authoring intent.
+ */
+const SDLC_CATALOG: InvariantEntry[] = parseInvariantEntries(
+  RAW_SDLC_ENTRIES as unknown[],
+);
+
+/**
+ * Return the shipped, default-on SDLC-* consumer catalog. No `devCatalog`-style
+ * gate — sdlc ships enabled; the override mechanism is the consumer's escape
+ * hatch, not a master switch.
+ */
+export function loadSdlcCatalog(): InvariantEntry[] {
+  return SDLC_CATALOG;
+}

--- a/servers/exarchos-mcp/src/views/effective-catalog.test.ts
+++ b/servers/exarchos-mcp/src/views/effective-catalog.test.ts
@@ -125,4 +125,30 @@ describe('handleViewInvariantsEffective', () => {
 
     expect(result.data).toEqual(core);
   });
+
+  it('ViewInvariants_ReviewPhase_SurfacesSdlcBaselineIdenticalToCoreFn', async () => {
+    // #1467: the default-on SDLC-* baseline must reach the view facade (and the
+    // CLI `--json` form) identically to the gate's resolved catalog — proving
+    // the now-non-empty sdlc layer flows through the single core fn (INV-2).
+    const args = {
+      repoRoot: fixture.repoRoot,
+      phase: 'review',
+      workflowType: 'feature',
+    };
+    const result = await handleViewInvariantsEffective(args);
+    expect(result.success).toBe(true);
+    const data = result.data as { entries: Array<{ id: string }> };
+    expect(data.entries.some((e) => e.id === 'SDLC-1')).toBe(true);
+
+    const loaded = loadExarchosConfig(fixture.repoRoot, {
+      findRepoRoot: () => fixture.repoRoot,
+    });
+    const core = resolveEffectiveCatalog({
+      repoRoot: fixture.repoRoot,
+      config: loaded?.config,
+      phase: 'review',
+      workflowType: 'feature',
+    });
+    expect(result.data).toEqual(core);
+  });
 });


### PR DESCRIPTION
## Summary

Stacked on #1465 (the v3 invariant **machinery**), this PR ships the **content** that machinery was missing — landing #1466 and #1467 together:

- **#1466 — dev v3 catalog content.** #1465's gate ran against an effectively-empty catalog (`schema-version: 2`, no v3 fields) and passed trivially. This bumps `docs/architecture/invariants.md` to v3 and authors the enforcement / affinity / severity / integrity-class fields so `check_invariant_conformance` actually bites.
- **#1467 — SDLC-* consumer catalog.** Ships the default-on, consumer-facing `SDLC-*` baseline and closes the sdlc-layer placeholder seam #1465 left at `resolve-effective-catalog.ts:131`. Preceded by a `/exarchos:discover` research artifact scoping the set + audience boundary.

## Changes

**#1466 — dev catalog (Approach B: mechanize-where-precise, calibrated)**
- `docs/architecture/invariants.md` → `schema-version: 3`.
- **INV-4** authored as the lone `mode: check` — a diff-precise grep scoped to generated `skills/<runtime>/**`, calibrated to zero findings on HEAD.
- **INV-1/3/6/11/13/14/5a/5d/2** authored as `mode: audit`. INV-6/5a/5d/2 were **demoted from the design's `mode: check` table to `mode: audit`** at implementation — the sanctioned Approach-B fallback: INV-6's lint has a frontmatter escape a diff-grep can't replicate, INV-5a/5d tool-count is a whole-repo (not diff) fact, INV-2's adapter grep is low-precision. Honors INV-4 (no check that pretends to prove what a grep can't see).
- `phase-affinity` / `workflow-affinity` / `severity` (oneshot⇒advisory) / `integrity-class` populated; DIM-4/5/6/8 marked `coverage: n/a` → coverage-closure lint green.
- `axiom_overlap` (underscore) **left unchanged** — the loader + coverage-closure read it; renaming to the v3 schema's kebab `axiom-overlap` would break coverage-closure.

**#1467 — SDLC catalog + seam**
- `servers/exarchos-mcp/src/architecture/sdlc-catalog.ts` (new): SDLC-1..5 (phase-observability, tdd-discipline, review-gate-honesty, branch-pr-discipline, recovery-posture), authored inline (the server is a single-file binary; `docs/` isn't in the plugin package) and Zod-validated. All `mode: audit`, `integrity-class: sdlc`, default-on, workflow-affinity excludes discovery. `loadSdlcCatalog()` returns a deep clone (immutable source, INV-1).
- `invariants-loader.ts`: extracted exported `parseInvariantEntries(raw[])` — one parse path shared by the file loader and the inline catalog (INV-2, no drift).
- `resolve-effective-catalog.ts:131`: seam closed — `const sdlc = loadSdlcCatalog()`, default-on, no gate, still pure.
- `docs/guides/authoring-invariants.md`: documents the shipped baseline, the dev/sdlc/user audience split, and the tune-to-advisory-not-disable override floor.

## Test Plan

- New `dev-catalog-content.test.ts` (16) + `sdlc-catalog.test.ts` (4): load the **live** catalogs and assert authored content, calibration, and end-to-end gate bite.
- `resolve-effective-catalog.test.ts`: default-on (devCatalog-disabled consumer still gets SDLC-*), discovery exclusion (both `discovery`/`discover` tokens), override-floor — SDLC-3 severity-clamp honored, `enabled:false` refused + warned (INV-11).
- `effective-catalog.test.ts`: view facade surfaces SDLC payload identical to the gate (INV-2).
- Two-stage review = **APPROVED** (0 HIGH). Non-blocking fixes applied (shared-instance clone, discovery-token hardening).
- `prepare_synthesis`: root suite **755 passed**, MCP suite **7210 passed**, `tsc --noEmit` clean, `skills:guard` exit 0, `lint:invariants` coverage-closure green (0 gaps, no new findings), stack healthy.

## Follow-ups (out of scope, logged)
- `axiom_overlap`→`axiom-overlap` schema/loader key unification (#1465-surface).
- `discover`/`discovery` token mismatch between `project-catalog.ts`/`WORKFLOW_VALUES` (`discover`) and the runtime workflow type (`discovery`) — the axis-substrate auto-exclusion branch is dormant; SDLC exclusion uses `workflow-affinity` regardless.
- `axis: sdlc` enum refinement (sdlc entries currently use `axis: substrate`).

Closes #1466. Closes #1467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
