### PR TITLE
fix(invariants): v2.10.0 RC2 — auto-emission audit, reclassify deterministic events model→auto (#1395)

### DIFF
--- a/docs/designs/2026-05-24-rc2-auto-emission-audit.md
+++ b/docs/designs/2026-05-24-rc2-auto-emission-audit.md
@@ -1,0 +1,203 @@
+# v2.10.0 RC2 — Auto-Emission Audit (deterministic events: model → auto)
+
+- **Date:** 2026-05-24
+- **Feature ID:** `v2-10-0-rc2-auto-emission`
+- **Milestone:** v2.10.0 — Agent Output Contract (#16)
+- **Current build:** `2.10.0-preview.4` (RC1 = PR #1464 landed)
+- **Target:** RC1 → **RC2 (this unit, #1395)** → GA
+- **Closes / advances:** #1395 (auto-emission audit + migration scope)
+- **Skills applied:** `/axiom:design` (DIM-*), `/design-invariants` (INV-*, dev-catalog active)
+- **Scope decision:** audit + migration only. The bolted-on rehydration-report
+  optimization *spike* (added to #1395 on 2026-05-16) and the #1301 harness
+  root-cause fix are **explicitly out of scope** — both are investigations, not
+  point fixes, and would reset the RC clock. Deferred to v2.11.
+
+## Problem
+
+Rehydration envelopes routinely return non-empty `_eventHints.missing`. The
+recurring offenders observed across workflows are `team.spawned`,
+`team.disbanded`, `review.routed`, and `shepherd.iteration` — every one a
+**deterministic state transition the runtime already performs**, not a model
+decision. Yet `EVENT_EMISSION_REGISTRY` (`servers/exarchos-mcp/src/event-store/schemas.ts:281`)
+classifies all four as `'model'`, so the gate nags the orchestrator to remember
+an `exarchos_event.append` for state the runtime already owns.
+
+This is a misplaced trust boundary. INV-12 draws the line precisely: the model
+emits what the model *decides*; the runtime emits what the runtime *determines*.
+Asking the model to hand-maintain a deterministic event is a redundant trust
+boundary — it adds drift risk (broken projections, `_eventHints` noise,
+downstream gate failures: cf. `feedback_orchestrator_task_assigned_emission`)
+without adding information the runtime didn't already have. The closed
+precedents #1179/#1180 fixed specific projection bugs; #1395 is the design layer
+above them — whether the model-vs-auto split itself is drawn correctly.
+
+GA promises the runtime can be trusted to drive its own SDLC. A handful of
+events the runtime *could* emit but instead delegates to model memory is a
+quiet correctness liability sitting on the GA path. This unit narrows the split
+to where the model genuinely holds information the runtime lacks.
+
+## Constraint analysis (Phase 0 — invariants + axiom dimensions)
+
+Dev-invariants catalog active (`.exarchos.yml: invariants.devCatalog: enabled`).
+Load-bearing for this unit:
+
+- **INV-1 (event-sourcing integrity).** The headline. A read-model is a left-fold
+  over the log; if a deterministic transition relies on the model remembering to
+  append, the log can diverge from what the runtime actually did. Moving the
+  append to the transition site makes the log a faithful fold rather than a
+  model-maintained ledger. The migration is *drift removal* — bugfix-shaped,
+  RC-safe.
+- **INV-12 (next_actions-as-affordance / trust boundary).** The model-vs-auto
+  split is the trust boundary itself. `_eventHints.missing` nagging for a
+  runtime-determined event is the boundary drawn one notch too far toward the
+  model. Reclassification is the corrective.
+- **INV-2 (facade-equivalence).** Any emission that moves must land in the shared
+  dispatch core (the handler), not in a CLI/MCP adapter, or parity breaks. The
+  Category-A event already satisfies this (`review/tools.ts` is core); the
+  audit must not introduce adapter-local emission.
+- **DIM-3 (contracts, lockstep).** `EVENT_EMISSION_REGISTRY`,
+  `PHASE_EXPECTED_EVENTS` (`orchestrate/check-event-emissions.ts`), and the
+  playbook renderer are a coupled contract. `check-event-emissions.ts` carries a
+  **compile-time assertion** that every entry in `PHASE_EXPECTED_EVENTS` is
+  `source === 'model'`; flipping a registry entry to `'auto'` *without*
+  simultaneously removing it from `PHASE_EXPECTED_EVENTS` throws at module load.
+  Migration is therefore atomic-per-event across three sites.
+- **DIM-2 / DIM-7 (observability / resilience).** Intended-vs-actual event-stream
+  drift is silent signal loss; auto-emission removes the class of failure.
+- **INV-15 (single-machine frame).** Any instrumentation hook is a local,
+  in-process handler-side append at the transition site — no scheduler,
+  supervisor, or cross-process coordination.
+
+Schema-v3 extensibility note: `registerEventType({ source })` lets consumers
+declare their own model/auto split. Getting the *built-in* split right makes the
+runtime a correct exemplar for consumer-registered events.
+
+## Inventory finding — the A/B/C split is already legible in code
+
+The audit categories (#1395): **A** = runtime already performs the transition in
+a handler and can emit now; **B** = genuinely model-decided (keep, document why);
+**C** = runtime *could* emit but needs new instrumentation. Grounding the four
+canonical offenders against the live machinery:
+
+| Event | Where it fires today | Category | Why |
+|---|---|---|---|
+| `review.routed` | `review/tools.ts:61` — `handleReviewTriage` **already appends it** from the dispatch core, with an idempotency key | **A** | Real MCP handler performs the routing decision and emits. Pure mis-registration: `schemas.ts:338` still says `'model'`. |
+| `team.spawned` | `runbooks/definitions.ts:57` — a model-walked `exarchos_event.append` runbook *step* ("emit before TeamCreate") | **C** | The transition is `native:TeamCreate` (a harness tool the MCP server does not own). No in-process handler seam to move the append into without a runbook-executor change. |
+| `team.disbanded` | `runbooks/definitions.ts:77` — model-walked step ("emit before SendMessage shutdown") | **C** | Same: bracketing tool is `native:SendMessage`/`TeamDelete`. |
+| `shepherd.iteration` | `runbooks/definitions.ts:131` — model-walked step inside the shepherd loop | **C** | No centralized iteration boundary in-process (matches the #1395 hypothesis). |
+
+The decisive structural fact: **A events are emitted by Exarchos MCP handlers;
+C events are emitted as runbook steps whose "transition" is a `native:` harness
+tool.** Auto-emitting a C event requires the *runbook executor* to fire the
+event when it executes the bracketing native step — a new emission seam. That is
+a **feature-shaped** change (it touches the runbook IR / workflow-SDK substrate,
+#1258), so it does not belong in an RC.
+
+This is exactly why #1395 was scoped "investigation → migration: only if the
+inventory classifies events as cleanly auto-emittable does a code change land."
+The inventory says: one clean A migration lands now; the C events are filed.
+
+## Approaches considered
+
+**Approach 1 — Reclassify A in-place; file C; document B (recommended).**
+Run the full per-workflow-type audit; migrate every Category-A event (at minimum
+`review.routed`, plus any other already-handler-emitted-but-`'model'`-registered
+event the audit surfaces) by an atomic three-site change; open one v2.11 sub-issue
+per C instrumentation gap; record B rationale in the playbook so audits don't
+relitigate. *Pros:* bugfix-shaped, RC-safe, closes the worst-offender nag,
+delivers the issue's full acceptance criteria (A/B/C table + sub-issues).
+*Cons:* C events keep nagging until v2.11 — but now *documented as intentional*.
+
+**Approach 2 — Build the runbook-executor auto-emit seam now (rejected).**
+Make the executor fire C events when it runs the bracketing native step, killing
+all four nags this RC. *Pros:* eliminates the nag entirely. *Cons:* a new runtime
+capability on the runbook IR = feature-shaped → **resets the RC clock**; couples
+to #1258 workflow-SDK substrate which owns runbook IR. Violates RC discipline.
+
+**Approach 3 — Suppress `_eventHints` for the four events without reclassifying
+(rejected).** Cosmetic mute. *Cons:* lies about the boundary, leaves the registry
+contract wrong, and defeats INV-1/INV-12 — the boundary stays misplaced; the
+nag just hides.
+
+**Selected: Approach 1.**
+
+## Design
+
+### Migration mechanism (per Category-A event — atomic across 3 sites)
+
+For each A event the audit confirms (anchor case: `review.routed`):
+
+1. **Registry** — flip `EVENT_EMISSION_REGISTRY[<event>]` from `'model'` to
+   `'auto'` in `event-store/schemas.ts`.
+2. **Phase-expected set** — remove `<event>` from every `PHASE_EXPECTED_EVENTS`
+   entry in `orchestrate/check-event-emissions.ts`. Required: the module's
+   compile-time assertion throws if an `'auto'` event remains listed there.
+3. **Renderer / hints** — the playbook renderer already separates model-emitted
+   `events:` from `autoEmittedEvents:` (`playbooks.ts`); ensure the migrated
+   event reads as auto (sibling list) so `_eventHints.missing` stops nagging and
+   the rehydrate envelope reports it correctly.
+
+Verification that A is genuinely auto: the handler emission must sit in the
+shared dispatch core with an idempotency key (INV-2 + INV-8). `review.routed`
+already satisfies this (`featureId:review.routed:<pr>` key). The audit rejects
+any candidate whose only emission is an adapter or a model instruction.
+
+### Audit deliverable (issue acceptance criteria)
+
+A per-workflow-type table — `docs/research/2026-05-24-auto-emission-audit.md` —
+classifying **every** event currently in any `PHASE_EXPECTED_EVENTS` entry as
+A/B/C with one-line rationale and emission-site citation. The four canonical
+offenders are explicitly addressed. (Today's `PHASE_EXPECTED_EVENTS` spans the
+`delegate`, `overhaul-delegate`, `review`, `overhaul-review`, `synthesize`, and
+`overhaul-update-docs` phases — the audit must cover all of them, not just the
+four.)
+
+### Category-C follow-ups (filed, not built here)
+
+One v2.11 sub-issue per C event, each naming the runbook-executor seam:
+`team.spawned` / `team.disbanded` (bracket `native:TeamCreate` /
+`native:SendMessage` in `AGENT_TEAMS_SAGA`), `shepherd.iteration` (centralize the
+shepherd loop boundary). Each references this design and #1258 (workflow-SDK IR
+owns runbook step semantics). Until then the C events stay `'model'` and remain
+in `PHASE_EXPECTED_EVENTS` — the nag persists but is now documented as
+*intentional, pending instrumentation*, which is the honest RC-safe state.
+
+### Category-B documentation
+
+If the full audit surfaces any genuinely model-decided event (free-text
+annotation, approval intent, qualitative review note — e.g. `review.finding`,
+`remediation.attempted`), record *why it stays model-emitted* inline in the
+playbook so future audits don't relitigate the line.
+
+## Test strategy (TDD)
+
+- **RED:** a registry-contract test asserting `review.routed` (and each confirmed
+  A event) resolves to `'auto'`; a `check-event-emissions` test proving the
+  migrated event no longer appears in any `PHASE_EXPECTED_EVENTS` entry and is
+  absent from `_eventHints.missing` for the relevant phase.
+- **Parity (INV-2):** the existing parity harness must show identical
+  CLI↔MCP `_eventHints` after migration.
+- **Regression guard:** retain the module-load compile-time assertion — it is the
+  mechanism that *forces* the three-site change to stay consistent; the test
+  suite must exercise the assert path (an `'auto'` event left in
+  `PHASE_EXPECTED_EVENTS` throws).
+- **Integration-suite gate (#1329, from RC1):** run the new full-suite gate after
+  the migration to confirm the contract change does not cascade.
+
+## Out of scope (deferred to v2.11)
+
+- Rehydration-report optimization spike (token accounting, think-aloud UX,
+  envelope reshape) — a `/discover` unit, not a fix.
+- #1301 harness path-resolution root fix — RC1's backstop protects GA; root
+  cause is the Claude Code file-tool layer (outside this repo).
+- The runbook-executor auto-emit seam for Category-C events (feature-shaped,
+  #1258 substrate).
+- All other v2.11-deferred milestone items (#1321, #1169, #1232–#1234, #1296,
+  #1353, #1352, #1088/#1342 epics).
+
+## Why this stays RC-safe
+
+The only code change that lands is a registry reclassification of events the
+runtime *already emits from its dispatch core* — drift removal under INV-1, not a
+new capability. C-event instrumentation (the feature-shaped work) is filed, not
+built. No new feature enters v2.10; the RC clock does not reset; GA is unblocked.

--- a/docs/plans/2026-05-24-rc2-auto-emission.md
+++ b/docs/plans/2026-05-24-rc2-auto-emission.md
@@ -1,0 +1,180 @@
+# Implementation Plan — v2.10.0 RC2 Auto-Emission Audit (#1395)
+
+- **Design:** `docs/designs/2026-05-24-rc2-auto-emission-audit.md`
+- **Feature ID:** `v2-10-0-rc2-auto-emission`
+- **Iron Law:** No production code without a failing test first.
+- **Blast radius (confirmed):** MCP-server only. No `skills-src` references
+  `review.routed`, so **no `npm run build:skills`** is required. The migration is
+  a pure *source-classification* change — the event is still emitted, validated,
+  and consumed identically; only its `EVENT_EMISSION_REGISTRY` source flips.
+
+## Coupling map (why migration is atomic-per-event)
+
+`review.routed` reclassification touches three coupled sites that must change
+together or the module throws at load:
+
+1. `event-store/schemas.ts:338` — registry source `'model'` → `'auto'`.
+2. `orchestrate/check-event-emissions.ts` — `PHASE_EXPECTED_EVENTS` lists
+   `review.routed` in **4** phases (`review`, `overhaul-review`, `synthesize`,
+   `overhaul-update-docs`); a compile-time assertion (`check-event-emissions.ts:65`)
+   throws if any listed event is non-`'model'`. Remove from all 4.
+3. `orchestrate/check-event-emissions.ts` `EVENT_DESCRIPTIONS` — dead hint entry
+   after removal (hygiene, DIM-5).
+
+Unaffected (stay green — proves behavior is unchanged): `review/tools.ts` emission,
+`review/tools.test.ts`, `verify-review-triage.test.ts`,
+`workflow-state-projection.test.ts`, the `EVENT_DATA_SCHEMAS` / type-union /
+`EventTypes` entries for `review.routed`.
+
+---
+
+### Task 1: A/B/C auto-emission audit (research deliverable — gates migration set)
+**Phase:** N/A (documentation; no production code → no RED/GREEN)
+
+1. Inventory every event in every `PHASE_EXPECTED_EVENTS` phase
+   (`delegate`, `overhaul-delegate`, `review`, `overhaul-review`, `synthesize`,
+   `overhaul-update-docs`) plus the four canonical offenders.
+2. Classify each **A** (handler in dispatch core already emits → migratable now),
+   **B** (genuinely model-decided → keep + document), or **C** (runtime could
+   emit but needs a runbook-executor seam → file follow-up). Cite the emission
+   site for each.
+3. Write `docs/research/2026-05-24-auto-emission-audit.md` with the table and a
+   one-line rationale per event. Confirm `review.routed = A`; confirm
+   `team.spawned`/`team.disbanded`/`shepherd.iteration = C`. Enumerate any
+   *additional* A events (these feed Task 3).
+
+**Acceptance:** per-phase A/B/C table; the four offenders explicitly addressed.
+**Dependencies:** None.
+**Parallelizable:** No (gates Tasks 2/3/5).
+
+---
+
+### Task 2: Migrate `review.routed` model → auto (anchor Category-A)
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Flip the registry contract test:
+   - File: `servers/exarchos-mcp/src/event-store/schemas.test.ts`
+   - Remove `'review.routed'` from `EventEmissionRegistry_ModelEvents_IncludesTeamAndReview`
+     (line ~94); add it to `EventEmissionRegistry_AutoEvents_IncludesWorkflowAndTask`
+     (line ~107). Test name intent: `EventEmissionRegistry_ReviewRouted_IsAuto`.
+   - Expected failure: registry still returns `'model'`.
+2. [RED] Assert it leaves the phase-expected set / hints:
+   - File: `servers/exarchos-mcp/src/orchestrate/check-event-emissions.test.ts`
+   - Change line 45 `.toContain('review.routed')` → `.not.toContain('review.routed')`;
+     add a hints test for the `review` phase asserting `review.routed` is absent
+     from `_eventHints.missing`. Intent: `CheckEventEmissions_ReviewRouted_NotExpectedFromModel`.
+   - Expected failure: it is still listed in `PHASE_EXPECTED_EVENTS`.
+3. [GREEN] Implement the atomic three-site change:
+   - `event-store/schemas.ts:338` — `'review.routed': 'auto'`.
+   - `orchestrate/check-event-emissions.ts` — remove `'review.routed'` from the
+     `review`, `overhaul-review`, `synthesize`, `overhaul-update-docs` entries of
+     `PHASE_EXPECTED_EVENTS`.
+4. [REFACTOR] Remove the now-dead `'review.routed'` entry from `EVENT_DESCRIPTIONS`
+   in `check-event-emissions.ts` (DIM-5 hygiene).
+
+**Acceptance:** RED tests pass; `review/tools.test.ts` + `verify-review-triage.test.ts`
++ projection tests remain green (behavior unchanged).
+**Dependencies:** Task 1 (confirms `review.routed = A`).
+**Parallelizable:** No (shares files with Tasks 3/4).
+
+---
+
+### Task 3: Migrate any additional confirmed Category-A events (conditional)
+**Phase:** RED → GREEN (per event)
+
+1. [RED] For each *additional* A event from Task 1's audit, add/flip its registry
+   source assertion (model→auto) in `schemas.test.ts` and remove it from the
+   relevant `PHASE_EXPECTED_EVENTS` entries in `check-event-emissions.test.ts`.
+   - Expected failure: registry/phase-set still list it as model.
+2. [GREEN] Apply the same atomic three-site change (registry flip + phase-set
+   removal + dead-description cleanup) per event.
+   - If Task 1 surfaces **no** additional A events, record "none additional"
+     in the audit doc and close this task as a no-op.
+
+**Acceptance:** every audit-confirmed A event resolves to `'auto'` and is absent
+from `PHASE_EXPECTED_EVENTS`; emission/consumption tests for each stay green.
+**Dependencies:** Task 1, Task 2 (same files — sequence after T-02).
+**Parallelizable:** No.
+
+---
+
+### Task 4: Regression guard — assertion path + CLI↔MCP parity (INV-2)
+**Phase:** RED → GREEN
+
+1. [RED] Assertion-path test:
+   - File: `servers/exarchos-mcp/src/orchestrate/check-event-emissions.test.ts`
+   - Add `PhaseExpectedEvents_AutoEventListed_ThrowsAtModuleLoad` proving the
+     compile-time invariant fires if an `'auto'` event is (re)introduced into
+     `PHASE_EXPECTED_EVENTS` — the mechanism that forces the three-site change to
+     stay consistent. (Use a guarded re-import / direct assertion harness so the
+     throw is observable without breaking module load for the suite.)
+   - Expected failure: no such guard test exists yet.
+2. [RED] Parity test:
+   - File: `servers/exarchos-mcp/src/__tests__/parity-harness.ts` (or the
+     existing `workflow/parity.test.ts` surface)
+   - Assert CLI and MCP produce identical `_eventHints` for a `review`-phase
+     fixture after migration. Intent: `Parity_EventHints_ReviewRouted_AutoOnBothFacades`.
+3. [GREEN] No new production code expected (the invariant + parity already hold
+   post-Task-2); if parity diverges, the fix lands in the shared dispatch core,
+   never an adapter (INV-2).
+
+**Acceptance:** assertion-path + parity tests green.
+**Dependencies:** Task 2 (and Task 3 if it migrated events).
+**Parallelizable:** No.
+
+---
+
+### Task 5: File Category-C follow-ups + document Category-B (RC discipline)
+**Phase:** N/A (issue filing + inline documentation)
+
+1. Open one v2.11 sub-issue per Category-C event, each naming the seam:
+   - `team.spawned` / `team.disbanded` → auto-emit from the runbook executor when
+     it runs the bracketing `native:TeamCreate` / `native:SendMessage` steps in
+     `AGENT_TEAMS_SAGA` (`runbooks/definitions.ts`).
+   - `shepherd.iteration` → centralize the shepherd loop iteration boundary.
+   - Each references this design + #1258 (workflow-SDK IR owns runbook semantics).
+2. Add inline comments at the C registry entries (`schemas.ts`) and the
+   surviving `PHASE_EXPECTED_EVENTS` entries noting *why they stay model-emitted
+   pending instrumentation* (so future audits don't relitigate — DIM-3/DIM-5).
+3. Record any Category-B rationale inline per Task 1's findings.
+
+**Acceptance:** C sub-issues filed and linked from #1395; B rationale documented.
+**Dependencies:** Task 1.
+**Parallelizable:** Yes (docs/issues only — disjoint from Tasks 2/3/4 code files).
+
+---
+
+### Task 6: Integration-suite gate (#1329, RC1) — confirm no cascade
+**Phase:** N/A (verification gate)
+
+1. Run `exarchos_orchestrate check_integration_suite` (the full-suite gate added
+   in RC1) on the integration tip after migration.
+2. Confirm file-load count and test totals match the clean baseline (no
+   `failed-to-load` cascade from the contract change).
+
+**Acceptance:** integration suite matches baseline; no regression.
+**Dependencies:** Tasks 2, 3, 4.
+**Parallelizable:** No (final gate).
+
+---
+
+## Parallelization summary
+
+```
+T-01 (audit) ──┬──> T-02 (review.routed migrate) ──> T-03 (additional A) ──> T-04 (guard+parity) ──> T-06 (gate)
+               └──> T-05 (C follow-ups + B docs)  [parallel — disjoint files]
+```
+
+- **Sequential chain:** T-01 → T-02 → T-03 → T-04 → T-06 (shared files:
+  `schemas.ts`, `check-event-emissions.ts`, and their tests).
+- **Parallel-safe:** T-05 (research doc + GitHub issues + inline comments) can run
+  alongside T-02–T-04.
+- **Dispatch shape:** small unit — one implementer for the code chain, optionally
+  one scaffolder/implementer for T-05 in parallel. Not a wide fan-out.
+
+## RC-safety check
+
+Only code change that lands: registry reclassification of events the runtime
+*already emits from its dispatch core* (drift removal, INV-1). C-event
+instrumentation (feature-shaped) is filed, not built. No feature enters v2.10 →
+RC clock does not reset → GA unblocked.

--- a/docs/research/2026-05-24-auto-emission-audit.md
+++ b/docs/research/2026-05-24-auto-emission-audit.md
@@ -1,0 +1,132 @@
+# Auto-Emission Audit — v2.10.0 RC2 (#1395)
+
+- **Date:** 2026-05-24
+- **Design:** `docs/designs/2026-05-24-rc2-auto-emission-audit.md`
+- **Plan:** `docs/plans/2026-05-24-rc2-auto-emission.md`
+- **Scope:** classify every event in any `PHASE_EXPECTED_EVENTS` phase plus the
+  four canonical offenders, and enumerate any additional Category-A events
+  (model-registered events a dispatch-core handler already emits).
+
+## Method
+
+- `PHASE_EXPECTED_EVENTS` source: `servers/exarchos-mcp/src/orchestrate/check-event-emissions.ts:55`.
+  The `delegate` / `overhaul-delegate` entries derive from
+  `getRegisteredEventTypes(...)` (`projections/rehydration/reducer.ts:799`),
+  filtered to `source === 'model'` via `modelEmittedOnly`.
+- Emission-site classification used `grep` for `type: '<event>'` appends across
+  `servers/exarchos-mcp/src`, excluding `*.test.ts`. An event is **A** only when
+  the append sits in a wired dispatch-core handler (not a runbook step, not an
+  adapter, not a dormant utility, not a guard/query, not a playbook descriptor).
+
+## Categories
+
+- **A** = runtime already performs the transition in a wired handler and appends
+  the event → migratable now (registry `model` → `auto`, plus removal from any
+  `PHASE_EXPECTED_EVENTS` entry to keep the compile-time assertion satisfied).
+- **B** = genuinely model-decided (free-text / qualitative / approval / dormant
+  utility not wired to a handler) → keep `model`, document why.
+- **C** = runtime *could* emit but it is currently a model-walked runbook step
+  whose transition is a `native:` harness tool → needs a runbook-executor seam →
+  defer to v2.11.
+
+## PHASE_EXPECTED_EVENTS coverage (all six phases)
+
+| Phase | Event | Category | Emission site / rationale |
+|---|---|---|---|
+| delegate | `task.assigned` | C | Coordination beat; recognised by reducer (`reducer.ts:773`) but emitted as model-walked beat, no handler append. |
+| delegate | `team.spawned` | C | `runbooks/definitions.ts:57` — model-walked `exarchos_event.append` step bracketing `native:TeamCreate`. |
+| delegate | `team.task.planned` | C | Model-walked planning beat; no handler append. |
+| delegate | `team.teammate.dispatched` | C | Model-walked dispatch beat; no handler append. |
+| delegate | `team.disbanded` | C | `runbooks/definitions.ts:77` — model-walked step bracketing `native:SendMessage`/`TeamDelete`. (guards.ts only *checks* for it, does not emit.) |
+| delegate | `task.progressed` | C | TDD phase-transition beat; model-walked, no handler append. |
+| overhaul-delegate | (same set minus `task.progressed`) | C | Mirror of delegate; refactor track runs no TDD. |
+| review | `team.spawned` | C | As above. |
+| review | `team.task.planned` | C | As above. |
+| review | `team.teammate.dispatched` | C | As above. |
+| review | `team.disbanded` | C | As above. |
+| review | `review.routed` | **A** | `review/tools.ts:60` — `emitRoutedEvents` (called from `handleReviewTriage`, `review/tools.ts:112`) appends with idempotency key `${featureId}:review.routed:${pr}`. Dispatch-core handler. |
+| overhaul-review | `team.spawned` / `team.task.planned` / `team.teammate.dispatched` / `team.disbanded` | C | As above. |
+| overhaul-review | `review.routed` | **A** | As above. |
+| synthesize | `team.spawned` / `team.disbanded` | C | As above. |
+| synthesize | `review.routed` | **A** | As above. |
+| synthesize | `stack.submitted` | C | No handler appends it (only an `EVENT_DESCRIPTIONS` hint); emitted as a model beat after submitting the PR stack. Could move to a VCS handler later — defer. |
+| synthesize | `shepherd.iteration` | C | `runbooks/definitions.ts:131` — model-walked step inside the shepherd loop; no centralized in-process iteration boundary (`assess-stack.ts:358` only *queries* it). |
+| overhaul-update-docs | `team.spawned` / `team.disbanded` | C | As above. |
+| overhaul-update-docs | `review.routed` | **A** | As above. |
+
+## Four canonical offenders (explicit)
+
+| Event | Category | Verdict |
+|---|---|---|
+| `review.routed` | **A** | Migrate now (anchor — T-02). |
+| `team.spawned` | C | Defer (runbook-executor seam, v2.11). |
+| `team.disbanded` | C | Defer (runbook-executor seam, v2.11). |
+| `shepherd.iteration` | C | Defer (centralize shepherd loop boundary, v2.11). |
+
+Confirmed: `review.routed = A`; `team.spawned` / `team.disbanded` /
+`shepherd.iteration` = C.
+
+## Additional Category-A events (feed T-03)
+
+Audited every other `model`-registered event in `EVENT_EMISSION_REGISTRY` for a
+wired handler append:
+
+| Event | Wired handler append? | Category | Site |
+|---|---|---|---|
+| `ci.status` | **Yes** | **A** | `emitCiStatusEvents` (`orchestrate/assess-stack.ts:313`) called from the assess-stack handler (`assess-stack.ts:483`), idempotency key `${featureId}:ci.status:${pr}:iter-${n}`. |
+| `quality.regression` | **Yes** | **A** | `emitRegressionEvents` (`quality/regression-detector.ts:89`) called from `handleViewCodeQuality` (`views/tools.ts:724`), deduped against existing `quality.regression` events. |
+| `review.finding` | No (dormant) | B | `emitReviewFindings` (`review/findings.ts:24`) is only reachable via `emitParsedFindings` (`review/comment-parser.ts:100`), which has **no production caller**. Not demonstrably handler-emitted. |
+| `review.escalated` | No (dormant) | B | Same — only via `emitParsedFindings`, uncalled. |
+| `review.completed` | No | B | `workflow/playbooks.ts:496` is a playbook descriptor advertised to the model, not a handler append. Genuinely model-decided (verdict/summary). |
+| `worktree.created` | No | C/B | `gate-utils.ts:131` and `delegation-readiness-view.ts:338` only *query* it; no handler append. Model/runbook emitted. |
+| `worktree.baseline` | No | C/B | No handler append; model/runbook emitted. |
+| `test.result` | No | C | No handler append; model beat. |
+| `typecheck.result` | No | C | No handler append; model beat. |
+| `stack.submitted` | No | C | No handler append (see synthesize row). |
+| `comment.posted` / `comment.resolved` | No | C | No handler append; model beats. |
+| `remediation.attempted` / `remediation.succeeded` | No | C | `runbooks/definitions.ts:134/139` — model-walked runbook steps. |
+| `session.tagged` | No | B/C | No handler append; model-decided session annotation. |
+| `task.assigned` / `task.progressed` | No | C | Coordination/TDD beats; no handler append. |
+| `team.task.assigned/completed/failed` | No | C | Team coordination beats; no handler append. |
+
+### Confirmed additional A events to migrate (T-03)
+
+- **`ci.status`** — assess-stack handler emits deterministically.
+- **`quality.regression`** — code-quality view handler emits deterministically.
+
+Neither appears in any `PHASE_EXPECTED_EVENTS` entry, so their migration is a
+registry-only flip (the compile-time assertion stays satisfied without a
+phase-set edit). They are real dispatch-core appends with dedup/idempotency, so
+they belong in the `auto` class under INV-1/INV-12.
+
+## Category-B rationale (kept `model`, documented)
+
+- `review.completed`, `review.finding`, `review.escalated` — qualitative review
+  outputs (verdict, finding text, escalation reason). The runtime does not
+  determine these; the model does. The finding/escalation emitters exist but are
+  dormant (no wired caller), so they are **not** demonstrably handler-emitted and
+  stay `model` until a handler actually drives them.
+- `session.tagged` — free-text session annotation; model-decided.
+
+## Category-C follow-ups (filed by orchestrator, not built here)
+
+One v2.11 sub-issue per C offender naming the runbook-executor seam:
+
+- `team.spawned` / `team.disbanded` — auto-emit from the runbook executor when it
+  runs the bracketing `native:TeamCreate` / `native:SendMessage` steps in
+  `AGENT_TEAMS_SAGA` (`runbooks/definitions.ts`).
+- `shepherd.iteration` — centralize the shepherd-loop iteration boundary so the
+  runtime can emit on each iteration.
+
+Each references this design + #1258 (workflow-SDK IR owns runbook step
+semantics). Until then the C events stay `model` and remain in
+`PHASE_EXPECTED_EVENTS` — the nag persists but is now documented as intentional,
+pending instrumentation.
+
+## Migration set (final)
+
+- **T-02:** `review.routed` (A, in 4 phase-sets).
+- **T-03:** `ci.status`, `quality.regression` (A, not in any phase-set — registry
+  flip only).
+</content>
+</invoke>

--- a/servers/exarchos-mcp/src/event-store/schemas.test.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.test.ts
@@ -91,7 +91,6 @@ describe('EVENT_EMISSION_REGISTRY', () => {
       'team.spawned',
       'team.task.assigned',
       'team.disbanded',
-      'review.routed',
       'review.finding',
       'review.escalated',
       'session.tagged',
@@ -114,6 +113,13 @@ describe('EVENT_EMISSION_REGISTRY', () => {
       'gate.executed',
       'state.patched',
       'tool.invoked',
+      // RC2 (#1395) — migrated model → auto: the runtime already emits these
+      // deterministically from a dispatch-core handler (review/tools.ts,
+      // assess-stack.ts, views/tools.ts respectively), so the model must no
+      // longer be nagged to hand-maintain them.
+      'review.routed',
+      'ci.status',
+      'quality.regression',
     ];
     for (const eventType of autoSpotChecks) {
       expect(EVENT_EMISSION_REGISTRY[eventType]).toBe('auto');

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -319,6 +319,21 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   'stack.enqueued': 'auto',
   'eval.judge.calibrated': 'auto',
 
+  // auto — RC2 (#1395): migrated from 'model'. The runtime emits these
+  // deterministically from a dispatch-core handler, so the model must no
+  // longer be nagged via _eventHints.missing to hand-maintain them (INV-1
+  // event-sourcing integrity, INV-12 trust boundary):
+  //   • review.routed       — review/tools.ts:60 (handleReviewTriage),
+  //                            idempotency key ${featureId}:review.routed:${pr}
+  //   • ci.status           — orchestrate/assess-stack.ts:313 (assess_stack),
+  //                            idempotency key …:ci.status:${pr}:iter-${n}
+  //   • quality.regression  — quality/regression-detector.ts:89, emitted from
+  //                            handleViewCodeQuality (views/tools.ts:724),
+  //                            deduped against existing regression events
+  'review.routed': 'auto',
+  'ci.status': 'auto',
+  'quality.regression': 'auto',
+
   // auto — emitted by the dispatch-core interceptor on the first non-rehydrate
   // handler invocation after a workflow.rehydrated event lands (T-12). Marks
   // "the rehydrated agent has consumed the phase machinery and started doing
@@ -326,7 +341,15 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   // Registration only; emission wired by T-12.
   'session.machinery_consumed': 'auto',
 
-  // model — must be emitted explicitly by the model via exarchos_event
+  // model — must be emitted explicitly by the model via exarchos_event.
+  //
+  // Category-C note (#1395): team.spawned / team.disbanded / shepherd.iteration
+  // are runtime-determined transitions that STAY model-emitted because their
+  // transition site is a model-walked runbook step bracketing a `native:`
+  // harness tool (runbooks/definitions.ts) — there is no in-process handler
+  // seam to move the append into yet. Auto-emitting them requires a
+  // runbook-executor seam (feature-shaped, deferred to v2.11 / #1258); until
+  // then the _eventHints.missing nag for them is intentional, not a defect.
   'team.spawned': 'model',
   'team.task.assigned': 'model',
   'team.task.completed': 'model',
@@ -334,8 +357,11 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   'team.disbanded': 'model',
   'team.task.planned': 'model',
   'team.teammate.dispatched': 'model',
+  // review.completed / review.finding / review.escalated stay model: they are
+  // qualitative model outputs (verdict, finding text, escalation reason). The
+  // finding/escalation emitters exist but are dormant (no wired caller), so
+  // they are not demonstrably handler-emitted (#1395 audit, Category B).
   'review.completed': 'model',
-  'review.routed': 'model',
   'review.finding': 'model',
   'review.escalated': 'model',
   'remediation.attempted': 'model',
@@ -346,11 +372,9 @@ export const EVENT_EMISSION_REGISTRY: Record<EventType, EventEmissionSource> = {
   'test.result': 'model',
   'typecheck.result': 'model',
   'stack.submitted': 'model',
-  'ci.status': 'model',
   'comment.posted': 'model',
   'comment.resolved': 'model',
   'shepherd.iteration': 'model',
-  'quality.regression': 'model',
   'task.assigned': 'model',
   'task.progressed': 'model',
 

--- a/servers/exarchos-mcp/src/orchestrate/check-event-emissions.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/check-event-emissions.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ToolResult } from '../format.js';
 import { EVENT_EMISSION_REGISTRY } from '../event-store/schemas.js';
+import type { EventType } from '../event-store/schemas.js';
 import type { EventStore } from '../event-store/store.js';
 
 // ─── Mock event store + materializer ────────────────────────────────────────
@@ -98,6 +99,47 @@ describe('PHASE_EXPECTED_EVENTS', () => {
         ).toBe('model');
       }
     }
+  });
+
+  it('PhaseExpectedEvents_AutoEventListed_ThrowsAtModuleLoad', () => {
+    // Regression guard (#1395, RC2). The module-load assertion in
+    // check-event-emissions.ts is the mechanism that FORCES the three-site
+    // migration to stay consistent: flipping a registry entry to 'auto'
+    // WITHOUT removing it from PHASE_EXPECTED_EVENTS must throw. We cannot
+    // re-import the real module to re-trigger its top-level throw without
+    // breaking this suite's own module load, so we re-implement the exact
+    // assertion loop here and feed it a phase set that (re)introduces an
+    // 'auto' event — proving the invariant fires.
+    //
+    // `review.routed` is now 'auto' (post-migration), so a phase set that
+    // lists it is precisely the violation the guard must catch.
+    expect(EVENT_EMISSION_REGISTRY['review.routed']).toBe('auto');
+
+    const assertModelOnly = (
+      phaseSets: Readonly<Record<string, readonly EventType[]>>,
+    ): void => {
+      for (const [, eventTypes] of Object.entries(phaseSets)) {
+        for (const eventType of eventTypes) {
+          if (EVENT_EMISSION_REGISTRY[eventType] !== 'model') {
+            throw new Error(
+              `PHASE_EXPECTED_EVENTS contains non-model event '${eventType}' ` +
+                `(source: ${EVENT_EMISSION_REGISTRY[eventType]})`,
+            );
+          }
+        }
+      }
+    };
+
+    const offendingPhaseSets: Readonly<Record<string, readonly EventType[]>> = {
+      review: ['team.spawned', 'review.routed'],
+    };
+
+    expect(() => assertModelOnly(offendingPhaseSets)).toThrow(
+      /non-model event 'review\.routed'.*source: auto/,
+    );
+
+    // And the real, post-migration phase sets must NOT trip the same loop.
+    expect(() => assertModelOnly(PHASE_EXPECTED_EVENTS)).not.toThrow();
   });
 });
 

--- a/servers/exarchos-mcp/src/orchestrate/check-event-emissions.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/check-event-emissions.test.ts
@@ -42,7 +42,38 @@ describe('PHASE_EXPECTED_EVENTS', () => {
   it('PhaseExpectedEvents_ReviewPhase_ExpectsReviewEvents', () => {
     const reviewEvents = PHASE_EXPECTED_EVENTS['review'];
     expect(reviewEvents).toBeDefined();
-    expect(reviewEvents).toContain('review.routed');
+    // RC2 (#1395): review.routed migrated model → auto (runtime emits it from
+    // review/tools.ts), so it must NOT be in the model-emitted phase set.
+    expect(reviewEvents).not.toContain('review.routed');
+    // Team coordination events stay model-emitted (Category C) pending a
+    // runbook-executor seam.
+    expect(reviewEvents).toContain('team.spawned');
+  });
+
+  it('CheckEventEmissions_ReviewRouted_NotExpectedFromModel', () => {
+    // review.routed is auto-emitted post-RC2; it must be absent from every
+    // PHASE_EXPECTED_EVENTS entry (the compile-time assertion would throw
+    // otherwise, since an 'auto' event cannot appear in a model-only set).
+    for (const [, eventTypes] of Object.entries(PHASE_EXPECTED_EVENTS)) {
+      expect(eventTypes).not.toContain('review.routed');
+    }
+  });
+
+  it('CheckEventEmissions_ReviewPhase_OmitsRoutedFromMissingHints', async () => {
+    mockViewState = { phase: 'review' };
+    // No events present — every model-emitted review-phase event is "missing",
+    // but review.routed (now auto) must NOT appear among the hints.
+    mockStore.query.mockResolvedValueOnce([]);
+
+    const result: ToolResult = await handleCheckEventEmissions(
+      { featureId: 'test-feature' },
+      STATE_DIR,
+      mockStore as unknown as EventStore,
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as { hints: Array<{ eventType: string }> };
+    expect(data.hints.map((h) => h.eventType)).not.toContain('review.routed');
   });
 
   it('PhaseExpectedEvents_SynthesizePhase_ExpectsStackAndShepherd', () => {

--- a/servers/exarchos-mcp/src/orchestrate/check-event-emissions.ts
+++ b/servers/exarchos-mcp/src/orchestrate/check-event-emissions.ts
@@ -86,7 +86,8 @@ const EVENT_DESCRIPTIONS: Readonly<Record<string, string>> = {
   'team.task.planned': 'Emit team.task.planned via exarchos_event for each planned task',
   'team.teammate.dispatched': 'Emit team.teammate.dispatched via exarchos_event after dispatching subagents',
   'team.disbanded': 'Emit team.disbanded via exarchos_event after all teammates complete',
-  'review.routed': 'Emit review.routed via exarchos_event after routing PRs to review',
+  // review.routed description removed in RC2 (#1395): now auto-emitted, never a
+  // model-emitted hint, so its description is dead. DIM-5 hygiene.
   'stack.submitted': 'Emit stack.submitted via exarchos_event after submitting the PR stack',
   'shepherd.iteration': 'Emit shepherd.iteration via exarchos_event after each shepherd loop iteration',
   'task.progressed': 'Emit task.progressed via exarchos_event after each TDD phase transition (red/green/refactor)',

--- a/servers/exarchos-mcp/src/orchestrate/check-event-emissions.ts
+++ b/servers/exarchos-mcp/src/orchestrate/check-event-emissions.ts
@@ -52,13 +52,20 @@ function modelEmittedOnly(types: readonly string[]): readonly EventType[] {
   return out;
 }
 
+// RC2 (#1395): `review.routed` was removed from every phase entry below — it is
+// now auto-emitted by handleReviewTriage (review/tools.ts), so the model is no
+// longer nagged for it. The surviving team.* / stack.submitted / shepherd.*
+// entries stay model-emitted (Category C): their transition is a model-walked
+// runbook step bracketing a `native:` harness tool, so auto-emission needs a
+// runbook-executor seam (deferred to v2.11 / #1258). Re-adding an `'auto'`
+// event here will trip the compile-time assertion immediately below.
 export const PHASE_EXPECTED_EVENTS: Readonly<Record<string, readonly EventType[]>> = {
   'delegate': modelEmittedOnly(getRegisteredEventTypes('delegate')),
   'overhaul-delegate': modelEmittedOnly(getRegisteredEventTypes('overhaul-delegate')),
-  'review': ['team.spawned', 'team.task.planned', 'team.teammate.dispatched', 'team.disbanded', 'review.routed'],
-  'overhaul-review': ['team.spawned', 'team.task.planned', 'team.teammate.dispatched', 'team.disbanded', 'review.routed'],
-  'synthesize': ['team.spawned', 'team.disbanded', 'review.routed', 'stack.submitted', 'shepherd.iteration'],
-  'overhaul-update-docs': ['team.spawned', 'team.disbanded', 'review.routed'],
+  'review': ['team.spawned', 'team.task.planned', 'team.teammate.dispatched', 'team.disbanded'],
+  'overhaul-review': ['team.spawned', 'team.task.planned', 'team.teammate.dispatched', 'team.disbanded'],
+  'synthesize': ['team.spawned', 'team.disbanded', 'stack.submitted', 'shepherd.iteration'],
+  'overhaul-update-docs': ['team.spawned', 'team.disbanded'],
 };
 
 // Compile-time assertion: every event in the registry must be model-emitted

--- a/servers/exarchos-mcp/src/orchestrate/parity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/parity.test.ts
@@ -340,4 +340,59 @@ describe('exarchos_orchestrate CLI-vs-MCP parity', () => {
     expect(normalize(cliResult)).toEqual(normalize(mcpResult));
     expect(cliResult.success).toBe(true);
   });
+
+  it('OrchestrateParity_CheckEventEmissions_ReviewRoutedAuto_CliAndMcp_ReturnEqualPayload', async () => {
+    // RC2 (#1395), INV-2 parity guard. After migrating `review.routed`
+    // model → auto, both carriers must compute identical `_eventHints` for a
+    // `review`-phase workflow: review.routed must NOT appear among the missing
+    // hints on either arm. Driving the stream into `review` phase via two seed
+    // events (workflow.started → workflow.transition to review) mirrors the
+    // rehydrate fixture and is independent of HSM guard state.
+    const streamId = 'parity-emissions-review';
+
+    const seedReviewPhase = async (
+      store: ArmContext['ctx']['eventStore'],
+    ): Promise<void> => {
+      await store.append(streamId, {
+        type: 'workflow.started',
+        data: { featureId: streamId, workflowType: 'feature' },
+      });
+      await store.append(streamId, {
+        type: 'workflow.transition',
+        data: { from: '', to: 'review' },
+      });
+    };
+
+    const cliArm = await createArm('parity-emissions-cli-');
+    arms.push(cliArm);
+    await seedReviewPhase(cliArm.ctx.eventStore);
+
+    // Act (CLI)
+    resetMaterializerCache();
+    const cliResult = await callCli(cliArm.ctx, 'check_event_emissions', {
+      featureId: streamId,
+    });
+
+    const mcpArm = await createArm('parity-emissions-mcp-');
+    arms.push(mcpArm);
+    await seedReviewPhase(mcpArm.ctx.eventStore);
+
+    // Act (MCP)
+    resetMaterializerCache();
+    const mcpResult = await callMcp(mcpArm.ctx, 'check_event_emissions', {
+      featureId: streamId,
+    });
+
+    // Assert — byte-equal payloads across carriers (INV-2)…
+    expect(normalize(cliResult)).toEqual(normalize(mcpResult));
+    expect(cliResult.success).toBe(true);
+
+    // …and review.routed must be absent from the missing-event hints on both.
+    const hintTypes = (r: ToolResult): string[] => {
+      const data = (r as { data?: { hints?: Array<{ eventType: string }> } }).data;
+      return (data?.hints ?? []).map((h) => h.eventType);
+    };
+    expect(hintTypes(cliResult)).not.toContain('review.routed');
+    expect(hintTypes(mcpResult)).not.toContain('review.routed');
+  });
 });


### PR DESCRIPTION
## Summary

v2.10.0 **RC2** — the last GA-path unit (RC1 = #1464). Closes the recurring
`_eventHints.missing` footgun by drawing the model-vs-auto trust boundary
(**INV-12**) where it belongs: the model emits what the model *decides*; the
runtime emits what the runtime *determines*. Events the dispatch core already
emits were mis-registered as `model`, so the gate nagged the orchestrator to
hand-maintain an append the runtime had already performed — a drift risk under
**INV-1** (the event log is a left-fold, not a model-maintained ledger).

RC-safe: this is a pure **source-classification** change (drift removal), not a
new feature. Events are still emitted, validated, and consumed identically —
only their `EVENT_EMISSION_REGISTRY` source flips. The RC clock does not reset.

## Changes

- **Audit (`docs/research/2026-05-24-auto-emission-audit.md`):** A/B/C
  classification of every `PHASE_EXPECTED_EVENTS` event across all 6 phases.
- **Category-A migrated `model → auto`:**
  - `review.routed` — emitted by `handleReviewTriage` (`review/tools.ts`);
    removed from all 4 phase sets (review, overhaul-review, synthesize,
    overhaul-update-docs).
  - `ci.status` — emitted by `assess_stack` (`assess-stack.ts`); registry-only.
  - `quality.regression` — emitted by `handleViewCodeQuality` (`views/tools.ts`);
    registry-only.
- **Category-C deferred → #1473** (v2.11): `team.spawned`, `team.disbanded`,
  `shepherd.iteration` stay `model` — they're model-walked runbook steps whose
  transition is a `native:` harness tool; auto-emission needs a runbook-executor
  seam (feature-shaped, composes with #1258). Inline rationale comments added.
- **Category-B documented:** `review.completed/finding/escalated`,
  `session.tagged` stay `model` (qualitative / model-decided).
- **Regression guard:** `PhaseExpectedEvents_AutoEventListed_ThrowsAtModuleLoad`
  proves the compile-time assertion fires if an `auto` event is reintroduced into
  `PHASE_EXPECTED_EVENTS` (the mechanism forcing the atomic three-site change);
  plus a CLI↔MCP `_eventHints` parity test (**INV-2**).

## Test Plan

- TDD RED→GREEN→REFACTOR commits (see history): RED registry/hints assertions →
  GREEN registry flip + phase-set removal → REFACTOR dead-description cleanup.
- Full MCP suite on integration tip (main worktree): **566 files / 7226 tests
  passing, 0 failures, no `failed-to-load` cascade** (#1329 gate).
- `tsc --noEmit` clean.
- Behavior-level tests unchanged and green (`review/tools.test.ts`,
  `verify-review-triage.test.ts`, `workflow-state-projection.test.ts`) — proves
  classification-only.
- Two-stage review: spec-review PASS (all 5 checks); quality-review APPROVED
  (0 HIGH / 0 MEDIUM / 1 LOW pre-existing).

Applies `/axiom:design` (DIM-1/3/5) + `/design-invariants` (INV-1/2/12).
MCP-server-only — no `build:skills` (nothing in `skills-src` references the
migrated events).

Closes #1395. Follow-ups: #1473 (Category-C runbook-executor seam), #1475 (rehydration-report optimization spike — the appended #1395 investigation, extracted to v2.11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
