### PR TITLE
feat(invariants): catalog content-complete + init/doctor onboarding (#1478, #1479)

### DIFF
--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -322,6 +322,10 @@ invariants:
       ToolResult. Adapters carry zero behavior — only presentation. Post-#1266,
       every action also registers a Zod outputSchema so parity is schema-checked
       in addition to byte-checked.
+    citations:
+      - "Alistair Cockburn, *Hexagonal Architecture (Ports & Adapters)* (2005): https://alistair.cockburn.us/hexagonal-architecture/"
+      - "Martin Fowler, *PresentationDomainDataLayering* (2015): https://martinfowler.com/bliki/PresentationDomainDataLayering.html"
+      - "Anthropic, *Model Context Protocol — Tools* (2024): https://modelcontextprotocol.io/specification/2025-06-18/server/tools"
     references:
       - docs/architecture/invariants/references/INV-2-facade-equivalence.md
       - servers/exarchos-mcp/src/orchestrate/check-invariant-conformance.ts
@@ -352,6 +356,10 @@ invariants:
       discovery prefers the MCP roots capability over cwd heuristics
       (post-#1269). The remote-MCP surface throws-not-degrades when called
       (#1081).
+    citations:
+      - "Jim Waldo et al., *A Note on Distributed Computing* (Sun Microsystems 1994): https://web.archive.org/web/2020/https://scholar.harvard.edu/files/waldo/files/waldo-94.pdf"
+      - "Anthropic, *Model Context Protocol — Transports* (2025): https://modelcontextprotocol.io/specification/2025-06-18/basic/transports"
+      - "Martin Fowler, *Patterns of Enterprise Application Architecture* — Remote Facade (Addison-Wesley 2002): https://martinfowler.com/eaaCatalog/remoteFacade.html"
     references:
       - docs/architecture/invariants/references/INV-3-basileus-forward.md
       - servers/exarchos-mcp/src/orchestrate/check-invariant-conformance.ts
@@ -397,6 +405,10 @@ invariants:
       INV-4 owns the *platform* axis (6 runtimes); INV-6 owns the orthogonal
       *workload* axis (workflow types). The two are complementary substrate
       properties — substrate guarantees hold across both axes.
+    citations:
+      - "Andrew Hunt & David Thomas, *The Pragmatic Programmer* — DRY / Single Source of Truth (Addison-Wesley 1999): https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/"
+      - "Anthropic, *Agent Skills* (2025): https://docs.anthropic.com/en/docs/agents-and-tools/agent-skills/overview"
+      - "Anthropic, *Model Context Protocol — Architecture* (2025): https://modelcontextprotocol.io/specification/2025-06-18/architecture"
     references:
       - docs/architecture/invariants/references/INV-4-platform-agnosticity.md
       - servers/exarchos-mcp/src/orchestrate/check-invariant-conformance.ts
@@ -426,6 +438,10 @@ invariants:
       via prose hints. Every tool description states when NOT to use the tool
       with a pointer to the alternative. Visible tool count stays under 15.
       Static reference content is exposed as MCP Resources, not tools.
+    citations:
+      - "Anthropic, *Model Context Protocol — Tools* (2025): https://modelcontextprotocol.io/specification/2025-06-18/server/tools"
+      - "Anthropic, *Writing effective tools for agents* (2025): https://www.anthropic.com/engineering/writing-tools-for-agents"
+      - "JSON Schema, *Validation* (draft 2020-12): https://json-schema.org/draft/2020-12/json-schema-validation"
     references:
       - docs/architecture/invariants/references/INV-5a-input-ergonomics.md
       - servers/exarchos-mcp/src/orchestrate/check-invariant-conformance.ts
@@ -448,6 +464,10 @@ invariants:
       registered outputSchema per action; long-running ops use Tasks (SEP-1686)
       not NDJSON. The affordance-as-perceived semantics of next_actions live
       in INV-12.
+    citations:
+      - "Anthropic, *Model Context Protocol — Tools (structured content & output schema)* (2025): https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content"
+      - "David L. Parnas, *On the Criteria To Be Used in Decomposing Systems into Modules* (CACM 1972): https://dl.acm.org/doi/10.1145/361598.361623"
+      - "JSON Schema, *Validation* (draft 2020-12): https://json-schema.org/draft/2020-12/json-schema-validation"
     references:
       - docs/architecture/invariants/references/INV-5b-output-contract.md
       - servers/exarchos-mcp/src/orchestrate/check-invariant-conformance.ts
@@ -468,6 +488,10 @@ invariants:
       dry-run-capable, JSON-explicit control-plane verbs. Agents query state;
       they don't drive scripts. ps / describe / wait / export are observation
       verbs; mutating verbs default to --dry-run.
+    citations:
+      - "Microsoft, *.NET Aspire overview* (2024): https://learn.microsoft.com/en-us/dotnet/aspire/get-started/aspire-overview"
+      - "Kubernetes, *kubectl --dry-run server-side apply* (2024): https://kubernetes.io/docs/reference/using-api/server-side-apply/"
+      - "Adam Wiggins, *The Twelve-Factor App — Admin processes* (2017): https://12factor.net/admin-processes"
     references:
       - docs/architecture/invariants/references/INV-5c-aspire-verbs.md
       - servers/exarchos-mcp/src/orchestrate/check-invariant-conformance.ts

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -63,7 +63,6 @@ invariants:
       - "SQLite WAL documentation: https://sqlite.org/wal.html"
     references:
       - servers/exarchos-mcp/src/event-store/atomic-appender.ts
-      - servers/exarchos-mcp/src/event-store/stream-lock-manager.ts
       - docs/architecture/runtime.md#§4
 
   - id: INV-8
@@ -87,7 +86,7 @@ invariants:
       - "Greg Young, *Versioning in an Event Sourced System* (Leanpub): https://leanpub.com/esversioning"
     references:
       - servers/exarchos-mcp/src/event-store/atomic-appender.ts
-      - servers/exarchos-mcp/src/dispatch/with-session.ts
+      - docs/architecture/runtime.md#§4
 
   - id: INV-9
     dimension: hsm-as-state-machine
@@ -109,7 +108,7 @@ invariants:
       - "Wolverine [AggregateHandler] workflow (Miller 2023): https://jeremydmiller.com/2023/12/06/building-a-critter-stack-application-wolverines-aggregate-handler-workflow-ftw/"
     references:
       - servers/exarchos-mcp/src/topology/phase-contract.ts
-      - servers/exarchos-mcp/src/hsm/
+      - servers/exarchos-mcp/src/workflow/hsm-definitions.ts
       - docs/architecture/runtime.md#§3-L4
 
   - id: INV-10
@@ -230,7 +229,7 @@ invariants:
       - "Greg Young, *Why Event Sourced Systems Fail*: https://www.youtube.com/watch?v=FKFu78ZEIi8"
     references:
       - servers/exarchos-mcp/src/orchestrate/merge-orchestrate.ts
-      - servers/exarchos-mcp/src/dispatch/with-session.ts
+      - servers/exarchos-mcp/src/event-store/atomic-appender.ts
       - docs/architecture/runtime.md#§4-process-manager-handlers
 
   - id: INV-14

--- a/docs/designs/2026-05-24-v2.10.0-ga-completion.md
+++ b/docs/designs/2026-05-24-v2.10.0-ga-completion.md
@@ -1,0 +1,218 @@
+---
+title: "v2.10.0 GA completion — remaining four issues in two PRs"
+date: 2026-05-24
+status: design
+feature-id: v2-10-ga-completion
+milestone: "v2.10.0 — Agent Output Contract"
+issues: [1478, 1479, 1476, 1470]
+discovery: docs/research/2026-05-24-hooks-templating-and-invariants-onboarding.md
+---
+
+# v2.10.0 GA completion
+
+## Scope
+
+The four open issues in milestone v2.10.0 all descend from one discovery
+(`docs/research/2026-05-24-hooks-templating-and-invariants-onboarding.md`).
+Their sole cross-issue dependency — the DIM-1..8 decision in #1477 — **landed at
+HEAD** (`583f6af3`), so every remaining issue is unblocked. We complete all four
+as **two independent PRs off `main`**, grouped by subsystem so neither PR needs to
+stack on the other:
+
+- **PR 1 — Invariants catalog & onboarding** (#1478 → #1479): `architecture/`,
+  `orchestrate/init/`, `orchestrate/doctor/`.
+- **PR 2 — Templating & workload-agnosticism** (#1476 + #1470): `src/build-skills.ts`,
+  `src/runtimes/`, `servers/exarchos-mcp/src/agents/`, `src/adapters/hooks.ts`,
+  and the generated `agents/` / `.cursor/` / `.github/` / `.opencode/` trees.
+
+The two PRs touch disjoint file sets, so they review and merge in either order.
+Within each PR there is a fixed internal order (below).
+
+---
+
+## PR 1 — Invariants catalog & onboarding
+
+### #1478 — make the dev catalog content-complete
+
+The catalog (`docs/architecture/invariants.md`, schema v3) is structurally sound
+(19 entries after #1477 excised DIM-*) but not content-complete. Verified against
+disk on 2026-05-24:
+
+- **Three broken `references:` paths** (target missing on disk): INV-7 →
+  `event-store/stream-lock-manager.ts`, INV-8 / INV-13 →
+  `dispatch/with-session.ts`, INV-9 → `hsm/`. `StreamLockManager` and
+  `withSession` both actually live in `event-store/atomic-appender.ts`; the HSM
+  lives in `workflow/hsm-definitions.ts`.
+- **Six+ substrate entries lack citations** (INV-2, INV-3, INV-4, INV-5a, INV-5b,
+  INV-5c — INV-5d is reference-only). The schema doc recommends ≥3 for
+  substrate-axis; the pinning test enforces only ≥2.
+- **No test guards reference-path existence** — `dev-catalog-content.test.ts`
+  checks frontmatter content only, which is why the three paths rotted silently.
+
+**Resolution (confirmed scope):**
+
+1. **Repoint, do not refactor.** Repoint INV-7 / INV-8 / INV-13 to
+   `event-store/atomic-appender.ts` and INV-9 to `workflow/hsm-definitions.ts`. We
+   do *not* extract `StreamLockManager` into a new file (DIM-5 hygiene: don't move
+   production substrate just to satisfy a doc pointer).
+2. **Backfill citations** for the six uncited substrate entries — real, verifiable
+   sources (author / title / year / URL). DIM-8 is the binding constraint here:
+   citations must be checkable, never LLM-invented. Reuse the citation style
+   already present on INV-1/7/8/etc.
+3. **Add a ref-path existence test** in `servers/exarchos-mcp/src/architecture/`
+   that walks every `references:` entry in the live catalog and asserts each
+   target exists on disk (a real path, not a doc anchor). DIM-4: the test reads the
+   *real* catalog file against the *real* filesystem, not a fixture.
+4. **Raise the citation floor to ≥3** in `invariants-loader.test.ts`, replacing the
+   deferred ≥2 pin, so the gap cannot reopen.
+
+INV alignment: the catalog is the single source of truth for `/ideate` Phase 0,
+`check_invariant_conformance`, and `vocabulary-lint`; all three must stay green.
+
+### #1479 — scaffold invariants config via `init` + `doctor` validation
+
+No new top-level command — both surfaces exist (`handleInit` /
+`seedExarchosConfig` at `orchestrate/init/seed-exarchos-config.ts`; the `doctor`
+action with `orchestrate/doctor/checks/`).
+
+1. **Extend `seed-exarchos-config.ts`** to append a commented `invariants:` stanza
+   (a `devCatalog: disabled` line with a one-line explanation, plus a stubbed
+   `catalogs:` example). Preserve idempotency — never overwrite.
+2. **Add a `doctor` check** (`orchestrate/doctor/checks/`) that parses any
+   configured user catalog files, validates against schema v3, warns on
+   reserved-namespace ids (`INV-*` / `SDLC-*`), and surfaces the dual-reader
+   inconsistency until reconciled.
+3. **Reconcile the dual config readers** — `loadExarchosConfig`
+   (`config/load-exarchos-config.ts`, strict) vs the lenient `readInvariantsConfig`
+   in `architecture/invariants-loader.ts`. Same `.exarchos.yml` must validate
+   identically across both paths.
+4. **Cross-link docs** — `docs/guides/authoring-invariants.md` and the `init` flow
+   point at each other and at the effective-catalog inspection command.
+
+**Internal order:** #1478 first. A catalog validator (#1479's `doctor` check)
+should validate a *correct* catalog; building it against the still-broken catalog
+would make the validator flag the very paths #1478 repairs.
+
+---
+
+## PR 2 — Templating & workload-agnosticism
+
+### #1476 — retire enforcement hooks; generate lifecycle-observer hooks
+
+The six hand-authored hooks in `hooks/hooks.json` are mostly enforcement/control,
+not observers. We pivot to **observe, don't enforce** at the hook layer.
+
+**This is ADR-gated** — it drops the `guard` `PreToolUse` enforcement contract (the
+only thing that *forces* the harness through phase guardrails today) and re-adds
+lifecycle events T-40 removed, now as observers. Write the ADR first.
+
+1. **ADR**: "Hook layer is observe-only; enforcement moves entirely inside the MCP
+   tools." Document the dropped `guard` contract and the observer event set.
+2. **Excise enforcement hooks + dead code** — remove `PreToolUse` /
+   `TaskCompleted` / `TeammateIdle` / `SubagentStart` from `hooks.json`; delete the
+   orphaned handlers (`cli-commands/guard.ts`, the enforcement paths in `gates.ts`,
+   `subagent-context.ts`) and their dispatch entries in
+   `servers/exarchos-mcp/src/adapters/hooks.ts`; remove now-dead tests. Grep-sweep
+   for every reference to the removed subcommands (DIM-5 hygiene: leave nothing
+   lingering).
+3. **`buildAllHooks()` pass** — sibling to the skills build in `src/build-skills.ts`,
+   rendering an observer-only `hooks-src/` source tree per runtime, substituting
+   `{{MCP_PREFIX}}` etc. Non-`hasHooks` runtimes (only `claude` is `true` in
+   `src/runtimes/types.ts:27`) emit nothing or a documented manual note. Claude
+   output lands at the well-known `hooks/hooks.json` path.
+4. **`hooks:guard` CI check** mirroring `skills:guard` (re-render, fail on
+   `git diff hooks/`). Extend `scripts/validate-plugin.sh`.
+5. **Fix the `subagent-stop` / dispatch-set inconsistency** — `SubagentStop` is
+   wired in `hooks.json` but absent from the hook dispatch set.
+
+DIM-1/DIM-2 are load-bearing: the new build pass introduces generated output; its
+source-of-truth ownership must be single (`hooks-src/`), and the dropped `guard`
+contract is a deliberate, *documented* (ADR) behavior loss — not a silent one.
+
+### #1470 — parameterize hardcoded npm/Node toolchain in subagent templates
+
+`servers/exarchos-mcp/src/agents/definitions.ts` bakes npm into the implementer /
+fixer / scaffolder prompts (verified: L70/L88/L92 worktree-hygiene examples; L158
+implementer `post-test` hook; L225 fixer `post-test` hook), and these render
+verbatim into every per-runtime variant. A non-Node consumer (Rust, Python, Go,
+.NET) inherits guidance and a test hook that do not apply. This violates INV-6
+(workload-agnosticism): governance orchestrates *how* an agent verifies, not
+*which* toolchain implements it.
+
+1. **Parameterize the verification commands** — placeholders
+   (`{{testCommand}}` / `{{typecheckCommand}}`) populated at dispatch time from the
+   project config (`.exarchos.yml` already carries `test`/`typecheck`/`install`
+   keys), with the current npm commands as a documented fallback default only.
+2. **Rewrite worktree-hygiene examples** in toolchain-neutral terms — the principle
+   (`git -C <worktree>`; run the project test command from the worktree) matters,
+   not `npm --prefix`.
+3. **Regenerate the rendered variants** via the generate-agents pipeline; re-run
+   the agent-drift tests + `skills:guard` so `agents/`, `.cursor/`, `.github/`,
+   `.opencode/`, and snapshot fixtures stay in sync.
+4. **Update `skills-src/delegation/references/{implementer,fixer}-prompt.md`** and
+   their `.test.sh` the same way.
+
+**Internal order:** the #1476 templating work establishes the per-runtime
+substitution discipline; #1470's parameterization rides the same placeholder
+spine, so land #1476's pipeline first, then #1470.
+
+---
+
+## Constraints applied (axiom DIM × INV catalog)
+
+No paired `design-invariants` skill is loaded (retired T-23); the project
+invariants are the INV-* dev catalog (`devCatalog: enabled`).
+
+- **DIM-3 Contracts** — the catalog frontmatter *is* a schema; #1478's ref-path
+  test is the missing cross-boundary guard. The dual config-reader reconciliation
+  (#1479) closes a contract divergence on the same `.exarchos.yml`.
+- **DIM-4 Test Fidelity** — #1478's guard and #1476/#1470's drift checks must
+  exercise the real artifacts (live catalog, generated trees), not fixtures, or
+  they re-create the false-confidence gap.
+- **DIM-5 Hygiene** — repoint not refactor (#1478); excise dead handlers with a
+  grep sweep (#1476); single source-of-truth for generated hooks/agents.
+- **DIM-8 Prose Quality** — backfilled citations (#1478) must be real and
+  verifiable, never invented.
+- **INV-6 Workload-agnosticism** — the direct target of #1470; the runtime
+  orchestrates verification without prescribing a toolchain.
+- **INV-4 Platform-agnosticity** — #1476/#1470 both generate per-runtime output;
+  source-of-truth edits go to `*-src/`, generated trees fail the guard if edited
+  directly.
+
+## PR topology & sequencing
+
+```
+main
+ ├─ PR 1  invariants catalog & onboarding   (#1478 → #1479)   [independent]
+ └─ PR 2  templating & workload-agnosticism (ADR + #1476 → #1470) [independent]
+```
+
+Two independent PRs off `main`; no stacking, no cross-PR rebase. Merge in either
+order. Within each PR the internal order is fixed.
+
+## Test plan (aggregate)
+
+- `cd servers/exarchos-mcp && npm run test:run` — architecture/, init/, doctor/,
+  agents/, hook-adapter suites.
+- `npm run build && npm run skills:guard` + the new `hooks:guard` — generated
+  trees match source.
+- #1478: ref-path test passes on the corrected catalog, fails if any `references:`
+  target is removed; `invariants_effective` for `phase=ideate, workflowType=feature`
+  loads without warning; ≥3 citation floor green.
+- #1479: `seed-exarchos-config` idempotency tests; new doctor-check unit tests;
+  integration `init` in temp repo → stanza present → enabling `devCatalog`
+  resolves.
+- #1470: agent-drift tests; manual check that a non-Node workload receives neutral
+  verification guidance with no stray npm.
+- #1476: grep sweep — zero references to removed enforcement subcommands; manual
+  install confirms observer hooks fire and no `PreToolUse` blocking occurs.
+
+## Risks
+
+- **#1476 behavior loss is intentional but real** — without the `guard` hook,
+  out-of-phase calls are no longer pre-empted at the harness boundary (MCP tools
+  still self-validate). The ADR must state this explicitly.
+- **Citation fabrication (#1478)** — mitigated by requiring verifiable URLs and
+  reusing existing citation patterns; reviewer spot-checks sources.
+- **Generated-tree drift (#1470, #1476)** — mitigated by `skills:guard` /
+  `hooks:guard` in CI.

--- a/docs/guides/authoring-invariants.md
+++ b/docs/guides/authoring-invariants.md
@@ -52,6 +52,14 @@ invariants:
 Listing is explicit by design (no auto-detection, matching the `devCatalog`
 precedent). Multiple files may be listed; they merge in order.
 
+`exarchos init` seeds a `.exarchos.yml` with this `invariants:` block already
+present **as comments** (a `devCatalog: disabled` line plus a stubbed
+`catalogs:` example), so the opt-in is discoverable without changing behavior —
+uncomment the keys you want. After editing, validate your catalog wiring with
+`exarchos doctor` (the `invariants-catalog` check parses every configured
+catalog and flags malformed files or reserved-namespace ids) and inspect the
+resolved result with `invariants_effective` ([§5](#5-inspect-the-effective-catalog)).
+
 ## 2. Author an entry
 
 A catalog file is YAML frontmatter with an `invariants:` list. Each entry mirrors
@@ -181,8 +189,16 @@ Authoring mistakes fail safe and loud:
 - A **single check leaf that throws** (e.g. an invalid regex) becomes a `LOW`
   finding naming the invariant id, not a gate crash.
 
+You can surface these same authoring mistakes *before* a review run with
+`exarchos doctor` — the `invariants-catalog` check resolves your configured
+catalogs and reports a Warning that names the offending file or reserved id.
+
 ## See also
 
 - [`.exarchos.yml` invariants block](exarchos-yml-invariants.md) — config reference.
+- `exarchos init` — seeds the commented `invariants:` onboarding stanza into a
+  new `.exarchos.yml` (see [§1](#1-register-a-catalog)).
+- `exarchos doctor` → `invariants-catalog` check — validates configured catalogs.
+- `invariants_effective` view — inspect the merged, projected catalog ([§5](#5-inspect-the-effective-catalog)).
 - Design: [`docs/designs/2026-05-23-invariants-projection-and-extensibility.md`](../designs/2026-05-23-invariants-projection-and-extensibility.md).
 - Shipped catalog (worked examples of entries): [`docs/architecture/invariants.md`](../architecture/invariants.md).

--- a/docs/plans/2026-05-24-v2.10.0-ga-completion.md
+++ b/docs/plans/2026-05-24-v2.10.0-ga-completion.md
@@ -1,0 +1,249 @@
+---
+title: "v2.10.0 GA completion — implementation plan"
+date: 2026-05-24
+status: plan
+feature-id: v2-10-ga-completion
+design: docs/designs/2026-05-24-v2.10.0-ga-completion.md
+issues: [1478, 1479, 1476, 1470]
+---
+
+# v2.10.0 GA completion — implementation plan
+
+TDD plan for the four remaining v2.10.0 issues, as **two independent PRs off
+`main`**. PR 1 and PR 2 touch disjoint file sets and run fully in parallel.
+
+**Iron Law:** no production code without a failing test first. Every task below is
+RED → GREEN → (REFACTOR).
+
+Branches:
+- PR 1: `feat/v2.10-invariants-onboarding`
+- PR 2: `feat/v2.10-templating-agnosticism`
+
+---
+
+## PR 1 — Invariants catalog & onboarding (#1478 → #1479)
+
+### Task 1: Ref-path existence guard + repoint broken refs (#1478)
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `devCatalog_everyReferencePathExistsOnDisk`
+   - File: `servers/exarchos-mcp/src/architecture/dev-catalog-ref-paths.test.ts`
+   - Loads the live catalog (`docs/architecture/invariants.md`), walks every
+     `references:` entry, asserts each resolves to a real file/dir via `existsSync`
+     (skip doc-anchor `#...` fragments).
+   - Expected failure: INV-7/INV-8/INV-13 → `event-store/stream-lock-manager.ts` /
+     `dispatch/with-session.ts` missing; INV-9 → `hsm/` missing.
+
+2. [GREEN] Repoint refs in `docs/architecture/invariants.md`
+   - INV-7, INV-8, INV-13 → `servers/exarchos-mcp/src/event-store/atomic-appender.ts`
+   - INV-9 → `servers/exarchos-mcp/src/workflow/hsm-definitions.ts`
+   - No production refactor (no `StreamLockManager` extraction).
+
+**Dependencies:** None
+**Parallelizable:** No (shares the catalog file with Task 2)
+
+### Task 2: Raise citation floor to ≥3 + backfill (#1478)
+**Phase:** RED → GREEN
+
+1. [RED] Raise the pin: `everySubstrateEntry_hasAtLeastThreeCitations`
+   - File: `servers/exarchos-mcp/src/architecture/invariants-loader.test.ts`
+     (replace the deferred "recommended ≥3, not enforced" note near L455; the
+     existing `>=2` *references* pin at L166 stays).
+   - Asserts each `axis: substrate` entry has `citations.length >= 3`.
+   - Expected failure: INV-2, INV-3, INV-4, INV-5a, INV-5b, INV-5c uncited.
+
+2. [GREEN] Backfill citations in `docs/architecture/invariants.md`
+   - Add ≥3 real, verifiable citations (author / title / year / URL) per entry,
+     matching the existing INV-1/7/8 citation style. DIM-8: sources must be
+     checkable, never invented.
+
+**Dependencies:** Task 1 (same file; land sequentially)
+**Parallelizable:** No
+
+### Task 3: Seed `invariants:` stanza in `init` (#1479)
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write test: `seedExarchosConfig_appendsCommentedInvariantsStanza` +
+   `seedExarchosConfig_invariantsStanza_isIdempotent`
+   - File: `servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.test.ts`
+   - Asserts seeded `.exarchos.yml` contains a commented `invariants:` block
+     (`devCatalog: disabled` + stubbed `catalogs:` example); re-running does not
+     duplicate or overwrite.
+
+2. [GREEN] Extend `seed-exarchos-config.ts` to emit the stanza (preserve the
+   never-overwrite idempotency at the existing guard).
+
+3. [REFACTOR] Factor the stanza template if the seed body grows unwieldy.
+
+**Dependencies:** None
+**Parallelizable:** Yes (different file from Tasks 1–2)
+
+### Task 4: `doctor` catalog-validation check (#1479)
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `doctorCatalogCheck_validCatalogPasses`,
+   `_malformedCatalogWarns`, `_reservedNamespaceIdWarns`
+   - File: `servers/exarchos-mcp/src/orchestrate/doctor/checks/invariants-catalog.test.ts`
+   - Validates configured user catalog files parse + match schema v3; warns on
+     reserved ids (`INV-*` / `SDLC-*`).
+
+2. [GREEN] Implement `checks/invariants-catalog.ts`; register in the doctor checks
+   index (`orchestrate/doctor/checks/index.ts`).
+
+**Dependencies:** Tasks 1–2 (validator should validate a corrected catalog)
+**Parallelizable:** No (after #1478)
+
+### Task 5: Reconcile dual config readers (#1479)
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `exarchosYml_validatesIdenticallyAcrossBothReaders`
+   - File: `servers/exarchos-mcp/src/config/load-exarchos-config.test.ts`
+   - A `.exarchos.yml` with a valid `invariants:` block but an invalid sibling key
+     behaves identically across `loadExarchosConfig` and
+     `readInvariantsConfig` (`architecture/invariants-loader.ts`).
+   - Expected failure: strict vs lenient divergence.
+
+2. [GREEN] Reconcile the two readers to one validation semantics.
+
+**Dependencies:** None
+**Parallelizable:** Yes
+
+### Task 6: Cross-link docs (#1479)
+**Phase:** REFACTOR (docs)
+
+- `docs/guides/authoring-invariants.md` ↔ `init` flow point at each other and at
+  the effective-catalog inspection command. No test (prose); verify with
+  `npm run lint:invariants` staying green.
+
+**Dependencies:** Task 3
+**Parallelizable:** Yes
+
+---
+
+## PR 2 — Templating & workload-agnosticism (ADR + #1476 → #1470)
+
+### Task 7: ADR — observe-only hook layer (#1476)
+**Phase:** Doc-first (no test)
+
+- Write `docs/adrs/2026-05-24-hook-layer-observe-only.md`: enforcement moves
+  entirely inside MCP tools; document the dropped `guard` `PreToolUse` contract
+  (out-of-phase calls no longer pre-empted at the harness boundary — intentional)
+  and the observer event set (session/subagent start-stop, compaction, tool error).
+
+**Dependencies:** None
+**Parallelizable:** Yes (gates Tasks 8–11)
+
+### Task 8: `buildAllHooks()` per-runtime templating pass (#1476)
+**Phase:** RED → GREEN → REFACTOR
+
+1. [RED] Write test: `buildAllHooks_rendersObserverHooksForClaude`,
+   `buildAllHooks_nonHasHooksRuntime_emitsNothingOrManualNote`
+   - File: `src/build-skills.test.ts` (or new `src/build-hooks.test.ts`)
+   - Renders `hooks-src/` per runtime; only `hasHooks` runtimes
+     (`runtimes/types.ts:27`, `claude` only) emit; substitutes `{{MCP_PREFIX}}`;
+     Claude output lands at `hooks/hooks.json`.
+
+2. [GREEN] Add `buildAllHooks(opts)` sibling to `buildAllSkills` (`build-skills.ts:1133`);
+   create the observer-only `hooks-src/` source tree.
+
+3. [REFACTOR] Share render/copy helpers with the skills path.
+
+**Dependencies:** Task 7
+**Parallelizable:** No (within PR2)
+
+### Task 9: Excise enforcement hooks + dead handlers (#1476)
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `hooksJson_containsObserverHooksOnly`,
+   `removedEnforcementSubcommands_haveNoReferences`
+   - File: `servers/exarchos-mcp/src/adapters/hooks.test.ts` + a grep-sweep test.
+   - `hooks.json` has no `PreToolUse`/`TaskCompleted`/`TeammateIdle`/`SubagentStart`;
+     zero references to `guard`/`task-gate`/`teammate-gate`/`subagent-context`.
+
+2. [GREEN] Delete `cli-commands/guard.ts`, enforcement paths in
+   `cli-commands/gates.ts`, `cli-commands/subagent-context.ts`; remove dispatch
+   entries in `adapters/hooks.ts`; drop now-dead tests.
+
+**Dependencies:** Task 7
+**Parallelizable:** No
+
+### Task 10: `hooks:guard` CI check (#1476)
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `hooksGuard_failsOnGeneratedDrift`
+   - Mirrors `skills:guard` — re-render, fail on `git diff hooks/`.
+   - Extend `scripts/validate-plugin.sh` (currently checks 6 hook types ~L168).
+
+2. [GREEN] Add the `hooks:guard` npm script + CI wiring.
+
+**Dependencies:** Tasks 8, 9
+**Parallelizable:** No
+
+### Task 11: Fix `subagent-stop` dispatch-set inconsistency (#1476)
+**Phase:** RED → GREEN
+
+1. [RED] Test: `subagentStop_isPresentInHookDispatchSet`
+   - `SubagentStop` is wired in `hooks.json` but absent from the dispatch set in
+     `adapters/hooks.ts`.
+
+2. [GREEN] Add `subagent-stop` to the dispatch set (recast as observer).
+
+**Dependencies:** Task 9
+**Parallelizable:** No
+
+### Task 12: Parameterize verification commands in definitions.ts (#1470)
+**Phase:** RED → GREEN
+
+1. [RED] Write test: `implementerHook_usesTestCommandPlaceholder_notHardcodedNpm`,
+   `fixerHook_usesTestCommandPlaceholder`
+   - File: `servers/exarchos-mcp/src/agents/definitions.test.ts`
+   - Asserts implementer (L158) / fixer (L225) `post-test` hooks resolve from the
+     project test command (`{{testCommand}}` / `.exarchos.yml`), with npm only as a
+     documented fallback default.
+
+2. [GREEN] Parameterize the commands in `agents/definitions.ts`.
+
+**Dependencies:** Task 8 (placeholder spine)
+**Parallelizable:** No
+
+### Task 13: Toolchain-neutral worktree-hygiene prose (#1470)
+**Phase:** RED → GREEN
+
+1. [RED] Test: `generatedAgentProse_containsNoHardcodedNpmPrefix`
+   - Asserts no `npm --prefix` literal in generated agent prose; the neutral
+     principle (`git -C <worktree>`, run the project test command) is present.
+
+2. [GREEN] Rewrite the worktree-hygiene examples in `definitions.ts` (L70/L88/L92).
+
+**Dependencies:** Task 12
+**Parallelizable:** No
+
+### Task 14: Regenerate variants + delegation reference prompts (#1470)
+**Phase:** GREEN (regeneration) → verify
+
+- Regenerate `agents/`, `.cursor/`, `.github/`, `.opencode/` via the generate-agents
+  pipeline; update `skills-src/delegation/references/{implementer,fixer}-prompt.md`
+  and their `.test.sh`. Agent-drift tests + `npm run skills:guard` green.
+
+**Dependencies:** Tasks 12, 13
+**Parallelizable:** No
+
+---
+
+## Parallelization summary
+
+| Group | Tasks | Notes |
+|---|---|---|
+| PR1 chain A (#1478) | 1 → 2 | same catalog file, sequential |
+| PR1 chain B (#1479) | 3, 5, 6 parallel; 4 after 1–2 | |
+| PR2 ADR gate | 7 | gates 8–11 |
+| PR2 chain A (#1476) | 8 → 9 → 10; 11 after 9 | |
+| PR2 chain B (#1470) | 12 → 13 → 14 (after 8) | |
+
+PR1 and PR2 run fully in parallel (disjoint files, separate branches).
+
+## Aggregate test commands
+
+- `cd servers/exarchos-mcp && npm run test:run`
+- `npm run build && npm run skills:guard` + new `hooks:guard`
+- `npm run lint:invariants` (vocabulary lint stays green)

--- a/servers/exarchos-mcp/src/architecture/dev-catalog-ref-paths.test.ts
+++ b/servers/exarchos-mcp/src/architecture/dev-catalog-ref-paths.test.ts
@@ -1,0 +1,60 @@
+// ─── Dev-catalog reference-path existence guard (issue #1478) ────────────────
+//
+// `dev-catalog-content.test.ts` checks frontmatter *content* only, which is why
+// three `references:` paths rotted silently (INV-7/8/13 → moved/renamed source,
+// INV-9 → removed `hsm/` directory). This guard walks EVERY `references:` entry
+// in the LIVE catalog (`docs/architecture/invariants.md`) and asserts each
+// resolves to a real path on disk (DIM-4: real catalog vs real filesystem, not a
+// fixture). Pure doc-anchor fragments (`#...`) are skipped; a `path#anchor` entry
+// has its path part checked.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadInvariants } from './invariants-loader.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const INVARIANTS_DOC = path.join(REPO_ROOT, 'docs/architecture/invariants.md');
+const ENABLED_CONFIG = { invariants: { devCatalog: 'enabled' as const } };
+
+/**
+ * Strip a trailing `#anchor` fragment so a `path#section` reference checks only
+ * the path component. A reference that is *only* an anchor (`#section`, no path)
+ * collapses to the empty string and is skipped by the caller.
+ */
+function pathPart(ref: string): string {
+  const hashIdx = ref.indexOf('#');
+  return hashIdx === -1 ? ref : ref.slice(0, hashIdx);
+}
+
+describe('dev-catalog reference paths — #1478 existence guard', () => {
+  it('devCatalog_everyReferencePathExistsOnDisk', () => {
+    const entries = loadInvariants(
+      INVARIANTS_DOC,
+      { scope: 'all' },
+      ENABLED_CONFIG,
+    );
+    expect(entries.length).toBeGreaterThan(0);
+
+    const missing: string[] = [];
+    for (const entry of entries) {
+      for (const ref of entry.references) {
+        const p = pathPart(ref).trim();
+        if (p === '') continue; // pure doc-anchor (`#section`) — nothing to resolve
+        const abs = path.resolve(REPO_ROOT, p);
+        if (!fs.existsSync(abs)) {
+          missing.push(`${entry.id} → ${ref}`);
+        }
+      }
+    }
+
+    expect(
+      missing,
+      `catalog references that do not resolve on disk:\n  ${missing.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.test.ts
@@ -452,11 +452,35 @@ invariants:
 
   // ─── Wave C2: citations field (schema-v2) ─────────────────────────────
   //
-  // Schema-v2 adds an optional `citations: string[]` field for external
-  // research grounding. Recommended (not enforced) ≥3 citations per
-  // substrate-axis entry; DIM-* axiom-pointer entries are exempt.
+  // Schema-v2 adds a `citations: string[]` field for external research
+  // grounding. As of #1478 the ≥3-citations floor for substrate-axis entries
+  // is ENFORCED (was previously a deferred ≥2-references-only pin). Two
+  // documented exemptions remain:
+  //   - INV-5d  — reference-only sub-discipline of INV-5; grounding lives on
+  //               the parent INV-5a/5b/5c entries.
+  //   - basileus-boundary — cross-product coordination entry whose grounding
+  //               is the Exarchos↔Basileus coordination ADR, addressed via
+  //               its references, not in-frontmatter citations.
   //
   // Spec: docs/proposals/2026-05-20-invariants-catalog-v2-spec.md §3
+
+  it('Invariants_EverySubstrateAxisEntry_HasAtLeastThreeCitations', () => {
+    // ENFORCED floor (#1478): every substrate-axis invariant carries ≥3 real,
+    // verifiable citations so the grounding gap cannot reopen silently. The
+    // exempt set is documented above and must stay small + intentional.
+    const CITATION_EXEMPT = new Set(['INV-5d', 'basileus-boundary']);
+    const entries = loadInvariants(INVARIANTS_DOC, undefined, ENABLED_CONFIG);
+    const substrate = entries.filter(
+      (e) => e.axis === 'substrate' && !CITATION_EXEMPT.has(e.id),
+    );
+    expect(substrate.length).toBeGreaterThan(0);
+    for (const entry of substrate) {
+      expect(
+        entry.citations?.length ?? 0,
+        `entry ${entry.id} has ${entry.citations?.length ?? 0} citations; substrate-axis entries need >= 3`,
+      ).toBeGreaterThanOrEqual(3);
+    }
+  });
 
   it('Invariants_SubstrateAxisEntries_AcceptCitationsField', () => {
     // Synthetic fixture with the new field. Loader must parse it into

--- a/servers/exarchos-mcp/src/architecture/invariants-loader.ts
+++ b/servers/exarchos-mcp/src/architecture/invariants-loader.ts
@@ -17,6 +17,7 @@ import path from 'node:path';
 import matter from 'gray-matter';
 import { parse as parseYaml } from 'yaml';
 import type { ExarchosConfig } from '../config/exarchos-config-schema.js';
+import { FullExarchosConfigSchema } from '../config/yaml-schema.js';
 import {
   InvariantEntryV3Schema,
   type Enforcement,
@@ -354,7 +355,7 @@ export function parseInvariantEntries(rawEntries: unknown): InvariantEntry[] {
  *
  * The walk-up is bounded by the filesystem root; we stop at the first hit.
  */
-function readInvariantsConfig(catalogFilePath: string): ExarchosConfig {
+export function readInvariantsConfig(catalogFilePath: string): ExarchosConfig {
   let dir = path.dirname(path.resolve(catalogFilePath));
   // Bounded walk-up: stop at filesystem root.
   while (true) {
@@ -371,35 +372,42 @@ function readInvariantsConfig(catalogFilePath: string): ExarchosConfig {
 }
 
 /**
- * Extract only the `invariants:` block from a `.exarchos.yml` file.
- * Tolerates files whose other top-level keys do not match
- * `ExarchosConfigSchema` (`agents:`, `review:`, etc. validated by the
- * parallel `ProjectConfigSchema` — see notes on `readInvariantsConfig`).
+ * Extract the `invariants:` block from a `.exarchos.yml` file, reconciled
+ * with the strict `loadExarchosConfig` reader (#1479).
  *
- * Returns `{}` on parse errors or when the `invariants` key is absent;
- * default-disabled at the loader handles both as "no flag set."
+ * Both readers now validate the *entire* document against the unified
+ * `FullExarchosConfigSchema` (the merge of the test-runtime concern and the
+ * project concern, see `config/yaml-schema.ts`), so they reach the SAME
+ * verdict on any given file: a key valid in either concern is accepted; a
+ * genuine typo or a malformed `invariants` block is rejected by both.
+ *
+ * This loader stays NON-throwing by contract — `loadInvariants` expects a
+ * `{}` fallback rather than an exception. So an invalid document degrades to
+ * `{}` here (no invariants flag honored), which mirrors `loadExarchosConfig`
+ * refusing to return a config for the same file: neither path keeps a bogus
+ * invariants block alive. Returns `{}` on read/parse errors or when the
+ * `invariants` key is absent; default-disabled at the loader handles both as
+ * "no flag set."
  */
 function parseInvariantsBlock(configPath: string): ExarchosConfig {
   try {
     const raw = fs.readFileSync(configPath, 'utf8');
     const doc = parseYaml(raw);
-    if (doc === null || doc === undefined || typeof doc !== 'object') {
+    const candidate: unknown =
+      doc === null || doc === undefined ? {} : doc;
+    if (typeof candidate !== 'object' || Array.isArray(candidate)) {
       return {};
     }
-    const invariants = (doc as Record<string, unknown>).invariants;
-    if (invariants === undefined || invariants === null) {
+    // Reconciled verdict: validate the whole file with the same unified
+    // schema the strict reader uses. An unknown sibling key or a malformed
+    // invariants block fails the parse, and we degrade to "no flag set" —
+    // identical observable behavior to the strict reader's rejection.
+    const result = FullExarchosConfigSchema.safeParse(candidate);
+    if (!result.success) {
       return {};
     }
-    // Project just the keys we care about; the loader treats unknown values
-    // as not-`'enabled'` so any malformed shape collapses to default-disabled.
-    if (typeof invariants === 'object' && !Array.isArray(invariants)) {
-      const devCatalog = (invariants as Record<string, unknown>).devCatalog;
-      if (devCatalog === 'enabled' || devCatalog === 'disabled') {
-        return { invariants: { devCatalog } };
-      }
-      return { invariants: {} };
-    }
-    return {};
+    const invariants = result.data.invariants;
+    return invariants === undefined ? {} : { invariants };
   } catch {
     return {};
   }

--- a/servers/exarchos-mcp/src/config/load-exarchos-config.test.ts
+++ b/servers/exarchos-mcp/src/config/load-exarchos-config.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:f
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { loadExarchosConfig } from './load-exarchos-config.js';
+import { readInvariantsConfig } from '../architecture/invariants-loader.js';
 
 describe('loadExarchosConfig', () => {
   let tmpRoot: string;
@@ -123,6 +124,94 @@ describe('loadExarchosConfig', () => {
     // No .exarchos.yml in worktree, findRepoRoot returns null.
     const result = loadExarchosConfig(worktree, { findRepoRoot: () => null });
     expect(result).toBeNull();
+  });
+
+  // ─── #1479: reconcile dual config readers ───────────────────────────────
+  //
+  // `loadExarchosConfig` (strict, ExarchosConfigSchema) and the lenient
+  // `readInvariantsConfig` (architecture/invariants-loader.ts) both parse the
+  // SAME `.exarchos.yml`. Before reconciliation they diverged: a file with an
+  // unknown sibling key threw under the strict reader but silently yielded its
+  // invariants block under the lenient one — so a typo'd config could disable
+  // governance under one path while passing the other. These tests pin the
+  // reconciled contract: both readers reach the same verdict on a given file.
+
+  it('dualReaders_KnownProjectSiblingKey_ValidInvariants_BothAccept', () => {
+    // `agents:` is a valid ProjectConfigSchema key — unknown to the bare
+    // ExarchosConfigSchema before reconciliation. Both readers must now accept
+    // the file and surface the valid invariants block.
+    const worktree = join(tmpRoot, 'wt');
+    mkdirSync(worktree, { recursive: true });
+    const cfgPath = join(worktree, '.exarchos.yml');
+    writeFileSync(
+      cfgPath,
+      [
+        'agents:',
+        '  default-model: opus',
+        'invariants:',
+        '  devCatalog: enabled',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    // Strict reader: no throw, invariants block present.
+    const strict = loadExarchosConfig(worktree, { findRepoRoot: () => null });
+    expect(strict).not.toBeNull();
+    expect(strict!.config.invariants?.devCatalog).toBe('enabled');
+
+    // Lenient reader: same verdict — invariants block honored.
+    const lenient = readInvariantsConfig(cfgPath);
+    expect(lenient.invariants?.devCatalog).toBe('enabled');
+  });
+
+  it('dualReaders_UnknownSiblingKey_ValidInvariants_BehaveIdentically', () => {
+    // A genuinely-unknown sibling key (typo) is invalid in BOTH schemas. The
+    // reconciled contract: the strict reader throws AND the lenient reader does
+    // NOT honor the invariants block from the invalid file (returns {}). A
+    // typo'd config cannot silently keep governance configuration alive on one
+    // path while failing the other.
+    const worktree = join(tmpRoot, 'wt');
+    mkdirSync(worktree, { recursive: true });
+    const cfgPath = join(worktree, '.exarchos.yml');
+    writeFileSync(
+      cfgPath,
+      [
+        'agentss: oops', // typo'd key — invalid under both schemas
+        'invariants:',
+        '  devCatalog: enabled',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    expect(() => loadExarchosConfig(worktree, { findRepoRoot: () => null })).toThrow(
+      /Invalid \.exarchos\.yml/,
+    );
+
+    const lenient = readInvariantsConfig(cfgPath);
+    expect(lenient.invariants?.devCatalog).toBeUndefined();
+  });
+
+  it('dualReaders_InvalidInvariantsBlock_BehaveIdentically', () => {
+    // A malformed invariants block (unknown nested key) must be rejected
+    // consistently: the strict reader throws and the lenient reader does not
+    // surface a bogus invariants config.
+    const worktree = join(tmpRoot, 'wt');
+    mkdirSync(worktree, { recursive: true });
+    const cfgPath = join(worktree, '.exarchos.yml');
+    writeFileSync(
+      cfgPath,
+      ['invariants:', '  devCatalog: enabled', '  bogusKey: true', ''].join('\n'),
+      'utf-8',
+    );
+
+    expect(() => loadExarchosConfig(worktree, { findRepoRoot: () => null })).toThrow(
+      /Invalid \.exarchos\.yml/,
+    );
+
+    const lenient = readInvariantsConfig(cfgPath);
+    expect(lenient.invariants?.devCatalog).toBeUndefined();
   });
 
   it('loadConfig_FieldsParsedCorrectly', () => {

--- a/servers/exarchos-mcp/src/config/load-exarchos-config.ts
+++ b/servers/exarchos-mcp/src/config/load-exarchos-config.ts
@@ -2,13 +2,16 @@ import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { execSync } from 'node:child_process';
 import { parse as parseYaml } from 'yaml';
-import { ExarchosConfigSchema, type ExarchosConfig } from './exarchos-config-schema.js';
+import { FullExarchosConfigSchema, type FullExarchosConfig } from './yaml-schema.js';
 
 const CONFIG_FILENAME = '.exarchos.yml';
 
 export interface LoadResult {
-  /** Validated config contents. */
-  config: ExarchosConfig;
+  /** Validated config contents. The unified schema (#1479) covers every
+   * known `.exarchos.yml` key — the test-runtime concern (test/typecheck/
+   * install/cli) AND the project concern (agents/review/workflow/...) — so a
+   * file with keys from either concern validates here without throwing. */
+  config: FullExarchosConfig;
   /** Absolute path of the file the config came from. */
   source: string;
 }
@@ -94,7 +97,7 @@ function readAndValidate(path: string): LoadResult {
   // Treat empty file / null document as empty config.
   const candidate: unknown = parsed === null || parsed === undefined ? {} : parsed;
 
-  const result = ExarchosConfigSchema.safeParse(candidate);
+  const result = FullExarchosConfigSchema.safeParse(candidate);
   if (!result.success) {
     const details = result.error.issues
       .map((issue) => {

--- a/servers/exarchos-mcp/src/config/yaml-schema.ts
+++ b/servers/exarchos-mcp/src/config/yaml-schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { InvariantsConfigSchema } from './exarchos-config-schema.js';
+import { InvariantsConfigSchema, ExarchosConfigSchema } from './exarchos-config-schema.js';
 
 // ─── Dimension Configuration ────────────────────────────────────────────────
 
@@ -167,3 +167,24 @@ export const ProjectConfigSchema = z.object({
 }).strict();
 
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
+
+// ─── Unified `.exarchos.yml` schema (#1479 dual-reader reconciliation) ──────
+//
+// The same `.exarchos.yml` is read by two paths that historically used
+// disjoint, both-`.strict()` schemas:
+//   - `loadExarchosConfig` (config/load-exarchos-config.ts) → ExarchosConfigSchema
+//     (test/typecheck/install/qualityHints/handoffLint/cli/invariants)
+//   - the architecture invariants loader's `readInvariantsConfig` → a hand-
+//     rolled lenient slice of the `invariants:` block.
+// Because each schema rejected the other's keys, a file valid for one reader
+// threw for the other, and a typo'd key silently kept its invariants block
+// alive on the lenient path. The unified schema is the merge of both
+// concern-schemas: a key valid in EITHER is accepted; a key valid in NEITHER
+// (a genuine typo) is still rejected. Both readers now share this one schema,
+// so they reach the same verdict on any given file. The shared `invariants`
+// block is identical in both source schemas, so the merge is conflict-free.
+export const FullExarchosConfigSchema = ExarchosConfigSchema.merge(
+  ProjectConfigSchema,
+).strict();
+
+export type FullExarchosConfig = z.infer<typeof FullExarchosConfigSchema>;

--- a/servers/exarchos-mcp/src/orchestrate/doctor/checks/__shared__/make-stub-probes.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/checks/__shared__/make-stub-probes.ts
@@ -34,6 +34,7 @@ export function makeStubProbes(overrides: Partial<DoctorProbes> = {}): DoctorPro
       installedVersion: throwing('plugin'),
       runningVersion: throwing('plugin'),
     },
+    invariants: { resolve: throwing('invariants') },
   };
   return { ...base, ...overrides };
 }

--- a/servers/exarchos-mcp/src/orchestrate/doctor/checks/invariants-catalog.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/checks/invariants-catalog.test.ts
@@ -5,9 +5,9 @@ import { invariantsCatalog } from './invariants-catalog.js';
 const controller = () => new AbortController().signal;
 
 describe('invariantsCatalog', () => {
-  it('InvariantsCatalog_ValidCatalog_NoWarnings_ReturnsPass', async () => {
+  it('InvariantsCatalog_ConfiguredNoWarnings_ReturnsPass', async () => {
     const probes = makeStubProbes({
-      invariants: { resolve: async () => ({ entryCount: 19, warnings: [] }) },
+      invariants: { resolve: async () => ({ configured: true, warnings: [] }) },
     });
 
     const result = await invariantsCatalog(probes, controller());
@@ -15,7 +15,6 @@ describe('invariantsCatalog', () => {
     expect(result.category).toBe('invariants');
     expect(result.name).toBe('invariants-catalog');
     expect(result.status).toBe('Pass');
-    expect(result.message).toContain('19');
     expect(result.fix).toBeUndefined();
   });
 
@@ -23,7 +22,7 @@ describe('invariantsCatalog', () => {
     const probes = makeStubProbes({
       invariants: {
         resolve: async () => ({
-          entryCount: 19,
+          configured: true,
           warnings: [
             "User invariant catalog 'docs/architecture/mine.md' failed to load and was skipped. Reason: bad YAML",
           ],
@@ -43,7 +42,7 @@ describe('invariantsCatalog', () => {
     const probes = makeStubProbes({
       invariants: {
         resolve: async () => ({
-          entryCount: 19,
+          configured: true,
           warnings: [
             "User catalog entry 'INV-99' uses a reserved id namespace (INV-*, SDLC-*) and was skipped; rename it.",
           ],
@@ -59,11 +58,11 @@ describe('invariantsCatalog', () => {
   });
 
   it('InvariantsCatalog_NoCatalogConfigured_ReturnsSkipped', async () => {
-    // entryCount 0 with no warnings means the dev catalog is disabled and no
-    // user catalogs are configured — nothing to validate (DIM-2: no silent
+    // configured:false with no warnings means the dev catalog is disabled and
+    // no user catalogs are configured — nothing to validate (DIM-2: no silent
     // skip; reason is populated).
     const probes = makeStubProbes({
-      invariants: { resolve: async () => ({ entryCount: 0, warnings: [] }) },
+      invariants: { resolve: async () => ({ configured: false, warnings: [] }) },
     });
 
     const result = await invariantsCatalog(probes, controller());
@@ -71,5 +70,20 @@ describe('invariantsCatalog', () => {
     expect(result.status).toBe('Skipped');
     expect(result.reason).toBeDefined();
     expect(result.reason!.length).toBeGreaterThan(0);
+  });
+
+  it('InvariantsCatalog_ConfiguredButNoPhaseMatchingEntries_StillPasses', async () => {
+    // Regression for the Seer MEDIUM (#1482): the decision keys off `configured`,
+    // not a phase-projected entry count. A catalog that IS configured and loaded
+    // cleanly but whose entries do not project to the resolver's phase (e.g. all
+    // `phase-affinity: ['review']`) must Pass — never Skip as "nothing
+    // configured". The resolver surfaces this as configured:true, warnings:[].
+    const probes = makeStubProbes({
+      invariants: { resolve: async () => ({ configured: true, warnings: [] }) },
+    });
+
+    const result = await invariantsCatalog(probes, controller());
+
+    expect(result.status).toBe('Pass');
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/doctor/checks/invariants-catalog.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/checks/invariants-catalog.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { makeStubProbes } from './__shared__/make-stub-probes.js';
+import { invariantsCatalog } from './invariants-catalog.js';
+
+const controller = () => new AbortController().signal;
+
+describe('invariantsCatalog', () => {
+  it('InvariantsCatalog_ValidCatalog_NoWarnings_ReturnsPass', async () => {
+    const probes = makeStubProbes({
+      invariants: { resolve: async () => ({ entryCount: 19, warnings: [] }) },
+    });
+
+    const result = await invariantsCatalog(probes, controller());
+
+    expect(result.category).toBe('invariants');
+    expect(result.name).toBe('invariants-catalog');
+    expect(result.status).toBe('Pass');
+    expect(result.message).toContain('19');
+    expect(result.fix).toBeUndefined();
+  });
+
+  it('InvariantsCatalog_MalformedUserCatalog_ReturnsWarning', async () => {
+    const probes = makeStubProbes({
+      invariants: {
+        resolve: async () => ({
+          entryCount: 19,
+          warnings: [
+            "User invariant catalog 'docs/architecture/mine.md' failed to load and was skipped. Reason: bad YAML",
+          ],
+        }),
+      },
+    });
+
+    const result = await invariantsCatalog(probes, controller());
+
+    expect(result.status).toBe('Warning');
+    expect(result.message).toContain('mine.md');
+    expect(result.fix).toBeDefined();
+    expect(result.fix!.length).toBeGreaterThan(0);
+  });
+
+  it('InvariantsCatalog_ReservedNamespaceId_ReturnsWarning', async () => {
+    const probes = makeStubProbes({
+      invariants: {
+        resolve: async () => ({
+          entryCount: 19,
+          warnings: [
+            "User catalog entry 'INV-99' uses a reserved id namespace (INV-*, SDLC-*) and was skipped; rename it.",
+          ],
+        }),
+      },
+    });
+
+    const result = await invariantsCatalog(probes, controller());
+
+    expect(result.status).toBe('Warning');
+    expect(result.message).toContain('INV-99');
+    expect(result.fix).toBeDefined();
+  });
+
+  it('InvariantsCatalog_NoCatalogConfigured_ReturnsSkipped', async () => {
+    // entryCount 0 with no warnings means the dev catalog is disabled and no
+    // user catalogs are configured — nothing to validate (DIM-2: no silent
+    // skip; reason is populated).
+    const probes = makeStubProbes({
+      invariants: { resolve: async () => ({ entryCount: 0, warnings: [] }) },
+    });
+
+    const result = await invariantsCatalog(probes, controller());
+
+    expect(result.status).toBe('Skipped');
+    expect(result.reason).toBeDefined();
+    expect(result.reason!.length).toBeGreaterThan(0);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/doctor/checks/invariants-catalog.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/checks/invariants-catalog.ts
@@ -6,8 +6,13 @@
  * every DR-9 degradation into a `warnings` list: malformed/missing user catalog
  * files and reserved-namespace ids (`INV-*` / `SDLC-*`) in a user catalog. Any
  * warning yields a doctor Warning that names the offending catalog/id; a clean
- * resolution with entries Passes; an empty resolution with no warnings Skips
- * (dev catalog disabled and no user catalogs configured — nothing to validate).
+ * resolution of a configured catalog Passes; when nothing user-validatable is
+ * configured (dev catalog disabled/absent and no user catalogs) it Skips.
+ *
+ * The Skip signal is `configured`, NOT an entry count: the resolver projects to
+ * a representative phase only to surface warnings, so a phase-filtered count
+ * would misreport a configured-but-non-matching catalog as "nothing to
+ * validate" (#1482 review).
  */
 
 import type { CheckFn } from './__shared__/make-stub-probes.js';
@@ -16,7 +21,7 @@ export const invariantsCatalog: CheckFn = async (probes, signal) => {
   const start = Date.now();
   const base = { category: 'invariants' as const, name: 'invariants-catalog' };
 
-  const { entryCount, warnings } = await probes.invariants.resolve(signal);
+  const { configured, warnings } = await probes.invariants.resolve(signal);
 
   if (warnings.length > 0) {
     const first = warnings[0]!;
@@ -34,7 +39,7 @@ export const invariantsCatalog: CheckFn = async (probes, signal) => {
     };
   }
 
-  if (entryCount === 0) {
+  if (!configured) {
     return {
       ...base,
       status: 'Skipped',
@@ -51,7 +56,7 @@ export const invariantsCatalog: CheckFn = async (probes, signal) => {
   return {
     ...base,
     status: 'Pass',
-    message: `Invariant catalog resolved cleanly: ${entryCount} entr${entryCount === 1 ? 'y' : 'ies'}, no warnings`,
+    message: 'Configured invariant catalog(s) resolved cleanly, no warnings',
     durationMs: Date.now() - start,
   };
 };

--- a/servers/exarchos-mcp/src/orchestrate/doctor/checks/invariants-catalog.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/checks/invariants-catalog.ts
@@ -1,0 +1,57 @@
+/**
+ * invariants-catalog — do the configured invariant catalogs parse and merge
+ * cleanly? (#1479)
+ *
+ * Resolves the effective catalog via `probes.invariants.resolve()`, which folds
+ * every DR-9 degradation into a `warnings` list: malformed/missing user catalog
+ * files and reserved-namespace ids (`INV-*` / `SDLC-*`) in a user catalog. Any
+ * warning yields a doctor Warning that names the offending catalog/id; a clean
+ * resolution with entries Passes; an empty resolution with no warnings Skips
+ * (dev catalog disabled and no user catalogs configured — nothing to validate).
+ */
+
+import type { CheckFn } from './__shared__/make-stub-probes.js';
+
+export const invariantsCatalog: CheckFn = async (probes, signal) => {
+  const start = Date.now();
+  const base = { category: 'invariants' as const, name: 'invariants-catalog' };
+
+  const { entryCount, warnings } = await probes.invariants.resolve(signal);
+
+  if (warnings.length > 0) {
+    const first = warnings[0]!;
+    const more = warnings.length > 1 ? ` (+${warnings.length - 1} more)` : '';
+    return {
+      ...base,
+      status: 'Warning',
+      message: `Invariant catalog resolution surfaced ${warnings.length} warning(s): ${first}${more}`,
+      fix:
+        'Fix the offending user catalog: repair its YAML, point ' +
+        'invariants.catalogs at the correct path, or rename any entry that ' +
+        'reuses the reserved INV-* / SDLC-* id namespace. Inspect the resolved ' +
+        'catalog with `exarchos view invariants_effective`.',
+      durationMs: Date.now() - start,
+    };
+  }
+
+  if (entryCount === 0) {
+    return {
+      ...base,
+      status: 'Skipped',
+      message:
+        'No invariant catalog to validate (dev catalog disabled, no user catalogs configured)',
+      reason:
+        'No invariant catalog to validate: invariants.devCatalog is disabled ' +
+        'and invariants.catalogs is empty. Enable the dev catalog or add a ' +
+        'user catalog in .exarchos.yml to validate one.',
+      durationMs: Date.now() - start,
+    };
+  }
+
+  return {
+    ...base,
+    status: 'Pass',
+    message: `Invariant catalog resolved cleanly: ${entryCount} entr${entryCount === 1 ? 'y' : 'ies'}, no warnings`,
+    durationMs: Date.now() - start,
+  };
+};

--- a/servers/exarchos-mcp/src/orchestrate/doctor/index.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/index.ts
@@ -1,5 +1,5 @@
 /**
- * handleDoctor — composes the 10 per-check modules into a single MCP
+ * handleDoctor — composes the 11 per-check modules into a single MCP
  * action.
  *
  * Design notes:

--- a/servers/exarchos-mcp/src/orchestrate/doctor/index.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/index.ts
@@ -36,10 +36,11 @@ import { agentMcpRegistered } from './checks/agent-mcp-registered.js';
 import { pluginSkillHashSync } from './checks/plugin-skill-hash-sync.js';
 import { pluginVersionMatch } from './checks/plugin-version-match.js';
 import { remoteMcpStub } from './checks/remote-mcp-stub.js';
+import { invariantsCatalog } from './checks/invariants-catalog.js';
 
 // ─── Canonical check list ──────────────────────────────────────────────────
 
-/** All 10 checks. Order is preserved in the output — callers can scan
+/** All 11 checks. Order is preserved in the output — callers can scan
  * top-to-bottom for the first Fail. */
 export const ALL_CHECKS: ReadonlyArray<CheckFn> = [
   runtimeNodeVersion,
@@ -52,6 +53,7 @@ export const ALL_CHECKS: ReadonlyArray<CheckFn> = [
   pluginSkillHashSync,
   pluginVersionMatch,
   remoteMcpStub,
+  invariantsCatalog,
 ];
 
 // ─── Per-check timeout ─────────────────────────────────────────────────────

--- a/servers/exarchos-mcp/src/orchestrate/doctor/probes.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/probes.test.ts
@@ -85,16 +85,43 @@ describe('buildProbes invariants.resolve — cwd-relative root resolution (#1482
   // inside this repo, which HAS a root `.exarchos.yml`.
   //
   // This test pins resolution to cwd: from a temp dir with no `.exarchos.yml`
-  // ancestor the resolver must return an empty result. Under the bug,
-  // module-relative resolution would find the in-repo config and report a
-  // non-empty catalog — so this fails RED on the bug, GREEN on the fix.
-  it('Resolve_CwdHasNoExarchosYmlAncestor_ReturnsEmptyNotInRepoCatalog', async () => {
+  // ancestor the resolver must report not-configured. Under the bug,
+  // module-relative resolution would find the in-repo config (devCatalog
+  // enabled) and report configured — so this fails RED on the bug, GREEN on
+  // the fix.
+  it('Resolve_CwdHasNoExarchosYmlAncestor_ReturnsNotConfigured', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-no-cfg-'));
     process.chdir(tmp);
     try {
       const probes = buildProbes(fakeContext());
       const result = await probes.invariants.resolve();
-      expect(result.entryCount).toBe(0);
+      expect(result.configured).toBe(false);
+      expect(result.warnings).toEqual([]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  // Regression for the Seer MEDIUM (#1482): `configured` must be
+  // phase-INDEPENDENT. A user catalog declared in `.exarchos.yml` counts as
+  // configured purely by being declared — even if it contributes zero entries
+  // for any phase. The old projected-entry-count signal returned 0 here and
+  // misreported a real configuration as "nothing to validate".
+  it('Resolve_UserCatalogDeclared_ReportsConfiguredRegardlessOfEntries', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-user-cat-'));
+    // A valid-but-empty user catalog: declared in config, loads without
+    // warning, contributes zero entries (frontmatter declares an empty
+    // `invariants:` array, which the loader requires).
+    fs.writeFileSync(path.join(tmp, 'my-catalog.md'), '---\ninvariants: []\n---\n');
+    fs.writeFileSync(
+      path.join(tmp, '.exarchos.yml'),
+      'invariants:\n  devCatalog: disabled\n  catalogs:\n    - ./my-catalog.md\n',
+    );
+    process.chdir(tmp);
+    try {
+      const probes = buildProbes(fakeContext());
+      const result = await probes.invariants.resolve();
+      expect(result.configured).toBe(true);
       expect(result.warnings).toEqual([]);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });

--- a/servers/exarchos-mcp/src/orchestrate/doctor/probes.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/probes.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { DispatchContext } from '../../core/dispatch.js';
 import { buildProbes } from './probes.js';
 
@@ -67,5 +70,34 @@ describe('buildProbes', () => {
 
     expect(result).toBe(sentinel);
     expect(recorded).toEqual([{ timeoutMs: 777 }]);
+  });
+});
+
+describe('buildProbes invariants.resolve — cwd-relative root resolution (#1482)', () => {
+  const originalCwd = process.cwd();
+  afterEach(() => process.chdir(originalCwd));
+
+  // Regression guard for the Seer HIGH finding: the invariants-catalog check
+  // resolved `.exarchos.yml` relative to THIS MODULE, not the user's cwd. In
+  // plugin mode the module lives under `~/.claude/plugins/...` (no
+  // `.exarchos.yml` ancestor), so the check silently Skipped and never
+  // validated the consumer's catalog. CI masked it because the module sits
+  // inside this repo, which HAS a root `.exarchos.yml`.
+  //
+  // This test pins resolution to cwd: from a temp dir with no `.exarchos.yml`
+  // ancestor the resolver must return an empty result. Under the bug,
+  // module-relative resolution would find the in-repo config and report a
+  // non-empty catalog — so this fails RED on the bug, GREEN on the fix.
+  it('Resolve_CwdHasNoExarchosYmlAncestor_ReturnsEmptyNotInRepoCatalog', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-no-cfg-'));
+    process.chdir(tmp);
+    try {
+      const probes = buildProbes(fakeContext());
+      const result = await probes.invariants.resolve();
+      expect(result.entryCount).toBe(0);
+      expect(result.warnings).toEqual([]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/servers/exarchos-mcp/src/orchestrate/doctor/probes.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/probes.ts
@@ -282,12 +282,14 @@ async function defaultRunningVersion(): Promise<string | null> {
  * surfaces every merge/load warning regardless of phase narrowing. DIM-1:
  * computed per call, no caching. A failure to load config degrades to an empty
  * resolution rather than throwing — the check decides Pass/Warning/Skip. */
-async function defaultResolveInvariants(): Promise<{
+async function defaultResolveInvariants(signal?: AbortSignal): Promise<{
   entryCount: number;
   warnings: string[];
 }> {
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
   const root = await findRepoRoot('.exarchos.yml');
   if (root === null) return { entryCount: 0, warnings: [] };
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
   let config;
   try {
     const loaded = loadExarchosConfig(root, { findRepoRoot: () => root });
@@ -335,6 +337,6 @@ export function buildProbes(ctx: DispatchContext): DoctorProbes {
       installedVersion: defaultInstalledPluginVersion,
       runningVersion: defaultRunningVersion,
     },
-    invariants: { resolve: () => defaultResolveInvariants() },
+    invariants: { resolve: (signal) => defaultResolveInvariants(signal) },
   };
 }

--- a/servers/exarchos-mcp/src/orchestrate/doctor/probes.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/probes.ts
@@ -33,6 +33,8 @@ import {
   type AgentEnvironment,
   type DetectorFs,
 } from '../../runtime/agent-environment-detector.js';
+import { loadExarchosConfig } from '../../config/load-exarchos-config.js';
+import { resolveEffectiveCatalog } from '../../architecture/resolve-effective-catalog.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -91,6 +93,18 @@ export interface DoctorPlugin {
   runningVersion(): Promise<string | null>;
 }
 
+export interface DoctorInvariantsCatalog {
+  /**
+   * Resolve the effective invariant catalog from `.exarchos.yml` and report
+   * the entry count plus any merge/load/reserved-namespace warnings folded by
+   * `resolveEffectiveCatalog` (DR-9). The check turns a non-empty `warnings`
+   * list into a doctor Warning, naming the offending catalog/id. `entryCount`
+   * is the number of resolved entries (0 when the dev catalog is disabled and
+   * no user catalogs are configured). Must honor `signal` and stay within the
+   * 2000ms probe budget (DIM-7). */
+  resolve(signal?: AbortSignal): Promise<{ entryCount: number; warnings: string[] }>;
+}
+
 export interface DoctorProbes {
   readonly fs: DoctorFs;
   readonly env: Readonly<Record<string, string | undefined>>;
@@ -102,6 +116,7 @@ export interface DoctorProbes {
   readonly stateDir: string;
   readonly skills: DoctorSkills;
   readonly plugin: DoctorPlugin;
+  readonly invariants: DoctorInvariantsCatalog;
 }
 
 const DEFAULT_FS: DoctorFs = {
@@ -261,6 +276,39 @@ async function defaultRunningVersion(): Promise<string | null> {
 }
 
 /**
+ * Resolve the effective invariant catalog from the project's `.exarchos.yml`
+ * and report entry count + DR-9 warnings (malformed/missing user catalogs,
+ * reserved-namespace ids). A representative `ideate`/`feature` projection key
+ * surfaces every merge/load warning regardless of phase narrowing. DIM-1:
+ * computed per call, no caching. A failure to load config degrades to an empty
+ * resolution rather than throwing — the check decides Pass/Warning/Skip. */
+async function defaultResolveInvariants(): Promise<{
+  entryCount: number;
+  warnings: string[];
+}> {
+  const root = await findRepoRoot('.exarchos.yml');
+  if (root === null) return { entryCount: 0, warnings: [] };
+  let config;
+  try {
+    const loaded = loadExarchosConfig(root, { findRepoRoot: () => root });
+    config = loaded?.config;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return {
+      entryCount: 0,
+      warnings: [`Failed to load .exarchos.yml at '${root}': ${reason}`],
+    };
+  }
+  const { entries, warnings } = resolveEffectiveCatalog({
+    repoRoot: root,
+    config,
+    phase: 'ideate',
+    workflowType: 'feature',
+  });
+  return { entryCount: entries.length, warnings };
+}
+
+/**
  * Build a DoctorProbes bundle from a DispatchContext. Each probe field
  * binds to a real runtime surface; tests bypass this factory entirely
  * by constructing a DoctorProbes literal with just the fields under
@@ -287,5 +335,6 @@ export function buildProbes(ctx: DispatchContext): DoctorProbes {
       installedVersion: defaultInstalledPluginVersion,
       runningVersion: defaultRunningVersion,
     },
+    invariants: { resolve: () => defaultResolveInvariants() },
   };
 }

--- a/servers/exarchos-mcp/src/orchestrate/doctor/probes.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/probes.ts
@@ -159,11 +159,21 @@ const DEFAULT_GIT: DoctorGit = {
   },
 };
 
-/** Resolve the repo root by walking up from this module until a
- * `package.json` is found. Computed per call (DIM-1 forbids module-
- * global caching). */
-async function findRepoRoot(marker: string): Promise<string | null> {
-  let dir = dirname(fileURLToPath(import.meta.url));
+/** Resolve a root by walking up from `startDir` until `marker` is found.
+ *
+ * `startDir` defaults to this module's directory — correct for locating the
+ * plugin's OWN artifacts (its `package.json`, its `skills-src/`). For a
+ * USER-project artifact (e.g. `.exarchos.yml`) callers MUST pass
+ * `process.cwd()`: in plugin mode the module lives under the plugin cache
+ * (`~/.claude/plugins/...`), which has no `.exarchos.yml` ancestor, so a
+ * module-relative walk would never find the consumer's config (#1482 review).
+ *
+ * Computed per call (DIM-1 forbids module-global caching). */
+async function findRepoRoot(
+  marker: string,
+  startDir: string = dirname(fileURLToPath(import.meta.url)),
+): Promise<string | null> {
+  let dir = startDir;
   for (let i = 0; i < 8; i++) {
     try {
       await nodeFs.access(join(dir, marker), fsConstants.F_OK);
@@ -287,7 +297,10 @@ async function defaultResolveInvariants(signal?: AbortSignal): Promise<{
   warnings: string[];
 }> {
   if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
-  const root = await findRepoRoot('.exarchos.yml');
+  // Resolve from the USER's cwd, NOT this module's location — `.exarchos.yml`
+  // is a consumer-project artifact and the module lives in the plugin cache in
+  // plugin mode (#1482 review). Mirrors the vcs-git-available check's cwd use.
+  const root = await findRepoRoot('.exarchos.yml', process.cwd());
   if (root === null) return { entryCount: 0, warnings: [] };
   if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
   let config;

--- a/servers/exarchos-mcp/src/orchestrate/doctor/probes.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/probes.ts
@@ -96,13 +96,16 @@ export interface DoctorPlugin {
 export interface DoctorInvariantsCatalog {
   /**
    * Resolve the effective invariant catalog from `.exarchos.yml` and report
-   * the entry count plus any merge/load/reserved-namespace warnings folded by
-   * `resolveEffectiveCatalog` (DR-9). The check turns a non-empty `warnings`
-   * list into a doctor Warning, naming the offending catalog/id. `entryCount`
-   * is the number of resolved entries (0 when the dev catalog is disabled and
-   * no user catalogs are configured). Must honor `signal` and stay within the
-   * 2000ms probe budget (DIM-7). */
-  resolve(signal?: AbortSignal): Promise<{ entryCount: number; warnings: string[] }>;
+   * whether any user-validatable catalog is `configured`, plus any
+   * merge/load/reserved-namespace warnings folded by `resolveEffectiveCatalog`
+   * (DR-9). The check turns a non-empty `warnings` list into a doctor Warning,
+   * naming the offending catalog/id. `configured` is `false` only when the dev
+   * catalog is disabled/absent AND no user catalogs are configured (the SDLC
+   * baseline is compiled-in and build-validated, so it does not count). It is
+   * phase-independent — a configured catalog whose entries do not project to a
+   * given phase still counts as configured. Must honor `signal` and stay
+   * within the 2000ms probe budget (DIM-7). */
+  resolve(signal?: AbortSignal): Promise<{ configured: boolean; warnings: string[] }>;
 }
 
 export interface DoctorProbes {
@@ -293,7 +296,7 @@ async function defaultRunningVersion(): Promise<string | null> {
  * computed per call, no caching. A failure to load config degrades to an empty
  * resolution rather than throwing — the check decides Pass/Warning/Skip. */
 async function defaultResolveInvariants(signal?: AbortSignal): Promise<{
-  entryCount: number;
+  configured: boolean;
   warnings: string[];
 }> {
   if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
@@ -301,7 +304,7 @@ async function defaultResolveInvariants(signal?: AbortSignal): Promise<{
   // is a consumer-project artifact and the module lives in the plugin cache in
   // plugin mode (#1482 review). Mirrors the vcs-git-available check's cwd use.
   const root = await findRepoRoot('.exarchos.yml', process.cwd());
-  if (root === null) return { entryCount: 0, warnings: [] };
+  if (root === null) return { configured: false, warnings: [] };
   if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
   let config;
   try {
@@ -310,17 +313,39 @@ async function defaultResolveInvariants(signal?: AbortSignal): Promise<{
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     return {
-      entryCount: 0,
+      configured: false,
       warnings: [`Failed to load .exarchos.yml at '${root}': ${reason}`],
     };
   }
-  const { entries, warnings } = resolveEffectiveCatalog({
+  // `configured` is the phase-INDEPENDENT Skip signal: is any USER-validatable
+  // catalog present? The dev catalog (gated + file on disk) or any user
+  // `catalogs` path. The built-in SDLC baseline is compiled-in and
+  // build-validated, so it is never a runtime validation target and does not
+  // count. The old signal — entry count after projecting to `ideate` —
+  // misreported a configured catalog whose entries are all non-`ideate` (e.g.
+  // `phase-affinity: ['review']`) as "nothing configured", making the Pass
+  // branch unreachable for such catalogs (#1482 review).
+  let devConfigured = false;
+  if (config?.invariants?.devCatalog === 'enabled') {
+    try {
+      await nodeFs.access(join(root, 'docs/architecture/invariants.md'), fsConstants.F_OK);
+      devConfigured = true;
+    } catch {
+      devConfigured = false;
+    }
+  }
+  const userConfigured = (config?.invariants?.catalogs?.length ?? 0) > 0;
+
+  // Phase key is arbitrary here: DR-9 warnings are folded pre-projection, so
+  // any phase surfaces every merge/load warning. We discard the projected
+  // entries and decide Skip-vs-validate on `configured` instead.
+  const { warnings } = resolveEffectiveCatalog({
     repoRoot: root,
     config,
     phase: 'ideate',
     workflowType: 'feature',
   });
-  return { entryCount: entries.length, warnings };
+  return { configured: devConfigured || userConfigured, warnings };
 }
 
 /**

--- a/servers/exarchos-mcp/src/orchestrate/doctor/schema.ts
+++ b/servers/exarchos-mcp/src/orchestrate/doctor/schema.ts
@@ -24,6 +24,7 @@ export const CheckCategorySchema = z.enum([
   'plugin',
   'env',
   'remote',
+  'invariants',
 ]);
 
 export const CheckResultSchema = z

--- a/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.test.ts
@@ -137,6 +137,57 @@ describe('seedExarchosConfig', () => {
     expect(body).toContain('https://github.com/lvlup-sw/exarchos/issues/1199');
   });
 
+  // ─── #1479: commented invariants: onboarding stanza ─────────────────────
+
+  it('seed_AppendsCommentedInvariantsStanza', () => {
+    const writes: Array<{ p: string; contents: string }> = [];
+    seedExarchosConfig('/repo', {
+      exists: () => false,
+      write: (p, contents) => writes.push({ p, contents }),
+      resolve: () => npmResolve(),
+    });
+
+    const body = writes[0].contents;
+    // The stanza is emitted COMMENTED so it documents the opt-in without
+    // changing behaviour (devCatalog stays effectively disabled until the
+    // operator uncomments it). The block carries a one-line explanation, a
+    // `devCatalog: disabled` line, and a stubbed `catalogs:` example.
+    expect(body).toContain('# invariants:');
+    expect(body).toMatch(/#\s*devCatalog:\s*disabled/);
+    expect(body).toMatch(/#\s*catalogs:/);
+    // The explanatory comment must mention what enabling the dev catalog does.
+    expect(body).toMatch(/dev[- ]catalog|architectural invariant/i);
+  });
+
+  it('seed_InvariantsStanza_IsCommentedNotActive', () => {
+    // The seeded stanza must not change the parsed/active config: a fresh
+    // seed should still load with no `invariants` block set (it is all
+    // comments), so behaviour is unchanged until the operator opts in.
+    const writes: Array<{ p: string; contents: string }> = [];
+    seedExarchosConfig('/repo', {
+      exists: () => false,
+      write: (p, contents) => writes.push({ p, contents }),
+      resolve: () => npmResolve(),
+    });
+    const body = writes[0].contents;
+    // No ACTIVE (uncommented) invariants: key at column 0.
+    expect(body).not.toMatch(/^invariants:/m);
+  });
+
+  it('seed_InvariantsStanza_IsIdempotent_NeverOverwrites', () => {
+    // Re-running on an existing config must not write at all (never
+    // overwrite, never duplicate the stanza).
+    const writeSpy = vi.fn<(p: string, contents: string) => void>();
+    const result = seedExarchosConfig('/repo', {
+      exists: () => true,
+      write: writeSpy,
+      resolve: () => npmResolve(),
+    });
+    expect(result.wrote).toBe(false);
+    expect(result.reason).toBe('already-exists');
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
   it('seed_RoundTripsThroughLoader', async () => {
     const tempDir = await mkdtemp(path.join(tmpdir(), 'seed-roundtrip-'));
     try {

--- a/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.ts
+++ b/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.ts
@@ -32,6 +32,23 @@ const HEADER = `# .exarchos.yml — Exarchos project configuration.
 # Docs: https://github.com/lvlup-sw/exarchos/issues/1199
 `;
 
+// Commented onboarding stanza for the architectural-invariants surface
+// (#1479). Emitted as comments so seeding documents the opt-in WITHOUT
+// changing behaviour: the dev catalog stays effectively disabled until the
+// operator uncomments the block. Authoring guide:
+// docs/guides/authoring-invariants.md; inspect the resolved catalog with
+// `exarchos view invariants_effective`.
+const INVARIANTS_STANZA = `
+# invariants:
+#   # Surface the built-in architectural-invariants dev catalog (INV-*) to
+#   # /ideate and the check_invariant_conformance gate. Default: disabled.
+#   devCatalog: disabled
+#   # Layer your own catalog files on top of the built-ins (paths relative to
+#   # this file). User ids must NOT reuse the reserved INV-* / SDLC-* prefixes.
+#   catalogs:
+#     - docs/architecture/my-invariants.md
+`;
+
 export interface SeedResult {
   /** Did we write a new config file? */
   wrote: boolean;
@@ -82,7 +99,7 @@ export function seedExarchosConfig(
   if (result.install !== null) body.install = result.install;
 
   const yamlBody = stringifyYaml(body);
-  const contents = HEADER + yamlBody;
+  const contents = HEADER + yamlBody + INVARIANTS_STANZA;
 
   write(target, contents);
 

--- a/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.ts
+++ b/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.ts
@@ -39,6 +39,10 @@ const HEADER = `# .exarchos.yml — Exarchos project configuration.
 // docs/guides/authoring-invariants.md; inspect the resolved catalog with
 // `exarchos view invariants_effective`.
 const INVARIANTS_STANZA = `
+# Architectural invariants (opt-in). Authoring guide:
+# docs/guides/authoring-invariants.md. After uncommenting, validate with
+# \`exarchos doctor\` (invariants-catalog check) and inspect the resolved
+# catalog with the \`invariants_effective\` view.
 # invariants:
 #   # Surface the built-in architectural-invariants dev catalog (INV-*) to
 #   # /ideate and the check_invariant_conformance gate. Default: disabled.


### PR DESCRIPTION
## Summary

Completes the invariants-catalog and onboarding half of the v2.10.0 GA cohort. Makes the dev invariants catalog content-complete (closing the silent reference-rot gap) and gives a fresh repo a real path to a working invariants config via `init` + `doctor`. Closes #1478 and #1479.

Design + plan: `docs/designs/2026-05-24-v2.10.0-ga-completion.md`, `docs/plans/2026-05-24-v2.10.0-ga-completion.md`.

## Changes

**#1478 — catalog content-complete**
- New ref-path existence guard (`architecture/dev-catalog-ref-paths.test.ts`) walks every `references:` entry against the real filesystem — closes the silent-rot gap that let 3 paths drift.
- Repointed the 3 broken refs: INV-7/8/13 → `event-store/atomic-appender.ts` (where `StreamLockManager`/`withSession` actually live), INV-9 → `workflow/hsm-definitions.ts`. Repoint only, no production refactor.
- Raised the substrate-axis citation floor from ≥2 (deferred) to an enforced ≥3 and backfilled real, verifiable citations for INV-2/3/4/5a/5b/5c.

**#1479 — init + doctor onboarding**
- `init` now seeds a commented `invariants:` stanza (`devCatalog: disabled` + stubbed `catalogs:`), idempotent.
- New `doctor` check validates catalog config (valid passes, malformed warns, reserved `INV-*`/`SDLC-*` ids warn).
- Reconciled the dual `.exarchos.yml` readers (`loadExarchosConfig` strict vs `readInvariantsConfig` lenient) onto one `FullExarchosConfigSchema`.
- Cross-linked `authoring-invariants.md` ↔ `init`/`doctor`/`invariants_effective`.

## Test Plan

- `cd servers/exarchos-mcp && npm run test:run` — new ref-path guard, ≥3-citation floor, doctor check, seed stanza, and dual-reader parity suites green.
- `npm run lint:invariants` — clean (0 findings).
- `tsc --noEmit` clean.
- Reviewer knowledge-checked all 18 backfilled citations as authentic (no fabrications).
- Note: 26 pre-existing `merge-orchestrate*`/`store.race` failures are unrelated to this branch — they fail identically on base `583f6af3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
