### PR TITLE
feat(invariants): default user catalog to .exarchos/invariants.md

### DIFF
--- a/servers/exarchos-mcp/src/orchestrate/composite.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.test.ts
@@ -314,7 +314,7 @@ describe('handleOrchestrate', () => {
     it('Composite_InvariantsScaffold_Dispatches', async () => {
       // P2/T7: dispatching action:'invariants_scaffold' reaches handleScaffold.
       const expected = successResult({
-        catalog: { wrote: true, path: '/repo/docs/architecture/my-invariants.md', reason: 'created' },
+        catalog: { wrote: true, path: '/repo/.exarchos/invariants.md', reason: 'created' },
         registration: { wrote: true, path: '/repo/.exarchos.yml', reason: 'registered' },
         tier: 'user',
         next_actions: ['doctor', 'view invariants_effective'],
@@ -323,7 +323,7 @@ describe('handleOrchestrate', () => {
       const args = {
         action: 'invariants_scaffold',
         repoRoot: '/repo',
-        path: 'docs/architecture/my-invariants.md',
+        path: '.exarchos/invariants.md',
         tier: 'user',
       };
 
@@ -335,7 +335,7 @@ describe('handleOrchestrate', () => {
       const callArgs = vi.mocked(handleScaffold).mock.calls[0]![0];
       expect(callArgs).toMatchObject({
         repoRoot: '/repo',
-        path: 'docs/architecture/my-invariants.md',
+        path: '.exarchos/invariants.md',
         tier: 'user',
       });
     });
@@ -354,7 +354,7 @@ describe('handleOrchestrate', () => {
       const args = {
         action: 'invariants_add',
         repoRoot: '/repo',
-        catalog: 'docs/architecture/my-invariants.md',
+        catalog: '.exarchos/invariants.md',
         tier: 'user',
         dryRun: false,
         entry: {

--- a/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.ts
+++ b/servers/exarchos-mcp/src/orchestrate/init/seed-exarchos-config.ts
@@ -50,7 +50,7 @@ const INVARIANTS_STANZA = `
 #   # Layer your own catalog files on top of the built-ins (paths relative to
 #   # this file). User ids must NOT reuse the reserved INV-* / SDLC-* prefixes.
 #   catalogs:
-#     - docs/architecture/my-invariants.md
+#     - .exarchos/invariants.md
 `;
 
 export interface SeedResult {

--- a/servers/exarchos-mcp/src/orchestrate/invariants/add.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/add.test.ts
@@ -86,14 +86,14 @@ const VALID_AUDIT_ENTRY = {
 describe('handleAdd — T8 validate + dry-run', () => {
   it('handleAdd_ValidEntry_DryRunReturnsRenderedDiff', async () => {
     const fake = makeFakeFs({
-      '/repo/docs/architecture/my-invariants.md': 'invariants: []\n',
+      '/repo/.exarchos/invariants.md': 'invariants: []\n',
     });
     const { ctx } = makeCtx();
 
     const result = await handleAdd(
       {
         repoRoot: '/repo',
-        catalog: 'docs/architecture/my-invariants.md',
+        catalog: '.exarchos/invariants.md',
         tier: 'user',
         entry: { ...VALID_AUDIT_ENTRY },
         dryRun: true,
@@ -123,7 +123,7 @@ describe('handleAdd — T8 validate + dry-run', () => {
 
   it('handleAdd_DryRunDefault_NoWrite', async () => {
     const fake = makeFakeFs({
-      '/repo/docs/architecture/my-invariants.md': 'invariants: []\n',
+      '/repo/.exarchos/invariants.md': 'invariants: []\n',
     });
     const { ctx } = makeCtx();
 
@@ -131,7 +131,7 @@ describe('handleAdd — T8 validate + dry-run', () => {
     const result = await handleAdd(
       {
         repoRoot: '/repo',
-        catalog: 'docs/architecture/my-invariants.md',
+        catalog: '.exarchos/invariants.md',
         tier: 'user',
         entry: { ...VALID_AUDIT_ENTRY },
       },
@@ -146,14 +146,14 @@ describe('handleAdd — T8 validate + dry-run', () => {
 
   it('handleAdd_CheckModeWithExecField_Rejected', async () => {
     const fake = makeFakeFs({
-      '/repo/docs/architecture/my-invariants.md': 'invariants: []\n',
+      '/repo/.exarchos/invariants.md': 'invariants: []\n',
     });
     const { ctx } = makeCtx();
 
     const result = await handleAdd(
       {
         repoRoot: '/repo',
-        catalog: 'docs/architecture/my-invariants.md',
+        catalog: '.exarchos/invariants.md',
         tier: 'user',
         entry: {
           dimension: 'd',
@@ -185,14 +185,14 @@ describe('handleAdd — T8 validate + dry-run', () => {
 
   it('handleAdd_UnknownLeafKind_Rejected', async () => {
     const fake = makeFakeFs({
-      '/repo/docs/architecture/my-invariants.md': 'invariants: []\n',
+      '/repo/.exarchos/invariants.md': 'invariants: []\n',
     });
     const { ctx } = makeCtx();
 
     const result = await handleAdd(
       {
         repoRoot: '/repo',
-        catalog: 'docs/architecture/my-invariants.md',
+        catalog: '.exarchos/invariants.md',
         tier: 'user',
         entry: {
           dimension: 'd',
@@ -247,14 +247,14 @@ describe('allocateNextId — T9 pure helper', () => {
 describe('handleAdd — T9 commit', () => {
   it('handleAdd_Commit_AppendsEntryToCatalog', async () => {
     const fake = makeFakeFs({
-      '/repo/docs/architecture/my-invariants.md': 'invariants: []\n',
+      '/repo/.exarchos/invariants.md': 'invariants: []\n',
     });
     const { ctx } = makeCtx();
 
     const result = await handleAdd(
       {
         repoRoot: '/repo',
-        catalog: 'docs/architecture/my-invariants.md',
+        catalog: '.exarchos/invariants.md',
         tier: 'user',
         entry: { ...VALID_AUDIT_ENTRY },
         dryRun: false,
@@ -265,14 +265,14 @@ describe('handleAdd — T9 commit', () => {
 
     expect(result.success).toBe(true);
     expect((result.data as { committed: boolean }).committed).toBe(true);
-    const written = fake.files.get('/repo/docs/architecture/my-invariants.md')!;
+    const written = fake.files.get('/repo/.exarchos/invariants.md')!;
     expect(written).toMatch(/id: U-1/);
     expect(written).toMatch(/mode: audit/);
   });
 
   it('handleAdd_AutoId_NextFreeInNamespace', async () => {
     const fake = makeFakeFs({
-      '/repo/docs/architecture/my-invariants.md':
+      '/repo/.exarchos/invariants.md':
         'invariants:\n  - id: U-1\n    dimension: d\n    axis: authoring\n    cost-of-load: reference-only\n    applies-to: ["src/**"]\n    summary: s\n    references: []\n  - id: U-2\n    dimension: d\n    axis: authoring\n    cost-of-load: reference-only\n    applies-to: ["src/**"]\n    summary: s\n    references: []\n',
     });
     const { ctx } = makeCtx();
@@ -280,7 +280,7 @@ describe('handleAdd — T9 commit', () => {
     const result = await handleAdd(
       {
         repoRoot: '/repo',
-        catalog: 'docs/architecture/my-invariants.md',
+        catalog: '.exarchos/invariants.md',
         tier: 'user',
         entry: { ...VALID_AUDIT_ENTRY },
         dryRun: false,
@@ -291,7 +291,7 @@ describe('handleAdd — T9 commit', () => {
 
     expect(result.success).toBe(true);
     expect((result.data as { id: string }).id).toBe('U-3');
-    const written = fake.files.get('/repo/docs/architecture/my-invariants.md')!;
+    const written = fake.files.get('/repo/.exarchos/invariants.md')!;
     expect(written).toMatch(/id: U-3/);
   });
 
@@ -300,7 +300,7 @@ describe('handleAdd — T9 commit', () => {
     // of the catalog (it's not yet in .exarchos.yml) emits catalog.registered
     // (INV-1). The events land on the per-tier invariants stream.
     const fake = makeFakeFs({
-      '/repo/docs/architecture/my-invariants.md': 'invariants: []\n',
+      '/repo/.exarchos/invariants.md': 'invariants: []\n',
       // .exarchos.yml has no catalog registration → first registration.
       '/repo/.exarchos.yml': 'test: npm test\n',
     });
@@ -309,7 +309,7 @@ describe('handleAdd — T9 commit', () => {
     const result = await handleAdd(
       {
         repoRoot: '/repo',
-        catalog: 'docs/architecture/my-invariants.md',
+        catalog: '.exarchos/invariants.md',
         tier: 'user',
         entry: { ...VALID_AUDIT_ENTRY },
         dryRun: false,
@@ -330,16 +330,16 @@ describe('handleAdd — T9 commit', () => {
   it('handleAdd_Commit_AlreadyRegisteredCatalog_NoCatalogRegisteredEvent', async () => {
     // When the catalog is already registered, only invariant.authored fires.
     const fake = makeFakeFs({
-      '/repo/docs/architecture/my-invariants.md': 'invariants: []\n',
+      '/repo/.exarchos/invariants.md': 'invariants: []\n',
       '/repo/.exarchos.yml':
-        'invariants:\n  catalogs:\n    - { path: docs/architecture/my-invariants.md, tier: user }\n',
+        'invariants:\n  catalogs:\n    - { path: .exarchos/invariants.md, tier: user }\n',
     });
     const { ctx, appended } = makeCtx();
 
     await handleAdd(
       {
         repoRoot: '/repo',
-        catalog: 'docs/architecture/my-invariants.md',
+        catalog: '.exarchos/invariants.md',
         tier: 'user',
         entry: { ...VALID_AUDIT_ENTRY },
         dryRun: false,
@@ -358,14 +358,14 @@ describe('handleAdd — T9 commit', () => {
     // (scalar/map) must not throw a raw TypeError on `.add`. The handler resets
     // the node to an empty sequence, then appends the validated entry.
     const fake = makeFakeFs({
-      '/repo/docs/architecture/my-invariants.md': 'invariants: not-a-list\n',
+      '/repo/.exarchos/invariants.md': 'invariants: not-a-list\n',
     });
     const { ctx } = makeCtx();
 
     const result = await handleAdd(
       {
         repoRoot: '/repo',
-        catalog: 'docs/architecture/my-invariants.md',
+        catalog: '.exarchos/invariants.md',
         tier: 'user',
         entry: { ...VALID_AUDIT_ENTRY },
         dryRun: false,
@@ -376,7 +376,7 @@ describe('handleAdd — T9 commit', () => {
 
     expect(result.success).toBe(true);
     expect((result.data as { committed: boolean }).committed).toBe(true);
-    const written = fake.files.get('/repo/docs/architecture/my-invariants.md')!;
+    const written = fake.files.get('/repo/.exarchos/invariants.md')!;
     expect(written).toMatch(/id: U-1/);
     expect(written).toMatch(/mode: audit/);
   });
@@ -428,16 +428,16 @@ describe('handleAdd — T9 commit', () => {
       '\n' +
       'Prose body.\n';
     const fake = makeFakeFs({
-      '/repo/docs/architecture/my-invariants.md': fenced,
+      '/repo/.exarchos/invariants.md': fenced,
       '/repo/.exarchos.yml':
-        'invariants:\n  devCatalog: enabled\n  catalogs:\n    - { path: docs/architecture/my-invariants.md, tier: user }\n',
+        'invariants:\n  devCatalog: enabled\n  catalogs:\n    - { path: .exarchos/invariants.md, tier: user }\n',
     });
     const { ctx } = makeCtx();
 
     const result = await handleAdd(
       {
         repoRoot: '/repo',
-        catalog: 'docs/architecture/my-invariants.md',
+        catalog: '.exarchos/invariants.md',
         tier: 'user',
         entry: { ...VALID_AUDIT_ENTRY },
         dryRun: false,
@@ -447,7 +447,7 @@ describe('handleAdd — T9 commit', () => {
     );
 
     expect(result.success).toBe(true);
-    const written = fake.files.get('/repo/docs/architecture/my-invariants.md')!;
+    const written = fake.files.get('/repo/.exarchos/invariants.md')!;
     // (a) markdown body survives.
     expect(written).toContain('Prose body.');
     expect(written).toContain('# Heading');

--- a/servers/exarchos-mcp/src/orchestrate/invariants/add.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/add.ts
@@ -51,7 +51,7 @@ export interface HandleAddArgs {
 }
 
 const DEFAULT_PATH: Record<'dev' | 'user', string> = {
-  user: 'docs/architecture/my-invariants.md',
+  user: '.exarchos/invariants.md',
   dev: '.exarchos/invariants.md',
 };
 

--- a/servers/exarchos-mcp/src/orchestrate/invariants/exarchos-yml-writer.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/exarchos-yml-writer.test.ts
@@ -43,7 +43,7 @@ describe('wireCatalogRegistration', () => {
 
     const result = wireCatalogRegistration(
       YML,
-      { path: 'docs/architecture/my-invariants.md', tier: 'user' },
+      { path: '.exarchos/invariants.md', tier: 'user' },
       fake.deps,
     );
 
@@ -52,7 +52,7 @@ describe('wireCatalogRegistration', () => {
     const yml = fake.files.get(YML)!;
     expect(yml).toMatch(/invariants:/);
     expect(yml).toMatch(/catalogs:/);
-    expect(yml).toMatch(/docs\/architecture\/my-invariants\.md/);
+    expect(yml).toMatch(/\.exarchos\/invariants\.md/);
     expect(yml).toMatch(/tier: user/);
   });
 
@@ -61,24 +61,24 @@ describe('wireCatalogRegistration', () => {
 
     const result = wireCatalogRegistration(
       YML,
-      { path: 'docs/architecture/my-invariants.md', tier: 'user' },
+      { path: '.exarchos/invariants.md', tier: 'user' },
       fake.deps,
     );
 
     expect(result.wrote).toBe(true);
     expect(result.reason).toBe('registered');
     const yml = fake.files.get(YML)!;
-    expect(yml).toMatch(/docs\/architecture\/my-invariants\.md/);
+    expect(yml).toMatch(/\.exarchos\/invariants\.md/);
   });
 
   it('WireCatalog_AlreadyRegistered_NoChange', () => {
     const seed =
-      'invariants:\n  catalogs:\n    - { path: docs/architecture/my-invariants.md, tier: user }\n';
+      'invariants:\n  catalogs:\n    - { path: .exarchos/invariants.md, tier: user }\n';
     const fake = makeFakeFs({ [YML]: seed });
 
     const result = wireCatalogRegistration(
       YML,
-      { path: 'docs/architecture/my-invariants.md', tier: 'user' },
+      { path: '.exarchos/invariants.md', tier: 'user' },
       fake.deps,
     );
 
@@ -90,12 +90,12 @@ describe('wireCatalogRegistration', () => {
 
   it('WireCatalog_AlreadyRegisteredAsBareString_NoChange', () => {
     const seed =
-      'invariants:\n  catalogs:\n    - docs/architecture/my-invariants.md\n';
+      'invariants:\n  catalogs:\n    - .exarchos/invariants.md\n';
     const fake = makeFakeFs({ [YML]: seed });
 
     const result = wireCatalogRegistration(
       YML,
-      { path: 'docs/architecture/my-invariants.md', tier: 'user' },
+      { path: '.exarchos/invariants.md', tier: 'user' },
       fake.deps,
     );
 
@@ -113,7 +113,7 @@ describe('wireCatalogRegistration', () => {
     expect(() =>
       wireCatalogRegistration(
         YML,
-        { path: 'docs/architecture/my-invariants.md', tier: 'user' },
+        { path: '.exarchos/invariants.md', tier: 'user' },
         fake.deps,
       ),
     ).not.toThrow();
@@ -128,7 +128,7 @@ describe('wireCatalogRegistration', () => {
     // The prior scalar is preserved as the first sequence element, and the
     // new registration is appended.
     expect(yml).toMatch(/legacy-string-value/);
-    expect(yml).toMatch(/docs\/architecture\/my-invariants\.md/);
+    expect(yml).toMatch(/\.exarchos\/invariants\.md/);
     expect(yml).toMatch(/docs\/architecture\/another\.md/);
   });
 
@@ -144,7 +144,7 @@ test: npm test
 
     const result = wireCatalogRegistration(
       YML,
-      { path: 'docs/architecture/my-invariants.md', tier: 'user' },
+      { path: '.exarchos/invariants.md', tier: 'user' },
       fake.deps,
     );
 
@@ -155,7 +155,7 @@ test: npm test
     expect(yml).toContain('# Architectural invariants (opt-in). Authoring guide:');
     expect(yml).toContain('# docs/guides/authoring-invariants.md.');
     // And the new registration is present.
-    expect(yml).toMatch(/docs\/architecture\/my-invariants\.md/);
+    expect(yml).toMatch(/\.exarchos\/invariants\.md/);
   });
 
   it('WireCatalog_SamePathDifferentTier_UpgradesInPlace', () => {

--- a/servers/exarchos-mcp/src/orchestrate/invariants/parity.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/parity.test.ts
@@ -38,7 +38,7 @@ import { handleAdd } from './add.js';
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
 const REPO_ROOT = '/parity-repo';
-const CATALOG_REL = 'docs/architecture/my-invariants.md';
+const CATALOG_REL = '.exarchos/invariants.md';
 
 const VALID_ENTRY = {
   dimension: 'example-dimension',

--- a/servers/exarchos-mcp/src/orchestrate/invariants/scaffold.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/scaffold.test.ts
@@ -47,7 +47,7 @@ describe('handleScaffold', () => {
     const fake = makeFakeFs();
 
     const result = await handleScaffold(
-      { repoRoot: '/repo', path: 'docs/architecture/my-invariants.md', tier: 'user' },
+      { repoRoot: '/repo', path: '.exarchos/invariants.md', tier: 'user' },
       fake.deps,
     );
 
@@ -58,7 +58,7 @@ describe('handleScaffold', () => {
     expect(data.catalog.wrote).toBe(true);
     expect(data.catalog.reason).toBe('created');
 
-    const written = fake.files.get('/repo/docs/architecture/my-invariants.md');
+    const written = fake.files.get('/repo/.exarchos/invariants.md');
     expect(written).toBeDefined();
     // v3-shaped: a top-level `invariants:` list key …
     expect(written).toMatch(/invariants:/);
@@ -69,11 +69,11 @@ describe('handleScaffold', () => {
   it('handleScaffold_ExistingFile_NoOverwrite', async () => {
     const existing = 'invariants:\n  - id: U-1\n';
     const fake = makeFakeFs({
-      '/repo/docs/architecture/my-invariants.md': existing,
+      '/repo/.exarchos/invariants.md': existing,
     });
 
     const result = await handleScaffold(
-      { repoRoot: '/repo', path: 'docs/architecture/my-invariants.md', tier: 'user' },
+      { repoRoot: '/repo', path: '.exarchos/invariants.md', tier: 'user' },
       fake.deps,
     );
 
@@ -86,10 +86,10 @@ describe('handleScaffold', () => {
     // The catalog file is untouched — no write to that path.
     expect(
       fake.writes.some(
-        (w) => w.path === '/repo/docs/architecture/my-invariants.md',
+        (w) => w.path === '/repo/.exarchos/invariants.md',
       ),
     ).toBe(false);
-    expect(fake.files.get('/repo/docs/architecture/my-invariants.md')).toBe(
+    expect(fake.files.get('/repo/.exarchos/invariants.md')).toBe(
       existing,
     );
   });
@@ -100,7 +100,7 @@ describe('handleScaffold', () => {
     });
 
     const result = await handleScaffold(
-      { repoRoot: '/repo', path: 'docs/architecture/my-invariants.md', tier: 'user' },
+      { repoRoot: '/repo', path: '.exarchos/invariants.md', tier: 'user' },
       fake.deps,
     );
 
@@ -113,17 +113,17 @@ describe('handleScaffold', () => {
     const yml = fake.files.get('/repo/.exarchos.yml');
     expect(yml).toBeDefined();
     expect(yml).toMatch(/invariants:/);
-    expect(yml).toMatch(/docs\/architecture\/my-invariants\.md/);
+    expect(yml).toMatch(/\.exarchos\/invariants\.md/);
   });
 
   it('handleScaffold_AlreadyRegistered_RegistrationIdempotent', async () => {
     const fake = makeFakeFs({
       '/repo/.exarchos.yml':
-        'invariants:\n  catalogs:\n    - { path: docs/architecture/my-invariants.md, tier: user }\n',
+        'invariants:\n  catalogs:\n    - { path: .exarchos/invariants.md, tier: user }\n',
     });
 
     const result = await handleScaffold(
-      { repoRoot: '/repo', path: 'docs/architecture/my-invariants.md', tier: 'user' },
+      { repoRoot: '/repo', path: '.exarchos/invariants.md', tier: 'user' },
       fake.deps,
     );
 
@@ -139,7 +139,7 @@ describe('handleScaffold', () => {
     const fake = makeFakeFs();
 
     const result = await handleScaffold(
-      { repoRoot: '/repo', path: 'docs/architecture/my-invariants.md', tier: 'user' },
+      { repoRoot: '/repo', path: '.exarchos/invariants.md', tier: 'user' },
       fake.deps,
     );
 

--- a/servers/exarchos-mcp/src/orchestrate/invariants/scaffold.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/scaffold.ts
@@ -49,7 +49,7 @@ export interface CatalogWriteResult {
 
 /** Default repo-relative starter path per tier. */
 const DEFAULT_PATH: Record<'dev' | 'user', string> = {
-  user: 'docs/architecture/my-invariants.md',
+  user: '.exarchos/invariants.md',
   dev: '.exarchos/invariants.md',
 };
 

--- a/servers/exarchos-mcp/src/registry.test.ts
+++ b/servers/exarchos-mcp/src/registry.test.ts
@@ -746,7 +746,7 @@ describe('TOOL_REGISTRY', () => {
     // applied downstream at dispatch).
     const parsed = action!.schema.safeParse({
       entry: { dimension: 'd' },
-      catalog: 'docs/architecture/my-invariants.md',
+      catalog: '.exarchos/invariants.md',
       tier: 'user',
     });
     expect(parsed.success).toBe(true);

--- a/skills-src/authoring-invariants/SKILL.md
+++ b/skills-src/authoring-invariants/SKILL.md
@@ -148,7 +148,7 @@ Scaffold a user catalog (idempotent; never overwrites):
 {{MCP_PREFIX}}exarchos_orchestrate({
   action: "invariants_scaffold",
   tier: "user",
-  path: "docs/architecture/my-invariants.md"
+  path: ".exarchos/invariants.md"
 })
 ```
 
@@ -158,7 +158,7 @@ Dry-run preview (DEFAULT — writes nothing):
 {{MCP_PREFIX}}exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* the fields from steps 1-4; NO id — auto-assigned */ }
 })
 ```
@@ -169,7 +169,7 @@ Commit after explicit confirmation:
 {{MCP_PREFIX}}exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* same entry */ },
   dryRun: false
 })

--- a/skills-src/authoring-invariants/references/worked-example.md
+++ b/skills-src/authoring-invariants/references/worked-example.md
@@ -68,7 +68,7 @@ so the verb assigns `U-3`.
 exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: {
     dimension: "audit-completeness",
     "applies-to": ["src/handlers/**"],
@@ -92,7 +92,7 @@ YAML entry, and a `+`-prefixed append diff.
 The agent shows the rendered entry and the diff, then asks explicitly:
 
 > "This will add `U-3` (audit-completeness, blocking, audit-mode) to
-> `docs/architecture/my-invariants.md`. Commit it?"
+> `.exarchos/invariants.md`. Commit it?"
 
 It does **not** proceed until the author confirms.
 

--- a/skills/claude/authoring-invariants/SKILL.md
+++ b/skills/claude/authoring-invariants/SKILL.md
@@ -148,7 +148,7 @@ Scaffold a user catalog (idempotent; never overwrites):
 mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "invariants_scaffold",
   tier: "user",
-  path: "docs/architecture/my-invariants.md"
+  path: ".exarchos/invariants.md"
 })
 ```
 
@@ -158,7 +158,7 @@ Dry-run preview (DEFAULT — writes nothing):
 mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* the fields from steps 1-4; NO id — auto-assigned */ }
 })
 ```
@@ -169,7 +169,7 @@ Commit after explicit confirmation:
 mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* same entry */ },
   dryRun: false
 })

--- a/skills/claude/authoring-invariants/references/worked-example.md
+++ b/skills/claude/authoring-invariants/references/worked-example.md
@@ -68,7 +68,7 @@ so the verb assigns `U-3`.
 exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: {
     dimension: "audit-completeness",
     "applies-to": ["src/handlers/**"],
@@ -92,7 +92,7 @@ YAML entry, and a `+`-prefixed append diff.
 The agent shows the rendered entry and the diff, then asks explicitly:
 
 > "This will add `U-3` (audit-completeness, blocking, audit-mode) to
-> `docs/architecture/my-invariants.md`. Commit it?"
+> `.exarchos/invariants.md`. Commit it?"
 
 It does **not** proceed until the author confirms.
 

--- a/skills/codex/authoring-invariants/SKILL.md
+++ b/skills/codex/authoring-invariants/SKILL.md
@@ -148,7 +148,7 @@ Scaffold a user catalog (idempotent; never overwrites):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_scaffold",
   tier: "user",
-  path: "docs/architecture/my-invariants.md"
+  path: ".exarchos/invariants.md"
 })
 ```
 
@@ -158,7 +158,7 @@ Dry-run preview (DEFAULT — writes nothing):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* the fields from steps 1-4; NO id — auto-assigned */ }
 })
 ```
@@ -169,7 +169,7 @@ Commit after explicit confirmation:
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* same entry */ },
   dryRun: false
 })

--- a/skills/codex/authoring-invariants/references/worked-example.md
+++ b/skills/codex/authoring-invariants/references/worked-example.md
@@ -68,7 +68,7 @@ so the verb assigns `U-3`.
 exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: {
     dimension: "audit-completeness",
     "applies-to": ["src/handlers/**"],
@@ -92,7 +92,7 @@ YAML entry, and a `+`-prefixed append diff.
 The agent shows the rendered entry and the diff, then asks explicitly:
 
 > "This will add `U-3` (audit-completeness, blocking, audit-mode) to
-> `docs/architecture/my-invariants.md`. Commit it?"
+> `.exarchos/invariants.md`. Commit it?"
 
 It does **not** proceed until the author confirms.
 

--- a/skills/copilot/authoring-invariants/SKILL.md
+++ b/skills/copilot/authoring-invariants/SKILL.md
@@ -148,7 +148,7 @@ Scaffold a user catalog (idempotent; never overwrites):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_scaffold",
   tier: "user",
-  path: "docs/architecture/my-invariants.md"
+  path: ".exarchos/invariants.md"
 })
 ```
 
@@ -158,7 +158,7 @@ Dry-run preview (DEFAULT — writes nothing):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* the fields from steps 1-4; NO id — auto-assigned */ }
 })
 ```
@@ -169,7 +169,7 @@ Commit after explicit confirmation:
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* same entry */ },
   dryRun: false
 })

--- a/skills/copilot/authoring-invariants/references/worked-example.md
+++ b/skills/copilot/authoring-invariants/references/worked-example.md
@@ -68,7 +68,7 @@ so the verb assigns `U-3`.
 exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: {
     dimension: "audit-completeness",
     "applies-to": ["src/handlers/**"],
@@ -92,7 +92,7 @@ YAML entry, and a `+`-prefixed append diff.
 The agent shows the rendered entry and the diff, then asks explicitly:
 
 > "This will add `U-3` (audit-completeness, blocking, audit-mode) to
-> `docs/architecture/my-invariants.md`. Commit it?"
+> `.exarchos/invariants.md`. Commit it?"
 
 It does **not** proceed until the author confirms.
 

--- a/skills/cursor/authoring-invariants/SKILL.md
+++ b/skills/cursor/authoring-invariants/SKILL.md
@@ -148,7 +148,7 @@ Scaffold a user catalog (idempotent; never overwrites):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_scaffold",
   tier: "user",
-  path: "docs/architecture/my-invariants.md"
+  path: ".exarchos/invariants.md"
 })
 ```
 
@@ -158,7 +158,7 @@ Dry-run preview (DEFAULT — writes nothing):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* the fields from steps 1-4; NO id — auto-assigned */ }
 })
 ```
@@ -169,7 +169,7 @@ Commit after explicit confirmation:
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* same entry */ },
   dryRun: false
 })

--- a/skills/cursor/authoring-invariants/references/worked-example.md
+++ b/skills/cursor/authoring-invariants/references/worked-example.md
@@ -68,7 +68,7 @@ so the verb assigns `U-3`.
 exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: {
     dimension: "audit-completeness",
     "applies-to": ["src/handlers/**"],
@@ -92,7 +92,7 @@ YAML entry, and a `+`-prefixed append diff.
 The agent shows the rendered entry and the diff, then asks explicitly:
 
 > "This will add `U-3` (audit-completeness, blocking, audit-mode) to
-> `docs/architecture/my-invariants.md`. Commit it?"
+> `.exarchos/invariants.md`. Commit it?"
 
 It does **not** proceed until the author confirms.
 

--- a/skills/generic/authoring-invariants/SKILL.md
+++ b/skills/generic/authoring-invariants/SKILL.md
@@ -148,7 +148,7 @@ Scaffold a user catalog (idempotent; never overwrites):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_scaffold",
   tier: "user",
-  path: "docs/architecture/my-invariants.md"
+  path: ".exarchos/invariants.md"
 })
 ```
 
@@ -158,7 +158,7 @@ Dry-run preview (DEFAULT — writes nothing):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* the fields from steps 1-4; NO id — auto-assigned */ }
 })
 ```
@@ -169,7 +169,7 @@ Commit after explicit confirmation:
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* same entry */ },
   dryRun: false
 })

--- a/skills/generic/authoring-invariants/references/worked-example.md
+++ b/skills/generic/authoring-invariants/references/worked-example.md
@@ -68,7 +68,7 @@ so the verb assigns `U-3`.
 exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: {
     dimension: "audit-completeness",
     "applies-to": ["src/handlers/**"],
@@ -92,7 +92,7 @@ YAML entry, and a `+`-prefixed append diff.
 The agent shows the rendered entry and the diff, then asks explicitly:
 
 > "This will add `U-3` (audit-completeness, blocking, audit-mode) to
-> `docs/architecture/my-invariants.md`. Commit it?"
+> `.exarchos/invariants.md`. Commit it?"
 
 It does **not** proceed until the author confirms.
 

--- a/skills/opencode/authoring-invariants/SKILL.md
+++ b/skills/opencode/authoring-invariants/SKILL.md
@@ -148,7 +148,7 @@ Scaffold a user catalog (idempotent; never overwrites):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_scaffold",
   tier: "user",
-  path: "docs/architecture/my-invariants.md"
+  path: ".exarchos/invariants.md"
 })
 ```
 
@@ -158,7 +158,7 @@ Dry-run preview (DEFAULT — writes nothing):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* the fields from steps 1-4; NO id — auto-assigned */ }
 })
 ```
@@ -169,7 +169,7 @@ Commit after explicit confirmation:
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* same entry */ },
   dryRun: false
 })

--- a/skills/opencode/authoring-invariants/references/worked-example.md
+++ b/skills/opencode/authoring-invariants/references/worked-example.md
@@ -68,7 +68,7 @@ so the verb assigns `U-3`.
 exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: {
     dimension: "audit-completeness",
     "applies-to": ["src/handlers/**"],
@@ -92,7 +92,7 @@ YAML entry, and a `+`-prefixed append diff.
 The agent shows the rendered entry and the diff, then asks explicitly:
 
 > "This will add `U-3` (audit-completeness, blocking, audit-mode) to
-> `docs/architecture/my-invariants.md`. Commit it?"
+> `.exarchos/invariants.md`. Commit it?"
 
 It does **not** proceed until the author confirms.
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -151,7 +151,7 @@ Scaffold a user catalog (idempotent; never overwrites):
 mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "invariants_scaffold",
   tier: "user",
-  path: "docs/architecture/my-invariants.md"
+  path: ".exarchos/invariants.md"
 })
 \`\`\`
 
@@ -161,7 +161,7 @@ Dry-run preview (DEFAULT — writes nothing):
 mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* the fields from steps 1-4; NO id — auto-assigned */ }
 })
 \`\`\`
@@ -172,7 +172,7 @@ Commit after explicit confirmation:
 mcp__plugin_exarchos_exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* same entry */ },
   dryRun: false
 })
@@ -5105,7 +5105,7 @@ Scaffold a user catalog (idempotent; never overwrites):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_scaffold",
   tier: "user",
-  path: "docs/architecture/my-invariants.md"
+  path: ".exarchos/invariants.md"
 })
 \`\`\`
 
@@ -5115,7 +5115,7 @@ Dry-run preview (DEFAULT — writes nothing):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* the fields from steps 1-4; NO id — auto-assigned */ }
 })
 \`\`\`
@@ -5126,7 +5126,7 @@ Commit after explicit confirmation:
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* same entry */ },
   dryRun: false
 })
@@ -10012,7 +10012,7 @@ Scaffold a user catalog (idempotent; never overwrites):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_scaffold",
   tier: "user",
-  path: "docs/architecture/my-invariants.md"
+  path: ".exarchos/invariants.md"
 })
 \`\`\`
 
@@ -10022,7 +10022,7 @@ Dry-run preview (DEFAULT — writes nothing):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* the fields from steps 1-4; NO id — auto-assigned */ }
 })
 \`\`\`
@@ -10033,7 +10033,7 @@ Commit after explicit confirmation:
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* same entry */ },
   dryRun: false
 })
@@ -14911,7 +14911,7 @@ Scaffold a user catalog (idempotent; never overwrites):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_scaffold",
   tier: "user",
-  path: "docs/architecture/my-invariants.md"
+  path: ".exarchos/invariants.md"
 })
 \`\`\`
 
@@ -14921,7 +14921,7 @@ Dry-run preview (DEFAULT — writes nothing):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* the fields from steps 1-4; NO id — auto-assigned */ }
 })
 \`\`\`
@@ -14932,7 +14932,7 @@ Commit after explicit confirmation:
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* same entry */ },
   dryRun: false
 })
@@ -19820,7 +19820,7 @@ Scaffold a user catalog (idempotent; never overwrites):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_scaffold",
   tier: "user",
-  path: "docs/architecture/my-invariants.md"
+  path: ".exarchos/invariants.md"
 })
 \`\`\`
 
@@ -19830,7 +19830,7 @@ Dry-run preview (DEFAULT — writes nothing):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* the fields from steps 1-4; NO id — auto-assigned */ }
 })
 \`\`\`
@@ -19841,7 +19841,7 @@ Commit after explicit confirmation:
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* same entry */ },
   dryRun: false
 })
@@ -24700,7 +24700,7 @@ Scaffold a user catalog (idempotent; never overwrites):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_scaffold",
   tier: "user",
-  path: "docs/architecture/my-invariants.md"
+  path: ".exarchos/invariants.md"
 })
 \`\`\`
 
@@ -24710,7 +24710,7 @@ Dry-run preview (DEFAULT — writes nothing):
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* the fields from steps 1-4; NO id — auto-assigned */ }
 })
 \`\`\`
@@ -24721,7 +24721,7 @@ Commit after explicit confirmation:
 mcp__exarchos__exarchos_orchestrate({
   action: "invariants_add",
   tier: "user",
-  catalog: "docs/architecture/my-invariants.md",
+  catalog: ".exarchos/invariants.md",
   entry: { /* same entry */ },
   dryRun: false
 })


### PR DESCRIPTION
## Summary

Makes `.exarchos/invariants.md` the **single canonical default** catalog location for both invariant tiers. User-tier `scaffold`/`add` now default there instead of `docs/architecture/my-invariants.md`, matching where the dev catalog already lives (relocated in #1487). `.exarchos/` is the config-dir home, so consumers get a clean, conventional location instead of cluttering `docs/architecture/`.

Follow-up to #1487 per request: "by default wire into `.exarchos/invariants.md`; set for our exarchos-configured invariants too" (the dev tier already defaults/registers there post-P5; this aligns the user tier).

## Changes

- `orchestrate/invariants/add.ts` + `scaffold.ts`: `DEFAULT_PATH.user` → `.exarchos/invariants.md` (dev was already `.exarchos/invariants.md`).
- Swept the sample-path references in the invariants tests, the `init` seed onboarding stanza (`seed-exarchos-config.ts`), and the `authoring-invariants` skill + worked-example to the new convention.
- Regenerated the 6 runtime skill renders + the migration snapshots.

## Test Plan

- MCP suite: **7173 passed** (0 failed). Root suite: **770 passed** (migration snapshots regenerated for the skill-content change).
- `npm run typecheck` clean. `npm run build:skills` clean; `skills:guard` satisfied by committing the regenerated tree.
- Behavior unchanged except the default; explicit `path`/`catalog` args are unaffected, and the bare-`.yml` test path is intentionally left as-is.

Note: in the Exarchos repo itself, `.exarchos/invariants.md` is the `tier: dev` catalog; a maintainer scaffolding with the user-tier default here would target the same file — not a real workflow (maintainers author with `--tier dev`), and consumers have no dev catalog, so `.exarchos/invariants.md` is unambiguously their user catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
