### PR TITLE
feat(invariants): make dev tier visibly exarchos-reserved (#1489)

### DIFF
--- a/docs/guides/authoring-invariants.md
+++ b/docs/guides/authoring-invariants.md
@@ -75,6 +75,16 @@ audiences are distinct: **dev** (`INV-*`, Exarchos's own runtime substrate,
 `devCatalog`-gated, you never see it) → **sdlc** (`SDLC-*`, this baseline) →
 **user** (your own `U-*` entries, §2).
 
+> **As a consumer, you always author into the `user` tier (`U-*`).** The `dev`
+> tier (`INV-*`) is *exarchos's own reserved substrate namespace* — not "for your
+> project's developers". Its `INV-1..6` ship inside the tool and merge into every
+> `invariants_effective` projection, so authoring into `dev` from your repo
+> silently collides your `INV-N` with exarchos's own (and `doctor` won't catch it
+> — it only flags `INV-*` in a *user* catalog). The authoring verbs reject
+> `tier: dev` outside the exarchos repo (heuristic: `package.json` name ≠
+> `@lvlup-sw/exarchos`) with a `RESERVED_TIER` error that redirects you to
+> `user`; a genuine exarchos fork overrides with `allowReservedTier: true`.
+
 ## Manual authoring (advanced)
 
 The rest of this guide is the **manual/advanced** path — registering catalogs

--- a/docs/plans/2026-05-25-invariant-tier-clarity.md
+++ b/docs/plans/2026-05-25-invariant-tier-clarity.md
@@ -1,0 +1,91 @@
+# Plan — Invariant tier clarity (dev vs user) — issue #1489
+
+**Workflow:** `refactor-invariant-tier-clarity` (overhaul track)
+**Branch:** `refactor/invariant-tier-clarity`
+
+## Problem
+
+The `authoring-invariants` skill frames invariant tiers as `user` vs `dev`
+without surfacing that `dev`/`INV-N` is exarchos's **own reserved substrate
+namespace**. A consumer reasonably misreads `dev` as "for my project's
+developers" and picks it, silently colliding their `INV-N` ids with exarchos's
+built-in `INV-1..6` in the merged `invariants_effective` projection. The
+`doctor` `invariants-catalog` check only flags `INV-*` ids in a catalog
+registered as **user** tier, so a consumer who self-declares `tier: dev` evades
+detection entirely.
+
+## Approach
+
+Single cohesive change implemented directly in one isolated worktree (TDD),
+not fanned out to subagents — the change is ~7 files with documented
+subagent-worktree-isolation hazards (#1301, stash collisions, stale worktrees)
+that aren't worth incurring at this size. Overhaul rigor preserved:
+plan-review checkpoint → review → doc-link verify → synthesize → merge checkpoint.
+
+## Design — the guardrail
+
+New shared module `servers/exarchos-mcp/src/orchestrate/invariants/reserved-tier-guard.ts`:
+
+- `export const EXARCHOS_PACKAGE_NAME = '@lvlup-sw/exarchos'`
+- `isExarchosRepo(repoRoot, deps): boolean` — reads `<repoRoot>/package.json`
+  via injected `ScaffoldDeps`; returns `true` iff parseable and `name ===
+  EXARCHOS_PACKAGE_NAME`. Missing / unreadable / unparseable / mismatched name
+  ⇒ `false` (treat "unknown" as "not exarchos" — `dev` is almost always a
+  mistake outside exarchos).
+- `assertDevTierAllowed({ tier, repoRoot, allowReservedTier }, deps): ToolResult | null`
+  — returns `null` (proceed) unless `tier === 'dev'` AND `!allowReservedTier`
+  AND `!isExarchosRepo(...)`. In that case returns an INV-5b carrier-shape
+  error: `code: 'RESERVED_TIER'`, a message explaining `dev`/`INV-N` is
+  exarchos's reserved substrate namespace and would collide with its built-in
+  `INV-*`, `suggestedFix` redirecting to `tier: 'user'`, and a note that
+  `allowReservedTier: true` overrides for a genuine exarchos fork.
+
+Wiring:
+
+- `handleScaffold` / `handleAdd`: call `assertDevTierAllowed` at entry, before
+  any fs mutation. Fires regardless of `dryRun` (so a dry-run preview never
+  even renders a dev-tier entry).
+- Add `allowReservedTier?: boolean` to `HandleScaffoldArgs` and `HandleAddArgs`.
+- `registry.ts`: add `allowReservedTier: z.boolean().optional()` to both the
+  `invariants_scaffold` and `invariants_add` Zod schemas (auto-emits the CLI
+  `--allow-reserved-tier` flag — schema-driven).
+- `composite.ts`: thread `allowReservedTier` through both arg constructions.
+
+## Tasks (TDD-ordered, sequential)
+
+1. **T1 — guardrail module + tests (RED→GREEN).**
+   Write `reserved-tier-guard.test.ts` covering: non-exarchos + `dev` → blocked
+   (RESERVED_TIER, suggestedFix=user); exarchos repo + `dev` → null;
+   `allowReservedTier: true` + `dev` → null; `tier: user` → null regardless;
+   missing/unparseable `package.json` → treated as non-exarchos (blocked).
+   Then implement `reserved-tier-guard.ts` to green.
+
+2. **T2 — wire into handlers + schemas.**
+   Add `allowReservedTier` to both arg interfaces, call `assertDevTierAllowed`
+   at the top of `handleScaffold` and `handleAdd`. Add the field to both Zod
+   schemas in `registry.ts` and thread through `composite.ts`. Extend
+   `scaffold.test.ts` / `add.test.ts` for the blocked-vs-allowed dispatch path.
+
+3. **T3 — docs reframe.**
+   - `skills-src/authoring-invariants/SKILL.md` step 3 (Weight): reframe
+     `integrity-class` as `user`/`U-N` = every consumer's default; `dev`/`INV-N`
+     = exarchos's own reserved substrate (only inside the exarchos repo;
+     authoring as a consumer collides). Touch the Number step + tool-invocation
+     prose where `dev`/`INV-N` is mentioned.
+   - `references/worked-example.md` step 3: one-line clarification.
+   - `docs/guides/authoring-invariants.md`: same reframe + document the
+     guardrail + `allowReservedTier` override.
+   - `scaffold.ts` `renderStarterCatalog()` comment: one line —
+     "Consumers always use `user`/`U-N`; `dev`/`INV-N` is exarchos-internal."
+
+4. **T4 — regenerate + verify.**
+   `npm run build:skills`; `npm run typecheck && npm run build && npm run
+   test:run`; `cd servers/exarchos-mcp && npm run test:run`; `npm run
+   skills:guard`. Doc-link verify in update-docs phase.
+
+## Out of scope
+
+- Changing the `doctor` `invariants-catalog` check (it already flags `INV-*` in
+  user catalogs; the gap is the self-declared-dev path, which the guardrail
+  closes at authoring time).
+- Renaming tiers or namespaces; changing the merge/projection semantics.

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -388,6 +388,19 @@ function validateInvariantsCommonArgs(
       },
     };
   }
+  if (
+    rest.allowReservedTier !== undefined &&
+    typeof rest.allowReservedTier !== 'boolean'
+  ) {
+    return {
+      success: false,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'allowReservedTier must be a boolean when provided',
+        expectedShape: { allowReservedTier: 'boolean' },
+      },
+    };
+  }
   return null;
 }
 
@@ -488,6 +501,7 @@ export async function handleOrchestrate(
       repoRoot: typeof rest.repoRoot === 'string' ? rest.repoRoot : process.cwd(),
       path: rest.path as string | undefined,
       tier: rest.tier as 'dev' | 'user' | undefined,
+      allowReservedTier: rest.allowReservedTier as boolean | undefined,
     };
     return envelopeWrap(await handleScaffold(scaffoldArgs, realScaffoldDeps()), startedAt);
   }
@@ -505,6 +519,7 @@ export async function handleOrchestrate(
       tier: rest.tier as 'dev' | 'user' | undefined,
       id: rest.id as string | undefined,
       dryRun: rest.dryRun === undefined ? true : Boolean(rest.dryRun),
+      allowReservedTier: rest.allowReservedTier as boolean | undefined,
     };
     return envelopeWrap(await handleAdd(addArgs, ctx, realScaffoldDeps()), startedAt);
   }

--- a/servers/exarchos-mcp/src/orchestrate/invariants/add.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/add.test.ts
@@ -382,7 +382,12 @@ describe('handleAdd — T9 commit', () => {
   });
 
   it('handleAdd_DevTier_UsesInvNamespace', async () => {
+    // The `dev`/INV-N tier is exarchos's own reserved substrate namespace, so it
+    // is only reachable from the exarchos repo itself — identified by its
+    // package.json name (#1489). Seed that so this exercises the legitimate
+    // in-exarchos path rather than tripping the reserved-tier guard.
     const fake = makeFakeFs({
+      '/repo/package.json': JSON.stringify({ name: '@lvlup-sw/exarchos' }),
       '/repo/.exarchos/invariants.md': 'invariants: []\n',
     });
     const { ctx } = makeCtx();
@@ -401,6 +406,36 @@ describe('handleAdd — T9 commit', () => {
 
     expect(result.success).toBe(true);
     expect((result.data as { id: string }).id).toBe('INV-1');
+  });
+
+  it('handleAdd_DevTier_NonExarchosRepo_BlockedAsReserved', async () => {
+    // A consumer repo (package.json name ≠ exarchos) authoring into tier:dev is
+    // rejected as a reserved-namespace collision and redirected to tier:user.
+    const fake = makeFakeFs({
+      '/repo/package.json': JSON.stringify({ name: '@acme/consumer' }),
+      '/repo/.exarchos/invariants.md': 'invariants: []\n',
+    });
+    const { ctx } = makeCtx();
+
+    const result = await handleAdd(
+      {
+        repoRoot: '/repo',
+        catalog: '.exarchos/invariants.md',
+        tier: 'dev',
+        entry: { ...VALID_AUDIT_ENTRY },
+        dryRun: false,
+      },
+      ctx,
+      fake.deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('RESERVED_TIER');
+    expect(result.error?.suggestedFix?.params.tier).toBe('user');
+    // Guard fires before any write — the catalog is untouched.
+    expect(fake.files.get('/repo/.exarchos/invariants.md')).toBe(
+      'invariants: []\n',
+    );
   });
 
   it('handleAdd_Commit_PreservesMarkdownBodyAndFrontmatterComments', async () => {

--- a/servers/exarchos-mcp/src/orchestrate/invariants/add.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/add.ts
@@ -285,7 +285,12 @@ export async function handleAdd(
   // repo BEFORE reading/validating anything, and regardless of dryRun — so a
   // dry-run preview never even renders a dev-tier entry (#1489).
   const reserved = assertDevTierAllowed(
-    { tier, repoRoot: args.repoRoot, allowReservedTier: args.allowReservedTier },
+    {
+      tier,
+      repoRoot: args.repoRoot,
+      allowReservedTier: args.allowReservedTier,
+      action: 'invariants_add',
+    },
     deps,
   );
   if (reserved) return reserved;

--- a/servers/exarchos-mcp/src/orchestrate/invariants/add.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/add.ts
@@ -31,6 +31,7 @@ import {
 } from '../../architecture/invariant-schema.js';
 import type { ScaffoldDeps } from './scaffold.js';
 import { wireCatalogRegistration } from './exarchos-yml-writer.js';
+import { assertDevTierAllowed } from './reserved-tier-guard.js';
 
 const CONFIG_FILENAME = '.exarchos.yml';
 const NEXT_ACTIONS = ['doctor', 'view invariants_effective'] as const;
@@ -48,6 +49,11 @@ export interface HandleAddArgs {
   readonly id?: string;
   /** Dry-run (default true, INV-5c): render + diff, write nothing. */
   readonly dryRun?: boolean;
+  /**
+   * Opt-in to author into exarchos's reserved `dev` namespace from a non-exarchos
+   * repo. Almost always a mistake outside the exarchos repo itself (#1489).
+   */
+  readonly allowReservedTier?: boolean;
 }
 
 const DEFAULT_PATH: Record<'dev' | 'user', string> = {
@@ -274,6 +280,16 @@ export async function handleAdd(
   deps: ScaffoldDeps,
 ): Promise<ToolResult> {
   const tier = args.tier ?? 'user';
+
+  // Reject authoring into exarchos's reserved `dev` namespace from a consumer
+  // repo BEFORE reading/validating anything, and regardless of dryRun — so a
+  // dry-run preview never even renders a dev-tier entry (#1489).
+  const reserved = assertDevTierAllowed(
+    { tier, repoRoot: args.repoRoot, allowReservedTier: args.allowReservedTier },
+    deps,
+  );
+  if (reserved) return reserved;
+
   const relCatalog = args.catalog ?? DEFAULT_PATH[tier];
   const catalogAbs = path.join(args.repoRoot, relCatalog);
   const dryRun = args.dryRun === undefined ? true : args.dryRun;

--- a/servers/exarchos-mcp/src/orchestrate/invariants/reserved-tier-guard.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/reserved-tier-guard.test.ts
@@ -1,0 +1,118 @@
+/**
+ * reserved-tier-guard — tests (#1489).
+ *
+ * `dev`/`INV-N` is exarchos's OWN reserved substrate namespace. A consumer who
+ * authors into `tier: dev` silently collides their `INV-N` ids with exarchos's
+ * built-in `INV-1..6` in the merged `invariants_effective` projection — and the
+ * `doctor` `invariants-catalog` check can't catch it, because the catalog is
+ * self-declared as dev tier. This guard rejects `tier: dev` at authoring time in
+ * any repo that is not exarchos itself, redirecting to `tier: user`.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  EXARCHOS_PACKAGE_NAME,
+  isExarchosRepo,
+  assertDevTierAllowed,
+} from './reserved-tier-guard.js';
+import type { ScaffoldDeps } from './scaffold.js';
+
+function makeDeps(files: Record<string, string>): ScaffoldDeps {
+  const map = new Map<string, string>(Object.entries(files));
+  return {
+    exists: (p) => map.has(p),
+    read: (p) => {
+      const c = map.get(p);
+      if (c === undefined) throw new Error(`ENOENT: ${p}`);
+      return c;
+    },
+    write: () => {
+      throw new Error('guard must not write');
+    },
+  };
+}
+
+const exarchosPkg = JSON.stringify({ name: EXARCHOS_PACKAGE_NAME });
+const consumerPkg = JSON.stringify({ name: '@acme/basileus' });
+
+describe('isExarchosRepo', () => {
+  it('isExarchosRepo_ExarchosPackageName_True', () => {
+    const deps = makeDeps({ '/repo/package.json': exarchosPkg });
+    expect(isExarchosRepo('/repo', deps)).toBe(true);
+  });
+
+  it('isExarchosRepo_ConsumerPackageName_False', () => {
+    const deps = makeDeps({ '/repo/package.json': consumerPkg });
+    expect(isExarchosRepo('/repo', deps)).toBe(false);
+  });
+
+  it('isExarchosRepo_MissingPackageJson_False', () => {
+    const deps = makeDeps({});
+    expect(isExarchosRepo('/repo', deps)).toBe(false);
+  });
+
+  it('isExarchosRepo_UnparseablePackageJson_False', () => {
+    const deps = makeDeps({ '/repo/package.json': '{ not valid json' });
+    expect(isExarchosRepo('/repo', deps)).toBe(false);
+  });
+});
+
+describe('assertDevTierAllowed', () => {
+  it('assertDevTierAllowed_UserTier_AllowsRegardlessOfRepo', () => {
+    const deps = makeDeps({ '/repo/package.json': consumerPkg });
+    expect(
+      assertDevTierAllowed({ tier: 'user', repoRoot: '/repo' }, deps),
+    ).toBeNull();
+  });
+
+  it('assertDevTierAllowed_UndefinedTier_Allows', () => {
+    // tier omitted ⇒ defaults to user downstream; nothing to guard.
+    const deps = makeDeps({ '/repo/package.json': consumerPkg });
+    expect(
+      assertDevTierAllowed({ tier: undefined, repoRoot: '/repo' }, deps),
+    ).toBeNull();
+  });
+
+  it('assertDevTierAllowed_DevTierInExarchosRepo_Allows', () => {
+    const deps = makeDeps({ '/repo/package.json': exarchosPkg });
+    expect(
+      assertDevTierAllowed({ tier: 'dev', repoRoot: '/repo' }, deps),
+    ).toBeNull();
+  });
+
+  it('assertDevTierAllowed_DevTierInConsumerRepo_Blocks', () => {
+    const deps = makeDeps({ '/repo/package.json': consumerPkg });
+    const result = assertDevTierAllowed(
+      { tier: 'dev', repoRoot: '/repo' },
+      deps,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.success).toBe(false);
+    expect(result!.error?.code).toBe('RESERVED_TIER');
+    // INV-5b carrier shape: redirect to tier: user so the agent self-corrects.
+    expect(result!.error?.suggestedFix?.params.tier).toBe('user');
+    // The override path is named so a genuine exarchos fork can proceed.
+    expect(JSON.stringify(result!.error)).toMatch(/allowReservedTier/);
+  });
+
+  it('assertDevTierAllowed_DevTierMissingPackageJson_Blocks', () => {
+    // "Unknown" repo is treated as not-exarchos: dev is almost always a mistake.
+    const deps = makeDeps({});
+    const result = assertDevTierAllowed(
+      { tier: 'dev', repoRoot: '/repo' },
+      deps,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.error?.code).toBe('RESERVED_TIER');
+  });
+
+  it('assertDevTierAllowed_DevTierWithOverride_Allows', () => {
+    const deps = makeDeps({ '/repo/package.json': consumerPkg });
+    expect(
+      assertDevTierAllowed(
+        { tier: 'dev', repoRoot: '/repo', allowReservedTier: true },
+        deps,
+      ),
+    ).toBeNull();
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/invariants/reserved-tier-guard.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/reserved-tier-guard.test.ts
@@ -61,7 +61,10 @@ describe('assertDevTierAllowed', () => {
   it('assertDevTierAllowed_UserTier_AllowsRegardlessOfRepo', () => {
     const deps = makeDeps({ '/repo/package.json': consumerPkg });
     expect(
-      assertDevTierAllowed({ tier: 'user', repoRoot: '/repo' }, deps),
+      assertDevTierAllowed(
+        { tier: 'user', repoRoot: '/repo', action: 'invariants_add' },
+        deps,
+      ),
     ).toBeNull();
   });
 
@@ -69,21 +72,27 @@ describe('assertDevTierAllowed', () => {
     // tier omitted ⇒ defaults to user downstream; nothing to guard.
     const deps = makeDeps({ '/repo/package.json': consumerPkg });
     expect(
-      assertDevTierAllowed({ tier: undefined, repoRoot: '/repo' }, deps),
+      assertDevTierAllowed(
+        { tier: undefined, repoRoot: '/repo', action: 'invariants_add' },
+        deps,
+      ),
     ).toBeNull();
   });
 
   it('assertDevTierAllowed_DevTierInExarchosRepo_Allows', () => {
     const deps = makeDeps({ '/repo/package.json': exarchosPkg });
     expect(
-      assertDevTierAllowed({ tier: 'dev', repoRoot: '/repo' }, deps),
+      assertDevTierAllowed(
+        { tier: 'dev', repoRoot: '/repo', action: 'invariants_add' },
+        deps,
+      ),
     ).toBeNull();
   });
 
   it('assertDevTierAllowed_DevTierInConsumerRepo_Blocks', () => {
     const deps = makeDeps({ '/repo/package.json': consumerPkg });
     const result = assertDevTierAllowed(
-      { tier: 'dev', repoRoot: '/repo' },
+      { tier: 'dev', repoRoot: '/repo', action: 'invariants_scaffold' },
       deps,
     );
     expect(result).not.toBeNull();
@@ -91,6 +100,11 @@ describe('assertDevTierAllowed', () => {
     expect(result!.error?.code).toBe('RESERVED_TIER');
     // INV-5b carrier shape: redirect to tier: user so the agent self-corrects.
     expect(result!.error?.suggestedFix?.params.tier).toBe('user');
+    // suggestedFix must be directly re-invokable: it carries the action so
+    // handleOrchestrate can route it (the guard echoes the caller's verb).
+    expect(result!.error?.suggestedFix?.params.action).toBe(
+      'invariants_scaffold',
+    );
     // The override path is named so a genuine exarchos fork can proceed.
     expect(JSON.stringify(result!.error)).toMatch(/allowReservedTier/);
   });
@@ -99,18 +113,24 @@ describe('assertDevTierAllowed', () => {
     // "Unknown" repo is treated as not-exarchos: dev is almost always a mistake.
     const deps = makeDeps({});
     const result = assertDevTierAllowed(
-      { tier: 'dev', repoRoot: '/repo' },
+      { tier: 'dev', repoRoot: '/repo', action: 'invariants_add' },
       deps,
     );
     expect(result).not.toBeNull();
     expect(result!.error?.code).toBe('RESERVED_TIER');
+    expect(result!.error?.suggestedFix?.params.action).toBe('invariants_add');
   });
 
   it('assertDevTierAllowed_DevTierWithOverride_Allows', () => {
     const deps = makeDeps({ '/repo/package.json': consumerPkg });
     expect(
       assertDevTierAllowed(
-        { tier: 'dev', repoRoot: '/repo', allowReservedTier: true },
+        {
+          tier: 'dev',
+          repoRoot: '/repo',
+          allowReservedTier: true,
+          action: 'invariants_add',
+        },
         deps,
       ),
     ).toBeNull();

--- a/servers/exarchos-mcp/src/orchestrate/invariants/reserved-tier-guard.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/reserved-tier-guard.ts
@@ -51,6 +51,13 @@ export interface DevTierGuardArgs {
   readonly repoRoot: string;
   /** Explicit opt-in for a genuine exarchos fork — bypasses the guard. */
   readonly allowReservedTier?: boolean;
+  /**
+   * The orchestrate action this guard is protecting. Echoed into
+   * `suggestedFix.params.action` so the carrier-shape fix is directly
+   * re-invokable (the guard is shared across both verbs, so the caller names
+   * its own action).
+   */
+  readonly action: 'invariants_scaffold' | 'invariants_add';
 }
 
 /**
@@ -82,6 +89,7 @@ export function assertDevTierAllowed(
       suggestedFix: {
         tool: 'exarchos_orchestrate',
         params: {
+          action: args.action,
           tier: 'user',
           note:
             "Re-run with tier: 'user' to author into your project's own " +

--- a/servers/exarchos-mcp/src/orchestrate/invariants/reserved-tier-guard.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/reserved-tier-guard.ts
@@ -1,0 +1,94 @@
+/**
+ * reserved-tier-guard — keep consumers out of exarchos's reserved namespace (#1489).
+ *
+ * `dev`/`INV-N` is exarchos's OWN substrate catalog. Its built-in `INV-1..6`
+ * ship inside the tool and merge into every `invariants_effective` projection.
+ * A consumer who authors into `tier: dev` allocates `INV-N` ids that collide
+ * with those built-ins — a SILENT namespace clash, not a validation error: the
+ * `doctor` `invariants-catalog` check only flags `INV-*` ids in a catalog
+ * registered as USER tier, so a self-declared dev catalog evades it entirely.
+ *
+ * The tier choice is not "which maintainer" — it is "exarchos-substrate vs
+ * project-authored". Outside the exarchos repo, `dev` is almost always a
+ * mistake. This guard makes that loud at authoring time: it rejects `tier: dev`
+ * in any repo whose `package.json` name is not exarchos's, returning an INV-5b
+ * carrier-shape error that redirects to `tier: user`. The rare legitimate case
+ * (a maintainer working in an exarchos fork) opts in via `allowReservedTier`.
+ *
+ * Pure-by-default: the `package.json` read flows through the injected
+ * `ScaffoldDeps` hooks, so the guard is exercisable without touching disk.
+ */
+import * as path from 'node:path';
+
+import type { ToolResult } from '../../format.js';
+import type { ScaffoldDeps } from './scaffold.js';
+
+/** The npm package name of the exarchos repo itself. */
+export const EXARCHOS_PACKAGE_NAME = '@lvlup-sw/exarchos';
+
+/**
+ * Is `repoRoot` the exarchos repo itself? True iff its `package.json` parses and
+ * declares `name === EXARCHOS_PACKAGE_NAME`. A missing, unreadable, or
+ * unparseable `package.json` — or any other name — yields `false`: we treat an
+ * unidentifiable repo as "not exarchos", because authoring into the reserved
+ * `dev` tier there is almost always a mistake.
+ */
+export function isExarchosRepo(repoRoot: string, deps: ScaffoldDeps): boolean {
+  const pkgPath = path.join(repoRoot, 'package.json');
+  if (!deps.exists(pkgPath)) return false;
+  try {
+    const parsed = JSON.parse(deps.read(pkgPath)) as { name?: unknown };
+    return parsed.name === EXARCHOS_PACKAGE_NAME;
+  } catch {
+    return false;
+  }
+}
+
+export interface DevTierGuardArgs {
+  /** Target tier. `undefined` defaults to `user` downstream — nothing to guard. */
+  readonly tier?: 'dev' | 'user';
+  /** Repo root the `package.json` heuristic resolves against. */
+  readonly repoRoot: string;
+  /** Explicit opt-in for a genuine exarchos fork — bypasses the guard. */
+  readonly allowReservedTier?: boolean;
+}
+
+/**
+ * Returns `null` when the call may proceed, or a `RESERVED_TIER` error
+ * `ToolResult` when a consumer is authoring into exarchos's reserved `dev`
+ * namespace. The guard fires only when ALL hold: `tier === 'dev'`, no
+ * `allowReservedTier` override, and the repo is not exarchos itself.
+ */
+export function assertDevTierAllowed(
+  args: DevTierGuardArgs,
+  deps: ScaffoldDeps,
+): ToolResult | null {
+  if (args.tier !== 'dev') return null;
+  if (args.allowReservedTier) return null;
+  if (isExarchosRepo(args.repoRoot, deps)) return null;
+
+  return {
+    success: false,
+    error: {
+      code: 'RESERVED_TIER',
+      message:
+        "tier: 'dev' is exarchos's own reserved substrate namespace (INV-N). " +
+        "Its built-in INV-1..6 merge into invariants_effective, so authoring " +
+        "here from a consumer repo collides your INV-N with exarchos's own. " +
+        "Use tier: 'user' (U-N) — the default for every repo consuming " +
+        'exarchos. Only pass allowReservedTier: true when working inside an ' +
+        'exarchos fork itself.',
+      expectedShape: { tier: "'user'" },
+      suggestedFix: {
+        tool: 'exarchos_orchestrate',
+        params: {
+          tier: 'user',
+          note:
+            "Re-run with tier: 'user' to author into your project's own " +
+            'namespace (U-N). The dev/INV-N tier is reserved for exarchos ' +
+            'itself; pass allowReservedTier: true only inside an exarchos fork.',
+        },
+      },
+    },
+  };
+}

--- a/servers/exarchos-mcp/src/orchestrate/invariants/scaffold.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/scaffold.test.ts
@@ -181,3 +181,56 @@ describe('renderStarterCatalog → loadInvariants round-trip (#1487)', () => {
     },
   );
 });
+
+/**
+ * #1489 — `dev`/INV-N is exarchos's reserved substrate namespace. Scaffolding a
+ * dev catalog from a consumer repo is rejected before any write; the exarchos
+ * repo itself (or an explicit override) is allowed.
+ */
+describe('handleScaffold reserved-tier guard (#1489)', () => {
+  it('handleScaffold_DevTier_NonExarchosRepo_BlockedAsReserved', async () => {
+    const fake = makeFakeFs({
+      '/repo/package.json': JSON.stringify({ name: '@acme/consumer' }),
+    });
+
+    const result = await handleScaffold(
+      { repoRoot: '/repo', tier: 'dev' },
+      fake.deps,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('RESERVED_TIER');
+    expect(result.error?.suggestedFix?.params.tier).toBe('user');
+    // No catalog file written — guard fires before the fs write.
+    expect(fake.writes).toHaveLength(0);
+  });
+
+  it('handleScaffold_DevTier_ExarchosRepo_Allows', async () => {
+    const fake = makeFakeFs({
+      '/repo/package.json': JSON.stringify({ name: '@lvlup-sw/exarchos' }),
+    });
+
+    const result = await handleScaffold(
+      { repoRoot: '/repo', tier: 'dev' },
+      fake.deps,
+    );
+
+    expect(result.success).toBe(true);
+    expect((result.data as { catalog: { wrote: boolean } }).catalog.wrote).toBe(
+      true,
+    );
+  });
+
+  it('handleScaffold_DevTier_WithOverride_Allows', async () => {
+    const fake = makeFakeFs({
+      '/repo/package.json': JSON.stringify({ name: '@acme/consumer' }),
+    });
+
+    const result = await handleScaffold(
+      { repoRoot: '/repo', tier: 'dev', allowReservedTier: true },
+      fake.deps,
+    );
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/invariants/scaffold.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/scaffold.ts
@@ -155,7 +155,12 @@ export async function handleScaffold(
   // Reject authoring into exarchos's reserved `dev` namespace from a consumer
   // repo BEFORE any fs write (#1489). Redirects to `tier: user`.
   const reserved = assertDevTierAllowed(
-    { tier, repoRoot: args.repoRoot, allowReservedTier: args.allowReservedTier },
+    {
+      tier,
+      repoRoot: args.repoRoot,
+      allowReservedTier: args.allowReservedTier,
+      action: 'invariants_scaffold',
+    },
     deps,
   );
   if (reserved) return reserved;

--- a/servers/exarchos-mcp/src/orchestrate/invariants/scaffold.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/scaffold.ts
@@ -84,6 +84,11 @@ export function renderStarterCatalog(tier: 'dev' | 'user'): string {
 # \`invariants_effective\` view. Authoring guide:
 # docs/guides/authoring-invariants.md.
 #
+# Consumers always use the \`user\` tier (\`U-N\` ids) — this catalog is your
+# project's own. The \`dev\` tier (\`INV-N\`) is exarchos-internal: it is
+# exarchos's own reserved substrate namespace and collides with its built-in
+# \`INV-*\` if reused from a consumer repo.
+#
 # Worked example (un-comment to start). \`mode: audit\` is pure judgment — an
 # LLM evaluates the prompt against the diff; always portable (INV-6). For a
 # declarative grep/structural check, use \`mode: check\` with a combinator tree

--- a/servers/exarchos-mcp/src/orchestrate/invariants/scaffold.ts
+++ b/servers/exarchos-mcp/src/orchestrate/invariants/scaffold.ts
@@ -21,6 +21,7 @@ import * as path from 'node:path';
 import type { ToolResult } from '../../format.js';
 import { wireCatalogRegistration } from './exarchos-yml-writer.js';
 import type { YmlWriterDeps } from './exarchos-yml-writer.js';
+import { assertDevTierAllowed } from './reserved-tier-guard.js';
 
 const CONFIG_FILENAME = '.exarchos.yml';
 
@@ -38,6 +39,11 @@ export interface HandleScaffoldArgs {
   readonly path?: string;
   /** Privilege tier of the catalog. Defaults to `user`. */
   readonly tier?: 'dev' | 'user';
+  /**
+   * Opt-in to author into exarchos's reserved `dev` namespace from a non-exarchos
+   * repo. Almost always a mistake outside the exarchos repo itself (#1489).
+   */
+  readonly allowReservedTier?: boolean;
 }
 
 /** Result of the catalog-file write step. */
@@ -140,6 +146,15 @@ export async function handleScaffold(
   deps: ScaffoldDeps,
 ): Promise<ToolResult> {
   const { tier, relPath } = resolveTargetPath(args);
+
+  // Reject authoring into exarchos's reserved `dev` namespace from a consumer
+  // repo BEFORE any fs write (#1489). Redirects to `tier: user`.
+  const reserved = assertDevTierAllowed(
+    { tier, repoRoot: args.repoRoot, allowReservedTier: args.allowReservedTier },
+    deps,
+  );
+  if (reserved) return reserved;
+
   const catalogAbs = path.join(args.repoRoot, relPath);
 
   const catalog = writeStarterCatalog(catalogAbs, tier, deps);

--- a/servers/exarchos-mcp/src/registry.ts
+++ b/servers/exarchos-mcp/src/registry.ts
@@ -2374,6 +2374,9 @@ const orchestrateActions: readonly ToolAction[] = [
       tier: z.enum(['dev', 'user']).optional(),
       path: z.string().optional(),
       repoRoot: z.string().optional(),
+      // #1489: `dev`/`INV-N` is exarchos's reserved substrate namespace. Outside
+      // the exarchos repo, tier:dev is rejected unless this override is set.
+      allowReservedTier: z.boolean().optional(),
     }),
     phases: ALL_PHASES,
     roles: ROLE_ANY,
@@ -2406,6 +2409,9 @@ const orchestrateActions: readonly ToolAction[] = [
       // dry-run default is enforced where the value is actually consumed.
       dryRun: z.boolean().optional(),
       repoRoot: z.string().optional(),
+      // #1489: `dev`/`INV-N` is exarchos's reserved substrate namespace. Outside
+      // the exarchos repo, tier:dev is rejected unless this override is set.
+      allowReservedTier: z.boolean().optional(),
     }),
     phases: ALL_PHASES,
     roles: ROLE_ANY,

--- a/skills-src/authoring-invariants/SKILL.md
+++ b/skills-src/authoring-invariants/SKILL.md
@@ -83,14 +83,32 @@ violated?") — that sharpens both the summary and the later enforcement.
 - `workflow-affinity`: workflow types (`feature | debug | refactor | discover |
   oneshot`). Absent ⇒ all.
 
-### 3. Weight — `severity` + `integrity-class`
+### 3. Weight — `severity`, `integrity-class`, and the `tier` you author into
 
 - `severity.default`: `blocking` or `advisory`.
 - `severity.by-workflow` (optional): downgrade for cheap workflows
   (e.g. `oneshot: advisory`).
-- `integrity-class`: `user` for a consumer-authored entry (the default target).
-  `dev` only when the author is a maintainer extending Exarchos's own substrate
-  catalog.
+- `integrity-class` (entry field; enum `substrate | sdlc | authoring | user`):
+  the entry's **override authority**, not its namespace. For a consumer-authored
+  rule this is `user`. (`substrate`/`sdlc` are exarchos's own classes — you do
+  not author those.)
+- **`tier` (the verb arg) picks the catalog _namespace_, and the choice is
+  *exarchos-substrate vs project-authored*, NOT "which developers".** This is the
+  one that bites — get it wrong and you silently collide with exarchos's own ids:
+  - **`tier: user` → `U-N` ids — your project's own invariants. The default for
+    _everyone_ consuming exarchos.** If you are authoring a rule for your own
+    repo, this is always the answer (even if your project happens to name its
+    rules `INV-N` internally — they map to `U-N` here).
+  - **`tier: dev` → `INV-N` ids — exarchos's _own_ reserved substrate catalog.**
+    Exarchos ships its own `INV-1..6` inside the tool, and they merge into every
+    `invariants_effective` projection. Authoring into `dev` from a consumer repo
+    **collides your `INV-N` with exarchos's own** — a silent namespace clash the
+    `doctor` check can't catch (it only flags `INV-*` in a *user* catalog). Use
+    `dev` **only when working inside the exarchos repo itself**. The verbs
+    enforce this: `invariants_scaffold` / `invariants_add` reject `tier: dev`
+    outside the exarchos repo (heuristic: `package.json` name ≠
+    `@lvlup-sw/exarchos`) with a `RESERVED_TIER` error that redirects to `user`;
+    a genuine exarchos fork opts in with `allowReservedTier: true`.
 
 ### 4. Enforce — DEFAULT `mode: audit`, `mode: check` is opt-in
 
@@ -194,5 +212,6 @@ For one `U-*` entry authored end-to-end through all 6 steps, see
 | Skip the dry-run | `dryRun: true` first, ALWAYS, then explicit confirm |
 | Silently re-invoke with `dryRun: false` | Make the confirmation step explicit |
 | Pick an id by hand | The verb auto-assigns the next free id in the namespace |
+| Author into `dev`/`INV-N` from a consumer repo | `dev` is exarchos's reserved substrate namespace — use `user`/`U-N` (the verb rejects consumer `tier: dev`) |
 | Infer globs from the framework | Ask the author to name the globs (INV-6) |
 | Skip `doctor` + `invariants_effective` after commit | Verify the resolved catalog and show the delta |

--- a/skills-src/authoring-invariants/references/worked-example.md
+++ b/skills-src/authoring-invariants/references/worked-example.md
@@ -35,7 +35,12 @@ The agent asks the author to name the paths and the phase where the rule bites.
 
 - `severity.default`: `blocking` (a missing audit event is a compliance gap)
 - `severity.by-workflow`: `{ oneshot: advisory }` (downgrade for cheap throwaway work)
-- `integrity-class`: `user` (consumer-authored)
+- `integrity-class`: `user` (the entry's override authority — consumer-authored)
+- author into **`tier: user`** (→ `U-N` ids) — the default namespace for
+  *everyone* consuming exarchos. `tier: dev` (→ `INV-N`) is exarchos's own
+  reserved substrate namespace, used only inside the exarchos repo itself; the
+  verbs reject a consumer `tier: dev` (see step 6a, where the verb is called
+  with `tier: "user"`).
 
 ## Step 4 — Enforce (DEFAULT `mode: audit`)
 

--- a/skills/claude/authoring-invariants/SKILL.md
+++ b/skills/claude/authoring-invariants/SKILL.md
@@ -83,14 +83,32 @@ violated?") — that sharpens both the summary and the later enforcement.
 - `workflow-affinity`: workflow types (`feature | debug | refactor | discover |
   oneshot`). Absent ⇒ all.
 
-### 3. Weight — `severity` + `integrity-class`
+### 3. Weight — `severity`, `integrity-class`, and the `tier` you author into
 
 - `severity.default`: `blocking` or `advisory`.
 - `severity.by-workflow` (optional): downgrade for cheap workflows
   (e.g. `oneshot: advisory`).
-- `integrity-class`: `user` for a consumer-authored entry (the default target).
-  `dev` only when the author is a maintainer extending Exarchos's own substrate
-  catalog.
+- `integrity-class` (entry field; enum `substrate | sdlc | authoring | user`):
+  the entry's **override authority**, not its namespace. For a consumer-authored
+  rule this is `user`. (`substrate`/`sdlc` are exarchos's own classes — you do
+  not author those.)
+- **`tier` (the verb arg) picks the catalog _namespace_, and the choice is
+  *exarchos-substrate vs project-authored*, NOT "which developers".** This is the
+  one that bites — get it wrong and you silently collide with exarchos's own ids:
+  - **`tier: user` → `U-N` ids — your project's own invariants. The default for
+    _everyone_ consuming exarchos.** If you are authoring a rule for your own
+    repo, this is always the answer (even if your project happens to name its
+    rules `INV-N` internally — they map to `U-N` here).
+  - **`tier: dev` → `INV-N` ids — exarchos's _own_ reserved substrate catalog.**
+    Exarchos ships its own `INV-1..6` inside the tool, and they merge into every
+    `invariants_effective` projection. Authoring into `dev` from a consumer repo
+    **collides your `INV-N` with exarchos's own** — a silent namespace clash the
+    `doctor` check can't catch (it only flags `INV-*` in a *user* catalog). Use
+    `dev` **only when working inside the exarchos repo itself**. The verbs
+    enforce this: `invariants_scaffold` / `invariants_add` reject `tier: dev`
+    outside the exarchos repo (heuristic: `package.json` name ≠
+    `@lvlup-sw/exarchos`) with a `RESERVED_TIER` error that redirects to `user`;
+    a genuine exarchos fork opts in with `allowReservedTier: true`.
 
 ### 4. Enforce — DEFAULT `mode: audit`, `mode: check` is opt-in
 
@@ -194,5 +212,6 @@ For one `U-*` entry authored end-to-end through all 6 steps, see
 | Skip the dry-run | `dryRun: true` first, ALWAYS, then explicit confirm |
 | Silently re-invoke with `dryRun: false` | Make the confirmation step explicit |
 | Pick an id by hand | The verb auto-assigns the next free id in the namespace |
+| Author into `dev`/`INV-N` from a consumer repo | `dev` is exarchos's reserved substrate namespace — use `user`/`U-N` (the verb rejects consumer `tier: dev`) |
 | Infer globs from the framework | Ask the author to name the globs (INV-6) |
 | Skip `doctor` + `invariants_effective` after commit | Verify the resolved catalog and show the delta |

--- a/skills/claude/authoring-invariants/references/worked-example.md
+++ b/skills/claude/authoring-invariants/references/worked-example.md
@@ -35,7 +35,12 @@ The agent asks the author to name the paths and the phase where the rule bites.
 
 - `severity.default`: `blocking` (a missing audit event is a compliance gap)
 - `severity.by-workflow`: `{ oneshot: advisory }` (downgrade for cheap throwaway work)
-- `integrity-class`: `user` (consumer-authored)
+- `integrity-class`: `user` (the entry's override authority — consumer-authored)
+- author into **`tier: user`** (→ `U-N` ids) — the default namespace for
+  *everyone* consuming exarchos. `tier: dev` (→ `INV-N`) is exarchos's own
+  reserved substrate namespace, used only inside the exarchos repo itself; the
+  verbs reject a consumer `tier: dev` (see step 6a, where the verb is called
+  with `tier: "user"`).
 
 ## Step 4 — Enforce (DEFAULT `mode: audit`)
 

--- a/skills/codex/authoring-invariants/SKILL.md
+++ b/skills/codex/authoring-invariants/SKILL.md
@@ -83,14 +83,32 @@ violated?") — that sharpens both the summary and the later enforcement.
 - `workflow-affinity`: workflow types (`feature | debug | refactor | discover |
   oneshot`). Absent ⇒ all.
 
-### 3. Weight — `severity` + `integrity-class`
+### 3. Weight — `severity`, `integrity-class`, and the `tier` you author into
 
 - `severity.default`: `blocking` or `advisory`.
 - `severity.by-workflow` (optional): downgrade for cheap workflows
   (e.g. `oneshot: advisory`).
-- `integrity-class`: `user` for a consumer-authored entry (the default target).
-  `dev` only when the author is a maintainer extending Exarchos's own substrate
-  catalog.
+- `integrity-class` (entry field; enum `substrate | sdlc | authoring | user`):
+  the entry's **override authority**, not its namespace. For a consumer-authored
+  rule this is `user`. (`substrate`/`sdlc` are exarchos's own classes — you do
+  not author those.)
+- **`tier` (the verb arg) picks the catalog _namespace_, and the choice is
+  *exarchos-substrate vs project-authored*, NOT "which developers".** This is the
+  one that bites — get it wrong and you silently collide with exarchos's own ids:
+  - **`tier: user` → `U-N` ids — your project's own invariants. The default for
+    _everyone_ consuming exarchos.** If you are authoring a rule for your own
+    repo, this is always the answer (even if your project happens to name its
+    rules `INV-N` internally — they map to `U-N` here).
+  - **`tier: dev` → `INV-N` ids — exarchos's _own_ reserved substrate catalog.**
+    Exarchos ships its own `INV-1..6` inside the tool, and they merge into every
+    `invariants_effective` projection. Authoring into `dev` from a consumer repo
+    **collides your `INV-N` with exarchos's own** — a silent namespace clash the
+    `doctor` check can't catch (it only flags `INV-*` in a *user* catalog). Use
+    `dev` **only when working inside the exarchos repo itself**. The verbs
+    enforce this: `invariants_scaffold` / `invariants_add` reject `tier: dev`
+    outside the exarchos repo (heuristic: `package.json` name ≠
+    `@lvlup-sw/exarchos`) with a `RESERVED_TIER` error that redirects to `user`;
+    a genuine exarchos fork opts in with `allowReservedTier: true`.
 
 ### 4. Enforce — DEFAULT `mode: audit`, `mode: check` is opt-in
 
@@ -194,5 +212,6 @@ For one `U-*` entry authored end-to-end through all 6 steps, see
 | Skip the dry-run | `dryRun: true` first, ALWAYS, then explicit confirm |
 | Silently re-invoke with `dryRun: false` | Make the confirmation step explicit |
 | Pick an id by hand | The verb auto-assigns the next free id in the namespace |
+| Author into `dev`/`INV-N` from a consumer repo | `dev` is exarchos's reserved substrate namespace — use `user`/`U-N` (the verb rejects consumer `tier: dev`) |
 | Infer globs from the framework | Ask the author to name the globs (INV-6) |
 | Skip `doctor` + `invariants_effective` after commit | Verify the resolved catalog and show the delta |

--- a/skills/codex/authoring-invariants/references/worked-example.md
+++ b/skills/codex/authoring-invariants/references/worked-example.md
@@ -35,7 +35,12 @@ The agent asks the author to name the paths and the phase where the rule bites.
 
 - `severity.default`: `blocking` (a missing audit event is a compliance gap)
 - `severity.by-workflow`: `{ oneshot: advisory }` (downgrade for cheap throwaway work)
-- `integrity-class`: `user` (consumer-authored)
+- `integrity-class`: `user` (the entry's override authority — consumer-authored)
+- author into **`tier: user`** (→ `U-N` ids) — the default namespace for
+  *everyone* consuming exarchos. `tier: dev` (→ `INV-N`) is exarchos's own
+  reserved substrate namespace, used only inside the exarchos repo itself; the
+  verbs reject a consumer `tier: dev` (see step 6a, where the verb is called
+  with `tier: "user"`).
 
 ## Step 4 — Enforce (DEFAULT `mode: audit`)
 

--- a/skills/copilot/authoring-invariants/SKILL.md
+++ b/skills/copilot/authoring-invariants/SKILL.md
@@ -83,14 +83,32 @@ violated?") — that sharpens both the summary and the later enforcement.
 - `workflow-affinity`: workflow types (`feature | debug | refactor | discover |
   oneshot`). Absent ⇒ all.
 
-### 3. Weight — `severity` + `integrity-class`
+### 3. Weight — `severity`, `integrity-class`, and the `tier` you author into
 
 - `severity.default`: `blocking` or `advisory`.
 - `severity.by-workflow` (optional): downgrade for cheap workflows
   (e.g. `oneshot: advisory`).
-- `integrity-class`: `user` for a consumer-authored entry (the default target).
-  `dev` only when the author is a maintainer extending Exarchos's own substrate
-  catalog.
+- `integrity-class` (entry field; enum `substrate | sdlc | authoring | user`):
+  the entry's **override authority**, not its namespace. For a consumer-authored
+  rule this is `user`. (`substrate`/`sdlc` are exarchos's own classes — you do
+  not author those.)
+- **`tier` (the verb arg) picks the catalog _namespace_, and the choice is
+  *exarchos-substrate vs project-authored*, NOT "which developers".** This is the
+  one that bites — get it wrong and you silently collide with exarchos's own ids:
+  - **`tier: user` → `U-N` ids — your project's own invariants. The default for
+    _everyone_ consuming exarchos.** If you are authoring a rule for your own
+    repo, this is always the answer (even if your project happens to name its
+    rules `INV-N` internally — they map to `U-N` here).
+  - **`tier: dev` → `INV-N` ids — exarchos's _own_ reserved substrate catalog.**
+    Exarchos ships its own `INV-1..6` inside the tool, and they merge into every
+    `invariants_effective` projection. Authoring into `dev` from a consumer repo
+    **collides your `INV-N` with exarchos's own** — a silent namespace clash the
+    `doctor` check can't catch (it only flags `INV-*` in a *user* catalog). Use
+    `dev` **only when working inside the exarchos repo itself**. The verbs
+    enforce this: `invariants_scaffold` / `invariants_add` reject `tier: dev`
+    outside the exarchos repo (heuristic: `package.json` name ≠
+    `@lvlup-sw/exarchos`) with a `RESERVED_TIER` error that redirects to `user`;
+    a genuine exarchos fork opts in with `allowReservedTier: true`.
 
 ### 4. Enforce — DEFAULT `mode: audit`, `mode: check` is opt-in
 
@@ -194,5 +212,6 @@ For one `U-*` entry authored end-to-end through all 6 steps, see
 | Skip the dry-run | `dryRun: true` first, ALWAYS, then explicit confirm |
 | Silently re-invoke with `dryRun: false` | Make the confirmation step explicit |
 | Pick an id by hand | The verb auto-assigns the next free id in the namespace |
+| Author into `dev`/`INV-N` from a consumer repo | `dev` is exarchos's reserved substrate namespace — use `user`/`U-N` (the verb rejects consumer `tier: dev`) |
 | Infer globs from the framework | Ask the author to name the globs (INV-6) |
 | Skip `doctor` + `invariants_effective` after commit | Verify the resolved catalog and show the delta |

--- a/skills/copilot/authoring-invariants/references/worked-example.md
+++ b/skills/copilot/authoring-invariants/references/worked-example.md
@@ -35,7 +35,12 @@ The agent asks the author to name the paths and the phase where the rule bites.
 
 - `severity.default`: `blocking` (a missing audit event is a compliance gap)
 - `severity.by-workflow`: `{ oneshot: advisory }` (downgrade for cheap throwaway work)
-- `integrity-class`: `user` (consumer-authored)
+- `integrity-class`: `user` (the entry's override authority — consumer-authored)
+- author into **`tier: user`** (→ `U-N` ids) — the default namespace for
+  *everyone* consuming exarchos. `tier: dev` (→ `INV-N`) is exarchos's own
+  reserved substrate namespace, used only inside the exarchos repo itself; the
+  verbs reject a consumer `tier: dev` (see step 6a, where the verb is called
+  with `tier: "user"`).
 
 ## Step 4 — Enforce (DEFAULT `mode: audit`)
 

--- a/skills/cursor/authoring-invariants/SKILL.md
+++ b/skills/cursor/authoring-invariants/SKILL.md
@@ -83,14 +83,32 @@ violated?") — that sharpens both the summary and the later enforcement.
 - `workflow-affinity`: workflow types (`feature | debug | refactor | discover |
   oneshot`). Absent ⇒ all.
 
-### 3. Weight — `severity` + `integrity-class`
+### 3. Weight — `severity`, `integrity-class`, and the `tier` you author into
 
 - `severity.default`: `blocking` or `advisory`.
 - `severity.by-workflow` (optional): downgrade for cheap workflows
   (e.g. `oneshot: advisory`).
-- `integrity-class`: `user` for a consumer-authored entry (the default target).
-  `dev` only when the author is a maintainer extending Exarchos's own substrate
-  catalog.
+- `integrity-class` (entry field; enum `substrate | sdlc | authoring | user`):
+  the entry's **override authority**, not its namespace. For a consumer-authored
+  rule this is `user`. (`substrate`/`sdlc` are exarchos's own classes — you do
+  not author those.)
+- **`tier` (the verb arg) picks the catalog _namespace_, and the choice is
+  *exarchos-substrate vs project-authored*, NOT "which developers".** This is the
+  one that bites — get it wrong and you silently collide with exarchos's own ids:
+  - **`tier: user` → `U-N` ids — your project's own invariants. The default for
+    _everyone_ consuming exarchos.** If you are authoring a rule for your own
+    repo, this is always the answer (even if your project happens to name its
+    rules `INV-N` internally — they map to `U-N` here).
+  - **`tier: dev` → `INV-N` ids — exarchos's _own_ reserved substrate catalog.**
+    Exarchos ships its own `INV-1..6` inside the tool, and they merge into every
+    `invariants_effective` projection. Authoring into `dev` from a consumer repo
+    **collides your `INV-N` with exarchos's own** — a silent namespace clash the
+    `doctor` check can't catch (it only flags `INV-*` in a *user* catalog). Use
+    `dev` **only when working inside the exarchos repo itself**. The verbs
+    enforce this: `invariants_scaffold` / `invariants_add` reject `tier: dev`
+    outside the exarchos repo (heuristic: `package.json` name ≠
+    `@lvlup-sw/exarchos`) with a `RESERVED_TIER` error that redirects to `user`;
+    a genuine exarchos fork opts in with `allowReservedTier: true`.
 
 ### 4. Enforce — DEFAULT `mode: audit`, `mode: check` is opt-in
 
@@ -194,5 +212,6 @@ For one `U-*` entry authored end-to-end through all 6 steps, see
 | Skip the dry-run | `dryRun: true` first, ALWAYS, then explicit confirm |
 | Silently re-invoke with `dryRun: false` | Make the confirmation step explicit |
 | Pick an id by hand | The verb auto-assigns the next free id in the namespace |
+| Author into `dev`/`INV-N` from a consumer repo | `dev` is exarchos's reserved substrate namespace — use `user`/`U-N` (the verb rejects consumer `tier: dev`) |
 | Infer globs from the framework | Ask the author to name the globs (INV-6) |
 | Skip `doctor` + `invariants_effective` after commit | Verify the resolved catalog and show the delta |

--- a/skills/cursor/authoring-invariants/references/worked-example.md
+++ b/skills/cursor/authoring-invariants/references/worked-example.md
@@ -35,7 +35,12 @@ The agent asks the author to name the paths and the phase where the rule bites.
 
 - `severity.default`: `blocking` (a missing audit event is a compliance gap)
 - `severity.by-workflow`: `{ oneshot: advisory }` (downgrade for cheap throwaway work)
-- `integrity-class`: `user` (consumer-authored)
+- `integrity-class`: `user` (the entry's override authority — consumer-authored)
+- author into **`tier: user`** (→ `U-N` ids) — the default namespace for
+  *everyone* consuming exarchos. `tier: dev` (→ `INV-N`) is exarchos's own
+  reserved substrate namespace, used only inside the exarchos repo itself; the
+  verbs reject a consumer `tier: dev` (see step 6a, where the verb is called
+  with `tier: "user"`).
 
 ## Step 4 — Enforce (DEFAULT `mode: audit`)
 

--- a/skills/generic/authoring-invariants/SKILL.md
+++ b/skills/generic/authoring-invariants/SKILL.md
@@ -83,14 +83,32 @@ violated?") — that sharpens both the summary and the later enforcement.
 - `workflow-affinity`: workflow types (`feature | debug | refactor | discover |
   oneshot`). Absent ⇒ all.
 
-### 3. Weight — `severity` + `integrity-class`
+### 3. Weight — `severity`, `integrity-class`, and the `tier` you author into
 
 - `severity.default`: `blocking` or `advisory`.
 - `severity.by-workflow` (optional): downgrade for cheap workflows
   (e.g. `oneshot: advisory`).
-- `integrity-class`: `user` for a consumer-authored entry (the default target).
-  `dev` only when the author is a maintainer extending Exarchos's own substrate
-  catalog.
+- `integrity-class` (entry field; enum `substrate | sdlc | authoring | user`):
+  the entry's **override authority**, not its namespace. For a consumer-authored
+  rule this is `user`. (`substrate`/`sdlc` are exarchos's own classes — you do
+  not author those.)
+- **`tier` (the verb arg) picks the catalog _namespace_, and the choice is
+  *exarchos-substrate vs project-authored*, NOT "which developers".** This is the
+  one that bites — get it wrong and you silently collide with exarchos's own ids:
+  - **`tier: user` → `U-N` ids — your project's own invariants. The default for
+    _everyone_ consuming exarchos.** If you are authoring a rule for your own
+    repo, this is always the answer (even if your project happens to name its
+    rules `INV-N` internally — they map to `U-N` here).
+  - **`tier: dev` → `INV-N` ids — exarchos's _own_ reserved substrate catalog.**
+    Exarchos ships its own `INV-1..6` inside the tool, and they merge into every
+    `invariants_effective` projection. Authoring into `dev` from a consumer repo
+    **collides your `INV-N` with exarchos's own** — a silent namespace clash the
+    `doctor` check can't catch (it only flags `INV-*` in a *user* catalog). Use
+    `dev` **only when working inside the exarchos repo itself**. The verbs
+    enforce this: `invariants_scaffold` / `invariants_add` reject `tier: dev`
+    outside the exarchos repo (heuristic: `package.json` name ≠
+    `@lvlup-sw/exarchos`) with a `RESERVED_TIER` error that redirects to `user`;
+    a genuine exarchos fork opts in with `allowReservedTier: true`.
 
 ### 4. Enforce — DEFAULT `mode: audit`, `mode: check` is opt-in
 
@@ -194,5 +212,6 @@ For one `U-*` entry authored end-to-end through all 6 steps, see
 | Skip the dry-run | `dryRun: true` first, ALWAYS, then explicit confirm |
 | Silently re-invoke with `dryRun: false` | Make the confirmation step explicit |
 | Pick an id by hand | The verb auto-assigns the next free id in the namespace |
+| Author into `dev`/`INV-N` from a consumer repo | `dev` is exarchos's reserved substrate namespace — use `user`/`U-N` (the verb rejects consumer `tier: dev`) |
 | Infer globs from the framework | Ask the author to name the globs (INV-6) |
 | Skip `doctor` + `invariants_effective` after commit | Verify the resolved catalog and show the delta |

--- a/skills/generic/authoring-invariants/references/worked-example.md
+++ b/skills/generic/authoring-invariants/references/worked-example.md
@@ -35,7 +35,12 @@ The agent asks the author to name the paths and the phase where the rule bites.
 
 - `severity.default`: `blocking` (a missing audit event is a compliance gap)
 - `severity.by-workflow`: `{ oneshot: advisory }` (downgrade for cheap throwaway work)
-- `integrity-class`: `user` (consumer-authored)
+- `integrity-class`: `user` (the entry's override authority — consumer-authored)
+- author into **`tier: user`** (→ `U-N` ids) — the default namespace for
+  *everyone* consuming exarchos. `tier: dev` (→ `INV-N`) is exarchos's own
+  reserved substrate namespace, used only inside the exarchos repo itself; the
+  verbs reject a consumer `tier: dev` (see step 6a, where the verb is called
+  with `tier: "user"`).
 
 ## Step 4 — Enforce (DEFAULT `mode: audit`)
 

--- a/skills/opencode/authoring-invariants/SKILL.md
+++ b/skills/opencode/authoring-invariants/SKILL.md
@@ -83,14 +83,32 @@ violated?") — that sharpens both the summary and the later enforcement.
 - `workflow-affinity`: workflow types (`feature | debug | refactor | discover |
   oneshot`). Absent ⇒ all.
 
-### 3. Weight — `severity` + `integrity-class`
+### 3. Weight — `severity`, `integrity-class`, and the `tier` you author into
 
 - `severity.default`: `blocking` or `advisory`.
 - `severity.by-workflow` (optional): downgrade for cheap workflows
   (e.g. `oneshot: advisory`).
-- `integrity-class`: `user` for a consumer-authored entry (the default target).
-  `dev` only when the author is a maintainer extending Exarchos's own substrate
-  catalog.
+- `integrity-class` (entry field; enum `substrate | sdlc | authoring | user`):
+  the entry's **override authority**, not its namespace. For a consumer-authored
+  rule this is `user`. (`substrate`/`sdlc` are exarchos's own classes — you do
+  not author those.)
+- **`tier` (the verb arg) picks the catalog _namespace_, and the choice is
+  *exarchos-substrate vs project-authored*, NOT "which developers".** This is the
+  one that bites — get it wrong and you silently collide with exarchos's own ids:
+  - **`tier: user` → `U-N` ids — your project's own invariants. The default for
+    _everyone_ consuming exarchos.** If you are authoring a rule for your own
+    repo, this is always the answer (even if your project happens to name its
+    rules `INV-N` internally — they map to `U-N` here).
+  - **`tier: dev` → `INV-N` ids — exarchos's _own_ reserved substrate catalog.**
+    Exarchos ships its own `INV-1..6` inside the tool, and they merge into every
+    `invariants_effective` projection. Authoring into `dev` from a consumer repo
+    **collides your `INV-N` with exarchos's own** — a silent namespace clash the
+    `doctor` check can't catch (it only flags `INV-*` in a *user* catalog). Use
+    `dev` **only when working inside the exarchos repo itself**. The verbs
+    enforce this: `invariants_scaffold` / `invariants_add` reject `tier: dev`
+    outside the exarchos repo (heuristic: `package.json` name ≠
+    `@lvlup-sw/exarchos`) with a `RESERVED_TIER` error that redirects to `user`;
+    a genuine exarchos fork opts in with `allowReservedTier: true`.
 
 ### 4. Enforce — DEFAULT `mode: audit`, `mode: check` is opt-in
 
@@ -194,5 +212,6 @@ For one `U-*` entry authored end-to-end through all 6 steps, see
 | Skip the dry-run | `dryRun: true` first, ALWAYS, then explicit confirm |
 | Silently re-invoke with `dryRun: false` | Make the confirmation step explicit |
 | Pick an id by hand | The verb auto-assigns the next free id in the namespace |
+| Author into `dev`/`INV-N` from a consumer repo | `dev` is exarchos's reserved substrate namespace — use `user`/`U-N` (the verb rejects consumer `tier: dev`) |
 | Infer globs from the framework | Ask the author to name the globs (INV-6) |
 | Skip `doctor` + `invariants_effective` after commit | Verify the resolved catalog and show the delta |

--- a/skills/opencode/authoring-invariants/references/worked-example.md
+++ b/skills/opencode/authoring-invariants/references/worked-example.md
@@ -35,7 +35,12 @@ The agent asks the author to name the paths and the phase where the rule bites.
 
 - `severity.default`: `blocking` (a missing audit event is a compliance gap)
 - `severity.by-workflow`: `{ oneshot: advisory }` (downgrade for cheap throwaway work)
-- `integrity-class`: `user` (consumer-authored)
+- `integrity-class`: `user` (the entry's override authority — consumer-authored)
+- author into **`tier: user`** (→ `U-N` ids) — the default namespace for
+  *everyone* consuming exarchos. `tier: dev` (→ `INV-N`) is exarchos's own
+  reserved substrate namespace, used only inside the exarchos repo itself; the
+  verbs reject a consumer `tier: dev` (see step 6a, where the verb is called
+  with `tier: "user"`).
 
 ## Step 4 — Enforce (DEFAULT `mode: audit`)
 

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -86,14 +86,32 @@ violated?") — that sharpens both the summary and the later enforcement.
 - \`workflow-affinity\`: workflow types (\`feature | debug | refactor | discover |
   oneshot\`). Absent ⇒ all.
 
-### 3. Weight — \`severity\` + \`integrity-class\`
+### 3. Weight — \`severity\`, \`integrity-class\`, and the \`tier\` you author into
 
 - \`severity.default\`: \`blocking\` or \`advisory\`.
 - \`severity.by-workflow\` (optional): downgrade for cheap workflows
   (e.g. \`oneshot: advisory\`).
-- \`integrity-class\`: \`user\` for a consumer-authored entry (the default target).
-  \`dev\` only when the author is a maintainer extending Exarchos's own substrate
-  catalog.
+- \`integrity-class\` (entry field; enum \`substrate | sdlc | authoring | user\`):
+  the entry's **override authority**, not its namespace. For a consumer-authored
+  rule this is \`user\`. (\`substrate\`/\`sdlc\` are exarchos's own classes — you do
+  not author those.)
+- **\`tier\` (the verb arg) picks the catalog _namespace_, and the choice is
+  *exarchos-substrate vs project-authored*, NOT "which developers".** This is the
+  one that bites — get it wrong and you silently collide with exarchos's own ids:
+  - **\`tier: user\` → \`U-N\` ids — your project's own invariants. The default for
+    _everyone_ consuming exarchos.** If you are authoring a rule for your own
+    repo, this is always the answer (even if your project happens to name its
+    rules \`INV-N\` internally — they map to \`U-N\` here).
+  - **\`tier: dev\` → \`INV-N\` ids — exarchos's _own_ reserved substrate catalog.**
+    Exarchos ships its own \`INV-1..6\` inside the tool, and they merge into every
+    \`invariants_effective\` projection. Authoring into \`dev\` from a consumer repo
+    **collides your \`INV-N\` with exarchos's own** — a silent namespace clash the
+    \`doctor\` check can't catch (it only flags \`INV-*\` in a *user* catalog). Use
+    \`dev\` **only when working inside the exarchos repo itself**. The verbs
+    enforce this: \`invariants_scaffold\` / \`invariants_add\` reject \`tier: dev\`
+    outside the exarchos repo (heuristic: \`package.json\` name ≠
+    \`@lvlup-sw/exarchos\`) with a \`RESERVED_TIER\` error that redirects to \`user\`;
+    a genuine exarchos fork opts in with \`allowReservedTier: true\`.
 
 ### 4. Enforce — DEFAULT \`mode: audit\`, \`mode: check\` is opt-in
 
@@ -197,6 +215,7 @@ For one \`U-*\` entry authored end-to-end through all 6 steps, see
 | Skip the dry-run | \`dryRun: true\` first, ALWAYS, then explicit confirm |
 | Silently re-invoke with \`dryRun: false\` | Make the confirmation step explicit |
 | Pick an id by hand | The verb auto-assigns the next free id in the namespace |
+| Author into \`dev\`/\`INV-N\` from a consumer repo | \`dev\` is exarchos's reserved substrate namespace — use \`user\`/\`U-N\` (the verb rejects consumer \`tier: dev\`) |
 | Infer globs from the framework | Ask the author to name the globs (INV-6) |
 | Skip \`doctor\` + \`invariants_effective\` after commit | Verify the resolved catalog and show the delta |
 "
@@ -5040,14 +5059,32 @@ violated?") — that sharpens both the summary and the later enforcement.
 - \`workflow-affinity\`: workflow types (\`feature | debug | refactor | discover |
   oneshot\`). Absent ⇒ all.
 
-### 3. Weight — \`severity\` + \`integrity-class\`
+### 3. Weight — \`severity\`, \`integrity-class\`, and the \`tier\` you author into
 
 - \`severity.default\`: \`blocking\` or \`advisory\`.
 - \`severity.by-workflow\` (optional): downgrade for cheap workflows
   (e.g. \`oneshot: advisory\`).
-- \`integrity-class\`: \`user\` for a consumer-authored entry (the default target).
-  \`dev\` only when the author is a maintainer extending Exarchos's own substrate
-  catalog.
+- \`integrity-class\` (entry field; enum \`substrate | sdlc | authoring | user\`):
+  the entry's **override authority**, not its namespace. For a consumer-authored
+  rule this is \`user\`. (\`substrate\`/\`sdlc\` are exarchos's own classes — you do
+  not author those.)
+- **\`tier\` (the verb arg) picks the catalog _namespace_, and the choice is
+  *exarchos-substrate vs project-authored*, NOT "which developers".** This is the
+  one that bites — get it wrong and you silently collide with exarchos's own ids:
+  - **\`tier: user\` → \`U-N\` ids — your project's own invariants. The default for
+    _everyone_ consuming exarchos.** If you are authoring a rule for your own
+    repo, this is always the answer (even if your project happens to name its
+    rules \`INV-N\` internally — they map to \`U-N\` here).
+  - **\`tier: dev\` → \`INV-N\` ids — exarchos's _own_ reserved substrate catalog.**
+    Exarchos ships its own \`INV-1..6\` inside the tool, and they merge into every
+    \`invariants_effective\` projection. Authoring into \`dev\` from a consumer repo
+    **collides your \`INV-N\` with exarchos's own** — a silent namespace clash the
+    \`doctor\` check can't catch (it only flags \`INV-*\` in a *user* catalog). Use
+    \`dev\` **only when working inside the exarchos repo itself**. The verbs
+    enforce this: \`invariants_scaffold\` / \`invariants_add\` reject \`tier: dev\`
+    outside the exarchos repo (heuristic: \`package.json\` name ≠
+    \`@lvlup-sw/exarchos\`) with a \`RESERVED_TIER\` error that redirects to \`user\`;
+    a genuine exarchos fork opts in with \`allowReservedTier: true\`.
 
 ### 4. Enforce — DEFAULT \`mode: audit\`, \`mode: check\` is opt-in
 
@@ -5151,6 +5188,7 @@ For one \`U-*\` entry authored end-to-end through all 6 steps, see
 | Skip the dry-run | \`dryRun: true\` first, ALWAYS, then explicit confirm |
 | Silently re-invoke with \`dryRun: false\` | Make the confirmation step explicit |
 | Pick an id by hand | The verb auto-assigns the next free id in the namespace |
+| Author into \`dev\`/\`INV-N\` from a consumer repo | \`dev\` is exarchos's reserved substrate namespace — use \`user\`/\`U-N\` (the verb rejects consumer \`tier: dev\`) |
 | Infer globs from the framework | Ask the author to name the globs (INV-6) |
 | Skip \`doctor\` + \`invariants_effective\` after commit | Verify the resolved catalog and show the delta |
 "
@@ -9947,14 +9985,32 @@ violated?") — that sharpens both the summary and the later enforcement.
 - \`workflow-affinity\`: workflow types (\`feature | debug | refactor | discover |
   oneshot\`). Absent ⇒ all.
 
-### 3. Weight — \`severity\` + \`integrity-class\`
+### 3. Weight — \`severity\`, \`integrity-class\`, and the \`tier\` you author into
 
 - \`severity.default\`: \`blocking\` or \`advisory\`.
 - \`severity.by-workflow\` (optional): downgrade for cheap workflows
   (e.g. \`oneshot: advisory\`).
-- \`integrity-class\`: \`user\` for a consumer-authored entry (the default target).
-  \`dev\` only when the author is a maintainer extending Exarchos's own substrate
-  catalog.
+- \`integrity-class\` (entry field; enum \`substrate | sdlc | authoring | user\`):
+  the entry's **override authority**, not its namespace. For a consumer-authored
+  rule this is \`user\`. (\`substrate\`/\`sdlc\` are exarchos's own classes — you do
+  not author those.)
+- **\`tier\` (the verb arg) picks the catalog _namespace_, and the choice is
+  *exarchos-substrate vs project-authored*, NOT "which developers".** This is the
+  one that bites — get it wrong and you silently collide with exarchos's own ids:
+  - **\`tier: user\` → \`U-N\` ids — your project's own invariants. The default for
+    _everyone_ consuming exarchos.** If you are authoring a rule for your own
+    repo, this is always the answer (even if your project happens to name its
+    rules \`INV-N\` internally — they map to \`U-N\` here).
+  - **\`tier: dev\` → \`INV-N\` ids — exarchos's _own_ reserved substrate catalog.**
+    Exarchos ships its own \`INV-1..6\` inside the tool, and they merge into every
+    \`invariants_effective\` projection. Authoring into \`dev\` from a consumer repo
+    **collides your \`INV-N\` with exarchos's own** — a silent namespace clash the
+    \`doctor\` check can't catch (it only flags \`INV-*\` in a *user* catalog). Use
+    \`dev\` **only when working inside the exarchos repo itself**. The verbs
+    enforce this: \`invariants_scaffold\` / \`invariants_add\` reject \`tier: dev\`
+    outside the exarchos repo (heuristic: \`package.json\` name ≠
+    \`@lvlup-sw/exarchos\`) with a \`RESERVED_TIER\` error that redirects to \`user\`;
+    a genuine exarchos fork opts in with \`allowReservedTier: true\`.
 
 ### 4. Enforce — DEFAULT \`mode: audit\`, \`mode: check\` is opt-in
 
@@ -10058,6 +10114,7 @@ For one \`U-*\` entry authored end-to-end through all 6 steps, see
 | Skip the dry-run | \`dryRun: true\` first, ALWAYS, then explicit confirm |
 | Silently re-invoke with \`dryRun: false\` | Make the confirmation step explicit |
 | Pick an id by hand | The verb auto-assigns the next free id in the namespace |
+| Author into \`dev\`/\`INV-N\` from a consumer repo | \`dev\` is exarchos's reserved substrate namespace — use \`user\`/\`U-N\` (the verb rejects consumer \`tier: dev\`) |
 | Infer globs from the framework | Ask the author to name the globs (INV-6) |
 | Skip \`doctor\` + \`invariants_effective\` after commit | Verify the resolved catalog and show the delta |
 "
@@ -14846,14 +14903,32 @@ violated?") — that sharpens both the summary and the later enforcement.
 - \`workflow-affinity\`: workflow types (\`feature | debug | refactor | discover |
   oneshot\`). Absent ⇒ all.
 
-### 3. Weight — \`severity\` + \`integrity-class\`
+### 3. Weight — \`severity\`, \`integrity-class\`, and the \`tier\` you author into
 
 - \`severity.default\`: \`blocking\` or \`advisory\`.
 - \`severity.by-workflow\` (optional): downgrade for cheap workflows
   (e.g. \`oneshot: advisory\`).
-- \`integrity-class\`: \`user\` for a consumer-authored entry (the default target).
-  \`dev\` only when the author is a maintainer extending Exarchos's own substrate
-  catalog.
+- \`integrity-class\` (entry field; enum \`substrate | sdlc | authoring | user\`):
+  the entry's **override authority**, not its namespace. For a consumer-authored
+  rule this is \`user\`. (\`substrate\`/\`sdlc\` are exarchos's own classes — you do
+  not author those.)
+- **\`tier\` (the verb arg) picks the catalog _namespace_, and the choice is
+  *exarchos-substrate vs project-authored*, NOT "which developers".** This is the
+  one that bites — get it wrong and you silently collide with exarchos's own ids:
+  - **\`tier: user\` → \`U-N\` ids — your project's own invariants. The default for
+    _everyone_ consuming exarchos.** If you are authoring a rule for your own
+    repo, this is always the answer (even if your project happens to name its
+    rules \`INV-N\` internally — they map to \`U-N\` here).
+  - **\`tier: dev\` → \`INV-N\` ids — exarchos's _own_ reserved substrate catalog.**
+    Exarchos ships its own \`INV-1..6\` inside the tool, and they merge into every
+    \`invariants_effective\` projection. Authoring into \`dev\` from a consumer repo
+    **collides your \`INV-N\` with exarchos's own** — a silent namespace clash the
+    \`doctor\` check can't catch (it only flags \`INV-*\` in a *user* catalog). Use
+    \`dev\` **only when working inside the exarchos repo itself**. The verbs
+    enforce this: \`invariants_scaffold\` / \`invariants_add\` reject \`tier: dev\`
+    outside the exarchos repo (heuristic: \`package.json\` name ≠
+    \`@lvlup-sw/exarchos\`) with a \`RESERVED_TIER\` error that redirects to \`user\`;
+    a genuine exarchos fork opts in with \`allowReservedTier: true\`.
 
 ### 4. Enforce — DEFAULT \`mode: audit\`, \`mode: check\` is opt-in
 
@@ -14957,6 +15032,7 @@ For one \`U-*\` entry authored end-to-end through all 6 steps, see
 | Skip the dry-run | \`dryRun: true\` first, ALWAYS, then explicit confirm |
 | Silently re-invoke with \`dryRun: false\` | Make the confirmation step explicit |
 | Pick an id by hand | The verb auto-assigns the next free id in the namespace |
+| Author into \`dev\`/\`INV-N\` from a consumer repo | \`dev\` is exarchos's reserved substrate namespace — use \`user\`/\`U-N\` (the verb rejects consumer \`tier: dev\`) |
 | Infer globs from the framework | Ask the author to name the globs (INV-6) |
 | Skip \`doctor\` + \`invariants_effective\` after commit | Verify the resolved catalog and show the delta |
 "
@@ -19755,14 +19831,32 @@ violated?") — that sharpens both the summary and the later enforcement.
 - \`workflow-affinity\`: workflow types (\`feature | debug | refactor | discover |
   oneshot\`). Absent ⇒ all.
 
-### 3. Weight — \`severity\` + \`integrity-class\`
+### 3. Weight — \`severity\`, \`integrity-class\`, and the \`tier\` you author into
 
 - \`severity.default\`: \`blocking\` or \`advisory\`.
 - \`severity.by-workflow\` (optional): downgrade for cheap workflows
   (e.g. \`oneshot: advisory\`).
-- \`integrity-class\`: \`user\` for a consumer-authored entry (the default target).
-  \`dev\` only when the author is a maintainer extending Exarchos's own substrate
-  catalog.
+- \`integrity-class\` (entry field; enum \`substrate | sdlc | authoring | user\`):
+  the entry's **override authority**, not its namespace. For a consumer-authored
+  rule this is \`user\`. (\`substrate\`/\`sdlc\` are exarchos's own classes — you do
+  not author those.)
+- **\`tier\` (the verb arg) picks the catalog _namespace_, and the choice is
+  *exarchos-substrate vs project-authored*, NOT "which developers".** This is the
+  one that bites — get it wrong and you silently collide with exarchos's own ids:
+  - **\`tier: user\` → \`U-N\` ids — your project's own invariants. The default for
+    _everyone_ consuming exarchos.** If you are authoring a rule for your own
+    repo, this is always the answer (even if your project happens to name its
+    rules \`INV-N\` internally — they map to \`U-N\` here).
+  - **\`tier: dev\` → \`INV-N\` ids — exarchos's _own_ reserved substrate catalog.**
+    Exarchos ships its own \`INV-1..6\` inside the tool, and they merge into every
+    \`invariants_effective\` projection. Authoring into \`dev\` from a consumer repo
+    **collides your \`INV-N\` with exarchos's own** — a silent namespace clash the
+    \`doctor\` check can't catch (it only flags \`INV-*\` in a *user* catalog). Use
+    \`dev\` **only when working inside the exarchos repo itself**. The verbs
+    enforce this: \`invariants_scaffold\` / \`invariants_add\` reject \`tier: dev\`
+    outside the exarchos repo (heuristic: \`package.json\` name ≠
+    \`@lvlup-sw/exarchos\`) with a \`RESERVED_TIER\` error that redirects to \`user\`;
+    a genuine exarchos fork opts in with \`allowReservedTier: true\`.
 
 ### 4. Enforce — DEFAULT \`mode: audit\`, \`mode: check\` is opt-in
 
@@ -19866,6 +19960,7 @@ For one \`U-*\` entry authored end-to-end through all 6 steps, see
 | Skip the dry-run | \`dryRun: true\` first, ALWAYS, then explicit confirm |
 | Silently re-invoke with \`dryRun: false\` | Make the confirmation step explicit |
 | Pick an id by hand | The verb auto-assigns the next free id in the namespace |
+| Author into \`dev\`/\`INV-N\` from a consumer repo | \`dev\` is exarchos's reserved substrate namespace — use \`user\`/\`U-N\` (the verb rejects consumer \`tier: dev\`) |
 | Infer globs from the framework | Ask the author to name the globs (INV-6) |
 | Skip \`doctor\` + \`invariants_effective\` after commit | Verify the resolved catalog and show the delta |
 "
@@ -24635,14 +24730,32 @@ violated?") — that sharpens both the summary and the later enforcement.
 - \`workflow-affinity\`: workflow types (\`feature | debug | refactor | discover |
   oneshot\`). Absent ⇒ all.
 
-### 3. Weight — \`severity\` + \`integrity-class\`
+### 3. Weight — \`severity\`, \`integrity-class\`, and the \`tier\` you author into
 
 - \`severity.default\`: \`blocking\` or \`advisory\`.
 - \`severity.by-workflow\` (optional): downgrade for cheap workflows
   (e.g. \`oneshot: advisory\`).
-- \`integrity-class\`: \`user\` for a consumer-authored entry (the default target).
-  \`dev\` only when the author is a maintainer extending Exarchos's own substrate
-  catalog.
+- \`integrity-class\` (entry field; enum \`substrate | sdlc | authoring | user\`):
+  the entry's **override authority**, not its namespace. For a consumer-authored
+  rule this is \`user\`. (\`substrate\`/\`sdlc\` are exarchos's own classes — you do
+  not author those.)
+- **\`tier\` (the verb arg) picks the catalog _namespace_, and the choice is
+  *exarchos-substrate vs project-authored*, NOT "which developers".** This is the
+  one that bites — get it wrong and you silently collide with exarchos's own ids:
+  - **\`tier: user\` → \`U-N\` ids — your project's own invariants. The default for
+    _everyone_ consuming exarchos.** If you are authoring a rule for your own
+    repo, this is always the answer (even if your project happens to name its
+    rules \`INV-N\` internally — they map to \`U-N\` here).
+  - **\`tier: dev\` → \`INV-N\` ids — exarchos's _own_ reserved substrate catalog.**
+    Exarchos ships its own \`INV-1..6\` inside the tool, and they merge into every
+    \`invariants_effective\` projection. Authoring into \`dev\` from a consumer repo
+    **collides your \`INV-N\` with exarchos's own** — a silent namespace clash the
+    \`doctor\` check can't catch (it only flags \`INV-*\` in a *user* catalog). Use
+    \`dev\` **only when working inside the exarchos repo itself**. The verbs
+    enforce this: \`invariants_scaffold\` / \`invariants_add\` reject \`tier: dev\`
+    outside the exarchos repo (heuristic: \`package.json\` name ≠
+    \`@lvlup-sw/exarchos\`) with a \`RESERVED_TIER\` error that redirects to \`user\`;
+    a genuine exarchos fork opts in with \`allowReservedTier: true\`.
 
 ### 4. Enforce — DEFAULT \`mode: audit\`, \`mode: check\` is opt-in
 
@@ -24746,6 +24859,7 @@ For one \`U-*\` entry authored end-to-end through all 6 steps, see
 | Skip the dry-run | \`dryRun: true\` first, ALWAYS, then explicit confirm |
 | Silently re-invoke with \`dryRun: false\` | Make the confirmation step explicit |
 | Pick an id by hand | The verb auto-assigns the next free id in the namespace |
+| Author into \`dev\`/\`INV-N\` from a consumer repo | \`dev\` is exarchos's reserved substrate namespace — use \`user\`/\`U-N\` (the verb rejects consumer \`tier: dev\`) |
 | Infer globs from the framework | Ask the author to name the globs (INV-6) |
 | Skip \`doctor\` + \`invariants_effective\` after commit | Verify the resolved catalog and show the delta |
 "


### PR DESCRIPTION
## Summary

Closes #1489. Authoring an invariant catalog in a **consumer** repo, the `dev`
vs `user` tier choice was genuinely ambiguous: `dev` reads like "for my
project's developers", but it is actually **exarchos's own reserved substrate
namespace**. A consumer who picks `dev` allocates `INV-N` ids that silently
collide with exarchos's built-in `INV-1..6` in the merged `invariants_effective`
projection — and `doctor` can't catch it (it only flags `INV-*` in a *user*
catalog, so a self-declared dev catalog evades the check). The tier choice isn't
"which maintainer", it's **exarchos-substrate vs project-authored** — a framing
the skill never stated and, worse, conflated with the separate `integrity-class`
field.

This makes that distinction loud in both the docs and the verbs.

## Changes

**Guardrail (code)**
- New `servers/exarchos-mcp/src/orchestrate/invariants/reserved-tier-guard.ts`:
  `isExarchosRepo()` (reads `package.json` name) + `assertDevTierAllowed()`.
- `invariants_scaffold` / `invariants_add` now reject `tier: dev` from a
  non-exarchos repo (name ≠ `@lvlup-sw/exarchos`) with an INV-5b carrier-shape
  `RESERVED_TIER` error that redirects to `tier: user`. Fires **before any fs
  write**, regardless of `dryRun`, so a dry-run preview never even renders a
  dev-tier entry. Missing/unparseable `package.json` is treated as not-exarchos.
- New `allowReservedTier?: boolean` override (Zod schema → auto-emits
  `--allow-reserved-tier`) for a genuine exarchos fork.

**Docs reframe**
- `skills-src/authoring-invariants/SKILL.md` step 3: separates `integrity-class`
  (override authority: `substrate|sdlc|authoring|user`) from `tier` (the
  namespace — `user`/`U-N` for every consumer, `dev`/`INV-N` reserved for
  exarchos). New anti-pattern row. Regenerated across 8 runtimes.
- `references/worked-example.md`, `docs/guides/authoring-invariants.md`,
  and the `scaffold.ts` starter-template comment carry the same clarification.

## Test Plan

- New `reserved-tier-guard.test.ts` (10 tests): non-exarchos+dev blocked,
  exarchos+dev allowed, override allowed, `tier: user` always allowed,
  missing/unparseable `package.json` → blocked.
- Extended `scaffold.test.ts` / `add.test.ts` for the blocked-vs-allowed
  dispatch path (guard fires before write; catalog untouched).
- `servers/exarchos-mcp` suite: **7187 passed**, 0 failed.
- Root suite: **770 passed** (skills-render snapshots updated for the 6
  `authoring-invariants` runtime variants).
- `npm run typecheck` clean · `npm run build` clean · `npm run skills:guard`
  exit 0 · `check_static_analysis` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)