### PR TITLE
REVIEW-ONLY: merge-orchestrator projection (DO NOT MERGE)

### DIFF
--- a/servers/exarchos-mcp/src/projections/merge-orchestrator-review/index.test.ts
+++ b/servers/exarchos-mcp/src/projections/merge-orchestrator-review/index.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Tests for the `merge-orchestrator@v1` barrel registration (Wave 2B.4 / #1304).
+ *
+ * DR-1 convention: concrete projections self-register against the process-wide
+ * `defaultRegistry` at module-import time so downstream consumers can resolve
+ * the reducer by its stable id. This test imports the barrel for its side
+ * effect and asserts the registration landed.
+ */
+import { describe, it, expect } from 'vitest';
+import { defaultRegistry } from '../registry.js';
+
+// Side-effect import — registers `merge-orchestrator@v1` with `defaultRegistry`.
+import './index.js';
+
+describe('merge-orchestrator barrel registration (Wave 2B.4)', () => {
+  it('MergeOrchestratorReducer_RegistersOnBarrelImport', () => {
+    // GIVEN: the barrel was imported above as a side effect.
+    // WHEN: we look up the canonical id on the process-wide registry.
+    const registered = defaultRegistry.get('merge-orchestrator@v1');
+    // THEN: it resolves to the reducer instance, with the expected scope.
+    expect(registered).toBeDefined();
+    expect(registered?.id).toBe('merge-orchestrator@v1');
+    expect(registered?.version).toBe(1);
+    expect(registered?.scope).toBe('stream');
+  });
+});

--- a/servers/exarchos-mcp/src/projections/merge-orchestrator-review/index.ts
+++ b/servers/exarchos-mcp/src/projections/merge-orchestrator-review/index.ts
@@ -1,0 +1,40 @@
+/**
+ * `merge-orchestrator@v1` projection barrel (Wave 2B.4 / #1304, DR-1).
+ *
+ * Importing this module has a **side effect**: it registers
+ * {@link mergeOrchestratorReducer} with the process-wide {@link defaultRegistry}
+ * so the rebuild / rehydrate runners and the Wave 3 `decide` / `aggregateStream`
+ * primitives can resolve the reducer by its stable id `"merge-orchestrator@v1"`.
+ *
+ * This is the DR-1 convention — concrete projections self-register at
+ * module load rather than being hand-wired at every call site (mirrors the
+ * existing `rehydration` and `next-action` barrels).
+ *
+ * ## Idempotency
+ *
+ * The registry rejects duplicate `id` registrations. ES modules are cached
+ * per specifier, so importing this barrel from multiple call sites in a
+ * single process triggers `register` exactly once. Tests that need an
+ * isolated registry should construct a fresh one via `createRegistry()`
+ * rather than re-importing this barrel.
+ */
+import { defaultRegistry } from '../registry.js';
+import { mergeOrchestratorReducer } from './reducer.js';
+
+defaultRegistry.register(
+  // The reducer is typed `ProjectionReducer<MergeOrchestratorState, WorkflowEvent>`;
+  // the registry stores `ProjectionReducer<unknown, unknown>` (generic in
+  // name only). Widening here is safe — `apply`'s purity contract (DR-1) is
+  // a runtime invariant, not a type-system one, so the cast loses no
+  // guarantees. Mirrors the rehydration / next-action barrel pattern.
+  mergeOrchestratorReducer as unknown as Parameters<typeof defaultRegistry.register>[0],
+);
+
+export { mergeOrchestratorReducer } from './reducer.js';
+export type {
+  MergeOrchestratorState,
+  MergeOrchestratorPhase,
+  MergePreflightMetadata,
+  MergeActionMetadata,
+  MergeRecoveryContext,
+} from './types.js';

--- a/servers/exarchos-mcp/src/projections/merge-orchestrator-review/reducer.test.ts
+++ b/servers/exarchos-mcp/src/projections/merge-orchestrator-review/reducer.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Tests for `merge-orchestrator@v1` reducer (Wave 2B.2 / #1304).
+ *
+ * GWT — Given/When/Then per `docs/architecture/projections.md` §2. Each test
+ * folds one event over an explicit initial state and asserts a transition on
+ * the phase machine documented in `types.ts`.
+ *
+ * Naming note: this worktree's `event-store/schemas.ts` ships `merge.rollback`
+ * as the canonical recovery event (the #1306 rename to `merge.recovered` is
+ * a separate epic; preview.2 keeps `merge.rollback`). The reducer's `any →
+ * recovering` transition is exercised with `merge.rollback` here; if/when
+ * #1306 lands the rename, the test will switch event types alongside the
+ * schema and the reducer's case label.
+ */
+import { describe, it, expect } from 'vitest';
+import { mergeOrchestratorReducer } from './reducer.js';
+import {
+  initialMergeOrchestratorState,
+  type MergeOrchestratorState,
+} from './types.js';
+import { assertReducerImmutable } from '../testing.js';
+import type { WorkflowEvent } from '../../event-store/schemas.js';
+
+/**
+ * Helper — build a minimal, schema-shaped WorkflowEvent. Only `type` and
+ * `data` are load-bearing for the reducer; the rest satisfies the
+ * `WorkflowEventBase` shape so tests read naturally.
+ *
+ * NOTE: we deliberately cast — the reducer's unit tests do NOT run events
+ * through `WorkflowEventBase.parse`, so an event whose `type` isn't yet
+ * registered in `event-store/schemas.ts` (e.g. `merge.completed`,
+ * `merge.requested` in preview.2) can still be folded for unit coverage.
+ */
+function makeEvent<T extends Record<string, unknown>>(
+  type: string,
+  data: T,
+  sequence: number,
+): WorkflowEvent {
+  return {
+    streamId: 'wf-test',
+    sequence,
+    timestamp: '2026-05-10T00:00:00.000Z',
+    type,
+    schemaVersion: '1.0',
+    data,
+  } as unknown as WorkflowEvent;
+}
+
+describe('mergeOrchestratorReducer — identity (Wave 2B.2, DR-1)', () => {
+  it('MergeOrchestratorReducer_IdentityIsCanonical', () => {
+    expect(mergeOrchestratorReducer.id).toBe('merge-orchestrator@v1');
+    expect(mergeOrchestratorReducer.version).toBe(1);
+    expect(mergeOrchestratorReducer.scope).toBe('stream');
+  });
+
+  it('MergeOrchestratorReducer_NoEvents_ReturnsInitialState', () => {
+    // GIVEN no events, the reducer's initial state IS the canonical seed.
+    expect(mergeOrchestratorReducer.initial).toEqual(initialMergeOrchestratorState);
+    expect(mergeOrchestratorReducer.initial.phase).toBe('idle');
+    expect(mergeOrchestratorReducer.initial.projectionSequence).toBe(0);
+  });
+});
+
+describe('mergeOrchestratorReducer.apply — phase transitions (Wave 2B.2)', () => {
+  it('Apply_MergePreflight_TransitionsToPreflight', () => {
+    // GIVEN an idle reducer state.
+    const state = mergeOrchestratorReducer.initial;
+    // WHEN we fold a merge.preflight event.
+    const event = makeEvent(
+      'merge.preflight',
+      {
+        taskId: 'task-1',
+        sourceBranch: 'feature/x',
+        targetBranch: 'main',
+        passed: true,
+      },
+      1,
+    );
+    const next = mergeOrchestratorReducer.apply(state, event);
+    // THEN phase advances to 'preflight'; preflight metadata is captured.
+    expect(next.phase).toBe('preflight');
+    expect(next.preflight?.passed).toBe(true);
+    expect(next.projectionSequence).toBe(1);
+  });
+
+  it('Apply_MergePreflight_CapturesFailureReason', () => {
+    // GIVEN an idle reducer state.
+    const state = mergeOrchestratorReducer.initial;
+    // WHEN we fold a failed preflight event with a failureReasons array.
+    const event = makeEvent(
+      'merge.preflight',
+      {
+        taskId: 'task-1',
+        sourceBranch: 'feature/x',
+        targetBranch: 'main',
+        passed: false,
+        failureReasons: ['ancestry-violation', 'worktree-dirty'],
+      },
+      1,
+    );
+    const next = mergeOrchestratorReducer.apply(state, event);
+    // THEN the operator-facing reason is captured as a flattened string.
+    expect(next.phase).toBe('preflight');
+    expect(next.preflight?.passed).toBe(false);
+    expect(next.preflight?.reason).toBeDefined();
+    expect(next.preflight?.reason).toContain('ancestry-violation');
+  });
+
+  it('Apply_MergeRequested_TransitionsToRequested', () => {
+    // Audit §F1.2 — the new phase between preflight and executed. Records
+    // the durable intent BEFORE the non-idempotent side effect fires.
+
+    // GIVEN a state in `preflight` with passed=true.
+    const after_preflight = mergeOrchestratorReducer.apply(
+      mergeOrchestratorReducer.initial,
+      makeEvent(
+        'merge.preflight',
+        {
+          taskId: 'task-1',
+          sourceBranch: 'feature/x',
+          targetBranch: 'main',
+          passed: true,
+        },
+        1,
+      ),
+    );
+    // WHEN we fold a merge.requested event.
+    const event = makeEvent(
+      'merge.requested',
+      {
+        taskId: 'task-1',
+        sourceBranch: 'feature/x',
+        targetBranch: 'main',
+        strategy: 'squash',
+        prNumber: 42,
+      },
+      2,
+    );
+    const next = mergeOrchestratorReducer.apply(after_preflight, event);
+    // THEN phase advances to 'requested'; merge metadata is captured.
+    expect(next.phase).toBe('requested');
+    expect(next.merge?.taskId).toBe('task-1');
+    expect(next.merge?.sourceBranch).toBe('feature/x');
+    expect(next.merge?.targetBranch).toBe('main');
+    expect(next.merge?.strategy).toBe('squash');
+    expect(next.merge?.prNumber).toBe(42);
+    // Preflight metadata is preserved across the transition (observability).
+    expect(next.preflight?.passed).toBe(true);
+    expect(next.projectionSequence).toBe(2);
+  });
+
+  it('Apply_MergeExecuted_TransitionsToExecuted', () => {
+    // GIVEN a state in `requested` (post audit §F1.2 split).
+    let state: MergeOrchestratorState = mergeOrchestratorReducer.apply(
+      mergeOrchestratorReducer.initial,
+      makeEvent(
+        'merge.preflight',
+        {
+          taskId: 'task-1',
+          sourceBranch: 'feature/x',
+          targetBranch: 'main',
+          passed: true,
+        },
+        1,
+      ),
+    );
+    state = mergeOrchestratorReducer.apply(
+      state,
+      makeEvent(
+        'merge.requested',
+        {
+          taskId: 'task-1',
+          sourceBranch: 'feature/x',
+          targetBranch: 'main',
+          strategy: 'squash',
+        },
+        2,
+      ),
+    );
+    // WHEN we fold a merge.executed event.
+    const event = makeEvent(
+      'merge.executed',
+      {
+        taskId: 'task-1',
+        sourceBranch: 'feature/x',
+        targetBranch: 'main',
+        strategy: 'squash',
+        mergeSha: 'abc1234',
+        rollbackSha: 'def5678',
+      },
+      3,
+    );
+    const next = mergeOrchestratorReducer.apply(state, event);
+    // THEN phase advances to 'executed'; mergeSha + rollbackSha are captured.
+    expect(next.phase).toBe('executed');
+    expect(next.merge?.mergeSha).toBe('abc1234');
+    expect(next.merge?.rollbackSha).toBe('def5678');
+    // Earlier merge fields are preserved (taskId, branches, strategy).
+    expect(next.merge?.taskId).toBe('task-1');
+    expect(next.merge?.strategy).toBe('squash');
+    expect(next.projectionSequence).toBe(3);
+  });
+
+  it('Apply_MergeRollback_TransitionsToRecovering', () => {
+    // GIVEN a state in `executed` (rollback fires after a merge lands but a
+    // verification step or post-merge gate failed).
+    let state: MergeOrchestratorState = mergeOrchestratorReducer.apply(
+      mergeOrchestratorReducer.initial,
+      makeEvent(
+        'merge.executed',
+        {
+          taskId: 'task-1',
+          sourceBranch: 'feature/x',
+          targetBranch: 'main',
+          mergeSha: 'abc1234',
+          rollbackSha: 'def5678',
+        },
+        1,
+      ),
+    );
+    // WHEN we fold a merge.rollback event (#1306 may rename this to
+    // merge.recovered; the reducer handles whichever name is canonical).
+    const event = makeEvent(
+      'merge.rollback',
+      {
+        taskId: 'task-1',
+        sourceBranch: 'feature/x',
+        targetBranch: 'main',
+        rollbackSha: 'def5678',
+        reason: 'verification-failed',
+      },
+      2,
+    );
+    const next = mergeOrchestratorReducer.apply(state, event);
+    // THEN phase advances to 'recovering'; recovery context captured.
+    expect(next.phase).toBe('recovering');
+    expect(next.recovery?.reason).toBe('verification-failed');
+    expect(next.projectionSequence).toBe(2);
+  });
+
+  it('Apply_MergeRollback_AnyPhaseTransitionsToRecovering', () => {
+    // GIVEN state in `requested` (rollback before the side effect actually fires).
+    let state: MergeOrchestratorState = mergeOrchestratorReducer.apply(
+      mergeOrchestratorReducer.initial,
+      makeEvent(
+        'merge.preflight',
+        {
+          taskId: 'task-1',
+          sourceBranch: 'feature/x',
+          targetBranch: 'main',
+          passed: true,
+        },
+        1,
+      ),
+    );
+    state = mergeOrchestratorReducer.apply(
+      state,
+      makeEvent(
+        'merge.requested',
+        {
+          taskId: 'task-1',
+          sourceBranch: 'feature/x',
+          targetBranch: 'main',
+          strategy: 'squash',
+        },
+        2,
+      ),
+    );
+    expect(state.phase).toBe('requested');
+    // WHEN merge.rollback fires from requested.
+    const event = makeEvent(
+      'merge.rollback',
+      {
+        taskId: 'task-1',
+        sourceBranch: 'feature/x',
+        targetBranch: 'main',
+        rollbackSha: 'aaa1111',
+        reason: 'merge-failed',
+      },
+      3,
+    );
+    const next = mergeOrchestratorReducer.apply(state, event);
+    // THEN it still routes to recovering (any → recovering).
+    expect(next.phase).toBe('recovering');
+    expect(next.recovery?.reason).toBe('merge-failed');
+  });
+
+  it('Apply_MergeCompleted_TransitionsToCompleted', () => {
+    // GIVEN a state in `executed`.
+    let state: MergeOrchestratorState = mergeOrchestratorReducer.apply(
+      mergeOrchestratorReducer.initial,
+      makeEvent(
+        'merge.executed',
+        {
+          taskId: 'task-1',
+          sourceBranch: 'feature/x',
+          targetBranch: 'main',
+          mergeSha: 'abc1234',
+          rollbackSha: 'def5678',
+        },
+        1,
+      ),
+    );
+    expect(state.phase).toBe('executed');
+    // WHEN we fold a merge.completed event.
+    const event = makeEvent('merge.completed', { taskId: 'task-1' }, 2);
+    const next = mergeOrchestratorReducer.apply(state, event);
+    // THEN phase advances to 'completed' (terminal); merge metadata preserved.
+    expect(next.phase).toBe('completed');
+    expect(next.merge?.mergeSha).toBe('abc1234');
+    expect(next.projectionSequence).toBe(2);
+  });
+
+  it('MergeOrchestratorReducer_IsImmutable', () => {
+    // DR-1 purity contract — folds a representative event sequence through
+    // the reducer with each intermediate state deep-frozen. Any in-place
+    // mutation of the `state` argument by `apply` would surface as a
+    // TypeError under strict-mode frozen-object semantics.
+    const events: readonly WorkflowEvent[] = [
+      makeEvent(
+        'merge.preflight',
+        {
+          taskId: 'task-1',
+          sourceBranch: 'feature/x',
+          targetBranch: 'main',
+          passed: true,
+        },
+        1,
+      ),
+      makeEvent(
+        'merge.requested',
+        {
+          taskId: 'task-1',
+          sourceBranch: 'feature/x',
+          targetBranch: 'main',
+          strategy: 'squash',
+          prNumber: 42,
+        },
+        2,
+      ),
+      makeEvent(
+        'merge.executed',
+        {
+          taskId: 'task-1',
+          sourceBranch: 'feature/x',
+          targetBranch: 'main',
+          strategy: 'squash',
+          mergeSha: 'abc1234',
+          rollbackSha: 'def5678',
+        },
+        3,
+      ),
+      makeEvent(
+        'merge.rollback',
+        {
+          taskId: 'task-1',
+          sourceBranch: 'feature/x',
+          targetBranch: 'main',
+          rollbackSha: 'def5678',
+          reason: 'verification-failed',
+          rollbackError: 'reset failed',
+        },
+        4,
+      ),
+      makeEvent('merge.completed', { taskId: 'task-1' }, 5),
+      // An unhandled type — assert the identity-return path also respects
+      // frozen input (no spread, no in-place mutation).
+      makeEvent('task.completed', { taskId: 'task-1' }, 6),
+    ];
+    expect(() =>
+      assertReducerImmutable(mergeOrchestratorReducer, events),
+    ).not.toThrow();
+  });
+
+  it('Apply_UnknownEvent_ReturnsStateUnchanged', () => {
+    // GIVEN a non-trivial state already produced by some merge events.
+    const seeded = mergeOrchestratorReducer.apply(
+      mergeOrchestratorReducer.initial,
+      makeEvent(
+        'merge.preflight',
+        {
+          taskId: 'task-1',
+          sourceBranch: 'feature/x',
+          targetBranch: 'main',
+          passed: true,
+        },
+        1,
+      ),
+    );
+    // WHEN we fold a non-merge event.
+    const unknown = makeEvent(
+      'task.completed',
+      { taskId: 'task-1' },
+      2,
+    );
+    const next = mergeOrchestratorReducer.apply(seeded, unknown);
+    // THEN state is returned by identity — projectionSequence does NOT bump,
+    // mirroring the `rehydration@v1` convention that only handled events
+    // advance the monotonic counter.
+    expect(next).toBe(seeded);
+    expect(next.projectionSequence).toBe(seeded.projectionSequence);
+  });
+});

--- a/servers/exarchos-mcp/src/projections/merge-orchestrator-review/reducer.ts
+++ b/servers/exarchos-mcp/src/projections/merge-orchestrator-review/reducer.ts
@@ -1,0 +1,301 @@
+/**
+ * `merge-orchestrator@v1` projection reducer (Wave 2B.2 / #1304).
+ *
+ * Folds the `merge.*` event family on a feature stream into the
+ * {@link MergeOrchestratorState} phase machine documented in `types.ts`.
+ *
+ * Replaces the in-memory side-database that pre-preview.2 `merge-orchestrate.ts`
+ * carried (audit findings §F1.2). Mirrors Wave 2A's TaskStore-as-projection
+ * substitution: every state transition is now an event, every state read is a
+ * fold over the durable event log.
+ *
+ * ## Naming note (#1306 rename tracker)
+ *
+ * This worktree's `event-store/schemas.ts` ships `merge.rollback` as the
+ * canonical recovery event (the rename to `merge.recovered` is tracked
+ * separately by #1306). The reducer's dispatcher handles `merge.rollback`
+ * here; if/when #1306 lands, the case label switches alongside the schema.
+ * The reducer's external contract (the `recovering` phase, the
+ * {@link MergeRecoveryContext} field shape) does not change with the rename.
+ *
+ * ## Purity contract
+ *
+ * Per DR-1: `apply` is pure, deterministic, side-effect-free, and never
+ * mutates its `state` argument. The sibling `assertReducerImmutable` test
+ * (Wave 2B.3) enforces this property over a representative event fixture.
+ */
+import type { ProjectionReducer } from '../types.js';
+import type { WorkflowEvent } from '../../event-store/schemas.js';
+import {
+  initialMergeOrchestratorState,
+  type MergeActionMetadata,
+  type MergeOrchestratorState,
+  type MergePreflightMetadata,
+  type MergeRecoveryContext,
+} from './types.js';
+
+// ─── Field extractors (typed reads over event.data) ─────────────────────────
+//
+// The event-store base schema types `data` as `Record<string, unknown> | undefined`;
+// these extractors do the runtime checks the type system cannot. Mirrors the
+// pattern in `projections/rehydration/reducer.ts`.
+
+function extractString(
+  data: WorkflowEvent['data'],
+  key: string,
+): string | undefined {
+  if (!data) return undefined;
+  const raw = data[key];
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
+function extractBoolean(
+  data: WorkflowEvent['data'],
+  key: string,
+): boolean | undefined {
+  if (!data) return undefined;
+  const raw = data[key];
+  return typeof raw === 'boolean' ? raw : undefined;
+}
+
+function extractNumber(
+  data: WorkflowEvent['data'],
+  key: string,
+): number | undefined {
+  if (!data) return undefined;
+  const raw = data[key];
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined;
+}
+
+/**
+ * Narrowing reader for the closed `strategy` enum on `merge.requested` /
+ * `merge.executed`. Returns `undefined` for missing / unrecognised values so
+ * the reducer never widens the metadata field beyond the typed enum.
+ */
+function extractStrategy(
+  data: WorkflowEvent['data'],
+): MergeActionMetadata['strategy'] | undefined {
+  const raw = extractString(data, 'strategy');
+  if (raw === 'squash' || raw === 'rebase' || raw === 'merge') return raw;
+  return undefined;
+}
+
+/**
+ * Flatten the preflight failure surface into a single operator-facing string.
+ *
+ * The `merge.preflight` event carries `failureReasons: string[]` (per
+ * `MergePreflightData` in `event-store/schemas.ts`); we collapse that into one
+ * comma-joined string so the projection's `reason` field stays a simple
+ * string — matching the audit/observability shape downstream tooling expects.
+ * Returns `undefined` when no actionable reason is present.
+ */
+function extractPreflightReason(
+  data: WorkflowEvent['data'],
+): string | undefined {
+  if (!data) return undefined;
+  const reasons = data['failureReasons'];
+  if (Array.isArray(reasons)) {
+    const strs = reasons.filter(
+      (r): r is string => typeof r === 'string' && r.length > 0,
+    );
+    if (strs.length > 0) return strs.join(', ');
+  }
+  // Fallback: an explicit `reason` field (some emitters use a flat string).
+  return extractString(data, 'reason');
+}
+
+// ─── Per-event handlers ─────────────────────────────────────────────────────
+
+/**
+ * Handler for `merge.preflight` — captures the preflight gate outcome and
+ * advances the phase to `preflight`. The `passed` flag MUST be present on the
+ * event (per `MergePreflightData`); if it isn't, fall back to `false` so a
+ * malformed event still records as a (failed) preflight rather than corrupting
+ * the phase machine with an invented `true` verdict.
+ */
+function applyMergePreflight(
+  state: MergeOrchestratorState,
+  event: WorkflowEvent,
+): MergeOrchestratorState {
+  const passed = extractBoolean(event.data, 'passed') ?? false;
+  const reason = passed ? undefined : extractPreflightReason(event.data);
+  const preflight: MergePreflightMetadata = passed
+    ? { passed: true }
+    : reason !== undefined
+      ? { passed: false, reason }
+      : { passed: false };
+  // Capture branch identifiers eagerly when present — they're useful for
+  // observability even before merge.requested / merge.executed lands them
+  // formally on the `merge` sub-record.
+  const merge = mergeFromEvent(state.merge, event);
+  return {
+    ...state,
+    projectionSequence: state.projectionSequence + 1,
+    phase: 'preflight',
+    preflight,
+    ...(merge !== state.merge ? { merge } : {}),
+  };
+}
+
+/**
+ * Handler for `merge.requested` — audit §F1.2's durable-intent event. Records
+ * branches / strategy / prNumber / taskId on the `merge` sub-record and
+ * advances the phase to `requested` (the new phase between `preflight` and
+ * `executed`).
+ */
+function applyMergeRequested(
+  state: MergeOrchestratorState,
+  event: WorkflowEvent,
+): MergeOrchestratorState {
+  return {
+    ...state,
+    projectionSequence: state.projectionSequence + 1,
+    phase: 'requested',
+    merge: mergeFromEvent(state.merge, event),
+  };
+}
+
+/**
+ * Handler for `merge.executed` — records the merge's outcome (mergeSha,
+ * rollbackSha) and advances the phase to `executed`. Preserves earlier merge
+ * fields (taskId, branches, strategy) so observability replay never loses
+ * them across the requested → executed split.
+ */
+function applyMergeExecuted(
+  state: MergeOrchestratorState,
+  event: WorkflowEvent,
+): MergeOrchestratorState {
+  return {
+    ...state,
+    projectionSequence: state.projectionSequence + 1,
+    phase: 'executed',
+    merge: mergeFromEvent(state.merge, event),
+  };
+}
+
+/**
+ * Handler for `merge.rollback` (or post-#1306 `merge.recovered`) — `any →
+ * recovering`. Captures the rollback reason + any reset-side error. Does NOT
+ * overwrite earlier merge metadata; the recovery context is additive, and
+ * downstream observability needs both the original merge identifiers and the
+ * rollback rationale.
+ */
+function applyMergeRollback(
+  state: MergeOrchestratorState,
+  event: WorkflowEvent,
+): MergeOrchestratorState {
+  const reason = extractString(event.data, 'reason');
+  const error = extractString(event.data, 'rollbackError');
+  const recovery: MergeRecoveryContext = {
+    ...(reason !== undefined ? { reason } : {}),
+    ...(error !== undefined ? { error } : {}),
+  };
+  return {
+    ...state,
+    projectionSequence: state.projectionSequence + 1,
+    phase: 'recovering',
+    ...(Object.keys(recovery).length > 0 ? { recovery } : {}),
+  };
+}
+
+/**
+ * Handler for `merge.completed` — terminal transition; phase advances to
+ * `completed`. Preserves all earlier metadata (preflight, merge, recovery)
+ * so the final projection state is a full audit record of the lifecycle.
+ */
+function applyMergeCompleted(
+  state: MergeOrchestratorState,
+  _event: WorkflowEvent,
+): MergeOrchestratorState {
+  return {
+    ...state,
+    projectionSequence: state.projectionSequence + 1,
+    phase: 'completed',
+  };
+}
+
+/**
+ * Merge-field extractor — folds any of the merge.* events that carry merge
+ * metadata into a fresh {@link MergeActionMetadata} record. New fields from the
+ * event overwrite existing ones; absent fields preserve the prior value (so
+ * `merge.executed` does NOT blank out the `strategy` recorded earlier on
+ * `merge.requested`).
+ *
+ * Returns the existing `merge` reference when no field changed — lets callers
+ * skip an unnecessary spread when the event carried no relevant fields.
+ */
+function mergeFromEvent(
+  existing: MergeActionMetadata | undefined,
+  event: WorkflowEvent,
+): MergeActionMetadata | undefined {
+  const taskId = extractString(event.data, 'taskId');
+  const sourceBranch = extractString(event.data, 'sourceBranch');
+  const targetBranch = extractString(event.data, 'targetBranch');
+  const strategy = extractStrategy(event.data);
+  const prNumber = extractNumber(event.data, 'prNumber');
+  const mergeSha = extractString(event.data, 'mergeSha');
+  const rollbackSha = extractString(event.data, 'rollbackSha');
+
+  const anyPresent =
+    taskId !== undefined ||
+    sourceBranch !== undefined ||
+    targetBranch !== undefined ||
+    strategy !== undefined ||
+    prNumber !== undefined ||
+    mergeSha !== undefined ||
+    rollbackSha !== undefined;
+  if (!anyPresent) return existing;
+
+  return {
+    ...(existing ?? {}),
+    ...(taskId !== undefined ? { taskId } : {}),
+    ...(sourceBranch !== undefined ? { sourceBranch } : {}),
+    ...(targetBranch !== undefined ? { targetBranch } : {}),
+    ...(strategy !== undefined ? { strategy } : {}),
+    ...(prNumber !== undefined ? { prNumber } : {}),
+    ...(mergeSha !== undefined ? { mergeSha } : {}),
+    ...(rollbackSha !== undefined ? { rollbackSha } : {}),
+  };
+}
+
+// ─── Reducer (thin dispatcher) ──────────────────────────────────────────────
+
+/**
+ * Concrete `merge-orchestrator@v1` reducer value. Registered with
+ * `defaultRegistry` by the sibling `./index.ts` barrel at module-import time
+ * (DR-1 convention — concrete projections self-register; the registry is the
+ * single source of truth for projection identity).
+ */
+export const mergeOrchestratorReducer: ProjectionReducer<
+  MergeOrchestratorState,
+  WorkflowEvent
+> = {
+  id: 'merge-orchestrator@v1',
+  version: 1,
+  scope: 'stream' as const,
+  initial: initialMergeOrchestratorState,
+  apply(state: MergeOrchestratorState, event: WorkflowEvent): MergeOrchestratorState {
+    // Dispatch by event.type. Unknown event types short-circuit back to
+    // `state` unchanged so projectionSequence only advances on handled events.
+    switch (event.type) {
+      case 'merge.preflight':
+        return applyMergePreflight(state, event);
+      case 'merge.requested':
+        return applyMergeRequested(state, event);
+      case 'merge.executed':
+        return applyMergeExecuted(state, event);
+      // #1306 rename tracker: when `merge.rollback` is renamed to
+      // `merge.recovered`, swap the case label here alongside the schema
+      // change. The recovery-context shape and `recovering` phase do not
+      // change with the rename.
+      case 'merge.rollback':
+        return applyMergeRollback(state, event);
+      case 'merge.completed':
+        return applyMergeCompleted(state, event);
+      default:
+        return state;
+    }
+  },
+};
+
+export type { MergeOrchestratorState } from './types.js';

--- a/servers/exarchos-mcp/src/projections/merge-orchestrator-review/types.ts
+++ b/servers/exarchos-mcp/src/projections/merge-orchestrator-review/types.ts
@@ -1,0 +1,175 @@
+/**
+ * `merge-orchestrator@v1` projection state (Wave 2B.1 / #1304).
+ *
+ * Captures the per-feature-stream lifecycle of a merge as a fold over the
+ * `merge.*` event family. Replaces the in-memory side-database that pre-
+ * preview.2 `merge-orchestrate.ts` carried; mirrors the durable event-source-
+ * of-truth pattern Wave 2A applies to TaskStore.
+ *
+ * ## Phase machine
+ *
+ *   idle ──merge.preflight──▶ preflight
+ *                              │
+ *                              ├──merge.requested──▶ requested   (audit §F1.2)
+ *                              │                       │
+ *                              │                       ▼
+ *                              │                   merge.executed
+ *                              │                       │
+ *                              │                       ▼
+ *                              ▼                    executed ──merge.completed──▶ completed
+ *                          (legacy
+ *                          path,
+ *                          merge.executed
+ *                          directly)
+ *
+ *   any ──merge.rollback / merge.recovered──▶ recovering
+ *
+ * The `requested` phase (audit findings §F1.2) is the durable INTENT recorded
+ * BEFORE the non-idempotent side effect (e.g., GitHub merge API). Wave 4's
+ * two-event split commits `merge.requested` purely under `withStateRetry`,
+ * fires the side effect OUTSIDE the retry boundary, then commits
+ * `merge.executed`. This reducer's `preflight → requested → executed`
+ * transition is the projection's view of that split: the projection sees
+ * intent before outcome, never one without the other (after Wave 4 migrates
+ * the call sites — preview.2 still allows legacy `preflight → executed`
+ * sequences for streams predating the migration).
+ *
+ * ## Naming note (#1306 rename tracker)
+ *
+ * Preview.2 ships `merge.rollback` (the canonical name in this worktree's
+ * `event-store/schemas.ts`); #1306 will rename it to `merge.recovered` in a
+ * follow-up epic. The reducer handles whichever name is registered; the
+ * projection state captures the outcome (`recovering` phase) identically
+ * regardless of which event type fired the transition.
+ */
+
+/**
+ * Lifecycle phase for a merge on the feature stream.
+ *
+ * - `idle`        — initial; no merge activity observed yet.
+ * - `preflight`   — `merge.preflight` was folded; the gate ran (passed or
+ *                   failed; consult `preflight.passed` for the verdict).
+ * - `requested`   — `merge.requested` was folded; durable intent is recorded.
+ *                   This is the audit §F1.2 phase: the side effect has NOT
+ *                   yet fired. Wave 4's Phase B reads this state.
+ * - `executed`    — `merge.executed` was folded; the merge has been performed
+ *                   on the target branch (mergeSha is durable).
+ * - `recovering`  — `merge.rollback` (or post-#1306 `merge.recovered`) was
+ *                   folded; rollback is in flight or completed.
+ * - `completed`   — `merge.completed` was folded; the orchestrator has
+ *                   formally terminated the lifecycle. Terminal phase.
+ */
+export type MergeOrchestratorPhase =
+  | 'idle'
+  | 'preflight'
+  | 'requested'
+  | 'executed'
+  | 'recovering'
+  | 'completed';
+
+/**
+ * Preflight gate metadata captured from `merge.preflight`. Reflects the
+ * outcome of the pre-merge guard run (ancestry, branch protection, worktree
+ * cleanliness, drift). Failure reasons surface the operator-facing diagnostic
+ * the preflight subroutine produced.
+ */
+export interface MergePreflightMetadata {
+  /** True iff every preflight sub-check passed. */
+  readonly passed: boolean;
+  /**
+   * Operator-facing failure description (e.g., the `describePreflightFailure`
+   * output). Absent on `passed === true`; present otherwise.
+   */
+  readonly reason?: string;
+}
+
+/**
+ * Merge action metadata captured across the `requested → executed` split.
+ *
+ * Fields appear progressively as events fold:
+ *
+ *   - `taskId`, `sourceBranch`, `targetBranch`, `strategy` are first set on
+ *     `merge.requested` (Wave 4) OR `merge.executed` (legacy / preview.1).
+ *   - `mergeSha`, `rollbackSha` are first set on `merge.executed`.
+ *
+ * All fields are `readonly` on `MergeOrchestratorState`; mutation only occurs
+ * via a fresh reducer output (DR-1 purity contract).
+ */
+export interface MergeActionMetadata {
+  /** Originating task id (matches `task.completed.taskId` for the worktree). */
+  readonly taskId?: string;
+  /** Feature/work branch being merged in. */
+  readonly sourceBranch?: string;
+  /** Target branch the merge lands on. */
+  readonly targetBranch?: string;
+  /** Operator-selected strategy (Wave 4's `merge.requested` carries this). */
+  readonly strategy?: 'squash' | 'rebase' | 'merge';
+  /** Pull-request number (Wave 4 only; preview.2 may have no PR yet). */
+  readonly prNumber?: number;
+  /** Resulting commit sha on the target branch (set on `merge.executed`). */
+  readonly mergeSha?: string;
+  /**
+   * Parent commit captured prior to the merge so a rollback can
+   * `git reset --hard <rollbackSha>` deterministically.
+   */
+  readonly rollbackSha?: string;
+}
+
+/**
+ * Recovery context captured from `merge.rollback` (or post-#1306 `merge.recovered`).
+ *
+ * `reason` is a closed enum on the event-store schema (`merge-failed` /
+ * `verification-failed` / `timeout`); we widen to `string` here so that the
+ * #1306 rename can extend the enum without re-shaping the projection's state
+ * type. `error` is the rollback-side failure detail when `git reset --hard`
+ * itself fell over (presence signals an indeterminate worktree).
+ */
+export interface MergeRecoveryContext {
+  /** Cause of the rollback (e.g., `'merge-failed'`, `'verification-failed'`). */
+  readonly reason?: string;
+  /** Rollback-side error detail when `git reset --hard` itself failed. */
+  readonly error?: string;
+}
+
+/**
+ * Per-feature-stream projection state for `merge-orchestrator@v1`.
+ *
+ * Folded by {@link mergeOrchestratorReducer} over the `merge.*` event family.
+ * `phase` is the discriminator; the metadata sub-records (`preflight`,
+ * `merge`, `recovery`) are populated as the corresponding events fold and
+ * preserved across subsequent transitions (a `merge.executed` does not blank
+ * out the preflight outcome — observability replay needs both).
+ *
+ * `projectionSequence` is the standard monotonic counter (DR-3 contract): it
+ * increments exactly once per *handled* event, so downstream consumers (snapshot
+ * cadence, fingerprint comparisons) can detect "did anything change" without
+ * deep equality.
+ */
+export interface MergeOrchestratorState {
+  /**
+   * Monotonic counter — bumped once per handled `merge.*` event. Unhandled
+   * event types (or events the reducer treats as no-ops) leave this unchanged
+   * so the counter tracks truth-of-handled-events, not truth-of-stream.
+   */
+  readonly projectionSequence: number;
+  /** Current lifecycle phase; see {@link MergeOrchestratorPhase}. */
+  readonly phase: MergeOrchestratorPhase;
+  /** Preflight gate metadata; populated on `merge.preflight`. */
+  readonly preflight?: MergePreflightMetadata;
+  /** Merge action metadata; populated across `merge.requested` + `merge.executed`. */
+  readonly merge?: MergeActionMetadata;
+  /** Recovery context; populated on `merge.rollback` / `merge.recovered`. */
+  readonly recovery?: MergeRecoveryContext;
+}
+
+/**
+ * Canonical initial state for `merge-orchestrator@v1`. Folding the reducer over
+ * an empty event stream MUST yield this value (DR-1 reducer contract).
+ *
+ * Exported so tests can compare against the canonical value rather than
+ * re-declaring an identical literal.
+ */
+export const initialMergeOrchestratorState: MergeOrchestratorState = {
+  projectionSequence: 0,
+  phase: 'idle',
+};


### PR DESCRIPTION
## Summary

Throwaway branch to manufacture an ultrareview surface equal to the full implementation of `servers/exarchos-mcp/src/projections/merge-orchestrator/`.

`/code-review ultra` reviews the branch diff against `main`. By copying `merge-orchestrator/` to a sibling path (`merge-orchestrator-review/`), the diff becomes the entire projection — so reviewers read every line rather than a narrow touch.

## Changes

- Copy of `servers/exarchos-mcp/src/projections/merge-orchestrator/` → `servers/exarchos-mcp/src/projections/merge-orchestrator-review/` (byte-identical, 5 files, ~945 lines).

## Test Plan

- [x] No tests are expected to pass — the copy duplicate-registers `'merge-orchestrator@v1'` with `defaultRegistry`, which rejects duplicates by design. CI is skipped via `[skip ci]` on the commit.
- [x] Branch will be deleted and PR closed unmerged after the review concludes.

## Review focus (for ultrareview agents)

Treat the diff under `merge-orchestrator-review/` as the implementation under review, not as a duplicate. Evaluate against `.exarchos/invariants.md` — particularly:

- **INV-1** (event-sourcing-integrity): reducer purity, left-fold over events, no in-place mutation, structural sharing.
- **INV-13** (process-manager two-event split): does the `preflight → requested → executed` phase machine faithfully model the durable-intent split? Is `requested` reachable / unreachable in a way that matches the schemas in `event-store/schemas.ts`?
- **INV-14** (native-primitive-first recovery): is `MergeRecoveryContext` rich enough to discriminate the `'reset-keep-blocked' | 'reset-failed' | 'unexpected-mid-merge-drift'` cases the invariant names?
- **INV-10** (liveness event protocol): where does this projection sit in the `executing_started` / paired-terminal protocol? Is the `requested` phase a sufficient projection-side proxy?
- Schema/code coherence: `merge.completed` is folded by the reducer and asserted by tests, but is it registered in `event-store/schemas.ts`? (Spoiler: check `MergeCompletedData` — there isn't one in the file as of `main` at branch time.)

## Provenance

- Source: `servers/exarchos-mcp/src/projections/merge-orchestrator/` at `main` HEAD (`49079575`).
- Manufactured for a `/code-review ultra` run by request — there is no underlying change to ship.