### PR TITLE
fix(ci): skip Playwright browser download in npm-ci-retry to stop the 300s npm ci wedge

### DIFF
--- a/docs/rca/2026-05-31-npm-ci-playwright-browser-wedge.md
+++ b/docs/rca/2026-05-31-npm-ci-playwright-browser-wedge.md
@@ -1,0 +1,173 @@
+# RCA: CI `npm ci` wedges for 300s — promptfoo's optional Playwright Chromium download
+
+## Summary
+
+Every CI job that installs full devDependencies (`Root Package`, `Exarchos MCP
+Server`, `E2E Process`, `Outcome Tests`) fails on `ubuntu-latest` with `npm ci`
+timing out — SIGTERM after the 300s per-attempt cap, on all 3 retries, on every
+branch including `main`. The wedge is **not** network egress and **not** the
+`better-sqlite3` prebuild fetch that an earlier mitigation targeted. The actual
+cause is `promptfoo`'s **optional** dependency `@playwright/browser-chromium`,
+whose postinstall downloads a ~150MB Chromium build from the Playwright CDN — a
+host that is uncached, unprobed, and unaffected by `npm_config_build_from_source`.
+
+## Symptom
+
+```text
+==> npm ci attempt 1/3 (timeout 300s, kill-after 30s): npm ci
+added 189 packages, and audited 190 packages in 6s
+npm warn deprecated prebuild-install@7.1.3: No longer maintained. …
+   <~5 minutes of silence>
+npm error signal SIGTERM
+==> npm ci attempt 1/3 stalled or failed; retrying in 5s...
+   …repeats for attempts 2/3 and 3/3…
+==> npm ci failed after 3 attempts
+##[error]Process completed with exit code 1.
+```
+
+`mergeStateStatus: BLOCKED`, `CI Gate: FAILURE`. All PRs are unmergeable.
+
+### Reproduction Steps
+
+1. On a cold runner (no `~/.cache/ms-playwright`), run a full-devDependency
+   `npm ci` in `servers/exarchos-mcp` (i.e. **without** `--omit=dev`).
+2. Tarball install finishes in ~6s (npm cache warm), then the lifecycle-script
+   phase runs `@playwright/browser-chromium`'s postinstall, which fetches a
+   fallback Chromium from the Playwright CDN.
+3. The download exceeds the 300s `npm-ci-retry.sh` cap and is SIGTERM/SIGKILLed;
+   each retry restarts the download cold, so all 3 attempts fail identically.
+
+Locally reproduced with `npm ci --foreground-scripts`, which surfaces the
+otherwise-buffered postinstall output:
+
+```text
+> @playwright/browser-chromium@1.58.2 install
+BEWARE: your OS is not officially supported by Playwright;
+        downloading fallback build for ubuntu24.04-x64.
+```
+
+### Observed vs Expected
+
+- **Observed:** `npm ci` hangs in the postinstall phase and is killed at 300s,
+  consistently, on every full-install job.
+- **Expected:** `npm ci` completes in well under the cap (~47s once the browser
+  download is skipped — verified locally).
+
+## Root Cause
+
+`promptfoo` (an **eval-only** devDependency of `servers/exarchos-mcp`) declares
+these as **optional** dependencies, each with a binary-downloading install
+script:
+
+| Optional dep (via promptfoo) | Postinstall behavior |
+|------------------------------|----------------------|
+| `@playwright/browser-chromium` | downloads ~150MB Chromium from the Playwright CDN |
+| `@huggingface/transformers` → `onnxruntime-node` | downloads ONNX runtime binaries |
+| `sharp` / `@huggingface/transformers` → `sharp` | libvips native binary |
+
+A plain `npm ci` installs `optionalDependencies` by default, so the full-install
+CI jobs pull and run all of these. `@playwright/browser-chromium` is the wedge:
+the GitHub-hosted `ubuntu-latest` image is now **ubuntu-24.04**, which Playwright
+1.58.2 marks "not officially supported", so it downloads an even slower
+**fallback** Chromium build. The download is not in the npm cache, lives on a CDN
+none of our diagnostics probed, and routinely exceeds the 300s cap on a cold
+runner.
+
+### Why the existing mitigations missed it
+
+- **`npm_config_build_from_source: 'true'`** (added in `dfb51ff9` for the same
+  symptom) only governs `prebuild-install` (better-sqlite3). It has no effect on
+  Playwright/ONNX/sharp downloads — and npm itself flags it as an *"Unknown env
+  config"* anyway (prebuild-install reads it directly from env).
+- **The CDN connectivity probe** checked `registry.npmjs.org`,
+  `objects.githubusercontent.com`, the better-sqlite3 releases host, and
+  `nodejs.org` — all healthy (0.05–0.8s). It never probed the Playwright CDN, so
+  "all healthy" was misleading.
+- **`--omit=dev` jobs pass** (Binary Matrix) precisely because they prune
+  `promptfoo` and therefore its optional browser/ML downloads — the clean
+  control that isolates devDependencies as the differentiator.
+
+### Code Location
+
+- `scripts/npm-ci-retry.sh` — the shared install chokepoint (used by `ci.yml`
+  and `eval-gate.yml`); 300s cap with no browser-download suppression.
+- `servers/exarchos-mcp/package.json` — `promptfoo` devDependency.
+- `.github/workflows/ci.yml:22-23` — `npm_config_build_from_source` env (the
+  mitigation that addressed the wrong binary).
+
+## Contributing Factors
+
+- [x] Wrong layer mitigated — the prior fix and the probe both targeted the
+      better-sqlite3 / GitHub-Releases path, not the Playwright CDN.
+- [x] Heavy eval-only tooling on the critical install path — `promptfoo`'s
+      browser/ML optional deps are installed by jobs that never use them.
+- [x] Buffered postinstall output — npm's default (non-`--foreground-scripts`)
+      hides which install script is hanging, so the symptom read as a generic
+      "npm ci hang" rather than "Chromium download hang".
+- [x] Runner image drift — `ubuntu-latest` → 24.04 pushed Playwright onto its
+      slower unsupported-OS fallback download.
+
+## Fix Approach
+
+Default `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` inside `scripts/npm-ci-retry.sh`,
+the single shared install primitive. No job that runs `npm ci` through the
+wrapper drives a browser (the eval configs use LLM/assertion providers — no
+Playwright browser provider), so skipping the download is safe for every
+consumer (`ci.yml` and `eval-gate.yml`) in one place. The default is an
+override-able floor: a job that genuinely needs browsers sets
+`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0`.
+
+### Changes Required
+
+| File | Change |
+|------|--------|
+| `scripts/npm-ci-retry.sh` | `export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="${PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD:-1}"` before the retry loop, with rationale comment |
+| `scripts/npm-ci-retry.test.sh` | Two assertions: default is `1`; a caller-set value is not clobbered |
+
+### Risks
+
+- Skipping the browser breaks any job that drives a Playwright browser. None do
+  today (confirmed: no browser provider in `servers/exarchos-mcp/src/evals/`),
+  and the opt-out (`=0`) restores the download for a future one. Low risk.
+- The fix lives in the wrapper, so it also changes `eval-gate.yml`'s install.
+  Verified the eval suite needs `promptfoo` but not its browser. Low risk.
+
+### Verification
+
+- `bash scripts/npm-ci-retry.test.sh` → 7/7 pass.
+- Scratch `npm ci` through the wrapper (cold `node_modules`, no env preset):
+  install completes in **47s** (was 300s×3 wedge), `@playwright/browser-chromium
+  install` prints *"Skipping browsers download…"*, and `better-sqlite3`'s native
+  binary is still built and present.
+
+## Prevention
+
+### Immediate Actions
+
+- [x] Skip the browser download at the shared wrapper (this change).
+
+### Long-term Improvements
+
+- [ ] Re-evaluate whether `npm_config_build_from_source` is still needed now that
+      the real wedge is gone (the better-sqlite3 releases CDN probed healthy);
+      if kept, set it as a recognized npm config to drop the "Unknown env config"
+      warning, or scope it to `prebuild-install` only.
+- [ ] Consider moving `promptfoo` out of the default MCP devDependency install
+      (e.g. an opt-in eval install) so eval-only tooling never sits on the
+      critical path for unit/integration/e2e jobs.
+- [ ] Extend the CDN connectivity probe to include the Playwright CDN so a future
+      browser-download stall is visible in the probe rather than as a silent hang.
+
+## Timeline
+
+| Event | Date | Notes |
+|-------|------|-------|
+| Reported | 2026-05-31 | `npm ci` failures across CI during `/exarchos:shepherd` of PR #1497 |
+| Investigated | 2026-05-31 | Thorough track; root cause confirmed via foreground-scripts repro + `--omit=dev` control |
+| Fixed | 2026-05-31 | `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` default in `npm-ci-retry.sh` |
+| Verified | 2026-05-31 | 7/7 wrapper tests; 47s scratch install with browser skipped, better-sqlite3 intact |
+
+## Related
+
+- Prior (mis-targeted) mitigation: `dfb51ff9` `npm_config_build_from_source` + CDN probe, referencing RCA `docs/rca/2026-05-30-state-source-integrity.md`.
+- Unblocks: PR #1497 (`refactor/design-gate-parity`) and `main` CI.

--- a/scripts/npm-ci-retry.sh
+++ b/scripts/npm-ci-retry.sh
@@ -26,6 +26,18 @@ timeout_s="${NPM_CI_TIMEOUT_SECONDS:-300}"
 kill_after_s="${NPM_CI_KILL_AFTER_SECONDS:-30}"
 retry_sleep_s="${NPM_CI_RETRY_SLEEP_SECONDS:-5}"
 
+# Skip the Playwright browser download by default. `promptfoo` (an eval-only
+# devDependency) pulls the optional `@playwright/browser-chromium`, whose
+# postinstall fetches a ~150MB Chromium from the Playwright CDN — uncached, and
+# the actual cause of the silent 300s `npm ci` wedge on cold CI runners (the
+# hosted `ubuntu-24.04` image is "not officially supported" by Playwright, so it
+# downloads an even slower fallback build). `npm_config_build_from_source` does
+# NOT cover this — that only governs prebuild-install (better-sqlite3). No job
+# that runs `npm ci` here drives a browser, so skip it. A job that genuinely
+# needs browsers opts back in with `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0`.
+# See RCA docs/rca/2026-05-31-npm-ci-playwright-browser-wedge.md.
+export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="${PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD:-1}"
+
 for i in $(seq 1 "$attempts"); do
   echo "==> npm ci attempt ${i}/${attempts} (timeout ${timeout_s}s, kill-after ${kill_after_s}s): npm ci $*"
   # `-k`: `timeout` sends SIGTERM at ${timeout_s}; if `npm ci` — or a child it

--- a/scripts/npm-ci-retry.test.sh
+++ b/scripts/npm-ci-retry.test.sh
@@ -25,6 +25,9 @@ count=0
 [ -f "$FAKE_COUNT_FILE" ] && count="$(cat "$FAKE_COUNT_FILE")"
 count=$((count + 1))
 echo "$count" > "$FAKE_COUNT_FILE"
+# Surface the env the wrapper handed us so tests can assert install-time policy
+# (e.g. the Playwright browser-download skip). Captured in OUT.
+echo "ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=${PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD:-<unset>}"
 case "$FAKE_MODE" in
   succeed)            exit 0 ;;
   fail)               exit 1 ;;
@@ -97,6 +100,33 @@ if [ "$RC" -eq 0 ] && [ "$CALLS" -ge 2 ]; then
   pass "stalled (SIGTERM-ignoring) attempt is killed and retried to success"
 else
   fail "stall kill-after recovery" "rc=$RC calls=$CALLS (124 ⇒ SUT hung — kill-after not applied)"
+fi
+
+# ── Test 5: defaults PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 ─────────────────────
+# promptfoo's optional @playwright/browser-chromium postinstall downloads a
+# ~150MB Chromium from the Playwright CDN — uncached, unprobed, and the cause
+# of the 300s npm-ci wedge on cold runners. The wrapper must skip it by default
+# (no CI job drives a browser). See RCA docs/rca/2026-05-31-npm-ci-playwright-browser-wedge.md.
+run_sut succeed 1 5
+if printf '%s\n' "$OUT" | grep -q 'ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1'; then
+  pass "wrapper defaults PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1"
+else
+  fail "default browser-download skip" "got: $(printf '%s\n' "$OUT" | grep 'ENV PLAYWRIGHT' || echo none)"
+fi
+
+# ── Test 6: a caller-set PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD is respected ───────
+# The default is an override-able floor: a job that genuinely needs browsers
+# sets =0 and the wrapper must not clobber it.
+tmp6="$(mktemp -d)"; : > "$tmp6/count"; make_fake_npm "$tmp6"
+OUT6="$(PATH="$tmp6:$PATH" FAKE_MODE=succeed FAKE_COUNT_FILE="$tmp6/count" \
+       NPM_CI_ATTEMPTS=1 NPM_CI_TIMEOUT_SECONDS=5 NPM_CI_KILL_AFTER_SECONDS=1 \
+       NPM_CI_RETRY_SLEEP_SECONDS=0 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0 \
+       timeout 30 bash "$SUT" ci 2>&1)"
+rm -rf "$tmp6"
+if printf '%s\n' "$OUT6" | grep -q 'ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0'; then
+  pass "caller-set PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0 is respected (not overridden)"
+else
+  fail "opt-out respected" "got: $(printf '%s\n' "$OUT6" | grep 'ENV PLAYWRIGHT' || echo none)"
 fi
 
 # ── Summary ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Full-devDependency `npm ci` CI jobs (`Root Package`, `Exarchos MCP Server`, `E2E Process`, `Outcome Tests`) were timing out — SIGTERM at the 300s per-attempt cap on all 3 retries, on **every branch including `main`** — blocking all merges. This was previously mis-attributed to a self-hosted-runner flake and to the better-sqlite3 prebuild CDN; it is neither.

**Root cause:** `promptfoo` (an eval-only devDependency of `servers/exarchos-mcp`) pulls the **optional** `@playwright/browser-chromium`, whose postinstall downloads a ~150 MB Chromium from the Playwright CDN. `ubuntu-latest` is now `ubuntu-24.04`, which Playwright 1.58.2 marks *"not officially supported"*, so it fetches an even slower **fallback** build. That download is uncached, lives on a CDN our connectivity probe never checked, and is **not** governed by `npm_config_build_from_source` (which only covers `prebuild-install` / better-sqlite3). The `--omit=dev` Binary Matrix jobs pass precisely because they prune `promptfoo` and its optional browser/ML downloads — the control that isolates devDependencies as the differentiator.

Full investigation: [`docs/rca/2026-05-31-npm-ci-playwright-browser-wedge.md`](docs/rca/2026-05-31-npm-ci-playwright-browser-wedge.md).

## Changes

- **`scripts/npm-ci-retry.sh`** — default `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` before the retry loop. This is the single shared install chokepoint (used by `ci.yml` and `eval-gate.yml`), so the fix covers every consumer in one place. No job that installs through the wrapper drives a browser (eval configs use LLM/assertion providers — no Playwright browser provider), so the skip is safe everywhere. The default is override-able: a browser-needing job sets `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0`.
- **`scripts/npm-ci-retry.test.sh`** — two new assertions: the wrapper defaults the skip to `1`, and a caller-set value is respected (not clobbered).
- **`docs/rca/2026-05-31-npm-ci-playwright-browser-wedge.md`** — RCA.

## Test Plan

- [x] `bash scripts/npm-ci-retry.test.sh` → **7/7 pass** (5 existing + 2 new).
- [x] Scratch `npm ci` through the wrapper (cold `node_modules`, no env preset): install drops from a **300s × 3 wedge to 47s**; `@playwright/browser-chromium install` logs *"Skipping browsers download…"*; `better-sqlite3` native binary still built and present.
- [x] Verified no browser provider in `servers/exarchos-mcp/src/evals/` (eval-gate unaffected by the skip).
- [ ] CI green on this PR (the jobs that were wedging).

Unblocks `main` and PR #1497.