### PR TITLE
fix(ci): route benchmark-gate + release npm ci through the wrapper (browser-skip)

### DIFF
--- a/.github/workflows/benchmark-gate.yml
+++ b/.github/workflows/benchmark-gate.yml
@@ -21,12 +21,20 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            servers/exarchos-mcp/package-lock.json
 
+      # Route through the shared wrapper so the MCP install inherits the
+      # Playwright browser-download skip (promptfoo's optional
+      # @playwright/browser-chromium otherwise wedges `npm ci` past the cap on a
+      # cold runner) plus retry/timeout resilience. A plain `npm ci` here
+      # bypassed both. See docs/rca/2026-05-31-npm-ci-playwright-browser-wedge.md.
       - name: Install root dependencies
-        run: npm ci
+        run: bash "$GITHUB_WORKSPACE/scripts/npm-ci-retry.sh"
 
       - name: Install MCP server dependencies
-        run: npm ci
+        run: bash "$GITHUB_WORKSPACE/scripts/npm-ci-retry.sh"
         working-directory: servers/exarchos-mcp
 
       - name: Run benchmarks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,10 @@ jobs:
         with:
           bun-version: 1.3.13
 
-      - run: npm ci
-      - run: cd servers/exarchos-mcp && npm ci
+      # Route through the shared wrapper for the Playwright browser-download
+      # skip + retry/timeout (see docs/rca/2026-05-31-npm-ci-playwright-browser-wedge.md).
+      - run: bash "$GITHUB_WORKSPACE/scripts/npm-ci-retry.sh"
+      - run: cd servers/exarchos-mcp && bash "$GITHUB_WORKSPACE/scripts/npm-ci-retry.sh"
       - run: npm run typecheck
       - run: npm run test:run
       - run: npm run build
@@ -155,12 +157,14 @@ jobs:
       - name: Install root dependencies
         # The MCP build entry transitively imports `src/runtimes/load.ts`
         # which requires `js-yaml`; without root deps the bun --compile step
-        # fails with "Could not resolve: js-yaml".
-        run: npm ci
+        # fails with "Could not resolve: js-yaml". Route through the shared
+        # wrapper for the Playwright browser-download skip + retry/timeout
+        # (see docs/rca/2026-05-31-npm-ci-playwright-browser-wedge.md).
+        run: bash "$GITHUB_WORKSPACE/scripts/npm-ci-retry.sh"
 
       - name: Install MCP server dependencies
         working-directory: servers/exarchos-mcp
-        run: npm ci
+        run: bash "$GITHUB_WORKSPACE/scripts/npm-ci-retry.sh"
 
       - name: Build binary for ${{ matrix.target }}
         run: bun run scripts/build-binary.ts --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary

Follow-up to #1502. That PR fixed the Playwright browser-download wedge in `scripts/npm-ci-retry.sh` (defaults `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`), but two workflows install the `servers/exarchos-mcp` tree with a **plain `npm ci`** that bypasses the wrapper — so they still pull `promptfoo`'s optional `@playwright/browser-chromium` and wedge `npm ci` past the timeout on a cold runner:

- **`benchmark-gate.yml`** — the visible failure; `benchmark` stalls on every PR (e.g. #1497).
- **`release.yml`** — both the Publish job and the Binary Matrix install the MCP tree; would wedge on the next release.

Root cause and full investigation: [`docs/rca/2026-05-31-npm-ci-playwright-browser-wedge.md`](docs/rca/2026-05-31-npm-ci-playwright-browser-wedge.md).

## Changes

- **`benchmark-gate.yml`** — route both `npm ci` steps through `scripts/npm-ci-retry.sh`; add the MCP lockfile to the setup-node `cache-dependency-path` so the MCP install is cache-warm.
- **`release.yml`** — route the Publish job and Binary Matrix MCP-tree `npm ci` calls (and paired root installs, for retry resilience) through the wrapper.
- `fresh-install-smoke.yml` intentionally unchanged — it does a deliberate root-only install (no MCP tree), so it is not exposed.

## Test Plan

- [x] `python3 -c "import yaml"` parses both workflows.
- [x] Wrapper behavior already covered by `scripts/npm-ci-retry.test.sh` (7/7, landed in #1502).
- [ ] **`benchmark` check on this PR goes green** — this PR's own benchmark-gate run is the end-to-end proof (it was the stalling job).