### PR TITLE
fix(delegation): pin native subagent worktree base to integration tip (#1509, #1501)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "worktree": {
+    "baseRef": "head"
+  }
+}

--- a/.codex/agents/fixer.toml
+++ b/.codex/agents/fixer.toml
@@ -30,6 +30,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \\
+  && echo "BASE OK" \\
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/.codex/agents/implementer.toml
+++ b/.codex/agents/implementer.toml
@@ -30,6 +30,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \\
+  && echo "BASE OK" \\
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/.codex/agents/scaffolder.toml
+++ b/.codex/agents/scaffolder.toml
@@ -30,6 +30,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \\
+  && echo "BASE OK" \\
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/.cursor/agents/fixer.md
+++ b/.cursor/agents/fixer.md
@@ -57,6 +57,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Failure Context
 {{failureContext}}
 

--- a/.cursor/agents/implementer.md
+++ b/.cursor/agents/implementer.md
@@ -57,6 +57,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Task
 {{taskDescription}}
 

--- a/.cursor/agents/scaffolder.md
+++ b/.cursor/agents/scaffolder.md
@@ -57,6 +57,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Task
 {{taskDescription}}
 

--- a/.github/agents/fixer.agent.md
+++ b/.github/agents/fixer.agent.md
@@ -57,6 +57,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/.github/agents/implementer.agent.md
+++ b/.github/agents/implementer.agent.md
@@ -57,6 +57,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/.github/agents/scaffolder.agent.md
+++ b/.github/agents/scaffolder.agent.md
@@ -58,6 +58,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/.opencode/agents/fixer.md
+++ b/.opencode/agents/fixer.md
@@ -73,6 +73,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/.opencode/agents/implementer.md
+++ b/.opencode/agents/implementer.md
@@ -73,6 +73,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/.opencode/agents/scaffolder.md
+++ b/.opencode/agents/scaffolder.md
@@ -74,6 +74,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/agents/fixer.md
+++ b/agents/fixer.md
@@ -64,6 +64,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -66,6 +66,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/agents/scaffolder.md
+++ b/agents/scaffolder.md
@@ -56,6 +56,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/docs/designs/2026-05-31-implementer-worktree-base.md
+++ b/docs/designs/2026-05-31-implementer-worktree-base.md
@@ -1,0 +1,130 @@
+# Fix Design: Pin native subagent worktrees to the integration tip
+
+**Issues:** #1509, #1501 (bundled) · **Milestone:** v2.10.1
+**RCA:** [`docs/rca/2026-05-31-implementer-worktree-base.md`](../rca/2026-05-31-implementer-worktree-base.md)
+**Workflow:** `debug-implementer-worktree-base` (thorough-track) · **Invariant:** INV-11
+
+## Goal
+
+Make native `isolation: worktree` subagents base on the orchestrator's
+integration tip instead of `main`, with a fail-closed guard so a misconfigured
+or unsupported host **halts loud** rather than silently dispatching onto a stale
+base. Keep `isolation: worktree` on the agent definitions.
+
+## Design
+
+Two layers + prose/dogfood, no new public tool surface.
+
+### Layer 1 — `worktree.baseRef: "head"` (primary lever)
+
+The documented Claude Code setting that branches worktrees from local `HEAD`
+(= integration tip at dispatch time) instead of `origin/HEAD`. Worktrees are
+clean-tree, so only *committed* HEAD state propagates — composes with the
+existing commit-before-dispatch discipline.
+
+- **This repo (dogfood):** create committed `.claude/settings.json`:
+  ```json
+  { "worktree": { "baseRef": "head" } }
+  ```
+  `.claude/settings.json` is absent today; `settings.local.json` (personal) is
+  the wrong home for a shared invariant. New file, single key.
+
+### Layer 2 — detect-and-block in `prepare_delegation` (delivery to consumers)
+
+Exarchos ships as a binary + plugin and does not own a consumer's
+`.claude/settings.json`, so the setting cannot be applied transparently. Instead,
+gate dispatch on it.
+
+**Seam:** `servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts`. The
+handler already runs DR-1 ancestry + DR-2 worktree-location guards and **skips
+the worktree check when `nativeIsolation: true`** (L522) — the exact branch with
+no base verification. Add a new `baseRef` guard *in that branch*.
+
+```
+if (args.nativeIsolation) {
+  const effective = resolveWorktreeBaseRef(process.cwd());   // new helper
+  guardOutcomes.baseRef.passed = effective === 'head';
+  if (effective !== 'head') {
+    emit preflight.blocked { reason: 'worktree-baseref-unset', details: {...} }
+    emit dispatch.preflight (aggregate)
+    return { success: true, data: { blocked: true, reason: 'worktree-baseref-unset',
+             effective, remediation: { file: '.claude/settings.json',
+             patch: { worktree: { baseRef: 'head' } } } }, next_actions: [...] }
+  }
+}
+```
+
+- **Settings resolution helper** `resolveWorktreeBaseRef(cwd)`: read, in Claude
+  Code precedence order, `.claude/settings.local.json` → `.claude/settings.json`
+  → `~/.claude/settings.json`; return the first `worktree.baseRef` found, else
+  `null`. Resolve consumer paths from `process.cwd()`, **never** `import.meta.url`
+  (plugin-mode module-relative resolution silently fails — known footgun). Missing
+  / malformed files are swallowed and treated as unset (**fail-closed → block**).
+  Cannot see enterprise/CLI-arg overrides; that residual is covered by Layer 3.
+- **`guardOutcomes`** gains `baseRef: { passed: boolean }`; folded into the
+  `emitDispatchPreflight` aggregate and the `dispatch.preflight` event `guards`
+  map. Runs after ancestry, before the `preflight.executed` summary;
+  `checksRun` becomes `['ancestry', 'baseRef']` on the native path.
+- **`nativeIsolation: false`** path is **unchanged** — that is the
+  exarchos-managed worktree route (`setup-worktree.ts` sets `baseBranch`
+  explicitly), which is not exposed to the bug.
+
+### Layer 3 — version-independent ancestry assert (safety net)
+
+A pure-git STEP 0 baked into the implementer dispatch template so any host that
+ignores `baseRef` still fails closed:
+
+```bash
+git -C "$WORKTREE" merge-base --is-ancestor "$INTEGRATION_TIP" HEAD \
+  && echo "BASE OK" \
+  || { echo "BASE STALE — worktree is not based on the integration tip; halting"; exit 1; }
+```
+
+The orchestrator fills `[integration-tip]` from the workflow's integration
+branch — which it already holds (workflow state / current HEAD). `merge-base
+--is-ancestor` accepts a **branch ref**, not just a SHA, so no result-threading
+from `prepare_delegation` is required; the assert works directly against the
+integration branch name the orchestrator passes into the dispatch prompt.
+(`prepare_delegation` does record the integration branch on its `preflight.executed`
+audit event for observability.) Replaces the hand-pinned `git reset --hard <tip>`
+operators run today (#1501).
+
+### Layer 4 — prose + runbook
+
+`skills-src/delegation/SKILL.md` §"When integration advances mid-wave": correct
+the base contract (default = `origin/HEAD`; integration-tip base requires
+`baseRef: "head"`), add the prerequisite + the STEP 0 assert. Regenerate
+`skills/<runtime>/` and agents. Add operator runbook note (stop hand-pinning).
+
+## Invariants validation (per design discipline)
+
+| INV | Verdict |
+|---|---|
+| **INV-11** posture | ✅ Core fix — a `task-isolated` agent's base becomes bounded by construction (setting) + fail-closed guard, not operator convention. |
+| **INV-4** platform-agnosticity | ⚠️→✅ `baseRef` is Claude-Code-specific. The Layer-2 guard is gated on `nativeIsolation` (the CC path) and lives in dispatch-core TS, not skill bodies. In `skills-src/delegation/SKILL.md` the `baseRef` instruction is wrapped in a `<!-- requires:claude -->` guard (or tokenized); the Layer-3 ancestry assert is **pure git → unconditional across all 6 runtimes**. Edit `skills-src/`, regenerate. |
+| **INV-5b** output-contract | ✅ Blocked result keeps the `{ success:true, data:{ blocked:true, reason, … } }` shape used by sibling guards, plus `next_actions` remediation affordance. |
+| **INV-12** next-actions | ✅ The block publishes the remediation as a perceivable affordance, not buried prose. |
+| **INV-1** event-sourcing | ✅ Guard emits `preflight.blocked` / `dispatch.preflight`; reads consumer `settings.json` as *input*, derives no cross-call state from it. |
+| **INV-2** facade-equivalence | ✅ Guard lives in the shared handler; CLI + MCP inherit it; no adapter behavior. |
+| **INV-6** workload-agnosticism | ✅ No workflow-type branching; delegation mechanics only. |
+| **INV-5c** aspire-verbs | ✅ `prepare_delegation` stays queryable + fail-loud; no silent mutation of consumer settings. |
+
+## Task breakdown (TDD)
+
+| # | Task | Tests-first |
+|---|---|---|
+| T1 | `resolveWorktreeBaseRef(cwd)` settings-resolution helper | precedence (local>project>user), unset→null, malformed→null, head/fresh values |
+| T2 | `prepare_delegation` baseRef guard + `guardOutcomes`/event wiring + integration-tip SHA in result | block when unset/fresh; pass when head; `nativeIsolation:false` skips guard; event shape |
+| T3 | `skills-src/delegation/SKILL.md` prose + STEP 0 + `requires:claude` guard; regenerate `skills/` + agents | `skills:guard` clean; INV-4 lint clean; delegation skill `.test.sh` green |
+| T4 | Create `.claude/settings.json` `{worktree:{baseRef:head}}` (dogfood) | n/a (config) |
+| T5 | Operator runbook note | n/a (docs) |
+
+T1+T2 are the code core (co-located vitest). Given the change is small, cohesive,
+and *itself repairs the delegation path*, implement inline in the main worktree
+rather than delegating onto the very mechanism under repair.
+
+## Out of scope
+
+- Dropping `isolation: worktree` (#1509 opt 1) / self-heal rebase (#1509 opt 2) — unnecessary; lever exists.
+- `WorktreeCreate` hook (heavy; disables `.worktreeinclude`) — Layer 1+2 suffice.
+- #1119 mid-wave ancestry-advance handling — separate, pre-existing.

--- a/docs/rca/2026-05-31-implementer-worktree-base.md
+++ b/docs/rca/2026-05-31-implementer-worktree-base.md
@@ -1,0 +1,165 @@
+# RCA: Native `isolation: worktree` bases subagent worktrees on `main`, not the integration tip
+
+**Issues:** [#1509](https://github.com/lvlup-sw/exarchos/issues/1509) (bug), [#1501](https://github.com/lvlup-sw/exarchos/issues/1501) (spike) — bundled.
+**Milestone:** v2.10.1 · **Workflow:** `debug-implementer-worktree-base` (thorough-track)
+**Invariant:** INV-11 (posture-declared-capabilities — a `task-isolated` agent's base is part of its bounded-by-construction contract).
+
+## Summary
+
+`exarchos-implementer` (and `fixer`, `scaffolder`) declare `isolation: worktree`
+in their agent frontmatter (`agents/implementer.md:25`). On Claude Code, native
+worktree isolation branches the subagent's worktree from the repository's
+**default branch (`origin/HEAD` → `main`)**, not from the orchestrator's current
+HEAD / integration branch. For any feature branch stacked above `main`, the
+subagent receives a base missing every prerequisite in-branch commit, so a
+correct, mergeable TDD implementation is impossible. A disciplined agent
+self-blocks with zero file changes (the observed-and-correct outcome); a less
+careful one could silently reintroduce pre-migration code on a divergent base.
+
+This was reported twice from the field (#1509 dynatoi, #1501 canonical-identity)
+as an *inferred* behavior. This RCA records the **authoritative, documented**
+base-selection rule (closing the #1501 spike) and the durable fix.
+
+## Symptom
+
+The merge-orchestrator/dispatch path produces a subagent whose worktree HEAD is
+`main`'s tip rather than the integration branch's tip:
+
+```text
+# Obs A (#1509) — repo lvlup-sw/dynatoi
+Orchestrator on feature/chain-of-command (92 commits ahead of main) @ b198065
+Dispatched exarchos-implementer (isolation: worktree)
+→ .claude/worktrees/agent-<id> @ 15fc02b == `git rev-parse main`   (92 commits behind)
+→ ForcePool / House / RelationalModifier / provider seams ALL absent → agent STOPPED
+
+# Obs B (#1501) — feat/canonical-identity-schema @ fafe60f8 (P-16 tip)
+→ worktree HEAD == cfd5875e (main tip / merge-base)
+→ git merge-base --is-ancestor fafe60f8 HEAD  ⇒  NO
+→ P-01..P-16 chain missing; deriveRoleLinks, ref tests, migrated GET handler absent
+→ GREEN phase impossible → agent halted (0 commits, BLOCKED)
+```
+
+### Reproduction
+
+1. Check out any branch that is ahead of `origin/HEAD` (a stacked feature/integration branch).
+2. Dispatch a subagent whose frontmatter declares `isolation: worktree` (e.g. `exarchos-implementer`), with default Claude Code settings.
+3. In the subagent's worktree, run `git rev-parse HEAD` and `git rev-parse main`.
+
+**Observed:** worktree HEAD == `main` tip; in-branch prerequisites absent.
+**Expected (per delegation contract):** worktree based at the integration branch's tip.
+
+## Root cause
+
+### Authoritative base-selection rule (closes #1501 spike)
+
+Verified against the official Claude Code documentation
+(`code.claude.com/docs/en/worktrees.md`, `…/sub-agents.md`), not inferred:
+
+> "Worktrees branch from your repository's default branch, `origin/HEAD`, so they
+> start from a clean tree matching the remote. If no remote is configured or the
+> fetch fails, the worktree falls back to your current local `HEAD`."
+
+> "Subagent worktrees use the same base branch as `--worktree`, so they branch
+> from your repository's default branch **unless `worktree.baseRef` is set to
+> `"head"`**."
+
+| Question | Authoritative answer |
+|---|---|
+| Default base | `origin/HEAD` (default branch = `main`); falls back to local `HEAD` only if no remote / fetch fails |
+| Override | `worktree.baseRef: "head"` in `.claude/settings.json` → branches from **local HEAD**. Accepts only `"fresh"` \| `"head"` — *not* arbitrary refs |
+| Tool vs frontmatter | No difference — both paths use the same base-selection logic and respect `worktree.baseRef` |
+| Inherited changes | None — worktrees are a **clean tree**; only *committed* state at the chosen base propagates. `.worktreeinclude` copies gitignored files only |
+| Full override | `WorktreeCreate` hook replaces git worktree logic entirely (heavy; disables `.worktreeinclude`) |
+
+So both field observations were correct **and by design**. The documented remedy
+the issue authors did not know about: `worktree.baseRef: "head"` makes new
+worktrees "carry your unpushed commits and feature-branch state, which is useful
+when isolating subagents that need to operate on in-progress work" — our exact
+use case.
+
+### The exarchos-side defects
+
+1. **Contract violated, undelivered prerequisite.** The delegation skill
+   (`skills-src/delegation/SKILL.md:392`) asserts: *"Each subagent worktree is
+   created at the integration branch's tip at dispatch time."* That sentence is
+   **false under default Claude Code settings** — it only becomes true once
+   `worktree.baseRef: "head"` is set, which exarchos neither sets nor documents.
+   The "When integration advances mid-wave" runbook reasons about worktrees
+   *advancing past* the integration tip while, by default, they never start there.
+
+2. **No dispatch-time base guard.** `prepare-delegation.ts` runs a DR-1 ancestry
+   preflight (integration branch descends from `main`) and a DR-2 worktree-location
+   assertion — but **skips the worktree check entirely when `nativeIsolation: true`**
+   (`prepare-delegation.ts:522`), trusting Claude Code to "manage isolation
+   natively." Nothing verifies the *base commit* that native isolation actually
+   selects. The only ancestry check that could catch a stale base runs at **merge**
+   time (`merge-preflight.ts`), long after the wasted dispatch. The blind spot is
+   exactly the `nativeIsolation: true` path.
+
+3. **Upstream remedy assumed absent.** #1509 opt 3 / #1501 opt 3 proposed *filing
+   upstream* for a base param. It already exists (`worktree.baseRef`), so the
+   "drop isolation" (#1509 opt 1) and "self-heal rebase" (#1509 opt 2 / #1501) work
+   is unnecessary.
+
+## Impact
+
+Delegation via native `isolation: worktree` is unusable for **any integration
+branch != `main`** — i.e. every stacked-PR workflow, which the delegation skill
+explicitly supports. Today operators hand-prepend a `git reset --hard
+<integration-tip>` STEP 0 to each dispatch (the in-use workaround in #1501); the
+fallback (non-isolated agent on an orchestrator-managed worktree) bypasses the
+agent definition's system prompt, hooks, skills, and `memory: project`.
+
+## Fix decision (recorded — closes #1501 acceptance box 2)
+
+Two-layer, defense-in-depth. **Keep `isolation: worktree`** on the agent
+definitions; the upstream lever exists.
+
+1. **Primary lever — `worktree.baseRef: "head"`.** Set it in this repo's
+   `.claude/settings.json` (dogfood + fixes our own stacked delegation). Aligns
+   native isolation with the delegation contract: worktrees base on local HEAD =
+   the integration tip at dispatch time. Composes with the existing
+   commit-before-dispatch discipline (clean-tree worktrees propagate only
+   *committed* HEAD state).
+
+2. **Delivery to consumers — detect-and-block in `prepare_delegation`.** Exarchos
+   ships as a binary + plugin and does not own a consumer's `.claude/settings.json`,
+   so the setting cannot be applied transparently. Instead, when
+   `nativeIsolation: true`, `prepare_delegation` reads the consumer's
+   `.claude/settings.json`; if `worktree.baseRef !== "head"`, it emits a
+   `preflight.blocked` (reason `worktree-baseref-unset`) with the exact JSON to add
+   — **never silently dispatching onto `main`**. This is the loud-fail of #1509 opt
+   4, elevated from a post-hoc guard to a pre-dispatch gate, and it occupies the
+   precise branch that currently skips all base verification (line 522).
+
+3. **Safety net — version-independent base-ancestry assert.** A
+   `git merge-base --is-ancestor <integration-tip> HEAD` check baked into the
+   implementer dispatch template (delegation skill), so on any Claude Code version
+   that does not honor `baseRef` (or if it is misconfigured), the agent **halts
+   loud** instead of building on a stale base. Replaces the hand-pinned operator
+   STEP 0.
+
+4. **Truth-up the prose** — correct `skills-src/delegation/SKILL.md` to state the
+   `baseRef: "head"` prerequisite and the default `origin/HEAD` behavior; regenerate
+   rendered skills/agents. Add the operator runbook note (#1501 acceptance box 3).
+
+INV-11 holds: a `task-isolated` agent's worktree base is now bounded by
+construction (the setting) plus a fail-closed guard, not by operator convention.
+
+## Affected surfaces
+
+| Surface | Change |
+|---|---|
+| `.claude/settings.json` (this repo) | add `worktree.baseRef: "head"` |
+| `servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts` | new `baseRef` guard in the `nativeIsolation` branch (~L520) + `guardOutcomes` extension |
+| `skills-src/delegation/SKILL.md` (~L390) | correct base contract + add baseRef prerequisite + ancestry STEP 0; regenerate `skills/<runtime>/` |
+| `agents/{implementer,fixer,scaffolder}.md` | **unchanged** — keep `isolation: worktree` |
+| docs runbook | operator note: stop hand-pinning the base |
+
+## References
+
+- `code.claude.com/docs/en/worktrees.md` §"Choose the base branch", §"Isolate subagents with worktrees"
+- `code.claude.com/docs/en/sub-agents.md` §"Supported frontmatter fields"
+- `skills-src/delegation/SKILL.md` §"When integration advances mid-wave"
+- `servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts` (DR-1/DR-2 preflight; `nativeIsolation` skip at L522)
+- Related: #1119 (merge-orchestrator ancestry preflight, same stacked-branch family)

--- a/docs/rca/2026-05-31-implementer-worktree-base.md
+++ b/docs/rca/2026-05-31-implementer-worktree-base.md
@@ -58,7 +58,7 @@ Verified against the official Claude Code documentation
 > "Worktrees branch from your repository's default branch, `origin/HEAD`, so they
 > start from a clean tree matching the remote. If no remote is configured or the
 > fetch fails, the worktree falls back to your current local `HEAD`."
-
+>
 > "Subagent worktrees use the same base branch as `--worktree`, so they branch
 > from your repository's default branch **unless `worktree.baseRef` is set to
 > `"head"`**."

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/fixer.md
@@ -64,6 +64,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/implementer.md
@@ -66,6 +66,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
+++ b/servers/exarchos-mcp/src/agents/__fixtures__/snapshots/claude/scaffolder.md
@@ -56,6 +56,23 @@ Before making ANY file changes:
    `.worktrees`, not the literal substring `.worktrees/`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale `main`. Native `isolation: worktree` branches
+from the repo default branch (`origin/HEAD`) unless `worktree.baseRef: "head"`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+```bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`<integration-tip>` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/servers/exarchos-mcp/src/agents/definitions.ts
+++ b/servers/exarchos-mcp/src/agents/definitions.ts
@@ -65,6 +65,23 @@ Before making ANY file changes:
    \`.worktrees\`, not the literal substring \`.worktrees/\`.)
 3. If NOT in worktree: STOP and report error
 
+## Base Verification
+Before making ANY file changes, verify your worktree is based on the
+**integration tip**, not a stale \`main\`. Native \`isolation: worktree\` branches
+from the repo default branch (\`origin/HEAD\`) unless \`worktree.baseRef: "head"\`
+is set; this assert halts loud if the base is wrong, so you never build on a
+base missing prerequisite in-branch commits (issues #1509 / #1501):
+
+\`\`\`bash
+git -C "<absolute worktree path>" merge-base --is-ancestor "<integration-tip>" HEAD \\
+  && echo "BASE OK" \\
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+\`\`\`
+
+\`<integration-tip>\` is the workflow's integration branch (or its tip SHA),
+supplied by the orchestrator at dispatch. If this fails, STOP and report — do
+NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Worktree Hygiene (MANDATORY — applies to every command, not just startup)
 
 The startup check above only verifies you booted in the right place. Shell

--- a/servers/exarchos-mcp/src/event-store/schemas.ts
+++ b/servers/exarchos-mcp/src/event-store/schemas.ts
@@ -1994,6 +1994,11 @@ export const DispatchPreflightData = z.object({
     worktree: z.object({ passed: z.boolean() }),
     protectedBranch: z.object({ passed: z.boolean() }),
     mainWorktree: z.object({ passed: z.boolean() }),
+    // #1509/#1501 — native-isolation worktree base-pin guard. Optional so
+    // the non-native dispatch path and `runPreflightGuards` (which never
+    // run it) remain schema-valid; populated only on the `nativeIsolation`
+    // path where Claude Code selects the worktree base.
+    baseRef: z.object({ passed: z.boolean() }).optional(),
   }),
   passed: z.boolean(),
   durationMs: z.number().nonnegative(),

--- a/servers/exarchos-mcp/src/orchestrate/composite.ts
+++ b/servers/exarchos-mcp/src/orchestrate/composite.ts
@@ -197,7 +197,12 @@ function adaptArgsWithStateDirAndEventStore<T>(
 function adaptSetupWorktree(): ActionHandler {
   return async (args, stateDir, ctx) => {
     const featureId = (args as { featureId?: string }).featureId;
-    let workflowState: { tasks?: Array<{ id: string; branch?: string }> } | undefined;
+    let workflowState:
+      | {
+          tasks?: Array<{ id: string; branch?: string }>;
+          synthesis?: { integrationBranch?: string };
+        }
+      | undefined;
 
     if (featureId && ctx?.eventStore) {
       try {
@@ -210,12 +215,13 @@ function adaptSetupWorktree(): ActionHandler {
           featureId,
           WORKFLOW_STATE_VIEW,
         );
-        const view = materializer.materialize<{ tasks: Array<{ id: string; branch?: string }> }>(
-          featureId,
-          WORKFLOW_STATE_VIEW,
-          events,
-        );
-        workflowState = { tasks: view.tasks };
+        const view = materializer.materialize<{
+          tasks: Array<{ id: string; branch?: string }>;
+          synthesis?: { integrationBranch?: string };
+        }>(featureId, WORKFLOW_STATE_VIEW, events);
+        // #1509/#1501: project synthesis.integrationBranch so the handler can
+        // base managed worktrees on the integration tip, not a stale `main`.
+        workflowState = { tasks: view.tasks, synthesis: view.synthesis };
       } catch {
         // Best-effort: missing/unreadable state is not a setup_worktree
         // failure — handler falls back to legacy default branch.

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.test.ts
@@ -36,6 +36,15 @@ vi.mock('./dispatch-guard.js', () => ({
   probeStashAndEmit: vi.fn().mockResolvedValue(undefined),
 }));
 
+// #1509/#1501 — default the native-isolation base-pin guard to "pinned" so
+// existing nativeIsolation tests reach the readiness logic. Tests that exercise
+// the block override the return value per-case.
+vi.mock('./worktree-baseref.js', () => ({
+  assertWorktreeBaseRefPinned: vi
+    .fn()
+    .mockReturnValue({ pinned: true, effective: 'head', checked: [] }),
+}));
+
 vi.mock('../workflow/checkpoint.js', () => ({
   shouldEnforceCheckpoint: vi.fn().mockReturnValue({ gated: false }),
   CHECKPOINT_OPERATION_THRESHOLD: 20,
@@ -62,6 +71,7 @@ import {
   assertCurrentBranchNotProtected,
 } from './dispatch-guard.js';
 import { shouldEnforceCheckpoint } from '../workflow/checkpoint.js';
+import { assertWorktreeBaseRefPinned } from './worktree-baseref.js';
 import { DEFAULTS } from '../config/resolve.js';
 
 const STATE_DIR = '/tmp/test-state';
@@ -221,6 +231,12 @@ describe('handlePrepareDelegation', () => {
       expected: 'main worktree (no .claude/worktrees/ in path)',
     });
     vi.mocked(shouldEnforceCheckpoint).mockReturnValue({ gated: false });
+    // #1509/#1501 — default the native-isolation base-pin guard to "pinned".
+    vi.mocked(assertWorktreeBaseRefPinned).mockReturnValue({
+      pinned: true,
+      effective: 'head',
+      checked: [],
+    });
   });
 
   it('PrepareDelegation_MissingFeatureId_ReturnsInvalidInput', async () => {
@@ -889,6 +905,78 @@ describe('handlePrepareDelegation', () => {
     const data = result.data as { ready: boolean; isolation: string; blockers?: string[] };
     expect(data.ready).toBe(true);
     expect(data.isolation).toBe('native');
+  });
+
+  // ─── #1509/#1501: native-isolation worktree base-pin guard ────────────────
+
+  it('PrepareDelegation_NativeIsolation_BaseRefUnset_BlocksWithRemediation', async () => {
+    // Arrange: nativeIsolation requested, but worktree.baseRef is NOT pinned to
+    // "head" — Claude Code would branch the subagent worktree from main.
+    const state = readyWorkflowState();
+    setupMaterializer(state, undefined, readyDelegationReadiness());
+    vi.mocked(assertWorktreeBaseRefPinned).mockReturnValue({
+      pinned: false,
+      effective: null,
+      checked: ['/repo/.claude/settings.local.json', '/repo/.claude/settings.json'],
+      reason: 'worktree-baseref-unset',
+      remediation: { file: '.claude/settings.json', patch: { worktree: { baseRef: 'head' } } },
+      hint: 'set worktree.baseRef:"head"',
+    });
+    const args = { featureId: 'test-feature', nativeIsolation: true };
+
+    // Act
+    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+    // Assert — dispatch is blocked loud, with the exact remediation
+    expect(result.success).toBe(true);
+    const data = result.data as {
+      blocked: boolean;
+      reason: string;
+      effective: string | null;
+      remediation: { file: string; patch: unknown };
+    };
+    expect(data.blocked).toBe(true);
+    expect(data.reason).toBe('worktree-baseref-unset');
+    expect(data.effective).toBeNull();
+    expect(data.remediation).toEqual({
+      file: '.claude/settings.json',
+      patch: { worktree: { baseRef: 'head' } },
+    });
+  });
+
+  it('PrepareDelegation_NativeIsolation_BaseRefPinned_RunsGuardAndProceeds', async () => {
+    // Arrange: nativeIsolation with baseRef pinned (default mock) → proceeds.
+    const state = readyWorkflowState();
+    setupMaterializer(state, undefined, readyDelegationReadiness());
+    vi.mocked(generateQualityHints).mockReturnValue([]);
+    const args = { featureId: 'test-feature', nativeIsolation: true };
+
+    // Act
+    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+    // Assert — guard ran on the native path, dispatch proceeds
+    expect(assertWorktreeBaseRefPinned).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    const data = result.data as { ready: boolean; isolation?: string; blocked?: boolean };
+    expect(data.blocked).toBeUndefined();
+    expect(data.ready).toBe(true);
+    expect(data.isolation).toBe('native');
+  });
+
+  it('PrepareDelegation_NonNativeIsolation_DoesNotRunBaseRefGuard', async () => {
+    // Arrange: default (non-native) path — the baseRef guard is irrelevant
+    // (exarchos manages the worktree base explicitly via setup_worktree).
+    const state = readyWorkflowState();
+    setupMaterializer(state, undefined, readyDelegationReadiness());
+    vi.mocked(generateQualityHints).mockReturnValue([]);
+    const args = { featureId: 'test-feature' };
+
+    // Act
+    const result = await handlePrepareDelegation(args, STATE_DIR, makeCtx(mockStore, STATE_DIR));
+
+    // Assert — guard never consulted on the non-native path
+    expect(assertWorktreeBaseRefPinned).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
   });
 
   it('PrepareDelegation_NativeIsolationFalse_PreservesWorktreeBlockers', async () => {

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -25,6 +25,7 @@ import {
   probeStashAndEmit,
 } from './dispatch-guard.js';
 import type { AncestryResult } from './dispatch-guard.js';
+import { assertWorktreeBaseRefPinned } from './worktree-baseref.js';
 import {
   WORKFLOW_STATE_VIEW,
 } from '../views/workflow-state-projection.js';
@@ -417,11 +418,15 @@ export async function handlePrepareDelegation(
       worktree: { passed: boolean };
       protectedBranch: { passed: boolean };
       mainWorktree: { passed: boolean };
+      baseRef: { passed: boolean };
     } = {
       ancestry: { passed: true },
       worktree: { passed: true },
       protectedBranch: { passed: true },
       mainWorktree: { passed: true },
+      // #1509/#1501: only runs on the nativeIsolation path; `true` here means
+      // "no failure observed" for dispatches that never run the guard.
+      baseRef: { passed: true },
     };
 
     /**
@@ -436,7 +441,8 @@ export async function handlePrepareDelegation(
         guardOutcomes.ancestry.passed &&
         guardOutcomes.worktree.passed &&
         guardOutcomes.protectedBranch.passed &&
-        guardOutcomes.mainWorktree.passed;
+        guardOutcomes.mainWorktree.passed &&
+        guardOutcomes.baseRef.passed;
       await emitAuditEvent(store, streamId, {
         type: 'dispatch.preflight',
         data: {
@@ -445,6 +451,7 @@ export async function handlePrepareDelegation(
             worktree: { passed: guardOutcomes.worktree.passed },
             protectedBranch: { passed: guardOutcomes.protectedBranch.passed },
             mainWorktree: { passed: guardOutcomes.mainWorktree.passed },
+            baseRef: { passed: guardOutcomes.baseRef.passed },
           },
           passed,
           durationMs: Date.now() - preflightStart,
@@ -549,9 +556,46 @@ export async function handlePrepareDelegation(
           },
         };
       }
+    } else {
+      // ─── DR-2b (#1509/#1501): Native-isolation worktree base-pin guard ──
+      // Claude Code's `isolation: worktree` branches the subagent worktree
+      // from origin/HEAD (default branch = main) unless the consumer sets
+      // `worktree.baseRef: "head"`. Without the pin, a subagent dispatched
+      // onto a stacked/non-main integration branch gets a base missing every
+      // in-branch prerequisite — the #1509/#1501 failure. Fail loud here with
+      // the exact remediation rather than silently dispatching onto main.
+      const baseRefResult = assertWorktreeBaseRefPinned();
+      guardOutcomes.baseRef.passed = baseRefResult.pinned;
+      if (!baseRefResult.pinned) {
+        await emitAuditEvent(store, streamId, {
+          type: 'preflight.blocked',
+          data: {
+            reason: baseRefResult.reason,
+            details: {
+              effective: baseRefResult.effective,
+              checked: baseRefResult.checked,
+              remediation: baseRefResult.remediation,
+            },
+          },
+        });
+        await emitDispatchPreflight();
+
+        return {
+          success: true,
+          data: {
+            blocked: true,
+            reason: baseRefResult.reason,
+            effective: baseRefResult.effective,
+            remediation: baseRefResult.remediation,
+            hint: baseRefResult.hint,
+          },
+        };
+      }
     }
 
-    const checksRun = args.nativeIsolation ? ['ancestry'] : ['ancestry', 'worktree'];
+    const checksRun = args.nativeIsolation
+      ? ['ancestry', 'baseRef']
+      : ['ancestry', 'worktree'];
     await emitAuditEvent(store, streamId, {
       type: 'preflight.executed',
       data: {

--- a/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
+++ b/servers/exarchos-mcp/src/orchestrate/prepare-delegation.ts
@@ -451,7 +451,13 @@ export async function handlePrepareDelegation(
             worktree: { passed: guardOutcomes.worktree.passed },
             protectedBranch: { passed: guardOutcomes.protectedBranch.passed },
             mainWorktree: { passed: guardOutcomes.mainWorktree.passed },
-            baseRef: { passed: guardOutcomes.baseRef.passed },
+            // #1509/#1501: the baseRef guard runs only on the nativeIsolation
+            // path. Omit it on non-native dispatches so telemetry reflects
+            // "not executed" by absence rather than a misleading passed:true
+            // (schema marks baseRef optional for exactly this reason).
+            ...(args.nativeIsolation
+              ? { baseRef: { passed: guardOutcomes.baseRef.passed } }
+              : {}),
           },
           passed,
           durationMs: Date.now() - preflightStart,

--- a/servers/exarchos-mcp/src/orchestrate/setup-worktree.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/setup-worktree.test.ts
@@ -1139,4 +1139,99 @@ describe('handleSetupWorktree', () => {
       expect(data.report).toMatch(/Branch created.*default/i);
     });
   });
+
+  // ── base-branch resolution (#1509/#1501 managed-path parity) ────────────
+  //
+  // The Exarchos-managed (non-native) worktree path must base subagent
+  // worktrees on the INTEGRATION TIP, not a stale `main`. Resolution mirrors
+  // prepare_delegation's integration-branch derivation:
+  //   args.baseBranch > synthesis.integrationBranch > current HEAD > 'main'
+  // The current-HEAD fallback closes the silent `?? 'main'` footgun: the
+  // orchestrator runs setup_worktree from the integration checkout, so HEAD
+  // *is* the integration tip when nothing more specific is supplied.
+
+  describe('base-branch resolution (#1509/#1501)', () => {
+    // Returns `currentBranch` for `git rev-parse --abbrev-ref HEAD`; lets each
+    // test stand the repo on an arbitrary integration branch.
+    function setupBaseResolutionMocks(currentBranch: string) {
+      vi.mocked(execFileSync).mockImplementation((cmd: unknown, args: unknown) => {
+        const cmdStr = String(cmd);
+        const argsArr = args as string[];
+        if (cmdStr === 'git' && argsArr.includes('show-ref')) {
+          const error = new Error('not found') as Error & { status: number };
+          error.status = 1;
+          throw error; // branch absent → handler creates it
+        }
+        if (cmdStr === 'git' && argsArr.includes('rev-parse') && argsArr.includes('--abbrev-ref')) {
+          return currentBranch;
+        }
+        if (cmdStr === 'git' && argsArr.includes('rev-parse')) return ''; // bare rev-parse HEAD / --git-dir
+        if (cmdStr === 'git' && argsArr.includes('branch')) return '';
+        if (cmdStr === 'git' && argsArr.includes('worktree')) return '';
+        return '';
+      });
+      vi.mocked(existsSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return true;
+        if (path.endsWith('/package.json')) return true;
+        return false;
+      });
+      vi.mocked(readFileSync).mockImplementation((p: unknown) => {
+        const path = String(p);
+        if (path === '/repo/.gitignore') return '.worktrees/\n';
+        if (path.endsWith('package.json')) return VALID_PACKAGE_JSON;
+        return '';
+      });
+    }
+
+    // Extract the base ref from the `git branch <name> <base>` invocation.
+    function createdBranchBase(): string | undefined {
+      const call = vi.mocked(execFileSync).mock.calls.find((c) => {
+        const a = c[1] as string[];
+        return c[0] === 'git' && Array.isArray(a) && a[2] === 'branch';
+      });
+      const a = call?.[1] as string[] | undefined;
+      return a?.[a.length - 1];
+    }
+
+    it('BaseBranch_ExplicitArg_Wins', () => {
+      setupBaseResolutionMocks('feat/head');
+      handleSetupWorktree(
+        { repoRoot: '/repo', taskId: 'T1', taskName: 'x', skipTests: true, baseBranch: 'release/x' },
+        { synthesis: { integrationBranch: 'feat/int' } },
+      );
+      expect(createdBranchBase()).toBe('release/x');
+    });
+
+    it('BaseBranch_SynthesisIntegrationBranch_WhenNoArg', () => {
+      setupBaseResolutionMocks('feat/head');
+      handleSetupWorktree(
+        { repoRoot: '/repo', taskId: 'T1', taskName: 'x', skipTests: true },
+        { synthesis: { integrationBranch: 'feat/int' } },
+      );
+      expect(createdBranchBase()).toBe('feat/int');
+    });
+
+    it('BaseBranch_CurrentHead_WhenNoArgOrSynthesis', () => {
+      // The regression guard: a stacked integration branch must NOT silently
+      // base on main. With no arg and no synthesis state, HEAD is the tip.
+      setupBaseResolutionMocks('feat/stacked');
+      handleSetupWorktree(
+        { repoRoot: '/repo', taskId: 'T1', taskName: 'x', skipTests: true },
+        undefined,
+      );
+      expect(createdBranchBase()).toBe('feat/stacked');
+      expect(createdBranchBase()).not.toBe('main');
+    });
+
+    it('BaseBranch_FallsBackToMain_WhenHeadUnresolvable', () => {
+      // Detached HEAD with no resolvable ref/SHA → safe legacy default.
+      setupBaseResolutionMocks('HEAD');
+      handleSetupWorktree(
+        { repoRoot: '/repo', taskId: 'T1', taskName: 'x', skipTests: true },
+        undefined,
+      );
+      expect(createdBranchBase()).toBe('main');
+    });
+  });
 });

--- a/servers/exarchos-mcp/src/orchestrate/setup-worktree.ts
+++ b/servers/exarchos-mcp/src/orchestrate/setup-worktree.ts
@@ -41,6 +41,14 @@ export interface SetupWorktreeArgs {
  */
 interface SetupWorktreeWorkflowState {
   readonly tasks?: ReadonlyArray<{ id: string; branch?: string }>;
+  /**
+   * #1509/#1501: the workflow's integration branch. When present it is the
+   * authoritative base for subagent worktrees on the managed (non-native)
+   * path — mirrors `prepare_delegation`'s `synthesis.integrationBranch`
+   * derivation so both isolation paths uphold the same base-correctness
+   * guarantee across all six runtimes (INV-4).
+   */
+  readonly synthesis?: { readonly integrationBranch?: string };
 }
 
 type CheckStatus = 'pass' | 'fail' | 'skip';
@@ -237,11 +245,78 @@ function resolveBranchName(
   return { name: `feature/${args.taskId}-${args.taskName}`, source: 'default' };
 }
 
+// ─── Base-branch resolution (#1509 / #1501) ──────────────────────────────────
+//
+// The managed (non-native) worktree path previously hardcoded `?? 'main'` as
+// the base, silently branching every subagent worktree off `main` even on a
+// stacked / non-`main` integration branch — the same #1509/#1501 footgun the
+// native-isolation guard now blocks. Resolution mirrors `prepare_delegation`'s
+// integration-branch derivation so both paths uphold the same base-correctness
+// guarantee across all six runtimes (INV-4):
+//
+//   1. args.baseBranch                     — explicit caller override
+//   2. workflowState.synthesis.integrationBranch — the planned integration tip
+//   3. current HEAD                        — the orchestrator runs setup_worktree
+//                                            from the integration checkout, so
+//                                            HEAD *is* the tip when nothing more
+//                                            specific is supplied
+//   4. 'main'                              — legacy default (only when HEAD is
+//                                            unresolvable, e.g. detached + bare)
+
+type BaseBranchSource = 'arg' | 'workflow state' | 'HEAD' | 'default';
+
+interface ResolvedBase {
+  readonly base: string;
+  readonly source: BaseBranchSource;
+}
+
+/**
+ * Best-effort current-branch detection. Returns the branch name, or the commit
+ * SHA when detached, or `null` when neither resolves (e.g. an unborn HEAD).
+ * Never throws — git failures collapse to `null` so resolution falls through to
+ * the legacy default rather than aborting setup.
+ */
+function detectCurrentBranch(repoRoot: string): string | null {
+  try {
+    const ref = gitExec(repoRoot, ['rev-parse', '--abbrev-ref', 'HEAD']).trim();
+    if (ref && ref !== 'HEAD') return ref;
+  } catch {
+    // fall through to SHA / null
+  }
+  try {
+    const sha = gitExec(repoRoot, ['rev-parse', 'HEAD']).trim();
+    if (sha) return sha;
+  } catch {
+    // fall through to null
+  }
+  return null;
+}
+
+/** Pure base-branch resolution (priority order documented above). */
+function resolveBaseBranch(
+  args: SetupWorktreeArgs,
+  workflowState: SetupWorktreeWorkflowState | undefined,
+  currentBranch: string | null,
+): ResolvedBase {
+  if (args.baseBranch && args.baseBranch.length > 0) {
+    return { base: args.baseBranch, source: 'arg' };
+  }
+  const integration = workflowState?.synthesis?.integrationBranch;
+  if (integration && integration.length > 0) {
+    return { base: integration, source: 'workflow state' };
+  }
+  if (currentBranch && currentBranch.length > 0 && currentBranch !== 'HEAD') {
+    return { base: currentBranch, source: 'HEAD' };
+  }
+  return { base: 'main', source: 'default' };
+}
+
 function createBranch(
   repoRoot: string,
   branchName: string,
   baseBranch: string,
   source: BranchSource,
+  baseSource: BaseBranchSource,
 ): CheckResult {
   // Check if branch already exists
   try {
@@ -260,13 +335,13 @@ function createBranch(
     return {
       name: `Branch created`,
       status: 'pass',
-      detail: `${branchName} from ${baseBranch} (from ${source})`,
+      detail: `${branchName} from ${baseBranch} [base: ${baseSource}] (from ${source})`,
     };
   } catch {
     return {
       name: `Branch created`,
       status: 'fail',
-      detail: `Failed to create ${branchName} from ${baseBranch} (from ${source})`,
+      detail: `Failed to create ${branchName} from ${baseBranch} [base: ${baseSource}] (from ${source})`,
     };
   }
 }
@@ -411,7 +486,11 @@ export function handleSetupWorktree(
     };
   }
 
-  const baseBranch = args.baseBranch ?? 'main';
+  // #1509/#1501: resolve the worktree base from the integration tip, never a
+  // silent `main`, so managed-path worktrees match the native-isolation
+  // guarantee. See resolveBaseBranch for the priority order.
+  const resolvedBase = resolveBaseBranch(args, workflowState, detectCurrentBranch(args.repoRoot));
+  const baseBranch = resolvedBase.base;
   const skipTests = args.skipTests ?? false;
 
   // DR-3 (T-09, #1204): resolve branch with priority args > state > default.
@@ -428,7 +507,7 @@ export function handleSetupWorktree(
   checks.push(ensureGitignored(args.repoRoot));
 
   // Step 2: Create feature branch
-  checks.push(createBranch(args.repoRoot, branchName, baseBranch, resolvedBranch.source));
+  checks.push(createBranch(args.repoRoot, branchName, baseBranch, resolvedBranch.source, resolvedBase.source));
 
   // Step 3: Create worktree
   checks.push(createWorktree(args.repoRoot, worktreePath, branchName));

--- a/servers/exarchos-mcp/src/orchestrate/worktree-baseref.test.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree-baseref.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import {
+  resolveWorktreeBaseRef,
+  assertWorktreeBaseRefPinned,
+} from './worktree-baseref.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const CWD = '/repo';
+const HOME = '/home/u';
+
+const PROJECT = path.join(CWD, '.claude', 'settings.json');
+const LOCAL = path.join(CWD, '.claude', 'settings.local.json');
+const USER = path.join(HOME, '.claude', 'settings.json');
+
+/** Build an injectable reader from a path→contents map; missing paths → null. */
+function reader(files: Record<string, string>): (p: string) => string | null {
+  return (p: string) => (p in files ? files[p]! : null);
+}
+
+const headSettings = JSON.stringify({ worktree: { baseRef: 'head' } });
+const freshSettings = JSON.stringify({ worktree: { baseRef: 'fresh' } });
+
+// ─── resolveWorktreeBaseRef ─────────────────────────────────────────────────
+
+describe('resolveWorktreeBaseRef', () => {
+  it('resolves "head" from the project .claude/settings.json', () => {
+    const result = resolveWorktreeBaseRef({
+      cwd: CWD,
+      home: HOME,
+      readFile: reader({ [PROJECT]: headSettings }),
+    });
+    expect(result.effective).toBe('head');
+    expect(result.source).toBe(PROJECT);
+  });
+
+  it('returns null when baseRef is unset across the whole cascade', () => {
+    const result = resolveWorktreeBaseRef({
+      cwd: CWD,
+      home: HOME,
+      readFile: reader({ [PROJECT]: JSON.stringify({ permissions: {} }) }),
+    });
+    expect(result.effective).toBeNull();
+    expect(result.source).toBeUndefined();
+  });
+
+  it('lists the inspected files in precedence order (local > project > user)', () => {
+    const result = resolveWorktreeBaseRef({
+      cwd: CWD,
+      home: HOME,
+      readFile: reader({}),
+    });
+    expect(result.checked).toEqual([LOCAL, PROJECT, USER]);
+  });
+
+  it('lets settings.local.json override the project settings', () => {
+    const result = resolveWorktreeBaseRef({
+      cwd: CWD,
+      home: HOME,
+      readFile: reader({ [LOCAL]: freshSettings, [PROJECT]: headSettings }),
+    });
+    expect(result.effective).toBe('fresh');
+    expect(result.source).toBe(LOCAL);
+  });
+
+  it('falls back to the user-level settings when project files are absent', () => {
+    const result = resolveWorktreeBaseRef({
+      cwd: CWD,
+      home: HOME,
+      readFile: reader({ [USER]: headSettings }),
+    });
+    expect(result.effective).toBe('head');
+    expect(result.source).toBe(USER);
+  });
+
+  it('skips a malformed settings file and falls through to the next', () => {
+    const result = resolveWorktreeBaseRef({
+      cwd: CWD,
+      home: HOME,
+      readFile: reader({ [LOCAL]: '{ not valid json', [PROJECT]: headSettings }),
+    });
+    expect(result.effective).toBe('head');
+    expect(result.source).toBe(PROJECT);
+  });
+
+  it('treats all-malformed settings as unset (fail-closed, no throw)', () => {
+    const result = resolveWorktreeBaseRef({
+      cwd: CWD,
+      home: HOME,
+      readFile: reader({ [LOCAL]: '}{', [PROJECT]: 'nope', [USER]: '[1,2' }),
+    });
+    expect(result.effective).toBeNull();
+  });
+
+  it('ignores a non-enum baseRef value', () => {
+    const result = resolveWorktreeBaseRef({
+      cwd: CWD,
+      home: HOME,
+      readFile: reader({ [PROJECT]: JSON.stringify({ worktree: { baseRef: 'origin/main' } }) }),
+    });
+    expect(result.effective).toBeNull();
+  });
+});
+
+// ─── assertWorktreeBaseRefPinned ────────────────────────────────────────────
+
+describe('assertWorktreeBaseRefPinned', () => {
+  it('passes when baseRef is pinned to "head"', () => {
+    const result = assertWorktreeBaseRefPinned({
+      cwd: CWD,
+      home: HOME,
+      readFile: reader({ [PROJECT]: headSettings }),
+    });
+    expect(result.pinned).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(result.remediation).toBeUndefined();
+  });
+
+  it('blocks with remediation when baseRef is unset', () => {
+    const result = assertWorktreeBaseRefPinned({
+      cwd: CWD,
+      home: HOME,
+      readFile: reader({}),
+    });
+    expect(result.pinned).toBe(false);
+    expect(result.reason).toBe('worktree-baseref-unset');
+    expect(result.remediation).toEqual({
+      file: '.claude/settings.json',
+      patch: { worktree: { baseRef: 'head' } },
+    });
+    expect(result.hint).toMatch(/baseRef/);
+  });
+
+  it('blocks when baseRef is "fresh" (worktrees would still branch from origin/HEAD)', () => {
+    const result = assertWorktreeBaseRefPinned({
+      cwd: CWD,
+      home: HOME,
+      readFile: reader({ [PROJECT]: freshSettings }),
+    });
+    expect(result.pinned).toBe(false);
+    expect(result.reason).toBe('worktree-baseref-unset');
+    expect(result.effective).toBe('fresh');
+  });
+});

--- a/servers/exarchos-mcp/src/orchestrate/worktree-baseref.ts
+++ b/servers/exarchos-mcp/src/orchestrate/worktree-baseref.ts
@@ -1,0 +1,163 @@
+// ─── Worktree baseRef Resolution (#1509 / #1501) ─────────────────────────────
+//
+// Claude Code native `isolation: worktree` branches a subagent's worktree from
+// the repository's default branch (`origin/HEAD` → main) UNLESS the consumer's
+// settings set `worktree.baseRef: "head"`, which bases worktrees on local HEAD
+// (= the integration tip at dispatch time). Without it, every stacked-branch
+// delegation lands on a stale base missing all in-branch prerequisites.
+//
+// Exarchos ships as a binary + plugin and does not own a consumer's
+// `.claude/settings.json`, so it cannot set the value transparently. Instead,
+// `prepare_delegation` reads the effective value and BLOCKS dispatch (fail-loud)
+// when native isolation is requested without the pin in place.
+//
+// The reader is injectable so the resolution logic stays pure and unit-testable;
+// the default reader is the only impurity. Consumer files are resolved from
+// `process.cwd()` — never `import.meta.url` (plugin-mode module-relative
+// resolution silently fails). See docs/rca/2026-05-31-implementer-worktree-base.md.
+// ────────────────────────────────────────────────────────────────────────────
+
+import { readFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/** The only values Claude Code accepts for `worktree.baseRef`. */
+export type BaseRefValue = 'fresh' | 'head';
+
+const BASE_REF_VALUES: ReadonlySet<string> = new Set<BaseRefValue>(['fresh', 'head']);
+
+/** Reads a file's contents, or returns `null` when absent/unreadable. */
+export type SettingsReader = (filePath: string) => string | null;
+
+export interface ResolveWorktreeBaseRefOptions {
+  /** Project root the orchestrator is dispatching from. Defaults to `process.cwd()`. */
+  readonly cwd?: string;
+  /** User home dir for the user-level settings cascade. Defaults to `os.homedir()`. */
+  readonly home?: string;
+  /** Injectable reader (testing). Defaults to a swallow-on-error `fs` reader. */
+  readonly readFile?: SettingsReader;
+}
+
+export interface WorktreeBaseRefResult {
+  /** Effective `worktree.baseRef` across the settings cascade, or `null` if unset/invalid. */
+  readonly effective: BaseRefValue | null;
+  /** Settings files inspected, highest-precedence first. */
+  readonly checked: readonly string[];
+  /** The file that supplied `effective`, when one did. */
+  readonly source?: string;
+}
+
+export interface WorktreeBaseRefAssertion {
+  /** True only when the effective value is `"head"` (worktrees base on local HEAD). */
+  readonly pinned: boolean;
+  readonly effective: BaseRefValue | null;
+  readonly checked: readonly string[];
+  /** Set when not pinned — the dispatch-blocking reason. */
+  readonly reason?: 'worktree-baseref-unset';
+  /** Operator-facing remediation: the exact file + patch to add. */
+  readonly remediation?: {
+    readonly file: string;
+    readonly patch: { readonly worktree: { readonly baseRef: 'head' } };
+  };
+  /** Short human hint mirrored from `remediation`. */
+  readonly hint?: string;
+}
+
+const REMEDIATION = {
+  file: '.claude/settings.json',
+  patch: { worktree: { baseRef: 'head' } },
+} as const;
+
+/**
+ * Default reader: `fs.readFileSync` with all errors (ENOENT, permission,
+ * directory) collapsed to `null`. Absence is a non-signal, not a throw.
+ */
+const defaultReader: SettingsReader = (filePath: string): string | null => {
+  try {
+    return readFileSync(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Parse a settings file's `worktree.baseRef`, returning the enum value or
+ * `null` for absent/malformed/non-enum. Never throws.
+ */
+function readBaseRef(contents: string | null): BaseRefValue | null {
+  if (contents === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const worktree = (parsed as { worktree?: unknown }).worktree;
+  if (typeof worktree !== 'object' || worktree === null) return null;
+  const value = (worktree as { baseRef?: unknown }).baseRef;
+  if (typeof value === 'string' && BASE_REF_VALUES.has(value)) {
+    return value as BaseRefValue;
+  }
+  return null;
+}
+
+/**
+ * Resolve the effective `worktree.baseRef` across the Claude Code settings
+ * cascade in precedence order:
+ *   1. `<cwd>/.claude/settings.local.json`  (personal project overrides)
+ *   2. `<cwd>/.claude/settings.json`        (shared project settings)
+ *   3. `<home>/.claude/settings.json`       (user settings)
+ *
+ * Enterprise-managed and CLI-argument overrides are not reachable from here;
+ * the version-independent ancestry assert (Layer 3) covers that residual.
+ * The first file to declare a valid `baseRef` wins.
+ */
+export function resolveWorktreeBaseRef(
+  options: ResolveWorktreeBaseRefOptions = {},
+): WorktreeBaseRefResult {
+  const cwd = options.cwd ?? process.cwd();
+  const home = options.home ?? os.homedir();
+  const read = options.readFile ?? defaultReader;
+
+  const checked: string[] = [
+    path.join(cwd, '.claude', 'settings.local.json'),
+    path.join(cwd, '.claude', 'settings.json'),
+    path.join(home, '.claude', 'settings.json'),
+  ];
+
+  for (const filePath of checked) {
+    const value = readBaseRef(read(filePath));
+    if (value !== null) {
+      return { effective: value, checked, source: filePath };
+    }
+  }
+
+  return { effective: null, checked };
+}
+
+/**
+ * Assert that worktrees are pinned to local HEAD (`baseRef: "head"`). When they
+ * are not — unset, `"fresh"`, or unparseable — return a blocking result with the
+ * exact remediation so `prepare_delegation` can fail loud instead of silently
+ * dispatching a native-isolation subagent onto `origin/HEAD` (main).
+ */
+export function assertWorktreeBaseRefPinned(
+  options: ResolveWorktreeBaseRefOptions = {},
+): WorktreeBaseRefAssertion {
+  const { effective, checked } = resolveWorktreeBaseRef(options);
+  if (effective === 'head') {
+    return { pinned: true, effective, checked };
+  }
+  return {
+    pinned: false,
+    effective,
+    checked,
+    reason: 'worktree-baseref-unset',
+    remediation: REMEDIATION,
+    hint:
+      'native isolation:worktree branches subagent worktrees from origin/HEAD (main), ' +
+      'not the integration tip — set worktree.baseRef:"head" in .claude/settings.json ' +
+      'so worktrees base on the integration branch at dispatch time',
+  };
+}

--- a/skills-src/delegation/SKILL.md
+++ b/skills-src/delegation/SKILL.md
@@ -389,14 +389,36 @@ first.
 
 ### Why this happens
 
-Each subagent worktree is created at the integration branch's tip at
-dispatch time. When the orchestrator merges sibling worktrees serially,
-each merge moves the integration branch forward. A worktree that was
-dispatched against an older integration tip will fail the ancestry
-preflight when its turn comes.
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
 
 This is expected behavior under the current single-writer merge contract —
 preflight is fail-only on purpose so the operator stays in control.
+
+<!-- requires:native:isolation:worktree -->
+> **Prerequisite — pin the worktree base.** Native `isolation: worktree`
+> branches subagent worktrees from the repository's default branch
+> (`origin/HEAD` → `main`), **not** the integration tip, unless
+> `worktree.baseRef: "head"` is set in `.claude/settings.json`. Without the pin,
+> a subagent dispatched onto any stacked / non-`main` integration branch gets a
+> base missing every in-branch prerequisite commit (issues #1509 / #1501).
+> `prepare_delegation` fails loud with this exact remediation when
+> `nativeIsolation` is requested and the pin is absent:
+>
+> ```json
+> { "worktree": { "baseRef": "head" } }
+> ```
+>
+> Worktrees are a clean checkout, so only *committed* HEAD state propagates —
+> commit design / plan / research before dispatching.
+>
+> With the pin in place (and the implementer's own base assert as backstop),
+> operators no longer hand-prepend a `git reset --hard <integration-tip>` STEP 0
+> to each dispatch — base correctness is enforced by configuration + guard.
+<!-- /requires -->
 
 ### Recovery procedure
 

--- a/skills-src/delegation/references/implementer-prompt.md
+++ b/skills-src/delegation/references/implementer-prompt.md
@@ -357,7 +357,7 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
-## CRITICAL: Base Verification (MANDATORY)
+## CRITICAL: Base Verification (MANDATORY) (Example)
 
 Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
 

--- a/skills-src/delegation/references/implementer-prompt.md
+++ b/skills-src/delegation/references/implementer-prompt.md
@@ -52,6 +52,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main`. On native-isolation runtimes the worktree base depends on `worktree.baseRef` (see the delegation skill); this assert is the version-independent safety net that halts loud if the base is wrong — so you never build on a base missing prerequisite in-branch commits (issues #1509 / #1501).
+
+```bash
+git merge-base --is-ancestor "[integration-tip]" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`[integration-tip]` is the workflow's integration branch (or its tip SHA), supplied by the orchestrator at dispatch. If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Task Description
 [Full task description from implementation plan - never reference external files]
 
@@ -344,6 +356,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
+
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
+
+```bash
+git merge-base --is-ancestor "feat/registration" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
 
 ## Task Description
 Implement email validation for user registration. The validator should:

--- a/skills-src/delegation/references/worktree-enforcement.md
+++ b/skills-src/delegation/references/worktree-enforcement.md
@@ -11,20 +11,33 @@ All implementation tasks MUST run in isolated worktrees, not the main project ro
 
 ## Pre-Dispatch Checklist
 
-Before dispatching ANY implementer, run the worktree setup script:
+Before dispatching ANY implementer, run the worktree setup script. Always
+pass `featureId` so the action can base the worktree on the workflow's
+**integration tip** (`synthesis.integrationBranch`), not a stale `main`:
 
 ```typescript
 exarchos_orchestrate({
   action: "setup_worktree",
   repoRoot: "<project-root>",
+  featureId: "<feature-id>",
   taskId: "<task-id>",
   taskName: "<task-name>"
+  // baseBranch: "<integration-branch>"  // optional explicit override
 })
 ```
 
+**Base-branch resolution (#1509 / #1501):** the feature branch is created from
+the first available of `baseBranch` arg → `synthesis.integrationBranch` (from
+state) → current `HEAD` → `main`. On a stacked / non-`main` integration
+branch, omitting `featureId` AND running from outside the integration checkout
+is the one way to silently land on `main` — so pass `featureId`, or set
+`baseBranch` explicitly. This is the managed-path equivalent of the native
+`worktree.baseRef:"head"` guard: both ensure subagent worktrees branch from the
+integration tip across all six runtimes.
+
 **Validates:**
 - `.worktrees/` is gitignored (adds to `.gitignore` if missing)
-- Feature branch created (`feature/<task-id>-<task-name>` from base branch)
+- Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree
 - Baseline tests pass in worktree

--- a/skills/claude/delegation/SKILL.md
+++ b/skills/claude/delegation/SKILL.md
@@ -395,14 +395,35 @@ first.
 
 ### Why this happens
 
-Each subagent worktree is created at the integration branch's tip at
-dispatch time. When the orchestrator merges sibling worktrees serially,
-each merge moves the integration branch forward. A worktree that was
-dispatched against an older integration tip will fail the ancestry
-preflight when its turn comes.
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
 
 This is expected behavior under the current single-writer merge contract —
 preflight is fail-only on purpose so the operator stays in control.
+
+
+> **Prerequisite — pin the worktree base.** Native `isolation: worktree`
+> branches subagent worktrees from the repository's default branch
+> (`origin/HEAD` → `main`), **not** the integration tip, unless
+> `worktree.baseRef: "head"` is set in `.claude/settings.json`. Without the pin,
+> a subagent dispatched onto any stacked / non-`main` integration branch gets a
+> base missing every in-branch prerequisite commit (issues #1509 / #1501).
+> `prepare_delegation` fails loud with this exact remediation when
+> `nativeIsolation` is requested and the pin is absent:
+>
+> ```json
+> { "worktree": { "baseRef": "head" } }
+> ```
+>
+> Worktrees are a clean checkout, so only *committed* HEAD state propagates —
+> commit design / plan / research before dispatching.
+>
+> With the pin in place (and the implementer's own base assert as backstop),
+> operators no longer hand-prepend a `git reset --hard <integration-tip>` STEP 0
+> to each dispatch — base correctness is enforced by configuration + guard.
 
 ### Recovery procedure
 

--- a/skills/claude/delegation/references/implementer-prompt.md
+++ b/skills/claude/delegation/references/implementer-prompt.md
@@ -362,7 +362,7 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
-## CRITICAL: Base Verification (MANDATORY)
+## CRITICAL: Base Verification (MANDATORY) (Example)
 
 Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
 

--- a/skills/claude/delegation/references/implementer-prompt.md
+++ b/skills/claude/delegation/references/implementer-prompt.md
@@ -52,6 +52,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main`. On native-isolation runtimes the worktree base depends on `worktree.baseRef` (see the delegation skill); this assert is the version-independent safety net that halts loud if the base is wrong — so you never build on a base missing prerequisite in-branch commits (issues #1509 / #1501).
+
+```bash
+git merge-base --is-ancestor "[integration-tip]" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`[integration-tip]` is the workflow's integration branch (or its tip SHA), supplied by the orchestrator at dispatch. If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Task Description
 [Full task description from implementation plan - never reference external files]
 
@@ -349,6 +361,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
+
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
+
+```bash
+git merge-base --is-ancestor "feat/registration" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
 
 ## Task Description
 Implement email validation for user registration. The validator should:

--- a/skills/claude/delegation/references/worktree-enforcement.md
+++ b/skills/claude/delegation/references/worktree-enforcement.md
@@ -11,20 +11,33 @@ All implementation tasks MUST run in isolated worktrees, not the main project ro
 
 ## Pre-Dispatch Checklist
 
-Before dispatching ANY implementer, run the worktree setup script:
+Before dispatching ANY implementer, run the worktree setup script. Always
+pass `featureId` so the action can base the worktree on the workflow's
+**integration tip** (`synthesis.integrationBranch`), not a stale `main`:
 
 ```typescript
 exarchos_orchestrate({
   action: "setup_worktree",
   repoRoot: "<project-root>",
+  featureId: "<feature-id>",
   taskId: "<task-id>",
   taskName: "<task-name>"
+  // baseBranch: "<integration-branch>"  // optional explicit override
 })
 ```
 
+**Base-branch resolution (#1509 / #1501):** the feature branch is created from
+the first available of `baseBranch` arg → `synthesis.integrationBranch` (from
+state) → current `HEAD` → `main`. On a stacked / non-`main` integration
+branch, omitting `featureId` AND running from outside the integration checkout
+is the one way to silently land on `main` — so pass `featureId`, or set
+`baseBranch` explicitly. This is the managed-path equivalent of the native
+`worktree.baseRef:"head"` guard: both ensure subagent worktrees branch from the
+integration tip across all six runtimes.
+
 **Validates:**
 - `.worktrees/` is gitignored (adds to `.gitignore` if missing)
-- Feature branch created (`feature/<task-id>-<task-name>` from base branch)
+- Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree
 - Baseline tests pass in worktree

--- a/skills/codex/delegation/SKILL.md
+++ b/skills/codex/delegation/SKILL.md
@@ -350,14 +350,15 @@ first.
 
 ### Why this happens
 
-Each subagent worktree is created at the integration branch's tip at
-dispatch time. When the orchestrator merges sibling worktrees serially,
-each merge moves the integration branch forward. A worktree that was
-dispatched against an older integration tip will fail the ancestry
-preflight when its turn comes.
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
 
 This is expected behavior under the current single-writer merge contract —
 preflight is fail-only on purpose so the operator stays in control.
+
 
 ### Recovery procedure
 

--- a/skills/codex/delegation/references/implementer-prompt.md
+++ b/skills/codex/delegation/references/implementer-prompt.md
@@ -52,6 +52,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main`. On native-isolation runtimes the worktree base depends on `worktree.baseRef` (see the delegation skill); this assert is the version-independent safety net that halts loud if the base is wrong — so you never build on a base missing prerequisite in-branch commits (issues #1509 / #1501).
+
+```bash
+git merge-base --is-ancestor "[integration-tip]" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`[integration-tip]` is the workflow's integration branch (or its tip SHA), supplied by the orchestrator at dispatch. If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Task Description
 [Full task description from implementation plan - never reference external files]
 
@@ -321,6 +333,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
+
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
+
+```bash
+git merge-base --is-ancestor "feat/registration" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
 
 ## Task Description
 Implement email validation for user registration. The validator should:

--- a/skills/codex/delegation/references/implementer-prompt.md
+++ b/skills/codex/delegation/references/implementer-prompt.md
@@ -334,7 +334,7 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
-## CRITICAL: Base Verification (MANDATORY)
+## CRITICAL: Base Verification (MANDATORY) (Example)
 
 Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
 

--- a/skills/codex/delegation/references/worktree-enforcement.md
+++ b/skills/codex/delegation/references/worktree-enforcement.md
@@ -11,20 +11,33 @@ All implementation tasks MUST run in isolated worktrees, not the main project ro
 
 ## Pre-Dispatch Checklist
 
-Before dispatching ANY implementer, run the worktree setup script:
+Before dispatching ANY implementer, run the worktree setup script. Always
+pass `featureId` so the action can base the worktree on the workflow's
+**integration tip** (`synthesis.integrationBranch`), not a stale `main`:
 
 ```typescript
 exarchos_orchestrate({
   action: "setup_worktree",
   repoRoot: "<project-root>",
+  featureId: "<feature-id>",
   taskId: "<task-id>",
   taskName: "<task-name>"
+  // baseBranch: "<integration-branch>"  // optional explicit override
 })
 ```
 
+**Base-branch resolution (#1509 / #1501):** the feature branch is created from
+the first available of `baseBranch` arg → `synthesis.integrationBranch` (from
+state) → current `HEAD` → `main`. On a stacked / non-`main` integration
+branch, omitting `featureId` AND running from outside the integration checkout
+is the one way to silently land on `main` — so pass `featureId`, or set
+`baseBranch` explicitly. This is the managed-path equivalent of the native
+`worktree.baseRef:"head"` guard: both ensure subagent worktrees branch from the
+integration tip across all six runtimes.
+
 **Validates:**
 - `.worktrees/` is gitignored (adds to `.gitignore` if missing)
-- Feature branch created (`feature/<task-id>-<task-name>` from base branch)
+- Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree
 - Baseline tests pass in worktree

--- a/skills/copilot/delegation/SKILL.md
+++ b/skills/copilot/delegation/SKILL.md
@@ -342,14 +342,15 @@ first.
 
 ### Why this happens
 
-Each subagent worktree is created at the integration branch's tip at
-dispatch time. When the orchestrator merges sibling worktrees serially,
-each merge moves the integration branch forward. A worktree that was
-dispatched against an older integration tip will fail the ancestry
-preflight when its turn comes.
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
 
 This is expected behavior under the current single-writer merge contract —
 preflight is fail-only on purpose so the operator stays in control.
+
 
 ### Recovery procedure
 

--- a/skills/copilot/delegation/references/implementer-prompt.md
+++ b/skills/copilot/delegation/references/implementer-prompt.md
@@ -52,6 +52,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main`. On native-isolation runtimes the worktree base depends on `worktree.baseRef` (see the delegation skill); this assert is the version-independent safety net that halts loud if the base is wrong — so you never build on a base missing prerequisite in-branch commits (issues #1509 / #1501).
+
+```bash
+git merge-base --is-ancestor "[integration-tip]" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`[integration-tip]` is the workflow's integration branch (or its tip SHA), supplied by the orchestrator at dispatch. If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Task Description
 [Full task description from implementation plan - never reference external files]
 
@@ -317,6 +329,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
+
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
+
+```bash
+git merge-base --is-ancestor "feat/registration" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
 
 ## Task Description
 Implement email validation for user registration. The validator should:

--- a/skills/copilot/delegation/references/implementer-prompt.md
+++ b/skills/copilot/delegation/references/implementer-prompt.md
@@ -330,7 +330,7 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
-## CRITICAL: Base Verification (MANDATORY)
+## CRITICAL: Base Verification (MANDATORY) (Example)
 
 Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
 

--- a/skills/copilot/delegation/references/worktree-enforcement.md
+++ b/skills/copilot/delegation/references/worktree-enforcement.md
@@ -11,20 +11,33 @@ All implementation tasks MUST run in isolated worktrees, not the main project ro
 
 ## Pre-Dispatch Checklist
 
-Before dispatching ANY implementer, run the worktree setup script:
+Before dispatching ANY implementer, run the worktree setup script. Always
+pass `featureId` so the action can base the worktree on the workflow's
+**integration tip** (`synthesis.integrationBranch`), not a stale `main`:
 
 ```typescript
 exarchos_orchestrate({
   action: "setup_worktree",
   repoRoot: "<project-root>",
+  featureId: "<feature-id>",
   taskId: "<task-id>",
   taskName: "<task-name>"
+  // baseBranch: "<integration-branch>"  // optional explicit override
 })
 ```
 
+**Base-branch resolution (#1509 / #1501):** the feature branch is created from
+the first available of `baseBranch` arg → `synthesis.integrationBranch` (from
+state) → current `HEAD` → `main`. On a stacked / non-`main` integration
+branch, omitting `featureId` AND running from outside the integration checkout
+is the one way to silently land on `main` — so pass `featureId`, or set
+`baseBranch` explicitly. This is the managed-path equivalent of the native
+`worktree.baseRef:"head"` guard: both ensure subagent worktrees branch from the
+integration tip across all six runtimes.
+
 **Validates:**
 - `.worktrees/` is gitignored (adds to `.gitignore` if missing)
-- Feature branch created (`feature/<task-id>-<task-name>` from base branch)
+- Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree
 - Baseline tests pass in worktree

--- a/skills/cursor/delegation/SKILL.md
+++ b/skills/cursor/delegation/SKILL.md
@@ -352,14 +352,15 @@ first.
 
 ### Why this happens
 
-Each subagent worktree is created at the integration branch's tip at
-dispatch time. When the orchestrator merges sibling worktrees serially,
-each merge moves the integration branch forward. A worktree that was
-dispatched against an older integration tip will fail the ancestry
-preflight when its turn comes.
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
 
 This is expected behavior under the current single-writer merge contract —
 preflight is fail-only on purpose so the operator stays in control.
+
 
 ### Recovery procedure
 

--- a/skills/cursor/delegation/references/implementer-prompt.md
+++ b/skills/cursor/delegation/references/implementer-prompt.md
@@ -52,6 +52,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main`. On native-isolation runtimes the worktree base depends on `worktree.baseRef` (see the delegation skill); this assert is the version-independent safety net that halts loud if the base is wrong — so you never build on a base missing prerequisite in-branch commits (issues #1509 / #1501).
+
+```bash
+git merge-base --is-ancestor "[integration-tip]" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`[integration-tip]` is the workflow's integration branch (or its tip SHA), supplied by the orchestrator at dispatch. If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Task Description
 [Full task description from implementation plan - never reference external files]
 
@@ -322,6 +334,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
+
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
+
+```bash
+git merge-base --is-ancestor "feat/registration" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
 
 ## Task Description
 Implement email validation for user registration. The validator should:

--- a/skills/cursor/delegation/references/implementer-prompt.md
+++ b/skills/cursor/delegation/references/implementer-prompt.md
@@ -335,7 +335,7 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
-## CRITICAL: Base Verification (MANDATORY)
+## CRITICAL: Base Verification (MANDATORY) (Example)
 
 Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
 

--- a/skills/cursor/delegation/references/worktree-enforcement.md
+++ b/skills/cursor/delegation/references/worktree-enforcement.md
@@ -11,20 +11,33 @@ All implementation tasks MUST run in isolated worktrees, not the main project ro
 
 ## Pre-Dispatch Checklist
 
-Before dispatching ANY implementer, run the worktree setup script:
+Before dispatching ANY implementer, run the worktree setup script. Always
+pass `featureId` so the action can base the worktree on the workflow's
+**integration tip** (`synthesis.integrationBranch`), not a stale `main`:
 
 ```typescript
 exarchos_orchestrate({
   action: "setup_worktree",
   repoRoot: "<project-root>",
+  featureId: "<feature-id>",
   taskId: "<task-id>",
   taskName: "<task-name>"
+  // baseBranch: "<integration-branch>"  // optional explicit override
 })
 ```
 
+**Base-branch resolution (#1509 / #1501):** the feature branch is created from
+the first available of `baseBranch` arg → `synthesis.integrationBranch` (from
+state) → current `HEAD` → `main`. On a stacked / non-`main` integration
+branch, omitting `featureId` AND running from outside the integration checkout
+is the one way to silently land on `main` — so pass `featureId`, or set
+`baseBranch` explicitly. This is the managed-path equivalent of the native
+`worktree.baseRef:"head"` guard: both ensure subagent worktrees branch from the
+integration tip across all six runtimes.
+
 **Validates:**
 - `.worktrees/` is gitignored (adds to `.gitignore` if missing)
-- Feature branch created (`feature/<task-id>-<task-name>` from base branch)
+- Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree
 - Baseline tests pass in worktree

--- a/skills/generic/delegation/SKILL.md
+++ b/skills/generic/delegation/SKILL.md
@@ -323,14 +323,15 @@ first.
 
 ### Why this happens
 
-Each subagent worktree is created at the integration branch's tip at
-dispatch time. When the orchestrator merges sibling worktrees serially,
-each merge moves the integration branch forward. A worktree that was
-dispatched against an older integration tip will fail the ancestry
-preflight when its turn comes.
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
 
 This is expected behavior under the current single-writer merge contract —
 preflight is fail-only on purpose so the operator stays in control.
+
 
 ### Recovery procedure
 

--- a/skills/generic/delegation/references/implementer-prompt.md
+++ b/skills/generic/delegation/references/implementer-prompt.md
@@ -52,6 +52,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main`. On native-isolation runtimes the worktree base depends on `worktree.baseRef` (see the delegation skill); this assert is the version-independent safety net that halts loud if the base is wrong — so you never build on a base missing prerequisite in-branch commits (issues #1509 / #1501).
+
+```bash
+git merge-base --is-ancestor "[integration-tip]" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`[integration-tip]` is the workflow's integration branch (or its tip SHA), supplied by the orchestrator at dispatch. If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Task Description
 [Full task description from implementation plan - never reference external files]
 
@@ -317,6 +329,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
+
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
+
+```bash
+git merge-base --is-ancestor "feat/registration" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
 
 ## Task Description
 Implement email validation for user registration. The validator should:

--- a/skills/generic/delegation/references/implementer-prompt.md
+++ b/skills/generic/delegation/references/implementer-prompt.md
@@ -330,7 +330,7 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
-## CRITICAL: Base Verification (MANDATORY)
+## CRITICAL: Base Verification (MANDATORY) (Example)
 
 Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
 

--- a/skills/generic/delegation/references/worktree-enforcement.md
+++ b/skills/generic/delegation/references/worktree-enforcement.md
@@ -11,20 +11,33 @@ All implementation tasks MUST run in isolated worktrees, not the main project ro
 
 ## Pre-Dispatch Checklist
 
-Before dispatching ANY implementer, run the worktree setup script:
+Before dispatching ANY implementer, run the worktree setup script. Always
+pass `featureId` so the action can base the worktree on the workflow's
+**integration tip** (`synthesis.integrationBranch`), not a stale `main`:
 
 ```typescript
 exarchos_orchestrate({
   action: "setup_worktree",
   repoRoot: "<project-root>",
+  featureId: "<feature-id>",
   taskId: "<task-id>",
   taskName: "<task-name>"
+  // baseBranch: "<integration-branch>"  // optional explicit override
 })
 ```
 
+**Base-branch resolution (#1509 / #1501):** the feature branch is created from
+the first available of `baseBranch` arg → `synthesis.integrationBranch` (from
+state) → current `HEAD` → `main`. On a stacked / non-`main` integration
+branch, omitting `featureId` AND running from outside the integration checkout
+is the one way to silently land on `main` — so pass `featureId`, or set
+`baseBranch` explicitly. This is the managed-path equivalent of the native
+`worktree.baseRef:"head"` guard: both ensure subagent worktrees branch from the
+integration tip across all six runtimes.
+
 **Validates:**
 - `.worktrees/` is gitignored (adds to `.gitignore` if missing)
-- Feature branch created (`feature/<task-id>-<task-name>` from base branch)
+- Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree
 - Baseline tests pass in worktree

--- a/skills/opencode/delegation/SKILL.md
+++ b/skills/opencode/delegation/SKILL.md
@@ -350,14 +350,15 @@ first.
 
 ### Why this happens
 
-Each subagent worktree is created at the integration branch's tip at
-dispatch time. When the orchestrator merges sibling worktrees serially,
-each merge moves the integration branch forward. A worktree that was
-dispatched against an older integration tip will fail the ancestry
-preflight when its turn comes.
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
 
 This is expected behavior under the current single-writer merge contract —
 preflight is fail-only on purpose so the operator stays in control.
+
 
 ### Recovery procedure
 

--- a/skills/opencode/delegation/references/implementer-prompt.md
+++ b/skills/opencode/delegation/references/implementer-prompt.md
@@ -52,6 +52,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main`. On native-isolation runtimes the worktree base depends on `worktree.baseRef` (see the delegation skill); this assert is the version-independent safety net that halts loud if the base is wrong — so you never build on a base missing prerequisite in-branch commits (issues #1509 / #1501).
+
+```bash
+git merge-base --is-ancestor "[integration-tip]" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+`[integration-tip]` is the workflow's integration branch (or its tip SHA), supplied by the orchestrator at dispatch. If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
+
 ## Task Description
 [Full task description from implementation plan - never reference external files]
 
@@ -321,6 +333,18 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 ```
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
+
+## CRITICAL: Base Verification (MANDATORY)
+
+Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
+
+```bash
+git merge-base --is-ancestor "feat/registration" HEAD \
+  && echo "BASE OK" \
+  || { echo "ERROR: worktree base is not a descendant of the integration tip — halting"; exit 1; }
+```
+
+If this fails, STOP and report — do NOT rebase or reset to self-heal; the orchestrator owns base correction.
 
 ## Task Description
 Implement email validation for user registration. The validator should:

--- a/skills/opencode/delegation/references/implementer-prompt.md
+++ b/skills/opencode/delegation/references/implementer-prompt.md
@@ -334,7 +334,7 @@ pwd | grep -q "\.worktrees" || { echo "ERROR: Not in worktree!"; exit 1; }
 
 This check prevents accidental modifications to the main project root, which would cause merge conflicts with other parallel tasks.
 
-## CRITICAL: Base Verification (MANDATORY)
+## CRITICAL: Base Verification (MANDATORY) (Example)
 
 Before making ANY file changes, verify your worktree is based on the **integration tip**, not a stale `main` (issues #1509 / #1501):
 

--- a/skills/opencode/delegation/references/worktree-enforcement.md
+++ b/skills/opencode/delegation/references/worktree-enforcement.md
@@ -11,20 +11,33 @@ All implementation tasks MUST run in isolated worktrees, not the main project ro
 
 ## Pre-Dispatch Checklist
 
-Before dispatching ANY implementer, run the worktree setup script:
+Before dispatching ANY implementer, run the worktree setup script. Always
+pass `featureId` so the action can base the worktree on the workflow's
+**integration tip** (`synthesis.integrationBranch`), not a stale `main`:
 
 ```typescript
 exarchos_orchestrate({
   action: "setup_worktree",
   repoRoot: "<project-root>",
+  featureId: "<feature-id>",
   taskId: "<task-id>",
   taskName: "<task-name>"
+  // baseBranch: "<integration-branch>"  // optional explicit override
 })
 ```
 
+**Base-branch resolution (#1509 / #1501):** the feature branch is created from
+the first available of `baseBranch` arg → `synthesis.integrationBranch` (from
+state) → current `HEAD` → `main`. On a stacked / non-`main` integration
+branch, omitting `featureId` AND running from outside the integration checkout
+is the one way to silently land on `main` — so pass `featureId`, or set
+`baseBranch` explicitly. This is the managed-path equivalent of the native
+`worktree.baseRef:"head"` guard: both ensure subagent worktrees branch from the
+integration tip across all six runtimes.
+
 **Validates:**
 - `.worktrees/` is gitignored (adds to `.gitignore` if missing)
-- Feature branch created (`feature/<task-id>-<task-name>` from base branch)
+- Feature branch created (`feature/<task-id>-<task-name>` from the resolved integration tip)
 - Git worktree added at `.worktrees/<task-id>-<task-name>`
 - `npm install` ran in worktree
 - Baseline tests pass in worktree

--- a/test/migration/__snapshots__/snapshots.test.ts.snap
+++ b/test/migration/__snapshots__/snapshots.test.ts.snap
@@ -1247,14 +1247,35 @@ first.
 
 ### Why this happens
 
-Each subagent worktree is created at the integration branch's tip at
-dispatch time. When the orchestrator merges sibling worktrees serially,
-each merge moves the integration branch forward. A worktree that was
-dispatched against an older integration tip will fail the ancestry
-preflight when its turn comes.
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
 
 This is expected behavior under the current single-writer merge contract —
 preflight is fail-only on purpose so the operator stays in control.
+
+
+> **Prerequisite — pin the worktree base.** Native \`isolation: worktree\`
+> branches subagent worktrees from the repository's default branch
+> (\`origin/HEAD\` → \`main\`), **not** the integration tip, unless
+> \`worktree.baseRef: "head"\` is set in \`.claude/settings.json\`. Without the pin,
+> a subagent dispatched onto any stacked / non-\`main\` integration branch gets a
+> base missing every in-branch prerequisite commit (issues #1509 / #1501).
+> \`prepare_delegation\` fails loud with this exact remediation when
+> \`nativeIsolation\` is requested and the pin is absent:
+>
+> \`\`\`json
+> { "worktree": { "baseRef": "head" } }
+> \`\`\`
+>
+> Worktrees are a clean checkout, so only *committed* HEAD state propagates —
+> commit design / plan / research before dispatching.
+>
+> With the pin in place (and the implementer's own base assert as backstop),
+> operators no longer hand-prepend a \`git reset --hard <integration-tip>\` STEP 0
+> to each dispatch — base correctness is enforced by configuration + guard.
 
 ### Recovery procedure
 
@@ -6133,14 +6154,15 @@ first.
 
 ### Why this happens
 
-Each subagent worktree is created at the integration branch's tip at
-dispatch time. When the orchestrator merges sibling worktrees serially,
-each merge moves the integration branch forward. A worktree that was
-dispatched against an older integration tip will fail the ancestry
-preflight when its turn comes.
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
 
 This is expected behavior under the current single-writer merge contract —
 preflight is fail-only on purpose so the operator stays in control.
+
 
 ### Recovery procedure
 
@@ -11009,14 +11031,15 @@ first.
 
 ### Why this happens
 
-Each subagent worktree is created at the integration branch's tip at
-dispatch time. When the orchestrator merges sibling worktrees serially,
-each merge moves the integration branch forward. A worktree that was
-dispatched against an older integration tip will fail the ancestry
-preflight when its turn comes.
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
 
 This is expected behavior under the current single-writer merge contract —
 preflight is fail-only on purpose so the operator stays in control.
+
 
 ### Recovery procedure
 
@@ -15895,14 +15918,15 @@ first.
 
 ### Why this happens
 
-Each subagent worktree is created at the integration branch's tip at
-dispatch time. When the orchestrator merges sibling worktrees serially,
-each merge moves the integration branch forward. A worktree that was
-dispatched against an older integration tip will fail the ancestry
-preflight when its turn comes.
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
 
 This is expected behavior under the current single-writer merge contract —
 preflight is fail-only on purpose so the operator stays in control.
+
 
 ### Recovery procedure
 
@@ -20752,14 +20776,15 @@ first.
 
 ### Why this happens
 
-Each subagent worktree is created at the integration branch's tip at
-dispatch time. When the orchestrator merges sibling worktrees serially,
-each merge moves the integration branch forward. A worktree that was
-dispatched against an older integration tip will fail the ancestry
-preflight when its turn comes.
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
 
 This is expected behavior under the current single-writer merge contract —
 preflight is fail-only on purpose so the operator stays in control.
+
 
 ### Recovery procedure
 
@@ -25636,14 +25661,15 @@ first.
 
 ### Why this happens
 
-Each subagent worktree is created at the integration branch's tip at
-dispatch time. When the orchestrator merges sibling worktrees serially,
-each merge moves the integration branch forward. A worktree that was
-dispatched against an older integration tip will fail the ancestry
-preflight when its turn comes.
+With the worktree base pinned to local HEAD (see prerequisite below), each
+subagent worktree is created at the integration branch's tip at dispatch time.
+When the orchestrator merges sibling worktrees serially, each merge moves the
+integration branch forward. A worktree that was dispatched against an older
+integration tip will fail the ancestry preflight when its turn comes.
 
 This is expected behavior under the current single-writer merge contract —
 preflight is fail-only on purpose so the operator stays in control.
+
 
 ### Recovery procedure
 


### PR DESCRIPTION
## Summary

Native Claude Code `isolation: worktree` branches subagent worktrees from `origin/HEAD` (the default branch, `main`), **not** the orchestrator's integration tip — so every stacked-branch delegation lands on a base missing its in-branch prerequisites. Reported twice from the field (#1509 dynatoi, #1501 canonical-identity) as *inferred* behavior.

This bundle resolves the **#1501 spike authoritatively** (verified against `code.claude.com/docs`: the documented override `worktree.baseRef: "head"` bases worktrees on local HEAD = integration tip at dispatch time) and ships the **#1509 fix** as three defense-in-depth layers, keeping `isolation: worktree` (the upstream remedy already exists). Upholds **INV-11** (a task-isolated agent's base is bounded by construction, not operator convention) and **INV-4** (the Claude-specific setting is guarded so it renders only on Claude Code).

Closes #1509. Closes #1501.

## Changes

- **Layer 1 — primary lever:** committed `.claude/settings.json` `{ "worktree": { "baseRef": "head" } }` (dogfood; aligns native isolation with the delegation contract).
- **Layer 2 — delivery (detect-and-block):** new `worktree-baseref.ts` (`resolveWorktreeBaseRef` / `assertWorktreeBaseRefPinned` — injectable settings cascade local > project > user, `process.cwd()`-rooted, fail-closed on unset/`fresh`/malformed). Wired into `prepare_delegation` as a `nativeIsolation`-only guard (DR-2b): blocks loud with the exact remediation instead of silently dispatching onto `main`. `guardOutcomes.baseRef` + `dispatch.preflight` guards map wired; `DispatchPreflightData.guards.baseRef` added **optional** so existing emitters stay valid. Non-native path unchanged.
- **Layer 3 — version-independent safety net:** a pure-git `merge-base --is-ancestor <integration-tip> HEAD` assert baked into the shared `WORKTREE_ENTRY_CONTRACT` (implementer/fixer/scaffolder) and the cross-runtime implementer-prompt template — fails closed on hosts that ignore `baseRef`, and instructs the agent not to self-heal.
- **Prose:** corrected the delegation skill's false "created at the integration branch's tip" contract; baseRef prerequisite wrapped in `<!-- requires:native:isolation:worktree -->` (renders only on Claude Code). Regenerated 108 skill variants / 20 agent files; snapshot fixtures refreshed.
- **Docs:** RCA (`docs/rca/2026-05-31-implementer-worktree-base.md`) records the authoritative base-selection rule; fix design (`docs/designs/2026-05-31-implementer-worktree-base.md`).

## Test Plan

- [x] New unit tests: `worktree-baseref.test.ts` (11 — precedence, unset, malformed, non-enum, fresh/head, block/pass/remediation)
- [x] New `prepare_delegation` wiring tests (3 — block-on-unset-with-remediation, pinned-proceeds, non-native-skips-guard)
- [x] Full MCP suite: **7299 passed, 0 failed, 21 skipped**
- [x] `tsc --noEmit` clean
- [x] `npm run build:skills` idempotent (checksum-proven) → `skills:guard` passes; INV-4 verified (baseRef renders only in `skills/claude`)
- [x] `lint:invariants` 0 findings · `lint:inv6` exit 0 · `implementer-prompt.md.test.sh` PASS
- [x] Two-stage review: spec-compliance PASS, code-quality PASS (0 findings) → verdict **APPROVED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
