### PR TITLE
feat(v2.10.1): cross-harness canonical workflow names + harness setup docs (#1472, #1471)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ Exarchos is local agent governance for Claude Code — event-sourced SDLC workfl
 npm run build          # tsc + bun → dist/ (includes MCP server + CLI bundles)
 npm run test:run       # vitest single run
 npm run typecheck      # tsc --noEmit
-npm run build:skills   # render skills-src/ → skills/<runtime>/ per-runtime variants
-npm run skills:guard   # CI: fails if generated skills/ is out of sync with skills-src/
+npm run build:skills   # render skills-src/ → skills/<runtime>/ variants + command-aliases/<runtime>/
+npm run skills:guard   # CI: fails if generated skills/ or command-aliases/ drift from sources
 
 # MCP server tests (build is handled by root `npm run build`)
 cd servers/exarchos-mcp && npm run test:run
@@ -19,7 +19,7 @@ cd servers/exarchos-mcp && npm run test:run
 
 - **Installer** — Bootstrap scripts (`scripts/get-exarchos.sh`, `scripts/get-exarchos.ps1`) download the single-file binary from GitHub Releases; plugin packaging registers commands/skills/rules via the `.claude-plugin/` manifest. The npx-based `src/install.ts` was removed in v2.9 (task 3.1).
 - **Content layers** — Commands (`commands/*.md`); Skills source-of-truth at `skills-src/<name>/SKILL.md` (with `{{TOKEN}}` placeholders and `references/`) rendered to `skills/<runtime>/<name>/SKILL.md` per runtime (Claude Code, Codex, Copilot, Cursor, OpenCode, generic); Rules (`rules/*.md` — safety only; domain rules in `skills-src/*/references/`). Structured Markdown, not executable code.
-- **Skills renderer** (`src/build-skills.ts`) — `npm run build:skills` walks `skills-src/`, substitutes placeholders from `runtimes/<name>.yaml`, copies each skill's `references/` verbatim into every runtime variant, honors `SKILL.<runtime>.md` structural overrides, and prunes stale output. A vocabulary lint runs as a pre-flight; `npm run skills:guard` re-renders and fails CI on any `git diff skills/` drift.
+- **Skills renderer** (`src/build-skills.ts`) — `npm run build:skills` walks `skills-src/`, substitutes placeholders from `runtimes/<name>.yaml`, copies each skill's `references/` verbatim into every runtime variant, honors `SKILL.<runtime>.md` structural overrides, and prunes stale output. A vocabulary lint runs as a pre-flight; `npm run skills:guard` re-renders and fails CI on any `git diff skills/` or `command-aliases/` drift. For runtimes that declare `capabilities.canonicalCommandAliases` (opencode today), the build also emits canonical-name command aliases (`/ideate`, `/plan`, …) to `command-aliases/<runtime>/` from the `COMMAND_TO_SKILL` source-of-truth in `src/config/canonical-skills.ts`, so workflow names stay consistent across harnesses (INV-4).
 - **MCP server** (`servers/exarchos-mcp/`) — 4 visible composite tools (`exarchos_workflow`, `exarchos_event`, `exarchos_orchestrate`, `exarchos_view`) + 1 hidden sync tool (`exarchos_sync`). Uses `@modelcontextprotocol/sdk` + `zod` over stdio.
 - **Orchestrate handlers** (`servers/exarchos-mcp/src/orchestrate/`) — TypeScript handlers for all workflow actions. Each handler accepts typed args, returns structured `ToolResult`. No bash dependency for workflow operations.
 - **Toolchain resolution** — `src/config/toolchains.ts` is the single source of truth for toolchain *identity* (markers → id + `projectType`); `test-runtime-resolver.ts`, `static-analysis.ts`, and `new-project.ts` are thin consumers (no independent marker lists or command literals). `resolveTestRuntime` is a synchronous, per-field **layered resolver**: override > `.exarchos.yml` direct > user `toolchains:` > task-runner (`task-runners.ts`: Taskfile/just/mise/Makefile) > built-in registry > unresolved. Node PM detection reads a vendored `package-manager-detector` lockfile table (`src/config/vendor/`, regenerate via `npm run vendor:sync:pm-detector`). See [`docs/guides/toolchain-resolution.md`](docs/guides/toolchain-resolution.md). Upholds INV-6/INV-4.

--- a/command-aliases/opencode/checkpoint.md
+++ b/command-aliases/opencode/checkpoint.md
@@ -1,0 +1,9 @@
+---
+description: Save workflow state and prepare for session handoff
+---
+
+# /checkpoint
+
+Canonical alias for the Exarchos `/checkpoint` workflow command.
+
+Invoke the `workflow-state` skill to handle: $ARGUMENTS

--- a/command-aliases/opencode/cleanup.md
+++ b/command-aliases/opencode/cleanup.md
@@ -1,0 +1,9 @@
+---
+description: Resolve merged workflow to completed state
+---
+
+# /cleanup
+
+Canonical alias for the Exarchos `/cleanup` workflow command.
+
+Invoke the `cleanup` skill to handle: $ARGUMENTS

--- a/command-aliases/opencode/debug.md
+++ b/command-aliases/opencode/debug.md
@@ -1,0 +1,9 @@
+---
+description: Start debug workflow for bugs and regressions
+---
+
+# /debug
+
+Canonical alias for the Exarchos `/debug` workflow command.
+
+Invoke the `debug` skill to handle: $ARGUMENTS

--- a/command-aliases/opencode/delegate.md
+++ b/command-aliases/opencode/delegate.md
@@ -1,5 +1,5 @@
 ---
-description: Dispatch tasks to Claude Code subagents
+description: Dispatch tasks to subagents
 ---
 
 # /delegate

--- a/command-aliases/opencode/delegate.md
+++ b/command-aliases/opencode/delegate.md
@@ -1,0 +1,9 @@
+---
+description: Dispatch tasks to Claude Code subagents
+---
+
+# /delegate
+
+Canonical alias for the Exarchos `/delegate` workflow command.
+
+Invoke `delegation`, then `git-worktrees` skills to handle: $ARGUMENTS

--- a/command-aliases/opencode/discover.md
+++ b/command-aliases/opencode/discover.md
@@ -1,0 +1,9 @@
+---
+description: Start a discovery workflow for research and document deliverables
+---
+
+# /discover
+
+Canonical alias for the Exarchos `/discover` workflow command.
+
+Invoke the `discovery` skill to handle: $ARGUMENTS

--- a/command-aliases/opencode/dogfood.md
+++ b/command-aliases/opencode/dogfood.md
@@ -1,0 +1,9 @@
+---
+description: "Review failed tool calls in this session, diagnose root causes, and triage into code bug / docs issue / user error"
+---
+
+# /dogfood
+
+Canonical alias for the Exarchos `/dogfood` workflow command.
+
+Invoke the `dogfood` skill to handle: $ARGUMENTS

--- a/command-aliases/opencode/ideate.md
+++ b/command-aliases/opencode/ideate.md
@@ -1,0 +1,9 @@
+---
+description: Start collaborative design exploration for a feature or problem
+---
+
+# /ideate
+
+Canonical alias for the Exarchos `/ideate` workflow command.
+
+Invoke the `brainstorming` skill to handle: $ARGUMENTS

--- a/command-aliases/opencode/invariants.md
+++ b/command-aliases/opencode/invariants.md
@@ -1,0 +1,9 @@
+---
+description: Author an architectural invariant catalog entry through a guided interview
+---
+
+# /invariants
+
+Canonical alias for the Exarchos `/invariants` workflow command.
+
+Invoke the `authoring-invariants` skill to handle: $ARGUMENTS

--- a/command-aliases/opencode/oneshot.md
+++ b/command-aliases/opencode/oneshot.md
@@ -1,0 +1,9 @@
+---
+description: Run a lightweight oneshot workflow — plan + TDD implement + optional PR
+---
+
+# /oneshot
+
+Canonical alias for the Exarchos `/oneshot` workflow command.
+
+Invoke `oneshot-workflow`, then `synthesis` skills to handle: $ARGUMENTS

--- a/command-aliases/opencode/plan.md
+++ b/command-aliases/opencode/plan.md
@@ -1,0 +1,9 @@
+---
+description: Create TDD implementation plan from design document
+---
+
+# /plan
+
+Canonical alias for the Exarchos `/plan` workflow command.
+
+Invoke the `implementation-planning` skill to handle: $ARGUMENTS

--- a/command-aliases/opencode/prune.md
+++ b/command-aliases/opencode/prune.md
@@ -1,0 +1,9 @@
+---
+description: Prune stale workflows from the pipeline (dry-run → confirm → apply)
+---
+
+# /prune
+
+Canonical alias for the Exarchos `/prune` workflow command.
+
+Invoke the `prune-workflows` skill to handle: $ARGUMENTS

--- a/command-aliases/opencode/refactor.md
+++ b/command-aliases/opencode/refactor.md
@@ -1,0 +1,9 @@
+---
+description: Start refactor workflow for code improvement
+---
+
+# /refactor
+
+Canonical alias for the Exarchos `/refactor` workflow command.
+
+Invoke the `refactor` skill to handle: $ARGUMENTS

--- a/command-aliases/opencode/review.md
+++ b/command-aliases/opencode/review.md
@@ -1,0 +1,9 @@
+---
+description: Run two-stage review (spec compliance + code quality)
+---
+
+# /review
+
+Canonical alias for the Exarchos `/review` workflow command.
+
+Invoke `quality-review`, then `spec-review` skills to handle: $ARGUMENTS

--- a/command-aliases/opencode/shepherd.md
+++ b/command-aliases/opencode/shepherd.md
@@ -1,0 +1,9 @@
+---
+description: Shepherd PRs through CI and reviews to merge readiness
+---
+
+# /shepherd
+
+Canonical alias for the Exarchos `/shepherd` workflow command.
+
+Invoke the `shepherd` skill to handle: $ARGUMENTS

--- a/command-aliases/opencode/synthesize.md
+++ b/command-aliases/opencode/synthesize.md
@@ -1,0 +1,9 @@
+---
+description: Create pull request from feature branch
+---
+
+# /synthesize
+
+Canonical alias for the Exarchos `/synthesize` workflow command.
+
+Invoke the `synthesis` skill to handle: $ARGUMENTS

--- a/command-aliases/opencode/tdd.md
+++ b/command-aliases/opencode/tdd.md
@@ -1,0 +1,9 @@
+---
+description: "Plan implementation following strict TDD (Red-Green-Refactor)."
+---
+
+# /tdd
+
+Canonical alias for the Exarchos `/tdd` workflow command.
+
+Invoke the `implementation-planning` skill to handle: $ARGUMENTS

--- a/commands/delegate.md
+++ b/commands/delegate.md
@@ -1,5 +1,5 @@
 ---
-description: Dispatch tasks to Claude Code subagents
+description: Dispatch tasks to subagents
 ---
 
 # Delegate

--- a/docs/designs/2026-05-31-cross-harness-canonical-names-plan.md
+++ b/docs/designs/2026-05-31-cross-harness-canonical-names-plan.md
@@ -1,0 +1,100 @@
+# Implementation Plan — Cross-harness canonical names + setup docs (v2.10.1 Bundle A)
+
+**Workflow:** `refactor-v2-10-1-milestone` · **Track:** overhaul · **Design:**
+[`2026-05-31-cross-harness-canonical-names.md`](./2026-05-31-cross-harness-canonical-names.md)
+**Issues:** #1472, #1471
+
+Verified facts grounding this plan (per-runtime command-autoload investigation done upfront):
+- **opencode** ✅ — autoloads commands from `~/.config/opencode/commands/` (global) and
+  `.opencode/commands/` (project); markdown + YAML frontmatter (`description`, `agent`,
+  `model`, `subtask`); body is the prompt template, supports `$ARGUMENTS`. Gives the bare
+  canonical name `/ideate`. (opencode.ai/docs/commands)
+- **codex** ⚠️ — custom prompts (`~/.codex/prompts/*.md`, frontmatter + `$ARGUMENTS`) exist
+  but are **deprecated** (OpenAI now recommends *skills* for reusable instructions) **and**
+  are invoked namespaced as `/prompts:<name>`, i.e. `/prompts:ideate` — not the bare
+  canonical name. Emitting deprecated, non-bare aliases is low value. (developers.openai.com/codex/custom-prompts)
+- **copilot** ❌ — Copilot CLI has **no custom-command autoload**; custom slash commands from
+  a prompts dir are an open feature request (github/copilot-cli #618, #1113). Only VS Code
+  reads `.github/prompts/*.prompt.md`. Cannot emit working CLI aliases today.
+- **cursor / generic** — `hasSlashCommands: false`; no command surface at all.
+- **Conclusion:** opencode is the *only* runtime that can take a clean canonical alias this
+  cycle. This is a verified decision, not a deferral.
+- `CHAIN` already references canonical names; the gap is that those names aren't installed
+  off the Claude path → INV-4 parity gap, not cosmetic.
+
+## Tasks (TDD, dependency-ordered)
+
+### T1 — Canonical↔skill map as source-of-truth + drift guard  *(no deps)*
+- **RED:** `src/config/canonical-skills.test.ts` parses every `commands/*.md` "Skill
+  Reference" (`@skills/<dir>/SKILL.md`) and asserts it agrees with the map; commands with
+  no skill (`rehydrate`, `tag`, `autocompact`) are declared command-only; `review` maps to
+  both `spec-review` + `quality-review`.
+- **GREEN:** `src/config/canonical-skills.ts` exporting `COMMAND_TO_SKILL` (+ the
+  command-only set). Guard green.
+- **Files:** 2 new. Blast radius: tiny. Foundation for T2/T5.
+
+### T2 — Emit canonical-name alias artifacts (opencode) during build  *(deps: T1)*
+Scope is **opencode-only**, decided by the verified investigation above (codex aliases are
+deprecated + namespaced; copilot CLI has no autoload; cursor/generic have no command surface).
+The gating is driven by an explicit per-runtime capability, not a hardcoded "opencode" check —
+so adding a future runtime is a data change.
+- **RED:** test that the builder emits a canonical alias command file per `COMMAND_TO_SKILL`
+  entry **only** for runtimes flagged as supporting bare canonical command-aliases (opencode
+  today); emits nothing for cursor/generic/codex/copilot. Shape/snapshot test on the
+  generated tree.
+- Add an explicit capability to `runtimes/*.yaml` (e.g. `capabilities.canonicalCommandAliases:
+  true` on opencode only) so the builder gates on declared capability, not a name literal —
+  upholds INV-4 (no harness coupling in logic).
+- **GREEN:** extend `src/build-skills.ts` (or new `src/build-command-aliases.ts`) to render
+  alias files to a generated tree `command-aliases/<runtime>/<canonical>.md`. Each alias =
+  frontmatter (`description` lifted from the command) + body that invokes the underlying
+  skill via the runtime's skill-invoke convention (the `CHAIN`/skill directive), passing
+  `$ARGUMENTS`.
+- **Files:** `src/build-skills.ts` (+ optional new module), tests, generated
+  `command-aliases/opencode/*.md`. Medium.
+
+### T3 — install-skills installs aliases + prints destination/restart  *(deps: T2)*
+- **RED:** test that `install-skills --agent opencode` copies `command-aliases/opencode/*`
+  to opencode's `commandsInstallPath` and prints the destination path + restart hint
+  (the #1471 nice-to-have).
+- **GREEN:** add `commandsInstallPath: "~/.config/opencode/commands"` to
+  `runtimes/opencode.yaml`; wire copy + post-install summary in `src/install-skills.ts`.
+- **Files:** `src/install-skills.ts`, `runtimes/opencode.yaml`, tests. Medium.
+
+### T4 — Guard regenerated aliases against drift  *(deps: T2)*
+- **RED/GREEN:** extend the existing `skills:guard` re-render+`git diff` to also cover
+  `command-aliases/**` (or add an analogous `aliases:guard`); wire into `build` + CI the
+  same way `skills:guard` is. Drift fails CI.
+- **Files:** guard script + `package.json`. Small.
+
+### T5 — Harness setup docs (#1471)  *(deps: T1 for names; T2/T3 for accurate behavior)*
+- Add a per-runtime matrix + sections to `documentation/guide/installation.md`:
+  config-file location, MCP config shape (opencode stdio `config.json` from the issue),
+  stdio-vs-port, skill install command + destination (`skillsInstallPath`), restart
+  requirement — for opencode/codex/cursor/copilot/generic. Document the canonical-name
+  behavior, **which runtimes get canonical aliases (opencode) and which don't yet**
+  (codex/copilot pending; cursor/generic by-design no-commands), and the chaining-name
+  caveat for the latter. No silent caps — state coverage explicitly. Use the verified
+  per-runtime findings (top of doc): opencode = bare canonical aliases; codex = deprecated
+  namespaced prompts, skills recommended (link developers.openai.com/codex/custom-prompts);
+  copilot = no CLI autoload yet (link github/copilot-cli #618, #1113); cursor/generic = skill
+  descriptive name is the entry point + chaining-name caveat.
+- **Files:** `documentation/guide/installation.md`. Docs.
+
+*(Former T6 "verify codex/copilot" resolved upfront — see verified facts at top. No separate
+research task; its findings are folded into T2 scope and T5 docs.)*
+
+## Sequencing for delegation
+- Wave 1: **T1** (foundation).
+- Wave 2: **T2** (after T1).
+- Wave 3: **T3** + **T4** (after T2).
+- Wave 4: **T5** docs (after behavior is real).
+
+## Definition of done
+- `COMMAND_TO_SKILL` is the single SoT; commands prose can't drift (CI guard).
+- opencode users invoke `/ideate`,`/plan`,… and the auto-chain resolves on opencode.
+- `install-skills` prints destination + restart hint.
+- `installation.md` documents all five non-Claude runtimes + alias coverage + caveats.
+- INV-4 conformance: no Claude-only leak; `skills-src/` + `runtimes/` + map are SoT;
+  generated trees (`skills/**`, `command-aliases/**`) are never hand-edited.
+- `npm run build`, `typecheck`, `test:run`, `skills:guard` all green.

--- a/docs/designs/2026-05-31-cross-harness-canonical-names.md
+++ b/docs/designs/2026-05-31-cross-harness-canonical-names.md
@@ -1,0 +1,103 @@
+# Cross-harness canonical workflow names + setup docs (v2.10.1 Bundle A)
+
+**Workflow:** `refactor-v2-10-1-milestone` (overhaul track)
+**Issues:** #1472 (consistent workflow names across harnesses), #1471 (harness-specific setup docs)
+**Date:** 2026-05-31
+**Status:** brief → plan
+
+## Problem
+
+Claude Code users invoke canonical workflow names — `/exarchos:ideate`, `/exarchos:plan`,
+`/exarchos:delegate`, … — sourced from `commands/*.md`. Non-Claude runtimes
+(opencode, codex, copilot, cursor, generic) receive **no command layer**; they get only
+the skills, installed under their *descriptive* directory names (`brainstorming`,
+`implementation-planning`, `delegation`, …). So the same workflow has a different
+user-facing name depending on the harness.
+
+This is more than cosmetic. The auto-chain directive is rendered from the `CHAIN`
+placeholder, which already references **canonical** names:
+
+- `claude.yaml`: `CHAIN: 'Skill({ skill: "exarchos:{{next}}", args: "{{args}}" })'`
+- `opencode.yaml`: `CHAIN: "[Invoke the exarchos:{{next}} skill with args: {{args}}]"`
+
+`{{next}}` is substituted with canonical names (`ideate`→`plan`→`delegate`). On Claude
+this resolves (commands exist). On non-Claude runtimes the referenced skill name
+(`exarchos:plan`) **is not installed** — the installed skill is `implementation-planning`.
+The chaining guarantee therefore does not hold off the Claude path.
+
+**Invariant framing — INV-4 (platform-agnosticity):** the six runtimes are first-class;
+a workflow affordance that exists on Claude must exist on every runtime's path. Today the
+canonical-name affordance (and the chaining that depends on it) leaks Claude-only. This
+bundle closes that parity gap. Source-of-truth edits stay in `skills-src/` / `runtimes/` /
+a new map module; generated `skills/<runtime>/**` is never hand-edited.
+
+## Current state (verified)
+
+- The canonical↔skill mapping exists **only as prose** — one `@skills/<dir>/SKILL.md`
+  line per `commands/*.md`. No structured/declarative table anywhere.
+- `src/build-skills.ts` renders `skills-src/` → `skills/<runtime>/<skill>/SKILL.md`. It
+  emits **nothing** from `commands/`; commands are Claude-only and are loaded by the
+  plugin manifest (`.claude-plugin/plugin.json`), not by the renderer.
+- `src/install-skills.ts` copies skills (or shells out to `npx skills add`); it installs
+  **no command artifacts**.
+- `hasSlashCommands` is `true` for claude, opencode, codex, copilot; `false` for cursor,
+  generic. Only claude is wired today.
+- Per-runtime command-autoload location/format is **undocumented in this repo** for
+  opencode/codex/copilot. opencode is the only one proven (the #1472 reporter hand-authored
+  opencode command aliases that worked).
+
+## Goals
+
+1. **Single source-of-truth** for the canonical↔skill map, replacing 17 scattered prose
+   references as the authority, with a guard that every `commands/*.md` "Skill Reference"
+   line agrees with the map (drift fails CI, mirroring `skills:guard`).
+2. **Canonical-name aliases on non-Claude runtimes** so users invoke `ideate`/`plan`/… and
+   so the `CHAIN` directive resolves — emitted by the build, installed by `install-skills`,
+   only for runtimes whose command-autoload convention is known and verified.
+3. **Harness-specific setup docs** (#1471) in `documentation/guide/installation.md`:
+   per-runtime config-file location, MCP config shape, stdio vs port, skill install command
+   + destination, restart requirement — plus the canonical-name behavior and any caveat
+   for runtimes where aliases are not yet emitted.
+
+## Approach
+
+### Map as source-of-truth (low risk)
+Add `src/config/canonical-skills.ts` exporting `COMMAND_TO_SKILL` (canonical name →
+skill dir; `review` maps to both `spec-review` + `quality-review`; `rehydrate`/`tag`/
+`autocompact` have no skill and are command-only). Add a guard test that parses each
+`commands/*.md` "Skill Reference" line and asserts agreement with the map — so the map and
+the prose can never drift.
+
+### Alias emission (scoped to proven runtimes)
+During `npm run build:skills`, for runtimes with `hasSlashCommands: true` **and** a known
+command-autoload convention, emit canonical-name alias artifacts (lightweight command files
+that delegate to the underlying skill, mirroring the reporter's proven opencode setup).
+`install-skills` installs them to the runtime's command dir.
+
+- **opencode** — verify exact dir/format (`~/.config/opencode/command/*.md` expected;
+  the reporter proved aliases work). Emit + install.
+- **codex/copilot** — `hasSlashCommands: true` but command-autoload convention unconfirmed
+  in-repo. **Do not emit broken artifacts.** Confirm the convention; if confirmed, emit; if
+  not, document the gap (#1471) and leave for a follow-up. No silent cap — the docs state
+  exactly which runtimes get canonical aliases and which don't yet.
+- **cursor/generic** — `hasSlashCommands: false`; no alias layer. Document that the skill's
+  descriptive name is the entry point, and note the chaining-name caveat.
+
+### Docs (#1471)
+Add a per-runtime matrix + short sections to `documentation/guide/installation.md`, sourced
+from `runtimes/*.yaml` (skillsInstallPath, mcpPrefix, preferredFacade) and the facade doc.
+Include the opencode MCP `config.json`/stdio example from the issue, the install command,
+the destination path, and the restart hint. Optionally have `install-skills` print the
+destination + restart hint after install (the issue's nice-to-have).
+
+## Out of scope / explicitly deferred
+- **#1485** (SessionStart hook + SessionEnd) — Bundle B, separate workflow. Part (b) decided:
+  **keep** SessionEnd provenance telemetry (recorded on the issue).
+- **#1473** (Category-C auto-emission) — deferred to **#1258 / v3.0.0**; needs a runbook
+  executor that does not exist today. Moved off this milestone.
+
+## Risks
+- **Per-runtime command-autoload format** for opencode/codex/copilot is the only real
+  unknown; the plan must verify before emitting, never ship broken alias pointers.
+- Doubling user-facing names (descriptive skill + canonical alias) could confuse — mitigate
+  by making the alias a thin delegator and documenting the relationship.

--- a/docs/designs/2026-05-31-cross-harness-canonical-names.md
+++ b/docs/designs/2026-05-31-cross-harness-canonical-names.md
@@ -74,8 +74,8 @@ command-autoload convention, emit canonical-name alias artifacts (lightweight co
 that delegate to the underlying skill, mirroring the reporter's proven opencode setup).
 `install-skills` installs them to the runtime's command dir.
 
-- **opencode** — verify exact dir/format (`~/.config/opencode/command/*.md` expected;
-  the reporter proved aliases work). Emit + install.
+- **opencode** — verified: autoloads markdown commands from `~/.config/opencode/commands/`
+  (plural) and `.opencode/commands/`. Emit + install.
 - **codex/copilot** — `hasSlashCommands: true` but command-autoload convention unconfirmed
   in-repo. **Do not emit broken artifacts.** Confirm the convention; if confirmed, emit; if
   not, document the gap (#1471) and leave for a follow-up. No silent cap — the docs state

--- a/documentation/guide/installation.md
+++ b/documentation/guide/installation.md
@@ -89,6 +89,64 @@ The lvlup-sw marketplace is hosted at [lvlup-sw/.github](https://github.com/lvlu
 
 Restart Claude Code after the install so the new MCP server registration takes effect.
 
+## Other harnesses (opencode, Codex, Cursor, Copilot, generic)
+
+Exarchos is **additive to your harness choice** — the CLI binary is the same everywhere; only the skill/command wiring differs. Install the CLI (above), register the MCP server in your harness's config, then install the skills with `exarchos install-skills --agent <runtime>`.
+
+The MCP server always speaks **stdio** (`exarchos mcp`) — there is no port to configure on any runtime. Outside Claude Code the MCP tools surface under the bare prefix `mcp__exarchos__` (Claude Code wraps them in its plugin namespace, `mcp__plugin_exarchos_exarchos__`).
+
+| Runtime | MCP transport | Skill install command | Skills destination | Canonical command names | Restart? |
+|---|---|---|---|---|---|
+| **Claude Code** | stdio (plugin) | (plugin, see above) | `~/.claude/skills` | native — `/exarchos:ideate`, `/exarchos:plan`, … | yes |
+| **opencode** | stdio | `exarchos install-skills --agent opencode` | `~/.config/opencode/skills` | ✅ `/ideate`, `/plan`, … (installed to `~/.config/opencode/commands`) | yes |
+| **Codex** | stdio | `exarchos install-skills --agent codex` | `$HOME/.agents/skills` | ⚠️ not emitted (see below) | yes (new session) |
+| **Cursor** | stdio | `exarchos install-skills --agent cursor` | `~/.cursor/skills` | — (no custom slash commands) | yes |
+| **Copilot CLI** | stdio | `exarchos install-skills --agent copilot` | `~/.copilot/skills` | ❌ not supported yet (see below) | yes |
+| **generic** | stdio | `exarchos install-skills --agent generic` | `~/.agents/skills` | — (no custom slash commands) | n/a |
+
+`install-skills` prints the skills destination, the commands destination (where applicable), and a restart hint when it finishes — so you don't have to memorize the paths above.
+
+### Canonical workflow names across harnesses
+
+Inside Claude Code the workflow is driven by canonical command names — `/exarchos:ideate`, `/exarchos:plan`, `/exarchos:delegate`, `/exarchos:review`, `/exarchos:synthesize`, `/exarchos:cleanup`, and so on. The underlying skills carry *descriptive* names (`brainstorming`, `implementation-planning`, `delegation`, …), so on harnesses that only see the skills, the names would otherwise differ.
+
+To keep the names stable, Exarchos generates a thin **canonical-name command-alias layer** for harnesses whose command system can autoload it. Coverage today:
+
+- **opencode** ✅ — `install-skills --agent opencode` writes `/ideate`, `/plan`, `/delegate`, … to `~/.config/opencode/commands/`, each delegating to the matching skill. So `/ideate` works the same way it does in Claude Code. (opencode autoloads markdown commands from that directory.)
+- **Codex** ⚠️ — Codex's custom-prompt mechanism (`~/.codex/prompts/*.md`) is [deprecated in favor of skills](https://developers.openai.com/codex/custom-prompts) and invokes prompts namespaced as `/prompts:<name>`, not the bare `/ideate`. Exarchos therefore does **not** emit aliases for Codex; invoke the descriptive skill directly (e.g. the `brainstorming` skill for ideate).
+- **Copilot CLI** ❌ — Copilot CLI does not yet autoload custom slash commands from a prompts directory (tracked upstream: [github/copilot-cli#618](https://github.com/github/copilot-cli/issues/618), [#1113](https://github.com/github/copilot-cli/issues/1113)). Aliases will be emitted once that lands.
+- **Cursor / generic** — no custom-slash-command surface; the skill's descriptive name is the entry point.
+
+On runtimes without the alias layer, note the **chaining caveat**: skill prose that says "invoke the `exarchos:plan` skill" refers to the canonical name; map it to the descriptive skill (`implementation-planning`) until aliases are available for that runtime.
+
+### Example: opencode
+
+Register the MCP server in `~/.config/opencode/config.json` (stdio, no port):
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "exarchos": {
+      "type": "local",
+      "enabled": true,
+      "command": ["exarchos", "mcp"],
+      "env": {
+        "WORKFLOW_STATE_DIR": "/home/USER/.claude/workflow-state"
+      }
+    }
+  }
+}
+```
+
+Then install skills (and the canonical aliases):
+
+```bash
+exarchos install-skills --agent opencode
+```
+
+Skills land in `~/.config/opencode/skills/`, aliases in `~/.config/opencode/commands/`. **Restart opencode** (or reload) afterward to pick them up. Do not copy Claude-only env such as `EXARCHOS_PLUGIN_ROOT` into the opencode config — it is meaningless outside the Claude plugin and only clutters the environment.
+
 ## Validation
 
 ```bash

--- a/runtimes/opencode.yaml
+++ b/runtimes/opencode.yaml
@@ -54,6 +54,13 @@ supportedCapabilities:
   isolation:worktree: advisory
   session:resume: advisory
 skillsInstallPath: "~/.config/opencode/skills"
+# Directory OpenCode autoloads bare canonical-name slash-command aliases from
+# (global config dir). install-skills copies the generated
+# `command-aliases/opencode/*.md` tree here after installing skills
+# (T3, #1471/#1472). Only set on runtimes that declare
+# `capabilities.canonicalCommandAliases` — the install gate keys off this
+# field + the source tree, never an "opencode" literal (INV-4).
+commandsInstallPath: "~/.config/opencode/commands"
 detection:
   binaries:
     - opencode

--- a/runtimes/opencode.yaml
+++ b/runtimes/opencode.yaml
@@ -25,6 +25,15 @@ capabilities:
   hasHooks: false
   hasSkillChaining: false
   mcpPrefix: "mcp__exarchos__"
+  # OpenCode autoloads bare canonical-name slash commands from
+  # `~/.config/opencode/commands/<name>.md` (global) / `.opencode/commands/`
+  # (project). It is the ONLY runtime this cycle that can take a clean
+  # canonical alias (`/ideate`, `/plan`, ...) — codex's custom prompts are
+  # deprecated + namespaced (`/prompts:ideate`), copilot CLI has no autoload,
+  # and cursor/generic expose no command surface. The skills build keys
+  # alias emission off this declared capability, not an "opencode" literal
+  # (INV-4). See docs/designs/2026-05-31-cross-harness-canonical-names-plan.md.
+  canonicalCommandAliases: true
 # Fine-grained support matrix consumed by the prose renderer (Tasks 8/9)
 # to gate `<!-- requires:* -->` and `<!-- requires:native:* -->` blocks.
 # Mirrors `OpenCodeAdapter.supportLevels` in

--- a/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.js
+++ b/servers/exarchos-mcp/src/cli-commands/install-skills-bridge.js
@@ -44,7 +44,11 @@
  *             #1213 review-item #4 reversal, #1214.
  */
 
-import { installSkills, findSkillsSourceDir } from '../../../../src/install-skills.js';
+import {
+  installSkills,
+  findSkillsSourceDir,
+  findCommandAliasesSourceDir,
+} from '../../../../src/install-skills.js';
 import { loadAllRuntimes } from '../../../../src/runtimes/load.js';
 import { EMBEDDED_RUNTIMES } from '../../../../src/runtimes/embedded.js';
 import { fileURLToPath } from 'node:url';
@@ -115,5 +119,12 @@ export async function runInstallSkills(opts, deps = {}) {
   // shell-out — same behavior as before #1355.
   const skillsSource = findSkillsSourceDir();
 
-  await installer({ agent: opts.agent, runtimes, skillsSource });
+  // T3 (#1471/#1472): opt the binary into the canonical command-alias
+  // install by resolving the `command-aliases/` source tree the same way
+  // (cwd, binary-relative, src-relative). When it misses (undefined) the
+  // installer skips the alias copy. Only runtimes that declare
+  // `commandsInstallPath` (opencode today) actually receive aliases.
+  const aliasesSource = findCommandAliasesSourceDir();
+
+  await installer({ agent: opts.agent, runtimes, skillsSource, aliasesSource });
 }

--- a/src/build-command-aliases.test.ts
+++ b/src/build-command-aliases.test.ts
@@ -14,10 +14,18 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { buildCommandAliases } from './build-command-aliases.js';
+import { buildCommandAliases, emitCommandAliases } from './build-command-aliases.js';
 import { COMMAND_TO_SKILL } from './config/canonical-skills.js';
 import { loadRuntime } from './runtimes/load.js';
-import { mkdtempSync, rmSync, readFileSync, existsSync, readdirSync } from 'node:fs';
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  existsSync,
+  readdirSync,
+  writeFileSync,
+  mkdirSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -113,6 +121,71 @@ describe('buildCommandAliases — capability gating', () => {
     expect(existsSync(join(outDir, 'generic'))).toBe(false);
     expect(existsSync(join(outDir, 'cursor'))).toBe(false);
     expect(existsSync(join(outDir, 'codex'))).toBe(false);
+  });
+});
+
+describe('emitCommandAliases — stale cleanup across all runtimes', () => {
+  // loadAllRuntimes requires every runtime map present, so write all six;
+  // only opencode's `canonicalCommandAliases` is toggled by `opencodeEnabled`.
+  function writeToggleRuntimes(runtimesDir: string, opencodeEnabled: boolean): void {
+    mkdirSync(runtimesDir, { recursive: true });
+    const names = ['generic', 'claude', 'codex', 'opencode', 'copilot', 'cursor'];
+    for (const name of names) {
+      const enabled = name === 'opencode' ? opencodeEnabled : false;
+      writeFileSync(
+        join(runtimesDir, `${name}.yaml`),
+        [
+          `name: ${name}`,
+          'preferredFacade: cli',
+          'capabilities:',
+          '  hasSubagents: true',
+          '  hasSlashCommands: true',
+          '  hasHooks: false',
+          '  hasSkillChaining: false',
+          `  mcpPrefix: "mcp__${name}__"`,
+          `  canonicalCommandAliases: ${enabled}`,
+          `skillsInstallPath: "~/.${name}/skills"`,
+          ...(name === 'opencode'
+            ? ['commandsInstallPath: "~/.config/opencode/commands"']
+            : []),
+          'detection:',
+          '  binaries: []',
+          '  envVars: []',
+          'placeholders:',
+          `  MCP_PREFIX: "mcp__${name}__"`,
+          '  COMMAND_PREFIX: "/"',
+          '  TASK_TOOL: "Task"',
+          '  CHAIN: "[invoke {{next}} with {{args}}]"',
+          "  SPAWN_AGENT_CALL: 'Task({ prompt: \"{{prompt}}\" })'",
+          '  SUBAGENT_COMPLETION_HOOK: "inline"',
+          '  SUBAGENT_RESULT_API: "inline"',
+          '',
+        ].join('\n'),
+      );
+    }
+  }
+
+  it('prunes a runtime alias tree after canonicalCommandAliases is disabled', () => {
+    const runtimesDir = makeTempDir();
+    const outDir = makeTempDir();
+
+    // First pass: capability ON → full alias tree emitted.
+    writeToggleRuntimes(runtimesDir, true);
+    emitCommandAliases({ runtimesDir, commandsDir: REPO_COMMANDS_DIR, outDir });
+    const aliasDir = join(outDir, 'opencode');
+    expect(
+      readdirSync(aliasDir).filter((f) => f.endsWith('.md')).length,
+    ).toBe(COMMAND_KEYS.length);
+
+    // Second pass: capability OFF → the now-orphaned tree must be pruned,
+    // even though the runtime no longer emits (regression guard for the
+    // cleanup-only-emitting-runtimes bug).
+    writeToggleRuntimes(runtimesDir, false);
+    emitCommandAliases({ runtimesDir, commandsDir: REPO_COMMANDS_DIR, outDir });
+    const remaining = existsSync(aliasDir)
+      ? readdirSync(aliasDir).filter((f) => f.endsWith('.md'))
+      : [];
+    expect(remaining).toEqual([]);
   });
 });
 

--- a/src/build-command-aliases.test.ts
+++ b/src/build-command-aliases.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for canonical-name command alias emission (T2, v2.10.1 Bundle A, #1472).
+ *
+ * The emitter renders one thin "alias" command file per `COMMAND_TO_SKILL`
+ * entry, but ONLY for runtimes that declare the `canonicalCommandAliases`
+ * capability. Today that is opencode alone; cursor/generic/codex/copilot
+ * declare no such capability and must receive ZERO alias files (INV-4: the
+ * gate is a declared per-runtime capability, never a hardcoded "opencode"
+ * literal).
+ *
+ * These tests consume the REAL `COMMAND_TO_SKILL` map and the REAL command
+ * files, writing into a temp output dir so they assert the production
+ * behavior end-to-end.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { buildCommandAliases } from './build-command-aliases.js';
+import { COMMAND_TO_SKILL } from './config/canonical-skills.js';
+import { loadRuntime } from './runtimes/load.js';
+import { mkdtempSync, rmSync, readFileSync, existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '..');
+const REPO_RUNTIMES_DIR = join(REPO_ROOT, 'runtimes');
+const REPO_COMMANDS_DIR = join(REPO_ROOT, 'commands');
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'aliases-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()!;
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+});
+
+const COMMAND_KEYS = Object.keys(COMMAND_TO_SKILL).sort();
+
+describe('buildCommandAliases — capability gating', () => {
+  it('emits one alias file per COMMAND_TO_SKILL entry for opencode (has capability)', () => {
+    const opencode = loadRuntime(join(REPO_RUNTIMES_DIR, 'opencode.yaml'));
+    const outDir = makeTempDir();
+
+    const report = buildCommandAliases({
+      runtimes: [opencode],
+      commandsDir: REPO_COMMANDS_DIR,
+      outDir,
+    });
+
+    expect(report.filesWritten).toBe(COMMAND_KEYS.length);
+
+    const aliasDir = join(outDir, 'opencode');
+    const emitted = readdirSync(aliasDir)
+      .filter((f) => f.endsWith('.md'))
+      .map((f) => f.replace(/\.md$/, ''))
+      .sort();
+    expect(emitted).toEqual(COMMAND_KEYS);
+  });
+
+  it('emits ZERO files for a runtime without the capability (cursor)', () => {
+    const cursor = loadRuntime(join(REPO_RUNTIMES_DIR, 'cursor.yaml'));
+    const outDir = makeTempDir();
+
+    const report = buildCommandAliases({
+      runtimes: [cursor],
+      commandsDir: REPO_COMMANDS_DIR,
+      outDir,
+    });
+
+    expect(report.filesWritten).toBe(0);
+    expect(existsSync(join(outDir, 'cursor'))).toBe(false);
+  });
+
+  it.each(['generic', 'codex', 'copilot', 'cursor'])(
+    'emits ZERO files for %s (no canonicalCommandAliases capability)',
+    (name) => {
+      const rt = loadRuntime(join(REPO_RUNTIMES_DIR, `${name}.yaml`));
+      const outDir = makeTempDir();
+
+      const report = buildCommandAliases({
+        runtimes: [rt],
+        commandsDir: REPO_COMMANDS_DIR,
+        outDir,
+      });
+
+      expect(report.filesWritten).toBe(0);
+      expect(existsSync(join(outDir, name))).toBe(false);
+    },
+  );
+
+  it('only emits for the capable runtimes in a mixed batch', () => {
+    const runtimes = ['generic', 'opencode', 'cursor', 'codex'].map((n) =>
+      loadRuntime(join(REPO_RUNTIMES_DIR, `${n}.yaml`)),
+    );
+    const outDir = makeTempDir();
+
+    buildCommandAliases({ runtimes, commandsDir: REPO_COMMANDS_DIR, outDir });
+
+    expect(existsSync(join(outDir, 'opencode'))).toBe(true);
+    expect(existsSync(join(outDir, 'generic'))).toBe(false);
+    expect(existsSync(join(outDir, 'cursor'))).toBe(false);
+    expect(existsSync(join(outDir, 'codex'))).toBe(false);
+  });
+});
+
+describe('buildCommandAliases — alias file shape', () => {
+  function emitOpencode(): string {
+    const opencode = loadRuntime(join(REPO_RUNTIMES_DIR, 'opencode.yaml'));
+    const outDir = makeTempDir();
+    buildCommandAliases({
+      runtimes: [opencode],
+      commandsDir: REPO_COMMANDS_DIR,
+      outDir,
+    });
+    return join(outDir, 'opencode');
+  }
+
+  it('lifts the description from the command frontmatter', () => {
+    const aliasDir = emitOpencode();
+    const ideate = readFileSync(join(aliasDir, 'ideate.md'), 'utf8');
+    // commands/ideate.md frontmatter:
+    //   description: Start collaborative design exploration for a feature or problem
+    const cmdSrc = readFileSync(join(REPO_COMMANDS_DIR, 'ideate.md'), 'utf8');
+    const cmdDesc = cmdSrc.match(/^description:\s*(.+)$/m)?.[1].trim();
+    expect(cmdDesc).toBeTruthy();
+    expect(ideate).toMatch(/^---\n/);
+    const aliasDesc = ideate.match(/^description:\s*(.+)$/m)?.[1].trim();
+    expect(aliasDesc).toBe(cmdDesc);
+  });
+
+  it('body references the single mapped skill and passes $ARGUMENTS', () => {
+    const aliasDir = emitOpencode();
+    const ideate = readFileSync(join(aliasDir, 'ideate.md'), 'utf8');
+    // ideate → brainstorming
+    expect(ideate).toContain('brainstorming');
+    expect(ideate).toContain('$ARGUMENTS');
+  });
+
+  it('multi-skill commands name every mapped skill in order (review)', () => {
+    const aliasDir = emitOpencode();
+    const review = readFileSync(join(aliasDir, 'review.md'), 'utf8');
+    // review → [quality-review, spec-review] (map order)
+    expect(review).toContain('quality-review');
+    expect(review).toContain('spec-review');
+    expect(review.indexOf('quality-review')).toBeLessThan(
+      review.indexOf('spec-review'),
+    );
+    expect(review).toContain('$ARGUMENTS');
+  });
+
+  it('multi-skill commands name every mapped skill in order (delegate)', () => {
+    const aliasDir = emitOpencode();
+    const delegate = readFileSync(join(aliasDir, 'delegate.md'), 'utf8');
+    // delegate → [delegation, git-worktrees]
+    expect(delegate).toContain('delegation');
+    expect(delegate).toContain('git-worktrees');
+    expect(delegate.indexOf('delegation')).toBeLessThan(
+      delegate.indexOf('git-worktrees'),
+    );
+  });
+
+  it('does NOT emit alias files for COMMAND_ONLY commands', () => {
+    const aliasDir = emitOpencode();
+    for (const cmd of ['autocompact', 'tag']) {
+      expect(existsSync(join(aliasDir, `${cmd}.md`))).toBe(false);
+    }
+  });
+
+  it('is deterministic: two runs produce byte-identical output', () => {
+    const opencode = loadRuntime(join(REPO_RUNTIMES_DIR, 'opencode.yaml'));
+    const a = makeTempDir();
+    const b = makeTempDir();
+    buildCommandAliases({ runtimes: [opencode], commandsDir: REPO_COMMANDS_DIR, outDir: a });
+    buildCommandAliases({ runtimes: [opencode], commandsDir: REPO_COMMANDS_DIR, outDir: b });
+    for (const key of COMMAND_KEYS) {
+      const fa = readFileSync(join(a, 'opencode', `${key}.md`), 'utf8');
+      const fb = readFileSync(join(b, 'opencode', `${key}.md`), 'utf8');
+      expect(fa).toBe(fb);
+    }
+  });
+});

--- a/src/build-command-aliases.ts
+++ b/src/build-command-aliases.ts
@@ -215,13 +215,25 @@ function cleanStaleAliasFiles(root: string, keep: Set<string>): void {
         if (hadSurvivors) {
           survivorCount++;
         } else {
-          rmSync(full, { recursive: true, force: true });
+          try {
+            rmSync(full, { recursive: true, force: true });
+          } catch (err) {
+            throw new Error(
+              `cleanStaleAliasFiles: failed to remove directory "${full}": ${String(err)}`,
+            );
+          }
         }
       } else if (st.isFile()) {
         if (keep.has(resolve(full))) {
           survivorCount++;
         } else {
-          rmSync(full, { force: true });
+          try {
+            rmSync(full, { force: true });
+          } catch (err) {
+            throw new Error(
+              `cleanStaleAliasFiles: failed to remove file "${full}": ${String(err)}`,
+            );
+          }
         }
       }
     }

--- a/src/build-command-aliases.ts
+++ b/src/build-command-aliases.ts
@@ -180,9 +180,11 @@ export function buildCommandAliases(opts: {
  * prune emptied directories bottom-up. Scoped to a per-runtime subtree
  * (`command-aliases/<runtime>/`) so unrelated files are never touched.
  *
- * Mirrors `cleanStaleFiles` in `build-skills.ts`; kept local so the
- * alias emitter is self-contained and the drift guard can reuse the same
- * emit+clean pass without importing build-skills internals.
+ * Modeled on `cleanStaleFiles` in `build-skills.ts` but, unlike that older
+ * twin, does not swallow filesystem errors: a failed read/stat/remove during
+ * cleanup is a real fault (drift correctness depends on it) and is rethrown
+ * with path context rather than silently skipped — per the repo's
+ * no-silent-catches guideline.
  */
 function cleanStaleAliasFiles(root: string, keep: Set<string>): void {
   if (!existsSync(root)) return;
@@ -191,8 +193,10 @@ function cleanStaleAliasFiles(root: string, keep: Set<string>): void {
     let entries: string[];
     try {
       entries = readdirSync(dir);
-    } catch {
-      return false;
+    } catch (err) {
+      throw new Error(
+        `cleanStaleAliasFiles: failed to read directory "${dir}": ${String(err)}`,
+      );
     }
 
     let survivorCount = 0;
@@ -201,29 +205,23 @@ function cleanStaleAliasFiles(root: string, keep: Set<string>): void {
       let st;
       try {
         st = statSync(full);
-      } catch {
-        continue;
+      } catch (err) {
+        throw new Error(
+          `cleanStaleAliasFiles: failed to stat "${full}": ${String(err)}`,
+        );
       }
       if (st.isDirectory()) {
         const hadSurvivors = walk(full);
         if (hadSurvivors) {
           survivorCount++;
         } else {
-          try {
-            rmSync(full, { recursive: true, force: true });
-          } catch {
-            /* best-effort */
-          }
+          rmSync(full, { recursive: true, force: true });
         }
       } else if (st.isFile()) {
         if (keep.has(resolve(full))) {
           survivorCount++;
         } else {
-          try {
-            rmSync(full, { force: true });
-          } catch {
-            /* best-effort */
-          }
+          rmSync(full, { force: true });
         }
       }
     }
@@ -257,9 +255,14 @@ export function emitCommandAliases(opts: {
   const runtimes = loadAllRuntimes(runtimesDir);
   const report = buildCommandAliases({ runtimes, commandsDir, outDir });
 
+  // Clean across ALL loaded runtimes, not just the emitting ones: a runtime
+  // that previously declared `canonicalCommandAliases` and later dropped it
+  // would otherwise leave its `command-aliases/<runtime>/` tree orphaned
+  // forever. `keep` only contains paths under emitting runtimes' subtrees, so
+  // a non-emitting runtime's stale dir is fully pruned with the same keep-set.
   const keep = new Set(report.writtenPaths);
-  for (const rtName of report.runtimesEmitted) {
-    cleanStaleAliasFiles(join(outDir, rtName), keep);
+  for (const rt of runtimes) {
+    cleanStaleAliasFiles(join(outDir, rt.name), keep);
   }
 
   return report;

--- a/src/build-command-aliases.ts
+++ b/src/build-command-aliases.ts
@@ -26,10 +26,19 @@
  * drift-guarded by T4.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { join, resolve } from 'node:path';
 import type { RuntimeMap } from './runtimes/types.js';
 import { COMMAND_TO_SKILL } from './config/canonical-skills.js';
+import { loadAllRuntimes } from './runtimes/load.js';
 
 /**
  * Summary of an alias-emission pass so callers (the build entry point,
@@ -164,4 +173,94 @@ export function buildCommandAliases(opts: {
     writtenPaths,
     runtimesEmitted,
   };
+}
+
+/**
+ * Recursively remove any file under `root` not present in `keep`, then
+ * prune emptied directories bottom-up. Scoped to a per-runtime subtree
+ * (`command-aliases/<runtime>/`) so unrelated files are never touched.
+ *
+ * Mirrors `cleanStaleFiles` in `build-skills.ts`; kept local so the
+ * alias emitter is self-contained and the drift guard can reuse the same
+ * emit+clean pass without importing build-skills internals.
+ */
+function cleanStaleAliasFiles(root: string, keep: Set<string>): void {
+  if (!existsSync(root)) return;
+
+  const walk = (dir: string): boolean => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return false;
+    }
+
+    let survivorCount = 0;
+    for (const entry of entries) {
+      const full = join(dir, entry);
+      let st;
+      try {
+        st = statSync(full);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) {
+        const hadSurvivors = walk(full);
+        if (hadSurvivors) {
+          survivorCount++;
+        } else {
+          try {
+            rmSync(full, { recursive: true, force: true });
+          } catch {
+            /* best-effort */
+          }
+        }
+      } else if (st.isFile()) {
+        if (keep.has(resolve(full))) {
+          survivorCount++;
+        } else {
+          try {
+            rmSync(full, { force: true });
+          } catch {
+            /* best-effort */
+          }
+        }
+      }
+    }
+    return survivorCount > 0;
+  };
+
+  walk(root);
+}
+
+/**
+ * Full alias-emission pass: load runtimes from `runtimesDir`, emit the
+ * canonical-name alias tree via {@link buildCommandAliases}, then drop any
+ * pre-existing alias file (per emitting runtime) this run did not produce
+ * so renamed/removed commands don't linger.
+ *
+ * This is the single deterministic entry point shared by `build:skills`'s
+ * `main()` and the `skills:guard` drift check, so both regenerate the
+ * `command-aliases/**` tree identically before reporting or diffing.
+ *
+ * @param opts.runtimesDir - Directory of `runtimes/<name>.yaml` maps.
+ * @param opts.commandsDir - Directory of canonical `commands/<name>.md`.
+ * @param opts.outDir - Output root (`command-aliases/`).
+ * @returns The {@link CommandAliasReport} from the emission pass.
+ */
+export function emitCommandAliases(opts: {
+  runtimesDir: string;
+  commandsDir: string;
+  outDir: string;
+}): CommandAliasReport {
+  const { runtimesDir, commandsDir, outDir } = opts;
+  const runtimes = loadAllRuntimes(runtimesDir);
+  const report = buildCommandAliases({ runtimes, commandsDir, outDir });
+
+  const keep = new Set(report.writtenPaths);
+  for (const rtName of report.runtimesEmitted) {
+    cleanStaleAliasFiles(join(outDir, rtName), keep);
+  }
+
+  return report;
 }

--- a/src/build-command-aliases.ts
+++ b/src/build-command-aliases.ts
@@ -1,0 +1,167 @@
+/**
+ * Canonical-name command alias emitter (T2, v2.10.1 Bundle A, #1472).
+ *
+ * Some runtimes autoload **bare canonical-name** slash commands from a
+ * commands directory (e.g. opencode reads `~/.config/opencode/commands/
+ * <name>.md`). For those runtimes the skills build emits one thin "alias"
+ * command file per `COMMAND_TO_SKILL` entry: a markdown file with YAML
+ * frontmatter whose `description` is lifted from the canonical command
+ * (`commands/<name>.md`) and whose body is a short directive that delegates
+ * to the underlying skill(s), passing `$ARGUMENTS` through. This installs the
+ * bare canonical names (`/ideate`, `/plan`, ...) off the Claude path,
+ * closing the INV-4 parity gap noted in the design.
+ *
+ * The emission gate is the runtime's declared
+ * `capabilities.canonicalCommandAliases` flag — never a hardcoded
+ * runtime-name literal. Only opencode declares it this cycle; codex
+ * (deprecated, namespaced prompts), copilot (no CLI autoload), and
+ * cursor/generic (no command surface) declare nothing and receive zero
+ * files. Adding a future runtime is a pure data change in its YAML.
+ *
+ * `COMMAND_ONLY` commands (`autocompact`, `rehydrate`, `tag`) are skill-less
+ * and intentionally excluded here — they are tracked as a known gap in T5.
+ *
+ * The generated tree `command-aliases/<runtime>/<canonical>.md` is a build
+ * artifact (like `skills/`): deterministic, never hand-edited, and
+ * drift-guarded by T4.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import type { RuntimeMap } from './runtimes/types.js';
+import { COMMAND_TO_SKILL } from './config/canonical-skills.js';
+
+/**
+ * Summary of an alias-emission pass so callers (the build entry point,
+ * tests) can report on what happened without re-scanning the output tree.
+ */
+export interface CommandAliasReport {
+  /** Total alias `.md` files written across all capable runtimes. */
+  filesWritten: number;
+  /** Absolute paths of every file produced, for stale-cleanup tracking. */
+  writtenPaths: string[];
+  /** Names of runtimes that received aliases (had the capability). */
+  runtimesEmitted: string[];
+}
+
+/**
+ * Extract the `description` value from a command file's YAML frontmatter.
+ *
+ * Command frontmatter is a small, flat block delimited by `---` fences; we
+ * read only the `description:` line rather than pulling in a YAML parser,
+ * matching how the co-located drift guard parses these files. Throws if the
+ * file has no `description` so a malformed command surfaces at build time
+ * rather than emitting an alias with an empty description.
+ */
+function readCommandDescription(commandPath: string): string {
+  const src = readFileSync(commandPath, 'utf8');
+  const match = src.match(/^description:\s*(.+?)\s*$/m);
+  if (!match) {
+    throw new Error(
+      `buildCommandAliases: ${commandPath} has no \`description:\` frontmatter ` +
+        `to lift into the canonical alias.`,
+    );
+  }
+  return match[1].trim();
+}
+
+/**
+ * Render a single alias command file body.
+ *
+ * The directive matches the voice of opencode's `CHAIN` placeholder
+ * (`[Invoke the exarchos:<skill> skill with args: <args>]`): name every
+ * mapped skill, in `COMMAND_TO_SKILL` order, and thread `$ARGUMENTS`
+ * through so the runtime's argument substitution reaches the skill.
+ */
+function renderAliasBody(command: string, skills: readonly string[]): string {
+  const skillList =
+    skills.length === 1
+      ? `the \`${skills[0]}\` skill`
+      : skills.map((s) => `\`${s}\``).join(', then ') + ' skills';
+  return (
+    `# /${command}\n` +
+    `\n` +
+    `Canonical alias for the Exarchos \`/${command}\` workflow command.\n` +
+    `\n` +
+    `Invoke ${skillList} to handle: $ARGUMENTS\n`
+  );
+}
+
+/**
+ * Render the full alias file (frontmatter + body) for one canonical command.
+ */
+function renderAliasFile(
+  command: string,
+  skills: readonly string[],
+  description: string,
+): string {
+  return (
+    `---\n` +
+    `description: ${description}\n` +
+    `---\n` +
+    `\n` +
+    renderAliasBody(command, skills)
+  );
+}
+
+/**
+ * Emit canonical-name command alias files for every runtime in `runtimes`
+ * that declares `capabilities.canonicalCommandAliases: true`.
+ *
+ * For each capable runtime, writes one `command-aliases/<runtime>/
+ * <canonical>.md` file per `COMMAND_TO_SKILL` entry. Output ordering is
+ * stable (the map's key order is insertion order, and content is a pure
+ * function of the map + command frontmatter) so the tree can be
+ * drift-guarded.
+ *
+ * Runtimes lacking the capability are skipped entirely — no directory is
+ * created for them.
+ *
+ * @param opts.runtimes - Loaded runtime maps to consider.
+ * @param opts.commandsDir - Directory of canonical `commands/<name>.md`
+ *   files (source of the lifted `description`).
+ * @param opts.outDir - Output root; each capable runtime gets a
+ *   `<outDir>/<runtime>/` subdirectory.
+ * @returns A populated {@link CommandAliasReport}.
+ */
+export function buildCommandAliases(opts: {
+  runtimes: readonly RuntimeMap[];
+  commandsDir: string;
+  outDir: string;
+}): CommandAliasReport {
+  const { runtimes, commandsDir, outDir } = opts;
+  const writtenPaths: string[] = [];
+  const runtimesEmitted: string[] = [];
+
+  // Iterate commands in map order for deterministic output.
+  const commandEntries = Object.entries(COMMAND_TO_SKILL);
+
+  for (const rt of runtimes) {
+    if (rt.capabilities.canonicalCommandAliases !== true) continue;
+    runtimesEmitted.push(rt.name);
+
+    const runtimeOutDir = join(outDir, rt.name);
+    mkdirSync(runtimeOutDir, { recursive: true });
+
+    for (const [command, skills] of commandEntries) {
+      const commandPath = join(commandsDir, `${command}.md`);
+      if (!existsSync(commandPath)) {
+        throw new Error(
+          `buildCommandAliases: COMMAND_TO_SKILL references "${command}" but ` +
+            `${commandPath} does not exist. The map and commands/ are out of sync.`,
+        );
+      }
+      const description = readCommandDescription(commandPath);
+      const contents = renderAliasFile(command, skills, description);
+      const outFile = join(runtimeOutDir, `${command}.md`);
+      writeFileSync(outFile, contents);
+      writtenPaths.push(resolve(outFile));
+    }
+  }
+
+  return {
+    filesWritten: writtenPaths.length,
+    writtenPaths,
+    runtimesEmitted,
+  };
+}

--- a/src/build-skills.ts
+++ b/src/build-skills.ts
@@ -31,7 +31,7 @@ import {
 } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { loadAllRuntimes } from './runtimes/load.js';
-import { buildCommandAliases } from './build-command-aliases.js';
+import { emitCommandAliases } from './build-command-aliases.js';
 import type { RuntimeMap, SupportedCapabilityName } from './runtimes/types.js';
 import { RuntimeTokenKey, SupportedCapabilityKey } from './runtimes/types.js';
 import { resolveMainDeps, type MainDeps } from './cli-helpers.js';
@@ -1764,18 +1764,15 @@ export function main(_argv: string[], deps: MainDeps = {}): void {
     // declaring `capabilities.canonicalCommandAliases` (opencode this
     // cycle). The gate is the declared capability, not a name literal
     // (INV-4). The generated `command-aliases/<runtime>/*.md` tree is a
-    // build artifact like `skills/` — deterministic and drift-guarded.
-    const runtimes = loadAllRuntimes(runtimesDir);
-    const aliasReport = buildCommandAliases({ runtimes, commandsDir, outDir: aliasOutDir });
+    // build artifact like `skills/` — deterministic and drift-guarded
+    // (T4). `emitCommandAliases` performs the emit + per-runtime stale
+    // cleanup as one deterministic pass shared with `skills:guard`.
+    const aliasReport = emitCommandAliases({
+      runtimesDir,
+      commandsDir,
+      outDir: aliasOutDir,
+    });
     aliasFilesWritten = aliasReport.filesWritten;
-    // Stale cleanup: per emitting runtime, drop any pre-existing alias
-    // file this run did not produce so renamed/removed commands don't
-    // linger. Scoped to `<aliasOutDir>/<runtime>/` so unrelated files
-    // are never touched.
-    const aliasKeep = new Set(aliasReport.writtenPaths);
-    for (const rtName of aliasReport.runtimesEmitted) {
-      cleanStaleFiles(join(aliasOutDir, rtName), aliasKeep);
-    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     errLog(`[build:skills] error: ${msg}`);

--- a/src/build-skills.ts
+++ b/src/build-skills.ts
@@ -31,6 +31,7 @@ import {
 } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { loadAllRuntimes } from './runtimes/load.js';
+import { buildCommandAliases } from './build-command-aliases.js';
 import type { RuntimeMap, SupportedCapabilityName } from './runtimes/types.js';
 import { RuntimeTokenKey, SupportedCapabilityKey } from './runtimes/types.js';
 import { resolveMainDeps, type MainDeps } from './cli-helpers.js';
@@ -1751,10 +1752,30 @@ export function main(_argv: string[], deps: MainDeps = {}): void {
   const srcDir = join(root, 'skills-src');
   const outDir = join(root, 'skills');
   const runtimesDir = join(root, 'runtimes');
+  const commandsDir = join(root, 'commands');
+  const aliasOutDir = join(root, 'command-aliases');
 
   let report: BuildReport;
+  let aliasFilesWritten = 0;
   try {
     report = buildAllSkills({ srcDir, outDir, runtimesDir });
+
+    // T2 (#1472): emit canonical-name command alias files for any runtime
+    // declaring `capabilities.canonicalCommandAliases` (opencode this
+    // cycle). The gate is the declared capability, not a name literal
+    // (INV-4). The generated `command-aliases/<runtime>/*.md` tree is a
+    // build artifact like `skills/` — deterministic and drift-guarded.
+    const runtimes = loadAllRuntimes(runtimesDir);
+    const aliasReport = buildCommandAliases({ runtimes, commandsDir, outDir: aliasOutDir });
+    aliasFilesWritten = aliasReport.filesWritten;
+    // Stale cleanup: per emitting runtime, drop any pre-existing alias
+    // file this run did not produce so renamed/removed commands don't
+    // linger. Scoped to `<aliasOutDir>/<runtime>/` so unrelated files
+    // are never touched.
+    const aliasKeep = new Set(aliasReport.writtenPaths);
+    for (const rtName of aliasReport.runtimesEmitted) {
+      cleanStaleFiles(join(aliasOutDir, rtName), aliasKeep);
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     errLog(`[build:skills] error: ${msg}`);
@@ -1770,6 +1791,9 @@ export function main(_argv: string[], deps: MainDeps = {}): void {
   );
   if (report.overridesUsed.length > 0) {
     log(`[build:skills] used ${report.overridesUsed.length} runtime override(s)`);
+  }
+  if (aliasFilesWritten > 0) {
+    log(`[build:skills] wrote ${aliasFilesWritten} canonical command alias(es)`);
   }
   for (const warning of report.warnings) {
     errLog(`[build:skills] warning: ${warning}`);

--- a/src/config/canonical-skills.test.ts
+++ b/src/config/canonical-skills.test.ts
@@ -1,0 +1,123 @@
+/**
+ * T1 (v2.10.1 Bundle A, #1472) — Canonical command → skill map drift guard.
+ *
+ * `COMMAND_TO_SKILL` (in `./canonical-skills.ts`) is the single source-of-truth
+ * mapping from a canonical workflow command name to the underlying skill
+ * directory name(s) it delegates to. This test derives the *expected* mapping
+ * from the actual `commands/*.md` files at test time and asserts the map agrees,
+ * so the human-readable "Skill Reference" prose in the command files cannot drift
+ * away from the machine-readable map without failing CI.
+ *
+ * A command file may reference MORE THAN ONE skill (e.g. `delegate.md` ->
+ * `delegation` + `git-worktrees`; `review.md` -> `spec-review` + `quality-review`).
+ * Only `@skills/<dir>/SKILL.md` references count — `@skills/<dir>/references/*.md`
+ * include paths are NOT skill entry points and must be ignored.
+ *
+ * Commands that delegate to no skill (`autocompact`, `rehydrate`, `tag`) are
+ * declared in `COMMAND_ONLY` and must NOT appear in `COMMAND_TO_SKILL`.
+ *
+ * Scope: content-only validation of the markdown command templates against the
+ * map. No runtime execution required.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { dirname, join, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { COMMAND_TO_SKILL, COMMAND_ONLY } from './canonical-skills.js';
+
+// `src/config/` → repo root is two levels up.
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const commandsDir = join(repoRoot, 'commands');
+const skillsSrcDir = join(repoRoot, 'skills-src');
+
+/** Matches a skill *entry-point* reference, e.g. `@skills/spec-review/SKILL.md`. */
+const SKILL_REF = /@skills\/([^/]+)\/SKILL\.md/g;
+
+/** All command file base names (without `.md`). */
+const commandNames = readdirSync(commandsDir)
+  .filter((f) => f.endsWith('.md'))
+  .map((f) => basename(f, '.md'))
+  .sort();
+
+/** Parse the distinct skill dirs a single command file references. */
+function referencedSkills(command: string): string[] {
+  const body = readFileSync(join(commandsDir, `${command}.md`), 'utf-8');
+  const dirs = new Set<string>();
+  for (const match of body.matchAll(SKILL_REF)) {
+    dirs.add(match[1]);
+  }
+  return [...dirs].sort();
+}
+
+const sorted = (xs: readonly string[]): string[] => [...xs].sort();
+
+describe('canonical-skills map (T1, #1472)', () => {
+  it('covers every command file as either a mapped command or command-only', () => {
+    for (const command of commandNames) {
+      const mapped = command in COMMAND_TO_SKILL;
+      const commandOnly = COMMAND_ONLY.has(command);
+      expect(
+        mapped || commandOnly,
+        `command "${command}" is neither in COMMAND_TO_SKILL nor COMMAND_ONLY`,
+      ).toBe(true);
+      // A command is one or the other, never both.
+      expect(
+        mapped && commandOnly,
+        `command "${command}" appears in BOTH COMMAND_TO_SKILL and COMMAND_ONLY`,
+      ).toBe(false);
+    }
+  });
+
+  it('maps each command to exactly the skills its file references', () => {
+    for (const command of commandNames) {
+      const actual = referencedSkills(command);
+      if (actual.length === 0) {
+        // No skill entry-point reference → must be declared command-only.
+        expect(
+          COMMAND_ONLY.has(command),
+          `command "${command}" references no skill but is not in COMMAND_ONLY`,
+        ).toBe(true);
+        expect(
+          command in COMMAND_TO_SKILL,
+          `command "${command}" references no skill but appears in COMMAND_TO_SKILL`,
+        ).toBe(false);
+      } else {
+        expect(
+          sorted(COMMAND_TO_SKILL[command] ?? []),
+          `COMMAND_TO_SKILL["${command}"] drifted from its file's @skills/.../SKILL.md references`,
+        ).toEqual(actual);
+      }
+    }
+  });
+
+  it('only contains keys that correspond to a real commands/<key>.md file', () => {
+    for (const command of Object.keys(COMMAND_TO_SKILL)) {
+      expect(
+        existsSync(join(commandsDir, `${command}.md`)),
+        `COMMAND_TO_SKILL key "${command}" has no commands/${command}.md file`,
+      ).toBe(true);
+    }
+  });
+
+  it('only declares command-only names that correspond to a real commands/<name>.md file', () => {
+    for (const command of COMMAND_ONLY) {
+      expect(
+        existsSync(join(commandsDir, `${command}.md`)),
+        `COMMAND_ONLY entry "${command}" has no commands/${command}.md file`,
+      ).toBe(true);
+    }
+  });
+
+  it('references only skill dirs that exist under skills-src/<dir>/SKILL.md', () => {
+    for (const [command, dirs] of Object.entries(COMMAND_TO_SKILL)) {
+      for (const dir of dirs) {
+        expect(
+          existsSync(join(skillsSrcDir, dir, 'SKILL.md')),
+          `COMMAND_TO_SKILL["${command}"] points at missing skills-src/${dir}/SKILL.md`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/src/config/canonical-skills.ts
+++ b/src/config/canonical-skills.ts
@@ -1,0 +1,58 @@
+/**
+ * T1 (v2.10.1 Bundle A, #1472) — Canonical command → skill source-of-truth.
+ *
+ * `COMMAND_TO_SKILL` is the single authoritative mapping from a canonical
+ * workflow command name (the `commands/<name>.md` slash command, e.g. `/ideate`)
+ * to the underlying skill directory name(s) under `skills-src/<dir>/` that the
+ * command delegates to. Downstream consumers (T2 alias emission, T5 docs) read
+ * this map instead of re-deriving it, so there is exactly one place the mapping
+ * lives.
+ *
+ * Derived from the "Skill Reference" prose in each command file — specifically
+ * every `@skills/<dir>/SKILL.md` entry-point reference. A command may reference
+ * more than one skill:
+ *   - `delegate`  → `delegation` + `git-worktrees`
+ *   - `oneshot`   → `oneshot-workflow` + `synthesis`
+ *   - `review`    → `quality-review` + `spec-review`
+ *
+ * `@skills/<dir>/references/*.md` include paths are NOT skill entry points and
+ * are deliberately excluded.
+ *
+ * Commands that delegate to no skill are listed in `COMMAND_ONLY` and MUST NOT
+ * appear in `COMMAND_TO_SKILL`. The co-located drift guard
+ * (`canonical-skills.test.ts`) re-derives this map from the actual command files
+ * and fails CI on any divergence.
+ */
+
+/**
+ * Canonical command name → sorted list of skill directory names it delegates to.
+ * Skill dirs are sorted to give a stable, comparable shape for the drift guard.
+ */
+export const COMMAND_TO_SKILL: Readonly<Record<string, readonly string[]>> = {
+  checkpoint: ['workflow-state'],
+  cleanup: ['cleanup'],
+  debug: ['debug'],
+  delegate: ['delegation', 'git-worktrees'],
+  discover: ['discovery'],
+  dogfood: ['dogfood'],
+  ideate: ['brainstorming'],
+  invariants: ['authoring-invariants'],
+  oneshot: ['oneshot-workflow', 'synthesis'],
+  plan: ['implementation-planning'],
+  prune: ['prune-workflows'],
+  refactor: ['refactor'],
+  review: ['quality-review', 'spec-review'],
+  shepherd: ['shepherd'],
+  synthesize: ['synthesis'],
+  tdd: ['implementation-planning'],
+} as const;
+
+/**
+ * Canonical commands that delegate to no skill — they carry their own inline
+ * prompt (or defer to a `rules/*.md` rule) rather than chaining into a skill.
+ */
+export const COMMAND_ONLY: ReadonlySet<string> = new Set<string>([
+  'autocompact',
+  'rehydrate',
+  'tag',
+]);

--- a/src/install-skills.test.ts
+++ b/src/install-skills.test.ts
@@ -21,6 +21,7 @@ import {
   registerExarchosInClaudeJson,
   type SpawnResult,
 } from './install-skills.js';
+import { expandTilde } from './install-skills.js';
 
 /**
  * Minimal valid runtime map factory for unit-test use. Overrides let each
@@ -524,6 +525,169 @@ describe('registerExarchosInClaudeJson (#1217)', () => {
       const afterMtime = fs.statSync(configPath).mtimeMs;
       expect(afterMtime).toBe(beforeMtime);
     } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── T3 — install canonical command aliases + post-install summary ───────────
+// (#1471/#1472, v2.10.1 Bundle A)
+//
+// When a runtime declares `commandsInstallPath` AND a generated
+// `command-aliases/<runtime>/` source tree exists, install-skills must also
+// copy those `*.md` alias files into the expanded commands directory and print
+// a post-install summary (skills dest + commands dest + restart hint). The gate
+// is the presence of `commandsInstallPath` + source tree — never an "opencode"
+// literal (INV-4).
+
+describe('installSkills command aliases (T3, #1471/#1472)', () => {
+  /**
+   * opencode runtime fixture: declares `commandsInstallPath`, mirroring the
+   * real `runtimes/opencode.yaml`. The other fields match the production map
+   * closely enough for the install path resolution.
+   */
+  const OPENCODE = makeRuntime({
+    name: 'opencode',
+    capabilities: {
+      hasSubagents: true,
+      hasSlashCommands: true,
+      hasHooks: false,
+      hasSkillChaining: false,
+      mcpPrefix: 'mcp__exarchos__',
+      canonicalCommandAliases: true,
+    },
+    skillsInstallPath: '~/.config/opencode/skills',
+    commandsInstallPath: '~/.config/opencode/commands',
+    detection: { binaries: ['opencode'], envVars: [] },
+  });
+
+  /**
+   * Build a temporary `skills/` source tree containing the per-runtime
+   * subtree `<root>/<runtime>/<skill>/SKILL.md`, plus a sibling
+   * `command-aliases/<runtime>/<name>.md` tree. Returns the two source roots
+   * and a disposer. The skills source is needed so the local-copy fast path
+   * (which the alias copy hangs off of) engages.
+   */
+  function makeAliasFixture(runtimeName: string): {
+    skillsSource: string;
+    aliasesSource: string;
+    aliasFiles: string[];
+    dispose: () => void;
+  } {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-aliases-'));
+    const skillsSource = path.join(tmp, 'skills');
+    const aliasesSource = path.join(tmp, 'command-aliases');
+
+    // One trivial skill so copyLocalSkills finds something to copy.
+    const skillDir = path.join(skillsSource, runtimeName, 'sample-skill');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# sample\n', 'utf8');
+
+    // Two alias files under command-aliases/<runtime>/.
+    const aliasDir = path.join(aliasesSource, runtimeName);
+    fs.mkdirSync(aliasDir, { recursive: true });
+    const aliasFiles = ['ideate.md', 'plan.md'];
+    for (const f of aliasFiles) {
+      fs.writeFileSync(path.join(aliasDir, f), `---\ndescription: ${f}\n---\n`, 'utf8');
+    }
+
+    return {
+      skillsSource,
+      aliasesSource,
+      aliasFiles,
+      dispose: () => fs.rmSync(tmp, { recursive: true, force: true }),
+    };
+  }
+
+  it('InstallSkills_OpencodeWithCommandsPath_CopiesAliasFiles', async () => {
+    const fx = makeAliasFixture('opencode');
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-home-'));
+    try {
+      await installSkills({
+        agent: 'opencode',
+        runtimes: [OPENCODE],
+        spawn: fakeSpawn().fn,
+        log: () => {},
+        errLog: () => {},
+        homeDir: () => home,
+        skillsSource: fx.skillsSource,
+        aliasesSource: fx.aliasesSource,
+        registerMcp: () => {},
+      });
+
+      // Alias files must land in the expanded commandsInstallPath.
+      const destDir = expandTilde('~/.config/opencode/commands', home);
+      for (const f of fx.aliasFiles) {
+        expect(fs.existsSync(path.join(destDir, f))).toBe(true);
+      }
+    } finally {
+      fx.dispose();
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('InstallSkills_RuntimeWithoutCommandsPath_WritesNoAliasFiles', async () => {
+    // generic has no commandsInstallPath — even if an aliases source tree
+    // happens to exist, nothing must be written for it.
+    const fx = makeAliasFixture('generic');
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-home-'));
+    const GENERIC_NO_CMDS = makeRuntime({
+      name: 'generic',
+      skillsInstallPath: '~/.agents/skills',
+      detection: { binaries: [], envVars: [] },
+    });
+    try {
+      await installSkills({
+        agent: 'generic',
+        runtimes: [GENERIC_NO_CMDS],
+        spawn: fakeSpawn().fn,
+        log: () => {},
+        errLog: () => {},
+        homeDir: () => home,
+        skillsSource: fx.skillsSource,
+        aliasesSource: fx.aliasesSource,
+        registerMcp: () => {},
+      });
+
+      // No commands directory should have been created at all.
+      const commandsRoot = path.join(home, '.config', 'opencode', 'commands');
+      expect(fs.existsSync(commandsRoot)).toBe(false);
+      // And the generic agents dir must contain no `.md` alias files.
+      const genericCmds = expandTilde('~/.agents/commands', home);
+      expect(fs.existsSync(genericCmds)).toBe(false);
+    } finally {
+      fx.dispose();
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('InstallSkills_Opencode_PrintsDestinationsAndRestartHint', async () => {
+    const fx = makeAliasFixture('opencode');
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-home-'));
+    const logs: string[] = [];
+    try {
+      await installSkills({
+        agent: 'opencode',
+        runtimes: [OPENCODE],
+        spawn: fakeSpawn().fn,
+        log: (msg) => logs.push(msg),
+        errLog: () => {},
+        homeDir: () => home,
+        skillsSource: fx.skillsSource,
+        aliasesSource: fx.aliasesSource,
+        registerMcp: () => {},
+      });
+
+      const joined = logs.join('\n');
+      const skillsDest = expandTilde('~/.config/opencode/skills', home);
+      const cmdsDest = expandTilde('~/.config/opencode/commands', home);
+      // Summary names both destinations.
+      expect(joined).toContain(skillsDest);
+      expect(joined).toContain(cmdsDest);
+      // ...and includes a restart hint.
+      expect(joined.toLowerCase()).toContain('restart');
+    } finally {
+      fx.dispose();
       fs.rmSync(home, { recursive: true, force: true });
     }
   });

--- a/src/install-skills.test.ts
+++ b/src/install-skills.test.ts
@@ -626,6 +626,35 @@ describe('installSkills command aliases (T3, #1471/#1472)', () => {
     }
   });
 
+  it('InstallSkills_OpencodeShellOutPath_StillCopiesAliasFiles', async () => {
+    // When skillsSource is undefined, skills install via the upstream
+    // `npx skills add` shell-out. Alias install runs *after* that branch too,
+    // so opencode must still get its /ideate, /plan, ... commands.
+    const fx = makeAliasFixture('opencode');
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'exarchos-home-'));
+    try {
+      await installSkills({
+        agent: 'opencode',
+        runtimes: [OPENCODE],
+        spawn: fakeSpawn().fn,
+        log: () => {},
+        errLog: () => {},
+        homeDir: () => home,
+        skillsSource: undefined,
+        aliasesSource: fx.aliasesSource,
+        registerMcp: () => {},
+      });
+
+      const destDir = expandTilde('~/.config/opencode/commands', home);
+      for (const f of fx.aliasFiles) {
+        expect(fs.existsSync(path.join(destDir, f))).toBe(true);
+      }
+    } finally {
+      fx.dispose();
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it('InstallSkills_RuntimeWithoutCommandsPath_WritesNoAliasFiles', async () => {
     // generic has no commandsInstallPath — even if an aliases source tree
     // happens to exist, nothing must be written for it.

--- a/src/install-skills.ts
+++ b/src/install-skills.ts
@@ -150,6 +150,31 @@ export interface InstallSkillsOpts {
    * Only invoked when the local-copy fast path runs (see `skillsSource`).
    */
   copyDir?: (src: string, dest: string) => void;
+  /**
+   * Optional explicit path to the per-runtime command-alias source tree
+   * (the directory that contains `<runtime>/<canonical>.md` children — i.e.
+   * the repo's `command-aliases/` directory, a build artifact emitted by
+   * `build-command-aliases.ts`). When provided AND the resolved runtime
+   * declares `commandsInstallPath` AND `<aliasesSource>/<runtime.name>/`
+   * exists, `installSkills()` copies every alias `*.md` file into the
+   * expanded `commandsInstallPath` so the bare canonical names (`/ideate`,
+   * `/plan`, ...) autoload off the Claude path (T3, #1471/#1472).
+   *
+   * The copy runs regardless of which skills-install transport ran (the
+   * local-copy fast path or the upstream `npx skills add` shell-out) — it
+   * is gated purely on the presence of `commandsInstallPath` + a viable
+   * source tree, never a runtime-name literal (INV-4). When `undefined`,
+   * `installSkills()` does NOT auto-detect — the bridge supplies
+   * `findCommandAliasesSourceDir()` explicitly, mirroring `skillsSource`.
+   */
+  aliasesSource?: string;
+  /**
+   * Injectable single-file copy used by the command-alias install. Default
+   * wraps `fs.copyFileSync(src, dest)`. Tests inject a recorder so they can
+   * assert what was copied without touching disk. Only invoked when the
+   * command-alias copy runs (see `aliasesSource`).
+   */
+  copyFile?: (src: string, dest: string) => void;
 }
 
 /**
@@ -293,6 +318,154 @@ export function copyLocalSkills(
   }
 
   return skillDirs;
+}
+
+/**
+ * Default single-file copy: wraps `fs.copyFileSync`. Pulled into a named
+ * helper so `installSkills` can default `opts.copyFile` to a stable
+ * reference and tests can inject a recorder.
+ */
+function defaultCopyFile(src: string, dest: string): void {
+  fs.copyFileSync(src, dest);
+}
+
+/**
+ * Copy every `*.md` alias file under `sourceDir` (a directory of flat
+ * `<canonical>.md` command-alias files) into `destDir`, creating `destDir`
+ * if needed. Returns the list of file names copied so the caller can log a
+ * manifest.
+ *
+ * Only top-level `*.md` files are copied — the alias tree is flat by
+ * construction (`build-command-aliases.ts` emits `<runtime>/<name>.md`).
+ * Existing files in `destDir` are overwritten (the alias content is a pure
+ * function of the canonical command map, so a re-copy is byte-stable); other
+ * files the user keeps in their commands dir are left untouched.
+ *
+ * Used by the T3 command-alias install (#1471/#1472).
+ */
+export function copyCommandAliases(
+  sourceDir: string,
+  destDir: string,
+  copyFile: (src: string, dest: string) => void = defaultCopyFile,
+): string[] {
+  const aliasFiles = fs
+    .readdirSync(sourceDir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith('.md'))
+    .map((e) => e.name);
+
+  if (aliasFiles.length === 0) return [];
+
+  fs.mkdirSync(destDir, { recursive: true });
+  for (const file of aliasFiles) {
+    copyFile(path.join(sourceDir, file), path.join(destDir, file));
+  }
+  return aliasFiles;
+}
+
+/**
+ * Auto-detect the local command-alias source directory — the parent of
+ * `<runtime>/<canonical>.md` (i.e. the repo's `command-aliases/`
+ * directory). Mirrors {@link findSkillsSourceDir}'s candidate resolution
+ * (cwd, compiled-binary `dist/bin/../..`, src-relative dev path) so the
+ * binary's command-alias install works in both the test harness and a
+ * developer checkout.
+ *
+ * Returns the first candidate that exists as a directory, or `undefined`
+ * when none do (the caller skips the alias copy). T3, #1471/#1472.
+ */
+export function findCommandAliasesSourceDir(): string | undefined {
+  const candidates: string[] = [];
+  candidates.push(path.join(process.cwd(), 'command-aliases'));
+  try {
+    if (typeof process.execPath === 'string' && process.execPath.length > 0) {
+      candidates.push(
+        path.resolve(path.dirname(process.execPath), '..', '..', 'command-aliases'),
+      );
+    }
+  } catch {
+    // process.execPath is always defined under Node/Bun, but guard anyway.
+  }
+  try {
+    if (typeof import.meta.url === 'string' && import.meta.url.startsWith('file:')) {
+      const here = path.dirname(fileURLToPath(import.meta.url));
+      candidates.push(path.resolve(here, '..', 'command-aliases'));
+    }
+  } catch {
+    // import.meta.url may be a non-file: URL inside bun-compile output.
+  }
+  for (const c of candidates) {
+    try {
+      if (fs.statSync(c).isDirectory()) return c;
+    } catch {
+      // Candidate doesn't exist — try next.
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Install canonical command aliases for `runtime`, when applicable, and
+ * return the expanded destination path so the caller can include it in the
+ * post-install summary.
+ *
+ * The copy is gated purely on (a) the runtime declaring
+ * `commandsInstallPath`, (b) `opts.aliasesSource` being supplied, and (c)
+ * `<aliasesSource>/<runtime.name>/` existing as a directory — never a
+ * runtime-name literal (INV-4). It runs regardless of which skills-install
+ * transport ran, so opencode gets its `/ideate`, `/plan`, ... aliases
+ * whether skills came via the local-copy fast path or the upstream shell-out.
+ *
+ * Returns the expanded commands destination if files were copied, else
+ * `undefined`. T3, #1471/#1472.
+ */
+function installCommandAliases(
+  runtime: RuntimeMap,
+  opts: InstallSkillsOpts,
+  home: string,
+  log: (msg: string) => void,
+): string | undefined {
+  const aliasesSource = opts.aliasesSource;
+  if (!aliasesSource || !runtime.commandsInstallPath) return undefined;
+
+  const runtimeAliasDir = path.join(aliasesSource, runtime.name);
+  let sourceIsViable = false;
+  try {
+    sourceIsViable = fs.statSync(runtimeAliasDir).isDirectory();
+  } catch {
+    sourceIsViable = false;
+  }
+  if (!sourceIsViable) return undefined;
+
+  const destDir = expandTilde(runtime.commandsInstallPath, home);
+  const copyFile = opts.copyFile ?? defaultCopyFile;
+  const copied = copyCommandAliases(runtimeAliasDir, destDir, copyFile);
+  if (copied.length === 0) return undefined;
+
+  log(
+    `Installed ${copied.length} command alias${copied.length === 1 ? '' : 'es'} → ${destDir}`,
+  );
+  return destDir;
+}
+
+/**
+ * Print the post-install summary: skills destination, commands destination
+ * (when aliases were installed), and a restart hint so the user reloads the
+ * runtime to pick up the new content. Kept concise and routed through the
+ * injected `log` so tests can assert on it (the #1471 nice-to-have).
+ */
+function printInstallSummary(
+  log: (msg: string) => void,
+  skillsDest: string,
+  commandsDest: string | undefined,
+  runtimeName: string,
+): void {
+  log('');
+  log('Install complete.');
+  log(`  Skills:   ${skillsDest}`);
+  if (commandsDest) {
+    log(`  Commands: ${commandsDest}`);
+  }
+  log(`Restart ${runtimeName} (or reload) to pick up new skills/commands.`);
 }
 
 /**
@@ -468,6 +641,11 @@ export async function installSkills(opts: InstallSkillsOpts): Promise<void> {
       const installed = copyLocalSkills(runtimeSourceDir, destDir, copyDir);
       log(`Installed ${installed.length} skill${installed.length === 1 ? '' : 's'}: ${installed.join(', ')}`);
 
+      // Install canonical command aliases (T3, #1471/#1472) — gated on the
+      // runtime declaring `commandsInstallPath` + a viable alias source tree,
+      // never a runtime-name literal (INV-4).
+      const commandsDest = installCommandAliases(runtime, opts, home, log);
+
       // Mirror the post-success MCP registration that the spawn path
       // performs for the `claude` runtime — install-skills' contract
       // is "skills land + claude gets MCP wired up", regardless of
@@ -483,6 +661,8 @@ export async function installSkills(opts: InstallSkillsOpts): Promise<void> {
           );
         }
       }
+
+      printInstallSummary(log, destDir, commandsDest, runtime.name);
       return;
     }
   }
@@ -506,11 +686,10 @@ export async function installSkills(opts: InstallSkillsOpts): Promise<void> {
   //     pointing into npm's cache disappear if the cache is GC'd; copies
   //     survive across sessions and are byte-stable for idempotence.
   const home = homeDirFn();
-  // `expandTilde` retained as an exported helper for downstream callers /
-  // future runtimes; it's no longer needed in the argv since `--target` is
-  // not a valid upstream flag.
-  const _target = expandTilde(runtime.skillsInstallPath, home);
-  void _target;
+  // The expanded skills destination. No longer needed in the argv (`--target`
+  // is not a valid upstream flag), but reused below for the post-install
+  // summary so the user sees where skills landed.
+  const skillsDest = expandTilde(runtime.skillsInstallPath, home);
 
   const skillsAgentId = mapRuntimeToSkillsCliAgent(runtime.name);
   const cmd = 'npx';
@@ -569,6 +748,12 @@ export async function installSkills(opts: InstallSkillsOpts): Promise<void> {
       );
     }
   }
+
+  // Install canonical command aliases (T3, #1471/#1472) on the shell-out
+  // path too — gated on `commandsInstallPath` + a viable alias source tree,
+  // never a runtime-name literal (INV-4). Then print the post-install summary.
+  const commandsDest = installCommandAliases(runtime, opts, home, log);
+  printInstallSummary(log, skillsDest, commandsDest, runtime.name);
 }
 
 /**

--- a/src/install-skills.ts
+++ b/src/install-skills.ts
@@ -373,30 +373,42 @@ export function copyCommandAliases(
  * Returns the first candidate that exists as a directory, or `undefined`
  * when none do (the caller skips the alias copy). T3, #1471/#1472.
  */
+/**
+ * True for the only errors a path *probe* is allowed to swallow: the
+ * candidate simply isn't there (`ENOENT`) or a path component isn't a
+ * directory (`ENOTDIR`). Anything else (`EACCES`, `EIO`, a non-`file:`
+ * URL passed to `fileURLToPath`, ...) is a real fault that must surface
+ * rather than be silently treated as "candidate missing" — per the repo's
+ * no-silent-catches guideline.
+ */
+function isIgnorablePathProbeError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
 export function findCommandAliasesSourceDir(): string | undefined {
   const candidates: string[] = [];
   candidates.push(path.join(process.cwd(), 'command-aliases'));
-  try {
-    if (typeof process.execPath === 'string' && process.execPath.length > 0) {
-      candidates.push(
-        path.resolve(path.dirname(process.execPath), '..', '..', 'command-aliases'),
-      );
-    }
-  } catch {
-    // process.execPath is always defined under Node/Bun, but guard anyway.
+  if (typeof process.execPath === 'string' && process.execPath.length > 0) {
+    candidates.push(
+      path.resolve(path.dirname(process.execPath), '..', '..', 'command-aliases'),
+    );
   }
   try {
     if (typeof import.meta.url === 'string' && import.meta.url.startsWith('file:')) {
       const here = path.dirname(fileURLToPath(import.meta.url));
       candidates.push(path.resolve(here, '..', 'command-aliases'));
     }
-  } catch {
-    // import.meta.url may be a non-file: URL inside bun-compile output.
+  } catch (err) {
+    // A genuine non-file: URL under bun-compile output is benign; anything
+    // else is unexpected and should not be hidden.
+    if (!isIgnorablePathProbeError(err)) throw err;
   }
   for (const c of candidates) {
     try {
       if (fs.statSync(c).isDirectory()) return c;
-    } catch {
+    } catch (err) {
+      if (!isIgnorablePathProbeError(err)) throw err;
       // Candidate doesn't exist — try next.
     }
   }
@@ -431,7 +443,9 @@ function installCommandAliases(
   let sourceIsViable = false;
   try {
     sourceIsViable = fs.statSync(runtimeAliasDir).isDirectory();
-  } catch {
+  } catch (err) {
+    // No alias subtree for this runtime is expected; surface real I/O faults.
+    if (!isIgnorablePathProbeError(err)) throw err;
     sourceIsViable = false;
   }
   if (!sourceIsViable) return undefined;

--- a/src/runtimes/embedded.ts
+++ b/src/runtimes/embedded.ts
@@ -121,6 +121,7 @@ const RAW_RUNTIMES = [
     },
     "preferredFacade": "cli",
     "skillsInstallPath": "~/.config/opencode/skills",
+    "commandsInstallPath": "~/.config/opencode/commands",
     "detection": {
       "binaries": [
         "opencode"

--- a/src/runtimes/embedded.ts
+++ b/src/runtimes/embedded.ts
@@ -116,7 +116,8 @@ const RAW_RUNTIMES = [
       "hasSlashCommands": true,
       "hasHooks": false,
       "hasSkillChaining": false,
-      "mcpPrefix": "mcp__exarchos__"
+      "mcpPrefix": "mcp__exarchos__",
+      "canonicalCommandAliases": true
     },
     "preferredFacade": "cli",
     "skillsInstallPath": "~/.config/opencode/skills",

--- a/src/runtimes/types.ts
+++ b/src/runtimes/types.ts
@@ -152,6 +152,17 @@ export const RuntimeMapSchema = z
     // DR-1: preferred skill-authoring facade for this runtime.
     preferredFacade: z.enum(['mcp', 'cli']),
     skillsInstallPath: z.string(),
+    /**
+     * Directory the runtime autoloads bare canonical-name slash-command
+     * aliases from (e.g. opencode's `~/.config/opencode/commands`). Optional:
+     * only runtimes that declare `capabilities.canonicalCommandAliases` and
+     * therefore receive a generated `command-aliases/<runtime>/` tree set this.
+     * When present, `installSkills()` copies the alias `*.md` files here after
+     * installing skills (T3, #1471/#1472). The install gate keys off the
+     * presence of this field + the source tree, never a runtime-name literal
+     * (INV-4: no harness coupling in logic).
+     */
+    commandsInstallPath: z.string().optional(),
     detection: DetectionSchema,
     placeholders: z.record(z.string(), z.string()),
     // Zod v4's `z.record(enum, value)` enforces exhaustive coverage of

--- a/src/runtimes/types.ts
+++ b/src/runtimes/types.ts
@@ -27,6 +27,16 @@ const CapabilitiesSchema = z
     hasHooks: z.boolean(),
     hasSkillChaining: z.boolean(),
     mcpPrefix: z.string(),
+    /**
+     * Whether this runtime can autoload **bare canonical-name** command
+     * aliases (e.g. `/ideate`, `/plan`) from a commands directory, so the
+     * skills build should emit thin alias command files for it (T2,
+     * #1472). Optional + defaults to absent/false: only opencode declares
+     * `true` this cycle. The build gate keys off this declared capability,
+     * never a hardcoded runtime-name literal, so adding a future runtime
+     * is a pure data change (INV-4: no harness coupling in logic).
+     */
+    canonicalCommandAliases: z.boolean().optional(),
   })
   .strict();
 

--- a/src/skills-guard.test.ts
+++ b/src/skills-guard.test.ts
@@ -18,6 +18,9 @@
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { runSkillsGuard } from './skills-guard.js';
 import { buildAllSkills, clearRegistryLookup } from './build-skills.js';
+import { buildCommandAliases } from './build-command-aliases.js';
+import { loadAllRuntimes } from './runtimes/load.js';
+import { COMMAND_TO_SKILL } from './config/canonical-skills.js';
 import {
   mkdtempSync,
   writeFileSync,
@@ -475,5 +478,205 @@ describe('skills-guard — task 011 CALL macro determinism', () => {
     const secondResult = runSkillsGuard({ cwd: root, regenerateAgents: noopRegenerateAgents });
     expect(secondResult.ok).toBe(true);
     expect(secondResult.exitCode).toBe(0);
+  });
+});
+
+/**
+ * T4 (#1472): the same guard that protects `skills/` must also protect
+ * the generated `command-aliases/**` tree emitted by T2's
+ * `buildCommandAliases`. The alias tree is a build artifact like
+ * `skills/`: a contributor who edits a `commands/*.md` description (the
+ * lifted source) or the `COMMAND_TO_SKILL` map without regenerating must
+ * get a red CI signal, exactly as for skills drift.
+ *
+ * Determinism note: `buildAllSkills` (the function the guard already
+ * calls) does NOT emit aliases — alias emission lives in
+ * `buildCommandAliases`, invoked separately by `build:skills`'s `main()`.
+ * So the guard cannot simply widen its diff scope; it must also
+ * regenerate aliases before diffing. These tests lock that in.
+ */
+const ALIASES_OPENCODE_DIR = join('command-aliases', 'opencode');
+
+/**
+ * Write runtime fixtures for the alias path. Identical to
+ * `writeRuntimeFixtures` but flips `capabilities.canonicalCommandAliases`
+ * on for opencode (and off for everyone else) so `buildCommandAliases`
+ * emits exactly one tree — `command-aliases/opencode/` — mirroring the
+ * real repo state after T2.
+ */
+function writeAliasRuntimeFixtures(runtimesDir: string): void {
+  mkdirSync(runtimesDir, { recursive: true });
+  const names = ['generic', 'claude', 'codex', 'opencode', 'copilot', 'cursor'];
+  for (const name of names) {
+    writeFileSync(
+      join(runtimesDir, `${name}.yaml`),
+      [
+        `name: ${name}`,
+        `preferredFacade: mcp`,
+        `capabilities:`,
+        `  hasSubagents: true`,
+        `  hasSlashCommands: true`,
+        `  hasHooks: true`,
+        `  hasSkillChaining: true`,
+        `  mcpPrefix: "mcp__${name}__"`,
+        `  canonicalCommandAliases: ${name === 'opencode' ? 'true' : 'false'}`,
+        `skillsInstallPath: "~/.${name}/skills"`,
+        `detection:`,
+        `  binaries: []`,
+        `  envVars: []`,
+        `placeholders:`,
+        `  AGENT_LABEL: "agent"`,
+        `  MCP_PREFIX: "mcp__${name}__"`,
+        `  COMMAND_PREFIX: "/"`,
+        `  TASK_TOOL: "Task"`,
+        `  CHAIN: "[invoke {{next}} with {{args}}]"`,
+        `  SPAWN_AGENT_CALL: 'Task({ prompt: \"{{prompt}}\" })'`,
+        `  SUBAGENT_COMPLETION_HOOK: "subagent completion signal (poll-based)"`,
+        `  SUBAGENT_RESULT_API: "[poll subagent result]"`,
+        ``,
+      ].join('\n'),
+    );
+  }
+}
+
+/**
+ * Provision a temp project that also has the alias inputs:
+ *   - `commands/<name>.md` (frontmatter `description`) for every
+ *     `COMMAND_TO_SKILL` key — the source `buildCommandAliases` lifts
+ *   - opencode runtime with `canonicalCommandAliases: true`
+ *   - `skills/` + `command-aliases/opencode/` both generated and committed
+ * so `git diff` starts clean across both trees.
+ */
+function provisionProjectWithAliases(): string {
+  const root = makeTempDir();
+
+  mkdirSync(join(root, 'skills-src', 'foo'), { recursive: true });
+  writeFileSync(
+    join(root, 'skills-src', 'foo', 'SKILL.md'),
+    'Hello {{AGENT_LABEL}}\n',
+  );
+  writeAliasRuntimeFixtures(join(root, 'runtimes'));
+
+  // One command file per map entry so `buildCommandAliases` finds its
+  // lifted `description` source for every canonical name.
+  const commandsDir = join(root, 'commands');
+  mkdirSync(commandsDir, { recursive: true });
+  for (const command of Object.keys(COMMAND_TO_SKILL)) {
+    writeFileSync(
+      join(commandsDir, `${command}.md`),
+      [`---`, `description: Run the ${command} workflow.`, `---`, ``, `# /${command}`, ``].join(
+        '\n',
+      ),
+    );
+  }
+
+  buildAllSkills({
+    srcDir: join(root, 'skills-src'),
+    outDir: join(root, 'skills'),
+    runtimesDir: join(root, 'runtimes'),
+  });
+
+  // Seed the alias tree exactly as `build:skills`'s main() does.
+  buildCommandAliases({
+    runtimes: loadAllRuntimes(join(root, 'runtimes')),
+    commandsDir,
+    outDir: join(root, 'command-aliases'),
+  });
+
+  const gitEnv = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'test',
+    GIT_AUTHOR_EMAIL: 'test@example.com',
+    GIT_COMMITTER_NAME: 'test',
+    GIT_COMMITTER_EMAIL: 'test@example.com',
+  };
+  execSync('git init -q -b main', { cwd: root, env: gitEnv });
+  execSync('git add -A', { cwd: root, env: gitEnv });
+  execSync('git commit -q -m "seed"', { cwd: root, env: gitEnv });
+
+  return root;
+}
+
+describe('skills-guard — T4 command-aliases/ drift (#1472)', () => {
+  it('AliasesGuard_CleanBuild_Passes', () => {
+    const root = provisionProjectWithAliases();
+
+    const result = runSkillsGuard({
+      cwd: root,
+      regenerateAgents: noopRegenerateAgents,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.exitCode).toBe(0);
+    // Sanity: the alias tree exists and was seeded.
+    const firstCommand = Object.keys(COMMAND_TO_SKILL)[0];
+    expect(
+      existsSync(join(root, ALIASES_OPENCODE_DIR, `${firstCommand}.md`)),
+    ).toBe(true);
+  });
+
+  it('AliasesGuard_StaleCommandDescription_Fails', () => {
+    const root = provisionProjectWithAliases();
+
+    // A contributor edits a command description (the lifted source) but
+    // forgets to regenerate. The committed `command-aliases/` tree is now
+    // stale relative to source. The guard must regenerate + diff and fail.
+    const firstCommand = Object.keys(COMMAND_TO_SKILL)[0];
+    writeFileSync(
+      join(root, 'commands', `${firstCommand}.md`),
+      [
+        `---`,
+        `description: Run the ${firstCommand} workflow — DESCRIPTION CHANGED.`,
+        `---`,
+        ``,
+        `# /${firstCommand}`,
+        ``,
+      ].join('\n'),
+    );
+
+    const result = runSkillsGuard({
+      cwd: root,
+      regenerateAgents: noopRegenerateAgents,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).not.toBe(0);
+    // The drift must be attributed to the alias tree, naming the path so
+    // a developer can see which artifact is stale.
+    expect(result.message).toMatch(/command-aliases/);
+  });
+
+  it('AliasesGuard_DirectAliasEdit_Detected', () => {
+    const root = provisionProjectWithAliases();
+
+    // Simulate a developer hand-editing a generated alias file and
+    // committing it. A fresh regeneration overwrites the hand-edit, so
+    // `git diff command-aliases/` against HEAD is non-empty.
+    const firstCommand = Object.keys(COMMAND_TO_SKILL)[0];
+    const generated = join(root, ALIASES_OPENCODE_DIR, `${firstCommand}.md`);
+    const before = readFileSync(generated, 'utf8');
+    writeFileSync(generated, before + '\n<!-- hand edit -->\n');
+
+    const gitEnv = {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    };
+    execSync('git add -A', { cwd: root, env: gitEnv });
+    execSync('git commit -q -m "hand-edit generated alias"', {
+      cwd: root,
+      env: gitEnv,
+    });
+
+    const result = runSkillsGuard({
+      cwd: root,
+      regenerateAgents: noopRegenerateAgents,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.message).toMatch(/command-aliases\/opencode/);
   });
 });

--- a/src/skills-guard.ts
+++ b/src/skills-guard.ts
@@ -23,6 +23,7 @@
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 import { buildAllSkills } from './build-skills.js';
+import { emitCommandAliases } from './build-command-aliases.js';
 import { resolveMainDeps, type MainDeps } from './cli-helpers.js';
 
 /**
@@ -76,6 +77,17 @@ const REMEDIATION =
  */
 const REMEDIATION_AGENTS =
   "Generated agents are stale. Run 'npm run generate:agents' and commit the result.";
+
+/**
+ * Remediation for the `command-aliases/` drift path (T4, #1472). The
+ * generated alias tree is produced by the same `npm run build:skills`
+ * pass that renders `skills/` (the build entry point calls
+ * `emitCommandAliases` after `buildAllSkills`), so the fix is identical:
+ * rebuild and commit. Kept distinct from `REMEDIATION` only so the
+ * failure header names the alias tree, not skills.
+ */
+const REMEDIATION_ALIASES =
+  "Generated command aliases are stale. Run 'npm run build:skills' and commit the result.";
 
 /**
  * Default production regenerator. Spawns `tsx` against
@@ -174,6 +186,41 @@ export function runSkillsGuard(opts: SkillsGuardOptions): SkillsGuardResult {
     if (skillsDiff !== null) failures.push(skillsDiff);
   }
 
+  // ─── Command-aliases check (T4, #1472) ────────────────────────────
+
+  // The generated `command-aliases/**` tree is a build artifact like
+  // `skills/`, but it is emitted by `emitCommandAliases` — a step the
+  // build entry point runs *after* `buildAllSkills`, NOT by
+  // `buildAllSkills` itself. So the guard must regenerate it here before
+  // diffing; widening the diff scope alone would never catch drift
+  // because the committed tree would always match an un-regenerated copy
+  // of itself. A contributor who edits a `commands/*.md` description or
+  // the `COMMAND_TO_SKILL` map without rebuilding gets a red signal here.
+  let aliasesBuildFailed = false;
+  try {
+    emitCommandAliases({
+      runtimesDir: join(cwd, 'runtimes'),
+      commandsDir: join(cwd, 'commands'),
+      outDir: join(cwd, 'command-aliases'),
+    });
+  } catch (err) {
+    aliasesBuildFailed = true;
+    const detail = err instanceof Error ? err.message : String(err);
+    failures.push(
+      `[skills:guard] command-alias emission failed: ${detail}\n${REMEDIATION_ALIASES}`,
+    );
+  }
+
+  if (!aliasesBuildFailed) {
+    const aliasesDiff = checkGitDiff(
+      cwd,
+      'command-aliases/',
+      REMEDIATION_ALIASES,
+      'command-aliases',
+    );
+    if (aliasesDiff !== null) failures.push(aliasesDiff);
+  }
+
   // ─── Agents check ─────────────────────────────────────────────────
 
   // Step 2a: regenerate `agents/`. Same failure semantics as the
@@ -234,7 +281,8 @@ export function runSkillsGuard(opts: SkillsGuardOptions): SkillsGuardResult {
   return {
     ok: true,
     exitCode: 0,
-    message: '[skills:guard] skills/ and agents/ are in sync with sources',
+    message:
+      '[skills:guard] skills/, command-aliases/ and agents/ are in sync with sources',
   };
 }
 


### PR DESCRIPTION
## Summary

v2.10.1 milestone **Bundle A** — closes #1472 and #1471.

Non-Claude harnesses exposed workflow skills under *descriptive* names (`brainstorming`, `implementation-planning`, …) while Claude Code uses *canonical* names (`/exarchos:ideate`, `/exarchos:plan`, …). This was not merely cosmetic: the `CHAIN` auto-chain directive already references canonical names (`exarchos:plan`), which are **not installed off the Claude path**, so chaining silently broke on opencode — an **INV-4 (platform-agnosticity)** parity gap.

This PR establishes a single source-of-truth canonical↔skill map and emits a capability-gated canonical-name **command-alias layer** for harnesses whose command system can autoload it. Coverage is decided by upfront investigation, not guesswork: **opencode** gets clean bare aliases (`/ideate`, …); **Codex** prompts are deprecated + namespaced (`/prompts:*`) so we don't emit; **Copilot CLI** has no custom-command autoload yet ([copilot-cli#618](https://github.com/github/copilot-cli/issues/618), [#1113](https://github.com/github/copilot-cli/issues/1113)); **Cursor/generic** have no command surface.

## Changes

- **T1 — canonical↔skill SoT** (`src/config/canonical-skills.ts`): `COMMAND_TO_SKILL` map + `COMMAND_ONLY` set, with a drift guard test that re-derives expectations from live `commands/*.md` references (catches any prose↔map drift). Surfaced multi-skill commands: `delegate→[delegation, git-worktrees]`, `oneshot→[oneshot-workflow, synthesis]`, `review→[quality-review, spec-review]`.
- **T2 — alias emission** (`src/build-command-aliases.ts`, `src/build-skills.ts`): `npm run build:skills` emits `command-aliases/<runtime>/<canonical>.md` for runtimes declaring `capabilities.canonicalCommandAliases` (opencode only). Gating is data-driven — no harness name literal in logic (INV-4). 16 aliases generated.
- **T3 — install** (`src/install-skills.ts`, `runtimes/opencode.yaml`): `install-skills --agent opencode` copies aliases to `~/.config/opencode/commands/` and prints a post-install summary (skills dest, commands dest, restart hint). Gated on `commandsInstallPath` presence.
- **T4 — drift guard** (`src/skills-guard.ts`): `skills:guard` now **regenerates** `command-aliases/` before diffing (not a no-op pathspec widening); rides the existing CI step, no workflow change.
- **T5 — docs** (`documentation/guide/installation.md`): per-runtime setup matrix (stdio MCP transport, install command, skills destination, restart) for opencode/Codex/Cursor/Copilot/generic + canonical-name coverage table with citations + chaining caveat + opencode `config.json` example. `CLAUDE.md` architecture bullets updated.

Design + plan: `docs/designs/2026-05-31-cross-harness-canonical-names*.md`.

**Out of scope (deferred this milestone):** #1485 (SessionStart hook + SessionEnd — Bundle B; (b) decided: keep provenance telemetry) and #1473 (Category-C auto-emission — moved to #1258/v3.0.0; needs a runbook executor that doesn't exist yet).

## Test Plan

- `npm run typecheck` — clean.
- `npm run test:run` — **794 passed**, 6 skipped (94 files); new tests: canonical-skills drift guard (5), alias emitter capability-gating + shape (13), install alias copy + summary (3), guard regenerate-before-diff (10).
- `npm run skills:guard` — exit 0, `skills/, command-aliases/ and agents/ are in sync with sources`.
- Two-stage review (spec + INV-4 + correctness + quality + docs): **APPROVE**; both non-blocking nits fixed (delegate description leak genericized; design path corrected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)